### PR TITLE
rocjitsu: Fix CDNA AccVGPR storage sizing in the CU physical VGPR file

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/checkpoint.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/checkpoint.cpp
@@ -117,7 +117,7 @@ void save_checkpoint(const std::string &path, const SoC &soc, uint64_t tick,
 
           auto sgprs_vec =
               builder.CreateVector(cu->sgpr_data(w->sgpr_alloc().base), w->num_sgprs());
-          size_t vgpr_bytes = static_cast<size_t>(w->num_vgprs()) *
+          size_t vgpr_bytes = static_cast<size_t>(cu->vgpr_allocation_block_size()) *
                               static_cast<size_t>(w->wf_size()) * sizeof(uint32_t);
           auto vgprs_vec = builder.CreateVector(cu->vgpr_data(w->vgpr_alloc().base), vgpr_bytes);
 
@@ -252,7 +252,7 @@ LoadedConfig restore_checkpoint(const std::string &path) {
           }
 
           if (auto *vgprs = wf_state->vgprs()) {
-            size_t vgpr_bytes = static_cast<size_t>(wf->num_vgprs()) *
+            size_t vgpr_bytes = static_cast<size_t>(cu->vgpr_allocation_block_size()) *
                                 static_cast<size_t>(wf->wf_size()) * sizeof(uint32_t);
             size_t copy_size = std::min<size_t>(vgprs->size(), vgpr_bytes);
             std::memcpy(cu->vgpr_data(wf->vgpr_alloc().base), vgprs->data(), copy_size);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/accvgpr_layout.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/accvgpr_layout.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_ISA_ARCH_AMDGPU_SHARED_ACCVGPR_LAYOUT_H_
+#define ROCJITSU_ISA_ARCH_AMDGPU_SHARED_ACCVGPR_LAYOUT_H_
+
+#include <cstdint>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+/// AccVGPR offset within a unified VGPR block. On CDNA3/4, AccVGPRs occupy
+/// the second half of the 512-register block: acc0 = vgpr_base + 256.
+constexpr uint32_t ACC_VGPR_OFFSET = 256;
+
+} // namespace amdgpu
+} // namespace rocjitsu
+
+#endif // ROCJITSU_ISA_ARCH_AMDGPU_SHARED_ACCVGPR_LAYOUT_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -23,6 +23,7 @@
 ///   - Input A[row][k]: use input_loc(dim=M, K, B, i=row, k, b, bits).
 ///     Input B[col][k]: use input_loc(dim=N, K, B, i=col, k, b, bits).
 
+#include "rocjitsu/isa/arch/amdgpu/shared/accvgpr_layout.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "util/data_types.h"
 #include "util/except.h"
@@ -64,10 +65,6 @@ struct PackedOutputLoc {
   uint32_t lane;
   uint32_t sub_element;
 };
-
-/// AccVGPR offset within a unified VGPR block. On CDNA3/4, AccVGPRs occupy
-/// the second half of the 512-register block: acc0 = vgpr_base + 256.
-constexpr uint32_t ACC_VGPR_OFFSET = 256;
 
 /// Resolve VGPR base for an MFMA destination operand.
 /// The acc_cd bit in the MFMA encoding determines whether the destination

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -556,8 +556,8 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
       init_wavefront_regs(cu, wf, entry, global_wg_id, w);
       wg_wavefronts.push_back(wf);
     }
-    plugin_group_->onAmdgpuWorkgroupDispatched(entry.dispatch_id, global_wg_id, entry.vgprs_per_wf,
-                                               entry.sgprs_per_wf,
+    plugin_group_->onAmdgpuWorkgroupDispatched(entry.dispatch_id, global_wg_id,
+                                               cu->vgpr_allocation_block_size(), entry.sgprs_per_wf,
                                                std::span<Wavefront *>(wg_wavefronts));
     for (auto *wf : wg_wavefronts)
       plugin_group_->onAmdgpuWavefrontDispatched(*wf);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -125,7 +125,7 @@ Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t sg
   // values from previous kernel runs.
   std::fill(&sgpr_file_[sgpr_base], &sgpr_file_[sgpr_base] + config_.sgprs_per_wf, 0u);
   std::memset(vgpr_data(static_cast<uint32_t>(vgpr_base)), 0,
-              config_.vgprs_per_wf * wf_size_ * sizeof(uint32_t));
+              vgpr_allocation_block_size() * wf_size_ * sizeof(uint32_t));
 
   // Invalidate the L1 scalar cache so this wavefront reads fresh kernel
   // arguments from L2/memory rather than stale lines from a prior kernel.
