### PR TITLE
[AMD-SMI] Harden ualoe_lib: bounds checks, MAC overread guards, pre-5.1 polyfill

### DIFF
--- a/projects/amdsmi/include/ualoe_lib/cbl_cfg/uapi.h
+++ b/projects/amdsmi/include/ualoe_lib/cbl_cfg/uapi.h
@@ -25,8 +25,23 @@
 
 #include <linux/if_ether.h>
 #include <linux/ioctl.h>
-#include <linux/time_types.h>
 #include <linux/types.h>
+#include <linux/version.h>
+
+/* <linux/time_types.h> only exists in kernel headers >= 5.1 (Aug 2019).
+ * Provide a portable shim for older targets (e.g. Debian 10 / kernel 4.19),
+ * matching the kernel definition exactly. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 1, 0)
+#include <linux/time_types.h>
+#else
+#ifndef __kernel_timespec_defined
+#define __kernel_timespec_defined
+struct __kernel_timespec {
+  __kernel_long_t tv_sec;
+  long long tv_nsec;
+};
+#endif
+#endif
 
 #define CFG_LABEL_SIZE 32
 #define CFG_PCI_ADDR_MAX_LEN 32

--- a/projects/amdsmi/src/ualoe_lib/ualoe_cdev.c
+++ b/projects/amdsmi/src/ualoe_lib/ualoe_cdev.c
@@ -152,12 +152,12 @@ int ualoe_cdev_close(ualoe_handle_t handle) {
   int rc;
 
   rc = ualoe_cdev_find_handle(handle, &cdev_handle);
-  if (!rc) {
-    pthread_mutex_lock(&cdev_handle_lock);
-    LIST_REMOVE(cdev_handle, lentry);
-    pthread_mutex_unlock(&cdev_handle_lock);
-    free(cdev_handle);
-  }
+  if (rc) return rc;
+
+  pthread_mutex_lock(&cdev_handle_lock);
+  LIST_REMOVE(cdev_handle, lentry);
+  pthread_mutex_unlock(&cdev_handle_lock);
+  free(cdev_handle);
 
   ualoe_cb_fini(handle);
 
@@ -573,6 +573,14 @@ int ualoe_cdev_telemetry_get(ualoe_handle_t handle, ualoe_telemetry_t* telemetry
     /* Skip NULL datasets (filtered categories) */
     if (telemetry->datasets[i] == NULL) continue;
 
+    if (cfg_tele.datasets[i].instance_count > CFG_TELEMETRY_MAX_INSTANCES) {
+      ualoe_log_error(
+          "Failed to get telemetry, category %d instance_count %u exceeds maximum %d.\n", i,
+          cfg_tele.datasets[i].instance_count, CFG_TELEMETRY_MAX_INSTANCES);
+      rc = EINVAL;
+      goto out_free_instances;
+    }
+
     telemetry->datasets[i]->category = cfg_tele.datasets[i].category;
     telemetry->datasets[i]->generation_count = cfg_tele.datasets[i].generation_count;
     telemetry->datasets[i]->timestamp = cfg_tele.datasets[i].timestamp;
@@ -588,6 +596,13 @@ int ualoe_cdev_telemetry_get(ualoe_handle_t handle, ualoe_telemetry_t* telemetry
 
       telemetry->datasets[i]->instances[j].logical_idx =
           cfg_tele.datasets[i].instances[j].logical_id;
+      if (cfg_tele.datasets[i].instances[j].item_count > CFG_TELEMETRY_MAX_ITEMS) {
+        ualoe_log_error(
+            "Failed to get telemetry, category %d instance %d item_count %u exceeds maximum %d.\n",
+            i, j, cfg_tele.datasets[i].instances[j].item_count, CFG_TELEMETRY_MAX_ITEMS);
+        rc = EINVAL;
+        goto out_free_instances;
+      }
       telemetry->datasets[i]->instances[j].item_count =
           cfg_tele.datasets[i].instances[j].item_count;
       for (int k = 0; k < telemetry->datasets[i]->instances[j].item_count; k++) {

--- a/projects/amdsmi/src/ualoe_lib/ualoe_nl.c
+++ b/projects/amdsmi/src/ualoe_lib/ualoe_nl.c
@@ -230,16 +230,16 @@ int ualoe_nl_open(const char* name, ualoe_handle_t* handle) {
   rc = ualoe_nl_connect(nl_handle, name);
   if (rc) goto free_socket;
 
-  pthread_mutex_lock(&handle_lock);
-  LIST_INSERT_HEAD(&open_handles, nl_handle, lentry);
-  pthread_mutex_unlock(&handle_lock);
-
   /**
    * For now, keep cdev fd for ioctl calls until netlink support is
    * added for all operations.
    */
   rc = ualoe_cdev_open(name, &nl_handle->cdev_fd);
   if (rc) goto free_socket;
+
+  pthread_mutex_lock(&handle_lock);
+  LIST_INSERT_HEAD(&open_handles, nl_handle, lentry);
+  pthread_mutex_unlock(&handle_lock);
 
   *handle = nl_handle->fd;
 
@@ -1857,9 +1857,11 @@ static int ifoe_nl_parse_netport_state(const struct nlattr* attr, void* data) {
       state->loopback_mode = mnl_attr_get_u32(attr);
       break;
     case CFG_ATTR_NETPORT_IFOE_MAC_ADDR:
+      if (mnl_attr_get_payload_len(attr) < UALOE_MAC_ADDRESS_SIZE) return MNL_CB_ERROR;
       memcpy(state->ifoe_mac_addr, mnl_attr_get_payload(attr), UALOE_MAC_ADDRESS_SIZE);
       break;
     case CFG_ATTR_NETPORT_PERM_ADDR:
+      if (mnl_attr_get_payload_len(attr) < UALOE_MAC_ADDRESS_SIZE) return MNL_CB_ERROR;
       memcpy(state->permanent_mac_addr, mnl_attr_get_payload(attr), UALOE_MAC_ADDRESS_SIZE);
       break;
     default:


### PR DESCRIPTION
Consolidate the ualoe_lib infrastructure changes that were previously
scattered across other AMD SMI PRs into one focused change:

**uapi.h:**
- Polyfill `__kernel_timespec` for kernel headers < 5.1, so targets with
  older sanitized UAPI headers (e.g. Debian 10 / kernel 4.19) build.

**ualoe_cdev.c:**
- Bounds-check telemetry `instance_count` and `item_count` against
  `CFG_TELEMETRY_MAX_INSTANCES` / `CFG_TELEMETRY_MAX_ITEMS`, returning EINVAL
  instead of overflowing the caller's buffers.
- Flatten `ualoe_cdev_close()` to early-return on lookup failure.

**ualoe_nl.c:**
- Register the handle in `open_handles` only after `ualoe_cdev_open()`
  succeeds, so a half-open handle is never visible to other threads.
- Reject netport MAC attributes shorter than `UALOE_MAC_ADDRESS_SIZE`
  before memcpy, preventing a buffer overread from malformed netlink data.