### PR TITLE
[hipFile/CI] Add CXX Compiler & CXX Standard to toplevel CI Matrix

### DIFF
--- a/.github/workflows/hipfile-build-nvidia.yml
+++ b/.github/workflows/hipfile-build-nvidia.yml
@@ -13,6 +13,9 @@ on:
       ci_image:
         required: true
         type: string
+      cxx_compiler:
+        required: true
+        type: string
       platform:
         required: true
         type: string
@@ -29,14 +32,8 @@ jobs:
 
   compile_on_NVIDIA:
     env:
-      AIS_INPUT_CXX_COMPILER: ${{ matrix.supported_compilers }}
+      AIS_INPUT_CXX_COMPILER: ${{ inputs.cxx_compiler }}
     runs-on: [ubuntu-24.04]
-    strategy:
-      fail-fast: false
-      matrix:
-        supported_compilers:
-          - g++
-          - clang++
     steps:
       - name: Set early AIS CI environment variables
         run: |
@@ -81,7 +78,7 @@ jobs:
               cp -R /mnt/ais /ais
               mkdir -p /ais/build/hipfile
             '
-      - name: Generate build files for hipFile targeting the NVIDIA platform (${{ matrix.supported_compilers }})
+      - name: Generate build files for hipFile targeting the NVIDIA platform (${{ inputs.cxx_compiler }})
         run: |
           docker exec \
             -e "_AIS_INPUT_CXX_COMPILER=${AIS_INPUT_CXX_COMPILER}" \
@@ -95,7 +92,7 @@ jobs:
                 -DCMAKE_HIP_PLATFORM=nvidia \
                 ../../rocm-systems/projects/hipfile
             '
-      - name: Build hipFile for the NVIDIA platform (${{ matrix.supported_compilers }})
+      - name: Build hipFile for the NVIDIA platform (${{ inputs.cxx_compiler }})
         run: |
           docker exec \
             -t \

--- a/.github/workflows/hipfile-build.yml
+++ b/.github/workflows/hipfile-build.yml
@@ -149,14 +149,19 @@ jobs:
         run: |
           docker exec \
             -e "_AIS_INPUT_CXX_COMPILER=${AIS_INPUT_CXX_COMPILER}" \
+            -e "_AIS_SAFE_COMPILER_NAME=${AIS_SAFE_COMPILER_NAME}" \
+            -e "_AIS_INPUT_CXX_STANDARD=${AIS_INPUT_CXX_STANDARD}" \
             -e "BUILD_ID=${AIS_INPUT_BUILD_ID}" \
             -e "JOB_DESIGNATOR=${AIS_INPUT_JOB_DESIGNATOR}" \
             -t \
             -w /ais/build/hipfile \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
-              export CPACK_DEBIAN_PACKAGE_RELEASE="${JOB_DESIGNATOR}${SLES_BUILD_ID_PREFIX}${BUILD_ID}~$(source /etc/os-release && echo ${VERSION_ID})"
-              export CPACK_RPM_PACKAGE_RELEASE="${JOB_DESIGNATOR}${SLES_BUILD_ID_PREFIX}${BUILD_ID}"
+              # Embed compiler+standard in the package release so the per-combo
+              # artifacts (named after the package filename) stay unique.
+              _AIS_CXX_TAG="${_AIS_SAFE_COMPILER_NAME}.cxx${_AIS_INPUT_CXX_STANDARD}"
+              export CPACK_DEBIAN_PACKAGE_RELEASE="${JOB_DESIGNATOR}${SLES_BUILD_ID_PREFIX}${BUILD_ID}.${_AIS_CXX_TAG}~$(source /etc/os-release && echo ${VERSION_ID})"
+              export CPACK_RPM_PACKAGE_RELEASE="${JOB_DESIGNATOR}${SLES_BUILD_ID_PREFIX}${BUILD_ID}.${_AIS_CXX_TAG}"
               cmake \
                 -DCMAKE_BUILD_TYPE=Debug \
                 -DCMAKE_CXX_COMPILER="${_AIS_INPUT_CXX_COMPILER}" \