@@ -149,7 +149,7 @@ Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t sg
   wf->trace_inst_count_ = 0;
 
   std::fill(sgpr_to_wave_.begin() + sgpr_base, sgpr_to_wave_.begin() + sgpr_base + sgprs, wf);
-  fill_vgpr_to_wave(static_cast<uint32_t>(vgpr_base), vgprs, wf);
+  fill_vgpr_to_wave(static_cast<uint32_t>(vgpr_base), vgpr_allocation_block_size(), wf);
 
   util::Logger::cp("DISPATCH_WF cu=", this->full_path(), " wf=", wf->wf_id(), " slot=", slot,
                    " pc=0x", std::hex, pc, std::dec, " wg=", wg_id, " pid=", wf->process_id());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -29,6 +29,7 @@
 #include "simdojo/sim/exec_mode.h"
 #include "simdojo/sim/simulation.h"
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cstdint>
@@ -435,6 +436,9 @@ protected:
   /// @brief Count the number of free VGPR allocation blocks.
   virtual uint32_t free_vgpr_blocks() const = 0;
 
+  /// @brief Number of physical VGPR registers in one allocation block.
+  virtual uint32_t vgpr_allocation_block_size() const = 0;
+
   /// @brief Update wavefront states (WAITCNT, BARRIER, ENDING transitions).
   void update_wf_states();
 
@@ -562,8 +566,11 @@ public:
   IsaExecComputeUnit(std::string name, const ComputeUnitCore::Config &config, GpuMemory *memory,
                      L2Cache *l2)
       : ExecComputeUnit<Mode>(std::move(name), config, memory, l2, Isa::WF_SIZE) {
-    vgpr_file_.init(config.num_wf_slots * config.vgprs_per_wf, config.vgprs_per_wf);
-    vgpr_to_wave_.resize(config.num_wf_slots * config.vgprs_per_wf, nullptr);
+    constexpr uint32_t accvgpr_extent =
+        Isa::MAX_ACC_VGPRS_PER_WF == 0 ? 0 : Isa::MAX_VGPRS_PER_WF + Isa::MAX_ACC_VGPRS_PER_WF;
+    vgprs_per_block_ = std::max(config.vgprs_per_wf, accvgpr_extent);
+    vgpr_file_.init(config.num_wf_slots * vgprs_per_block_, vgprs_per_block_);
+    vgpr_to_wave_.resize(config.num_wf_slots * vgprs_per_block_, nullptr);
     for (uint32_t i = 0; i < config.num_wf_slots; ++i)
       this->wfs_[i] = std::make_unique<IsaWavefront<Isa>>(*this, i);
     this->sram_ecc_ = Isa::SRAM_ECC;
@@ -613,6 +620,8 @@ protected:
 
   uint32_t free_vgpr_blocks() const override { return vgpr_file_.free_block_count(); }
 
+  uint32_t vgpr_allocation_block_size() const override { return vgprs_per_block_; }
+
   /// @brief Execute one instruction on the given wavefront.
   ///
   /// @brief Execute one instruction on the given wavefront via direct dispatch.
@@ -621,6 +630,7 @@ protected:
 private:
   simdojo::RegisterFile<Vgpr> vgpr_file_{"vgpr"};
   std::vector<Wavefront *> vgpr_to_wave_; ///< Physical VGPR → owning wavefront.
+  uint32_t vgprs_per_block_ = 0;
 };
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -8,6 +8,7 @@
 #define ROCJITSU_VM_AMDGPU_COMPUTE_UNIT_H_
 
 #include "rocjitsu/base/api.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/accvgpr_layout.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
@@ -371,6 +372,9 @@ public:
   /// @returns Mutable pointer to the raw VGPR data.
   virtual uint8_t *vgpr_data(uint32_t base) = 0;
 
