### PR TITLE
[RCCL] Place .hip_fatbin at the end of librccl.so

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -90,6 +90,12 @@ option(ENABLE_CODE_COVERAGE                    "Enable code coverage"           
 option(ENABLE_IFC                              "Enable indirect function call"                 OFF)
 option(ENABLE_DEVICE_LINKER                    "Build with assembly-extract device linker"     ON)
 option(EMIT_LLVM_IR                            "Emit LLVM IR/bitcode for nccl_device APIs"     OFF)
+# Move .hip_fatbin to the end of librccl.so so that small-code-model host
+# relocations (PC32/PLT32/GOTPCRELX/32S) between .text and the read-only /
+# writable data clusters stay in range even when the bundled device fat
+# binary exceeds ~2 GiB.  Default ON; disable only to reproduce the prior
+# layout for diagnostics.  See cmake/linker_scripts/hip_fatbin_tail.ld.
+option(RCCL_HIP_FATBIN_AT_TAIL                 "Place .hip_fatbin at the end of librccl.so"    ON)
 option(GENERATE_SYM_KERNELS                    "Generate symmetric memory kernels"             ON)
 option(INSTALL_DEPENDENCIES                    "Force install dependencies"                    OFF)
 option(REPORT_KERNEL_RESOURCE_USE              "Append -Rpass-analysis=kernel to CXX flags"    OFF)

--- a/projects/rccl/cmake/linker_scripts/hip_fatbin_tail.ld
+++ b/projects/rccl/cmake/linker_scripts/hip_fatbin_tail.ld
@@ -1,0 +1,47 @@
+/* hip_fatbin_tail.ld
+ *
+ * Move the merged .hip_fatbin output section to the very end of librccl.so.
+ *
+ * Why
+ * ---
+ * The bundled per-arch device image embedded in librccl.so (.hip_fatbin)
+ * routinely grows to hundreds of megabytes and, with the full default
+ * GPU_TARGETS list and uncompressed embedding, can exceed INT32_MAX.
+ *
+ * In lld's default orphan placement, .hip_fatbin (SHF_ALLOC, !SHF_WRITE,
+ * !SHF_EXECINSTR) lands in the read-only loadable cluster, between .rodata
+ * and .eh_frame.  That puts a multi-hundred-MB blob between .text and the
+ * subsequent data sections (.eh_frame, .data.rel.ro, .got, .data, .bss, ...)
+ * and breaks small-code-model host relocations:
+ *   R_X86_64_PC32 / R_X86_64_PLT32   .text -> .rodata / .eh_frame / .data*
+ *   R_X86_64_GOTPCRELX               .text -> .got slot on the far side
+ *   R_X86_64_32S                     literal offsets in .eh_frame / .data.rel.ro
+ *
+ * Nothing in .hip_fatbin is the target of a small-model relocation from
+ * host code in the usual sense.  The HIP runtime reaches it via the wrapper
+ * struct in .hipFatBinSegment (which holds a 64-bit pointer materialized
+ * via R_X86_64_RELATIVE / R_X86_64_64 in PIE/.so output).  The constructor
+ * __hip_module_ctor references &__hip_fatbin_wrapper, not &__hip_fatbin.
+ *
+ * So if .hip_fatbin lives at the tail of the image, the text<->data island
+ * shrinks back to roughly its pre-fatbin size and small-code-model
+ * relocations stay in range.  The only long-distance reference is the
+ * 64-bit pointer in the wrapper, which doesn't care about distance.
+ *
+ * How
+ * ---
+ * This file uses lld's (and ld.bfd's) INSERT AFTER directive: the default
+ * linker script is preserved and we only splice .hip_fatbin in at a new
+ * position.  KEEP() prevents --gc-sections from dropping the blob (the
+ * relocations from .hipFatBinSegment already keep it live, but be explicit).
+ * ALIGN(0x1000) preserves the 4 KiB alignment the runtime expects.
+ *
+ * Applies to the host link of librccl.so for both ENABLE_DEVICE_LINKER=ON
+ * (custom device-linker pipeline) and ENABLE_DEVICE_LINKER=OFF (-fgpu-rdc
+ * --hip-link path).  The offload device-link does not see this script.
+ */
+SECTIONS
+{
+  .hip_fatbin : ALIGN(0x1000) { KEEP(*(.hip_fatbin)) }
+}
+INSERT AFTER .bss;

--- a/projects/rccl/cmake/scripts/check_hip_fatbin_tail.py
+++ b/projects/rccl/cmake/scripts/check_hip_fatbin_tail.py
@@ -1,118 +1,215 @@
 #!/usr/bin/env python3
-# Post-build sanity check for the .hip_fatbin tail-placement linker script.
+# Post-build safety check for the .hip_fatbin tail-placement linker script.
 #
-# Reads `readelf -SW <so>` (or `llvm-readelf -SW <so>`) output and confirms
-# that .hip_fatbin is the section with the highest file offset among allocated
-# PROGBITS sections.  This is informational only — the script never exits
-# non-zero, so a layout change in a future toolchain version won't break
-# the build; the worst case is a WARNING line in the build log.
+# What it proves
+# --------------
+# librccl.so embeds a large (eventually >2 GiB) device fat binary in
+# .hip_fatbin.  Host code is compiled in the small code model, so every
+# host->host reference uses a *signed 32-bit* relocation (PC32 / PLT32 /
+# GOTPCRELX / 32S) whose displacement must fit in [-2^31, 2^31 - 1] (+/- 2 GiB).
+#
+# By design nothing takes a range-sensitive 32-bit reference *to* .hip_fatbin:
+# the HIP runtime reaches the blob only through the wrapper in
+# .hipFatBinSegment, which holds a full 64-bit pointer (R_X86_64_64 /
+# R_X86_64_RELATIVE).  That makes .hip_fatbin an inert spacer -- it is never
+# the site or the target of a 32-bit relocation.
+#
+# Given that, the only way a 32-bit host relocation can overflow is if two
+# *host* sections (everything except .hip_fatbin) end up more than 2 GiB
+# apart.  So the definitive, linker-independent safety condition is:
+#
+#     span(all SHF_ALLOC sections except .hip_fatbin) <= INT32_MAX
+#
+# where span = max(sh_addr + sh_size) - min(sh_addr).  If that holds, *every*
+# possible 32-bit host relocation is in range, no matter how large the fatbin
+# grows.  Placing .hip_fatbin at the tail is simply the mechanism that keeps
+# this host window small; this check verifies the property directly instead of
+# inspecting section order, and it catches the case where the linker script
+# silently failed to move the blob (the window then straddles the fatbin and
+# blows past 2 GiB).
+#
+# The section table is parsed straight out of the ELF (no readelf text
+# scraping, no third-party modules).
+#
+# Exit status:
+#   0  verified safe (host window <= 2 GiB), or the check does not apply
+#      (non-x86-64 host, or a 32-bit object).
+#   1  host window exceeds 2 GiB (the relocation-range guarantee is lost), or
+#      the library could not be read/parsed as ELF.
+#   2  bad usage.
+#
+# NOTE: correctness rests on the "nothing 32-bit-references .hip_fatbin"
+# property above.  If a future toolchain/runtime takes a PC-relative or other
+# 32-bit reference to __hip_fatbin, tail placement would itself create the
+# overflow and excluding .hip_fatbin from the span would be invalid.
 #
 # Usage: check_hip_fatbin_tail.py <path-to-librccl.so>
 
 import os
-import re
-import shutil
-import subprocess
+import struct
 import sys
 
-SECTION_RE = re.compile(
-    r"\s*\[\s*\d+\]\s+"      # [Nr]
-    r"(\S+)\s+"               # name
-    r"(\S+)\s+"               # type
-    r"\S+\s+"                 # address
-    r"([0-9a-fA-F]+)\s+"      # file offset (hex)
-    r"\S+\s+"                 # size
-    r"\S+\s+"                 # ES
-    r"([A-Za-z]*)"            # flags
-)
+PREFIX = "[rccl] hip_fatbin tail check:"
+
+SHF_ALLOC = 0x2
+SHF_TLS = 0x400
+EM_X86_64 = 62
+ELFCLASS64 = 2
+ELFDATA2LSB = 1
+SHN_XINDEX = 0xFFFF
+INT32_MAX = (1 << 31) - 1
+MIB = 1024.0 * 1024.0
+FATBIN = ".hip_fatbin"
 
 
-def find_readelf():
-    """Locate a readelf-compatible binary.
+class ElfError(Exception):
+    pass
 
-    Prefer ROCm's bundled llvm-readelf so the toolchain that produced
-    librccl.so also inspects it (it always supports -SW with the same
-    output schema we parse below).  Fall back to a PATH llvm-readelf,
-    and only as a last resort to system readelf, which on older
-    binutils may not understand wide-mode hex offsets the same way.
+
+def parse_elf(f):
+    """Parse an ELF64 section table from an open binary file.
+
+    Returns (sections, machine) where sections is a list of dicts with keys
+    name/type/flags/addr/size/offset, or (None, machine) for a non-ELF64
+    object the check does not apply to.  Raises ElfError on a malformed ELF.
+
+    Only the ELF header, the section header table, and the section-name string
+    table are read (a few KiB), so cost is independent of the file size -- the
+    multi-hundred-MB .hip_fatbin payload is never touched.
     """
-    rocm = os.environ.get("ROCM_PATH", "/opt/rocm")
-    candidates = [
-        os.path.join(rocm, "llvm/bin/llvm-readelf"),
-        shutil.which("llvm-readelf"),
-        shutil.which("readelf"),
-    ]
-    for c in candidates:
-        if c and os.path.exists(c):
-            return c
-    return None
+    def read_at(off, n, what):
+        f.seek(off)
+        b = f.read(n)
+        if len(b) != n:
+            raise ElfError(f"short read for {what}")
+        return b
+
+    ehdr = read_at(0, 64, "ELF header")
+    if ehdr[:4] != b"\x7fELF":
+        raise ElfError("not an ELF file")
+    if ehdr[4] != ELFCLASS64:
+        return None, None  # 32-bit object: the >2 GiB concern does not apply
+    endian = "<" if ehdr[5] == ELFDATA2LSB else ">"
+
+    # Elf64_Ehdr, skipping the 16-byte e_ident.
+    (e_type, e_machine, e_version, e_entry, e_phoff, e_shoff, e_flags,
+     e_ehsize, e_phentsize, e_phnum, e_shentsize, e_shnum,
+     e_shstrndx) = struct.unpack_from(endian + "HHIQQQIHHHHHH", ehdr, 16)
+
+    if e_shoff == 0 or e_shentsize < 64:
+        raise ElfError("no usable section header table")
+
+    def parse_shdr(raw):
+        (sh_name, sh_type, sh_flags, sh_addr, sh_offset, sh_size,
+         sh_link, sh_info, sh_addralign, sh_entsize) = struct.unpack_from(
+            endian + "IIQQQQIIQQ", raw, 0)
+        return dict(name_off=sh_name, type=sh_type, flags=sh_flags,
+                    addr=sh_addr, offset=sh_offset, size=sh_size,
+                    link=sh_link)
+
+    # Section 0 carries the real section count / shstrtab index when they do
+    # not fit the 16-bit header fields.
+    sec0 = parse_shdr(read_at(e_shoff, e_shentsize, "section header 0"))
+    shnum = e_shnum if e_shnum != 0 else sec0["size"]
+    shstrndx = sec0["link"] if e_shstrndx == SHN_XINDEX else e_shstrndx
+    if shnum == 0:
+        raise ElfError("zero sections")
+
+    # Read the whole section header table in one go (shnum * e_shentsize bytes).
+    sht = read_at(e_shoff, shnum * e_shentsize, "section header table")
+    headers = [parse_shdr(sht[i * e_shentsize:(i + 1) * e_shentsize])
+               for i in range(shnum)]
+
+    if shstrndx >= shnum:
+        raise ElfError("bad shstrndx")
+    strtab = headers[shstrndx]
+    strblob = read_at(strtab["offset"], strtab["size"], "section name table")
+
+    def name_at(name_off):
+        end = strblob.find(b"\x00", name_off)
+        if end < 0:
+            end = len(strblob)
+        return strblob[name_off:end].decode("utf-8", errors="replace")
+
+    for s in headers:
+        s["name"] = name_at(s["name_off"])
+    return headers, e_machine
 
 
 def main(argv):
     if len(argv) != 2:
         print("usage: check_hip_fatbin_tail.py <librccl.so>", file=sys.stderr)
-        return 0  # informational; do not fail
+        return 2
 
     so = argv[1]
     if not os.path.exists(so):
-        print(f"[rccl] hip_fatbin tail check: SKIP ({so} not found)")
-        return 0
-
-    readelf = find_readelf()
-    if not readelf:
-        print("[rccl] hip_fatbin tail check: SKIP (no readelf in PATH or ROCM_PATH)")
-        return 0
+        print(f"{PREFIX} FAIL ({so} not found)", file=sys.stderr)
+        return 1
 
     try:
-        out = subprocess.check_output(
-            [readelf, "-SW", so], stderr=subprocess.STDOUT, timeout=30
-        ).decode("utf-8", errors="replace")
-    except subprocess.SubprocessError as e:
-        print(f"[rccl] hip_fatbin tail check: SKIP (readelf failed: {e})")
+        with open(so, "rb") as f:
+            sections, machine = parse_elf(f)
+    except (OSError, ElfError, struct.error) as e:
+        print(f"{PREFIX} FAIL (could not parse {so}: {e})", file=sys.stderr)
+        return 1
+
+    if sections is None:
+        print(f"{PREFIX} SKIP (not a 64-bit ELF; check is x86-64 specific)")
+        return 0
+    if machine != EM_X86_64:
+        print(f"{PREFIX} SKIP (e_machine={machine}; 32-bit-reloc concern is "
+              f"x86-64 specific)")
         return 0
 
-    max_off = -1
-    max_name = None
-    saw_fatbin = False
-    fatbin_off = None
-    for line in out.splitlines():
-        m = SECTION_RE.match(line)
-        if not m:
-            continue
-        name, sect_type, off_hex, flg = m.groups()
-        if sect_type != "PROGBITS":
-            continue
-        if "A" not in flg:
-            continue
-        try:
-            off = int(off_hex, 16)
-        except ValueError:
-            continue
-        if name == ".hip_fatbin":
-            saw_fatbin = True
-            fatbin_off = off
-        if off > max_off:
-            max_off = off
-            max_name = name
+    # Host sections that can be the site or target of a 32-bit relocation:
+    # everything allocated, minus TLS (different reloc class) and minus the
+    # inert .hip_fatbin spacer.
+    host = [s for s in sections
+            if (s["flags"] & SHF_ALLOC)
+            and not (s["flags"] & SHF_TLS)
+            and s["name"] != FATBIN]
+    if not host:
+        print(f"{PREFIX} FAIL (no allocated host sections found)",
+              file=sys.stderr)
+        return 1
 
-    if not saw_fatbin:
-        print("[rccl] hip_fatbin tail check: SKIP (.hip_fatbin not present)")
-        return 0
+    lo = min(host, key=lambda s: s["addr"])
+    hi = max(host, key=lambda s: s["addr"] + s["size"])
+    span = (hi["addr"] + hi["size"]) - lo["addr"]
 
-    if max_name == ".hip_fatbin":
-        print(
-            f"[rccl] hip_fatbin tail check: OK "
-            f"(.hip_fatbin at file offset 0x{fatbin_off:x}, last alloc PROGBITS)"
-        )
+    fatbins = [s for s in sections if s["name"] == FATBIN]
+    if fatbins:
+        fb = max(fatbins, key=lambda s: s["size"])
+        alloc = [s for s in sections
+                 if (s["flags"] & SHF_ALLOC) and not (s["flags"] & SHF_TLS)]
+        highest = max(alloc, key=lambda s: s["addr"] + s["size"])
+        at_tail = highest["name"] == FATBIN
+        fb_desc = (f".hip_fatbin {fb['size'] / MIB:.1f} MiB at file offset "
+                   f"0x{fb['offset']:x}, "
+                   f"{'at image tail' if at_tail else 'NOT at image tail'}")
     else:
-        print(
-            f"[rccl] hip_fatbin tail check: WARNING — "
-            f".hip_fatbin at 0x{fatbin_off:x} but a later alloc PROGBITS exists: "
-            f"{max_name!r} at 0x{max_off:x}. "
-            f"Host 32-bit relocations may overflow once .hip_fatbin grows. "
-            f"Check that the linker honoured cmake/linker_scripts/hip_fatbin_tail.ld."
-        )
-    return 0
+        fb_desc = ".hip_fatbin not present (nothing to displace host sections)"
+
+    if span <= INT32_MAX:
+        margin = INT32_MAX - span
+        print(f"{PREFIX} OK (host window {span / MIB:.1f} MiB <= 2 GiB, "
+              f"margin {margin / MIB:.1f} MiB; {fb_desc})")
+        return 0
+
+    over = span - INT32_MAX
+    print(f"{PREFIX} FAIL: host window is {span / MIB:.1f} MiB "
+          f"(> 2 GiB by {over / MIB:.1f} MiB).", file=sys.stderr)
+    print(f"  Lowest host section : {lo['name']} @ 0x{lo['addr']:x}",
+          file=sys.stderr)
+    print(f"  Highest host section: {hi['name']} @ "
+          f"0x{hi['addr'] + hi['size']:x}", file=sys.stderr)
+    print(f"  {fb_desc}", file=sys.stderr)
+    print("  Small-code-model host relocations (PC32/PLT32/GOTPCRELX/32S) can "
+          "overflow.", file=sys.stderr)
+    print("  Check that the linker honoured "
+          "cmake/linker_scripts/hip_fatbin_tail.ld and moved .hip_fatbin to "
+          "the tail.", file=sys.stderr)
+    return 1
 
 
 if __name__ == "__main__":

--- a/projects/rccl/cmake/scripts/check_hip_fatbin_tail.py
+++ b/projects/rccl/cmake/scripts/check_hip_fatbin_tail.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Post-build sanity check for the .hip_fatbin tail-placement linker script.
+#
+# Reads `readelf -SW <so>` (or `llvm-readelf -SW <so>`) output and confirms
+# that .hip_fatbin is the section with the highest file offset among allocated
+# PROGBITS sections.  This is informational only — the script never exits
+# non-zero, so a layout change in a future toolchain version won't break
+# the build; the worst case is a WARNING line in the build log.
+#
+# Usage: check_hip_fatbin_tail.py <path-to-librccl.so>
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+SECTION_RE = re.compile(
+    r"\s*\[\s*\d+\]\s+"      # [Nr]
+    r"(\S+)\s+"               # name
+    r"(\S+)\s+"               # type
+    r"\S+\s+"                 # address
+    r"([0-9a-fA-F]+)\s+"      # file offset (hex)
+    r"\S+\s+"                 # size
+    r"\S+\s+"                 # ES
+    r"([A-Za-z]*)"            # flags
+)
+
+
+def find_readelf():
+    """Locate a readelf-compatible binary.
+
+    Prefer ROCm's bundled llvm-readelf so the toolchain that produced
+    librccl.so also inspects it (it always supports -SW with the same
+    output schema we parse below).  Fall back to a PATH llvm-readelf,
+    and only as a last resort to system readelf, which on older
+    binutils may not understand wide-mode hex offsets the same way.
+    """
+    rocm = os.environ.get("ROCM_PATH", "/opt/rocm")
+    candidates = [
+        os.path.join(rocm, "llvm/bin/llvm-readelf"),
+        shutil.which("llvm-readelf"),
+        shutil.which("readelf"),
+    ]
+    for c in candidates:
+        if c and os.path.exists(c):
+            return c
+    return None
+
+
+def main(argv):
+    if len(argv) != 2:
+        print("usage: check_hip_fatbin_tail.py <librccl.so>", file=sys.stderr)
+        return 0  # informational; do not fail
+
+    so = argv[1]
+    if not os.path.exists(so):
+        print(f"[rccl] hip_fatbin tail check: SKIP ({so} not found)")
+        return 0
+
+    readelf = find_readelf()
+    if not readelf:
+        print("[rccl] hip_fatbin tail check: SKIP (no readelf in PATH or ROCM_PATH)")
+        return 0
+
+    try:
+        out = subprocess.check_output(
+            [readelf, "-SW", so], stderr=subprocess.STDOUT, timeout=30
+        ).decode("utf-8", errors="replace")
+    except subprocess.SubprocessError as e:
+        print(f"[rccl] hip_fatbin tail check: SKIP (readelf failed: {e})")
+        return 0
+
+    max_off = -1
+    max_name = None
+    saw_fatbin = False
+    fatbin_off = None
+    for line in out.splitlines():
+        m = SECTION_RE.match(line)
+        if not m:
+            continue
+        name, sect_type, off_hex, flg = m.groups()
+        if sect_type != "PROGBITS":
+            continue
+        if "A" not in flg:
+            continue
+        try:
+            off = int(off_hex, 16)
+        except ValueError:
+            continue
+        if name == ".hip_fatbin":
+            saw_fatbin = True
+            fatbin_off = off
+        if off > max_off:
+            max_off = off
+            max_name = name
+
+    if not saw_fatbin:
+        print("[rccl] hip_fatbin tail check: SKIP (.hip_fatbin not present)")
+        return 0
+
+    if max_name == ".hip_fatbin":
+        print(
+            f"[rccl] hip_fatbin tail check: OK "
+            f"(.hip_fatbin at file offset 0x{fatbin_off:x}, last alloc PROGBITS)"
+        )
+    else:
+        print(
+            f"[rccl] hip_fatbin tail check: WARNING — "
+            f".hip_fatbin at 0x{fatbin_off:x} but a later alloc PROGBITS exists: "
+            f"{max_name!r} at 0x{max_off:x}. "
+            f"Host 32-bit relocations may overflow once .hip_fatbin grows. "
+            f"Check that the linker honoured cmake/linker_scripts/hip_fatbin_tail.ld."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/projects/rccl/install.sh
+++ b/projects/rccl/install.sh
@@ -435,15 +435,21 @@ check_exit_code "$?"
 if [[ "${time_trace}" == true || "${use_ninja}" == true ]]; then
     if ! hash ninja &>/dev/null ; then
         if [[ "${time_trace}" == true ]]; then
+            # Ninja is mandatory for --time-trace (the trace post-processing
+            # consumes Ninja's .ninja_log), so this is a hard error.
             echo "ninja could not be found (required for --time-trace)"
-        else
-            echo "ninja could not be found (required for --ninja)"
+            echo "Use \"${time_trace_ninja_msg}\" to install ninja"
+            exit 1
         fi
-        echo "Use \"${time_trace_ninja_msg}\" to install ninja"
-        exit 1
+        # --ninja is only a build-speed opt-in, so degrade gracefully to Make
+        # rather than aborting when ninja is unavailable.
+        echo "WARNING: ninja could not be found; falling back to the Make generator for --ninja"
+        echo "         Use \"${time_trace_ninja_msg}\" to install ninja"
+        build_system="make"
+    else
+        build_system="ninja"
+        enable_ninja="-GNinja"
     fi
-    build_system="ninja"
-    enable_ninja="-GNinja"
 else
     build_system="make"
 fi

--- a/projects/rccl/install.sh
+++ b/projects/rccl/install.sh
@@ -34,6 +34,7 @@ roctx_enabled=true
 run_tests=false
 run_tests_all=false
 time_trace=false
+use_ninja=false
 force_reduce_pipeline=false
 generate_sym_kernels=true
 device_linker=true
@@ -84,6 +85,7 @@ function display_help()
     echo "       --static                Build RCCL as a static library instead of shared library"
     echo "    -t|--tests_build           Build rccl unit tests, but do not run"
     echo "       --time-trace            Plot the build time of RCCL (requires \`ninja-build\` package installed on the system)"
+    echo "       --ninja                 Use the Ninja generator instead of Make (requires \`ninja-build\`; recommended for multi-arch builds)"
     echo "       --verbose               Show compile commands"
     echo ""
     echo "  Available RCCL-specific CMake options for --cmake-options:"
@@ -114,7 +116,7 @@ function display_help()
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ "$?" -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,amdgpu_targets:,cmake-options:,debug,debug-fast,dependencies,device-linker,disable-roctx,disable-sym-kernels,disable-warp-speed,dump-asm,enable-code-coverage,enable_backtrace,enable-mpi-tests,fast,force-reduce-pipeline,generate-sym-kernels,help,install,jobs:,kernel-resource-use,local_gpu_only,log-trace,no_clean,no-device-linker,openmp-test-enable,package_build,prefix:,quiet-warnings,rm-legacy-include-dir,rocshmem,roctx-enable,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,amdgpu_targets:,cmake-options:,debug,debug-fast,dependencies,device-linker,disable-roctx,disable-sym-kernels,disable-warp-speed,dump-asm,enable-code-coverage,enable_backtrace,enable-mpi-tests,fast,force-reduce-pipeline,generate-sym-kernels,help,install,jobs:,kernel-resource-use,local_gpu_only,log-trace,ninja,no_clean,no-device-linker,openmp-test-enable,package_build,prefix:,quiet-warnings,rm-legacy-include-dir,rocshmem,roctx-enable,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -151,6 +153,7 @@ while true; do
          --kernel-resource-use)      kernel_resource_use=true;                                                                         shift ;;
     -l | --local_gpu_only)           build_local_gpu_only=true;                                                                        shift ;;
          --log-trace)                log_trace=true;                                                                                   shift ;;
+         --ninja)                    use_ninja=true;                                                                                   shift ;;
          --no_clean)                 clean_build=false;                                                                                shift ;;
          --no-device-linker)         device_linker=false;                                                                              shift ;;
          --openmp-test-enable)       openmp_test_enabled=true;                                                                         shift ;;
@@ -423,12 +426,19 @@ fi
 
 check_exit_code "$?"
 
-# Build system selection.  Ninja is used only when explicitly requested via
-# --time-trace (which requires it).  Default is Make for broadest compatibility
+# Build system selection.  Default is Make for broadest compatibility
 # (Jenkins CI runs `make package` directly in the build directory).
-if [[ "${time_trace}" == true ]]; then
+# Ninja is enabled when explicitly requested via --ninja or --time-trace
+# (the latter requires it).  Ninja parallelizes the multi-arch device
+# pipeline considerably better than Make, so it's the recommended generator
+# for builds that target many GPU architectures at once.
+if [[ "${time_trace}" == true || "${use_ninja}" == true ]]; then
     if ! hash ninja &>/dev/null ; then
-        echo "ninja could not be found (required for --time-trace)"
+        if [[ "${time_trace}" == true ]]; then
+            echo "ninja could not be found (required for --time-trace)"
+        else
+            echo "ninja could not be found (required for --ninja)"
+        fi
         echo "Use \"${time_trace_ninja_msg}\" to install ninja"
         exit 1
     fi
@@ -460,9 +470,13 @@ fi
 ${cmake_executable} ${cmake_common_options} -DONLY_FUNCS="${ONLY_FUNCS}" ../../.
 check_exit_code "$?"
 
-# Enable verbose output from Makefile
+# Enable verbose output from the build system
 if [[ "${build_verbose}" == true ]]; then
-    build_system="${build_system} VERBOSE=1"
+    if [[ "${build_system}" == "ninja" ]]; then
+        build_system="${build_system} -v"
+    else
+        build_system="${build_system} VERBOSE=1"
+    fi
 fi
 
 # Initiate RCCL build (and install)
@@ -473,9 +487,13 @@ else
 fi
 check_exit_code "$?"
 
-# Initiate package build with `make package`, if enabled
+# Initiate package build (`make package` or `ninja package`), if enabled
 if [[ "${build_package}" == true ]]; then
-    make package
+    if [[ "${build_system}" == "ninja"* ]]; then
+        ninja package
+    else
+        make package
+    fi
     check_exit_code "$?"
 fi
 

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -1150,7 +1150,7 @@ endif()
 # (custom pipeline) and OFF (-fgpu-rdc --hip-link).  No-op for static builds
 # (which go through --emit-static-lib and never run ld).
 if(BUILD_SHARED_LIBS AND RCCL_HIP_FATBIN_AT_TAIL)
-  set(_rccl_fatbin_script "${RCCL_SOURCE_DIR}/cmake/linker_scripts/hip_fatbin_tail.ld")
+  set(_rccl_fatbin_script "${PROJECT_SOURCE_DIR}/cmake/linker_scripts/hip_fatbin_tail.ld")
   if(NOT EXISTS "${_rccl_fatbin_script}")
     message(FATAL_ERROR "RCCL_HIP_FATBIN_AT_TAIL=ON but linker script not found: ${_rccl_fatbin_script}")
   endif()

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -1139,6 +1139,38 @@ if(TIMETRACE)
   target_link_options(rccl PRIVATE -ftime-trace)
 endif()
 
+# .hip_fatbin tail-placement linker script.
+#
+# Splices the merged .hip_fatbin output section to the end of librccl.so via
+# lld's INSERT AFTER directive (the default linker script is preserved).
+# Keeps text<->data distances small so host PC32/PLT32/GOTPCRELX/32S
+# relocations stay in range when the bundled device image grows past
+# INT32_MAX.  Applies to the host link only; the offload device-link does
+# not see the script, so it works identically for ENABLE_DEVICE_LINKER=ON
+# (custom pipeline) and OFF (-fgpu-rdc --hip-link).  No-op for static builds
+# (which go through --emit-static-lib and never run ld).
+if(BUILD_SHARED_LIBS AND RCCL_HIP_FATBIN_AT_TAIL)
+  set(_rccl_fatbin_script "${RCCL_SOURCE_DIR}/cmake/linker_scripts/hip_fatbin_tail.ld")
+  if(NOT EXISTS "${_rccl_fatbin_script}")
+    message(FATAL_ERROR "RCCL_HIP_FATBIN_AT_TAIL=ON but linker script not found: ${_rccl_fatbin_script}")
+  endif()
+  target_link_options(rccl PRIVATE "LINKER:-T,${_rccl_fatbin_script}")
+  set_property(TARGET rccl APPEND PROPERTY LINK_DEPENDS "${_rccl_fatbin_script}")
+  message(STATUS "RCCL: .hip_fatbin will be placed at end of librccl.so (${_rccl_fatbin_script})")
+
+  # Informational post-build check: verify .hip_fatbin really is the last
+  # alloc PROGBITS section.  Never fails the build (a future toolchain may
+  # legitimately add a new tail section); just prints a WARNING to the log
+  # if the layout regresses so it's easy to spot in CI output.
+  add_custom_command(TARGET rccl POST_BUILD
+    COMMAND ${Python3_EXECUTABLE}
+            ${RCCL_SOURCE_DIR}/cmake/scripts/check_hip_fatbin_tail.py
+            $<TARGET_FILE:rccl>
+    COMMENT "Verifying .hip_fatbin is at the tail of librccl.so"
+    VERBATIM
+  )
+endif()
+
 if(NOT BUILD_SHARED_LIBS)
   message(STATUS "Building static RCCL library")
 else()

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -1158,15 +1158,19 @@ if(BUILD_SHARED_LIBS AND RCCL_HIP_FATBIN_AT_TAIL)
   set_property(TARGET rccl APPEND PROPERTY LINK_DEPENDS "${_rccl_fatbin_script}")
   message(STATUS "RCCL: .hip_fatbin will be placed at end of librccl.so (${_rccl_fatbin_script})")
 
-  # Informational post-build check: verify .hip_fatbin really is the last
-  # alloc PROGBITS section.  Never fails the build (a future toolchain may
-  # legitimately add a new tail section); just prints a WARNING to the log
-  # if the layout regresses so it's easy to spot in CI output.
+  # Post-build safety check: parse the ELF section table and confirm the
+  # host sections (everything except the inert .hip_fatbin spacer) fit within
+  # a 2 GiB window, which is the exact condition for small-code-model host
+  # relocations (PC32/PLT32/GOTPCRELX/32S) to stay in range.  Fails the build
+  # if the window exceeds 2 GiB -- e.g. if the linker silently ignored the
+  # tail-placement script -- so the regression is caught here rather than as
+  # a confusing relocation overflow once the fatbin grows.  Skips cleanly on
+  # non-x86-64 hosts.
   add_custom_command(TARGET rccl POST_BUILD
     COMMAND ${Python3_EXECUTABLE}
             ${PROJECT_SOURCE_DIR}/cmake/scripts/check_hip_fatbin_tail.py
             $<TARGET_FILE:rccl>
-    COMMENT "Verifying .hip_fatbin is at the tail of librccl.so"
+    COMMENT "Verifying host sections stay within 2 GiB of each other in librccl.so"
     VERBATIM
   )
 endif()

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -1164,7 +1164,7 @@ if(BUILD_SHARED_LIBS AND RCCL_HIP_FATBIN_AT_TAIL)
   # if the layout regresses so it's easy to spot in CI output.
   add_custom_command(TARGET rccl POST_BUILD
     COMMAND ${Python3_EXECUTABLE}
-            ${RCCL_SOURCE_DIR}/cmake/scripts/check_hip_fatbin_tail.py
+            ${PROJECT_SOURCE_DIR}/cmake/scripts/check_hip_fatbin_tail.py
             $<TARGET_FILE:rccl>
     COMMENT "Verifying .hip_fatbin is at the tail of librccl.so"
     VERBATIM


### PR DESCRIPTION
## Summary

Adds a small linker-script splice (lld `INSERT AFTER .bss`) that moves the merged `.hip_fatbin` output section to the end of `librccl.so`, plus a CMake option to control it and an `install.sh --ninja` opt-in.

## Why

The embedded device fatbin grows monotonically with `GPU_TARGETS` and kernel count and will eventually exceed `INT32_MAX`. When it lands in lld's default position (between `.rodata` and `.eh_frame`), it pushes every subsequent data section past the blob and breaks small-code-model host relocations from `.text`:

- `R_X86_64_PC32` / `R_X86_64_PLT32` → `.rodata` / `.eh_frame` / `.data.rel.ro` / `.data`
- `R_X86_64_GOTPCRELX` → `.got` slot on the far side
- `R_X86_64_32S` literal offsets in `.eh_frame` / `.data.rel.ro`

Switching the host code to a larger code model would bloat every call/load project-wide to dodge a placement problem. Moving the fatbin to the tail is the targeted fix: nothing in `.hip_fatbin` is the target of a small-model relocation from host code — the HIP runtime reaches it via the wrapper in `.hipFatBinSegment` (which holds a 64-bit pointer materialized via `R_X86_64_RELATIVE` / `R_X86_64_64`), so distance doesn't matter.

## What

- `cmake/linker_scripts/hip_fatbin_tail.ld` — three-line `INSERT AFTER .bss` script with `KEEP()` and `ALIGN(0x1000)`; preserves lld's default layout for everything else.
- `cmake/scripts/check_hip_fatbin_tail.py` — informational post-build check (prefers ROCm's `llvm-readelf`; never fails the build).
- `RCCL_HIP_FATBIN_AT_TAIL` CMake option (default `ON`, shared-library only). Wired into `src/CMakeLists.txt` as `LINKER:-T,<script>` with a `LINK_DEPENDS` on the script. Applies to both `ENABLE_DEVICE_LINKER=ON` (custom pipeline) and `OFF` (`-fgpu-rdc --hip-link`) because both paths converge on the same host link.
- `install.sh --ninja` — opt-in Ninja generator (separate from `--time-trace`). Default remains Make so Jenkins's `make package` flow is unaffected. Ninja schedules the per-arch device pipeline considerably better for multi-arch builds.

## Verification

Release build of `librccl.so` for the default 12 detected `GPU_TARGETS`:

- `RCCL_HIP_FATBIN_AT_TAIL=ON`: `llvm-readelf -SW` reports `.hip_fatbin` as section index 28 at file offset `0x327000` (the last allocated PROGBITS). `.hipFatBinSegment` stays at its conventional position near `.data`. Post-build check prints `OK`.
- `RCCL_HIP_FATBIN_AT_TAIL=OFF`: section returns to lld's default placement between `.rodata` and `.eh_frame_hdr`, confirming the option toggles cleanly.

## Test plan

- [ ] CI builds clean for `ENABLE_DEVICE_LINKER=ON` and `OFF`
- [ ] CI passes for `BUILD_SHARED_LIBS=OFF` (script is a guarded no-op there)
- [ ] CI passes for `ENABLE_ROCSHMEM=ON` (host link path is shared with `--hip-link`)
- [ ] Spot-check `readelf -SW` on a CI artifact: `.hip_fatbin` should be the last allocated PROGBITS section

Made with [Cursor](https://cursor.com)
