### PR TITLE
Fix missing WMMA XDL 4  for gfx1250

### DIFF
--- a/projects/rocprof-trace-decoder/source/mi400/mi400wave.cpp
+++ b/projects/rocprof-trace-decoder/source/mi400/mi400wave.cpp
@@ -197,6 +197,7 @@ enum EINST
     reserved_valu_4,
     reserved_valu_2,
     wmma_ld_scale,
+    wmma_xdl_4,
     valu_dpmacc_32 = 187,
     vmem_other_simd_start,
     block_store = 222,
@@ -319,9 +320,11 @@ static std::unordered_map<int, mapped_inst_t> table_map_to_common_type{
     {(int) EINST::cluster_barrier_signal, {WaveInstCategory::MSG, 1}            },
 
     {(int) EINST::wmma_spfp_16,           {WaveInstCategory::VALU, 16}          },
+    {(int) EINST::wmma_xdl_4,             {WaveInstCategory::VALU, 4}           },
     {(int) EINST::wmma_xdl_8,             {WaveInstCategory::VALU, 8}           },
     {(int) EINST::wmma_xdl_16,            {WaveInstCategory::VALU, 16}          },
     {(int) EINST::wmma_ld_scale,          {WaveInstCategory::LD_SCALE, 1}       },
+    {(int) EINST::valu_dpmacc_32,         {WaveInstCategory::VALU, 32}          },
 
     {(int) EINST::lds_other_simd_1,       {WaveInstCategory::LDS_OTHER_SIMD, 1} },
     {(int) EINST::lds_other_simd_2,       {WaveInstCategory::LDS_OTHER_SIMD, 2} },

--- a/projects/rocprof-trace-decoder/test/unit/mi400_test.cpp
+++ b/projects/rocprof-trace-decoder/test/unit/mi400_test.cpp
@@ -192,6 +192,17 @@ TEST(MI400WaveTest, MapToCommonTypeBlockStore)
     EXPECT_EQ(mapped2.cycles, 4);
 }
 
+TEST(MI400WaveTest, MapToCommonTypeWmma)
+{
+    auto xdl4 = mi400::map_to_common_type(184, 0);
+    EXPECT_EQ(xdl4.category, WaveInstCategory::VALU);
+    EXPECT_EQ(xdl4.cycles, 4);
+
+    auto dp32 = mi400::map_to_common_type(187, 0);
+    EXPECT_EQ(dp32.category, WaveInstCategory::VALU);
+    EXPECT_EQ(dp32.cycles, 32);
+}
+
 //=============================================================================
 // MI400 Token Generator Tests
 //=============================================================================


### PR DESCRIPTION
## Motivation

Rocprof trace decoder was missing the inst encoding for a few WMMA instructions

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AIPROFSDK-893

## Test Plan

Added unit tests

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