+  /// @brief Number of physical VGPR registers in one allocation block.
+  virtual uint32_t vgpr_allocation_block_size() const = 0;
+
   /// @brief Typed view of a single VGPR as the file's @c simdojo::VectorReg.
   /// @details The abstract CU exposes the VGPR file only as a byte pointer
   /// (@c vgpr_data), which erases the wavefront-size template parameter. The
@@ -435,9 +439,6 @@ protected:
 
   /// @brief Count the number of free VGPR allocation blocks.
   virtual uint32_t free_vgpr_blocks() const = 0;
-
-  /// @brief Number of physical VGPR registers in one allocation block.
-  virtual uint32_t vgpr_allocation_block_size() const = 0;
 
   /// @brief Update wavefront states (WAITCNT, BARRIER, ENDING transitions).
   void update_wf_states();
@@ -566,9 +567,14 @@ public:
   IsaExecComputeUnit(std::string name, const ComputeUnitCore::Config &config, GpuMemory *memory,
                      L2Cache *l2)
       : ExecComputeUnit<Mode>(std::move(name), config, memory, l2, Isa::WF_SIZE) {
-    constexpr uint32_t accvgpr_extent =
-        Isa::MAX_ACC_VGPRS_PER_WF == 0 ? 0 : Isa::MAX_VGPRS_PER_WF + Isa::MAX_ACC_VGPRS_PER_WF;
-    vgprs_per_block_ = std::max(config.vgprs_per_wf, accvgpr_extent);
+    static_assert(!HasAccVgpr<Isa> || Isa::MAX_VGPRS_PER_WF == ACC_VGPR_OFFSET,
+                  "AccVGPR allocation base must match execution-side addressing");
+    // AccVGPR operands are addressed after the normal VGPR bank in the same
+    // physical file, so acc0 lives at base + ACC_VGPR_OFFSET.
+    constexpr uint32_t accvgpr_physical_base = ACC_VGPR_OFFSET;
+    constexpr uint32_t accvgpr_physical_limit =
+        Isa::MAX_ACC_VGPRS_PER_WF == 0 ? 0 : accvgpr_physical_base + Isa::MAX_ACC_VGPRS_PER_WF;
+    vgprs_per_block_ = std::max(config.vgprs_per_wf, accvgpr_physical_limit);
     vgpr_file_.init(config.num_wf_slots * vgprs_per_block_, vgprs_per_block_);
     vgpr_to_wave_.resize(config.num_wf_slots * vgprs_per_block_, nullptr);
     for (uint32_t i = 0; i < config.num_wf_slots; ++i)
@@ -620,8 +626,10 @@ protected:
 
   uint32_t free_vgpr_blocks() const override { return vgpr_file_.free_block_count(); }
 
+public:
   uint32_t vgpr_allocation_block_size() const override { return vgprs_per_block_; }
 
+protected:
   /// @brief Execute one instruction on the given wavefront.
   ///
   /// @brief Execute one instruction on the given wavefront via direct dispatch.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin.h
@@ -89,8 +89,10 @@ public:
   virtual void onAmdgpuDispatchExecutionEnd(uint32_t /*dispatch_id*/) {}
 
   /// Called after a workgroup's wavefronts have been dispatched to a CU.
+  /// @param physical_vgpr_count Physical VGPR allocation block size per wavefront.
   virtual void onAmdgpuWorkgroupDispatched(uint32_t /*dispatch_id*/, uint32_t /*wg_id*/,
-                                           uint32_t /*vgpr_count*/, uint32_t /*sgpr_count*/,
+                                           uint32_t /*physical_vgpr_count*/,
+                                           uint32_t /*sgpr_count*/,
                                            std::span<amdgpu::Wavefront *> /*wavefronts*/) {}
 
   /// Called when the last wavefront of a workgroup has halted.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
@@ -103,10 +103,11 @@ public:
   }
 
   virtual void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id,
