### PR TITLE
CLR: aql log priority

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -110,15 +110,16 @@ static unsigned extractAqlBits(unsigned v, unsigned pos, unsigned width) {
 static inline void logAqlDispatchPacket(const hsa_queue_t* queue, uint16_t header,
                                         const hsa_kernel_dispatch_packet_t* pkt,
                                         uint64_t rptr, uint64_t wptr,
+                                        amd::CommandQueue::Priority priority,
                                         const char* prefix = "") {
   ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL,
-          "SWq=0x%zx, HWq=0x%zx, id=%d,%s Dispatch Header = "
+          "SWq=0x%zx, HWq=0x%zx, id=%d, priority=%d,%s Dispatch Header = "
           "0x%x (type=%d, barrier=%d, acquire=%d, release=%d), "
           "setup=%d, grid=[%u, %u, %u], workgroup=[%u, %u, %u], "
           "private_seg_size=%u, group_seg_size=%u, kernel_obj=0x%zx, "
           "kernarg_address=0x%zx, completion_signal=0x%zx, correlation_id=%zu, "
           "rptr=%lu, wptr=%lu",
-          queue, queue->base_address, queue->id, prefix, header,
+          queue, queue->base_address, queue->id, static_cast<int>(priority), prefix, header,
           extractAqlBits(header, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE),
           extractAqlBits(header, HSA_PACKET_HEADER_BARRIER, HSA_PACKET_HEADER_WIDTH_BARRIER),
           extractAqlBits(header, HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE,
@@ -134,15 +135,15 @@ static inline void logAqlDispatchPacket(const hsa_queue_t* queue, uint16_t heade
 
 static inline void logAqlDispatchPacketExtended(
     const hsa_queue_t* queue, uint16_t header, const hsa_amd_ext_kernel_dispatch_packet_t* pkt,
-    uint64_t rptr, uint64_t wptr, const char* prefix = "") {
+    uint64_t rptr, uint64_t wptr, amd::CommandQueue::Priority priority, const char* prefix = "") {
   ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL,
-          "SWq=0x%zx, HWq=0x%zx, id=%d,%s Dispatch Header = "
+          "SWq=0x%zx, HWq=0x%zx, id=%d, priority=%d,%s Dispatch Header = "
           "0x%x (type=%d, barrier=%d, acquire=%d, release=%d), "
           "setup=%d, cluster_count=[%u, %u, %u], cluster_size=[%u, %u, %u], "
           "workgroup=[%u, %u, %u], private_seg_size=%u, group_seg_size=%u, kernel_obj=0x%zx, "
           "kernarg_address=0x%zx, dep_signal=0x%zx, completion_signal=0x%zx, "
           "rptr=%lu, wptr=%lu",
-          queue, queue->base_address, queue->id, prefix, header,
+          queue, queue->base_address, queue->id, static_cast<int>(priority), prefix, header,
           extractAqlBits(header, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE),
           extractAqlBits(header, HSA_PACKET_HEADER_BARRIER, HSA_PACKET_HEADER_WIDTH_BARRIER),
           extractAqlBits(header, HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE,
@@ -159,15 +160,16 @@ static inline void logAqlDispatchPacketExtended(
 static inline void logAqlBarrierPacket(const hsa_queue_t* queue, uint16_t header,
                                        const hsa_barrier_and_packet_t* pkt,
                                        uint64_t rptr, uint64_t wptr,
+                                       amd::CommandQueue::Priority priority,
                                        const char* prefix = "") {
   uint16_t pktType = extractAqlBits(header, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE);
   const char* typeStr = (pktType == HSA_PACKET_TYPE_BARRIER_OR) ? "Barrier-OR" : "Barrier-AND";
   ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL,
-          "SWq=0x%zx, HWq=0x%zx, id=%d,%s %s Header = "
+          "SWq=0x%zx, HWq=0x%zx, id=%d, priority=%d,%s %s Header = "
           "0x%x (type=%d, barrier=%d, acquire=%d, release=%d), "
           "dep_signal=[0x%zx, 0x%zx, 0x%zx, 0x%zx, 0x%zx], "
           "completion_signal=0x%zx, rptr=%lu, wptr=%lu",
-          queue, queue->base_address, queue->id, prefix, typeStr, header,
+          queue, queue->base_address, queue->id, static_cast<int>(priority), prefix, typeStr, header,
           pktType,
           extractAqlBits(header, HSA_PACKET_HEADER_BARRIER, HSA_PACKET_HEADER_WIDTH_BARRIER),
           extractAqlBits(header, HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE,
@@ -183,13 +185,14 @@ static inline void logAqlBarrierPacket(const hsa_queue_t* queue, uint16_t header
 static inline void logAqlBarrierValuePacket(const hsa_queue_t* queue, uint16_t header,
                                             const hsa_amd_barrier_value_packet_t* pkt,
                                             uint64_t rptr, uint64_t wptr,
+                                            amd::CommandQueue::Priority priority,
                                             const char* prefix = "") {
   ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL,
-          "SWq=0x%zx, HWq=0x%zx, id=%d,%s BarrierValue Header = 0x%x AmdFormat = 0x%x "
+          "SWq=0x%zx, HWq=0x%zx, id=%d, priority=%d,%s BarrierValue Header = 0x%x AmdFormat = 0x%x "
           "(type=%d, barrier=%d, acquire=%d, release=%d), "
           "signal=0x%zx, value=0x%llx, mask=0x%llx, cond=%s, "
           "completion_signal=0x%zx, rptr=%lu, wptr=%lu",
-          queue, queue->base_address, queue->id, prefix,
+          queue, queue->base_address, queue->id, static_cast<int>(priority), prefix,
           header, HSA_AMD_PACKET_TYPE_BARRIER_VALUE,
           extractAqlBits(header, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE),
           extractAqlBits(header, HSA_PACKET_HEADER_BARRIER, HSA_PACKET_HEADER_WIDTH_BARRIER),
@@ -1336,7 +1339,6 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
   if (header != 0) {
     packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), header, rest);
   }
-  // Gate the entire dispatch-packet logging path on the log level.
   if (IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
     char buf[32];
     const char* virtual_pipe_prefix = "";
@@ -1349,11 +1351,11 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
     if (dev().settings().ext_dispatch_packet_) {
       logAqlDispatchPacketExtended(
           gpu_queue_, header, reinterpret_cast<hsa_amd_ext_kernel_dispatch_packet_t*>(packet),
-          rptr, index, virtual_pipe_prefix);
+          rptr, index, priority_, virtual_pipe_prefix);
     } else {
       logAqlDispatchPacket(gpu_queue_, header,
                            reinterpret_cast<hsa_kernel_dispatch_packet_t*>(packet),
-                           rptr, index, virtual_pipe_prefix);
+                           rptr, index, priority_, virtual_pipe_prefix);
     }
   }
   // Optimization for native AQL path in Windows has problems with PM4 emulation,
@@ -1587,7 +1589,7 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
           if (pktType == HSA_PACKET_TYPE_VENDOR_SPECIFIC) {
             logAqlDispatchPacketExtended(gpu_queue_, hdr,
                 reinterpret_cast<hsa_amd_ext_kernel_dispatch_packet_t*>(slot),
-                Hsa::queue_load_read_index_scacquire(gpu_queue_), slotIdx, " Graph");
+                Hsa::queue_load_read_index_scacquire(gpu_queue_), slotIdx, priority_, " Graph");
           } else {
           ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL,
                   "SWq=0x%zx, HWq=0x%zx, id=%d, Dispatch Header = "
@@ -1631,7 +1633,8 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
           ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2,
                   "Graph ShaderName :%s, device id : %u", tag, dev().index());
           logAqlBarrierPacket(gpu_queue_, hdr, bpkt,
-                              Hsa::queue_load_read_index_scacquire(gpu_queue_), slotIdx, tag);
+                              Hsa::queue_load_read_index_scacquire(gpu_queue_), slotIdx, priority_,
+                              tag);
         }
       }
     }
@@ -1766,7 +1769,8 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
       virtual_pipe_prefix = buf;
     }
     logAqlBarrierPacket(gpu_queue_, packetHeader, &barrier_packet_,
-                        Hsa::queue_load_read_index_relaxed(gpu_queue_), index, virtual_pipe_prefix);
+                        Hsa::queue_load_read_index_relaxed(gpu_queue_), index, priority_,
+                        virtual_pipe_prefix);
   }
 
   // Clear dependent signals for the next packet