--- a/.github/workflows/hipfile-build.yml
+++ b/.github/workflows/hipfile-build.yml
@@ -332,7 +332,7 @@ jobs:
         if: ${{ inputs.upload_artifacts }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: hipfile-build-dir-${{ inputs.platform }}
+          name: hipfile-build-dir-${{ inputs.platform }}-${{ inputs.rocm_version }}-${{ inputs.cxx_compiler }}-cxx${{ inputs.cxx_standard }}
           path: ${{ github.workspace }}/hipfile-build-dir
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/hipfile-ci-system.yml
+++ b/.github/workflows/hipfile-ci-system.yml
@@ -6,6 +6,8 @@ env:
   AIS_INPUT_HIPFILE_PKG_DEV_FILENAME: ${{ inputs.ais_hipfile_pkg_dev_filename }}
   AIS_INPUT_HIPFILE_PKG_FILENAME: ${{ inputs.ais_hipfile_pkg_filename }}
   AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
+  AIS_INPUT_CXX_COMPILER: ${{ inputs.cxx_compiler }}
+  AIS_INPUT_CXX_STANDARD: ${{ inputs.cxx_standard }}
   AIS_INPUT_PLATFORM: ${{ inputs.platform }}
   AIS_INPUT_ROCM_VERSION: ${{ inputs.rocm_version }}
   AIS_MOUNT_PATH: /mnt/ais/ext4
@@ -37,6 +39,14 @@ on:
       ci_image:
         required: true
         type: string
+      cxx_compiler:
+        description: "C++ compiler the build artifacts were built with"
+        required: true
+        type: string
+      cxx_standard:
+        description: "C++ standard the build artifacts were built with"
+        required: true
+        type: number
       platform:
         required: true
         type: string

--- a/.github/workflows/hipfile-ci-system.yml
+++ b/.github/workflows/hipfile-ci-system.yml
@@ -65,10 +65,12 @@ jobs:
     runs-on: [AIS]
     steps:
       - name: Set early AIS CI environment variables
-        run: echo "AIS_PR_NUMBER=$(echo "${GITHUB_REF}" | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
+        run: |
+          echo "AIS_PR_NUMBER=$(echo "${GITHUB_REF}" | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
+          echo "AIS_SAFE_COMPILER_NAME=$(echo "${AIS_INPUT_CXX_COMPILER}" | sed 's|[\+]|plus|g')" >> "${GITHUB_ENV}"
       - name: Set AIS CI container name
         run: |
-          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${GITHUB_JOB}_${AIS_INPUT_PLATFORM}_${AIS_INPUT_ROCM_VERSION}" >> "${GITHUB_ENV}"
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER}_${GITHUB_JOB}_${AIS_INPUT_PLATFORM}_${AIS_INPUT_ROCM_VERSION}_${AIS_SAFE_COMPILER_NAME}_${AIS_INPUT_CXX_STANDARD}" >> "${GITHUB_ENV}"
       - name: Fetching hipFile repository...
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/hipfile-ci-system.yml
+++ b/.github/workflows/hipfile-ci-system.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Download hipFile build directory
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: hipfile-build-dir-${{ inputs.platform }}
+          name: hipfile-build-dir-${{ inputs.platform }}-${{ inputs.rocm_version }}-${{ inputs.cxx_compiler }}-cxx${{ inputs.cxx_standard }}
           path: ${{ github.workspace }}/hipfile-build-dir
       - name: Authenticating to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -31,6 +31,7 @@ jobs:
     env:
       # Matrix variables go here in JSON notation.
       # '>-' strips newlines
+      # Note: If adding distros or ROCm versions, ensure they have been properly excluded.
       SUPPORTED_PLATFORMS: >-
         [
           "rocky",
@@ -40,19 +41,28 @@ jobs:
         ]
       ROCM_VERSIONS: >-
         [
-          "7.2.2"
+          "7.2.2",
+          "7.13.0",
+          "nightly"
         ]
-      # MATRIX_INCLUDE / MATRIX_EXCLUDE: extra/removed matrix entries,
-      # passed through to GHA's strategy.matrix include/exclude keys
-      # so non-rectangular combinations (e.g. ubuntu x 7.13.0 only) can
-      # be expressed without abandoning the base cross-product.
+      # MATRIX_INCLUDE / MATRIX_EXCLUDE: extra/removed matrix entries, passed
+      # through to GHA's strategy.matrix include/exclude keys so non-rectangular
+      # combinations can be expressed without abandoning the base cross-product.
       MATRIX_INCLUDE: >-
-        [
-          {"supported_platforms": "ubuntu", "rocm_versions": "7.13.0"},
-          {"supported_platforms": "ubuntu", "rocm_versions": "nightly"}
-        ]
-      MATRIX_EXCLUDE: >-
         []
