### PR TITLE
rocjitsu: SIMD fast-path for MFMA/WMMA/VALU gap ops

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -52,6 +52,11 @@ include(rj_log)
 option(RJ_SANITIZER "Enable sanitizer (asan, ubsan, tsan, or msan)" "")
 option(RJ_CLANG_TIDY "Enable clang-tidy static analysis" OFF)
 option(
+    RJ_ENABLE_EXPENSIVE_CHECKS
+    "Enable expensive exhaustive test suites (MFMA/WMMA SIMD bit-exactness)"
+    OFF
+)
+option(
     LTO
     "Enable link-time optimization (IPO) for Release / RelWithDebInfo"
     OFF

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/matrix.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/matrix.py
@@ -11,6 +11,62 @@ from __future__ import annotations
 
 from amdisa.gpuisa import Instruction
 
+# Input families that have specialized (compile-time M/N/K) MFMA kernels in the
+# hand-maintained mma_exec.h. CDNA MFMA and RDNA WMMA both flow through the
+# GFX9 MFMA-layout helpers (exec_f32/exec_i32_i8), so the same spec templates
+# apply to both; gfx1250 WMMA uses its own wave32 spec helpers (handled below).
+# The spec templates fall back to the generic runtime path for unsupported
+# shapes / when stdx::simd is unavailable, so emitting them is always safe.
+_MFMA_F32_SPEC = {'F32': 'f32', 'XF32': 'f32', 'F16': 'f16', 'BF16': 'bf16'}
+_F8_FIXED = frozenset({'FP8_FP8', 'FP8_BF8', 'BF8_FP8', 'BF8_BF8'})
+
+
+def _mma_targ(M: int, N: int, K: int, B: int, *, batch_optional: bool) -> str:
+    """Spec template argument list, dropping a defaulted BATCH==1."""
+    if batch_optional and B == 1:
+        return f'{M}, {N}, {K}'
+    return f'{M}, {N}, {K}, {B}'
+
+
+def _f8_bools(input_type: str) -> tuple[str, str]:
+    """(A_FP8, B_FP8) C++ bool literals for a fixed f8 input family."""
+    parts = input_type.split('_')
+    return (
+        'true' if parts[0] == 'FP8' else 'false',
+        'true' if parts[1] == 'FP8' else 'false',
+    )
+
+
+def _gfx1250_wmma_spec(
+    result_type: str, input_type: str, M: int, N: int, K: int
+) -> str | None:
+    """Specialized gfx1250 (wave32) dense-WMMA kernel name for a given shape,
+    or None to use the generic runtime path. Returns the full callee including
+    template args; the call site supplies (cu, dst, s0, s1, s2, const_acc)."""
+    if input_type in _F8_FIXED:
+        a_fp8, b_fp8 = _f8_bools(input_type)
+        if result_type == 'F32':
+            return f'exec_wmma_f32_f8_spec<{M}, {N}, {K}, {a_fp8}, {b_fp8}>'
+        if result_type == 'F16':
+            return f'exec_wmma_f16_f8_spec<{M}, {N}, {K}, {a_fp8}, {b_fp8}>'
+        return None
+    if result_type == 'F16':
+        if input_type == 'F16' and (M, N, K) == (16, 16, 32):
+            return f'exec_wmma_f16_spec<{M}, {N}, {K}>'
+        return None
+    if result_type == 'BF16':
+        if input_type == 'BF16' and (M, N, K) == (16, 16, 32):
+            return f'exec_wmma_bf16_spec<{M}, {N}, {K}>'
+        return None
+    # result F32
+    if input_type in ('F32', 'XF32') and N % 16 == 0:
+        return f'exec_wmma_f32_f32_spec<{M}, {N}, {K}>'
+    if input_type == 'F16' and (M, N, K) == (16, 16, 32):
+        return 'exec_wmma_f32_16x16x32_f16'
+    if input_type == 'BF16' and (M, N, K) == (16, 16, 32):
+        return 'exec_wmma_f32_16x16x32_bf16'
+    return None
+
 
 def gen_accvgpr_read(dst: list[str], src: list[str]) -> str:
     """Generate V_ACCVGPR_READ: copy ACCVGPR → VGPR."""
@@ -257,10 +313,39 @@ def gen_mfma(
         L.append(f'                 s2, const_acc);')
     elif result_type == 'I32':
         if arch == 'gfx1250':
+            # LLVM's gfx1250 IU WMMA convention overloads neg_lo: bit set means
+            # signed extension, bit clear means unsigned.
+            if is_swmmac:
+                if input_type in ('IU4', 'IU8'):
+                    suffix = '4' if input_type == 'IU4' else '8'
+                    L.append(
+                        f'  auto extract_a = (inst_.neg & 0x1u) ? amdgpu::extract_i{suffix}'
+                        f' : amdgpu::extract_u{suffix};'
+                    )
+                    L.append(
+                        f'  auto extract_b = (inst_.neg & 0x2u) ? amdgpu::extract_i{suffix}'
+                        f' : amdgpu::extract_u{suffix};'
+                    )
+                else:
+                    L.append(f'  auto extract_a = amdgpu::extract_i8;')
+                    L.append(f'  auto extract_b = amdgpu::extract_i8;')
+                L.append(
+                    f'  amdgpu::exec_swmmac_i32(cu, {M}, {N}, {K}, {in_bits}, dst, src0_base,'
+                    f' src1_base, s2, index_base, {swmmac_index_entries}, index_key,'
+                    f' extract_a, extract_b, inst_.clamp, const_acc);'
+                )
+                return '\n'.join(L)
+            # The iu8 16x16x64 WMMA has a specialized kernel taking the
+            # per-operand signedness directly.
+            if input_type == 'IU8' and (M, N, K) == (16, 16, 64):
+                L.append(
+                    f'  amdgpu::exec_wmma_i32_16x16x64_iu8(cu, dst, src0_base, src1_base, s2,'
+                    f' /*a_signed=*/(inst_.neg & 0x1u) != 0,'
+                    f' /*b_signed=*/(inst_.neg & 0x2u) != 0, inst_.clamp, const_acc);'
+                )
+                return '\n'.join(L)
             if input_type in ('IU4', 'IU8'):
                 suffix = '4' if input_type == 'IU4' else '8'
-                # LLVM's gfx1250 IU WMMA convention overloads neg_lo:
-                # bit set means signed extension, bit clear means unsigned.
                 L.append(
                     f'  auto extract_a = (inst_.neg & 0x1u) ? amdgpu::extract_i{suffix}'
                     f' : amdgpu::extract_u{suffix};'
@@ -272,34 +357,26 @@ def gen_mfma(
             else:
                 L.append(f'  auto extract_a = amdgpu::extract_i8;')
                 L.append(f'  auto extract_b = amdgpu::extract_i8;')
-            if is_swmmac:
+            L.append(
+                f'  amdgpu::exec_wmma_i32(cu, {M}, {N}, {K}, {in_bits}, dst, src0_base,'
+                f' src1_base, s2, extract_a, extract_b, inst_.clamp, const_acc);'
+            )
+        else:
+            s0b = f'amdgpu::src_base(vb, {s0}.encoding_value_)'
+            s1b = f'amdgpu::src_base(vb, {s1}.encoding_value_)'
+            # i8 MFMA (CDNA) / i8 WMMA (RDNA) share the GFX9 layout helper; the
+            # spec template needs N a multiple of the SIMD width.
+            if N % 16 == 0:
+                targ = _mma_targ(M, N, K, B, batch_optional=True)
                 L.append(
-                    f'  amdgpu::exec_swmmac_i32(cu, {M}, {N}, {K}, {in_bits}, dst,'
+                    f'  amdgpu::exec_i32_mfma_i8_spec<{targ}>(cu, dst, {s0b}, {s1b}, s2,'
+                    f' const_acc);'
                 )
             else:
-                L.append(f'  amdgpu::exec_wmma_i32(cu, {M}, {N}, {K}, {in_bits}, dst,')
-            L.append(f'                         src0_base,')
-            L.append(f'                         src1_base,')
-            if is_swmmac:
                 L.append(
-                    f'                         s2, index_base, {swmmac_index_entries}, index_key,'
-                    f' extract_a, extract_b, inst_.clamp, const_acc);'
+                    f'  amdgpu::exec_i32_i8(cu, {M}, {N}, {K}, {B}, dst, {s0b}, {s1b}, s2,'
+                    f' const_acc);'
                 )
-                return '\n'.join(L)
-        else:
-            L.append(f'  amdgpu::exec_i32_i8(cu, {M}, {N}, {K}, {B}, dst,')
-            L.append(
-                f'                     amdgpu::src_base(vb, {s0}.encoding_value_),'
-            )
-            L.append(
-                f'                     amdgpu::src_base(vb, {s1}.encoding_value_),'
-            )
-        if arch == 'gfx1250':
-            L.append(
-                f'                     s2, extract_a, extract_b, inst_.clamp, const_acc);'
-            )
-        else:
-            L.append(f'                     s2, const_acc);')
     else:
         # F32, F16, and BF16 matrix results accumulate in f32. gfx1250 WMMA
         # uses a wave32 layout; CDNA MFMA uses the GFX9 MFMA layout helpers.
@@ -330,22 +407,37 @@ def gen_mfma(
         # A-matrix broadcast and B-matrix lane permutation. RDNA does
         # not have MFMA (only WMMA), so these fields don't exist.
         if arch == 'gfx1250':
-            if result_type == 'F16':
-                exec_fn = 'exec_swmmac_f16' if is_swmmac else 'exec_wmma_f16'
-            elif result_type == 'BF16':
-                exec_fn = 'exec_swmmac_bf16' if is_swmmac else 'exec_wmma_bf16'
-            else:
-                exec_fn = 'exec_swmmac_f32' if is_swmmac else 'exec_wmma_f32'
-            L.append(f'  amdgpu::{exec_fn}(cu, {M}, {N}, {K}, {in_bits}, dst,')
-            L.append(f'                    src0_base,')
-            L.append(f'                    src1_base,')
             if is_swmmac:
+                if result_type == 'F16':
+                    exec_fn = 'exec_swmmac_f16'
+                elif result_type == 'BF16':
+                    exec_fn = 'exec_swmmac_bf16'
+                else:
+                    exec_fn = 'exec_swmmac_f32'
                 L.append(
-                    f'                    s2, index_base, {swmmac_index_entries}, index_key, {ea}, {eb},'
+                    f'  amdgpu::{exec_fn}(cu, {M}, {N}, {K}, {in_bits}, dst, src0_base,'
+                    f' src1_base, s2, index_base, {swmmac_index_entries}, index_key,'
+                    f' {ea}, {eb}, const_acc);'
                 )
-                L.append(f'                    const_acc);')
             else:
-                L.append(f'                    s2, {ea}, {eb}, const_acc);')
+                # Dense WMMA: a specialized wave32 kernel where one exists, else
+                # the generic exec_wmma_* runtime path.
+                spec = _gfx1250_wmma_spec(result_type, input_type, M, N, K)
+                if spec is not None:
+                    L.append(
+                        f'  amdgpu::{spec}(cu, dst, src0_base, src1_base, s2, const_acc);'
+                    )
+                else:
+                    if result_type == 'F16':
+                        exec_fn = 'exec_wmma_f16'
+                    elif result_type == 'BF16':
+                        exec_fn = 'exec_wmma_bf16'
+                    else:
+                        exec_fn = 'exec_wmma_f32'
+                    L.append(
+                        f'  amdgpu::{exec_fn}(cu, {M}, {N}, {K}, {in_bits}, dst, src0_base,'
+                        f' src1_base, s2, {ea}, {eb}, const_acc);'
+                    )
         elif input_type in ('F8_F6_F4', 'F8F6F4'):
             # f8f6f4 MFMA: cbsz/blgp encode data format, NOT lane
             # permutation. Use dispatch_matrix_fmt_pair to select the
@@ -389,14 +481,37 @@ def gen_mfma(
             L.append('  if (!dispatched)')
             L.append('    throw util::UnimplementedInst(mnemonic());')
         else:
+            # CDNA1-4 VOP3P_MFMA encoding has cbsz/abid/blgp fields for A-matrix
+            # broadcast and B-matrix lane permutation; RDNA WMMA does not, so
+            # pass 0 (the spec templates require the args explicitly).
             has_blgp = arch in ('cdna1', 'cdna2', 'cdna3', 'cdna4')
-            L.append(f'  amdgpu::exec_f32(cu, {M}, {N}, {K}, {B}, {in_bits}, dst,')
-            L.append(f'                 amdgpu::src_base(vb, {s0}.encoding_value_),')
-            L.append(f'                 amdgpu::src_base(vb, {s1}.encoding_value_),')
-            if has_blgp:
-                L.append(f'                 s2, {ea}, {eb}, const_acc,')
-                L.append(f'                 inst_.cbsz, inst_.abid, inst_.blgp);')
+            cbsz = 'inst_.cbsz' if has_blgp else '0u'
+            abid = 'inst_.abid' if has_blgp else '0u'
+            blgp = 'inst_.blgp' if has_blgp else '0u'
+            s0b = f'amdgpu::src_base(vb, {s0}.encoding_value_)'
+            s1b = f'amdgpu::src_base(vb, {s1}.encoding_value_)'
+            if N % 16 == 0 and input_type in _F8_FIXED:
+                a_fp8, b_fp8 = _f8_bools(input_type)
+                L.append(
+                    f'  amdgpu::exec_f32_mfma_f8_spec<{M}, {N}, {K}, {a_fp8}, {b_fp8}>('
+                    f'cu, dst, {s0b}, {s1b}, s2, const_acc, {cbsz}, {abid}, {blgp});'
+                )
+            elif N % 16 == 0 and input_type in _MFMA_F32_SPEC:
+                fam = _MFMA_F32_SPEC[input_type]
+                targ = _mma_targ(M, N, K, B, batch_optional=(fam != 'f32'))
+                L.append(
+                    f'  amdgpu::exec_f32_mfma_{fam}_spec<{targ}>(cu, dst, {s0b}, {s1b}, s2,'
+                    f' const_acc, {cbsz}, {abid}, {blgp});'
+                )
+            elif has_blgp:
+                L.append(
+                    f'  amdgpu::exec_f32(cu, {M}, {N}, {K}, {B}, {in_bits}, dst, {s0b}, {s1b},'
+                    f' s2, {ea}, {eb}, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);'
+                )
             else:
-                L.append(f'                 s2, {ea}, {eb}, const_acc);')
+                L.append(
+                    f'  amdgpu::exec_f32(cu, {M}, {N}, {K}, {B}, {in_bits}, dst, {s0b}, {s1b},'
+                    f' s2, {ea}, {eb}, const_acc);'
+                )
 
     return '\n'.join(L)

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -164,8 +164,12 @@ _STD_MATH: dict[SemaNodeKind, str] = {
     SemaNodeKind.SIN: 'std::sin',
     SemaNodeKind.COS: 'std::cos',
     SemaNodeKind.LOG2: 'std::log2',
-    SemaNodeKind.FLOOR: 'std::floor',
-    SemaNodeKind.TRUNC: 'std::trunc',
+    # floor/trunc go through util:: wrappers that quiet a signaling NaN so the
+    # generated scalar bodies agree with the SIMD fast paths (and the GPU) under
+    # gcc, whose glibc floorf/truncf pass sNaN through unquieted (clang's
+    # roundss/roundsd quiet it). See util::floor_scalar in util/simd.h.
+    SemaNodeKind.FLOOR: 'util::floor_scalar',
+    SemaNodeKind.TRUNC: 'util::trunc_scalar',
 }
 
 
@@ -1066,7 +1070,7 @@ _INLINE_UNARY_OPS: dict[str, str] = {
     '(v < 0 ? (0u - static_cast<uint32_t>(v))'
     ' : static_cast<uint32_t>(v)); }}()',
     'rndne': 'std::nearbyint({0})',
-    'ceil': 'std::ceil({0})',
+    'ceil': 'util::ceil_scalar({0})',
     'exp2': 'amdgpu::transcendental::exp_f32({0})',
     'bcnt': 'static_cast<uint32_t>(std::popcount({0}))',
     'bcnt1': 'static_cast<uint32_t>(std::popcount({0}))',

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -1769,6 +1769,15 @@ SIMD_VOP3_UNARY_INT_EXTRA: dict[str, tuple[str, str, str]] = {
 # tie (matching the f32 finding) — accepted divergences, with the A/B test
 # skipping NaN-input and zero-tie lanes (same convention as v_max_f32 / v_min_f32
 # in SIMD_VOP2_BINARY).
+# VOP3-only f32 binary ops (no VOP2 twin, so not reachable via the _vop3
+# auto-route). Per-source abs/neg + result omod/clamp applied by the f32 binary
+# glue; the functor sees already-modified native<float> args. Currently the
+# IEEE-2019 maximum/minimum (NaN-propagating, signed-zero-ordered) forms.
+SIMD_VOP3_BINARY_FP32: dict[str, str] = {
+    'v_maximum_f32_vop3': '[](auto a, auto b) { return util::ieee_maximum_simd(a, b); }',
+    'v_minimum_f32_vop3': '[](auto a, auto b) { return util::ieee_minimum_simd(a, b); }',
+}
+
 SIMD_VOP3_BINARY_FP64: dict[str, str] = {
     'v_add_f64_vop3': '[](auto a, auto b) { return a + b; }',
     'v_mul_f64_vop3': '[](auto a, auto b) { return a * b; }',
@@ -1777,6 +1786,9 @@ SIMD_VOP3_BINARY_FP64: dict[str, str] = {
     # IEEE-2019 num twins: scalar bodies are the same std::fmax / std::fmin.
     'v_max_num_f64_vop3': '[](auto a, auto b) { return util::stdx::fmax(a, b); }',
     'v_min_num_f64_vop3': '[](auto a, auto b) { return util::stdx::fmin(a, b); }',
+    # IEEE-2019 maximum/minimum (NaN-propagating, signed-zero-ordered).
+    'v_maximum_f64_vop3': '[](auto a, auto b) { return util::ieee_maximum_simd(a, b); }',
+    'v_minimum_f64_vop3': '[](auto a, auto b) { return util::ieee_minimum_simd(a, b); }',
 }
 
 # Plain f64 unary: scalar bodies are std::ceil / std::floor / std::trunc /
@@ -1884,6 +1896,13 @@ SIMD_VOP3_TERNARY_FP32: dict[str, str] = {
     'v_min3_num_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmin(a, b), c); }',
     'v_minmax_num_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmin(a, b), c); }',
     'v_maxmin_num_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmax(a, b), c); }',
+    # IEEE-2019 maximum/minimum 3-input + combined forms. The scalar bodies are
+    # the exact nested composition of the binary maximum/minimum (NaN-propagating,
+    # signed-zero-ordered) — see util::ieee_{maximum,minimum}_simd.
+    'v_maximum3_f32_vop3': '[](auto a, auto b, auto c) { return util::ieee_maximum_simd(util::ieee_maximum_simd(a, b), c); }',
+    'v_minimum3_f32_vop3': '[](auto a, auto b, auto c) { return util::ieee_minimum_simd(util::ieee_minimum_simd(a, b), c); }',
+    'v_maximumminimum_f32_vop3': '[](auto a, auto b, auto c) { return util::ieee_minimum_simd(util::ieee_maximum_simd(a, b), c); }',
+    'v_minimummaximum_f32_vop3': '[](auto a, auto b, auto c) { return util::ieee_maximum_simd(util::ieee_minimum_simd(a, b), c); }',
     # v_div_fixup_f32: per-AMD-spec `else if` cascade selecting the result
     # among NaN/Inf/zero copysign cases. Lives as a helper in simd_glue.h
     # (div_fixup_f32_simd) — bit-exact match to the scalar body's predicate
@@ -1923,6 +1942,11 @@ SIMD_VOP3_TERNARY_FP16: dict[str, str] = {
     'v_min3_num_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmin(a, b), c); }',
     'v_minmax_num_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmin(a, b), c); }',
     'v_maxmin_num_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmax(a, b), c); }',
+    # IEEE-2019 maximum/minimum 3-input + combined (f16; widened to f32 by glue).
+    'v_maximum3_f16_vop3': '[](auto a, auto b, auto c) { return util::ieee_maximum_simd(util::ieee_maximum_simd(a, b), c); }',
+    'v_minimum3_f16_vop3': '[](auto a, auto b, auto c) { return util::ieee_minimum_simd(util::ieee_minimum_simd(a, b), c); }',
+    'v_maximumminimum_f16_vop3': '[](auto a, auto b, auto c) { return util::ieee_minimum_simd(util::ieee_maximum_simd(a, b), c); }',
+    'v_minimummaximum_f16_vop3': '[](auto a, auto b, auto c) { return util::ieee_maximum_simd(util::ieee_minimum_simd(a, b), c); }',
 }
 
 # f64 ternary FMA.
@@ -2529,6 +2553,11 @@ def simd_probe_line(template_name: str) -> str | None:
     if spec3binx is not None:
         cpp_t, cpp_op = spec3binx
         return f'  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT({cpp_t}, {cpp_op});'
+    # VOP3-only f32 binary (no VOP2 twin): IEEE maximum/minimum. Per-source
+    # abs/neg + result omod/clamp applied by the f32 binary glue.
+    spec3binf32 = SIMD_VOP3_BINARY_FP32.get(template_name)
+    if spec3binf32 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3_BINARY_FP(float32_t, {spec3binf32});'
     # VOP3 f64 binary (add/mul/max/min). Per-source abs/neg + result omod/clamp
     # in the f64 domain.
     spec3binf64 = SIMD_VOP3_BINARY_FP64.get(template_name)

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -1293,13 +1293,16 @@ SIMD_VOP3P_DOT_INT: dict[str, str] = {
     'v_dot2_u32_u16_vop3p': '16, false',
 }
 
-# v_dot2_f32_f16 — two f16 products + an f32 accumulator into one f32 lane.
-# op_sel half-select (gated default), neg/neg_hi sign flips, optional clamp
-# to [0,1]. Functorless / fixed-op.
-SIMD_VOP3P_DOT_F16: set[str] = {
+# v_dot2_f32_{f16,bf16} — two half-precision products + an f32 accumulator into
+# one f32 lane. op_sel half-select (gated default), neg/neg_hi sign flips,
+# optional clamp to [0,1]. Functorless / fixed-op. The set spans BOTH 16-bit
+# float formats: v_dot2_f32_bf16's generated scalar body is byte-identical to the
+# f16 form (it widens each half via util::f16_to_f32 with the same
+# op_sel/neg/clamp handling, verified by diff), so both route through the same
+# glue. Named _F16_OR_BF16 to make that span explicit (the emitted macro keeps
+# the shorter ROCJITSU_TRY_SIMD_VOP3P_DOT_F16 name — the widening path is shared).
+SIMD_VOP3P_DOT_F16_OR_BF16: set[str] = {
     'v_dot2_f32_f16_vop3p',
-    # v_dot2_f32_bf16: generated scalar body is byte-identical to the f16 form
-    # (it widens via util::f16_to_f32, same op_sel/neg/clamp), verified by diff.
     'v_dot2_f32_bf16_vop3p',
 }
 
@@ -1750,38 +1753,16 @@ SIMD_VOP3_BINARY_INT_EXTRA: dict[str, tuple[str, str]] = {
         ' auto hi = b; util::stdx::where(b > 0xFFFFu, hi) = 0xFFFFu;'
         ' return (hi << 16) | lo; }',
     ),
-    # v_cvt_pk_i16_f32 / v_cvt_pk_u16_f32: despite the mnemonic, the generated
-    # scalar body reads src as int32 and signed-clamps to [-32768, 32767] — i.e.
-    # byte-for-byte the v_cvt_pk_i16_i32 body above (verified by diff). Reuse the
-    # identical signed-clamp functor (NOT the u16_u32 unsigned one).
-    'v_cvt_pk_i16_f32_vop3': (
-        'uint32_t',
-        '[](auto a, auto b) {'
-        ' using I = util::native<int32_t>;'
-        ' using U = util::native<uint32_t>;'
-        ' I lo = util::stdx::static_simd_cast<I>(a);'
-        ' util::stdx::where(lo < I(-32768), lo) = I(-32768);'
-        ' util::stdx::where(lo > I(32767), lo) = I(32767);'
-        ' I hi = util::stdx::static_simd_cast<I>(b);'
-        ' util::stdx::where(hi < I(-32768), hi) = I(-32768);'
-        ' util::stdx::where(hi > I(32767), hi) = I(32767);'
-        ' return ((util::stdx::static_simd_cast<U>(hi) & 0xFFFFu) << 16) |'
-        ' (util::stdx::static_simd_cast<U>(lo) & 0xFFFFu); }',
-    ),
-    'v_cvt_pk_u16_f32_vop3': (
-        'uint32_t',
-        '[](auto a, auto b) {'
-        ' using I = util::native<int32_t>;'
-        ' using U = util::native<uint32_t>;'
-        ' I lo = util::stdx::static_simd_cast<I>(a);'
-        ' util::stdx::where(lo < I(-32768), lo) = I(-32768);'
-        ' util::stdx::where(lo > I(32767), lo) = I(32767);'
-        ' I hi = util::stdx::static_simd_cast<I>(b);'
-        ' util::stdx::where(hi < I(-32768), hi) = I(-32768);'
-        ' util::stdx::where(hi > I(32767), hi) = I(32767);'
-        ' return ((util::stdx::static_simd_cast<U>(hi) & 0xFFFFu) << 16) |'
-        ' (util::stdx::static_simd_cast<U>(lo) & 0xFFFFu); }',
-    ),
+    # v_cvt_pk_i16_f32 / v_cvt_pk_u16_f32 are deliberately NOT SIMD-specialized.
+    # Their scalar bodies are FLOAT-input converts: bit_cast each src to f32, then
+    # clamp the float value (i16: [-32768, 32767]; u16: [0, 65535]) and truncate
+    # before packing the low/high 16-bit halves. The integer VOP3 binary glue
+    # (try_execute_binary_vop3_simd<uint32_t>) feeds the functor the raw 32-bit
+    # lane *bits*, so any int-domain functor here would clamp the float's bit
+    # pattern as an integer — a different result for essentially every finite
+    # input (e.g. 1.0f -> bits 0x3F800000 -> clamps to 32767 instead of 1). Leave
+    # them on the (correct) scalar path. Only the int-domain twins
+    # v_cvt_pk_i16_i32 / v_cvt_pk_u16_u32 above are safe to route through this glue.
     # Normalized f32 pack-converts. src read as raw f32 (bit_cast), scale by K,
     # clamp, isnan->0, truncate, pack 16|16. Helpers in util/simd.h.
     # QUIRK: only the no-underscore v_cvt_pknorm_i16_f32 uses the true i16 lambda
@@ -2732,7 +2713,7 @@ def simd_probe_line(template_name: str) -> str | None:
     specdot = SIMD_VOP3P_DOT_INT.get(template_name)
     if specdot is not None:
         return f'  ROCJITSU_TRY_SIMD_VOP3P_DOT_INT({specdot});'
-    if template_name in SIMD_VOP3P_DOT_F16:
+    if template_name in SIMD_VOP3P_DOT_F16_OR_BF16:
         return '  ROCJITSU_TRY_SIMD_VOP3P_DOT_F16();'
     # VOP3P mixed-sign integer dots (dot4 iu8, dot8 iu4).
     specdotm = SIMD_VOP3P_DOT_INT_MIXED.get(template_name)

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -1288,6 +1288,35 @@ SIMD_VOP3P_DOT_F16: set[str] = {
     'v_dot2_f32_bf16_vop3p',
 }
 
+# VOP3P mixed-sign integer dots: per-operand signedness from inst.neg bits 0/1
+# at runtime (src0/src1); int32 accumulate from src2; lower-clamp-to-0; no
+# op_sel/neg_hi in the scalar bodies. key -> ElemBits.
+SIMD_VOP3P_DOT_INT_MIXED: dict[str, str] = {
+    'v_dot4_i32_iu8_vop3p': '8',
+    'v_dot8_i32_iu4_vop3p': '4',
+}
+
+# VOP2/VOP3 dst-accumulate integer dots (the "c" forms). Accumulator is vdst
+# (read + write), NOT src2; all signed; no op_sel/neg/clamp. Keyed by full
+# template_name (incl _vop2/_vop3) — the only structural difference is the 2nd
+# source member (vsrc1 vs src1), passed as the Vop3 bool. Value = "ElemBits, Vop3".
+SIMD_DOTC_INT: dict[str, str] = {
+    'v_dot2c_i32_i16_vop2': '16, false',
+    'v_dot2c_i32_i16_vop3': '16, true',
+    'v_dot4c_i32_i8_vop2': '8, false',
+    'v_dot4c_i32_i8_vop3': '8, true',
+    'v_dot8c_i32_i4_vop2': '4, false',
+    'v_dot8c_i32_i4_vop3': '4, true',
+}
+
+# VOP2/VOP3 dst-accumulate f16 dot (v_dot2c_f32_f16). Accumulator is vdst (f32
+# bits); bracketing acc + (a0*b0 + a1*b1) matches the scalar facc += ... form.
+# Value = "Vop3".
+SIMD_DOTC_F16: dict[str, str] = {
+    'v_dot2c_f32_f16_vop2': 'false',
+    'v_dot2c_f32_f16_vop3': 'true',
+}
+
 
 # --- VOPC compare -> VCC ---------------------------------------------------
 #
@@ -2672,6 +2701,17 @@ def simd_probe_line(template_name: str) -> str | None:
         return f'  ROCJITSU_TRY_SIMD_VOP3P_DOT_INT({specdot});'
     if template_name in SIMD_VOP3P_DOT_F16:
         return '  ROCJITSU_TRY_SIMD_VOP3P_DOT_F16();'
+    # VOP3P mixed-sign integer dots (dot4 iu8, dot8 iu4).
+    specdotm = SIMD_VOP3P_DOT_INT_MIXED.get(template_name)
+    if specdotm is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3P_DOT_INT_MIXED({specdotm});'
+    # VOP2/VOP3 dst-accumulate integer dots (v_dot{2,4,8}c_*; vdst is the accum).
+    specdotc = SIMD_DOTC_INT.get(template_name)
+    if specdotc is not None:
+        return f'  ROCJITSU_TRY_SIMD_DOTC_INT({specdotc});'
+    specdotcf16 = SIMD_DOTC_F16.get(template_name)
+    if specdotcf16 is not None:
+        return f'  ROCJITSU_TRY_SIMD_DOTC_F16({specdotcf16});'
     # VOP3P fma_mix / mad_mix (six ops, three destination shapes). Same body
     # for all; the routing picks the matching glue specialization.
     if template_name in SIMD_VOP3P_FMA_MIX_F32:

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -1999,6 +1999,13 @@ SIMD_VOP3_TERNARY_FP32: dict[str, str] = {
     'v_minimum3_f32_vop3': '[](auto a, auto b, auto c) { return util::ieee_minimum_simd(util::ieee_minimum_simd(a, b), c); }',
     'v_maximumminimum_f32_vop3': '[](auto a, auto b, auto c) { return util::ieee_minimum_simd(util::ieee_maximum_simd(a, b), c); }',
     'v_minimummaximum_f32_vop3': '[](auto a, auto b, auto c) { return util::ieee_maximum_simd(util::ieee_minimum_simd(a, b), c); }',
+    # Cubemap face ops: ternary f32, per-source abs/neg + result omod/clamp via
+    # the glue; the face-selection is a bit-exact where-cascade (helpers in
+    # simd_glue.h). cubema is inline (exact ×2 of fmax of abs).
+    'v_cubeid_f32_vop3': '[](auto x, auto y, auto z) { return util::cube_id_f32_simd(x, y, z); }',
+    'v_cubema_f32_vop3': '[](auto x, auto y, auto z) { return 2.0f * util::stdx::fmax(util::stdx::abs(x), util::stdx::fmax(util::stdx::abs(y), util::stdx::abs(z))); }',
+    'v_cubesc_f32_vop3': '[](auto x, auto y, auto z) { return util::cube_sc_f32_simd(x, y, z); }',
+    'v_cubetc_f32_vop3': '[](auto x, auto y, auto z) { return util::cube_tc_f32_simd(x, y, z); }',
     # v_div_fixup_f32: per-AMD-spec `else if` cascade selecting the result
     # among NaN/Inf/zero copysign cases. Lives as a helper in simd_glue.h
     # (div_fixup_f32_simd) — bit-exact match to the scalar body's predicate

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -212,6 +212,32 @@ SIMD_VOP2_BINARY: dict[str, tuple[str, str]] = {
         ' return util::f32_to_f16_simd('
         'util::stdx::fmin(util::f16_to_f32_simd(a), util::f16_to_f32_simd(b))); }',
     ),
+    # IEEE-2019 maximumNumber/minimumNumber (gfx1250/rdna4). Their generated
+    # scalar bodies are std::fmax / std::fmin — byte-for-byte the legacy
+    # v_max_f*/v_min_f* bodies above — so the functors are identical and inherit
+    # the same accepted NaN-payload / signed-zero-tie carve-out. The _vop3 twins
+    # auto-route from these _vop2 entries (f32 -> VOP3_BINARY_FP, f16 ->
+    # VOP3_BINARY_INT with the widening functor, mirroring v_max_f16_vop3).
+    'v_max_num_f32_vop2': (
+        'float32_t',
+        '[](auto a, auto b) { return util::stdx::fmax(a, b); }',
+    ),
+    'v_min_num_f32_vop2': (
+        'float32_t',
+        '[](auto a, auto b) { return util::stdx::fmin(a, b); }',
+    ),
+    'v_max_num_f16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' return util::f32_to_f16_simd('
+        'util::stdx::fmax(util::f16_to_f32_simd(a), util::f16_to_f32_simd(b))); }',
+    ),
+    'v_min_num_f16_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' return util::f32_to_f16_simd('
+        'util::stdx::fmin(util::f16_to_f32_simd(a), util::f16_to_f32_simd(b))); }',
+    ),
     # --- f16 binary (low 16 bits f16, result zero-extended). Same f32
     # intermediate as the scalar bodies (single final round) ⇒ bit-identical. ---
     'v_add_f16_vop2': (
@@ -1748,6 +1774,9 @@ SIMD_VOP3_BINARY_FP64: dict[str, str] = {
     'v_mul_f64_vop3': '[](auto a, auto b) { return a * b; }',
     'v_max_f64_vop3': '[](auto a, auto b) { return util::stdx::fmax(a, b); }',
     'v_min_f64_vop3': '[](auto a, auto b) { return util::stdx::fmin(a, b); }',
+    # IEEE-2019 num twins: scalar bodies are the same std::fmax / std::fmin.
+    'v_max_num_f64_vop3': '[](auto a, auto b) { return util::stdx::fmax(a, b); }',
+    'v_min_num_f64_vop3': '[](auto a, auto b) { return util::stdx::fmin(a, b); }',
 }
 
 # Plain f64 unary: scalar bodies are std::ceil / std::floor / std::trunc /
@@ -1849,6 +1878,12 @@ SIMD_VOP3_TERNARY_FP32: dict[str, str] = {
     # minmax = max(min(a,b),c); maxmin = min(max(a,b),c). (RDNA3+.)
     'v_minmax_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmin(a, b), c); }',
     'v_maxmin_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmax(a, b), c); }',
+    # IEEE-2019 num twins (gfx1250/rdna4): identical fmax/fmin compositions as
+    # the legacy max3/min3/minmax/maxmin bodies above.
+    'v_max3_num_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmax(a, b), c); }',
+    'v_min3_num_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmin(a, b), c); }',
+    'v_minmax_num_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmin(a, b), c); }',
+    'v_maxmin_num_f32_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmax(a, b), c); }',
     # v_div_fixup_f32: per-AMD-spec `else if` cascade selecting the result
     # among NaN/Inf/zero copysign cases. Lives as a helper in simd_glue.h
     # (div_fixup_f32_simd) — bit-exact match to the scalar body's predicate
@@ -1883,6 +1918,11 @@ SIMD_VOP3_TERNARY_FP16: dict[str, str] = {
     'v_med3_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmin(util::stdx::fmax(a, b), c), util::stdx::fmin(a, b)); }',
     'v_minmax_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmin(a, b), c); }',
     'v_maxmin_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmax(a, b), c); }',
+    # IEEE-2019 num twins (f16): same fmax/fmin compositions, widened by the glue.
+    'v_max3_num_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmax(a, b), c); }',
+    'v_min3_num_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmin(a, b), c); }',
+    'v_minmax_num_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmin(a, b), c); }',
+    'v_maxmin_num_f16_vop3': '[](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmax(a, b), c); }',
 }
 
 # f64 ternary FMA.

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -1738,6 +1738,57 @@ SIMD_VOP3_BINARY_INT_EXTRA: dict[str, tuple[str, str]] = {
         ' return ((util::stdx::static_simd_cast<U>(hi) & 0xFFFFu) << 16) |'
         ' (util::stdx::static_simd_cast<U>(lo) & 0xFFFFu); }',
     ),
+    # Normalized f32 pack-converts. src read as raw f32 (bit_cast), scale by K,
+    # clamp, isnan->0, truncate, pack 16|16. Helpers in util/simd.h.
+    # QUIRK: only the no-underscore v_cvt_pknorm_i16_f32 uses the true i16 lambda
+    # (K=32767, signed). EVERY OTHER spelling/width — including the
+    # underscore-spelled v_cvt_pk_norm_i16_f32 and the _f16 forms (which also read
+    # src as raw f32, not f16) — uses the u16 lambda (K=65535, [0,65535]). This
+    # mirrors the generated scalar bodies verbatim (a codegen quirk; do not fix).
+    'v_cvt_pknorm_i16_f32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' using U = util::native<uint32_t>;'
+        ' auto lo = util::cvt_pknorm_i16_f32_simd(std::bit_cast<util::native<float>>(a));'
+        ' auto hi = util::cvt_pknorm_i16_f32_simd(std::bit_cast<util::native<float>>(b));'
+        ' return ((util::stdx::static_simd_cast<U>(hi) & 0xFFFFu) << 16) |'
+        ' (util::stdx::static_simd_cast<U>(lo) & 0xFFFFu); }',
+    ),
+    'v_cvt_pk_norm_i16_f32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' auto lo = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(a));'
+        ' auto hi = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(b));'
+        ' return ((hi & 0xFFFFu) << 16) | (lo & 0xFFFFu); }',
+    ),
+    'v_cvt_pk_norm_i16_f16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' auto lo = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(a));'
+        ' auto hi = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(b));'
+        ' return ((hi & 0xFFFFu) << 16) | (lo & 0xFFFFu); }',
+    ),
+    'v_cvt_pknorm_u16_f32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' auto lo = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(a));'
+        ' auto hi = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(b));'
+        ' return ((hi & 0xFFFFu) << 16) | (lo & 0xFFFFu); }',
+    ),
+    'v_cvt_pk_norm_u16_f32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' auto lo = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(a));'
+        ' auto hi = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(b));'
+        ' return ((hi & 0xFFFFu) << 16) | (lo & 0xFFFFu); }',
+    ),
+    'v_cvt_pk_norm_u16_f16_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' auto lo = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(a));'
+        ' auto hi = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(b));'
+        ' return ((hi & 0xFFFFu) << 16) | (lo & 0xFFFFu); }',
+    ),
     'v_add_i32_vop3': ('uint32_t', '[](auto a, auto b) { return a + b; }'),
     'v_sub_i32_vop3': ('uint32_t', '[](auto a, auto b) { return a - b; }'),
     'v_add_nc_i32_vop3': ('uint32_t', '[](auto a, auto b) { return a + b; }'),

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -1929,6 +1929,36 @@ SIMD_VOP3_UNARY_FP16: dict[str, str] = {
 }
 
 
+# VOP3 frexp twins routed through the EXISTING unary FP glue. Their generated
+# scalar bodies apply src0 abs/neg, compute the frexp exp/mantissa, then apply
+# result omod/clamp on the (float-domain) value and bit_cast / f32_to_f16 it to
+# the dst — exactly what the f32 / f16 unary FP glue produces. So only the
+# functor differs from the proven VOP1 forms.
+#   route 'fp16' -> ROCJITSU_TRY_SIMD_VOP3_UNARY_FP16   (f16<->f32 widen glue)
+#   route 'fp32' -> ROCJITSU_TRY_SIMD_VOP3_UNARY_FP(float32_t, float32_t, ...)
+# frexp_exp returns the uint32 two's-complement exponent (±0/Inf/NaN -> 0); the
+# static_simd_cast<float> reproduces the scalar `(float)(uint32_t)exp` exactly
+# (negative exp -> large float -> f16 +Inf, like scalar). frexp_mant_f32_simd is
+# the already-proven VOP1 helper. (v_frexp_exp_i32_f64 needs a new f64->f32
+# mixed-width glue and stays in _VOP3_UNARY_SKIP / scalar for now.)
+SIMD_VOP3_FREXP_FP: dict[str, tuple[str, str]] = {
+    'v_frexp_mant_f16_vop3': (
+        'fp16',
+        '[](auto a) { return util::frexp_mant_f32_simd(std::bit_cast<util::native<uint32_t>>(a)); }',
+    ),
+    'v_frexp_exp_i16_f16_vop3': (
+        'fp16',
+        '[](auto a) { return util::stdx::static_simd_cast<util::native<float>>('
+        'util::frexp_exp_f32_simd(std::bit_cast<util::native<uint32_t>>(a))); }',
+    ),
+    'v_frexp_exp_i32_f32_vop3': (
+        'fp32',
+        '[](auto a) { return util::stdx::static_simd_cast<util::native<float>>('
+        'util::frexp_exp_f32_simd(std::bit_cast<util::native<uint32_t>>(a))); }',
+    ),
+}
+
+
 # --- VOP3 floating-point ternary (FMA / MAD family) ------------------------
 #
 # v_fma_*: util::stdx::fma (fused multiply-add, single-rounded). v_fmac/v_mac:
@@ -2638,6 +2668,12 @@ def simd_probe_line(template_name: str) -> str | None:
         return f'  ROCJITSU_TRY_SIMD_VOP3_UNARY_FP64({spec3unaf64});'
     # VOP3 f16 unary (widen-then-modify-then-narrow). FTZ-free ops only:
     # ceil/floor/trunc/rndne/sqrt. Transcendentals deferred.
+    specfrexp = SIMD_VOP3_FREXP_FP.get(template_name)
+    if specfrexp is not None:
+        route, fn = specfrexp
+        if route == 'fp16':
+            return f'  ROCJITSU_TRY_SIMD_VOP3_UNARY_FP16({fn});'
+        return f'  ROCJITSU_TRY_SIMD_VOP3_UNARY_FP(float32_t, float32_t, {fn});'
     spec3unaf16 = SIMD_VOP3_UNARY_FP16.get(template_name)
     if spec3unaf16 is not None:
         return f'  ROCJITSU_TRY_SIMD_VOP3_UNARY_FP16({spec3unaf16});'

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -238,6 +238,24 @@ SIMD_VOP2_BINARY: dict[str, tuple[str, str]] = {
         ' return util::f32_to_f16_simd('
         'util::stdx::fmin(util::f16_to_f32_simd(a), util::f16_to_f32_simd(b))); }',
     ),
+    # v_cvt_pkrtz_f16_f32 (both spellings): pack two f32 -> two f16 (round toward
+    # zero is what f32_to_f16/f32_to_f16_simd implement; proven bit-identical).
+    # Inputs arrive as raw u32 lanes, bit_cast to f32. The VOP3 twins carry no
+    # modifiers (verified) so they auto-route to VOP3_BINARY_INT with this functor.
+    'v_cvt_pkrtz_f16_f32_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' auto lo = util::f32_to_f16_simd(std::bit_cast<util::native<float>>(a));'
+        ' auto hi = util::f32_to_f16_simd(std::bit_cast<util::native<float>>(b));'
+        ' return lo | (hi << 16); }',
+    ),
+    'v_cvt_pk_rtz_f16_f32_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' auto lo = util::f32_to_f16_simd(std::bit_cast<util::native<float>>(a));'
+        ' auto hi = util::f32_to_f16_simd(std::bit_cast<util::native<float>>(b));'
+        ' return lo | (hi << 16); }',
+    ),
     # --- f16 binary (low 16 bits f16, result zero-extended). Same f32
     # intermediate as the scalar bodies (single final round) ⇒ bit-identical. ---
     'v_add_f16_vop2': (
@@ -1252,6 +1270,9 @@ SIMD_VOP3P_DOT_INT: dict[str, str] = {
 # to [0,1]. Functorless / fixed-op.
 SIMD_VOP3P_DOT_F16: set[str] = {
     'v_dot2_f32_f16_vop3p',
+    # v_dot2_f32_bf16: generated scalar body is byte-identical to the f16 form
+    # (it widens via util::f16_to_f32, same op_sel/neg/clamp), verified by diff.
+    'v_dot2_f32_bf16_vop3p',
 }
 
 
@@ -1671,6 +1692,38 @@ SIMD_VOP3_BINARY_INT_EXTRA: dict[str, tuple[str, str]] = {
         ' auto lo = a; util::stdx::where(a > 0xFFFFu, lo) = 0xFFFFu;'
         ' auto hi = b; util::stdx::where(b > 0xFFFFu, hi) = 0xFFFFu;'
         ' return (hi << 16) | lo; }',
+    ),
+    # v_cvt_pk_i16_f32 / v_cvt_pk_u16_f32: despite the mnemonic, the generated
+    # scalar body reads src as int32 and signed-clamps to [-32768, 32767] — i.e.
+    # byte-for-byte the v_cvt_pk_i16_i32 body above (verified by diff). Reuse the
+    # identical signed-clamp functor (NOT the u16_u32 unsigned one).
+    'v_cvt_pk_i16_f32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' using I = util::native<int32_t>;'
+        ' using U = util::native<uint32_t>;'
+        ' I lo = util::stdx::static_simd_cast<I>(a);'
+        ' util::stdx::where(lo < I(-32768), lo) = I(-32768);'
+        ' util::stdx::where(lo > I(32767), lo) = I(32767);'
+        ' I hi = util::stdx::static_simd_cast<I>(b);'
+        ' util::stdx::where(hi < I(-32768), hi) = I(-32768);'
+        ' util::stdx::where(hi > I(32767), hi) = I(32767);'
+        ' return ((util::stdx::static_simd_cast<U>(hi) & 0xFFFFu) << 16) |'
+        ' (util::stdx::static_simd_cast<U>(lo) & 0xFFFFu); }',
+    ),
+    'v_cvt_pk_u16_f32_vop3': (
+        'uint32_t',
+        '[](auto a, auto b) {'
+        ' using I = util::native<int32_t>;'
+        ' using U = util::native<uint32_t>;'
+        ' I lo = util::stdx::static_simd_cast<I>(a);'
+        ' util::stdx::where(lo < I(-32768), lo) = I(-32768);'
+        ' util::stdx::where(lo > I(32767), lo) = I(32767);'
+        ' I hi = util::stdx::static_simd_cast<I>(b);'
+        ' util::stdx::where(hi < I(-32768), hi) = I(-32768);'
+        ' util::stdx::where(hi > I(32767), hi) = I(32767);'
+        ' return ((util::stdx::static_simd_cast<U>(hi) & 0xFFFFu) << 16) |'
+        ' (util::stdx::static_simd_cast<U>(lo) & 0xFFFFu); }',
     ),
     'v_add_i32_vop3': ('uint32_t', '[](auto a, auto b) { return a + b; }'),
     'v_sub_i32_vop3': ('uint32_t', '[](auto a, auto b) { return a - b; }'),

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -1257,6 +1257,21 @@ SIMD_VOP3P_PK_TERNARY_FP16: dict[str, str] = {
     'v_pk_fma_f16_vop3p': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
 }
 
+# VOP3P packed-f32 binary. Each operand is a 64-bit consecutive-VGPR pair of two
+# f32 (lo/hi). Glue extracts each f32 half (narrow32 width), applies neg/neg_hi
+# (sign-bit toggle), runs the per-half functor, repacks. No clamp on any pk_f32
+# scalar body. Default packing only (op_sel = 0, op_sel_hi = 3).
+SIMD_VOP3P_PK_BINARY_F32: dict[str, str] = {
+    'v_pk_add_f32_vop3p': '[](auto a, auto b) { return a + b; }',
+    'v_pk_mul_f32_vop3p': '[](auto a, auto b) { return a * b; }',
+}
+
+# pk_fma_f32 — 3-source FMA per half. op_sel_hi_2 == 1 gate (src2-hi select).
+# NaN-input payload divergence accepted.
+SIMD_VOP3P_PK_TERNARY_F32: dict[str, str] = {
+    'v_pk_fma_f32_vop3p': '[](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); }',
+}
+
 # v_pk_mov_b32 — default-packing-only fast path. Each src is a 64-bit pair
 # (consecutive VGPRs), result is (src0_lo, src1_hi). Functorless / fixed-op.
 SIMD_VOP3P_MOV_B32: set[str] = {
@@ -2036,6 +2051,18 @@ SIMD_VOP3_FREXP_FP: dict[str, tuple[str, str]] = {
         '[](auto a) { return util::stdx::static_simd_cast<util::native<float>>('
         'util::frexp_exp_f32_simd(std::bit_cast<util::native<uint32_t>>(a))); }',
     ),
+    # f64 source -> float(exp) dst. Mixed-width (read64 / narrow32 store): the new
+    # cvt-vop3 f64->b32 glue applies the f64 src abs/neg + float omod/clamp.
+    # frexp_exp_f64_simd returns the int32 exp in the low 32 bits of each 64-bit
+    # lane; narrow to uint32 (scalar `(uint32_t)exp`) then to float (scalar
+    # unsigned `(float)(uint32_t)exp`). The intermediate uint32 narrow is
+    # load-bearing — a direct uint64->float would convert the full 64-bit value.
+    'v_frexp_exp_i32_f64_vop3': (
+        'fp64cvt',
+        '[](auto s) { return util::stdx::static_simd_cast<util::narrow32<float32_t>>('
+        'util::stdx::static_simd_cast<util::narrow32<uint32_t>>('
+        'util::frexp_exp_f64_simd(s))); }',
+    ),
 }
 
 
@@ -2693,6 +2720,12 @@ def simd_probe_line(template_name: str) -> str | None:
     specpkf16t = SIMD_VOP3P_PK_TERNARY_FP16.get(template_name)
     if specpkf16t is not None:
         return f'  ROCJITSU_TRY_SIMD_VOP3P_PK_TERNARY_FP16({specpkf16t});'
+    specpkf32 = SIMD_VOP3P_PK_BINARY_F32.get(template_name)
+    if specpkf32 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3P_PK_BINARY_F32({specpkf32});'
+    specpkf32t = SIMD_VOP3P_PK_TERNARY_F32.get(template_name)
+    if specpkf32t is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP3P_PK_TERNARY_F32({specpkf32t});'
     if template_name in SIMD_VOP3P_MOV_B32:
         return '  ROCJITSU_TRY_SIMD_VOP3P_MOV_B32();'
     # VOP3P integer dot products (dot4 i8/u8, dot8 i4/u4, dot2 i16/u16).
@@ -2771,6 +2804,8 @@ def simd_probe_line(template_name: str) -> str | None:
         route, fn = specfrexp
         if route == 'fp16':
             return f'  ROCJITSU_TRY_SIMD_VOP3_UNARY_FP16({fn});'
+        if route == 'fp64cvt':
+            return f'  ROCJITSU_TRY_SIMD_CVT_VOP3_F64_TO_B32_FP({fn});'
         return f'  ROCJITSU_TRY_SIMD_VOP3_UNARY_FP(float32_t, float32_t, {fn});'
     spec3unaf16 = SIMD_VOP3_UNARY_FP16.get(template_name)
     if spec3unaf16 is not None:

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -937,6 +937,19 @@ SIMD_VOP2_FMA_F64: dict[str, str] = {
 }
 
 
+# template_name -> cpp_bin_op (over native<double>, no modifiers). VOP2 f64
+# binary forms: scalar bodies read src0/vsrc1 as read_lane64, no abs/neg/omod/
+# clamp. add/mul are bit-exact; max_num/min_num use util::stdx::fmax/fmin (scalar
+# is std::fmax/std::fmin) with the same accepted NaN-payload / signed-zero-tie
+# carve-out as the f64 vop3 forms in SIMD_VOP3_BINARY_FP64.
+SIMD_VOP2_BINARY_FP64: dict[str, str] = {
+    'v_add_f64_vop2': '[](auto a, auto b) { return a + b; }',
+    'v_mul_f64_vop2': '[](auto a, auto b) { return a * b; }',
+    'v_max_num_f64_vop2': '[](auto a, auto b) { return util::stdx::fmax(a, b); }',
+    'v_min_num_f64_vop2': '[](auto a, auto b) { return util::stdx::fmin(a, b); }',
+}
+
+
 # --- 64-bit-lane VOP1 unary (f64 math + v_mov_b64) -------------------------
 #
 # Maps template_name -> (lane_cpp_type, unary functor). Read/written as
@@ -2446,6 +2459,9 @@ def simd_probe_line(template_name: str) -> str | None:
     specf64 = SIMD_VOP2_FMA_F64.get(template_name)
     if specf64 is not None:
         return f'  ROCJITSU_TRY_SIMD_VOP2_FMA_F64({specf64});'
+    spec2binf64 = SIMD_VOP2_BINARY_FP64.get(template_name)
+    if spec2binf64 is not None:
+        return f'  ROCJITSU_TRY_SIMD_VOP2_BINARY_FP64({spec2binf64});'
     spec1f64 = SIMD_VOP1_UNARY_F64.get(template_name)
     if spec1f64 is not None:
         lane_t, cpp_op = spec1f64

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/vop3p.cpp
@@ -606,9 +606,9 @@ void VMfmaF3232x32x1f32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 1, 2, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<32, 32, 1, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x1f32Vop3pMfma::VMfmaF3216x16x1f32Vop3pMfma(const MachineInst *inst)
@@ -637,9 +637,9 @@ void VMfmaF3216x16x1f32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 1, 4, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<16, 16, 1, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF324x4x1f32Vop3pMfma::VMfmaF324x4x1f32Vop3pMfma(const MachineInst *inst)
@@ -699,9 +699,9 @@ void VMfmaF3232x32x2f32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 2, 1, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<32, 32, 2, 1>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x4f32Vop3pMfma::VMfmaF3216x16x4f32Vop3pMfma(const MachineInst *inst)
@@ -730,9 +730,9 @@ void VMfmaF3216x16x4f32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 4, 1, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<16, 16, 4, 1>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3232x32x4f16Vop3pMfma::VMfmaF3232x32x4f16Vop3pMfma(const MachineInst *inst)
@@ -761,9 +761,9 @@ void VMfmaF3232x32x4f16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 4, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x4f16Vop3pMfma::VMfmaF3216x16x4f16Vop3pMfma(const MachineInst *inst)
@@ -792,9 +792,9 @@ void VMfmaF3216x16x4f16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 4, 4, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF324x4x4f16Vop3pMfma::VMfmaF324x4x4f16Vop3pMfma(const MachineInst *inst)
@@ -854,9 +854,9 @@ void VMfmaF3232x32x8f16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 8, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<32, 32, 8>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                            const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x16f16Vop3pMfma::VMfmaF3216x16x16f16Vop3pMfma(const MachineInst *inst)
@@ -885,9 +885,9 @@ void VMfmaF3216x16x16f16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaI3232x32x4i8Vop3pMfma::VMfmaI3232x32x4i8Vop3pMfma(const MachineInst *inst)
@@ -916,8 +916,9 @@ void VMfmaI3232x32x4i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 32, 32, 4, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc);
 }
 
 VMfmaI3216x16x4i8Vop3pMfma::VMfmaI3216x16x4i8Vop3pMfma(const MachineInst *inst)
@@ -946,8 +947,9 @@ void VMfmaI3216x16x4i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 4, 4, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc);
 }
 
 VMfmaI324x4x4i8Vop3pMfma::VMfmaI324x4x4i8Vop3pMfma(const MachineInst *inst)
@@ -1006,8 +1008,9 @@ void VMfmaI3232x32x8i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 32, 32, 8, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<32, 32, 8>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                           amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                           const_acc);
 }
 
 VMfmaI3216x16x16i8Vop3pMfma::VMfmaI3216x16x16i8Vop3pMfma(const MachineInst *inst)
@@ -1036,8 +1039,9 @@ void VMfmaI3216x16x16i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 16, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                            const_acc);
 }
 
 VMfmaF3232x32x2bf16Vop3pMfma::VMfmaF3232x32x2bf16Vop3pMfma(const MachineInst *inst)
@@ -1066,9 +1070,9 @@ void VMfmaF3232x32x2bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 2, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<32, 32, 2, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x2bf16Vop3pMfma::VMfmaF3216x16x2bf16Vop3pMfma(const MachineInst *inst)
@@ -1097,9 +1101,9 @@ void VMfmaF3216x16x2bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 2, 4, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 2, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF324x4x2bf16Vop3pMfma::VMfmaF324x4x2bf16Vop3pMfma(const MachineInst *inst)
@@ -1159,9 +1163,9 @@ void VMfmaF3232x32x4bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 4, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<32, 32, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x8bf16Vop3pMfma::VMfmaF3216x16x8bf16Vop3pMfma(const MachineInst *inst)
@@ -1190,9 +1194,9 @@ void VMfmaF3216x16x8bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 8, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 8>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 } // namespace cdna1

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/vop3p.cpp
@@ -556,59 +556,7 @@ VPkFmaF32Vop3p::VPkFmaF32Vop3p(const MachineInst *inst)
 }
 
 void VPkFmaF32Vop3p::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t s0_lo_w = src0.read_lane(wf, lane);
-    uint32_t s0_hi_w = s0_lo_w;
-    if (src0.encoding_value_ >= 256 && src0.encoding_value_ <= 511) {
-      uint64_t s0_pair_w = src0.read_lane64(wf, lane);
-      s0_lo_w = static_cast<uint32_t>(s0_pair_w);
-      s0_hi_w = static_cast<uint32_t>(s0_pair_w >> 32);
-    }
-    uint32_t s1_lo_w = src1.read_lane(wf, lane);
-    uint32_t s1_hi_w = s1_lo_w;
-    if (src1.encoding_value_ >= 256 && src1.encoding_value_ <= 511) {
-      uint64_t s1_pair_w = src1.read_lane64(wf, lane);
-      s1_lo_w = static_cast<uint32_t>(s1_pair_w);
-      s1_hi_w = static_cast<uint32_t>(s1_pair_w >> 32);
-    }
-    uint32_t s2_lo_w = src2.read_lane(wf, lane);
-    uint32_t s2_hi_w = s2_lo_w;
-    if (src2.encoding_value_ >= 256 && src2.encoding_value_ <= 511) {
-      uint64_t s2_pair_w = src2.read_lane64(wf, lane);
-      s2_lo_w = static_cast<uint32_t>(s2_pair_w);
-      s2_hi_w = static_cast<uint32_t>(s2_pair_w >> 32);
-    }
-    bool sel0_lo = (inst_.op_sel >> 0) & 1;
-    bool sel1_lo = (inst_.op_sel >> 1) & 1;
-    bool sel2_lo = (inst_.op_sel >> 2) & 1;
-    bool sel0_hi = (inst_.op_sel_hi >> 0) & 1;
-    bool sel1_hi = (inst_.op_sel_hi >> 1) & 1;
-    bool sel2_hi = inst_.op_sel_hi_2;
-    float a_lo = std::bit_cast<float>(sel0_lo ? s0_hi_w : s0_lo_w);
-    float a_hi = std::bit_cast<float>(sel0_hi ? s0_hi_w : s0_lo_w);
-    float b_lo = std::bit_cast<float>(sel1_lo ? s1_hi_w : s1_lo_w);
-    float b_hi = std::bit_cast<float>(sel1_hi ? s1_hi_w : s1_lo_w);
-    float c_lo = std::bit_cast<float>(sel2_lo ? s2_hi_w : s2_lo_w);
-    float c_hi = std::bit_cast<float>(sel2_hi ? s2_hi_w : s2_lo_w);
-    if (inst_.neg & 1)
-      a_lo = -a_lo;
-    if (inst_.neg & 2)
-      b_lo = -b_lo;
-    if (inst_.neg & 4)
-      c_lo = -c_lo;
-    if (inst_.neg_hi & 1)
-      a_hi = -a_hi;
-    if (inst_.neg_hi & 2)
-      b_hi = -b_hi;
-    if (inst_.neg_hi & 4)
-      c_hi = -c_hi;
-    uint32_t rlo = std::bit_cast<uint32_t>(std::fma(a_lo, b_lo, c_lo));
-    uint32_t rhi = std::bit_cast<uint32_t>(std::fma(a_hi, b_hi, c_hi));
-    vdst.write_lane64(wf, lane, static_cast<uint64_t>(rlo) | (static_cast<uint64_t>(rhi) << 32));
-  }
+  amdgpu::execute_v_pk_fma_f32_vop3p(*this, wf);
 }
 
 VPkMulF32Vop3p::VPkMulF32Vop3p(const MachineInst *inst)
@@ -625,44 +573,7 @@ VPkMulF32Vop3p::VPkMulF32Vop3p(const MachineInst *inst)
 }
 
 void VPkMulF32Vop3p::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t s0_lo_w = src0.read_lane(wf, lane);
-    uint32_t s0_hi_w = s0_lo_w;
-    if (src0.encoding_value_ >= 256 && src0.encoding_value_ <= 511) {
-      uint64_t s0_pair_w = src0.read_lane64(wf, lane);
-      s0_lo_w = static_cast<uint32_t>(s0_pair_w);
-      s0_hi_w = static_cast<uint32_t>(s0_pair_w >> 32);
-    }
-    uint32_t s1_lo_w = src1.read_lane(wf, lane);
-    uint32_t s1_hi_w = s1_lo_w;
-    if (src1.encoding_value_ >= 256 && src1.encoding_value_ <= 511) {
-      uint64_t s1_pair_w = src1.read_lane64(wf, lane);
-      s1_lo_w = static_cast<uint32_t>(s1_pair_w);
-      s1_hi_w = static_cast<uint32_t>(s1_pair_w >> 32);
-    }
-    bool sel0_lo = (inst_.op_sel >> 0) & 1;
-    bool sel1_lo = (inst_.op_sel >> 1) & 1;
-    bool sel0_hi = (inst_.op_sel_hi >> 0) & 1;
-    bool sel1_hi = (inst_.op_sel_hi >> 1) & 1;
-    float a_lo = std::bit_cast<float>(sel0_lo ? s0_hi_w : s0_lo_w);
-    float a_hi = std::bit_cast<float>(sel0_hi ? s0_hi_w : s0_lo_w);
-    float b_lo = std::bit_cast<float>(sel1_lo ? s1_hi_w : s1_lo_w);
-    float b_hi = std::bit_cast<float>(sel1_hi ? s1_hi_w : s1_lo_w);
-    if (inst_.neg & 1)
-      a_lo = -a_lo;
-    if (inst_.neg & 2)
-      b_lo = -b_lo;
-    if (inst_.neg_hi & 1)
-      a_hi = -a_hi;
-    if (inst_.neg_hi & 2)
-      b_hi = -b_hi;
-    uint32_t rlo = std::bit_cast<uint32_t>(a_lo * b_lo);
-    uint32_t rhi = std::bit_cast<uint32_t>(a_hi * b_hi);
-    vdst.write_lane64(wf, lane, static_cast<uint64_t>(rlo) | (static_cast<uint64_t>(rhi) << 32));
-  }
+  amdgpu::execute_v_pk_mul_f32_vop3p(*this, wf);
 }
 
 VPkAddF32Vop3p::VPkAddF32Vop3p(const MachineInst *inst)
@@ -679,44 +590,7 @@ VPkAddF32Vop3p::VPkAddF32Vop3p(const MachineInst *inst)
 }
 
 void VPkAddF32Vop3p::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t s0_lo_w = src0.read_lane(wf, lane);
-    uint32_t s0_hi_w = s0_lo_w;
-    if (src0.encoding_value_ >= 256 && src0.encoding_value_ <= 511) {
-      uint64_t s0_pair_w = src0.read_lane64(wf, lane);
-      s0_lo_w = static_cast<uint32_t>(s0_pair_w);
-      s0_hi_w = static_cast<uint32_t>(s0_pair_w >> 32);
-    }
-    uint32_t s1_lo_w = src1.read_lane(wf, lane);
-    uint32_t s1_hi_w = s1_lo_w;
-    if (src1.encoding_value_ >= 256 && src1.encoding_value_ <= 511) {
-      uint64_t s1_pair_w = src1.read_lane64(wf, lane);
-      s1_lo_w = static_cast<uint32_t>(s1_pair_w);
-      s1_hi_w = static_cast<uint32_t>(s1_pair_w >> 32);
-    }
-    bool sel0_lo = (inst_.op_sel >> 0) & 1;
-    bool sel1_lo = (inst_.op_sel >> 1) & 1;
-    bool sel0_hi = (inst_.op_sel_hi >> 0) & 1;
-    bool sel1_hi = (inst_.op_sel_hi >> 1) & 1;
-    float a_lo = std::bit_cast<float>(sel0_lo ? s0_hi_w : s0_lo_w);
-    float a_hi = std::bit_cast<float>(sel0_hi ? s0_hi_w : s0_lo_w);
-    float b_lo = std::bit_cast<float>(sel1_lo ? s1_hi_w : s1_lo_w);
-    float b_hi = std::bit_cast<float>(sel1_hi ? s1_hi_w : s1_lo_w);
-    if (inst_.neg & 1)
-      a_lo = -a_lo;
-    if (inst_.neg & 2)
-      b_lo = -b_lo;
-    if (inst_.neg_hi & 1)
-      a_hi = -a_hi;
-    if (inst_.neg_hi & 2)
-      b_hi = -b_hi;
-    uint32_t rlo = std::bit_cast<uint32_t>(a_lo + b_lo);
-    uint32_t rhi = std::bit_cast<uint32_t>(a_hi + b_hi);
-    vdst.write_lane64(wf, lane, static_cast<uint64_t>(rlo) | (static_cast<uint64_t>(rhi) << 32));
-  }
+  amdgpu::execute_v_pk_add_f32_vop3p(*this, wf);
 }
 
 VPkMovB32Vop3p::VPkMovB32Vop3p(const MachineInst *inst)
@@ -805,9 +679,9 @@ void VMfmaF3232x32x1f32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 1, 2, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<32, 32, 1, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x1f32Vop3pMfma::VMfmaF3216x16x1f32Vop3pMfma(const MachineInst *inst)
@@ -836,9 +710,9 @@ void VMfmaF3216x16x1f32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 1, 4, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<16, 16, 1, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF324x4x1f32Vop3pMfma::VMfmaF324x4x1f32Vop3pMfma(const MachineInst *inst)
@@ -898,9 +772,9 @@ void VMfmaF3232x32x2f32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 2, 1, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<32, 32, 2, 1>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x4f32Vop3pMfma::VMfmaF3216x16x4f32Vop3pMfma(const MachineInst *inst)
@@ -929,9 +803,9 @@ void VMfmaF3216x16x4f32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 4, 1, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<16, 16, 4, 1>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3232x32x4f16Vop3pMfma::VMfmaF3232x32x4f16Vop3pMfma(const MachineInst *inst)
@@ -961,9 +835,9 @@ void VMfmaF3232x32x4f16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 4, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x4f16Vop3pMfma::VMfmaF3216x16x4f16Vop3pMfma(const MachineInst *inst)
@@ -992,9 +866,9 @@ void VMfmaF3216x16x4f16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 4, 4, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF324x4x4f16Vop3pMfma::VMfmaF324x4x4f16Vop3pMfma(const MachineInst *inst)
@@ -1054,9 +928,9 @@ void VMfmaF3232x32x8f16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 8, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<32, 32, 8>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                            const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x16f16Vop3pMfma::VMfmaF3216x16x16f16Vop3pMfma(const MachineInst *inst)
@@ -1085,9 +959,9 @@ void VMfmaF3216x16x16f16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaI3232x32x4i8Vop3pMfma::VMfmaI3232x32x4i8Vop3pMfma(const MachineInst *inst)
@@ -1117,8 +991,9 @@ void VMfmaI3232x32x4i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 32, 32, 4, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc);
 }
 
 VMfmaI3216x16x4i8Vop3pMfma::VMfmaI3216x16x4i8Vop3pMfma(const MachineInst *inst)
@@ -1147,8 +1022,9 @@ void VMfmaI3216x16x4i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 4, 4, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc);
 }
 
 VMfmaI324x4x4i8Vop3pMfma::VMfmaI324x4x4i8Vop3pMfma(const MachineInst *inst)
@@ -1207,8 +1083,9 @@ void VMfmaI3232x32x8i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 32, 32, 8, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<32, 32, 8>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                           amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                           const_acc);
 }
 
 VMfmaI3216x16x16i8Vop3pMfma::VMfmaI3216x16x16i8Vop3pMfma(const MachineInst *inst)
@@ -1237,8 +1114,9 @@ void VMfmaI3216x16x16i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 16, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                            const_acc);
 }
 
 VMfmaF3232x32x4bf161kVop3pMfma::VMfmaF3232x32x4bf161kVop3pMfma(const MachineInst *inst)
@@ -1268,9 +1146,9 @@ void VMfmaF3232x32x4bf161kVop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 4, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x4bf161kVop3pMfma::VMfmaF3216x16x4bf161kVop3pMfma(const MachineInst *inst)
@@ -1299,9 +1177,9 @@ void VMfmaF3216x16x4bf161kVop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 4, 4, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF324x4x4bf161kVop3pMfma::VMfmaF324x4x4bf161kVop3pMfma(const MachineInst *inst)
@@ -1361,9 +1239,9 @@ void VMfmaF3232x32x8bf161kVop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 8, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<32, 32, 8>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x16bf161kVop3pMfma::VMfmaF3216x16x16bf161kVop3pMfma(const MachineInst *inst)
@@ -1392,9 +1270,9 @@ void VMfmaF3216x16x16bf161kVop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3232x32x2bf16Vop3pMfma::VMfmaF3232x32x2bf16Vop3pMfma(const MachineInst *inst)
@@ -1424,9 +1302,9 @@ void VMfmaF3232x32x2bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 2, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<32, 32, 2, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x2bf16Vop3pMfma::VMfmaF3216x16x2bf16Vop3pMfma(const MachineInst *inst)
@@ -1455,9 +1333,9 @@ void VMfmaF3216x16x2bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 2, 4, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 2, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF324x4x2bf16Vop3pMfma::VMfmaF324x4x2bf16Vop3pMfma(const MachineInst *inst)
@@ -1517,9 +1395,9 @@ void VMfmaF3232x32x4bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 4, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<32, 32, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x8bf16Vop3pMfma::VMfmaF3216x16x8bf16Vop3pMfma(const MachineInst *inst)
@@ -1548,9 +1426,9 @@ void VMfmaF3216x16x8bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 8, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 8>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF6416x16x4f64Vop3pMfma::VMfmaF6416x16x4f64Vop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vop3p.cpp
@@ -678,9 +678,9 @@ void VMfmaF3216x16x8Xf32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 8, 1, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<16, 16, 8, 1>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3232x32x4Xf32Vop3pMfma::VMfmaF3232x32x4Xf32Vop3pMfma(const MachineInst *inst)
@@ -709,9 +709,9 @@ void VMfmaF3232x32x4Xf32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 4, 1, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<32, 32, 4, 1>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3232x32x12bF32Vop3pMfma::VMfmaF3232x32x12bF32Vop3pMfma(const MachineInst *inst)
@@ -741,9 +741,9 @@ void VMfmaF3232x32x12bF32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 1, 2, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<32, 32, 1, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x14bF32Vop3pMfma::VMfmaF3216x16x14bF32Vop3pMfma(const MachineInst *inst)
@@ -772,9 +772,9 @@ void VMfmaF3216x16x14bF32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 1, 4, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<16, 16, 1, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF324x4x116bF32Vop3pMfma::VMfmaF324x4x116bF32Vop3pMfma(const MachineInst *inst)
@@ -834,9 +834,9 @@ void VMfmaF3232x32x2F32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 2, 1, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<32, 32, 2, 1>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x4F32Vop3pMfma::VMfmaF3216x16x4F32Vop3pMfma(const MachineInst *inst)
@@ -865,9 +865,9 @@ void VMfmaF3216x16x4F32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 4, 1, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<16, 16, 4, 1>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3232x32x42bF16Vop3pMfma::VMfmaF3232x32x42bF16Vop3pMfma(const MachineInst *inst)
@@ -897,9 +897,9 @@ void VMfmaF3232x32x42bF16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 4, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x44bF16Vop3pMfma::VMfmaF3216x16x44bF16Vop3pMfma(const MachineInst *inst)
@@ -928,9 +928,9 @@ void VMfmaF3216x16x44bF16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 4, 4, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF324x4x416bF16Vop3pMfma::VMfmaF324x4x416bF16Vop3pMfma(const MachineInst *inst)
@@ -990,9 +990,9 @@ void VMfmaF3232x32x8F16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 8, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<32, 32, 8>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                            const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x16F16Vop3pMfma::VMfmaF3216x16x16F16Vop3pMfma(const MachineInst *inst)
@@ -1021,9 +1021,9 @@ void VMfmaF3216x16x16F16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaI3232x32x42bI8Vop3pMfma::VMfmaI3232x32x42bI8Vop3pMfma(const MachineInst *inst)
@@ -1053,8 +1053,9 @@ void VMfmaI3232x32x42bI8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 32, 32, 4, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc);
 }
 
 VMfmaI3216x16x44bI8Vop3pMfma::VMfmaI3216x16x44bI8Vop3pMfma(const MachineInst *inst)
@@ -1083,8 +1084,9 @@ void VMfmaI3216x16x44bI8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 4, 4, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc);
 }
 
 VMfmaI324x4x416bI8Vop3pMfma::VMfmaI324x4x416bI8Vop3pMfma(const MachineInst *inst)
@@ -1143,8 +1145,9 @@ void VMfmaI3232x32x16I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 32, 32, 16, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<32, 32, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                            const_acc);
 }
 
 VMfmaI3216x16x32I8Vop3pMfma::VMfmaI3216x16x32I8Vop3pMfma(const MachineInst *inst)
@@ -1173,8 +1176,9 @@ void VMfmaI3216x16x32I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 32, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 32>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                            const_acc);
 }
 
 VMfmaF3232x32x42bBf16Vop3pMfma::VMfmaF3232x32x42bBf16Vop3pMfma(const MachineInst *inst)
@@ -1204,9 +1208,9 @@ void VMfmaF3232x32x42bBf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 4, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x44bBf16Vop3pMfma::VMfmaF3216x16x44bBf16Vop3pMfma(const MachineInst *inst)
@@ -1235,9 +1239,9 @@ void VMfmaF3216x16x44bBf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 4, 4, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF324x4x416bBf16Vop3pMfma::VMfmaF324x4x416bBf16Vop3pMfma(const MachineInst *inst)
@@ -1297,9 +1301,9 @@ void VMfmaF3232x32x8Bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 8, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<32, 32, 8>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x16Bf16Vop3pMfma::VMfmaF3216x16x16Bf16Vop3pMfma(const MachineInst *inst)
@@ -1328,9 +1332,9 @@ void VMfmaF3216x16x16Bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VSmfmacF3216x16x32F16Vop3pMfma::VSmfmacF3216x16x32F16Vop3pMfma(const MachineInst *inst)
@@ -1585,9 +1589,10 @@ void VMfmaF3216x16x32Bf8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
-                   amdgpu::extract_bf8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, false, false>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VMfmaF3216x16x32Bf8Fp8Vop3pMfma::VMfmaF3216x16x32Bf8Fp8Vop3pMfma(const MachineInst *inst)
@@ -1616,9 +1621,10 @@ void VMfmaF3216x16x32Bf8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
-                   amdgpu::extract_fp8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, false, true>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VMfmaF3216x16x32Fp8Bf8Vop3pMfma::VMfmaF3216x16x32Fp8Bf8Vop3pMfma(const MachineInst *inst)
@@ -1647,9 +1653,10 @@ void VMfmaF3216x16x32Fp8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                   amdgpu::extract_bf8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, true, false>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VMfmaF3216x16x32Fp8Fp8Vop3pMfma::VMfmaF3216x16x32Fp8Fp8Vop3pMfma(const MachineInst *inst)
@@ -1678,9 +1685,10 @@ void VMfmaF3216x16x32Fp8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                   amdgpu::extract_fp8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, true, true>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VMfmaF3232x32x16Bf8Bf8Vop3pMfma::VMfmaF3232x32x16Bf8Bf8Vop3pMfma(const MachineInst *inst)
@@ -1709,9 +1717,10 @@ void VMfmaF3232x32x16Bf8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 16, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
-                   amdgpu::extract_bf8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<32, 32, 16, false, false>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VMfmaF3232x32x16Bf8Fp8Vop3pMfma::VMfmaF3232x32x16Bf8Fp8Vop3pMfma(const MachineInst *inst)
@@ -1740,9 +1749,10 @@ void VMfmaF3232x32x16Bf8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 16, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
-                   amdgpu::extract_fp8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<32, 32, 16, false, true>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VMfmaF3232x32x16Fp8Bf8Vop3pMfma::VMfmaF3232x32x16Fp8Bf8Vop3pMfma(const MachineInst *inst)
@@ -1771,9 +1781,10 @@ void VMfmaF3232x32x16Fp8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 16, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                   amdgpu::extract_bf8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<32, 32, 16, true, false>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VMfmaF3232x32x16Fp8Fp8Vop3pMfma::VMfmaF3232x32x16Fp8Fp8Vop3pMfma(const MachineInst *inst)
@@ -1802,9 +1813,10 @@ void VMfmaF3232x32x16Fp8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 16, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                   amdgpu::extract_fp8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<32, 32, 16, true, true>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VSmfmacF3216x16x64Bf8Bf8Vop3pMfma::VSmfmacF3216x16x64Bf8Bf8Vop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop2.cpp
@@ -7701,22 +7701,7 @@ void VDot2cF32F16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     src0.set_delegate(dpp_src0_.get());
   if (dpp_src1_)
     vsrc1.set_delegate(dpp_src1_.get());
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a = src0.read_lane(wf, lane);
-    uint32_t b = vsrc1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(vdst.read_lane(wf, lane));
-    float a0 = util::f16_to_f32(static_cast<uint16_t>(a & 0xFFFF));
-    float a1 = util::f16_to_f32(static_cast<uint16_t>((a >> 16) & 0xFFFF));
-    float b0 = util::f16_to_f32(static_cast<uint16_t>(b & 0xFFFF));
-    float b1 = util::f16_to_f32(static_cast<uint16_t>((b >> 16) & 0xFFFF));
-    float facc = std::bit_cast<float>(static_cast<uint32_t>(acc));
-    facc += a0 * b0 + a1 * b1;
-    acc = static_cast<int32_t>(std::bit_cast<uint32_t>(facc));
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
-  }
+  amdgpu::execute_v_dot2c_f32_f16_vop2(*this, wf);
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -7862,20 +7847,7 @@ void VDot2cI32I16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     src0.set_delegate(dpp_src0_.get());
   if (dpp_src1_)
     vsrc1.set_delegate(dpp_src1_.get());
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a = src0.read_lane(wf, lane);
-    uint32_t b = vsrc1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(vdst.read_lane(wf, lane));
-    int16_t a0 = static_cast<int16_t>(a & 0xFFFF);
-    int16_t a1 = static_cast<int16_t>((a >> 16) & 0xFFFF);
-    int16_t b0 = static_cast<int16_t>(b & 0xFFFF);
-    int16_t b1 = static_cast<int16_t>((b >> 16) & 0xFFFF);
-    acc += static_cast<int32_t>(a0) * b0 + static_cast<int32_t>(a1) * b1;
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
-  }
+  amdgpu::execute_v_dot2c_i32_i16_vop2(*this, wf);
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -8009,20 +7981,7 @@ void VDot4cI32I8Vop2::execute_impl(amdgpu::Wavefront &wf) {
     src0.set_delegate(dpp_src0_.get());
   if (dpp_src1_)
     vsrc1.set_delegate(dpp_src1_.get());
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a = src0.read_lane(wf, lane);
-    uint32_t b = vsrc1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(vdst.read_lane(wf, lane));
-    for (int i = 0; i < 4; ++i) {
-      int8_t ea = static_cast<int8_t>((a >> (i * 8)) & 0xFF);
-      int8_t eb = static_cast<int8_t>((b >> (i * 8)) & 0xFF);
-      acc += static_cast<int32_t>(ea) * static_cast<int32_t>(eb);
-    }
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
-  }
+  amdgpu::execute_v_dot4c_i32_i8_vop2(*this, wf);
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -8156,24 +8115,7 @@ void VDot8cI32I4Vop2::execute_impl(amdgpu::Wavefront &wf) {
     src0.set_delegate(dpp_src0_.get());
   if (dpp_src1_)
     vsrc1.set_delegate(dpp_src1_.get());
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a = src0.read_lane(wf, lane);
-    uint32_t b = vsrc1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(vdst.read_lane(wf, lane));
-    for (int i = 0; i < 8; ++i) {
-      int32_t ea = static_cast<int32_t>((a >> (i * 4)) & 0xF);
-      if (ea & 8)
-        ea |= ~0xF;
-      int32_t eb = static_cast<int32_t>((b >> (i * 4)) & 0xF);
-      if (eb & 8)
-        eb |= ~0xF;
-      acc += ea * eb;
-    }
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
-  }
+  amdgpu::execute_v_dot8c_i32_i4_vop2(*this, wf);
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3.cpp
@@ -2104,22 +2104,7 @@ VDot2cF32F16Vop3::VDot2cF32F16Vop3(const MachineInst *inst)
 }
 
 void VDot2cF32F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a = src0.read_lane(wf, lane);
-    uint32_t b = src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(vdst.read_lane(wf, lane));
-    float a0 = util::f16_to_f32(static_cast<uint16_t>(a & 0xFFFF));
-    float a1 = util::f16_to_f32(static_cast<uint16_t>((a >> 16) & 0xFFFF));
-    float b0 = util::f16_to_f32(static_cast<uint16_t>(b & 0xFFFF));
-    float b1 = util::f16_to_f32(static_cast<uint16_t>((b >> 16) & 0xFFFF));
-    float facc = std::bit_cast<float>(static_cast<uint32_t>(acc));
-    facc += a0 * b0 + a1 * b1;
-    acc = static_cast<int32_t>(std::bit_cast<uint32_t>(facc));
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
-  }
+  amdgpu::execute_v_dot2c_f32_f16_vop3(*this, wf);
 }
 
 VDot2cI32I16Vop3::VDot2cI32I16Vop3(const MachineInst *inst)
@@ -2137,20 +2122,7 @@ VDot2cI32I16Vop3::VDot2cI32I16Vop3(const MachineInst *inst)
 }
 
 void VDot2cI32I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a = src0.read_lane(wf, lane);
-    uint32_t b = src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(vdst.read_lane(wf, lane));
-    int16_t a0 = static_cast<int16_t>(a & 0xFFFF);
-    int16_t a1 = static_cast<int16_t>((a >> 16) & 0xFFFF);
-    int16_t b0 = static_cast<int16_t>(b & 0xFFFF);
-    int16_t b1 = static_cast<int16_t>((b >> 16) & 0xFFFF);
-    acc += static_cast<int32_t>(a0) * b0 + static_cast<int32_t>(a1) * b1;
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
-  }
+  amdgpu::execute_v_dot2c_i32_i16_vop3(*this, wf);
 }
 
 VDot4cI32I8Vop3::VDot4cI32I8Vop3(const MachineInst *inst)
@@ -2168,20 +2140,7 @@ VDot4cI32I8Vop3::VDot4cI32I8Vop3(const MachineInst *inst)
 }
 
 void VDot4cI32I8Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a = src0.read_lane(wf, lane);
-    uint32_t b = src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(vdst.read_lane(wf, lane));
-    for (int i = 0; i < 4; ++i) {
-      int8_t ea = static_cast<int8_t>((a >> (i * 8)) & 0xFF);
-      int8_t eb = static_cast<int8_t>((b >> (i * 8)) & 0xFF);
-      acc += static_cast<int32_t>(ea) * static_cast<int32_t>(eb);
-    }
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
-  }
+  amdgpu::execute_v_dot4c_i32_i8_vop3(*this, wf);
 }
 
 VDot8cI32I4Vop3::VDot8cI32I4Vop3(const MachineInst *inst)
@@ -2199,24 +2158,7 @@ VDot8cI32I4Vop3::VDot8cI32I4Vop3(const MachineInst *inst)
 }
 
 void VDot8cI32I4Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a = src0.read_lane(wf, lane);
-    uint32_t b = src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(vdst.read_lane(wf, lane));
-    for (int i = 0; i < 8; ++i) {
-      int32_t ea = static_cast<int32_t>((a >> (i * 4)) & 0xF);
-      if (ea & 8)
-        ea |= ~0xF;
-      int32_t eb = static_cast<int32_t>((b >> (i * 4)) & 0xF);
-      if (eb & 8)
-        eb |= ~0xF;
-      acc += ea * eb;
-    }
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
-  }
+  amdgpu::execute_v_dot8c_i32_i4_vop3(*this, wf);
 }
 
 VFmacF32Vop3::VFmacF32Vop3(const MachineInst *inst)
@@ -9046,55 +8988,7 @@ VMinimum3F32Vop3::VMinimum3F32Vop3(const MachineInst *inst)
 }
 
 void VMinimum3F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>([&]() {
-                      float v = [&]() {
-                        float v = [&]() {
-                          auto a = [&]() {
-                            float sv = std::bit_cast<float>(src0.read_lane(wf, lane));
-                            if (inst_.abs & (1u << 0))
-                              sv = std::fabs(sv);
-                            if (inst_.neg & (1u << 0))
-                              sv = -sv;
-                            return sv;
-                          }();
-                          auto b = [&]() {
-                            float sv = std::bit_cast<float>(src1.read_lane(wf, lane));
-                            if (inst_.abs & (1u << 1))
-                              sv = std::fabs(sv);
-                            if (inst_.neg & (1u << 1))
-                              sv = -sv;
-                            return sv;
-                          }();
-                          auto c = [&]() {
-                            float sv = std::bit_cast<float>(src2.read_lane(wf, lane));
-                            if (inst_.abs & (1u << 2))
-                              sv = std::fabs(sv);
-                            if (inst_.neg & (1u << 2))
-                              sv = -sv;
-                            return sv;
-                          }();
-                          if (std::isnan(a) || std::isnan(b) || std::isnan(c))
-                            return std::numeric_limits<decltype(a)>::quiet_NaN();
-                          auto ab = (a == b) ? (std::signbit(a) ? a : b) : (a < b ? a : b);
-                          return (ab == c) ? (std::signbit(ab) ? ab : c) : (ab < c ? ab : c);
-                        }();
-                        if (inst_.omod == 1)
-                          v *= 2.0f;
-                        else if (inst_.omod == 2)
-                          v *= 4.0f;
-                        else if (inst_.omod == 3)
-                          v *= 0.5f;
-                        return v;
-                      }();
-                      if (inst_.clamp)
-                        v = std::clamp(v, 0.0f, 1.0f);
-                      return v;
-                    }()));
-  }
+  amdgpu::execute_v_minimum3_f32_vop3(*this, wf);
 }
 
 VMaximum3F32Vop3::VMaximum3F32Vop3(const MachineInst *inst)
@@ -9113,55 +9007,7 @@ VMaximum3F32Vop3::VMaximum3F32Vop3(const MachineInst *inst)
 }
 
 void VMaximum3F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>([&]() {
-                      float v = [&]() {
-                        float v = [&]() {
-                          auto a = [&]() {
-                            float sv = std::bit_cast<float>(src0.read_lane(wf, lane));
-                            if (inst_.abs & (1u << 0))
-                              sv = std::fabs(sv);
-                            if (inst_.neg & (1u << 0))
-                              sv = -sv;
-                            return sv;
-                          }();
-                          auto b = [&]() {
-                            float sv = std::bit_cast<float>(src1.read_lane(wf, lane));
-                            if (inst_.abs & (1u << 1))
-                              sv = std::fabs(sv);
-                            if (inst_.neg & (1u << 1))
-                              sv = -sv;
-                            return sv;
-                          }();
-                          auto c = [&]() {
-                            float sv = std::bit_cast<float>(src2.read_lane(wf, lane));
-                            if (inst_.abs & (1u << 2))
-                              sv = std::fabs(sv);
-                            if (inst_.neg & (1u << 2))
-                              sv = -sv;
-                            return sv;
-                          }();
-                          if (std::isnan(a) || std::isnan(b) || std::isnan(c))
-                            return std::numeric_limits<decltype(a)>::quiet_NaN();
-                          auto ab = (a == b) ? (std::signbit(a) ? b : a) : (a > b ? a : b);
-                          return (ab == c) ? (std::signbit(ab) ? c : ab) : (ab > c ? ab : c);
-                        }();
-                        if (inst_.omod == 1)
-                          v *= 2.0f;
-                        else if (inst_.omod == 2)
-                          v *= 4.0f;
-                        else if (inst_.omod == 3)
-                          v *= 0.5f;
-                        return v;
-                      }();
-                      if (inst_.clamp)
-                        v = std::clamp(v, 0.0f, 1.0f);
-                      return v;
-                    }()));
-  }
+  amdgpu::execute_v_maximum3_f32_vop3(*this, wf);
 }
 
 VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -993,8 +993,9 @@ void VMfmaI3216x16x64I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 64, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 64>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                            const_acc);
 }
 
 VMfmaF3232x32x16Bf16Vop3pMfma::VMfmaF3232x32x16Bf16Vop3pMfma(const MachineInst *inst)
@@ -1054,8 +1055,9 @@ void VMfmaI3232x32x32I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 32, 32, 32, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<32, 32, 32>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                            const_acc);
 }
 
 VSmfmacF3216x16x64Bf16Vop3pMfma::VSmfmacF3216x16x64Bf16Vop3pMfma(const MachineInst *inst)
@@ -1885,8 +1887,9 @@ void VMfmaI3232x32x16I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 32, 32, 16, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<32, 32, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                            const_acc);
 }
 
 VMfmaI3216x16x32I8Vop3pMfma::VMfmaI3216x16x32I8Vop3pMfma(const MachineInst *inst)
@@ -1915,8 +1918,9 @@ void VMfmaI3216x16x32I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 32, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 32>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                            const_acc);
 }
 
 VSmfmacF3216x16x64F16Vop3pMfma::VSmfmacF3216x16x64F16Vop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -1463,9 +1463,9 @@ void VMfmaF3232x32x42bF16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 4, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x44bF16Vop3pMfma::VMfmaF3216x16x44bF16Vop3pMfma(const MachineInst *inst)
@@ -1494,9 +1494,9 @@ void VMfmaF3216x16x44bF16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 4, 4, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF324x4x416bF16Vop3pMfma::VMfmaF324x4x416bF16Vop3pMfma(const MachineInst *inst)
@@ -1706,8 +1706,9 @@ void VMfmaI3232x32x42bI8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 32, 32, 4, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc);
 }
 
 VMfmaI3216x16x44bI8Vop3pMfma::VMfmaI3216x16x44bI8Vop3pMfma(const MachineInst *inst)
@@ -1736,8 +1737,9 @@ void VMfmaI3216x16x44bI8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 4, 4, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc);
 }
 
 VMfmaI324x4x416bI8Vop3pMfma::VMfmaI324x4x416bI8Vop3pMfma(const MachineInst *inst)
@@ -2006,9 +2008,9 @@ void VMfmaF3232x32x42bBf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 4, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x44bBf16Vop3pMfma::VMfmaF3216x16x44bBf16Vop3pMfma(const MachineInst *inst)
@@ -2037,9 +2039,9 @@ void VMfmaF3216x16x44bBf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 4, 4, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF324x4x416bBf16Vop3pMfma::VMfmaF324x4x416bBf16Vop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -1823,9 +1823,9 @@ void VMfmaF3216x16x32F16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_16x16x32_f16(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                     amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc,
+                                     inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3232x32x16F16Vop3pMfma::VMfmaF3232x32x16F16Vop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -1224,9 +1224,9 @@ void VMfmaF3232x32x12bF32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 1, 2, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<32, 32, 1, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x14bF32Vop3pMfma::VMfmaF3216x16x14bF32Vop3pMfma(const MachineInst *inst)
@@ -1255,9 +1255,9 @@ void VMfmaF3216x16x14bF32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 1, 4, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<16, 16, 1, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF324x4x116bF32Vop3pMfma::VMfmaF324x4x116bF32Vop3pMfma(const MachineInst *inst)
@@ -1346,9 +1346,9 @@ void VMfmaF3232x32x2F32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 2, 1, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<32, 32, 2, 1>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x4F32Vop3pMfma::VMfmaF3216x16x4F32Vop3pMfma(const MachineInst *inst)
@@ -1377,9 +1377,9 @@ void VMfmaF3216x16x4F32Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 4, 1, 32, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f32,
-                   amdgpu::extract_f32, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f32_spec<16, 16, 4, 1>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VSmfmacF3232x32x32Bf16Vop3pMfma::VSmfmacF3232x32x32Bf16Vop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -1583,9 +1583,9 @@ void VMfmaF3232x32x8F16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 8, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<32, 32, 8>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                            const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x16F16Vop3pMfma::VMfmaF3216x16x16F16Vop3pMfma(const MachineInst *inst)
@@ -1614,9 +1614,9 @@ void VMfmaF3216x16x16F16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VSmfmacF3232x32x64Bf8Fp8Vop3pMfma::VSmfmacF3232x32x64Bf8Fp8Vop3pMfma(const MachineInst *inst)
@@ -1823,9 +1823,9 @@ void VMfmaF3216x16x32F16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_16x16x32_f16(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                     amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc,
-                                     inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 32>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3232x32x16F16Vop3pMfma::VMfmaF3232x32x16F16Vop3pMfma(const MachineInst *inst)
@@ -1854,9 +1854,9 @@ void VMfmaF3232x32x16F16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 16, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f16_spec<32, 32, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaI3232x32x16I8Vop3pMfma::VMfmaI3232x32x16I8Vop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -2381,9 +2381,10 @@ void VMfmaF3216x16x32Bf8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
-                   amdgpu::extract_bf8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, false, false>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VMfmaF3216x16x32Bf8Fp8Vop3pMfma::VMfmaF3216x16x32Bf8Fp8Vop3pMfma(const MachineInst *inst)
@@ -2412,9 +2413,10 @@ void VMfmaF3216x16x32Bf8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
-                   amdgpu::extract_fp8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, false, true>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VMfmaF3216x16x32Fp8Bf8Vop3pMfma::VMfmaF3216x16x32Fp8Bf8Vop3pMfma(const MachineInst *inst)
@@ -2443,9 +2445,10 @@ void VMfmaF3216x16x32Fp8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                   amdgpu::extract_bf8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, true, false>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VMfmaF3216x16x32Fp8Fp8Vop3pMfma::VMfmaF3216x16x32Fp8Fp8Vop3pMfma(const MachineInst *inst)
@@ -2474,9 +2477,10 @@ void VMfmaF3216x16x32Fp8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                   amdgpu::extract_fp8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, true, true>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VMfmaF3232x32x16Bf8Bf8Vop3pMfma::VMfmaF3232x32x16Bf8Bf8Vop3pMfma(const MachineInst *inst)
@@ -2505,9 +2509,10 @@ void VMfmaF3232x32x16Bf8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 16, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
-                   amdgpu::extract_bf8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<32, 32, 16, false, false>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VMfmaF3232x32x16Bf8Fp8Vop3pMfma::VMfmaF3232x32x16Bf8Fp8Vop3pMfma(const MachineInst *inst)
@@ -2536,9 +2541,10 @@ void VMfmaF3232x32x16Bf8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 16, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
-                   amdgpu::extract_fp8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<32, 32, 16, false, true>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VMfmaF3232x32x16Fp8Bf8Vop3pMfma::VMfmaF3232x32x16Fp8Bf8Vop3pMfma(const MachineInst *inst)
@@ -2567,9 +2573,10 @@ void VMfmaF3232x32x16Fp8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 16, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                   amdgpu::extract_bf8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<32, 32, 16, true, false>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VMfmaF3232x32x16Fp8Fp8Vop3pMfma::VMfmaF3232x32x16Fp8Fp8Vop3pMfma(const MachineInst *inst)
@@ -2598,9 +2605,10 @@ void VMfmaF3232x32x16Fp8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 16, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                   amdgpu::extract_fp8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_f8_spec<32, 32, 16, true, true>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz, inst_.abid,
+      inst_.blgp);
 }
 
 VSmfmacF3216x16x64Bf8Bf8Vop3pMfma::VSmfmacF3216x16x64Bf8Bf8Vop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -364,36 +364,7 @@ VDot2F32Bf16Vop3p::VDot2F32Bf16Vop3p(const MachineInst *inst)
 }
 
 void VDot2F32Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t raw0 = src0.read_lane(wf, lane);
-    uint32_t raw1 = src1.read_lane(wf, lane);
-    bool sel0_lo = (inst_.op_sel >> 0) & 1;
-    bool sel1_lo = (inst_.op_sel >> 1) & 1;
-    bool sel0_hi = (inst_.op_sel_hi >> 0) & 1;
-    bool sel1_hi = (inst_.op_sel_hi >> 1) & 1;
-    float a0 = util::f16_to_f32(static_cast<uint16_t>(sel0_lo ? (raw0 >> 16) : raw0));
-    float a1 = util::f16_to_f32(static_cast<uint16_t>(sel0_hi ? (raw0 >> 16) : raw0));
-    float b0 = util::f16_to_f32(static_cast<uint16_t>(sel1_lo ? (raw1 >> 16) : raw1));
-    float b1 = util::f16_to_f32(static_cast<uint16_t>(sel1_hi ? (raw1 >> 16) : raw1));
-    if (inst_.neg & 1)
-      a0 = -a0;
-    if (inst_.neg & 2)
-      b0 = -b0;
-    if (inst_.neg_hi & 1)
-      a1 = -a1;
-    if (inst_.neg_hi & 2)
-      b1 = -b1;
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    if (inst_.neg & 4)
-      acc = -acc;
-    float result = a0 * b0 + a1 * b1 + acc;
-    if (inst_.clamp)
-      result = std::clamp(result, 0.0f, 1.0f);
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(result));
-  }
+  amdgpu::execute_v_dot2_f32_bf16_vop3p(*this, wf);
 }
 
 VPkMinimum3F16Vop3p::VPkMinimum3F16Vop3p(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -962,9 +962,9 @@ void VMfmaF3216x16x32Bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 32>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaI3216x16x64I8Vop3pMfma::VMfmaI3216x16x64I8Vop3pMfma(const MachineInst *inst)
@@ -1023,9 +1023,9 @@ void VMfmaF3232x32x16Bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 16, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<32, 32, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaI3232x32x32I8Vop3pMfma::VMfmaI3232x32x32I8Vop3pMfma(const MachineInst *inst)
@@ -2095,9 +2095,9 @@ void VMfmaF3232x32x8Bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 32, 32, 8, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<32, 32, 8>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VMfmaF3216x16x16Bf16Vop3pMfma::VMfmaF3216x16x16Bf16Vop3pMfma(const MachineInst *inst)
@@ -2126,9 +2126,9 @@ void VMfmaF3216x16x16Bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
 }
 
 VSmfmacF3216x16x32F16Vop3pMfma::VSmfmacF3216x16x32F16Vop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu.cpp
@@ -3222,52 +3222,7 @@ VMinNumF16Vop3::VMinNumF16Vop3(const MachineInst *inst)
 }
 
 void VMinNumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
-        float v = [&]() {
-          float v = std::fmin(
-              [&]() {
-                float sv = util::f16_to_f32(static_cast<uint16_t>(
-                    ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
-                                               : src0.read_lane(wf, lane))));
-                if (inst_.abs & (1u << 0))
-                  sv = std::fabs(sv);
-                if (inst_.neg & (1u << 0))
-                  sv = -sv;
-                return sv;
-              }(),
-              [&]() {
-                float sv = util::f16_to_f32(static_cast<uint16_t>(
-                    ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
-                                               : src1.read_lane(wf, lane))));
-                if (inst_.abs & (1u << 1))
-                  sv = std::fabs(sv);
-                if (inst_.neg & (1u << 1))
-                  sv = -sv;
-                return sv;
-              }());
-          if (inst_.omod == 1)
-            v *= 2.0f;
-          else if (inst_.omod == 2)
-            v *= 4.0f;
-          else if (inst_.omod == 3)
-            v *= 0.5f;
-          return v;
-        }();
-        if (inst_.clamp)
-          v = std::clamp(v, 0.0f, 1.0f);
-        return v;
-      }())));
-      uint32_t old_dst = vdst.read_lane(wf, lane);
-      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
-                                                    : ((old_dst & 0xffff0000u) | src_half);
-      vdst.write_lane(wf, lane, merged);
-    }
-  }
+  amdgpu::execute_v_min_num_f16_vop3(*this, wf);
 }
 
 VMaxNumF16Vop3::VMaxNumF16Vop3(const MachineInst *inst)
@@ -3309,52 +3264,7 @@ VMaxNumF16Vop3::VMaxNumF16Vop3(const MachineInst *inst)
 }
 
 void VMaxNumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
-        float v = [&]() {
-          float v = std::fmax(
-              [&]() {
-                float sv = util::f16_to_f32(static_cast<uint16_t>(
-                    ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
-                                               : src0.read_lane(wf, lane))));
-                if (inst_.abs & (1u << 0))
-                  sv = std::fabs(sv);
-                if (inst_.neg & (1u << 0))
-                  sv = -sv;
-                return sv;
-              }(),
-              [&]() {
-                float sv = util::f16_to_f32(static_cast<uint16_t>(
-                    ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
-                                               : src1.read_lane(wf, lane))));
-                if (inst_.abs & (1u << 1))
-                  sv = std::fabs(sv);
-                if (inst_.neg & (1u << 1))
-                  sv = -sv;
-                return sv;
-              }());
-          if (inst_.omod == 1)
-            v *= 2.0f;
-          else if (inst_.omod == 2)
-            v *= 4.0f;
-          else if (inst_.omod == 3)
-            v *= 0.5f;
-          return v;
-        }();
-        if (inst_.clamp)
-          v = std::clamp(v, 0.0f, 1.0f);
-        return v;
-      }())));
-      uint32_t old_dst = vdst.read_lane(wf, lane);
-      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
-                                                    : ((old_dst & 0xffff0000u) | src_half);
-      vdst.write_lane(wf, lane, merged);
-    }
-  }
+  amdgpu::execute_v_max_num_f16_vop3(*this, wf);
 }
 
 VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_cvt.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_cvt.cpp
@@ -800,45 +800,7 @@ VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
 }
 
 void VFrexpMantF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
-        float v = [&]() {
-          float v = [&]() {
-            int e;
-            return std::frexp(static_cast<float>([&]() {
-                                float sv = util::f16_to_f32(static_cast<uint16_t>(
-                                    ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
-                                                               : src0.read_lane(wf, lane))));
-                                if (inst_.abs & (1u << 0))
-                                  sv = std::fabs(sv);
-                                if (inst_.neg & (1u << 0))
-                                  sv = -sv;
-                                return sv;
-                              }()),
-                              &e);
-          }();
-          if (inst_.omod == 1)
-            v *= 2.0f;
-          else if (inst_.omod == 2)
-            v *= 4.0f;
-          else if (inst_.omod == 3)
-            v *= 0.5f;
-          return v;
-        }();
-        if (inst_.clamp)
-          v = std::clamp(v, 0.0f, 1.0f);
-        return v;
-      }())));
-      uint32_t old_dst = vdst.read_lane(wf, lane);
-      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
-                                                    : ((old_dst & 0xffff0000u) | src_half);
-      vdst.write_lane(wf, lane, merged);
-    }
-  }
+  amdgpu::execute_v_frexp_mant_f16_vop3(*this, wf);
 }
 
 VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
@@ -866,47 +828,7 @@ VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
 }
 
 void VFrexpExpI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
-        float v = [&]() {
-          float v = [&]() {
-            float s = [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
-                                             : src0.read_lane(wf, lane))));
-              if (inst_.abs & (1u << 0))
-                sv = std::fabs(sv);
-              if (inst_.neg & (1u << 0))
-                sv = -sv;
-              return sv;
-            }();
-            int exp = 0;
-            if (s != 0.0f && !std::isnan(s) && !std::isinf(s))
-              std::frexp(s, &exp);
-            return static_cast<uint32_t>(exp);
-          }();
-          if (inst_.omod == 1)
-            v *= 2.0f;
-          else if (inst_.omod == 2)
-            v *= 4.0f;
-          else if (inst_.omod == 3)
-            v *= 0.5f;
-          return v;
-        }();
-        if (inst_.clamp)
-          v = std::clamp(v, 0.0f, 1.0f);
-        return v;
-      }())));
-      uint32_t old_dst = vdst.read_lane(wf, lane);
-      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
-                                                    : ((old_dst & 0xffff0000u) | src_half);
-      vdst.write_lane(wf, lane, merged);
-    }
-  }
+  amdgpu::execute_v_frexp_exp_i16_f16_vop3(*this, wf);
 }
 
 VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
@@ -5147,22 +5069,7 @@ VCvtPkNormI16F16Vop3::VCvtPkNormI16F16Vop3(const MachineInst *inst)
 }
 
 void VCvtPkNormI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
-    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
-    auto cvt_u16 = [](float f) -> uint16_t {
-      if (std::isnan(f))
-        return 0;
-      return static_cast<uint16_t>(std::clamp(f * 65535.0f, 0.0f, 65535.0f));
-    };
-    uint16_t lo = cvt_u16(s0);
-    uint16_t hi = cvt_u16(s1);
-    vdst.write_lane(wf, lane,
-                    (static_cast<uint32_t>(hi) << 16) | (static_cast<uint32_t>(lo) & 0xFFFF));
-  }
+  amdgpu::execute_v_cvt_pk_norm_i16_f16_vop3(*this, wf);
 }
 
 VCvtPkNormU16F16Vop3::VCvtPkNormU16F16Vop3(const MachineInst *inst)
@@ -5204,22 +5111,7 @@ VCvtPkNormU16F16Vop3::VCvtPkNormU16F16Vop3(const MachineInst *inst)
 }
 
 void VCvtPkNormU16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
-    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
-    auto cvt_u16 = [](float f) -> uint16_t {
-      if (std::isnan(f))
-        return 0;
-      return static_cast<uint16_t>(std::clamp(f * 65535.0f, 0.0f, 65535.0f));
-    };
-    uint16_t lo = cvt_u16(s0);
-    uint16_t hi = cvt_u16(s1);
-    vdst.write_lane(wf, lane,
-                    (static_cast<uint32_t>(hi) << 16) | (static_cast<uint32_t>(lo) & 0xFFFF));
-  }
+  amdgpu::execute_v_cvt_pk_norm_u16_f16_vop3(*this, wf);
 }
 
 VCvtPkNormI16F32Vop3::VCvtPkNormI16F32Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_ternary.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_ternary.cpp
@@ -1326,63 +1326,7 @@ VMin3NumF16Vop3::VMin3NumF16Vop3(const MachineInst *inst)
 }
 
 void VMin3NumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
-        float v = [&]() {
-          float v =
-              std::fmin(std::fmin(
-                            [&]() {
-                              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
-                                                             : src0.read_lane(wf, lane))));
-                              if (inst_.abs & (1u << 0))
-                                sv = std::fabs(sv);
-                              if (inst_.neg & (1u << 0))
-                                sv = -sv;
-                              return sv;
-                            }(),
-                            [&]() {
-                              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
-                                                             : src1.read_lane(wf, lane))));
-                              if (inst_.abs & (1u << 1))
-                                sv = std::fabs(sv);
-                              if (inst_.neg & (1u << 1))
-                                sv = -sv;
-                              return sv;
-                            }()),
-                        [&]() {
-                          float sv = util::f16_to_f32(static_cast<uint16_t>(
-                              ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
-                                                         : src2.read_lane(wf, lane))));
-                          if (inst_.abs & (1u << 2))
-                            sv = std::fabs(sv);
-                          if (inst_.neg & (1u << 2))
-                            sv = -sv;
-                          return sv;
-                        }());
-          if (inst_.omod == 1)
-            v *= 2.0f;
-          else if (inst_.omod == 2)
-            v *= 4.0f;
-          else if (inst_.omod == 3)
-            v *= 0.5f;
-          return v;
-        }();
-        if (inst_.clamp)
-          v = std::clamp(v, 0.0f, 1.0f);
-        return v;
-      }())));
-      uint32_t old_dst = vdst.read_lane(wf, lane);
-      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
-                                                    : ((old_dst & 0xffff0000u) | src_half);
-      vdst.write_lane(wf, lane, merged);
-    }
-  }
+  amdgpu::execute_v_min3_num_f16_vop3(*this, wf);
 }
 
 VMax3NumF16Vop3::VMax3NumF16Vop3(const MachineInst *inst)
@@ -1438,63 +1382,7 @@ VMax3NumF16Vop3::VMax3NumF16Vop3(const MachineInst *inst)
 }
 
 void VMax3NumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
-        float v = [&]() {
-          float v =
-              std::fmax(std::fmax(
-                            [&]() {
-                              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
-                                                             : src0.read_lane(wf, lane))));
-                              if (inst_.abs & (1u << 0))
-                                sv = std::fabs(sv);
-                              if (inst_.neg & (1u << 0))
-                                sv = -sv;
-                              return sv;
-                            }(),
-                            [&]() {
-                              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
-                                                             : src1.read_lane(wf, lane))));
-                              if (inst_.abs & (1u << 1))
-                                sv = std::fabs(sv);
-                              if (inst_.neg & (1u << 1))
-                                sv = -sv;
-                              return sv;
-                            }()),
-                        [&]() {
-                          float sv = util::f16_to_f32(static_cast<uint16_t>(
-                              ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
-                                                         : src2.read_lane(wf, lane))));
-                          if (inst_.abs & (1u << 2))
-                            sv = std::fabs(sv);
-                          if (inst_.neg & (1u << 2))
-                            sv = -sv;
-                          return sv;
-                        }());
-          if (inst_.omod == 1)
-            v *= 2.0f;
-          else if (inst_.omod == 2)
-            v *= 4.0f;
-          else if (inst_.omod == 3)
-            v *= 0.5f;
-          return v;
-        }();
-        if (inst_.clamp)
-          v = std::clamp(v, 0.0f, 1.0f);
-        return v;
-      }())));
-      uint32_t old_dst = vdst.read_lane(wf, lane);
-      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
-                                                    : ((old_dst & 0xffff0000u) | src_half);
-      vdst.write_lane(wf, lane, merged);
-    }
-  }
+  amdgpu::execute_v_max3_num_f16_vop3(*this, wf);
 }
 
 VMinimum3F32Vop3::VMinimum3F32Vop3(const MachineInst *inst)
@@ -1662,67 +1550,7 @@ VMinimum3F16Vop3::VMinimum3F16Vop3(const MachineInst *inst)
 }
 
 void VMinimum3F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
-        float v = [&]() {
-          float v = [&]() {
-            auto a = [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
-                                             : src0.read_lane(wf, lane))));
-              if (inst_.abs & (1u << 0))
-                sv = std::fabs(sv);
-              if (inst_.neg & (1u << 0))
-                sv = -sv;
-              return sv;
-            }();
-            auto b = [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
-                                             : src1.read_lane(wf, lane))));
-              if (inst_.abs & (1u << 1))
-                sv = std::fabs(sv);
-              if (inst_.neg & (1u << 1))
-                sv = -sv;
-              return sv;
-            }();
-            auto c = [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                  ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
-                                             : src2.read_lane(wf, lane))));
-              if (inst_.abs & (1u << 2))
-                sv = std::fabs(sv);
-              if (inst_.neg & (1u << 2))
-                sv = -sv;
-              return sv;
-            }();
-            if (std::isnan(a) || std::isnan(b) || std::isnan(c))
-              return std::numeric_limits<decltype(a)>::quiet_NaN();
-            auto ab = (a == b) ? (std::signbit(a) ? a : b) : (a < b ? a : b);
-            return (ab == c) ? (std::signbit(ab) ? ab : c) : (ab < c ? ab : c);
-          }();
-          if (inst_.omod == 1)
-            v *= 2.0f;
-          else if (inst_.omod == 2)
-            v *= 4.0f;
-          else if (inst_.omod == 3)
-            v *= 0.5f;
-          return v;
-        }();
-        if (inst_.clamp)
-          v = std::clamp(v, 0.0f, 1.0f);
-        return v;
-      }())));
-      uint32_t old_dst = vdst.read_lane(wf, lane);
-      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
-                                                    : ((old_dst & 0xffff0000u) | src_half);
-      vdst.write_lane(wf, lane, merged);
-    }
-  }
+  amdgpu::execute_v_minimum3_f16_vop3(*this, wf);
 }
 
 VMaximum3F16Vop3::VMaximum3F16Vop3(const MachineInst *inst)
@@ -1778,67 +1606,7 @@ VMaximum3F16Vop3::VMaximum3F16Vop3(const MachineInst *inst)
 }
 
 void VMaximum3F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
-        float v = [&]() {
-          float v = [&]() {
-            auto a = [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
-                                             : src0.read_lane(wf, lane))));
-              if (inst_.abs & (1u << 0))
-                sv = std::fabs(sv);
-              if (inst_.neg & (1u << 0))
-                sv = -sv;
-              return sv;
-            }();
-            auto b = [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
-                                             : src1.read_lane(wf, lane))));
-              if (inst_.abs & (1u << 1))
-                sv = std::fabs(sv);
-              if (inst_.neg & (1u << 1))
-                sv = -sv;
-              return sv;
-            }();
-            auto c = [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                  ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
-                                             : src2.read_lane(wf, lane))));
-              if (inst_.abs & (1u << 2))
-                sv = std::fabs(sv);
-              if (inst_.neg & (1u << 2))
-                sv = -sv;
-              return sv;
-            }();
-            if (std::isnan(a) || std::isnan(b) || std::isnan(c))
-              return std::numeric_limits<decltype(a)>::quiet_NaN();
-            auto ab = (a == b) ? (std::signbit(a) ? b : a) : (a > b ? a : b);
-            return (ab == c) ? (std::signbit(ab) ? c : ab) : (ab > c ? ab : c);
-          }();
-          if (inst_.omod == 1)
-            v *= 2.0f;
-          else if (inst_.omod == 2)
-            v *= 4.0f;
-          else if (inst_.omod == 3)
-            v *= 0.5f;
-          return v;
-        }();
-        if (inst_.clamp)
-          v = std::clamp(v, 0.0f, 1.0f);
-        return v;
-      }())));
-      uint32_t old_dst = vdst.read_lane(wf, lane);
-      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
-                                                    : ((old_dst & 0xffff0000u) | src_half);
-      vdst.write_lane(wf, lane, merged);
-    }
-  }
+  amdgpu::execute_v_maximum3_f16_vop3(*this, wf);
 }
 
 VMed3NumF32Vop3::VMed3NumF32Vop3(const MachineInst *inst)
@@ -3873,63 +3641,7 @@ VMinmaxNumF16Vop3::VMinmaxNumF16Vop3(const MachineInst *inst)
 }
 
 void VMinmaxNumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
-        float v = [&]() {
-          float v =
-              std::fmax(std::fmin(
-                            [&]() {
-                              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
-                                                             : src0.read_lane(wf, lane))));
-                              if (inst_.abs & (1u << 0))
-                                sv = std::fabs(sv);
-                              if (inst_.neg & (1u << 0))
-                                sv = -sv;
-                              return sv;
-                            }(),
-                            [&]() {
-                              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
-                                                             : src1.read_lane(wf, lane))));
-                              if (inst_.abs & (1u << 1))
-                                sv = std::fabs(sv);
-                              if (inst_.neg & (1u << 1))
-                                sv = -sv;
-                              return sv;
-                            }()),
-                        [&]() {
-                          float sv = util::f16_to_f32(static_cast<uint16_t>(
-                              ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
-                                                         : src2.read_lane(wf, lane))));
-                          if (inst_.abs & (1u << 2))
-                            sv = std::fabs(sv);
-                          if (inst_.neg & (1u << 2))
-                            sv = -sv;
-                          return sv;
-                        }());
-          if (inst_.omod == 1)
-            v *= 2.0f;
-          else if (inst_.omod == 2)
-            v *= 4.0f;
-          else if (inst_.omod == 3)
-            v *= 0.5f;
-          return v;
-        }();
-        if (inst_.clamp)
-          v = std::clamp(v, 0.0f, 1.0f);
-        return v;
-      }())));
-      uint32_t old_dst = vdst.read_lane(wf, lane);
-      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
-                                                    : ((old_dst & 0xffff0000u) | src_half);
-      vdst.write_lane(wf, lane, merged);
-    }
-  }
+  amdgpu::execute_v_minmax_num_f16_vop3(*this, wf);
 }
 
 VMaxminNumF16Vop3::VMaxminNumF16Vop3(const MachineInst *inst)
@@ -3985,63 +3697,7 @@ VMaxminNumF16Vop3::VMaxminNumF16Vop3(const MachineInst *inst)
 }
 
 void VMaxminNumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
-        float v = [&]() {
-          float v =
-              std::fmin(std::fmax(
-                            [&]() {
-                              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
-                                                             : src0.read_lane(wf, lane))));
-                              if (inst_.abs & (1u << 0))
-                                sv = std::fabs(sv);
-                              if (inst_.neg & (1u << 0))
-                                sv = -sv;
-                              return sv;
-                            }(),
-                            [&]() {
-                              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
-                                                             : src1.read_lane(wf, lane))));
-                              if (inst_.abs & (1u << 1))
-                                sv = std::fabs(sv);
-                              if (inst_.neg & (1u << 1))
-                                sv = -sv;
-                              return sv;
-                            }()),
-                        [&]() {
-                          float sv = util::f16_to_f32(static_cast<uint16_t>(
-                              ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
-                                                         : src2.read_lane(wf, lane))));
-                          if (inst_.abs & (1u << 2))
-                            sv = std::fabs(sv);
-                          if (inst_.neg & (1u << 2))
-                            sv = -sv;
-                          return sv;
-                        }());
-          if (inst_.omod == 1)
-            v *= 2.0f;
-          else if (inst_.omod == 2)
-            v *= 4.0f;
-          else if (inst_.omod == 3)
-            v *= 0.5f;
-          return v;
-        }();
-        if (inst_.clamp)
-          v = std::clamp(v, 0.0f, 1.0f);
-        return v;
-      }())));
-      uint32_t old_dst = vdst.read_lane(wf, lane);
-      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
-                                                    : ((old_dst & 0xffff0000u) | src_half);
-      vdst.write_lane(wf, lane, merged);
-    }
-  }
+  amdgpu::execute_v_maxmin_num_f16_vop3(*this, wf);
 }
 
 VMinimummaximumF32Vop3::VMinimummaximumF32Vop3(const MachineInst *inst)
@@ -4209,67 +3865,7 @@ VMinimummaximumF16Vop3::VMinimummaximumF16Vop3(const MachineInst *inst)
 }
 
 void VMinimummaximumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
-        float v = [&]() {
-          float v = [&]() {
-            auto a = [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
-                                             : src0.read_lane(wf, lane))));
-              if (inst_.abs & (1u << 0))
-                sv = std::fabs(sv);
-              if (inst_.neg & (1u << 0))
-                sv = -sv;
-              return sv;
-            }();
-            auto b = [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
-                                             : src1.read_lane(wf, lane))));
-              if (inst_.abs & (1u << 1))
-                sv = std::fabs(sv);
-              if (inst_.neg & (1u << 1))
-                sv = -sv;
-              return sv;
-            }();
-            auto c = [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                  ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
-                                             : src2.read_lane(wf, lane))));
-              if (inst_.abs & (1u << 2))
-                sv = std::fabs(sv);
-              if (inst_.neg & (1u << 2))
-                sv = -sv;
-              return sv;
-            }();
-            if (std::isnan(a) || std::isnan(b) || std::isnan(c))
-              return std::numeric_limits<decltype(a)>::quiet_NaN();
-            auto ab = (a == b) ? (std::signbit(a) ? a : b) : (a < b ? a : b);
-            return (ab == c) ? (std::signbit(ab) ? c : ab) : (ab > c ? ab : c);
-          }();
-          if (inst_.omod == 1)
-            v *= 2.0f;
-          else if (inst_.omod == 2)
-            v *= 4.0f;
-          else if (inst_.omod == 3)
-            v *= 0.5f;
-          return v;
-        }();
-        if (inst_.clamp)
-          v = std::clamp(v, 0.0f, 1.0f);
-        return v;
-      }())));
-      uint32_t old_dst = vdst.read_lane(wf, lane);
-      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
-                                                    : ((old_dst & 0xffff0000u) | src_half);
-      vdst.write_lane(wf, lane, merged);
-    }
-  }
+  amdgpu::execute_v_minimummaximum_f16_vop3(*this, wf);
 }
 
 VMaximumminimumF16Vop3::VMaximumminimumF16Vop3(const MachineInst *inst)
@@ -4325,67 +3921,7 @@ VMaximumminimumF16Vop3::VMaximumminimumF16Vop3(const MachineInst *inst)
 }
 
 void VMaximumminimumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
-        float v = [&]() {
-          float v = [&]() {
-            auto a = [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
-                                             : src0.read_lane(wf, lane))));
-              if (inst_.abs & (1u << 0))
-                sv = std::fabs(sv);
-              if (inst_.neg & (1u << 0))
-                sv = -sv;
-              return sv;
-            }();
-            auto b = [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
-                                             : src1.read_lane(wf, lane))));
-              if (inst_.abs & (1u << 1))
-                sv = std::fabs(sv);
-              if (inst_.neg & (1u << 1))
-                sv = -sv;
-              return sv;
-            }();
-            auto c = [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(
-                  ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
-                                             : src2.read_lane(wf, lane))));
-              if (inst_.abs & (1u << 2))
-                sv = std::fabs(sv);
-              if (inst_.neg & (1u << 2))
-                sv = -sv;
-              return sv;
-            }();
-            if (std::isnan(a) || std::isnan(b) || std::isnan(c))
-              return std::numeric_limits<decltype(a)>::quiet_NaN();
-            auto ab = (a == b) ? (std::signbit(a) ? b : a) : (a > b ? a : b);
-            return (ab == c) ? (std::signbit(ab) ? ab : c) : (ab < c ? ab : c);
-          }();
-          if (inst_.omod == 1)
-            v *= 2.0f;
-          else if (inst_.omod == 2)
-            v *= 4.0f;
-          else if (inst_.omod == 3)
-            v *= 0.5f;
-          return v;
-        }();
-        if (inst_.clamp)
-          v = std::clamp(v, 0.0f, 1.0f);
-        return v;
-      }())));
-      uint32_t old_dst = vdst.read_lane(wf, lane);
-      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
-                                                    : ((old_dst & 0xffff0000u) | src_half);
-      vdst.write_lane(wf, lane, merged);
-    }
-  }
+  amdgpu::execute_v_maximumminimum_f16_vop3(*this, wf);
 }
 
 VAshrPkI8I32Vop3::VAshrPkI8I32Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p.cpp
@@ -5494,10 +5494,9 @@ void VWmmaI3216x16x64Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  auto extract_a = (inst_.neg & 0x1u) ? amdgpu::extract_i8 : amdgpu::extract_u8;
-  auto extract_b = (inst_.neg & 0x2u) ? amdgpu::extract_i8 : amdgpu::extract_u8;
-  amdgpu::exec_wmma_i32(cu, 16, 16, 64, 8, dst, src0_base, src1_base, s2, extract_a, extract_b,
-                        inst_.clamp, const_acc);
+  amdgpu::exec_wmma_i32_16x16x64_iu8(cu, dst, src0_base, src1_base, s2,
+                                     /*a_signed=*/(inst_.neg & 0x1u) != 0,
+                                     /*b_signed=*/(inst_.neg & 0x2u) != 0, inst_.clamp, const_acc);
 }
 
 VSwmmacF3216x16x128Fp8Fp8Vop3p::VSwmmacF3216x16x128Fp8Fp8Vop3p(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p.cpp
@@ -4176,8 +4176,7 @@ void VWmmaF1616x16x32F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f16(cu, 16, 16, 32, 16, dst, src0_base, src1_base, s2, amdgpu::extract_f16,
-                        amdgpu::extract_f16, const_acc);
+  amdgpu::exec_wmma_f16_spec<16, 16, 32>(cu, dst, src0_base, src1_base, s2, const_acc);
 }
 
 VWmmaF3216x16x32Bf16Vop3p::VWmmaF3216x16x32Bf16Vop3p(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p.cpp
@@ -4102,8 +4102,7 @@ void VWmmaF3216x16x32F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f32(cu, 16, 16, 32, 16, dst, src0_base, src1_base, s2, amdgpu::extract_f16,
-                        amdgpu::extract_f16, const_acc);
+  amdgpu::exec_wmma_f32_16x16x32_f16(cu, dst, src0_base, src1_base, s2, const_acc);
 }
 
 VWmmaF1616x16x32F16Vop3p::VWmmaF1616x16x32F16Vop3p(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p.cpp
@@ -4026,8 +4026,7 @@ void VWmmaF3216x16x4F32Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f32(cu, 16, 16, 4, 32, dst, src0_base, src1_base, s2, amdgpu::extract_f32,
-                        amdgpu::extract_f32, const_acc);
+  amdgpu::exec_wmma_f32_f32_spec<16, 16, 4>(cu, dst, src0_base, src1_base, s2, const_acc);
 }
 
 VWmmaF3216x16x32F16Vop3p::VWmmaF3216x16x32F16Vop3p(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p.cpp
@@ -4886,8 +4886,8 @@ void VWmmaF3216x16x64Fp8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f32(cu, 16, 16, 64, 8, dst, src0_base, src1_base, s2, amdgpu::extract_fp8,
-                        amdgpu::extract_fp8, const_acc);
+  amdgpu::exec_wmma_f32_f8_spec<16, 16, 64, true, true>(cu, dst, src0_base, src1_base, s2,
+                                                        const_acc);
 }
 
 VWmmaF3216x16x64Fp8Bf8Vop3p::VWmmaF3216x16x64Fp8Bf8Vop3p(const MachineInst *inst)
@@ -4962,8 +4962,8 @@ void VWmmaF3216x16x64Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f32(cu, 16, 16, 64, 8, dst, src0_base, src1_base, s2, amdgpu::extract_fp8,
-                        amdgpu::extract_bf8, const_acc);
+  amdgpu::exec_wmma_f32_f8_spec<16, 16, 64, true, false>(cu, dst, src0_base, src1_base, s2,
+                                                         const_acc);
 }
 
 VWmmaF3216x16x64Bf8Fp8Vop3p::VWmmaF3216x16x64Bf8Fp8Vop3p(const MachineInst *inst)
@@ -5038,8 +5038,8 @@ void VWmmaF3216x16x64Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f32(cu, 16, 16, 64, 8, dst, src0_base, src1_base, s2, amdgpu::extract_bf8,
-                        amdgpu::extract_fp8, const_acc);
+  amdgpu::exec_wmma_f32_f8_spec<16, 16, 64, false, true>(cu, dst, src0_base, src1_base, s2,
+                                                         const_acc);
 }
 
 VWmmaF3216x16x64Bf8Bf8Vop3p::VWmmaF3216x16x64Bf8Bf8Vop3p(const MachineInst *inst)
@@ -5114,8 +5114,8 @@ void VWmmaF3216x16x64Bf8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f32(cu, 16, 16, 64, 8, dst, src0_base, src1_base, s2, amdgpu::extract_bf8,
-                        amdgpu::extract_bf8, const_acc);
+  amdgpu::exec_wmma_f32_f8_spec<16, 16, 64, false, false>(cu, dst, src0_base, src1_base, s2,
+                                                          const_acc);
 }
 
 VWmmaF1616x16x64Fp8Fp8Vop3p::VWmmaF1616x16x64Fp8Fp8Vop3p(const MachineInst *inst)
@@ -5190,8 +5190,8 @@ void VWmmaF1616x16x64Fp8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f16(cu, 16, 16, 64, 8, dst, src0_base, src1_base, s2, amdgpu::extract_fp8,
-                        amdgpu::extract_fp8, const_acc);
+  amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, true, true>(cu, dst, src0_base, src1_base, s2,
+                                                        const_acc);
 }
 
 VWmmaF1616x16x64Fp8Bf8Vop3p::VWmmaF1616x16x64Fp8Bf8Vop3p(const MachineInst *inst)
@@ -5266,8 +5266,8 @@ void VWmmaF1616x16x64Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f16(cu, 16, 16, 64, 8, dst, src0_base, src1_base, s2, amdgpu::extract_fp8,
-                        amdgpu::extract_bf8, const_acc);
+  amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, true, false>(cu, dst, src0_base, src1_base, s2,
+                                                         const_acc);
 }
 
 VWmmaF1616x16x64Bf8Fp8Vop3p::VWmmaF1616x16x64Bf8Fp8Vop3p(const MachineInst *inst)
@@ -5342,8 +5342,8 @@ void VWmmaF1616x16x64Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f16(cu, 16, 16, 64, 8, dst, src0_base, src1_base, s2, amdgpu::extract_bf8,
-                        amdgpu::extract_fp8, const_acc);
+  amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, false, true>(cu, dst, src0_base, src1_base, s2,
+                                                         const_acc);
 }
 
 VWmmaF1616x16x64Bf8Bf8Vop3p::VWmmaF1616x16x64Bf8Bf8Vop3p(const MachineInst *inst)
@@ -5418,8 +5418,8 @@ void VWmmaF1616x16x64Bf8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f16(cu, 16, 16, 64, 8, dst, src0_base, src1_base, s2, amdgpu::extract_bf8,
-                        amdgpu::extract_bf8, const_acc);
+  amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, false, false>(cu, dst, src0_base, src1_base, s2,
+                                                          const_acc);
 }
 
 VWmmaI3216x16x64Iu8Vop3p::VWmmaI3216x16x64Iu8Vop3p(const MachineInst *inst)
@@ -6311,8 +6311,8 @@ void VWmmaF3216x16x128Fp8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f32(cu, 16, 16, 128, 8, dst, src0_base, src1_base, s2, amdgpu::extract_fp8,
-                        amdgpu::extract_fp8, const_acc);
+  amdgpu::exec_wmma_f32_f8_spec<16, 16, 128, true, true>(cu, dst, src0_base, src1_base, s2,
+                                                         const_acc);
 }
 
 VWmmaF3216x16x128Fp8Bf8Vop3p::VWmmaF3216x16x128Fp8Bf8Vop3p(const MachineInst *inst)
@@ -6387,8 +6387,8 @@ void VWmmaF3216x16x128Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f32(cu, 16, 16, 128, 8, dst, src0_base, src1_base, s2, amdgpu::extract_fp8,
-                        amdgpu::extract_bf8, const_acc);
+  amdgpu::exec_wmma_f32_f8_spec<16, 16, 128, true, false>(cu, dst, src0_base, src1_base, s2,
+                                                          const_acc);
 }
 
 VWmmaF3216x16x128Bf8Fp8Vop3p::VWmmaF3216x16x128Bf8Fp8Vop3p(const MachineInst *inst)
@@ -6463,8 +6463,8 @@ void VWmmaF3216x16x128Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f32(cu, 16, 16, 128, 8, dst, src0_base, src1_base, s2, amdgpu::extract_bf8,
-                        amdgpu::extract_fp8, const_acc);
+  amdgpu::exec_wmma_f32_f8_spec<16, 16, 128, false, true>(cu, dst, src0_base, src1_base, s2,
+                                                          const_acc);
 }
 
 VWmmaF3216x16x128Bf8Bf8Vop3p::VWmmaF3216x16x128Bf8Bf8Vop3p(const MachineInst *inst)
@@ -6539,8 +6539,8 @@ void VWmmaF3216x16x128Bf8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f32(cu, 16, 16, 128, 8, dst, src0_base, src1_base, s2, amdgpu::extract_bf8,
-                        amdgpu::extract_bf8, const_acc);
+  amdgpu::exec_wmma_f32_f8_spec<16, 16, 128, false, false>(cu, dst, src0_base, src1_base, s2,
+                                                           const_acc);
 }
 
 VWmmaF1616x16x128Fp8Fp8Vop3p::VWmmaF1616x16x128Fp8Fp8Vop3p(const MachineInst *inst)
@@ -6615,8 +6615,8 @@ void VWmmaF1616x16x128Fp8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f16(cu, 16, 16, 128, 8, dst, src0_base, src1_base, s2, amdgpu::extract_fp8,
-                        amdgpu::extract_fp8, const_acc);
+  amdgpu::exec_wmma_f16_f8_spec<16, 16, 128, true, true>(cu, dst, src0_base, src1_base, s2,
+                                                         const_acc);
 }
 
 VWmmaF1616x16x128Fp8Bf8Vop3p::VWmmaF1616x16x128Fp8Bf8Vop3p(const MachineInst *inst)
@@ -6691,8 +6691,8 @@ void VWmmaF1616x16x128Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f16(cu, 16, 16, 128, 8, dst, src0_base, src1_base, s2, amdgpu::extract_fp8,
-                        amdgpu::extract_bf8, const_acc);
+  amdgpu::exec_wmma_f16_f8_spec<16, 16, 128, true, false>(cu, dst, src0_base, src1_base, s2,
+                                                          const_acc);
 }
 
 VWmmaF1616x16x128Bf8Fp8Vop3p::VWmmaF1616x16x128Bf8Fp8Vop3p(const MachineInst *inst)
@@ -6767,8 +6767,8 @@ void VWmmaF1616x16x128Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f16(cu, 16, 16, 128, 8, dst, src0_base, src1_base, s2, amdgpu::extract_bf8,
-                        amdgpu::extract_fp8, const_acc);
+  amdgpu::exec_wmma_f16_f8_spec<16, 16, 128, false, true>(cu, dst, src0_base, src1_base, s2,
+                                                          const_acc);
 }
 
 VWmmaF1616x16x128Bf8Bf8Vop3p::VWmmaF1616x16x128Bf8Bf8Vop3p(const MachineInst *inst)
@@ -6843,8 +6843,8 @@ void VWmmaF1616x16x128Bf8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f16(cu, 16, 16, 128, 8, dst, src0_base, src1_base, s2, amdgpu::extract_bf8,
-                        amdgpu::extract_bf8, const_acc);
+  amdgpu::exec_wmma_f16_f8_spec<16, 16, 128, false, false>(cu, dst, src0_base, src1_base, s2,
+                                                           const_acc);
 }
 
 VWmmaF3232x16x128F4Vop3p::VWmmaF3232x16x128F4Vop3p(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p.cpp
@@ -4251,8 +4251,7 @@ void VWmmaF3216x16x32Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f32(cu, 16, 16, 32, 16, dst, src0_base, src1_base, s2, amdgpu::extract_bf16,
-                        amdgpu::extract_bf16, const_acc);
+  amdgpu::exec_wmma_f32_16x16x32_bf16(cu, dst, src0_base, src1_base, s2, const_acc);
 }
 
 VWmmaBf1616x16x32Bf16Vop3p::VWmmaBf1616x16x32Bf16Vop3p(const MachineInst *inst)
@@ -4327,8 +4326,7 @@ void VWmmaBf1616x16x32Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_bf16(cu, 16, 16, 32, 16, dst, src0_base, src1_base, s2, amdgpu::extract_bf16,
-                         amdgpu::extract_bf16, const_acc);
+  amdgpu::exec_wmma_bf16_spec<16, 16, 32>(cu, dst, src0_base, src1_base, s2, const_acc);
 }
 
 VWmmaBf16f3216x16x32Bf16Vop3p::VWmmaBf16f3216x16x32Bf16Vop3p(const MachineInst *inst)
@@ -4403,8 +4401,7 @@ void VWmmaBf16f3216x16x32Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   } else {
     const_acc = src2.read_scalar(wf);
   }
-  amdgpu::exec_wmma_f32(cu, 16, 16, 32, 16, dst, src0_base, src1_base, s2, amdgpu::extract_bf16,
-                        amdgpu::extract_bf16, const_acc);
+  amdgpu::exec_wmma_f32_16x16x32_bf16(cu, dst, src0_base, src1_base, s2, const_acc);
 }
 
 VSwmmacF3216x16x64F16Vop3p::VSwmmacF3216x16x64F16Vop3p(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
@@ -4816,18 +4816,7 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
-    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
-    int16_t lo = static_cast<int16_t>(std::clamp(f0, -32768.0f, 32767.0f));
-    int16_t hi = static_cast<int16_t>(std::clamp(f1, -32768.0f, 32767.0f));
-    vdst.write_lane(wf, lane,
-                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
-                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
-  }
+  amdgpu::execute_v_cvt_pk_i16_f32_vop3(*this, wf);
 }
 
 VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
@@ -4852,18 +4841,7 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
-    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
-    uint16_t lo = static_cast<uint16_t>(std::clamp(f0, 0.0f, 65535.0f));
-    uint16_t hi = static_cast<uint16_t>(std::clamp(f1, 0.0f, 65535.0f));
-    vdst.write_lane(wf, lane,
-                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
-                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
-  }
+  amdgpu::execute_v_cvt_pk_u16_f32_vop3(*this, wf);
 }
 
 VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
@@ -4816,7 +4816,18 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_i16_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    int16_t lo = static_cast<int16_t>(std::clamp(f0, -32768.0f, 32767.0f));
+    int16_t hi = static_cast<int16_t>(std::clamp(f1, -32768.0f, 32767.0f));
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
 }
 
 VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
@@ -4841,7 +4852,18 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_u16_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    uint16_t lo = static_cast<uint16_t>(std::clamp(f0, 0.0f, 65535.0f));
+    uint16_t hi = static_cast<uint16_t>(std::clamp(f1, 0.0f, 65535.0f));
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
 }
 
 VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3p.cpp
@@ -828,9 +828,9 @@ void VWmmaF3216x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, 0u, 0u, 0u);
 }
 
 VWmmaF3216x16x16Bf16Vop3p::VWmmaF3216x16x16Bf16Vop3p(const MachineInst *inst)
@@ -868,9 +868,9 @@ void VWmmaF3216x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16, 2>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
 }
 
 VWmmaF1616x16x16F16Vop3p::VWmmaF1616x16x16F16Vop3p(const MachineInst *inst)
@@ -908,9 +908,9 @@ void VWmmaF1616x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, 0u, 0u, 0u);
 }
 
 VWmmaBf1616x16x16Bf16Vop3p::VWmmaBf1616x16x16Bf16Vop3p(const MachineInst *inst)
@@ -948,9 +948,9 @@ void VWmmaBf1616x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16, 2>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
 }
 
 VWmmaI3216x16x16Iu8Vop3p::VWmmaI3216x16x16Iu8Vop3p(const MachineInst *inst)
@@ -988,8 +988,9 @@ void VWmmaI3216x16x16Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 16, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc);
 }
 
 VWmmaI3216x16x16Iu4Vop3p::VWmmaI3216x16x16Iu4Vop3p(const MachineInst *inst)
@@ -1027,8 +1028,9 @@ void VWmmaI3216x16x16Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 16, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc);
 }
 
 } // namespace rdna3

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
@@ -4816,18 +4816,7 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
-    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
-    int16_t lo = static_cast<int16_t>(std::clamp(f0, -32768.0f, 32767.0f));
-    int16_t hi = static_cast<int16_t>(std::clamp(f1, -32768.0f, 32767.0f));
-    vdst.write_lane(wf, lane,
-                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
-                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
-  }
+  amdgpu::execute_v_cvt_pk_i16_f32_vop3(*this, wf);
 }
 
 VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
@@ -4852,18 +4841,7 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
-    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
-    uint16_t lo = static_cast<uint16_t>(std::clamp(f0, 0.0f, 65535.0f));
-    uint16_t hi = static_cast<uint16_t>(std::clamp(f1, 0.0f, 65535.0f));
-    vdst.write_lane(wf, lane,
-                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
-                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
-  }
+  amdgpu::execute_v_cvt_pk_u16_f32_vop3(*this, wf);
 }
 
 VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
@@ -4816,7 +4816,18 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_i16_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    int16_t lo = static_cast<int16_t>(std::clamp(f0, -32768.0f, 32767.0f));
+    int16_t hi = static_cast<int16_t>(std::clamp(f1, -32768.0f, 32767.0f));
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
 }
 
 VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
@@ -4841,7 +4852,18 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_u16_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    uint16_t lo = static_cast<uint16_t>(std::clamp(f0, 0.0f, 65535.0f));
+    uint16_t hi = static_cast<uint16_t>(std::clamp(f1, 0.0f, 65535.0f));
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
 }
 
 VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3p.cpp
@@ -828,9 +828,9 @@ void VWmmaF3216x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, 0u, 0u, 0u);
 }
 
 VWmmaF3216x16x16Bf16Vop3p::VWmmaF3216x16x16Bf16Vop3p(const MachineInst *inst)
@@ -868,9 +868,9 @@ void VWmmaF3216x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16, 2>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
 }
 
 VWmmaF1616x16x16F16Vop3p::VWmmaF1616x16x16F16Vop3p(const MachineInst *inst)
@@ -908,9 +908,9 @@ void VWmmaF1616x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, 0u, 0u, 0u);
 }
 
 VWmmaBf1616x16x16Bf16Vop3p::VWmmaBf1616x16x16Bf16Vop3p(const MachineInst *inst)
@@ -948,9 +948,9 @@ void VWmmaBf1616x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16, 2>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
 }
 
 VWmmaI3216x16x16Iu8Vop3p::VWmmaI3216x16x16Iu8Vop3p(const MachineInst *inst)
@@ -988,8 +988,9 @@ void VWmmaI3216x16x16Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 16, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc);
 }
 
 VWmmaI3216x16x16Iu4Vop3p::VWmmaI3216x16x16Iu4Vop3p(const MachineInst *inst)
@@ -1027,8 +1028,9 @@ void VWmmaI3216x16x16Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 16, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc);
 }
 
 } // namespace rdna3_5

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
@@ -5584,18 +5584,7 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
-    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
-    int16_t lo = static_cast<int16_t>(std::clamp(f0, -32768.0f, 32767.0f));
-    int16_t hi = static_cast<int16_t>(std::clamp(f1, -32768.0f, 32767.0f));
-    vdst.write_lane(wf, lane,
-                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
-                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
-  }
+  amdgpu::execute_v_cvt_pk_i16_f32_vop3(*this, wf);
 }
 
 VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
@@ -5620,18 +5609,7 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
-    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
-    uint16_t lo = static_cast<uint16_t>(std::clamp(f0, 0.0f, 65535.0f));
-    uint16_t hi = static_cast<uint16_t>(std::clamp(f1, 0.0f, 65535.0f));
-    vdst.write_lane(wf, lane,
-                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
-                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
-  }
+  amdgpu::execute_v_cvt_pk_u16_f32_vop3(*this, wf);
 }
 
 VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
@@ -5584,7 +5584,18 @@ VCvtPkI16F32Vop3::VCvtPkI16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_i16_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    int16_t lo = static_cast<int16_t>(std::clamp(f0, -32768.0f, 32767.0f));
+    int16_t hi = static_cast<int16_t>(std::clamp(f1, -32768.0f, 32767.0f));
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
 }
 
 VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
@@ -5609,7 +5620,18 @@ VCvtPkU16F32Vop3::VCvtPkU16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_u16_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    uint16_t lo = static_cast<uint16_t>(std::clamp(f0, 0.0f, 65535.0f));
+    uint16_t hi = static_cast<uint16_t>(std::clamp(f1, 0.0f, 65535.0f));
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                        static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
 }
 
 VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3p.cpp
@@ -1746,9 +1746,9 @@ void VWmmaF3216x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, 0u, 0u, 0u);
 }
 
 VWmmaF3216x16x16Bf16Vop3p::VWmmaF3216x16x16Bf16Vop3p(const MachineInst *inst)
@@ -1786,9 +1786,9 @@ void VWmmaF3216x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16, 2>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
 }
 
 VWmmaF1616x16x16F16Vop3p::VWmmaF1616x16x16F16Vop3p(const MachineInst *inst)
@@ -1826,9 +1826,9 @@ void VWmmaF1616x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, 0u, 0u, 0u);
 }
 
 VWmmaBf1616x16x16Bf16Vop3p::VWmmaBf1616x16x16Bf16Vop3p(const MachineInst *inst)
@@ -1866,9 +1866,9 @@ void VWmmaBf1616x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc, 0u, 0u, 0u);
 }
 
 VWmmaI3216x16x16Iu8Vop3p::VWmmaI3216x16x16Iu8Vop3p(const MachineInst *inst)
@@ -1906,8 +1906,9 @@ void VWmmaI3216x16x16Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 16, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc);
 }
 
 VWmmaI3216x16x16Iu4Vop3p::VWmmaI3216x16x16Iu4Vop3p(const MachineInst *inst)
@@ -1945,8 +1946,9 @@ void VWmmaI3216x16x16Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 16, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc);
 }
 
 VWmmaF3216x16x16Fp8Fp8Vop3p::VWmmaF3216x16x16Fp8Fp8Vop3p(const MachineInst *inst)
@@ -1984,9 +1986,9 @@ void VWmmaF3216x16x16Fp8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                   amdgpu::extract_fp8, const_acc);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 16, true, true>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
 }
 
 VWmmaF3216x16x16Fp8Bf8Vop3p::VWmmaF3216x16x16Fp8Bf8Vop3p(const MachineInst *inst)
@@ -2024,9 +2026,9 @@ void VWmmaF3216x16x16Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                   amdgpu::extract_bf8, const_acc);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 16, true, false>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
 }
 
 VWmmaF3216x16x16Bf8Fp8Vop3p::VWmmaF3216x16x16Bf8Fp8Vop3p(const MachineInst *inst)
@@ -2064,9 +2066,9 @@ void VWmmaF3216x16x16Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
-                   amdgpu::extract_fp8, const_acc);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 16, false, true>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
 }
 
 VWmmaF3216x16x16Bf8Bf8Vop3p::VWmmaF3216x16x16Bf8Bf8Vop3p(const MachineInst *inst)
@@ -2104,9 +2106,9 @@ void VWmmaF3216x16x16Bf8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 16, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
-                   amdgpu::extract_bf8, const_acc);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 16, false, false>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
 }
 
 VWmmaI3216x16x32Iu4Vop3p::VWmmaI3216x16x32Iu4Vop3p(const MachineInst *inst)
@@ -2144,8 +2146,9 @@ void VWmmaI3216x16x32Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 32, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 32, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc);
 }
 
 VSwmmacF3216x16x32F16Vop3p::VSwmmacF3216x16x32F16Vop3p(const MachineInst *inst)
@@ -2183,9 +2186,9 @@ void VSwmmacF3216x16x32F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 32, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                                const_acc, 0u, 0u, 0u);
 }
 
 VSwmmacF3216x16x32Bf16Vop3p::VSwmmacF3216x16x32Bf16Vop3p(const MachineInst *inst)
@@ -2223,9 +2226,9 @@ void VSwmmacF3216x16x32Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 32, 2>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
 }
 
 VSwmmacF1616x16x32F16Vop3p::VSwmmacF1616x16x32F16Vop3p(const MachineInst *inst)
@@ -2263,9 +2266,9 @@ void VSwmmacF1616x16x32F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
-                   amdgpu::extract_f16, const_acc);
+  amdgpu::exec_f32_mfma_f16_spec<16, 16, 32>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                             const_acc, 0u, 0u, 0u);
 }
 
 VSwmmacBf1616x16x32Bf16Vop3p::VSwmmacBf1616x16x32Bf16Vop3p(const MachineInst *inst)
@@ -2303,9 +2306,9 @@ void VSwmmacBf1616x16x32Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
-                   amdgpu::extract_bf16, const_acc);
+  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 32>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                              const_acc, 0u, 0u, 0u);
 }
 
 VSwmmacI3216x16x32Iu8Vop3p::VSwmmacI3216x16x32Iu8Vop3p(const MachineInst *inst)
@@ -2343,8 +2346,9 @@ void VSwmmacI3216x16x32Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 32, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 32, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc);
 }
 
 VSwmmacI3216x16x32Iu4Vop3p::VSwmmacI3216x16x32Iu4Vop3p(const MachineInst *inst)
@@ -2382,8 +2386,9 @@ void VSwmmacI3216x16x32Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 32, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 32, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc);
 }
 
 VSwmmacI3216x16x64Iu4Vop3p::VSwmmacI3216x16x64Iu4Vop3p(const MachineInst *inst)
@@ -2421,8 +2426,9 @@ void VSwmmacI3216x16x64Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_i8(cu, 16, 16, 64, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+  amdgpu::exec_i32_mfma_i8_spec<16, 16, 64, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
+                                               const_acc);
 }
 
 VSwmmacF3216x16x32Fp8Fp8Vop3p::VSwmmacF3216x16x32Fp8Fp8Vop3p(const MachineInst *inst)
@@ -2460,9 +2466,9 @@ void VSwmmacF3216x16x32Fp8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                   amdgpu::extract_fp8, const_acc);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, true, true>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
 }
 
 VSwmmacF3216x16x32Fp8Bf8Vop3p::VSwmmacF3216x16x32Fp8Bf8Vop3p(const MachineInst *inst)
@@ -2500,9 +2506,9 @@ void VSwmmacF3216x16x32Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                   amdgpu::extract_bf8, const_acc);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, true, false>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
 }
 
 VSwmmacF3216x16x32Bf8Fp8Vop3p::VSwmmacF3216x16x32Bf8Fp8Vop3p(const MachineInst *inst)
@@ -2540,9 +2546,9 @@ void VSwmmacF3216x16x32Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
-                   amdgpu::extract_fp8, const_acc);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, false, true>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
 }
 
 VSwmmacF3216x16x32Bf8Bf8Vop3p::VSwmmacF3216x16x32Bf8Bf8Vop3p(const MachineInst *inst)
@@ -2580,9 +2586,9 @@ void VSwmmacF3216x16x32Bf8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32(cu, 16, 16, 32, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
-                   amdgpu::extract_bf8, const_acc);
+  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, false, false>(
+      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
+      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
 }
 
 } // namespace rdna4

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -14498,6 +14498,9 @@ inline void execute_v_max_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
 template <typename Inst>
 inline void execute_v_maximum3_f16_vop3([[maybe_unused]] Inst &inst,
                                         [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP16([](auto a, auto b, auto c) {
+    return util::ieee_maximum_simd(util::ieee_maximum_simd(a, b), c);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -14553,6 +14556,9 @@ inline void execute_v_maximum3_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_maximum3_f32_vop3([[maybe_unused]] Inst &inst,
                                         [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP32([](auto a, auto b, auto c) {
+    return util::ieee_maximum_simd(util::ieee_maximum_simd(a, b), c);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -14655,6 +14661,8 @@ inline void execute_v_maximum_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_maximum_f32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_FP(float32_t,
+                                   [](auto a, auto b) { return util::ieee_maximum_simd(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -14702,6 +14710,7 @@ inline void execute_v_maximum_f32_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_maximum_f64_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_FP64([](auto a, auto b) { return util::ieee_maximum_simd(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -14751,6 +14760,9 @@ inline void execute_v_maximum_f64_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_maximumminimum_f16_vop3([[maybe_unused]] Inst &inst,
                                               [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP16([](auto a, auto b, auto c) {
+    return util::ieee_minimum_simd(util::ieee_maximum_simd(a, b), c);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -14806,6 +14818,9 @@ inline void execute_v_maximumminimum_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_maximumminimum_f32_vop3([[maybe_unused]] Inst &inst,
                                               [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP32([](auto a, auto b, auto c) {
+    return util::ieee_minimum_simd(util::ieee_maximum_simd(a, b), c);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -16170,6 +16185,9 @@ inline void execute_v_min_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
 template <typename Inst>
 inline void execute_v_minimum3_f16_vop3([[maybe_unused]] Inst &inst,
                                         [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP16([](auto a, auto b, auto c) {
+    return util::ieee_minimum_simd(util::ieee_minimum_simd(a, b), c);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -16225,6 +16243,9 @@ inline void execute_v_minimum3_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_minimum3_f32_vop3([[maybe_unused]] Inst &inst,
                                         [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP32([](auto a, auto b, auto c) {
+    return util::ieee_minimum_simd(util::ieee_minimum_simd(a, b), c);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -16327,6 +16348,8 @@ inline void execute_v_minimum_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_minimum_f32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_FP(float32_t,
+                                   [](auto a, auto b) { return util::ieee_minimum_simd(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -16374,6 +16397,7 @@ inline void execute_v_minimum_f32_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_minimum_f64_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_FP64([](auto a, auto b) { return util::ieee_minimum_simd(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -16423,6 +16447,9 @@ inline void execute_v_minimum_f64_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_minimummaximum_f16_vop3([[maybe_unused]] Inst &inst,
                                               [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP16([](auto a, auto b, auto c) {
+    return util::ieee_maximum_simd(util::ieee_minimum_simd(a, b), c);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -16478,6 +16505,9 @@ inline void execute_v_minimummaximum_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_minimummaximum_f32_vop3([[maybe_unused]] Inst &inst,
                                               [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP32([](auto a, auto b, auto c) {
+    return util::ieee_maximum_simd(util::ieee_minimum_simd(a, b), c);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -9696,35 +9696,6 @@ inline void execute_v_cvt_off_f32_i4_vop3([[maybe_unused]] Inst &inst,
 }
 
 template <typename Inst>
-inline void execute_v_cvt_pk_i16_f32_vop3([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
-    using I = util::native<int32_t>;
-    using U = util::native<uint32_t>;
-    I lo = util::stdx::static_simd_cast<I>(a);
-    util::stdx::where(lo < I(-32768), lo) = I(-32768);
-    util::stdx::where(lo > I(32767), lo) = I(32767);
-    I hi = util::stdx::static_simd_cast<I>(b);
-    util::stdx::where(hi < I(-32768), hi) = I(-32768);
-    util::stdx::where(hi > I(32767), hi) = I(32767);
-    return ((util::stdx::static_simd_cast<U>(hi) & 0xFFFFu) << 16) |
-           (util::stdx::static_simd_cast<U>(lo) & 0xFFFFu);
-  });
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float f0 = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
-    float f1 = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
-    int16_t lo = static_cast<int16_t>(std::clamp(f0, -32768.0f, 32767.0f));
-    int16_t hi = static_cast<int16_t>(std::clamp(f1, -32768.0f, 32767.0f));
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
-                             static_cast<uint32_t>(static_cast<uint16_t>(lo)));
-  }
-}
-
-template <typename Inst>
 inline void execute_v_cvt_pk_i16_i32_vop3([[maybe_unused]] Inst &inst,
                                           [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
@@ -9894,35 +9865,6 @@ inline void execute_v_cvt_pk_rtz_f16_f32_vop3([[maybe_unused]] Inst &inst,
     uint32_t lo = util::f32_to_f16(s0);
     uint32_t hi = util::f32_to_f16(s1);
     inst.vdst.write_lane(wf, lane, lo | (hi << 16));
-  }
-}
-
-template <typename Inst>
-inline void execute_v_cvt_pk_u16_f32_vop3([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
-    using I = util::native<int32_t>;
-    using U = util::native<uint32_t>;
-    I lo = util::stdx::static_simd_cast<I>(a);
-    util::stdx::where(lo < I(-32768), lo) = I(-32768);
-    util::stdx::where(lo > I(32767), lo) = I(32767);
-    I hi = util::stdx::static_simd_cast<I>(b);
-    util::stdx::where(hi < I(-32768), hi) = I(-32768);
-    util::stdx::where(hi > I(32767), hi) = I(32767);
-    return ((util::stdx::static_simd_cast<U>(hi) & 0xFFFFu) << 16) |
-           (util::stdx::static_simd_cast<U>(lo) & 0xFFFFu);
-  });
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float f0 = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
-    float f1 = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
-    uint16_t lo = static_cast<uint16_t>(std::clamp(f0, 0.0f, 65535.0f));
-    uint16_t hi = static_cast<uint16_t>(std::clamp(f1, 0.0f, 65535.0f));
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
-                             static_cast<uint32_t>(static_cast<uint16_t>(lo)));
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -12596,6 +12596,10 @@ inline void execute_v_frexp_exp_i32_f64_vop1([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_frexp_exp_i32_f64_vop3([[maybe_unused]] Inst &inst,
                                              [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_CVT_VOP3_F64_TO_B32_FP([](auto s) {
+    return util::stdx::static_simd_cast<util::narrow32<float32_t>>(
+        util::stdx::static_simd_cast<util::narrow32<uint32_t>>(util::frexp_exp_f64_simd(s)));
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -17870,6 +17874,7 @@ inline void execute_v_pk_add_f16_vop3p([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_pk_add_f32_vop3p([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3P_PK_BINARY_F32([](auto a, auto b) { return a + b; });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -18052,6 +18057,8 @@ inline void execute_v_pk_fma_f16_vop3p([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_pk_fma_f32_vop3p([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3P_PK_TERNARY_F32(
+      [](auto a, auto b, auto c) { return util::stdx::fma(a, b, c); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -18511,6 +18518,7 @@ inline void execute_v_pk_mul_f16_vop3p([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_pk_mul_f32_vop3p([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3P_PK_BINARY_F32([](auto a, auto b) { return a * b; });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -13896,6 +13896,8 @@ inline void execute_v_max3_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]
 template <typename Inst>
 inline void execute_v_max3_num_f16_vop3([[maybe_unused]] Inst &inst,
                                         [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP16(
+      [](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmax(a, b), c); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -13949,6 +13951,8 @@ inline void execute_v_max3_num_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_max3_num_f32_vop3([[maybe_unused]] Inst &inst,
                                         [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP32(
+      [](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmax(a, b), c); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -14259,6 +14263,10 @@ inline void execute_v_max_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
 template <typename Inst>
 inline void execute_v_max_num_f16_vop2([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP2_BINARY(uint32_t, [](auto a, auto b) {
+    return util::f32_to_f16_simd(
+        util::stdx::fmax(util::f16_to_f32_simd(a), util::f16_to_f32_simd(b)));
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -14274,6 +14282,10 @@ inline void execute_v_max_num_f16_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_max_num_f16_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
+    return util::f32_to_f16_simd(
+        util::stdx::fmax(util::f16_to_f32_simd(a), util::f16_to_f32_simd(b)));
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -14316,6 +14328,7 @@ inline void execute_v_max_num_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_max_num_f32_vop2([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP2_BINARY(float32_t, [](auto a, auto b) { return util::stdx::fmax(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -14330,6 +14343,8 @@ inline void execute_v_max_num_f32_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_max_num_f32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_FP(float32_t,
+                                   [](auto a, auto b) { return util::stdx::fmax(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -14385,6 +14400,7 @@ inline void execute_v_max_num_f64_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_max_num_f64_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_FP64([](auto a, auto b) { return util::stdx::fmax(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -14963,6 +14979,8 @@ inline void execute_v_maxmin_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
 template <typename Inst>
 inline void execute_v_maxmin_num_f16_vop3([[maybe_unused]] Inst &inst,
                                           [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP16(
+      [](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmax(a, b), c); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -15016,6 +15034,8 @@ inline void execute_v_maxmin_num_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_maxmin_num_f32_vop3([[maybe_unused]] Inst &inst,
                                           [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP32(
+      [](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmax(a, b), c); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -15548,6 +15568,8 @@ inline void execute_v_min3_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]
 template <typename Inst>
 inline void execute_v_min3_num_f16_vop3([[maybe_unused]] Inst &inst,
                                         [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP16(
+      [](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmin(a, b), c); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -15601,6 +15623,8 @@ inline void execute_v_min3_num_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_min3_num_f32_vop3([[maybe_unused]] Inst &inst,
                                         [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP32(
+      [](auto a, auto b, auto c) { return util::stdx::fmin(util::stdx::fmin(a, b), c); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -15911,6 +15935,10 @@ inline void execute_v_min_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
 template <typename Inst>
 inline void execute_v_min_num_f16_vop2([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP2_BINARY(uint32_t, [](auto a, auto b) {
+    return util::f32_to_f16_simd(
+        util::stdx::fmin(util::f16_to_f32_simd(a), util::f16_to_f32_simd(b)));
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -15926,6 +15954,10 @@ inline void execute_v_min_num_f16_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_min_num_f16_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
+    return util::f32_to_f16_simd(
+        util::stdx::fmin(util::f16_to_f32_simd(a), util::f16_to_f32_simd(b)));
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -15968,6 +16000,7 @@ inline void execute_v_min_num_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_min_num_f32_vop2([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP2_BINARY(float32_t, [](auto a, auto b) { return util::stdx::fmin(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -15982,6 +16015,8 @@ inline void execute_v_min_num_f32_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_min_num_f32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_FP(float32_t,
+                                   [](auto a, auto b) { return util::stdx::fmin(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -16037,6 +16072,7 @@ inline void execute_v_min_num_f64_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_min_num_f64_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_FP64([](auto a, auto b) { return util::stdx::fmin(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -16615,6 +16651,8 @@ inline void execute_v_minmax_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
 template <typename Inst>
 inline void execute_v_minmax_num_f16_vop3([[maybe_unused]] Inst &inst,
                                           [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP16(
+      [](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmin(a, b), c); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -16668,6 +16706,8 @@ inline void execute_v_minmax_num_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_minmax_num_f32_vop3([[maybe_unused]] Inst &inst,
                                           [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP32(
+      [](auto a, auto b, auto c) { return util::stdx::fmax(util::stdx::fmin(a, b), c); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -2904,6 +2904,7 @@ inline void execute_v_add_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
 
 template <typename Inst>
 inline void execute_v_add_f64_vop2([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP2_BINARY_FP64([](auto a, auto b) { return a + b; });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -14563,6 +14564,7 @@ inline void execute_v_max_num_f32_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_max_num_f64_vop2([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP2_BINARY_FP64([](auto a, auto b) { return util::stdx::fmax(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -16250,6 +16252,7 @@ inline void execute_v_min_num_f32_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_min_num_f64_vop2([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP2_BINARY_FP64([](auto a, auto b) { return util::stdx::fmin(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -17255,6 +17258,7 @@ inline void execute_v_mul_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
 
 template <typename Inst>
 inline void execute_v_mul_f64_vop2([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP2_BINARY_FP64([](auto a, auto b) { return a * b; });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -1632,14 +1632,15 @@ inline void execute_s_flbit_i32_i64_sop1([[maybe_unused]] Inst &inst,
 
 template <typename Inst>
 inline void execute_s_floor_f16_sop1([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  float result = std::floor(util::f16_to_f32(static_cast<uint16_t>(inst.ssrc0.read_scalar(wf))));
+  float result =
+      util::floor_scalar(util::f16_to_f32(static_cast<uint16_t>(inst.ssrc0.read_scalar(wf))));
   inst.sdst.write_scalar(wf, util::f32_to_f16(result));
   wf.write_scc((result != 0));
 }
 
 template <typename Inst>
 inline void execute_s_floor_f32_sop1([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  float result = std::floor(std::bit_cast<float>(inst.ssrc0.read_scalar(wf)));
+  float result = util::floor_scalar(std::bit_cast<float>(inst.ssrc0.read_scalar(wf)));
   inst.sdst.write_scalar(wf, std::bit_cast<uint32_t>(result));
   wf.write_scc((result != 0.0f));
 }
@@ -2510,14 +2511,15 @@ inline void execute_s_trap_sopp([[maybe_unused]] Inst &inst, [[maybe_unused]] Wa
 
 template <typename Inst>
 inline void execute_s_trunc_f16_sop1([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  float result = std::trunc(util::f16_to_f32(static_cast<uint16_t>(inst.ssrc0.read_scalar(wf))));
+  float result =
+      util::trunc_scalar(util::f16_to_f32(static_cast<uint16_t>(inst.ssrc0.read_scalar(wf))));
   inst.sdst.write_scalar(wf, util::f32_to_f16(result));
   wf.write_scc((result != 0));
 }
 
 template <typename Inst>
 inline void execute_s_trunc_f32_sop1([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  float result = std::trunc(std::bit_cast<float>(inst.ssrc0.read_scalar(wf)));
+  float result = util::trunc_scalar(std::bit_cast<float>(inst.ssrc0.read_scalar(wf)));
   inst.sdst.write_scalar(wf, std::bit_cast<uint32_t>(result));
   wf.write_scc((result != 0.0f));
 }
@@ -3525,7 +3527,7 @@ inline void execute_v_ceil_f16_vop1([[maybe_unused]] Inst &inst, [[maybe_unused]
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane,
-                         util::f32_to_f16(std::ceil(util::f16_to_f32(
+                         util::f32_to_f16(util::ceil_scalar(util::f16_to_f32(
                              static_cast<uint16_t>(inst.src0.read_lane(wf, lane))))));
   }
 }
@@ -3539,7 +3541,7 @@ inline void execute_v_ceil_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]
       continue;
     inst.vdst.write_lane(wf, lane, util::f32_to_f16([&]() {
                            float v = [&]() {
-                             float v = std::ceil([&]() {
+                             float v = util::ceil_scalar([&]() {
                                float sv = util::f16_to_f32(
                                    static_cast<uint16_t>(inst.src0.read_lane(wf, lane)));
                                if (inst.inst_.abs & (1u << 0))
@@ -3570,9 +3572,9 @@ inline void execute_v_ceil_f32_vop1([[maybe_unused]] Inst &inst, [[maybe_unused]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(
-        wf, lane,
-        std::bit_cast<uint32_t>(std::ceil(std::bit_cast<float>(inst.src0.read_lane(wf, lane)))));
+    inst.vdst.write_lane(wf, lane,
+                         std::bit_cast<uint32_t>(util::ceil_scalar(
+                             std::bit_cast<float>(inst.src0.read_lane(wf, lane)))));
   }
 }
 
@@ -3585,7 +3587,7 @@ inline void execute_v_ceil_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]
       continue;
     inst.vdst.write_lane(wf, lane, std::bit_cast<uint32_t>([&]() {
                            float v = [&]() {
-                             float v = std::ceil([&]() {
+                             float v = util::ceil_scalar([&]() {
                                float sv = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
                                if (inst.inst_.abs & (1u << 0))
                                  sv = std::fabs(sv);
@@ -3615,9 +3617,9 @@ inline void execute_v_ceil_f64_vop1([[maybe_unused]] Inst &inst, [[maybe_unused]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane64(
-        wf, lane,
-        std::bit_cast<uint64_t>(std::ceil(std::bit_cast<double>(inst.src0.read_lane64(wf, lane)))));
+    inst.vdst.write_lane64(wf, lane,
+                           std::bit_cast<uint64_t>(util::ceil_scalar(
+                               std::bit_cast<double>(inst.src0.read_lane64(wf, lane)))));
   }
 }
 
@@ -3630,7 +3632,7 @@ inline void execute_v_ceil_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]
       continue;
     inst.vdst.write_lane64(wf, lane, std::bit_cast<uint64_t>([&]() {
                              double v = [&]() {
-                               double v = std::ceil([&]() {
+                               double v = util::ceil_scalar([&]() {
                                  double sv = std::bit_cast<double>(inst.src0.read_lane64(wf, lane));
                                  if (inst.inst_.abs & (1u << 0))
                                    sv = std::fabs(sv);
@@ -11390,7 +11392,7 @@ inline void execute_v_floor_f16_vop1([[maybe_unused]] Inst &inst, [[maybe_unused
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane,
-                         util::f32_to_f16(std::floor(util::f16_to_f32(
+                         util::f32_to_f16(util::floor_scalar(util::f16_to_f32(
                              static_cast<uint16_t>(inst.src0.read_lane(wf, lane))))));
   }
 }
@@ -11404,7 +11406,7 @@ inline void execute_v_floor_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     inst.vdst.write_lane(wf, lane, util::f32_to_f16([&]() {
                            float v = [&]() {
-                             float v = std::floor([&]() {
+                             float v = util::floor_scalar([&]() {
                                float sv = util::f16_to_f32(
                                    static_cast<uint16_t>(inst.src0.read_lane(wf, lane)));
                                if (inst.inst_.abs & (1u << 0))
@@ -11435,9 +11437,9 @@ inline void execute_v_floor_f32_vop1([[maybe_unused]] Inst &inst, [[maybe_unused
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(
-        wf, lane,
-        std::bit_cast<uint32_t>(std::floor(std::bit_cast<float>(inst.src0.read_lane(wf, lane)))));
+    inst.vdst.write_lane(wf, lane,
+                         std::bit_cast<uint32_t>(util::floor_scalar(
+                             std::bit_cast<float>(inst.src0.read_lane(wf, lane)))));
   }
 }
 
@@ -11450,7 +11452,7 @@ inline void execute_v_floor_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     inst.vdst.write_lane(wf, lane, std::bit_cast<uint32_t>([&]() {
                            float v = [&]() {
-                             float v = std::floor([&]() {
+                             float v = util::floor_scalar([&]() {
                                float sv = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
                                if (inst.inst_.abs & (1u << 0))
                                  sv = std::fabs(sv);
@@ -11481,8 +11483,8 @@ inline void execute_v_floor_f64_vop1([[maybe_unused]] Inst &inst, [[maybe_unused
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane64(wf, lane,
-                           std::bit_cast<uint64_t>(
-                               std::floor(std::bit_cast<double>(inst.src0.read_lane64(wf, lane)))));
+                           std::bit_cast<uint64_t>(util::floor_scalar(
+                               std::bit_cast<double>(inst.src0.read_lane64(wf, lane)))));
   }
 }
 
@@ -11495,7 +11497,7 @@ inline void execute_v_floor_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     inst.vdst.write_lane64(wf, lane, std::bit_cast<uint64_t>([&]() {
                              double v = [&]() {
-                               double v = std::floor([&]() {
+                               double v = util::floor_scalar([&]() {
                                  double sv = std::bit_cast<double>(inst.src0.read_lane64(wf, lane));
                                  if (inst.inst_.abs & (1u << 0))
                                    sv = std::fabs(sv);
@@ -20247,7 +20249,7 @@ inline void execute_v_trunc_f16_vop1([[maybe_unused]] Inst &inst, [[maybe_unused
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane,
-                         util::f32_to_f16(std::trunc(util::f16_to_f32(
+                         util::f32_to_f16(util::trunc_scalar(util::f16_to_f32(
                              static_cast<uint16_t>(inst.src0.read_lane(wf, lane))))));
   }
 }
@@ -20261,7 +20263,7 @@ inline void execute_v_trunc_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     inst.vdst.write_lane(wf, lane, util::f32_to_f16([&]() {
                            float v = [&]() {
-                             float v = std::trunc([&]() {
+                             float v = util::trunc_scalar([&]() {
                                float sv = util::f16_to_f32(
                                    static_cast<uint16_t>(inst.src0.read_lane(wf, lane)));
                                if (inst.inst_.abs & (1u << 0))
@@ -20292,9 +20294,9 @@ inline void execute_v_trunc_f32_vop1([[maybe_unused]] Inst &inst, [[maybe_unused
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(
-        wf, lane,
-        std::bit_cast<uint32_t>(std::trunc(std::bit_cast<float>(inst.src0.read_lane(wf, lane)))));
+    inst.vdst.write_lane(wf, lane,
+                         std::bit_cast<uint32_t>(util::trunc_scalar(
+                             std::bit_cast<float>(inst.src0.read_lane(wf, lane)))));
   }
 }
 
@@ -20307,7 +20309,7 @@ inline void execute_v_trunc_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     inst.vdst.write_lane(wf, lane, std::bit_cast<uint32_t>([&]() {
                            float v = [&]() {
-                             float v = std::trunc([&]() {
+                             float v = util::trunc_scalar([&]() {
                                float sv = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
                                if (inst.inst_.abs & (1u << 0))
                                  sv = std::fabs(sv);
@@ -20338,8 +20340,8 @@ inline void execute_v_trunc_f64_vop1([[maybe_unused]] Inst &inst, [[maybe_unused
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane64(wf, lane,
-                           std::bit_cast<uint64_t>(
-                               std::trunc(std::bit_cast<double>(inst.src0.read_lane64(wf, lane)))));
+                           std::bit_cast<uint64_t>(util::trunc_scalar(
+                               std::bit_cast<double>(inst.src0.read_lane64(wf, lane)))));
   }
 }
 
@@ -20352,7 +20354,7 @@ inline void execute_v_trunc_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     inst.vdst.write_lane64(wf, lane, std::bit_cast<uint64_t>([&]() {
                              double v = [&]() {
-                               double v = std::trunc([&]() {
+                               double v = util::trunc_scalar([&]() {
                                  double sv = std::bit_cast<double>(inst.src0.read_lane64(wf, lane));
                                  if (inst.inst_.abs & (1u << 0))
                                    sv = std::fabs(sv);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -9683,6 +9683,133 @@ inline void execute_v_cvt_off_f32_i4_vop3([[maybe_unused]] Inst &inst,
 }
 
 template <typename Inst>
+inline void execute_v_cvt_pk_bf8_f32_vop3([[maybe_unused]] Inst &inst,
+                                          [[maybe_unused]] Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
+    float s1 = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
+    uint32_t lo = util::f32_to_bf8_e5m2_rne(s0);
+    uint32_t hi = util::f32_to_bf8_e5m2_rne(s1);
+    inst.vdst.write_lane(wf, lane, lo | (hi << 8));
+  }
+}
+
+template <typename Inst>
+inline void execute_v_cvt_pk_f32_bf8_vop1([[maybe_unused]] Inst &inst,
+                                          [[maybe_unused]] Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t raw = inst.src0.read_lane(wf, lane);
+    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(raw & 0xFFu));
+    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    inst.vdst.write_lane64(wf, lane,
+                           static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
+}
+
+template <typename Inst>
+inline void execute_v_cvt_pk_f32_bf8_vop3([[maybe_unused]] Inst &inst,
+                                          [[maybe_unused]] Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t raw = inst.src0.read_lane(wf, lane);
+    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(raw & 0xFFu));
+    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    inst.vdst.write_lane64(wf, lane,
+                           static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
+}
+
+template <typename Inst>
+inline void execute_v_cvt_pk_f32_fp8_vop1([[maybe_unused]] Inst &inst,
+                                          [[maybe_unused]] Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t raw = inst.src0.read_lane(wf, lane);
+    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(raw & 0xFFu));
+    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    inst.vdst.write_lane64(wf, lane,
+                           static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
+}
+
+template <typename Inst>
+inline void execute_v_cvt_pk_f32_fp8_vop3([[maybe_unused]] Inst &inst,
+                                          [[maybe_unused]] Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t raw = inst.src0.read_lane(wf, lane);
+    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(raw & 0xFFu));
+    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
+    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
+    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
+    inst.vdst.write_lane64(wf, lane,
+                           static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
+  }
+}
+
+template <typename Inst>
+inline void execute_v_cvt_pk_fp8_f32_vop3([[maybe_unused]] Inst &inst,
+                                          [[maybe_unused]] Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
+    float s1 = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
+    uint32_t lo = util::f32_to_fp8_e4m3_rne(s0);
+    uint32_t hi = util::f32_to_fp8_e4m3_rne(s1);
+    inst.vdst.write_lane(wf, lane, lo | (hi << 8));
+  }
+}
+
+template <typename Inst>
+inline void execute_v_cvt_pk_i16_f32_vop3([[maybe_unused]] Inst &inst,
+                                          [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
+    using I = util::native<int32_t>;
+    using U = util::native<uint32_t>;
+    I lo = util::stdx::static_simd_cast<I>(a);
+    util::stdx::where(lo < I(-32768), lo) = I(-32768);
+    util::stdx::where(lo > I(32767), lo) = I(32767);
+    I hi = util::stdx::static_simd_cast<I>(b);
+    util::stdx::where(hi < I(-32768), hi) = I(-32768);
+    util::stdx::where(hi > I(32767), hi) = I(32767);
+    return ((util::stdx::static_simd_cast<U>(hi) & 0xFFFFu) << 16) |
+           (util::stdx::static_simd_cast<U>(lo) & 0xFFFFu);
+  });
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t s0 = inst.src0.read_lane(wf, lane);
+    uint32_t s1 = inst.src1.read_lane(wf, lane);
+    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
+    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    inst.vdst.write_lane(wf, lane,
+                         (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                             static_cast<uint32_t>(static_cast<uint16_t>(lo)));
+  }
+}
+
+template <typename Inst>
 inline void execute_v_cvt_pk_i16_i32_vop3([[maybe_unused]] Inst &inst,
                                           [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
@@ -9798,6 +9925,11 @@ inline void execute_v_cvt_pk_norm_u16_f32_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_cvt_pk_rtz_f16_f32_vop2([[maybe_unused]] Inst &inst,
                                               [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP2_BINARY(uint32_t, [](auto a, auto b) {
+    auto lo = util::f32_to_f16_simd(std::bit_cast<util::native<float>>(a));
+    auto hi = util::f32_to_f16_simd(std::bit_cast<util::native<float>>(b));
+    return lo | (hi << 16);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -9813,6 +9945,11 @@ inline void execute_v_cvt_pk_rtz_f16_f32_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_cvt_pk_rtz_f16_f32_vop3([[maybe_unused]] Inst &inst,
                                               [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
+    auto lo = util::f32_to_f16_simd(std::bit_cast<util::native<float>>(a));
+    auto hi = util::f32_to_f16_simd(std::bit_cast<util::native<float>>(b));
+    return lo | (hi << 16);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -9822,6 +9959,35 @@ inline void execute_v_cvt_pk_rtz_f16_f32_vop3([[maybe_unused]] Inst &inst,
     uint32_t lo = util::f32_to_f16(s0);
     uint32_t hi = util::f32_to_f16(s1);
     inst.vdst.write_lane(wf, lane, lo | (hi << 16));
+  }
+}
+
+template <typename Inst>
+inline void execute_v_cvt_pk_u16_f32_vop3([[maybe_unused]] Inst &inst,
+                                          [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
+    using I = util::native<int32_t>;
+    using U = util::native<uint32_t>;
+    I lo = util::stdx::static_simd_cast<I>(a);
+    util::stdx::where(lo < I(-32768), lo) = I(-32768);
+    util::stdx::where(lo > I(32767), lo) = I(32767);
+    I hi = util::stdx::static_simd_cast<I>(b);
+    util::stdx::where(hi < I(-32768), hi) = I(-32768);
+    util::stdx::where(hi > I(32767), hi) = I(32767);
+    return ((util::stdx::static_simd_cast<U>(hi) & 0xFFFFu) << 16) |
+           (util::stdx::static_simd_cast<U>(lo) & 0xFFFFu);
+  });
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t s0 = inst.src0.read_lane(wf, lane);
+    uint32_t s1 = inst.src1.read_lane(wf, lane);
+    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
+    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    inst.vdst.write_lane(wf, lane,
+                         (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
+                             static_cast<uint32_t>(static_cast<uint16_t>(lo)));
   }
 }
 
@@ -9926,6 +10092,11 @@ inline void execute_v_cvt_pknorm_u16_f32_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_cvt_pkrtz_f16_f32_vop2([[maybe_unused]] Inst &inst,
                                              [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP2_BINARY(uint32_t, [](auto a, auto b) {
+    auto lo = util::f32_to_f16_simd(std::bit_cast<util::native<float>>(a));
+    auto hi = util::f32_to_f16_simd(std::bit_cast<util::native<float>>(b));
+    return lo | (hi << 16);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -9941,6 +10112,11 @@ inline void execute_v_cvt_pkrtz_f16_f32_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_cvt_pkrtz_f16_f32_vop3([[maybe_unused]] Inst &inst,
                                              [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
+    auto lo = util::f32_to_f16_simd(std::bit_cast<util::native<float>>(a));
+    auto hi = util::f32_to_f16_simd(std::bit_cast<util::native<float>>(b));
+    return lo | (hi << 16);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -10610,6 +10786,7 @@ inline void execute_v_div_scale_f64_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_dot2_f32_bf16_vop3p([[maybe_unused]] Inst &inst,
                                           [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3P_DOT_F16();
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -9694,104 +9694,6 @@ inline void execute_v_cvt_off_f32_i4_vop3([[maybe_unused]] Inst &inst,
 }
 
 template <typename Inst>
-inline void execute_v_cvt_pk_bf8_f32_vop3([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float s0 = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
-    float s1 = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
-    uint32_t lo = util::f32_to_bf8_e5m2_rne(s0);
-    uint32_t hi = util::f32_to_bf8_e5m2_rne(s1);
-    inst.vdst.write_lane(wf, lane, lo | (hi << 8));
-  }
-}
-
-template <typename Inst>
-inline void execute_v_cvt_pk_f32_bf8_vop1([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t raw = inst.src0.read_lane(wf, lane);
-    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(raw & 0xFFu));
-    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
-    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
-    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
-    inst.vdst.write_lane64(wf, lane,
-                           static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
-  }
-}
-
-template <typename Inst>
-inline void execute_v_cvt_pk_f32_bf8_vop3([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t raw = inst.src0.read_lane(wf, lane);
-    float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(raw & 0xFFu));
-    float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
-    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
-    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
-    inst.vdst.write_lane64(wf, lane,
-                           static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
-  }
-}
-
-template <typename Inst>
-inline void execute_v_cvt_pk_f32_fp8_vop1([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t raw = inst.src0.read_lane(wf, lane);
-    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(raw & 0xFFu));
-    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
-    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
-    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
-    inst.vdst.write_lane64(wf, lane,
-                           static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
-  }
-}
-
-template <typename Inst>
-inline void execute_v_cvt_pk_f32_fp8_vop3([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t raw = inst.src0.read_lane(wf, lane);
-    float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(raw & 0xFFu));
-    float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((raw >> 8) & 0xFFu));
-    uint32_t lo_bits = std::bit_cast<uint32_t>(lo);
-    uint32_t hi_bits = std::bit_cast<uint32_t>(hi);
-    inst.vdst.write_lane64(wf, lane,
-                           static_cast<uint64_t>(lo_bits) | (static_cast<uint64_t>(hi_bits) << 32));
-  }
-}
-
-template <typename Inst>
-inline void execute_v_cvt_pk_fp8_f32_vop3([[maybe_unused]] Inst &inst,
-                                          [[maybe_unused]] Wavefront &wf) {
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    float s0 = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
-    float s1 = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
-    uint32_t lo = util::f32_to_fp8_e4m3_rne(s0);
-    uint32_t hi = util::f32_to_fp8_e4m3_rne(s1);
-    inst.vdst.write_lane(wf, lane, lo | (hi << 8));
-  }
-}
-
-template <typename Inst>
 inline void execute_v_cvt_pk_i16_f32_vop3([[maybe_unused]] Inst &inst,
                                           [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
@@ -9810,10 +9712,10 @@ inline void execute_v_cvt_pk_i16_f32_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t s0 = inst.src0.read_lane(wf, lane);
-    uint32_t s1 = inst.src1.read_lane(wf, lane);
-    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
-    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    float f0 = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
+    int16_t lo = static_cast<int16_t>(std::clamp(f0, -32768.0f, 32767.0f));
+    int16_t hi = static_cast<int16_t>(std::clamp(f1, -32768.0f, 32767.0f));
     inst.vdst.write_lane(wf, lane,
                          (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
                              static_cast<uint32_t>(static_cast<uint16_t>(lo)));
@@ -10012,10 +9914,10 @@ inline void execute_v_cvt_pk_u16_f32_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t s0 = inst.src0.read_lane(wf, lane);
-    uint32_t s1 = inst.src1.read_lane(wf, lane);
-    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
-    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    float f0 = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
+    uint16_t lo = static_cast<uint16_t>(std::clamp(f0, 0.0f, 65535.0f));
+    uint16_t hi = static_cast<uint16_t>(std::clamp(f1, 0.0f, 65535.0f));
     inst.vdst.write_lane(wf, lane,
                          (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
                              static_cast<uint32_t>(static_cast<uint16_t>(lo)));
@@ -14526,7 +14428,7 @@ inline void execute_v_max_num_f16_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_max_num_f16_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_F16(uint32_t, [](auto a, auto b) {
     return util::f32_to_f16_simd(
         util::stdx::fmax(util::f16_to_f32_simd(a), util::f16_to_f32_simd(b)));
   });
@@ -16214,7 +16116,7 @@ inline void execute_v_min_num_f16_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_min_num_f16_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_F16(uint32_t, [](auto a, auto b) {
     return util::f32_to_f16_simd(
         util::stdx::fmin(util::f16_to_f32_simd(a), util::f16_to_f32_simd(b)));
   });

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -10951,6 +10951,7 @@ inline void execute_v_dot2_u32_u16_vop3p([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_dot2c_f32_f16_vop2([[maybe_unused]] Inst &inst,
                                          [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_DOTC_F16(false);
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -10972,6 +10973,7 @@ inline void execute_v_dot2c_f32_f16_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_dot2c_f32_f16_vop3([[maybe_unused]] Inst &inst,
                                          [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_DOTC_F16(true);
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -10993,6 +10995,7 @@ inline void execute_v_dot2c_f32_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_dot2c_i32_i16_vop2([[maybe_unused]] Inst &inst,
                                          [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_DOTC_INT(16, false);
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -11012,6 +11015,7 @@ inline void execute_v_dot2c_i32_i16_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_dot2c_i32_i16_vop3([[maybe_unused]] Inst &inst,
                                          [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_DOTC_INT(16, true);
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -11054,6 +11058,7 @@ inline void execute_v_dot4_i32_i8_vop3p([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_dot4_i32_iu8_vop3p([[maybe_unused]] Inst &inst,
                                          [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3P_DOT_INT_MIXED(8);
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -11103,6 +11108,7 @@ inline void execute_v_dot4_u32_u8_vop3p([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_dot4c_i32_i8_vop2([[maybe_unused]] Inst &inst,
                                         [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_DOTC_INT(8, false);
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -11122,6 +11128,7 @@ inline void execute_v_dot4c_i32_i8_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_dot4c_i32_i8_vop3([[maybe_unused]] Inst &inst,
                                         [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_DOTC_INT(8, true);
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -11168,6 +11175,7 @@ inline void execute_v_dot8_i32_i4_vop3p([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_dot8_i32_iu4_vop3p([[maybe_unused]] Inst &inst,
                                          [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3P_DOT_INT_MIXED(4);
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -11217,6 +11225,7 @@ inline void execute_v_dot8_u32_u4_vop3p([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_dot8c_i32_i4_vop2([[maybe_unused]] Inst &inst,
                                         [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_DOTC_INT(4, false);
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -11240,6 +11249,7 @@ inline void execute_v_dot8c_i32_i4_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_dot8c_i32_i4_vop3([[maybe_unused]] Inst &inst,
                                         [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_DOTC_INT(4, true);
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -12420,6 +12420,10 @@ inline void execute_v_frexp_exp_i16_f16_vop1([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_frexp_exp_i16_f16_vop3([[maybe_unused]] Inst &inst,
                                              [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_UNARY_FP16([](auto a) {
+    return util::stdx::static_simd_cast<util::native<float>>(
+        util::frexp_exp_f32_simd(std::bit_cast<util::native<uint32_t>>(a)));
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -12478,6 +12482,10 @@ inline void execute_v_frexp_exp_i32_f32_vop1([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_frexp_exp_i32_f32_vop3([[maybe_unused]] Inst &inst,
                                              [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_UNARY_FP(float32_t, float32_t, [](auto a) {
+    return util::stdx::static_simd_cast<util::native<float>>(
+        util::frexp_exp_f32_simd(std::bit_cast<util::native<uint32_t>>(a)));
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -12595,6 +12603,8 @@ inline void execute_v_frexp_mant_f16_vop1([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_frexp_mant_f16_vop3([[maybe_unused]] Inst &inst,
                                           [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_UNARY_FP16(
+      [](auto a) { return util::frexp_mant_f32_simd(std::bit_cast<util::native<uint32_t>>(a)); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -8485,6 +8485,8 @@ inline void execute_v_ctz_i32_b32_vop3([[maybe_unused]] Inst &inst,
 
 template <typename Inst>
 inline void execute_v_cubeid_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP32(
+      [](auto x, auto y, auto z) { return util::cube_id_f32_simd(x, y, z); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -8540,6 +8542,10 @@ inline void execute_v_cubeid_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
 
 template <typename Inst>
 inline void execute_v_cubema_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP32([](auto x, auto y, auto z) {
+    return 2.0f * util::stdx::fmax(util::stdx::abs(x),
+                                   util::stdx::fmax(util::stdx::abs(y), util::stdx::abs(z)));
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -8591,6 +8597,8 @@ inline void execute_v_cubema_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
 
 template <typename Inst>
 inline void execute_v_cubesc_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP32(
+      [](auto x, auto y, auto z) { return util::cube_sc_f32_simd(x, y, z); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -8646,6 +8654,8 @@ inline void execute_v_cubesc_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
 
 template <typename Inst>
 inline void execute_v_cubetc_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP32(
+      [](auto x, auto y, auto z) { return util::cube_tc_f32_simd(x, y, z); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -9852,6 +9852,11 @@ inline void execute_v_cvt_pk_i16_i32_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_cvt_pk_norm_i16_f16_vop3([[maybe_unused]] Inst &inst,
                                                [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
+    auto lo = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(a));
+    auto hi = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(b));
+    return ((hi & 0xFFFFu) << 16) | (lo & 0xFFFFu);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -9873,6 +9878,11 @@ inline void execute_v_cvt_pk_norm_i16_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_cvt_pk_norm_i16_f32_vop3([[maybe_unused]] Inst &inst,
                                                [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
+    auto lo = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(a));
+    auto hi = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(b));
+    return ((hi & 0xFFFFu) << 16) | (lo & 0xFFFFu);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -9894,6 +9904,11 @@ inline void execute_v_cvt_pk_norm_i16_f32_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_cvt_pk_norm_u16_f16_vop3([[maybe_unused]] Inst &inst,
                                                [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
+    auto lo = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(a));
+    auto hi = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(b));
+    return ((hi & 0xFFFFu) << 16) | (lo & 0xFFFFu);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -9915,6 +9930,11 @@ inline void execute_v_cvt_pk_norm_u16_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_cvt_pk_norm_u16_f32_vop3([[maybe_unused]] Inst &inst,
                                                [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
+    auto lo = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(a));
+    auto hi = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(b));
+    return ((hi & 0xFFFFu) << 16) | (lo & 0xFFFFu);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -10061,6 +10081,13 @@ inline void execute_v_cvt_pkaccum_u8_f32_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_cvt_pknorm_i16_f32_vop3([[maybe_unused]] Inst &inst,
                                               [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
+    using U = util::native<uint32_t>;
+    auto lo = util::cvt_pknorm_i16_f32_simd(std::bit_cast<util::native<float>>(a));
+    auto hi = util::cvt_pknorm_i16_f32_simd(std::bit_cast<util::native<float>>(b));
+    return ((util::stdx::static_simd_cast<U>(hi) & 0xFFFFu) << 16) |
+           (util::stdx::static_simd_cast<U>(lo) & 0xFFFFu);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -10082,6 +10109,11 @@ inline void execute_v_cvt_pknorm_i16_f32_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_cvt_pknorm_u16_f32_vop3([[maybe_unused]] Inst &inst,
                                               [[maybe_unused]] Wavefront &wf) {
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
+    auto lo = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(a));
+    auto hi = util::cvt_pknorm_u16_f32_simd(std::bit_cast<util::native<float>>(b));
+    return ((hi & 0xFFFFu) << 16) | (lo & 0xFFFFu);
+  });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -1027,6 +1027,80 @@ inline void exec_wmma_f32_16x16x32_f16(amdgpu::ComputeUnitCore &cu, uint32_t dst
   }
 }
 
+/// Fast path for v_wmma_f32_16x16x32_bf16 / v_wmma_bf16f32_16x16x32_bf16
+/// (gfx1250, wave32). Identical to exec_wmma_f32_16x16x32_f16 except the bulk
+/// input convert is the bf16 zero-extend (no F16C needed). Falls back to the
+/// generic exec_wmma_f32 without AVX-512 / under force-scalar.
+inline void exec_wmma_f32_16x16x32_bf16(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
+                                        uint32_t s1, uint32_t s2,
+                                        uint32_t const_acc = ACC_FROM_VGPR) {
+  constexpr uint32_t M = 16, N = 16, K = 32, in_bits = 16;
+  if constexpr (!util::has_stdx_simd) {
+    exec_wmma_f32(cu, M, N, K, in_bits, dst, s0, s1, s2, amdgpu::extract_bf16, amdgpu::extract_bf16,
+                  const_acc);
+    return;
+  } else {
+    if (util::force_scalar() || util::native<float>::size() != 16) {
+      exec_wmma_f32(cu, M, N, K, in_bits, dst, s0, s1, s2, amdgpu::extract_bf16,
+                    amdgpu::extract_bf16, const_acc);
+      return;
+    }
+    require_wmma_wave32(cu);
+    const uint32_t wf = cu.wf_size();
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    alignas(64) float A_buf[M * K]; // A[row][k]
+    alignas(64) float B_buf[K * N]; // B[k][col]
+    alignas(64) float C_buf[M * N]; // C[row][col]
+    // A and B each occupy 8 VGPRs x wf lanes = 2*8*wf packed bf16 (16 bf16/lane
+    // for K=32). Bulk-convert the region to f32 once, then the hoist is a pure
+    // f32 index-shuffle (bf16 j of word w sub s -> flat (w*wf+lane)*2+s).
+    constexpr uint32_t NUM_IN_REGS = 8;
+    const uint32_t n_halves = 2 * NUM_IN_REGS * wf;
+    alignas(64) float A_f32[2 * NUM_IN_REGS * 64];
+    alignas(64) float B_f32[2 * NUM_IN_REGS * 64];
+    util::bf16_to_f32_block(reinterpret_cast<const uint16_t *>(a_words), A_f32, n_halves);
+    util::bf16_to_f32_block(reinterpret_cast<const uint16_t *>(b_words), B_f32, n_halves);
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_32(M, N, row, col);
+        C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
+                                   ? std::bit_cast<float>(const_acc)
+                                   : std::bit_cast<float>(c_words[out.reg * wf + out.lane]);
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t k = 0; k < K; ++k) {
+        auto al = wmma_input_loc(M, K, row, k, in_bits);
+        A_buf[row * K + k] = A_f32[(al.vgpr_offset * wf + al.lane) * 2 + al.sub_element];
+      }
+    for (uint32_t k = 0; k < K; ++k)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto bl = wmma_input_loc(N, K, col, k, in_bits);
+        B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 2 + bl.sub_element];
+      }
+    // Dense 16x32 * 32x16 -> 16x16 matmul, 16-lane stdx FMA per row.
+    for (uint32_t row = 0; row < M; ++row) {
+      util::native<float> c_row;
+      c_row.copy_from(&C_buf[row * N], util::stdx::vector_aligned);
+      for (uint32_t k = 0; k < K; ++k) {
+        util::native<float> a_bcast(A_buf[row * K + k]);
+        util::native<float> b_row;
+        b_row.copy_from(&B_buf[k * N], util::stdx::vector_aligned);
+        c_row = util::stdx::fma(a_bcast, b_row, c_row);
+      }
+      c_row.copy_to(&C_buf[row * N], util::stdx::vector_aligned);
+    }
+    // Scatter directly back to VGPRs (no Result staging vector).
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_32(M, N, row, col);
+        d_words[out.reg * wf + out.lane] = std::bit_cast<uint32_t>(C_buf[row * N + col]);
+      }
+  }
+}
+
 /// Fast path for the f32-input WMMA shapes (v_wmma_f32_*_f32). f32 inputs, so no
 /// F16C convert — the hoist reads each operand word straight through vgpr_data.
 /// Compile-time M/N/K fully unroll the matmul, looped over N in zmm-width chunks
@@ -1523,6 +1597,101 @@ void exec_wmma_bf16(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_
         return util::bf16_to_f32(static_cast<uint16_t>((raw >> (sub * 16)) & 0xFFFF));
       },
       [](float val) { return util::f32_to_bf16(val); }, const_acc);
+}
+
+/// Fast path for the bf16-output WMMA shapes (v_wmma_bf16_*_bf16). Like the
+/// f16-out specialization but with the bf16 bulk input convert (zero-extend)
+/// and bf16 truncation on output. Falls back to generic exec_wmma_bf16 without
+/// AVX-512 / under force-scalar.
+template <uint32_t M, uint32_t N, uint32_t K>
+inline void exec_wmma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                                uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
+  constexpr uint32_t in_bits = 16;
+  static_assert(N % 16 == 0, "specialized bf16 WMMA assumes N is a multiple of the zmm width");
+  auto fallback = [&]() {
+    exec_wmma_bf16(cu, M, N, K, in_bits, dst, s0, s1, s2, amdgpu::extract_bf16,
+                   amdgpu::extract_bf16, const_acc);
+  };
+  if constexpr (!util::has_stdx_simd) {
+    fallback();
+    return;
+  } else {
+    if (util::force_scalar() || util::native<float>::size() != 16) {
+      fallback();
+      return;
+    }
+    require_wmma_wave32(cu);
+    constexpr uint32_t W = 16;
+    const uint32_t wf = cu.wf_size();
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    alignas(64) float A_buf[M * K];
+    alignas(64) float B_buf[K * N];
+    alignas(64) float C_buf[M * N];
+    alignas(64) float A_f32[M * K];
+    alignas(64) float B_f32[N * K];
+    util::bf16_to_f32_block(reinterpret_cast<const uint16_t *>(a_words), A_f32, M * K);
+    util::bf16_to_f32_block(reinterpret_cast<const uint16_t *>(b_words), B_f32, N * K);
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_16(M, N, row, col);
+        uint32_t raw = c_words[out.reg * wf + out.lane];
+        C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
+                                   ? std::bit_cast<float>(const_acc)
+                                   : util::bf16_to_f32(static_cast<uint16_t>(
+                                         (raw >> (out.sub_element * 16)) & 0xFFFF));
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t k = 0; k < K; ++k) {
+        auto al = wmma_input_loc(M, K, row, k, in_bits);
+        A_buf[row * K + k] = A_f32[(al.vgpr_offset * wf + al.lane) * 2 + al.sub_element];
+      }
+    for (uint32_t k = 0; k < K; ++k)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto bl = wmma_input_loc(N, K, col, k, in_bits);
+        B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 2 + bl.sub_element];
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t c0 = 0; c0 < N; c0 += W) {
+        util::native<float> c_row;
+        c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
+        for (uint32_t k = 0; k < K; ++k) {
+          util::native<float> a_bcast(A_buf[row * K + k]);
+          util::native<float> b_row;
+          b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
+          c_row = util::stdx::fma(a_bcast, b_row, c_row);
+        }
+        c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
+      }
+    // Pack f32 results to bf16 (truncation), two per dst word.
+    constexpr uint32_t DST_REGS = ((M * N) / WMMA_WAVE32 + 1) / 2;
+    alignas(64) uint32_t words[DST_REGS * WMMA_WAVE32] = {};
+    alignas(64) uint8_t masks[DST_REGS * WMMA_WAVE32] = {};
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_16(M, N, row, col);
+        uint32_t idx = out.reg * WMMA_WAVE32 + out.lane;
+        uint32_t shift = out.sub_element * 16;
+        uint16_t v = util::f32_to_bf16(C_buf[row * N + col]);
+        words[idx] = (words[idx] & ~(0xFFFFu << shift)) | (static_cast<uint32_t>(v) << shift);
+        masks[idx] |= 1u << out.sub_element;
+      }
+    for (uint32_t reg = 0; reg < DST_REGS; ++reg)
+      for (uint32_t lane = 0; lane < WMMA_WAVE32; ++lane) {
+        uint32_t idx = reg * WMMA_WAVE32 + lane;
+        uint32_t word = words[idx];
+        if (masks[idx] != 0x3u) {
+          uint32_t old = d_words[reg * wf + lane];
+          if ((masks[idx] & 0x1u) == 0)
+            word = (word & 0xFFFF0000u) | (old & 0x0000FFFFu);
+          if ((masks[idx] & 0x2u) == 0)
+            word = (word & 0x0000FFFFu) | (old & 0xFFFF0000u);
+        }
+        d_words[reg * wf + lane] = word;
+      }
+  }
 }
 
 template <typename ExtractA, typename ExtractB>
@@ -2662,6 +2831,90 @@ inline void exec_f32_mfma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, ui
       util::Logger::vm([&](auto &os) {
         os << std::format("MFMA_NAN_DETECTED (simd) dst=v{} s0=v{} s1=v{} s2=v{} {}x{}x{}_f16", dst,
                           s0, s1, s2, M, N, K);
+      });
+    }
+  }
+}
+
+/// Fast path for the bf16-input MFMA shapes (v_mfma_f32_*_bf16). Identical to
+/// the f16 specialization except the bulk input convert is the bf16 zero-extend
+/// (no F16C needed). Falls back to the generic exec_f32 without AVX-512 / under
+/// force-scalar / with cbsz|blgp.
+template <uint32_t M, uint32_t N, uint32_t K>
+inline void exec_f32_mfma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
+                                    uint32_t s1, uint32_t s2, uint32_t const_acc, uint32_t cbsz,
+                                    uint32_t abid, uint32_t blgp) {
+  constexpr uint32_t B = 1, in_bits = 16;
+  static_assert(N % 16 == 0, "specialized bf16 MFMA assumes N is a multiple of the zmm width");
+  if constexpr (!util::has_stdx_simd) {
+    exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_bf16, amdgpu::extract_bf16,
+             const_acc, cbsz, abid, blgp);
+    return;
+  } else {
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16) {
+      exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_bf16, amdgpu::extract_bf16,
+               const_acc, cbsz, abid, blgp);
+      return;
+    }
+    constexpr uint32_t W = 16; // guaranteed by the native<float>::size()==16 guard above
+    const uint32_t wf = cu.wf_size();
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    alignas(64) float A_buf[M * K]; // A[row][k]
+    alignas(64) float B_buf[K * N]; // B[k][col]
+    alignas(64) float C_buf[M * N]; // C[row][col]
+    // Bulk-convert the packed bf16 regions to f32 once (zero-extend + shift),
+    // then the hoist is a pure f32 index-shuffle.
+    alignas(64) float A_f32[M * K];
+    alignas(64) float B_f32[N * K];
+    util::bf16_to_f32_block(reinterpret_cast<const uint16_t *>(a_words), A_f32, M * K);
+    util::bf16_to_f32_block(reinterpret_cast<const uint16_t *>(b_words), B_f32, N * K);
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = output_loc_32(M, N, row, col, 0);
+        C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
+                                   ? std::bit_cast<float>(const_acc)
+                                   : std::bit_cast<float>(c_words[out.reg * wf + out.lane]);
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t k = 0; k < K; ++k) {
+        auto al = input_loc(M, K, B, row, k, 0, in_bits);
+        A_buf[row * K + k] = A_f32[(al.vgpr_offset * wf + al.lane) * 2 + al.sub_element];
+      }
+    for (uint32_t k = 0; k < K; ++k)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto bl = input_loc(N, K, B, col, k, 0, in_bits);
+        B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 2 + bl.sub_element];
+      }
+    // Dense MxKxN matmul, W-lane (zmm) stdx FMA over N (N/W chunks per row).
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t c0 = 0; c0 < N; c0 += W) {
+        util::native<float> c_row;
+        c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
+        for (uint32_t k = 0; k < K; ++k) {
+          util::native<float> a_bcast(A_buf[row * K + k]);
+          util::native<float> b_row;
+          b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
+          c_row = util::stdx::fma(a_bcast, b_row, c_row);
+        }
+        c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
+      }
+    // Scatter directly back to VGPRs (no Result staging vector).
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    bool has_nan_or_inf = false;
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = output_loc_32(M, N, row, col, 0);
+        float fv = C_buf[row * N + col];
+        d_words[out.reg * wf + out.lane] = std::bit_cast<uint32_t>(fv);
+        if (std::isnan(fv) || std::isinf(fv))
+          has_nan_or_inf = true;
+      }
+    if (has_nan_or_inf) {
+      util::Logger::vm([&](auto &os) {
+        os << std::format("MFMA_NAN_DETECTED (simd) dst=v{} s0=v{} s1=v{} s2=v{} {}x{}x{}_bf16",
+                          dst, s0, s1, s2, M, N, K);
       });
     }
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -567,6 +567,20 @@ template <typename Run> bool dispatch_matrix_fmt_pair(uint32_t a_fmt, uint32_t b
 /// integer MAC is exact, so the SIMD and scalar paths are bit-identical.
 /// Templated so the `if constexpr (has_stdx_simd)` callers never instantiate it
 /// on a platform without <experimental/simd>.
+///
+/// Cbuf is the in/out accumulator: each (row,col) is read as the starting value,
+/// the K products are added, and the result written back. Callers come in two
+/// flavors — most pre-seed Cbuf with the hardware C accumulator (D = C + A*B in
+/// place), while the int32 WMMA paths instead leave Cbuf ZERO and add the
+/// hardware accumulator afterward in wider precision (for saturation). That is
+/// why the staging buffers are zero-initialized as a uniform convention: it is
+/// load-bearing for the zero-start callers and harmless (redundant) for the
+/// pre-seeded ones.
+///
+/// Read-bounds: only the used region is touched — Abuf[row*K+k] for row<M,k<K,
+/// and Bbuf/Cbuf[..*stride+col] for col<N (the vectorized loop is bounded by
+/// `col + W <= N`, the remainder is a scalar tail at col<N). The padding columns
+/// [N, stride) — present only so each row starts W-aligned — are never read.
 template <typename T>
 void wmma_simd_matmul(uint32_t M, uint32_t N, uint32_t K, uint32_t W, uint32_t stride,
                       const T *Abuf, const T *Bbuf, T *Cbuf) {
@@ -668,14 +682,21 @@ void exec_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_
     constexpr size_t MAX_AB = 2048;      // max M*K over all MFMA shapes
     constexpr size_t MAX_BSTRIDE = 4096; // max K*stride
     constexpr size_t MAX_C = 1024;       // max M*stride
+    // Combined stack frame for the three staging buffers below (currently 28
+    // KiB); tripwire so an added/larger shape can't silently blow the stack.
+    static_assert((MAX_AB + MAX_BSTRIDE + MAX_C) * sizeof(float) <= 48 * 1024,
+                  "MFMA SIMD staging buffers exceed the 48 KiB stack budget");
     const uint32_t stride = ((N + W - 1) / W) * W;
     if (util::force_scalar() || static_cast<size_t>(M) * K > MAX_AB ||
         static_cast<size_t>(K) * stride > MAX_BSTRIDE || static_cast<size_t>(M) * stride > MAX_C) {
       run_scalar();
     } else {
-      alignas(64) float Abuf[MAX_AB];
-      alignas(64) float Bbuf[MAX_BSTRIDE];
-      alignas(64) float Cbuf[MAX_C];
+      // Zero-initialized as the uniform staging-buffer convention (see the
+      // zero-init policy on wmma_simd_matmul). C is pre-seeded just below, so the
+      // init is redundant here, but matching the WMMA paths keeps one rule.
+      alignas(64) float Abuf[MAX_AB] = {};
+      alignas(64) float Bbuf[MAX_BSTRIDE] = {};
+      alignas(64) float Cbuf[MAX_C] = {};
       for (uint32_t b = 0; b < B; ++b) {
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t col = 0; col < N; ++col) {
@@ -768,6 +789,11 @@ void exec_f32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K, u
 constexpr size_t WMMA_SIMD_MAX_AB = 2048;      // max M*K
 constexpr size_t WMMA_SIMD_MAX_BSTRIDE = 4096; // max K*stride
 constexpr size_t WMMA_SIMD_MAX_C = 1024;       // max M*stride
+// Combined stack frame for the WMMA/SWMMAC staging buffers (currently 28 KiB for
+// the float and int32 paths); tripwire against silent stack-frame growth.
+static_assert((WMMA_SIMD_MAX_AB + WMMA_SIMD_MAX_BSTRIDE + WMMA_SIMD_MAX_C) * sizeof(float) <=
+                  48 * 1024,
+              "WMMA SIMD staging buffers exceed the 48 KiB stack budget");
 
 template <typename ExtractA, typename ExtractB>
 void exec_wmma_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K,
@@ -1968,14 +1994,18 @@ void exec_f32_scaled(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32
     constexpr size_t MAX_AB = 2048;
     constexpr size_t MAX_BSTRIDE = 4096;
     constexpr size_t MAX_C = 1024;
+    static_assert((MAX_AB + MAX_BSTRIDE + MAX_C) * sizeof(float) <= 48 * 1024,
+                  "MFMA SIMD staging buffers exceed the 48 KiB stack budget");
     const uint32_t stride = ((N + W - 1) / W) * W;
     if (util::force_scalar() || static_cast<size_t>(M) * K > MAX_AB ||
         static_cast<size_t>(K) * stride > MAX_BSTRIDE || static_cast<size_t>(M) * N > MAX_C) {
       run_scalar();
     } else {
-      alignas(64) float Abuf[MAX_AB];
-      alignas(64) float Bbuf[MAX_BSTRIDE];
-      alignas(64) float Cacc[MAX_C];
+      // Zero-initialized staging buffers (uniform convention; see
+      // wmma_simd_matmul). Cacc is pre-seeded below.
+      alignas(64) float Abuf[MAX_AB] = {};
+      alignas(64) float Bbuf[MAX_BSTRIDE] = {};
+      alignas(64) float Cacc[MAX_C] = {};
       for (uint32_t b = 0; b < B; ++b) {
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t k = 0; k < K; ++k) {
@@ -2128,14 +2158,18 @@ inline void exec_i32_i8(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uin
     constexpr size_t MAX_AB = 2048;
     constexpr size_t MAX_BSTRIDE = 4096;
     constexpr size_t MAX_C = 1024;
+    static_assert((MAX_AB + MAX_BSTRIDE + MAX_C) * sizeof(int32_t) <= 48 * 1024,
+                  "MFMA SIMD staging buffers exceed the 48 KiB stack budget");
     const uint32_t stride = ((N + W - 1) / W) * W;
     if (util::force_scalar() || static_cast<size_t>(M) * K > MAX_AB ||
         static_cast<size_t>(K) * stride > MAX_BSTRIDE || static_cast<size_t>(M) * stride > MAX_C) {
       run_scalar();
     } else {
-      alignas(64) int32_t Abuf[MAX_AB];
-      alignas(64) int32_t Bbuf[MAX_BSTRIDE];
-      alignas(64) int32_t Cbuf[MAX_C];
+      // Zero-initialized staging buffers (uniform convention; see
+      // wmma_simd_matmul). Cbuf is pre-seeded below.
+      alignas(64) int32_t Abuf[MAX_AB] = {};
+      alignas(64) int32_t Bbuf[MAX_BSTRIDE] = {};
+      alignas(64) int32_t Cbuf[MAX_C] = {};
       for (uint32_t b = 0; b < B; ++b) {
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t col = 0; col < N; ++col) {
@@ -2506,14 +2540,18 @@ inline void exec_f64(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32
     constexpr size_t MAX_AB = 2048;
     constexpr size_t MAX_BSTRIDE = 2048;
     constexpr size_t MAX_C = 1024;
+    static_assert((MAX_AB + MAX_BSTRIDE + MAX_C) * sizeof(double) <= 48 * 1024,
+                  "MFMA SIMD staging buffers exceed the 48 KiB stack budget");
     const uint32_t stride = ((N + W - 1) / W) * W;
     if (util::force_scalar() || static_cast<size_t>(M) * K > MAX_AB ||
         static_cast<size_t>(K) * stride > MAX_BSTRIDE || static_cast<size_t>(M) * stride > MAX_C) {
       run_scalar();
     } else {
-      alignas(64) double Abuf[MAX_AB];
-      alignas(64) double Bbuf[MAX_BSTRIDE];
-      alignas(64) double Cbuf[MAX_C];
+      // Zero-initialized staging buffers (uniform convention; see
+      // wmma_simd_matmul). Cbuf is pre-seeded below.
+      alignas(64) double Abuf[MAX_AB] = {};
+      alignas(64) double Bbuf[MAX_BSTRIDE] = {};
+      alignas(64) double Cbuf[MAX_C] = {};
       for (uint32_t b = 0; b < B; ++b) {
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t col = 0; col < N; ++col) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -1101,6 +1101,95 @@ inline void exec_wmma_f32_16x16x32_bf16(amdgpu::ComputeUnitCore &cu, uint32_t ds
   }
 }
 
+/// Compile-time fp8 (e4m3) vs bf8 (e5m2) bulk-convert selector for the f8 spec
+/// kernels: converts `n` packed bytes starting at `words` to f32 through the
+/// 256-entry LUTs (bit-exact with extract_fp8/extract_bf8 by construction).
+template <bool FP8> inline void f8_to_f32_block(const uint32_t *words, float *dst, size_t n) {
+  if constexpr (FP8)
+    util::fp8_e4m3_to_f32_block(reinterpret_cast<const uint8_t *>(words), dst, n);
+  else
+    util::bf8_e5m2_to_f32_block(reinterpret_cast<const uint8_t *>(words), dst, n);
+}
+
+/// Fast path for the dense f32-out fp8/bf8-input WMMA shapes
+/// (v_wmma_f32_16x16x{64,128}_{fp8,bf8}_{fp8,bf8}, gfx1250, wave32). Identical
+/// to the f16/bf16 specializations except the bulk input convert is the f8 LUT
+/// gather; A/B formats are compile-time selected. Sparse SWMMAC stays generic.
+/// Falls back to the generic exec_wmma_f32_mixed without AVX-512 / under
+/// force-scalar.
+template <uint32_t M, uint32_t N, uint32_t K, bool A_FP8, bool B_FP8>
+inline void exec_wmma_f32_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
+                                  uint32_t s1, uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
+  constexpr uint32_t in_bits = 8;
+  static_assert(N % 16 == 0, "specialized f8 WMMA assumes N is a multiple of the zmm width");
+  constexpr auto ea = A_FP8 ? &extract_fp8 : &extract_bf8;
+  constexpr auto eb = B_FP8 ? &extract_fp8 : &extract_bf8;
+  auto fallback = [&]() {
+    exec_wmma_f32_mixed(cu, M, N, K, in_bits, in_bits, dst, s0, s1, s2, ea, eb, const_acc);
+  };
+  if constexpr (!util::has_stdx_simd) {
+    fallback();
+    return;
+  } else {
+    if (util::force_scalar() || util::native<float>::size() != 16) {
+      fallback();
+      return;
+    }
+    require_wmma_wave32(cu);
+    constexpr uint32_t W = 16;
+    const uint32_t wf = cu.wf_size();
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    alignas(64) float A_buf[M * K]; // A[row][k]
+    alignas(64) float B_buf[K * N]; // B[k][col]
+    alignas(64) float C_buf[M * N]; // C[row][col]
+    // Bulk-convert each whole packed f8 region to f32 once, then the hoist is a
+    // pure f32 index-shuffle (byte of word w lane l sub s -> (w*wf+l)*4+s).
+    alignas(64) float A_f32[M * K];
+    alignas(64) float B_f32[N * K];
+    f8_to_f32_block<A_FP8>(a_words, A_f32, M * K);
+    f8_to_f32_block<B_FP8>(b_words, B_f32, N * K);
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_32(M, N, row, col);
+        C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
+                                   ? std::bit_cast<float>(const_acc)
+                                   : std::bit_cast<float>(c_words[out.reg * wf + out.lane]);
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t k = 0; k < K; ++k) {
+        auto al = wmma_input_loc(M, K, row, k, in_bits);
+        A_buf[row * K + k] = A_f32[(al.vgpr_offset * wf + al.lane) * 4 + al.sub_element];
+      }
+    for (uint32_t k = 0; k < K; ++k)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto bl = wmma_input_loc(N, K, col, k, in_bits);
+        B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 4 + bl.sub_element];
+      }
+    // Dense MxKxN matmul, W-lane (zmm) stdx FMA over N (N/W chunks per row).
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t c0 = 0; c0 < N; c0 += W) {
+        util::native<float> c_row;
+        c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
+        for (uint32_t k = 0; k < K; ++k) {
+          util::native<float> a_bcast(A_buf[row * K + k]);
+          util::native<float> b_row;
+          b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
+          c_row = util::stdx::fma(a_bcast, b_row, c_row);
+        }
+        c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
+      }
+    // Scatter directly back to VGPRs (no Result staging vector).
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_32(M, N, row, col);
+        d_words[out.reg * wf + out.lane] = std::bit_cast<uint32_t>(C_buf[row * N + col]);
+      }
+  }
+}
+
 /// Fast path for the f32-input WMMA shapes (v_wmma_f32_*_f32). f32 inputs, so no
 /// F16C convert — the hoist reads each operand word straight through vgpr_data.
 /// Compile-time M/N/K fully unroll the matmul, looped over N in zmm-width chunks
@@ -1675,6 +1764,104 @@ inline void exec_wmma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint3
         uint32_t idx = out.reg * WMMA_WAVE32 + out.lane;
         uint32_t shift = out.sub_element * 16;
         uint16_t v = util::f32_to_bf16(C_buf[row * N + col]);
+        words[idx] = (words[idx] & ~(0xFFFFu << shift)) | (static_cast<uint32_t>(v) << shift);
+        masks[idx] |= 1u << out.sub_element;
+      }
+    for (uint32_t reg = 0; reg < DST_REGS; ++reg)
+      for (uint32_t lane = 0; lane < WMMA_WAVE32; ++lane) {
+        uint32_t idx = reg * WMMA_WAVE32 + lane;
+        uint32_t word = words[idx];
+        if (masks[idx] != 0x3u) {
+          uint32_t old = d_words[reg * wf + lane];
+          if ((masks[idx] & 0x1u) == 0)
+            word = (word & 0xFFFF0000u) | (old & 0x0000FFFFu);
+          if ((masks[idx] & 0x2u) == 0)
+            word = (word & 0x0000FFFFu) | (old & 0xFFFF0000u);
+        }
+        d_words[reg * wf + lane] = word;
+      }
+  }
+}
+
+/// Fast path for the dense f16-out fp8/bf8-input WMMA shapes
+/// (v_wmma_f16_16x16x{64,128}_{fp8,bf8}_{fp8,bf8}). Like the f16-out f16
+/// specialization for the matmul + packed 16-bit output map, but the bulk
+/// input convert is the f8 LUT gather; A/B formats are compile-time selected.
+/// Falls back to the generic exec_wmma_f16 without AVX-512 / under
+/// force-scalar.
+template <uint32_t M, uint32_t N, uint32_t K, bool A_FP8, bool B_FP8>
+inline void exec_wmma_f16_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
+                                  uint32_t s1, uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
+  constexpr uint32_t in_bits = 8;
+  static_assert(N % 16 == 0, "specialized f8 WMMA assumes N is a multiple of the zmm width");
+  constexpr auto ea = A_FP8 ? &extract_fp8 : &extract_bf8;
+  constexpr auto eb = B_FP8 ? &extract_fp8 : &extract_bf8;
+  auto fallback = [&]() {
+    exec_wmma_f16(cu, M, N, K, in_bits, dst, s0, s1, s2, ea, eb, const_acc);
+  };
+  if constexpr (!util::has_stdx_simd) {
+    fallback();
+    return;
+  } else {
+    if (util::force_scalar() || util::native<float>::size() != 16) {
+      fallback();
+      return;
+    }
+    require_wmma_wave32(cu);
+    constexpr uint32_t W = 16;
+    const uint32_t wf = cu.wf_size();
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    alignas(64) float A_buf[M * K];
+    alignas(64) float B_buf[K * N];
+    alignas(64) float C_buf[M * N];
+    alignas(64) float A_f32[M * K];
+    alignas(64) float B_f32[N * K];
+    f8_to_f32_block<A_FP8>(a_words, A_f32, M * K);
+    f8_to_f32_block<B_FP8>(b_words, B_f32, N * K);
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_16(M, N, row, col);
+        uint32_t raw = c_words[out.reg * wf + out.lane];
+        C_buf[row * N + col] =
+            (const_acc != ACC_FROM_VGPR)
+                ? std::bit_cast<float>(const_acc)
+                : util::f16_to_f32(static_cast<uint16_t>((raw >> (out.sub_element * 16)) & 0xFFFF));
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t k = 0; k < K; ++k) {
+        auto al = wmma_input_loc(M, K, row, k, in_bits);
+        A_buf[row * K + k] = A_f32[(al.vgpr_offset * wf + al.lane) * 4 + al.sub_element];
+      }
+    for (uint32_t k = 0; k < K; ++k)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto bl = wmma_input_loc(N, K, col, k, in_bits);
+        B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 4 + bl.sub_element];
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t c0 = 0; c0 < N; c0 += W) {
+        util::native<float> c_row;
+        c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
+        for (uint32_t k = 0; k < K; ++k) {
+          util::native<float> a_bcast(A_buf[row * K + k]);
+          util::native<float> b_row;
+          b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
+          c_row = util::stdx::fma(a_bcast, b_row, c_row);
+        }
+        c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
+      }
+    // Pack f32 results to f16, two per dst word (the WMMA 16-bit output map).
+    constexpr uint32_t DST_REGS = ((M * N) / WMMA_WAVE32 + 1) / 2;
+    alignas(64) uint32_t words[DST_REGS * WMMA_WAVE32] = {};
+    alignas(64) uint8_t masks[DST_REGS * WMMA_WAVE32] = {};
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_16(M, N, row, col);
+        uint32_t idx = out.reg * WMMA_WAVE32 + out.lane;
+        uint32_t shift = out.sub_element * 16;
+        uint16_t v = util::f32_to_f16(C_buf[row * N + col]);
         words[idx] = (words[idx] & ~(0xFFFFu << shift)) | (static_cast<uint32_t>(v) << shift);
         masks[idx] |= 1u << out.sub_element;
       }
@@ -2999,6 +3186,93 @@ inline void exec_f32_mfma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, u
       util::Logger::vm([&](auto &os) {
         os << std::format("MFMA_NAN_DETECTED (simd) dst=v{} s0=v{} s1=v{} s2=v{} {}x{}x{}_bf16",
                           dst, s0, s1, s2, M, N, K);
+      });
+    }
+  }
+}
+
+/// Fast path for the dense (B=1) fp8/bf8-input MFMA shapes
+/// (v_mfma_f32_{16x16x32,32x32x16}_{fp8,bf8}_{fp8,bf8}). Identical to the
+/// f16/bf16 specializations except the bulk input convert is the f8 LUT gather
+/// (bit-exact with extract_fp8/extract_bf8 by construction); A/B formats are
+/// compile-time selected. Falls back to the generic exec_f32 without AVX-512 /
+/// under force-scalar / with cbsz|blgp.
+template <uint32_t M, uint32_t N, uint32_t K, bool A_FP8, bool B_FP8>
+inline void exec_f32_mfma_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
+                                  uint32_t s1, uint32_t s2, uint32_t const_acc, uint32_t cbsz,
+                                  uint32_t abid, uint32_t blgp) {
+  constexpr uint32_t B = 1, in_bits = 8;
+  static_assert(N % 16 == 0, "specialized f8 MFMA assumes N is a multiple of the zmm width");
+  constexpr auto ea = A_FP8 ? &extract_fp8 : &extract_bf8;
+  constexpr auto eb = B_FP8 ? &extract_fp8 : &extract_bf8;
+  if constexpr (!util::has_stdx_simd) {
+    exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, ea, eb, const_acc, cbsz, abid, blgp);
+    return;
+  } else {
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16) {
+      exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, ea, eb, const_acc, cbsz, abid, blgp);
+      return;
+    }
+    constexpr uint32_t W = 16; // guaranteed by the native<float>::size()==16 guard above
+    const uint32_t wf = cu.wf_size();
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    alignas(64) float A_buf[M * K]; // A[row][k]
+    alignas(64) float B_buf[K * N]; // B[k][col]
+    alignas(64) float C_buf[M * N]; // C[row][col]
+    // Bulk-convert the packed f8 regions to f32 once through the LUTs, then the
+    // hoist is a pure f32 index-shuffle (byte of word w lane l sub s ->
+    // (w*wf+l)*4+s).
+    alignas(64) float A_f32[M * K];
+    alignas(64) float B_f32[N * K];
+    f8_to_f32_block<A_FP8>(a_words, A_f32, M * K);
+    f8_to_f32_block<B_FP8>(b_words, B_f32, N * K);
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = output_loc_32(M, N, row, col, 0);
+        C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
+                                   ? std::bit_cast<float>(const_acc)
+                                   : std::bit_cast<float>(c_words[out.reg * wf + out.lane]);
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t k = 0; k < K; ++k) {
+        auto al = input_loc(M, K, B, row, k, 0, in_bits);
+        A_buf[row * K + k] = A_f32[(al.vgpr_offset * wf + al.lane) * 4 + al.sub_element];
+      }
+    for (uint32_t k = 0; k < K; ++k)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto bl = input_loc(N, K, B, col, k, 0, in_bits);
+        B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 4 + bl.sub_element];
+      }
+    // Dense MxKxN matmul, W-lane (zmm) stdx FMA over N (N/W chunks per row).
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t c0 = 0; c0 < N; c0 += W) {
+        util::native<float> c_row;
+        c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
+        for (uint32_t k = 0; k < K; ++k) {
+          util::native<float> a_bcast(A_buf[row * K + k]);
+          util::native<float> b_row;
+          b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
+          c_row = util::stdx::fma(a_bcast, b_row, c_row);
+        }
+        c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
+      }
+    // Scatter directly back to VGPRs (no Result staging vector).
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    bool has_nan_or_inf = false;
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = output_loc_32(M, N, row, col, 0);
+        float fv = C_buf[row * N + col];
+        d_words[out.reg * wf + out.lane] = std::bit_cast<uint32_t>(fv);
+        if (std::isnan(fv) || std::isinf(fv))
+          has_nan_or_inf = true;
+      }
+    if (has_nan_or_inf) {
+      util::Logger::vm([&](auto &os) {
+        os << std::format("MFMA_NAN_DETECTED (simd) dst=v{} s0=v{} s1=v{} s2=v{} {}x{}x{}_f8", dst,
+                          s0, s1, s2, M, N, K);
       });
     }
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -28,6 +28,7 @@
 #include "util/data_types.h"
 #include "util/except.h"
 #include "util/meta_programming.h"
+#include "util/simd.h"
 
 #include <algorithm>
 #include <bit>
@@ -577,31 +578,118 @@ void exec_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_
   };
   std::vector<Result> results;
   results.reserve(M * N * B);
-  for (uint32_t b = 0; b < B; ++b) {
-    for (uint32_t row = 0; row < M; ++row) {
-      for (uint32_t col = 0; col < N; ++col) {
-        // AMD convention: i=row (register dimension), j=col (lane dimension).
-        auto out = output_loc_32(M, N, row, col, b);
-        float acc = (const_acc != ACC_FROM_VGPR)
-                        ? std::bit_cast<float>(const_acc)
-                        : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
-        for (uint32_t k = 0; k < K; ++k) {
-          auto al = input_loc(M, K, B, row, k, b, a_bits);
-          auto bl = input_loc(N, K, B, col, k, b, b_bits);
-          // Apply cbsz/abid lane permutation to A input.
-          if (cbsz != 0)
-            al.lane = permute_a_lane(al.lane, cbsz, abid);
-          // Apply blgp lane permutation to B input.
-          if (blgp != 0)
-            bl.lane = permute_b_lane(bl.lane, blgp);
-          float a_val = ea(cu, s0, al);
-          float b_val = eb(cu, s1, bl);
-          acc += a_val * b_val;
+
+  // Scalar reference: D[i][j] = C[i][j] + sum_k A[i][k] * B[k][j], accumulated
+  // per output in K order (non-fused multiply-add).
+  auto run_scalar = [&]() {
+    for (uint32_t b = 0; b < B; ++b) {
+      for (uint32_t row = 0; row < M; ++row) {
+        for (uint32_t col = 0; col < N; ++col) {
+          // AMD convention: i=row (register dimension), j=col (lane dimension).
+          auto out = output_loc_32(M, N, row, col, b);
+          float acc = (const_acc != ACC_FROM_VGPR)
+                          ? std::bit_cast<float>(const_acc)
+                          : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
+          for (uint32_t k = 0; k < K; ++k) {
+            auto al = input_loc(M, K, B, row, k, b, a_bits);
+            auto bl = input_loc(N, K, B, col, k, b, b_bits);
+            // Apply cbsz/abid lane permutation to A input.
+            if (cbsz != 0)
+              al.lane = permute_a_lane(al.lane, cbsz, abid);
+            // Apply blgp lane permutation to B input.
+            if (blgp != 0)
+              bl.lane = permute_b_lane(bl.lane, blgp);
+            float a_val = ea(cu, s0, al);
+            float b_val = eb(cu, s1, bl);
+            acc += a_val * b_val;
+          }
+          results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
         }
-        results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
       }
     }
+  };
+
+  // SIMD fast path. Works for any MFMA shape and any f32-producing extract
+  // (f16/bf16/fp8/bf8/f32). Per block: hoist A into row-major (row,k), B into
+  // row-major (k,col), and C into (row,col) dense f32 buffers (lane
+  // permutation folded in during the hoist), then run the dense MxNxK matmul
+  // as native-width FMA rows over the N (column) dimension. Uses fused FMA,
+  // matching the GFX9 MFMA hardware's single-rounding MACs (the scalar path
+  // above is non-fused; results agree to a few ULP). N columns that don't
+  // fill a full SIMD lane group fall to a scalar (fused) tail.
+  if constexpr (util::has_stdx_simd) {
+    // Pad the column (N) leading dimension up to a SIMD-width multiple so
+    // every matmul row starts W-aligned: the inner loop then uses aligned
+    // loads/stores for any N, and the staging buffers live on the stack
+    // (no per-call heap allocation). MAX_* bound every real MFMA shape;
+    // anything larger (or a forced-scalar run) falls back to the scalar path.
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
+    constexpr size_t MAX_AB = 2048;      // max M*K over all MFMA shapes
+    constexpr size_t MAX_BSTRIDE = 4096; // max K*stride
+    constexpr size_t MAX_C = 1024;       // max M*stride
+    const uint32_t stride = ((N + W - 1) / W) * W;
+    if (util::force_scalar() || static_cast<size_t>(M) * K > MAX_AB ||
+        static_cast<size_t>(K) * stride > MAX_BSTRIDE || static_cast<size_t>(M) * stride > MAX_C) {
+      run_scalar();
+    } else {
+      alignas(64) float Abuf[MAX_AB];
+      alignas(64) float Bbuf[MAX_BSTRIDE];
+      alignas(64) float Cbuf[MAX_C];
+      for (uint32_t b = 0; b < B; ++b) {
+        for (uint32_t row = 0; row < M; ++row)
+          for (uint32_t col = 0; col < N; ++col) {
+            auto out = output_loc_32(M, N, row, col, b);
+            Cbuf[row * stride + col] =
+                (const_acc != ACC_FROM_VGPR)
+                    ? std::bit_cast<float>(const_acc)
+                    : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
+          }
+        for (uint32_t row = 0; row < M; ++row)
+          for (uint32_t k = 0; k < K; ++k) {
+            auto al = input_loc(M, K, B, row, k, b, a_bits);
+            if (cbsz != 0)
+              al.lane = permute_a_lane(al.lane, cbsz, abid);
+            Abuf[row * K + k] = ea(cu, s0, al);
+          }
+        for (uint32_t k = 0; k < K; ++k)
+          for (uint32_t col = 0; col < N; ++col) {
+            auto bl = input_loc(N, K, B, col, k, b, b_bits);
+            if (blgp != 0)
+              bl.lane = permute_b_lane(bl.lane, blgp);
+            Bbuf[k * stride + col] = eb(cu, s1, bl);
+          }
+        for (uint32_t row = 0; row < M; ++row) {
+          uint32_t col = 0;
+          for (; col + W <= N; col += W) {
+            util::native<float> c;
+            c.copy_from(&Cbuf[row * stride + col], util::stdx::vector_aligned);
+            for (uint32_t k = 0; k < K; ++k) {
+              util::native<float> a(Abuf[row * K + k]);
+              util::native<float> bv;
+              bv.copy_from(&Bbuf[k * stride + col], util::stdx::vector_aligned);
+              c = util::stdx::fma(a, bv, c);
+            }
+            c.copy_to(&Cbuf[row * stride + col], util::stdx::vector_aligned);
+          }
+          for (; col < N; ++col) {
+            float acc = Cbuf[row * stride + col];
+            for (uint32_t k = 0; k < K; ++k)
+              acc = std::fma(Abuf[row * K + k], Bbuf[k * stride + col], acc);
+            Cbuf[row * stride + col] = acc;
+          }
+        }
+        for (uint32_t row = 0; row < M; ++row)
+          for (uint32_t col = 0; col < N; ++col) {
+            auto out = output_loc_32(M, N, row, col, b);
+            results.push_back(
+                {out.reg, out.lane, std::bit_cast<uint32_t>(Cbuf[row * stride + col])});
+          }
+      }
+    }
+  } else {
+    run_scalar();
   }
+
   bool has_nan = false;
   for (const auto &r : results) {
     cu.write_vgpr(dst + r.reg, r.lane, r.val);
@@ -973,37 +1061,125 @@ void exec_f32_scaled(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32
   std::vector<Result> results;
   results.reserve(M * N * B);
   uint32_t num_blocks = (K + BLOCK_K - 1) / BLOCK_K;
-  for (uint32_t b = 0; b < B; ++b) {
-    for (uint32_t row = 0; row < M; ++row) {
-      for (uint32_t col = 0; col < N; ++col) {
-        auto out = output_loc_32(M, N, row, col, b);
-        float acc = (const_acc != ACC_FROM_VGPR)
-                        ? std::bit_cast<float>(const_acc)
-                        : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
-        for (uint32_t blk = 0; blk < num_blocks; ++blk) {
-          float block_sum = 0.0f;
-          uint32_t k_start = blk * BLOCK_K;
-          uint32_t k_end = std::min(k_start + BLOCK_K, K);
-          for (uint32_t k = k_start; k < k_end; ++k) {
-            auto al = input_loc(M, K, B, row, k, b, in_bits);
-            auto bl = input_loc(N, K, B, col, k, b, in_bits);
-            if (cbsz != 0)
-              al.lane = permute_a_lane(al.lane, cbsz, abid);
-            if (blgp != 0)
-              bl.lane = permute_b_lane(bl.lane, blgp);
-            block_sum += ea(cu, s0, al) * eb(cu, s1, bl);
+
+  // Per-block E8M0 scale factor for output (row,col,b) in K-block blk.
+  auto scale_exp_for = [&](uint32_t row, uint32_t col, uint32_t b, uint32_t blk) -> int {
+    auto out = output_loc_32(M, N, row, col, b);
+    uint32_t sa_raw = cu.read_vgpr(scale_a_base, out.lane);
+    uint32_t sb_raw = cu.read_vgpr(scale_b_base, out.lane);
+    uint8_t sa_e8m0 = static_cast<uint8_t>((sa_raw >> (blk * 8)) & 0xFF);
+    uint8_t sb_e8m0 = static_cast<uint8_t>((sb_raw >> (blk * 8)) & 0xFF);
+    return static_cast<int>(sa_e8m0) + static_cast<int>(sb_e8m0) - 254;
+  };
+
+  auto run_scalar = [&]() {
+    for (uint32_t b = 0; b < B; ++b) {
+      for (uint32_t row = 0; row < M; ++row) {
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = output_loc_32(M, N, row, col, b);
+          float acc = (const_acc != ACC_FROM_VGPR)
+                          ? std::bit_cast<float>(const_acc)
+                          : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
+          for (uint32_t blk = 0; blk < num_blocks; ++blk) {
+            float block_sum = 0.0f;
+            uint32_t k_start = blk * BLOCK_K;
+            uint32_t k_end = std::min(k_start + BLOCK_K, K);
+            for (uint32_t k = k_start; k < k_end; ++k) {
+              auto al = input_loc(M, K, B, row, k, b, in_bits);
+              auto bl = input_loc(N, K, B, col, k, b, in_bits);
+              if (cbsz != 0)
+                al.lane = permute_a_lane(al.lane, cbsz, abid);
+              if (blgp != 0)
+                bl.lane = permute_b_lane(bl.lane, blgp);
+              block_sum += ea(cu, s0, al) * eb(cu, s1, bl);
+            }
+            acc += std::ldexp(block_sum, scale_exp_for(row, col, b, blk));
           }
-          uint32_t sa_raw = cu.read_vgpr(scale_a_base, out.lane);
-          uint32_t sb_raw = cu.read_vgpr(scale_b_base, out.lane);
-          uint8_t sa_e8m0 = static_cast<uint8_t>((sa_raw >> (blk * 8)) & 0xFF);
-          uint8_t sb_e8m0 = static_cast<uint8_t>((sb_raw >> (blk * 8)) & 0xFF);
-          int scale_exp = static_cast<int>(sa_e8m0) + static_cast<int>(sb_e8m0) - 254;
-          acc += std::ldexp(block_sum, scale_exp);
+          results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
         }
-        results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
       }
     }
+  };
+
+  // SIMD fast path: hoist A/B into dense f32 buffers (lane permutation folded
+  // in), then for each row accumulate each K-block's partial product as
+  // native-width FMA rows over the N (column) dimension. The per-output E8M0
+  // scale + ldexp accumulation stays scalar (cheap: O(num_blocks) per output
+  // vs O(K) MACs). A scalar tail covers trailing N columns.
+  if constexpr (util::has_stdx_simd) {
+    // Column-padded, stack-allocated, aligned B loads. See exec_f32_mixed.
+    // Cacc is touched scalar (per-output ldexp) so it keeps an N pitch.
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
+    constexpr size_t MAX_AB = 2048;
+    constexpr size_t MAX_BSTRIDE = 4096;
+    constexpr size_t MAX_C = 1024;
+    const uint32_t stride = ((N + W - 1) / W) * W;
+    if (util::force_scalar() || static_cast<size_t>(M) * K > MAX_AB ||
+        static_cast<size_t>(K) * stride > MAX_BSTRIDE || static_cast<size_t>(M) * N > MAX_C) {
+      run_scalar();
+    } else {
+      alignas(64) float Abuf[MAX_AB];
+      alignas(64) float Bbuf[MAX_BSTRIDE];
+      alignas(64) float Cacc[MAX_C];
+      for (uint32_t b = 0; b < B; ++b) {
+        for (uint32_t row = 0; row < M; ++row)
+          for (uint32_t k = 0; k < K; ++k) {
+            auto al = input_loc(M, K, B, row, k, b, in_bits);
+            if (cbsz != 0)
+              al.lane = permute_a_lane(al.lane, cbsz, abid);
+            Abuf[row * K + k] = ea(cu, s0, al);
+          }
+        for (uint32_t k = 0; k < K; ++k)
+          for (uint32_t col = 0; col < N; ++col) {
+            auto bl = input_loc(N, K, B, col, k, b, in_bits);
+            if (blgp != 0)
+              bl.lane = permute_b_lane(bl.lane, blgp);
+            Bbuf[k * stride + col] = eb(cu, s1, bl);
+          }
+        for (uint32_t row = 0; row < M; ++row)
+          for (uint32_t col = 0; col < N; ++col) {
+            auto out = output_loc_32(M, N, row, col, b);
+            Cacc[row * N + col] = (const_acc != ACC_FROM_VGPR)
+                                      ? std::bit_cast<float>(const_acc)
+                                      : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
+          }
+        for (uint32_t row = 0; row < M; ++row) {
+          for (uint32_t blk = 0; blk < num_blocks; ++blk) {
+            uint32_t k_start = blk * BLOCK_K;
+            uint32_t k_end = std::min(k_start + BLOCK_K, K);
+            uint32_t col = 0;
+            alignas(64) float bs[64];
+            for (; col + W <= N; col += W) {
+              util::native<float> acc(0.0f);
+              for (uint32_t k = k_start; k < k_end; ++k) {
+                util::native<float> a(Abuf[row * K + k]);
+                util::native<float> bv;
+                bv.copy_from(&Bbuf[k * stride + col], util::stdx::vector_aligned);
+                acc = util::stdx::fma(a, bv, acc);
+              }
+              acc.copy_to(bs, util::stdx::vector_aligned);
+              for (uint32_t j = 0; j < W; ++j)
+                Cacc[row * N + col + j] += std::ldexp(bs[j], scale_exp_for(row, col + j, b, blk));
+            }
+            for (; col < N; ++col) {
+              float block_sum = 0.0f;
+              for (uint32_t k = k_start; k < k_end; ++k)
+                block_sum = std::fma(Abuf[row * K + k], Bbuf[k * stride + col], block_sum);
+              Cacc[row * N + col] += std::ldexp(block_sum, scale_exp_for(row, col, b, blk));
+            }
+          }
+        }
+        for (uint32_t row = 0; row < M; ++row)
+          for (uint32_t col = 0; col < N; ++col) {
+            auto out = output_loc_32(M, N, row, col, b);
+            results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(Cacc[row * N + col])});
+          }
+      }
+    }
+  } else {
+    run_scalar();
   }
+
   for (const auto &r : results)
     cu.write_vgpr(dst + r.reg, r.lane, r.val);
 }
@@ -1066,23 +1242,95 @@ inline void exec_i32_i8(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uin
   };
   std::vector<Result> results;
   results.reserve(M * N * B);
-  for (uint32_t b = 0; b < B; ++b) {
-    for (uint32_t row = 0; row < M; ++row) {
-      for (uint32_t col = 0; col < N; ++col) {
-        // AMD convention: i=row (register dimension), j=col (lane dimension).
-        auto out = output_loc_32(M, N, row, col, b);
-        int32_t acc = (const_acc != ACC_FROM_VGPR)
-                          ? static_cast<int32_t>(const_acc)
-                          : static_cast<int32_t>(cu.read_vgpr(s2 + out.reg, out.lane));
-        for (uint32_t k = 0; k < K; ++k) {
-          auto al = input_loc(M, K, B, row, k, b, 8);
-          auto bl = input_loc(N, K, B, col, k, b, 8);
-          acc += extract_i8(cu, s0, al) * extract_i8(cu, s1, bl);
+
+  auto run_scalar = [&]() {
+    for (uint32_t b = 0; b < B; ++b) {
+      for (uint32_t row = 0; row < M; ++row) {
+        for (uint32_t col = 0; col < N; ++col) {
+          // AMD convention: i=row (register dimension), j=col (lane dimension).
+          auto out = output_loc_32(M, N, row, col, b);
+          int32_t acc = (const_acc != ACC_FROM_VGPR)
+                            ? static_cast<int32_t>(const_acc)
+                            : static_cast<int32_t>(cu.read_vgpr(s2 + out.reg, out.lane));
+          for (uint32_t k = 0; k < K; ++k) {
+            auto al = input_loc(M, K, B, row, k, b, 8);
+            auto bl = input_loc(N, K, B, col, k, b, 8);
+            acc += extract_i8(cu, s0, al) * extract_i8(cu, s1, bl);
+          }
+          results.push_back({out.reg, out.lane, static_cast<uint32_t>(acc)});
         }
-        results.push_back({out.reg, out.lane, static_cast<uint32_t>(acc)});
       }
     }
+  };
+
+  // SIMD fast path mirrors exec_f32_mixed: hoist A/B/C into dense int32
+  // buffers, then run the matmul as native-width int32 multiply-accumulate
+  // over the N dimension. Integer MAC is exact, so the SIMD and scalar paths
+  // are bit-identical. A scalar tail handles trailing N columns.
+  if constexpr (util::has_stdx_simd) {
+    // Column-padded, stack-allocated, aligned. See exec_f32_mixed.
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<int32_t>::size());
+    constexpr size_t MAX_AB = 2048;
+    constexpr size_t MAX_BSTRIDE = 4096;
+    constexpr size_t MAX_C = 1024;
+    const uint32_t stride = ((N + W - 1) / W) * W;
+    if (util::force_scalar() || static_cast<size_t>(M) * K > MAX_AB ||
+        static_cast<size_t>(K) * stride > MAX_BSTRIDE || static_cast<size_t>(M) * stride > MAX_C) {
+      run_scalar();
+    } else {
+      alignas(64) int32_t Abuf[MAX_AB];
+      alignas(64) int32_t Bbuf[MAX_BSTRIDE];
+      alignas(64) int32_t Cbuf[MAX_C];
+      for (uint32_t b = 0; b < B; ++b) {
+        for (uint32_t row = 0; row < M; ++row)
+          for (uint32_t col = 0; col < N; ++col) {
+            auto out = output_loc_32(M, N, row, col, b);
+            Cbuf[row * stride + col] =
+                (const_acc != ACC_FROM_VGPR)
+                    ? static_cast<int32_t>(const_acc)
+                    : static_cast<int32_t>(cu.read_vgpr(s2 + out.reg, out.lane));
+          }
+        for (uint32_t row = 0; row < M; ++row)
+          for (uint32_t k = 0; k < K; ++k) {
+            auto al = input_loc(M, K, B, row, k, b, 8);
+            Abuf[row * K + k] = extract_i8(cu, s0, al);
+          }
+        for (uint32_t k = 0; k < K; ++k)
+          for (uint32_t col = 0; col < N; ++col) {
+            auto bl = input_loc(N, K, B, col, k, b, 8);
+            Bbuf[k * stride + col] = extract_i8(cu, s1, bl);
+          }
+        for (uint32_t row = 0; row < M; ++row) {
+          uint32_t col = 0;
+          for (; col + W <= N; col += W) {
+            util::native<int32_t> c;
+            c.copy_from(&Cbuf[row * stride + col], util::stdx::vector_aligned);
+            for (uint32_t k = 0; k < K; ++k) {
+              util::native<int32_t> a(Abuf[row * K + k]);
+              util::native<int32_t> bv;
+              bv.copy_from(&Bbuf[k * stride + col], util::stdx::vector_aligned);
+              c += a * bv;
+            }
+            c.copy_to(&Cbuf[row * stride + col], util::stdx::vector_aligned);
+          }
+          for (; col < N; ++col) {
+            int32_t acc = Cbuf[row * stride + col];
+            for (uint32_t k = 0; k < K; ++k)
+              acc += Abuf[row * K + k] * Bbuf[k * stride + col];
+            Cbuf[row * stride + col] = acc;
+          }
+        }
+        for (uint32_t row = 0; row < M; ++row)
+          for (uint32_t col = 0; col < N; ++col) {
+            auto out = output_loc_32(M, N, row, col, b);
+            results.push_back({out.reg, out.lane, static_cast<uint32_t>(Cbuf[row * stride + col])});
+          }
+      }
+    }
+  } else {
+    run_scalar();
   }
+
   for (const auto &r : results)
     cu.write_vgpr(dst + r.reg, r.lane, r.val);
 }
@@ -1193,30 +1441,108 @@ inline void exec_f64(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32
   };
   std::vector<Result> results;
   results.reserve(M * N * B);
-  for (uint32_t b = 0; b < B; ++b) {
-    for (uint32_t row = 0; row < M; ++row) {
-      for (uint32_t col = 0; col < N; ++col) {
-        // AMD convention: i=row (register dimension), j=col (lane dimension).
-        auto out = output_loc_64(M, N, row, col, b);
-        double acc;
-        if (const_acc != ACC_FROM_VGPR) {
-          acc = static_cast<double>(std::bit_cast<float>(const_acc));
-        } else {
-          uint32_t lo = cu.read_vgpr(s2 + out.reg, out.lane);
-          uint32_t hi = cu.read_vgpr(s2 + out.reg + 1, out.lane);
-          acc = std::bit_cast<double>(static_cast<uint64_t>(hi) << 32 | lo);
+
+  auto run_scalar = [&]() {
+    for (uint32_t b = 0; b < B; ++b) {
+      for (uint32_t row = 0; row < M; ++row) {
+        for (uint32_t col = 0; col < N; ++col) {
+          // AMD convention: i=row (register dimension), j=col (lane dimension).
+          auto out = output_loc_64(M, N, row, col, b);
+          double acc;
+          if (const_acc != ACC_FROM_VGPR) {
+            acc = static_cast<double>(std::bit_cast<float>(const_acc));
+          } else {
+            uint32_t lo = cu.read_vgpr(s2 + out.reg, out.lane);
+            uint32_t hi = cu.read_vgpr(s2 + out.reg + 1, out.lane);
+            acc = std::bit_cast<double>(static_cast<uint64_t>(hi) << 32 | lo);
+          }
+          for (uint32_t k = 0; k < K; ++k) {
+            auto al = input_loc(M, K, B, row, k, b, 64);
+            auto bl = input_loc(N, K, B, col, k, b, 64);
+            acc += extract_f64(cu, s0, al) * extract_f64(cu, s1, bl);
+          }
+          uint64_t bits = std::bit_cast<uint64_t>(acc);
+          results.push_back(
+              {out.reg, out.lane, static_cast<uint32_t>(bits), static_cast<uint32_t>(bits >> 32)});
         }
-        for (uint32_t k = 0; k < K; ++k) {
-          auto al = input_loc(M, K, B, row, k, b, 64);
-          auto bl = input_loc(N, K, B, col, k, b, 64);
-          acc += extract_f64(cu, s0, al) * extract_f64(cu, s1, bl);
-        }
-        uint64_t bits = std::bit_cast<uint64_t>(acc);
-        results.push_back(
-            {out.reg, out.lane, static_cast<uint32_t>(bits), static_cast<uint32_t>(bits >> 32)});
       }
     }
+  };
+
+  // SIMD fast path mirrors exec_f32_mixed with native<double> lanes (8-wide on
+  // AVX-512) and fused FMA, matching the GFX9 f64 MFMA single-rounding MACs.
+  // A scalar (fused) tail covers the trailing N columns.
+  if constexpr (util::has_stdx_simd) {
+    // Column-padded, stack-allocated, aligned. See exec_f32_mixed. MAX_BSTRIDE
+    // is half the f32 cap because native<double> packs half as many lanes.
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<double>::size());
+    constexpr size_t MAX_AB = 2048;
+    constexpr size_t MAX_BSTRIDE = 2048;
+    constexpr size_t MAX_C = 1024;
+    const uint32_t stride = ((N + W - 1) / W) * W;
+    if (util::force_scalar() || static_cast<size_t>(M) * K > MAX_AB ||
+        static_cast<size_t>(K) * stride > MAX_BSTRIDE || static_cast<size_t>(M) * stride > MAX_C) {
+      run_scalar();
+    } else {
+      alignas(64) double Abuf[MAX_AB];
+      alignas(64) double Bbuf[MAX_BSTRIDE];
+      alignas(64) double Cbuf[MAX_C];
+      for (uint32_t b = 0; b < B; ++b) {
+        for (uint32_t row = 0; row < M; ++row)
+          for (uint32_t col = 0; col < N; ++col) {
+            auto out = output_loc_64(M, N, row, col, b);
+            if (const_acc != ACC_FROM_VGPR) {
+              Cbuf[row * stride + col] = static_cast<double>(std::bit_cast<float>(const_acc));
+            } else {
+              uint32_t lo = cu.read_vgpr(s2 + out.reg, out.lane);
+              uint32_t hi = cu.read_vgpr(s2 + out.reg + 1, out.lane);
+              Cbuf[row * stride + col] =
+                  std::bit_cast<double>(static_cast<uint64_t>(hi) << 32 | lo);
+            }
+          }
+        for (uint32_t row = 0; row < M; ++row)
+          for (uint32_t k = 0; k < K; ++k) {
+            auto al = input_loc(M, K, B, row, k, b, 64);
+            Abuf[row * K + k] = extract_f64(cu, s0, al);
+          }
+        for (uint32_t k = 0; k < K; ++k)
+          for (uint32_t col = 0; col < N; ++col) {
+            auto bl = input_loc(N, K, B, col, k, b, 64);
+            Bbuf[k * stride + col] = extract_f64(cu, s1, bl);
+          }
+        for (uint32_t row = 0; row < M; ++row) {
+          uint32_t col = 0;
+          for (; col + W <= N; col += W) {
+            util::native<double> c;
+            c.copy_from(&Cbuf[row * stride + col], util::stdx::vector_aligned);
+            for (uint32_t k = 0; k < K; ++k) {
+              util::native<double> a(Abuf[row * K + k]);
+              util::native<double> bv;
+              bv.copy_from(&Bbuf[k * stride + col], util::stdx::vector_aligned);
+              c = util::stdx::fma(a, bv, c);
+            }
+            c.copy_to(&Cbuf[row * stride + col], util::stdx::vector_aligned);
+          }
+          for (; col < N; ++col) {
+            double acc = Cbuf[row * stride + col];
+            for (uint32_t k = 0; k < K; ++k)
+              acc = std::fma(Abuf[row * K + k], Bbuf[k * stride + col], acc);
+            Cbuf[row * stride + col] = acc;
+          }
+        }
+        for (uint32_t row = 0; row < M; ++row)
+          for (uint32_t col = 0; col < N; ++col) {
+            auto out = output_loc_64(M, N, row, col, b);
+            uint64_t bits = std::bit_cast<uint64_t>(Cbuf[row * stride + col]);
+            results.push_back({out.reg, out.lane, static_cast<uint32_t>(bits),
+                               static_cast<uint32_t>(bits >> 32)});
+          }
+      }
+    }
+  } else {
+    run_scalar();
   }
+
   for (const auto &r : results) {
     cu.write_vgpr(dst + r.reg, r.lane, r.lo);
     cu.write_vgpr(dst + r.reg + 1, r.lane, r.hi);
@@ -1571,6 +1897,101 @@ void exec_smfmac_f32_32x32x64_fp8(ComputeUnitCore &cu, uint32_t dst, uint32_t s0
   }
   for (const auto &r : results)
     cu.write_vgpr(dst + r.reg, r.lane, r.val);
+}
+
+/// Fast path for v_mfma_f32_16x16x32_f16. This single MFMA shape is the only
+/// MFMA variant fired by OPT-125M fp16 eager forward (488k invocations per
+/// forward; ~4B internal MACs). Kept as a dedicated specialization (rather
+/// than forwarding to generic exec_f32) because the compile-time M/N/K/B let
+/// the compiler fully unroll the 16-row x 32-K inner matmul into straight-line
+/// AVX-512 FMAs — a runtime-dimension loop is materially slower on this hot
+/// path. Hoists A and B into dense f32 buffers via extract_f16, runs the
+/// matmul as 16 zmm-wide f32 FMA rows (512 zmm FMAs per MFMA), and scatters
+/// directly back to VGPRs (no Result staging vector). VGPR access is batched
+/// through vgpr_data (one base pointer per operand, no per-element virtual
+/// read_vgpr/write_vgpr). Falls back to the generic exec_f32 when:
+///   - <experimental/simd> is unavailable
+///   - host native_simd<float> is not 16 lanes (i.e. no AVX-512)
+///   - cbsz/blgp lane permutation is non-default
+///   - RJ_FORCE_SCALAR is set
+inline void exec_f32_mfma_16x16x32_f16(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
+                                       uint32_t s1, uint32_t s2, uint32_t const_acc, uint32_t cbsz,
+                                       uint32_t abid, uint32_t blgp) {
+  constexpr uint32_t M = 16, N = 16, K = 32, B = 1, in_bits = 16;
+  if constexpr (!util::has_stdx_simd) {
+    exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_f16, amdgpu::extract_f16,
+             const_acc, cbsz, abid, blgp);
+    return;
+  } else {
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16) {
+      exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_f16, amdgpu::extract_f16,
+               const_acc, cbsz, abid, blgp);
+      return;
+    }
+    const uint32_t wf = cu.wf_size();
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    alignas(64) float A_buf[M * K]; // A[row][k]
+    alignas(64) float B_buf[K * N]; // B[k][col]
+    alignas(64) float C_buf[M * N]; // C[row][col]
+    // The A/B inputs each occupy 4 VGPRs x wf lanes = 2*4*wf packed f16. Bulk
+    // convert the whole region to f32 once with F16C (one vector op per 16
+    // halves) instead of 1024 branchy scalar f16_to_f32 calls, then the hoist
+    // below is a pure f32 index-shuffle (f16 j of word w sub s -> flat j=w*2+s).
+    constexpr uint32_t NUM_IN_REGS = 4;
+    const uint32_t n_halves = 2 * NUM_IN_REGS * wf;
+    alignas(64) float A_f32[2 * NUM_IN_REGS * 64];
+    alignas(64) float B_f32[2 * NUM_IN_REGS * 64];
+    util::f16_to_f32_block(reinterpret_cast<const uint16_t *>(a_words), A_f32, n_halves);
+    util::f16_to_f32_block(reinterpret_cast<const uint16_t *>(b_words), B_f32, n_halves);
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = output_loc_32(M, N, row, col, 0);
+        C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
+                                   ? std::bit_cast<float>(const_acc)
+                                   : std::bit_cast<float>(c_words[out.reg * wf + out.lane]);
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t k = 0; k < K; ++k) {
+        auto al = input_loc(M, K, B, row, k, 0, in_bits);
+        A_buf[row * K + k] = A_f32[(al.vgpr_offset * wf + al.lane) * 2 + al.sub_element];
+      }
+    for (uint32_t k = 0; k < K; ++k)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto bl = input_loc(N, K, B, col, k, 0, in_bits);
+        B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 2 + bl.sub_element];
+      }
+    // Dense 16x32 * 32x16 -> 16x16 matmul, 16-lane stdx FMA per row.
+    for (uint32_t row = 0; row < M; ++row) {
+      util::native<float> c_row;
+      c_row.copy_from(&C_buf[row * N], util::stdx::vector_aligned);
+      for (uint32_t k = 0; k < K; ++k) {
+        util::native<float> a_bcast(A_buf[row * K + k]);
+        util::native<float> b_row;
+        b_row.copy_from(&B_buf[k * N], util::stdx::vector_aligned);
+        c_row = util::stdx::fma(a_bcast, b_row, c_row);
+      }
+      c_row.copy_to(&C_buf[row * N], util::stdx::vector_aligned);
+    }
+    // Scatter directly back to VGPRs (no Result staging vector).
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    bool has_nan_or_inf = false;
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = output_loc_32(M, N, row, col, 0);
+        float fv = C_buf[row * N + col];
+        d_words[out.reg * wf + out.lane] = std::bit_cast<uint32_t>(fv);
+        if (std::isnan(fv) || std::isinf(fv))
+          has_nan_or_inf = true;
+      }
+    if (has_nan_or_inf) {
+      util::Logger::vm([&](auto &os) {
+        os << std::format("MFMA_NAN_DETECTED (simd) dst=v{} s0=v{} s1=v{} s2=v{} 16x16x32_f16", dst,
+                          s0, s1, s2);
+      });
+    }
+  }
 }
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -3025,11 +3025,11 @@ inline void exec_f32_mfma_f32_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, ui
   }
 }
 
-template <uint32_t M, uint32_t N, uint32_t K>
+template <uint32_t M, uint32_t N, uint32_t K, uint32_t BATCH = 1>
 inline void exec_f32_mfma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
                                    uint32_t s1, uint32_t s2, uint32_t const_acc, uint32_t cbsz,
                                    uint32_t abid, uint32_t blgp) {
-  constexpr uint32_t B = 1, in_bits = 16;
+  constexpr uint32_t B = BATCH, in_bits = 16;
   static_assert(N % 16 == 0, "specialized f16 MFMA assumes N is a multiple of the zmm width");
   if constexpr (!util::has_stdx_simd) {
     exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_f16, amdgpu::extract_f16,
@@ -3046,58 +3046,60 @@ inline void exec_f32_mfma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, ui
     const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
     const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
     const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
-    alignas(64) float A_buf[M * K]; // A[row][k]
-    alignas(64) float B_buf[K * N]; // B[k][col]
-    alignas(64) float C_buf[M * N]; // C[row][col]
-    // A/B occupy M*K and N*K packed f16 over their VGPRs. Bulk-convert each whole
-    // region to f32 once with F16C (one vector op per 16 halves) instead of
-    // branchy per-element f16_to_f32, then the hoist is a pure f32 index-shuffle
-    // (f16 of word w lane l sub s -> flat (w*wf+l)*2+s).
-    alignas(64) float A_f32[M * K];
-    alignas(64) float B_f32[N * K];
-    util::f16_to_f32_block(reinterpret_cast<const uint16_t *>(a_words), A_f32, M * K);
-    util::f16_to_f32_block(reinterpret_cast<const uint16_t *>(b_words), B_f32, N * K);
-    for (uint32_t row = 0; row < M; ++row)
-      for (uint32_t col = 0; col < N; ++col) {
-        auto out = output_loc_32(M, N, row, col, 0);
-        C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
-                                   ? std::bit_cast<float>(const_acc)
-                                   : std::bit_cast<float>(c_words[out.reg * wf + out.lane]);
-      }
-    for (uint32_t row = 0; row < M; ++row)
-      for (uint32_t k = 0; k < K; ++k) {
-        auto al = input_loc(M, K, B, row, k, 0, in_bits);
-        A_buf[row * K + k] = A_f32[(al.vgpr_offset * wf + al.lane) * 2 + al.sub_element];
-      }
-    for (uint32_t k = 0; k < K; ++k)
-      for (uint32_t col = 0; col < N; ++col) {
-        auto bl = input_loc(N, K, B, col, k, 0, in_bits);
-        B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 2 + bl.sub_element];
-      }
-    // Dense MxKxN matmul, W-lane (zmm) stdx FMA over N (N/W chunks per row).
-    for (uint32_t row = 0; row < M; ++row)
-      for (uint32_t c0 = 0; c0 < N; c0 += W) {
-        util::native<float> c_row;
-        c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
-        for (uint32_t k = 0; k < K; ++k) {
-          util::native<float> a_bcast(A_buf[row * K + k]);
-          util::native<float> b_row;
-          b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
-          c_row = util::stdx::fma(a_bcast, b_row, c_row);
-        }
-        c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
-      }
-    // Scatter directly back to VGPRs (no Result staging vector).
     uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    alignas(64) float A_buf[M * K]; // A[row][k] (one batch block)
+    alignas(64) float B_buf[K * N]; // B[k][col] (one batch block)
+    alignas(64) float C_buf[M * N]; // C[row][col] (one batch block)
+    // A/B occupy M*K*B and N*K*B packed f16 over their VGPRs. Bulk-convert each
+    // whole region to f32 once with F16C (one vector op per 16 halves) instead
+    // of branchy per-element f16_to_f32, then the hoist is a pure f32
+    // index-shuffle (f16 of word w lane l sub s -> flat (w*wf+l)*2+s).
+    alignas(64) float A_f32[M * K * B];
+    alignas(64) float B_f32[N * K * B];
+    util::f16_to_f32_block(reinterpret_cast<const uint16_t *>(a_words), A_f32, M * K * B);
+    util::f16_to_f32_block(reinterpret_cast<const uint16_t *>(b_words), B_f32, N * K * B);
     bool has_nan_or_inf = false;
-    for (uint32_t row = 0; row < M; ++row)
-      for (uint32_t col = 0; col < N; ++col) {
-        auto out = output_loc_32(M, N, row, col, 0);
-        float fv = C_buf[row * N + col];
-        d_words[out.reg * wf + out.lane] = std::bit_cast<uint32_t>(fv);
-        if (std::isnan(fv) || std::isinf(fv))
-          has_nan_or_inf = true;
-      }
+    for (uint32_t b = 0; b < B; ++b) {
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = output_loc_32(M, N, row, col, b);
+          C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
+                                     ? std::bit_cast<float>(const_acc)
+                                     : std::bit_cast<float>(c_words[out.reg * wf + out.lane]);
+        }
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t k = 0; k < K; ++k) {
+          auto al = input_loc(M, K, B, row, k, b, in_bits);
+          A_buf[row * K + k] = A_f32[(al.vgpr_offset * wf + al.lane) * 2 + al.sub_element];
+        }
+      for (uint32_t k = 0; k < K; ++k)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto bl = input_loc(N, K, B, col, k, b, in_bits);
+          B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 2 + bl.sub_element];
+        }
+      // Dense MxKxN matmul, W-lane (zmm) stdx FMA over N (N/W chunks per row).
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t c0 = 0; c0 < N; c0 += W) {
+          util::native<float> c_row;
+          c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
+          for (uint32_t k = 0; k < K; ++k) {
+            util::native<float> a_bcast(A_buf[row * K + k]);
+            util::native<float> b_row;
+            b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
+            c_row = util::stdx::fma(a_bcast, b_row, c_row);
+          }
+          c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
+        }
+      // Scatter directly back to VGPRs (no Result staging vector).
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = output_loc_32(M, N, row, col, b);
+          float fv = C_buf[row * N + col];
+          d_words[out.reg * wf + out.lane] = std::bit_cast<uint32_t>(fv);
+          if (std::isnan(fv) || std::isinf(fv))
+            has_nan_or_inf = true;
+        }
+    }
     if (has_nan_or_inf) {
       util::Logger::vm([&](auto &os) {
         os << std::format("MFMA_NAN_DETECTED (simd) dst=v{} s0=v{} s1=v{} s2=v{} {}x{}x{}_f16", dst,
@@ -3111,11 +3113,11 @@ inline void exec_f32_mfma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, ui
 /// the f16 specialization except the bulk input convert is the bf16 zero-extend
 /// (no F16C needed). Falls back to the generic exec_f32 without AVX-512 / under
 /// force-scalar / with cbsz|blgp.
-template <uint32_t M, uint32_t N, uint32_t K>
+template <uint32_t M, uint32_t N, uint32_t K, uint32_t BATCH = 1>
 inline void exec_f32_mfma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
                                     uint32_t s1, uint32_t s2, uint32_t const_acc, uint32_t cbsz,
                                     uint32_t abid, uint32_t blgp) {
-  constexpr uint32_t B = 1, in_bits = 16;
+  constexpr uint32_t B = BATCH, in_bits = 16;
   static_assert(N % 16 == 0, "specialized bf16 MFMA assumes N is a multiple of the zmm width");
   if constexpr (!util::has_stdx_simd) {
     exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_bf16, amdgpu::extract_bf16,
@@ -3132,56 +3134,58 @@ inline void exec_f32_mfma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, u
     const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
     const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
     const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
-    alignas(64) float A_buf[M * K]; // A[row][k]
-    alignas(64) float B_buf[K * N]; // B[k][col]
-    alignas(64) float C_buf[M * N]; // C[row][col]
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    alignas(64) float A_buf[M * K]; // A[row][k] (one batch block)
+    alignas(64) float B_buf[K * N]; // B[k][col] (one batch block)
+    alignas(64) float C_buf[M * N]; // C[row][col] (one batch block)
     // Bulk-convert the packed bf16 regions to f32 once (zero-extend + shift),
     // then the hoist is a pure f32 index-shuffle.
-    alignas(64) float A_f32[M * K];
-    alignas(64) float B_f32[N * K];
-    util::bf16_to_f32_block(reinterpret_cast<const uint16_t *>(a_words), A_f32, M * K);
-    util::bf16_to_f32_block(reinterpret_cast<const uint16_t *>(b_words), B_f32, N * K);
-    for (uint32_t row = 0; row < M; ++row)
-      for (uint32_t col = 0; col < N; ++col) {
-        auto out = output_loc_32(M, N, row, col, 0);
-        C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
-                                   ? std::bit_cast<float>(const_acc)
-                                   : std::bit_cast<float>(c_words[out.reg * wf + out.lane]);
-      }
-    for (uint32_t row = 0; row < M; ++row)
-      for (uint32_t k = 0; k < K; ++k) {
-        auto al = input_loc(M, K, B, row, k, 0, in_bits);
-        A_buf[row * K + k] = A_f32[(al.vgpr_offset * wf + al.lane) * 2 + al.sub_element];
-      }
-    for (uint32_t k = 0; k < K; ++k)
-      for (uint32_t col = 0; col < N; ++col) {
-        auto bl = input_loc(N, K, B, col, k, 0, in_bits);
-        B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 2 + bl.sub_element];
-      }
-    // Dense MxKxN matmul, W-lane (zmm) stdx FMA over N (N/W chunks per row).
-    for (uint32_t row = 0; row < M; ++row)
-      for (uint32_t c0 = 0; c0 < N; c0 += W) {
-        util::native<float> c_row;
-        c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
-        for (uint32_t k = 0; k < K; ++k) {
-          util::native<float> a_bcast(A_buf[row * K + k]);
-          util::native<float> b_row;
-          b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
-          c_row = util::stdx::fma(a_bcast, b_row, c_row);
-        }
-        c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
-      }
-    // Scatter directly back to VGPRs (no Result staging vector).
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    alignas(64) float A_f32[M * K * B];
+    alignas(64) float B_f32[N * K * B];
+    util::bf16_to_f32_block(reinterpret_cast<const uint16_t *>(a_words), A_f32, M * K * B);
+    util::bf16_to_f32_block(reinterpret_cast<const uint16_t *>(b_words), B_f32, N * K * B);
     bool has_nan_or_inf = false;
-    for (uint32_t row = 0; row < M; ++row)
-      for (uint32_t col = 0; col < N; ++col) {
-        auto out = output_loc_32(M, N, row, col, 0);
-        float fv = C_buf[row * N + col];
-        d_words[out.reg * wf + out.lane] = std::bit_cast<uint32_t>(fv);
-        if (std::isnan(fv) || std::isinf(fv))
-          has_nan_or_inf = true;
-      }
+    for (uint32_t b = 0; b < B; ++b) {
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = output_loc_32(M, N, row, col, b);
+          C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
+                                     ? std::bit_cast<float>(const_acc)
+                                     : std::bit_cast<float>(c_words[out.reg * wf + out.lane]);
+        }
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t k = 0; k < K; ++k) {
+          auto al = input_loc(M, K, B, row, k, b, in_bits);
+          A_buf[row * K + k] = A_f32[(al.vgpr_offset * wf + al.lane) * 2 + al.sub_element];
+        }
+      for (uint32_t k = 0; k < K; ++k)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto bl = input_loc(N, K, B, col, k, b, in_bits);
+          B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 2 + bl.sub_element];
+        }
+      // Dense MxKxN matmul, W-lane (zmm) stdx FMA over N (N/W chunks per row).
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t c0 = 0; c0 < N; c0 += W) {
+          util::native<float> c_row;
+          c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
+          for (uint32_t k = 0; k < K; ++k) {
+            util::native<float> a_bcast(A_buf[row * K + k]);
+            util::native<float> b_row;
+            b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
+            c_row = util::stdx::fma(a_bcast, b_row, c_row);
+          }
+          c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
+        }
+      // Scatter directly back to VGPRs (no Result staging vector).
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = output_loc_32(M, N, row, col, b);
+          float fv = C_buf[row * N + col];
+          d_words[out.reg * wf + out.lane] = std::bit_cast<uint32_t>(fv);
+          if (std::isnan(fv) || std::isinf(fv))
+            has_nan_or_inf = true;
+        }
+    }
     if (has_nan_or_inf) {
       util::Logger::vm([&](auto &os) {
         os << std::format("MFMA_NAN_DETECTED (simd) dst=v{} s0=v{} s1=v{} s2=v{} {}x{}x{}_bf16",
@@ -3278,18 +3282,19 @@ inline void exec_f32_mfma_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uin
   }
 }
 
-/// Fast path for the dense (B=1) i8-input MFMA shapes (v_mfma_i32_*_i8). Same
-/// structure as the f16 specialization but integer: the packed i8 inputs are
-/// bulk sign-extended to int32 once, the hoist is a pure i32 index-shuffle,
-/// and the matmul runs as constexpr-unrolled zmm-wide int32 MACs. There is no
-/// clamp on the i8 MFMA path: both scalar and SIMD accumulate (and wrap) in
-/// 32 bits, so they agree bit for bit on every output (SIMD wraps in uint32
-/// to keep the wrap well-defined). Falls back to the generic exec_i32_i8
-/// without AVX-512 / under force-scalar.
-template <uint32_t M, uint32_t N, uint32_t K>
+/// Fast path for the dense i8-input MFMA shapes (v_mfma_i32_*_i8), including
+/// the batched (BATCH>1) variants. Same structure as the f16 specialization
+/// but integer: the packed i8 inputs are bulk sign-extended to int32 once,
+/// the hoist is a pure i32 index-shuffle, and the matmul runs as
+/// constexpr-unrolled zmm-wide int32 MACs. There is no clamp on the i8 MFMA
+/// path: both scalar and SIMD accumulate (and wrap) in 32 bits, so they agree
+/// bit for bit on every output (SIMD wraps in uint32 to keep the wrap
+/// well-defined). Falls back to the generic exec_i32_i8 without AVX-512 /
+/// under force-scalar.
+template <uint32_t M, uint32_t N, uint32_t K, uint32_t BATCH = 1>
 inline void exec_i32_mfma_i8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
                                   uint32_t s1, uint32_t s2, uint32_t const_acc) {
-  constexpr uint32_t B = 1, in_bits = 8;
+  constexpr uint32_t B = BATCH, in_bits = 8;
   static_assert(N % 16 == 0, "specialized i8 MFMA assumes N is a multiple of the zmm width");
   if constexpr (!util::has_stdx_simd) {
     exec_i32_i8(cu, M, N, K, B, dst, s0, s1, s2, const_acc);
@@ -3307,52 +3312,54 @@ inline void exec_i32_mfma_i8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uin
     // Accumulate in unsigned 32-bit (wrap is well-defined and identical mod
     // 2^32 to the intended signed wrap), so the SIMD path has no signed-
     // overflow UB.
-    alignas(64) uint32_t A_buf[M * K]; // A[row][k] (sign-extended bits)
-    alignas(64) uint32_t B_buf[K * N]; // B[k][col] (sign-extended bits)
-    alignas(64) uint32_t C_buf[M * N]; // C[row][col]
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    alignas(64) uint32_t A_buf[M * K]; // A[row][k] (sign-extended bits, one batch block)
+    alignas(64) uint32_t B_buf[K * N]; // B[k][col] (sign-extended bits, one batch block)
+    alignas(64) uint32_t C_buf[M * N]; // C[row][col] (one batch block)
     // Bulk sign-extend the packed i8 regions to int32 once, then the hoist is
     // a pure i32 index-shuffle (byte of word w lane l sub s -> (w*wf+l)*4+s).
-    alignas(64) int32_t A_i32[M * K];
-    alignas(64) int32_t B_i32[N * K];
-    util::i8_to_i32_block(reinterpret_cast<const int8_t *>(a_words), A_i32, M * K);
-    util::i8_to_i32_block(reinterpret_cast<const int8_t *>(b_words), B_i32, N * K);
-    for (uint32_t row = 0; row < M; ++row)
-      for (uint32_t col = 0; col < N; ++col) {
-        auto out = output_loc_32(M, N, row, col, 0);
-        C_buf[row * N + col] =
-            (const_acc != ACC_FROM_VGPR) ? const_acc : c_words[out.reg * wf + out.lane];
-      }
-    for (uint32_t row = 0; row < M; ++row)
-      for (uint32_t k = 0; k < K; ++k) {
-        auto al = input_loc(M, K, B, row, k, 0, in_bits);
-        A_buf[row * K + k] = A_i32[(al.vgpr_offset * wf + al.lane) * 4 + al.sub_element];
-      }
-    for (uint32_t k = 0; k < K; ++k)
-      for (uint32_t col = 0; col < N; ++col) {
-        auto bl = input_loc(N, K, B, col, k, 0, in_bits);
-        B_buf[k * N + col] = B_i32[(bl.vgpr_offset * wf + bl.lane) * 4 + bl.sub_element];
-      }
-    // Dense MxKxN matmul, W-lane (zmm) stdx u32 MAC over N (N/W chunks per
-    // row); unsigned wrap matches the scalar signed accumulation mod 2^32.
-    for (uint32_t row = 0; row < M; ++row)
-      for (uint32_t c0 = 0; c0 < N; c0 += W) {
-        util::native<uint32_t> c_row;
-        c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
-        for (uint32_t k = 0; k < K; ++k) {
-          util::native<uint32_t> a_bcast(A_buf[row * K + k]);
-          util::native<uint32_t> b_row;
-          b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
-          c_row += a_bcast * b_row;
+    alignas(64) int32_t A_i32[M * K * B];
+    alignas(64) int32_t B_i32[N * K * B];
+    util::i8_to_i32_block(reinterpret_cast<const int8_t *>(a_words), A_i32, M * K * B);
+    util::i8_to_i32_block(reinterpret_cast<const int8_t *>(b_words), B_i32, N * K * B);
+    for (uint32_t b = 0; b < B; ++b) {
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = output_loc_32(M, N, row, col, b);
+          C_buf[row * N + col] =
+              (const_acc != ACC_FROM_VGPR) ? const_acc : c_words[out.reg * wf + out.lane];
         }
-        c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
-      }
-    // Scatter directly back to VGPRs (no Result staging vector).
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
-    for (uint32_t row = 0; row < M; ++row)
-      for (uint32_t col = 0; col < N; ++col) {
-        auto out = output_loc_32(M, N, row, col, 0);
-        d_words[out.reg * wf + out.lane] = C_buf[row * N + col];
-      }
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t k = 0; k < K; ++k) {
+          auto al = input_loc(M, K, B, row, k, b, in_bits);
+          A_buf[row * K + k] = A_i32[(al.vgpr_offset * wf + al.lane) * 4 + al.sub_element];
+        }
+      for (uint32_t k = 0; k < K; ++k)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto bl = input_loc(N, K, B, col, k, b, in_bits);
+          B_buf[k * N + col] = B_i32[(bl.vgpr_offset * wf + bl.lane) * 4 + bl.sub_element];
+        }
+      // Dense MxKxN matmul, W-lane (zmm) stdx u32 MAC over N (N/W chunks per
+      // row); unsigned wrap matches the scalar signed accumulation mod 2^32.
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t c0 = 0; c0 < N; c0 += W) {
+          util::native<uint32_t> c_row;
+          c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
+          for (uint32_t k = 0; k < K; ++k) {
+            util::native<uint32_t> a_bcast(A_buf[row * K + k]);
+            util::native<uint32_t> b_row;
+            b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
+            c_row += a_bcast * b_row;
+          }
+          c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
+        }
+      // Scatter directly back to VGPRs (no Result staging vector).
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = output_loc_32(M, N, row, col, b);
+          d_words[out.reg * wf + out.lane] = C_buf[row * N + col];
+        }
+    }
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -2121,9 +2121,11 @@ inline void exec_wmma_i32_16x16x64_iu8(amdgpu::ComputeUnitCore &cu, uint32_t dst
     const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
     const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
     const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
-    alignas(64) int32_t A_buf[M * K]; // A[row][k]
-    alignas(64) int32_t B_buf[K * N]; // B[k][col]
-    alignas(64) int32_t S_buf[M * N]; // sum-of-products, accumulator added at pack
+    // Accumulate in unsigned 32-bit (wrap is well-defined; identical mod 2^32
+    // to the intended signed wrap), sign-restore via int32 cast at pack time.
+    alignas(64) uint32_t A_buf[M * K]; // A[row][k] (sign-/zero-extended bits)
+    alignas(64) uint32_t B_buf[K * N]; // B[k][col] (sign-/zero-extended bits)
+    alignas(64) uint32_t S_buf[M * N]; // sum-of-products, accumulator added at pack
     // Bulk-extend the packed byte regions to int32 once, then the hoist is a
     // pure i32 index-shuffle (byte j of word w lane l sub s -> (w*wf+l)*4+s).
     alignas(64) int32_t A_i32[M * K];
@@ -2146,12 +2148,13 @@ inline void exec_wmma_i32_16x16x64_iu8(amdgpu::ComputeUnitCore &cu, uint32_t dst
         auto bl = wmma_input_loc(N, K, col, k, in_bits);
         B_buf[k * N + col] = B_i32[(bl.vgpr_offset * wf + bl.lane) * 4 + bl.sub_element];
       }
-    // Dense 16x64 * 64x16 -> 16x16 product-sum, 16-lane stdx i32 MAC per row.
+    // Dense 16x64 * 64x16 -> 16x16 product-sum, 16-lane stdx u32 MAC per row
+    // (unsigned to avoid signed-overflow UB; bits match the signed math).
     for (uint32_t row = 0; row < M; ++row) {
-      util::native<int32_t> s_row(0);
+      util::native<uint32_t> s_row(0);
       for (uint32_t k = 0; k < K; ++k) {
-        util::native<int32_t> a_bcast(A_buf[row * K + k]);
-        util::native<int32_t> b_row;
+        util::native<uint32_t> a_bcast(A_buf[row * K + k]);
+        util::native<uint32_t> b_row;
         b_row.copy_from(&B_buf[k * N], util::stdx::vector_aligned);
         s_row += a_bcast * b_row;
       }
@@ -2167,7 +2170,7 @@ inline void exec_wmma_i32_16x16x64_iu8(amdgpu::ComputeUnitCore &cu, uint32_t dst
             (const_acc != ACC_FROM_VGPR)
                 ? static_cast<int64_t>(static_cast<int32_t>(const_acc))
                 : static_cast<int64_t>(static_cast<int32_t>(c_words[out.reg * wf + out.lane]));
-        acc += static_cast<int64_t>(S_buf[row * N + col]);
+        acc += static_cast<int64_t>(static_cast<int32_t>(S_buf[row * N + col]));
         d_words[out.reg * wf + out.lane] = pack_i32_acc(acc, clamp);
       }
   }
@@ -3006,8 +3009,9 @@ inline void exec_f32_mfma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, u
 /// bulk sign-extended to int32 once, the hoist is a pure i32 index-shuffle,
 /// and the matmul runs as constexpr-unrolled zmm-wide int32 MACs. There is no
 /// clamp on the i8 MFMA path: both scalar and SIMD accumulate (and wrap) in
-/// 32 bits, so they agree bit for bit on every output. Falls back to the
-/// generic exec_i32_i8 without AVX-512 / under force-scalar.
+/// 32 bits, so they agree bit for bit on every output (SIMD wraps in uint32
+/// to keep the wrap well-defined). Falls back to the generic exec_i32_i8
+/// without AVX-512 / under force-scalar.
 template <uint32_t M, uint32_t N, uint32_t K>
 inline void exec_i32_mfma_i8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
                                   uint32_t s1, uint32_t s2, uint32_t const_acc) {
@@ -3026,9 +3030,12 @@ inline void exec_i32_mfma_i8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uin
     const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
     const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
     const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
-    alignas(64) int32_t A_buf[M * K]; // A[row][k]
-    alignas(64) int32_t B_buf[K * N]; // B[k][col]
-    alignas(64) int32_t C_buf[M * N]; // C[row][col]
+    // Accumulate in unsigned 32-bit (wrap is well-defined and identical mod
+    // 2^32 to the intended signed wrap), so the SIMD path has no signed-
+    // overflow UB.
+    alignas(64) uint32_t A_buf[M * K]; // A[row][k] (sign-extended bits)
+    alignas(64) uint32_t B_buf[K * N]; // B[k][col] (sign-extended bits)
+    alignas(64) uint32_t C_buf[M * N]; // C[row][col]
     // Bulk sign-extend the packed i8 regions to int32 once, then the hoist is
     // a pure i32 index-shuffle (byte of word w lane l sub s -> (w*wf+l)*4+s).
     alignas(64) int32_t A_i32[M * K];
@@ -3038,9 +3045,8 @@ inline void exec_i32_mfma_i8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uin
     for (uint32_t row = 0; row < M; ++row)
       for (uint32_t col = 0; col < N; ++col) {
         auto out = output_loc_32(M, N, row, col, 0);
-        C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
-                                   ? static_cast<int32_t>(const_acc)
-                                   : static_cast<int32_t>(c_words[out.reg * wf + out.lane]);
+        C_buf[row * N + col] =
+            (const_acc != ACC_FROM_VGPR) ? const_acc : c_words[out.reg * wf + out.lane];
       }
     for (uint32_t row = 0; row < M; ++row)
       for (uint32_t k = 0; k < K; ++k) {
@@ -3052,14 +3058,15 @@ inline void exec_i32_mfma_i8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uin
         auto bl = input_loc(N, K, B, col, k, 0, in_bits);
         B_buf[k * N + col] = B_i32[(bl.vgpr_offset * wf + bl.lane) * 4 + bl.sub_element];
       }
-    // Dense MxKxN matmul, W-lane (zmm) stdx i32 MAC over N (N/W chunks per row).
+    // Dense MxKxN matmul, W-lane (zmm) stdx u32 MAC over N (N/W chunks per
+    // row); unsigned wrap matches the scalar signed accumulation mod 2^32.
     for (uint32_t row = 0; row < M; ++row)
       for (uint32_t c0 = 0; c0 < N; c0 += W) {
-        util::native<int32_t> c_row;
+        util::native<uint32_t> c_row;
         c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
         for (uint32_t k = 0; k < K; ++k) {
-          util::native<int32_t> a_bcast(A_buf[row * K + k]);
-          util::native<int32_t> b_row;
+          util::native<uint32_t> a_bcast(A_buf[row * K + k]);
+          util::native<uint32_t> b_row;
           b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
           c_row += a_bcast * b_row;
         }
@@ -3070,7 +3077,7 @@ inline void exec_i32_mfma_i8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uin
     for (uint32_t row = 0; row < M; ++row)
       for (uint32_t col = 0; col < N; ++col) {
         auto out = output_loc_32(M, N, row, col, 0);
-        d_words[out.reg * wf + out.lane] = static_cast<uint32_t>(C_buf[row * N + col]);
+        d_words[out.reg * wf + out.lane] = C_buf[row * N + col];
       }
   }
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -2044,9 +2044,10 @@ inline void exec_wmma_i32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, u
     }
   };
 
-  // SIMD fast path: int32 accumulation is exact and cannot overflow for WMMA's
-  // i8/i4 inputs at K <= 128 (max |acc| ~1M << 2^31), so it matches the scalar
-  // int64+clamp result bit-for-bit; the final pack_i32_acc still clamps.
+  // SIMD fast path: the K-sum of products is exact in int32 for WMMA's i8/i4
+  // inputs at K <= 128 (max |sum| ~2M << 2^31). The int32 accumulator is added
+  // in 64-bit at pack time so pack_i32_acc saturates exactly like the scalar
+  // int64 reference even when C sits near INT32_MAX/INT32_MIN.
   if constexpr (util::has_stdx_simd) {
     constexpr uint32_t W = static_cast<uint32_t>(util::native<int32_t>::size());
     const uint32_t stride = ((N + W - 1) / W) * W;
@@ -2059,14 +2060,6 @@ inline void exec_wmma_i32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, u
       alignas(64) int32_t Bbuf[WMMA_SIMD_MAX_BSTRIDE] = {};
       alignas(64) int32_t Cbuf[WMMA_SIMD_MAX_C] = {};
       for (uint32_t row = 0; row < M; ++row)
-        for (uint32_t col = 0; col < N; ++col) {
-          auto out = wmma_output_loc_32(M, N, row, col);
-          Cbuf[row * stride + col] =
-              (const_acc != ACC_FROM_VGPR)
-                  ? static_cast<int32_t>(const_acc)
-                  : static_cast<int32_t>(cu.read_vgpr(s2 + out.reg, out.lane));
-        }
-      for (uint32_t row = 0; row < M; ++row)
         for (uint32_t k = 0; k < K; ++k)
           Abuf[row * K + k] = ea(cu, s0, wmma_input_loc(M, K, row, k, in_bits));
       for (uint32_t k = 0; k < K; ++k)
@@ -2076,8 +2069,12 @@ inline void exec_wmma_i32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, u
       for (uint32_t row = 0; row < M; ++row)
         for (uint32_t col = 0; col < N; ++col) {
           auto out = wmma_output_loc_32(M, N, row, col);
-          results.push_back({out.reg, out.lane,
-                             pack_i32_acc(static_cast<int64_t>(Cbuf[row * stride + col]), clamp)});
+          int64_t acc = (const_acc != ACC_FROM_VGPR)
+                            ? static_cast<int64_t>(static_cast<int32_t>(const_acc))
+                            : static_cast<int64_t>(
+                                  static_cast<int32_t>(cu.read_vgpr(s2 + out.reg, out.lane)));
+          acc += static_cast<int64_t>(Cbuf[row * stride + col]);
+          results.push_back({out.reg, out.lane, pack_i32_acc(acc, clamp)});
         }
     }
   } else {
@@ -2092,6 +2089,88 @@ inline void exec_wmma_i32_i8(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N
                              uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
                              uint32_t const_acc = ACC_FROM_VGPR) {
   exec_wmma_i32(cu, M, N, K, 8, dst, s0, s1, s2, extract_i8, extract_i8, false, const_acc);
+}
+
+/// Fast path for v_wmma_i32_16x16x64_iu8 (gfx1250, wave32, dense). Same recipe
+/// as the f16/bf16 specializations: bulk sign-/zero-extend the packed i8
+/// inputs (per the A/B sign selects from the neg bits) to int32 once, then run
+/// a constexpr-unrolled int32 matmul with direct vgpr_data access. The K-sum
+/// of products is exact in int32 (|sum| <= 64 * 16384) and is added to the
+/// int32 accumulator in 64-bit at pack time, so clamp saturation matches the
+/// scalar int64 reference bit for bit; with clamp off both wrap mod 2^32.
+/// Falls back to the generic exec_wmma_i32 without AVX-512 / under
+/// force-scalar.
+inline void exec_wmma_i32_16x16x64_iu8(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
+                                       uint32_t s1, uint32_t s2, bool a_signed, bool b_signed,
+                                       bool clamp, uint32_t const_acc = ACC_FROM_VGPR) {
+  constexpr uint32_t M = 16, N = 16, K = 64, in_bits = 8;
+  auto fallback = [&]() {
+    exec_wmma_i32(cu, M, N, K, in_bits, dst, s0, s1, s2, a_signed ? extract_i8 : extract_u8,
+                  b_signed ? extract_i8 : extract_u8, clamp, const_acc);
+  };
+  if constexpr (!util::has_stdx_simd) {
+    fallback();
+    return;
+  } else {
+    if (util::force_scalar() || util::native<float>::size() != 16) {
+      fallback();
+      return;
+    }
+    require_wmma_wave32(cu);
+    const uint32_t wf = cu.wf_size();
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    alignas(64) int32_t A_buf[M * K]; // A[row][k]
+    alignas(64) int32_t B_buf[K * N]; // B[k][col]
+    alignas(64) int32_t S_buf[M * N]; // sum-of-products, accumulator added at pack
+    // Bulk-extend the packed byte regions to int32 once, then the hoist is a
+    // pure i32 index-shuffle (byte j of word w lane l sub s -> (w*wf+l)*4+s).
+    alignas(64) int32_t A_i32[M * K];
+    alignas(64) int32_t B_i32[N * K];
+    if (a_signed)
+      util::i8_to_i32_block(reinterpret_cast<const int8_t *>(a_words), A_i32, M * K);
+    else
+      util::u8_to_i32_block(reinterpret_cast<const uint8_t *>(a_words), A_i32, M * K);
+    if (b_signed)
+      util::i8_to_i32_block(reinterpret_cast<const int8_t *>(b_words), B_i32, N * K);
+    else
+      util::u8_to_i32_block(reinterpret_cast<const uint8_t *>(b_words), B_i32, N * K);
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t k = 0; k < K; ++k) {
+        auto al = wmma_input_loc(M, K, row, k, in_bits);
+        A_buf[row * K + k] = A_i32[(al.vgpr_offset * wf + al.lane) * 4 + al.sub_element];
+      }
+    for (uint32_t k = 0; k < K; ++k)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto bl = wmma_input_loc(N, K, col, k, in_bits);
+        B_buf[k * N + col] = B_i32[(bl.vgpr_offset * wf + bl.lane) * 4 + bl.sub_element];
+      }
+    // Dense 16x64 * 64x16 -> 16x16 product-sum, 16-lane stdx i32 MAC per row.
+    for (uint32_t row = 0; row < M; ++row) {
+      util::native<int32_t> s_row(0);
+      for (uint32_t k = 0; k < K; ++k) {
+        util::native<int32_t> a_bcast(A_buf[row * K + k]);
+        util::native<int32_t> b_row;
+        b_row.copy_from(&B_buf[k * N], util::stdx::vector_aligned);
+        s_row += a_bcast * b_row;
+      }
+      s_row.copy_to(&S_buf[row * N], util::stdx::vector_aligned);
+    }
+    // Add the accumulator in 64-bit and pack (saturating when clamp is set),
+    // scattering directly back to VGPRs.
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_32(M, N, row, col);
+        int64_t acc =
+            (const_acc != ACC_FROM_VGPR)
+                ? static_cast<int64_t>(static_cast<int32_t>(const_acc))
+                : static_cast<int64_t>(static_cast<int32_t>(c_words[out.reg * wf + out.lane]));
+        acc += static_cast<int64_t>(S_buf[row * N + col]);
+        d_words[out.reg * wf + out.lane] = pack_i32_acc(acc, clamp);
+      }
+  }
 }
 
 template <typename ExtractA, typename ExtractB>
@@ -2138,8 +2217,10 @@ inline void exec_swmmac_i32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N,
   };
 
   // SIMD fast path: per-row gather, single row through the int32 matmul core
-  // (M=1). int32 accumulation is exact for i8/i4 inputs (no overflow), matching
-  // the scalar int64+clamp result; pack_i32_acc still clamps at the end.
+  // (M=1). The K-sum of products is exact in int32 for i8/i4 inputs (no
+  // overflow); the int32 accumulator is added in 64-bit at pack time so
+  // pack_i32_acc saturates exactly like the scalar int64 reference even when
+  // C sits near INT32_MAX/INT32_MIN.
   if constexpr (util::has_stdx_simd) {
     constexpr uint32_t W = static_cast<uint32_t>(util::native<int32_t>::size());
     const uint32_t stride = ((N + W - 1) / W) * W;
@@ -2152,12 +2233,8 @@ inline void exec_swmmac_i32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N,
       alignas(64) int32_t Bbuf[WMMA_SIMD_MAX_BSTRIDE] = {};
       alignas(64) int32_t Cbuf[WMMA_SIMD_MAX_C] = {};
       for (uint32_t row = 0; row < M; ++row) {
-        for (uint32_t col = 0; col < N; ++col) {
-          auto out = wmma_output_loc_32(M, N, row, col);
-          Cbuf[col] = (const_acc != ACC_FROM_VGPR)
-                          ? static_cast<int32_t>(const_acc)
-                          : static_cast<int32_t>(cu.read_vgpr(acc_base + out.reg, out.lane));
-        }
+        for (uint32_t col = 0; col < N; ++col)
+          Cbuf[col] = 0;
         for (uint32_t ck = 0; ck < compressed_k; ++ck) {
           Abuf[ck] = ea(cu, s0, wmma_input_loc(M, K / 2, row, ck, in_bits));
           const uint32_t dense_k = dense_k_for(row, ck);
@@ -2167,8 +2244,12 @@ inline void exec_swmmac_i32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N,
         wmma_simd_matmul<int32_t>(1, N, compressed_k, W, stride, Abuf, Bbuf, Cbuf);
         for (uint32_t col = 0; col < N; ++col) {
           auto out = wmma_output_loc_32(M, N, row, col);
-          results.push_back(
-              {out.reg, out.lane, pack_i32_acc(static_cast<int64_t>(Cbuf[col]), clamp)});
+          int64_t acc = (const_acc != ACC_FROM_VGPR)
+                            ? static_cast<int64_t>(static_cast<int32_t>(const_acc))
+                            : static_cast<int64_t>(
+                                  static_cast<int32_t>(cu.read_vgpr(acc_base + out.reg, out.lane)));
+          acc += static_cast<int64_t>(Cbuf[col]);
+          results.push_back({out.reg, out.lane, pack_i32_acc(acc, clamp)});
         }
       }
     }
@@ -2917,6 +2998,80 @@ inline void exec_f32_mfma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, u
                           dst, s0, s1, s2, M, N, K);
       });
     }
+  }
+}
+
+/// Fast path for the dense (B=1) i8-input MFMA shapes (v_mfma_i32_*_i8). Same
+/// structure as the f16 specialization but integer: the packed i8 inputs are
+/// bulk sign-extended to int32 once, the hoist is a pure i32 index-shuffle,
+/// and the matmul runs as constexpr-unrolled zmm-wide int32 MACs. There is no
+/// clamp on the i8 MFMA path: both scalar and SIMD accumulate (and wrap) in
+/// 32 bits, so they agree bit for bit on every output. Falls back to the
+/// generic exec_i32_i8 without AVX-512 / under force-scalar.
+template <uint32_t M, uint32_t N, uint32_t K>
+inline void exec_i32_mfma_i8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
+                                  uint32_t s1, uint32_t s2, uint32_t const_acc) {
+  constexpr uint32_t B = 1, in_bits = 8;
+  static_assert(N % 16 == 0, "specialized i8 MFMA assumes N is a multiple of the zmm width");
+  if constexpr (!util::has_stdx_simd) {
+    exec_i32_i8(cu, M, N, K, B, dst, s0, s1, s2, const_acc);
+    return;
+  } else {
+    if (util::force_scalar() || util::native<float>::size() != 16) {
+      exec_i32_i8(cu, M, N, K, B, dst, s0, s1, s2, const_acc);
+      return;
+    }
+    constexpr uint32_t W = 16; // guaranteed by the native<float>::size()==16 guard above
+    const uint32_t wf = cu.wf_size();
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    alignas(64) int32_t A_buf[M * K]; // A[row][k]
+    alignas(64) int32_t B_buf[K * N]; // B[k][col]
+    alignas(64) int32_t C_buf[M * N]; // C[row][col]
+    // Bulk sign-extend the packed i8 regions to int32 once, then the hoist is
+    // a pure i32 index-shuffle (byte of word w lane l sub s -> (w*wf+l)*4+s).
+    alignas(64) int32_t A_i32[M * K];
+    alignas(64) int32_t B_i32[N * K];
+    util::i8_to_i32_block(reinterpret_cast<const int8_t *>(a_words), A_i32, M * K);
+    util::i8_to_i32_block(reinterpret_cast<const int8_t *>(b_words), B_i32, N * K);
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = output_loc_32(M, N, row, col, 0);
+        C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
+                                   ? static_cast<int32_t>(const_acc)
+                                   : static_cast<int32_t>(c_words[out.reg * wf + out.lane]);
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t k = 0; k < K; ++k) {
+        auto al = input_loc(M, K, B, row, k, 0, in_bits);
+        A_buf[row * K + k] = A_i32[(al.vgpr_offset * wf + al.lane) * 4 + al.sub_element];
+      }
+    for (uint32_t k = 0; k < K; ++k)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto bl = input_loc(N, K, B, col, k, 0, in_bits);
+        B_buf[k * N + col] = B_i32[(bl.vgpr_offset * wf + bl.lane) * 4 + bl.sub_element];
+      }
+    // Dense MxKxN matmul, W-lane (zmm) stdx i32 MAC over N (N/W chunks per row).
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t c0 = 0; c0 < N; c0 += W) {
+        util::native<int32_t> c_row;
+        c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
+        for (uint32_t k = 0; k < K; ++k) {
+          util::native<int32_t> a_bcast(A_buf[row * K + k]);
+          util::native<int32_t> b_row;
+          b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
+          c_row += a_bcast * b_row;
+        }
+        c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
+      }
+    // Scatter directly back to VGPRs (no Result staging vector).
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = output_loc_32(M, N, row, col, 0);
+        d_words[out.reg * wf + out.lane] = static_cast<uint32_t>(C_buf[row * N + col]);
+      }
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -968,6 +968,84 @@ void exec_wmma_f32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t
   exec_wmma_f32_mixed(cu, M, N, K, in_bits, in_bits, dst, s0, s1, s2, ea, eb, const_acc);
 }
 
+/// Fast path for v_wmma_f32_16x16x32_f16 (gfx1250, wave32) — the WMMA analogue
+/// of exec_f32_mfma_16x16x32_f16. Compile-time M/N/K let the compiler fully
+/// unroll the 16-row x 32-K matmul into straight-line AVX-512 FMAs; the f16
+/// inputs are bulk-converted once with F16C (one vector op per 16 halves)
+/// instead of branchy per-element extract_f16; VGPRs are accessed through one
+/// vgpr_data base pointer per operand and the result scatters directly (no
+/// Result staging vector). Falls back to the generic exec_wmma_f32 without
+/// AVX-512 / under force-scalar.
+inline void exec_wmma_f32_16x16x32_f16(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
+                                       uint32_t s1, uint32_t s2,
+                                       uint32_t const_acc = ACC_FROM_VGPR) {
+  constexpr uint32_t M = 16, N = 16, K = 32, in_bits = 16;
+  if constexpr (!util::has_stdx_simd) {
+    exec_wmma_f32(cu, M, N, K, in_bits, dst, s0, s1, s2, amdgpu::extract_f16, amdgpu::extract_f16,
+                  const_acc);
+    return;
+  } else {
+    if (util::force_scalar() || util::native<float>::size() != 16) {
+      exec_wmma_f32(cu, M, N, K, in_bits, dst, s0, s1, s2, amdgpu::extract_f16, amdgpu::extract_f16,
+                    const_acc);
+      return;
+    }
+    require_wmma_wave32(cu);
+    const uint32_t wf = cu.wf_size();
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    alignas(64) float A_buf[M * K]; // A[row][k]
+    alignas(64) float B_buf[K * N]; // B[k][col]
+    alignas(64) float C_buf[M * N]; // C[row][col]
+    // A and B each occupy 8 VGPRs x wf lanes = 2*8*wf packed f16 (16 f16/lane
+    // for K=32). Bulk-convert the region to f32 once, then the hoist is a pure
+    // f32 index-shuffle (f16 j of word w sub s -> flat (w*wf+lane)*2+s).
+    constexpr uint32_t NUM_IN_REGS = 8;
+    const uint32_t n_halves = 2 * NUM_IN_REGS * wf;
+    alignas(64) float A_f32[2 * NUM_IN_REGS * 64];
+    alignas(64) float B_f32[2 * NUM_IN_REGS * 64];
+    util::f16_to_f32_block(reinterpret_cast<const uint16_t *>(a_words), A_f32, n_halves);
+    util::f16_to_f32_block(reinterpret_cast<const uint16_t *>(b_words), B_f32, n_halves);
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_32(M, N, row, col);
+        C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
+                                   ? std::bit_cast<float>(const_acc)
+                                   : std::bit_cast<float>(c_words[out.reg * wf + out.lane]);
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t k = 0; k < K; ++k) {
+        auto al = wmma_input_loc(M, K, row, k, in_bits);
+        A_buf[row * K + k] = A_f32[(al.vgpr_offset * wf + al.lane) * 2 + al.sub_element];
+      }
+    for (uint32_t k = 0; k < K; ++k)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto bl = wmma_input_loc(N, K, col, k, in_bits);
+        B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 2 + bl.sub_element];
+      }
+    // Dense 16x32 * 32x16 -> 16x16 matmul, 16-lane stdx FMA per row.
+    for (uint32_t row = 0; row < M; ++row) {
+      util::native<float> c_row;
+      c_row.copy_from(&C_buf[row * N], util::stdx::vector_aligned);
+      for (uint32_t k = 0; k < K; ++k) {
+        util::native<float> a_bcast(A_buf[row * K + k]);
+        util::native<float> b_row;
+        b_row.copy_from(&B_buf[k * N], util::stdx::vector_aligned);
+        c_row = util::stdx::fma(a_bcast, b_row, c_row);
+      }
+      c_row.copy_to(&C_buf[row * N], util::stdx::vector_aligned);
+    }
+    // Scatter directly back to VGPRs (no Result staging vector).
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_32(M, N, row, col);
+        d_words[out.reg * wf + out.lane] = std::bit_cast<uint32_t>(C_buf[row * N + col]);
+      }
+  }
+}
+
 template <typename ExtractA, typename ExtractB>
 void exec_swmmac_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K,
                            uint32_t a_bits, uint32_t b_bits, uint32_t dst, uint32_t s0, uint32_t s1,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -740,6 +740,55 @@ void exec_f32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K, u
                  blgp);
 }
 
+/// Column (N) leading-dimension pitch rounding A/B/C buffers up to a SIMD-width
+/// multiple, so every matmul row starts W-aligned. Bounds every real WMMA shape
+/// (M,N <= 16, K <= 128); anything larger falls back to the scalar path.
+constexpr size_t WMMA_SIMD_MAX_AB = 2048;      // max M*K
+constexpr size_t WMMA_SIMD_MAX_BSTRIDE = 4096; // max K*stride
+constexpr size_t WMMA_SIMD_MAX_C = 1024;       // max M*stride
+
+/// Shared SIMD core for the WMMA/SWMMAC executors. For every (row,col),
+/// Cbuf[row*stride+col] += sum_k Abuf[row*K+k] * Bbuf[k*stride+col], run as
+/// native-width rows over the col (N) dimension with a scalar tail. A/B/C must
+/// already be hoisted into dense buffers (lane permutation, per-element scale,
+/// and 2:4 sparsity gather folded in by the caller). Float uses fused FMA
+/// (matching the hardware's single-rounding MACs; the scalar reference is
+/// non-fused, so f32 agrees to a few ULP and packed f16/bf16 rounds identically);
+/// integer MAC is exact, so the SIMD and scalar paths are bit-identical.
+/// Templated so the `if constexpr (has_stdx_simd)` callers never instantiate it
+/// on a platform without <experimental/simd>.
+template <typename T>
+inline void wmma_simd_matmul(uint32_t M, uint32_t N, uint32_t K, uint32_t W, uint32_t stride,
+                             const T *Abuf, const T *Bbuf, T *Cbuf) {
+  for (uint32_t row = 0; row < M; ++row) {
+    uint32_t col = 0;
+    for (; col + W <= N; col += W) {
+      util::native<T> c;
+      c.copy_from(&Cbuf[row * stride + col], util::stdx::vector_aligned);
+      for (uint32_t k = 0; k < K; ++k) {
+        util::native<T> a(Abuf[row * K + k]);
+        util::native<T> bv;
+        bv.copy_from(&Bbuf[k * stride + col], util::stdx::vector_aligned);
+        if constexpr (std::is_floating_point_v<T>)
+          c = util::stdx::fma(a, bv, c);
+        else
+          c += a * bv;
+      }
+      c.copy_to(&Cbuf[row * stride + col], util::stdx::vector_aligned);
+    }
+    for (; col < N; ++col) {
+      T acc = Cbuf[row * stride + col];
+      for (uint32_t k = 0; k < K; ++k) {
+        if constexpr (std::is_floating_point_v<T>)
+          acc = std::fma(Abuf[row * K + k], Bbuf[k * stride + col], acc);
+        else
+          acc += Abuf[row * K + k] * Bbuf[k * stride + col];
+      }
+      Cbuf[row * stride + col] = acc;
+    }
+  }
+}
+
 template <typename ExtractA, typename ExtractB>
 void exec_wmma_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K,
                          uint32_t a_bits, uint32_t b_bits, uint32_t dst, uint32_t s0, uint32_t s1,
@@ -753,20 +802,62 @@ void exec_wmma_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, ui
   };
   std::vector<Result> results;
   results.reserve(M * N);
-  for (uint32_t row = 0; row < M; ++row) {
-    for (uint32_t col = 0; col < N; ++col) {
-      auto out = wmma_output_loc_32(M, N, row, col);
-      float acc = (const_acc != ACC_FROM_VGPR)
-                      ? std::bit_cast<float>(const_acc)
-                      : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
-      for (uint32_t k = 0; k < K; ++k) {
-        auto al = wmma_input_loc(M, K, row, k, a_bits);
-        auto bl = wmma_input_loc(N, K, col, k, b_bits);
-        acc += ea(cu, s0, al) * eb(cu, s1, bl);
+
+  auto run_scalar = [&]() {
+    for (uint32_t row = 0; row < M; ++row) {
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_32(M, N, row, col);
+        float acc = (const_acc != ACC_FROM_VGPR)
+                        ? std::bit_cast<float>(const_acc)
+                        : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
+        for (uint32_t k = 0; k < K; ++k) {
+          auto al = wmma_input_loc(M, K, row, k, a_bits);
+          auto bl = wmma_input_loc(N, K, col, k, b_bits);
+          acc += ea(cu, s0, al) * eb(cu, s1, bl);
+        }
+        results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
       }
-      results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
     }
+  };
+
+  // SIMD fast path: hoist A/B/C into dense f32 buffers, then run the dense
+  // MxNxK matmul as native-width FMA rows over the N (column) dimension.
+  if constexpr (util::has_stdx_simd) {
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
+    const uint32_t stride = ((N + W - 1) / W) * W;
+    if (util::force_scalar() || static_cast<size_t>(M) * K > WMMA_SIMD_MAX_AB ||
+        static_cast<size_t>(K) * stride > WMMA_SIMD_MAX_BSTRIDE ||
+        static_cast<size_t>(M) * stride > WMMA_SIMD_MAX_C) {
+      run_scalar();
+    } else {
+      alignas(64) float Abuf[WMMA_SIMD_MAX_AB] = {};
+      alignas(64) float Bbuf[WMMA_SIMD_MAX_BSTRIDE] = {};
+      alignas(64) float Cbuf[WMMA_SIMD_MAX_C] = {};
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = wmma_output_loc_32(M, N, row, col);
+          Cbuf[row * stride + col] =
+              (const_acc != ACC_FROM_VGPR)
+                  ? std::bit_cast<float>(const_acc)
+                  : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
+        }
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t k = 0; k < K; ++k)
+          Abuf[row * K + k] = ea(cu, s0, wmma_input_loc(M, K, row, k, a_bits));
+      for (uint32_t k = 0; k < K; ++k)
+        for (uint32_t col = 0; col < N; ++col)
+          Bbuf[k * stride + col] = eb(cu, s1, wmma_input_loc(N, K, col, k, b_bits));
+      wmma_simd_matmul<float>(M, N, K, W, stride, Abuf, Bbuf, Cbuf);
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = wmma_output_loc_32(M, N, row, col);
+          results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(Cbuf[row * stride + col])});
+        }
+    }
+  } else {
+    run_scalar();
   }
+
   for (const auto &r : results)
     cu.write_vgpr(dst + r.reg, r.lane, r.val);
 }
@@ -787,29 +878,85 @@ void exec_wmma_f32_scaled_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_
   };
   std::vector<Result> results;
   results.reserve(M * N);
-  for (uint32_t row = 0; row < M; ++row) {
-    for (uint32_t col = 0; col < N; ++col) {
-      auto out = wmma_output_loc_32(M, N, row, col);
-      float acc = (const_acc != ACC_FROM_VGPR)
-                      ? std::bit_cast<float>(const_acc)
-                      : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
-      const uint32_t a_scale_word = scale_a_word(wmma_scale_lane(row, matrix_a_scale));
-      const uint32_t b_scale_word = scale_b_word(wmma_scale_lane(col, matrix_b_scale));
-      for (uint32_t k = 0; k < K; ++k) {
-        auto al = wmma_input_loc(M, K, row, k, a_bits);
-        auto bl = wmma_input_loc(N, K, col, k, b_bits);
-        const uint32_t a_scale_byte = wmma_scale_byte(al);
-        const uint32_t b_scale_byte =
-            (b_bits == 4) ? wmma_b_fp4_scale_byte(k) : wmma_scale_byte(bl);
-        const float a_scale = decode_wmma_scale_byte(
-            static_cast<uint8_t>((a_scale_word >> (a_scale_byte * 8)) & 0xffu), matrix_a_scale_fmt);
-        const float b_scale = decode_wmma_scale_byte(
-            static_cast<uint8_t>((b_scale_word >> (b_scale_byte * 8)) & 0xffu), matrix_b_scale_fmt);
-        acc += ea(cu, s0, al) * eb(cu, s1, bl) * a_scale * b_scale;
+
+  // Per-element A scale (folds into Abuf): f(row, k). Per-element B scale (folds
+  // into Bbuf): f(col, k). With both folded in, the product reduces to the plain
+  // dense matmul A*B that wmma_simd_matmul computes.
+  auto a_scale_for = [&](uint32_t a_scale_word, const InputLoc &al) -> float {
+    return decode_wmma_scale_byte(
+        static_cast<uint8_t>((a_scale_word >> (wmma_scale_byte(al) * 8)) & 0xffu),
+        matrix_a_scale_fmt);
+  };
+  auto b_scale_for = [&](uint32_t b_scale_word, const InputLoc &bl, uint32_t k) -> float {
+    const uint32_t b_scale_byte = (b_bits == 4) ? wmma_b_fp4_scale_byte(k) : wmma_scale_byte(bl);
+    return decode_wmma_scale_byte(
+        static_cast<uint8_t>((b_scale_word >> (b_scale_byte * 8)) & 0xffu), matrix_b_scale_fmt);
+  };
+
+  auto run_scalar = [&]() {
+    for (uint32_t row = 0; row < M; ++row) {
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_32(M, N, row, col);
+        float acc = (const_acc != ACC_FROM_VGPR)
+                        ? std::bit_cast<float>(const_acc)
+                        : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
+        const uint32_t a_scale_word = scale_a_word(wmma_scale_lane(row, matrix_a_scale));
+        const uint32_t b_scale_word = scale_b_word(wmma_scale_lane(col, matrix_b_scale));
+        for (uint32_t k = 0; k < K; ++k) {
+          auto al = wmma_input_loc(M, K, row, k, a_bits);
+          auto bl = wmma_input_loc(N, K, col, k, b_bits);
+          acc += ea(cu, s0, al) * eb(cu, s1, bl) * a_scale_for(a_scale_word, al) *
+                 b_scale_for(b_scale_word, bl, k);
+        }
+        results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
       }
-      results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
     }
+  };
+
+  if constexpr (util::has_stdx_simd) {
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
+    const uint32_t stride = ((N + W - 1) / W) * W;
+    if (util::force_scalar() || static_cast<size_t>(M) * K > WMMA_SIMD_MAX_AB ||
+        static_cast<size_t>(K) * stride > WMMA_SIMD_MAX_BSTRIDE ||
+        static_cast<size_t>(M) * stride > WMMA_SIMD_MAX_C) {
+      run_scalar();
+    } else {
+      alignas(64) float Abuf[WMMA_SIMD_MAX_AB] = {};
+      alignas(64) float Bbuf[WMMA_SIMD_MAX_BSTRIDE] = {};
+      alignas(64) float Cbuf[WMMA_SIMD_MAX_C] = {};
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = wmma_output_loc_32(M, N, row, col);
+          Cbuf[row * stride + col] =
+              (const_acc != ACC_FROM_VGPR)
+                  ? std::bit_cast<float>(const_acc)
+                  : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
+        }
+      for (uint32_t row = 0; row < M; ++row) {
+        const uint32_t a_scale_word = scale_a_word(wmma_scale_lane(row, matrix_a_scale));
+        for (uint32_t k = 0; k < K; ++k) {
+          auto al = wmma_input_loc(M, K, row, k, a_bits);
+          Abuf[row * K + k] = ea(cu, s0, al) * a_scale_for(a_scale_word, al);
+        }
+      }
+      for (uint32_t col = 0; col < N; ++col) {
+        const uint32_t b_scale_word = scale_b_word(wmma_scale_lane(col, matrix_b_scale));
+        for (uint32_t k = 0; k < K; ++k) {
+          auto bl = wmma_input_loc(N, K, col, k, b_bits);
+          Bbuf[k * stride + col] = eb(cu, s1, bl) * b_scale_for(b_scale_word, bl, k);
+        }
+      }
+      wmma_simd_matmul<float>(M, N, K, W, stride, Abuf, Bbuf, Cbuf);
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = wmma_output_loc_32(M, N, row, col);
+          results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(Cbuf[row * stride + col])});
+        }
+    }
+  } else {
+    run_scalar();
   }
+
   for (const auto &r : results)
     cu.write_vgpr(dst + r.reg, r.lane, r.val);
 }
@@ -837,25 +984,72 @@ void exec_swmmac_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, 
   results.reserve(M * N);
 
   const uint32_t compressed_k = K / 2;
-  for (uint32_t row = 0; row < M; ++row) {
-    for (uint32_t col = 0; col < N; ++col) {
-      auto out = wmma_output_loc_32(M, N, row, col);
-      float acc = (const_acc != ACC_FROM_VGPR)
-                      ? std::bit_cast<float>(const_acc)
-                      : std::bit_cast<float>(cu.read_vgpr(acc_base + out.reg, out.lane));
-      for (uint32_t ck = 0; ck < compressed_k; ++ck) {
-        auto al = wmma_input_loc(M, K / 2, row, ck, a_bits);
-        const uint32_t metadata_lane = row + (ck / index_entries) * M;
-        const uint32_t local_ck = ck % index_entries;
-        const uint64_t index_set =
-            read_swmmac_index_set(cu, index_base, metadata_lane, index_entries, index_key);
-        const uint32_t dense_k = swmmac_dense_k(index_set, ck, local_ck);
-        auto bl = wmma_input_loc(N, K, col, dense_k, b_bits);
-        acc += ea(cu, s0, al) * eb(cu, s1, bl);
+
+  // dense_k depends on (row, ck) via the row's metadata, not on col — so the
+  // gathered B column is shared across all col for a fixed row. Resolve it once.
+  auto dense_k_for = [&](uint32_t row, uint32_t ck) -> uint32_t {
+    const uint32_t metadata_lane = row + (ck / index_entries) * M;
+    const uint32_t local_ck = ck % index_entries;
+    const uint64_t index_set =
+        read_swmmac_index_set(cu, index_base, metadata_lane, index_entries, index_key);
+    return swmmac_dense_k(index_set, ck, local_ck);
+  };
+
+  auto run_scalar = [&]() {
+    for (uint32_t row = 0; row < M; ++row) {
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_32(M, N, row, col);
+        float acc = (const_acc != ACC_FROM_VGPR)
+                        ? std::bit_cast<float>(const_acc)
+                        : std::bit_cast<float>(cu.read_vgpr(acc_base + out.reg, out.lane));
+        for (uint32_t ck = 0; ck < compressed_k; ++ck) {
+          auto al = wmma_input_loc(M, K / 2, row, ck, a_bits);
+          auto bl = wmma_input_loc(N, K, col, dense_k_for(row, ck), b_bits);
+          acc += ea(cu, s0, al) * eb(cu, s1, bl);
+        }
+        results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
       }
-      results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
     }
+  };
+
+  // SIMD fast path: because the B gather is row-dependent, hoist each row's A
+  // (compressed_k) and B (compressed_k x col, with dense_k folded in) into dense
+  // buffers, then run that single row through the shared matmul core (M=1).
+  if constexpr (util::has_stdx_simd) {
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
+    const uint32_t stride = ((N + W - 1) / W) * W;
+    if (util::force_scalar() || static_cast<size_t>(compressed_k) > WMMA_SIMD_MAX_AB ||
+        static_cast<size_t>(compressed_k) * stride > WMMA_SIMD_MAX_BSTRIDE ||
+        stride > WMMA_SIMD_MAX_C) {
+      run_scalar();
+    } else {
+      alignas(64) float Abuf[WMMA_SIMD_MAX_AB] = {};
+      alignas(64) float Bbuf[WMMA_SIMD_MAX_BSTRIDE] = {};
+      alignas(64) float Cbuf[WMMA_SIMD_MAX_C] = {};
+      for (uint32_t row = 0; row < M; ++row) {
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = wmma_output_loc_32(M, N, row, col);
+          Cbuf[col] = (const_acc != ACC_FROM_VGPR)
+                          ? std::bit_cast<float>(const_acc)
+                          : std::bit_cast<float>(cu.read_vgpr(acc_base + out.reg, out.lane));
+        }
+        for (uint32_t ck = 0; ck < compressed_k; ++ck) {
+          Abuf[ck] = ea(cu, s0, wmma_input_loc(M, K / 2, row, ck, a_bits));
+          const uint32_t dense_k = dense_k_for(row, ck);
+          for (uint32_t col = 0; col < N; ++col)
+            Bbuf[ck * stride + col] = eb(cu, s1, wmma_input_loc(N, K, col, dense_k, b_bits));
+        }
+        wmma_simd_matmul<float>(1, N, compressed_k, W, stride, Abuf, Bbuf, Cbuf);
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = wmma_output_loc_32(M, N, row, col);
+          results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(Cbuf[col])});
+        }
+      }
+    }
+  } else {
+    run_scalar();
   }
+
   for (const auto &r : results)
     cu.write_vgpr(dst + r.reg, r.lane, r.val);
 }
@@ -883,19 +1077,61 @@ void exec_wmma_packed16(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uin
   };
   std::vector<Result> results;
   results.reserve(M * N);
-  for (uint32_t row = 0; row < M; ++row) {
-    for (uint32_t col = 0; col < N; ++col) {
-      auto out = wmma_output_loc_16(M, N, row, col);
-      float acc = (const_acc != ACC_FROM_VGPR)
-                      ? std::bit_cast<float>(const_acc)
-                      : read_acc(cu, s2 + out.reg, out.lane, out.sub_element);
-      for (uint32_t k = 0; k < K; ++k) {
-        auto al = wmma_input_loc(M, K, row, k, in_bits);
-        auto bl = wmma_input_loc(N, K, col, k, in_bits);
-        acc += ea(cu, s0, al) * eb(cu, s1, bl);
+
+  auto run_scalar = [&]() {
+    for (uint32_t row = 0; row < M; ++row) {
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_16(M, N, row, col);
+        float acc = (const_acc != ACC_FROM_VGPR)
+                        ? std::bit_cast<float>(const_acc)
+                        : read_acc(cu, s2 + out.reg, out.lane, out.sub_element);
+        for (uint32_t k = 0; k < K; ++k) {
+          auto al = wmma_input_loc(M, K, row, k, in_bits);
+          auto bl = wmma_input_loc(N, K, col, k, in_bits);
+          acc += ea(cu, s0, al) * eb(cu, s1, bl);
+        }
+        results.push_back({out.reg, out.lane, out.sub_element, pack_result(acc)});
       }
-      results.push_back({out.reg, out.lane, out.sub_element, pack_result(acc)});
     }
+  };
+
+  // SIMD fast path: run the f32 matmul vectorized over N into a dense grid, then
+  // pack each result to 16 bits via the caller's pack_result. The masked 2-per-
+  // word scatter below is unchanged.
+  if constexpr (util::has_stdx_simd) {
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
+    const uint32_t stride = ((N + W - 1) / W) * W;
+    if (util::force_scalar() || static_cast<size_t>(M) * K > WMMA_SIMD_MAX_AB ||
+        static_cast<size_t>(K) * stride > WMMA_SIMD_MAX_BSTRIDE ||
+        static_cast<size_t>(M) * stride > WMMA_SIMD_MAX_C) {
+      run_scalar();
+    } else {
+      alignas(64) float Abuf[WMMA_SIMD_MAX_AB] = {};
+      alignas(64) float Bbuf[WMMA_SIMD_MAX_BSTRIDE] = {};
+      alignas(64) float Cbuf[WMMA_SIMD_MAX_C] = {};
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = wmma_output_loc_16(M, N, row, col);
+          Cbuf[row * stride + col] = (const_acc != ACC_FROM_VGPR)
+                                         ? std::bit_cast<float>(const_acc)
+                                         : read_acc(cu, s2 + out.reg, out.lane, out.sub_element);
+        }
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t k = 0; k < K; ++k)
+          Abuf[row * K + k] = ea(cu, s0, wmma_input_loc(M, K, row, k, in_bits));
+      for (uint32_t k = 0; k < K; ++k)
+        for (uint32_t col = 0; col < N; ++col)
+          Bbuf[k * stride + col] = eb(cu, s1, wmma_input_loc(N, K, col, k, in_bits));
+      wmma_simd_matmul<float>(M, N, K, W, stride, Abuf, Bbuf, Cbuf);
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = wmma_output_loc_16(M, N, row, col);
+          results.push_back(
+              {out.reg, out.lane, out.sub_element, pack_result(Cbuf[row * stride + col])});
+        }
+    }
+  } else {
+    run_scalar();
   }
 
   uint32_t dst_regs = ((M * N) / WMMA_WAVE32 + 1) / 2;
@@ -940,24 +1176,67 @@ void exec_swmmac_packed16(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, u
   results.reserve(M * N);
 
   const uint32_t compressed_k = K / 2;
-  for (uint32_t row = 0; row < M; ++row) {
-    for (uint32_t col = 0; col < N; ++col) {
-      auto out = wmma_output_loc_16(M, N, row, col);
-      float acc = (const_acc != ACC_FROM_VGPR)
-                      ? std::bit_cast<float>(const_acc)
-                      : read_acc(cu, acc_base + out.reg, out.lane, out.sub_element);
-      for (uint32_t ck = 0; ck < compressed_k; ++ck) {
-        auto al = wmma_input_loc(M, K / 2, row, ck, in_bits);
-        const uint32_t metadata_lane = row + (ck / index_entries) * M;
-        const uint32_t local_ck = ck % index_entries;
-        const uint64_t index_set =
-            read_swmmac_index_set(cu, index_base, metadata_lane, index_entries, index_key);
-        const uint32_t dense_k = swmmac_dense_k(index_set, ck, local_ck);
-        auto bl = wmma_input_loc(N, K, col, dense_k, in_bits);
-        acc += ea(cu, s0, al) * eb(cu, s1, bl);
+
+  auto dense_k_for = [&](uint32_t row, uint32_t ck) -> uint32_t {
+    const uint32_t metadata_lane = row + (ck / index_entries) * M;
+    const uint32_t local_ck = ck % index_entries;
+    const uint64_t index_set =
+        read_swmmac_index_set(cu, index_base, metadata_lane, index_entries, index_key);
+    return swmmac_dense_k(index_set, ck, local_ck);
+  };
+
+  auto run_scalar = [&]() {
+    for (uint32_t row = 0; row < M; ++row) {
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_16(M, N, row, col);
+        float acc = (const_acc != ACC_FROM_VGPR)
+                        ? std::bit_cast<float>(const_acc)
+                        : read_acc(cu, acc_base + out.reg, out.lane, out.sub_element);
+        for (uint32_t ck = 0; ck < compressed_k; ++ck) {
+          auto al = wmma_input_loc(M, K / 2, row, ck, in_bits);
+          auto bl = wmma_input_loc(N, K, col, dense_k_for(row, ck), in_bits);
+          acc += ea(cu, s0, al) * eb(cu, s1, bl);
+        }
+        results.push_back({out.reg, out.lane, out.sub_element, pack_result(acc)});
       }
-      results.push_back({out.reg, out.lane, out.sub_element, pack_result(acc)});
     }
+  };
+
+  // SIMD fast path: per-row gather (dense_k is row-dependent) into dense f32
+  // buffers, single row through the matmul core (M=1), pack to 16 bits.
+  if constexpr (util::has_stdx_simd) {
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<float>::size());
+    const uint32_t stride = ((N + W - 1) / W) * W;
+    if (util::force_scalar() || static_cast<size_t>(compressed_k) > WMMA_SIMD_MAX_AB ||
+        static_cast<size_t>(compressed_k) * stride > WMMA_SIMD_MAX_BSTRIDE ||
+        stride > WMMA_SIMD_MAX_C) {
+      run_scalar();
+    } else {
+      alignas(64) float Abuf[WMMA_SIMD_MAX_AB] = {};
+      alignas(64) float Bbuf[WMMA_SIMD_MAX_BSTRIDE] = {};
+      alignas(64) float Cbuf[WMMA_SIMD_MAX_C] = {};
+      for (uint32_t row = 0; row < M; ++row) {
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = wmma_output_loc_16(M, N, row, col);
+          Cbuf[col] = (const_acc != ACC_FROM_VGPR)
+                          ? std::bit_cast<float>(const_acc)
+                          : read_acc(cu, acc_base + out.reg, out.lane, out.sub_element);
+        }
+        for (uint32_t ck = 0; ck < compressed_k; ++ck) {
+          Abuf[ck] = ea(cu, s0, wmma_input_loc(M, K / 2, row, ck, in_bits));
+          const uint32_t dense_k = dense_k_for(row, ck);
+          for (uint32_t col = 0; col < N; ++col)
+            Bbuf[ck * stride + col] = eb(cu, s1, wmma_input_loc(N, K, col, dense_k, in_bits));
+        }
+        wmma_simd_matmul<float>(1, N, compressed_k, W, stride, Abuf, Bbuf, Cbuf);
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = wmma_output_loc_16(M, N, row, col);
+          results.push_back({out.reg, out.lane, out.sub_element, pack_result(Cbuf[col])});
+        }
+      }
+    }
+  } else {
+    run_scalar();
   }
 
   uint32_t dst_regs = ((M * N) / WMMA_WAVE32 + 1) / 2;
@@ -1356,21 +1635,65 @@ inline void exec_wmma_i32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, u
   };
   std::vector<Result> results;
   results.reserve(M * N);
-  for (uint32_t row = 0; row < M; ++row) {
-    for (uint32_t col = 0; col < N; ++col) {
-      auto out = wmma_output_loc_32(M, N, row, col);
-      int64_t acc =
-          (const_acc != ACC_FROM_VGPR)
-              ? static_cast<int64_t>(static_cast<int32_t>(const_acc))
-              : static_cast<int64_t>(static_cast<int32_t>(cu.read_vgpr(s2 + out.reg, out.lane)));
-      for (uint32_t k = 0; k < K; ++k) {
-        auto al = wmma_input_loc(M, K, row, k, in_bits);
-        auto bl = wmma_input_loc(N, K, col, k, in_bits);
-        acc += static_cast<int64_t>(ea(cu, s0, al)) * static_cast<int64_t>(eb(cu, s1, bl));
+
+  auto run_scalar = [&]() {
+    for (uint32_t row = 0; row < M; ++row) {
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_32(M, N, row, col);
+        int64_t acc =
+            (const_acc != ACC_FROM_VGPR)
+                ? static_cast<int64_t>(static_cast<int32_t>(const_acc))
+                : static_cast<int64_t>(static_cast<int32_t>(cu.read_vgpr(s2 + out.reg, out.lane)));
+        for (uint32_t k = 0; k < K; ++k) {
+          auto al = wmma_input_loc(M, K, row, k, in_bits);
+          auto bl = wmma_input_loc(N, K, col, k, in_bits);
+          acc += static_cast<int64_t>(ea(cu, s0, al)) * static_cast<int64_t>(eb(cu, s1, bl));
+        }
+        results.push_back({out.reg, out.lane, pack_i32_acc(acc, clamp)});
       }
-      results.push_back({out.reg, out.lane, pack_i32_acc(acc, clamp)});
     }
+  };
+
+  // SIMD fast path: int32 accumulation is exact and cannot overflow for WMMA's
+  // i8/i4 inputs at K <= 128 (max |acc| ~1M << 2^31), so it matches the scalar
+  // int64+clamp result bit-for-bit; the final pack_i32_acc still clamps.
+  if constexpr (util::has_stdx_simd) {
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<int32_t>::size());
+    const uint32_t stride = ((N + W - 1) / W) * W;
+    if (util::force_scalar() || static_cast<size_t>(M) * K > WMMA_SIMD_MAX_AB ||
+        static_cast<size_t>(K) * stride > WMMA_SIMD_MAX_BSTRIDE ||
+        static_cast<size_t>(M) * stride > WMMA_SIMD_MAX_C) {
+      run_scalar();
+    } else {
+      alignas(64) int32_t Abuf[WMMA_SIMD_MAX_AB] = {};
+      alignas(64) int32_t Bbuf[WMMA_SIMD_MAX_BSTRIDE] = {};
+      alignas(64) int32_t Cbuf[WMMA_SIMD_MAX_C] = {};
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = wmma_output_loc_32(M, N, row, col);
+          Cbuf[row * stride + col] =
+              (const_acc != ACC_FROM_VGPR)
+                  ? static_cast<int32_t>(const_acc)
+                  : static_cast<int32_t>(cu.read_vgpr(s2 + out.reg, out.lane));
+        }
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t k = 0; k < K; ++k)
+          Abuf[row * K + k] = ea(cu, s0, wmma_input_loc(M, K, row, k, in_bits));
+      for (uint32_t k = 0; k < K; ++k)
+        for (uint32_t col = 0; col < N; ++col)
+          Bbuf[k * stride + col] = eb(cu, s1, wmma_input_loc(N, K, col, k, in_bits));
+      wmma_simd_matmul<int32_t>(M, N, K, W, stride, Abuf, Bbuf, Cbuf);
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = wmma_output_loc_32(M, N, row, col);
+          results.push_back({out.reg, out.lane,
+                             pack_i32_acc(static_cast<int64_t>(Cbuf[row * stride + col]), clamp)});
+        }
+    }
+  } else {
+    run_scalar();
   }
+
   for (const auto &r : results)
     cu.write_vgpr(dst + r.reg, r.lane, r.val);
 }
@@ -1397,26 +1720,72 @@ inline void exec_swmmac_i32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N,
   results.reserve(M * N);
 
   const uint32_t compressed_k = K / 2;
-  for (uint32_t row = 0; row < M; ++row) {
-    for (uint32_t col = 0; col < N; ++col) {
-      auto out = wmma_output_loc_32(M, N, row, col);
-      int64_t acc = (const_acc != ACC_FROM_VGPR)
-                        ? static_cast<int64_t>(static_cast<int32_t>(const_acc))
-                        : static_cast<int64_t>(
-                              static_cast<int32_t>(cu.read_vgpr(acc_base + out.reg, out.lane)));
-      for (uint32_t ck = 0; ck < compressed_k; ++ck) {
-        auto al = wmma_input_loc(M, K / 2, row, ck, in_bits);
-        const uint32_t metadata_lane = row + (ck / index_entries) * M;
-        const uint32_t local_ck = ck % index_entries;
-        const uint64_t index_set =
-            read_swmmac_index_set(cu, index_base, metadata_lane, index_entries, index_key);
-        const uint32_t dense_k = swmmac_dense_k(index_set, ck, local_ck);
-        auto bl = wmma_input_loc(N, K, col, dense_k, in_bits);
-        acc += static_cast<int64_t>(ea(cu, s0, al)) * static_cast<int64_t>(eb(cu, s1, bl));
+
+  auto dense_k_for = [&](uint32_t row, uint32_t ck) -> uint32_t {
+    const uint32_t metadata_lane = row + (ck / index_entries) * M;
+    const uint32_t local_ck = ck % index_entries;
+    const uint64_t index_set =
+        read_swmmac_index_set(cu, index_base, metadata_lane, index_entries, index_key);
+    return swmmac_dense_k(index_set, ck, local_ck);
+  };
+
+  auto run_scalar = [&]() {
+    for (uint32_t row = 0; row < M; ++row) {
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_32(M, N, row, col);
+        int64_t acc = (const_acc != ACC_FROM_VGPR)
+                          ? static_cast<int64_t>(static_cast<int32_t>(const_acc))
+                          : static_cast<int64_t>(
+                                static_cast<int32_t>(cu.read_vgpr(acc_base + out.reg, out.lane)));
+        for (uint32_t ck = 0; ck < compressed_k; ++ck) {
+          auto al = wmma_input_loc(M, K / 2, row, ck, in_bits);
+          auto bl = wmma_input_loc(N, K, col, dense_k_for(row, ck), in_bits);
+          acc += static_cast<int64_t>(ea(cu, s0, al)) * static_cast<int64_t>(eb(cu, s1, bl));
+        }
+        results.push_back({out.reg, out.lane, pack_i32_acc(acc, clamp)});
       }
-      results.push_back({out.reg, out.lane, pack_i32_acc(acc, clamp)});
     }
+  };
+
+  // SIMD fast path: per-row gather, single row through the int32 matmul core
+  // (M=1). int32 accumulation is exact for i8/i4 inputs (no overflow), matching
+  // the scalar int64+clamp result; pack_i32_acc still clamps at the end.
+  if constexpr (util::has_stdx_simd) {
+    constexpr uint32_t W = static_cast<uint32_t>(util::native<int32_t>::size());
+    const uint32_t stride = ((N + W - 1) / W) * W;
+    if (util::force_scalar() || static_cast<size_t>(compressed_k) > WMMA_SIMD_MAX_AB ||
+        static_cast<size_t>(compressed_k) * stride > WMMA_SIMD_MAX_BSTRIDE ||
+        stride > WMMA_SIMD_MAX_C) {
+      run_scalar();
+    } else {
+      alignas(64) int32_t Abuf[WMMA_SIMD_MAX_AB] = {};
+      alignas(64) int32_t Bbuf[WMMA_SIMD_MAX_BSTRIDE] = {};
+      alignas(64) int32_t Cbuf[WMMA_SIMD_MAX_C] = {};
+      for (uint32_t row = 0; row < M; ++row) {
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = wmma_output_loc_32(M, N, row, col);
+          Cbuf[col] = (const_acc != ACC_FROM_VGPR)
+                          ? static_cast<int32_t>(const_acc)
+                          : static_cast<int32_t>(cu.read_vgpr(acc_base + out.reg, out.lane));
+        }
+        for (uint32_t ck = 0; ck < compressed_k; ++ck) {
+          Abuf[ck] = ea(cu, s0, wmma_input_loc(M, K / 2, row, ck, in_bits));
+          const uint32_t dense_k = dense_k_for(row, ck);
+          for (uint32_t col = 0; col < N; ++col)
+            Bbuf[ck * stride + col] = eb(cu, s1, wmma_input_loc(N, K, col, dense_k, in_bits));
+        }
+        wmma_simd_matmul<int32_t>(1, N, compressed_k, W, stride, Abuf, Bbuf, Cbuf);
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = wmma_output_loc_32(M, N, row, col);
+          results.push_back(
+              {out.reg, out.lane, pack_i32_acc(static_cast<int64_t>(Cbuf[col]), clamp)});
+        }
+      }
+    }
+  } else {
+    run_scalar();
   }
+
   for (const auto &r : results)
     cu.write_vgpr(dst + r.reg, r.lane, r.val);
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -2361,10 +2361,12 @@ void exec_smfmac_f32_32x32x64_fp8(ComputeUnitCore &cu, uint32_t dst, uint32_t s0
 ///   - host native_simd<float> is not 16 lanes (i.e. no AVX-512)
 ///   - cbsz/blgp lane permutation is non-default
 ///   - RJ_FORCE_SCALAR is set
-inline void exec_f32_mfma_16x16x32_f16(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
-                                       uint32_t s1, uint32_t s2, uint32_t const_acc, uint32_t cbsz,
-                                       uint32_t abid, uint32_t blgp) {
-  constexpr uint32_t M = 16, N = 16, K = 32, B = 1, in_bits = 16;
+template <uint32_t M, uint32_t N, uint32_t K>
+inline void exec_f32_mfma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
+                                   uint32_t s1, uint32_t s2, uint32_t const_acc, uint32_t cbsz,
+                                   uint32_t abid, uint32_t blgp) {
+  constexpr uint32_t B = 1, in_bits = 16;
+  static_assert(N % 16 == 0, "specialized f16 MFMA assumes N is a multiple of the zmm width");
   if constexpr (!util::has_stdx_simd) {
     exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_f16, amdgpu::extract_f16,
              const_acc, cbsz, abid, blgp);
@@ -2375,6 +2377,7 @@ inline void exec_f32_mfma_16x16x32_f16(amdgpu::ComputeUnitCore &cu, uint32_t dst
                const_acc, cbsz, abid, blgp);
       return;
     }
+    constexpr uint32_t W = 16; // guaranteed by the native<float>::size()==16 guard above
     const uint32_t wf = cu.wf_size();
     const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
     const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
@@ -2382,16 +2385,14 @@ inline void exec_f32_mfma_16x16x32_f16(amdgpu::ComputeUnitCore &cu, uint32_t dst
     alignas(64) float A_buf[M * K]; // A[row][k]
     alignas(64) float B_buf[K * N]; // B[k][col]
     alignas(64) float C_buf[M * N]; // C[row][col]
-    // The A/B inputs each occupy 4 VGPRs x wf lanes = 2*4*wf packed f16. Bulk
-    // convert the whole region to f32 once with F16C (one vector op per 16
-    // halves) instead of 1024 branchy scalar f16_to_f32 calls, then the hoist
-    // below is a pure f32 index-shuffle (f16 j of word w sub s -> flat j=w*2+s).
-    constexpr uint32_t NUM_IN_REGS = 4;
-    const uint32_t n_halves = 2 * NUM_IN_REGS * wf;
-    alignas(64) float A_f32[2 * NUM_IN_REGS * 64];
-    alignas(64) float B_f32[2 * NUM_IN_REGS * 64];
-    util::f16_to_f32_block(reinterpret_cast<const uint16_t *>(a_words), A_f32, n_halves);
-    util::f16_to_f32_block(reinterpret_cast<const uint16_t *>(b_words), B_f32, n_halves);
+    // A/B occupy M*K and N*K packed f16 over their VGPRs. Bulk-convert each whole
+    // region to f32 once with F16C (one vector op per 16 halves) instead of
+    // branchy per-element f16_to_f32, then the hoist is a pure f32 index-shuffle
+    // (f16 of word w lane l sub s -> flat (w*wf+l)*2+s).
+    alignas(64) float A_f32[M * K];
+    alignas(64) float B_f32[N * K];
+    util::f16_to_f32_block(reinterpret_cast<const uint16_t *>(a_words), A_f32, M * K);
+    util::f16_to_f32_block(reinterpret_cast<const uint16_t *>(b_words), B_f32, N * K);
     for (uint32_t row = 0; row < M; ++row)
       for (uint32_t col = 0; col < N; ++col) {
         auto out = output_loc_32(M, N, row, col, 0);
@@ -2409,18 +2410,19 @@ inline void exec_f32_mfma_16x16x32_f16(amdgpu::ComputeUnitCore &cu, uint32_t dst
         auto bl = input_loc(N, K, B, col, k, 0, in_bits);
         B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 2 + bl.sub_element];
       }
-    // Dense 16x32 * 32x16 -> 16x16 matmul, 16-lane stdx FMA per row.
-    for (uint32_t row = 0; row < M; ++row) {
-      util::native<float> c_row;
-      c_row.copy_from(&C_buf[row * N], util::stdx::vector_aligned);
-      for (uint32_t k = 0; k < K; ++k) {
-        util::native<float> a_bcast(A_buf[row * K + k]);
-        util::native<float> b_row;
-        b_row.copy_from(&B_buf[k * N], util::stdx::vector_aligned);
-        c_row = util::stdx::fma(a_bcast, b_row, c_row);
+    // Dense MxKxN matmul, W-lane (zmm) stdx FMA over N (N/W chunks per row).
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t c0 = 0; c0 < N; c0 += W) {
+        util::native<float> c_row;
+        c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
+        for (uint32_t k = 0; k < K; ++k) {
+          util::native<float> a_bcast(A_buf[row * K + k]);
+          util::native<float> b_row;
+          b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
+          c_row = util::stdx::fma(a_bcast, b_row, c_row);
+        }
+        c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
       }
-      c_row.copy_to(&C_buf[row * N], util::stdx::vector_aligned);
-    }
     // Scatter directly back to VGPRs (no Result staging vector).
     uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
     bool has_nan_or_inf = false;
@@ -2434,8 +2436,8 @@ inline void exec_f32_mfma_16x16x32_f16(amdgpu::ComputeUnitCore &cu, uint32_t dst
       }
     if (has_nan_or_inf) {
       util::Logger::vm([&](auto &os) {
-        os << std::format("MFMA_NAN_DETECTED (simd) dst=v{} s0=v{} s1=v{} s2=v{} 16x16x32_f16", dst,
-                          s0, s1, s2);
+        os << std::format("MFMA_NAN_DETECTED (simd) dst=v{} s0=v{} s1=v{} s2=v{} {}x{}x{}_f16", dst,
+                          s0, s1, s2, M, N, K);
       });
     }
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -1422,6 +1422,101 @@ void exec_wmma_f16(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t
       [](float val) { return util::f32_to_f16(val); }, const_acc);
 }
 
+/// Fast path for the f16-output WMMA shapes (v_wmma_f16_*_f16). Like the f32-out
+/// f16 specialization for the input convert + matmul, but the result is packed
+/// to 16 bits (2 per dst word) and written through the WMMA 16-bit output map.
+/// Falls back to generic exec_wmma_f16 without AVX-512 / under force-scalar.
+template <uint32_t M, uint32_t N, uint32_t K>
+inline void exec_wmma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                               uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
+  constexpr uint32_t in_bits = 16;
+  static_assert(N % 16 == 0, "specialized f16 WMMA assumes N is a multiple of the zmm width");
+  auto fallback = [&]() {
+    exec_wmma_f16(cu, M, N, K, in_bits, dst, s0, s1, s2, amdgpu::extract_f16, amdgpu::extract_f16,
+                  const_acc);
+  };
+  if constexpr (!util::has_stdx_simd) {
+    fallback();
+    return;
+  } else {
+    if (util::force_scalar() || util::native<float>::size() != 16) {
+      fallback();
+      return;
+    }
+    require_wmma_wave32(cu);
+    constexpr uint32_t W = 16;
+    const uint32_t wf = cu.wf_size();
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    alignas(64) float A_buf[M * K];
+    alignas(64) float B_buf[K * N];
+    alignas(64) float C_buf[M * N];
+    alignas(64) float A_f32[M * K];
+    alignas(64) float B_f32[N * K];
+    util::f16_to_f32_block(reinterpret_cast<const uint16_t *>(a_words), A_f32, M * K);
+    util::f16_to_f32_block(reinterpret_cast<const uint16_t *>(b_words), B_f32, N * K);
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_16(M, N, row, col);
+        uint32_t raw = c_words[out.reg * wf + out.lane];
+        C_buf[row * N + col] =
+            (const_acc != ACC_FROM_VGPR)
+                ? std::bit_cast<float>(const_acc)
+                : util::f16_to_f32(static_cast<uint16_t>((raw >> (out.sub_element * 16)) & 0xFFFF));
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t k = 0; k < K; ++k) {
+        auto al = wmma_input_loc(M, K, row, k, in_bits);
+        A_buf[row * K + k] = A_f32[(al.vgpr_offset * wf + al.lane) * 2 + al.sub_element];
+      }
+    for (uint32_t k = 0; k < K; ++k)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto bl = wmma_input_loc(N, K, col, k, in_bits);
+        B_buf[k * N + col] = B_f32[(bl.vgpr_offset * wf + bl.lane) * 2 + bl.sub_element];
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t c0 = 0; c0 < N; c0 += W) {
+        util::native<float> c_row;
+        c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
+        for (uint32_t k = 0; k < K; ++k) {
+          util::native<float> a_bcast(A_buf[row * K + k]);
+          util::native<float> b_row;
+          b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
+          c_row = util::stdx::fma(a_bcast, b_row, c_row);
+        }
+        c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
+      }
+    // Pack f32 results to f16, two per dst word (the WMMA 16-bit output map).
+    constexpr uint32_t DST_REGS = ((M * N) / WMMA_WAVE32 + 1) / 2;
+    alignas(64) uint32_t words[DST_REGS * WMMA_WAVE32] = {};
+    alignas(64) uint8_t masks[DST_REGS * WMMA_WAVE32] = {};
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_16(M, N, row, col);
+        uint32_t idx = out.reg * WMMA_WAVE32 + out.lane;
+        uint32_t shift = out.sub_element * 16;
+        uint16_t v = util::f32_to_f16(C_buf[row * N + col]);
+        words[idx] = (words[idx] & ~(0xFFFFu << shift)) | (static_cast<uint32_t>(v) << shift);
+        masks[idx] |= 1u << out.sub_element;
+      }
+    for (uint32_t reg = 0; reg < DST_REGS; ++reg)
+      for (uint32_t lane = 0; lane < WMMA_WAVE32; ++lane) {
+        uint32_t idx = reg * WMMA_WAVE32 + lane;
+        uint32_t word = words[idx];
+        if (masks[idx] != 0x3u) {
+          uint32_t old = d_words[reg * wf + lane];
+          if ((masks[idx] & 0x1u) == 0)
+            word = (word & 0xFFFF0000u) | (old & 0x0000FFFFu);
+          if ((masks[idx] & 0x2u) == 0)
+            word = (word & 0x0000FFFFu) | (old & 0xFFFF0000u);
+        }
+        d_words[reg * wf + lane] = word;
+      }
+  }
+}
+
 template <typename ExtractA, typename ExtractB>
 void exec_swmmac_f16(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K,
                      uint32_t in_bits, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t acc_base,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -558,6 +558,48 @@ template <typename Run> bool dispatch_matrix_fmt_pair(uint32_t a_fmt, uint32_t b
 // Execution kernels
 // ---------------------------------------------------------------------------
 
+/// Shared SIMD core for the MFMA/WMMA/SWMMAC executors. For every (row,col),
+/// Cbuf[row*stride+col] += sum_k Abuf[row*K+k] * Bbuf[k*stride+col], run as
+/// native-width rows over the col (N) dimension with a scalar tail. A/B/C must
+/// already be hoisted into dense buffers (lane permutation, per-element scale,
+/// and 2:4 sparsity gather folded in by the caller). Float uses fused FMA
+/// (matching the hardware's single-rounding MACs; the scalar reference is
+/// non-fused, so f32 agrees to a few ULP and packed f16/bf16 rounds identically);
+/// integer MAC is exact, so the SIMD and scalar paths are bit-identical.
+/// Templated so the `if constexpr (has_stdx_simd)` callers never instantiate it
+/// on a platform without <experimental/simd>.
+template <typename T>
+inline void wmma_simd_matmul(uint32_t M, uint32_t N, uint32_t K, uint32_t W, uint32_t stride,
+                             const T *Abuf, const T *Bbuf, T *Cbuf) {
+  for (uint32_t row = 0; row < M; ++row) {
+    uint32_t col = 0;
+    for (; col + W <= N; col += W) {
+      util::native<T> c;
+      c.copy_from(&Cbuf[row * stride + col], util::stdx::vector_aligned);
+      for (uint32_t k = 0; k < K; ++k) {
+        util::native<T> a(Abuf[row * K + k]);
+        util::native<T> bv;
+        bv.copy_from(&Bbuf[k * stride + col], util::stdx::vector_aligned);
+        if constexpr (std::is_floating_point_v<T>)
+          c = util::stdx::fma(a, bv, c);
+        else
+          c += a * bv;
+      }
+      c.copy_to(&Cbuf[row * stride + col], util::stdx::vector_aligned);
+    }
+    for (; col < N; ++col) {
+      T acc = Cbuf[row * stride + col];
+      for (uint32_t k = 0; k < K; ++k) {
+        if constexpr (std::is_floating_point_v<T>)
+          acc = std::fma(Abuf[row * K + k], Bbuf[k * stride + col], acc);
+        else
+          acc += Abuf[row * K + k] * Bbuf[k * stride + col];
+      }
+      Cbuf[row * stride + col] = acc;
+    }
+  }
+}
+
 /// Generic MFMA execute for f32 output: D = C + A x B.
 ///
 /// All inputs are read before any outputs are written to avoid WAR hazards
@@ -658,26 +700,7 @@ void exec_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_
               bl.lane = permute_b_lane(bl.lane, blgp);
             Bbuf[k * stride + col] = eb(cu, s1, bl);
           }
-        for (uint32_t row = 0; row < M; ++row) {
-          uint32_t col = 0;
-          for (; col + W <= N; col += W) {
-            util::native<float> c;
-            c.copy_from(&Cbuf[row * stride + col], util::stdx::vector_aligned);
-            for (uint32_t k = 0; k < K; ++k) {
-              util::native<float> a(Abuf[row * K + k]);
-              util::native<float> bv;
-              bv.copy_from(&Bbuf[k * stride + col], util::stdx::vector_aligned);
-              c = util::stdx::fma(a, bv, c);
-            }
-            c.copy_to(&Cbuf[row * stride + col], util::stdx::vector_aligned);
-          }
-          for (; col < N; ++col) {
-            float acc = Cbuf[row * stride + col];
-            for (uint32_t k = 0; k < K; ++k)
-              acc = std::fma(Abuf[row * K + k], Bbuf[k * stride + col], acc);
-            Cbuf[row * stride + col] = acc;
-          }
-        }
+        wmma_simd_matmul<float>(M, N, K, W, stride, Abuf, Bbuf, Cbuf);
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t col = 0; col < N; ++col) {
             auto out = output_loc_32(M, N, row, col, b);
@@ -746,48 +769,6 @@ void exec_f32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K, u
 constexpr size_t WMMA_SIMD_MAX_AB = 2048;      // max M*K
 constexpr size_t WMMA_SIMD_MAX_BSTRIDE = 4096; // max K*stride
 constexpr size_t WMMA_SIMD_MAX_C = 1024;       // max M*stride
-
-/// Shared SIMD core for the WMMA/SWMMAC executors. For every (row,col),
-/// Cbuf[row*stride+col] += sum_k Abuf[row*K+k] * Bbuf[k*stride+col], run as
-/// native-width rows over the col (N) dimension with a scalar tail. A/B/C must
-/// already be hoisted into dense buffers (lane permutation, per-element scale,
-/// and 2:4 sparsity gather folded in by the caller). Float uses fused FMA
-/// (matching the hardware's single-rounding MACs; the scalar reference is
-/// non-fused, so f32 agrees to a few ULP and packed f16/bf16 rounds identically);
-/// integer MAC is exact, so the SIMD and scalar paths are bit-identical.
-/// Templated so the `if constexpr (has_stdx_simd)` callers never instantiate it
-/// on a platform without <experimental/simd>.
-template <typename T>
-inline void wmma_simd_matmul(uint32_t M, uint32_t N, uint32_t K, uint32_t W, uint32_t stride,
-                             const T *Abuf, const T *Bbuf, T *Cbuf) {
-  for (uint32_t row = 0; row < M; ++row) {
-    uint32_t col = 0;
-    for (; col + W <= N; col += W) {
-      util::native<T> c;
-      c.copy_from(&Cbuf[row * stride + col], util::stdx::vector_aligned);
-      for (uint32_t k = 0; k < K; ++k) {
-        util::native<T> a(Abuf[row * K + k]);
-        util::native<T> bv;
-        bv.copy_from(&Bbuf[k * stride + col], util::stdx::vector_aligned);
-        if constexpr (std::is_floating_point_v<T>)
-          c = util::stdx::fma(a, bv, c);
-        else
-          c += a * bv;
-      }
-      c.copy_to(&Cbuf[row * stride + col], util::stdx::vector_aligned);
-    }
-    for (; col < N; ++col) {
-      T acc = Cbuf[row * stride + col];
-      for (uint32_t k = 0; k < K; ++k) {
-        if constexpr (std::is_floating_point_v<T>)
-          acc = std::fma(Abuf[row * K + k], Bbuf[k * stride + col], acc);
-        else
-          acc += Abuf[row * K + k] * Bbuf[k * stride + col];
-      }
-      Cbuf[row * stride + col] = acc;
-    }
-  }
-}
 
 template <typename ExtractA, typename ExtractB>
 void exec_wmma_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -1046,6 +1046,73 @@ inline void exec_wmma_f32_16x16x32_f16(amdgpu::ComputeUnitCore &cu, uint32_t dst
   }
 }
 
+/// Fast path for the f32-input WMMA shapes (v_wmma_f32_*_f32). f32 inputs, so no
+/// F16C convert — the hoist reads each operand word straight through vgpr_data.
+/// Compile-time M/N/K fully unroll the matmul, looped over N in zmm-width chunks
+/// (N a multiple of 16). Falls back to generic exec_wmma_f32 without AVX-512 /
+/// under force-scalar.
+template <uint32_t M, uint32_t N, uint32_t K>
+inline void exec_wmma_f32_f32_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
+                                   uint32_t s1, uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
+  constexpr uint32_t in_bits = 32;
+  static_assert(N % 16 == 0, "specialized f32 WMMA assumes N is a multiple of the zmm width");
+  if constexpr (!util::has_stdx_simd) {
+    exec_wmma_f32(cu, M, N, K, in_bits, dst, s0, s1, s2, amdgpu::extract_f32, amdgpu::extract_f32,
+                  const_acc);
+    return;
+  } else {
+    if (util::force_scalar() || util::native<float>::size() != 16) {
+      exec_wmma_f32(cu, M, N, K, in_bits, dst, s0, s1, s2, amdgpu::extract_f32, amdgpu::extract_f32,
+                    const_acc);
+      return;
+    }
+    require_wmma_wave32(cu);
+    constexpr uint32_t W = 16;
+    const uint32_t wf = cu.wf_size();
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    alignas(64) float A_buf[M * K];
+    alignas(64) float B_buf[K * N];
+    alignas(64) float C_buf[M * N];
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_32(M, N, row, col);
+        C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
+                                   ? std::bit_cast<float>(const_acc)
+                                   : std::bit_cast<float>(c_words[out.reg * wf + out.lane]);
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t k = 0; k < K; ++k) {
+        auto al = wmma_input_loc(M, K, row, k, in_bits);
+        A_buf[row * K + k] = std::bit_cast<float>(a_words[al.vgpr_offset * wf + al.lane]);
+      }
+    for (uint32_t k = 0; k < K; ++k)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto bl = wmma_input_loc(N, K, col, k, in_bits);
+        B_buf[k * N + col] = std::bit_cast<float>(b_words[bl.vgpr_offset * wf + bl.lane]);
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t c0 = 0; c0 < N; c0 += W) {
+        util::native<float> c_row;
+        c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
+        for (uint32_t k = 0; k < K; ++k) {
+          util::native<float> a_bcast(A_buf[row * K + k]);
+          util::native<float> b_row;
+          b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
+          c_row = util::stdx::fma(a_bcast, b_row, c_row);
+        }
+        c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
+      }
+    for (uint32_t row = 0; row < M; ++row)
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = wmma_output_loc_32(M, N, row, col);
+        d_words[out.reg * wf + out.lane] = std::bit_cast<uint32_t>(C_buf[row * N + col]);
+      }
+  }
+}
+
 template <typename ExtractA, typename ExtractB>
 void exec_swmmac_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K,
                            uint32_t a_bits, uint32_t b_bits, uint32_t dst, uint32_t s0, uint32_t s1,
@@ -2361,6 +2428,87 @@ void exec_smfmac_f32_32x32x64_fp8(ComputeUnitCore &cu, uint32_t dst, uint32_t s0
 ///   - host native_simd<float> is not 16 lanes (i.e. no AVX-512)
 ///   - cbsz/blgp lane permutation is non-default
 ///   - RJ_FORCE_SCALAR is set
+/// Fast path for the f32-input MFMA shapes (v_mfma_f32_*_f32). Like the f16
+/// specialization but the inputs are already f32, so there is no F16C convert —
+/// the hoist reads each operand word straight through vgpr_data. BATCH covers
+/// the batched shapes (e.g. 32x32x1x2). Compile-time M/N/K/BATCH fully unroll
+/// the matmul; it loops over N in zmm-width chunks (N must be a multiple of 16,
+/// so the 4x4 shape stays on the generic path). Falls back to the generic
+/// exec_f32 without AVX-512 / under force-scalar / with cbsz|blgp.
+template <uint32_t M, uint32_t N, uint32_t K, uint32_t BATCH>
+inline void exec_f32_mfma_f32_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
+                                   uint32_t s1, uint32_t s2, uint32_t const_acc, uint32_t cbsz,
+                                   uint32_t abid, uint32_t blgp) {
+  constexpr uint32_t in_bits = 32;
+  static_assert(N % 16 == 0, "specialized f32 MFMA assumes N is a multiple of the zmm width");
+  if constexpr (!util::has_stdx_simd) {
+    exec_f32(cu, M, N, K, BATCH, in_bits, dst, s0, s1, s2, amdgpu::extract_f32, amdgpu::extract_f32,
+             const_acc, cbsz, abid, blgp);
+    return;
+  } else {
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16) {
+      exec_f32(cu, M, N, K, BATCH, in_bits, dst, s0, s1, s2, amdgpu::extract_f32,
+               amdgpu::extract_f32, const_acc, cbsz, abid, blgp);
+      return;
+    }
+    constexpr uint32_t W = 16;
+    const uint32_t wf = cu.wf_size();
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    alignas(64) float A_buf[M * K];
+    alignas(64) float B_buf[K * N];
+    alignas(64) float C_buf[M * N];
+    bool has_nan_or_inf = false;
+    for (uint32_t b = 0; b < BATCH; ++b) {
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = output_loc_32(M, N, row, col, b);
+          C_buf[row * N + col] = (const_acc != ACC_FROM_VGPR)
+                                     ? std::bit_cast<float>(const_acc)
+                                     : std::bit_cast<float>(c_words[out.reg * wf + out.lane]);
+        }
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t k = 0; k < K; ++k) {
+          auto al = input_loc(M, K, BATCH, row, k, b, in_bits);
+          A_buf[row * K + k] = std::bit_cast<float>(a_words[al.vgpr_offset * wf + al.lane]);
+        }
+      for (uint32_t k = 0; k < K; ++k)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto bl = input_loc(N, K, BATCH, col, k, b, in_bits);
+          B_buf[k * N + col] = std::bit_cast<float>(b_words[bl.vgpr_offset * wf + bl.lane]);
+        }
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t c0 = 0; c0 < N; c0 += W) {
+          util::native<float> c_row;
+          c_row.copy_from(&C_buf[row * N + c0], util::stdx::vector_aligned);
+          for (uint32_t k = 0; k < K; ++k) {
+            util::native<float> a_bcast(A_buf[row * K + k]);
+            util::native<float> b_row;
+            b_row.copy_from(&B_buf[k * N + c0], util::stdx::vector_aligned);
+            c_row = util::stdx::fma(a_bcast, b_row, c_row);
+          }
+          c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
+        }
+      for (uint32_t row = 0; row < M; ++row)
+        for (uint32_t col = 0; col < N; ++col) {
+          auto out = output_loc_32(M, N, row, col, b);
+          float fv = C_buf[row * N + col];
+          d_words[out.reg * wf + out.lane] = std::bit_cast<uint32_t>(fv);
+          if (std::isnan(fv) || std::isinf(fv))
+            has_nan_or_inf = true;
+        }
+    }
+    if (has_nan_or_inf) {
+      util::Logger::vm([&](auto &os) {
+        os << std::format("MFMA_NAN_DETECTED (simd) dst=v{} s0=v{} s1=v{} s2=v{} {}x{}x{}_f32", dst,
+                          s0, s1, s2, M, N, K);
+      });
+    }
+  }
+}
+
 template <uint32_t M, uint32_t N, uint32_t K>
 inline void exec_f32_mfma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
                                    uint32_t s1, uint32_t s2, uint32_t const_acc, uint32_t cbsz,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -109,8 +109,7 @@ constexpr uint32_t WMMA_WAVE32 = 32;
 /// @param get_const Lazy callback returning the 32-bit constant value; only
 ///        called when src2 is not a VGPR. Typically: [&]{ return src2.read_scalar(wf); }
 template <AccMode Mode = AccMode::Unified, typename F>
-inline uint32_t resolve_acc(uint32_t vb, uint32_t dst, int src2_ev, uint32_t &const_acc,
-                            F &&get_const) {
+uint32_t resolve_acc(uint32_t vb, uint32_t dst, int src2_ev, uint32_t &const_acc, F &&get_const) {
   if constexpr (Mode == AccMode::Unified || Mode == AccMode::Separate) {
     if (src2_ev >= 768 && src2_ev <= 1023) {
       const_acc = ACC_FROM_VGPR;
@@ -569,8 +568,8 @@ template <typename Run> bool dispatch_matrix_fmt_pair(uint32_t a_fmt, uint32_t b
 /// Templated so the `if constexpr (has_stdx_simd)` callers never instantiate it
 /// on a platform without <experimental/simd>.
 template <typename T>
-inline void wmma_simd_matmul(uint32_t M, uint32_t N, uint32_t K, uint32_t W, uint32_t stride,
-                             const T *Abuf, const T *Bbuf, T *Cbuf) {
+void wmma_simd_matmul(uint32_t M, uint32_t N, uint32_t K, uint32_t W, uint32_t stride,
+                      const T *Abuf, const T *Bbuf, T *Cbuf) {
   for (uint32_t row = 0; row < M; ++row) {
     uint32_t col = 0;
     for (; col + W <= N; col += W) {
@@ -1104,7 +1103,7 @@ inline void exec_wmma_f32_16x16x32_bf16(amdgpu::ComputeUnitCore &cu, uint32_t ds
 /// Compile-time fp8 (e4m3) vs bf8 (e5m2) bulk-convert selector for the f8 spec
 /// kernels: converts `n` packed bytes starting at `words` to f32 through the
 /// 256-entry LUTs (bit-exact with extract_fp8/extract_bf8 by construction).
-template <bool FP8> inline void f8_to_f32_block(const uint32_t *words, float *dst, size_t n) {
+template <bool FP8> void f8_to_f32_block(const uint32_t *words, float *dst, size_t n) {
   if constexpr (FP8)
     util::fp8_e4m3_to_f32_block(reinterpret_cast<const uint8_t *>(words), dst, n);
   else
@@ -1118,8 +1117,8 @@ template <bool FP8> inline void f8_to_f32_block(const uint32_t *words, float *ds
 /// Falls back to the generic exec_wmma_f32_mixed without AVX-512 / under
 /// force-scalar.
 template <uint32_t M, uint32_t N, uint32_t K, bool A_FP8, bool B_FP8>
-inline void exec_wmma_f32_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
-                                  uint32_t s1, uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
+void exec_wmma_f32_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                           uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
   constexpr uint32_t in_bits = 8;
   static_assert(N % 16 == 0, "specialized f8 WMMA assumes N is a multiple of the zmm width");
   constexpr auto ea = A_FP8 ? &extract_fp8 : &extract_bf8;
@@ -1196,8 +1195,8 @@ inline void exec_wmma_f32_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uin
 /// (N a multiple of 16). Falls back to generic exec_wmma_f32 without AVX-512 /
 /// under force-scalar.
 template <uint32_t M, uint32_t N, uint32_t K>
-inline void exec_wmma_f32_f32_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
-                                   uint32_t s1, uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
+void exec_wmma_f32_f32_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                            uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
   constexpr uint32_t in_bits = 32;
   static_assert(N % 16 == 0, "specialized f32 WMMA assumes N is a multiple of the zmm width");
   if constexpr (!util::has_stdx_simd) {
@@ -1571,8 +1570,8 @@ void exec_wmma_f16(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t
 /// to 16 bits (2 per dst word) and written through the WMMA 16-bit output map.
 /// Falls back to generic exec_wmma_f16 without AVX-512 / under force-scalar.
 template <uint32_t M, uint32_t N, uint32_t K>
-inline void exec_wmma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
-                               uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
+void exec_wmma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                        uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
   constexpr uint32_t in_bits = 16;
   static_assert(N % 16 == 0, "specialized f16 WMMA assumes N is a multiple of the zmm width");
   auto fallback = [&]() {
@@ -1693,8 +1692,8 @@ void exec_wmma_bf16(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_
 /// and bf16 truncation on output. Falls back to generic exec_wmma_bf16 without
 /// AVX-512 / under force-scalar.
 template <uint32_t M, uint32_t N, uint32_t K>
-inline void exec_wmma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
-                                uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
+void exec_wmma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                         uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
   constexpr uint32_t in_bits = 16;
   static_assert(N % 16 == 0, "specialized bf16 WMMA assumes N is a multiple of the zmm width");
   auto fallback = [&]() {
@@ -1790,8 +1789,8 @@ inline void exec_wmma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint3
 /// Falls back to the generic exec_wmma_f16 without AVX-512 / under
 /// force-scalar.
 template <uint32_t M, uint32_t N, uint32_t K, bool A_FP8, bool B_FP8>
-inline void exec_wmma_f16_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
-                                  uint32_t s1, uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
+void exec_wmma_f16_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                           uint32_t s2, uint32_t const_acc = ACC_FROM_VGPR) {
   constexpr uint32_t in_bits = 8;
   static_assert(N % 16 == 0, "specialized f8 WMMA assumes N is a multiple of the zmm width");
   constexpr auto ea = A_FP8 ? &extract_fp8 : &extract_bf8;
@@ -2200,10 +2199,9 @@ inline uint32_t pack_i32_acc(int64_t acc, bool clamp) {
 }
 
 template <typename ExtractA, typename ExtractB>
-inline void exec_wmma_i32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K,
-                          uint32_t in_bits, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
-                          ExtractA ea, ExtractB eb, bool clamp,
-                          uint32_t const_acc = ACC_FROM_VGPR) {
+void exec_wmma_i32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K,
+                   uint32_t in_bits, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
+                   ExtractA ea, ExtractB eb, bool clamp, uint32_t const_acc = ACC_FROM_VGPR) {
   require_wmma_wave32(cu);
   struct Result {
     uint32_t reg;
@@ -2364,11 +2362,10 @@ inline void exec_wmma_i32_16x16x64_iu8(amdgpu::ComputeUnitCore &cu, uint32_t dst
 }
 
 template <typename ExtractA, typename ExtractB>
-inline void exec_swmmac_i32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K,
-                            uint32_t in_bits, uint32_t dst, uint32_t s0, uint32_t s1,
-                            uint32_t acc_base, uint32_t index_base, uint32_t index_entries,
-                            uint32_t index_key, ExtractA ea, ExtractB eb, bool clamp,
-                            uint32_t const_acc = ACC_FROM_VGPR) {
+void exec_swmmac_i32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K,
+                     uint32_t in_bits, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t acc_base,
+                     uint32_t index_base, uint32_t index_entries, uint32_t index_key, ExtractA ea,
+                     ExtractB eb, bool clamp, uint32_t const_acc = ACC_FROM_VGPR) {
   require_wmma_wave32(cu);
   struct Result {
     uint32_t reg;
@@ -2952,9 +2949,9 @@ void exec_smfmac_f32_32x32x64_fp8(ComputeUnitCore &cu, uint32_t dst, uint32_t s0
 /// so the 4x4 shape stays on the generic path). Falls back to the generic
 /// exec_f32 without AVX-512 / under force-scalar / with cbsz|blgp.
 template <uint32_t M, uint32_t N, uint32_t K, uint32_t BATCH>
-inline void exec_f32_mfma_f32_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
-                                   uint32_t s1, uint32_t s2, uint32_t const_acc, uint32_t cbsz,
-                                   uint32_t abid, uint32_t blgp) {
+void exec_f32_mfma_f32_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                            uint32_t s2, uint32_t const_acc, uint32_t cbsz, uint32_t abid,
+                            uint32_t blgp) {
   constexpr uint32_t in_bits = 32;
   static_assert(N % 16 == 0, "specialized f32 MFMA assumes N is a multiple of the zmm width");
   if constexpr (!util::has_stdx_simd) {
@@ -3026,9 +3023,9 @@ inline void exec_f32_mfma_f32_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, ui
 }
 
 template <uint32_t M, uint32_t N, uint32_t K, uint32_t BATCH = 1>
-inline void exec_f32_mfma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
-                                   uint32_t s1, uint32_t s2, uint32_t const_acc, uint32_t cbsz,
-                                   uint32_t abid, uint32_t blgp) {
+void exec_f32_mfma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                            uint32_t s2, uint32_t const_acc, uint32_t cbsz, uint32_t abid,
+                            uint32_t blgp) {
   constexpr uint32_t B = BATCH, in_bits = 16;
   static_assert(N % 16 == 0, "specialized f16 MFMA assumes N is a multiple of the zmm width");
   if constexpr (!util::has_stdx_simd) {
@@ -3114,9 +3111,9 @@ inline void exec_f32_mfma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, ui
 /// (no F16C needed). Falls back to the generic exec_f32 without AVX-512 / under
 /// force-scalar / with cbsz|blgp.
 template <uint32_t M, uint32_t N, uint32_t K, uint32_t BATCH = 1>
-inline void exec_f32_mfma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
-                                    uint32_t s1, uint32_t s2, uint32_t const_acc, uint32_t cbsz,
-                                    uint32_t abid, uint32_t blgp) {
+void exec_f32_mfma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                             uint32_t s2, uint32_t const_acc, uint32_t cbsz, uint32_t abid,
+                             uint32_t blgp) {
   constexpr uint32_t B = BATCH, in_bits = 16;
   static_assert(N % 16 == 0, "specialized bf16 MFMA assumes N is a multiple of the zmm width");
   if constexpr (!util::has_stdx_simd) {
@@ -3202,9 +3199,9 @@ inline void exec_f32_mfma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, u
 /// compile-time selected. Falls back to the generic exec_f32 without AVX-512 /
 /// under force-scalar / with cbsz|blgp.
 template <uint32_t M, uint32_t N, uint32_t K, bool A_FP8, bool B_FP8>
-inline void exec_f32_mfma_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
-                                  uint32_t s1, uint32_t s2, uint32_t const_acc, uint32_t cbsz,
-                                  uint32_t abid, uint32_t blgp) {
+void exec_f32_mfma_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                           uint32_t s2, uint32_t const_acc, uint32_t cbsz, uint32_t abid,
+                           uint32_t blgp) {
   constexpr uint32_t B = 1, in_bits = 8;
   static_assert(N % 16 == 0, "specialized f8 MFMA assumes N is a multiple of the zmm width");
   constexpr auto ea = A_FP8 ? &extract_fp8 : &extract_bf8;
@@ -3292,8 +3289,8 @@ inline void exec_f32_mfma_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uin
 /// well-defined). Falls back to the generic exec_i32_i8 without AVX-512 /
 /// under force-scalar.
 template <uint32_t M, uint32_t N, uint32_t K, uint32_t BATCH = 1>
-inline void exec_i32_mfma_i8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
-                                  uint32_t s1, uint32_t s2, uint32_t const_acc) {
+void exec_i32_mfma_i8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                           uint32_t s2, uint32_t const_acc) {
   constexpr uint32_t B = BATCH, in_bits = 8;
   static_assert(N % 16 == 0, "specialized i8 MFMA assumes N is a multiple of the zmm width");
   if constexpr (!util::has_stdx_simd) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -2976,6 +2976,170 @@ template <typename Inst>
   return false;
 }
 
+/// VOP3P mixed-sign integer dot product (v_dot4_i32_iu8 / v_dot8_i32_iu4).
+/// Same structure as try_execute_vop3p_dot_int_simd but the per-operand
+/// signedness is chosen at RUNTIME from inst.neg (bit 0 -> src0 signed, bit 1
+/// -> src1 signed) — hoisted out of the chunk loop. src2 is the int32
+/// accumulator seed; clamp (when set) is the lower clamp to 0. The 8/4-bit
+/// scalar bodies read no op_sel/neg_hi, so no gate.
+template <int ElemBits, typename Inst>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vop3p_dot_int_mixed_simd(Inst &inst, Wavefront &wf) {
+  static_assert(ElemBits == 8 || ElemBits == 4, "iu dot ElemBits must be 8/4");
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  constexpr int N = 32 / ElemBits;
+  constexpr uint32_t kElemMask = (ElemBits == 8) ? 0xFFu : 0xFu;
+  constexpr int kShift = 32 - ElemBits;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const bool clamp = inst.inst_.clamp;
+  const bool src0_signed = (inst.inst_.neg & 0x1u) != 0;
+  const bool src1_signed = (inst.inst_.neg & 0x2u) != 0;
+  using U = util::native<uint32_t>;
+  using I = util::native<int32_t>;
+  const I kZeroI(0);
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const U raw0 = read_simd<uint32_t>(inst.src0, wf, base);
+    const U raw1 = read_simd<uint32_t>(inst.src1, wf, base);
+    const U acc = read_simd<uint32_t>(inst.src2, wf, base);
+    I sum = std::bit_cast<I>(acc);
+    for (int i = 0; i < N; ++i) {
+      const U ea = (raw0 >> (i * ElemBits)) & kElemMask;
+      const U eb = (raw1 >> (i * ElemBits)) & kElemMask;
+      // Sign-extend the low ElemBits when the operand is signed (same shift
+      // trick as the signed dot path); plain zero-extended reinterpret when
+      // unsigned. Sign choice is per operand, resolved at runtime.
+      const I a = src0_signed ? ((util::stdx::static_simd_cast<I>(ea) << kShift) >> kShift)
+                              : std::bit_cast<I>(ea);
+      const I b = src1_signed ? ((util::stdx::static_simd_cast<I>(eb) << kShift) >> kShift)
+                              : std::bit_cast<I>(eb);
+      sum += a * b;
+    }
+    if (clamp)
+      util::stdx::where(sum < kZeroI, sum) = kZeroI;
+    write_simd<uint32_t>(inst.vdst, wf, base, std::bit_cast<U>(sum), chunk);
+  }
+  return true;
+}
+
+template <int ElemBits, typename Inst>
+[[nodiscard]] inline bool try_execute_vop3p_dot_int_mixed_simd(Inst &, Wavefront &) {
+  return false;
+}
+
+/// VOP2/VOP3 dst-accumulate integer dot product (the "c" forms:
+/// v_dot2c_i32_i16, v_dot4c_i32_i8, v_dot8c_i32_i4). The accumulator is the
+/// DESTINATION register (inst.vdst), read as the accumulate source and written
+/// as the result. VOP2 reads its 2nd source as inst.vsrc1, VOP3 as inst.src1
+/// (selected by the Vop3 flag via if constexpr). All *c int forms are signed;
+/// accumulation is int32-exact. The scalar bodies carry no op_sel/neg/clamp.
+template <int ElemBits, bool Vop3, typename Inst>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_dotc_int_simd(Inst &inst, Wavefront &wf) {
+  static_assert(ElemBits == 16 || ElemBits == 8 || ElemBits == 4, "dotc ElemBits must be 16/8/4");
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  if constexpr (Vop3) {
+    if (!inst.src1.simd_capable())
+      return false;
+  } else {
+    if (!inst.vsrc1.simd_capable())
+      return false;
+  }
+  constexpr int N = 32 / ElemBits;
+  constexpr uint32_t kElemMask = (ElemBits == 16) ? 0xFFFFu : (ElemBits == 8) ? 0xFFu : 0xFu;
+  constexpr int kShift = 32 - ElemBits;
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  using U = util::native<uint32_t>;
+  using I = util::native<int32_t>;
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const U raw0 = read_simd<uint32_t>(inst.src0, wf, base);
+    U raw1;
+    if constexpr (Vop3)
+      raw1 = read_simd<uint32_t>(inst.src1, wf, base);
+    else
+      raw1 = read_simd<uint32_t>(inst.vsrc1, wf, base);
+    const U acc = read_simd<uint32_t>(inst.vdst, wf, base); // accumulator from dst
+    I sum = std::bit_cast<I>(acc);
+    for (int i = 0; i < N; ++i) {
+      const U ea = (raw0 >> (i * ElemBits)) & kElemMask;
+      const U eb = (raw1 >> (i * ElemBits)) & kElemMask;
+      const I a = (util::stdx::static_simd_cast<I>(ea) << kShift) >> kShift;
+      const I b = (util::stdx::static_simd_cast<I>(eb) << kShift) >> kShift;
+      sum += a * b;
+    }
+    write_simd<uint32_t>(inst.vdst, wf, base, std::bit_cast<U>(sum), chunk);
+  }
+  return true;
+}
+
+template <int ElemBits, bool Vop3, typename Inst>
+[[nodiscard]] inline bool try_execute_dotc_int_simd(Inst &, Wavefront &) {
+  return false;
+}
+
+/// VOP2/VOP3 dst-accumulate f16 dot product (v_dot2c_f32_f16). Two f16 products
+/// of src0 and src1/vsrc1 (widened via f16_to_f32_simd) plus the f32
+/// accumulator read from the DESTINATION register. Bracketing matches the
+/// scalar `facc += a0*b0 + a1*b1` exactly: acc + ((a0*b0)+(a1*b1)). No
+/// op_sel/neg/clamp. NaN-payload divergence accepted (shared f16 carve-out).
+template <bool Vop3, typename Inst>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_dotc_f16_simd(Inst &inst, Wavefront &wf) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  if constexpr (Vop3) {
+    if (!inst.src1.simd_capable())
+      return false;
+  } else {
+    if (!inst.vsrc1.simd_capable())
+      return false;
+  }
+  using T = uint32_t;
+  constexpr std::size_t W = util::native_width_v<T>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  using F = util::native<float>;
+  using U = util::native<uint32_t>;
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const U raw0 = read_simd<uint32_t>(inst.src0, wf, base);
+    U raw1;
+    if constexpr (Vop3)
+      raw1 = read_simd<uint32_t>(inst.src1, wf, base);
+    else
+      raw1 = read_simd<uint32_t>(inst.vsrc1, wf, base);
+    const F acc = std::bit_cast<F>(read_simd<uint32_t>(inst.vdst, wf, base));
+    const F a0 = util::f16_to_f32_simd(raw0 & 0xFFFFu);
+    const F a1 = util::f16_to_f32_simd(raw0 >> 16);
+    const F b0 = util::f16_to_f32_simd(raw1 & 0xFFFFu);
+    const F b1 = util::f16_to_f32_simd(raw1 >> 16);
+    const F r = acc + (a0 * b0 + a1 * b1);
+    write_simd<uint32_t>(inst.vdst, wf, base, std::bit_cast<U>(r), chunk);
+  }
+  return true;
+}
+
+template <bool Vop3, typename Inst>
+[[nodiscard]] inline bool try_execute_dotc_f16_simd(Inst &, Wavefront &) {
+  return false;
+}
+
 } // namespace amdgpu
 } // namespace rocjitsu
 
@@ -3328,6 +3492,23 @@ template <typename Inst>
 /// VOP3P v_dot2_f32_f16 probe. Functorless / fixed-op.
 #define ROCJITSU_TRY_SIMD_VOP3P_DOT_F16()                                                          \
   if (::rocjitsu::amdgpu::try_execute_vop3p_dot_f16_simd(inst, wf))                                \
+  return
+
+/// VOP3P mixed-sign integer dot probe (v_dot4_i32_iu8 / v_dot8_i32_iu4). Arg:
+/// ElemBits (8 or 4). Per-operand sign read at runtime from inst.neg.
+#define ROCJITSU_TRY_SIMD_VOP3P_DOT_INT_MIXED(ElemBits)                                            \
+  if (::rocjitsu::amdgpu::try_execute_vop3p_dot_int_mixed_simd<ElemBits>(inst, wf))                \
+  return
+
+/// VOP2/VOP3 dst-accumulate integer dot probe (the "c" forms). Args:
+/// (ElemBits, Vop3) — e.g. (8, true) for v_dot4c_i32_i8_vop3.
+#define ROCJITSU_TRY_SIMD_DOTC_INT(...)                                                            \
+  if (::rocjitsu::amdgpu::try_execute_dotc_int_simd<__VA_ARGS__>(inst, wf))                        \
+  return
+
+/// VOP2/VOP3 dst-accumulate f16 dot probe (v_dot2c_f32_f16). Arg: Vop3 bool.
+#define ROCJITSU_TRY_SIMD_DOTC_F16(...)                                                            \
+  if (::rocjitsu::amdgpu::try_execute_dotc_f16_simd<__VA_ARGS__>(inst, wf))                        \
   return
 
 #endif // ROCJITSU_ISA_AMDGPU_SHARED_SIMD_GLUE_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -42,8 +42,7 @@ inline bool simd_force_scalar() { return util::force_scalar(); }
 /// sign bit and unary minus flips it (both NaN-payload preserving), so the
 /// vector form is a pure sign-bit AND/XOR — bit-identical on every input.
 template <unsigned SrcIdx>
-inline util::native<float> apply_vop3_src_mod_f32(util::native<float> v, uint32_t abs,
-                                                  uint32_t neg) {
+util::native<float> apply_vop3_src_mod_f32(util::native<float> v, uint32_t abs, uint32_t neg) {
   using U = util::native<uint32_t>;
   U b = std::bit_cast<U>(v);
   if (abs & (1u << SrcIdx))
@@ -59,8 +58,7 @@ inline util::native<float> apply_vop3_src_mod_f32(util::native<float> v, uint32_
 /// the vector form is a pure AND/XOR — bit-identical incl. NaN payload,
 /// matching the scalar lambda the f64 VOP3 bodies emit.
 template <unsigned SrcIdx>
-inline util::native<double> apply_vop3_src_mod_f64(util::native<double> v, uint32_t abs,
-                                                   uint32_t neg) {
+util::native<double> apply_vop3_src_mod_f64(util::native<double> v, uint32_t abs, uint32_t neg) {
   using U = util::native<uint64_t>;
   U b = std::bit_cast<U>(v);
   if (abs & (1u << SrcIdx))
@@ -77,7 +75,7 @@ inline util::native<double> apply_vop3_src_mod_f64(util::native<double> v, uint3
 /// matching `std::clamp(v, T(0), T(1))`. Instantiated for float and double; the
 /// `_f32`/`_f64` wrappers below name the two lane types the VOP3 paths use.
 template <typename T>
-inline util::native<T> apply_vop3_dst_mod(util::native<T> v, uint32_t omod, uint32_t clamp) {
+util::native<T> apply_vop3_dst_mod(util::native<T> v, uint32_t omod, uint32_t clamp) {
   if (omod == 1)
     v = v * T(2);
   else if (omod == 2)
@@ -108,7 +106,7 @@ inline util::native<float> apply_vop3_dst_mod_f32(util::native<float> v, uint32_
 /// per-chunk loop then issues a value-semantic `r->simd_load<T>(base)` directly
 /// off the resolved (loop-invariant) object with no further dispatch and no raw
 /// pointer in the kernel body — the storage pointer never escapes `VgprStorage`.
-template <typename Op> inline const VgprStorage *simd_src_reg(const Op &op, const Wavefront &wf) {
+template <typename Op> const VgprStorage *simd_src_reg(const Op &op, const Wavefront &wf) {
   const VgprStorage *r = SimdAccess::vgpr_storage(op, wf);
   if (r)
     SimdAccess::notify_read(op, wf, 0, wf.wf_size(), 0xF);
@@ -117,7 +115,7 @@ template <typename Op> inline const VgprStorage *simd_src_reg(const Op &op, cons
 
 /// Mutable counterpart of `simd_src_reg` for the dst write path (single
 /// `simd_vgpr_storage_mut` dispatch).
-template <typename Op> inline VgprStorage *simd_dst_reg(const Op &op, Wavefront &wf) {
+template <typename Op> VgprStorage *simd_dst_reg(const Op &op, Wavefront &wf) {
   return SimdAccess::vgpr_storage_mut(op, wf);
 }
 
@@ -126,8 +124,7 @@ template <typename Op> inline VgprStorage *simd_dst_reg(const Op &op, Wavefront 
 /// hi = reg N+1), or `{nullptr, nullptr}` for a non-VGPR operand. The glue's
 /// 64-bit kernels structured-bind this and issue value-semantic
 /// `lo->simd_load64<T>(*hi, base)` — no raw pointer in the kernel body.
-template <typename Op>
-inline ConstVgprStoragePair64 simd_src_reg64(const Op &op, const Wavefront &wf) {
+template <typename Op> ConstVgprStoragePair64 simd_src_reg64(const Op &op, const Wavefront &wf) {
   ConstVgprStoragePair64 p = SimdAccess::vgpr_storage64(op, wf);
   if (p.lo)
     SimdAccess::notify_read(op, wf, 0, wf.wf_size(), 0xF);
@@ -136,7 +133,7 @@ inline ConstVgprStoragePair64 simd_src_reg64(const Op &op, const Wavefront &wf) 
 
 /// Mutable counterpart of `simd_src_reg64` for the 64-bit dst write path
 /// (single `simd_vgpr_storage64_mut` dispatch).
-template <typename Op> inline VgprStoragePair64 simd_dst_reg64(const Op &op, Wavefront &wf) {
+template <typename Op> VgprStoragePair64 simd_dst_reg64(const Op &op, Wavefront &wf) {
   return SimdAccess::vgpr_storage64_mut(op, wf);
 }
 
@@ -146,15 +143,15 @@ template <typename Op> inline VgprStoragePair64 simd_dst_reg64(const Op &op, Wav
 /// invariant (hoisted before the chunk loop), so this is a plain null test +
 /// inlined load — no raw pointer escapes the kernel body.
 template <typename T>
-inline util::native<T> simd_load_or(const VgprStorage *r, uint32_t base, util::native<T> bcast) {
+util::native<T> simd_load_or(const VgprStorage *r, uint32_t base, util::native<T> bcast) {
   return r ? r->template simd_load<T>(base) : bcast;
 }
 
 /// Narrow (native_width64-wide) counterpart of `simd_load_or` for the
 /// mixed-width f64<->32-bit glue.
 template <typename T>
-inline util::narrow32<T> simd_load_narrow_or(const VgprStorage *r, uint32_t base,
-                                             util::narrow32<T> bcast) {
+util::narrow32<T> simd_load_narrow_or(const VgprStorage *r, uint32_t base,
+                                      util::narrow32<T> bcast) {
   return r ? r->template simd_load_narrow<T>(base) : bcast;
 }
 
@@ -163,16 +160,15 @@ inline util::narrow32<T> simd_load_narrow_or(const VgprStorage *r, uint32_t base
 /// storage, otherwise the pre-broadcast scalar `bcast`. The resolved pair is
 /// loop-invariant — no raw pointer escapes the kernel body.
 template <typename T>
-inline util::native<T> simd_load64_or(const ConstVgprStoragePair64 &p, uint32_t base,
-                                      util::native<T> bcast) {
+util::native<T> simd_load64_or(const ConstVgprStoragePair64 &p, uint32_t base,
+                               util::native<T> bcast) {
   return p.lo ? p.lo->template simd_load64<T>(*p.hi, base) : bcast;
 }
 
 /// Mutable-pair overload of `simd_load64_or`, for the dst-accumulate (fmac) f64
 /// paths whose vdst pair is both the accumulator source and the destination.
 template <typename T>
-inline util::native<T> simd_load64_or(const VgprStoragePair64 &p, uint32_t base,
-                                      util::native<T> bcast) {
+util::native<T> simd_load64_or(const VgprStoragePair64 &p, uint32_t base, util::native<T> bcast) {
   return p.lo ? p.lo->template simd_load64<T>(*p.hi, base) : bcast;
 }
 
@@ -402,7 +398,7 @@ template <typename T, typename Inst, typename BinOp>
 /// Trivially inlined to `return false;` so the generated probe at the
 /// call site costs nothing on toolchains without `<experimental/simd>`.
 template <typename T, typename Inst, typename BinOp>
-[[nodiscard]] inline bool try_execute_binary_vop2_simd(Inst &, Wavefront &, BinOp) {
+[[nodiscard]] bool try_execute_binary_vop2_simd(Inst &, Wavefront &, BinOp) {
   return false;
 }
 
@@ -449,7 +445,7 @@ template <typename Tin, typename Tout, typename Inst, typename UnOp>
 
 /// Unconstrained fallback for the unary path; see the binary-path note above.
 template <typename Tin, typename Tout, typename Inst, typename UnOp>
-[[nodiscard]] inline bool try_execute_unary_vop1_simd(Inst &, Wavefront &, UnOp) {
+[[nodiscard]] bool try_execute_unary_vop1_simd(Inst &, Wavefront &, UnOp) {
   return false;
 }
 
@@ -466,7 +462,7 @@ template <typename Value, typename Mask> struct SimdCarry {
 /// Deduce-and-wrap helper for the carry functors. Keeps each functor a single
 /// expression while leaving the mask type implicit.
 template <typename Value, typename Mask>
-inline SimdCarry<Value, Mask> make_simd_carry(Value value, Mask carry) {
+SimdCarry<Value, Mask> make_simd_carry(Value value, Mask carry) {
   return {value, carry};
 }
 
@@ -527,7 +523,7 @@ template <typename Inst, typename CarryOp>
 
 /// Unconstrained fallback for the carry path; see the binary-path note above.
 template <typename Inst, typename CarryOp>
-[[nodiscard]] inline bool try_execute_binary_vop2_carry_simd(Inst &, Wavefront &, CarryOp) {
+[[nodiscard]] bool try_execute_binary_vop2_carry_simd(Inst &, Wavefront &, CarryOp) {
   return false;
 }
 
@@ -580,8 +576,7 @@ template <typename T, typename Inst, typename FmaOp>
 
 /// Unconstrained fallback for the ternary path; see the binary-path note above.
 template <typename T, typename Inst, typename FmaOp>
-[[nodiscard]] inline bool try_execute_ternary_vop2_simd(Inst &, Wavefront &, util::native<T>,
-                                                        FmaOp) {
+[[nodiscard]] bool try_execute_ternary_vop2_simd(Inst &, Wavefront &, util::native<T>, FmaOp) {
   return false;
 }
 
@@ -630,7 +625,7 @@ template <typename T, typename Inst, typename FmaOp>
 
 /// Unconstrained fallback for the f64 ternary path; see the binary-path note.
 template <typename T, typename Inst, typename FmaOp>
-[[nodiscard]] inline bool try_execute_ternary_vop2_f64_simd(Inst &, Wavefront &, FmaOp) {
+[[nodiscard]] bool try_execute_ternary_vop2_f64_simd(Inst &, Wavefront &, FmaOp) {
   return false;
 }
 
@@ -671,7 +666,7 @@ template <typename Inst, typename BinOp>
 
 /// Unconstrained fallback for the f64 vop2 binary path.
 template <typename Inst, typename BinOp>
-[[nodiscard]] inline bool try_execute_binary_vop2_f64_simd(Inst &, Wavefront &, BinOp) {
+[[nodiscard]] bool try_execute_binary_vop2_f64_simd(Inst &, Wavefront &, BinOp) {
   return false;
 }
 
@@ -714,7 +709,7 @@ template <typename T, typename Inst, typename UnOp>
 
 /// Unconstrained fallback for the f64 unary path; see the binary-path note.
 template <typename T, typename Inst, typename UnOp>
-[[nodiscard]] inline bool try_execute_unary_vop1_f64_simd(Inst &, Wavefront &, UnOp) {
+[[nodiscard]] bool try_execute_unary_vop1_f64_simd(Inst &, Wavefront &, UnOp) {
   return false;
 }
 
@@ -773,7 +768,7 @@ template <typename Tout, typename Inst, typename CvtOp>
 
 /// Unconstrained fallback for the f64->b32 cvt path; see the binary-path note.
 template <typename Tout, typename Inst, typename CvtOp>
-[[nodiscard]] inline bool try_execute_cvt_f64_to_b32_simd(Inst &, Wavefront &, CvtOp) {
+[[nodiscard]] bool try_execute_cvt_f64_to_b32_simd(Inst &, Wavefront &, CvtOp) {
   return false;
 }
 
@@ -810,7 +805,7 @@ template <typename Tin, typename Inst, typename CvtOp>
 
 /// Unconstrained fallback for the b32->f64 cvt path; see the binary-path note.
 template <typename Tin, typename Inst, typename CvtOp>
-[[nodiscard]] inline bool try_execute_cvt_b32_to_f64_simd(Inst &, Wavefront &, CvtOp) {
+[[nodiscard]] bool try_execute_cvt_b32_to_f64_simd(Inst &, Wavefront &, CvtOp) {
   return false;
 }
 
@@ -868,7 +863,7 @@ template <typename Inst, typename CvtOp>
 }
 
 template <typename Inst, typename CvtOp>
-[[nodiscard]] inline bool try_execute_cvt_vop3_f64_to_b32_fp_simd(Inst &, Wavefront &, CvtOp) {
+[[nodiscard]] bool try_execute_cvt_vop3_f64_to_b32_fp_simd(Inst &, Wavefront &, CvtOp) {
   return false;
 }
 
@@ -912,8 +907,7 @@ template <typename Inst>
 }
 
 /// Unconstrained fallback for the cndmask path; see the binary-path note above.
-template <typename Inst>
-[[nodiscard]] inline bool try_execute_cndmask_vop2_simd(Inst &, Wavefront &) {
+template <typename Inst> [[nodiscard]] bool try_execute_cndmask_vop2_simd(Inst &, Wavefront &) {
   return false;
 }
 
@@ -960,8 +954,7 @@ template <typename Inst>
 }
 
 /// Unconstrained fallback for the VOP3 cndmask path; see the binary-path note.
-template <typename Inst>
-[[nodiscard]] inline bool try_execute_cndmask_vop3_simd(Inst &, Wavefront &) {
+template <typename Inst> [[nodiscard]] bool try_execute_cndmask_vop3_simd(Inst &, Wavefront &) {
   return false;
 }
 
@@ -1005,8 +998,7 @@ template <typename Inst>
   return true;
 }
 
-template <typename Inst>
-[[nodiscard]] inline bool try_execute_cndmask_b16_vop3_simd(Inst &, Wavefront &) {
+template <typename Inst> [[nodiscard]] bool try_execute_cndmask_b16_vop3_simd(Inst &, Wavefront &) {
   return false;
 }
 
@@ -1058,7 +1050,7 @@ template <typename T, typename Inst, typename CmpOp>
 
 /// Unconstrained fallback for the VOPC path; see the binary-path note above.
 template <typename T, typename Inst, typename CmpOp>
-[[nodiscard]] inline bool try_execute_vopc_simd(Inst &, Wavefront &, CmpOp) {
+[[nodiscard]] bool try_execute_vopc_simd(Inst &, Wavefront &, CmpOp) {
   return false;
 }
 
@@ -1102,7 +1094,7 @@ template <typename T, typename Inst, typename CmpOp>
 
 /// Unconstrained fallback for the 64-bit VOPC path; see the binary-path note.
 template <typename T, typename Inst, typename CmpOp>
-[[nodiscard]] inline bool try_execute_vopc64_simd(Inst &, Wavefront &, CmpOp) {
+[[nodiscard]] bool try_execute_vopc64_simd(Inst &, Wavefront &, CmpOp) {
   return false;
 }
 
@@ -1151,7 +1143,7 @@ template <typename Inst, typename CmpOp>
 
 /// Unconstrained fallback for the f64 class path; see the binary-path note.
 template <typename Inst, typename CmpOp>
-[[nodiscard]] inline bool try_execute_vopc_class_f64_simd(Inst &, Wavefront &, CmpOp) {
+[[nodiscard]] bool try_execute_vopc_class_f64_simd(Inst &, Wavefront &, CmpOp) {
   return false;
 }
 
@@ -1209,7 +1201,7 @@ template <typename Inst, typename CmpOp>
 
 /// Unconstrained fallback for the VOP3 b32 class path; see the binary-path note.
 template <typename Inst, typename CmpOp>
-[[nodiscard]] inline bool try_execute_vop3_class_b32_simd(Inst &, Wavefront &, uint32_t, CmpOp) {
+[[nodiscard]] bool try_execute_vop3_class_b32_simd(Inst &, Wavefront &, uint32_t, CmpOp) {
   return false;
 }
 
@@ -1263,7 +1255,7 @@ template <typename Inst, typename CmpOp>
 
 /// Unconstrained fallback for the VOP3 f64 class path; see the binary-path note.
 template <typename Inst, typename CmpOp>
-[[nodiscard]] inline bool try_execute_vop3_class_f64_simd(Inst &, Wavefront &, uint64_t, CmpOp) {
+[[nodiscard]] bool try_execute_vop3_class_f64_simd(Inst &, Wavefront &, uint64_t, CmpOp) {
   return false;
 }
 
@@ -1304,7 +1296,7 @@ template <typename T, typename Inst, typename BinOp>
 /// Unconstrained fallback for the VOP3 integer binary path; see the VOP2
 /// binary-path note above.
 template <typename T, typename Inst, typename BinOp>
-[[nodiscard]] inline bool try_execute_binary_vop3_simd(Inst &, Wavefront &, BinOp) {
+[[nodiscard]] bool try_execute_binary_vop3_simd(Inst &, Wavefront &, BinOp) {
   return false;
 }
 
@@ -1315,8 +1307,7 @@ template <typename T, typename Inst, typename BinOp>
 /// to scalar whenever any modifier field is set; the (common) unmodified case
 /// still takes the integer fast path.
 template <typename T, typename Inst, typename BinOp>
-[[nodiscard]] inline bool try_execute_binary_vop3_f16_simd(Inst &inst, Wavefront &wf,
-                                                           BinOp bin_op) {
+[[nodiscard]] bool try_execute_binary_vop3_f16_simd(Inst &inst, Wavefront &wf, BinOp bin_op) {
   if (inst.inst_.abs != 0u || inst.inst_.neg != 0u || inst.inst_.omod != 0u ||
       inst.inst_.clamp != 0u)
     return false;
@@ -1361,7 +1352,7 @@ template <typename T, typename Inst, typename BinOp>
 
 /// Unconstrained fallback for the VOP3 f32 binary path.
 template <typename T, typename Inst, typename BinOp>
-[[nodiscard]] inline bool try_execute_binary_vop3_fp_simd(Inst &, Wavefront &, BinOp) {
+[[nodiscard]] bool try_execute_binary_vop3_fp_simd(Inst &, Wavefront &, BinOp) {
   return false;
 }
 
@@ -1408,7 +1399,7 @@ template <typename T, typename Inst, typename CmpOp>
 
 /// Unconstrained fallback for the VOP3 integer VOPC path; see the binary-path note.
 template <typename T, typename Inst, typename CmpOp>
-[[nodiscard]] inline bool try_execute_vopc_vop3_int_simd(Inst &, Wavefront &, CmpOp) {
+[[nodiscard]] bool try_execute_vopc_vop3_int_simd(Inst &, Wavefront &, CmpOp) {
   return false;
 }
 
@@ -1454,7 +1445,7 @@ template <typename T, typename Inst, typename CmpOp>
 
 /// Unconstrained fallback for the 64-bit VOP3 integer VOPC path; see the binary-path note.
 template <typename T, typename Inst, typename CmpOp>
-[[nodiscard]] inline bool try_execute_vopc64_vop3_int_simd(Inst &, Wavefront &, CmpOp) {
+[[nodiscard]] bool try_execute_vopc64_vop3_int_simd(Inst &, Wavefront &, CmpOp) {
   return false;
 }
 
@@ -1503,7 +1494,7 @@ template <typename Inst, typename CmpOp>
 
 /// Unconstrained fallback for the VOP3 f32 VOPC path; see the binary-path note.
 template <typename Inst, typename CmpOp>
-[[nodiscard]] inline bool try_execute_vopc_vop3_fp32_simd(Inst &, Wavefront &, CmpOp) {
+[[nodiscard]] bool try_execute_vopc_vop3_fp32_simd(Inst &, Wavefront &, CmpOp) {
   return false;
 }
 
@@ -1554,7 +1545,7 @@ template <typename Inst, typename CmpOp>
 
 /// Unconstrained fallback for the VOP3 f16 VOPC path; see the binary-path note.
 template <typename Inst, typename CmpOp>
-[[nodiscard]] inline bool try_execute_vopc_vop3_fp16_simd(Inst &, Wavefront &, CmpOp) {
+[[nodiscard]] bool try_execute_vopc_vop3_fp16_simd(Inst &, Wavefront &, CmpOp) {
   return false;
 }
 
@@ -1606,7 +1597,7 @@ template <typename Inst, typename CmpOp>
 
 /// Unconstrained fallback for the VOP3 f64 VOPC path; see the binary-path note.
 template <typename Inst, typename CmpOp>
-[[nodiscard]] inline bool try_execute_vopc64_vop3_fp64_simd(Inst &, Wavefront &, CmpOp) {
+[[nodiscard]] bool try_execute_vopc64_vop3_fp64_simd(Inst &, Wavefront &, CmpOp) {
   return false;
 }
 
@@ -1654,7 +1645,7 @@ template <typename Inst, typename BinOp>
 
 /// Unconstrained fallback for the VOP3 f64 binary path; see the binary-path note.
 template <typename Inst, typename BinOp>
-[[nodiscard]] inline bool try_execute_binary_vop3_fp64_simd(Inst &, Wavefront &, BinOp) {
+[[nodiscard]] bool try_execute_binary_vop3_fp64_simd(Inst &, Wavefront &, BinOp) {
   return false;
 }
 
@@ -1693,7 +1684,7 @@ template <typename Inst, typename UnOp>
 
 /// Unconstrained fallback for the VOP3 f64 unary path; see the binary-path note.
 template <typename Inst, typename UnOp>
-[[nodiscard]] inline bool try_execute_unary_vop3_fp64_simd(Inst &, Wavefront &, UnOp) {
+[[nodiscard]] bool try_execute_unary_vop3_fp64_simd(Inst &, Wavefront &, UnOp) {
   return false;
 }
 
@@ -1737,7 +1728,7 @@ template <typename Inst, typename UnOp>
 
 /// Unconstrained fallback for the VOP3 f16 unary path; see the binary-path note.
 template <typename Inst, typename UnOp>
-[[nodiscard]] inline bool try_execute_unary_vop3_fp16_simd(Inst &, Wavefront &, UnOp) {
+[[nodiscard]] bool try_execute_unary_vop3_fp16_simd(Inst &, Wavefront &, UnOp) {
   return false;
 }
 
@@ -1780,7 +1771,7 @@ template <typename T, typename Inst, typename TernOp>
 
 /// Unconstrained fallback for the VOP3 integer ternary path; see binary-path note.
 template <typename T, typename Inst, typename TernOp>
-[[nodiscard]] inline bool try_execute_ternary_vop3_simd(Inst &, Wavefront &, TernOp) {
+[[nodiscard]] bool try_execute_ternary_vop3_simd(Inst &, Wavefront &, TernOp) {
   return false;
 }
 
@@ -1826,7 +1817,7 @@ template <typename Inst, typename FmaOp>
 }
 
 template <typename Inst, typename FmaOp>
-[[nodiscard]] inline bool try_execute_ternary_vop3_fp_simd(Inst &, Wavefront &, FmaOp) {
+[[nodiscard]] bool try_execute_ternary_vop3_fp_simd(Inst &, Wavefront &, FmaOp) {
   return false;
 }
 
@@ -1874,7 +1865,7 @@ template <typename Inst, typename FmaOp>
 }
 
 template <typename Inst, typename FmaOp>
-[[nodiscard]] inline bool try_execute_ternary_vop3_fp16_simd(Inst &, Wavefront &, FmaOp) {
+[[nodiscard]] bool try_execute_ternary_vop3_fp16_simd(Inst &, Wavefront &, FmaOp) {
   return false;
 }
 
@@ -1921,7 +1912,7 @@ template <typename Inst, typename FmaOp>
 }
 
 template <typename Inst, typename FmaOp>
-[[nodiscard]] inline bool try_execute_ternary_vop3_fp64_simd(Inst &, Wavefront &, FmaOp) {
+[[nodiscard]] bool try_execute_ternary_vop3_fp64_simd(Inst &, Wavefront &, FmaOp) {
   return false;
 }
 
@@ -1969,7 +1960,7 @@ template <typename Inst, typename FmaOp>
 }
 
 template <typename Inst, typename FmaOp>
-[[nodiscard]] inline bool try_execute_fmac_vop3_fp_simd(Inst &, Wavefront &, FmaOp) {
+[[nodiscard]] bool try_execute_fmac_vop3_fp_simd(Inst &, Wavefront &, FmaOp) {
   return false;
 }
 
@@ -2015,7 +2006,7 @@ template <typename Inst, typename FmaOp>
 }
 
 template <typename Inst, typename FmaOp>
-[[nodiscard]] inline bool try_execute_fmac_vop3_fp16_simd(Inst &, Wavefront &, FmaOp) {
+[[nodiscard]] bool try_execute_fmac_vop3_fp16_simd(Inst &, Wavefront &, FmaOp) {
   return false;
 }
 
@@ -2060,7 +2051,7 @@ template <typename Inst, typename FmaOp>
 }
 
 template <typename Inst, typename FmaOp>
-[[nodiscard]] inline bool try_execute_fmac_vop3_fp64_simd(Inst &, Wavefront &, FmaOp) {
+[[nodiscard]] bool try_execute_fmac_vop3_fp64_simd(Inst &, Wavefront &, FmaOp) {
   return false;
 }
 
@@ -2103,7 +2094,7 @@ template <typename Inst, typename Op>
 }
 
 template <typename Inst, typename Op>
-[[nodiscard]] inline bool try_execute_ldexp_vop3_fp32_simd(Inst &, Wavefront &, Op) {
+[[nodiscard]] bool try_execute_ldexp_vop3_fp32_simd(Inst &, Wavefront &, Op) {
   return false;
 }
 
@@ -2146,7 +2137,7 @@ template <typename Inst, typename Op>
 }
 
 template <typename Inst, typename Op>
-[[nodiscard]] inline bool try_execute_ldexp_vop3_fp64_simd(Inst &, Wavefront &, Op) {
+[[nodiscard]] bool try_execute_ldexp_vop3_fp64_simd(Inst &, Wavefront &, Op) {
   return false;
 }
 
@@ -2185,7 +2176,7 @@ template <typename Tin, typename Tout, typename Inst, typename UnOp>
 
 /// Unconstrained fallback for the VOP3 f32 unary path.
 template <typename Tin, typename Tout, typename Inst, typename UnOp>
-[[nodiscard]] inline bool try_execute_unary_vop3_fp_simd(Inst &, Wavefront &, UnOp) {
+[[nodiscard]] bool try_execute_unary_vop3_fp_simd(Inst &, Wavefront &, UnOp) {
   return false;
 }
 
@@ -2306,8 +2297,7 @@ template <typename Inst>
   return true;
 }
 
-template <typename Inst>
-[[nodiscard]] inline bool try_execute_div_fmas_f32_simd(Inst &, Wavefront &) {
+template <typename Inst> [[nodiscard]] bool try_execute_div_fmas_f32_simd(Inst &, Wavefront &) {
   return false;
 }
 
@@ -2363,8 +2353,7 @@ template <typename Inst>
   return true;
 }
 
-template <typename Inst>
-[[nodiscard]] inline bool try_execute_div_fmas_f64_simd(Inst &, Wavefront &) {
+template <typename Inst> [[nodiscard]] bool try_execute_div_fmas_f64_simd(Inst &, Wavefront &) {
   return false;
 }
 
@@ -2405,7 +2394,7 @@ template <typename Inst, typename ShiftOp>
   return true;
 }
 template <typename Inst, typename ShiftOp>
-[[nodiscard]] inline bool try_execute_shift64_vop3_simd(Inst &, Wavefront &, ShiftOp) {
+[[nodiscard]] bool try_execute_shift64_vop3_simd(Inst &, Wavefront &, ShiftOp) {
   return false;
 }
 
@@ -2445,8 +2434,7 @@ template <typename Inst>
   }
   return true;
 }
-template <typename Inst>
-[[nodiscard]] inline bool try_execute_lshl_add_u64_simd(Inst &, Wavefront &) {
+template <typename Inst> [[nodiscard]] bool try_execute_lshl_add_u64_simd(Inst &, Wavefront &) {
   return false;
 }
 
@@ -2487,7 +2475,7 @@ template <typename Inst, typename MadOp>
   return true;
 }
 template <typename Inst, typename MadOp>
-[[nodiscard]] inline bool try_execute_mad_wide64_vop3_simd(Inst &, Wavefront &, MadOp) {
+[[nodiscard]] bool try_execute_mad_wide64_vop3_simd(Inst &, Wavefront &, MadOp) {
   return false;
 }
 
@@ -2533,7 +2521,7 @@ template <typename Inst, typename CarryOp>
   return true;
 }
 template <typename Inst, typename CarryOp>
-[[nodiscard]] inline bool try_execute_binary_vop3_co_simd(Inst &, Wavefront &, CarryOp) {
+[[nodiscard]] bool try_execute_binary_vop3_co_simd(Inst &, Wavefront &, CarryOp) {
   return false;
 }
 
@@ -2581,7 +2569,7 @@ template <typename Inst, typename CarryOp>
   return true;
 }
 template <typename Inst, typename CarryOp>
-[[nodiscard]] inline bool try_execute_binary_vop3_cin_simd(Inst &, Wavefront &, CarryOp) {
+[[nodiscard]] bool try_execute_binary_vop3_cin_simd(Inst &, Wavefront &, CarryOp) {
   return false;
 }
 
@@ -2670,7 +2658,7 @@ template <FmaMixDst DstMode, typename Inst>
 }
 
 template <FmaMixDst DstMode, typename Inst>
-[[nodiscard]] inline bool try_execute_vop3p_fma_mix_simd(Inst &, Wavefront &) {
+[[nodiscard]] bool try_execute_vop3p_fma_mix_simd(Inst &, Wavefront &) {
   return false;
 }
 
@@ -2715,7 +2703,7 @@ template <typename Inst, typename Op>
 }
 
 template <typename Inst, typename Op>
-[[nodiscard]] inline bool try_execute_vop3p_pk_binary_int_simd(Inst &, Wavefront &, Op) {
+[[nodiscard]] bool try_execute_vop3p_pk_binary_int_simd(Inst &, Wavefront &, Op) {
   return false;
 }
 
@@ -2753,7 +2741,7 @@ template <typename Inst, typename Op>
 }
 
 template <typename Inst, typename Op>
-[[nodiscard]] inline bool try_execute_vop3p_pk_ternary_int_simd(Inst &, Wavefront &, Op) {
+[[nodiscard]] bool try_execute_vop3p_pk_ternary_int_simd(Inst &, Wavefront &, Op) {
   return false;
 }
 
@@ -2812,7 +2800,7 @@ template <typename Inst, typename Op>
 }
 
 template <typename Inst, typename Op>
-[[nodiscard]] inline bool try_execute_vop3p_pk_binary_fp16_simd(Inst &, Wavefront &, Op) {
+[[nodiscard]] bool try_execute_vop3p_pk_binary_fp16_simd(Inst &, Wavefront &, Op) {
   return false;
 }
 
@@ -2879,7 +2867,7 @@ template <typename Inst, typename Op>
 }
 
 template <typename Inst, typename Op>
-[[nodiscard]] inline bool try_execute_vop3p_pk_ternary_fp16_simd(Inst &, Wavefront &, Op) {
+[[nodiscard]] bool try_execute_vop3p_pk_ternary_fp16_simd(Inst &, Wavefront &, Op) {
   return false;
 }
 
@@ -2922,7 +2910,7 @@ template <typename Inst, typename Op>
 }
 
 template <typename Inst, typename Op>
-[[nodiscard]] inline bool try_execute_vop3p_pk_binary_f32_simd(Inst &, Wavefront &, Op) {
+[[nodiscard]] bool try_execute_vop3p_pk_binary_f32_simd(Inst &, Wavefront &, Op) {
   return false;
 }
 
@@ -2968,7 +2956,7 @@ template <typename Inst, typename Op>
 }
 
 template <typename Inst, typename Op>
-[[nodiscard]] inline bool try_execute_vop3p_pk_ternary_f32_simd(Inst &, Wavefront &, Op) {
+[[nodiscard]] bool try_execute_vop3p_pk_ternary_f32_simd(Inst &, Wavefront &, Op) {
   return false;
 }
 
@@ -3006,8 +2994,7 @@ template <typename Inst>
   return true;
 }
 
-template <typename Inst>
-[[nodiscard]] inline bool try_execute_vop3p_mov_b32_simd(Inst &, Wavefront &) {
+template <typename Inst> [[nodiscard]] bool try_execute_vop3p_mov_b32_simd(Inst &, Wavefront &) {
   return false;
 }
 
@@ -3082,7 +3069,7 @@ template <int ElemBits, bool Signed, typename Inst>
 }
 
 template <int ElemBits, bool Signed, typename Inst>
-[[nodiscard]] inline bool try_execute_vop3p_dot_int_simd(Inst &, Wavefront &) {
+[[nodiscard]] bool try_execute_vop3p_dot_int_simd(Inst &, Wavefront &) {
   return false;
 }
 
@@ -3148,8 +3135,7 @@ template <typename Inst>
   return true;
 }
 
-template <typename Inst>
-[[nodiscard]] inline bool try_execute_vop3p_dot_f16_simd(Inst &, Wavefront &) {
+template <typename Inst> [[nodiscard]] bool try_execute_vop3p_dot_f16_simd(Inst &, Wavefront &) {
   return false;
 }
 
@@ -3207,7 +3193,7 @@ template <int ElemBits, typename Inst>
 }
 
 template <int ElemBits, typename Inst>
-[[nodiscard]] inline bool try_execute_vop3p_dot_int_mixed_simd(Inst &, Wavefront &) {
+[[nodiscard]] bool try_execute_vop3p_dot_int_mixed_simd(Inst &, Wavefront &) {
   return false;
 }
 
@@ -3264,7 +3250,7 @@ template <int ElemBits, bool Vop3, typename Inst>
 }
 
 template <int ElemBits, bool Vop3, typename Inst>
-[[nodiscard]] inline bool try_execute_dotc_int_simd(Inst &, Wavefront &) {
+[[nodiscard]] bool try_execute_dotc_int_simd(Inst &, Wavefront &) {
   return false;
 }
 
@@ -3313,7 +3299,7 @@ template <bool Vop3, typename Inst>
 }
 
 template <bool Vop3, typename Inst>
-[[nodiscard]] inline bool try_execute_dotc_f16_simd(Inst &, Wavefront &) {
+[[nodiscard]] bool try_execute_dotc_f16_simd(Inst &, Wavefront &) {
   return false;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -269,6 +269,36 @@ inline util::native<T> read_simd64(const Op &op, const Wavefront &wf, uint32_t l
   return util::broadcast64<T>(op.read_scalar64(wf));
 }
 
+/// Per-half f32 reader for the packed-f32 VOP3P family (v_pk_add/mul/fma_f32).
+/// In a VGPR pair {N, N+1}, register N holds the LO f32 of every lane and N+1
+/// the HI f32, so each half is a native-width native<float> read of one
+/// register (no 64-bit-lane / narrow32 detour). For a non-VGPR source the
+/// pk_f32 scalar bodies splat the single 32-bit operand into BOTH halves, so
+/// lo == hi == broadcast(read_scalar). The `p.lo != nullptr` gate is bit-exact
+/// to the scalar's `encoding_value_ in [256,511]` VGPR-range test.
+struct PkF32Halves {
+  util::native<float> lo;
+  util::native<float> hi;
+};
+template <typename Op>
+  requires(util::has_stdx_simd)
+inline PkF32Halves read_pkf32_halves(const Op &op, const Wavefront &wf, uint32_t lane_base) {
+  ConstVgprStoragePair64 p = simd_src_reg64(op, wf);
+  if (p.lo)
+    return {p.lo->template simd_load<float>(lane_base), p.hi->template simd_load<float>(lane_base)};
+  const util::native<float> b = util::broadcast<float>(op.read_scalar(wf));
+  return {b, b};
+}
+
+/// In-vector f32 sign flip (neg modifier): XOR the sign bit. Bit-exact to the
+/// scalar `x = -x` for all values incl. ±0 / ±Inf / NaN (payload preserved).
+inline util::native<float> pkf32_neg(util::native<float> v, bool do_neg) {
+  if (!do_neg)
+    return v;
+  return std::bit_cast<util::native<float>>(std::bit_cast<util::native<uint32_t>>(v) ^
+                                            util::native<uint32_t>(0x80000000u));
+}
+
 /// 64-bit-lane masked store of `v` into an operand at `lane_base`, writing only
 /// the lanes set in `mask`. Falls back to per-lane `write_lane64` when the dst is
 /// not contiguous VGPR storage.
@@ -781,6 +811,64 @@ template <typename Tin, typename Inst, typename CvtOp>
 /// Unconstrained fallback for the b32->f64 cvt path; see the binary-path note.
 template <typename Tin, typename Inst, typename CvtOp>
 [[nodiscard]] inline bool try_execute_cvt_b32_to_f64_simd(Inst &, Wavefront &, CvtOp) {
+  return false;
+}
+
+/// VOP3 mixed-width f64-source -> 32-bit-fp-dst fast path: the 64-bit-in /
+/// 32-bit-out counterpart of the f64 unary FP glue, for v_frexp_exp_i32_f64
+/// (the lone f64 VOP3 cvt whose body keeps the modifiers around an
+/// f64 -> float(exp) -> bit_cast tail). Reads src0 as native<double>
+/// (native_width64 lanes), applies src0 abs/neg in the f64 domain, runs cvt_op
+/// (native<double> -> narrow32<float> = the exponent as float), then applies the
+/// result omod/clamp INLINE at narrow32 width (apply_vop3_dst_mod_f32 is
+/// native<float>-wide — a different width than narrow32<float>), and stores the
+/// 32-bit results. All steps bit-exact: frexp_exp_f64_simd is the proven VOP1
+/// helper (op 48), apply_vop3_src_mod_f64 is the same helper the tested f64
+/// unary ops use, and the (float)(uint32) cast + power-of-two omod + ordered
+/// clamp mirror the scalar tail (the exp is always finite, so NaN handling is
+/// moot).
+template <typename Inst, typename CvtOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_cvt_vop3_f64_to_b32_fp_simd(Inst &inst, Wavefront &wf,
+                                                                  CvtOp cvt_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  const uint32_t abs = inst.inst_.abs;
+  const uint32_t neg = inst.inst_.neg;
+  const uint32_t omod = inst.inst_.omod;
+  const uint32_t clamp = inst.inst_.clamp;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  VgprStorage *rd = simd_dst_reg(inst.vdst, wf);
+  const auto s_bcast =
+      rs0.lo ? util::native<double>{} : util::broadcast64<double>(inst.src0.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto s = apply_vop3_src_mod_f64<0>(simd_load64_or<double>(rs0, base, s_bcast), abs, neg);
+    util::narrow32<float> v = cvt_op(s);
+    // Inline omod/clamp at narrow32<float> width (mirrors apply_vop3_dst_mod):
+    // IEEE-exact power-of-two scale, ordered-compare saturation to [0,1].
+    if (omod == 1)
+      v = v * 2.0f;
+    else if (omod == 2)
+      v = v * 4.0f;
+    else if (omod == 3)
+      v = v * 0.5f;
+    if (clamp) {
+      util::stdx::where(v < 0.0f, v) = 0.0f;
+      util::stdx::where(v > 1.0f, v) = 1.0f;
+    }
+    write_simd_narrow_at<float>(rd, inst.vdst, wf, base, v, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename CvtOp>
+[[nodiscard]] inline bool try_execute_cvt_vop3_f64_to_b32_fp_simd(Inst &, Wavefront &, CvtOp) {
   return false;
 }
 
@@ -2795,6 +2883,95 @@ template <typename Inst, typename Op>
   return false;
 }
 
+/// VOP3P packed-f32 binary fast path (v_pk_add_f32 / v_pk_mul_f32). In a VGPR
+/// pair {N, N+1} register N is the LO f32 of every lane, N+1 the HI f32, so each
+/// half is a native-width native<float> read of one register (read_pkf32_halves)
+/// and the per-half arithmetic runs at full native width. Default-packing gate
+/// (op_sel == 0, op_sel_hi == 3) bails to scalar otherwise — under default
+/// packing the lo result comes from the lo halves and hi from the hi halves.
+/// neg/neg_hi bits 0/1 sign-flip the respective half. No clamp on any pk_f32
+/// scalar body. Non-VGPR sources splat the 32-bit operand into both halves.
+template <typename Inst, typename Op>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vop3p_pk_binary_f32_simd(Inst &inst, Wavefront &wf, Op op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  if (inst.inst_.op_sel != 0u || inst.inst_.op_sel_hi != 3u)
+    return false;
+  constexpr std::size_t W = util::native_width_v<float>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const bool neg0_lo = inst.inst_.neg & 1u;
+  const bool neg1_lo = inst.inst_.neg & 2u;
+  const bool neg0_hi = inst.inst_.neg_hi & 1u;
+  const bool neg1_hi = inst.inst_.neg_hi & 2u;
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const PkF32Halves a = read_pkf32_halves(inst.src0, wf, base);
+    const PkF32Halves b = read_pkf32_halves(inst.src1, wf, base);
+    const util::native<float> r_lo = op(pkf32_neg(a.lo, neg0_lo), pkf32_neg(b.lo, neg1_lo));
+    const util::native<float> r_hi = op(pkf32_neg(a.hi, neg0_hi), pkf32_neg(b.hi, neg1_hi));
+    rd64.lo->template simd_store<float>(base, r_lo, chunk);
+    rd64.hi->template simd_store<float>(base, r_hi, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename Op>
+[[nodiscard]] inline bool try_execute_vop3p_pk_binary_f32_simd(Inst &, Wavefront &, Op) {
+  return false;
+}
+
+/// VOP3P packed-f32 ternary fast path (v_pk_fma_f32). 3-source FMA per half;
+/// same per-register native<float> read/write as the binary form. Default-
+/// packing gate adds op_sel_hi_2 == 1 (the src2-hi select). neg/neg_hi bits
+/// 0/1/2 sign-flip the respective half. No clamp. NaN-input payload divergence
+/// between stdx::fma and std::fma accepted (same carve-out as the f16 pk ternary
+/// / fma_mix slices).
+template <typename Inst, typename Op>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_vop3p_pk_ternary_f32_simd(Inst &inst, Wavefront &wf, Op op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
+      !inst.src2.simd_capable() || !inst.vdst.simd_capable())
+    return false;
+  if (inst.inst_.op_sel != 0u || inst.inst_.op_sel_hi != 3u || inst.inst_.op_sel_hi_2 != 1u)
+    return false;
+  constexpr std::size_t W = util::native_width_v<float>;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const bool neg0_lo = inst.inst_.neg & 1u;
+  const bool neg1_lo = inst.inst_.neg & 2u;
+  const bool neg2_lo = inst.inst_.neg & 4u;
+  const bool neg0_hi = inst.inst_.neg_hi & 1u;
+  const bool neg1_hi = inst.inst_.neg_hi & 2u;
+  const bool neg2_hi = inst.inst_.neg_hi & 4u;
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const PkF32Halves a = read_pkf32_halves(inst.src0, wf, base);
+    const PkF32Halves b = read_pkf32_halves(inst.src1, wf, base);
+    const PkF32Halves c = read_pkf32_halves(inst.src2, wf, base);
+    const util::native<float> r_lo =
+        op(pkf32_neg(a.lo, neg0_lo), pkf32_neg(b.lo, neg1_lo), pkf32_neg(c.lo, neg2_lo));
+    const util::native<float> r_hi =
+        op(pkf32_neg(a.hi, neg0_hi), pkf32_neg(b.hi, neg1_hi), pkf32_neg(c.hi, neg2_hi));
+    rd64.lo->template simd_store<float>(base, r_lo, chunk);
+    rd64.hi->template simd_store<float>(base, r_hi, chunk);
+  }
+  return true;
+}
+
+template <typename Inst, typename Op>
+[[nodiscard]] inline bool try_execute_vop3p_pk_ternary_f32_simd(Inst &, Wavefront &, Op) {
+  return false;
+}
+
 /// VOP3P v_pk_mov_b32 SIMD fast path. Default packing only (op_sel == 0,
 /// op_sel_hi == 3): the result is a 64-bit pair `(src0_lo, src1_hi)`,
 /// where the per-source pair is the consecutive {base, base+1} VGPRs
@@ -3226,6 +3403,12 @@ template <bool Vop3, typename Inst>
   if (::rocjitsu::amdgpu::try_execute_cvt_b32_to_f64_simd<Tin>(inst, wf, __VA_ARGS__))             \
   return
 
+/// VOP3 f64-source -> 32-bit-fp-dst cvt counterpart (src0 abs/neg + result
+/// omod/clamp; for v_frexp_exp_i32_f64). Functor: native<double> -> narrow32<float>.
+#define ROCJITSU_TRY_SIMD_CVT_VOP3_F64_TO_B32_FP(...)                                              \
+  if (::rocjitsu::amdgpu::try_execute_cvt_vop3_f64_to_b32_fp_simd(inst, wf, __VA_ARGS__))          \
+  return
+
 /// VOPC compare counterpart. `T` is the 32-bit lane read type; the comparison
 /// functor (which may convert/narrow inside) is variadic so its commas pass
 /// through as one token sequence.
@@ -3476,6 +3659,18 @@ template <bool Vop3, typename Inst>
 /// VOP3P packed-16 f16 ternary probe (3-source pk_fma_f16).
 #define ROCJITSU_TRY_SIMD_VOP3P_PK_TERNARY_FP16(...)                                               \
   if (::rocjitsu::amdgpu::try_execute_vop3p_pk_ternary_fp16_simd(inst, wf, __VA_ARGS__))           \
+  return
+
+/// VOP3P packed-f32 binary probe (v_pk_add_f32 / v_pk_mul_f32). Functor takes
+/// (a, b) as narrow32<float> (neg-applied) and returns narrow32<float>.
+#define ROCJITSU_TRY_SIMD_VOP3P_PK_BINARY_F32(...)                                                 \
+  if (::rocjitsu::amdgpu::try_execute_vop3p_pk_binary_f32_simd(inst, wf, __VA_ARGS__))             \
+  return
+
+/// VOP3P packed-f32 ternary probe (v_pk_fma_f32). Functor takes (a, b, c) as
+/// narrow32<float>; default-packing gate adds op_sel_hi_2 == 1.
+#define ROCJITSU_TRY_SIMD_VOP3P_PK_TERNARY_F32(...)                                                \
+  if (::rocjitsu::amdgpu::try_execute_vop3p_pk_ternary_f32_simd(inst, wf, __VA_ARGS__))            \
   return
 
 /// VOP3P v_pk_mov_b32 probe. Functorless / fixed-op.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -604,6 +604,47 @@ template <typename T, typename Inst, typename FmaOp>
   return false;
 }
 
+/// 64-bit-lane VOP2 binary SIMD fast path (v_add_f64 / v_mul_f64 /
+/// v_max_num_f64 / v_min_num_f64). VOP2 has no abs/neg/omod/clamp fields and
+/// reads its second source as `vsrc1` (not `src1`); otherwise identical to the
+/// f64 FMA vop2 path minus the dst-accumulate operand. add/mul are bit-exact;
+/// fmax/fmin carry the accepted NaN-payload / signed-zero-tie carve-out (same as
+/// the f64 vop3 binary path and every other min/max).
+template <typename Inst, typename BinOp>
+  requires(util::has_stdx_simd)
+[[nodiscard]] inline bool try_execute_binary_vop2_f64_simd(Inst &inst, Wavefront &wf,
+                                                           BinOp bin_op) {
+  if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.vsrc1.simd_capable() ||
+      !inst.vdst.simd_capable())
+    return false;
+  using T = double;
+  constexpr std::size_t W = util::native_width64;
+  const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
+  const uint64_t exec = wf.exec();
+  const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
+  const ConstVgprStoragePair64 rs1 = simd_src_reg64(inst.vsrc1, wf);
+  const VgprStoragePair64 rd64 = simd_dst_reg64(inst.vdst, wf);
+  const auto a_bcast =
+      rs0.lo ? util::native<T>{} : util::broadcast64<T>(inst.src0.read_scalar64(wf));
+  const auto b_bcast =
+      rs1.lo ? util::native<T>{} : util::broadcast64<T>(inst.vsrc1.read_scalar64(wf));
+  for (uint32_t base = 0; base < wf.wf_size(); base += static_cast<uint32_t>(W)) {
+    const uint64_t chunk = (exec >> base) & chunk_full;
+    if (chunk == 0)
+      continue;
+    const auto a = simd_load64_or<T>(rs0, base, a_bcast);
+    const auto b = simd_load64_or<T>(rs1, base, b_bcast);
+    write_simd64_at<T>(rd64, inst.vdst, wf, base, bin_op(a, b), chunk);
+  }
+  return true;
+}
+
+/// Unconstrained fallback for the f64 vop2 binary path.
+template <typename Inst, typename BinOp>
+[[nodiscard]] inline bool try_execute_binary_vop2_f64_simd(Inst &, Wavefront &, BinOp) {
+  return false;
+}
+
 /// 64-bit-lane VOP1 unary SIMD fast path. The 64-bit counterpart of
 /// try_execute_unary_vop1_simd: reads src0 as `native<T>` through the split
 /// lo/hi VGPR-pair path (read_simd64), applies `un_op` (`native<T> ->
@@ -2992,6 +3033,13 @@ template <typename Inst>
 /// commas pass through as one token sequence.
 #define ROCJITSU_TRY_SIMD_VOP2_FMA_F64(...)                                                        \
   if (::rocjitsu::amdgpu::try_execute_ternary_vop2_f64_simd<double>(inst, wf, __VA_ARGS__))        \
+  return
+
+/// 64-bit-lane VOP2 binary counterpart (v_add/mul/max_num/min_num_f64). Lane
+/// type fixed to double, read/written through the split lo/hi VGPR-pair path
+/// (vsrc1 as the second source). Variadic in the functor.
+#define ROCJITSU_TRY_SIMD_VOP2_BINARY_FP64(...)                                                    \
+  if (::rocjitsu::amdgpu::try_execute_binary_vop2_f64_simd(inst, wf, __VA_ARGS__))                 \
   return
 
 /// 64-bit-lane VOP1 unary counterpart. `T` is the 64-bit lane type (`double`

--- a/emulation/rocjitsu/lib/util/include/util/data_types.h
+++ b/emulation/rocjitsu/lib/util/include/util/data_types.h
@@ -170,6 +170,47 @@ inline uint16_t f32_to_bf16(float val) {
   return static_cast<uint16_t>(f >> 16);
 }
 
+namespace detail {
+
+#if defined(UTIL_HAS_X86_F16C)
+/// x86 specialization: bf16->f32 is a zero-extend + 16-bit left shift, so it
+/// needs no F16C, only the wide integer ops. AVX-512 does 16/instr, AVX2 8.
+inline void bf16_to_f32_block_arch(const uint16_t *src, float *dst, size_t n, size_t &i) {
+#if defined(__AVX512F__)
+  for (; i + 16 <= n; i += 16) {
+    __m512i w =
+        _mm512_cvtepu16_epi32(_mm256_loadu_si256(reinterpret_cast<const __m256i *>(src + i)));
+    _mm512_storeu_ps(&dst[i], _mm512_castsi512_ps(_mm512_slli_epi32(w, 16)));
+  }
+#endif
+#if defined(__AVX2__)
+  for (; i + 8 <= n; i += 8) {
+    __m256i w = _mm256_cvtepu16_epi32(_mm_loadu_si128(reinterpret_cast<const __m128i *>(src + i)));
+    _mm256_storeu_ps(&dst[i], _mm256_castsi256_ps(_mm256_slli_epi32(w, 16)));
+  }
+#endif
+}
+#else
+/// Portable fallback: no vector advance; the scalar shift loop in
+/// bf16_to_f32_block does all the work (and trivially auto-vectorizes).
+inline void bf16_to_f32_block_arch(const uint16_t *, float *, size_t, size_t &) {}
+#endif
+
+} // namespace detail
+
+/// @brief Convert `n` contiguous BFloat16 values to float.
+///
+/// The bf16->f32 widening is exact (zero-extend into the low mantissa bits),
+/// so the vector and scalar paths are bit-identical for every input including
+/// NaN payloads. Hot path: MFMA/WMMA bf16 input gather.
+inline void bf16_to_f32_block(const uint16_t *src, float *dst, size_t n) {
+  size_t i = 0;
+  detail::bf16_to_f32_block_arch(src, dst, n, i);
+  for (; i < n; ++i)
+    dst[i] = bf16_to_f32(src[i]);
+}
+
+/// @brief Convert a float to 16-bit BFloat16 with round-to-nearest-even.
 inline uint16_t f32_to_bf16_rne(float val) {
   uint32_t f = std::bit_cast<uint32_t>(val);
   if ((f & 0x7f800000u) != 0x7f800000u) {

--- a/emulation/rocjitsu/lib/util/include/util/data_types.h
+++ b/emulation/rocjitsu/lib/util/include/util/data_types.h
@@ -4,6 +4,7 @@
 #ifndef UTIL_DATA_TYPES_H_
 #define UTIL_DATA_TYPES_H_
 
+#include <array>
 #include <bit>
 #include <cmath>
 #include <cstddef>
@@ -516,8 +517,52 @@ inline uint8_t f32_to_bf8_e5m2_sr(float val, uint32_t seed) {
   return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 2) | mant);
 }
 
-// ---- Generalized SR + OCP MX helpers (used by gfx1250 WMMA) ----
+namespace detail {
 
+/// 256-entry fp8/bf8 -> f32 tables filled from the scalar converters, so every
+/// entry (including the NaN payloads) is bit-exact with the per-element path
+/// by construction.
+inline const float *fp8_e4m3_lut() {
+  static const auto lut = [] {
+    std::array<float, 256> t{};
+    for (uint32_t i = 0; i < 256; ++i)
+      t[i] = fp8_e4m3_to_f32(static_cast<uint8_t>(i));
+    return t;
+  }();
+  return lut.data();
+}
+
+inline const float *bf8_e5m2_lut() {
+  static const auto lut = [] {
+    std::array<float, 256> t{};
+    for (uint32_t i = 0; i < 256; ++i)
+      t[i] = bf8_e5m2_to_f32(static_cast<uint8_t>(i));
+    return t;
+  }();
+  return lut.data();
+}
+
+} // namespace detail
+
+/// @brief Convert `n` contiguous E4M3 FP8 bytes to float via the lookup table.
+///
+/// Bit-exact with fp8_e4m3_to_f32 for every code. The scalar gather loop is
+/// enough to amortize the per-element converter cost on the MFMA/WMMA bulk
+/// hoists (no vector path needed; works on every target).
+inline void fp8_e4m3_to_f32_block(const uint8_t *src, float *dst, size_t n) {
+  const float *lut = detail::fp8_e4m3_lut();
+  for (size_t i = 0; i < n; ++i)
+    dst[i] = lut[src[i]];
+}
+
+/// @brief Convert `n` contiguous E5M2 BF8 bytes to float via the lookup table.
+inline void bf8_e5m2_to_f32_block(const uint8_t *src, float *dst, size_t n) {
+  const float *lut = detail::bf8_e5m2_lut();
+  for (size_t i = 0; i < n; ++i)
+    dst[i] = lut[src[i]];
+}
+
+// ---- Generalized SR + OCP MX helpers (used by gfx1250 WMMA) ----
 inline uint32_t f32_to_binary_float_sr(float val, uint32_t seed, uint32_t exp_bits,
                                        uint32_t mant_bits, int32_t bias, int32_t max_exp,
                                        int32_t min_exp, uint32_t nan_code, uint32_t inf_code) {

--- a/emulation/rocjitsu/lib/util/include/util/data_types.h
+++ b/emulation/rocjitsu/lib/util/include/util/data_types.h
@@ -210,6 +210,67 @@ inline void bf16_to_f32_block(const uint16_t *src, float *dst, size_t n) {
     dst[i] = bf16_to_f32(src[i]);
 }
 
+namespace detail {
+
+#if defined(UTIL_HAS_X86_F16C)
+/// x86 specialization: i8->i32 / u8->i32 are plain sign-/zero-extends, no
+/// F16C needed. AVX-512 does 16/instr, AVX2 8.
+inline void i8_to_i32_block_arch(const int8_t *src, int32_t *dst, size_t n, size_t &i) {
+#if defined(__AVX512F__)
+  for (; i + 16 <= n; i += 16)
+    _mm512_storeu_si512(
+        reinterpret_cast<__m512i *>(&dst[i]),
+        _mm512_cvtepi8_epi32(_mm_loadu_si128(reinterpret_cast<const __m128i *>(src + i))));
+#endif
+#if defined(__AVX2__)
+  for (; i + 8 <= n; i += 8)
+    _mm256_storeu_si256(
+        reinterpret_cast<__m256i *>(&dst[i]),
+        _mm256_cvtepi8_epi32(_mm_loadl_epi64(reinterpret_cast<const __m128i *>(src + i))));
+#endif
+}
+inline void u8_to_i32_block_arch(const uint8_t *src, int32_t *dst, size_t n, size_t &i) {
+#if defined(__AVX512F__)
+  for (; i + 16 <= n; i += 16)
+    _mm512_storeu_si512(
+        reinterpret_cast<__m512i *>(&dst[i]),
+        _mm512_cvtepu8_epi32(_mm_loadu_si128(reinterpret_cast<const __m128i *>(src + i))));
+#endif
+#if defined(__AVX2__)
+  for (; i + 8 <= n; i += 8)
+    _mm256_storeu_si256(
+        reinterpret_cast<__m256i *>(&dst[i]),
+        _mm256_cvtepu8_epi32(_mm_loadl_epi64(reinterpret_cast<const __m128i *>(src + i))));
+#endif
+}
+#else
+/// Portable fallback: no vector advance; the scalar extend loops below do all
+/// the work (and trivially auto-vectorize).
+inline void i8_to_i32_block_arch(const int8_t *, int32_t *, size_t, size_t &) {}
+inline void u8_to_i32_block_arch(const uint8_t *, int32_t *, size_t, size_t &) {}
+#endif
+
+} // namespace detail
+
+/// @brief Sign-extend `n` contiguous int8 values to int32.
+///
+/// Exact widening, so vector and scalar paths are bit-identical for every
+/// input. Hot path: integer MFMA/WMMA i8 input gather.
+inline void i8_to_i32_block(const int8_t *src, int32_t *dst, size_t n) {
+  size_t i = 0;
+  detail::i8_to_i32_block_arch(src, dst, n, i);
+  for (; i < n; ++i)
+    dst[i] = static_cast<int32_t>(src[i]);
+}
+
+/// @brief Zero-extend `n` contiguous uint8 values to int32 (unsigned iu8 WMMA).
+inline void u8_to_i32_block(const uint8_t *src, int32_t *dst, size_t n) {
+  size_t i = 0;
+  detail::u8_to_i32_block_arch(src, dst, n, i);
+  for (; i < n; ++i)
+    dst[i] = static_cast<int32_t>(src[i]);
+}
+
 /// @brief Convert a float to 16-bit BFloat16 with round-to-nearest-even.
 inline uint16_t f32_to_bf16_rne(float val) {
   uint32_t f = std::bit_cast<uint32_t>(val);

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -567,6 +567,35 @@ inline native<float> bf8_e5m2_to_f32_simd(native<uint32_t> v) {
   return std::bit_cast<native<float>>(out);
 }
 
+/// Vector ports of the IEEE-2019 maximum / minimum operations (the non-"num"
+/// forms used by v_maximum_*/v_minimum_* on gfx1250/rdna4). Unlike fmax/fmin
+/// these PROPAGATE NaN (any NaN input -> canonical qNaN) and order signed zeros
+/// (-0 < +0): maximum of a ±0 tie is +0, minimum is -0. Bit-identical to the
+/// scalar bodies:
+///   if (isnan(a)||isnan(b)) return qNaN;
+///   if (a==b)              return signbit(a) ? <tie> : <other>;
+///   return a <cmp> b ? a : b;
+template <typename V> inline V ieee_maximum_simd(V a, V b) {
+  const auto nan = stdx::isnan(a) || stdx::isnan(b);
+  const auto eq = (a == b);
+  const auto sa = stdx::signbit(a); // true when a is negative (incl. -0)
+  V res = b;                        // a < b (and the a==b,!sa case start)
+  stdx::where(a > b, res) = a;
+  stdx::where(eq && !sa, res) = a; // ±0 / equal tie: pick the +signed operand
+  stdx::where(nan, res) = V(std::numeric_limits<typename V::value_type>::quiet_NaN());
+  return res;
+}
+template <typename V> inline V ieee_minimum_simd(V a, V b) {
+  const auto nan = stdx::isnan(a) || stdx::isnan(b);
+  const auto eq = (a == b);
+  const auto sa = stdx::signbit(a);
+  V res = b; // a > b (and the a==b,!sa case)
+  stdx::where(a < b, res) = a;
+  stdx::where(eq && sa, res) = a; // ±0 / equal tie: pick the -signed operand
+  stdx::where(nan, res) = V(std::numeric_limits<typename V::value_type>::quiet_NaN());
+  return res;
+}
+
 /// Vector port of the f32 `std::frexp` mantissa over raw float bits. Returns the
 /// significand m with |m| in [0.5, 1) such that input = m * 2^e (e via
 /// frexp_exp_f32_simd). Normal lanes force the exponent field to 126 and keep

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -596,6 +596,55 @@ template <typename V> inline V ieee_minimum_simd(V a, V b) {
   return res;
 }
 
+/// Cubemap face ops (back v_cube{id,sc,tc}_f32). The scalar bodies select among
+/// the three axes by an `else if` cascade on |x|,|y|,|z| with `>=` ties: the X
+/// face wins ties, then Y, then Z. The vector forms apply the blends in reverse
+/// priority (Z default, Y overwrite, X overwrite last) so X wins ties exactly as
+/// scalar. Every branch is a bit-identical value copy / sign flip of the
+/// (already abs/neg-applied) inputs — no FP arithmetic — so byte-identical. NaN
+/// inputs make every `>=` mask false -> the Z-axis default, matching scalar.
+/// (cubema = 2 * fmax(|x|,fmax(|y|,|z|)) is emitted inline at the call site.)
+inline native<float> cube_id_f32_simd(native<float> x, native<float> y, native<float> z) {
+  using F = native<float>;
+  const F ax = stdx::abs(x), ay = stdx::abs(y), az = stdx::abs(z);
+  const auto x_face = (ax >= ay) && (ax >= az);
+  const auto y_face = (ay >= ax) && (ay >= az);
+  F r = F(5.0f);
+  stdx::where(z >= F(0.0f), r) = F(4.0f); // Z face: z>=0 ? 4 : 5
+  F yv = F(3.0f);
+  stdx::where(y >= F(0.0f), yv) = F(2.0f);
+  stdx::where(y_face, r) = yv;
+  F xv = F(1.0f);
+  stdx::where(x >= F(0.0f), xv) = F(0.0f);
+  stdx::where(x_face, r) = xv;
+  return r;
+}
+inline native<float> cube_sc_f32_simd(native<float> x, native<float> y, native<float> z) {
+  using F = native<float>;
+  const F ax = stdx::abs(x), ay = stdx::abs(y), az = stdx::abs(z);
+  const auto x_face = (ax >= ay) && (ax >= az);
+  const auto y_face = (ay >= ax) && (ay >= az);
+  F r = x;
+  stdx::where(z >= F(0.0f), r) = -x; // Z face: z>=0 ? -x : x
+  stdx::where(y_face, r) = x;
+  F xv = -z;
+  stdx::where(x >= F(0.0f), xv) = z; // X face: x>=0 ? z : -z
+  stdx::where(x_face, r) = xv;
+  return r;
+}
+inline native<float> cube_tc_f32_simd(native<float> x, native<float> y, native<float> z) {
+  using F = native<float>;
+  const F ax = stdx::abs(x), ay = stdx::abs(y), az = stdx::abs(z);
+  const auto x_face = (ax >= ay) && (ax >= az);
+  const auto y_face = (ay >= ax) && (ay >= az);
+  F r = -y; // Z face and X face both return -y
+  F yv = z;
+  stdx::where(y >= F(0.0f), yv) = -z; // Y face: y>=0 ? -z : z
+  stdx::where(y_face, r) = yv;
+  stdx::where(x_face, r) = -y; // restore -y on ties where the Y mask also fired
+  return r;
+}
+
 /// Vector port of the f32 `std::frexp` mantissa over raw float bits. Returns the
 /// significand m with |m| in [0.5, 1) such that input = m * 2^e (e via
 /// frexp_exp_f32_simd). Normal lanes force the exponent field to 126 and keep

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -46,7 +46,7 @@ namespace stdx = std::experimental;
 template <class T> using native = stdx::native_simd<T>;
 
 /// Native-SIMD width measured in 32-bit lanes. Convenience constant.
-template <class T> inline constexpr std::size_t native_width_v = native<T>::size();
+template <class T> constexpr std::size_t native_width_v = native<T>::size();
 #else
 // Fallback definitions so `if constexpr (has_stdx_simd)` discarded
 // branches compile out even in non-template callers (e.g. gtest TEST
@@ -57,21 +57,21 @@ template <class T> struct native {
   static constexpr std::size_t size() { return 1; }
   constexpr T operator[](std::size_t) const { return T{}; }
 };
-template <class T> inline constexpr std::size_t native_width_v = native<T>::size();
-template <class T> inline native<T> load(const uint32_t *) { return {}; }
-template <class T> inline native<T> broadcast(uint32_t) { return {}; }
-template <class T> inline void masked_store(uint32_t *, native<T>, uint64_t) {}
-template <class T> inline void blit_to_buffer(uint32_t (&)[native<T>::size()], native<T>) {}
-template <class T> inline native<T> load64(const uint32_t *, const uint32_t *) { return {}; }
-template <class T> inline native<T> broadcast64(uint64_t) { return {}; }
-template <class T> inline void masked_store64(uint32_t *, uint32_t *, native<T>, uint64_t) {}
+template <class T> constexpr std::size_t native_width_v = native<T>::size();
+template <class T> native<T> load(const uint32_t *) { return {}; }
+template <class T> native<T> broadcast(uint32_t) { return {}; }
+template <class T> void masked_store(uint32_t *, native<T>, uint64_t) {}
+template <class T> void blit_to_buffer(uint32_t (&)[native<T>::size()], native<T>) {}
+template <class T> native<T> load64(const uint32_t *, const uint32_t *) { return {}; }
+template <class T> native<T> broadcast64(uint64_t) { return {}; }
+template <class T> void masked_store64(uint32_t *, uint32_t *, native<T>, uint64_t) {}
 template <class T> struct narrow32 {
   static constexpr std::size_t size() { return 1; }
   constexpr T operator[](std::size_t) const { return T{}; }
 };
-template <class T> inline narrow32<T> load_narrow(const uint32_t *) { return {}; }
-template <class T> inline narrow32<T> broadcast_narrow(uint32_t) { return {}; }
-template <class T> inline void masked_store_narrow(uint32_t *, narrow32<T>, uint64_t) {}
+template <class T> narrow32<T> load_narrow(const uint32_t *) { return {}; }
+template <class T> narrow32<T> broadcast_narrow(uint32_t) { return {}; }
+template <class T> void masked_store_narrow(uint32_t *, narrow32<T>, uint64_t) {}
 #endif
 
 /// Native-SIMD width for 64-bit lane types (e.g. native<uint64_t>/<double>),
@@ -83,7 +83,7 @@ inline constexpr std::size_t native_width64 = native<uint64_t>::size();
 #if __has_include(<experimental/simd>)
 /// Load `native<T>` from contiguous uint32_t storage. T must be a
 /// 32-bit trivially-copyable type.
-template <class T> inline native<T> load(const uint32_t *p) {
+template <class T> native<T> load(const uint32_t *p) {
   using Bits = stdx::native_simd<uint32_t>;
   using Val = native<T>;
   static_assert(sizeof(T) == sizeof(uint32_t));
@@ -97,7 +97,7 @@ template <class T> inline native<T> load(const uint32_t *p) {
 
 /// Broadcast `broadcast_bits` (bit-cast to T) to every lane of
 /// `native<T>`. T must be a 32-bit trivially-copyable type.
-template <class T> inline native<T> broadcast(uint32_t broadcast_bits) {
+template <class T> native<T> broadcast(uint32_t broadcast_bits) {
   using Val = native<T>;
   static_assert(sizeof(T) == sizeof(uint32_t));
   if constexpr (std::is_same_v<T, uint32_t>)
@@ -109,7 +109,7 @@ template <class T> inline native<T> broadcast(uint32_t broadcast_bits) {
 /// Store `v` into contiguous uint32_t storage at `dst`, blending in only
 /// the lanes whose bit is set in `mask`. If `mask` covers the full SIMD
 /// width, falls through to a straight contiguous store.
-template <class T> inline void masked_store(uint32_t *dst, native<T> v, uint64_t mask) {
+template <class T> void masked_store(uint32_t *dst, native<T> v, uint64_t mask) {
   using Bits = stdx::native_simd<uint32_t>;
   using Val = native<T>;
   static_assert(sizeof(T) == sizeof(uint32_t));
@@ -136,7 +136,7 @@ template <class T> inline void masked_store(uint32_t *dst, native<T> v, uint64_t
 /// Same as masked_store, but writes to a caller-supplied uint32_t buffer
 /// instead of contiguous lane storage. For operands whose dst is not a
 /// contiguous VGPR (rocjitsu falls back to write_lane_chunk in that case).
-template <class T> inline void blit_to_buffer(uint32_t (&buf)[native<T>::size()], native<T> v) {
+template <class T> void blit_to_buffer(uint32_t (&buf)[native<T>::size()], native<T> v) {
   using Bits = stdx::native_simd<uint32_t>;
   Bits bits = [&] {
     if constexpr (std::is_same_v<T, uint32_t>)
@@ -154,7 +154,7 @@ template <class T> inline void blit_to_buffer(uint32_t (&buf)[native<T>::size()]
 /// `Operand::read_lane64`. `native_width64` lanes are combined; this is a scalar
 /// gather (the two arrays are not a single contiguous 64-bit load) chosen for
 /// bit-exactness over raw throughput.
-template <class T> inline native<T> load64(const uint32_t *lo, const uint32_t *hi) {
+template <class T> native<T> load64(const uint32_t *lo, const uint32_t *hi) {
   static_assert(sizeof(T) == sizeof(uint64_t));
   using U64 = stdx::native_simd<uint64_t>;
   static_assert(sizeof(native<T>) == sizeof(U64));
@@ -172,7 +172,7 @@ template <class T> inline native<T> load64(const uint32_t *lo, const uint32_t *h
 /// Broadcast `broadcast_bits` (bit-cast to T) to every lane of `native<T>` for a
 /// 64-bit lane type. The companion of `broadcast` for the f64/i64 path; used when
 /// a source operand resolves to a scalar/immediate rather than per-lane storage.
-template <class T> inline native<T> broadcast64(uint64_t broadcast_bits) {
+template <class T> native<T> broadcast64(uint64_t broadcast_bits) {
   static_assert(sizeof(T) == sizeof(uint64_t));
   using Val = native<T>;
   if constexpr (std::is_same_v<T, uint64_t>)
@@ -186,8 +186,7 @@ template <class T> inline native<T> broadcast64(uint64_t broadcast_bits) {
 /// 64-bit value is split back into lo (low 32) and hi (high 32), mirroring
 /// `Operand::write_lane64`. No full-mask contiguous fast path: lo/hi are
 /// separate registers, so the store is always a per-lane scatter.
-template <class T>
-inline void masked_store64(uint32_t *lo, uint32_t *hi, native<T> v, uint64_t mask) {
+template <class T> void masked_store64(uint32_t *lo, uint32_t *hi, native<T> v, uint64_t mask) {
   static_assert(sizeof(T) == sizeof(uint64_t));
   using U64 = stdx::native_simd<uint64_t>;
   static_assert(sizeof(native<T>) == sizeof(U64));
@@ -220,7 +219,7 @@ template <class T> using narrow32 = stdx::fixed_size_simd<T, native_width64>;
 /// `fixed_size_simd` is not trivially copyable (so `std::bit_cast` of the whole
 /// vector is ill-formed, unlike `native_simd`); the bit reinterpretation is done
 /// per lane through the trivially-copyable scalar `T`.
-template <class T> inline narrow32<T> load_narrow(const uint32_t *p) {
+template <class T> narrow32<T> load_narrow(const uint32_t *p) {
   static_assert(sizeof(T) == sizeof(uint32_t));
   if constexpr (std::is_same_v<T, uint32_t>) {
     return narrow32<uint32_t>(p, stdx::element_aligned);
@@ -235,7 +234,7 @@ template <class T> inline narrow32<T> load_narrow(const uint32_t *p) {
 /// Broadcast `broadcast_bits` (bit-cast to T) to every lane of `narrow32<T>`.
 /// Companion of `broadcast` for the narrow (8-wide) cvt path; used when a source
 /// operand resolves to a scalar/immediate rather than per-lane storage.
-template <class T> inline narrow32<T> broadcast_narrow(uint32_t broadcast_bits) {
+template <class T> narrow32<T> broadcast_narrow(uint32_t broadcast_bits) {
   static_assert(sizeof(T) == sizeof(uint32_t));
   if constexpr (std::is_same_v<T, uint32_t>)
     return narrow32<T>(broadcast_bits);
@@ -247,7 +246,7 @@ template <class T> inline narrow32<T> broadcast_narrow(uint32_t broadcast_bits) 
 /// storage at `dst`, blending in only the lanes whose bit is set in `mask`. The
 /// 32-bit-dst counterpart of `masked_store` for the f64-src cvt glue, which
 /// writes only `native_width64` 32-bit lanes per chunk.
-template <class T> inline void masked_store_narrow(uint32_t *dst, narrow32<T> v, uint64_t mask) {
+template <class T> void masked_store_narrow(uint32_t *dst, narrow32<T> v, uint64_t mask) {
   static_assert(sizeof(T) == sizeof(uint32_t));
   constexpr std::size_t W = native_width64;
   const uint64_t full = util::mask<uint64_t>(static_cast<int>(W));
@@ -366,8 +365,7 @@ inline native<uint32_t> f32_to_f16_simd(native<float> val) {
 ///     intrinsic produced (IEEE-754 round-to-integer keeps the operand sign on
 ///     a zero result, so this is exactly the sign of the *input*).
 /// Bit-identical to the scalar reference at every native width.
-template <class Float, class Round>
-inline native<Float> round_fixup_simd(native<Float> a, Round round) {
+template <class Float, class Round> native<Float> round_fixup_simd(native<Float> a, Round round) {
   using F = native<Float>;
   using U = std::conditional_t<sizeof(Float) == 4, native<uint32_t>, native<uint64_t>>;
   using Bits = typename U::value_type;
@@ -575,7 +573,7 @@ inline native<float> bf8_e5m2_to_f32_simd(native<uint32_t> v) {
 ///   if (isnan(a)||isnan(b)) return qNaN;
 ///   if (a==b)              return signbit(a) ? <tie> : <other>;
 ///   return a <cmp> b ? a : b;
-template <typename V> inline V ieee_maximum_simd(V a, V b) {
+template <typename V> V ieee_maximum_simd(V a, V b) {
   const auto nan = stdx::isnan(a) || stdx::isnan(b);
   const auto eq = (a == b);
   const auto sa = stdx::signbit(a); // true when a is negative (incl. -0)
@@ -585,7 +583,7 @@ template <typename V> inline V ieee_maximum_simd(V a, V b) {
   stdx::where(nan, res) = V(std::numeric_limits<typename V::value_type>::quiet_NaN());
   return res;
 }
-template <typename V> inline V ieee_minimum_simd(V a, V b) {
+template <typename V> V ieee_minimum_simd(V a, V b) {
   const auto nan = stdx::isnan(a) || stdx::isnan(b);
   const auto eq = (a == b);
   const auto sa = stdx::signbit(a);
@@ -880,7 +878,7 @@ inline native<uint32_t> mul_hi_i32_simd(native<uint32_t> a, native<uint32_t> b) 
 #if !__has_include(<experimental/simd>)
 // Fallback stub for non-template gtest callers (e.g. UtilSimd.FlushDenormF32),
 // whose discarded `if constexpr (has_stdx_simd)` branch is still type-checked.
-template <class T> inline native<T> flush_denorm_f32_simd(native<T>) { return {}; }
+template <class T> native<T> flush_denorm_f32_simd(native<T>) { return {}; }
 inline native<float> trunc_simd(native<float>) { return {}; }
 inline native<float> ceil_simd(native<float>) { return {}; }
 inline native<float> floor_simd(native<float>) { return {}; }

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -7,6 +7,7 @@
 #include "util/bit.h"
 
 #include <bit>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
@@ -419,6 +420,31 @@ inline native<double> floor_simd(native<double> a) {
 inline native<double> rndne_simd(native<double> a) {
   return round_fixup_simd<double>(a, [](native<double> x) { return stdx::nearbyint(x); });
 }
+
+/// Scalar round-to-integer matching the round_fixup_simd / AMD-hardware NaN
+/// behavior on every compiler. clang lowers std::floor/ceil/trunc to the
+/// roundss/roundsd instruction, which quiets a signaling NaN (sign + payload
+/// preserved, quiet bit set) — exactly what the SIMD fast paths and the GPU
+/// produce. gcc's glibc floorf/floor/ceil/trunc instead pass an sNaN through
+/// verbatim, so the generated scalar body would disagree with its own SIMD
+/// fast path (and with hardware) under gcc. Quiet explicitly there; on clang
+/// this is an idempotent no-op left to the compiler. (std::nearbyint already
+/// quiets under glibc, so rndne needs no fixup.)
+#if defined(__GNUC__) && !defined(__clang__)
+template <class F> inline F quiet_snan_scalar(F a, F r) {
+  using U = std::conditional_t<sizeof(F) == 4, uint32_t, uint64_t>;
+  constexpr U kQuiet = U(1) << (sizeof(F) == 4 ? 22 : 51);
+  return std::isnan(a) ? std::bit_cast<F>(std::bit_cast<U>(a) | kQuiet) : r;
+}
+#else
+template <class F> inline F quiet_snan_scalar(F /*a*/, F r) { return r; }
+#endif
+inline float floor_scalar(float a) { return quiet_snan_scalar(a, std::floor(a)); }
+inline double floor_scalar(double a) { return quiet_snan_scalar(a, std::floor(a)); }
+inline float ceil_scalar(float a) { return quiet_snan_scalar(a, std::ceil(a)); }
+inline double ceil_scalar(double a) { return quiet_snan_scalar(a, std::ceil(a)); }
+inline float trunc_scalar(float a) { return quiet_snan_scalar(a, std::trunc(a)); }
+inline double trunc_scalar(double a) { return quiet_snan_scalar(a, std::trunc(a)); }
 
 /// Flush f32 denormals to sign-preserving zero (FTZ). Branchless vector port of
 /// `amdgpu::transcendental::flush_denorm_f32`: a lane with biased exponent 0 and

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -645,6 +645,28 @@ inline native<float> cube_tc_f32_simd(native<float> x, native<float> y, native<f
   return r;
 }
 
+/// Normalized f32->int16 / ->uint16 pack-convert lanes (back v_cvt_pk[_]norm_*).
+/// Scalar: `isnan(f) ? 0 : static_cast<intN>(clamp(f * K, lo, hi))`. The NaN->0
+/// blend is done in the FLOAT domain (so the mask type matches) before the int
+/// truncation, avoiding any float-mask -> int-mask conversion. Clamp keeps the
+/// value in range so static_simd_cast (truncate-toward-zero) matches the scalar
+/// cast; the caller masks &0xFFFF when packing. i16: K=32767, clamp
+/// [-32768,32767]; u16: K=65535, clamp [0,65535].
+inline native<int32_t> cvt_pknorm_i16_f32_simd(native<float> f) {
+  native<float> p = f * native<float>(32767.0f);
+  stdx::where(p < native<float>(-32768.0f), p) = native<float>(-32768.0f);
+  stdx::where(p > native<float>(32767.0f), p) = native<float>(32767.0f);
+  stdx::where(stdx::isnan(f), p) = native<float>(0.0f);
+  return stdx::static_simd_cast<native<int32_t>>(p);
+}
+inline native<uint32_t> cvt_pknorm_u16_f32_simd(native<float> f) {
+  native<float> p = f * native<float>(65535.0f);
+  stdx::where(p < native<float>(0.0f), p) = native<float>(0.0f);
+  stdx::where(p > native<float>(65535.0f), p) = native<float>(65535.0f);
+  stdx::where(stdx::isnan(f), p) = native<float>(0.0f);
+  return stdx::static_simd_cast<native<uint32_t>>(p);
+}
+
 /// Vector port of the f32 `std::frexp` mantissa over raw float bits. Returns the
 /// significand m with |m| in [0.5, 1) such that input = m * 2^e (e via
 /// frexp_exp_f32_simd). Normal lanes force the exponent field to 126 and keep

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -94,6 +94,7 @@ add_executable(
     simd_correctness/vop3_cndmask_pack_simd_correctness_test.cpp
     simd_correctness/vop3_div_helpers_simd_correctness_test.cpp
     simd_correctness/vop3_b16_rdna_simd_correctness_test.cpp
+    simd_correctness/vop3_cvt_pk_f32_rdna_correctness_test.cpp
     simd_correctness/vop3_ternary_fp_simd_correctness_test.cpp
     simd_correctness/vop3_fmac_simd_correctness_test.cpp
     simd_correctness/vop3_ldexp_simd_correctness_test.cpp

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(
     decode_execute_benchmark.cpp
     util_simd_test.cpp
     v_add_simd_benchmark.cpp
+    mfma_simd_benchmark.cpp
     simd_correctness/vop1_cvt_f64_scalar_correctness_test.cpp
     simd_correctness/vopc_cmp_class_scalar_correctness_test.cpp
     simd_correctness/vop2_simd_correctness_test.cpp

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(
     util_simd_test.cpp
     v_add_simd_benchmark.cpp
     mfma_simd_benchmark.cpp
+    wmma_simd_benchmark.cpp
     simd_correctness/vop1_cvt_f64_scalar_correctness_test.cpp
     simd_correctness/vopc_cmp_class_scalar_correctness_test.cpp
     simd_correctness/vop2_simd_correctness_test.cpp

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -108,6 +108,14 @@ add_executable(
     data_types_test.cpp
     drm_info_layout_test.cpp
 )
+if(RJ_ENABLE_EXPENSIVE_CHECKS)
+    target_sources(
+        rocjitsu_tests
+        PRIVATE
+            simd_correctness/mfma_simd_exact_test.cpp
+            simd_correctness/wmma_simd_exact_test.cpp
+    )
+endif()
 target_link_libraries(
     rocjitsu_tests
     PRIVATE

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -129,7 +129,10 @@ target_link_libraries(
 rj_configure_target(rocjitsu_tests TEST)
 
 include(GoogleTest)
-gtest_discover_tests(rocjitsu_tests)
+# Benchmarks are timing tools, not correctness tests; keep them out of the
+# default ctest run (invoke them directly via
+# ./rocjitsu_tests --gtest_filter='*Benchmark*').
+gtest_discover_tests(rocjitsu_tests TEST_FILTER -*Benchmark*)
 
 add_executable(
     rj_dbt_translate_smoke_test

--- a/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
@@ -44,10 +44,11 @@ namespace {
 using namespace rocjitsu;
 using Clock = std::chrono::steady_clock;
 
-constexpr uint32_t WF_SIZE = 64;
-constexpr uint32_t SGPRS_PER_WF = 106;
-constexpr uint32_t VGPRS_PER_WF = 256;
-constexpr int ITERATIONS = 4000;
+// Shared with the WMMA benchmark via mma_test_util.h (single source of truth).
+constexpr uint32_t WF_SIZE = mma_test::MFMA_WF_SIZE;
+constexpr uint32_t SGPRS_PER_WF = mma_test::SGPRS_PER_WF;
+constexpr uint32_t VGPRS_PER_WF = mma_test::VGPRS_PER_WF;
+constexpr int ITERATIONS = mma_test::BENCH_ITERATIONS;
 
 // VGPR layout: A inputs at s0, B inputs at s1, output at DST. The 64-register
 // spacing comfortably clears the small per-operand register footprint of every

--- a/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
@@ -16,6 +16,7 @@
 ///     the scalar reference is non-fused, so results agree to a small relative
 ///     tolerance, not bit-exactly.
 
+#include "mma_test_util.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
@@ -198,28 +199,6 @@ void bench(const char *label, BenchFixture &fx, const std::function<void()> &run
   EXPECT_GT(sd.gmacs, 0.0) << label << ": simd path produced no work";
 }
 
-// Small finite generator: values in roughly [-1, 1], deterministic per call.
-struct SmallGen {
-  std::mt19937 rng;
-  std::uniform_real_distribution<float> dist{-1.0f, 1.0f};
-  explicit SmallGen(uint32_t seed) : rng(seed) {}
-  float operator()() { return dist(rng); }
-};
-
-struct SmallI8Gen {
-  std::mt19937 rng;
-  std::uniform_int_distribution<int> dist{-8, 7};
-  explicit SmallI8Gen(uint32_t seed) : rng(seed) {}
-  int operator()() { return dist(rng); }
-};
-
-#define SKIP_IF_NO_SIMD()                                                                          \
-  if constexpr (!util::has_stdx_simd) {                                                            \
-    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";                    \
-  } else if (util::native<float>::size() <= 1) {                                                   \
-    GTEST_SKIP() << "host native_simd width is 1 — no SIMD speedup possible";                      \
-  }
-
 } // namespace
 
 // v_mfma_f32_16x16x32_f16: the dominant MFMA shape in fp16 transformer
@@ -228,8 +207,8 @@ TEST(MfmaSimdBenchmark, F32_16x16x32_f16) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 32, B = 1, bits = 16;
-  fx.seed(S0_OFF, /*regs=*/8, bits, SmallGen(1));
-  fx.seed(S1_OFF, /*regs=*/8, bits, SmallGen(2));
+  fx.seed(S0_OFF, /*regs=*/8, bits, mma_test::SmallGen(1));
+  fx.seed(S1_OFF, /*regs=*/8, bits, mma_test::SmallGen(2));
   auto run = [&] {
     amdgpu::exec_f32(*fx.cu, M, N, K, B, bits, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
                      fx.vbase + S1_OFF, 0, amdgpu::extract_f16, amdgpu::extract_f16,
@@ -244,8 +223,8 @@ TEST(MfmaSimdBenchmark, F32_16x16x32_f16_Specialized) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 32, B = 1, bits = 16;
-  fx.seed(S0_OFF, /*regs=*/8, bits, SmallGen(1));
-  fx.seed(S1_OFF, /*regs=*/8, bits, SmallGen(2));
+  fx.seed(S0_OFF, /*regs=*/8, bits, mma_test::SmallGen(1));
+  fx.seed(S1_OFF, /*regs=*/8, bits, mma_test::SmallGen(2));
   auto run = [&] {
     amdgpu::exec_f32_mfma_f16_spec<16, 16, 32>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
                                                fx.vbase + S1_OFF, 0, /*const_acc=*/0, /*cbsz=*/0,
@@ -259,8 +238,8 @@ TEST(MfmaSimdBenchmark, F32_32x32x8_f16_Specialized) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 32, N = 32, K = 8, B = 1, bits = 16;
-  fx.seed(S0_OFF, 8, bits, SmallGen(21));
-  fx.seed(S1_OFF, 8, bits, SmallGen(22));
+  fx.seed(S0_OFF, 8, bits, mma_test::SmallGen(21));
+  fx.seed(S1_OFF, 8, bits, mma_test::SmallGen(22));
   auto run = [&] {
     amdgpu::exec_f32_mfma_f16_spec<32, 32, 8>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
                                               fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
@@ -272,8 +251,8 @@ TEST(MfmaSimdBenchmark, F32_16x16x16_f16_Specialized) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 16, B = 1, bits = 16;
-  fx.seed(S0_OFF, 8, bits, SmallGen(23));
-  fx.seed(S1_OFF, 8, bits, SmallGen(24));
+  fx.seed(S0_OFF, 8, bits, mma_test::SmallGen(23));
+  fx.seed(S1_OFF, 8, bits, mma_test::SmallGen(24));
   auto run = [&] {
     amdgpu::exec_f32_mfma_f16_spec<16, 16, 16>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
                                                fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
@@ -285,8 +264,8 @@ TEST(MfmaSimdBenchmark, F32_32x32x16_f16_Specialized) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 32, N = 32, K = 16, B = 1, bits = 16;
-  fx.seed(S0_OFF, 8, bits, SmallGen(25));
-  fx.seed(S1_OFF, 8, bits, SmallGen(26));
+  fx.seed(S0_OFF, 8, bits, mma_test::SmallGen(25));
+  fx.seed(S1_OFF, 8, bits, mma_test::SmallGen(26));
   auto run = [&] {
     amdgpu::exec_f32_mfma_f16_spec<32, 32, 16>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
                                                fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
@@ -299,8 +278,8 @@ TEST(MfmaSimdBenchmark, F32_32x32x16_f16) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 32, N = 32, K = 16, B = 1, bits = 16;
-  fx.seed(S0_OFF, 8, bits, SmallGen(3));
-  fx.seed(S1_OFF, 8, bits, SmallGen(4));
+  fx.seed(S0_OFF, 8, bits, mma_test::SmallGen(3));
+  fx.seed(S1_OFF, 8, bits, mma_test::SmallGen(4));
   auto run = [&] {
     amdgpu::exec_f32(*fx.cu, M, N, K, B, bits, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
                      fx.vbase + S1_OFF, 0, amdgpu::extract_f16, amdgpu::extract_f16,
@@ -314,8 +293,8 @@ TEST(MfmaSimdBenchmark, F32_16x16x32_fp8) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 32, B = 1, bits = 8;
-  fx.seed(S0_OFF, 8, bits, SmallGen(5));
-  fx.seed(S1_OFF, 8, bits, SmallGen(6));
+  fx.seed(S0_OFF, 8, bits, mma_test::SmallGen(5));
+  fx.seed(S1_OFF, 8, bits, mma_test::SmallGen(6));
   auto run = [&] {
     amdgpu::exec_f32(*fx.cu, M, N, K, B, bits, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
                      fx.vbase + S1_OFF, 0, amdgpu::extract_fp8, amdgpu::extract_fp8,
@@ -329,8 +308,8 @@ TEST(MfmaSimdBenchmark, I32_16x16x32_i8) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 32, B = 1;
-  fx.seed_i8(S0_OFF, 8, SmallI8Gen(7));
-  fx.seed_i8(S1_OFF, 8, SmallI8Gen(8));
+  fx.seed_i8(S0_OFF, 8, mma_test::SmallI8Gen(7));
+  fx.seed_i8(S1_OFF, 8, mma_test::SmallI8Gen(8));
   auto run = [&] {
     amdgpu::exec_i32_i8(*fx.cu, M, N, K, B, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
                         fx.vbase + S1_OFF, 0, /*const_acc=*/0);
@@ -343,8 +322,8 @@ TEST(MfmaSimdBenchmark, I32_32x32x16_i8) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 32, N = 32, K = 16, B = 1;
-  fx.seed_i8(S0_OFF, 8, SmallI8Gen(9));
-  fx.seed_i8(S1_OFF, 8, SmallI8Gen(10));
+  fx.seed_i8(S0_OFF, 8, mma_test::SmallI8Gen(9));
+  fx.seed_i8(S1_OFF, 8, mma_test::SmallI8Gen(10));
   auto run = [&] {
     amdgpu::exec_i32_i8(*fx.cu, M, N, K, B, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
                         fx.vbase + S1_OFF, 0, /*const_acc=*/0);
@@ -359,8 +338,8 @@ TEST(MfmaSimdBenchmark, F32Scaled_16x16x128_fp8) {
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 128, B = 1, bits = 8;
   constexpr uint32_t SCALE_A = 192, SCALE_B = 200;
-  fx.seed(S0_OFF, 8, bits, SmallGen(13));
-  fx.seed(S1_OFF, 8, bits, SmallGen(14));
+  fx.seed(S0_OFF, 8, bits, mma_test::SmallGen(13));
+  fx.seed(S1_OFF, 8, bits, mma_test::SmallGen(14));
   for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
     fx.cu->write_vgpr(fx.vbase + SCALE_A, lane, 0x7F7F7F7Fu); // e8m0 = 127 per block
     fx.cu->write_vgpr(fx.vbase + SCALE_B, lane, 0x7F7F7F7Fu);
@@ -381,8 +360,8 @@ TEST(MfmaSimdBenchmark, F64_16x16x4_f64) {
     GTEST_SKIP() << "no native f64 SIMD";
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 4, B = 1;
-  fx.seed_f64(S0_OFF, 8, SmallGen(11));
-  fx.seed_f64(S1_OFF, 8, SmallGen(12));
+  fx.seed_f64(S0_OFF, 8, mma_test::SmallGen(11));
+  fx.seed_f64(S1_OFF, 8, mma_test::SmallGen(12));
   auto run = [&] {
     amdgpu::exec_f64(*fx.cu, M, N, K, B, fx.vbase + DST_OFF, fx.vbase + S0_OFF, fx.vbase + S1_OFF,
                      0, /*const_acc=*/0);
@@ -396,8 +375,8 @@ TEST(MfmaSimdBenchmark, F32_32x32x2_f32_Specialized) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 32, N = 32, K = 2, B = 1, bits = 32;
-  fx.seed(S0_OFF, 16, bits, SmallGen(31));
-  fx.seed(S1_OFF, 16, bits, SmallGen(32));
+  fx.seed(S0_OFF, 16, bits, mma_test::SmallGen(31));
+  fx.seed(S1_OFF, 16, bits, mma_test::SmallGen(32));
   auto run = [&] {
     amdgpu::exec_f32_mfma_f32_spec<32, 32, 2, 1>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
                                                  fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
@@ -409,8 +388,8 @@ TEST(MfmaSimdBenchmark, F32_16x16x4_f32_Specialized) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 4, B = 1, bits = 32;
-  fx.seed(S0_OFF, 16, bits, SmallGen(33));
-  fx.seed(S1_OFF, 16, bits, SmallGen(34));
+  fx.seed(S0_OFF, 16, bits, mma_test::SmallGen(33));
+  fx.seed(S1_OFF, 16, bits, mma_test::SmallGen(34));
   auto run = [&] {
     amdgpu::exec_f32_mfma_f32_spec<16, 16, 4, 1>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
                                                  fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
@@ -422,8 +401,8 @@ TEST(MfmaSimdBenchmark, F32_32x32x1x2_f32_Specialized) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 32, N = 32, K = 1, B = 2, bits = 32;
-  fx.seed(S0_OFF, 16, bits, SmallGen(35));
-  fx.seed(S1_OFF, 16, bits, SmallGen(36));
+  fx.seed(S0_OFF, 16, bits, mma_test::SmallGen(35));
+  fx.seed(S1_OFF, 16, bits, mma_test::SmallGen(36));
   auto run = [&] {
     amdgpu::exec_f32_mfma_f32_spec<32, 32, 1, 2>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
                                                  fx.vbase + S1_OFF, 0, 0, 0, 0, 0);

--- a/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
@@ -384,6 +384,38 @@ TEST(MfmaSimdBenchmark, F32_16x16x32_fp8) {
   bench("v_mfma_f32_16x16x32_fp8", fx, run, double(M) * N * K * B, /*is_int=*/false);
 }
 
+// Dense fp8/bf8 shapes: dedicated constexpr specializations (256-entry LUT
+// bulk convert instead of per-element extract_fp8/extract_bf8).
+TEST(MfmaSimdBenchmark, F32_16x16x32_fp8_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32, B = 1, bits = 8;
+  fx.seed(S0_OFF, 8, bits, mma_test::SmallGen(5));
+  fx.seed(S1_OFF, 8, bits, mma_test::SmallGen(6));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, true, true>(*fx.cu, fx.vbase + DST_OFF,
+                                                          fx.vbase + S0_OFF, fx.vbase + S1_OFF, 0,
+                                                          /*const_acc=*/0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_16x16x32_fp8_fp8 [specialized]", fx, run, double(M) * N * K * B,
+        /*is_int=*/false);
+}
+
+TEST(MfmaSimdBenchmark, F32_32x32x16_bf8_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 32, K = 16, B = 1, bits = 8;
+  fx.seed(S0_OFF, 8, bits, mma_test::SmallGen(15));
+  fx.seed(S1_OFF, 8, bits, mma_test::SmallGen(16));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_f8_spec<32, 32, 16, false, false>(*fx.cu, fx.vbase + DST_OFF,
+                                                            fx.vbase + S0_OFF, fx.vbase + S1_OFF, 0,
+                                                            /*const_acc=*/0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_32x32x16_bf8_bf8 [specialized]", fx, run, double(M) * N * K * B,
+        /*is_int=*/false);
+}
+
 // v_mfma_i32_16x16x32_i8: integer path, exact SIMD-vs-scalar agreement.
 TEST(MfmaSimdBenchmark, I32_16x16x32_i8) {
   SKIP_IF_NO_SIMD();

--- a/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
@@ -389,3 +389,45 @@ TEST(MfmaSimdBenchmark, F64_16x16x4_f64) {
   };
   bench("v_mfma_f64_16x16x4_f64", fx, run, double(M) * N * K * B, /*is_int=*/false);
 }
+
+// f32-input MFMA shapes (no F16C convert; specialization gain is the
+// addressing-unroll + raw vgpr_data + no-heap, not a convert).
+TEST(MfmaSimdBenchmark, F32_32x32x2_f32_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 32, K = 2, B = 1, bits = 32;
+  fx.seed(S0_OFF, 16, bits, SmallGen(31));
+  fx.seed(S1_OFF, 16, bits, SmallGen(32));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_f32_spec<32, 32, 2, 1>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                                 fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_32x32x2_f32 [specialized]", fx, run, double(M) * N * K * B, /*is_int=*/false);
+}
+
+TEST(MfmaSimdBenchmark, F32_16x16x4_f32_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 4, B = 1, bits = 32;
+  fx.seed(S0_OFF, 16, bits, SmallGen(33));
+  fx.seed(S1_OFF, 16, bits, SmallGen(34));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_f32_spec<16, 16, 4, 1>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                                 fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_16x16x4_f32 [specialized]", fx, run, double(M) * N * K * B, /*is_int=*/false);
+}
+
+TEST(MfmaSimdBenchmark, F32_32x32x1x2_f32_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 32, K = 1, B = 2, bits = 32;
+  fx.seed(S0_OFF, 16, bits, SmallGen(35));
+  fx.seed(S1_OFF, 16, bits, SmallGen(36));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_f32_spec<32, 32, 1, 2>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                                 fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_32x32x1_f32 (B=2) [specialized]", fx, run, double(M) * N * K * B,
+        /*is_int=*/false);
+}

--- a/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
@@ -577,3 +577,89 @@ TEST(MfmaSimdBenchmark, F32_32x32x1x2_f32_Specialized) {
   bench("v_mfma_f32_32x32x1_f32 (B=2) [specialized]", fx, run, double(M) * N * K * B,
         /*is_int=*/false);
 }
+
+// Batched f16/bf16/i8 MFMA shapes, now also specialized (per-batch block
+// matmul over the same constexpr-unrolled kernel).
+TEST(MfmaSimdBenchmark, F32_32x32x4x2_f16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 32, K = 4, B = 2, bits = 16;
+  fx.seed(S0_OFF, 2, bits, mma_test::SmallGen(51));
+  fx.seed(S1_OFF, 2, bits, mma_test::SmallGen(52));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_f16_spec<32, 32, 4, 2>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                                 fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_32x32x4_f16 (B=2) [specialized]", fx, run, double(M) * N * K * B,
+        /*is_int=*/false);
+}
+
+TEST(MfmaSimdBenchmark, F32_16x16x4x4_f16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 4, B = 4, bits = 16;
+  fx.seed(S0_OFF, 2, bits, mma_test::SmallGen(53));
+  fx.seed(S1_OFF, 2, bits, mma_test::SmallGen(54));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_f16_spec<16, 16, 4, 4>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                                 fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_16x16x4_f16 (B=4) [specialized]", fx, run, double(M) * N * K * B,
+        /*is_int=*/false);
+}
+
+TEST(MfmaSimdBenchmark, F32_32x32x4x2_bf16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 32, K = 4, B = 2;
+  fx.seed_bf16(S0_OFF, 2, mma_test::SmallGen(55));
+  fx.seed_bf16(S1_OFF, 2, mma_test::SmallGen(56));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_bf16_spec<32, 32, 4, 2>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                                  fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_32x32x4_bf16 (B=2) [specialized]", fx, run, double(M) * N * K * B,
+        /*is_int=*/false);
+}
+
+TEST(MfmaSimdBenchmark, F32_16x16x4x4_bf16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 4, B = 4;
+  fx.seed_bf16(S0_OFF, 2, mma_test::SmallGen(57));
+  fx.seed_bf16(S1_OFF, 2, mma_test::SmallGen(58));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_bf16_spec<16, 16, 4, 4>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                                  fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_16x16x4_bf16 (B=4) [specialized]", fx, run, double(M) * N * K * B,
+        /*is_int=*/false);
+}
+
+TEST(MfmaSimdBenchmark, I32_32x32x4x2_i8_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 32, K = 4, B = 2;
+  fx.seed_i8(S0_OFF, 1, mma_test::SmallI8Gen(15));
+  fx.seed_i8(S1_OFF, 1, mma_test::SmallI8Gen(16));
+  auto run = [&] {
+    amdgpu::exec_i32_mfma_i8_spec<32, 32, 4, 2>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                                fx.vbase + S1_OFF, 0, /*const_acc=*/0);
+  };
+  bench("v_mfma_i32_32x32x4_i8 (B=2) [specialized]", fx, run, double(M) * N * K * B,
+        /*is_int=*/true);
+}
+
+TEST(MfmaSimdBenchmark, I32_16x16x4x4_i8_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 4, B = 4;
+  fx.seed_i8(S0_OFF, 1, mma_test::SmallI8Gen(17));
+  fx.seed_i8(S1_OFF, 1, mma_test::SmallI8Gen(18));
+  auto run = [&] {
+    amdgpu::exec_i32_mfma_i8_spec<16, 16, 4, 4>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                                fx.vbase + S1_OFF, 0, /*const_acc=*/0);
+  };
+  bench("v_mfma_i32_16x16x4_i8 (B=4) [specialized]", fx, run, double(M) * N * K * B,
+        /*is_int=*/true);
+}

--- a/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
@@ -1,0 +1,351 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file mfma_simd_benchmark.cpp
+/// @brief A/B microbenchmark: SIMD vs forced-scalar execution of the shared
+/// MFMA execute kernels (exec_f32 / exec_i32_i8 / exec_f64), covering the
+/// CDNA4 MFMA shapes that route through them.
+///
+/// Both modes run in the same process; the `amdgpu::simd_force_scalar()`
+/// thread-local flag flips the kernel between its dense native-width matmul
+/// (SIMD) and the per-output scalar triple-loop. The benchmark drives the
+/// execute kernels directly (no decode) so it isolates the matmul body, then
+/// reports ns/MFMA and speedup and checks SIMD-vs-scalar agreement:
+///   - i32/i8 output: integer MAC is exact, bit-identical.
+///   - f32/f64 output: SIMD uses fused FMA (matching GFX9 MFMA hardware) while
+///     the scalar reference is non-fused, so results agree to a small relative
+///     tolerance, not bit-exactly.
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/simd_glue.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+#include "util/data_types.h"
+#include "util/simd.h"
+#include "util/simd_test_hooks.h"
+
+#include <gtest/gtest.h>
+
+#include <bit>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <functional>
+#include <random>
+#include <vector>
+
+namespace {
+
+using namespace rocjitsu;
+using Clock = std::chrono::steady_clock;
+
+constexpr uint32_t WF_SIZE = 64;
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr int ITERATIONS = 4000;
+
+// VGPR layout: A inputs at s0, B inputs at s1, output at DST. The 64-register
+// spacing comfortably clears the small per-operand register footprint of every
+// shape benchmarked here.
+constexpr uint32_t S0_OFF = 0;
+constexpr uint32_t S1_OFF = 64;
+constexpr uint32_t DST_OFF = 128;
+constexpr uint32_t OUT_REGS = 32; // dst window read back for the correctness check.
+
+struct BenchFixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  amdgpu::Wavefront *wf = nullptr;
+  uint32_t vbase = 0;
+
+  BenchFixture() : gpu_mem("mfma_simd_bench_mem"), l2("mfma_simd_bench_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_CDNA4;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_mfma_simd", cfg, &gpu_mem, &l2);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+    if (wf)
+      vbase = wf->vgpr_alloc().base;
+  }
+
+  // Pack `n` small floats produced by `gen` into the source VGPR range
+  // [vbase+off .. ), bit_width bits per element (8/16/32), row-major over
+  // (reg, lane). The exact layout doesn't matter for the benchmark — both
+  // modes read the same bytes — only that values are finite and bounded so
+  // the accumulated matmul stays finite.
+  template <typename Gen> void seed(uint32_t off, uint32_t regs, uint32_t bit_width, Gen gen) {
+    for (uint32_t reg = 0; reg < regs; ++reg) {
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+        uint32_t word = 0;
+        if (bit_width == 32) {
+          word = std::bit_cast<uint32_t>(gen());
+        } else if (bit_width == 16) {
+          uint16_t lo = util::f32_to_f16(gen());
+          uint16_t hi = util::f32_to_f16(gen());
+          word = lo | (static_cast<uint32_t>(hi) << 16);
+        } else { // 8-bit fp8 e4m3
+          for (uint32_t byte = 0; byte < 4; ++byte)
+            word |= static_cast<uint32_t>(util::f32_to_fp8_e4m3(gen())) << (byte * 8);
+        }
+        cu->write_vgpr(vbase + off + reg, lane, word);
+      }
+    }
+  }
+
+  // Pack `regs` words of small int8 values into the source VGPR range.
+  template <typename Gen> void seed_i8(uint32_t off, uint32_t regs, Gen gen) {
+    for (uint32_t reg = 0; reg < regs; ++reg)
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+        uint32_t word = 0;
+        for (uint32_t byte = 0; byte < 4; ++byte)
+          word |= (static_cast<uint32_t>(static_cast<uint8_t>(gen())) << (byte * 8));
+        cu->write_vgpr(vbase + off + reg, lane, word);
+      }
+  }
+
+  // Pack `regs` pairs (lo,hi) of small f64 values into the source range.
+  template <typename Gen> void seed_f64(uint32_t off, uint32_t reg_pairs, Gen gen) {
+    for (uint32_t p = 0; p < reg_pairs; ++p)
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+        uint64_t bits = std::bit_cast<uint64_t>(static_cast<double>(gen()));
+        cu->write_vgpr(vbase + off + 2 * p, lane, static_cast<uint32_t>(bits));
+        cu->write_vgpr(vbase + off + 2 * p + 1, lane, static_cast<uint32_t>(bits >> 32));
+      }
+  }
+
+  std::vector<uint32_t> snapshot_out() const {
+    std::vector<uint32_t> out(OUT_REGS * WF_SIZE);
+    for (uint32_t reg = 0; reg < OUT_REGS; ++reg)
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+        out[reg * WF_SIZE + lane] = cu->read_vgpr(vbase + DST_OFF + reg, lane);
+    return out;
+  }
+};
+
+struct ModeStats {
+  double ns_per_inst = 0;
+  double gmacs = 0; // billion MACs/s
+  uint64_t total_ns = 0;
+};
+
+ModeStats time_mode(const std::function<void()> &run, bool force_scalar, double macs_per_call) {
+  util::set_force_scalar_for_testing(force_scalar);
+  for (int i = 0; i < 50; ++i) // warmup
+    run();
+  auto t0 = Clock::now();
+  for (int i = 0; i < ITERATIONS; ++i)
+    run();
+  auto t1 = Clock::now();
+  util::set_force_scalar_for_testing(false);
+  ModeStats s;
+  s.total_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+  s.ns_per_inst = static_cast<double>(s.total_ns) / ITERATIONS;
+  s.gmacs = (macs_per_call * ITERATIONS) / static_cast<double>(s.total_ns); // MACs/ns == G/s
+  return s;
+}
+
+// Drive one MFMA kernel A/B. `run` invokes the kernel once (reads s0/s1,
+// writes dst). `is_int` selects exact vs tolerance correctness comparison.
+void bench(const char *label, BenchFixture &fx, const std::function<void()> &run, double macs,
+           bool is_int) {
+  ASSERT_NE(fx.cu, nullptr);
+  ASSERT_NE(fx.wf, nullptr);
+
+  util::set_force_scalar_for_testing(true);
+  run();
+  auto result_scalar = fx.snapshot_out();
+  util::set_force_scalar_for_testing(false);
+  run();
+  auto result_simd = fx.snapshot_out();
+
+  if (is_int) {
+    for (size_t i = 0; i < result_scalar.size(); ++i)
+      EXPECT_EQ(result_scalar[i], result_simd[i]) << label << ": int divergence at index " << i;
+  } else {
+    double max_rel = 0.0;
+    for (size_t i = 0; i < result_scalar.size(); ++i) {
+      float a = std::bit_cast<float>(result_scalar[i]);
+      float b = std::bit_cast<float>(result_simd[i]);
+      if (!std::isfinite(a) || !std::isfinite(b))
+        continue;
+      double denom = std::abs(a) + 1e-6;
+      max_rel = std::max(max_rel, std::abs(static_cast<double>(a) - b) / denom);
+    }
+    EXPECT_LT(max_rel, 1e-3) << label << ": fused-vs-nonfused relative error too large";
+  }
+
+  ModeStats sc = time_mode(run, /*force_scalar=*/true, macs);
+  ModeStats sd = time_mode(run, /*force_scalar=*/false, macs);
+  double speedup = (sd.ns_per_inst > 0) ? (sc.ns_per_inst / sd.ns_per_inst) : 0.0;
+  std::printf("\n  === %s (CDNA4, wave64) ===\n"
+              "  iterations: %d   MACs/MFMA: %.0f\n"
+              "  scalar : %9.1f ns/MFMA  (%6.2f GMAC/s)  wall %.1f ms\n"
+              "  simd   : %9.1f ns/MFMA  (%6.2f GMAC/s)  wall %.1f ms\n"
+              "  speedup: %5.2fx\n",
+              label, ITERATIONS, macs, sc.ns_per_inst, sc.gmacs,
+              static_cast<double>(sc.total_ns) / 1e6, sd.ns_per_inst, sd.gmacs,
+              static_cast<double>(sd.total_ns) / 1e6, speedup);
+
+  EXPECT_GT(sc.gmacs, 0.0) << label << ": scalar baseline produced no work";
+  EXPECT_GT(sd.gmacs, 0.0) << label << ": simd path produced no work";
+}
+
+// Small finite generator: values in roughly [-1, 1], deterministic per call.
+struct SmallGen {
+  std::mt19937 rng;
+  std::uniform_real_distribution<float> dist{-1.0f, 1.0f};
+  explicit SmallGen(uint32_t seed) : rng(seed) {}
+  float operator()() { return dist(rng); }
+};
+
+struct SmallI8Gen {
+  std::mt19937 rng;
+  std::uniform_int_distribution<int> dist{-8, 7};
+  explicit SmallI8Gen(uint32_t seed) : rng(seed) {}
+  int operator()() { return dist(rng); }
+};
+
+#define SKIP_IF_NO_SIMD()                                                                          \
+  if constexpr (!util::has_stdx_simd) {                                                            \
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";                    \
+  } else if (util::native<float>::size() <= 1) {                                                   \
+    GTEST_SKIP() << "host native_simd width is 1 — no SIMD speedup possible";                      \
+  }
+
+} // namespace
+
+// v_mfma_f32_16x16x32_f16: the dominant MFMA shape in fp16 transformer
+// forward passes (N=16 == one AVX-512 f32 lane group).
+TEST(MfmaSimdBenchmark, F32_16x16x32_f16) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32, B = 1, bits = 16;
+  fx.seed(S0_OFF, /*regs=*/8, bits, SmallGen(1));
+  fx.seed(S1_OFF, /*regs=*/8, bits, SmallGen(2));
+  auto run = [&] {
+    amdgpu::exec_f32(*fx.cu, M, N, K, B, bits, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                     fx.vbase + S1_OFF, 0, amdgpu::extract_f16, amdgpu::extract_f16,
+                     /*const_acc=*/0);
+  };
+  bench("v_mfma_f32_16x16x32_f16", fx, run, double(M) * N * K * B, /*is_int=*/false);
+}
+
+// Dedicated hot-path specialization (the function the generated OPT-125M call
+// site actually invokes): constexpr dims + F16C bulk f16->f32 conversion.
+TEST(MfmaSimdBenchmark, F32_16x16x32_f16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32, B = 1, bits = 16;
+  fx.seed(S0_OFF, /*regs=*/8, bits, SmallGen(1));
+  fx.seed(S1_OFF, /*regs=*/8, bits, SmallGen(2));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_16x16x32_f16(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                       fx.vbase + S1_OFF, 0, /*const_acc=*/0, /*cbsz=*/0,
+                                       /*abid=*/0, /*blgp=*/0);
+  };
+  bench("v_mfma_f32_16x16x32_f16 [specialized]", fx, run, double(M) * N * K * B, /*is_int=*/false);
+}
+
+// v_mfma_f32_32x32x16_f16: N=32 == two AVX-512 f32 lane groups.
+TEST(MfmaSimdBenchmark, F32_32x32x16_f16) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 32, K = 16, B = 1, bits = 16;
+  fx.seed(S0_OFF, 8, bits, SmallGen(3));
+  fx.seed(S1_OFF, 8, bits, SmallGen(4));
+  auto run = [&] {
+    amdgpu::exec_f32(*fx.cu, M, N, K, B, bits, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                     fx.vbase + S1_OFF, 0, amdgpu::extract_f16, amdgpu::extract_f16,
+                     /*const_acc=*/0);
+  };
+  bench("v_mfma_f32_32x32x16_f16", fx, run, double(M) * N * K * B, /*is_int=*/false);
+}
+
+// v_mfma_f32_16x16x32_bf8 (fp8 path, in_bits=8, N=16).
+TEST(MfmaSimdBenchmark, F32_16x16x32_fp8) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32, B = 1, bits = 8;
+  fx.seed(S0_OFF, 8, bits, SmallGen(5));
+  fx.seed(S1_OFF, 8, bits, SmallGen(6));
+  auto run = [&] {
+    amdgpu::exec_f32(*fx.cu, M, N, K, B, bits, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                     fx.vbase + S1_OFF, 0, amdgpu::extract_fp8, amdgpu::extract_fp8,
+                     /*const_acc=*/0);
+  };
+  bench("v_mfma_f32_16x16x32_fp8", fx, run, double(M) * N * K * B, /*is_int=*/false);
+}
+
+// v_mfma_i32_16x16x32_i8: integer path, exact SIMD-vs-scalar agreement.
+TEST(MfmaSimdBenchmark, I32_16x16x32_i8) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32, B = 1;
+  fx.seed_i8(S0_OFF, 8, SmallI8Gen(7));
+  fx.seed_i8(S1_OFF, 8, SmallI8Gen(8));
+  auto run = [&] {
+    amdgpu::exec_i32_i8(*fx.cu, M, N, K, B, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                        fx.vbase + S1_OFF, 0, /*const_acc=*/0);
+  };
+  bench("v_mfma_i32_16x16x32_i8", fx, run, double(M) * N * K * B, /*is_int=*/true);
+}
+
+// v_mfma_i32_32x32x16_i8: integer, N=32.
+TEST(MfmaSimdBenchmark, I32_32x32x16_i8) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 32, K = 16, B = 1;
+  fx.seed_i8(S0_OFF, 8, SmallI8Gen(9));
+  fx.seed_i8(S1_OFF, 8, SmallI8Gen(10));
+  auto run = [&] {
+    amdgpu::exec_i32_i8(*fx.cu, M, N, K, B, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                        fx.vbase + S1_OFF, 0, /*const_acc=*/0);
+  };
+  bench("v_mfma_i32_32x32x16_i8", fx, run, double(M) * N * K * B, /*is_int=*/true);
+}
+
+// v_mfma_scale_f32_16x16x128_f8f6f4: MX-scaled fp8 path (exec_f32_scaled),
+// in_bits=8, K=128 (4 K-blocks), N=16. Scales seeded to e8m0 127 (factor 1).
+TEST(MfmaSimdBenchmark, F32Scaled_16x16x128_fp8) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 128, B = 1, bits = 8;
+  constexpr uint32_t SCALE_A = 192, SCALE_B = 200;
+  fx.seed(S0_OFF, 8, bits, SmallGen(13));
+  fx.seed(S1_OFF, 8, bits, SmallGen(14));
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    fx.cu->write_vgpr(fx.vbase + SCALE_A, lane, 0x7F7F7F7Fu); // e8m0 = 127 per block
+    fx.cu->write_vgpr(fx.vbase + SCALE_B, lane, 0x7F7F7F7Fu);
+  }
+  auto run = [&] {
+    amdgpu::exec_f32_scaled(*fx.cu, M, N, K, B, bits, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                            fx.vbase + S1_OFF, 0, amdgpu::extract_fp8, amdgpu::extract_fp8,
+                            /*const_acc=*/0, /*cbsz=*/0, /*abid=*/0, /*blgp=*/0, fx.vbase + SCALE_A,
+                            fx.vbase + SCALE_B);
+  };
+  bench("v_mfma_scale_f32_16x16x128_fp8", fx, run, double(M) * N * K * B, /*is_int=*/false);
+}
+
+// v_mfma_f64_16x16x4_f64: f64 path (native<double> == 8 lanes, N=16).
+TEST(MfmaSimdBenchmark, F64_16x16x4_f64) {
+  SKIP_IF_NO_SIMD();
+  if (util::native<double>::size() <= 1)
+    GTEST_SKIP() << "no native f64 SIMD";
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 4, B = 1;
+  fx.seed_f64(S0_OFF, 8, SmallGen(11));
+  fx.seed_f64(S1_OFF, 8, SmallGen(12));
+  auto run = [&] {
+    amdgpu::exec_f64(*fx.cu, M, N, K, B, fx.vbase + DST_OFF, fx.vbase + S0_OFF, fx.vbase + S1_OFF,
+                     0, /*const_acc=*/0);
+  };
+  bench("v_mfma_f64_16x16x4_f64", fx, run, double(M) * N * K * B, /*is_int=*/false);
+}

--- a/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
@@ -101,6 +101,16 @@ struct BenchFixture {
     }
   }
 
+  // Pack `regs` words of small bf16 values into the source VGPR range.
+  template <typename Gen> void seed_bf16(uint32_t off, uint32_t regs, Gen gen) {
+    for (uint32_t reg = 0; reg < regs; ++reg)
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+        uint16_t lo = util::f32_to_bf16(gen());
+        uint16_t hi = util::f32_to_bf16(gen());
+        cu->write_vgpr(vbase + off + reg, lane, lo | (static_cast<uint32_t>(hi) << 16));
+      }
+  }
+
   // Pack `regs` words of small int8 values into the source VGPR range.
   template <typename Gen> void seed_i8(uint32_t off, uint32_t regs, Gen gen) {
     for (uint32_t reg = 0; reg < regs; ++reg)
@@ -286,6 +296,77 @@ TEST(MfmaSimdBenchmark, F32_32x32x16_f16) {
                      /*const_acc=*/0);
   };
   bench("v_mfma_f32_32x32x16_f16", fx, run, double(M) * N * K * B, /*is_int=*/false);
+}
+
+// bf16 shapes: generic baseline + the four specialized kernels (bf16 bulk
+// zero-extend convert instead of F16C).
+TEST(MfmaSimdBenchmark, F32_16x16x32_bf16) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32, B = 1, bits = 16;
+  fx.seed_bf16(S0_OFF, 8, mma_test::SmallGen(41));
+  fx.seed_bf16(S1_OFF, 8, mma_test::SmallGen(42));
+  auto run = [&] {
+    amdgpu::exec_f32(*fx.cu, M, N, K, B, bits, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                     fx.vbase + S1_OFF, 0, amdgpu::extract_bf16, amdgpu::extract_bf16,
+                     /*const_acc=*/0);
+  };
+  bench("v_mfma_f32_16x16x32_bf16", fx, run, double(M) * N * K * B, /*is_int=*/false);
+}
+
+TEST(MfmaSimdBenchmark, F32_16x16x32_bf16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32, B = 1;
+  fx.seed_bf16(S0_OFF, 8, mma_test::SmallGen(41));
+  fx.seed_bf16(S1_OFF, 8, mma_test::SmallGen(42));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_bf16_spec<16, 16, 32>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                                fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_16x16x32_bf16 [specialized]", fx, run, double(M) * N * K * B,
+        /*is_int=*/false);
+}
+
+TEST(MfmaSimdBenchmark, F32_32x32x8_bf16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 32, K = 8, B = 1;
+  fx.seed_bf16(S0_OFF, 8, mma_test::SmallGen(43));
+  fx.seed_bf16(S1_OFF, 8, mma_test::SmallGen(44));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_bf16_spec<32, 32, 8>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                               fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_32x32x8_bf16 [specialized]", fx, run, double(M) * N * K * B, /*is_int=*/false);
+}
+
+TEST(MfmaSimdBenchmark, F32_16x16x16_bf16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 16, B = 1;
+  fx.seed_bf16(S0_OFF, 8, mma_test::SmallGen(45));
+  fx.seed_bf16(S1_OFF, 8, mma_test::SmallGen(46));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                                fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_16x16x16_bf16 [specialized]", fx, run, double(M) * N * K * B,
+        /*is_int=*/false);
+}
+
+TEST(MfmaSimdBenchmark, F32_32x32x16_bf16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 32, K = 16, B = 1;
+  fx.seed_bf16(S0_OFF, 8, mma_test::SmallGen(47));
+  fx.seed_bf16(S1_OFF, 8, mma_test::SmallGen(48));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_bf16_spec<32, 32, 16>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                                fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_32x32x16_bf16 [specialized]", fx, run, double(M) * N * K * B,
+        /*is_int=*/false);
 }
 
 // v_mfma_f32_16x16x32_bf8 (fp8 path, in_bits=8, N=16).

--- a/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
@@ -247,11 +247,51 @@ TEST(MfmaSimdBenchmark, F32_16x16x32_f16_Specialized) {
   fx.seed(S0_OFF, /*regs=*/8, bits, SmallGen(1));
   fx.seed(S1_OFF, /*regs=*/8, bits, SmallGen(2));
   auto run = [&] {
-    amdgpu::exec_f32_mfma_16x16x32_f16(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
-                                       fx.vbase + S1_OFF, 0, /*const_acc=*/0, /*cbsz=*/0,
-                                       /*abid=*/0, /*blgp=*/0);
+    amdgpu::exec_f32_mfma_f16_spec<16, 16, 32>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                               fx.vbase + S1_OFF, 0, /*const_acc=*/0, /*cbsz=*/0,
+                                               /*abid=*/0, /*blgp=*/0);
   };
   bench("v_mfma_f32_16x16x32_f16 [specialized]", fx, run, double(M) * N * K * B, /*is_int=*/false);
+}
+
+// Remaining cdna4 f16 MFMA shapes, now also specialized.
+TEST(MfmaSimdBenchmark, F32_32x32x8_f16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 32, K = 8, B = 1, bits = 16;
+  fx.seed(S0_OFF, 8, bits, SmallGen(21));
+  fx.seed(S1_OFF, 8, bits, SmallGen(22));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_f16_spec<32, 32, 8>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                              fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_32x32x8_f16 [specialized]", fx, run, double(M) * N * K * B, /*is_int=*/false);
+}
+
+TEST(MfmaSimdBenchmark, F32_16x16x16_f16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 16, B = 1, bits = 16;
+  fx.seed(S0_OFF, 8, bits, SmallGen(23));
+  fx.seed(S1_OFF, 8, bits, SmallGen(24));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_f16_spec<16, 16, 16>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                               fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_16x16x16_f16 [specialized]", fx, run, double(M) * N * K * B, /*is_int=*/false);
+}
+
+TEST(MfmaSimdBenchmark, F32_32x32x16_f16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 32, K = 16, B = 1, bits = 16;
+  fx.seed(S0_OFF, 8, bits, SmallGen(25));
+  fx.seed(S1_OFF, 8, bits, SmallGen(26));
+  auto run = [&] {
+    amdgpu::exec_f32_mfma_f16_spec<32, 32, 16>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                               fx.vbase + S1_OFF, 0, 0, 0, 0, 0);
+  };
+  bench("v_mfma_f32_32x32x16_f16 [specialized]", fx, run, double(M) * N * K * B, /*is_int=*/false);
 }
 
 // v_mfma_f32_32x32x16_f16: N=32 == two AVX-512 f32 lane groups.

--- a/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
@@ -412,6 +412,60 @@ TEST(MfmaSimdBenchmark, I32_32x32x16_i8) {
   bench("v_mfma_i32_32x32x16_i8", fx, run, double(M) * N * K * B, /*is_int=*/true);
 }
 
+// Dense i8 shapes: dedicated constexpr specializations (i8 bulk sign-extend
+// convert instead of per-element extract_i8).
+TEST(MfmaSimdBenchmark, I32_16x16x32_i8_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32, B = 1;
+  fx.seed_i8(S0_OFF, 8, mma_test::SmallI8Gen(7));
+  fx.seed_i8(S1_OFF, 8, mma_test::SmallI8Gen(8));
+  auto run = [&] {
+    amdgpu::exec_i32_mfma_i8_spec<16, 16, 32>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                              fx.vbase + S1_OFF, 0, /*const_acc=*/0);
+  };
+  bench("v_mfma_i32_16x16x32_i8 [specialized]", fx, run, double(M) * N * K * B, /*is_int=*/true);
+}
+
+TEST(MfmaSimdBenchmark, I32_32x32x16_i8_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 32, K = 16, B = 1;
+  fx.seed_i8(S0_OFF, 8, mma_test::SmallI8Gen(9));
+  fx.seed_i8(S1_OFF, 8, mma_test::SmallI8Gen(10));
+  auto run = [&] {
+    amdgpu::exec_i32_mfma_i8_spec<32, 32, 16>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                              fx.vbase + S1_OFF, 0, /*const_acc=*/0);
+  };
+  bench("v_mfma_i32_32x32x16_i8 [specialized]", fx, run, double(M) * N * K * B, /*is_int=*/true);
+}
+
+TEST(MfmaSimdBenchmark, I32_16x16x64_i8_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 64, B = 1;
+  fx.seed_i8(S0_OFF, 16, mma_test::SmallI8Gen(11));
+  fx.seed_i8(S1_OFF, 16, mma_test::SmallI8Gen(12));
+  auto run = [&] {
+    amdgpu::exec_i32_mfma_i8_spec<16, 16, 64>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                              fx.vbase + S1_OFF, 0, /*const_acc=*/0);
+  };
+  bench("v_mfma_i32_16x16x64_i8 [specialized]", fx, run, double(M) * N * K * B, /*is_int=*/true);
+}
+
+TEST(MfmaSimdBenchmark, I32_32x32x32_i8_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 32, N = 32, K = 32, B = 1;
+  fx.seed_i8(S0_OFF, 16, mma_test::SmallI8Gen(13));
+  fx.seed_i8(S1_OFF, 16, mma_test::SmallI8Gen(14));
+  auto run = [&] {
+    amdgpu::exec_i32_mfma_i8_spec<32, 32, 32>(*fx.cu, fx.vbase + DST_OFF, fx.vbase + S0_OFF,
+                                              fx.vbase + S1_OFF, 0, /*const_acc=*/0);
+  };
+  bench("v_mfma_i32_32x32x32_i8 [specialized]", fx, run, double(M) * N * K * B, /*is_int=*/true);
+}
+
 // v_mfma_scale_f32_16x16x128_f8f6f4: MX-scaled fp8 path (exec_f32_scaled),
 // in_bits=8, K=128 (4 K-blocks), N=16. Scales seeded to e8m0 127 (factor 1).
 TEST(MfmaSimdBenchmark, F32Scaled_16x16x128_fp8) {

--- a/emulation/rocjitsu/tests/mma_test_util.h
+++ b/emulation/rocjitsu/tests/mma_test_util.h
@@ -15,6 +15,17 @@
 
 namespace mma_test {
 
+// Wavefront sizes for the two MMA families (differ by design, so they are named
+// rather than a single shared WF_SIZE).
+constexpr uint32_t MFMA_WF_SIZE = 64; // CDNA MFMA is wave64.
+constexpr uint32_t WMMA_WF_SIZE = 32; // gfx1250 / RDNA WMMA is wave32.
+
+// Register-file dimensions and iteration count shared verbatim by the MFMA and
+// WMMA SIMD benchmarks.
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr int BENCH_ITERATIONS = 4000;
+
 // Small finite generator: values in roughly [-1, 1], deterministic per call.
 struct SmallGen {
   std::mt19937 rng;

--- a/emulation/rocjitsu/tests/mma_test_util.h
+++ b/emulation/rocjitsu/tests/mma_test_util.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file mma_test_util.h
+/// @brief Shared generators and skip guard for the MFMA/WMMA SIMD test
+/// suites and benchmarks.
+
+#pragma once
+
+#include "util/simd.h"
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+namespace mma_test {
+
+// Small finite generator: values in roughly [-1, 1], deterministic per call.
+struct SmallGen {
+  std::mt19937 rng;
+  std::uniform_real_distribution<float> dist{-1.0f, 1.0f};
+  explicit SmallGen(uint32_t seed) : rng(seed) {}
+  float operator()() { return dist(rng); }
+};
+
+struct SmallI8Gen {
+  std::mt19937 rng;
+  std::uniform_int_distribution<int> dist{-8, 7};
+  explicit SmallI8Gen(uint32_t seed) : rng(seed) {}
+  int operator()() { return dist(rng); }
+};
+
+} // namespace mma_test
+
+#define SKIP_IF_NO_SIMD()                                                                          \
+  if constexpr (!util::has_stdx_simd) {                                                            \
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";                    \
+  } else if (util::native<float>::size() <= 1) {                                                   \
+    GTEST_SKIP() << "host native_simd width is 1 — no SIMD fast path";                             \
+  }

--- a/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
@@ -127,6 +127,8 @@ TEST(MfmaSimdExact, F16Spec_AllShapes) {
   spec(amdgpu::exec_f32_mfma_f16_spec<32, 32, 16>, "spec_f16_32x32x16");
   spec(amdgpu::exec_f32_mfma_f16_spec<32, 32, 8>, "spec_f16_32x32x8");
   spec(amdgpu::exec_f32_mfma_f16_spec<16, 16, 16>, "spec_f16_16x16x16");
+  spec(amdgpu::exec_f32_mfma_f16_spec<32, 32, 4, 2>, "spec_f16_32x32x4x2");
+  spec(amdgpu::exec_f32_mfma_f16_spec<16, 16, 4, 4>, "spec_f16_16x16x4x4");
 }
 
 // --- specialized bf16 kernels (constexpr dims + bf16 zero-extend bulk convert) ---
@@ -141,6 +143,8 @@ TEST(MfmaSimdExact, Bf16Spec_AllShapes) {
   spec(amdgpu::exec_f32_mfma_bf16_spec<32, 32, 16>, "spec_bf16_32x32x16");
   spec(amdgpu::exec_f32_mfma_bf16_spec<32, 32, 8>, "spec_bf16_32x32x8");
   spec(amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16>, "spec_bf16_16x16x16");
+  spec(amdgpu::exec_f32_mfma_bf16_spec<32, 32, 4, 2>, "spec_bf16_32x32x4x2");
+  spec(amdgpu::exec_f32_mfma_bf16_spec<16, 16, 4, 4>, "spec_bf16_16x16x4x4");
 }
 
 // --- specialized fp8/bf8 kernels (constexpr dims + LUT bulk convert), all four
@@ -219,6 +223,8 @@ TEST(MfmaSimdExact, I8Spec_AllShapes) {
   spec(amdgpu::exec_i32_mfma_i8_spec<32, 32, 32>, "spec_i8_32x32x32");
   spec(amdgpu::exec_i32_mfma_i8_spec<32, 32, 16>, "spec_i8_32x32x16");
   spec(amdgpu::exec_i32_mfma_i8_spec<16, 16, 32>, "spec_i8_16x16x32");
+  spec(amdgpu::exec_i32_mfma_i8_spec<32, 32, 4, 2>, "spec_i8_32x32x4x2");
+  spec(amdgpu::exec_i32_mfma_i8_spec<16, 16, 4, 4>, "spec_i8_16x16x4x4");
 }
 
 // --- f64 MFMA ---

--- a/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
@@ -65,7 +65,7 @@ void run_i8(const char *label, uint32_t M, uint32_t N, uint32_t K, uint32_t B) {
 
 // --- exec_f32 generic, f16 inputs: every dispatched CDNA4 f16 shape ---
 TEST(MfmaSimdExact, F32_f16_AllShapes) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   const struct {
     uint32_t m, n, k, b;
   } shapes[] = {{16, 16, 32, 1}, {32, 32, 16, 1}, {32, 32, 8, 1}, {16, 16, 16, 1},
@@ -76,7 +76,7 @@ TEST(MfmaSimdExact, F32_f16_AllShapes) {
 
 // --- exec_f32 generic, bf16 inputs ---
 TEST(MfmaSimdExact, F32_bf16_AllShapes) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   const struct {
     uint32_t m, n, k, b;
   } shapes[] = {{16, 16, 32, 1}, {32, 32, 16, 1}, {4, 4, 4, 16}, {16, 16, 4, 4}, {32, 32, 4, 2}};
@@ -87,7 +87,7 @@ TEST(MfmaSimdExact, F32_bf16_AllShapes) {
 
 // --- exec_f32 generic, fp8/bf8 inputs incl. mixed A/B pairs ---
 TEST(MfmaSimdExact, F32_f8_AllShapes) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   const struct {
     uint32_t m, n, k;
   } shapes[] = {{16, 16, 32}, {32, 32, 16}, {16, 16, 128}, {32, 32, 64}};
@@ -101,14 +101,14 @@ TEST(MfmaSimdExact, F32_f8_AllShapes) {
 
 // --- exec_f32 generic, f32 inputs (4x4 stays generic; bigger go specialized) ---
 TEST(MfmaSimdExact, F32_f32_Generic4x4) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   run_f32("f32_f32_4x4x1x16", Fmt::F32, 4, 4, 1, 16, 32, amdgpu::extract_f32, amdgpu::extract_f32);
   run_f32("f32_f32_4x4x4x16", Fmt::F32, 4, 4, 4, 16, 32, amdgpu::extract_f32, amdgpu::extract_f32);
 }
 
 // --- cbsz/abid/blgp lane-permutation paths (folded into the SIMD hoist) ---
 TEST(MfmaSimdExact, F32_f16_Permuted) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   run_f32("f32_f16_cbsz1", Fmt::F16, 16, 16, 4, 4, 16, amdgpu::extract_f16, amdgpu::extract_f16,
           /*cbsz=*/1, /*abid=*/0, /*blgp=*/0);
   run_f32("f32_f16_blgp1", Fmt::F16, 16, 16, 4, 4, 16, amdgpu::extract_f16, amdgpu::extract_f16,
@@ -117,7 +117,7 @@ TEST(MfmaSimdExact, F32_f16_Permuted) {
 
 // --- specialized f16 kernels (constexpr dims + F16C bulk convert) ---
 TEST(MfmaSimdExact, F16Spec_AllShapes) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   auto spec = [](auto fn, const char *label) {
     run_case(label, Fmt::F16, Fmt::F32, [fn](MfmaFixture &fx, uint32_t const_acc) {
       fn(*fx.cu, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1, fx.vbase + ACC, const_acc, 0, 0, 0);
@@ -131,7 +131,7 @@ TEST(MfmaSimdExact, F16Spec_AllShapes) {
 
 // --- specialized f32 kernels ---
 TEST(MfmaSimdExact, F32Spec_AllShapes) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   auto spec = [](auto fn, const char *label) {
     run_case(label, Fmt::F32, Fmt::F32, [fn](MfmaFixture &fx, uint32_t const_acc) {
       fn(*fx.cu, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1, fx.vbase + ACC, const_acc, 0, 0, 0);
@@ -145,7 +145,7 @@ TEST(MfmaSimdExact, F32Spec_AllShapes) {
 
 // --- MX-scaled fp8/bf8 (per-32-block e8m0 scales: power-of-two, exact) ---
 TEST(MfmaSimdExact, F32Scaled) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   constexpr uint32_t SCALE_A = 240, SCALE_B = 248;
   auto scaled = [&](const char *label, Fmt fmt, uint32_t m, uint32_t n, uint32_t k, auto ex) {
     run_case(label, fmt, Fmt::F32, [=](MfmaFixture &fx, uint32_t const_acc) {
@@ -162,7 +162,7 @@ TEST(MfmaSimdExact, F32Scaled) {
 
 // --- integer i8 MFMA: exact MAC, every dispatched shape ---
 TEST(MfmaSimdExact, I32_i8_AllShapes) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   const struct {
     uint32_t m, n, k, b;
   } shapes[] = {{16, 16, 64, 1}, {32, 32, 32, 1}, {32, 32, 16, 1}, {16, 16, 32, 1},
@@ -173,7 +173,7 @@ TEST(MfmaSimdExact, I32_i8_AllShapes) {
 
 // --- f64 MFMA ---
 TEST(MfmaSimdExact, F64_AllShapes) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   if (util::native<double>::size() <= 1)
     GTEST_SKIP() << "no native f64 SIMD";
   const struct {

--- a/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
@@ -1,0 +1,187 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file mfma_simd_exact_test.cpp
+/// @brief Expensive bit-exact SIMD-vs-scalar checks for every CDNA4 MFMA
+/// execute kernel and shape (generic, specialized, scaled, i8, f64).
+/// Built only with -DRJ_ENABLE_EXPENSIVE_CHECKS=ON.
+///
+/// Each case runs identical pre-seeded VGPR state through the forced-scalar
+/// path then the SIMD path and asserts the full dst window matches word for
+/// word. Inputs are rounding-free (see mma_exact_test_support.h) so fused
+/// (SIMD) and non-fused (scalar) accumulation cannot legitimately differ.
+
+#include "mma_exact_test_support.h"
+
+namespace {
+
+using namespace rocjitsu;
+using namespace mma_exact;
+
+constexpr uint32_t WF = 64;
+constexpr uint32_t S0 = 0, S1 = 64, ACC = 128, DST = 192, DST_REGS = 32;
+constexpr uint32_t IN_REGS = 16, ACC_REGS = 32;
+constexpr uint32_t CONST_ONE = 0x3F800000u;
+
+struct MfmaFixture : ExactFixture {
+  MfmaFixture() : ExactFixture(ROCJITSU_CODE_ARCH_CDNA4, WF) {}
+};
+
+// Drive one (kernel, fmt) case across all trial modes and both accumulator
+// sources (VGPR window + 1.0f immediate).
+void run_case(const char *label, Fmt fmt, Fmt acc_fmt,
+              const std::function<void(MfmaFixture &, uint32_t)> &kernel) {
+  MfmaFixture fx;
+  ASSERT_NE(fx.wf, nullptr);
+  for (auto [mode, seed] : trials_for(fmt)) {
+    fx.seed(S0, IN_REGS, fmt, mode, seed + 1);
+    fx.seed(S1, IN_REGS, fmt, mode, seed + 2);
+    auto reseed_acc = [&] { fx.seed(ACC, ACC_REGS, acc_fmt, Mode::RandomInt, seed + 3); };
+    for (uint32_t const_acc : {amdgpu::ACC_FROM_VGPR, CONST_ONE}) {
+      expect_bit_exact(label, mode, fx, reseed_acc, [&] { kernel(fx, const_acc); }, DST, DST_REGS);
+      if (testing::Test::HasFatalFailure())
+        return;
+    }
+  }
+}
+
+template <typename Ea, typename Eb>
+void run_f32(const char *label, Fmt fmt, uint32_t M, uint32_t N, uint32_t K, uint32_t B,
+             uint32_t bits, Ea ea, Eb eb, uint32_t cbsz = 0, uint32_t abid = 0, uint32_t blgp = 0) {
+  run_case(label, fmt, Fmt::F32, [=](MfmaFixture &fx, uint32_t const_acc) {
+    amdgpu::exec_f32(*fx.cu, M, N, K, B, bits, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1,
+                     fx.vbase + ACC, ea, eb, const_acc, cbsz, abid, blgp);
+  });
+}
+
+void run_i8(const char *label, uint32_t M, uint32_t N, uint32_t K, uint32_t B) {
+  run_case(label, Fmt::I8, Fmt::I8, [=](MfmaFixture &fx, uint32_t const_acc) {
+    amdgpu::exec_i32_i8(*fx.cu, M, N, K, B, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1,
+                        fx.vbase + ACC, const_acc);
+  });
+}
+
+} // namespace
+
+// --- exec_f32 generic, f16 inputs: every dispatched CDNA4 f16 shape ---
+TEST(MfmaSimdExact, F32_f16_AllShapes) {
+  MMA_SKIP_IF_NO_SIMD();
+  const struct {
+    uint32_t m, n, k, b;
+  } shapes[] = {{16, 16, 32, 1}, {32, 32, 16, 1}, {32, 32, 8, 1}, {16, 16, 16, 1},
+                {4, 4, 4, 16},   {16, 16, 4, 4},  {32, 32, 4, 2}};
+  for (auto s : shapes)
+    run_f32("f32_f16", Fmt::F16, s.m, s.n, s.k, s.b, 16, amdgpu::extract_f16, amdgpu::extract_f16);
+}
+
+// --- exec_f32 generic, bf16 inputs ---
+TEST(MfmaSimdExact, F32_bf16_AllShapes) {
+  MMA_SKIP_IF_NO_SIMD();
+  const struct {
+    uint32_t m, n, k, b;
+  } shapes[] = {{16, 16, 32, 1}, {32, 32, 16, 1}, {4, 4, 4, 16}, {16, 16, 4, 4}, {32, 32, 4, 2}};
+  for (auto s : shapes)
+    run_f32("f32_bf16", Fmt::BF16, s.m, s.n, s.k, s.b, 16, amdgpu::extract_bf16,
+            amdgpu::extract_bf16);
+}
+
+// --- exec_f32 generic, fp8/bf8 inputs incl. mixed A/B pairs ---
+TEST(MfmaSimdExact, F32_f8_AllShapes) {
+  MMA_SKIP_IF_NO_SIMD();
+  const struct {
+    uint32_t m, n, k;
+  } shapes[] = {{16, 16, 32}, {32, 32, 16}, {16, 16, 128}, {32, 32, 64}};
+  for (auto s : shapes) {
+    run_f32("f32_fp8", Fmt::FP8, s.m, s.n, s.k, 1, 8, amdgpu::extract_fp8, amdgpu::extract_fp8);
+    run_f32("f32_bf8", Fmt::BF8, s.m, s.n, s.k, 1, 8, amdgpu::extract_bf8, amdgpu::extract_bf8);
+  }
+  run_f32("f32_fp8_bf8", Fmt::FP8, 16, 16, 32, 1, 8, amdgpu::extract_fp8, amdgpu::extract_bf8);
+  run_f32("f32_bf8_fp8", Fmt::BF8, 32, 32, 16, 1, 8, amdgpu::extract_bf8, amdgpu::extract_fp8);
+}
+
+// --- exec_f32 generic, f32 inputs (4x4 stays generic; bigger go specialized) ---
+TEST(MfmaSimdExact, F32_f32_Generic4x4) {
+  MMA_SKIP_IF_NO_SIMD();
+  run_f32("f32_f32_4x4x1x16", Fmt::F32, 4, 4, 1, 16, 32, amdgpu::extract_f32, amdgpu::extract_f32);
+  run_f32("f32_f32_4x4x4x16", Fmt::F32, 4, 4, 4, 16, 32, amdgpu::extract_f32, amdgpu::extract_f32);
+}
+
+// --- cbsz/abid/blgp lane-permutation paths (folded into the SIMD hoist) ---
+TEST(MfmaSimdExact, F32_f16_Permuted) {
+  MMA_SKIP_IF_NO_SIMD();
+  run_f32("f32_f16_cbsz1", Fmt::F16, 16, 16, 4, 4, 16, amdgpu::extract_f16, amdgpu::extract_f16,
+          /*cbsz=*/1, /*abid=*/0, /*blgp=*/0);
+  run_f32("f32_f16_blgp1", Fmt::F16, 16, 16, 4, 4, 16, amdgpu::extract_f16, amdgpu::extract_f16,
+          /*cbsz=*/0, /*abid=*/0, /*blgp=*/1);
+}
+
+// --- specialized f16 kernels (constexpr dims + F16C bulk convert) ---
+TEST(MfmaSimdExact, F16Spec_AllShapes) {
+  MMA_SKIP_IF_NO_SIMD();
+  auto spec = [](auto fn, const char *label) {
+    run_case(label, Fmt::F16, Fmt::F32, [fn](MfmaFixture &fx, uint32_t const_acc) {
+      fn(*fx.cu, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1, fx.vbase + ACC, const_acc, 0, 0, 0);
+    });
+  };
+  spec(amdgpu::exec_f32_mfma_f16_spec<16, 16, 32>, "spec_f16_16x16x32");
+  spec(amdgpu::exec_f32_mfma_f16_spec<32, 32, 16>, "spec_f16_32x32x16");
+  spec(amdgpu::exec_f32_mfma_f16_spec<32, 32, 8>, "spec_f16_32x32x8");
+  spec(amdgpu::exec_f32_mfma_f16_spec<16, 16, 16>, "spec_f16_16x16x16");
+}
+
+// --- specialized f32 kernels ---
+TEST(MfmaSimdExact, F32Spec_AllShapes) {
+  MMA_SKIP_IF_NO_SIMD();
+  auto spec = [](auto fn, const char *label) {
+    run_case(label, Fmt::F32, Fmt::F32, [fn](MfmaFixture &fx, uint32_t const_acc) {
+      fn(*fx.cu, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1, fx.vbase + ACC, const_acc, 0, 0, 0);
+    });
+  };
+  spec(amdgpu::exec_f32_mfma_f32_spec<32, 32, 2, 1>, "spec_f32_32x32x2");
+  spec(amdgpu::exec_f32_mfma_f32_spec<16, 16, 4, 1>, "spec_f32_16x16x4");
+  spec(amdgpu::exec_f32_mfma_f32_spec<32, 32, 1, 2>, "spec_f32_32x32x1x2");
+  spec(amdgpu::exec_f32_mfma_f32_spec<16, 16, 1, 4>, "spec_f32_16x16x1x4");
+}
+
+// --- MX-scaled fp8/bf8 (per-32-block e8m0 scales: power-of-two, exact) ---
+TEST(MfmaSimdExact, F32Scaled) {
+  MMA_SKIP_IF_NO_SIMD();
+  constexpr uint32_t SCALE_A = 240, SCALE_B = 248;
+  auto scaled = [&](const char *label, Fmt fmt, uint32_t m, uint32_t n, uint32_t k, auto ex) {
+    run_case(label, fmt, Fmt::F32, [=](MfmaFixture &fx, uint32_t const_acc) {
+      fx.seed_words(SCALE_A, 4, 0xA5);
+      fx.seed_words(SCALE_B, 4, 0x5A);
+      amdgpu::exec_f32_scaled(*fx.cu, m, n, k, 1, 8, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1,
+                              fx.vbase + ACC, ex, ex, const_acc, 0, 0, 0, fx.vbase + SCALE_A,
+                              fx.vbase + SCALE_B);
+    });
+  };
+  scaled("scaled_fp8_16x16x128", Fmt::FP8, 16, 16, 128, amdgpu::extract_fp8);
+  scaled("scaled_bf8_32x32x64", Fmt::BF8, 32, 32, 64, amdgpu::extract_bf8);
+}
+
+// --- integer i8 MFMA: exact MAC, every dispatched shape ---
+TEST(MfmaSimdExact, I32_i8_AllShapes) {
+  MMA_SKIP_IF_NO_SIMD();
+  const struct {
+    uint32_t m, n, k, b;
+  } shapes[] = {{16, 16, 64, 1}, {32, 32, 32, 1}, {32, 32, 16, 1}, {16, 16, 32, 1},
+                {32, 32, 4, 2},  {16, 16, 4, 4},  {4, 4, 4, 16}};
+  for (auto s : shapes)
+    run_i8("i32_i8", s.m, s.n, s.k, s.b);
+}
+
+// --- f64 MFMA ---
+TEST(MfmaSimdExact, F64_AllShapes) {
+  MMA_SKIP_IF_NO_SIMD();
+  if (util::native<double>::size() <= 1)
+    GTEST_SKIP() << "no native f64 SIMD";
+  const struct {
+    uint32_t m, n, k, b;
+  } shapes[] = {{16, 16, 4, 1}, {4, 4, 4, 4}};
+  for (auto s : shapes)
+    run_case("f64", Fmt::F64, Fmt::F64, [=](MfmaFixture &fx, uint32_t const_acc) {
+      amdgpu::exec_f64(*fx.cu, s.m, s.n, s.k, s.b, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1,
+                       fx.vbase + ACC, const_acc);
+    });
+}

--- a/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
@@ -129,6 +129,20 @@ TEST(MfmaSimdExact, F16Spec_AllShapes) {
   spec(amdgpu::exec_f32_mfma_f16_spec<16, 16, 16>, "spec_f16_16x16x16");
 }
 
+// --- specialized bf16 kernels (constexpr dims + bf16 zero-extend bulk convert) ---
+TEST(MfmaSimdExact, Bf16Spec_AllShapes) {
+  SKIP_IF_NO_SIMD();
+  auto spec = [](auto fn, const char *label) {
+    run_case(label, Fmt::BF16, Fmt::F32, [fn](MfmaFixture &fx, uint32_t const_acc) {
+      fn(*fx.cu, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1, fx.vbase + ACC, const_acc, 0, 0, 0);
+    });
+  };
+  spec(amdgpu::exec_f32_mfma_bf16_spec<16, 16, 32>, "spec_bf16_16x16x32");
+  spec(amdgpu::exec_f32_mfma_bf16_spec<32, 32, 16>, "spec_bf16_32x32x16");
+  spec(amdgpu::exec_f32_mfma_bf16_spec<32, 32, 8>, "spec_bf16_32x32x8");
+  spec(amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16>, "spec_bf16_16x16x16");
+}
+
 // --- specialized f32 kernels ---
 TEST(MfmaSimdExact, F32Spec_AllShapes) {
   SKIP_IF_NO_SIMD();

--- a/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
@@ -143,6 +143,26 @@ TEST(MfmaSimdExact, Bf16Spec_AllShapes) {
   spec(amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16>, "spec_bf16_16x16x16");
 }
 
+// --- specialized fp8/bf8 kernels (constexpr dims + LUT bulk convert), all four
+// A/B format pairs on both dense shapes. The trial modes drive NaN, Inf (bf8),
+// denorm, and max-finite f8 codes through both paths. ---
+TEST(MfmaSimdExact, F8Spec_AllShapes) {
+  SKIP_IF_NO_SIMD();
+  auto spec = [](auto fn, Fmt fmt, const char *label) {
+    run_case(label, fmt, Fmt::F32, [fn](MfmaFixture &fx, uint32_t const_acc) {
+      fn(*fx.cu, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1, fx.vbase + ACC, const_acc, 0, 0, 0);
+    });
+  };
+  spec(amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, true, true>, Fmt::FP8, "spec_fp8_fp8_16x16x32");
+  spec(amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, true, false>, Fmt::FP8, "spec_fp8_bf8_16x16x32");
+  spec(amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, false, true>, Fmt::BF8, "spec_bf8_fp8_16x16x32");
+  spec(amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, false, false>, Fmt::BF8, "spec_bf8_bf8_16x16x32");
+  spec(amdgpu::exec_f32_mfma_f8_spec<32, 32, 16, true, true>, Fmt::FP8, "spec_fp8_fp8_32x32x16");
+  spec(amdgpu::exec_f32_mfma_f8_spec<32, 32, 16, true, false>, Fmt::FP8, "spec_fp8_bf8_32x32x16");
+  spec(amdgpu::exec_f32_mfma_f8_spec<32, 32, 16, false, true>, Fmt::BF8, "spec_bf8_fp8_32x32x16");
+  spec(amdgpu::exec_f32_mfma_f8_spec<32, 32, 16, false, false>, Fmt::BF8, "spec_bf8_bf8_32x32x16");
+}
+
 // --- specialized f32 kernels ---
 TEST(MfmaSimdExact, F32Spec_AllShapes) {
   SKIP_IF_NO_SIMD();

--- a/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/mfma_simd_exact_test.cpp
@@ -185,6 +185,22 @@ TEST(MfmaSimdExact, I32_i8_AllShapes) {
     run_i8("i32_i8", s.m, s.n, s.k, s.b);
 }
 
+// --- specialized i8 kernels (constexpr dims + i8 sign-extend bulk convert) ---
+// The accumulator window is seeded with random words spanning the full int32
+// range, so wrap-around near INT32_MAX/INT32_MIN is exercised on both paths.
+TEST(MfmaSimdExact, I8Spec_AllShapes) {
+  SKIP_IF_NO_SIMD();
+  auto spec = [](auto fn, const char *label) {
+    run_case(label, Fmt::I8, Fmt::I8, [fn](MfmaFixture &fx, uint32_t const_acc) {
+      fn(*fx.cu, fx.vbase + DST, fx.vbase + S0, fx.vbase + S1, fx.vbase + ACC, const_acc);
+    });
+  };
+  spec(amdgpu::exec_i32_mfma_i8_spec<16, 16, 64>, "spec_i8_16x16x64");
+  spec(amdgpu::exec_i32_mfma_i8_spec<32, 32, 32>, "spec_i8_32x32x32");
+  spec(amdgpu::exec_i32_mfma_i8_spec<32, 32, 16>, "spec_i8_32x32x16");
+  spec(amdgpu::exec_i32_mfma_i8_spec<16, 16, 32>, "spec_i8_16x16x32");
+}
+
 // --- f64 MFMA ---
 TEST(MfmaSimdExact, F64_AllShapes) {
   SKIP_IF_NO_SIMD();

--- a/emulation/rocjitsu/tests/simd_correctness/mma_exact_test_support.h
+++ b/emulation/rocjitsu/tests/simd_correctness/mma_exact_test_support.h
@@ -1,0 +1,290 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file mma_exact_test_support.h
+/// @brief Shared fixture for the expensive MFMA/WMMA SIMD-vs-scalar bit-exact
+/// suites (enabled by RJ_ENABLE_EXPENSIVE_CHECKS).
+///
+/// The fused-FMA SIMD path and the non-fused scalar path can only round apart
+/// when an intermediate K-sum actually rounds, so the random generators seed
+/// integer-valued elements that stay exact through every product and partial
+/// sum (max |prod| 64, max K-sum 8192 < 2^24); boundary modes drive the
+/// rounding-free corners directly (NaN, +/-Inf, +/-0, denormals, max-finite
+/// overflow, +1/-1 cancellation). Under those inputs SIMD and scalar must be
+/// bit-identical, and the suites assert word-for-word EXPECT_EQ on the dst.
+
+#pragma once
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+#include "util/data_types.h"
+#include "util/simd.h"
+#include "util/simd_test_hooks.h"
+
+#include <gtest/gtest.h>
+
+#include <bit>
+#include <cstdint>
+#include <functional>
+#include <random>
+#include <vector>
+
+namespace mma_exact {
+
+using namespace rocjitsu;
+
+// Input element formats the executors consume.
+enum class Fmt { F16, BF16, F32, F64, FP8, BF8, RAW4, RAW6, I8 };
+
+// Per-trial seeding pattern.
+enum class Mode {
+  RandomInt,  // small integer-valued elements (exact through every sum)
+  Zeros,      // +0 everywhere
+  SignedZero, // alternating +0 / -0
+  NaN,        // NaN in A, ones in B (skipped for formats without NaN)
+  Inf,        // +/-Inf in A, ones in B (skipped for formats without Inf)
+  Denorm,     // min subnormal everywhere
+  MaxFinite,  // max finite everywhere (sums overflow to Inf identically)
+  Cancel,     // alternating +1 / -1
+};
+
+inline bool fmt_has_nan(Fmt f) { return f != Fmt::RAW4 && f != Fmt::RAW6 && f != Fmt::I8; }
+inline bool fmt_has_inf(Fmt f) {
+  return f == Fmt::F16 || f == Fmt::BF16 || f == Fmt::F32 || f == Fmt::F64 || f == Fmt::BF8;
+}
+inline uint32_t fmt_bits(Fmt f) {
+  switch (f) {
+  case Fmt::F32:
+    return 32;
+  case Fmt::F64:
+    return 64;
+  case Fmt::F16:
+  case Fmt::BF16:
+    return 16;
+  case Fmt::RAW4:
+    return 4;
+  case Fmt::RAW6:
+    return 6;
+  default:
+    return 8;
+  }
+}
+
+// Encode one element for `mode`; `idx` decorrelates alternating patterns and
+// `rng` drives the random-int mode. Returned value is the raw element bits.
+inline uint64_t encode_element(Fmt f, Mode mode, uint32_t idx, std::mt19937 &rng) {
+  auto pick_int = [&](int lo, int hi) {
+    return static_cast<float>(std::uniform_int_distribution<int>(lo, hi)(rng));
+  };
+  float v = 0.0f;
+  switch (mode) {
+  case Mode::RandomInt:
+    v = pick_int(f == Fmt::BF8 ? -4 : -8, f == Fmt::BF8 ? 4 : 7);
+    break;
+  case Mode::Zeros:
+    v = 0.0f;
+    break;
+  case Mode::SignedZero:
+    v = (idx & 1) ? -0.0f : 0.0f;
+    break;
+  case Mode::Cancel:
+    v = (idx & 1) ? -1.0f : 1.0f;
+    break;
+  default:
+    break; // NaN / Inf / Denorm / MaxFinite handled per-format below
+  }
+  switch (f) {
+  case Fmt::F16:
+    if (mode == Mode::NaN)
+      return 0x7E00;
+    if (mode == Mode::Inf)
+      return (idx & 1) ? 0xFC00 : 0x7C00;
+    if (mode == Mode::Denorm)
+      return 0x0001;
+    if (mode == Mode::MaxFinite)
+      return 0x7BFF;
+    return util::f32_to_f16(v);
+  case Fmt::BF16:
+    if (mode == Mode::NaN)
+      return 0x7FC0;
+    if (mode == Mode::Inf)
+      return (idx & 1) ? 0xFF80 : 0x7F80;
+    if (mode == Mode::Denorm)
+      return 0x0001;
+    if (mode == Mode::MaxFinite)
+      return 0x7F7F;
+    return util::f32_to_bf16(v);
+  case Fmt::F32:
+    if (mode == Mode::NaN)
+      return 0x7FC00000u;
+    if (mode == Mode::Inf)
+      return (idx & 1) ? 0xFF800000u : 0x7F800000u;
+    if (mode == Mode::Denorm)
+      return 0x00000001u;
+    if (mode == Mode::MaxFinite)
+      return 0x7F7FFFFFu;
+    return std::bit_cast<uint32_t>(v);
+  case Fmt::F64:
+    if (mode == Mode::NaN)
+      return 0x7FF8000000000000ull;
+    if (mode == Mode::Inf)
+      return (idx & 1) ? 0xFFF0000000000000ull : 0x7FF0000000000000ull;
+    if (mode == Mode::Denorm)
+      return 0x0000000000000001ull;
+    if (mode == Mode::MaxFinite)
+      return 0x7FEFFFFFFFFFFFFFull;
+    return std::bit_cast<uint64_t>(static_cast<double>(v));
+  case Fmt::FP8: // e4m3: NaN 0x7F, no Inf, denorm 0x01, max 0x7E (448)
+    if (mode == Mode::NaN)
+      return 0x7F;
+    if (mode == Mode::Denorm)
+      return 0x01;
+    if (mode == Mode::MaxFinite)
+      return 0x7E;
+    return util::f32_to_fp8_e4m3_rne(v);
+  case Fmt::BF8: // e5m2: NaN 0x7E, Inf 0x7C, denorm 0x01, max 0x7B
+    if (mode == Mode::NaN)
+      return 0x7E;
+    if (mode == Mode::Inf)
+      return (idx & 1) ? 0xFC : 0x7C;
+    if (mode == Mode::Denorm)
+      return 0x01;
+    if (mode == Mode::MaxFinite)
+      return 0x7B;
+    return util::f32_to_bf8_e5m2_rne(v);
+  case Fmt::RAW4: // every e2m1 pattern is small and exact; random bits suffice
+    return (mode == Mode::RandomInt) ? (rng() & 0xF) : (mode == Mode::Zeros ? 0 : (idx * 5) & 0xF);
+  case Fmt::RAW6:
+    return (mode == Mode::RandomInt) ? (rng() & 0x3F)
+                                     : (mode == Mode::Zeros ? 0 : (idx * 11) & 0x3F);
+  case Fmt::I8:
+    if (mode == Mode::MaxFinite)
+      return 0x7F;
+    if (mode == Mode::Denorm)
+      return 0x80; // INT8_MIN: the int analogue of the magnitude corner
+    if (mode == Mode::Cancel)
+      return (idx & 1) ? 0xFF : 0x01;
+    if (mode == Mode::RandomInt)
+      return rng() & 0xFF;
+    return 0;
+  }
+  return 0;
+}
+
+// One CU + one wave; the suite seeds raw VGPR words, so the architecture only
+// matters for wave width (CDNA4 MFMA = wave64, gfx1250 WMMA = wave32).
+struct ExactFixture {
+  static constexpr uint32_t SGPRS = 106;
+  static constexpr uint32_t VGPRS = 256;
+
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  amdgpu::Wavefront *wf = nullptr;
+  uint32_t vbase = 0;
+  uint32_t wf_size;
+
+  explicit ExactFixture(rj_code_arch_t arch, uint32_t wave)
+      : gpu_mem("mma_exact_mem"), l2("mma_exact_l2"), wf_size(wave) {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = arch;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS;
+    cfg.vgprs_per_wf = VGPRS;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_mma_exact", cfg, &gpu_mem, &l2);
+    wf = cu->dispatch_wf(0, 0, SGPRS, VGPRS);
+    if (wf)
+      vbase = wf->vgpr_alloc().base;
+  }
+
+  // Fill `regs` registers with elements of `fmt` in `mode`. 64-bit elements
+  // occupy (lo,hi) register pairs; `regs` must be even for those.
+  void seed(uint32_t off, uint32_t regs, Fmt fmt, Mode mode, uint32_t seed) {
+    std::mt19937 rng(seed);
+    const uint32_t bits = fmt_bits(fmt);
+    uint32_t idx = 0;
+    if (bits == 64) {
+      for (uint32_t reg = 0; reg + 1 < regs; reg += 2)
+        for (uint32_t lane = 0; lane < wf_size; ++lane) {
+          uint64_t v = encode_element(fmt, mode, idx++, rng);
+          cu->write_vgpr(vbase + off + reg, lane, static_cast<uint32_t>(v));
+          cu->write_vgpr(vbase + off + reg + 1, lane, static_cast<uint32_t>(v >> 32));
+        }
+      return;
+    }
+    for (uint32_t reg = 0; reg < regs; ++reg)
+      for (uint32_t lane = 0; lane < wf_size; ++lane) {
+        uint64_t word = 0;
+        for (uint32_t pos = 0; pos < 32; pos += bits)
+          word |= encode_element(fmt, mode, idx++, rng) << pos;
+        cu->write_vgpr(vbase + off + reg, lane, static_cast<uint32_t>(word));
+      }
+  }
+
+  void seed_words(uint32_t off, uint32_t regs, uint32_t seed) {
+    std::mt19937 rng(seed);
+    for (uint32_t reg = 0; reg < regs; ++reg)
+      for (uint32_t lane = 0; lane < wf_size; ++lane)
+        cu->write_vgpr(vbase + off + reg, lane, rng());
+  }
+
+  std::vector<uint32_t> snapshot(uint32_t off, uint32_t regs) const {
+    std::vector<uint32_t> out(static_cast<size_t>(regs) * wf_size);
+    for (uint32_t reg = 0; reg < regs; ++reg)
+      for (uint32_t lane = 0; lane < wf_size; ++lane)
+        out[static_cast<size_t>(reg) * wf_size + lane] = cu->read_vgpr(vbase + off + reg, lane);
+    return out;
+  }
+};
+
+// Run `kernel` forced-scalar then SIMD over identical pre-seeded state and
+// assert the dst window matches bit-for-bit. `reseed_acc` restores the
+// accumulator window between runs (the kernels write dst == acc in-place for
+// the WMMA suites).
+inline void expect_bit_exact(const char *label, Mode mode, ExactFixture &fx,
+                             const std::function<void()> &reseed_acc,
+                             const std::function<void()> &kernel, uint32_t dst_off,
+                             uint32_t dst_regs) {
+  reseed_acc();
+  util::set_force_scalar_for_testing(true);
+  kernel();
+  util::set_force_scalar_for_testing(false);
+  auto scalar = fx.snapshot(dst_off, dst_regs);
+
+  reseed_acc();
+  kernel();
+  auto simd = fx.snapshot(dst_off, dst_regs);
+
+  for (size_t i = 0; i < scalar.size(); ++i)
+    ASSERT_EQ(scalar[i], simd[i]) << label << " mode=" << static_cast<int>(mode)
+                                  << ": SIMD diverges from scalar at word " << i << " (scalar=0x"
+                                  << std::hex << scalar[i] << " simd=0x" << simd[i] << ")";
+}
+
+// All modes applicable to `fmt`, plus 4 random seeds.
+inline std::vector<std::pair<Mode, uint32_t>> trials_for(Fmt fmt) {
+  std::vector<std::pair<Mode, uint32_t>> t = {
+      {Mode::RandomInt, 11}, {Mode::RandomInt, 22}, {Mode::RandomInt, 33},
+      {Mode::RandomInt, 44}, {Mode::Zeros, 0},      {Mode::SignedZero, 0},
+      {Mode::Denorm, 0},     {Mode::MaxFinite, 0},  {Mode::Cancel, 0},
+  };
+  if (fmt_has_nan(fmt))
+    t.push_back({Mode::NaN, 0});
+  if (fmt_has_inf(fmt))
+    t.push_back({Mode::Inf, 0});
+  return t;
+}
+
+#define MMA_SKIP_IF_NO_SIMD()                                                                      \
+  if constexpr (!util::has_stdx_simd) {                                                            \
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";                    \
+  } else if (util::native<float>::size() <= 1) {                                                   \
+    GTEST_SKIP() << "host native_simd width is 1 — SIMD path never taken";                         \
+  }
+
+} // namespace mma_exact

--- a/emulation/rocjitsu/tests/simd_correctness/mma_exact_test_support.h
+++ b/emulation/rocjitsu/tests/simd_correctness/mma_exact_test_support.h
@@ -15,6 +15,7 @@
 
 #pragma once
 
+#include "../mma_test_util.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
@@ -279,12 +280,5 @@ inline std::vector<std::pair<Mode, uint32_t>> trials_for(Fmt fmt) {
     t.push_back({Mode::Inf, 0});
   return t;
 }
-
-#define MMA_SKIP_IF_NO_SIMD()                                                                      \
-  if constexpr (!util::has_stdx_simd) {                                                            \
-    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";                    \
-  } else if (util::native<float>::size() <= 1) {                                                   \
-    GTEST_SKIP() << "host native_simd width is 1 — SIMD path never taken";                         \
-  }
 
 } // namespace mma_exact

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_cvt_pk_f32_rdna_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_cvt_pk_f32_rdna_correctness_test.cpp
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file vop3_cvt_pk_f32_rdna_correctness_test.cpp
+/// @brief Value-correctness check for v_cvt_pk_i16_f32 / v_cvt_pk_u16_f32, two
+/// FLOAT-input packed converts that are RDNA3+ only (no CDNA4 decode path).
+///
+/// Regression guard for the SIMD fast-path bug fixed alongside this file: these
+/// ops were briefly routed through the integer VOP3 binary glue
+/// (try_execute_binary_vop3_simd<uint32_t>), which feeds the functor the raw
+/// 32-bit lane *bits*. The functor then clamped the float's bit pattern as an
+/// int32 to [-32768, 32767] — a wrong result for essentially every finite input
+/// (e.g. 40000.0f packed to 32767 instead of 40000), and the u16 form silently
+/// used the signed i16 range. They are now (correctly) left on the scalar path:
+///   v_cvt_pk_i16_f32: lane = (uint16_t)(int16_t)clamp(f, -32768, 32767)
+///   v_cvt_pk_u16_f32: lane = (uint16_t)clamp(f, 0, 65535)
+/// with src0 -> low half, src1 -> high half of the dst.
+///
+/// Each case is executed twice in the same process (force-scalar and force-SIMD
+/// gate) and BOTH runs are asserted equal to an independent golden reference, so
+/// any future re-introduction of a mismatched SIMD functor is caught. The CU and
+/// decoder are built for RDNA3; VOP3 encoding marker is 0x35<<26.
+
+#include "util/simd_test_hooks.h"
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/execute_shared.h"
+#include "rocjitsu/isa/decoder.h"
+#include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include "util/simd.h"
+
+#include <algorithm>
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+
+namespace {
+
+using namespace rocjitsu;
+
+constexpr uint32_t WF_SIZE = 32; // RDNA3 wave32
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr uint32_t kDstVgpr = 4;
+constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
+
+// RDNA3 VOP3 opcodes (from rdna3/test_encodings.h: 0xD7060000 / 0xD7070000).
+constexpr uint32_t kOpCvtPkI16F32 = 774;
+constexpr uint32_t kOpCvtPkU16F32 = 775;
+
+// RDNA3 VOP3 (encoding[31:26]=0x35). word0 = vdst[7:0] | op[25:16] | enc[31:26];
+// word1 = src0[8:0] | src1[17:9] | src2[26:18]. No modifiers used here.
+constexpr void rdna3_vop3_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                                 uint32_t words[2]) {
+  words[0] = (vdst & 0xFF) | ((op & 0x3FF) << 16) | (0x35u << 26);
+  words[1] = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9);
+}
+
+// Finite inputs covering: in-range, fractional (truncation), the signed/unsigned
+// boundaries, over/underflow, and negatives. Deliberately includes 40000.0f —
+// the value that exposed the original bug (clamps to 40000 for u16, but the
+// broken int-domain SIMD path produced 32767).
+const std::array<float, 16> kInputs = {{
+    0.0f,
+    1.0f,
+    100.5f,
+    40000.0f,
+    70000.0f,
+    -5.0f,
+    -40000.0f,
+    32767.0f,
+    32768.0f,
+    65535.0f,
+    65536.0f,
+    12345.75f,
+    255.5f,
+    1000.0f,
+    -1.0f,
+    60000.0f,
+}};
+
+uint16_t cvt_i16(float f) {
+  return static_cast<uint16_t>(static_cast<int16_t>(std::clamp(f, -32768.0f, 32767.0f)));
+}
+uint16_t cvt_u16(float f) { return static_cast<uint16_t>(std::clamp(f, 0.0f, 65535.0f)); }
+
+// Golden: src0 (f0) -> low 16, src1 (f1) -> high 16.
+uint32_t golden(bool is_u16, float f0, float f1) {
+  uint16_t lo = is_u16 ? cvt_u16(f0) : cvt_i16(f0);
+  uint16_t hi = is_u16 ? cvt_u16(f1) : cvt_i16(f1);
+  return (static_cast<uint32_t>(hi) << 16) | static_cast<uint32_t>(lo);
+}
+
+struct Fixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  std::unique_ptr<Decoder> decoder;
+  amdgpu::Wavefront *wf = nullptr;
+
+  Fixture() : gpu_mem("cvt_pk_f32_mem"), l2("cvt_pk_f32_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_RDNA3;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
+    cu = amdgpu::ComputeUnitCore::create("cu_cvt_pk_f32", cfg, &gpu_mem, &l2);
+    decoder = Decoder::create(ROCJITSU_CODE_ARCH_RDNA3);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+  }
+
+  float f0_for(uint32_t lane) const { return kInputs[lane % kInputs.size()]; }
+  float f1_for(uint32_t lane) const { return kInputs[(lane + 7) % kInputs.size()]; }
+
+  void seed(uint64_t exec) {
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      cu->write_vgpr(vb + 0, lane, std::bit_cast<uint32_t>(f0_for(lane)));
+      cu->write_vgpr(vb + 1, lane, std::bit_cast<uint32_t>(f1_for(lane)));
+      cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    wf->set_exec(exec);
+  }
+
+  std::array<uint32_t, WF_SIZE> run(Instruction *inst, uint64_t exec) {
+    seed(exec);
+    cu->execute_instruction(inst, *wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    uint32_t vb = wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = cu->read_vgpr(vb + kDstVgpr, lane);
+    return out;
+  }
+};
+
+// Restores the process force-scalar gate on scope exit.
+struct ForceScalarGuard {
+  bool orig;
+  ForceScalarGuard() : orig(util::force_scalar()) {}
+  ~ForceScalarGuard() { util::set_force_scalar_for_testing(orig); }
+};
+
+void check_op(uint32_t opcode, bool is_u16, uint64_t exec) {
+  ForceScalarGuard gate_guard;
+  const char *name = is_u16 ? "v_cvt_pk_u16_f32" : "v_cvt_pk_i16_f32";
+
+  auto run_mode = [&](bool force_scalar) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    rdna3_vop3_encode(opcode, kDstVgpr, /*src0=*/256, /*src1=*/257, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << name << " decode failed";
+    auto out = fx.run(inst, exec);
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  Fixture ref; // only used for the per-lane input mapping
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (!active) {
+      EXPECT_EQ(scalar_out[lane], DST_SENTINEL) << name << ": clobbered inactive lane " << lane;
+      EXPECT_EQ(simd_out[lane], DST_SENTINEL) << name << ": clobbered inactive lane " << lane;
+      continue;
+    }
+    const uint32_t want = golden(is_u16, ref.f0_for(lane), ref.f1_for(lane));
+    EXPECT_EQ(scalar_out[lane], want) << name << " (scalar) lane " << lane
+                                      << " f0=" << ref.f0_for(lane) << " f1=" << ref.f1_for(lane);
+    EXPECT_EQ(simd_out[lane], want) << name << " (simd) lane " << lane << " f0=" << ref.f0_for(lane)
+                                    << " f1=" << ref.f1_for(lane);
+  }
+}
+
+TEST(Vop3CvtPkF32RdnaCorrectness, I16_FullExec) {
+  check_op(kOpCvtPkI16F32, /*is_u16=*/false, /*exec=*/0xFFFFFFFFULL);
+}
+TEST(Vop3CvtPkF32RdnaCorrectness, I16_PartialExec) {
+  check_op(kOpCvtPkI16F32, /*is_u16=*/false, /*exec=*/0xA5A58001ULL);
+}
+TEST(Vop3CvtPkF32RdnaCorrectness, U16_FullExec) {
+  check_op(kOpCvtPkU16F32, /*is_u16=*/true, /*exec=*/0xFFFFFFFFULL);
+}
+TEST(Vop3CvtPkF32RdnaCorrectness, U16_PartialExec) {
+  check_op(kOpCvtPkU16F32, /*is_u16=*/true, /*exec=*/0xA5A58001ULL);
+}
+
+// Pin the exact value that exposed the bug: 40000.0f converts to 40000 for u16
+// (clamp [0, 65535]) but to 32767 for i16 (clamp [-32768, 32767]). The broken
+// SIMD path produced 32767 for BOTH; assert they now differ as expected.
+TEST(Vop3CvtPkF32RdnaCorrectness, BugMarker_40000) {
+  ForceScalarGuard gate_guard;
+  for (bool force_scalar : {true, false}) {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    ASSERT_NE(fx.cu, nullptr);
+    uint32_t vb = fx.wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      fx.cu->write_vgpr(vb + 0, lane, std::bit_cast<uint32_t>(40000.0f));
+      fx.cu->write_vgpr(vb + 1, lane, std::bit_cast<uint32_t>(40000.0f));
+      fx.cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    fx.wf->set_exec(0xFFFFFFFFULL);
+
+    auto exec_op = [&](uint32_t opcode) -> uint32_t {
+      uint32_t words[4] = {0u, 0u, 0u, 0u};
+      rdna3_vop3_encode(opcode, kDstVgpr, 256, 257, words);
+      Instruction *inst = fx.decoder->decode(words);
+      EXPECT_NE(inst, nullptr);
+      fx.cu->execute_instruction(inst, *fx.wf);
+      uint32_t r = fx.cu->read_vgpr(vb + kDstVgpr, 0);
+      delete inst;
+      return r;
+    };
+
+    // u16: 40000 in both halves -> 0x9C40_9C40.
+    EXPECT_EQ(exec_op(kOpCvtPkU16F32), 0x9C409C40u)
+        << "force_scalar=" << force_scalar << ": u16 must clamp to [0, 65535]";
+    // i16: 40000 saturates to 32767 (0x7FFF) in both halves -> 0x7FFF_7FFF.
+    EXPECT_EQ(exec_op(kOpCvtPkI16F32), 0x7FFF7FFFu)
+        << "force_scalar=" << force_scalar << ": i16 must clamp to [-32768, 32767]";
+  }
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_cvt_pk_f32_rdna_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_cvt_pk_f32_rdna_correctness_test.cpp
@@ -16,6 +16,14 @@
 ///   v_cvt_pk_u16_f32: lane = (uint16_t)clamp(f, 0, 65535)
 /// with src0 -> low half, src1 -> high half of the dst.
 ///
+/// This file also pins the deliberate codegen QUIRK in the *normalized* packs:
+/// RDNA spells them v_cvt_pk_norm_{i16,u16}_f32 (underscore), and the underscore
+/// i16 form is generated with the UNSIGNED u16 lambda — clamp(f * 65535, 0,
+/// 65535) — despite "i16" in its name (see simd_codegen.py "QUIRK"). The
+/// no-underscore signed spelling (v_cvt_pknorm_i16_f32) is CDNA-only and not
+/// decodable here. The norm cases below lock the underscore form to u16 so a
+/// future "the name says i16" change is caught on both the scalar and SIMD path.
+///
 /// Each case is executed twice in the same process (force-scalar and force-SIMD
 /// gate) and BOTH runs are asserted equal to an independent golden reference, so
 /// any future re-introduction of a mismatched SIMD functor is caught. The CU and
@@ -37,8 +45,10 @@
 #include <algorithm>
 #include <array>
 #include <bit>
+#include <cmath>
 #include <cstdint>
 #include <gtest/gtest.h>
+#include <limits>
 #include <memory>
 
 namespace {
@@ -54,6 +64,10 @@ constexpr uint32_t DST_SENTINEL = 0xCDCDCDCDu;
 // RDNA3 VOP3 opcodes (from rdna3/test_encodings.h: 0xD7060000 / 0xD7070000).
 constexpr uint32_t kOpCvtPkI16F32 = 774;
 constexpr uint32_t kOpCvtPkU16F32 = 775;
+// Normalized i16 pack (rdna3/test_encodings.h: 0xD7210000). Note the underscore
+// spelling — RDNA exposes v_cvt_pk_norm_i16_f32, which despite its name is
+// generated with the u16-normalized lambda (the QUIRK we pin below).
+constexpr uint32_t kOpCvtPkNormI16F32 = 801; // 0xD7210000 >> 16 & 0x3FF
 
 // RDNA3 VOP3 (encoding[31:26]=0x35). word0 = vdst[7:0] | op[25:16] | enc[31:26];
 // word1 = src0[8:0] | src1[17:9] | src2[26:18]. No modifiers used here.
@@ -97,6 +111,47 @@ uint32_t golden(bool is_u16, float f0, float f1) {
   uint16_t hi = is_u16 ? cvt_u16(f1) : cvt_i16(f1);
   return (static_cast<uint32_t>(hi) << 16) | static_cast<uint32_t>(lo);
 }
+
+// --- Normalized pack-convert (the underscore-spelling u16 quirk) ------------
+// Both arch-generated lambdas scale by K, clamp, map NaN->0, then truncate
+// toward zero (mirrors execute_shared.h / util::cvt_pknorm_*_f32_simd). The
+// QUIRK: v_cvt_pk_norm_i16_f32 (underscore) uses the UNSIGNED form below.
+uint16_t cvt_norm_u16(float f) {
+  if (std::isnan(f))
+    return 0;
+  return static_cast<uint16_t>(std::clamp(f * 65535.0f, 0.0f, 65535.0f));
+}
+// What a (wrong) signed-i16 reading would produce — used only to show the two
+// spellings diverge, never as the expected result for the underscore form.
+uint16_t cvt_norm_i16_wrong(float f) {
+  if (std::isnan(f))
+    return 0;
+  return static_cast<uint16_t>(static_cast<int16_t>(std::clamp(f * 32767.0f, -32768.0f, 32767.0f)));
+}
+uint32_t golden_norm_u16(float f0, float f1) {
+  return (static_cast<uint32_t>(cvt_norm_u16(f1)) << 16) | static_cast<uint32_t>(cvt_norm_u16(f0));
+}
+// The value the underscore form must NOT produce (signed-i16 reading).
+uint32_t golden_norm_i16_wrong(float f0, float f1) {
+  return (static_cast<uint32_t>(cvt_norm_i16_wrong(f1)) << 16) |
+         static_cast<uint32_t>(cvt_norm_i16_wrong(f0));
+}
+
+// Normalized-domain inputs: in-range, fractional/truncation, the i16/u16
+// divergence points (±1.0), out-of-range (clamped), negatives (-> 0 under u16),
+// and NaN (-> 0).
+const std::array<float, 8> kNormInputs = {{
+    0.0f,
+    1.0f,
+    0.5f,
+    -1.0f,
+    -0.5f,
+    2.0f,
+    0.25f,
+    std::numeric_limits<float>::quiet_NaN(),
+}};
+float norm_f0_for(uint32_t lane) { return kNormInputs[lane % kNormInputs.size()]; }
+float norm_f1_for(uint32_t lane) { return kNormInputs[(lane + 3) % kNormInputs.size()]; }
 
 struct Fixture {
   amdgpu::GpuMemory gpu_mem;
@@ -232,6 +287,101 @@ TEST(Vop3CvtPkF32RdnaCorrectness, BugMarker_40000) {
     // i16: 40000 saturates to 32767 (0x7FFF) in both halves -> 0x7FFF_7FFF.
     EXPECT_EQ(exec_op(kOpCvtPkI16F32), 0x7FFF7FFFu)
         << "force_scalar=" << force_scalar << ": i16 must clamp to [-32768, 32767]";
+  }
+}
+
+// Drives v_cvt_pk_norm_i16_f32 in both gate modes against the UNSIGNED golden.
+// Seeds the norm input set directly (Fixture::seed feeds the non-norm kInputs).
+void check_cvt_pk_norm_i16(uint64_t exec) {
+  ForceScalarGuard gate_guard;
+  const char *name = "v_cvt_pk_norm_i16_f32";
+
+  auto run_mode = [&](bool force_scalar) -> std::array<uint32_t, WF_SIZE> {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    EXPECT_NE(fx.cu, nullptr);
+    EXPECT_NE(fx.wf, nullptr);
+    uint32_t vb = fx.wf->vgpr_alloc().base;
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+      fx.cu->write_vgpr(vb + 0, lane, std::bit_cast<uint32_t>(norm_f0_for(lane)));
+      fx.cu->write_vgpr(vb + 1, lane, std::bit_cast<uint32_t>(norm_f1_for(lane)));
+      fx.cu->write_vgpr(vb + kDstVgpr, lane, DST_SENTINEL);
+    }
+    fx.wf->set_exec(exec);
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    rdna3_vop3_encode(kOpCvtPkNormI16F32, kDstVgpr, /*src0=*/256, /*src1=*/257, words);
+    Instruction *inst = fx.decoder->decode(words);
+    EXPECT_NE(inst, nullptr) << name << " decode failed";
+    fx.cu->execute_instruction(inst, *fx.wf);
+    std::array<uint32_t, WF_SIZE> out{};
+    for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+      out[lane] = fx.cu->read_vgpr(vb + kDstVgpr, lane);
+    delete inst;
+    return out;
+  };
+
+  const auto scalar_out = run_mode(/*force_scalar=*/true);
+  const auto simd_out = run_mode(/*force_scalar=*/false);
+
+  for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+    const bool active = (exec >> lane) & 1ULL;
+    if (!active) {
+      EXPECT_EQ(scalar_out[lane], DST_SENTINEL) << name << ": clobbered inactive lane " << lane;
+      EXPECT_EQ(simd_out[lane], DST_SENTINEL) << name << ": clobbered inactive lane " << lane;
+      continue;
+    }
+    const uint32_t want = golden_norm_u16(norm_f0_for(lane), norm_f1_for(lane));
+    EXPECT_EQ(scalar_out[lane], want) << name << " (scalar) lane " << lane;
+    EXPECT_EQ(simd_out[lane], want) << name << " (simd) lane " << lane;
+  }
+}
+
+TEST(Vop3CvtPkF32RdnaCorrectness, NormI16_UsesUnsignedU16_FullExec) {
+  check_cvt_pk_norm_i16(/*exec=*/0xFFFFFFFFULL);
+}
+TEST(Vop3CvtPkF32RdnaCorrectness, NormI16_UsesUnsignedU16_PartialExec) {
+  check_cvt_pk_norm_i16(/*exec=*/0xA5A58001ULL);
+}
+
+// Pin the quirk at the values where signed-i16 and unsigned-u16 normalization
+// diverge: +1.0 -> 0xFFFF under u16 (vs 0x7FFF under i16); -1.0 -> 0x0000 under
+// u16 (vs 0x8001 under i16). The underscore spelling MUST produce the u16
+// result. If someone "corrects" the codegen to signed i16, these flip and fail.
+TEST(Vop3CvtPkF32RdnaCorrectness, NormI16_QuirkMarker) {
+  ForceScalarGuard gate_guard;
+  for (bool force_scalar : {true, false}) {
+    util::set_force_scalar_for_testing(force_scalar);
+    Fixture fx;
+    ASSERT_NE(fx.cu, nullptr);
+    uint32_t vb = fx.wf->vgpr_alloc().base;
+    // lane 0: (+1.0, +1.0) -> both halves 0xFFFF; lane 1: (-1.0, -1.0) -> 0.
+    fx.cu->write_vgpr(vb + 0, 0, std::bit_cast<uint32_t>(1.0f));
+    fx.cu->write_vgpr(vb + 1, 0, std::bit_cast<uint32_t>(1.0f));
+    fx.cu->write_vgpr(vb + 0, 1, std::bit_cast<uint32_t>(-1.0f));
+    fx.cu->write_vgpr(vb + 1, 1, std::bit_cast<uint32_t>(-1.0f));
+    fx.cu->write_vgpr(vb + kDstVgpr, 0, DST_SENTINEL);
+    fx.cu->write_vgpr(vb + kDstVgpr, 1, DST_SENTINEL);
+    fx.wf->set_exec(0x3ULL);
+
+    uint32_t words[4] = {0u, 0u, 0u, 0u};
+    rdna3_vop3_encode(kOpCvtPkNormI16F32, kDstVgpr, 256, 257, words);
+    Instruction *inst = fx.decoder->decode(words);
+    ASSERT_NE(inst, nullptr);
+    fx.cu->execute_instruction(inst, *fx.wf);
+    const uint32_t lane0 = fx.cu->read_vgpr(vb + kDstVgpr, 0);
+    const uint32_t lane1 = fx.cu->read_vgpr(vb + kDstVgpr, 1);
+    delete inst;
+
+    EXPECT_EQ(lane0, 0xFFFFFFFFu)
+        << "force_scalar=" << force_scalar
+        << ": v_cvt_pk_norm_i16_f32 must use UNSIGNED u16 (+1.0 -> 0xFFFF, not 0x7FFF)";
+    EXPECT_EQ(lane1, 0x00000000u) << "force_scalar=" << force_scalar
+                                  << ": negatives clamp to 0 under u16 normalization";
+    // Sanity: the signed-i16 reading we are guarding against differs at both lanes.
+    EXPECT_NE(lane0, golden_norm_i16_wrong(1.0f, 1.0f))
+        << "i16 reading leaked into the underscore spelling";
+    EXPECT_NE(lane1, golden_norm_i16_wrong(-1.0f, -1.0f))
+        << "i16 reading leaked into the underscore spelling";
   }
 }
 

--- a/emulation/rocjitsu/tests/simd_correctness/wmma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/wmma_simd_exact_test.cpp
@@ -159,6 +159,40 @@ TEST(WmmaSimdExact, F8Dense) {
   }
 }
 
+// --- specialized dense fp8/bf8 kernels (constexpr dims + LUT bulk convert):
+// all four A/B format pairs, K=64 and K=128, f32 and f16 output. ---
+TEST(WmmaSimdExact, F8SpecDense) {
+  SKIP_IF_NO_SIMD();
+  auto spec_f32 = [](auto fn, Fmt fmt, const char *label) {
+    run_case(label, fmt, Fmt::F32, [fn](WmmaFixture &fx, uint32_t ca) {
+      fn(*fx.cu, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1, fx.vbase + ACC, ca);
+    });
+  };
+  auto spec_f16 = [](auto fn, Fmt fmt, const char *label) {
+    run_case(label, fmt, Fmt::F16, [fn](WmmaFixture &fx, uint32_t ca) {
+      fn(*fx.cu, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1, fx.vbase + ACC, ca);
+    });
+  };
+  spec_f32(amdgpu::exec_wmma_f32_f8_spec<16, 16, 64, true, true>, Fmt::FP8, "spec_f32_fp8_fp8_k64");
+  spec_f32(amdgpu::exec_wmma_f32_f8_spec<16, 16, 64, true, false>, Fmt::FP8,
+           "spec_f32_fp8_bf8_k64");
+  spec_f32(amdgpu::exec_wmma_f32_f8_spec<16, 16, 64, false, true>, Fmt::BF8,
+           "spec_f32_bf8_fp8_k64");
+  spec_f32(amdgpu::exec_wmma_f32_f8_spec<16, 16, 64, false, false>, Fmt::BF8,
+           "spec_f32_bf8_bf8_k64");
+  spec_f32(amdgpu::exec_wmma_f32_f8_spec<16, 16, 128, true, true>, Fmt::FP8,
+           "spec_f32_fp8_fp8_k128");
+  spec_f32(amdgpu::exec_wmma_f32_f8_spec<16, 16, 128, false, false>, Fmt::BF8,
+           "spec_f32_bf8_bf8_k128");
+  spec_f16(amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, true, true>, Fmt::FP8, "spec_f16_fp8_fp8_k64");
+  spec_f16(amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, false, false>, Fmt::BF8,
+           "spec_f16_bf8_bf8_k64");
+  spec_f16(amdgpu::exec_wmma_f16_f8_spec<16, 16, 128, true, false>, Fmt::FP8,
+           "spec_f16_fp8_bf8_k128");
+  spec_f16(amdgpu::exec_wmma_f16_f8_spec<16, 16, 128, false, true>, Fmt::BF8,
+           "spec_f16_bf8_fp8_k128");
+}
+
 // --- sparse f16/fp8 SWMMAC ---
 TEST(WmmaSimdExact, Sparse) {
   SKIP_IF_NO_SIMD();

--- a/emulation/rocjitsu/tests/simd_correctness/wmma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/wmma_simd_exact_test.cpp
@@ -202,6 +202,53 @@ TEST(WmmaSimdExact, I32) {
   });
 }
 
+// --- specialized dense iu8 kernel: all sign combos, clamp on and off ---
+TEST(WmmaSimdExact, I32Iu8Spec) {
+  SKIP_IF_NO_SIMD();
+  for (bool clamp : {false, true})
+    for (bool a_signed : {false, true})
+      for (bool b_signed : {false, true})
+        run_case("wmma_i32_16x16x64_iu8_spec", Fmt::I8, Fmt::I8, [=](WmmaFixture &fx, uint32_t ca) {
+          amdgpu::exec_wmma_i32_16x16x64_iu8(*fx.cu, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                                             fx.vbase + ACC, a_signed, b_signed, clamp, ca);
+        });
+}
+
+// --- specialized dense iu8 kernel: saturation corners ---
+// Accumulator seeded just below INT32_MAX / just above INT32_MIN so the i64
+// add crosses the int32 boundary: with clamp it must saturate, without it
+// wrap, identically to the scalar reference.
+TEST(WmmaSimdExact, I32Iu8SpecSaturation) {
+  SKIP_IF_NO_SIMD();
+  struct Corner {
+    uint32_t acc_word;
+    Mode a_mode; // sum direction picked via A pattern: 0x7F = up, 0x80 = down
+  };
+  const Corner corners[] = {{0x7FFFFF00u, Mode::MaxFinite}, {0x80000100u, Mode::Denorm}};
+  for (auto c : corners)
+    for (bool clamp : {false, true}) {
+      WmmaFixture fx;
+      ASSERT_NE(fx.wf, nullptr);
+      fx.seed(S0, IN_REGS, Fmt::I8, c.a_mode, 1);        // A: all 0x7F or all 0x80 (signed -128)
+      fx.seed(S1, IN_REGS, Fmt::I8, Mode::MaxFinite, 2); // B: all 0x7F
+      auto reseed_acc = [&] {
+        for (uint32_t reg = 0; reg < ACC_REGS; ++reg)
+          for (uint32_t lane = 0; lane < WF; ++lane)
+            fx.cu->write_vgpr(fx.vbase + ACC + reg, lane, c.acc_word);
+      };
+      expect_bit_exact(
+          "wmma_i32_16x16x64_iu8_spec_sat", c.a_mode, fx, reseed_acc,
+          [&] {
+            amdgpu::exec_wmma_i32_16x16x64_iu8(*fx.cu, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                                               fx.vbase + ACC, /*a_signed=*/true,
+                                               /*b_signed=*/false, clamp, amdgpu::ACC_FROM_VGPR);
+          },
+          ACC, ACC_REGS);
+      if (testing::Test::HasFatalFailure())
+        return;
+    }
+}
+
 // --- mixed-format dense (fp4/fp6/bf6 paths) and fp4 32x16 shape ---
 TEST(WmmaSimdExact, MixedFmt) {
   SKIP_IF_NO_SIMD();

--- a/emulation/rocjitsu/tests/simd_correctness/wmma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/wmma_simd_exact_test.cpp
@@ -182,15 +182,27 @@ TEST(WmmaSimdExact, F8SpecDense) {
            "spec_f32_bf8_bf8_k64");
   spec_f32(amdgpu::exec_wmma_f32_f8_spec<16, 16, 128, true, true>, Fmt::FP8,
            "spec_f32_fp8_fp8_k128");
+  spec_f32(amdgpu::exec_wmma_f32_f8_spec<16, 16, 128, true, false>, Fmt::FP8,
+           "spec_f32_fp8_bf8_k128");
+  spec_f32(amdgpu::exec_wmma_f32_f8_spec<16, 16, 128, false, true>, Fmt::BF8,
+           "spec_f32_bf8_fp8_k128");
   spec_f32(amdgpu::exec_wmma_f32_f8_spec<16, 16, 128, false, false>, Fmt::BF8,
            "spec_f32_bf8_bf8_k128");
   spec_f16(amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, true, true>, Fmt::FP8, "spec_f16_fp8_fp8_k64");
+  spec_f16(amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, true, false>, Fmt::FP8,
+           "spec_f16_fp8_bf8_k64");
+  spec_f16(amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, false, true>, Fmt::BF8,
+           "spec_f16_bf8_fp8_k64");
   spec_f16(amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, false, false>, Fmt::BF8,
            "spec_f16_bf8_bf8_k64");
+  spec_f16(amdgpu::exec_wmma_f16_f8_spec<16, 16, 128, true, true>, Fmt::FP8,
+           "spec_f16_fp8_fp8_k128");
   spec_f16(amdgpu::exec_wmma_f16_f8_spec<16, 16, 128, true, false>, Fmt::FP8,
            "spec_f16_fp8_bf8_k128");
   spec_f16(amdgpu::exec_wmma_f16_f8_spec<16, 16, 128, false, true>, Fmt::BF8,
            "spec_f16_bf8_fp8_k128");
+  spec_f16(amdgpu::exec_wmma_f16_f8_spec<16, 16, 128, false, false>, Fmt::BF8,
+           "spec_f16_bf8_bf8_k128");
 }
 
 // --- sparse f16/fp8 SWMMAC ---

--- a/emulation/rocjitsu/tests/simd_correctness/wmma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/wmma_simd_exact_test.cpp
@@ -125,6 +125,14 @@ TEST(WmmaSimdExact, Bf16) {
     amdgpu::exec_wmma_bf16(*fx.cu, 16, 16, 32, 16, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
                            fx.vbase + ACC, amdgpu::extract_bf16, amdgpu::extract_bf16, ca);
   });
+  run_case("wmma_f32_16x16x32_bf16_spec", Fmt::BF16, Fmt::F32, [](WmmaFixture &fx, uint32_t ca) {
+    amdgpu::exec_wmma_f32_16x16x32_bf16(*fx.cu, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                                        fx.vbase + ACC, ca);
+  });
+  run_case("wmma_bf16_16x16x32_bf16_spec", Fmt::BF16, Fmt::BF16, [](WmmaFixture &fx, uint32_t ca) {
+    amdgpu::exec_wmma_bf16_spec<16, 16, 32>(*fx.cu, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                                            fx.vbase + ACC, ca);
+  });
   run_sparse_f32("swmmac_f32_16x16x64_bf16", Fmt::BF16, 64, 16, amdgpu::extract_bf16,
                  amdgpu::extract_bf16);
   run_case("swmmac_bf16_16x16x64_bf16", Fmt::BF16, Fmt::BF16, [](WmmaFixture &fx, uint32_t ca) {

--- a/emulation/rocjitsu/tests/simd_correctness/wmma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/wmma_simd_exact_test.cpp
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file wmma_simd_exact_test.cpp
+/// @brief Expensive bit-exact SIMD-vs-scalar checks for every gfx1250
+/// WMMA/SWMMAC execute kernel and shape (dense, sparse, packed16, i32, mixed,
+/// scaled, specialized). Built only with -DRJ_ENABLE_EXPENSIVE_CHECKS=ON.
+///
+/// Same scheme as the MFMA suite: identical pre-seeded VGPR state through the
+/// forced-scalar path then the SIMD path, dst compared word for word, inputs
+/// rounding-free (see mma_exact_test_support.h). The WMMA kernels accumulate
+/// in-place (dst == acc), so the accumulator window is reseeded before each
+/// run.
+
+#include "mma_exact_test_support.h"
+
+namespace {
+
+using namespace rocjitsu;
+using namespace mma_exact;
+
+constexpr uint32_t WF = 32;
+constexpr uint32_t S0 = 0, S1 = 32, ACC = 64, INDEX = 96;
+constexpr uint32_t IN_REGS = 16, ACC_REGS = 8, INDEX_REGS = 4;
+constexpr uint32_t INDEX_ENTRIES = 16, INDEX_KEY = 0;
+constexpr uint32_t CONST_ONE = 0x3F800000u;
+constexpr uint32_t SCALE_A = 100, SCALE_B = 104;
+
+struct WmmaFixture : ExactFixture {
+  WmmaFixture() : ExactFixture(ROCJITSU_CODE_ARCH_GFX1250, WF) {}
+};
+
+// Drive one (kernel, fmt) case across all trial modes and both accumulator
+// sources. dst == acc, so reseed_acc restores the window between runs.
+void run_case(const char *label, Fmt fmt, Fmt acc_fmt,
+              const std::function<void(WmmaFixture &, uint32_t)> &kernel) {
+  WmmaFixture fx;
+  ASSERT_NE(fx.wf, nullptr);
+  for (auto [mode, seed] : trials_for(fmt)) {
+    fx.seed(S0, IN_REGS, fmt, mode, seed + 1);
+    fx.seed(S1, IN_REGS, fmt, mode, seed + 2);
+    fx.seed_words(INDEX, INDEX_REGS, seed + 4); // any 2-bit index pattern is valid
+    auto reseed_acc = [&] { fx.seed(ACC, ACC_REGS, acc_fmt, Mode::RandomInt, seed + 3); };
+    for (uint32_t const_acc : {amdgpu::ACC_FROM_VGPR, CONST_ONE}) {
+      expect_bit_exact(label, mode, fx, reseed_acc, [&] { kernel(fx, const_acc); }, ACC, ACC_REGS);
+      if (testing::Test::HasFatalFailure())
+        return;
+    }
+  }
+}
+
+template <typename Ea, typename Eb>
+void run_dense_f32(const char *label, Fmt fmt, uint32_t M, uint32_t N, uint32_t K, uint32_t bits,
+                   Ea ea, Eb eb) {
+  run_case(label, fmt, Fmt::F32, [=](WmmaFixture &fx, uint32_t const_acc) {
+    amdgpu::exec_wmma_f32(*fx.cu, M, N, K, bits, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                          fx.vbase + ACC, ea, eb, const_acc);
+  });
+}
+
+template <typename Ea, typename Eb>
+void run_dense_f16(const char *label, Fmt fmt, uint32_t K, uint32_t bits, Ea ea, Eb eb) {
+  run_case(label, fmt, Fmt::F16, [=](WmmaFixture &fx, uint32_t const_acc) {
+    amdgpu::exec_wmma_f16(*fx.cu, 16, 16, K, bits, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                          fx.vbase + ACC, ea, eb, const_acc);
+  });
+}
+
+template <typename Ea, typename Eb>
+void run_sparse_f32(const char *label, Fmt fmt, uint32_t K, uint32_t bits, Ea ea, Eb eb) {
+  run_case(label, fmt, Fmt::F32, [=](WmmaFixture &fx, uint32_t const_acc) {
+    amdgpu::exec_swmmac_f32(*fx.cu, 16, 16, K, bits, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                            fx.vbase + ACC, fx.vbase + INDEX, INDEX_ENTRIES, INDEX_KEY, ea, eb,
+                            const_acc);
+  });
+}
+
+template <typename Ea, typename Eb>
+void run_sparse_f16(const char *label, Fmt fmt, uint32_t K, uint32_t bits, Ea ea, Eb eb) {
+  run_case(label, fmt, Fmt::F16, [=](WmmaFixture &fx, uint32_t const_acc) {
+    amdgpu::exec_swmmac_f16(*fx.cu, 16, 16, K, bits, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                            fx.vbase + ACC, fx.vbase + INDEX, INDEX_ENTRIES, INDEX_KEY, ea, eb,
+                            const_acc);
+  });
+}
+
+} // namespace
+
+// --- dense f32-out, f16 inputs (generic + both specialized kernels) ---
+TEST(WmmaSimdExact, F32_f16) {
+  MMA_SKIP_IF_NO_SIMD();
+  run_dense_f32("wmma_f32_16x16x16_f16", Fmt::F16, 16, 16, 16, 16, amdgpu::extract_f16,
+                amdgpu::extract_f16);
+  run_dense_f32("wmma_f32_16x16x32_f16", Fmt::F16, 16, 16, 32, 16, amdgpu::extract_f16,
+                amdgpu::extract_f16);
+  run_case("wmma_f32_16x16x32_f16_spec", Fmt::F16, Fmt::F32, [](WmmaFixture &fx, uint32_t ca) {
+    amdgpu::exec_wmma_f32_16x16x32_f16(*fx.cu, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                                       fx.vbase + ACC, ca);
+  });
+  run_case("wmma_f32_16x16x4_f32_spec", Fmt::F32, Fmt::F32, [](WmmaFixture &fx, uint32_t ca) {
+    amdgpu::exec_wmma_f32_f32_spec<16, 16, 4>(*fx.cu, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                                              fx.vbase + ACC, ca);
+  });
+}
+
+// --- dense f16-out (packed16, generic + specialized) ---
+TEST(WmmaSimdExact, F16_f16) {
+  MMA_SKIP_IF_NO_SIMD();
+  run_dense_f16("wmma_f16_16x16x16_f16", Fmt::F16, 16, 16, amdgpu::extract_f16,
+                amdgpu::extract_f16);
+  run_dense_f16("wmma_f16_16x16x32_f16", Fmt::F16, 32, 16, amdgpu::extract_f16,
+                amdgpu::extract_f16);
+  run_case("wmma_f16_16x16x32_f16_spec", Fmt::F16, Fmt::F16, [](WmmaFixture &fx, uint32_t ca) {
+    amdgpu::exec_wmma_f16_spec<16, 16, 32>(*fx.cu, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                                           fx.vbase + ACC, ca);
+  });
+}
+
+// --- dense bf16 inputs: f32-out and packed bf16-out ---
+TEST(WmmaSimdExact, Bf16) {
+  MMA_SKIP_IF_NO_SIMD();
+  run_dense_f32("wmma_f32_16x16x32_bf16", Fmt::BF16, 16, 16, 32, 16, amdgpu::extract_bf16,
+                amdgpu::extract_bf16);
+  run_case("wmma_bf16_16x16x32_bf16", Fmt::BF16, Fmt::BF16, [](WmmaFixture &fx, uint32_t ca) {
+    amdgpu::exec_wmma_bf16(*fx.cu, 16, 16, 32, 16, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                           fx.vbase + ACC, amdgpu::extract_bf16, amdgpu::extract_bf16, ca);
+  });
+  run_sparse_f32("swmmac_f32_16x16x64_bf16", Fmt::BF16, 64, 16, amdgpu::extract_bf16,
+                 amdgpu::extract_bf16);
+  run_case("swmmac_bf16_16x16x64_bf16", Fmt::BF16, Fmt::BF16, [](WmmaFixture &fx, uint32_t ca) {
+    amdgpu::exec_swmmac_bf16(*fx.cu, 16, 16, 64, 16, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                             fx.vbase + ACC, fx.vbase + INDEX, INDEX_ENTRIES, INDEX_KEY,
+                             amdgpu::extract_bf16, amdgpu::extract_bf16, ca);
+  });
+}
+
+// --- dense fp8/bf8 inputs, all four A/B combos, K=64 and K=128, f32/f16 out ---
+TEST(WmmaSimdExact, F8Dense) {
+  MMA_SKIP_IF_NO_SIMD();
+  for (uint32_t k : {64u, 128u}) {
+    run_dense_f32("wmma_f32_fp8_fp8", Fmt::FP8, 16, 16, k, 8, amdgpu::extract_fp8,
+                  amdgpu::extract_fp8);
+    run_dense_f32("wmma_f32_fp8_bf8", Fmt::FP8, 16, 16, k, 8, amdgpu::extract_fp8,
+                  amdgpu::extract_bf8);
+    run_dense_f32("wmma_f32_bf8_fp8", Fmt::BF8, 16, 16, k, 8, amdgpu::extract_bf8,
+                  amdgpu::extract_fp8);
+    run_dense_f32("wmma_f32_bf8_bf8", Fmt::BF8, 16, 16, k, 8, amdgpu::extract_bf8,
+                  amdgpu::extract_bf8);
+    run_dense_f16("wmma_f16_fp8_fp8", Fmt::FP8, k, 8, amdgpu::extract_fp8, amdgpu::extract_fp8);
+    run_dense_f16("wmma_f16_bf8_bf8", Fmt::BF8, k, 8, amdgpu::extract_bf8, amdgpu::extract_bf8);
+  }
+}
+
+// --- sparse f16/fp8 SWMMAC ---
+TEST(WmmaSimdExact, Sparse) {
+  MMA_SKIP_IF_NO_SIMD();
+  run_sparse_f32("swmmac_f32_16x16x32_f16", Fmt::F16, 32, 16, amdgpu::extract_f16,
+                 amdgpu::extract_f16);
+  run_sparse_f32("swmmac_f32_16x16x64_f16", Fmt::F16, 64, 16, amdgpu::extract_f16,
+                 amdgpu::extract_f16);
+  run_sparse_f16("swmmac_f16_16x16x64_f16", Fmt::F16, 64, 16, amdgpu::extract_f16,
+                 amdgpu::extract_f16);
+  run_sparse_f32("swmmac_f32_16x16x128_fp8", Fmt::FP8, 128, 8, amdgpu::extract_fp8,
+                 amdgpu::extract_fp8);
+  run_sparse_f32("swmmac_f32_16x16x128_bf8", Fmt::BF8, 128, 8, amdgpu::extract_bf8,
+                 amdgpu::extract_bf8);
+  run_sparse_f16("swmmac_f16_16x16x128_fp8", Fmt::FP8, 128, 8, amdgpu::extract_fp8,
+                 amdgpu::extract_fp8);
+  run_sparse_f16("swmmac_f16_16x16x128_bf8", Fmt::BF8, 128, 8, amdgpu::extract_bf8,
+                 amdgpu::extract_bf8);
+}
+
+// --- integer WMMA/SWMMAC, signed/unsigned, clamp on and off ---
+TEST(WmmaSimdExact, I32) {
+  MMA_SKIP_IF_NO_SIMD();
+  run_case("wmma_i32_16x16x16_i8", Fmt::I8, Fmt::I8, [](WmmaFixture &fx, uint32_t ca) {
+    amdgpu::exec_wmma_i32_i8(*fx.cu, 16, 16, 16, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                             fx.vbase + ACC, ca);
+  });
+  for (bool clamp : {false, true}) {
+    run_case("wmma_i32_16x16x64_iu8", Fmt::I8, Fmt::I8, [clamp](WmmaFixture &fx, uint32_t ca) {
+      amdgpu::exec_wmma_i32(*fx.cu, 16, 16, 64, 8, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                            fx.vbase + ACC, amdgpu::extract_i8, amdgpu::extract_u8, clamp, ca);
+    });
+    run_case("swmmac_i32_16x16x128_i8", Fmt::I8, Fmt::I8, [clamp](WmmaFixture &fx, uint32_t ca) {
+      amdgpu::exec_swmmac_i32(*fx.cu, 16, 16, 128, 8, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                              fx.vbase + ACC, fx.vbase + INDEX, 32, INDEX_KEY, amdgpu::extract_i8,
+                              amdgpu::extract_i8, clamp, ca);
+    });
+  }
+  run_case("swmmac_i32_16x16x32_i8", Fmt::I8, Fmt::I8, [](WmmaFixture &fx, uint32_t ca) {
+    amdgpu::exec_swmmac_i32_i8(*fx.cu, 16, 16, 32, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
+                               fx.vbase + ACC, fx.vbase + INDEX, INDEX_ENTRIES, INDEX_KEY, ca);
+  });
+}
+
+// --- mixed-format dense (fp4/fp6/bf6 paths) and fp4 32x16 shape ---
+TEST(WmmaSimdExact, MixedFmt) {
+  MMA_SKIP_IF_NO_SIMD();
+  run_dense_f32("wmma_f32_32x16x128_fp4", Fmt::RAW4, 32, 16, 128, 4, amdgpu::extract_fp4,
+                amdgpu::extract_fp4);
+  run_case("wmma_f32_mixed_fp4_fp4", Fmt::RAW4, Fmt::F32, [](WmmaFixture &fx, uint32_t ca) {
+    amdgpu::exec_wmma_f32_mixed(*fx.cu, 16, 16, 128, 4, 4, fx.vbase + ACC, fx.vbase + S0,
+                                fx.vbase + S1, fx.vbase + ACC, amdgpu::extract_fp4,
+                                amdgpu::extract_fp4, ca);
+  });
+  run_case("wmma_f32_mixed_fp6_bf6", Fmt::RAW6, Fmt::F32, [](WmmaFixture &fx, uint32_t ca) {
+    amdgpu::exec_wmma_f32_mixed(*fx.cu, 16, 16, 128, 6, 6, fx.vbase + ACC, fx.vbase + S0,
+                                fx.vbase + S1, fx.vbase + ACC, amdgpu::extract_fp6,
+                                amdgpu::extract_bf6, ca);
+  });
+  run_case("wmma_f32_mixed_fp8_fp6", Fmt::FP8, Fmt::F32, [](WmmaFixture &fx, uint32_t ca) {
+    amdgpu::exec_wmma_f32_mixed(*fx.cu, 16, 16, 128, 8, 6, fx.vbase + ACC, fx.vbase + S0,
+                                fx.vbase + S1, fx.vbase + ACC, amdgpu::extract_fp8,
+                                amdgpu::extract_fp6, ca);
+  });
+}
+
+// --- scaled mixed-format dense (e8m0 power-of-two scales stay exact) ---
+// Scale bytes are constrained to [2^-15, 2^16]: the scalar path folds scales
+// after the a*b product while the SIMD hoist folds them into A and B, so the
+// two only agree bit-for-bit while no intermediate overflows or underflows.
+TEST(WmmaSimdExact, ScaledMixed) {
+  MMA_SKIP_IF_NO_SIMD();
+  auto seed_scales = [](WmmaFixture &fx, uint32_t off, uint32_t seed) {
+    std::mt19937 rng(seed);
+    for (uint32_t reg = 0; reg < 4; ++reg)
+      for (uint32_t lane = 0; lane < WF; ++lane) {
+        uint32_t w = 0;
+        for (uint32_t b = 0; b < 4; ++b)
+          w |= (0x70u + (rng() & 0x1Fu)) << (b * 8); // e8m0 in [2^-15, 2^16]
+        fx.cu->write_vgpr(fx.vbase + off + reg, lane, w);
+      }
+  };
+  run_case("wmma_f32_scaled_fp8", Fmt::FP8, Fmt::F32, [&](WmmaFixture &fx, uint32_t ca) {
+    seed_scales(fx, SCALE_A, 0xA5);
+    seed_scales(fx, SCALE_B, 0x5A);
+    auto sa = [&fx](uint32_t lane) { return fx.cu->read_vgpr(fx.vbase + SCALE_A, lane); };
+    auto sb = [&fx](uint32_t lane) { return fx.cu->read_vgpr(fx.vbase + SCALE_B, lane); };
+    amdgpu::exec_wmma_f32_scaled_mixed(*fx.cu, 16, 16, 128, 8, 8, fx.vbase + ACC, fx.vbase + S0,
+                                       fx.vbase + S1, fx.vbase + ACC, amdgpu::extract_fp8,
+                                       amdgpu::extract_fp8, ca, sa, sb, /*matrix_a_scale=*/0,
+                                       /*matrix_b_scale=*/0, /*matrix_a_scale_fmt=*/0,
+                                       /*matrix_b_scale_fmt=*/0);
+  });
+}

--- a/emulation/rocjitsu/tests/simd_correctness/wmma_simd_exact_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/wmma_simd_exact_test.cpp
@@ -88,7 +88,7 @@ void run_sparse_f16(const char *label, Fmt fmt, uint32_t K, uint32_t bits, Ea ea
 
 // --- dense f32-out, f16 inputs (generic + both specialized kernels) ---
 TEST(WmmaSimdExact, F32_f16) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   run_dense_f32("wmma_f32_16x16x16_f16", Fmt::F16, 16, 16, 16, 16, amdgpu::extract_f16,
                 amdgpu::extract_f16);
   run_dense_f32("wmma_f32_16x16x32_f16", Fmt::F16, 16, 16, 32, 16, amdgpu::extract_f16,
@@ -105,7 +105,7 @@ TEST(WmmaSimdExact, F32_f16) {
 
 // --- dense f16-out (packed16, generic + specialized) ---
 TEST(WmmaSimdExact, F16_f16) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   run_dense_f16("wmma_f16_16x16x16_f16", Fmt::F16, 16, 16, amdgpu::extract_f16,
                 amdgpu::extract_f16);
   run_dense_f16("wmma_f16_16x16x32_f16", Fmt::F16, 32, 16, amdgpu::extract_f16,
@@ -118,7 +118,7 @@ TEST(WmmaSimdExact, F16_f16) {
 
 // --- dense bf16 inputs: f32-out and packed bf16-out ---
 TEST(WmmaSimdExact, Bf16) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   run_dense_f32("wmma_f32_16x16x32_bf16", Fmt::BF16, 16, 16, 32, 16, amdgpu::extract_bf16,
                 amdgpu::extract_bf16);
   run_case("wmma_bf16_16x16x32_bf16", Fmt::BF16, Fmt::BF16, [](WmmaFixture &fx, uint32_t ca) {
@@ -136,7 +136,7 @@ TEST(WmmaSimdExact, Bf16) {
 
 // --- dense fp8/bf8 inputs, all four A/B combos, K=64 and K=128, f32/f16 out ---
 TEST(WmmaSimdExact, F8Dense) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   for (uint32_t k : {64u, 128u}) {
     run_dense_f32("wmma_f32_fp8_fp8", Fmt::FP8, 16, 16, k, 8, amdgpu::extract_fp8,
                   amdgpu::extract_fp8);
@@ -153,7 +153,7 @@ TEST(WmmaSimdExact, F8Dense) {
 
 // --- sparse f16/fp8 SWMMAC ---
 TEST(WmmaSimdExact, Sparse) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   run_sparse_f32("swmmac_f32_16x16x32_f16", Fmt::F16, 32, 16, amdgpu::extract_f16,
                  amdgpu::extract_f16);
   run_sparse_f32("swmmac_f32_16x16x64_f16", Fmt::F16, 64, 16, amdgpu::extract_f16,
@@ -172,7 +172,7 @@ TEST(WmmaSimdExact, Sparse) {
 
 // --- integer WMMA/SWMMAC, signed/unsigned, clamp on and off ---
 TEST(WmmaSimdExact, I32) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   run_case("wmma_i32_16x16x16_i8", Fmt::I8, Fmt::I8, [](WmmaFixture &fx, uint32_t ca) {
     amdgpu::exec_wmma_i32_i8(*fx.cu, 16, 16, 16, fx.vbase + ACC, fx.vbase + S0, fx.vbase + S1,
                              fx.vbase + ACC, ca);
@@ -196,7 +196,7 @@ TEST(WmmaSimdExact, I32) {
 
 // --- mixed-format dense (fp4/fp6/bf6 paths) and fp4 32x16 shape ---
 TEST(WmmaSimdExact, MixedFmt) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   run_dense_f32("wmma_f32_32x16x128_fp4", Fmt::RAW4, 32, 16, 128, 4, amdgpu::extract_fp4,
                 amdgpu::extract_fp4);
   run_case("wmma_f32_mixed_fp4_fp4", Fmt::RAW4, Fmt::F32, [](WmmaFixture &fx, uint32_t ca) {
@@ -221,7 +221,7 @@ TEST(WmmaSimdExact, MixedFmt) {
 // after the a*b product while the SIMD hoist folds them into A and B, so the
 // two only agree bit-for-bit while no intermediate overflows or underflows.
 TEST(WmmaSimdExact, ScaledMixed) {
-  MMA_SKIP_IF_NO_SIMD();
+  SKIP_IF_NO_SIMD();
   auto seed_scales = [](WmmaFixture &fx, uint32_t off, uint32_t seed) {
     std::mt19937 rng(seed);
     for (uint32_t reg = 0; reg < 4; ++reg)

--- a/emulation/rocjitsu/tests/util_simd_test.cpp
+++ b/emulation/rocjitsu/tests/util_simd_test.cpp
@@ -578,6 +578,125 @@ TEST(UtilSimd, FlushDenormF32) {
   }
 }
 
+// --- IEEE-2019 maximum / minimum (NaN-propagating, signed-zero-ordered) ------
+//
+// util::ieee_{maximum,minimum}_simd back the v_maximum_*/v_minimum_* gap ops.
+// They must be bit-identical to the scalar bodies the generator emits, which is
+// the exact expression below. The grid pairs every IEEE class against every
+// other so ±0 ties, NaN-in-either, Inf, and ordinary compares are all covered.
+
+// Bit pattern of a float/double as an unsigned integer, for exact lane-value
+// comparison (EXPECT_EQ on the raw bits distinguishes NaN payloads and ±0,
+// which == on the float values would not).
+//
+// Both overloads share a single uint64_t return type so the helper is
+// type-generic at the call sites. The float overload therefore zero-extends
+// its 32-bit pattern into the 64-bit result; this is intentional and safe
+// because only same-type lanes are ever compared (float-vs-float or
+// double-vs-double), so the high 32 zero bits are present on both sides of any
+// float comparison and never change the result.
+inline uint64_t bits_of(float v) { return std::bit_cast<uint32_t>(v); }
+inline uint64_t bits_of(double v) { return std::bit_cast<uint64_t>(v); }
+
+// Scalar references — literally the generated VOP3 body's inner expression.
+template <typename T> T scalar_ieee_maximum(T a, T b) {
+  if (std::isnan(a) || std::isnan(b))
+    return std::numeric_limits<T>::quiet_NaN();
+  if (a == b)
+    return std::signbit(a) ? b : a;
+  return a > b ? a : b;
+}
+template <typename T> T scalar_ieee_minimum(T a, T b) {
+  if (std::isnan(a) || std::isnan(b))
+    return std::numeric_limits<T>::quiet_NaN();
+  if (a == b)
+    return std::signbit(a) ? a : b;
+  return a < b ? a : b;
+}
+
+template <typename T> std::array<T, 13> ieee_minmax_grid() {
+  const T inf = std::numeric_limits<T>::infinity();
+  const T qnan = std::numeric_limits<T>::quiet_NaN();
+  const T den = std::numeric_limits<T>::denorm_min();
+  return {T(0), -T(0), T(1), -T(1), T(2), -T(2), T(0.5), inf, -inf, qnan, -qnan, den, -den};
+}
+
+template <typename V, typename T, typename SimdFn, typename ScalarFn>
+void check_ieee_minmax(SimdFn simd_fn, ScalarFn scalar_fn) {
+  constexpr std::size_t W = V::size();
+  const auto grid = ieee_minmax_grid<T>();
+  for (T bv : grid) {
+    // Fill a vector with `bv` in every lane and sweep `av` across the grid so
+    // both same-class (ties) and cross-class pairs are exercised per lane.
+    for (T av : grid) {
+      alignas(V) T abuf[W];
+      alignas(V) T bbuf[W];
+      for (std::size_t i = 0; i < W; ++i) {
+        abuf[i] = av;
+        bbuf[i] = bv;
+      }
+      V a(abuf, util::stdx::vector_aligned);
+      V b(bbuf, util::stdx::vector_aligned);
+      V r = simd_fn(a, b);
+      const T expect = scalar_fn(av, bv);
+      for (std::size_t i = 0; i < W; ++i) {
+        const T rv = r[i];
+        EXPECT_EQ(bits_of(rv), bits_of(expect)) << "av=" << av << " bv=" << bv << " lane=" << i;
+      }
+    }
+  }
+}
+
+TEST(UtilSimd, IeeeMaximum_F32_BitExact) {
+  SKIP_IF_NO_SIMD();
+  check_ieee_minmax<util::native<float>, float>(
+      [](auto a, auto b) { return util::ieee_maximum_simd(a, b); }, scalar_ieee_maximum<float>);
+}
+TEST(UtilSimd, IeeeMinimum_F32_BitExact) {
+  SKIP_IF_NO_SIMD();
+  check_ieee_minmax<util::native<float>, float>(
+      [](auto a, auto b) { return util::ieee_minimum_simd(a, b); }, scalar_ieee_minimum<float>);
+}
+TEST(UtilSimd, IeeeMaximum_F64_BitExact) {
+  SKIP_IF_NO_SIMD();
+  check_ieee_minmax<util::native<double>, double>(
+      [](auto a, auto b) { return util::ieee_maximum_simd(a, b); }, scalar_ieee_maximum<double>);
+}
+TEST(UtilSimd, IeeeMinimum_F64_BitExact) {
+  SKIP_IF_NO_SIMD();
+  check_ieee_minmax<util::native<double>, double>(
+      [](auto a, auto b) { return util::ieee_minimum_simd(a, b); }, scalar_ieee_minimum<double>);
+}
+
+// The 3-input / combined gap ops are exact nested compositions of the binary
+// helper; verify the composition matches the nested scalar reference too.
+TEST(UtilSimd, IeeeMaximum3_F32_BitExact) {
+  SKIP_IF_NO_SIMD();
+  using V = util::native<float>;
+  constexpr std::size_t W = V::size();
+  const auto grid = ieee_minmax_grid<float>();
+  for (float cv : grid)
+    for (float bv : grid)
+      for (float av : grid) {
+        alignas(V) float a_[W], b_[W], c_[W];
+        for (std::size_t i = 0; i < W; ++i) {
+          a_[i] = av;
+          b_[i] = bv;
+          c_[i] = cv;
+        }
+        V a(a_, util::stdx::vector_aligned), b(b_, util::stdx::vector_aligned),
+            c(c_, util::stdx::vector_aligned);
+        // maximumminimum = minimum(maximum(a,b), c) — exercises both helpers.
+        V r = util::ieee_minimum_simd(util::ieee_maximum_simd(a, b), c);
+        float expect = scalar_ieee_minimum(scalar_ieee_maximum(av, bv), cv);
+        for (std::size_t i = 0; i < W; ++i) {
+          const float rv = r[i];
+          EXPECT_EQ(bits_of(rv), bits_of(expect))
+              << "av=" << av << " bv=" << bv << " cv=" << cv << " lane=" << i;
+        }
+      }
+}
+
 #undef SKIP_IF_NO_SIMD
 
 } // namespace

--- a/emulation/rocjitsu/tests/util_simd_test.cpp
+++ b/emulation/rocjitsu/tests/util_simd_test.cpp
@@ -697,6 +697,90 @@ TEST(UtilSimd, IeeeMaximum3_F32_BitExact) {
       }
 }
 
+// --- Cubemap face ops (v_cube{id,ma,sc,tc}_f32) ------------------------------
+//
+// util::cube_{id,sc,tc}_f32_simd back the v_cube* gap ops; they must be
+// bit-identical to the generated scalar bodies (transcribed verbatim below).
+// Sweep every sign/magnitude/tie/zero/Inf/NaN triple.
+
+float scalar_cubeid(float x, float y, float z) {
+  float ax = std::fabs(x), ay = std::fabs(y), az = std::fabs(z);
+  if (ax >= ay && ax >= az)
+    return x >= 0 ? 0.0f : 1.0f;
+  if (ay >= ax && ay >= az)
+    return y >= 0 ? 2.0f : 3.0f;
+  return z >= 0 ? 4.0f : 5.0f;
+}
+float scalar_cubesc(float x, float y, float z) {
+  float ax = std::fabs(x), ay = std::fabs(y), az = std::fabs(z);
+  if (ax >= ay && ax >= az)
+    return x >= 0 ? z : -z;
+  if (ay >= ax && ay >= az)
+    return x;
+  return z >= 0 ? -x : x;
+}
+float scalar_cubetc(float x, float y, float z) {
+  float ax = std::fabs(x), ay = std::fabs(y), az = std::fabs(z);
+  if (ax >= ay && ax >= az)
+    return -y;
+  if (ay >= ax && ay >= az)
+    return y >= 0 ? -z : z;
+  return -y;
+}
+float scalar_cubema(float x, float y, float z) {
+  float ax = std::fabs(x), ay = std::fabs(y), az = std::fabs(z);
+  return 2.0f * std::fmax(ax, std::fmax(ay, az));
+}
+
+template <typename SimdFn, typename ScalarFn> void check_cube(SimdFn simd_fn, ScalarFn scalar_fn) {
+  using V = util::native<float>;
+  constexpr std::size_t W = V::size();
+  const std::array<float, 9> grid = {{-2.0f, -1.0f, -0.0f, 0.0f, 0.5f, 1.0f, 2.0f,
+                                      std::numeric_limits<float>::infinity(),
+                                      std::numeric_limits<float>::quiet_NaN()}};
+  for (float zv : grid)
+    for (float yv : grid)
+      for (float xv : grid) {
+        alignas(V) float xb[W], yb[W], zb[W];
+        for (std::size_t i = 0; i < W; ++i) {
+          xb[i] = xv;
+          yb[i] = yv;
+          zb[i] = zv;
+        }
+        V x(xb, util::stdx::vector_aligned), y(yb, util::stdx::vector_aligned),
+            z(zb, util::stdx::vector_aligned);
+        V r = simd_fn(x, y, z);
+        const float expect = scalar_fn(xv, yv, zv);
+        for (std::size_t i = 0; i < W; ++i) {
+          const float rv = r[i];
+          EXPECT_EQ(bits_of(rv), bits_of(expect))
+              << "x=" << xv << " y=" << yv << " z=" << zv << " lane=" << i;
+        }
+      }
+}
+
+TEST(UtilSimd, CubeId_F32_BitExact) {
+  SKIP_IF_NO_SIMD();
+  check_cube([](auto x, auto y, auto z) { return util::cube_id_f32_simd(x, y, z); }, scalar_cubeid);
+}
+TEST(UtilSimd, CubeSc_F32_BitExact) {
+  SKIP_IF_NO_SIMD();
+  check_cube([](auto x, auto y, auto z) { return util::cube_sc_f32_simd(x, y, z); }, scalar_cubesc);
+}
+TEST(UtilSimd, CubeTc_F32_BitExact) {
+  SKIP_IF_NO_SIMD();
+  check_cube([](auto x, auto y, auto z) { return util::cube_tc_f32_simd(x, y, z); }, scalar_cubetc);
+}
+TEST(UtilSimd, CubeMa_F32_BitExact) {
+  SKIP_IF_NO_SIMD();
+  check_cube(
+      [](auto x, auto y, auto z) {
+        return 2.0f * util::stdx::fmax(util::stdx::abs(x),
+                                       util::stdx::fmax(util::stdx::abs(y), util::stdx::abs(z)));
+      },
+      scalar_cubema);
+}
+
 #undef SKIP_IF_NO_SIMD
 
 } // namespace

--- a/emulation/rocjitsu/tests/util_simd_test.cpp
+++ b/emulation/rocjitsu/tests/util_simd_test.cpp
@@ -781,6 +781,43 @@ TEST(UtilSimd, CubeMa_F32_BitExact) {
       scalar_cubema);
 }
 
+// --- Normalized pack-convert lanes (v_cvt_pk[_]norm_{i16,u16}_*) -------------
+
+int16_t scalar_cvt_pknorm_i16(float f) {
+  if (std::isnan(f))
+    return 0;
+  return static_cast<int16_t>(std::clamp(f * 32767.0f, -32768.0f, 32767.0f));
+}
+uint16_t scalar_cvt_pknorm_u16(float f) {
+  if (std::isnan(f))
+    return 0;
+  return static_cast<uint16_t>(std::clamp(f * 65535.0f, 0.0f, 65535.0f));
+}
+
+TEST(UtilSimd, CvtPkNormI16_F32_BitExact) {
+  SKIP_IF_NO_SIMD();
+  using V = util::native<float>;
+  constexpr std::size_t W = V::size();
+  const std::array<float, 14> grid = {{0.0f, -0.0f, 0.5f, -0.5f, 1.0f, -1.0f, 2.0f, -2.0f, 0.99999f,
+                                       1e30f, -1e30f, std::numeric_limits<float>::infinity(),
+                                       -std::numeric_limits<float>::infinity(),
+                                       std::numeric_limits<float>::quiet_NaN()}};
+  for (float fv : grid) {
+    alignas(V) float fb[W];
+    for (std::size_t i = 0; i < W; ++i)
+      fb[i] = fv;
+    V f(fb, util::stdx::vector_aligned);
+    auto ri = util::cvt_pknorm_i16_f32_simd(f);
+    auto ru = util::cvt_pknorm_u16_f32_simd(f);
+    for (std::size_t i = 0; i < W; ++i) {
+      EXPECT_EQ(static_cast<uint16_t>(static_cast<int32_t>(ri[i])),
+                static_cast<uint16_t>(scalar_cvt_pknorm_i16(fv)))
+          << "i16 f=" << fv << " lane=" << i;
+      EXPECT_EQ(static_cast<uint16_t>(ru[i]), scalar_cvt_pknorm_u16(fv)) << "u16 f=" << fv;
+    }
+  }
+}
+
 #undef SKIP_IF_NO_SIMD
 
 } // namespace

--- a/emulation/rocjitsu/tests/v_add_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/v_add_simd_benchmark.cpp
@@ -418,7 +418,7 @@ TEST(VAddSimdBenchmark, Cdna4_VCmpClassF32_Vop3) {
     return;
   }
   uint32_t w0 = (106u & 0xFF) | ((16u & 0x3FF) << 16) | (0x34u << 26); // vdst=VCC, op=16
-  uint32_t w1 = 256u | (1u << 9);                                      // src0=v0, src1=v1
+  uint32_t w1 = 256u | (257u << 9);                                    // src0=v0, src1=v1
   run_words("v_cmp_class_f32_e64 v0, v1 -> vcc", w0, w1, /*sanitize_finite=*/false);
 }
 
@@ -610,7 +610,7 @@ TEST(VAddSimdBenchmark, Cdna4_VAdd3U32_Vop3) {
   }
   // VOP3: word0 = vdst|op<<16|0x34<<26; word1 = src0|src1<<9|src2<<18.
   uint32_t w0 = (2u) | ((511u & 0x3FF) << 16) | (0x34u << 26);
-  uint32_t w1 = 256u | (1u << 9) | (3u << 18); // src0=v0 src1=v1 src2=v3
+  uint32_t w1 = 256u | (257u << 9) | (259u << 18); // src0=v0 src1=v1 src2=v3
   run_words("v_add3_u32_e64 v2, v0, v1, v3", w0, w1, /*sanitize_finite=*/false);
 }
 
@@ -672,7 +672,7 @@ TEST(VAddSimdBenchmark, Cdna4_VDivFmasF32_Vop3) {
     return;
   }
   uint32_t w0 = (6u) | ((482u & 0x3FF) << 16) | (0x34u << 26);
-  uint32_t w1 = 256u | (1u << 9) | (2u << 18); // src0=v0 src1=v1 src2=v2
+  uint32_t w1 = 256u | (257u << 9) | (258u << 18); // src0=v0 src1=v1 src2=v2
   run_words("v_div_fmas_f32_e64 v6, v0, v1, v2", w0, w1, /*sanitize_finite=*/true);
 }
 
@@ -687,7 +687,7 @@ TEST(VAddSimdBenchmark, Cdna4_VCndmaskB32_Vop3) {
   // VOP3 ternary encoding: word0 = vdst|op<<16|0x34<<26; word1 = src0|src1<<9|
   // src2<<18. src2=VCC=106. Selector pattern is set by seed_inputs (vcc init).
   uint32_t w0 = (2u) | ((256u & 0x3FF) << 16) | (0x34u << 26);
-  uint32_t w1 = 256u | (1u << 9) | (106u << 18);
+  uint32_t w1 = 256u | (257u << 9) | (106u << 18);
   run_words("v_cndmask_b32_e64 v2, v0, v1, vcc", w0, w1, /*sanitize_finite=*/false);
 }
 
@@ -716,7 +716,7 @@ TEST(VAddSimdBenchmark, Cdna4_VFmaF32_Vop3) {
   }
   // VOP3 ternary: word0 vdst|op<<16|0x34<<26; word1 src0|src1<<9|src2<<18.
   uint32_t w0 = (6u) | ((459u & 0x3FF) << 16) | (0x34u << 26);
-  uint32_t w1 = 256u | (1u << 9) | (2u << 18); // src0=v0 src1=v1 src2=v2
+  uint32_t w1 = 256u | (257u << 9) | (258u << 18); // src0=v0 src1=v1 src2=v2
   run_words("v_fma_f32_e64 v6, v0, v1, v2", w0, w1, /*sanitize_finite=*/true);
 }
 
@@ -750,7 +750,7 @@ TEST(VAddSimdBenchmark, Cdna4_VCubemaF32_Vop3) {
     return;
   }
   uint32_t w0, w1;
-  vop3_tern_encode(455, /*vdst=*/3, /*src0=*/256, /*src1=*/257, /*src2=*/2, w0, w1);
+  vop3_tern_encode(455, /*vdst=*/3, /*src0=*/256, /*src1=*/257, /*src2=*/258, w0, w1);
   run_words("v_cubema_f32_e64 v3, v0, v1, v2", w0, w1, /*sanitize_finite=*/true);
 }
 

--- a/emulation/rocjitsu/tests/v_add_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/v_add_simd_benchmark.cpp
@@ -61,6 +61,29 @@ constexpr void vop3_bin_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32
   w1 = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((omod & 0x3) << 27) | ((neg & 0x7) << 29);
 }
 
+// CDNA4 VOP3 ternary encoding (src0/src1/src2, no modifiers). Same word0 as
+// vop3_bin_encode; word1 adds src2 in [26:18].
+constexpr void vop3_tern_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1,
+                                uint32_t src2, uint32_t &w0, uint32_t &w1) {
+  w0 = (vdst & 0xFF) | ((op & 0x3FF) << 16) | (0x34u << 26);
+  w1 = (src0 & 0x1FF) | ((src1 & 0x1FF) << 9) | ((src2 & 0x1FF) << 18);
+}
+
+// CDNA4 VOP3P encoding (matches Vop3pMachineInst bitfields). word0 = vdst[7:0] |
+// neg_hi[10:8] | op_sel[13:11] | op_sel_hi_2[14] | clamp[15] | op[22:16] |
+// 0x1A7<<23; word1 = src0[8:0] | src1[17:9] | src2[26:18] | op_sel_hi[28:27] |
+// neg[31:29]. Default packing for the f32 pk fast path is op_sel = 0,
+// op_sel_hi = 3 (the binary-f32 probe bails to scalar otherwise).
+constexpr void vop3p_encode(uint32_t op, uint32_t vdst, uint32_t src0, uint32_t src1, uint32_t src2,
+                            uint32_t op_sel, uint32_t op_sel_hi, uint32_t op_sel_hi_2, uint32_t neg,
+                            uint32_t neg_hi, uint32_t clamp, uint32_t &w0, uint32_t &w1) {
+  w0 = (vdst & 0xFFu) | ((neg_hi & 0x7u) << 8) | ((op_sel & 0x7u) << 11) |
+       ((op_sel_hi_2 & 0x1u) << 14) | ((clamp & 0x1u) << 15) | ((op & 0x7Fu) << 16) |
+       (0x1A7u << 23);
+  w1 = (src0 & 0x1FFu) | ((src1 & 0x1FFu) << 9) | ((src2 & 0x1FFu) << 18) |
+       ((op_sel_hi & 0x3u) << 27) | ((neg & 0x7u) << 29);
+}
+
 struct BenchFixture {
   amdgpu::GpuMemory gpu_mem;
   amdgpu::L2Cache l2;
@@ -106,6 +129,23 @@ struct BenchFixture {
       cu->write_vgpr(vbase + 0, lane, r0);
       cu->write_vgpr(vbase + 1, lane, r1);
       cu->write_vgpr(vbase + 2, lane, 0u); // dst
+      // Extra inputs for the ternary / 64-bit-pair / VOP3P cases below
+      // (v2..v5). Seeded with the same deterministic stream so the f64 / pk
+      // forms read finite (sanitized when requested) values, not stale VGPRs.
+      uint32_t r2 = static_cast<uint32_t>(rng());
+      uint32_t r3 = static_cast<uint32_t>(rng());
+      uint32_t r4 = static_cast<uint32_t>(rng());
+      uint32_t r5 = static_cast<uint32_t>(rng());
+      if (sanitize_finite) {
+        r2 = sanitize(r2);
+        r3 = sanitize(r3);
+        r4 = sanitize(r4);
+        r5 = sanitize(r5);
+      }
+      cu->write_vgpr(vbase + 2, lane, r2);
+      cu->write_vgpr(vbase + 3, lane, r3);
+      cu->write_vgpr(vbase + 4, lane, r4);
+      cu->write_vgpr(vbase + 5, lane, r5);
     }
     wf->set_exec(~0ULL); // All lanes active.
   }
@@ -678,6 +718,97 @@ TEST(VAddSimdBenchmark, Cdna4_VFmaF32_Vop3) {
   uint32_t w0 = (6u) | ((459u & 0x3FF) << 16) | (0x34u << 26);
   uint32_t w1 = 256u | (1u << 9) | (2u << 18); // src0=v0 src1=v1 src2=v2
   run_words("v_fma_f32_e64 v6, v0, v1, v2", w0, w1, /*sanitize_finite=*/true);
+}
+
+// === SIMD gap-family representatives (this session) ===
+//
+// One TEST per representative op from the newly-SIMD'd families, timed in
+// whichever mode the process runs (RJ_FORCE_SCALAR). All CDNA4-decodable;
+// opcodes verified against cdna4/decoder.cpp's sub_decode_vop3 / sub_decode_vop3p
+// tables (and cdna4/test_encodings.h). NOTE: v_cvt_pk_i16_f32 was DROPPED — it
+// does not exist on CDNA4 (only v_cvt_pk_i16_i32 / v_cvt_pknorm_i16_f32 are
+// present), so it is not decodable by this fixture.
+
+// v_cvt_pknorm_u16_f32_e64 v2, v0, v1  (CDNA4 VOP3 opcode 661) — binary f32 ->
+// packed normalized u16 (two clamped/scaled lanes into one 32-bit dst). Inputs
+// sanitized to finite normals for the SIMD fast path.
+TEST(VAddSimdBenchmark, Cdna4_VCvtPknormU16F32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(661, /*vdst=*/2, /*src0=*/256, /*src1=*/257, 0, 0, 0, 0, w0, w1);
+  run_words("v_cvt_pknorm_u16_f32_e64 v2, v0, v1", w0, w1, /*sanitize_finite=*/true);
+}
+
+// v_cubema_f32_e64 v3, v0, v1, v2  (CDNA4 VOP3 opcode 455) — cubemap major-axis
+// ternary: 2*max(|x|,|y|,|z|). src0/src1/src2 = v0/v1/v2; finite-sanitized.
+TEST(VAddSimdBenchmark, Cdna4_VCubemaF32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_tern_encode(455, /*vdst=*/3, /*src0=*/256, /*src1=*/257, /*src2=*/2, w0, w1);
+  run_words("v_cubema_f32_e64 v3, v0, v1, v2", w0, w1, /*sanitize_finite=*/true);
+}
+
+// v_dot4c_i32_i8_e64 v2, v0, v1  (CDNA4 VOP3 opcode 313) — dst-accumulate 4xi8
+// dot: vdst += sum(i8(v0)*i8(v1)). The accumulator is vdst (v2), so looping the
+// SAME instruction creates a loop-carried RAW dependency on v2 in BOTH modes —
+// the measured ratio reflects store->load latency, not the dot fast path (which
+// does engage; bit-equivalence is checked by Vop3pDotSimdCorrectness's "c"
+// forms). Reported for family coverage; read the speedup as a lower bound.
+TEST(VAddSimdBenchmark, Cdna4_VDot4cI32I8_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(313, /*vdst=*/2, /*src0=*/256, /*src1=*/257, 0, 0, 0, 0, w0, w1);
+  run_words("v_dot4c_i32_i8_e64 v2, v0, v1 (acc)", w0, w1, /*sanitize_finite=*/false);
+}
+
+// v_add_f64_e64 v2:v3, v0:v1, v4:v5  (CDNA4 VOP3 opcode 640) — f64 binary on
+// 64-bit VGPR pairs. (This duplicates Cdna4_VAddF64_Vop3 above; included here so
+// the gap-family table has the f64 binary representative in one place.) src0 =
+// v0:v1, src1 = v4:v5, dst = v2:v3.
+TEST(VAddSimdBenchmark, Cdna4_VAddF64Pair_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(640, /*vdst=*/2, /*src0=*/256, /*src1=*/260, 0, 0, 0, 0, w0, w1);
+  run_words("v_add_f64_e64 v2:v3, v0:v1, v4:v5", w0, w1, /*sanitize_finite=*/false);
+}
+
+// v_pk_add_f32 v2:v3, v0:v1, v4:v5  (CDNA4 VOP3P opcode 50) — packed f32 add on
+// 64-bit VGPR pairs (two f32 lanes per pair). Default packing op_sel = 0,
+// op_sel_hi = 3 (required for the f32 pk fast path; non-default bails to
+// scalar). src0 = v0:v1, src1 = v4:v5, dst = v2:v3; finite-sanitized.
+TEST(VAddSimdBenchmark, Cdna4_VPkAddF32_Vop3p) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3p_encode(/*op=*/50, /*vdst=*/2, /*src0=*/256, /*src1=*/260, /*src2=*/0, /*op_sel=*/0,
+               /*op_sel_hi=*/3, /*op_sel_hi_2=*/0, /*neg=*/0, /*neg_hi=*/0, /*clamp=*/0, w0, w1);
+  run_words("v_pk_add_f32 v2:v3, v0:v1, v4:v5", w0, w1, /*sanitize_finite=*/true);
+}
+
+// v_frexp_exp_i32_f32_e64 v2, v0  (CDNA4 VOP3 opcode 371) — f32 -> i32 frexp
+// exponent (unary). Raw finite inputs (the exponent extraction is bit-exact).
+TEST(VAddSimdBenchmark, Cdna4_VFrexpExpI32F32_Vop3) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";
+    return;
+  }
+  uint32_t w0, w1;
+  vop3_bin_encode(371, /*vdst=*/2, /*src0=*/256, /*src1=*/0, 0, 0, 0, 0, w0, w1);
+  run_words("v_frexp_exp_i32_f32_e64 v2, v0", w0, w1, /*sanitize_finite=*/true);
 }
 
 // Diagnostic: report whether the SIMD fast path is compiled in.

--- a/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
@@ -356,3 +356,17 @@ TEST(WmmaSimdBenchmark, F32_16x16x4_f32_Specialized) {
   };
   bench("v_wmma_f32_16x16x4_f32 [specialized]", fx, run, double(M) * N * K, Cmp::F32Tol);
 }
+
+// Dense WMMA, f16 output, f16 input, K=32 — specialized (constexpr + F16C).
+TEST(WmmaSimdBenchmark, F16_16x16x32_f16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32, bits = 16;
+  fx.seed(S0_OFF, 16, bits, SmallGen(51));
+  fx.seed(S1_OFF, 16, bits, SmallGen(52));
+  auto run = [&] {
+    amdgpu::exec_wmma_f16_spec<16, 16, 32>(*fx.cu, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                                           fx.vbase + S1_OFF, fx.vbase + S2_OFF, /*const_acc=*/0);
+  };
+  bench("v_wmma_f16_16x16x32_f16 [specialized]", fx, run, double(M) * N * K, Cmp::F16Tol);
+}

--- a/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
@@ -341,3 +341,18 @@ TEST(WmmaSimdBenchmark, F32_16x16x32_f16_Specialized) {
   };
   bench("v_wmma_f32_16x16x32_f16 [specialized]", fx, run, double(M) * N * K, Cmp::F32Tol);
 }
+
+// Dense WMMA, f32 output, f32 input (no convert), specialized.
+TEST(WmmaSimdBenchmark, F32_16x16x4_f32_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 4, bits = 32;
+  fx.seed(S0_OFF, 16, bits, SmallGen(41));
+  fx.seed(S1_OFF, 16, bits, SmallGen(42));
+  auto run = [&] {
+    amdgpu::exec_wmma_f32_f32_spec<16, 16, 4>(*fx.cu, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                                              fx.vbase + S1_OFF, fx.vbase + S2_OFF,
+                                              /*const_acc=*/0);
+  };
+  bench("v_wmma_f32_16x16x4_f32 [specialized]", fx, run, double(M) * N * K, Cmp::F32Tol);
+}

--- a/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
@@ -312,3 +312,32 @@ TEST(WmmaSimdBenchmark, SwmmacI32_16x16x32_i8) {
   };
   bench("v_swmmac_i32_16x16x32_i8", fx, run, double(M) * N * (K / 2), Cmp::IntExact);
 }
+
+// Dense WMMA, f32 output, f16 input, K=32 — the real gfx1250 shape, generic path.
+TEST(WmmaSimdBenchmark, F32_16x16x32_f16) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32, bits = 16;
+  fx.seed(S0_OFF, 16, bits, SmallGen(13));
+  fx.seed(S1_OFF, 16, bits, SmallGen(14));
+  auto run = [&] {
+    amdgpu::exec_wmma_f32(*fx.cu, M, N, K, bits, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                          fx.vbase + S1_OFF, fx.vbase + S2_OFF, amdgpu::extract_f16,
+                          amdgpu::extract_f16, /*const_acc=*/0);
+  };
+  bench("v_wmma_f32_16x16x32_f16", fx, run, double(M) * N * K, Cmp::F32Tol);
+}
+
+// Dedicated constexpr-dims + F16C specialization for the same shape.
+TEST(WmmaSimdBenchmark, F32_16x16x32_f16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32, bits = 16;
+  fx.seed(S0_OFF, 16, bits, SmallGen(13));
+  fx.seed(S1_OFF, 16, bits, SmallGen(14));
+  auto run = [&] {
+    amdgpu::exec_wmma_f32_16x16x32_f16(*fx.cu, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                                       fx.vbase + S1_OFF, fx.vbase + S2_OFF, /*const_acc=*/0);
+  };
+  bench("v_wmma_f32_16x16x32_f16 [specialized]", fx, run, double(M) * N * K, Cmp::F32Tol);
+}

--- a/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
@@ -75,6 +75,7 @@ struct BenchFixture {
     cfg.num_wf_slots = 1;
     cfg.sgprs_per_wf = SGPRS_PER_WF;
     cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cfg.lds_size_kb = 64;
     cu = amdgpu::ComputeUnitCore::create("cu_wmma_simd", cfg, &gpu_mem, &l2);
     wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
     if (wf)

--- a/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
@@ -43,10 +43,11 @@ namespace {
 using namespace rocjitsu;
 using Clock = std::chrono::steady_clock;
 
-constexpr uint32_t WF_SIZE = 32; // gfx1250 / RDNA4 WMMA is wave32.
-constexpr uint32_t SGPRS_PER_WF = 106;
-constexpr uint32_t VGPRS_PER_WF = 256;
-constexpr int ITERATIONS = 4000;
+// Shared with the MFMA benchmark via mma_test_util.h (single source of truth).
+constexpr uint32_t WF_SIZE = mma_test::WMMA_WF_SIZE;
+constexpr uint32_t SGPRS_PER_WF = mma_test::SGPRS_PER_WF;
+constexpr uint32_t VGPRS_PER_WF = mma_test::VGPRS_PER_WF;
+constexpr int ITERATIONS = mma_test::BENCH_ITERATIONS;
 
 // VGPR layout: A inputs at s0, B inputs at s1, accumulator/output at S2, sparse
 // metadata at INDEX. The 32-register spacing clears the per-operand footprint of

--- a/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
@@ -1,0 +1,314 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file wmma_simd_benchmark.cpp
+/// @brief A/B microbenchmark: SIMD vs forced-scalar execution of the shared
+/// WMMA/SWMMAC execute kernels (exec_wmma_f32 / exec_wmma_i32 / exec_wmma_f16 /
+/// exec_swmmac_*), covering the gfx1250 (RDNA4, wave32) matrix shapes that route
+/// through them.
+///
+/// Both modes run in the same process; util::set_force_scalar_for_testing flips
+/// the kernel between its dense native-width matmul (SIMD) and the per-output
+/// scalar triple-loop. The benchmark drives the execute kernels directly (no
+/// decode) so it isolates the matmul body, then reports ns/op and speedup and
+/// checks SIMD-vs-scalar agreement:
+///   - i32 output: integer MAC is exact, bit-identical.
+///   - f32/f16/bf16 output: SIMD uses fused FMA (matching the hardware) while the
+///     scalar reference is non-fused, so results agree to a small tolerance.
+
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+#include "util/data_types.h"
+#include "util/simd.h"
+#include "util/simd_test_hooks.h"
+
+#include <gtest/gtest.h>
+
+#include <bit>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <functional>
+#include <random>
+#include <vector>
+
+namespace {
+
+using namespace rocjitsu;
+using Clock = std::chrono::steady_clock;
+
+constexpr uint32_t WF_SIZE = 32; // gfx1250 / RDNA4 WMMA is wave32.
+constexpr uint32_t SGPRS_PER_WF = 106;
+constexpr uint32_t VGPRS_PER_WF = 256;
+constexpr int ITERATIONS = 4000;
+
+// VGPR layout: A inputs at s0, B inputs at s1, accumulator/output at S2, sparse
+// metadata at INDEX. The 32-register spacing clears the per-operand footprint of
+// every shape benchmarked here.
+constexpr uint32_t S0_OFF = 0;
+constexpr uint32_t S1_OFF = 32;
+constexpr uint32_t S2_OFF = 64;
+constexpr uint32_t INDEX_OFF = 96;
+constexpr uint32_t OUT_REGS = 8; // dst window read back for the correctness check.
+
+constexpr uint32_t INDEX_ENTRIES = 16;
+constexpr uint32_t INDEX_KEY = 0;
+
+enum class Cmp { IntExact, F32Tol, F16Tol, Bf16Tol };
+
+struct BenchFixture {
+  amdgpu::GpuMemory gpu_mem;
+  amdgpu::L2Cache l2;
+  std::unique_ptr<amdgpu::ComputeUnitCore> cu;
+  amdgpu::Wavefront *wf = nullptr;
+  uint32_t vbase = 0;
+
+  BenchFixture() : gpu_mem("wmma_simd_bench_mem"), l2("wmma_simd_bench_l2") {
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = ROCJITSU_CODE_ARCH_GFX1250;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = SGPRS_PER_WF;
+    cfg.vgprs_per_wf = VGPRS_PER_WF;
+    cu = amdgpu::ComputeUnitCore::create("cu_wmma_simd", cfg, &gpu_mem, &l2);
+    wf = cu->dispatch_wf(0, 0, SGPRS_PER_WF, VGPRS_PER_WF);
+    if (wf)
+      vbase = wf->vgpr_alloc().base;
+  }
+
+  // Pack `regs` words of small floats (bit_width 16/32 per element) into the
+  // VGPR range [vbase+off ..). Both modes read the same bytes, so the exact WMMA
+  // lane layout is irrelevant to the A/B comparison.
+  template <typename Gen> void seed(uint32_t off, uint32_t regs, uint32_t bit_width, Gen gen) {
+    for (uint32_t reg = 0; reg < regs; ++reg)
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+        uint32_t word = 0;
+        if (bit_width == 32) {
+          word = std::bit_cast<uint32_t>(gen());
+        } else { // 16-bit f16
+          uint16_t lo = util::f32_to_f16(gen());
+          uint16_t hi = util::f32_to_f16(gen());
+          word = lo | (static_cast<uint32_t>(hi) << 16);
+        }
+        cu->write_vgpr(vbase + off + reg, lane, word);
+      }
+  }
+
+  template <typename Gen> void seed_i8(uint32_t off, uint32_t regs, Gen gen) {
+    for (uint32_t reg = 0; reg < regs; ++reg)
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+        uint32_t word = 0;
+        for (uint32_t byte = 0; byte < 4; ++byte)
+          word |= (static_cast<uint32_t>(static_cast<uint8_t>(gen())) << (byte * 8));
+        cu->write_vgpr(vbase + off + reg, lane, word);
+      }
+  }
+
+  void seed_words(uint32_t off, uint32_t regs, uint32_t value) {
+    for (uint32_t reg = 0; reg < regs; ++reg)
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+        cu->write_vgpr(vbase + off + reg, lane, value);
+  }
+
+  std::vector<uint32_t> snapshot_out() const {
+    std::vector<uint32_t> out(OUT_REGS * WF_SIZE);
+    for (uint32_t reg = 0; reg < OUT_REGS; ++reg)
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane)
+        out[reg * WF_SIZE + lane] = cu->read_vgpr(vbase + S2_OFF + reg, lane);
+    return out;
+  }
+};
+
+double rel_err(float a, float b) {
+  if (!std::isfinite(a) || !std::isfinite(b))
+    return 0.0;
+  return std::abs(static_cast<double>(a) - b) / (std::abs(a) + 1e-6);
+}
+
+void compare(const char *label, Cmp cmp, const std::vector<uint32_t> &sc,
+             const std::vector<uint32_t> &sd) {
+  double max_rel = 0.0;
+  for (size_t i = 0; i < sc.size(); ++i) {
+    switch (cmp) {
+    case Cmp::IntExact: {
+      EXPECT_EQ(sc[i], sd[i]) << label << ": int divergence at index " << i;
+      break;
+    }
+    case Cmp::F32Tol:
+      max_rel =
+          std::max(max_rel, rel_err(std::bit_cast<float>(sc[i]), std::bit_cast<float>(sd[i])));
+      break;
+    case Cmp::F16Tol:
+      for (uint32_t h = 0; h < 2; ++h) {
+        float a = util::f16_to_f32(static_cast<uint16_t>((sc[i] >> (h * 16)) & 0xFFFF));
+        float b = util::f16_to_f32(static_cast<uint16_t>((sd[i] >> (h * 16)) & 0xFFFF));
+        max_rel = std::max(max_rel, rel_err(a, b));
+      }
+      break;
+    case Cmp::Bf16Tol:
+      for (uint32_t h = 0; h < 2; ++h) {
+        float a = util::bf16_to_f32(static_cast<uint16_t>((sc[i] >> (h * 16)) & 0xFFFF));
+        float b = util::bf16_to_f32(static_cast<uint16_t>((sd[i] >> (h * 16)) & 0xFFFF));
+        max_rel = std::max(max_rel, rel_err(a, b));
+      }
+      break;
+    }
+  }
+  if (cmp != Cmp::IntExact) {
+    EXPECT_LT(max_rel, 5e-3) << label << ": fused-vs-nonfused relative error too large";
+  }
+}
+
+// Drive one WMMA kernel A/B: run scalar then SIMD, compare dst, then time both.
+void bench(const char *label, BenchFixture &fx, const std::function<void()> &run, double macs,
+           Cmp cmp) {
+  ASSERT_NE(fx.cu, nullptr);
+  ASSERT_NE(fx.wf, nullptr);
+
+  util::set_force_scalar_for_testing(true);
+  run();
+  auto result_scalar = fx.snapshot_out();
+  util::set_force_scalar_for_testing(false);
+  run();
+  auto result_simd = fx.snapshot_out();
+  compare(label, cmp, result_scalar, result_simd);
+
+  auto time_mode = [&](bool force_scalar) -> double {
+    util::set_force_scalar_for_testing(force_scalar);
+    for (int i = 0; i < 50; ++i)
+      run();
+    auto t0 = Clock::now();
+    for (int i = 0; i < ITERATIONS; ++i)
+      run();
+    auto t1 = Clock::now();
+    util::set_force_scalar_for_testing(false);
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count() /
+           static_cast<double>(ITERATIONS);
+  };
+  double sc = time_mode(true);
+  double sd = time_mode(false);
+  std::printf("\n  === %s (gfx1250, wave32) ===\n"
+              "  MACs/op: %.0f   scalar: %9.1f ns   simd: %9.1f ns   speedup: %5.2fx\n",
+              label, macs, sc, sd, (sd > 0) ? sc / sd : 0.0);
+  EXPECT_GT(sc, 0.0);
+  EXPECT_GT(sd, 0.0);
+}
+
+struct SmallGen {
+  std::mt19937 rng;
+  std::uniform_real_distribution<float> dist{-1.0f, 1.0f};
+  explicit SmallGen(uint32_t seed) : rng(seed) {}
+  float operator()() { return dist(rng); }
+};
+
+struct SmallI8Gen {
+  std::mt19937 rng;
+  std::uniform_int_distribution<int> dist{-8, 7};
+  explicit SmallI8Gen(uint32_t seed) : rng(seed) {}
+  int operator()() { return dist(rng); }
+};
+
+#define SKIP_IF_NO_SIMD()                                                                          \
+  if constexpr (!util::has_stdx_simd) {                                                            \
+    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";                    \
+  } else if (util::native<float>::size() <= 1) {                                                   \
+    GTEST_SKIP() << "host native_simd width is 1 — no SIMD speedup possible";                      \
+  }
+
+} // namespace
+
+// Dense WMMA, f32 output, f16 input (the common transformer shape).
+TEST(WmmaSimdBenchmark, F32_16x16x16_f16) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 16, bits = 16;
+  fx.seed(S0_OFF, 16, bits, SmallGen(1));
+  fx.seed(S1_OFF, 16, bits, SmallGen(2));
+  auto run = [&] {
+    amdgpu::exec_wmma_f32(*fx.cu, M, N, K, bits, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                          fx.vbase + S1_OFF, fx.vbase + S2_OFF, amdgpu::extract_f16,
+                          amdgpu::extract_f16, /*const_acc=*/0);
+  };
+  bench("v_wmma_f32_16x16x16_f16", fx, run, double(M) * N * K, Cmp::F32Tol);
+}
+
+// Dense WMMA, f16 output (packed 2-per-word), f16 input.
+TEST(WmmaSimdBenchmark, F16_16x16x16_f16) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 16, bits = 16;
+  fx.seed(S0_OFF, 16, bits, SmallGen(3));
+  fx.seed(S1_OFF, 16, bits, SmallGen(4));
+  auto run = [&] {
+    amdgpu::exec_wmma_f16(*fx.cu, M, N, K, bits, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                          fx.vbase + S1_OFF, fx.vbase + S2_OFF, amdgpu::extract_f16,
+                          amdgpu::extract_f16, /*const_acc=*/0);
+  };
+  bench("v_wmma_f16_16x16x16_f16", fx, run, double(M) * N * K, Cmp::F16Tol);
+}
+
+// Dense WMMA, bf16 output (packed 2-per-word), bf16 input.
+TEST(WmmaSimdBenchmark, Bf16_16x16x16_bf16) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 16, bits = 16;
+  fx.seed(S0_OFF, 16, bits, SmallGen(5));
+  fx.seed(S1_OFF, 16, bits, SmallGen(6));
+  auto run = [&] {
+    amdgpu::exec_wmma_bf16(*fx.cu, M, N, K, bits, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                           fx.vbase + S1_OFF, fx.vbase + S2_OFF, amdgpu::extract_bf16,
+                           amdgpu::extract_bf16, /*const_acc=*/0);
+  };
+  bench("v_wmma_bf16_16x16x16_bf16", fx, run, double(M) * N * K, Cmp::Bf16Tol);
+}
+
+// Dense WMMA, i32 output, i8 input — integer MAC is exact (bit-identical).
+TEST(WmmaSimdBenchmark, I32_16x16x16_i8) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 16;
+  fx.seed_i8(S0_OFF, 16, SmallI8Gen(7));
+  fx.seed_i8(S1_OFF, 16, SmallI8Gen(8));
+  auto run = [&] {
+    amdgpu::exec_wmma_i32_i8(*fx.cu, M, N, K, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                             fx.vbase + S1_OFF, fx.vbase + S2_OFF, /*const_acc=*/0);
+  };
+  bench("v_wmma_i32_16x16x16_i8", fx, run, double(M) * N * K, Cmp::IntExact);
+}
+
+// Sparse SWMMAC, f32 output, f16 input (per-row 2:4 gather).
+TEST(WmmaSimdBenchmark, SwmmacF32_16x16x32_f16) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32, bits = 16;
+  fx.seed(S0_OFF, 16, bits, SmallGen(9));
+  fx.seed(S1_OFF, 16, bits, SmallGen(10));
+  fx.seed_words(INDEX_OFF, 2, 0xE4E4E4E4u); // arbitrary but valid 2-bit index set
+  auto run = [&] {
+    amdgpu::exec_swmmac_f32(*fx.cu, M, N, K, bits, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                            fx.vbase + S1_OFF, fx.vbase + S2_OFF, fx.vbase + INDEX_OFF,
+                            INDEX_ENTRIES, INDEX_KEY, amdgpu::extract_f16, amdgpu::extract_f16,
+                            /*const_acc=*/0);
+  };
+  bench("v_swmmac_f32_16x16x32_f16", fx, run, double(M) * N * (K / 2), Cmp::F32Tol);
+}
+
+// Sparse SWMMAC, i32 output, i8 input — exact.
+TEST(WmmaSimdBenchmark, SwmmacI32_16x16x32_i8) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32;
+  fx.seed_i8(S0_OFF, 16, SmallI8Gen(11));
+  fx.seed_i8(S1_OFF, 16, SmallI8Gen(12));
+  fx.seed_words(INDEX_OFF, 2, 0xE4E4E4E4u);
+  auto run = [&] {
+    amdgpu::exec_swmmac_i32_i8(*fx.cu, M, N, K, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                               fx.vbase + S1_OFF, fx.vbase + S2_OFF, fx.vbase + INDEX_OFF,
+                               INDEX_ENTRIES, INDEX_KEY, /*const_acc=*/0);
+  };
+  bench("v_swmmac_i32_16x16x32_i8", fx, run, double(M) * N * (K / 2), Cmp::IntExact);
+}

--- a/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
@@ -99,6 +99,16 @@ struct BenchFixture {
       }
   }
 
+  // Pack `regs` words of small bf16 values into the VGPR range.
+  template <typename Gen> void seed_bf16(uint32_t off, uint32_t regs, Gen gen) {
+    for (uint32_t reg = 0; reg < regs; ++reg)
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+        uint16_t lo = util::f32_to_bf16(gen());
+        uint16_t hi = util::f32_to_bf16(gen());
+        cu->write_vgpr(vbase + off + reg, lane, lo | (static_cast<uint32_t>(hi) << 16));
+      }
+  }
+
   template <typename Gen> void seed_i8(uint32_t off, uint32_t regs, Gen gen) {
     for (uint32_t reg = 0; reg < regs; ++reg)
       for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
@@ -335,6 +345,49 @@ TEST(WmmaSimdBenchmark, F32_16x16x4_f32_Specialized) {
                                               /*const_acc=*/0);
   };
   bench("v_wmma_f32_16x16x4_f32 [specialized]", fx, run, double(M) * N * K, Cmp::F32Tol);
+}
+
+// Dense WMMA, f32 output, bf16 input, K=32 — generic baseline vs specialized
+// (constexpr + bf16 bulk zero-extend convert).
+TEST(WmmaSimdBenchmark, F32_16x16x32_bf16) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32, bits = 16;
+  fx.seed_bf16(S0_OFF, 16, mma_test::SmallGen(61));
+  fx.seed_bf16(S1_OFF, 16, mma_test::SmallGen(62));
+  auto run = [&] {
+    amdgpu::exec_wmma_f32(*fx.cu, M, N, K, bits, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                          fx.vbase + S1_OFF, fx.vbase + S2_OFF, amdgpu::extract_bf16,
+                          amdgpu::extract_bf16, /*const_acc=*/0);
+  };
+  bench("v_wmma_f32_16x16x32_bf16", fx, run, double(M) * N * K, Cmp::F32Tol);
+}
+
+TEST(WmmaSimdBenchmark, F32_16x16x32_bf16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32;
+  fx.seed_bf16(S0_OFF, 16, mma_test::SmallGen(61));
+  fx.seed_bf16(S1_OFF, 16, mma_test::SmallGen(62));
+  auto run = [&] {
+    amdgpu::exec_wmma_f32_16x16x32_bf16(*fx.cu, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                                        fx.vbase + S1_OFF, fx.vbase + S2_OFF, /*const_acc=*/0);
+  };
+  bench("v_wmma_f32_16x16x32_bf16 [specialized]", fx, run, double(M) * N * K, Cmp::F32Tol);
+}
+
+// Dense WMMA, bf16 output, bf16 input, K=32 — specialized packed16 path.
+TEST(WmmaSimdBenchmark, Bf16_16x16x32_bf16_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 32;
+  fx.seed_bf16(S0_OFF, 16, mma_test::SmallGen(63));
+  fx.seed_bf16(S1_OFF, 16, mma_test::SmallGen(64));
+  auto run = [&] {
+    amdgpu::exec_wmma_bf16_spec<16, 16, 32>(*fx.cu, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                                            fx.vbase + S1_OFF, fx.vbase + S2_OFF, /*const_acc=*/0);
+  };
+  bench("v_wmma_bf16_16x16x32_bf16 [specialized]", fx, run, double(M) * N * K, Cmp::Bf16Tol);
 }
 
 // Dense WMMA, f16 output, f16 input, K=32 — specialized (constexpr + F16C).

--- a/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
@@ -16,6 +16,7 @@
 ///   - f32/f16/bf16 output: SIMD uses fused FMA (matching the hardware) while the
 ///     scalar reference is non-fused, so results agree to a small tolerance.
 
+#include "mma_test_util.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
@@ -198,27 +199,6 @@ void bench(const char *label, BenchFixture &fx, const std::function<void()> &run
   EXPECT_GT(sd, 0.0);
 }
 
-struct SmallGen {
-  std::mt19937 rng;
-  std::uniform_real_distribution<float> dist{-1.0f, 1.0f};
-  explicit SmallGen(uint32_t seed) : rng(seed) {}
-  float operator()() { return dist(rng); }
-};
-
-struct SmallI8Gen {
-  std::mt19937 rng;
-  std::uniform_int_distribution<int> dist{-8, 7};
-  explicit SmallI8Gen(uint32_t seed) : rng(seed) {}
-  int operator()() { return dist(rng); }
-};
-
-#define SKIP_IF_NO_SIMD()                                                                          \
-  if constexpr (!util::has_stdx_simd) {                                                            \
-    GTEST_SKIP() << "<experimental/simd> unavailable — scalar fallback in use";                    \
-  } else if (util::native<float>::size() <= 1) {                                                   \
-    GTEST_SKIP() << "host native_simd width is 1 — no SIMD speedup possible";                      \
-  }
-
 } // namespace
 
 // Dense WMMA, f32 output, f16 input (the common transformer shape).
@@ -226,8 +206,8 @@ TEST(WmmaSimdBenchmark, F32_16x16x16_f16) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 16, bits = 16;
-  fx.seed(S0_OFF, 16, bits, SmallGen(1));
-  fx.seed(S1_OFF, 16, bits, SmallGen(2));
+  fx.seed(S0_OFF, 16, bits, mma_test::SmallGen(1));
+  fx.seed(S1_OFF, 16, bits, mma_test::SmallGen(2));
   auto run = [&] {
     amdgpu::exec_wmma_f32(*fx.cu, M, N, K, bits, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
                           fx.vbase + S1_OFF, fx.vbase + S2_OFF, amdgpu::extract_f16,
@@ -241,8 +221,8 @@ TEST(WmmaSimdBenchmark, F16_16x16x16_f16) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 16, bits = 16;
-  fx.seed(S0_OFF, 16, bits, SmallGen(3));
-  fx.seed(S1_OFF, 16, bits, SmallGen(4));
+  fx.seed(S0_OFF, 16, bits, mma_test::SmallGen(3));
+  fx.seed(S1_OFF, 16, bits, mma_test::SmallGen(4));
   auto run = [&] {
     amdgpu::exec_wmma_f16(*fx.cu, M, N, K, bits, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
                           fx.vbase + S1_OFF, fx.vbase + S2_OFF, amdgpu::extract_f16,
@@ -256,8 +236,8 @@ TEST(WmmaSimdBenchmark, Bf16_16x16x16_bf16) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 16, bits = 16;
-  fx.seed(S0_OFF, 16, bits, SmallGen(5));
-  fx.seed(S1_OFF, 16, bits, SmallGen(6));
+  fx.seed(S0_OFF, 16, bits, mma_test::SmallGen(5));
+  fx.seed(S1_OFF, 16, bits, mma_test::SmallGen(6));
   auto run = [&] {
     amdgpu::exec_wmma_bf16(*fx.cu, M, N, K, bits, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
                            fx.vbase + S1_OFF, fx.vbase + S2_OFF, amdgpu::extract_bf16,
@@ -271,8 +251,8 @@ TEST(WmmaSimdBenchmark, I32_16x16x16_i8) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 16;
-  fx.seed_i8(S0_OFF, 16, SmallI8Gen(7));
-  fx.seed_i8(S1_OFF, 16, SmallI8Gen(8));
+  fx.seed_i8(S0_OFF, 16, mma_test::SmallI8Gen(7));
+  fx.seed_i8(S1_OFF, 16, mma_test::SmallI8Gen(8));
   auto run = [&] {
     amdgpu::exec_wmma_i32_i8(*fx.cu, M, N, K, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
                              fx.vbase + S1_OFF, fx.vbase + S2_OFF, /*const_acc=*/0);
@@ -285,8 +265,8 @@ TEST(WmmaSimdBenchmark, SwmmacF32_16x16x32_f16) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 32, bits = 16;
-  fx.seed(S0_OFF, 16, bits, SmallGen(9));
-  fx.seed(S1_OFF, 16, bits, SmallGen(10));
+  fx.seed(S0_OFF, 16, bits, mma_test::SmallGen(9));
+  fx.seed(S1_OFF, 16, bits, mma_test::SmallGen(10));
   fx.seed_words(INDEX_OFF, 2, 0xE4E4E4E4u); // arbitrary but valid 2-bit index set
   auto run = [&] {
     amdgpu::exec_swmmac_f32(*fx.cu, M, N, K, bits, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
@@ -302,8 +282,8 @@ TEST(WmmaSimdBenchmark, SwmmacI32_16x16x32_i8) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 32;
-  fx.seed_i8(S0_OFF, 16, SmallI8Gen(11));
-  fx.seed_i8(S1_OFF, 16, SmallI8Gen(12));
+  fx.seed_i8(S0_OFF, 16, mma_test::SmallI8Gen(11));
+  fx.seed_i8(S1_OFF, 16, mma_test::SmallI8Gen(12));
   fx.seed_words(INDEX_OFF, 2, 0xE4E4E4E4u);
   auto run = [&] {
     amdgpu::exec_swmmac_i32_i8(*fx.cu, M, N, K, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
@@ -318,8 +298,8 @@ TEST(WmmaSimdBenchmark, F32_16x16x32_f16) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 32, bits = 16;
-  fx.seed(S0_OFF, 16, bits, SmallGen(13));
-  fx.seed(S1_OFF, 16, bits, SmallGen(14));
+  fx.seed(S0_OFF, 16, bits, mma_test::SmallGen(13));
+  fx.seed(S1_OFF, 16, bits, mma_test::SmallGen(14));
   auto run = [&] {
     amdgpu::exec_wmma_f32(*fx.cu, M, N, K, bits, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
                           fx.vbase + S1_OFF, fx.vbase + S2_OFF, amdgpu::extract_f16,
@@ -333,8 +313,8 @@ TEST(WmmaSimdBenchmark, F32_16x16x32_f16_Specialized) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 32, bits = 16;
-  fx.seed(S0_OFF, 16, bits, SmallGen(13));
-  fx.seed(S1_OFF, 16, bits, SmallGen(14));
+  fx.seed(S0_OFF, 16, bits, mma_test::SmallGen(13));
+  fx.seed(S1_OFF, 16, bits, mma_test::SmallGen(14));
   auto run = [&] {
     amdgpu::exec_wmma_f32_16x16x32_f16(*fx.cu, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
                                        fx.vbase + S1_OFF, fx.vbase + S2_OFF, /*const_acc=*/0);
@@ -347,8 +327,8 @@ TEST(WmmaSimdBenchmark, F32_16x16x4_f32_Specialized) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 4, bits = 32;
-  fx.seed(S0_OFF, 16, bits, SmallGen(41));
-  fx.seed(S1_OFF, 16, bits, SmallGen(42));
+  fx.seed(S0_OFF, 16, bits, mma_test::SmallGen(41));
+  fx.seed(S1_OFF, 16, bits, mma_test::SmallGen(42));
   auto run = [&] {
     amdgpu::exec_wmma_f32_f32_spec<16, 16, 4>(*fx.cu, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
                                               fx.vbase + S1_OFF, fx.vbase + S2_OFF,
@@ -362,8 +342,8 @@ TEST(WmmaSimdBenchmark, F16_16x16x32_f16_Specialized) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;
   constexpr uint32_t M = 16, N = 16, K = 32, bits = 16;
-  fx.seed(S0_OFF, 16, bits, SmallGen(51));
-  fx.seed(S1_OFF, 16, bits, SmallGen(52));
+  fx.seed(S0_OFF, 16, bits, mma_test::SmallGen(51));
+  fx.seed(S1_OFF, 16, bits, mma_test::SmallGen(52));
   auto run = [&] {
     amdgpu::exec_wmma_f16_spec<16, 16, 32>(*fx.cu, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
                                            fx.vbase + S1_OFF, fx.vbase + S2_OFF, /*const_acc=*/0);

--- a/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
@@ -390,6 +390,36 @@ TEST(WmmaSimdBenchmark, Bf16_16x16x32_bf16_Specialized) {
   bench("v_wmma_bf16_16x16x32_bf16 [specialized]", fx, run, double(M) * N * K, Cmp::Bf16Tol);
 }
 
+// Dense WMMA, i32 output, iu8 input, K=64 — the real gfx1250 integer shape,
+// generic baseline vs specialized (constexpr + i8 bulk sign-extend convert).
+TEST(WmmaSimdBenchmark, I32_16x16x64_iu8) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 64;
+  fx.seed_i8(S0_OFF, 16, mma_test::SmallI8Gen(71));
+  fx.seed_i8(S1_OFF, 16, mma_test::SmallI8Gen(72));
+  auto run = [&] {
+    amdgpu::exec_wmma_i32(*fx.cu, M, N, K, 8, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                          fx.vbase + S1_OFF, fx.vbase + S2_OFF, amdgpu::extract_i8,
+                          amdgpu::extract_u8, /*clamp=*/false, /*const_acc=*/0);
+  };
+  bench("v_wmma_i32_16x16x64_iu8", fx, run, double(M) * N * K, Cmp::IntExact);
+}
+
+TEST(WmmaSimdBenchmark, I32_16x16x64_iu8_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 64;
+  fx.seed_i8(S0_OFF, 16, mma_test::SmallI8Gen(71));
+  fx.seed_i8(S1_OFF, 16, mma_test::SmallI8Gen(72));
+  auto run = [&] {
+    amdgpu::exec_wmma_i32_16x16x64_iu8(*fx.cu, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                                       fx.vbase + S1_OFF, fx.vbase + S2_OFF, /*a_signed=*/true,
+                                       /*b_signed=*/false, /*clamp=*/false, /*const_acc=*/0);
+  };
+  bench("v_wmma_i32_16x16x64_iu8 [specialized]", fx, run, double(M) * N * K, Cmp::IntExact);
+}
+
 // Dense WMMA, f16 output, f16 input, K=32 — specialized (constexpr + F16C).
 TEST(WmmaSimdBenchmark, F16_16x16x32_f16_Specialized) {
   SKIP_IF_NO_SIMD();

--- a/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/wmma_simd_benchmark.cpp
@@ -109,6 +109,18 @@ struct BenchFixture {
       }
   }
 
+  // Pack `regs` words of small fp8 (e4m3) codes into the VGPR range. Both modes
+  // read the same bytes, so the codes are equally valid for the bf8 paths.
+  template <typename Gen> void seed_f8(uint32_t off, uint32_t regs, Gen gen) {
+    for (uint32_t reg = 0; reg < regs; ++reg)
+      for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
+        uint32_t word = 0;
+        for (uint32_t byte = 0; byte < 4; ++byte)
+          word |= static_cast<uint32_t>(util::f32_to_fp8_e4m3(gen())) << (byte * 8);
+        cu->write_vgpr(vbase + off + reg, lane, word);
+      }
+  }
+
   template <typename Gen> void seed_i8(uint32_t off, uint32_t regs, Gen gen) {
     for (uint32_t reg = 0; reg < regs; ++reg)
       for (uint32_t lane = 0; lane < WF_SIZE; ++lane) {
@@ -418,6 +430,66 @@ TEST(WmmaSimdBenchmark, I32_16x16x64_iu8_Specialized) {
                                        /*b_signed=*/false, /*clamp=*/false, /*const_acc=*/0);
   };
   bench("v_wmma_i32_16x16x64_iu8 [specialized]", fx, run, double(M) * N * K, Cmp::IntExact);
+}
+
+// Dense WMMA, f32 output, fp8 input, K=64 — generic baseline vs specialized
+// (constexpr + 256-entry LUT bulk convert).
+TEST(WmmaSimdBenchmark, F32_16x16x64_fp8) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 64;
+  fx.seed_f8(S0_OFF, 16, mma_test::SmallGen(81));
+  fx.seed_f8(S1_OFF, 16, mma_test::SmallGen(82));
+  auto run = [&] {
+    amdgpu::exec_wmma_f32(*fx.cu, M, N, K, 8, fx.vbase + S2_OFF, fx.vbase + S0_OFF,
+                          fx.vbase + S1_OFF, fx.vbase + S2_OFF, amdgpu::extract_fp8,
+                          amdgpu::extract_fp8, /*const_acc=*/0);
+  };
+  bench("v_wmma_f32_16x16x64_fp8_fp8", fx, run, double(M) * N * K, Cmp::F32Tol);
+}
+
+TEST(WmmaSimdBenchmark, F32_16x16x64_fp8_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 64;
+  fx.seed_f8(S0_OFF, 16, mma_test::SmallGen(81));
+  fx.seed_f8(S1_OFF, 16, mma_test::SmallGen(82));
+  auto run = [&] {
+    amdgpu::exec_wmma_f32_f8_spec<16, 16, 64, true, true>(*fx.cu, fx.vbase + S2_OFF,
+                                                          fx.vbase + S0_OFF, fx.vbase + S1_OFF,
+                                                          fx.vbase + S2_OFF, /*const_acc=*/0);
+  };
+  bench("v_wmma_f32_16x16x64_fp8_fp8 [specialized]", fx, run, double(M) * N * K, Cmp::F32Tol);
+}
+
+// Dense WMMA, f32 output, bf8 input, K=128 — specialized.
+TEST(WmmaSimdBenchmark, F32_16x16x128_bf8_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 128;
+  fx.seed_f8(S0_OFF, 16, mma_test::SmallGen(83));
+  fx.seed_f8(S1_OFF, 16, mma_test::SmallGen(84));
+  auto run = [&] {
+    amdgpu::exec_wmma_f32_f8_spec<16, 16, 128, false, false>(*fx.cu, fx.vbase + S2_OFF,
+                                                             fx.vbase + S0_OFF, fx.vbase + S1_OFF,
+                                                             fx.vbase + S2_OFF, /*const_acc=*/0);
+  };
+  bench("v_wmma_f32_16x16x128_bf8_bf8 [specialized]", fx, run, double(M) * N * K, Cmp::F32Tol);
+}
+
+// Dense WMMA, f16 output, fp8 input, K=64 — specialized packed16 path.
+TEST(WmmaSimdBenchmark, F16_16x16x64_fp8_Specialized) {
+  SKIP_IF_NO_SIMD();
+  BenchFixture fx;
+  constexpr uint32_t M = 16, N = 16, K = 64;
+  fx.seed_f8(S0_OFF, 16, mma_test::SmallGen(85));
+  fx.seed_f8(S1_OFF, 16, mma_test::SmallGen(86));
+  auto run = [&] {
+    amdgpu::exec_wmma_f16_f8_spec<16, 16, 64, true, true>(*fx.cu, fx.vbase + S2_OFF,
+                                                          fx.vbase + S0_OFF, fx.vbase + S1_OFF,
+                                                          fx.vbase + S2_OFF, /*const_acc=*/0);
+  };
+  bench("v_wmma_f16_16x16x64_fp8_fp8 [specialized]", fx, run, double(M) * N * K, Cmp::F16Tol);
 }
 
 // Dense WMMA, f16 output, f16 input, K=32 — specialized (constexpr + F16C).


### PR DESCRIPTION
* Adds dense SIMD fast paths to the shared matrix executors (`mma_exec.h`) for all CDNA4 MFMA and gfx1250 WMMA shapes.
* constexpr-dim specialized kernels for the hot shapes across all dense input types: f16, f32, bf16, i8, fp8/bf8, plus the batched 2b/4b variants.
* Sparse SMFMAC/SWMMAC, 4x4x4_16b, scaled fp4/fp6, and f64 stay on the generic path.

This should cover majority of the SIMD'fiable ops.

## Test Plan
* SIMD results have to be bit-exact compared to scalar results.

## Test Result

* Execute-body microbench (AVX-512): MFMA f16 ≤282×, bf16 ≤209×, i8 ≤117×, fp8/bf8 ≤196×, batched 73–168×; WMMA f16 ≤158×, bf16 ≤163×, iu8 186×, f8 96–132×; f32 31–153×; integer paths bit-identical, f32 fused-FMA matching hardware.
* Bit-exact SIMD-vs-scalar suites for every executor/shape and every dispatched template instantiation (random + boundary inputs incl. NaN/Inf/denorm/saturation), built only with `-DRJ_ENABLE_EXPENSIVE_CHECKS=ON`.
* Benchmarks excluded from default ctest (`--gtest_filter='*Benchmark*'` to run).
* Now totalling 809/809 tests + all exact suites on AVX-512 and SSE2.


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
