### PR TITLE
[rocprofiler-compute] Correct CHANGELOG

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -15,6 +15,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Added support for GPU metrics on gfx1150 and gfx1152 hardware.
 
+* Added roofline benchmarking support for gfx1150 and gfx1152 hardware.
+
 ### Changed
 
 * Moved `--gui` and `--tui` analyze options to experimental status. These features now require the `--experimental` flag to be enabled (e.g., `rocprof-compute analyze --experimental --gui`).

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -2,24 +2,6 @@
 
 Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/](https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/).
 
-## Unreleased
-
-### Added
-
-* Added GPU benchmarking support for gfx1150 and gfx1152 hardware.
-* Added GPU support of GPU metrics for gfx1150 and gfx1152 hardware.
-
-### Changed
-
-### Removed
-
-### Optimized
-
-### Resolved issues
-
-### Upcoming changes
-
-### Known issues
 
 ## ROCm Compute Profiler 3.7.0 for ROCm 7.14.0
 
@@ -30,6 +12,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 * Added LDS arithmetic intensity as a roofline plot point and analysis database field.
 
 * Added backward compatibility for live attach mode to work with older ROCm 7.x.x releases.
+
+* Added GPU support of GPU metrics for gfx1150 and gfx1152 hardware.
 
 ### Changed
 

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -13,7 +13,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Added backward compatibility for live attach mode to work with older ROCm 7.x.x releases.
 
-* Added GPU support of GPU metrics for gfx1150 and gfx1152 hardware.
+* Added support for GPU metrics on gfx1150 and gfx1152 hardware.
 
 ### Changed
 


### PR DESCRIPTION
## Motivation

Correct the changelog sectioning.
CHANGELOG had 'unreleased' section removed early yesterday but was readded in a different commit after a merge resolve later yesterday.

## Technical Details

- Remove unreleased section
- Move GPU metrics bulletpoint into "added" section of 7.14
- Remove the GPU benchmarking bulletpoint; it is already covered in 7.14 Added section under the --bench-only entry

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