@@ -1852,7 +1856,7 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
     }
     logAqlBarrierValuePacket(gpu_queue_, packetHeader, &barrier_value_packet_,
                              Hsa::queue_load_read_index_relaxed(gpu_queue_), index,
-                             virtual_pipe_prefix);
+                             priority_, virtual_pipe_prefix);
   }
   // Clear dependent signals for the next packet
   barrier_value_packet_.signal = hsa_signal_t{};

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -105,6 +105,19 @@ stream:
   Unit_hipStreamCreateWithPriority_TestMultipleStreamWithPriority:
     <<: *level_2
     tags: [lifecycle]
+  Unit_hipStreamPriorityAqlLog_ChildWorkload:
+    <<: *level_2
+    # Internal helper, only invoked by the parent test via re-exec (by exact
+    # name, which still runs hidden [.] cases). Disabled everywhere so it does
+    # not run as a standalone no-op in the regular suite.
+    disabled: [amd_linux, amd_windows, amd_wsl, nvidia_linux, nvidia_windows]
+    tags: [lifecycle]
+  Unit_hipStreamPriorityAqlLog_TraceReportsPriority:
+    <<: *level_2
+    # Verifies AQL packet trace reports stream priority next to HWq; relies on
+    # AMD_LOG AQL output, so AMD/Linux only.
+    disabled: [amd_windows, amd_wsl, nvidia_linux, nvidia_windows]
+    tags: [lifecycle]
   Unit_hipStreamDestroy_Default:
     <<: *level_2
     tags: [lifecycle, smoke]

