### PR TITLE
[rocjitsu] Several fixes for FP San tests

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -5572,7 +5572,7 @@ class CodeGenerator:
 
     @staticmethod
     def _gen_narrow_cvt_header_REMOVED_PLACEHOLDER(out_path: str) -> None:
-        pass
+        return
         content_UNUSED = f"""\
 // REMOVED — narrow FP conversions now live in util/data_types.h
 

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -4696,6 +4696,9 @@ class CodeGenerator:
                     _size_overrides = self.isa_spec.profile.inst_size_overrides
                     if inst.name in _size_overrides:
                         ctor_body_parts.append(f'size_ = {_size_overrides[inst.name]};')
+                        private_members.append(cgen.Statement('uint32_t x2_dw1_ = 0'))
+                        init_list_parts.append('x2_dw1_(inst[-1])')
+                        init_list = ', '.join(init_list_parts)
 
                     ctor_body = ''.join(ctor_body_parts)
                     class_ctor_impl_str = (
@@ -6909,6 +6912,37 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
         decode_table_entries = []
         sub_decode_table_entries = []
         decode_funcs_found = set()
+        _custom_decode_bodies: dict[str, object] = {}
+        _vop3px2_opcode = self.isa_spec.profile.vop3px2_prefix_opcode
+        if _vop3px2_opcode is not None:
+            _ie_names = {
+                inst.name for ie in self.isa_spec.inst_encodings for inst in ie.insts
+            }
+            _vop3px2_active = any(
+                n in _ie_names for n in self.isa_spec.profile.inst_size_overrides
+            )
+            if _vop3px2_active:
+                for _dte in self.isa_spec.primary_decode_table:
+                    if (
+                        _dte is not None
+                        and not _dte.is_primary
+                        and _dte.sub_decode_funcs is not None
+                        and _dte.sub_decode_table
+                        and 'vop3p' in _dte.sub_decode_table
+                    ):
+                        _pfx = 'decodeVop3pX2Prefix'
+                        _dte.sub_decode_funcs[_vop3px2_opcode] = _pfx
+                        _custom_decode_bodies[_pfx] = cgen.Block(
+                            [
+                                cgen.Statement(
+                                    f'auto op = *reinterpret_cast<const {_dte.enc.fmt_enc_name}::OpEncoding *>(opcode + 2)'
+                                ),
+                                cgen.Statement(
+                                    f'return {_dte.sub_decode_table}[op.op](opcode + 2)'
+                                ),
+                            ]
+                        )
+                        break
         for dte in self.isa_spec.primary_decode_table:
             if dte is not None:
                 decode_table_entries.append(f'&Decoder::{dte.decode_func},')
@@ -6980,6 +7014,17 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                                         ],
                                     )
                                 )
+                                _fn_body = (
+                                    _custom_decode_bodies[fn]
+                                    if fn in _custom_decode_bodies
+                                    else cgen.Block(
+                                        [
+                                            cgen.Statement(
+                                                f'return std::make_unique<{class_name}>(opcode)'
+                                            )
+                                        ]
+                                    )
+                                )
                                 decode_table_funcs.append(
                                     cgen.FunctionBody(
                                         cgen.FunctionDeclaration(
@@ -6994,13 +7039,7 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                                                 )
                                             ],
                                         ),
-                                        cgen.Block(
-                                            [
-                                                cgen.Statement(
-                                                    f'return std::make_unique<{class_name}>(opcode)'
-                                                )
-                                            ]
-                                        ),
+                                        _fn_body,
                                     )
                                 )
                             sub_decode_table_entry_str.append(f'&Decoder::{fn},')

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -4696,9 +4696,13 @@ class CodeGenerator:
                     _size_overrides = self.isa_spec.profile.inst_size_overrides
                     if inst.name in _size_overrides:
                         ctor_body_parts.append(f'size_ = {_size_overrides[inst.name]};')
-                        private_members.append(cgen.Statement('uint32_t x2_dw1_ = 0'))
-                        init_list_parts.append('x2_dw1_(inst[-1])')
-                        init_list = ', '.join(init_list_parts)
+                        ctor_body_parts.append(
+                            'raw_words_ = {inst[-2], inst[-1], inst[0], inst[1]};'
+                            'raw_encoding_ = raw_words_.data();'
+                        )
+                        private_members.append(
+                            cgen.Statement('std::array<uint32_t, 4> raw_words_{}')
+                        )
 
                     ctor_body = ''.join(ctor_body_parts)
                     class_ctor_impl_str = (
@@ -5225,11 +5229,18 @@ class CodeGenerator:
                         False,
                     ),
                 ]
+                _has_size_overrides = any(
+                    i.name in self.isa_spec.profile.inst_size_overrides
+                    for i in all_insts
+                )
+                if _has_size_overrides:
+                    h_includes.append(('array', True))
                 if (
                     self._supports_gfx1250_scaled_wmma_vop3px2()
                     and enc.enc_name.upper() == 'ENC_VOP3P'
                 ):
-                    h_includes.append(('array', True))
+                    if not _has_size_overrides:
+                        h_includes.append(('array', True))
                     cpp_includes.append(('array', True))
                     inst_classes.append(
                         cgen.Line(self._emit_gfx1250_scaled_wmma_vop3px2_class())

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/__init__.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/__init__.py
@@ -191,7 +191,11 @@ def _register_handlers() -> None:
         c.src_ops,
         c.cls,
         c.op,
-        opsel='inst_.op_sel' if c.is_vop3 and 'op_sel' in c.enc_field_names else '0u',
+        opsel=(
+            'inst_.opsel'
+            if c.is_vop3 and 'opsel' in c.enc_field_names
+            else 'inst_.op_sel' if c.is_vop3 and 'op_sel' in c.enc_field_names else '0u'
+        ),
     )
     DISPATCH['vector_cvt_scale'] = lambda c: gen_vector_cvt_scale(
         c.dst_ops, c.src_ops, c.cls, c.op

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/matrix.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/matrix.py
@@ -78,8 +78,40 @@ def gen_mfma(
     dst_bits = inst.operands[0].size if inst.operands else 0
     dst_regs = max(1, dst_bits // 32)
 
-    # SMFMAC: per-lane dot-product functional model (no cross-lane mapping).
+    # SMFMAC: cross-lane matrix multiply-accumulate.
     if 'SMFMAC' in name:
+        _SMFMAC_READ = {
+            'F16': 'amdgpu::smfmac_read_f16',
+            'BF16': 'amdgpu::smfmac_read_bf16',
+            'FP8': 'amdgpu::smfmac_read_fp8',
+            'BF8': 'amdgpu::smfmac_read_bf8',
+        }
+        if arch_name == 'cdna4' and input_type != 'I8':
+            L = []
+            L.append(f'  auto &cu = wf.cu();')
+            L.append(f'  uint32_t vb = wf.vgpr_alloc().base;')
+            L.append(
+                f'  uint32_t dst = amdgpu::dst_base(vb, {d}.encoding_value_, inst_.acc_cd);'
+            )
+            L.append(f'  uint32_t s0b = amdgpu::src_base(vb, {s0}.encoding_value_);')
+            L.append(f'  uint32_t s1b = amdgpu::src_base(vb, {s1}.encoding_value_);')
+            L.append(f'  uint32_t idx = amdgpu::src_base(vb, {s2}.encoding_value_);')
+            if input_type in ('F16', 'BF16'):
+                read_fn = _SMFMAC_READ[input_type]
+                L.append(
+                    f'  amdgpu::exec_smfmac_f32_{M}x{N}x{K}_f16(cu, dst, s0b, s1b, idx, {read_fn});'
+                )
+            else:
+                parts = input_type.split('_')
+                read_a = _SMFMAC_READ.get(parts[0], 'amdgpu::smfmac_read_fp8')
+                read_b = _SMFMAC_READ.get(parts[1], 'amdgpu::smfmac_read_fp8')
+                L.append(
+                    f'  amdgpu::exec_smfmac_f32_{M}x{N}x{K}_fp8(cu, dst, s0b, s1b, idx, {read_a},'
+                )
+                L.append(f'                                        {read_b});')
+            return '\n'.join(L)
+
+        # Fallback: per-lane dot-product functional model.
         L = []
         L.append(
             f'  // MFMA: {name} \u2014 {M}x{N}x{K} {input_type}\u2192{result_type}'
@@ -368,6 +400,48 @@ def gen_mfma(
             else:
                 L.append(f'                    s2, {ea}, {eb}, const_acc);')
         else:
+            if input_type in ('F8_F6_F4', 'F8F6F4'):
+                L.append(
+                    f'  uint32_t s0b = amdgpu::src_base(vb, {s0}.encoding_value_);'
+                )
+                L.append(
+                    f'  uint32_t s1b = amdgpu::src_base(vb, {s1}.encoding_value_);'
+                )
+                L.append(f'  if (!(inst_.abid & 1u)) {{')
+                L.append(
+                    f'    amdgpu::dispatch_matrix_fmt_pair(inst_.cbsz, inst_.blgp,'
+                )
+                L.append(
+                    f'                                     [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {{'
+                )
+                L.append(
+                    f'                                       amdgpu::exec_f32_mixed(cu, {M}, {N}, {K}, {B}, a_bits, b_bits,'
+                )
+                L.append(
+                    f'                                                              dst, s0b, s1b, s2, ea, eb, const_acc);'
+                )
+                L.append(f'                                     }});')
+                L.append(f'  }} else {{')
+                L.append(
+                    f'    uint32_t sa_base = amdgpu::src_base(vb, x2_dw1_ & 0x1FFu);'
+                )
+                L.append(
+                    f'    uint32_t sb_base = amdgpu::src_base(vb, (x2_dw1_ >> 9) & 0x1FFu);'
+                )
+                L.append(f'    amdgpu::dispatch_matrix_fmt_pair(')
+                L.append(
+                    f'        inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {{'
+                )
+                L.append(
+                    f'          amdgpu::exec_f32_scaled_mixed(cu, {M}, {N}, {K}, {B}, a_bits, b_bits, dst, s0b, s1b, s2, ea,'
+                )
+                L.append(
+                    f'                                        eb, const_acc, sa_base, sb_base);'
+                )
+                L.append(f'        }});')
+                L.append(f'  }}')
+                return '\n'.join(L)
+
             has_blgp = arch in ('cdna1', 'cdna2', 'cdna3', 'cdna4')
             L.append(f'  amdgpu::exec_f32(cu, {M}, {N}, {K}, {B}, {in_bits}, dst,')
             L.append(f'                 amdgpu::src_base(vb, {s0}.encoding_value_),')
@@ -377,51 +451,5 @@ def gen_mfma(
                 L.append(f'                 inst_.cbsz, inst_.abid, inst_.blgp);')
             else:
                 L.append(f'                 s2, {ea}, {eb}, const_acc);')
-
-        if input_type in ('F8_F6_F4', 'F8F6F4'):
-            # Rewrite the MFMA call: if ABID[0]=1 (scaling enabled),
-            # use exec_f32_scaled which applies per-32-K-block E8M0
-            # exponent biases from scale VGPRs in the X2 prefix.
-            # Dwords 0-1 of the VOP3PX2 encoding are at inst[-2]/[-1]
-            # relative to the MFMA encoding pointer.
-            # Dword 1 bits [8:0] = scale_src0, bits [17:9] = scale_src1.
-            L_scaled = []
-            L_scaled.append('  if (inst_.abid & 1u) {')
-            L_scaled.append(
-                '    auto *raw = reinterpret_cast<const uint32_t *>(&inst_);'
-            )
-            L_scaled.append('    uint32_t x2_dw1 = raw[-1];')
-            L_scaled.append('    uint32_t scale_src0_enc = x2_dw1 & 0x1FFu;')
-            L_scaled.append('    uint32_t scale_src1_enc = (x2_dw1 >> 9) & 0x1FFu;')
-            L_scaled.append(
-                '    uint32_t sa_base = amdgpu::src_base(vb, scale_src0_enc);'
-            )
-            L_scaled.append(
-                '    uint32_t sb_base = amdgpu::src_base(vb, scale_src1_enc);'
-            )
-            L_scaled.append(
-                f'    amdgpu::exec_f32_scaled(cu, {M}, {N}, {K}, {B}, {in_bits}, dst,'
-            )
-            L_scaled.append(f'        amdgpu::src_base(vb, {s0}.encoding_value_),')
-            L_scaled.append(f'        amdgpu::src_base(vb, {s1}.encoding_value_),')
-            L_scaled.append(f'        s2, {ea}, {eb}, const_acc,')
-            L_scaled.append(
-                f'        inst_.cbsz, inst_.abid, inst_.blgp, sa_base, sb_base);'
-            )
-            L_scaled.append('  }')
-            # Replace the unscaled MFMA call with a conditional:
-            # if ABID[0]=1 use scaled path, else the existing unscaled path.
-            # Find and wrap the existing exec_f32 call in an else block.
-            for i, line in enumerate(L):
-                if 'amdgpu::exec_f32(' in line:
-                    L.insert(i, '  if (!(inst_.abid & 1u)) {')
-                    # Find the closing semicolon
-                    for j in range(i + 1, len(L)):
-                        if L[j].rstrip().endswith(';'):
-                            L.insert(j + 1, '  } else {')
-                            break
-                    break
-            L.extend(L_scaled)
-            L.append('  }')
 
     return '\n'.join(L)

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/matrix.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/matrix.py
@@ -423,10 +423,10 @@ def gen_mfma(
                 L.append(f'                                     }});')
                 L.append(f'  }} else {{')
                 L.append(
-                    f'    uint32_t sa_base = amdgpu::src_base(vb, x2_dw1_ & 0x1FFu);'
+                    f'    uint32_t sa_base = amdgpu::src_base(vb, raw_words_[1] & 0x1FFu);'
                 )
                 L.append(
-                    f'    uint32_t sb_base = amdgpu::src_base(vb, (x2_dw1_ >> 9) & 0x1FFu);'
+                    f'    uint32_t sb_base = amdgpu::src_base(vb, (raw_words_[1] >> 9) & 0x1FFu);'
                 )
                 L.append(f'    amdgpu::dispatch_matrix_fmt_pair(')
                 L.append(

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -247,13 +247,7 @@ def _writes_vcc(node: SemaNode) -> bool:
 
 def _vcc_init_expr(ctx: LoweringContext) -> str:
     """Return the C++ expression to initialize the vcc local variable."""
-    if ctx.vcc_dst:
-        return 'wf.vcc()'
-    if ctx.operand_map:
-        dst = ctx.operand_map.dst(0)
-        if dst:
-            return f'{dst.name}.read_scalar64(wf)'
-    return 'wf.vcc()'
+    return '0'
 
 
 def _vcc_write_stmt(ctx: LoweringContext) -> str:

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_cmp.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_cmp.py
@@ -28,11 +28,9 @@ def gen_vector_cmp_class(
     L.append('  uint64_t exec = wf.exec();')
     if is_cmpx:
         L.append('  uint64_t result = 0;')
-    elif dst:
-        # VOP3: initialize from destination register for inactive lanes.
-        L.append(f'  uint64_t vcc = {dst[0]}.read_scalar64(wf);')
     else:
-        L.append('  uint64_t vcc = wf.vcc();')
+        # All v_cmp variants zero inactive lanes regardless of encoding.
+        L.append('  uint64_t vcc = 0;')
     L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
     L.append('    if (!(exec & (1ULL << lane))) continue;')
     if dtype == 'f64':
@@ -277,17 +275,12 @@ def gen_vector_cmp(
 
     VOPC (VOP2-like): result always goes to VCC.
     VOP3: result goes to dst[0] (explicit SGPR pair, may be VCC or any SGPR).
-    Inactive lanes preserve the destination register's existing bits.
+    Inactive lanes are zeroed in the result regardless of encoding.
     """
     L = []
     L.append('  uint64_t exec = wf.exec();')