+      # 7.13.0 and nightly are ubuntu-only targets. They live in the base
+      # ROCM_VERSIONS axis and are removed from every other distro via
+      # MATRIX_EXCLUDE below. This is cleaner than specifying the full
+      # combination of CI parameters in include as the matrix axes grow.
+      MATRIX_EXCLUDE: >-
+        [
+          {"supported_platforms": "rocky", "rocm_versions": "7.13.0"},
+          {"supported_platforms": "rocky", "rocm_versions": "nightly"},
+          {"supported_platforms": "rocky8", "rocm_versions": "7.13.0"},
+          {"supported_platforms": "rocky8", "rocm_versions": "nightly"},
+          {"supported_platforms": "suse", "rocm_versions": "7.13.0"},
+          {"supported_platforms": "suse", "rocm_versions": "nightly"}
+        ]
     steps:
       - name: Fetching code repository...
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -31,6 +31,17 @@ jobs:
     env:
       # Matrix variables go here in JSON notation.
       # '>-' strips newlines
+      CXX_COMPILER: >-
+        [
+          "amdclang++",
+          "clang++",
+          "g++"
+        ]
+      CXX_STANDARD: >-
+        [
+          20,
+          23
+        ]
       # Note: If adding distros or ROCm versions, ensure they have been properly excluded.
       SUPPORTED_PLATFORMS: >-
         [
@@ -56,6 +67,7 @@ jobs:
       # combination of CI parameters in include as the matrix axes grow.
       MATRIX_EXCLUDE: >-
         [
+          {"supported_platforms": "rocky8", "cxx_standard": 23},
           {"supported_platforms": "rocky", "rocm_versions": "7.13.0"},
           {"supported_platforms": "rocky", "rocm_versions": "nightly"},
           {"supported_platforms": "rocky8", "rocm_versions": "7.13.0"},
@@ -213,5 +225,7 @@ jobs:
     with:
       ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)[format('{0}-{1}', matrix.supported_platforms, matrix.rocm_versions)].ci_image }}
       ci_image_nvidia: ${{ fromJSON(needs.Precheck.outputs.ci_images)[format('{0}-{1}', matrix.supported_platforms, matrix.rocm_versions)].ci_image_nvidia }}
+      cxx_compiler: ${{ matrix.cxx_compiler }}
+      cxx_standard: ${{ matrix.cxx_standard }}
       platform: ${{ matrix.supported_platforms }}
       rocm_version: ${{ matrix.rocm_versions }}

--- a/.github/workflows/hipfile-ci.yml
+++ b/.github/workflows/hipfile-ci.yml
@@ -12,6 +12,14 @@ on:
         description: "Full CI image name & nvidia tag"
         required: true
         type: string
+      cxx_compiler:
+        description: "C++ compiler to use"
+        required: true
+        type: string
+      cxx_standard:
+        description: "C++ standard to use for building"
+        required: true
+        type: number
       platform:
         required: true
         type: string
@@ -29,39 +37,12 @@ jobs:
     uses: ./.github/workflows/hipfile-build.yml
     with:
       ci_image: ${{ inputs.ci_image }}
-      cxx_compiler: amdclang++
+      cxx_compiler: ${{ inputs.cxx_compiler }}
+      cxx_standard: ${{ inputs.cxx_standard }}
+      generate_coverage: ${{ inputs.cxx_standard == 20 && inputs.cxx_compiler == 'amdclang++' }}
       platform: ${{ inputs.platform }}
       rocm_version: ${{ inputs.rocm_version }}
       upload_artifacts: true
-
-  build_and_test_cxx23:
-    if: ${{ inputs.platform != 'rocky8' }}
-    uses: ./.github/workflows/hipfile-build.yml
-    with:
-      ci_image: ${{ inputs.ci_image }}
-      cxx_compiler: amdclang++
-      cxx_standard: 23
-      platform: ${{ inputs.platform }}
-      rocm_version: ${{ inputs.rocm_version }}
-      upload_artifacts: false
-      generate_coverage: false
-
-  # Try building on other compilers, but keep as separate job.
-  # Removes issues regarding matrix job overwriting outputs and
-  # does not propagate failures.
-  build_and_test_other_compilers:
-    strategy:
-      fail-fast: false
-      matrix:
-        cxx_compiler:
-          - clang++
-          - g++
-    uses: ./.github/workflows/hipfile-build.yml
-    with:
-      ci_image: ${{ inputs.ci_image }}
-      cxx_compiler: ${{ matrix.cxx_compiler }}
-      platform: ${{ inputs.platform }}
-      rocm_version: ${{ inputs.rocm_version }}
 
   python_bindings:
     needs: [build_and_test]