-                                           uint32_t vgpr_count, uint32_t sgpr_count,
+                                           uint32_t physical_vgpr_count, uint32_t sgpr_count,
                                            std::span<amdgpu::Wavefront *> wavefronts) {
     for (auto &p : plugins_)
-      p->onAmdgpuWorkgroupDispatched(dispatch_id, wg_id, vgpr_count, sgpr_count, wavefronts);
+      p->onAmdgpuWorkgroupDispatched(dispatch_id, wg_id, physical_vgpr_count, sgpr_count,
+                                     wavefronts);
   }
 
   virtual void onAmdgpuWorkgroupCompleted(uint32_t dispatch_id, uint32_t wg_id) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/profiled_execution_plugin_group.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/profiled_execution_plugin_group.h
@@ -95,12 +95,12 @@ public:
     reset_profiles();
   }
 
-  void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id, uint32_t vgpr_count,
-                                   uint32_t sgpr_count,
+  void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id,
+                                   uint32_t physical_vgpr_count, uint32_t sgpr_count,
                                    std::span<amdgpu::Wavefront *> wavefronts) override {
     profiled_dispatch(prof_wg_dispatched_, [&]() {
-      ExecutionPluginGroup::onAmdgpuWorkgroupDispatched(dispatch_id, wg_id, vgpr_count, sgpr_count,
-                                                        wavefronts);
+      ExecutionPluginGroup::onAmdgpuWorkgroupDispatched(dispatch_id, wg_id, physical_vgpr_count,
+                                                        sgpr_count, wavefronts);
     });
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
@@ -163,7 +163,8 @@ void RaceDetectorPlugin::onAmdgpuDispatchPacketProcessed(const KernelDispatchInf
 }
 
 void RaceDetectorPlugin::onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id,
-                                                     uint32_t vgpr_count, uint32_t sgpr_count,
+                                                     uint32_t physical_vgpr_count,
+                                                     uint32_t sgpr_count,
                                                      std::span<amdgpu::Wavefront *> wavefronts) {
   uint32_t num_waves = static_cast<uint32_t>(wavefronts.size());
   WorkgroupKey key{dispatch_id, wg_id};
@@ -224,8 +225,8 @@ void RaceDetectorPlugin::onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint3
   // partition threads, so detectors_ and dispatch_disasm_ need protection.
   std::lock_guard<std::mutex> lock(dispatch_mutex_);
   detectors_[key] = std::make_unique<RaceDetector>(
-      static_cast<int>(num_waves), static_cast<int>(vgpr_count), static_cast<int>(sgpr_count),
-      Dim3d(static_cast<int>(wg_id)), std::move(handler));
+      static_cast<int>(num_waves), static_cast<int>(physical_vgpr_count),
+      static_cast<int>(sgpr_count), Dim3d(static_cast<int>(wg_id)), std::move(handler));
 
   auto &det = *detectors_[key];
   auto &dc = dispatch_disasm_[dispatch_id];

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
@@ -111,8 +111,8 @@ public:
 
   void onAmdgpuDispatchPacketProcessed(const KernelDispatchInfo &info) override;
 
-  void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id, uint32_t vgpr_count,
-                                   uint32_t sgpr_count,
+  void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id,
+                                   uint32_t physical_vgpr_count, uint32_t sgpr_count,
                                    std::span<amdgpu::Wavefront *> wavefronts) override;
 
   void onAmdgpuRouteMemoryInstruction(const Instruction &inst, amdgpu::Wavefront &wf) override;

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -6,8 +6,11 @@
 #include "embedded_schema.h"
 #include "rocjitsu/config/checkpoint.h"
 #include "rocjitsu/config/config_loader.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna3/isa.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/accvgpr_layout.h"
 #include "rocjitsu/vm/rj_vm.h"
 #include "rocjitsu/vm/soc.h"
+#include "rocjitsu/vm/virtual_machine.h"
 
 #include "simdojo/sim/simulation.h"
 