-    if dst:
-        # VOP3: initialize from the destination register so inactive
-        # lanes preserve its existing bits (not VCC).
-        L.append(f'  uint64_t vcc = {dst[0]}.read_scalar64(wf);')
-    else:
-        # VOPC: destination is VCC.
-        L.append('  uint64_t vcc = wf.vcc();')
+    # All v_cmp variants zero inactive lanes regardless of encoding.
+    L.append('  uint64_t vcc = 0;')
     L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
     L.append('    if (!(exec & (1ULL << lane))) continue;')
 

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_special.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_special.py
@@ -747,6 +747,30 @@ def gen_vector_cvt_pk(
                 L.append(
                     f'    {dst[0]}.write_lane(wf, lane, lo_bits | (hi_bits << 16));'
                 )
+        elif op in ('u16_f32', 'i16_f32'):
+            L.append(
+                f'    float f0 = std::bit_cast<float>({src[0]}.read_lane(wf, lane));'
+            )
+            L.append(
+                f'    float f1 = std::bit_cast<float>({src[1]}.read_lane(wf, lane));'
+            )
+            if op == 'u16_f32':
+                L.append(
+                    '    uint16_t lo = static_cast<uint16_t>(std::clamp(f0, 0.0f, 65535.0f));'
+                )
+                L.append(
+                    '    uint16_t hi = static_cast<uint16_t>(std::clamp(f1, 0.0f, 65535.0f));'
+                )
+            else:
+                L.append(
+                    '    int16_t lo = static_cast<int16_t>(std::clamp(f0, -32768.0f, 32767.0f));'
+                )
+                L.append(
+                    '    int16_t hi = static_cast<int16_t>(std::clamp(f1, -32768.0f, 32767.0f));'
+                )
+            L.append(
+                f'    {dst[0]}.write_lane(wf, lane, (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) | static_cast<uint32_t>(static_cast<uint16_t>(lo)));'
+            )
         else:
             L.append(f'    uint32_t s0 = {src[0]}.read_lane(wf, lane);')
             L.append(f'    uint32_t s1 = {src[1]}.read_lane(wf, lane);')
@@ -1030,11 +1054,26 @@ def gen_vector_cvt_scale(
 
 
 def _opsel_field(ctx) -> str:
-    """Return the correct opsel field name for the current ISA encoding."""
+    """Return the correct opsel field name for the current ISA encoding.
+
+    VOP3 encodings always have an opsel field in the machine instruction struct,
+    but the ISA spec may not list it as a ucode field for every instruction.
+    When encoding fields don't include it, fall back to the struct field name
+    based on ISA convention (op_sel for CDNA/RDNA3, opsel for RDNA4/gfx1250).
+    """
     if 'op_sel' in ctx.enc_field_names:
         return 'inst_.op_sel'
     if 'opsel' in ctx.enc_field_names:
         return 'inst_.opsel'
+    if ctx.is_vop3:
+        enc_map = getattr(ctx, 'encoding_map', None)
+        if enc_map and ctx.enc_name in enc_map:
+            fields = {f.name for f in enc_map[ctx.enc_name].ucode_fields}
+            if 'opsel' in fields:
+                return 'inst_.opsel'
+            if 'op_sel' in fields:
+                return 'inst_.op_sel'
+        return 'inst_.op_sel'
     return '0u'
 
 

--- a/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
+++ b/emulation/rocjitsu/lib/python/amdisa/isa_profile.py
@@ -180,6 +180,17 @@ class IsaProfile(ABC):
         return {}
 
     @property
+    def vop3px2_prefix_opcode(self) -> int | None:
+        """VOP3P opcode slot for the VOP3PX2 128-bit prefix decoder.
+
+        Returns the opcode index in the VOP3P sub-decode table where the
+        VOP3PX2 prefix handler should be placed.  The prefix reads the
+        actual MFMA opcode from DW2-DW3 and re-dispatches.  ``None``
+        means VOP3PX2 is not supported.
+        """
+        return None
+
+    @property
     def source_split_max_bytes(self) -> dict[str, int]:
         """Maximum generated source chunk size by encoding.
 
@@ -886,6 +897,10 @@ class CdnaProfile(_AmdgpuProfileBase):
             'V_MFMA_F32_16X16X128_F8F6F4': 16,
             'V_MFMA_F32_32X32X64_F8F6F4': 16,
         }
+
+    @property
+    def vop3px2_prefix_opcode(self) -> int | None:
+        return 0x2C
 
     # ISA dimension properties for CDNA3/4 (the two ISAs this profile covers).
     # Cdna1Profile and Cdna2Profile override the ones that differ.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/decoder.cpp
@@ -4687,6 +4687,11 @@ std::unique_ptr<Instruction> Decoder::decodeVDot8U32U4Vop3p(const MachineInst *o
   return std::make_unique<VDot8U32U4Vop3p>(opcode);
 }
 
+std::unique_ptr<Instruction> Decoder::decodeVop3pX2Prefix(const MachineInst *opcode) {
+  Vop3p::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode + 2);
+  return sub_decode_vop3p[op.op](opcode + 2);
+}
+
 std::unique_ptr<Instruction>
 Decoder::decodeVMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *opcode) {
   return std::make_unique<VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode);
@@ -8850,7 +8855,7 @@ const std::array<Decoder::DecodeFunc, 128> Decoder::sub_decode_vop3p = {
     &Decoder::decodeVDot4U32U8Vop3p,
     &Decoder::decodeVDot8I32I4Vop3p,
     &Decoder::decodeVDot8U32U4Vop3p,
-    &Decoder::decodeInvalid,
+    &Decoder::decodeVop3pX2Prefix,
     &Decoder::decodeVMfmaF3216x16x128F8f6f4Vop3pMfma,
     &Decoder::decodeVMfmaF3232x32x64F8f6f4Vop3pMfma,
     &Decoder::decodeInvalid,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/decoder.cpp
@@ -4688,7 +4688,7 @@ std::unique_ptr<Instruction> Decoder::decodeVDot8U32U4Vop3p(const MachineInst *o
 }
 
 std::unique_ptr<Instruction> Decoder::decodeVop3pX2Prefix(const MachineInst *opcode) {
-  Vop3p::OpEncoding op = *reinterpret_cast<const decltype(op) *>(opcode + 2);
+  auto op = *reinterpret_cast<const Vop3p::OpEncoding *>(opcode + 2);
   return sub_decode_vop3p[op.op](opcode + 2);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/decoder.h
@@ -1188,6 +1188,7 @@ private:
   static std::unique_ptr<Instruction> decodeVDot4U32U8Vop3p(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVDot8I32I4Vop3p(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode);
+  static std::unique_ptr<Instruction> decodeVop3pX2Prefix(const MachineInst *opcode);
   static std::unique_ptr<Instruction>
   decodeVMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *opcode);
   static std::unique_ptr<Instruction>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -843,7 +843,8 @@ VMfmaF3216x16x128F8f6f4Vop3pMfma::VMfmaF3216x16x128F8f6f4Vop3pMfma(const Machine
       src1(256, OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
            reinterpret_cast<const OpEncoding *>(inst)->src1),
       src2(128, OperandType::OPR_SRC_VGPR_OR_ACCVGPR_OR_CONST,
-           reinterpret_cast<const OpEncoding *>(inst)->src2) {
+           reinterpret_cast<const OpEncoding *>(inst)->src2),
+      x2_dw1_(inst[-1]) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   src_operands_[1] = &src1;
@@ -861,23 +862,22 @@ void VMfmaF3216x16x128F8f6f4Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
   if (!(inst_.abid & 1u)) {
-    amdgpu::exec_f32(cu, 16, 16, 128, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                     amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                     amdgpu::extract_fp8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+    amdgpu::dispatch_matrix_fmt_pair(inst_.cbsz, inst_.blgp,
+                                     [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
+                                       amdgpu::exec_f32_mixed(cu, 16, 16, 128, 1, a_bits, b_bits,
+                                                              dst, s0b, s1b, s2, ea, eb, const_acc);
+                                     });
   } else {
-    if (inst_.abid & 1u) {
-      auto *raw = reinterpret_cast<const uint32_t *>(&inst_);
-      uint32_t x2_dw1 = raw[-1];
-      uint32_t scale_src0_enc = x2_dw1 & 0x1FFu;
-      uint32_t scale_src1_enc = (x2_dw1 >> 9) & 0x1FFu;
-      uint32_t sa_base = amdgpu::src_base(vb, scale_src0_enc);
-      uint32_t sb_base = amdgpu::src_base(vb, scale_src1_enc);
-      amdgpu::exec_f32_scaled(
-          cu, 16, 16, 128, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-          amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8, amdgpu::extract_fp8,
-          const_acc, inst_.cbsz, inst_.abid, inst_.blgp, sa_base, sb_base);
-    }
+    uint32_t sa_base = amdgpu::src_base(vb, x2_dw1_ & 0x1FFu);
+    uint32_t sb_base = amdgpu::src_base(vb, (x2_dw1_ >> 9) & 0x1FFu);
+    amdgpu::dispatch_matrix_fmt_pair(
+        inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
+          amdgpu::exec_f32_scaled_mixed(cu, 16, 16, 128, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea,
+                                        eb, const_acc, sa_base, sb_base);
+        });
   }
 }
 
@@ -890,7 +890,8 @@ VMfmaF3232x32x64F8f6f4Vop3pMfma::VMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineIn
       src1(256, OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
            reinterpret_cast<const OpEncoding *>(inst)->src1),
       src2(512, OperandType::OPR_SRC_VGPR_OR_ACCVGPR_OR_CONST,
-           reinterpret_cast<const OpEncoding *>(inst)->src2) {
+           reinterpret_cast<const OpEncoding *>(inst)->src2),
+      x2_dw1_(inst[-1]) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   src_operands_[1] = &src1;
@@ -908,23 +909,22 @@ void VMfmaF3232x32x64F8f6f4Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
   if (!(inst_.abid & 1u)) {
-    amdgpu::exec_f32(cu, 32, 32, 64, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                     amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                     amdgpu::extract_fp8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp);
+    amdgpu::dispatch_matrix_fmt_pair(inst_.cbsz, inst_.blgp,
+                                     [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
+                                       amdgpu::exec_f32_mixed(cu, 32, 32, 64, 1, a_bits, b_bits,
+                                                              dst, s0b, s1b, s2, ea, eb, const_acc);
+                                     });
   } else {
-    if (inst_.abid & 1u) {
-      auto *raw = reinterpret_cast<const uint32_t *>(&inst_);
-      uint32_t x2_dw1 = raw[-1];
-      uint32_t scale_src0_enc = x2_dw1 & 0x1FFu;
-      uint32_t scale_src1_enc = (x2_dw1 >> 9) & 0x1FFu;
-      uint32_t sa_base = amdgpu::src_base(vb, scale_src0_enc);
-      uint32_t sb_base = amdgpu::src_base(vb, scale_src1_enc);
-      amdgpu::exec_f32_scaled(cu, 32, 32, 64, 1, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                              amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
-                              amdgpu::extract_fp8, const_acc, inst_.cbsz, inst_.abid, inst_.blgp,
-                              sa_base, sb_base);
-    }
+    uint32_t sa_base = amdgpu::src_base(vb, x2_dw1_ & 0x1FFu);
+    uint32_t sb_base = amdgpu::src_base(vb, (x2_dw1_ >> 9) & 0x1FFu);
+    amdgpu::dispatch_matrix_fmt_pair(
+        inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
+          amdgpu::exec_f32_scaled_mixed(cu, 32, 32, 64, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea,
+                                        eb, const_acc, sa_base, sb_base);
+        });
   }
 }
 
@@ -1069,22 +1069,13 @@ VSmfmacF3216x16x64Bf16Vop3pMfma::VSmfmacF3216x16x64Bf16Vop3pMfma(const MachineIn
 }
 
 void VSmfmacF3216x16x64Bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X64_BF16 — 16x16x64 BF16→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float a0 = util::bf16_to_f32(static_cast<uint16_t>(a_raw));
-    float a1 = util::bf16_to_f32(static_cast<uint16_t>(a_raw >> 16));
-    float b0 = util::bf16_to_f32(static_cast<uint16_t>(b_raw));
-    float b1 = util::bf16_to_f32(static_cast<uint16_t>(b_raw >> 16));
-    float dot = a0 * b0 + a1 * b1;
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x64_f16(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf16);
 }
 
 VSmfmacI3216x16x128I8Vop3pMfma::VSmfmacI3216x16x128I8Vop3pMfma(const MachineInst *inst)
@@ -1145,23 +1136,14 @@ VSmfmacF3216x16x128Bf8Bf8Vop3pMfma::VSmfmacF3216x16x128Bf8Bf8Vop3pMfma(const Mac
 }
 
 void VSmfmacF3216x16x128Bf8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X128_BF8_BF8 — 16x16x128 BF8_BF8→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::bf8_e5m2_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::bf8_e5m2_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x128_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf8,
+                                        amdgpu::smfmac_read_bf8);
 }
 
 VSmfmacF3216x16x128Bf8Fp8Vop3pMfma::VSmfmacF3216x16x128Bf8Fp8Vop3pMfma(const MachineInst *inst)
@@ -1183,23 +1165,14 @@ VSmfmacF3216x16x128Bf8Fp8Vop3pMfma::VSmfmacF3216x16x128Bf8Fp8Vop3pMfma(const Mac
 }
 
 void VSmfmacF3216x16x128Bf8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X128_BF8_FP8 — 16x16x128 BF8_FP8→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::bf8_e5m2_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::fp8_e4m3_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x128_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf8,
+                                        amdgpu::smfmac_read_fp8);
 }
 
 VSmfmacF3216x16x128Fp8Bf8Vop3pMfma::VSmfmacF3216x16x128Fp8Bf8Vop3pMfma(const MachineInst *inst)
@@ -1221,23 +1194,14 @@ VSmfmacF3216x16x128Fp8Bf8Vop3pMfma::VSmfmacF3216x16x128Fp8Bf8Vop3pMfma(const Mac
 }
 
 void VSmfmacF3216x16x128Fp8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X128_FP8_BF8 — 16x16x128 FP8_BF8→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::fp8_e4m3_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::bf8_e5m2_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x128_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_fp8,
+                                        amdgpu::smfmac_read_bf8);
 }
 
 VMfmaF3232x32x12bF32Vop3pMfma::VMfmaF3232x32x12bF32Vop3pMfma(const MachineInst *inst)
@@ -1353,23 +1317,14 @@ VSmfmacF3216x16x128Fp8Fp8Vop3pMfma::VSmfmacF3216x16x128Fp8Fp8Vop3pMfma(const Mac
 }
 
 void VSmfmacF3216x16x128Fp8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X128_FP8_FP8 — 16x16x128 FP8_FP8→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::fp8_e4m3_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::fp8_e4m3_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x128_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_fp8,
+                                        amdgpu::smfmac_read_fp8);
 }
 
 VMfmaF3232x32x2F32Vop3pMfma::VMfmaF3232x32x2F32Vop3pMfma(const MachineInst *inst)
@@ -1453,22 +1408,13 @@ VSmfmacF3232x32x32Bf16Vop3pMfma::VSmfmacF3232x32x32Bf16Vop3pMfma(const MachineIn
 }
 
 void VSmfmacF3232x32x32Bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X32_BF16 — 32x32x32 BF16→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float a0 = util::bf16_to_f32(static_cast<uint16_t>(a_raw));
-    float a1 = util::bf16_to_f32(static_cast<uint16_t>(a_raw >> 16));
-    float b0 = util::bf16_to_f32(static_cast<uint16_t>(b_raw));
-    float b1 = util::bf16_to_f32(static_cast<uint16_t>(b_raw >> 16));
-    float dot = a0 * b0 + a1 * b1;
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x32_f16(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf16);
 }
 
 VSmfmacI3232x32x64I8Vop3pMfma::VSmfmacI3232x32x64I8Vop3pMfma(const MachineInst *inst)
@@ -1623,23 +1569,14 @@ VSmfmacF3232x32x64Bf8Bf8Vop3pMfma::VSmfmacF3232x32x64Bf8Bf8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3232x32x64Bf8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X64_BF8_BF8 — 32x32x64 BF8_BF8→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::bf8_e5m2_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::bf8_e5m2_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x64_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf8,
+                                       amdgpu::smfmac_read_bf8);
 }
 
 VMfmaF3232x32x8F16Vop3pMfma::VMfmaF3232x32x8F16Vop3pMfma(const MachineInst *inst)
@@ -1723,23 +1660,14 @@ VSmfmacF3232x32x64Bf8Fp8Vop3pMfma::VSmfmacF3232x32x64Bf8Fp8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3232x32x64Bf8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X64_BF8_FP8 — 32x32x64 BF8_FP8→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::bf8_e5m2_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::fp8_e4m3_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x64_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf8,
+                                       amdgpu::smfmac_read_fp8);
 }
 
 VSmfmacF3232x32x64Fp8Bf8Vop3pMfma::VSmfmacF3232x32x64Fp8Bf8Vop3pMfma(const MachineInst *inst)
@@ -1761,23 +1689,14 @@ VSmfmacF3232x32x64Fp8Bf8Vop3pMfma::VSmfmacF3232x32x64Fp8Bf8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3232x32x64Fp8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X64_FP8_BF8 — 32x32x64 FP8_BF8→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::fp8_e4m3_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::bf8_e5m2_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x64_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_fp8,
+                                       amdgpu::smfmac_read_bf8);
 }
 
 VMfmaI3232x32x42bI8Vop3pMfma::VMfmaI3232x32x42bI8Vop3pMfma(const MachineInst *inst)
@@ -1890,23 +1809,14 @@ VSmfmacF3232x32x64Fp8Fp8Vop3pMfma::VSmfmacF3232x32x64Fp8Fp8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3232x32x64Fp8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X64_FP8_FP8 — 32x32x64 FP8_FP8→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::fp8_e4m3_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::fp8_e4m3_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x64_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_fp8,
+                                       amdgpu::smfmac_read_fp8);
 }
 
 VMfmaF3216x16x32F16Vop3pMfma::VMfmaF3216x16x32F16Vop3pMfma(const MachineInst *inst)
@@ -2050,22 +1960,13 @@ VSmfmacF3216x16x64F16Vop3pMfma::VSmfmacF3216x16x64F16Vop3pMfma(const MachineInst
 }
 
 void VSmfmacF3216x16x64F16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X64_F16 — 16x16x64 F16→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float a0 = util::f16_to_f32(static_cast<uint16_t>(a_raw));
-    float a1 = util::f16_to_f32(static_cast<uint16_t>(a_raw >> 16));
-    float b0 = util::f16_to_f32(static_cast<uint16_t>(b_raw));
-    float b1 = util::f16_to_f32(static_cast<uint16_t>(b_raw >> 16));
-    float dot = a0 * b0 + a1 * b1;
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x64_f16(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_f16);
 }
 
 VSmfmacF3232x32x32F16Vop3pMfma::VSmfmacF3232x32x32F16Vop3pMfma(const MachineInst *inst)
@@ -2087,22 +1988,13 @@ VSmfmacF3232x32x32F16Vop3pMfma::VSmfmacF3232x32x32F16Vop3pMfma(const MachineInst
 }
 
 void VSmfmacF3232x32x32F16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X32_F16 — 32x32x32 F16→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float a0 = util::f16_to_f32(static_cast<uint16_t>(a_raw));
-    float a1 = util::f16_to_f32(static_cast<uint16_t>(a_raw >> 16));
-    float b0 = util::f16_to_f32(static_cast<uint16_t>(b_raw));
-    float b1 = util::f16_to_f32(static_cast<uint16_t>(b_raw >> 16));
-    float dot = a0 * b0 + a1 * b1;
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x32_f16(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_f16);
 }
 
 VMfmaF3232x32x42bBf16Vop3pMfma::VMfmaF3232x32x42bBf16Vop3pMfma(const MachineInst *inst)
@@ -2280,22 +2172,13 @@ VSmfmacF3216x16x32F16Vop3pMfma::VSmfmacF3216x16x32F16Vop3pMfma(const MachineInst
 }
 
 void VSmfmacF3216x16x32F16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X32_F16 — 16x16x32 F16→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float a0 = util::f16_to_f32(static_cast<uint16_t>(a_raw));
-    float a1 = util::f16_to_f32(static_cast<uint16_t>(a_raw >> 16));
-    float b0 = util::f16_to_f32(static_cast<uint16_t>(b_raw));
-    float b1 = util::f16_to_f32(static_cast<uint16_t>(b_raw >> 16));
-    float dot = a0 * b0 + a1 * b1;
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x32_f16(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_f16);
 }
 
 VSmfmacF3232x32x16F16Vop3pMfma::VSmfmacF3232x32x16F16Vop3pMfma(const MachineInst *inst)
@@ -2317,22 +2200,13 @@ VSmfmacF3232x32x16F16Vop3pMfma::VSmfmacF3232x32x16F16Vop3pMfma(const MachineInst
 }
 
 void VSmfmacF3232x32x16F16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X16_F16 — 32x32x16 F16→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float a0 = util::f16_to_f32(static_cast<uint16_t>(a_raw));
-    float a1 = util::f16_to_f32(static_cast<uint16_t>(a_raw >> 16));
-    float b0 = util::f16_to_f32(static_cast<uint16_t>(b_raw));
-    float b1 = util::f16_to_f32(static_cast<uint16_t>(b_raw >> 16));
-    float dot = a0 * b0 + a1 * b1;
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x16_f16(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_f16);
 }
 
 VSmfmacF3216x16x32Bf16Vop3pMfma::VSmfmacF3216x16x32Bf16Vop3pMfma(const MachineInst *inst)
@@ -2354,22 +2228,13 @@ VSmfmacF3216x16x32Bf16Vop3pMfma::VSmfmacF3216x16x32Bf16Vop3pMfma(const MachineIn
 }
 
 void VSmfmacF3216x16x32Bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X32_BF16 — 16x16x32 BF16→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float a0 = util::bf16_to_f32(static_cast<uint16_t>(a_raw));
-    float a1 = util::bf16_to_f32(static_cast<uint16_t>(a_raw >> 16));
-    float b0 = util::bf16_to_f32(static_cast<uint16_t>(b_raw));
-    float b1 = util::bf16_to_f32(static_cast<uint16_t>(b_raw >> 16));
-    float dot = a0 * b0 + a1 * b1;
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x32_f16(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf16);
 }
 
 VSmfmacF3232x32x16Bf16Vop3pMfma::VSmfmacF3232x32x16Bf16Vop3pMfma(const MachineInst *inst)
@@ -2391,22 +2256,13 @@ VSmfmacF3232x32x16Bf16Vop3pMfma::VSmfmacF3232x32x16Bf16Vop3pMfma(const MachineIn
 }
 
 void VSmfmacF3232x32x16Bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X16_BF16 — 32x32x16 BF16→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float a0 = util::bf16_to_f32(static_cast<uint16_t>(a_raw));
-    float a1 = util::bf16_to_f32(static_cast<uint16_t>(a_raw >> 16));
-    float b0 = util::bf16_to_f32(static_cast<uint16_t>(b_raw));
-    float b1 = util::bf16_to_f32(static_cast<uint16_t>(b_raw >> 16));
-    float dot = a0 * b0 + a1 * b1;
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x16_f16(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf16);
 }
 
 VSmfmacI3216x16x64I8Vop3pMfma::VSmfmacI3216x16x64I8Vop3pMfma(const MachineInst *inst)
@@ -2814,23 +2670,14 @@ VSmfmacF3216x16x64Bf8Bf8Vop3pMfma::VSmfmacF3216x16x64Bf8Bf8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3216x16x64Bf8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X64_BF8_BF8 — 16x16x64 BF8_BF8→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::bf8_e5m2_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::bf8_e5m2_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x64_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf8,
+                                       amdgpu::smfmac_read_bf8);
 }
 
 VSmfmacF3216x16x64Bf8Fp8Vop3pMfma::VSmfmacF3216x16x64Bf8Fp8Vop3pMfma(const MachineInst *inst)
@@ -2852,23 +2699,14 @@ VSmfmacF3216x16x64Bf8Fp8Vop3pMfma::VSmfmacF3216x16x64Bf8Fp8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3216x16x64Bf8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X64_BF8_FP8 — 16x16x64 BF8_FP8→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::bf8_e5m2_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::fp8_e4m3_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x64_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf8,
+                                       amdgpu::smfmac_read_fp8);
 }
 
 VSmfmacF3216x16x64Fp8Bf8Vop3pMfma::VSmfmacF3216x16x64Fp8Bf8Vop3pMfma(const MachineInst *inst)
@@ -2890,23 +2728,14 @@ VSmfmacF3216x16x64Fp8Bf8Vop3pMfma::VSmfmacF3216x16x64Fp8Bf8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3216x16x64Fp8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X64_FP8_BF8 — 16x16x64 FP8_BF8→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::fp8_e4m3_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::bf8_e5m2_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x64_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_fp8,
+                                       amdgpu::smfmac_read_bf8);
 }
 
 VSmfmacF3216x16x64Fp8Fp8Vop3pMfma::VSmfmacF3216x16x64Fp8Fp8Vop3pMfma(const MachineInst *inst)
@@ -2928,23 +2757,14 @@ VSmfmacF3216x16x64Fp8Fp8Vop3pMfma::VSmfmacF3216x16x64Fp8Fp8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3216x16x64Fp8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X64_FP8_FP8 — 16x16x64 FP8_FP8→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::fp8_e4m3_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::fp8_e4m3_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x64_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_fp8,
+                                       amdgpu::smfmac_read_fp8);
 }
 
 VSmfmacF3232x32x32Bf8Bf8Vop3pMfma::VSmfmacF3232x32x32Bf8Bf8Vop3pMfma(const MachineInst *inst)
@@ -2966,23 +2786,14 @@ VSmfmacF3232x32x32Bf8Bf8Vop3pMfma::VSmfmacF3232x32x32Bf8Bf8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3232x32x32Bf8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X32_BF8_BF8 — 32x32x32 BF8_BF8→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::bf8_e5m2_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::bf8_e5m2_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x32_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf8,
+                                       amdgpu::smfmac_read_bf8);
 }
 
 VSmfmacF3232x32x32Bf8Fp8Vop3pMfma::VSmfmacF3232x32x32Bf8Fp8Vop3pMfma(const MachineInst *inst)
@@ -3004,23 +2815,14 @@ VSmfmacF3232x32x32Bf8Fp8Vop3pMfma::VSmfmacF3232x32x32Bf8Fp8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3232x32x32Bf8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X32_BF8_FP8 — 32x32x32 BF8_FP8→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::bf8_e5m2_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::fp8_e4m3_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x32_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf8,
+                                       amdgpu::smfmac_read_fp8);
 }
 
 VSmfmacF3232x32x32Fp8Bf8Vop3pMfma::VSmfmacF3232x32x32Fp8Bf8Vop3pMfma(const MachineInst *inst)
@@ -3042,23 +2844,14 @@ VSmfmacF3232x32x32Fp8Bf8Vop3pMfma::VSmfmacF3232x32x32Fp8Bf8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3232x32x32Fp8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X32_FP8_BF8 — 32x32x32 FP8_BF8→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::fp8_e4m3_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::bf8_e5m2_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x32_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_fp8,
+                                       amdgpu::smfmac_read_bf8);
 }
 
 VSmfmacF3232x32x32Fp8Fp8Vop3pMfma::VSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const MachineInst *inst)
@@ -3080,23 +2873,14 @@ VSmfmacF3232x32x32Fp8Fp8Vop3pMfma::VSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3232x32x32Fp8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X32_FP8_FP8 — 32x32x32 FP8_FP8→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::fp8_e4m3_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::fp8_e4m3_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x32_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_fp8,
+                                       amdgpu::smfmac_read_fp8);
 }
 
 } // namespace cdna4

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -843,8 +843,7 @@ VMfmaF3216x16x128F8f6f4Vop3pMfma::VMfmaF3216x16x128F8f6f4Vop3pMfma(const Machine
       src1(256, OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
            reinterpret_cast<const OpEncoding *>(inst)->src1),
       src2(128, OperandType::OPR_SRC_VGPR_OR_ACCVGPR_OR_CONST,
-           reinterpret_cast<const OpEncoding *>(inst)->src2),
-      x2_dw1_(inst[-1]) {
+           reinterpret_cast<const OpEncoding *>(inst)->src2) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   src_operands_[1] = &src1;
@@ -853,6 +852,8 @@ VMfmaF3216x16x128F8f6f4Vop3pMfma::VMfmaF3216x16x128F8f6f4Vop3pMfma(const Machine
   num_dst_ = 1;
   flags_ |= MFMA;
   size_ = 16;
+  raw_words_ = {inst[-2], inst[-1], inst[0], inst[1]};
+  raw_encoding_ = raw_words_.data();
 }
 
 void VMfmaF3216x16x128F8f6f4Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
@@ -871,8 +872,8 @@ void VMfmaF3216x16x128F8f6f4Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
                                                               dst, s0b, s1b, s2, ea, eb, const_acc);
                                      });
   } else {
-    uint32_t sa_base = amdgpu::src_base(vb, x2_dw1_ & 0x1FFu);
-    uint32_t sb_base = amdgpu::src_base(vb, (x2_dw1_ >> 9) & 0x1FFu);
+    uint32_t sa_base = amdgpu::src_base(vb, raw_words_[1] & 0x1FFu);
+    uint32_t sb_base = amdgpu::src_base(vb, (raw_words_[1] >> 9) & 0x1FFu);
     amdgpu::dispatch_matrix_fmt_pair(
         inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
           amdgpu::exec_f32_scaled_mixed(cu, 16, 16, 128, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea,
@@ -890,8 +891,7 @@ VMfmaF3232x32x64F8f6f4Vop3pMfma::VMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineIn
       src1(256, OperandType::OPR_SRC_VGPR_OR_ACCVGPR,
            reinterpret_cast<const OpEncoding *>(inst)->src1),
       src2(512, OperandType::OPR_SRC_VGPR_OR_ACCVGPR_OR_CONST,
-           reinterpret_cast<const OpEncoding *>(inst)->src2),
-      x2_dw1_(inst[-1]) {
+           reinterpret_cast<const OpEncoding *>(inst)->src2) {
   dst_operands_[0] = &vdst;
   src_operands_[0] = &src0;
   src_operands_[1] = &src1;
@@ -900,6 +900,8 @@ VMfmaF3232x32x64F8f6f4Vop3pMfma::VMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineIn
   num_dst_ = 1;
   flags_ |= MFMA;
   size_ = 16;
+  raw_words_ = {inst[-2], inst[-1], inst[0], inst[1]};
+  raw_encoding_ = raw_words_.data();
 }
 
 void VMfmaF3232x32x64F8f6f4Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
@@ -918,8 +920,8 @@ void VMfmaF3232x32x64F8f6f4Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
                                                               dst, s0b, s1b, s2, ea, eb, const_acc);
                                      });
   } else {
-    uint32_t sa_base = amdgpu::src_base(vb, x2_dw1_ & 0x1FFu);
-    uint32_t sb_base = amdgpu::src_base(vb, (x2_dw1_ >> 9) & 0x1FFu);
+    uint32_t sa_base = amdgpu::src_base(vb, raw_words_[1] & 0x1FFu);
+    uint32_t sb_base = amdgpu::src_base(vb, (raw_words_[1] >> 9) & 0x1FFu);
     amdgpu::dispatch_matrix_fmt_pair(
         inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
           amdgpu::exec_f32_scaled_mixed(cu, 32, 32, 64, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.h
@@ -10,6 +10,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna4/encodings.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/operand.h"
+#include <array>
 
 namespace rocjitsu {
 namespace cdna4 {
@@ -379,7 +380,7 @@ public:
   Operand src0;
   Operand src1;
   Operand src2;
-  uint32_t x2_dw1_ = 0;
+  std::array<uint32_t, 4> raw_words_{};
 };
 
 class VMfmaF3232x32x64F8f6f4Vop3pMfma : public Vop3pMfma {
@@ -390,7 +391,7 @@ public:
   Operand src0;
   Operand src1;
   Operand src2;
-  uint32_t x2_dw1_ = 0;
+  std::array<uint32_t, 4> raw_words_{};
 };
 
 class VMfmaF3216x16x32Bf16Vop3pMfma : public Vop3pMfma {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.h
@@ -379,6 +379,7 @@ public:
   Operand src0;
   Operand src1;
   Operand src2;
+  uint32_t x2_dw1_ = 0;
 };
 
 class VMfmaF3232x32x64F8f6f4Vop3pMfma : public Vop3pMfma {
@@ -389,6 +390,7 @@ public:
   Operand src0;
   Operand src1;
   Operand src2;
+  uint32_t x2_dw1_ = 0;
 };
 
 class VMfmaF3216x16x32Bf16Vop3pMfma : public Vop3pMfma {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_part1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_part1.cpp
@@ -2800,7 +2800,7 @@ void VCvtPkF32Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t packed = src0.read_lane(wf, lane);
-    bool src_hi = 0u & 1;
+    bool src_hi = inst_.opsel & 1;
     uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
     float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFFu));
     float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
@@ -2841,7 +2841,7 @@ void VCvtPkF32Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t packed = src0.read_lane(wf, lane);
-    bool src_hi = 0u & 1;
+    bool src_hi = inst_.opsel & 1;
     uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
     float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFFu));
     float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
@@ -2976,7 +2976,7 @@ void VCvtPkF16Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t packed = src0.read_lane(wf, lane);
-    bool src_hi = 0u & 1;
+    bool src_hi = inst_.opsel & 1;
     uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
     float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFFu));
     float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
@@ -3016,7 +3016,7 @@ void VCvtPkF16Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t packed = src0.read_lane(wf, lane);
-    bool src_hi = 0u & 1;
+    bool src_hi = inst_.opsel & 1;
     uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
     float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFFu));
     float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_part3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_part3.cpp
@@ -253,10 +253,10 @@ void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t s0 = src0.read_lane(wf, lane);
-    uint32_t s1 = src1.read_lane(wf, lane);
-    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
-    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    int16_t lo = static_cast<int16_t>(std::clamp(f0, -32768.0f, 32767.0f));
+    int16_t hi = static_cast<int16_t>(std::clamp(f1, -32768.0f, 32767.0f));
     vdst.write_lane(wf, lane,
                     (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
                         static_cast<uint32_t>(static_cast<uint16_t>(lo)));
@@ -306,10 +306,10 @@ void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t s0 = src0.read_lane(wf, lane);
-    uint32_t s1 = src1.read_lane(wf, lane);
-    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
-    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    uint16_t lo = static_cast<uint16_t>(std::clamp(f0, 0.0f, 65535.0f));
+    uint16_t hi = static_cast<uint16_t>(std::clamp(f1, 0.0f, 65535.0f));
     vdst.write_lane(wf, lane,
                     (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
                         static_cast<uint32_t>(static_cast<uint16_t>(lo)));
@@ -2554,7 +2554,7 @@ void VCvtPkFp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t lo = util::f32_to_fp8_e4m3_rne(s0);
     uint32_t hi = util::f32_to_fp8_e4m3_rne(s1);
     uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
-    bool word_hi = (0u >> 3) & 1;
+    bool word_hi = (inst_.opsel >> 3) & 1;
     uint32_t old = vdst.read_lane(wf, lane);
     if (word_hi)
       vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
@@ -2611,7 +2611,7 @@ void VCvtPkBf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t lo = util::f32_to_bf8_e5m2_rne(s0);
     uint32_t hi = util::f32_to_bf8_e5m2_rne(s1);
     uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
-    bool word_hi = (0u >> 3) & 1;
+    bool word_hi = (inst_.opsel >> 3) & 1;
     uint32_t old = vdst.read_lane(wf, lane);
     if (word_hi)
       vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
@@ -2977,7 +2977,7 @@ void VCvtPkFp8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t lo = util::f32_to_fp8_e4m3_rne(s0);
     uint32_t hi = util::f32_to_fp8_e4m3_rne(s1);
     uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
-    bool word_hi = (0u >> 3) & 1;
+    bool word_hi = (inst_.opsel >> 3) & 1;
     uint32_t old = vdst.read_lane(wf, lane);
     if (word_hi)
       vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
@@ -3021,7 +3021,7 @@ void VCvtPkBf8F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t lo = util::f32_to_bf8_e5m2_rne(s0);
     uint32_t hi = util::f32_to_bf8_e5m2_rne(s1);
     uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
-    bool word_hi = (0u >> 3) & 1;
+    bool word_hi = (inst_.opsel >> 3) & 1;
     uint32_t old = vdst.read_lane(wf, lane);
     if (word_hi)
       vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
@@ -4820,10 +4820,10 @@ void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t s0 = src0.read_lane(wf, lane);
-    uint32_t s1 = src1.read_lane(wf, lane);
-    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
-    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    int16_t lo = static_cast<int16_t>(std::clamp(f0, -32768.0f, 32767.0f));
+    int16_t hi = static_cast<int16_t>(std::clamp(f1, -32768.0f, 32767.0f));
     vdst.write_lane(wf, lane,
                     (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
                         static_cast<uint32_t>(static_cast<uint16_t>(lo)));
@@ -4856,10 +4856,10 @@ void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t s0 = src0.read_lane(wf, lane);
-    uint32_t s1 = src1.read_lane(wf, lane);
-    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
-    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    uint16_t lo = static_cast<uint16_t>(std::clamp(f0, 0.0f, 65535.0f));
+    uint16_t hi = static_cast<uint16_t>(std::clamp(f1, 0.0f, 65535.0f));
     vdst.write_lane(wf, lane,
                     (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
                         static_cast<uint32_t>(static_cast<uint16_t>(lo)));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
@@ -4820,10 +4820,10 @@ void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t s0 = src0.read_lane(wf, lane);
-    uint32_t s1 = src1.read_lane(wf, lane);
-    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
-    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    int16_t lo = static_cast<int16_t>(std::clamp(f0, -32768.0f, 32767.0f));
+    int16_t hi = static_cast<int16_t>(std::clamp(f1, -32768.0f, 32767.0f));
     vdst.write_lane(wf, lane,
                     (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
                         static_cast<uint32_t>(static_cast<uint16_t>(lo)));
@@ -4856,10 +4856,10 @@ void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t s0 = src0.read_lane(wf, lane);
-    uint32_t s1 = src1.read_lane(wf, lane);
-    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
-    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    uint16_t lo = static_cast<uint16_t>(std::clamp(f0, 0.0f, 65535.0f));
+    uint16_t hi = static_cast<uint16_t>(std::clamp(f1, 0.0f, 65535.0f));
     vdst.write_lane(wf, lane,
                     (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
                         static_cast<uint32_t>(static_cast<uint16_t>(lo)));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
@@ -1588,7 +1588,7 @@ void VCvtPkF32Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t packed = src0.read_lane(wf, lane);
-    bool src_hi = 0u & 1;
+    bool src_hi = inst_.opsel & 1;
     uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
     float lo = util::fp8_e4m3_to_f32(static_cast<uint8_t>(half & 0xFFu));
     float hi = util::fp8_e4m3_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
@@ -1620,7 +1620,7 @@ void VCvtPkF32Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t packed = src0.read_lane(wf, lane);
-    bool src_hi = 0u & 1;
+    bool src_hi = inst_.opsel & 1;
     uint32_t half = src_hi ? (packed >> 16) : (packed & 0xFFFFu);
     float lo = util::bf8_e5m2_to_f32(static_cast<uint8_t>(half & 0xFFu));
     float hi = util::bf8_e5m2_to_f32(static_cast<uint8_t>((half >> 8) & 0xFFu));
@@ -5588,10 +5588,10 @@ void VCvtPkI16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t s0 = src0.read_lane(wf, lane);
-    uint32_t s1 = src1.read_lane(wf, lane);
-    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
-    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    int16_t lo = static_cast<int16_t>(std::clamp(f0, -32768.0f, 32767.0f));
+    int16_t hi = static_cast<int16_t>(std::clamp(f1, -32768.0f, 32767.0f));
     vdst.write_lane(wf, lane,
                     (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
                         static_cast<uint32_t>(static_cast<uint16_t>(lo)));
@@ -5624,10 +5624,10 @@ void VCvtPkU16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t s0 = src0.read_lane(wf, lane);
-    uint32_t s1 = src1.read_lane(wf, lane);
-    int16_t lo = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s0), -32768, 32767));
-    int16_t hi = static_cast<int16_t>(std::clamp(static_cast<int32_t>(s1), -32768, 32767));
+    float f0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float f1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    uint16_t lo = static_cast<uint16_t>(std::clamp(f0, 0.0f, 65535.0f));
+    uint16_t hi = static_cast<uint16_t>(std::clamp(f1, 0.0f, 65535.0f));
     vdst.write_lane(wf, lane,
                     (static_cast<uint32_t>(static_cast<uint16_t>(hi)) << 16) |
                         static_cast<uint32_t>(static_cast<uint16_t>(lo)));
@@ -6763,7 +6763,7 @@ void VCvtPkFp8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t lo = util::f32_to_fp8_e4m3_rne(s0);
     uint32_t hi = util::f32_to_fp8_e4m3_rne(s1);
     uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
-    bool word_hi = (0u >> 3) & 1;
+    bool word_hi = (inst_.opsel >> 3) & 1;
     uint32_t old = vdst.read_lane(wf, lane);
     if (word_hi)
       vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));
@@ -6803,7 +6803,7 @@ void VCvtPkBf8F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     uint32_t lo = util::f32_to_bf8_e5m2_rne(s0);
     uint32_t hi = util::f32_to_bf8_e5m2_rne(s1);
     uint32_t packed = static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 8);
-    bool word_hi = (0u >> 3) & 1;
+    bool word_hi = (inst_.opsel >> 3) & 1;
     uint32_t old = vdst.read_lane(wf, lane);
     if (word_hi)
       vdst.write_lane(wf, lane, (old & 0xFFFFu) | (packed << 16));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -2691,7 +2691,7 @@ template <typename Inst>
 inline void execute_v_add_co_ci_u32_vop2([[maybe_unused]] Inst &inst,
                                          [[maybe_unused]] Wavefront &wf) {
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -2720,7 +2720,7 @@ inline void execute_v_add_co_ci_u32_vop3([[maybe_unused]] Inst &inst,
     return make_simd_carry(t2, c1 | c2);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -2745,7 +2745,7 @@ inline void execute_v_add_co_u32_vop2([[maybe_unused]] Inst &inst, [[maybe_unuse
     return make_simd_carry(s, s < a);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -2769,7 +2769,7 @@ inline void execute_v_add_co_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     return make_simd_carry(s, s < a);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -3124,7 +3124,7 @@ inline void execute_v_addc_co_u32_vop2([[maybe_unused]] Inst &inst,
     return make_simd_carry(t2, c1 | c2);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -3153,7 +3153,7 @@ inline void execute_v_addc_co_u32_vop3([[maybe_unused]] Inst &inst,
     return make_simd_carry(t2, c1 | c2);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -3767,7 +3767,7 @@ inline void execute_v_cmp_class_f16_vop3([[maybe_unused]] Inst &inst,
     return (cls & b) != 0u;
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -3843,7 +3843,7 @@ inline void execute_v_cmp_class_f16_vopc([[maybe_unused]] Inst &inst,
     return (cls & b) != 0u;
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -3914,7 +3914,7 @@ inline void execute_v_cmp_class_f32_vop3([[maybe_unused]] Inst &inst,
     return (cls & b) != 0u;
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -3983,7 +3983,7 @@ inline void execute_v_cmp_class_f32_vopc([[maybe_unused]] Inst &inst,
     return (cls & b) != 0u;
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4049,7 +4049,7 @@ inline void execute_v_cmp_class_f64_vop3([[maybe_unused]] Inst &inst,
     return (cls32 & m) != 0u;
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4121,7 +4121,7 @@ inline void execute_v_cmp_class_f64_vopc([[maybe_unused]] Inst &inst,
     return (cls32 & m) != 0u;
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4164,7 +4164,7 @@ template <typename Inst>
 inline void execute_v_cmp_eq_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return a == b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4197,7 +4197,7 @@ inline void execute_v_cmp_eq_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     return util::f16_to_f32_simd(a) == util::f16_to_f32_simd(b);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4214,7 +4214,7 @@ template <typename Inst>
 inline void execute_v_cmp_eq_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return a == b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4245,7 +4245,7 @@ template <typename Inst>
 inline void execute_v_cmp_eq_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(float32_t, [](auto a, auto b) { return a == b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4262,7 +4262,7 @@ template <typename Inst>
 inline void execute_v_cmp_eq_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return a == b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4293,7 +4293,7 @@ template <typename Inst>
 inline void execute_v_cmp_eq_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(double, [](auto a, auto b) { return a == b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4313,7 +4313,7 @@ inline void execute_v_cmp_eq_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4333,7 +4333,7 @@ inline void execute_v_cmp_eq_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
            ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4350,7 +4350,7 @@ template <typename Inst>
 inline void execute_v_cmp_eq_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(int32_t, [](auto a, auto b) { return a == b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4367,7 +4367,7 @@ template <typename Inst>
 inline void execute_v_cmp_eq_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(int32_t, [](auto a, auto b) { return a == b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4384,7 +4384,7 @@ template <typename Inst>
 inline void execute_v_cmp_eq_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(int64_t, [](auto a, auto b) { return a == b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4401,7 +4401,7 @@ template <typename Inst>
 inline void execute_v_cmp_eq_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(int64_t, [](auto a, auto b) { return a == b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4419,7 +4419,7 @@ inline void execute_v_cmp_eq_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(uint32_t,
                                   [](auto a, auto b) { return (a & 0xFFFFu) == (b & 0xFFFFu); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4436,7 +4436,7 @@ template <typename Inst>
 inline void execute_v_cmp_eq_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(uint32_t, [](auto a, auto b) { return (a & 0xFFFFu) == (b & 0xFFFFu); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4453,7 +4453,7 @@ template <typename Inst>
 inline void execute_v_cmp_eq_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(uint32_t, [](auto a, auto b) { return a == b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4469,7 +4469,7 @@ template <typename Inst>
 inline void execute_v_cmp_eq_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(uint32_t, [](auto a, auto b) { return a == b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4485,7 +4485,7 @@ template <typename Inst>
 inline void execute_v_cmp_eq_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(uint64_t, [](auto a, auto b) { return a == b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4502,7 +4502,7 @@ template <typename Inst>
 inline void execute_v_cmp_eq_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(uint64_t, [](auto a, auto b) { return a == b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4519,7 +4519,7 @@ template <typename Inst>
 inline void execute_v_cmp_f_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return decltype(a == b)(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4537,7 +4537,7 @@ inline void execute_v_cmp_f_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     return decltype(util::f16_to_f32_simd(a) == util::f16_to_f32_simd(b))(false);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4553,7 +4553,7 @@ template <typename Inst>
 inline void execute_v_cmp_f_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return decltype(a == b)(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4569,7 +4569,7 @@ template <typename Inst>
 inline void execute_v_cmp_f_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(float32_t, [](auto a, auto b) { return decltype(a == b)(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4585,7 +4585,7 @@ template <typename Inst>
 inline void execute_v_cmp_f_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return decltype(a == b)(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4601,7 +4601,7 @@ template <typename Inst>
 inline void execute_v_cmp_f_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(double, [](auto a, auto b) { return decltype(a == b)(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4620,7 +4620,7 @@ inline void execute_v_cmp_f_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
                     ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16))(false);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4639,7 +4639,7 @@ inline void execute_v_cmp_f_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
                     ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16))(false);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4655,7 +4655,7 @@ template <typename Inst>
 inline void execute_v_cmp_f_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(int32_t, [](auto a, auto b) { return decltype(a == b)(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4671,7 +4671,7 @@ template <typename Inst>
 inline void execute_v_cmp_f_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(int32_t, [](auto a, auto b) { return decltype(a == b)(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4688,7 +4688,7 @@ inline void execute_v_cmp_f_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(int64_t,
                                     [](auto a, auto b) { return decltype(a == b)(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4704,7 +4704,7 @@ template <typename Inst>
 inline void execute_v_cmp_f_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(int64_t, [](auto a, auto b) { return decltype(a == b)(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4721,7 +4721,7 @@ inline void execute_v_cmp_f_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(
       uint32_t, [](auto a, auto b) { return decltype((a & 0xFFFFu) == (b & 0xFFFFu))(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4738,7 +4738,7 @@ inline void execute_v_cmp_f_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC(
       uint32_t, [](auto a, auto b) { return decltype((a & 0xFFFFu) == (b & 0xFFFFu))(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4754,7 +4754,7 @@ template <typename Inst>
 inline void execute_v_cmp_f_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(uint32_t, [](auto a, auto b) { return decltype(a == b)(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4770,7 +4770,7 @@ template <typename Inst>
 inline void execute_v_cmp_f_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(uint32_t, [](auto a, auto b) { return decltype(a == b)(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4787,7 +4787,7 @@ inline void execute_v_cmp_f_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(uint64_t,
                                     [](auto a, auto b) { return decltype(a == b)(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4803,7 +4803,7 @@ template <typename Inst>
 inline void execute_v_cmp_f_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(uint64_t, [](auto a, auto b) { return decltype(a == b)(false); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4819,7 +4819,7 @@ template <typename Inst>
 inline void execute_v_cmp_ge_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return a >= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4852,7 +4852,7 @@ inline void execute_v_cmp_ge_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     return util::f16_to_f32_simd(a) >= util::f16_to_f32_simd(b);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4869,7 +4869,7 @@ template <typename Inst>
 inline void execute_v_cmp_ge_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return a >= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4900,7 +4900,7 @@ template <typename Inst>
 inline void execute_v_cmp_ge_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(float32_t, [](auto a, auto b) { return a >= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4917,7 +4917,7 @@ template <typename Inst>
 inline void execute_v_cmp_ge_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return a >= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4948,7 +4948,7 @@ template <typename Inst>
 inline void execute_v_cmp_ge_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(double, [](auto a, auto b) { return a >= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4968,7 +4968,7 @@ inline void execute_v_cmp_ge_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -4988,7 +4988,7 @@ inline void execute_v_cmp_ge_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
            ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5005,7 +5005,7 @@ template <typename Inst>
 inline void execute_v_cmp_ge_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(int32_t, [](auto a, auto b) { return a >= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5022,7 +5022,7 @@ template <typename Inst>
 inline void execute_v_cmp_ge_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(int32_t, [](auto a, auto b) { return a >= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5039,7 +5039,7 @@ template <typename Inst>
 inline void execute_v_cmp_ge_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(int64_t, [](auto a, auto b) { return a >= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5056,7 +5056,7 @@ template <typename Inst>
 inline void execute_v_cmp_ge_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(int64_t, [](auto a, auto b) { return a >= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5074,7 +5074,7 @@ inline void execute_v_cmp_ge_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(uint32_t,
                                   [](auto a, auto b) { return (a & 0xFFFFu) >= (b & 0xFFFFu); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5091,7 +5091,7 @@ template <typename Inst>
 inline void execute_v_cmp_ge_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(uint32_t, [](auto a, auto b) { return (a & 0xFFFFu) >= (b & 0xFFFFu); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5108,7 +5108,7 @@ template <typename Inst>
 inline void execute_v_cmp_ge_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(uint32_t, [](auto a, auto b) { return a >= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5124,7 +5124,7 @@ template <typename Inst>
 inline void execute_v_cmp_ge_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(uint32_t, [](auto a, auto b) { return a >= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5140,7 +5140,7 @@ template <typename Inst>
 inline void execute_v_cmp_ge_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(uint64_t, [](auto a, auto b) { return a >= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5157,7 +5157,7 @@ template <typename Inst>
 inline void execute_v_cmp_ge_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(uint64_t, [](auto a, auto b) { return a >= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5174,7 +5174,7 @@ template <typename Inst>
 inline void execute_v_cmp_gt_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return a > b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5206,7 +5206,7 @@ inline void execute_v_cmp_gt_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
   ROCJITSU_TRY_SIMD_VOPC(
       uint32_t, [](auto a, auto b) { return util::f16_to_f32_simd(a) > util::f16_to_f32_simd(b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5223,7 +5223,7 @@ template <typename Inst>
 inline void execute_v_cmp_gt_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return a > b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5254,7 +5254,7 @@ template <typename Inst>
 inline void execute_v_cmp_gt_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(float32_t, [](auto a, auto b) { return a > b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5271,7 +5271,7 @@ template <typename Inst>
 inline void execute_v_cmp_gt_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return a > b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5302,7 +5302,7 @@ template <typename Inst>
 inline void execute_v_cmp_gt_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(double, [](auto a, auto b) { return a > b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5322,7 +5322,7 @@ inline void execute_v_cmp_gt_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5342,7 +5342,7 @@ inline void execute_v_cmp_gt_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
            ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5359,7 +5359,7 @@ template <typename Inst>
 inline void execute_v_cmp_gt_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(int32_t, [](auto a, auto b) { return a > b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5376,7 +5376,7 @@ template <typename Inst>
 inline void execute_v_cmp_gt_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(int32_t, [](auto a, auto b) { return a > b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5393,7 +5393,7 @@ template <typename Inst>
 inline void execute_v_cmp_gt_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(int64_t, [](auto a, auto b) { return a > b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5410,7 +5410,7 @@ template <typename Inst>
 inline void execute_v_cmp_gt_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(int64_t, [](auto a, auto b) { return a > b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5428,7 +5428,7 @@ inline void execute_v_cmp_gt_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(uint32_t,
                                   [](auto a, auto b) { return (a & 0xFFFFu) > (b & 0xFFFFu); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5445,7 +5445,7 @@ template <typename Inst>
 inline void execute_v_cmp_gt_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(uint32_t, [](auto a, auto b) { return (a & 0xFFFFu) > (b & 0xFFFFu); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5462,7 +5462,7 @@ template <typename Inst>
 inline void execute_v_cmp_gt_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(uint32_t, [](auto a, auto b) { return a > b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5478,7 +5478,7 @@ template <typename Inst>
 inline void execute_v_cmp_gt_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(uint32_t, [](auto a, auto b) { return a > b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5494,7 +5494,7 @@ template <typename Inst>
 inline void execute_v_cmp_gt_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(uint64_t, [](auto a, auto b) { return a > b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5511,7 +5511,7 @@ template <typename Inst>
 inline void execute_v_cmp_gt_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(uint64_t, [](auto a, auto b) { return a > b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5528,7 +5528,7 @@ template <typename Inst>
 inline void execute_v_cmp_le_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return a <= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5561,7 +5561,7 @@ inline void execute_v_cmp_le_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     return util::f16_to_f32_simd(a) <= util::f16_to_f32_simd(b);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5578,7 +5578,7 @@ template <typename Inst>
 inline void execute_v_cmp_le_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return a <= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5609,7 +5609,7 @@ template <typename Inst>
 inline void execute_v_cmp_le_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(float32_t, [](auto a, auto b) { return a <= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5626,7 +5626,7 @@ template <typename Inst>
 inline void execute_v_cmp_le_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return a <= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5657,7 +5657,7 @@ template <typename Inst>
 inline void execute_v_cmp_le_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(double, [](auto a, auto b) { return a <= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5677,7 +5677,7 @@ inline void execute_v_cmp_le_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5697,7 +5697,7 @@ inline void execute_v_cmp_le_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
            ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5714,7 +5714,7 @@ template <typename Inst>
 inline void execute_v_cmp_le_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(int32_t, [](auto a, auto b) { return a <= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5731,7 +5731,7 @@ template <typename Inst>
 inline void execute_v_cmp_le_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(int32_t, [](auto a, auto b) { return a <= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5748,7 +5748,7 @@ template <typename Inst>
 inline void execute_v_cmp_le_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(int64_t, [](auto a, auto b) { return a <= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5765,7 +5765,7 @@ template <typename Inst>
 inline void execute_v_cmp_le_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(int64_t, [](auto a, auto b) { return a <= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5783,7 +5783,7 @@ inline void execute_v_cmp_le_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(uint32_t,
                                   [](auto a, auto b) { return (a & 0xFFFFu) <= (b & 0xFFFFu); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5800,7 +5800,7 @@ template <typename Inst>
 inline void execute_v_cmp_le_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(uint32_t, [](auto a, auto b) { return (a & 0xFFFFu) <= (b & 0xFFFFu); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5817,7 +5817,7 @@ template <typename Inst>
 inline void execute_v_cmp_le_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(uint32_t, [](auto a, auto b) { return a <= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5833,7 +5833,7 @@ template <typename Inst>
 inline void execute_v_cmp_le_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(uint32_t, [](auto a, auto b) { return a <= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5849,7 +5849,7 @@ template <typename Inst>
 inline void execute_v_cmp_le_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(uint64_t, [](auto a, auto b) { return a <= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5866,7 +5866,7 @@ template <typename Inst>
 inline void execute_v_cmp_le_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(uint64_t, [](auto a, auto b) { return a <= b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5883,7 +5883,7 @@ template <typename Inst>
 inline void execute_v_cmp_lg_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return (a < b) || (a > b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5933,7 +5933,7 @@ inline void execute_v_cmp_lg_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
            (util::f16_to_f32_simd(a) > util::f16_to_f32_simd(b));
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5952,7 +5952,7 @@ template <typename Inst>
 inline void execute_v_cmp_lg_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return (a < b) || (a > b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -5999,7 +5999,7 @@ template <typename Inst>
 inline void execute_v_cmp_lg_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(float32_t, [](auto a, auto b) { return (a < b) || (a > b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6018,7 +6018,7 @@ template <typename Inst>
 inline void execute_v_cmp_lg_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return (a < b) || (a > b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6065,7 +6065,7 @@ template <typename Inst>
 inline void execute_v_cmp_lg_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(double, [](auto a, auto b) { return (a < b) || (a > b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6084,7 +6084,7 @@ template <typename Inst>
 inline void execute_v_cmp_lt_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return a < b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6116,7 +6116,7 @@ inline void execute_v_cmp_lt_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
   ROCJITSU_TRY_SIMD_VOPC(
       uint32_t, [](auto a, auto b) { return util::f16_to_f32_simd(a) < util::f16_to_f32_simd(b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6133,7 +6133,7 @@ template <typename Inst>
 inline void execute_v_cmp_lt_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return a < b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6164,7 +6164,7 @@ template <typename Inst>
 inline void execute_v_cmp_lt_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(float32_t, [](auto a, auto b) { return a < b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6181,7 +6181,7 @@ template <typename Inst>
 inline void execute_v_cmp_lt_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return a < b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6212,7 +6212,7 @@ template <typename Inst>
 inline void execute_v_cmp_lt_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(double, [](auto a, auto b) { return a < b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6232,7 +6232,7 @@ inline void execute_v_cmp_lt_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6252,7 +6252,7 @@ inline void execute_v_cmp_lt_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
            ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6269,7 +6269,7 @@ template <typename Inst>
 inline void execute_v_cmp_lt_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(int32_t, [](auto a, auto b) { return a < b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6286,7 +6286,7 @@ template <typename Inst>
 inline void execute_v_cmp_lt_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(int32_t, [](auto a, auto b) { return a < b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6303,7 +6303,7 @@ template <typename Inst>
 inline void execute_v_cmp_lt_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(int64_t, [](auto a, auto b) { return a < b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6320,7 +6320,7 @@ template <typename Inst>
 inline void execute_v_cmp_lt_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(int64_t, [](auto a, auto b) { return a < b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6338,7 +6338,7 @@ inline void execute_v_cmp_lt_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(uint32_t,
                                   [](auto a, auto b) { return (a & 0xFFFFu) < (b & 0xFFFFu); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6355,7 +6355,7 @@ template <typename Inst>
 inline void execute_v_cmp_lt_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(uint32_t, [](auto a, auto b) { return (a & 0xFFFFu) < (b & 0xFFFFu); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6372,7 +6372,7 @@ template <typename Inst>
 inline void execute_v_cmp_lt_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(uint32_t, [](auto a, auto b) { return a < b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6388,7 +6388,7 @@ template <typename Inst>
 inline void execute_v_cmp_lt_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(uint32_t, [](auto a, auto b) { return a < b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6404,7 +6404,7 @@ template <typename Inst>
 inline void execute_v_cmp_lt_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(uint64_t, [](auto a, auto b) { return a < b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6421,7 +6421,7 @@ template <typename Inst>
 inline void execute_v_cmp_lt_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(uint64_t, [](auto a, auto b) { return a < b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6441,7 +6441,7 @@ inline void execute_v_cmp_ne_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6461,7 +6461,7 @@ inline void execute_v_cmp_ne_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
            ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6478,7 +6478,7 @@ template <typename Inst>
 inline void execute_v_cmp_ne_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(int32_t, [](auto a, auto b) { return a != b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6495,7 +6495,7 @@ template <typename Inst>
 inline void execute_v_cmp_ne_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(int32_t, [](auto a, auto b) { return a != b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6512,7 +6512,7 @@ template <typename Inst>
 inline void execute_v_cmp_ne_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(int64_t, [](auto a, auto b) { return a != b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6529,7 +6529,7 @@ template <typename Inst>
 inline void execute_v_cmp_ne_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(int64_t, [](auto a, auto b) { return a != b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6547,7 +6547,7 @@ inline void execute_v_cmp_ne_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(uint32_t,
                                   [](auto a, auto b) { return (a & 0xFFFFu) != (b & 0xFFFFu); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6564,7 +6564,7 @@ template <typename Inst>
 inline void execute_v_cmp_ne_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(uint32_t, [](auto a, auto b) { return (a & 0xFFFFu) != (b & 0xFFFFu); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6581,7 +6581,7 @@ template <typename Inst>
 inline void execute_v_cmp_ne_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(uint32_t, [](auto a, auto b) { return a != b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6597,7 +6597,7 @@ template <typename Inst>
 inline void execute_v_cmp_ne_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(uint32_t, [](auto a, auto b) { return a != b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6613,7 +6613,7 @@ template <typename Inst>
 inline void execute_v_cmp_ne_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(uint64_t, [](auto a, auto b) { return a != b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6630,7 +6630,7 @@ template <typename Inst>
 inline void execute_v_cmp_ne_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(uint64_t, [](auto a, auto b) { return a != b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6648,7 +6648,7 @@ inline void execute_v_cmp_neq_f16_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return a != b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6682,7 +6682,7 @@ inline void execute_v_cmp_neq_f16_vopc([[maybe_unused]] Inst &inst,
     return util::f16_to_f32_simd(a) != util::f16_to_f32_simd(b);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6700,7 +6700,7 @@ inline void execute_v_cmp_neq_f32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return a != b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6732,7 +6732,7 @@ inline void execute_v_cmp_neq_f32_vopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(float32_t, [](auto a, auto b) { return a != b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6750,7 +6750,7 @@ inline void execute_v_cmp_neq_f64_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return a != b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6782,7 +6782,7 @@ inline void execute_v_cmp_neq_f64_vopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(double, [](auto a, auto b) { return a != b; });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6800,7 +6800,7 @@ inline void execute_v_cmp_nge_f16_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return !(a >= b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6834,7 +6834,7 @@ inline void execute_v_cmp_nge_f16_vopc([[maybe_unused]] Inst &inst,
     return !(util::f16_to_f32_simd(a) >= util::f16_to_f32_simd(b));
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6852,7 +6852,7 @@ inline void execute_v_cmp_nge_f32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return !(a >= b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6884,7 +6884,7 @@ inline void execute_v_cmp_nge_f32_vopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(float32_t, [](auto a, auto b) { return !(a >= b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6902,7 +6902,7 @@ inline void execute_v_cmp_nge_f64_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return !(a >= b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6934,7 +6934,7 @@ inline void execute_v_cmp_nge_f64_vopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(double, [](auto a, auto b) { return !(a >= b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6952,7 +6952,7 @@ inline void execute_v_cmp_ngt_f16_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return !(a > b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -6986,7 +6986,7 @@ inline void execute_v_cmp_ngt_f16_vopc([[maybe_unused]] Inst &inst,
     return !(util::f16_to_f32_simd(a) > util::f16_to_f32_simd(b));
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7004,7 +7004,7 @@ inline void execute_v_cmp_ngt_f32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return !(a > b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7036,7 +7036,7 @@ inline void execute_v_cmp_ngt_f32_vopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(float32_t, [](auto a, auto b) { return !(a > b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7054,7 +7054,7 @@ inline void execute_v_cmp_ngt_f64_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return !(a > b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7086,7 +7086,7 @@ inline void execute_v_cmp_ngt_f64_vopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(double, [](auto a, auto b) { return !(a > b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7104,7 +7104,7 @@ inline void execute_v_cmp_nle_f16_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return !(a <= b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7138,7 +7138,7 @@ inline void execute_v_cmp_nle_f16_vopc([[maybe_unused]] Inst &inst,
     return !(util::f16_to_f32_simd(a) <= util::f16_to_f32_simd(b));
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7156,7 +7156,7 @@ inline void execute_v_cmp_nle_f32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return !(a <= b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7188,7 +7188,7 @@ inline void execute_v_cmp_nle_f32_vopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(float32_t, [](auto a, auto b) { return !(a <= b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7206,7 +7206,7 @@ inline void execute_v_cmp_nle_f64_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return !(a <= b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7238,7 +7238,7 @@ inline void execute_v_cmp_nle_f64_vopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(double, [](auto a, auto b) { return !(a <= b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7256,7 +7256,7 @@ inline void execute_v_cmp_nlg_f16_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return !((a < b) || (a > b)); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7307,7 +7307,7 @@ inline void execute_v_cmp_nlg_f16_vopc([[maybe_unused]] Inst &inst,
              (util::f16_to_f32_simd(a) > util::f16_to_f32_simd(b)));
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7327,7 +7327,7 @@ inline void execute_v_cmp_nlg_f32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return !((a < b) || (a > b)); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7375,7 +7375,7 @@ inline void execute_v_cmp_nlg_f32_vopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(float32_t, [](auto a, auto b) { return !((a < b) || (a > b)); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7395,7 +7395,7 @@ inline void execute_v_cmp_nlg_f64_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return !((a < b) || (a > b)); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7443,7 +7443,7 @@ inline void execute_v_cmp_nlg_f64_vopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(double, [](auto a, auto b) { return !((a < b) || (a > b)); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7463,7 +7463,7 @@ inline void execute_v_cmp_nlt_f16_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return !(a < b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7497,7 +7497,7 @@ inline void execute_v_cmp_nlt_f16_vopc([[maybe_unused]] Inst &inst,
     return !(util::f16_to_f32_simd(a) < util::f16_to_f32_simd(b));
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7515,7 +7515,7 @@ inline void execute_v_cmp_nlt_f32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return !(a < b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7547,7 +7547,7 @@ inline void execute_v_cmp_nlt_f32_vopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(float32_t, [](auto a, auto b) { return !(a < b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7565,7 +7565,7 @@ inline void execute_v_cmp_nlt_f64_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return !(a < b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7597,7 +7597,7 @@ inline void execute_v_cmp_nlt_f64_vopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(double, [](auto a, auto b) { return !(a < b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7615,7 +7615,7 @@ inline void execute_v_cmp_o_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16(
       [](auto a, auto b) { return !util::stdx::isnan(a) && !util::stdx::isnan(b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7649,7 +7649,7 @@ inline void execute_v_cmp_o_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
            !util::stdx::isnan(util::f16_to_f32_simd(b));
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7667,7 +7667,7 @@ inline void execute_v_cmp_o_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32(
       [](auto a, auto b) { return !util::stdx::isnan(a) && !util::stdx::isnan(b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7699,7 +7699,7 @@ inline void execute_v_cmp_o_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC(
       float32_t, [](auto a, auto b) { return !util::stdx::isnan(a) && !util::stdx::isnan(b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7717,7 +7717,7 @@ inline void execute_v_cmp_o_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64(
       [](auto a, auto b) { return !util::stdx::isnan(a) && !util::stdx::isnan(b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7749,7 +7749,7 @@ inline void execute_v_cmp_o_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC64(
       double, [](auto a, auto b) { return !util::stdx::isnan(a) && !util::stdx::isnan(b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7766,7 +7766,7 @@ template <typename Inst>
 inline void execute_v_cmp_t_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7781,7 +7781,7 @@ inline void execute_v_cmp_t_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
 template <typename Inst>
 inline void execute_v_cmp_t_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7797,7 +7797,7 @@ template <typename Inst>
 inline void execute_v_cmp_t_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7812,7 +7812,7 @@ inline void execute_v_cmp_t_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
 template <typename Inst>
 inline void execute_v_cmp_t_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7828,7 +7828,7 @@ template <typename Inst>
 inline void execute_v_cmp_t_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7843,7 +7843,7 @@ inline void execute_v_cmp_t_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
 template <typename Inst>
 inline void execute_v_cmp_t_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7862,7 +7862,7 @@ inline void execute_v_cmp_t_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
                     ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16))(true);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7881,7 +7881,7 @@ inline void execute_v_cmp_t_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
                     ((util::stdx::static_simd_cast<util::native<int32_t>>(b) << 16) >> 16))(true);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7897,7 +7897,7 @@ template <typename Inst>
 inline void execute_v_cmp_t_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(int32_t, [](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7913,7 +7913,7 @@ template <typename Inst>
 inline void execute_v_cmp_t_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(int32_t, [](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7929,7 +7929,7 @@ template <typename Inst>
 inline void execute_v_cmp_t_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(int64_t, [](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7945,7 +7945,7 @@ template <typename Inst>
 inline void execute_v_cmp_t_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(int64_t, [](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7962,7 +7962,7 @@ inline void execute_v_cmp_t_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(
       uint32_t, [](auto a, auto b) { return decltype((a & 0xFFFFu) == (b & 0xFFFFu))(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7979,7 +7979,7 @@ inline void execute_v_cmp_t_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC(
       uint32_t, [](auto a, auto b) { return decltype((a & 0xFFFFu) == (b & 0xFFFFu))(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -7995,7 +7995,7 @@ template <typename Inst>
 inline void execute_v_cmp_t_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_INT(uint32_t, [](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8011,7 +8011,7 @@ template <typename Inst>
 inline void execute_v_cmp_t_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(uint32_t, [](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8028,7 +8028,7 @@ inline void execute_v_cmp_t_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(uint64_t,
                                     [](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8044,7 +8044,7 @@ template <typename Inst>
 inline void execute_v_cmp_t_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(uint64_t, [](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8061,7 +8061,7 @@ inline void execute_v_cmp_tru_f16_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16([](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8080,7 +8080,7 @@ inline void execute_v_cmp_tru_f16_vopc([[maybe_unused]] Inst &inst,
     return decltype(util::f16_to_f32_simd(a) == util::f16_to_f32_simd(b))(true);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8097,7 +8097,7 @@ inline void execute_v_cmp_tru_f32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32([](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8114,7 +8114,7 @@ inline void execute_v_cmp_tru_f32_vopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC(float32_t, [](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8131,7 +8131,7 @@ inline void execute_v_cmp_tru_f64_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64([](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8148,7 +8148,7 @@ inline void execute_v_cmp_tru_f64_vopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOPC64(double, [](auto a, auto b) { return decltype(a == b)(true); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8165,7 +8165,7 @@ inline void execute_v_cmp_u_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP16(
       [](auto a, auto b) { return util::stdx::isnan(a) || util::stdx::isnan(b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8199,7 +8199,7 @@ inline void execute_v_cmp_u_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
            util::stdx::isnan(util::f16_to_f32_simd(b));
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8217,7 +8217,7 @@ inline void execute_v_cmp_u_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC_VOP3_FP32(
       [](auto a, auto b) { return util::stdx::isnan(a) || util::stdx::isnan(b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8249,7 +8249,7 @@ inline void execute_v_cmp_u_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC(
       float32_t, [](auto a, auto b) { return util::stdx::isnan(a) || util::stdx::isnan(b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8267,7 +8267,7 @@ inline void execute_v_cmp_u_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64(
       [](auto a, auto b) { return util::stdx::isnan(a) || util::stdx::isnan(b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -8299,7 +8299,7 @@ inline void execute_v_cmp_u_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
   ROCJITSU_TRY_SIMD_VOPC64(
       double, [](auto a, auto b) { return util::stdx::isnan(a) || util::stdx::isnan(b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -19269,7 +19269,7 @@ template <typename Inst>
 inline void execute_v_sub_co_ci_u32_vop2([[maybe_unused]] Inst &inst,
                                          [[maybe_unused]] Wavefront &wf) {
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -19298,7 +19298,7 @@ inline void execute_v_sub_co_ci_u32_vop3([[maybe_unused]] Inst &inst,
     return make_simd_carry(t2, bw1 | bw2);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -19320,7 +19320,7 @@ template <typename Inst>
 inline void execute_v_sub_co_u32_vop2([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP2_CARRY([](auto a, auto b, auto) { return make_simd_carry(a - b, a < b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -19340,7 +19340,7 @@ template <typename Inst>
 inline void execute_v_sub_co_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP3_CO([](auto a, auto b, auto) { return make_simd_carry(a - b, a < b); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -19625,7 +19625,7 @@ inline void execute_v_subb_co_u32_vop2([[maybe_unused]] Inst &inst,
     return make_simd_carry(t2, bw1 | bw2);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -19654,7 +19654,7 @@ inline void execute_v_subb_co_u32_vop3([[maybe_unused]] Inst &inst,
     return make_simd_carry(t2, bw1 | bw2);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -19683,7 +19683,7 @@ inline void execute_v_subbrev_co_u32_vop2([[maybe_unused]] Inst &inst,
     return make_simd_carry(t2, bw1 | bw2);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -19712,7 +19712,7 @@ inline void execute_v_subbrev_co_u32_vop3([[maybe_unused]] Inst &inst,
     return make_simd_carry(t2, bw1 | bw2);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -19734,7 +19734,7 @@ template <typename Inst>
 inline void execute_v_subrev_co_ci_u32_vop2([[maybe_unused]] Inst &inst,
                                             [[maybe_unused]] Wavefront &wf) {
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -19763,7 +19763,7 @@ inline void execute_v_subrev_co_ci_u32_vop3([[maybe_unused]] Inst &inst,
     return make_simd_carry(t2, bw1 | bw2);
   });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -19786,7 +19786,7 @@ inline void execute_v_subrev_co_u32_vop2([[maybe_unused]] Inst &inst,
                                          [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP2_CARRY([](auto a, auto b, auto) { return make_simd_carry(b - a, b < a); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
@@ -19807,7 +19807,7 @@ inline void execute_v_subrev_co_u32_vop3([[maybe_unused]] Inst &inst,
                                          [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP3_CO([](auto a, auto b, auto) { return make_simd_carry(b - a, b < a); });
   uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -1001,6 +1001,53 @@ void exec_f32_scaled(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32
     cu.write_vgpr(dst + r.reg, r.lane, r.val);
 }
 
+/// Scaled MFMA for mixed-format f8f6f4: A and B may have different bit widths.
+/// cbsz/blgp are used as format selectors (not lane permutations).
+template <typename ExtractA, typename ExtractB>
+void exec_f32_scaled_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K,
+                           uint32_t B, uint32_t a_bits, uint32_t b_bits, uint32_t dst, uint32_t s0,
+                           uint32_t s1, uint32_t s2, ExtractA ea, ExtractB eb, uint32_t const_acc,
+                           uint32_t scale_a_base, uint32_t scale_b_base) {
+  constexpr uint32_t BLOCK_K = 32;
+  struct Result {
+    uint32_t reg;
+    uint32_t lane;
+    uint32_t val;
+  };
+  std::vector<Result> results;
+  results.reserve(M * N * B);
+  uint32_t num_blocks = (K + BLOCK_K - 1) / BLOCK_K;
+  for (uint32_t b = 0; b < B; ++b) {
+    for (uint32_t row = 0; row < M; ++row) {
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = output_loc_32(M, N, row, col, b);
+        float acc = (const_acc != ACC_FROM_VGPR)
+                        ? std::bit_cast<float>(const_acc)
+                        : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
+        for (uint32_t blk = 0; blk < num_blocks; ++blk) {
+          float block_sum = 0.0f;
+          uint32_t k_start = blk * BLOCK_K;
+          uint32_t k_end = std::min(k_start + BLOCK_K, K);
+          for (uint32_t k = k_start; k < k_end; ++k) {
+            auto al = input_loc(M, K, B, row, k, b, a_bits);
+            auto bl = input_loc(N, K, B, col, k, b, b_bits);
+            block_sum += ea(cu, s0, al) * eb(cu, s1, bl);
+          }
+          uint32_t sa_raw = cu.read_vgpr(scale_a_base, out.lane);
+          uint32_t sb_raw = cu.read_vgpr(scale_b_base, out.lane);
+          uint8_t sa_e8m0 = static_cast<uint8_t>((sa_raw >> (blk * 8)) & 0xFF);
+          uint8_t sb_e8m0 = static_cast<uint8_t>((sb_raw >> (blk * 8)) & 0xFF);
+          int scale_exp = static_cast<int>(sa_e8m0) + static_cast<int>(sb_e8m0) - 254;
+          acc += std::ldexp(block_sum, scale_exp);
+        }
+        results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
+      }
+    }
+  }
+  for (const auto &r : results)
+    cu.write_vgpr(dst + r.reg, r.lane, r.val);
+}
+
 /// MFMA execute for i32 output with i8 input: D = C + A x B.
 inline void exec_i32_i8(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B,
                         uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
@@ -1167,6 +1214,356 @@ inline void exec_f64(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32
     cu.write_vgpr(dst + r.reg, r.lane, r.lo);
     cu.write_vgpr(dst + r.reg + 1, r.lane, r.hi);
   }
+}
+
+// ---------------------------------------------------------------------------
+// SMFMAC (Sparse Matrix FMA) helpers and execution functions.
+//
+// Structured 2:4 sparsity: A is half-density (2 of every 4 K positions are
+// nonzero). A per-lane index register selects which 2-of-4 positions are live.
+// Each 4-bit nibble in the index encodes two 2-bit position selectors (p0, p1).
+// ---------------------------------------------------------------------------
+
+inline float smfmac_read_fp8(ComputeUnitCore &cu, uint32_t base, uint32_t byte_idx, uint32_t lane) {
+  uint32_t raw = cu.read_vgpr(base + byte_idx / 4, lane);
+  return util::fp8_e4m3_to_f32(static_cast<uint8_t>((raw >> ((byte_idx % 4) * 8)) & 0xFF));
+}
+
+inline float smfmac_read_bf8(ComputeUnitCore &cu, uint32_t base, uint32_t byte_idx, uint32_t lane) {
+  uint32_t raw = cu.read_vgpr(base + byte_idx / 4, lane);
+  return util::bf8_e5m2_to_f32(static_cast<uint8_t>((raw >> ((byte_idx % 4) * 8)) & 0xFF));
+}
+
+inline float smfmac_read_f16(ComputeUnitCore &cu, uint32_t base, uint32_t elem, uint32_t lane) {
+  uint32_t raw = cu.read_vgpr(base + elem / 2, lane);
+  return util::f16_to_f32(static_cast<uint16_t>((raw >> ((elem % 2) * 16)) & 0xFFFF));
+}
+
+inline float smfmac_read_bf16(ComputeUnitCore &cu, uint32_t base, uint32_t elem, uint32_t lane) {
+  uint32_t raw = cu.read_vgpr(base + elem / 2, lane);
+  return util::bf16_to_f32(static_cast<uint16_t>((raw >> ((elem % 2) * 16)) & 0xFFFF));
+}
+
+/// SMFMAC 16x16x32 f16/bf16 (CDNA3 mai-insts). K=32, 8 sparse groups.
+/// A = v2 (4 halves/lane), B = v4 (8 halves/lane), D = v4 f32.
+template <typename Extract>
+void exec_smfmac_f32_16x16x32_f16(ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                                  uint32_t idx_base, Extract ex) {
+  struct Result {
+    uint32_t reg, lane, val;
+  };
+  std::vector<Result> results;
+  results.reserve(16 * 16);
+  for (uint32_t row = 0; row < 16; ++row) {
+    for (uint32_t col = 0; col < 16; ++col) {
+      auto out = output_loc_32(16, 16, row, col, 0);
+      float acc = std::bit_cast<float>(cu.read_vgpr(dst + out.reg, out.lane));
+      float Bcol[32];
+      for (int g = 0; g < 4; ++g)
+        for (int e = 0; e < 8; ++e)
+          Bcol[8 * g + e] = ex(cu, s1, e, g * 16 + col);
+      for (int q = 0; q < 8; ++q) {
+        int laneA = (q / 2) * 16 + row;
+        uint32_t idxval = cu.read_vgpr(idx_base, laneA);
+        int field = (idxval >> (4 * (q % 2))) & 0xF;
+        int p0 = field & 3, p1 = (field >> 2) & 3;
+        for (int s = 0; s < 2; ++s) {
+          float av = ex(cu, s0, (2 * q + s) % 4, laneA);
+          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+        }
+      }
+      results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
+    }
+  }
+  for (const auto &r : results)
+    cu.write_vgpr(dst + r.reg, r.lane, r.val);
+}
+
+/// SMFMAC 32x32x16 f16/bf16 (CDNA3 mai-insts). K=16, 4 sparse groups.
+/// A = v2 (4 halves/lane), B = v4 (8 halves/lane), D = v16 f32.
+template <typename Extract>
+void exec_smfmac_f32_32x32x16_f16(ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                                  uint32_t idx_base, Extract ex) {
+  struct Result {
+    uint32_t reg, lane, val;
+  };
+  std::vector<Result> results;
+  results.reserve(32 * 32);
+  for (uint32_t row = 0; row < 32; ++row) {
+    for (uint32_t col = 0; col < 32; ++col) {
+      auto out = output_loc_32(32, 32, row, col, 0);
+      float acc = std::bit_cast<float>(cu.read_vgpr(dst + out.reg, out.lane));
+      uint32_t jlow = col % 16, jhi = col / 16;
+      float Bcol[16];
+      for (int kgrp = 0; kgrp < 2; ++kgrp) {
+        uint32_t b_lane = 16 * (jhi + 2 * kgrp) + jlow;
+        for (int e = 0; e < 8; ++e)
+          Bcol[8 * kgrp + e] = ex(cu, s1, e, b_lane);
+      }
+      for (int q = 0; q < 4; ++q) {
+        int laneA = (q / 2) * 32 + row;
+        uint32_t idxval = cu.read_vgpr(idx_base, laneA);
+        int field = (idxval >> (4 * (q % 2))) & 0xF;
+        int p0 = field & 3, p1 = (field >> 2) & 3;
+        for (int s = 0; s < 2; ++s) {
+          float av = ex(cu, s0, (2 * q + s) % 4, laneA);
+          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+        }
+      }
+      results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
+    }
+  }
+  for (const auto &r : results)
+    cu.write_vgpr(dst + r.reg, r.lane, r.val);
+}
+
+/// SMFMAC 16x16x64 f16/bf16 (gfx950-insts). K=64, 16 sparse groups.
+/// A = v4 (8 halves/lane), B = v8 (16 halves/lane), D = v4 f32.
+template <typename Extract>
+void exec_smfmac_f32_16x16x64_f16(ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                                  uint32_t idx_base, Extract ex) {
+  struct Result {
+    uint32_t reg, lane, val;
+  };
+  std::vector<Result> results;
+  results.reserve(16 * 16);
+  for (uint32_t row = 0; row < 16; ++row) {
+    for (uint32_t col = 0; col < 16; ++col) {
+      auto out = output_loc_32(16, 16, row, col, 0);
+      float acc = std::bit_cast<float>(cu.read_vgpr(dst + out.reg, out.lane));
+      float Bcol[64];
+      for (int g = 0; g < 4; ++g)
+        for (int e = 0; e < 16; ++e) {
+          int k = 32 * (e / 8) + 8 * g + (e % 8);
+          Bcol[k] = ex(cu, s1, e, g * 16 + col);
+        }
+      for (int q = 0; q < 16; ++q) {
+        int laneA = (q / 4) * 16 + row;
+        uint32_t idxval = cu.read_vgpr(idx_base, laneA);
+        int field = (idxval >> (4 * (q % 4))) & 0xF;
+        int p0 = field & 3, p1 = (field >> 2) & 3;
+        for (int s = 0; s < 2; ++s) {
+          float av = ex(cu, s0, (2 * q + s) % 8, laneA);
+          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+        }
+      }
+      results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
+    }
+  }
+  for (const auto &r : results)
+    cu.write_vgpr(dst + r.reg, r.lane, r.val);
+}
+
+/// SMFMAC 32x32x32 f16/bf16 (gfx950-insts). K=32, 8 sparse groups.
+/// A = v4 (8 halves/lane), B = v8 (16 halves/lane), D = v16 f32.
+template <typename Extract>
+void exec_smfmac_f32_32x32x32_f16(ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                                  uint32_t idx_base, Extract ex) {
+  struct Result {
+    uint32_t reg, lane, val;
+  };
+  std::vector<Result> results;
+  results.reserve(32 * 32);
+  for (uint32_t row = 0; row < 32; ++row) {
+    for (uint32_t col = 0; col < 32; ++col) {
+      auto out = output_loc_32(32, 32, row, col, 0);
+      float acc = std::bit_cast<float>(cu.read_vgpr(dst + out.reg, out.lane));
+      float Bcol[32];
+      for (int sl = 0; sl < 2; ++sl) {
+        uint32_t src = col + 32 * sl;
+        int kgrp = sl;
+        for (int e = 0; e < 16; ++e) {
+          int k = 16 * (e / 8) + 8 * kgrp + 2 * ((e / 2) % 4) + (e % 2);
+          Bcol[k] = ex(cu, s1, e, src);
+        }
+      }
+      for (int q = 0; q < 8; ++q) {
+        int laneA = (q / 4) * 32 + row;
+        uint32_t idxval = cu.read_vgpr(idx_base, laneA);
+        int field = (idxval >> (4 * (q % 4))) & 0xF;
+        int p0 = field & 3, p1 = (field >> 2) & 3;
+        for (int s = 0; s < 2; ++s) {
+          float av = ex(cu, s0, (2 * q + s) % 8, laneA);
+          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+        }
+      }
+      results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
+    }
+  }
+  for (const auto &r : results)
+    cu.write_vgpr(dst + r.reg, r.lane, r.val);
+}
+
+/// SMFMAC 16x16x64 fp8 (CDNA3 fp8-insts). K=64, 16 sparse groups.
+/// A = v2 (8 bytes/lane), B = v4 (16 bytes/lane), D = v4 f32.
+template <typename ExtractA, typename ExtractB>
+void exec_smfmac_f32_16x16x64_fp8(ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                                  uint32_t idx_base, ExtractA ea, ExtractB eb) {
+  struct Result {
+    uint32_t reg, lane, val;
+  };
+  std::vector<Result> results;
+  results.reserve(16 * 16);
+  for (uint32_t row = 0; row < 16; ++row) {
+    for (uint32_t col = 0; col < 16; ++col) {
+      auto out = output_loc_32(16, 16, row, col, 0);
+      float acc = std::bit_cast<float>(cu.read_vgpr(dst + out.reg, out.lane));
+      float Bcol[64];
+      for (int g = 0; g < 4; ++g)
+        for (int e = 0; e < 16; ++e) {
+          int k = 32 * (e / 8) + 8 * g + (e % 8);
+          Bcol[k] = eb(cu, s1, e, g * 16 + col);
+        }
+      for (int q = 0; q < 16; ++q) {
+        int ga = ((2 * q) % 16) / 4;
+        int laneA = ga * 16 + row;
+        int idxlane = ((q % 8) / 2) * 16 + row;
+        int nb = 2 * (q / 8) + (q % 2);
+        uint32_t idxval = cu.read_vgpr(idx_base, idxlane);
+        int field = (idxval >> (4 * nb)) & 0xF;
+        int p0 = field & 3, p1 = (field >> 2) & 3;
+        for (int s = 0; s < 2; ++s) {
+          int cc = 2 * q + s;
+          int byte = 4 * (cc / 16) + (cc % 16) % 4;
+          float av = ea(cu, s0, byte, laneA);
+          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+        }
+      }
+      results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
+    }
+  }
+  for (const auto &r : results)
+    cu.write_vgpr(dst + r.reg, r.lane, r.val);
+}
+
+/// SMFMAC 32x32x32 fp8 (CDNA3 fp8-insts). K=32, 8 sparse groups.
+/// A = v2 (8 bytes/lane), B = v4 (16 bytes/lane), D = v16 f32.
+template <typename ExtractA, typename ExtractB>
+void exec_smfmac_f32_32x32x32_fp8(ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                                  uint32_t idx_base, ExtractA ea, ExtractB eb) {
+  struct Result {
+    uint32_t reg, lane, val;
+  };
+  std::vector<Result> results;
+  results.reserve(32 * 32);
+  for (uint32_t row = 0; row < 32; ++row) {
+    for (uint32_t col = 0; col < 32; ++col) {
+      auto out = output_loc_32(32, 32, row, col, 0);
+      float acc = std::bit_cast<float>(cu.read_vgpr(dst + out.reg, out.lane));
+      float Bcol[32];
+      for (int kgrp = 0; kgrp < 2; ++kgrp) {
+        uint32_t b_lane = col + 32 * kgrp;
+        for (int e = 0; e < 16; ++e) {
+          int k = 16 * (e / 8) + 8 * kgrp + 2 * ((e / 2) % 4) + (e % 2);
+          Bcol[k] = eb(cu, s1, e, b_lane);
+        }
+      }
+      for (int q = 0; q < 8; ++q) {
+        int ga = ((2 * q) % 8) / 4;
+        int laneA = ga * 32 + row;
+        int idxlane = ((q % 4) / 2) * 32 + row;
+        int nb = 2 * (q / 4) + (q % 2);
+        uint32_t idxval = cu.read_vgpr(idx_base, idxlane);
+        int field = (idxval >> (4 * nb)) & 0xF;
+        int p0 = field & 3, p1 = (field >> 2) & 3;
+        for (int s = 0; s < 2; ++s) {
+          int cc = 2 * q + s;
+          int byte = 4 * (cc / 8) + (cc % 8) % 4;
+          float av = ea(cu, s0, byte, laneA);
+          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+        }
+      }
+      results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
+    }
+  }
+  for (const auto &r : results)
+    cu.write_vgpr(dst + r.reg, r.lane, r.val);
+}
+
+/// SMFMAC 16x16x128 fp8 (gfx950-insts). K=128, 32 sparse groups.
+/// A = v4 (16 bytes/lane), B = v8 (32 bytes/lane), D = v4 f32.
+template <typename ExtractA, typename ExtractB>
+void exec_smfmac_f32_16x16x128_fp8(ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                                   uint32_t idx_base, ExtractA ea, ExtractB eb) {
+  struct Result {
+    uint32_t reg, lane, val;
+  };
+  std::vector<Result> results;
+  results.reserve(16 * 16);
+  for (uint32_t row = 0; row < 16; ++row) {
+    for (uint32_t col = 0; col < 16; ++col) {
+      auto out = output_loc_32(16, 16, row, col, 0);
+      float acc = std::bit_cast<float>(cu.read_vgpr(dst + out.reg, out.lane));
+      float Bcol[128];
+      for (int g = 0; g < 4; ++g)
+        for (int e = 0; e < 32; ++e) {
+          int k = 32 * (e / 8) + 8 * g + (e % 8);
+          Bcol[k] = eb(cu, s1, e, g * 16 + col);
+        }
+      for (int q = 0; q < 32; ++q) {
+        int idxlane = 16 * (2 * (q / 16) + ((q / 4) % 2)) + row;
+        int nb = 2 * ((q / 8) % 2) + 4 * ((q % 4) / 2) + ((q % 4) % 2);
+        uint32_t idxval = cu.read_vgpr(idx_base, idxlane);
+        int field = (idxval >> (4 * nb)) & 0xF;
+        int p0 = field & 3, p1 = (field >> 2) & 3;
+        for (int s = 0; s < 2; ++s) {
+          int cc = 2 * q + s;
+          int ga = 2 * ((cc >> 5) & 1) + ((cc >> 3) & 1);
+          int hb = 2 * ((cc >> 2) & 1) + ((cc >> 4) & 1);
+          int byte = 4 * hb + (cc & 3);
+          float av = ea(cu, s0, byte, ga * 16 + row);
+          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+        }
+      }
+      results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
+    }
+  }
+  for (const auto &r : results)
+    cu.write_vgpr(dst + r.reg, r.lane, r.val);
+}
+
+/// SMFMAC 32x32x64 fp8 (gfx950-insts). K=64, 16 sparse groups.
+/// A = v4 (16 bytes/lane), B = v8 (32 bytes/lane), D = v16 f32.
+template <typename ExtractA, typename ExtractB>
+void exec_smfmac_f32_32x32x64_fp8(ComputeUnitCore &cu, uint32_t dst, uint32_t s0, uint32_t s1,
+                                  uint32_t idx_base, ExtractA ea, ExtractB eb) {
+  struct Result {
+    uint32_t reg, lane, val;
+  };
+  std::vector<Result> results;
+  results.reserve(32 * 32);
+  for (uint32_t row = 0; row < 32; ++row) {
+    for (uint32_t col = 0; col < 32; ++col) {
+      auto out = output_loc_32(32, 32, row, col, 0);
+      float acc = std::bit_cast<float>(cu.read_vgpr(dst + out.reg, out.lane));
+      float Bcol[64];
+      for (int kgrp = 0; kgrp < 2; ++kgrp) {
+        uint32_t b_lane = kgrp * 32 + col;
+        for (int e = 0; e < 32; ++e) {
+          int k = 16 * (e / 8) + 8 * kgrp + (e % 8);
+          Bcol[k] = eb(cu, s1, e, b_lane);
+        }
+      }
+      for (int q = 0; q < 16; ++q) {
+        int idxlane = 32 * (q / 8) + row;
+        int nb = (q % 2) + 2 * ((q / 4) % 2) + 4 * ((q / 2) % 2);
+        uint32_t idxval = cu.read_vgpr(idx_base, idxlane);
+        int field = (idxval >> (4 * nb)) & 0xF;
+        int p0 = field & 3, p1 = (field >> 2) & 3;
+        for (int s = 0; s < 2; ++s) {
+          int cc = 2 * q + s;
+          int ga = (cc >> 4) & 1;
+          int hb = 2 * ((cc >> 2) & 1) + ((cc >> 3) & 1);
+          int byte = 4 * hb + (cc & 3);
+          float av = ea(cu, s0, byte, ga * 32 + row);
+          acc += av * Bcol[4 * q + (s == 0 ? p0 : p1)];
+        }
+      }
+      results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
+    }
+  }
+  for (const auto &r : results)
+    cu.write_vgpr(dst + r.reg, r.lane, r.val);
 }
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -447,7 +447,7 @@ inline SimdCarry<Value, Mask> make_simd_carry(Value value, Mask carry) {
 /// where `cin` carries the incoming VCC bit (0/1 per lane); ops without a
 /// carry-in ignore it. The result is masked-stored to vdst and the carry mask
 /// is merged into VCC at the chunk's bit offset for active EXEC lanes only —
-/// inactive-lane VCC bits are preserved, matching the scalar bodies.
+/// inactive-lane VCC bits are zeroed, matching the scalar bodies.
 template <typename Inst, typename CarryOp>
   requires(util::has_stdx_simd)
 [[nodiscard]] inline bool try_execute_binary_vop2_carry_simd(Inst &inst, Wavefront &wf,
@@ -459,11 +459,10 @@ template <typename Inst, typename CarryOp>
   constexpr std::size_t W = util::native_width_v<T>;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
   const uint64_t exec = wf.exec();
-  // Carry-in reads the incoming VCC; the result accumulates into a copy. Each
-  // lane touches only its own VCC bit, so the snapshot/copy split mirrors the
-  // scalar body, which reads wf.vcc() for carry-in and writes set_vcc() once.
+  // Carry-in reads the incoming VCC; the result accumulates from zero so that
+  // inactive lanes are zeroed (matching hardware and the scalar bodies).
   const uint64_t vcc_in = wf.vcc();
-  uint64_t vcc_out = vcc_in;
+  uint64_t vcc_out = 0;
   // Resolve operand base pointers once; see try_execute_binary_vop2_simd.
   const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
   const VgprStorage *r1 = simd_src_reg(inst.vsrc1, wf);
@@ -904,7 +903,7 @@ template <typename T, typename Inst, typename CmpOp>
   constexpr std::size_t W = util::native_width_v<T>;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
   const uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   // Resolve source base pointers once; see try_execute_binary_vop2_simd. VOPC
   // writes only the VCC mask, so there is no dst pointer to hoist.
   const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
@@ -937,7 +936,7 @@ template <typename T, typename Inst, typename CmpOp>
 /// 64-bit-lane VOPC compare SIMD fast path (f64/i64/u64 relations). Identical to
 /// try_execute_vopc_simd but reads each operand as `native<T>` (T = double /
 /// int64_t / uint64_t) through the split lo/hi VGPR-pair path (read_simd64), so
-/// it processes `native_width64` lanes per chunk. Same VCC merge / preservation.
+/// it processes `native_width64` lanes per chunk. Same VCC merge.
 template <typename T, typename Inst, typename CmpOp>
   requires(util::has_stdx_simd)
 [[nodiscard]] inline bool try_execute_vopc64_simd(Inst &inst, Wavefront &wf, CmpOp cmp_op) {
@@ -946,7 +945,7 @@ template <typename T, typename Inst, typename CmpOp>
   constexpr std::size_t W = util::native_width64;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
   const uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   // Resolve source base pointers once; see try_execute_binary_vop2_simd. VOPC
   // writes only the VCC mask, so there is no dst pointer to hoist.
   const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
@@ -995,7 +994,7 @@ template <typename Inst, typename CmpOp>
   constexpr std::size_t W = util::native_width64;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
   const uint64_t exec = wf.exec();
-  uint64_t vcc = wf.vcc();
+  uint64_t vcc = 0;
   // Resolve source base pointers once; see try_execute_binary_vop2_simd. VOPC
   // writes only the VCC mask, so there is no dst pointer to hoist.
   const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
@@ -1051,7 +1050,7 @@ template <typename Inst, typename CmpOp>
   const bool do_abs = (inst.inst_.abs & (1u << 0)) != 0;
   const bool do_neg = (inst.inst_.neg & (1u << 0)) != 0;
   const auto sm = util::broadcast<T>(signmask);
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   // Resolve source base pointers once; see try_execute_binary_vop2_simd. The
   // class test writes only the SGPR-pair mask, so there is no dst pointer to hoist.
   const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
@@ -1103,7 +1102,7 @@ template <typename Inst, typename CmpOp>
   const bool do_abs = (inst.inst_.abs & (1u << 0)) != 0;
   const bool do_neg = (inst.inst_.neg & (1u << 0)) != 0;
   const auto sm = util::broadcast64<uint64_t>(signmask);
-  uint64_t vcc = inst.vdst.read_scalar64(wf);
+  uint64_t vcc = 0;
   // Resolve source base pointers once; see try_execute_binary_vop2_simd. The
   // class test writes only the SGPR-pair mask, so there is no dst pointer to hoist.
   const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
@@ -1254,7 +1253,7 @@ template <typename T, typename Inst, typename CmpOp>
   constexpr std::size_t W = util::native_width_v<T>;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
   const uint64_t exec = wf.exec();
-  uint64_t dst = inst.vdst.read_scalar64(wf);
+  uint64_t dst = 0;
   // Resolve source base pointers once; see try_execute_binary_vop2_simd. The
   // compare writes only the SGPR-pair mask, so there is no dst pointer to hoist.
   const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
@@ -1298,7 +1297,7 @@ template <typename T, typename Inst, typename CmpOp>
   constexpr std::size_t W = util::native_width64;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
   const uint64_t exec = wf.exec();
-  uint64_t dst = inst.vdst.read_scalar64(wf);
+  uint64_t dst = 0;
   // Resolve source base pointers once; see try_execute_binary_vop2_simd. The
   // compare writes only the SGPR-pair mask, so there is no dst pointer to hoist.
   const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
@@ -1349,7 +1348,7 @@ template <typename Inst, typename CmpOp>
   constexpr std::size_t W = util::native_width_v<T>;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
   const uint64_t exec = wf.exec();
-  uint64_t dst = inst.vdst.read_scalar64(wf);
+  uint64_t dst = 0;
   // Resolve source base pointers once; see try_execute_binary_vop2_simd. The
   // compare writes only the SGPR-pair mask, so there is no dst pointer to hoist.
   const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
@@ -1398,7 +1397,7 @@ template <typename Inst, typename CmpOp>
   constexpr std::size_t W = util::native_width_v<T>;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
   const uint64_t exec = wf.exec();
-  uint64_t dst = inst.vdst.read_scalar64(wf);
+  uint64_t dst = 0;
   // Resolve source base pointers once; see try_execute_binary_vop2_simd. The
   // compare writes only the SGPR-pair mask, so there is no dst pointer to hoist.
   const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
@@ -1450,7 +1449,7 @@ template <typename Inst, typename CmpOp>
   constexpr std::size_t W = util::native_width64;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
   const uint64_t exec = wf.exec();
-  uint64_t dst = inst.vdst.read_scalar64(wf);
+  uint64_t dst = 0;
   // Resolve source base pointers once; see try_execute_binary_vop2_simd. The
   // compare writes only the SGPR-pair mask, so there is no dst pointer to hoist.
   const ConstVgprStoragePair64 rs0 = simd_src_reg64(inst.src0, wf);
@@ -2381,7 +2380,7 @@ template <typename Inst, typename CarryOp>
   constexpr std::size_t W = util::native_width_v<T>;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
   const uint64_t exec = wf.exec();
-  uint64_t carry_out = wf.vcc();
+  uint64_t carry_out = 0;
   const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
   const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
   const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));
@@ -2425,7 +2424,7 @@ template <typename Inst, typename CarryOp>
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
   const uint64_t exec = wf.exec();
   const uint64_t cin_all = inst.src2.read_scalar64(wf);
-  uint64_t carry_out = wf.vcc();
+  uint64_t carry_out = 0;
   const VgprStorage *r0 = simd_src_reg(inst.src0, wf);
   const VgprStorage *r1 = simd_src_reg(inst.src1, wf);
   const auto a_bcast = r0 ? util::native<T>{} : util::broadcast<T>(inst.src0.read_scalar(wf));

--- a/emulation/rocjitsu/tests/hip_cvt_narrow_test.cpp
+++ b/emulation/rocjitsu/tests/hip_cvt_narrow_test.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <limits>
 #include <vector>
 
 #include "util/data_types.h"

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_carry_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_carry_simd_correctness_test.cpp
@@ -195,12 +195,12 @@ void check_case(const CarryCase &c, uint64_t exec) {
             << c.label << ": clobbered inactive dst lane " << lane;
       }
     }
-    // Inactive EXEC lanes must keep their incoming VCC bit.
+    // Inactive EXEC lanes must be zeroed in the carry-out.
     const uint64_t inactive = ~exec;
-    EXPECT_EQ(simd_out.vcc & inactive, vcc_in & inactive)
-        << c.label << " vcc_in=0x" << std::hex << vcc_in << ": altered an inactive-lane VCC bit";
-    EXPECT_EQ(scalar_out.vcc & inactive, vcc_in & inactive)
-        << c.label << " vcc_in=0x" << std::hex << vcc_in << ": altered an inactive-lane VCC bit";
+    EXPECT_EQ(simd_out.vcc & inactive, 0ULL)
+        << c.label << " vcc_in=0x" << std::hex << vcc_in << ": inactive-lane VCC bit not zeroed";
+    EXPECT_EQ(scalar_out.vcc & inactive, 0ULL)
+        << c.label << " vcc_in=0x" << std::hex << vcc_in << ": inactive-lane VCC bit not zeroed";
   }
 }
 

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_carry_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_carry_simd_correctness_test.cpp
@@ -14,8 +14,8 @@
 /// asserted with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate
 /// in-process). Inputs deliberately seed the
 /// 32-bit carry/borrow boundary (0xFFFFFFFF+1, a<b, a==b+cin, ...) on the low
-/// lanes — random-only inputs hide these corners. In-process the test still
-/// checks inactive-lane dst/VCC preservation under full and partial EXEC masks.
+/// lanes — random-only inputs hide these corners. Inactive-lane carry-out VCC
+/// bits are zeroed under full and partial EXEC masks.
 
 #include "util/simd_test_hooks.h"
 
@@ -138,7 +138,7 @@ const CarryCase kCases[] = {
 };
 
 // Carry-in VCC patterns to seed before execution. addc/subb/subbrev read these;
-// the non-carry-in forms ignore them but must still leave inactive bits intact.
+// the non-carry-in forms ignore them. Inactive carry-out bits are zeroed.
 const uint64_t kVccPatterns[] = {
     0x0000000000000000ULL, 0xFFFFFFFFFFFFFFFFULL, 0xAAAAAAAAAAAAAAAAULL,
     0x5555555555555555ULL, 0x0123456789ABCDEFULL,
@@ -220,7 +220,7 @@ TEST(Vop2CarrySimdCorrectness, PartialExecMask) {
   }
   // Sparse/alternating pattern crossing SIMD chunk boundaries: exercises the
   // masked result store and per-chunk VCC merge (active bits updated, inactive
-  // preserved) on both halves of a wave64.
+  // zeroed) on both halves of a wave64.
   for (const auto &c : kCases)
     check_case(c, /*exec=*/0xA5A5'F0F0'1234'8001ULL);
 }

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_carry_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_carry_simd_correctness_test.cpp
@@ -10,7 +10,7 @@
 ///     v_add_co_ci_u32, v_sub_co_ci_u32, v_subrev_co_ci_u32
 /// All six cin-form scalar bodies pull per-lane carry-in from
 /// `inst.src2.read_scalar64(wf)` (SGPR-pair) and write co into
-/// `inst.sdst.write_scalar64`, with inactive lanes preserved from the
+/// `inst.sdst.write_scalar64`, with inactive lanes zeroed in the
 /// incoming VCC. Each (case, vcc_in, cin) runs TWICE in the same process -- once
 /// forcing the scalar body, once the SIMD fast path, with identical inputs --
 /// and the scalar-vs-SIMD equivalence on BOTH the destination VGPR AND the full

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_cmp_class_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_cmp_class_simd_correctness_test.cpp
@@ -10,7 +10,7 @@
 /// the scalar body, once the SIMD fast path, with identical inputs/EXEC/VCC-in
 /// -- and the full 64-bit VCC results are asserted equal with EXPECT_EQ
 /// (util::set_force_scalar_for_testing flips the gate in-process). In-process
-/// inactive-lane VCC bits must stay preserved under full and partial EXEC.
+/// inactive-lane VCC bits must be zeroed under full and partial EXEC.
 ///
 /// f16 and f32 read src0 as 32-bit raw bits; f64 reads src0 as a 64-bit VGPR pair
 /// while vsrc1 stays a 32-bit mask (the mixed-width class glue). The
@@ -236,10 +236,10 @@ void check_all(uint64_t exec) {
                                         << vcc_in << ": SIMD VCC diverged from scalar body";
 
         const uint64_t inactive = ~exec;
-        EXPECT_EQ(simd_vcc & inactive, vcc_in & inactive)
-            << c.name << " rot=" << rot << ": altered an inactive-lane VCC bit";
-        EXPECT_EQ(scalar_vcc & inactive, vcc_in & inactive)
-            << c.name << " rot=" << rot << ": altered an inactive-lane VCC bit";
+        EXPECT_EQ(simd_vcc & inactive, 0ULL)
+            << c.name << " rot=" << rot << ": inactive-lane VCC bit not zeroed";
+        EXPECT_EQ(scalar_vcc & inactive, 0ULL)
+            << c.name << " rot=" << rot << ": inactive-lane VCC bit not zeroed";
       }
     }
   }
@@ -289,10 +289,10 @@ void check_all_vop3(uint64_t exec) {
                 << std::hex << vcc_in << ": SIMD VCC diverged from scalar body";
 
             const uint64_t inactive = ~exec;
-            EXPECT_EQ(simd_vcc & inactive, vcc_in & inactive)
-                << c.name << " abs=" << abs << " neg=" << neg << ": altered inactive VCC bit";
-            EXPECT_EQ(scalar_vcc & inactive, vcc_in & inactive)
-                << c.name << " abs=" << abs << " neg=" << neg << ": altered inactive VCC bit";
+            EXPECT_EQ(simd_vcc & inactive, 0ULL)
+                << c.name << " abs=" << abs << " neg=" << neg << ": inactive VCC bit not zeroed";
+            EXPECT_EQ(scalar_vcc & inactive, 0ULL)
+                << c.name << " abs=" << abs << " neg=" << neg << ": inactive VCC bit not zeroed";
           }
         }
       }

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_simd_correctness_test.cpp
@@ -6,13 +6,12 @@
 /// compares wired into SIMD_VOPC / SIMD_VOPC64: the f32/f16/f64 relations
 /// (eq/ge/gt/le/lg/lt/neq/nge/ngt/nle/nlg/nlt/o/u/f/tru) and the
 /// i32/u32/i16/u16/i64/u64 relations (eq/ge/gt/le/lt/ne/f/t). Each writes one bit
-/// per active EXEC lane into VCC, preserving inactive bits. Each (opcode,
+/// per active EXEC lane into VCC, zeroing inactive-lane bits. Each (opcode,
 /// vcc_in) runs TWICE in the same process -- once forcing the scalar body, once
 /// the SIMD fast path, with identical inputs/EXEC/VCC-in -- and the full 64-bit
 /// VCC compare results are asserted equal with EXPECT_EQ
-/// (util::set_force_scalar_for_testing flips the gate in-process). In-process
-/// inactive-lane VCC bits must be zeroed;
-/// preserved under full and partial EXEC. The 64-bit relations exercise the
+/// (util::set_force_scalar_for_testing flips the gate in-process). Inactive-lane
+/// VCC bits are zeroed under full and partial EXEC. The 64-bit relations exercise the
 /// split lo/hi VGPR-pair read path. Inputs seed NaN/±Inf/±0/denorm (floats) and
 /// signed/extreme boundaries (ints); float compares are bit-exact in both modes.
 

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_simd_correctness_test.cpp
@@ -11,7 +11,7 @@
 /// the SIMD fast path, with identical inputs/EXEC/VCC-in -- and the full 64-bit
 /// VCC compare results are asserted equal with EXPECT_EQ
 /// (util::set_force_scalar_for_testing flips the gate in-process). In-process
-/// inactive-lane VCC bits must stay
+/// inactive-lane VCC bits must be zeroed;
 /// preserved under full and partial EXEC. The 64-bit relations exercise the
 /// split lo/hi VGPR-pair read path. Inputs seed NaN/±Inf/±0/denorm (floats) and
 /// signed/extreme boundaries (ints); float compares are bit-exact in both modes.
@@ -198,10 +198,10 @@ void check_all(uint64_t exec) {
                                       << vcc_in << ": SIMD VCC diverged from scalar body";
 
       const uint64_t inactive = ~exec;
-      EXPECT_EQ(simd_vcc & inactive, vcc_in & inactive)
-          << "VOPC opcode " << c.opcode << ": altered an inactive-lane VCC bit";
-      EXPECT_EQ(scalar_vcc & inactive, vcc_in & inactive)
-          << "VOPC opcode " << c.opcode << ": altered an inactive-lane VCC bit";
+      EXPECT_EQ(simd_vcc & inactive, 0ULL)
+          << "VOPC opcode " << c.opcode << ": inactive-lane VCC bit not zeroed";
+      EXPECT_EQ(scalar_vcc & inactive, 0ULL)
+          << "VOPC opcode " << c.opcode << ": inactive-lane VCC bit not zeroed";
     }
   }
 }

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp16_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp16_simd_correctness_test.cpp
@@ -12,7 +12,7 @@
 /// -- once forcing the scalar body, once the SIMD fast path, with identical
 /// inputs/EXEC/VCC-in -- and the 64-bit compare results are asserted equal with
 /// EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
-/// In-process inactive SGPR-pair bits must be preserved.
+/// In-process inactive SGPR-pair bits must be zeroed.
 
 #include "util/simd_test_hooks.h"
 
@@ -169,12 +169,12 @@ void check_case(const Case &c, uint64_t exec) {
               << std::hex << vcc_in << ": SIMD result diverged from scalar body";
 
           const uint64_t inactive = ~exec;
-          EXPECT_EQ(simd_vcc & inactive, vcc_in & inactive)
+          EXPECT_EQ(simd_vcc & inactive, 0ULL)
               << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot
-              << ": altered inactive-lane dst bit";
-          EXPECT_EQ(scalar_vcc & inactive, vcc_in & inactive)
+              << ": inactive-lane dst bit not zeroed";
+          EXPECT_EQ(scalar_vcc & inactive, 0ULL)
               << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot
-              << ": altered inactive-lane dst bit";
+              << ": inactive-lane dst bit not zeroed";
         }
       }
     }

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp32_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp32_simd_correctness_test.cpp
@@ -12,7 +12,7 @@
 /// same process -- once forcing the scalar body, once the SIMD fast path, with
 /// identical inputs/EXEC/VCC-in -- and the 64-bit compare results are asserted
 /// equal with EXPECT_EQ (util::set_force_scalar_for_testing flips the gate
-/// in-process). In-process inactive SGPR-pair bits must be preserved.
+/// in-process). In-process inactive SGPR-pair bits must be zeroed.
 
 #include "util/simd_test_hooks.h"
 
@@ -177,12 +177,12 @@ void check_case(const Case &c, uint64_t exec) {
               << std::hex << vcc_in << ": SIMD result diverged from scalar body";
 
           const uint64_t inactive = ~exec;
-          EXPECT_EQ(simd_vcc & inactive, vcc_in & inactive)
+          EXPECT_EQ(simd_vcc & inactive, 0ULL)
               << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot
-              << ": altered inactive-lane dst bit";
-          EXPECT_EQ(scalar_vcc & inactive, vcc_in & inactive)
+              << ": inactive-lane dst bit not zeroed";
+          EXPECT_EQ(scalar_vcc & inactive, 0ULL)
               << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot
-              << ": altered inactive-lane dst bit";
+              << ": inactive-lane dst bit not zeroed";
         }
       }
     }

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_fp64_simd_correctness_test.cpp
@@ -12,7 +12,7 @@
 /// -- once forcing the scalar body, once the SIMD fast path, with identical
 /// inputs/EXEC/VCC-in -- and the 64-bit compare results are asserted equal with
 /// EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
-/// In-process inactive SGPR-pair bits must be preserved.
+/// In-process inactive SGPR-pair bits must be zeroed.
 
 #include "util/simd_test_hooks.h"
 
@@ -174,12 +174,12 @@ void check_case(const Case &c, uint64_t exec) {
               << std::hex << vcc_in << ": SIMD result diverged from scalar body";
 
           const uint64_t inactive = ~exec;
-          EXPECT_EQ(simd_vcc & inactive, vcc_in & inactive)
+          EXPECT_EQ(simd_vcc & inactive, 0ULL)
               << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot
-              << ": altered inactive-lane dst bit";
-          EXPECT_EQ(scalar_vcc & inactive, vcc_in & inactive)
+              << ": inactive-lane dst bit not zeroed";
+          EXPECT_EQ(scalar_vcc & inactive, 0ULL)
               << c.name << " abs=" << abs << " neg=" << neg << " rot=" << rot
-              << ": altered inactive-lane dst bit";
+              << ": inactive-lane dst bit not zeroed";
         }
       }
     }

--- a/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_int_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vopc_vop3_int_simd_correctness_test.cpp
@@ -11,7 +11,7 @@
 /// -- once forcing the scalar body, once the SIMD fast path, with identical
 /// inputs/EXEC/VCC-in -- and the 64-bit compare results are asserted equal with
 /// EXPECT_EQ (util::set_force_scalar_for_testing flips the gate in-process).
-/// In-process inactive SGPR-pair bits must be preserved.
+/// In-process inactive SGPR-pair bits must be zeroed.
 ///
 /// Coverage: every (rel, suffix) pair routed through try_execute_vopc_vop3_*_int_simd
 /// — 8 rels × {i16,u16,i32,u32,i64,u64} = 48 ops, full + partial EXEC. Each lane
@@ -250,10 +250,10 @@ void check_case(const Case &c, uint64_t exec) {
                                       << vcc_in << ": SIMD result diverged from scalar body";
 
       const uint64_t inactive = ~exec;
-      EXPECT_EQ(simd_vcc & inactive, vcc_in & inactive)
-          << c.name << " rot=" << rot << ": altered inactive-lane dst bit";
-      EXPECT_EQ(scalar_vcc & inactive, vcc_in & inactive)
-          << c.name << " rot=" << rot << ": altered inactive-lane dst bit";
+      EXPECT_EQ(simd_vcc & inactive, 0ULL)
+          << c.name << " rot=" << rot << ": inactive-lane dst bit not zeroed";
+      EXPECT_EQ(scalar_vcc & inactive, 0ULL)
+          << c.name << " rot=" << rot << ": inactive-lane dst bit not zeroed";
     }
   }
 }


### PR DESCRIPTION
## Motivation
Fix issues across several floating point instruction classes that prevented FP San tests from passing. Additional correctness bugs identified during PR review have also been addressed, including codegen pipeline gaps that caused regeneration to overwrite correct hand-written C++.

## Technical Details
See the individual commit messages for the fixes needed. The following additional bugs were fixed based on PR review feedback:

- **VOP3 opsel always zero**: `src_hi` was computed from a hardcoded `0u & 1` (always false) instead of reading `inst_.opsel`, causing `v_cvt_pk_f32_{fp8,bf8}` and `v_cvt_pk_{fp8,bf8}_f32` to always decode/encode the low 16-bit half regardless of the opsel field. Fixed in `rdna4` and `gfx1250` generated C++ and in the `_opsel_field()` codegen helper.
- **`v_cvt_pk_u16_f32` wrong clamp range**: The unsigned U16 variant was clamping to the signed i16 range `[-32768, 32767]` and storing into `int16_t`. Fixed to use `uint16_t` with the correct unsigned range `[0.0f, 65535.0f]` and proper `std::bit_cast<float>` source interpretation. Fixed in `rdna3`, `rdna3_5`, `rdna4`, and `gfx1250`.
- **VOP3PX2 decoder ill-formed `decltype`**: The prefix decoder used `decltype(op)` in `op`'s own initializer, which is ill-formed C++. Changed to `auto` with an explicit cast type.
- **Dead placeholder in `_generator.py`**: A stub function used `pass` before unreachable code referencing undefined names; changed to `return` to prevent accidental fallthrough.
- **Missing `<limits>` include**: Added the missing `#include <limits>` to `hip_cvt_narrow_test.cpp`.
- **VOP3PX2 prefix decoding missing from codegen**: The codegen pipeline lacked support for emitting a `decodeVop3pX2Prefix` handler in the VOP3P sub-decode table. Added `vop3px2_prefix_opcode` profile property (0x2C for CDNA) and wired codegen to inject the prefix decoder and the `x2_dw1_` constructor member (initialized from `inst[-1]`) for VOP3PX2 MFMA instructions.
- **F8F6F4 MFMA using wrong dispatch path**: Codegen was emitting a fixed-width `exec_f32` call for F8F6F4 MFMAs instead of using `dispatch_matrix_fmt_pair` → `exec_f32_mixed` / `exec_f32_scaled_mixed`. Also removed the broken `reinterpret_cast(&inst_)[-1]` undefined-behavior pattern for accessing the X2 prefix dword.
- **SMFMAC cdna4 missing cross-lane helpers**: Codegen was emitting a naive per-lane functional model for cdna4 SMFMAC F16/BF16/FP8/BF8 instructions instead of calling the correct `exec_smfmac_*` helpers with the appropriate `smfmac_read_*` functions.

## JIRA ID
N/A

## Test Plan
Run CI and FP San tests

## Test Result
- All CI tests: PASSED
- FPSan classify, SMFMAC, and scaled MFMA tests: PASSED

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.