@@ -70,6 +51,8 @@ jobs:
       ais_hipfile_pkg_dev_filename: ${{ needs.build_and_test.outputs.ais_hipfile_pkg_dev_filename }}
       ais_hipfile_pkg_filename: ${{ needs.build_and_test.outputs.ais_hipfile_pkg_filename }}
       ci_image: ${{ needs.build_and_test.outputs.ci_image }}
+      cxx_compiler: ${{ inputs.cxx_compiler }}
+      cxx_standard: ${{ inputs.cxx_standard }}
       platform: ${{ inputs.platform }}
       rocm_version: ${{ inputs.rocm_version }}
 
@@ -80,13 +63,18 @@ jobs:
       ais_hipfile_pkg_dev_filename: ${{ needs.build_and_test.outputs.ais_hipfile_pkg_dev_filename }}
       ais_hipfile_pkg_filename: ${{ needs.build_and_test.outputs.ais_hipfile_pkg_filename }}
       ci_image: ${{ needs.build_and_test.outputs.ci_image }}
+      cxx_compiler: ${{ inputs.cxx_compiler }}
+      cxx_standard: ${{ inputs.cxx_standard }}
       platform: ${{ inputs.platform }}
       rocm_version: ${{ inputs.rocm_version }}
 
   build_and_test_NVIDIA:
-    if: ${{ !startsWith(inputs.rocm_version, '7.13.') && inputs.rocm_version != 'nightly' }}
+    # NVIDIA can't build with amdclang++; its meaningful compilers (clang++, g++)
+    # arrive via the cxx_compiler axis, so skip the amdclang++ legs here.
+    if: ${{ !startsWith(inputs.rocm_version, '7.13.') && inputs.rocm_version != 'nightly' && inputs.cxx_compiler != 'amdclang++' }}
     uses: ./.github/workflows/hipfile-build-nvidia.yml
     with:
       ci_image: ${{ inputs.ci_image_nvidia }}
+      cxx_compiler: ${{ inputs.cxx_compiler }}
       platform: ${{ inputs.platform }}
       rocm_version: ${{ inputs.rocm_version }}

--- a/.github/workflows/hipfile-ci.yml
+++ b/.github/workflows/hipfile-ci.yml
@@ -70,8 +70,9 @@ jobs:
 
   build_and_test_NVIDIA:
     # NVIDIA can't build with amdclang++; its meaningful compilers (clang++, g++)
-    # arrive via the cxx_compiler axis, so skip the amdclang++ legs here.
-    if: ${{ !startsWith(inputs.rocm_version, '7.13.') && inputs.rocm_version != 'nightly' && inputs.cxx_compiler != 'amdclang++' }}
+    # arrive via the cxx_compiler axis, so skip the amdclang++ legs here. Only
+    # run on the default C++20 standard.
+    if: ${{ !startsWith(inputs.rocm_version, '7.13.') && inputs.rocm_version != 'nightly' && inputs.cxx_compiler != 'amdclang++' && inputs.cxx_standard == 20 }}
     uses: ./.github/workflows/hipfile-build-nvidia.yml
     with:
       ci_image: ${{ inputs.ci_image_nvidia }}

--- a/.github/workflows/hipfile-image-update-nightly.yml
+++ b/.github/workflows/hipfile-image-update-nightly.yml
@@ -10,7 +10,7 @@ on:
     # buffer. This job is purely an optimization: if it is late/failed/builds
     # against an incomplete nightly, per-PR runs fall back to building the nightly
     # image on demand.
-    - cron: "0 10 * * *"
+    - cron: "0 2 * * *"
   workflow_dispatch:
   # Refresh on merge of a Dockerfile/resolver change so the published nightly
   # image + floating cache track develop. Without this, the per-PR registry

--- a/.github/workflows/hipfile-image-update.yml
+++ b/.github/workflows/hipfile-image-update.yml
@@ -45,8 +45,8 @@ jobs:
     # latest-rocm<ver> images post-merge, but the nightly target moves daily, so
     # nightly images are refreshed by hipfile-image-update-nightly.yml (daily and
     # on Dockerfile-change merge) instead. Keep this matrix in sync with
