### PR TITLE
[rocprofiler-sdk] Fix cmake and build issues

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/aqlprofile.hpp
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/aqlprofile.hpp
@@ -37,7 +37,16 @@
 #undef ROCPROFILER_INTERNAL_AQLPROFILE_INCLUDE
 
 #if ROCPROFILER_EXTERNAL_AQLPROFILE == 0
-#    include "lib/aqlprofile/util/hsa_rsrc_factory.h"
+extern "C" struct HsaApiTable;
+
+namespace rocprofiler
+{
+namespace aqlprofile
+{
+void
+hsa_rsrc_factory_init(::HsaApiTable* table);
+}
+}  // namespace rocprofiler
 #else
 
 extern "C" struct HsaApiTable;

--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/util/hsa_rsrc_factory.h
@@ -23,15 +23,7 @@
 #ifndef SRC_UTIL_HSA_RSRC_FACTORY_H_
 #define SRC_UTIL_HSA_RSRC_FACTORY_H_
 
-// Deliberate include cycle: aqlprofile.hpp -> hsa_rsrc_factory.h (when
-// ROCPROFILER_EXTERNAL_AQLPROFILE == 0) -> aqlprofile.hpp. The cycle is safe
-// because aqlprofile.hpp drives the ROCPROFILER_INTERNAL_AQLPROFILE_INCLUDE
-// gate and includes aql_profile_v2.h *before* including this header, and our
-// own include guard (SRC_UTIL_HSA_RSRC_FACTORY_H_) short-circuits the
-// re-entry. Do not reorder the includes in aqlprofile.hpp, or this cycle
-// will produce an incomplete aqlprofile_cu_bitmap_t at AgentInfo's point of
-// use below.
-#include "lib/aqlprofile/aqlprofile.hpp"  // aqlprofile_cu_bitmap_t (gated aql_profile_v2.h)
+#include "lib/aqlprofile/aqlprofile.hpp"  // aqlprofile_cu_bitmap_t
 #include "lib/aqlprofile/hsa_includes.h"
 
 #include <cstdint>

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/platform/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/platform/tests/CMakeLists.txt
@@ -18,19 +18,16 @@ target_link_libraries(
             GTest::gtest
             GTest::gtest_main)
 
-# Reuse the sysfs topology fixture from lib/tests so the gnulinux force-platform test can
-# resolve a real node tree on bare-metal CI.
-file(
-    GLOB _NODE_PROPERTIES
-    ${CMAKE_SOURCE_DIR}/source/lib/rocprofiler-sdk/tests/data/topology/nodes/*/properties)
-
+# Reuses the sysfs topology fixture from lib/tests so the gnulinux force-platform test can
+# resolve a real node tree on bare-metal CI. The sysfs topology should already exist in
+# the build directory so do not copy over the data again, especially since
+# rocprofiler_add_unit_test does not support DATA / CONFIGURE_FILES in a non-relative
+# child directory path.
 rocprofiler_add_unit_test(
     TARGET platform-dispatch-tests
     SOURCES ${ROCPROFILER_LIB_PLATFORM_TEST_SOURCES}
     TIMEOUT 30
     LABELS "unittests;platform-dispatch"
-    DATA "${CMAKE_SOURCE_DIR}/source/lib/rocprofiler-sdk/tests/data/topology/nodes"
-    CONFIGURE_FILES "${_NODE_PROPERTIES}"
     ENVIRONMENT
         "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
     FAIL_REGULAR_EXPRESSION "${ROCPROFILER_DEFAULT_FAIL_REGEX}")


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
- CMake should never add files to source tree
- Circular include warnings are terrible

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- remove copying over topology files to source directory in `source/lib/rocprofiler-sdk/platform/tests`
  - introduced by #6399 
- fix circular include between `source/lib/aqlprofile/aqlprofile.hpp` and `source/lib/aqlprofile/util/hsa_rsrc_factory.h`
  - introduced by #5943 

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
