### PR TITLE
[clr][graph] Skip empty node markers and remove pre/post barriers for uncaptured nodes

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1452,6 +1452,16 @@ hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
         size_t j = i;
         while (j < segment.nodes.size() && segment.nodes[j]->GraphCaptureEnabled()) {
           auto& currentNode = segment.nodes[j];
+          // Empty nodes are pure dependency points — no GPU commands or markers.
+          // Cross-stream ordering is handled by BuildSyncPlan barrier packets.
+          if (currentNode->GetType() == hipGraphNodeTypeEmpty) {
+            const size_t rangeIndex = newBatch.nodeRanges.size();
+            newBatch.nodeRanges.push_back({newBatch.dispatchPackets.size(), 0, true});
+            newBatch.nodeToRangeIndex[currentNode] = rangeIndex;
+            currentSegBatch.node_capture_status[j] = true;
+            ++j;
+            continue;
+          }
           // Capture packets for this node
           std::vector<uint8_t*> nodePackets;
           std::vector<const std::string*> nodeKernelNames;
@@ -1488,8 +1498,10 @@ hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
           ++j;
         }
 
-        // Add the batch containing all consecutive captured nodes and advance outer index
-        currentSegBatch.packet_batches.push_back(std::move(newBatch));
+        // Add the batch if it contains packets or captured zero-packet nodes (e.g. EMPTY).
+        if (!newBatch.dispatchPackets.empty() || !newBatch.nodeRanges.empty()) {
+          currentSegBatch.packet_batches.push_back(std::move(newBatch));
+        }
         i = j - 1;  // for-loop will ++i to j
       } else {
         // Non-capturable node
@@ -2001,9 +2013,7 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
   // attach_signal=true asks the dispatcher to give the last packet a real
   // completion signal (via Barriers().ActiveSignal) so a downstream
   // uncaptured node — typically an SDMA memcpy on a different engine — can
-  // wait on it directly through HwQueueTracker::WaitingSignal, avoiding
-  // the otherwise-required pre/post Marker barriers around the uncaptured
-  // node.
+  // wait on it directly through HwQueueTracker::WaitingSignal.
   auto dispatchCurrentBatch = [&](bool attach_signal = false) -> hipError_t {
     if (!segBatch || batchIndex >= segBatch->packet_batches.size()) {
       return hipSuccess;
@@ -2141,19 +2151,9 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
         if (status != hipSuccess) return status;
       }
     } else {
-      // Node doesn't support capture - execute individually.
-      // Flat dispatch bypasses the Barriers() tracker (ActiveSignal is skipped).
-      // Enqueue Markers before and after the non-captured node to:
-      //   Before: resync the Barriers() tracker so releaseGpuMemoryFence/WaitCurrent
-      //           can track queue progress for the node's internal operations.
-      //   After:  ensure the node's commands (e.g. host node blocking callbacks) are
-      //           fully flushed to the HW queue before the next flat batch is
-      //           dispatched, which writes directly to the HW queue.
-      auto pre_marker = new amd::Marker(*stream, kMarkerDisableFlush, {});
-      if (pre_marker != nullptr) {
-        pre_marker->enqueue();
-        pre_marker->release();
-      }
+      // Node doesn't support capture - execute individually. Upstream flat batches
+      // hand off via attach_signal (SDMA memcpy) or BuildSyncPlan dep barriers;
+      // no pre/post Markers needed around the uncaptured node.
       if (DEBUG_HIP_GRAPH_DOT_PRINT) {
         node->stream_id_ = stream->GetStreamId();
         node->hw_queue_id_ = stream->getQueueID();
@@ -2162,11 +2162,6 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
       status = node->CreateCommand(node->GetQueue());
       if (status != hipSuccess) return status;
       node->EnqueueCommands(stream);
-      auto post_marker = new amd::Marker(*stream, kMarkerDisableFlush, {});
-      if (post_marker != nullptr) {
-        post_marker->enqueue();
-        post_marker->release();
-      }
     }
   }
 

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2866,6 +2866,16 @@ class GraphEmptyNode : public GraphNode {
 
   GraphNode* clone() const override { return new GraphEmptyNode(*this); }
 
+  // Empty nodes participate in AQL capture as zero-packet dependency points.
+  // The capture loop registers them as zero-packet nodeRanges so dependency
+  // tracking works without emitting any GPU commands.
+  bool GraphCaptureEnabled() override {
+    if (parentGraph_ != nullptr && parentGraph_->IsSegmentSchedulingEnabled()) {
+      return true;
+    }
+    return false;
+  }
+
   hipError_t CreateCommand(hip::Stream* stream) override {
     hipError_t status = GraphNode::CreateCommand(stream);
     if (status != hipSuccess) {


### PR DESCRIPTION
## Summary

- **Empty node capture**: Empty nodes are pure dependency points with no GPU work. They are now recognized during AQL packet capture and registered as zero-packet ranges. Cross-stream ordering is handled entirely by \`BuildSyncPlan\` barrier packets — no separate Marker commands needed.

- **Remove pre/post Markers for uncaptured nodes**: Removed the \`pre_marker\`/\`post_marker\` pair enqueued around non-AQL nodes in \`EnqueueSegment\`. These were added to resync the \`Barriers()\` tracker but are unnecessary since upstream flat batches hand off via \`attach_signal\` (SDMA memcpy) or \`BuildSyncPlan\` dep barriers, and uncaptured node commands enqueue directly to the HW queue in order.

## Test plan

- [x] Run HIP graph tests: \`hipGraphLaunch\`, empty node dependencies, host nodes
- [x] Run PyFR couette-flow benchmark to verify no regression
- [x] Verify \`hipGraphNodeTypeEmpty\` nodes correctly propagate dependencies without emitting GPU packets

🤖 Generated with [Claude Code](https://claude.com/claude-code)