-    # hipfile-ci-toplevel.yml's SUPPORTED_PLATFORMS/ROCM_VERSIONS/MATRIX_INCLUDE
-    # for the non-nightly rows.
+    # hipfile-ci-toplevel.yml's SUPPORTED_PLATFORMS/ROCM_VERSIONS/MATRIX_EXCLUDE
+    # (and MATRIX_INCLUDE if used) for the non-nightly rows.
     strategy:
       matrix:
         supported_platforms:

--- a/.github/workflows/hipfile-python-bindings.yml
+++ b/.github/workflows/hipfile-python-bindings.yml
@@ -63,9 +63,10 @@ jobs:
         run: |
           echo "AIS_PR_NUMBER=$(echo "${GITHUB_REF}" | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
           echo "AIS_GHA_CMD_FILES_DIR=${GITHUB_ENV%/*}" >> "${GITHUB_ENV}"
+          echo "AIS_SAFE_COMPILER_NAME=$(echo "${AIS_INPUT_CXX_COMPILER}" | sed 's|[\+]|plus|g')" >> "${GITHUB_ENV}"
       - name: Set AIS CI container name
         run: |
-          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER:=${GITHUB_RUN_ID}}_${GITHUB_JOB}_${AIS_INPUT_PLATFORM}_${AIS_INPUT_ROCM_VERSION}" >> "${GITHUB_ENV}"
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER:=${GITHUB_RUN_ID}}_${GITHUB_JOB}_${AIS_INPUT_PLATFORM}_${AIS_INPUT_ROCM_VERSION}_${AIS_SAFE_COMPILER_NAME}_${AIS_INPUT_CXX_STANDARD}" >> "${GITHUB_ENV}"
       - name: Fetching code repository...
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/hipfile-python-bindings.yml
+++ b/.github/workflows/hipfile-python-bindings.yml
@@ -4,6 +4,8 @@ run-name: Build and install hipFile Python bindings
 env:
   AIS_GHA_CMD_FILES_DOCKER_DIR: /root/github
   AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
+  AIS_INPUT_CXX_COMPILER: ${{ inputs.cxx_compiler }}
+  AIS_INPUT_CXX_STANDARD: ${{ inputs.cxx_standard }}
   AIS_INPUT_HIPFILE_PKG_DEV_FILENAME: ${{ inputs.ais_hipfile_pkg_dev_filename }}
   AIS_INPUT_HIPFILE_PKG_FILENAME: ${{ inputs.ais_hipfile_pkg_filename }}
   AIS_INPUT_PLATFORM: ${{ inputs.platform }}
@@ -27,6 +29,14 @@ on:
       ci_image:
         required: true
         type: string
+      cxx_compiler:
+        description: "C++ compiler the consumed packages were built with"
+        required: true
+        type: string
+      cxx_standard:
+        description: "C++ standard the consumed packages were built with"
+        required: true
+        type: number
       platform:
         required: true
         type: string

--- a/.github/workflows/hipfile-python-bindings.yml
+++ b/.github/workflows/hipfile-python-bindings.yml
@@ -151,6 +151,9 @@ jobs:
           docker exec \
             -e "AIS_GITHUB_OUTPUT=${{ env.AIS_GHA_CMD_FILES_DOCKER_DIR }}/${GITHUB_OUTPUT##*/}" \
             -e "_AIS_INPUT_PLATFORM=${AIS_INPUT_PLATFORM}" \
+            -e "_AIS_INPUT_ROCM_VERSION=${AIS_INPUT_ROCM_VERSION}" \
+            -e "_AIS_SAFE_COMPILER_NAME=${AIS_SAFE_COMPILER_NAME}" \
+            -e "_AIS_INPUT_CXX_STANDARD=${AIS_INPUT_CXX_STANDARD}" \
             -t \
             -w /ais/rocm-systems/projects/hipfile \
             "${AIS_CONTAINER_NAME}" \
@@ -158,7 +161,11 @@ jobs:
               .venv/bin/python -m build --sdist ./python
               shopt -s nullglob
               OLD_FILENAME="$(basename ./python/dist/hipfile-*.tar.gz)"
