### PR TITLE
[rocjpeg] Add debug JPEG marker logging and improve unsupported JPEG error diagnostics in parser

### DIFF
--- a/projects/rocjpeg/src/rocjpeg_parser.cpp
+++ b/projects/rocjpeg/src/rocjpeg_parser.cpp
@@ -21,6 +21,7 @@ THE SOFTWARE.
 */
 #include "rocjpeg_parser.h"
 #include <algorithm>
+#include <cmath>
 #include <iomanip>
 #include <sstream>
 
@@ -258,7 +259,6 @@ bool RocJpegStreamParser::ParseSOF() {
         // CSS_411 and CSS_UNKNOWN already returned false above, so only indices 0-3,5 are reachable.
         static const char* css_names[] = { "4:4:4", "4:4:0", "4:2:2", "4:2:0", "4:1:1", "4:0:0" };
         int css_idx = static_cast<int>(jpeg_stream_parameters_.chroma_subsampling);
-        DebugLog(g_rocjpeg_logger, "  Chroma subsampling: " + ROCJPEG_STR(css_names[css_idx]));
         uint32_t sof_offset = static_cast<uint32_t>(sof_header - stream_start_) - 2;
         uint16_t frame_length = swap_bytes(sof_header);
         uint8_t precision = sof_header[2];
@@ -274,23 +274,25 @@ bool RocJpegStreamParser::ParseSOF() {
             << "\n  Number of Lines = " << height
             << "\n  Samples per Line = " << width
             << "\n  Image Size = " << width << " x " << height
+            << "\n  Chroma subsampling: " << css_names[css_idx]
             << "\n  Raw Image Orientation = " << (width >= height ? "Landscape" : "Portrait")
             << "\n  Number of Img components = " << static_cast<int>(num_comp);
+        static const char* comp_labels[] = { "Lum: Y", "Chrom: Cb", "Chrom: Cr" };
+        uint8_t max_h = jpeg_stream_parameters_.picture_parameter_buffer.components[0].h_sampling_factor;
+        uint8_t max_v = jpeg_stream_parameters_.picture_parameter_buffer.components[0].v_sampling_factor;
         for (int i = 0; i < num_comp; i++) {
             auto& c = jpeg_stream_parameters_.picture_parameter_buffer.components[i];
             uint8_t samp_fac_byte = (c.h_sampling_factor << 4) | c.v_sampling_factor;
-            std::string quant_label;
-            if (c.quantiser_table_selector == 0) quant_label = "Lum: Y";
-            else if (c.quantiser_table_selector == 1) quant_label = "Chrom: Cb";
-            else if (c.quantiser_table_selector == 2) quant_label = "Chrom: Cr";
-            else quant_label = "Unknown";
+            uint8_t subsamp_h = (c.h_sampling_factor > 0) ? max_h / c.h_sampling_factor : 0;
+            uint8_t subsamp_v = (c.v_sampling_factor > 0) ? max_v / c.v_sampling_factor : 0;
+            const char* comp_label = (i < 3) ? comp_labels[i] : "Unknown";
             oss << "\n    Component[" << std::dec << (i + 1) << "]: "
                 << "ID=0x" << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(c.component_id)
                 << ", Samp Fac=0x" << std::setw(2) << static_cast<int>(samp_fac_byte)
-                << " (Subsamp " << std::dec << static_cast<int>(c.h_sampling_factor)
-                << " x " << static_cast<int>(c.v_sampling_factor) << ")"
+                << " (Subsamp " << std::dec << static_cast<int>(subsamp_h)
+                << " x " << static_cast<int>(subsamp_v) << ")"
                 << ", Quant Tbl Sel=0x" << std::hex << std::setw(2) << static_cast<int>(c.quantiser_table_selector)
-                << " (" << quant_label << ")";
+                << " (" << comp_label << ")";
         }
         DebugLog(g_rocjpeg_logger, oss.str());
     }
@@ -315,11 +317,19 @@ bool RocJpegStreamParser::ParseDQT() {
     }
 
     uint16_t table_length = swap_bytes(stream_);
+    if (table_length < 2 || stream_ + table_length > stream_end_) {
+        ErrorLog(g_rocjpeg_logger, "Invalid DQT marker length!");
+        return false;
+    }
     dqt_block_end = stream_ + table_length;
     uint32_t dqt_offset = static_cast<uint32_t>(stream_ - stream_start_) - 2;
     stream_ += 2;
 
     while (stream_ < dqt_block_end) {
+        if (stream_ + 1 + 64 > dqt_block_end) {
+            ErrorLog(g_rocjpeg_logger, "Truncated JPEG: DQT segment too small to contain a complete quantization table!");
+            return false;
+        }
         quantization_table_index = *stream_++;
         if (quantization_table_index >> 4) {
             ErrorLog(g_rocjpeg_logger,"16 bits quantization table is not supported!");
@@ -336,15 +346,43 @@ bool RocJpegStreamParser::ParseDQT() {
         if (g_rocjpeg_logger.GetLogLevel() >= kRocJpegLogDebug) {
             int tbl_id = quantization_table_index & 0x0F;
             const uint8_t *tbl = jpeg_stream_parameters_.quantization_matrix_buffer.quantiser_table[tbl_id];
-            // Compute mean quantization value and approximate JPEG quality using the IJG formula:
-            //   scale = 5000/Q (Q<50) or 200-2Q (Q>=50), so inversely:
-            //   Q = (200 - mean) / 2  when mean < 100  (high quality, Q > 50)
-            //   Q = 5000 / mean       when mean >= 100 (low quality, Q <= 50)
+            // Standard IJG reference quantization tables (quality=50 baseline).
+            // scaling = mean(100 * actual[i] / ref[i])
+            static const uint8_t k_std_luma[64] = {
+                16, 11, 10, 16, 24, 40, 51, 61,
+                12, 12, 14, 19, 26, 58, 60, 55,
+                14, 13, 16, 24, 40, 57, 69, 56,
+                14, 17, 22, 29, 51, 87, 80, 62,
+                18, 22, 37, 56, 68,109,103, 77,
+                24, 35, 55, 64, 81,104,113, 92,
+                49, 64, 78, 87,103,121,120,101,
+                72, 92, 95, 98,112,100,103, 99
+            };
+            static const uint8_t k_std_chroma[64] = {
+                17, 18, 24, 47, 99, 99, 99, 99,
+                18, 21, 26, 66, 99, 99, 99, 99,
+                24, 26, 56, 99, 99, 99, 99, 99,
+                47, 66, 99, 99, 99, 99, 99, 99,
+                99, 99, 99, 99, 99, 99, 99, 99,
+                99, 99, 99, 99, 99, 99, 99, 99,
+                99, 99, 99, 99, 99, 99, 99, 99,
+                99, 99, 99, 99, 99, 99, 99, 99
+            };
+            const uint8_t *ref = (tbl_id == 0) ? k_std_luma : k_std_chroma;
             double sum = 0.0;
-            for (int k = 0; k < 64; k++) sum += tbl[k];
+            for (int k = 0; k < 64; k++) sum += 100.0 * tbl[k] / ref[k];
             double scaling = sum / 64.0;
+            double var_sum = 0.0;
+            for (int k = 0; k < 64; k++) {
+                double d = 100.0 * tbl[k] / ref[k] - scaling;
+                var_sum += d * d;
+            }
+            double variance = var_sum / 64.0;
+            // Quality: all-1s table is the minimum possible (Q=100); otherwise use IJG inverse formula.
+            bool all_min = true;
+            for (int k = 0; k < 64; k++) { if (tbl[k] != 1) { all_min = false; break; } }
             double quality;
-            if (scaling <= 1.0) quality = 100.0;
+            if (all_min) quality = 100.0;
             else if (scaling < 100.0) quality = std::max(0.0, (200.0 - scaling) / 2.0);
             else quality = std::max(0.0, 5000.0 / scaling);
 
@@ -366,7 +404,7 @@ bool RocJpegStreamParser::ParseDQT() {
             }
             oss << std::fixed << std::setprecision(2)
                 << "\n    Approx quality factor = " << quality
-                << " (mean quantization value = " << scaling << ")";
+                << " (scaling=" << scaling << " variance=" << variance << ")";
             DebugLog(g_rocjpeg_logger, oss.str());
         }
 
@@ -394,7 +432,12 @@ bool RocJpegStreamParser::ParseDHT() {
     }
 
     const uint8_t *dht_header = stream_;
-    length = swap_bytes(stream_) - 2;
+    uint16_t segment_length = swap_bytes(stream_);
+    if (segment_length < 2 || stream_ + segment_length > stream_end_) {
+        ErrorLog(g_rocjpeg_logger, "Invalid DHT marker length!");
+        return false;
+    }
+    length = static_cast<int32_t>(segment_length) - 2;
     stream_ += 2;
 
     while (length > 0) {

--- a/projects/rocjpeg/src/rocjpeg_parser.cpp
+++ b/projects/rocjpeg/src/rocjpeg_parser.cpp
@@ -20,8 +20,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 #include "rocjpeg_parser.h"
+#include <algorithm>
+#include <iomanip>
+#include <sstream>
 
-RocJpegStreamParser::RocJpegStreamParser() : stream_{nullptr}, stream_end_{nullptr}, stream_length_{0},
+RocJpegStreamParser::RocJpegStreamParser() : stream_{nullptr}, stream_start_{nullptr}, stream_end_{nullptr}, stream_length_{0},
     jpeg_stream_parameters_{} {
 }
 
@@ -50,6 +53,7 @@ bool RocJpegStreamParser::ParseJpegStream(const uint8_t *jpeg_stream, uint32_t j
     }
 
     stream_ = jpeg_stream;
+    stream_start_ = jpeg_stream;
     stream_length_ = jpeg_stream_size;
     stream_end_ = stream_ + stream_length_;
 
@@ -88,6 +92,10 @@ bool RocJpegStreamParser::ParseJpegStream(const uint8_t *jpeg_stream, uint32_t j
                     return false;
                 }
                 break;
+            case SOF2:
+                ErrorLog(g_rocjpeg_logger, "Progressive JPEG is not supported!");
+                FunctionExitLog(g_rocjpeg_logger);
+                return false;
             case DHT:
                 if (!ParseDHT()) {
                     FunctionExitLog(g_rocjpeg_logger);
@@ -183,12 +191,16 @@ bool RocJpegStreamParser::ParseSOF() {
         return false;
     }
 
+    const uint8_t *sof_header = stream_;
+
     jpeg_stream_parameters_.picture_parameter_buffer.picture_height = swap_bytes(stream_ + 3);
     jpeg_stream_parameters_.picture_parameter_buffer.picture_width = swap_bytes(stream_ + 5);
     jpeg_stream_parameters_.picture_parameter_buffer.num_components = stream_[7];
 
     if (jpeg_stream_parameters_.picture_parameter_buffer.num_components > NUM_COMPONENTS - 1) {
-        ErrorLog(g_rocjpeg_logger,"invalid number of JPEG components!");
+        ErrorLog(g_rocjpeg_logger, "Unsupported JPEG: " +
+            ROCJPEG_TOSTR(static_cast<int>(jpeg_stream_parameters_.picture_parameter_buffer.num_components)) +
+            " components found (CMYK/YCCK not supported, only YCbCr/grayscale with up to 3 components)!");
         return false;
     }
 
@@ -221,6 +233,68 @@ bool RocJpegStreamParser::ParseSOF() {
                                                                       jpeg_stream_parameters_.picture_parameter_buffer.components[0].v_sampling_factor,
                                                                       jpeg_stream_parameters_.picture_parameter_buffer.components[1].v_sampling_factor,
                                                                       jpeg_stream_parameters_.picture_parameter_buffer.components[2].v_sampling_factor);
+
+    if (jpeg_stream_parameters_.chroma_subsampling == CSS_411) {
+        ErrorLog(g_rocjpeg_logger, "Unsupported chroma subsampling: 4:1:1 is not supported!");
+        return false;
+    }
+    if (jpeg_stream_parameters_.chroma_subsampling == CSS_UNKNOWN) {
+        uint8_t num_comp = jpeg_stream_parameters_.picture_parameter_buffer.num_components;
+        std::string msg = "Unsupported chroma subsampling: unrecognized sampling factors "
+            "(Y=" + ROCJPEG_TOSTR(static_cast<int>(jpeg_stream_parameters_.picture_parameter_buffer.components[0].h_sampling_factor)) +
+            "x"  + ROCJPEG_TOSTR(static_cast<int>(jpeg_stream_parameters_.picture_parameter_buffer.components[0].v_sampling_factor));
+        if (num_comp > 1) {
+            msg += ", Cb=" + ROCJPEG_TOSTR(static_cast<int>(jpeg_stream_parameters_.picture_parameter_buffer.components[1].h_sampling_factor)) +
+                   "x"     + ROCJPEG_TOSTR(static_cast<int>(jpeg_stream_parameters_.picture_parameter_buffer.components[1].v_sampling_factor)) +
+                   ", Cr=" + ROCJPEG_TOSTR(static_cast<int>(jpeg_stream_parameters_.picture_parameter_buffer.components[2].h_sampling_factor)) +
+                   "x"     + ROCJPEG_TOSTR(static_cast<int>(jpeg_stream_parameters_.picture_parameter_buffer.components[2].v_sampling_factor));
+        }
+        msg += ")!";
+        ErrorLog(g_rocjpeg_logger, msg);
+        return false;
+    }
+
+    if (g_rocjpeg_logger.GetLogLevel() >= kRocJpegLogDebug) {
+        // CSS_411 and CSS_UNKNOWN already returned false above, so only indices 0-3,5 are reachable.
+        static const char* css_names[] = { "4:4:4", "4:4:0", "4:2:2", "4:2:0", "4:1:1", "4:0:0" };
+        int css_idx = static_cast<int>(jpeg_stream_parameters_.chroma_subsampling);
+        DebugLog(g_rocjpeg_logger, "  Chroma subsampling: " + ROCJPEG_STR(css_names[css_idx]));
+        uint32_t sof_offset = static_cast<uint32_t>(sof_header - stream_start_) - 2;
+        uint16_t frame_length = swap_bytes(sof_header);
+        uint8_t precision = sof_header[2];
+        uint16_t width = jpeg_stream_parameters_.picture_parameter_buffer.picture_width;
+        uint16_t height = jpeg_stream_parameters_.picture_parameter_buffer.picture_height;
+        uint8_t num_comp = jpeg_stream_parameters_.picture_parameter_buffer.num_components;
+        std::ostringstream oss;
+        oss << std::uppercase << std::hex << std::setfill('0');
+        oss << "\n*** Marker: SOF0 (Baseline DCT) (xFFC0) ***"
+            << "\n  OFFSET: 0x" << std::setw(8) << sof_offset
+            << "\n  Frame header length = " << std::dec << frame_length
+            << "\n  Precision = " << static_cast<int>(precision)
+            << "\n  Number of Lines = " << height
+            << "\n  Samples per Line = " << width
+            << "\n  Image Size = " << width << " x " << height
+            << "\n  Raw Image Orientation = " << (width >= height ? "Landscape" : "Portrait")
+            << "\n  Number of Img components = " << static_cast<int>(num_comp);
+        for (int i = 0; i < num_comp; i++) {
+            auto& c = jpeg_stream_parameters_.picture_parameter_buffer.components[i];
+            uint8_t samp_fac_byte = (c.h_sampling_factor << 4) | c.v_sampling_factor;
+            std::string quant_label;
+            if (c.quantiser_table_selector == 0) quant_label = "Lum: Y";
+            else if (c.quantiser_table_selector == 1) quant_label = "Chrom: Cb";
+            else if (c.quantiser_table_selector == 2) quant_label = "Chrom: Cr";
+            else quant_label = "Unknown";
+            oss << "\n    Component[" << std::dec << (i + 1) << "]: "
+                << "ID=0x" << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(c.component_id)
+                << ", Samp Fac=0x" << std::setw(2) << static_cast<int>(samp_fac_byte)
+                << " (Subsamp " << std::dec << static_cast<int>(c.h_sampling_factor)
+                << " x " << static_cast<int>(c.v_sampling_factor) << ")"
+                << ", Quant Tbl Sel=0x" << std::hex << std::setw(2) << static_cast<int>(c.quantiser_table_selector)
+                << " (" << quant_label << ")";
+        }
+        DebugLog(g_rocjpeg_logger, oss.str());
+    }
+
     return true;
 }
 
@@ -240,7 +314,9 @@ bool RocJpegStreamParser::ParseDQT() {
         return false;
     }
 
-    dqt_block_end = stream_ + swap_bytes(stream_);
+    uint16_t table_length = swap_bytes(stream_);
+    dqt_block_end = stream_ + table_length;
+    uint32_t dqt_offset = static_cast<uint32_t>(stream_ - stream_start_) - 2;
     stream_ += 2;
 
     while (stream_ < dqt_block_end) {
@@ -256,6 +332,43 @@ bool RocJpegStreamParser::ParseDQT() {
 
         std::memcpy(jpeg_stream_parameters_.quantization_matrix_buffer.quantiser_table[quantization_table_index & 0x0F], stream_, 64);
         jpeg_stream_parameters_.quantization_matrix_buffer.load_quantiser_table[quantization_table_index & 0x0F] = 1;
+
+        if (g_rocjpeg_logger.GetLogLevel() >= kRocJpegLogDebug) {
+            int tbl_id = quantization_table_index & 0x0F;
+            const uint8_t *tbl = jpeg_stream_parameters_.quantization_matrix_buffer.quantiser_table[tbl_id];
+            // Compute mean quantization value and approximate JPEG quality using the IJG formula:
+            //   scale = 5000/Q (Q<50) or 200-2Q (Q>=50), so inversely:
+            //   Q = (200 - mean) / 2  when mean < 100  (high quality, Q > 50)
+            //   Q = 5000 / mean       when mean >= 100 (low quality, Q <= 50)
+            double sum = 0.0;
+            for (int k = 0; k < 64; k++) sum += tbl[k];
+            double scaling = sum / 64.0;
+            double quality;
+            if (scaling <= 1.0) quality = 100.0;
+            else if (scaling < 100.0) quality = std::max(0.0, (200.0 - scaling) / 2.0);
+            else quality = std::max(0.0, 5000.0 / scaling);
+
+            std::string dest_label = (tbl_id == 0) ? "Luminance" : "Chrominance";
+            std::ostringstream oss;
+            oss << std::uppercase << std::hex << std::setfill('0');
+            oss << "\n*** Marker: DQT (xFFDB) ***"
+                << "\n  Define a Quantization Table."
+                << "\n  OFFSET: 0x" << std::setw(8) << dqt_offset
+                << "\n  Table length = " << std::dec << table_length
+                << "\n  ----"
+                << "\n  Precision=8 bits"
+                << "\n  Destination ID=" << tbl_id << " (" << dest_label << ")";
+            for (int row = 0; row < 8; row++) {
+                oss << "\n    DQT, Row #" << row << ":";
+                for (int col = 0; col < 8; col++) {
+                    oss << " " << std::setw(3) << std::setfill(' ') << static_cast<int>(tbl[row * 8 + col]);
+                }
+            }
+            oss << std::fixed << std::setprecision(2)
+                << "\n    Approx quality factor = " << quality
+                << " (mean quantization value = " << scaling << ")";
+            DebugLog(g_rocjpeg_logger, oss.str());
+        }
 
         stream_ += 64;
     }
@@ -280,6 +393,7 @@ bool RocJpegStreamParser::ParseDHT() {
         return false;
     }
 
+    const uint8_t *dht_header = stream_;
     length = swap_bytes(stream_) - 2;
     stream_ += 2;
 
@@ -321,6 +435,43 @@ bool RocJpegStreamParser::ParseDHT() {
             jpeg_stream_parameters_.huffman_table_buffer.load_huffman_table[huffman_table_id] = 1;
         }
 
+        if (g_rocjpeg_logger.GetLogLevel() >= kRocJpegLogDebug) {
+            uint32_t dht_offset = static_cast<uint32_t>(dht_header - stream_start_) - 2;
+            uint16_t dht_length = swap_bytes(dht_header);
+            // num_codes is the 16-byte array we copied just before the values
+            const uint8_t *num_codes = ac_huffman_table
+                ? jpeg_stream_parameters_.huffman_table_buffer.huffman_table[huffman_table_id].num_ac_codes
+                : jpeg_stream_parameters_.huffman_table_buffer.huffman_table[huffman_table_id].num_dc_codes;
+            const uint8_t *values = stream_;  // stream_ already advanced past 16 num_codes bytes, now at value bytes
+
+            std::ostringstream oss;
+            oss << std::uppercase << std::hex << std::setfill('0');
+            oss << "\n*** Marker: DHT (Define Huffman Table) (xFFC4) ***"
+                << "\n  OFFSET: 0x" << std::setw(8) << dht_offset
+                << "\n  Huffman table length = " << std::dec << dht_length
+                << "\n  ----"
+                << "\n  Destination ID = " << static_cast<int>(huffman_table_id)
+                << "\n  Class = " << (ac_huffman_table ? "1 (AC Table)" : "0 (DC / Lossless Table)");
+
+            uint32_t val_idx = 0;
+            uint32_t total_codes = 0;
+            for (int bit = 1; bit <= 16; bit++) {
+                uint8_t n = num_codes[bit - 1];
+                total_codes += n;
+                oss << "\n    Codes of length " << std::setw(2) << std::setfill('0') << bit
+                    << " bits (" << std::setw(3) << std::setfill('0') << std::dec << static_cast<int>(n) << " total): ";
+                // Print up to 16 values per row, wrap with indentation
+                for (uint8_t v = 0; v < n; v++) {
+                    if (v > 0 && v % 16 == 0) oss << "\n                                         ";
+                    oss << std::uppercase << std::hex << std::setw(2) << std::setfill('0')
+                        << static_cast<int>(values[val_idx]) << " ";
+                    val_idx++;
+                }
+            }
+            oss << "\n    Total number of codes: " << std::setw(3) << std::setfill('0') << std::dec << total_codes;
+            DebugLog(g_rocjpeg_logger, oss.str());
+        }
+
         length -= 1;
         length -= 16;
         length -= count;
@@ -346,10 +497,19 @@ bool RocJpegStreamParser::ParseSOS() {
         return false;
     }
 
+    const uint8_t *sos_header = stream_;
     uint32_t num_components = stream_[2];
 
-    if (num_components > NUM_COMPONENTS - 1 || num_components != jpeg_stream_parameters_.picture_parameter_buffer.num_components) {
-        ErrorLog(g_rocjpeg_logger, "Invalid number of component!");
+    if (num_components > NUM_COMPONENTS - 1) {
+        ErrorLog(g_rocjpeg_logger, "SOS has " + ROCJPEG_TOSTR(num_components) +
+            " components, exceeds maximum supported (" + ROCJPEG_TOSTR(NUM_COMPONENTS - 1) + ")!");
+        return false;
+    }
+    if (num_components != jpeg_stream_parameters_.picture_parameter_buffer.num_components) {
+        ErrorLog(g_rocjpeg_logger, "SOS component count (" + ROCJPEG_TOSTR(num_components) +
+            ") does not match SOF component count (" +
+            ROCJPEG_TOSTR(static_cast<int>(jpeg_stream_parameters_.picture_parameter_buffer.num_components)) +
+            ") - this may be a multi-scan progressive JPEG, which is not supported!");
         return false;
     }
     jpeg_stream_parameters_.slice_parameter_buffer.num_components = num_components;
@@ -375,6 +535,34 @@ bool RocJpegStreamParser::ParseSOS() {
             return false;
         }
     }
+
+    if (g_rocjpeg_logger.GetLogLevel() >= kRocJpegLogDebug) {
+        uint32_t sos_offset = static_cast<uint32_t>(sos_header - stream_start_) - 2;
+        uint16_t sos_length = swap_bytes(sos_header);
+        // stream_ now points at Ss, Se, Ah/Al bytes
+        uint8_t spectral_start = stream_[0];
+        uint8_t spectral_end   = stream_[1];
+        uint8_t succ_approx    = stream_[2];
+        std::ostringstream oss;
+        oss << std::uppercase << std::hex << std::setfill('0');
+        oss << "\n*** Marker: SOS (Start of Scan) (xFFDA) ***"
+            << "\n  OFFSET: 0x" << std::setw(8) << sos_offset
+            << "\n  Scan header length = " << std::dec << sos_length
+            << "\n  Number of img components = " << num_components;
+        for (uint32_t i = 0; i < num_components; i++) {
+            auto& c = jpeg_stream_parameters_.slice_parameter_buffer.components[i];
+            oss << "\n    Component[" << std::dec << (i + 1) << "]: "
+                << "selector=0x" << std::hex << std::setw(2) << static_cast<int>(c.component_selector)
+                << ", table=" << std::dec << static_cast<int>(c.dc_table_selector) << "(DC)"
+                << "," << static_cast<int>(c.ac_table_selector) << "(AC)";
+        }
+        oss << "\n  Spectral selection = " << std::dec << static_cast<int>(spectral_start)
+            << " .. " << static_cast<int>(spectral_end)
+            << "\n  Successive approximation = 0x" << std::hex << std::setw(2) << std::setfill('0')
+            << static_cast<int>(succ_approx);
+        DebugLog(g_rocjpeg_logger, oss.str());
+    }
+
     stream_ += 3;
 
     return true;
@@ -429,6 +617,14 @@ bool RocJpegStreamParser::ParseEOI() {
 
     jpeg_stream_parameters_.slice_parameter_buffer.slice_data_size = stream_temp - stream_;
     jpeg_stream_parameters_.slice_data_buffer = stream_;
+
+    if (g_rocjpeg_logger.GetLogLevel() >= kRocJpegLogDebug) {
+        uint32_t eoi_offset = static_cast<uint32_t>(stream_temp - stream_start_);
+        std::ostringstream oss;
+        oss << "\n*** Marker: EOI (End of Image) (xFFD9) ***"
+            << "\n  OFFSET: 0x" << std::uppercase << std::hex << std::setw(8) << std::setfill('0') << eoi_offset;
+        DebugLog(g_rocjpeg_logger, oss.str());
+    }
 
     return true;
 }

--- a/projects/rocjpeg/src/rocjpeg_parser.h
+++ b/projects/rocjpeg/src/rocjpeg_parser.h
@@ -44,13 +44,14 @@ THE SOFTWARE.
  * The `JpegMarkers` enum defines the common JPEG markers used in a JPEG stream.
  */
 enum JpegMarkers {
-    SOI = 0xD8, /**< Start Of Image */
-    SOF = 0xC0, /**< Start Of Frame for a baseline DCT-based JPEG. */
-    DHT = 0xC4, /**< Define Huffman Table */
-    DQT = 0xDB, /**< Define Quantization Table */
-    DRI = 0xDD, /**< Define Restart Interval */
-    SOS = 0xDA, /**< Start of Scan */
-    EOI = 0xD9, /**< End Of Image */
+    SOI  = 0xD8, /**< Start Of Image */
+    SOF  = 0xC0, /**< Start Of Frame for a baseline DCT-based JPEG. */
+    SOF2 = 0xC2, /**< Start Of Frame for a progressive DCT-based JPEG (not supported). */
+    DHT  = 0xC4, /**< Define Huffman Table */
+    DQT  = 0xDB, /**< Define Quantization Table */
+    DRI  = 0xDD, /**< Define Restart Interval */
+    SOS  = 0xDA, /**< Start of Scan */
+    EOI  = 0xD9, /**< End Of Image */
 };
 
 /**
@@ -263,6 +264,7 @@ class RocJpegStreamParser {
                                                uint8_t c1_v_sampling_factor, uint8_t c2_v_sampling_factor, uint8_t c3_v_sampling_factor);
 
         const uint8_t *stream_; ///< Pointer to the JPEG stream.
+        const uint8_t *stream_start_; ///< Pointer to the start of the JPEG stream (for offset computation).
         const uint8_t *stream_end_; ///< Pointer to the end of the JPEG stream.
         uint32_t stream_length_; ///< Length of the JPEG stream.
         JpegStreamParameters jpeg_stream_parameters_; ///< JPEG stream parameters.


### PR DESCRIPTION
## Motivation

This PR enhances rocJPEG logging by adding structured, offset-annotated debug logging for each major JPEG marker (SOF0, DQT, DHT, SOS, EOI), improves clarity of error messages for unsupported formats, and explicitly rejects progressive JPEGs (SOF2).

sample output:

```
ROCJPEG_LOG_LEVEL=4 ./jpegdecode -i  ~/install/share/rocjpeg/images/mug_420.jpg 
Reading images from disk, please wait!
Using GPU device 0: AMD Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
[3, Info] rocjpeg_api.cpp:123: 2274381572050 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] rocJpegCreate( 0, 0, 0x7fff0596b718 ): entry ...
[3, Info] rocjpeg_decoder.cpp:81: 2274381572066 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] InitializeDecoder(  ): entry ...
[3, Info] rocjpeg_decoder.cpp:50: 2274381572069 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] InitHIP( 0 ): entry ...
[3, Info] rocjpeg_decoder.cpp:50: 2274381592272 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] InitHIP( 0 ): exit (20203 us) ...
[3, Info] rocjpeg_vaapi_decoder.cpp:416: 2274381592356 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] InitializeDecoder(): gpu_uuids_to_render_nodes_map_: {e0b64ad979bec1fd: 128}
[3, Info] rocjpeg_vaapi_decoder.cpp:417: 2274381592362 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] InitializeDecoder(): Selected GPU UUID: e0b64ad979bec1fd
[3, Info] rocjpeg_vaapi_decoder.cpp:475: 2274381592366 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] InitVAAPI(): Opening DRM node: /dev/dri/renderD128
[3, Info] rocjpeg_vaapi_decoder.cpp:500: 2274381593624 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] InitVAAPI(): VA-API version 1.22
[3, Info] rocjpeg_vaapi_decoder.cpp:502: 2274381593634 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] InitVAAPI(): VA-API vendor: Mesa Gallium driver 26.0.0-devel for AMD Radeon RX 7900 XT (radeonsi, navi31, , DRM 3.64, 6.17.0-23-generic)
[3, Info] rocjpeg_vaapi_decoder.cpp:504: 2274381593638 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] InitVAAPI(): Trying to open /home/aryan/install/lib/rocm_sysdeps/lib/radeonsi_drv_video.so

[3, Info] rocjpeg_decoder.cpp:81: 2274381593728 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] InitializeDecoder(  ): exit (21662 us) ...
[3, Info] rocjpeg_api.cpp:123: 2274381593732 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] rocJpegCreate( 0, 0, 0x7fff0596b718 ): exit (21682 us) ...
[3, Info] rocjpeg_api.cpp:40: 2274381593735 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] rocJpegStreamCreate( 0x7fff0596b710 ): entry ...
[3, Info] rocjpeg_api.cpp:40: 2274381593738 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] rocJpegStreamCreate( 0x7fff0596b710 ): exit (3 us) ...
Input file name: /home/aryan/install/share/rocjpeg/images/mug_420.jpg
[3, Info] rocjpeg_api.cpp:75: 2274381594731 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] rocJpegStreamParse( 0x70b1f41c4010, 2340067, 0x55f2ebfec840 ): entry ...
[3, Info] rocjpeg_parser.cpp:48: 2274381594734 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] ParseJpegStream( 0x70b1f41c4010, 2340067 ): entry ...
[4, Debug] rocjpeg_parser.cpp:408: 2274381594759 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] ParseDQT(): 
*** Marker: DQT (xFFDB) ***
  Define a Quantization Table.
  OFFSET: 0x00001296
  Table length = 67
  ----
  Precision=8 bits
  Destination ID=0 (Luminance)
    DQT, Row #0:   1   1   1   1   1   1   1   1
    DQT, Row #1:   1   1   1   1   1   1   1   1
    DQT, Row #2:   1   1   1   1   1   1   1   1
    DQT, Row #3:   1   1   1   1   1   1   1   1
    DQT, Row #4:   1   1   1   1   1   1   1   1
    DQT, Row #5:   1   1   1   1   1   1   1   1
    DQT, Row #6:   1   1   1   1   1   1   1   1
    DQT, Row #7:   1   1   1   1   1   1   1   1
    Approx quality factor = 100.00 (scaling=2.99 variance=6.13)
[4, Debug] rocjpeg_parser.cpp:408: 2274381594772 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] ParseDQT(): 
*** Marker: DQT (xFFDB) ***
  Define a Quantization Table.
  OFFSET: 0x000012DB
  Table length = 67
  ----
  Precision=8 bits
  Destination ID=1 (Chrominance)
    DQT, Row #0:   1   1   1   1   1   1   1   1
    DQT, Row #1:   1   1   1   1   1   1   1   1
    DQT, Row #2:   1   1   1   1   1   1   1   1
    DQT, Row #3:   1   1   1   1   1   1   1   1
    DQT, Row #4:   1   1   1   1   1   1   1   1
    DQT, Row #5:   1   1   1   1   1   1   1   1
    DQT, Row #6:   1   1   1   1   1   1   1   1
    DQT, Row #7:   1   1   1   1   1   1   1   1
    Approx quality factor = 100.00 (scaling=1.54 variance=1.58)
[4, Debug] rocjpeg_parser.cpp:297: 2274381594790 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] ParseSOF(): 
*** Marker: SOF0 (Baseline DCT) (xFFC0) ***
  OFFSET: 0x00001320
  Frame header length = 17
  Precision = 8
  Number of Lines = 2160
  Samples per Line = 3840
  Image Size = 3840 x 2160
  Chroma subsampling: 4:2:0
  Raw Image Orientation = Landscape
  Number of Img components = 3
    Component[1]: ID=0x01, Samp Fac=0x22 (Subsamp 1 x 1), Quant Tbl Sel=0x00 (Lum: Y)
    Component[2]: ID=0x02, Samp Fac=0x11 (Subsamp 2 x 2), Quant Tbl Sel=0x01 (Chrom: Cb)
    Component[3]: ID=0x03, Samp Fac=0x11 (Subsamp 2 x 2), Quant Tbl Sel=0x01 (Chrom: Cr)
[4, Debug] rocjpeg_parser.cpp:515: 2274381594802 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] ParseDHT(): 
*** Marker: DHT (Define Huffman Table) (xFFC4) ***
  OFFSET: 0x00001333
  Huffman table length = 31
  ----
  Destination ID = 0
  Class = 0 (DC / Lossless Table)
    Codes of length 01 bits (000 total): 
    Codes of length 02 bits (002 total): 03 04 
    Codes of length 03 bits (002 total): 01 02 
    Codes of length 04 bits (003 total): 00 05 06 
    Codes of length 05 bits (001 total): 07 
    Codes of length 06 bits (001 total): 08 
    Codes of length 07 bits (001 total): 09 
    Codes of length 08 bits (001 total): 0A 
    Codes of length 09 bits (001 total): 0B 
    Codes of length 0A bits (000 total): 
    Codes of length 11 bits (000 total): 
    Codes of length 12 bits (000 total): 
    Codes of length 13 bits (000 total): 
    Codes of length 14 bits (000 total): 
    Codes of length 15 bits (000 total): 
    Codes of length 16 bits (000 total): 
    Total number of codes: 012
[4, Debug] rocjpeg_parser.cpp:515: 2274381594816 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] ParseDHT(): 
*** Marker: DHT (Define Huffman Table) (xFFC4) ***
  OFFSET: 0x00001354
  Huffman table length = 91
  ----
  Destination ID = 0
  Class = 1 (AC Table)
    Codes of length 01 bits (000 total): 
    Codes of length 02 bits (002 total): 01 02 
    Codes of length 03 bits (001 total): 11 
    Codes of length 04 bits (002 total): 03 21 
    Codes of length 05 bits (004 total): 00 04 12 31 
    Codes of length 06 bits (003 total): 05 41 51 
    Codes of length 07 bits (005 total): 06 13 22 61 71 
    Codes of length 08 bits (005 total): 32 81 91 A1 D1 
    Codes of length 09 bits (005 total): 07 52 B1 C1 F0 
    Codes of length 0A bits (005 total): 08 14 23 42 E1 
    Codes of length 0B bits (005 total): 62 72 92 A2 D2 
    Codes of length 0C bits (007 total): 09 15 33 53 82 E2 F1 
    Codes of length 0D bits (002 total): 24 B2 
    Codes of length 0E bits (001 total): C2 
    Codes of length 0F bits (002 total): 16 43 
    Codes of length 10 bits (023 total): 93 63 D3 0A 17 25 73 A3 34 54 83 18 19 B3 26 27 
                                         44 F2 35 64 C3 E3 46 
    Total number of codes: 072
[4, Debug] rocjpeg_parser.cpp:515: 2274381594829 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] ParseDHT(): 
*** Marker: DHT (Define Huffman Table) (xFFC4) ***
  OFFSET: 0x000013B1
  Huffman table length = 29
  ----
  Destination ID = 1
  Class = 0 (DC / Lossless Table)
    Codes of length 01 bits (001 total): 00 
    Codes of length 02 bits (000 total): 
    Codes of length 03 bits (003 total): 01 02 03 
    Codes of length 04 bits (001 total): 04 
    Codes of length 05 bits (001 total): 05 
    Codes of length 06 bits (001 total): 06 
    Codes of length 07 bits (001 total): 07 
    Codes of length 08 bits (001 total): 08 
    Codes of length 09 bits (001 total): 09 
    Codes of length 0A bits (000 total): 
    Codes of length 11 bits (000 total): 
    Codes of length 12 bits (000 total): 
    Codes of length 13 bits (000 total): 
    Codes of length 14 bits (000 total): 
    Codes of length 15 bits (000 total): 
    Codes of length 16 bits (000 total): 
    Total number of codes: 010
[4, Debug] rocjpeg_parser.cpp:515: 2274381594842 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] ParseDHT(): 
*** Marker: DHT (Define Huffman Table) (xFFC4) ***
  OFFSET: 0x000013D0
  Huffman table length = 83
  ----
  Destination ID = 1
  Class = 1 (AC Table)
    Codes of length 01 bits (000 total): 
    Codes of length 02 bits (001 total): 01 
    Codes of length 03 bits (001 total): 11 
    Codes of length 04 bits (004 total): 00 02 21 61 
    Codes of length 05 bits (007 total): 03 31 41 51 71 91 F0 
    Codes of length 06 bits (006 total): 12 22 52 81 A1 D1 
    Codes of length 07 bits (004 total): 04 62 B1 E1 
    Codes of length 08 bits (005 total): 13 32 82 A2 C1 
    Codes of length 09 bits (004 total): 05 42 92 F1 
    Codes of length 0A bits (000 total): 
    Codes of length 11 bits (004 total): 06 14 23 72 
    Codes of length 0C bits (004 total): 07 33 53 B2 
    Codes of length 0D bits (005 total): 15 43 C2 D2 E2 
    Codes of length 0E bits (001 total): 16 
    Codes of length 0F bits (001 total): 63 
    Codes of length 10 bits (017 total): 93 24 34 54 08 73 83 17 18 44 A3 35 F2 25 74 B3 
                                         D3 
    Total number of codes: 064
[4, Debug] rocjpeg_parser.cpp:606: 2274381594856 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] ParseSOS(): 
*** Marker: SOS (Start of Scan) (xFFDA) ***
  OFFSET: 0x00001425
  Scan header length = 12
  Number of img components = 3
    Component[1]: selector=0x01, table=0(DC),0(AC)
    Component[2]: selector=0x02, table=1(DC),1(AC)
    Component[3]: selector=0x03, table=1(DC),1(AC)
  Spectral selection = 0 .. 63
  Successive approximation = 0x00
[4, Debug] rocjpeg_parser.cpp:669: 2274381595378 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] ParseEOI(): 
*** Marker: EOI (End of Image) (xFFD9) ***
  OFFSET: 0x0023B4E1
[3, Info] rocjpeg_parser.cpp:48: 2274381595383 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] ParseJpegStream( 0x70b1f41c4010, 2340067 ): exit (649 us) ...
[3, Info] rocjpeg_api.cpp:75: 2274381595386 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] rocJpegStreamParse( 0x70b1f41c4010, 2340067, 0x55f2ebfec840 ): exit (655 us) ...
[3, Info] rocjpeg_api.cpp:188: 2274381595393 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] rocJpegGetImageInfo( 0x55f2ebf6dde0, 0x55f2ebfec840, 0x7fff0596b82a, 0x7fff0596b728, 0x7fff0596b810, 0x7fff0596b800 ): entry ...
[3, Info] rocjpeg_decoder.cpp:332: 2274381595397 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] GetImageInfo( 0x55f2ebfec840, 0x7fff0596b82a, 0x7fff0596b728, 0x7fff0596b810, 0x7fff0596b800 ): entry ...
[3, Info] rocjpeg_decoder.cpp:332: 2274381595400 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] GetImageInfo( 0x55f2ebfec840, 0x7fff0596b82a, 0x7fff0596b728, 0x7fff0596b810, 0x7fff0596b800 ): exit (3 us) ...
[3, Info] rocjpeg_api.cpp:188: 2274381595403 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] rocJpegGetImageInfo( 0x55f2ebf6dde0, 0x55f2ebfec840, 0x7fff0596b82a, 0x7fff0596b728, 0x7fff0596b810, 0x7fff0596b800 ): exit (10 us) ...
Input image resolution: 3840x2160
Chroma subsampling: YUV 4:2:0
Decoding started, please wait! ... 
[3, Info] rocjpeg_api.cpp:222: 2274381595488 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] rocJpegDecode( 0x55f2ebf6dde0, 0x55f2ebfec840, 0x7fff0596b6c0, 0x7fff0596b6e0 ): entry ...
[3, Info] rocjpeg_decoder.cpp:120: 2274381595492 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] Decode( 0x55f2ebfec840, 0x7fff0596b6c0, 0x7fff0596b6e0 ): entry ...
[3, Info] rocjpeg_decoder.cpp:120: 2274381607931 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] Decode( 0x55f2ebfec840, 0x7fff0596b6c0, 0x7fff0596b6e0 ): exit (12439 us) ...
[3, Info] rocjpeg_api.cpp:222: 2274381607937 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] rocJpegDecode( 0x55f2ebf6dde0, 0x55f2ebfec840, 0x7fff0596b6c0, 0x7fff0596b6e0 ): exit (12449 us) ...
Average processing time per image (ms): 12.4542
Average images per sec: 80.2941
[3, Info] rocjpeg_api.cpp:154: 2274381608091 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] rocJpegDestroy( 0x55f2ebf6dde0 ): entry ...
[3, Info] rocjpeg_api.cpp:154: 2274381610464 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] rocJpegDestroy( 0x55f2ebf6dde0 ): exit (2373 us) ...
[3, Info] rocjpeg_api.cpp:99: 2274381610471 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] rocJpegStreamDestroy( 0x55f2ebfec840 ): entry ...
[3, Info] rocjpeg_api.cpp:99: 2274381610474 us: [pid:1740825 tid:1740825 hashid:0xbc0a7] rocJpegStreamDestroy( 0x55f2ebfec840 ): exit (3 us) ...
Decoding completed!
```

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