--- a/projects/hip-tests/catch/unit/stream/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/stream/CMakeLists.txt
@@ -37,6 +37,7 @@ if(HIP_PLATFORM MATCHES "amd")
                hipStreamQuery_spt.cc
                hipStreamSynchronize_spt.cc
                hipStreamBatchMemOp.cc
+               hipStreamPriorityAqlLog.cc
                # disabled on NVIDIA due to lack of hipStreamGetCaptureInfo_v2 in cuda 13.0+
                 hipStreamLegacy.cc
 

--- a/projects/hip-tests/catch/unit/stream/hipStreamPriorityAqlLog.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamPriorityAqlLog.cc
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @addtogroup hipStreamPriorityAqlLog hipStreamPriorityAqlLog
+ * @{
+ * @ingroup StreamTest
+ * Validates that the AQL packet trace emitted by the runtime reports the stream
+ * priority next to the HWq, for each distinct HW queue priority bucket
+ * (Low/Normal/High). The priority is only observable in the AQL debug log
+ * (AMD_LOG_LEVEL=5, AMD_LOG_MASK=LOG_AQL), so the test re-executes itself in a
+ * child process with that logging enabled, captures the log, and verifies the
+ * tokens. AMD + Linux only.
+ */
+
+#include <hip_test_common.hh>
+
+#if HT_AMD && HT_LINUX
+
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace {
+
+// Env marker that tells a re-executed instance to run the kernel workload that
+// produces AQL packets, instead of driving a child.
+constexpr char kChildEnv[] = "HIP_TEST_AQL_PRIORITY_CHILD";
+
+__global__ void noopKernel() {}
+
+// Launch a kernel on a stream created at the given priority and synchronize, so
+// the runtime emits AQL dispatch/barrier packets tagged with that priority.
+void launchOnPriority(int priority) {
+  hipStream_t stream{nullptr};
+  HIP_CHECK(hipStreamCreateWithPriority(&stream, hipStreamDefault, priority));
+  hipLaunchKernelGGL(noopKernel, dim3(1), dim3(1), 0, stream);
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipStreamSynchronize(stream));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+std::string selfExePath() {
+  char buf[4096];
+  ssize_t n = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+  if (n <= 0) return std::string{};
+  buf[n] = '\0';
+  return std::string(buf);
+}
+
+}  // namespace
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Internal child workload (only runs when HIP_TEST_AQL_PRIORITY_CHILD is set).
+ *    Creates streams at High/Normal/Low priority and launches a kernel on each
+ *    so the AQL packet logger emits priority-tagged trace lines.
+ * Test source
+ * ------------------------
+ *  - catch\unit\stream\hipStreamPriorityAqlLog.cc
+ */
+HIP_TEST_CASE(Unit_hipStreamPriorityAqlLog_ChildWorkload) {
+  if (std::getenv(kChildEnv) == nullptr) {
+    // Not the child invocation; nothing to do when run directly.
+    SUCCEED("Skipping child workload outside of parent-driven run");
+    return;
+  }
+
+  int priorityLow = 0, priorityHigh = 0;
+  HIP_CHECK(hipDeviceGetStreamPriorityRange(&priorityLow, &priorityHigh));
+
+  // priorityHigh/priorityLow are the extremes of the supported range; the
+  // mid-range value maps to Normal (consistent with other stream-priority tests
+  // that treat (low + high) / 2 as normal priority).
+  launchOnPriority(priorityHigh);                       // -> priority=3 (High)
+  launchOnPriority((priorityLow + priorityHigh) / 2);  // -> priority=1 (Normal)
+  launchOnPriority(priorityLow);                        // -> priority=0 (Low)
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Re-executes this test binary as a child with AQL logging enabled
+ *    (AMD_LOG_LEVEL=5, AMD_LOG_MASK=LOG_AQL), running the child workload that
+ *    launches kernels on High/Normal/Low priority streams. Captures the child's
+ *    stderr log and verifies that every priority bucket is reported next to the
+ *    HWq in the AQL trace.
+ * Test source
+ * ------------------------
+ *  - catch\unit\stream\hipStreamPriorityAqlLog.cc
+ * Test requirements
+ * ------------------------
+ *  - Linux, AMD backend
+ */
+HIP_TEST_CASE(Unit_hipStreamPriorityAqlLog_TraceReportsPriority) {
+  // Guard against accidental recursion if invoked as a child.
+  if (std::getenv(kChildEnv) != nullptr) {
+    SUCCEED("Skipping parent driver inside child invocation");
+    return;
+  }
+
+  int priorityLow = 0, priorityHigh = 0;
+  HIP_CHECK(hipDeviceGetStreamPriorityRange(&priorityLow, &priorityHigh));
+  if (priorityLow == priorityHigh) {
+    WARN("Stream priority range not supported. Skipping test.");
+    return;
+  }
+
+  const std::string self = selfExePath();
+  REQUIRE_FALSE(self.empty());
+
+  const std::string logFile = "hip_aql_priority_" + std::to_string(getpid()) + ".log";
+
+  // Launch the child via fork()+execv() (no shell) so the executable path needs
+  // no quoting and the child starts a fresh process. AMD_LOG_LEVEL must be set
+  // before the child's runtime initializes, which an in-process change could not
+  // achieve. AMD_LOG_LEVEL=5 (LOG_DETAIL_DEBUG) + AMD_LOG_MASK=8 (LOG_AQL) emit
+  // the AQL packet trace, which now carries "priority=<bucket>" next to "HWq=".
+  const pid_t pid = fork();
+  REQUIRE(pid >= 0);
+  if (pid == 0) {
+    // Child: enable AQL logging, redirect stdout to /dev/null and stderr (where
+    // the log is written) to the capture file, then re-exec the child workload.
+    setenv(kChildEnv, "1", 1);
+    setenv("AMD_LOG_LEVEL", "5", 1);
+    setenv("AMD_LOG_MASK", "8", 1);
+    const int logFd = open(logFile.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (logFd < 0) _exit(127);
+    dup2(logFd, STDERR_FILENO);
+    const int devNull = open("/dev/null", O_WRONLY);
+    if (devNull >= 0) dup2(devNull, STDOUT_FILENO);
+    const char* argv[] = {self.c_str(), "Unit_hipStreamPriorityAqlLog_ChildWorkload", nullptr};
+    execv(self.c_str(), const_cast<char* const*>(argv));
+    _exit(127);  // execv only returns on failure
+  }
+
+  int status = 0;
+  REQUIRE(waitpid(pid, &status, 0) == pid);
+  REQUIRE(WIFEXITED(status));
+  REQUIRE(WEXITSTATUS(status) == 0);
+
+  std::ifstream in(logFile);
+  REQUIRE(in.good());
+  std::stringstream ss;
+  ss << in.rdbuf();
+  const std::string log = ss.str();
+  in.close();
+  std::remove(logFile.c_str());
+
+  // Require the priority to be reported on an actual AQL packet line, i.e. on
+  // the same line as an "HWq=" record. Matching the tokens anywhere in the log
+  // independently could pass on unrelated logging that happens to contain them.
+  // The runtime prints the raw amd::CommandQueue::Priority enum value:
+  // Low=0, Normal=1, High=3.
+  auto hwqLineHasPriority = [&log](int priorityValue) {
+    const std::string token = "priority=" + std::to_string(priorityValue);
+    std::istringstream stream(log);
+    std::string line;
+    while (std::getline(stream, line)) {
+      if (line.find("HWq=") != std::string::npos && line.find(token) != std::string::npos) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  // Each priority bucket we launched on must appear on an AQL packet line.
+  REQUIRE(hwqLineHasPriority(3));  // High
+  REQUIRE(hwqLineHasPriority(1));  // Normal
+  REQUIRE(hwqLineHasPriority(0));  // Low
+}
+
+/**
+ * End doxygen group StreamTest.
+ * @}
+ */
+
+#endif  // HT_AMD && HT_LINUX


### PR DESCRIPTION
## Motivation                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                 
  When debugging stream-to-hardware-queue (HWQ) assignment — particularly the multi-rank consistency and queue-distribution issues seen with dynamic queue mapping — the AQL packet trace shows the `HWq` and queue `id`, but not the queue *priority*. Since    
  streams are mapped into separate Low/Normal/High HW queue pools, knowing which priority bucket a packet's HWq belongs to is essential to correlate placement with priority. This PR adds the stream priority next to the HWq in the AQL packet log so that     
  information is directly readable from the trace.                                                                                                                                                                                                               
                                                                 
  ## Technical Details                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                 
  - Added a `priorityName()` helper in `rocvirtual.cpp` mapping `amd::CommandQueue::Priority` to a string.                                                                                                                                                       
  - Threaded the priority through all four AQL packet loggers — `logAqlDispatchPacket`, `logAqlDispatchPacketExtended`, `logAqlBarrierPacket`, `logAqlBarrierValuePacket` — printing `priority=<bucket>` immediately after `id=` (next to `HWq=`). Applies to 
  both dispatch and barrier packets.                                                                                                                                                                                                                          
  - Only `Low`/`Normal`/`High` map to distinct HW queue pools; `Medium` is folded into the Normal pool in `acquireQueue` (`HSA_AMD_QUEUE_PRIORITY_NORMAL`), so `priorityName` reports `Medium` as `Normal` to match the actual HW queue bucket rather than the
  requested enum.                                                                                                                                                                                                                                                
  - The trace is emitted via `ClPrint(LOG_DETAIL_DEBUG, LOG_AQL, ...)`, so it is gated behind `AMD_LOG_LEVEL>=5`; there is zero overhead at the default log level.
                                                                                                                                                                                                                                                                 
  Example output:                                                                                                                                                                                                                                                
  SWq=0x..., HWq=0x...acc00000, id=1, priority=High,   Dispatch Header = ...                                                                                                                                                                                     
  SWq=0x..., HWq=0x...ac400000, id=2, priority=Normal, Dispatch Header = ...                                                     
  SWq=0x..., HWq=0x...ac800000, id=4, priority=Low,    Barrier-AND Header = ...                                                                                                                                                                                  
                                                                                                                                                                                                                                                                 
  A hip-test (`unit/stream/hipStreamPriorityAqlLog.cc`) was added to cover the feature. It is self-contained: the parent test re-executes the binary in a child process with `AMD_LOG_LEVEL=5 AMD_LOG_MASK=8` set, runs a workload that launches kernels on
  High/Normal/Low priority streams, captures the child's AQL log, and asserts each priority bucket appears next to `HWq=`. Registered in `config/configs/unit/stream.yaml`, restricted to AMD + Linux.                                                           
                                                                                                                                                                                                                                                                 
  ## JIRA ID                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                 
  ROCM-26274                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                 
  ## Test Plan                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                 
  - Built `libamdhip64.so` with the change and confirmed the `priority=%s` format strings are present in the binary.                                                                                                                                             
  - Built the `StreamTest` catch executable with the new test compiled in.                                                                                                                                                                                       
  - Ran `Unit_hipStreamPriorityAqlLog_TraceReportsPriority` against the patched runtime on an AMD GPU (gfx1201), isolated via `ROCR_VISIBLE_DEVICES=0`.                                                                                                          
  - Negative control: ran the same test against the unpatched/stock `libamdhip64.so` to confirm the test actually exercises the feature.                                                                                                                         
                                                                                                                                                                                                                                                                 
  ## Test Result                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                 
  - Positive run (patched runtime): PASS — `All tests passed (8 assertions in 1 test case)`. Real trace confirmed `priority=High`, `priority=Normal`, and `priority=Low` printed next to `HWq=` on both dispatch and barrier packets, each on a distinct HW      
  queue.                                                                                                                                                                                                                                                         
  - Negative control (stock runtime): FAIL as expected — `assertions: 5 | 4 passed | 1 failed` (no `priority=` token emitted), confirming the test is meaningful and not trivially passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