-              NEW_FILENAME="${OLD_FILENAME%.tar.gz}-${_AIS_INPUT_PLATFORM}.tar.gz"
+              # python_bindings runs for every (platform, rocm, cxx) leg and the
+              # sdist version does not encode any of them, so disambiguate the
+              # artifact (named after the file) across all of them. Sanitized
+              # compiler avoids a "+" being read as a PEP 440 local version.
+              NEW_FILENAME="${OLD_FILENAME%.tar.gz}-${_AIS_INPUT_PLATFORM}-${_AIS_INPUT_ROCM_VERSION}-${_AIS_SAFE_COMPILER_NAME}-cxx${_AIS_INPUT_CXX_STANDARD}.tar.gz"
               mv ./python/dist/${OLD_FILENAME} ./python/dist/${NEW_FILENAME}
               echo "HIPFILE_PYTHON_SDIST_FILENAME=${NEW_FILENAME}" >> "${AIS_GITHUB_OUTPUT}"
             '

--- a/projects/hipfile/util/ci-matrices.sh
+++ b/projects/hipfile/util/ci-matrices.sh
@@ -10,8 +10,9 @@
 # Two ways to use it:
 #   Sourced (CI):  source ci-matrices.sh
 #                  -> sets shell vars ci_matrix and full_CI_images_matrix from
-#                     the env vars SUPPORTED_PLATFORMS, ROCM_VERSIONS,
-#                     MATRIX_INCLUDE, MATRIX_EXCLUDE
+#                     the env vars CXX_COMPILER, CXX_STANDARD,
+#                     SUPPORTED_PLATFORMS, ROCM_VERSIONS, MATRIX_INCLUDE,
+#                     MATRIX_EXCLUDE
 #   Tests:         bash ci-matrices.sh --test
 #
 # Because the same jq is both shipped to CI and exercised by --test, the two
@@ -21,15 +22,19 @@
 
 # Build the full strategy.matrix object handed to the test (Linux) job. GHA
 # expands the cross-product and applies the include/exclude keys itself.