@@ -250,6 +253,67 @@ TEST(CheckpointTest, SaveAndRestoreMemory) {
   auto restored = config::restore_checkpoint(path);
   EXPECT_EQ(restored.memory()->read32(0x1000), 0xDEADBEEFu);
   EXPECT_EQ(restored.memory()->read64(0x2000), 0x0123456789ABCDEFULL);
+
+  std::filesystem::remove(path);
+}
+
+TEST(CheckpointTest, SaveAndRestoreAccVgprs) {
+  const char *json = R"({"max_ticks":10000,"num_threads":1,
+    "vm":{"arch":"cdna3"},
+    "topology":{
+      "root":{
+        "name":"soc","type":"soc",
+        "children":[
+          {"name":"vram","type":"gpu_memory"},
+          {"name":"xcd0","type":"xcd","children":[
+            {"name":"l2","type":"l2_cache"},
+            {"name":"cp","type":"command_processor"},
+            {"name":"se0","type":"shader_engine","children":[
+              {"name":"cu[0:1]","type":"compute_unit","config":[
+                {"key":"num_wf_slots","value":"1"},
+                {"key":"sgprs_per_wf","value":"104"},
+                {"key":"vgprs_per_wf","value":"256"},
+                {"key":"lds_size_kb","value":"64"}
+              ]}
+            ]}
+          ]}
+        ]
+      },
+      "links":[
+        {"src":"xcd0.cp.req_0","dst":"xcd0.se0.cu0.cpl","latency":1,"weight":2},
+        {"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10}
+      ]
+    }
+  })";
+
+  auto loaded = config::load_config_from_string(json, rocjitsu::kEmbeddedSchema);
+  auto *cu = loaded.soc()->xcd(0)->shader_engine(0)->compute_unit(0);
+  ASSERT_NE(cu, nullptr);
+
+  auto *wf = cu->dispatch_wf(0, 0, cu->config().sgprs_per_wf, cu->config().vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+  const uint32_t acc0 = wf->vgpr_alloc().base + amdgpu::ACC_VGPR_OFFSET;
+  const uint32_t acc_last = acc0 + cdna3::Isa::MAX_ACC_VGPRS_PER_WF - 1;
+  cu->write_vgpr(acc0, 0, 0xA55A0001u);
+  cu->write_vgpr(acc_last, 0, 0xDEADBEEFu);
+
+  const char *path = "/tmp/rocjitsu_test_checkpoint_accvgpr.bin";
+  config::save_checkpoint(path, *loaded.soc(), 42, loaded.engine_config);
+  ASSERT_TRUE(std::filesystem::exists(path));
+
+  auto restored = config::restore_checkpoint(path);
+  auto *restored_vm = dynamic_cast<VirtualMachine *>(restored.build_result.root.get());
+  ASSERT_NE(restored_vm, nullptr);
+  auto *restored_cu = restored_vm->soc()->xcd(0)->shader_engine(0)->compute_unit(0);
+  ASSERT_NE(restored_cu, nullptr);
+  auto *restored_wf = restored_cu->wf(0);
+  ASSERT_NE(restored_wf, nullptr);
+  EXPECT_EQ(restored_cu->read_vgpr(restored_wf->vgpr_alloc().base + amdgpu::ACC_VGPR_OFFSET, 0),
+            0xA55A0001u);
+  EXPECT_EQ(restored_cu->read_vgpr(restored_wf->vgpr_alloc().base + amdgpu::ACC_VGPR_OFFSET +
+                                       cdna3::Isa::MAX_ACC_VGPRS_PER_WF - 1,
+                                   0),
+            0xDEADBEEFu);
 
   std::filesystem::remove(path);
 }

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -68,6 +68,8 @@ struct HookEvent {
   uint32_t dispatch_id = 0;
   uint32_t wg_id = 0;
   uint32_t wf_id = 0;
+  uint32_t physical_vgpr_count = 0;
+  uint32_t sgpr_count = 0;
   uint64_t pc = 0;
   std::string mnemonic;
 };
@@ -100,11 +102,14 @@ public:
     events.push_back(e);
   }
 
-  void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id, uint32_t, uint32_t,
+  void onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id,
+                                   uint32_t physical_vgpr_count, uint32_t sgpr_count,
                                    std::span<amdgpu::Wavefront *>) override {
     HookEvent e{HookEvent::WORKGROUP_DISPATCHED};
     e.dispatch_id = dispatch_id;
     e.wg_id = wg_id;
+    e.physical_vgpr_count = physical_vgpr_count;
+    e.sgpr_count = sgpr_count;
     events.push_back(e);
   }
 
