### PR TITLE
[hip-tests] [ASAN] fix indexing of test

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -56,18 +56,6 @@ DynCO::~DynCO() {
       assert(err == hipSuccess);
     }
 
-    if (elem.second->GetVarKind() == Var::DVK_Variable) {
-      for (auto dev : g_devices) {
-        amd::Memory* mem = nullptr;
-        hipError_t err = elem.second->GetDeviceVarPtr(&mem, dev->deviceId());
-        assert(err == hipSuccess);
-        if (mem != nullptr) {
-          // free also deletes the device ptr
-          err = ihipFree(memDevPtr(mem));
-          assert(err == hipSuccess);
-        }
-      }
-    }
     delete elem.second;
   }
   vars_.clear();

--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -403,15 +403,6 @@ hipError_t StatCO::RemoveFatBinary(FatBinaryInfo** module) {
   if (managedVarsIter != managedVars_.end()) {
     for (auto& managedVar : managedVarsIter->second) {
       hipError_t err = hipSuccess;
-      for (auto dev : g_devices) {
-        amd::Memory* mem = nullptr;
-        IHIP_RETURN_ONFAIL(managedVar->GetDeviceVarPtr(&mem, dev->deviceId()));
-        if (mem != nullptr) {
-          // free also deletes the device ptr
-          err = ihipFree(memDevPtr(mem));
-          assert(err == hipSuccess);
-        }
-      }
       if (managedVar->GetAllocFlag()) {  // check if it is a managed or host alloc
         err = ihipFree(*(static_cast<void**>(managedVar->GetManagedVarPtr())));
       } else {

--- a/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
@@ -311,12 +311,12 @@ static constexpr auto ROWS{8};
 static constexpr auto CHUNK_LOOP{100};
 
 
-template <typename T> __global__ void copy_var(T* A, T* B, size_t ROWS, size_t pitch_A) {
-  const size_t pitch = pitch_A / sizeof(T);
-  const size_t size = ROWS * pitch;
+template <typename T> __global__ void copy_var(T* A, T* B, size_t ROWS, size_t pitch_A, size_t pitch_B) {
+  const size_t pitcha = pitch_A / sizeof(T), pitchb = pitch_B / sizeof(T);
+  const size_t sizea = ROWS * pitcha, sizeb = ROWS * pitchb;
 
-  for (size_t i = 0; i < size; i += pitch) {
-    A[i] = B[i];
+  for (size_t ia = 0, ib = 0; ia < sizea && ib < sizeb; ia += pitcha, ib += sizeb) {
+    B[ib] = A[ia];
   }
 }
 template <typename T> static bool validateResult(T* A, T* B, size_t pitch_A) {
@@ -479,11 +479,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMallocPitch_KernelLaunch, int, float, double) {
   HIP_CHECK(hipMemcpy2D(A_d, pitch_A, A_h, COLUMNS * sizeof(TestType), COLUMNS * sizeof(TestType),
                         ROWS, hipMemcpyHostToDevice));
 
-
-  // Since we will be iterating over both array with same index
-  REQUIRE(pitch_A == pitch_B);
   hipLaunchKernelGGL(copy_var<TestType>, dim3(1), dim3(1), 0, 0, static_cast<TestType*>(A_d),
-                     static_cast<TestType*>(B_d), ROWS, pitch_A);
+                     static_cast<TestType*>(B_d), ROWS, pitch_A, pitch_B);
   HIP_CHECK(hipGetLastError());
 
 

--- a/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocPitch.cc
@@ -312,7 +312,10 @@ static constexpr auto CHUNK_LOOP{100};
 
 
 template <typename T> __global__ void copy_var(T* A, T* B, size_t ROWS, size_t pitch_A) {
-  for (uint64_t i = 0; i < ROWS * pitch_A; i = i + pitch_A) {
+  const size_t pitch = pitch_A / sizeof(T);
+  const size_t size = ROWS * pitch;
+
+  for (size_t i = 0; i < size; i += pitch) {
     A[i] = B[i];
   }
 }
@@ -477,6 +480,8 @@ HIP_TEMPLATE_TEST_CASE(Unit_hipMallocPitch_KernelLaunch, int, float, double) {
                         ROWS, hipMemcpyHostToDevice));
 
 
+  // Since we will be iterating over both array with same index
+  REQUIRE(pitch_A == pitch_B);
   hipLaunchKernelGGL(copy_var<TestType>, dim3(1), dim3(1), 0, 0, static_cast<TestType*>(A_d),
                      static_cast<TestType*>(B_d), ROWS, pitch_A);
   HIP_CHECK(hipGetLastError());


### PR DESCRIPTION
## Motivation

Fix the indexing of the test and remove the double free of resources in clr

## Technical Details

It was reading out of bounds. Fix the indexing to honor the size of types.
in CLR we are already removing memory when we destroy `managedVar`. Remove the double free of resources.

## JIRA ID

NA

## Test Plan

Tested with ASAN to show no out of bounds reads

## Test Result

The out of bound read error goes away.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