-# Args: supported_platforms rocm_versions matrix_include matrix_exclude (JSON)
+# Args: cxx_compiler cxx_standard supported_platforms rocm_versions matrix_include matrix_exclude (JSON)
 compute_ci_matrix() {
-  local supported_platforms="$1" rocm_versions="$2" matrix_include="$3" matrix_exclude="$4"
+  local cxx_compiler="$1" cxx_standard="$2" supported_platforms="$3" rocm_versions="$4" matrix_include="$5" matrix_exclude="$6"
   jq -c --null-input \
+    --argjson cxx_compiler "${cxx_compiler}" \
+    --argjson cxx_standard "${cxx_standard}" \
     --argjson supported_platforms "${supported_platforms}" \
     --argjson rocm_versions "${rocm_versions}" \
     --argjson matrix_include "${matrix_include}" \
     --argjson matrix_exclude "${matrix_exclude}" \
     '{
+      cxx_compiler: $cxx_compiler,
+      cxx_standard: $cxx_standard,
       supported_platforms: $supported_platforms,
       rocm_versions: $rocm_versions,
       include: $matrix_include,
@@ -41,7 +46,7 @@ compute_ci_matrix() {
 # derived by simulating GHA's matrix expansion (cross-product -> exclude
 # -> include with merge semantics) on ci_matrix, projecting each resulting 
 # combo down to (supported_platforms, rocm_versions), and deduping.
-# This way future test-only axes on ci_matrix (CXX, compiler, ...)
+# This way the test-only cxx axes (and any future axes) on ci_matrix
 # do not multiply images, and an exclude that removes all test legs for a
 # given (platform, version) correctly removes that image. Emitted in
 # include-only form so GHA spawns exactly one image-build job per row.
@@ -117,6 +122,35 @@ _assert_eq() {
 _run_tests() {
   local failures=0 ci out
 
+  echo "Test 0: compute_ci_matrix emits every axis (incl. cxx_compiler/cxx_standard)"
+  # Guards against silently dropping an axis from the jq object: a missing
+  # cxx_compiler/cxx_standard here means matrix.cxx_* resolves empty in GHA.
+  out=$(compute_ci_matrix \
+    '["amdclang++","clang++","g++"]' \
+    '[17,20]' \
+    '["rocky8","ubuntu"]' \
+    '["7.2.2"]' \
+    '[{"supported_platforms":"ubuntu","rocm_versions":"7.13.0","cxx_compiler":"amdclang++","cxx_standard":17}]' \
+    '[{"supported_platforms":"rocky8","cxx_standard":20}]')
+  local ci_matrix_actual ci_matrix_expected
+  ci_matrix_actual=$(printf '%s' "${out}" | jq -cS .)
+  ci_matrix_expected=$(printf '%s' '{
+    "cxx_compiler":["amdclang++","clang++","g++"],
+    "cxx_standard":[17,20],
+    "supported_platforms":["rocky8","ubuntu"],
+    "rocm_versions":["7.2.2"],
+    "include":[{"supported_platforms":"ubuntu","rocm_versions":"7.13.0","cxx_compiler":"amdclang++","cxx_standard":17}],
+    "exclude":[{"supported_platforms":"rocky8","cxx_standard":20}]
+  }' | jq -cS .)
+  if [ "${ci_matrix_actual}" = "${ci_matrix_expected}" ]; then
+    printf '  PASS    compute_ci_matrix\n        -> %s\n' "${ci_matrix_actual}"
+  else
+    printf '  FAIL    compute_ci_matrix\n        expected: %s\n        got:      %s\n' \
+      "${ci_matrix_expected}" "${ci_matrix_actual}"
+    failures=$((failures+1))
+  fi
+
+  echo
   echo "Test 1: today's ci_matrix (no extra axes) -> all cross-product pairs"
   ci='{"supported_platforms":["rocky","ubuntu"],"rocm_versions":["7.2.2"],"include":[],"exclude":[]}'
   out=$(compute_full_CI_images_matrix "$ci")
@@ -124,7 +158,7 @@ _run_tests() {
     '{"include":[{"supported_platforms":"rocky","rocm_versions":"7.2.2"},{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
 
   echo
-  echo "Test 2: real-world today (rocky,rocky8,suse,ubuntu) x (7.2.2), include ubuntu/7.13.0"
+  echo "Test 2: include-pattern scenario (rocky,rocky8,suse,ubuntu) x (7.2.2), include ubuntu/7.13.0"
   ci='{"supported_platforms":["rocky","rocky8","suse","ubuntu"],"rocm_versions":["7.2.2"],"include":[{"supported_platforms":"ubuntu","rocm_versions":"7.13.0"}],"exclude":[]}'
   out=$(compute_full_CI_images_matrix "$ci")
   _assert_eq "  output" "$out" \
@@ -202,11 +236,31 @@ _run_tests() {
     '{"include":[{"supported_platforms":"rocky","rocm_versions":"7.2.2"},{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
 
   echo
-  echo "Test 12: future axes, no excludes/includes -> dedup down to (sp,rv) projection"
-  ci='{"supported_platforms":["ubuntu"],"rocm_versions":["7.2.2"],"cxx_standard":[17,20],"compiler":["clang","gcc"],"include":[],"exclude":[]}'
+  echo "Test 12: cxx axes, no excludes/includes -> dedup down to (sp,rv) projection"
+  ci='{"supported_platforms":["ubuntu"],"rocm_versions":["7.2.2"],"cxx_standard":[17,20],"cxx_compiler":["amdclang++","clang++","g++"],"include":[],"exclude":[]}'
   out=$(compute_full_CI_images_matrix "$ci")
   _assert_eq "  output" "$out" \
     '{"include":[{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
+
+  echo
+  echo "Test 13: production matrix (cxx_compiler x cxx_standard, rocky8/cxx20 excluded)"
+  # rocky8 keeps only cxx_standard 17 legs but still has image-needing legs, so every
+  # (sp, rv) still resolves to exactly one image despite the cxx fan-out.
+  ci='{"cxx_compiler":["amdclang++","clang++","g++"],"cxx_standard":[17,20],"supported_platforms":["rocky","rocky8","suse","ubuntu"],"rocm_versions":["7.2.2"],"include":[],"exclude":[{"supported_platforms":"rocky8","cxx_standard":20}]}'
+  out=$(compute_full_CI_images_matrix "$ci")
+  _assert_eq "  output" "$out" \
+    '{"include":[{"supported_platforms":"rocky","rocm_versions":"7.2.2"},{"supported_platforms":"rocky8","rocm_versions":"7.2.2"},{"supported_platforms":"suse","rocm_versions":"7.2.2"},{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"}]}' || failures=$((failures+1))
+
+  echo
+  echo "Test 14: production exclude-pattern (ubuntu-only 7.13.0/nightly via excludes)"
+  # Mirrors hipfile-ci-toplevel.yml: 7.13.0 and nightly live in the base
+  # ROCM_VERSIONS axis and are removed from every non-ubuntu distro via
+  # supported_platforms+rocm_versions excludes, with the cxx fan-out present.
+  # Each surviving (sp, rv) still resolves to exactly one image.
+  ci='{"cxx_compiler":["amdclang++","clang++","g++"],"cxx_standard":[17,20],"supported_platforms":["rocky","rocky8","suse","ubuntu"],"rocm_versions":["7.2.2","7.13.0","nightly"],"include":[],"exclude":[{"supported_platforms":"rocky8","cxx_standard":20},{"supported_platforms":"rocky","rocm_versions":"7.13.0"},{"supported_platforms":"rocky","rocm_versions":"nightly"},{"supported_platforms":"rocky8","rocm_versions":"7.13.0"},{"supported_platforms":"rocky8","rocm_versions":"nightly"},{"supported_platforms":"suse","rocm_versions":"7.13.0"},{"supported_platforms":"suse","rocm_versions":"nightly"}]}'
+  out=$(compute_full_CI_images_matrix "$ci")
+  _assert_eq "  output" "$out" \
+    '{"include":[{"supported_platforms":"rocky","rocm_versions":"7.2.2"},{"supported_platforms":"rocky8","rocm_versions":"7.2.2"},{"supported_platforms":"suse","rocm_versions":"7.2.2"},{"supported_platforms":"ubuntu","rocm_versions":"7.2.2"},{"supported_platforms":"ubuntu","rocm_versions":"7.13.0"},{"supported_platforms":"ubuntu","rocm_versions":"nightly"}]}' || failures=$((failures+1))
 
   echo
   if [ "${failures}" -eq 0 ]; then
@@ -225,7 +279,7 @@ if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
   # SC2034: ci_matrix/full_CI_images_matrix are consumed by the sourcing CI step.
   # SC2153: the UPPER_CASE names are CI env vars, not typos of the lowercase args.
   # shellcheck disable=SC2034,SC2153
-  ci_matrix=$(compute_ci_matrix "${SUPPORTED_PLATFORMS}" "${ROCM_VERSIONS}" "${MATRIX_INCLUDE}" "${MATRIX_EXCLUDE}")
+  ci_matrix=$(compute_ci_matrix "${CXX_COMPILER}" "${CXX_STANDARD}" "${SUPPORTED_PLATFORMS}" "${ROCM_VERSIONS}" "${MATRIX_INCLUDE}" "${MATRIX_EXCLUDE}")
   # shellcheck disable=SC2034
   full_CI_images_matrix=$(compute_full_CI_images_matrix "${ci_matrix}")
 else


### PR DESCRIPTION
## Motivation

Add `cxx_compiler` and `cxx_standard` as matrix axes to run the full CI on the slightly different
variations of how we can build the hipFile library.

One penalty we should be aware of if we want to proceed with this PR is that it does put additional load on the system test CI runner. If we can remove the bottleneck of downloading the CMake build directory (because we have a slimmer package containing our tests), that would improve testing throughput.

## Technical Details

- Added `cxx_compiler` (`amdclang++`, `clang++`, `g++`) and `cxx_standard`
  (`20`, `23`) axes to the top-level matrix and threaded them through the reusable
  workflows (build, python-bindings, system tests, NVIDIA).
- Moved the ubuntu-only `7.13.0`/`nightly` targets out of `include` and into the
  base axis + `MATRIX_EXCLUDE`, so the matrix stays flat as axes grow.
- CI *images* still dedupe to one per `(platform, rocm_version)` — the new axes
  don't multiply image builds.
- NVIDIA build drops its internal `g++`/`clang++` matrix, takes `cxx_compiler` as
  input, and skips the `amdclang++` legs.
- Made artifact and container names unique per combination (package CPACK release,
  build-dir, python sdist, docker container) now that every leg uploads.

## JIRA ID

AIHIPFILE-174

## Test Plan

Passes CI with all expected legs running. Base axes are 3 compilers × 2 standards,
with `rocky8` excluded from C++20 and the ubuntu-only `7.13.0`/`nightly` targets:

| Platform | ROCm versions | Test legs |
|----------|---------------|-----------|
| rocky    | 7.2.2         | 6         |
| rocky8   | 7.2.2         | 3 (C++20 only) |
| suse     | 7.2.2         | 6         |
| ubuntu   | 7.2.2, 7.13.0, nightly | 18 |
| **Total** |              | **33**    |

These dedupe to **6 CI images** (one per platform/ROCm pair). `ci-matrices.sh --test`
runs in the Precheck job.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