@@ -486,6 +491,22 @@ TEST(HookOrderingTest, BarrierTwoWaves) {
 
   ASSERT_EQ(p->events.front().kind, HookEvent::INIT);
   ASSERT_EQ(p->events.back().kind, HookEvent::SHUTDOWN);
+}
+
+TEST(HookOrderingTest, WorkgroupDispatchedReportsPhysicalVgprBlockSize) {
+  PluginFixture f;
+  auto *p = f.attach_ordering_plugin();
+  const uint32_t code[] = {S_ENDPGM};
+  f.run_kernel(code, 1);
+  f.shutdown();
+
+  auto it = std::find_if(p->events.begin(), p->events.end(), [](const HookEvent &e) {
+    return e.kind == HookEvent::WORKGROUP_DISPATCHED;
+  });
+  ASSERT_NE(it, p->events.end());
+  EXPECT_EQ(it->physical_vgpr_count, f.cu()->vgpr_allocation_block_size());
+  EXPECT_GT(it->physical_vgpr_count, f.cu()->config().vgprs_per_wf);
+  EXPECT_EQ(it->sgpr_count, f.cu()->config().sgprs_per_wf);
 }
 
 TEST(HookOrderingTest, FiveDispatchLifecycle) {

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/isa/arch/amdgpu/cdna2/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/machine_insts.h"
+#include "rocjitsu/isa/arch/amdgpu/cdna4/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/machine_insts.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/rdna2/isa.h"
@@ -42,7 +43,9 @@ using namespace rocjitsu;
 static_assert(GpuIsa<cdna3::Isa>);
 static_assert(GpuIsa<gfx1250::Isa>);
 static_assert(GpuIsa<rdna4::Isa>);
+static_assert(HasAccVgpr<cdna2::Isa>);
 static_assert(HasAccVgpr<cdna3::Isa>);
+static_assert(HasAccVgpr<cdna4::Isa>);
 static_assert(!HasAccVgpr<gfx1250::Isa>);
 static_assert(!HasAccVgpr<rdna4::Isa>);
 static_assert(HasMonolithicWaitcnt<cdna3::Isa>);
@@ -60,6 +63,7 @@ static_assert(gfx1250::Isa::WF_SIZE_MAX == 32);
 static_assert(cdna1::Isa::MAX_ACC_VGPRS_PER_WF == 0);
 static_assert(cdna2::Isa::MAX_ACC_VGPRS_PER_WF == 256);
 static_assert(cdna3::Isa::MAX_ACC_VGPRS_PER_WF == 256);
+static_assert(cdna4::Isa::MAX_ACC_VGPRS_PER_WF == 256);
 
 // ---------------------------------------------------------------------------
 // MFMA register layout tests
@@ -149,6 +153,40 @@ TEST_P(CuFactoryTest, CreatesSuccessfully) {
   auto cu = amdgpu::ComputeUnitCore::create("test_cu", cfg, &mem, &l2);
   ASSERT_NE(cu, nullptr);
   EXPECT_EQ(cu->arch(), arch);
+}
+
+TEST(CuFactoryTest, AccVgprIsasDoNotAliasNextWaveSlot) {
+  for (rj_code_arch_t arch :
+       {ROCJITSU_CODE_ARCH_CDNA2, ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    SCOPED_TRACE(::testing::Message() << "arch=" << static_cast<int>(arch));
+    amdgpu::GpuMemory mem("test_mem");
+    amdgpu::L2Cache l2("test_l2");
+
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = arch;
+    cfg.num_wf_slots = 2;
+    cfg.sgprs_per_wf = 104;
+    cfg.vgprs_per_wf = 256;
+    cfg.lds_size_kb = 64;
+
+    auto cu = amdgpu::ComputeUnitCore::create("test_cu", cfg, &mem, &l2);
+    ASSERT_NE(cu, nullptr);
+
+    auto *wf0 = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+    ASSERT_NE(wf0, nullptr);
+    auto *wf1 = cu->dispatch_wf(1, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+    ASSERT_NE(wf1, nullptr);
+
+    const uint32_t wf0_acc0 = wf0->vgpr_alloc().base + 256;
+    const uint32_t wf1_v0 = wf1->vgpr_alloc().base;
+    EXPECT_NE(wf0_acc0, wf1_v0);
+
+    cu->write_vgpr(wf0_acc0, 0, 0xA55A0001u);
+    cu->write_vgpr(wf1_v0, 0, 0x5AA50002u);
+
+    EXPECT_EQ(cu->read_vgpr(wf0_acc0, 0), 0xA55A0001u);
+    EXPECT_EQ(cu->read_vgpr(wf1_v0, 0), 0x5AA50002u);
+  }
 }
 
 INSTANTIATE_TEST_SUITE_P(AllIsas, CuFactoryTest,

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -59,11 +59,13 @@ static_assert(HasMonolithicWaitcnt<rdna3::Isa>);
 static_assert(rdna2::Isa::WF_SIZE_MAX == 64);
 static_assert(gfx1250::Isa::WF_SIZE_MAX == 32);
 
-// CDNA1 has no AccVGPRs; CDNA2/3/4 have 256.
+// CDNA1 and GFX1250 have no AccVGPRs; CDNA2/3/4 have 256.
+constexpr uint32_t kCdnaAccVgprsPerWf = cdna2::Isa::MAX_ACC_VGPRS_PER_WF;
 static_assert(cdna1::Isa::MAX_ACC_VGPRS_PER_WF == 0);
-static_assert(cdna2::Isa::MAX_ACC_VGPRS_PER_WF == 256);
-static_assert(cdna3::Isa::MAX_ACC_VGPRS_PER_WF == 256);
-static_assert(cdna4::Isa::MAX_ACC_VGPRS_PER_WF == 256);
+static_assert(kCdnaAccVgprsPerWf == 256);
+static_assert(cdna3::Isa::MAX_ACC_VGPRS_PER_WF == kCdnaAccVgprsPerWf);
+static_assert(cdna4::Isa::MAX_ACC_VGPRS_PER_WF == kCdnaAccVgprsPerWf);
+static_assert(gfx1250::Isa::MAX_ACC_VGPRS_PER_WF == 0);
 
 // ---------------------------------------------------------------------------
 // MFMA register layout tests
@@ -129,7 +131,7 @@ TEST(MfmaExecTest, ResolveAccAccVgpr) {
   uint32_t result = amdgpu::resolve_acc<amdgpu::AccMode::Unified>(
       /*vb=*/100, /*dst=*/200, /*src2_ev=*/770, const_acc, [&]() -> uint32_t { return 99u; });
   EXPECT_EQ(const_acc, amdgpu::ACC_FROM_VGPR);
-  EXPECT_EQ(result, 100u + 256u + 2u); // vb + ACC_VGPR_OFFSET + (770 - 768)
+  EXPECT_EQ(result, 100u + amdgpu::ACC_VGPR_OFFSET + 2u);
 }
 
 // ---------------------------------------------------------------------------
@@ -155,7 +157,7 @@ TEST_P(CuFactoryTest, CreatesSuccessfully) {
   EXPECT_EQ(cu->arch(), arch);
 }
 
-TEST(CuFactoryTest, AccVgprIsasDoNotAliasNextWaveSlot) {
+TEST(CuFactoryTest, CdnaAccVgprsDoNotAliasNextWaveSlot) {
   for (rj_code_arch_t arch :
        {ROCJITSU_CODE_ARCH_CDNA2, ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
     SCOPED_TRACE(::testing::Message() << "arch=" << static_cast<int>(arch));
@@ -178,14 +180,53 @@ TEST(CuFactoryTest, AccVgprIsasDoNotAliasNextWaveSlot) {
     ASSERT_NE(wf1, nullptr);
 
     const uint32_t wf0_acc0 = wf0->vgpr_alloc().base + amdgpu::ACC_VGPR_OFFSET;
+    const uint32_t wf0_acc_last = wf0_acc0 + kCdnaAccVgprsPerWf - 1;
     const uint32_t wf1_v0 = wf1->vgpr_alloc().base;
     EXPECT_NE(wf0_acc0, wf1_v0);
+    EXPECT_LT(wf0_acc_last, wf1_v0);
 
     cu->write_vgpr(wf0_acc0, 0, 0xA55A0001u);
+    cu->write_vgpr(wf0_acc_last, 0, 0xDEADBEEFu);
     cu->write_vgpr(wf1_v0, 0, 0x5AA50002u);
 
     EXPECT_EQ(cu->read_vgpr(wf0_acc0, 0), 0xA55A0001u);
+    EXPECT_EQ(cu->read_vgpr(wf0_acc_last, 0), 0xDEADBEEFu);
     EXPECT_EQ(cu->read_vgpr(wf1_v0, 0), 0x5AA50002u);
+  }
+}
+
+TEST(CuFactoryTest, CdnaAccVgprsAreClearedOnRedispatch) {
+  for (rj_code_arch_t arch :
+       {ROCJITSU_CODE_ARCH_CDNA2, ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {
+    SCOPED_TRACE(::testing::Message() << "arch=" << static_cast<int>(arch));
+    amdgpu::GpuMemory mem("test_mem");
+    amdgpu::L2Cache l2("test_l2");
+
+    amdgpu::ComputeUnitCore::Config cfg{};
+    cfg.arch = arch;
+    cfg.num_wf_slots = 1;
+    cfg.sgprs_per_wf = 104;
+    cfg.vgprs_per_wf = 256;
+    cfg.lds_size_kb = 64;
+
+    auto cu = amdgpu::ComputeUnitCore::create("test_cu", cfg, &mem, &l2);
+    ASSERT_NE(cu, nullptr);
+
+    auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+    ASSERT_NE(wf, nullptr);
+    const uint32_t acc0 = wf->vgpr_alloc().base + amdgpu::ACC_VGPR_OFFSET;
+    const uint32_t acc_last = acc0 + kCdnaAccVgprsPerWf - 1;
+    cu->write_vgpr(acc0, 0, 0xFFFFFFFFu);
+    cu->write_vgpr(acc_last, 0, 0xDEADBEEFu);
+
+    cu->reset_all_wf();
+    wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+    ASSERT_NE(wf, nullptr);
+
+    EXPECT_EQ(cu->read_vgpr(wf->vgpr_alloc().base + amdgpu::ACC_VGPR_OFFSET, 0), 0u);
+    EXPECT_EQ(
+        cu->read_vgpr(wf->vgpr_alloc().base + amdgpu::ACC_VGPR_OFFSET + kCdnaAccVgprsPerWf - 1, 0),
+        0u);
   }
 }
 

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -177,7 +177,7 @@ TEST(CuFactoryTest, AccVgprIsasDoNotAliasNextWaveSlot) {
     auto *wf1 = cu->dispatch_wf(1, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
     ASSERT_NE(wf1, nullptr);
 
-    const uint32_t wf0_acc0 = wf0->vgpr_alloc().base + 256;
+    const uint32_t wf0_acc0 = wf0->vgpr_alloc().base + amdgpu::ACC_VGPR_OFFSET;
     const uint32_t wf1_v0 = wf1->vgpr_alloc().base;
     EXPECT_NE(wf0_acc0, wf1_v0);
 


### PR DESCRIPTION
## Reason
Hitting this assert:
```
[ RUN      ] DecodeExecuteBenchmark.Cdna4
rocjitsu_tests: /home/jakub/rocjitsu/gfx1250/rocm-systems/emulation/rocjitsu/lib/simdojo/include/simdojo/components/register_file.h:89: const RegType &simdojo::RegisterFile<simdojo::VectorReg<64, unsigned int>>::operator[](uint32_t) const [RegType = simdojo::VectorReg<64, unsigned int>]: Assertion `idx < totalregs' failed.
<end of output>
Test time =   1.36 sec
```
because AccVGPRs were being addressed as physical VGPR indices past the allocated VGPR block.

## Fix:
* Size CU VGPR allocation blocks to include the physical AccVGPR range for AccVGPR ISAs
* Add a regression covering all current AccVGPR ISAs: CDNA2, CDNA3, and CDNA4

## Test Plan
```
rocjitsu_tests --gtest_filter='CuFactoryTest.CdnaAccVgprsDoNotAliasNextWaveSlot:DecodeExecuteBenchmark.*:InstructionExecutionHarness.Cdna4:*MfmaF16Accumulation/cdna4:*MfmaF16AccumulationPatterned/cdna4:Vop3pMovB32SimdCorrectness.*' --gtest_color=no
```


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
