### PR TITLE
feat(rocSHMEM): Add reduce_scatter collective operation

### DIFF
--- a/projects/rocshmem/docs/api/coll.rst
+++ b/projects/rocshmem/docs/api/coll.rst
@@ -221,6 +221,31 @@ ROCSHMEM_FCOLLECT
 This routine concatenates blocks of data from multiple PEs to an array in every
 PE participating in the collective routine.
 
+ROCSHMEM_REDUCE_SCATTER
+-----------------------
+.. cpp:function:: __device__ int rocshmem_ctx_TYPENAME_OPNAME_reduce_scatter_wg(rocshmem_ctx_t ctx, rocshmem_team_t team, TYPE *dest, const TYPE *source, int nreduce)
+.. cpp:function:: __host__ int rocshmem_ctx_TYPENAME_OPNAME_reduce_scatter(rocshmem_ctx_t ctx, rocshmem_team_t team, TYPE *dest, const TYPE *source, int nreduce)
+
+  :param ctx:     Context with which to perform this collective.
+  :param team:    The team participating in the collective.
+  :param dest:    Destination address (``nreduce`` elements). Must be an address on the
+                  symmetric heap.
+  :param source:  Source address (``nreduce * n_pes`` elements). Must be an address on the
+                  symmetric heap.
+  :param nreduce: Number of elements each PE receives.
+  :returns:       Zero on successful local completion. Nonzero otherwise.
+
+**Description:**
+This routine performs a reduce-scatter operation across all PEs in the team.
+Each PE contributes ``nreduce * n_pes`` elements from ``source``; after the element-wise
+reduction across all PEs, PE ``i`` receives the ``nreduce`` elements corresponding to
+block ``i`` (i.e., ``source[i*nreduce .. (i+1)*nreduce - 1]`` reduced across all PEs)
+into its local ``dest`` buffer.
+
+This function must be called as a work-group collective (``_wg`` variant) or from host code.
+
+Valid ``TYPENAME``, ``TYPE``, and ``OPNAME`` values are listed in :ref:`REDUCE_TYPES`.
+
 ROCSHMEM_REDUCTION
 ------------------
 .. cpp:function:: __device__ int rocshmem_ctx_TYPENAME_OPNAME_reduce_wg(rocshmem_ctx_t ctx, rocshmem_team_t team, TYPE *dest, const TYPE *source, int nreduce)

--- a/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
@@ -468,17 +468,17 @@ __device__ ATTR_NO_INLINE void rocshmem_ctx_ulonglong_fcollect_wg(
 /**
  * @name SHMEM_REDUCE_SCATTER
  * @brief Perform a reduce-scatter between PEs in the team. Each PE contributes
- * nelems * n_pes elements from source; after reduction across all PEs,
- * PE i receives the nelems elements corresponding to block i.
+ * nreduce * n_pes elements from source; after reduction across all PEs,
+ * PE i receives the nreduce elements corresponding to block i.
  *
  * This function must be called as a work-group collective.
  *
  * @param[in] team         The team participating in the collective.
- * @param[in] dest         Destination address (nelems elements). Must be an
+ * @param[in] dest         Destination address (nreduce elements). Must be an
  *                         address on the symmetric heap.
- * @param[in] source       Source address (nelems * n_pes elements). Must be
+ * @param[in] source       Source address (nreduce * n_pes elements). Must be
  *                         an address on the symmetric heap.
- * @param[in] nelems      Number of elements each PE receives.
+ * @param[in] nreduce      Number of elements each PE receives.
  *
  * @return int (Zero on successful local completion. Nonzero otherwise.)
  */

--- a/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
@@ -466,6 +466,220 @@ __device__ ATTR_NO_INLINE void rocshmem_ctx_ulonglong_fcollect_wg(
 
 
 /**
+ * @name SHMEM_REDUCE_SCATTER
+ * @brief Perform a reduce-scatter between PEs in the team. Each PE contributes
+ * nelems * n_pes elements from source; after reduction across all PEs,
+ * PE i receives the nelems elements corresponding to block i.
+ *
+ * This function must be called as a work-group collective.
+ *
+ * @param[in] team         The team participating in the collective.
+ * @param[in] dest         Destination address (nelems elements). Must be an
+ *                         address on the symmetric heap.
+ * @param[in] source       Source address (nelems * n_pes elements). Must be
+ *                         an address on the symmetric heap.
+ * @param[in] nelems      Number of elements each PE receives.
+ *
+ * @return int (Zero on successful local completion. Nonzero otherwise.)
+ */
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_sum_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_min_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_max_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_prod_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_or_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_and_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_xor_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
+    int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_sum_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_min_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_max_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_prod_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_or_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_and_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_xor_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
+    int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_sum_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_min_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_max_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_prod_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_or_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_and_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_xor_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
+    int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_sum_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_min_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_max_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_prod_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_or_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_and_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_xor_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
+    int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_float_sum_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_float_min_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_float_max_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_float_prod_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source,
+    int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_double_sum_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_double_min_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_double_max_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source,
+    int nelems);
+__device__ ATTR_NO_INLINE int rocshmem_ctx_double_prod_reduce_scatter_wg(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source,
+    int nelems);
+
+/**
+ * @name SHMEM_REDUCE_SCATTER host-side
+ * @brief Host-side reduce-scatter: PE i receives the element-wise reduction
+ * of source[i*nreduce..(i+1)*nreduce-1] across all PEs.
+ */
+__host__ int rocshmem_ctx_short_sum_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source, int nreduce);
+__host__ int rocshmem_ctx_short_min_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source, int nreduce);
+__host__ int rocshmem_ctx_short_max_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source, int nreduce);
+__host__ int rocshmem_ctx_short_prod_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source, int nreduce);
+__host__ int rocshmem_ctx_short_or_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source, int nreduce);
+__host__ int rocshmem_ctx_short_and_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source, int nreduce);
+__host__ int rocshmem_ctx_short_xor_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source, int nreduce);
+
+__host__ int rocshmem_ctx_int_sum_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source, int nreduce);
+__host__ int rocshmem_ctx_int_min_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source, int nreduce);
+__host__ int rocshmem_ctx_int_max_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source, int nreduce);
+__host__ int rocshmem_ctx_int_prod_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source, int nreduce);
+__host__ int rocshmem_ctx_int_or_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source, int nreduce);
+__host__ int rocshmem_ctx_int_and_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source, int nreduce);
+__host__ int rocshmem_ctx_int_xor_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source, int nreduce);
+
+__host__ int rocshmem_ctx_long_sum_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source, int nreduce);
+__host__ int rocshmem_ctx_long_min_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source, int nreduce);
+__host__ int rocshmem_ctx_long_max_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source, int nreduce);
+__host__ int rocshmem_ctx_long_prod_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source, int nreduce);
+__host__ int rocshmem_ctx_long_or_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source, int nreduce);
+__host__ int rocshmem_ctx_long_and_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source, int nreduce);
+__host__ int rocshmem_ctx_long_xor_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source, int nreduce);
+
+__host__ int rocshmem_ctx_longlong_sum_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source, int nreduce);
+__host__ int rocshmem_ctx_longlong_min_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source, int nreduce);
+__host__ int rocshmem_ctx_longlong_max_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source, int nreduce);
+__host__ int rocshmem_ctx_longlong_prod_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source, int nreduce);
+__host__ int rocshmem_ctx_longlong_or_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source, int nreduce);
+__host__ int rocshmem_ctx_longlong_and_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source, int nreduce);
+__host__ int rocshmem_ctx_longlong_xor_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source, int nreduce);
+
+__host__ int rocshmem_ctx_float_sum_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source, int nreduce);
+__host__ int rocshmem_ctx_float_min_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source, int nreduce);
+__host__ int rocshmem_ctx_float_max_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source, int nreduce);
+__host__ int rocshmem_ctx_float_prod_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source, int nreduce);
+
+__host__ int rocshmem_ctx_double_sum_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source, int nreduce);
+__host__ int rocshmem_ctx_double_min_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source, int nreduce);
+__host__ int rocshmem_ctx_double_max_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source, int nreduce);
+__host__ int rocshmem_ctx_double_prod_reduce_scatter(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source, int nreduce);
+
+/**
  * @name SHMEM_REDUCTIONS
  * @brief Perform an allreduce between PEs in the active set. The caller
  * is blocked until the reduction completes.

--- a/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
@@ -484,117 +484,117 @@ __device__ ATTR_NO_INLINE void rocshmem_ctx_ulonglong_fcollect_wg(
  */
 __device__ ATTR_NO_INLINE int rocshmem_ctx_short_sum_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_short_min_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_short_max_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_short_prod_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_short_or_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_short_and_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_short_xor_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest, const short *source,
-    int nelems);
+    int nreduce);
 
 __device__ ATTR_NO_INLINE int rocshmem_ctx_int_sum_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_int_min_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_int_max_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_int_prod_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_int_or_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_int_and_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_int_xor_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest, const int *source,
-    int nelems);
+    int nreduce);
 
 __device__ ATTR_NO_INLINE int rocshmem_ctx_long_sum_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_long_min_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_long_max_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_long_prod_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_long_or_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_long_and_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_long_xor_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest, const long *source,
-    int nelems);
+    int nreduce);
 
 __device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_sum_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_min_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_max_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_prod_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_or_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_and_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_xor_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest, const long long *source,
-    int nelems);
+    int nreduce);
 
 __device__ ATTR_NO_INLINE int rocshmem_ctx_float_sum_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_float_min_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_float_max_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_float_prod_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest, const float *source,
-    int nelems);
+    int nreduce);
 
 __device__ ATTR_NO_INLINE int rocshmem_ctx_double_sum_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_double_min_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_double_max_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source,
-    int nelems);
+    int nreduce);
 __device__ ATTR_NO_INLINE int rocshmem_ctx_double_prod_reduce_scatter_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest, const double *source,
-    int nelems);
+    int nreduce);
 
 /**
  * @name SHMEM_REDUCE_SCATTER host-side

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -163,6 +163,7 @@ declare -A TEST_NUMBERS=(
   ["host_wait_until_all_status"]="146"
   ["host_wait_until_any_status"]="147"
   ["host_wait_until_some_status"]="148"
+  ["teamreducescatter"]="149"
 )
 
 # Detect which runtime to use
@@ -737,6 +738,10 @@ TestColl() {
   # check in the ring all-reduce path; this is a pre-existing bug unrelated to
   # work/sync pool alignment, so it is only run at 2 ranks here.
   ExecTest  "teamreduction"    2       1            64        32768
+
+  ExecTest  "teamreducescatter" 2     1            64        32768
+  ExecTest  "teamreducescatter" 4     1            64        32768
+  ExecTest  "teamreducescatter" 8     1            64        32768
 }
 
 TestOnStream() {

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -177,6 +177,15 @@ else
   USE_SLR=0
 fi
 
+# Detect wavefront size based on GPU architecture
+# gfx1100 and gfx1201 have wavefront size 32, most others have 64
+WAVE_SIZE=64
+if command -v rocminfo >/dev/null 2>&1; then
+  if rocminfo | grep -qE "Name:.*(gfx1100|gfx1201|gfx1250)"; then
+    WAVE_SIZE=32
+  fi
+fi
+
 # Router function - dispatches to appropriate implementation
 ExecTest() {
   if [ $USE_SLR -eq 1 ]; then
@@ -739,9 +748,9 @@ TestColl() {
   # work/sync pool alignment, so it is only run at 2 ranks here.
   ExecTest  "teamreduction"    2       1            64        32768
 
-  ExecTest  "teamreducescatter" 2     1            64        32768
-  ExecTest  "teamreducescatter" 4     1            64        32768
-  ExecTest  "teamreducescatter" 8     1            64        32768
+  ExecTest  "teamreducescatter" 2      1            64        32768
+  ExecTest  "teamreducescatter" 4      1            64        32768
+  ExecTest  "teamreducescatter" 8      1            64        32768
 }
 
 TestOnStream() {
@@ -904,15 +913,6 @@ TestTiles() {
   ##############################################################################
   #       | Name                      | Ranks | Workgroups | Threads | Max Message Size #
   ##############################################################################
-
-  # Detect wavefront size based on GPU architecture
-  # gfx1100 and gfx1201 have wavefront size 32, most others have 64
-  WAVE_SIZE=64
-  if command -v rocminfo >/dev/null 2>&1; then
-    if rocminfo | grep -qE "Name:.*(gfx1100|gfx1201)"; then
-      WAVE_SIZE=32
-    fi
-  fi
 
   ExecTest  "tile_put_contiguous"       2       1            1
   ExecTest  "tile_put_rowmajor"         2       1            1

--- a/projects/rocshmem/src/backend_bc.cpp
+++ b/projects/rocshmem/src/backend_bc.cpp
@@ -269,6 +269,7 @@ void Backend::dump_stats() {
     pstat("Put_Signal_NBI",        device_stats.getStat(NUM_PUT_SIGNAL_NBI));
     pstat("WG_Put_Signal_NBI",     device_stats.getStat(NUM_PUT_SIGNAL_NBI_WG));
     pstat("WAVE_Put_Signal_NBI",   device_stats.getStat(NUM_PUT_SIGNAL_NBI_WAVE));
+    pstat("ReduceScatter",         device_stats.getStat(NUM_REDUCE_SCATTER));
     LOG_INFO("%s", buf);
   }
 

--- a/projects/rocshmem/src/backend_bc.cpp
+++ b/projects/rocshmem/src/backend_bc.cpp
@@ -194,7 +194,7 @@ void Backend::dump_stats() {
     if (val) { append("  %-30s %llu\n", name, static_cast<unsigned long long>(val)); ++n_printed; }
   };
 
-  static_assert(NUM_STATS == 68,
+  static_assert(NUM_STATS == 69,
     "rocshmem_stats enum changed; update dump_stats device section");
   const auto& device_stats{globalStats};
   uint64_t device_total = 0;

--- a/projects/rocshmem/src/context.hpp
+++ b/projects/rocshmem/src/context.hpp
@@ -213,7 +213,7 @@ class Context {
   __device__ int reduce(rocshmem_team_t team, T* dest, const T* source, int nreduce);
 
   template <typename T, ROCSHMEM_OP Op>
-  __device__ int reduce_scatter(rocshmem_team_t team, T* dest, const T* source, int nreduce);
+  __device__ int reduce_scatter_wg(rocshmem_team_t team, T* dest, const T* source, int nreduce);
 
   template <typename T>
   __device__ void put(T* dest, const T* source, size_t nelems, int pe);

--- a/projects/rocshmem/src/context.hpp
+++ b/projects/rocshmem/src/context.hpp
@@ -212,6 +212,9 @@ class Context {
   template <typename T, ROCSHMEM_OP Op>
   __device__ int reduce(rocshmem_team_t team, T* dest, const T* source, int nreduce);
 
+  template <typename T, ROCSHMEM_OP Op>
+  __device__ int reduce_scatter(rocshmem_team_t team, T* dest, const T* source, int nreduce);
+
   template <typename T>
   __device__ void put(T* dest, const T* source, size_t nelems, int pe);
 
@@ -572,7 +575,11 @@ class Context {
 
   template <typename T, ROCSHMEM_OP Op>
   __host__ int reduce(rocshmem_team_t team, T* dest, const T* source, int nreduce);
-  
+
+  template <typename T, ROCSHMEM_OP Op>
+  __host__ int reduce_scatter(rocshmem_team_t team, T* dest, const T* source,
+                              int nreduce);
+
   template <typename T, ROCSHMEM_OP Op>
   __host__ int reduce_on_stream(rocshmem_team_t team, T* dest, const T* source,
                                  int nreduce, hipStream_t stream);

--- a/projects/rocshmem/src/context_tmpl_device.hpp
+++ b/projects/rocshmem/src/context_tmpl_device.hpp
@@ -97,6 +97,20 @@ __device__ int Context::reduce(rocshmem_team_t team, T *dest, const T *source,
   DISPATCH_RET(reduce<PAIR(T, Op)>(team, dest, source, nreduce));
 }
 
+template <typename T, ROCSHMEM_OP Op>
+__device__ int Context::reduce_scatter(rocshmem_team_t team, T *dest,
+                                       const T *source, int nreduce) {
+  if (nreduce == 0) {
+    return ROCSHMEM_SUCCESS;
+  }
+
+  if (is_thread_zero_in_block()) {
+    ctxStats.incStat(NUM_REDUCE_SCATTER);
+  }
+
+  DISPATCH_RET(reduce_scatter<PAIR(T, Op)>(team, dest, source, nreduce));
+}
+
 template <typename T>
 __device__ void Context::put(T *dest, const T *source, size_t nelems, int pe) {
   if (nelems == 0) {

--- a/projects/rocshmem/src/context_tmpl_device.hpp
+++ b/projects/rocshmem/src/context_tmpl_device.hpp
@@ -98,8 +98,8 @@ __device__ int Context::reduce(rocshmem_team_t team, T *dest, const T *source,
 }
 
 template <typename T, ROCSHMEM_OP Op>
-__device__ int Context::reduce_scatter(rocshmem_team_t team, T *dest,
-                                       const T *source, int nreduce) {
+__device__ int Context::reduce_scatter_wg(rocshmem_team_t team, T *dest,
+                                          const T *source, int nreduce) {
   if (nreduce == 0) {
     return ROCSHMEM_SUCCESS;
   }
@@ -108,7 +108,7 @@ __device__ int Context::reduce_scatter(rocshmem_team_t team, T *dest,
     ctxStats.incStat(NUM_REDUCE_SCATTER);
   }
 
-  DISPATCH_RET(reduce_scatter<PAIR(T, Op)>(team, dest, source, nreduce));
+  DISPATCH_RET(reduce_scatter_wg<PAIR(T, Op)>(team, dest, source, nreduce));
 }
 
 template <typename T>

--- a/projects/rocshmem/src/context_tmpl_host.hpp
+++ b/projects/rocshmem/src/context_tmpl_host.hpp
@@ -239,6 +239,18 @@ __host__ int Context::reduce(rocshmem_team_t team, T *dest, const T *source,
 }
 
 template <typename T, ROCSHMEM_OP Op>
+__host__ int Context::reduce_scatter(rocshmem_team_t team, T *dest,
+                                     const T *source, int nreduce) {
+  if (nreduce == 0) {
+    return ROCSHMEM_SUCCESS;
+  }
+
+  ctxHostStats.incStat(NUM_HOST_TO_ALL);
+
+  HOST_DISPATCH_RET(reduce_scatter<PAIR(T, Op)>(team, dest, source, nreduce));
+}
+
+template <typename T, ROCSHMEM_OP Op>
 __host__ int Context::reduce_on_stream(rocshmem_team_t team, T* dest, const T* source,
                                 int nreduce, hipStream_t stream) {
   if (nreduce == 0) return ROCSHMEM_SUCCESS;

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -144,6 +144,10 @@ class GDAContext : public Context {
   template <typename T, ROCSHMEM_OP Op>
   __device__ int reduce(rocshmem_team_t team, T *dest, const T *source, int nreduce);
 
+  template <typename T, ROCSHMEM_OP Op>
+  __device__ int reduce_scatter(rocshmem_team_t team, T *dest, const T *source,
+                                int nreduce);
+
   template <typename T>
   __device__ void broadcast(rocshmem_team_t team, T *dest, const T *source,
                             int nelems, int pe_root);

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -145,8 +145,8 @@ class GDAContext : public Context {
   __device__ int reduce(rocshmem_team_t team, T *dest, const T *source, int nreduce);
 
   template <typename T, ROCSHMEM_OP Op>
-  __device__ int reduce_scatter(rocshmem_team_t team, T *dest, const T *source,
-                                int nreduce);
+  __device__ int reduce_scatter_wg(rocshmem_team_t team, T *dest, const T *source,
+                                   int nreduce);
 
   template <typename T>
   __device__ void broadcast(rocshmem_team_t team, T *dest, const T *source,

--- a/projects/rocshmem/src/gda/context_gda_host.hpp
+++ b/projects/rocshmem/src/gda/context_gda_host.hpp
@@ -139,7 +139,11 @@ class GDAHostContext : public Context {
   __host__ int reduce(rocshmem_team_t team, T *dest, const T *source, int nreduce);
 
   template <typename T, ROCSHMEM_OP Op>
-  __host__ int reduce_on_stream(rocshmem_team_t team, T *dest, const T *source, 
+  __host__ int reduce_scatter(rocshmem_team_t team, T *dest, const T *source,
+                              int nreduce);
+
+  template <typename T, ROCSHMEM_OP Op>
+  __host__ int reduce_on_stream(rocshmem_team_t team, T *dest, const T *source,
                                 int nreduce, hipStream_t stream);
 
   template <typename T>

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -580,8 +580,8 @@ __device__ int GDAContext::reduce(rocshmem_team_t team, T *dest,
  * multiple workgroups share the same team pSync/pWrk/dest buffers.
  */
 template <typename T, ROCSHMEM_OP Op>
-__device__ int GDAContext::reduce_scatter(rocshmem_team_t team, T *dest,
-                                          const T *source, int nreduce) {
+__device__ int GDAContext::reduce_scatter_wg(rocshmem_team_t team, T *dest,
+                                             const T *source, int nreduce) {
   GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
 
   int PE_size   = team_obj->tinfo_wrt_world->size;

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -652,10 +652,9 @@ __device__ int GDAContext::reduce_scatter(rocshmem_team_t team, T *dest,
       }
       threadfence_system();
       __syncthreads();
+      // Sync with workgroup 0 of other PEs
+      barrier_wg(team);
     }
-
-    // All workgroups participate in the cross-PE barrier after each chunk.
-    barrier_wg(team);
   }
 
   return ROCSHMEM_SUCCESS;

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -570,6 +570,95 @@ __device__ int GDAContext::reduce(rocshmem_team_t team, T *dest,
   return ROCSHMEM_SUCCESS;
 }
 
+/*
+ * Reduce-scatter: PE r receives the element-wise reduction of
+ * source[r*nreduce .. (r+1)*nreduce - 1] across all PEs into dest[0..nreduce-1].
+ *
+ * Algorithm: each PE s sends source_s[r*nreduce+offset..+count] to PE r's
+ * pWrk at slot s (pWrk[team_rank_s * chunk_size]).  PE r then reduces all
+ * pWrk slots into dest.  Chunked when chunk_size < nreduce.
+ */
+template <typename T, ROCSHMEM_OP Op>
+__device__ int GDAContext::reduce_scatter(rocshmem_team_t team, T *dest,
+                                          const T *source, int nreduce) {
+  GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
+
+  int PE_size   = team_obj->tinfo_wrt_world->size;
+  int PE_start  = team_obj->tinfo_wrt_world->pe_start;
+  int stride    = team_obj->tinfo_wrt_world->stride;
+  int team_rank = (my_pe - PE_start) / stride;
+
+  long *pSync = team_obj->reduce_pSync;
+  T    *pWrk  = reinterpret_cast<T *>(team_obj->pWrk);
+
+  ActiveWFInfo wf_info(ctx_id_, ThreadScope::wg);
+
+  int wg_id   = get_flat_block_id();
+  int wg_size = get_flat_block_size();
+
+  int pWrk_elems = (int)(ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE * sizeof(double) / sizeof(T));
+  int chunk_size = max(1, pWrk_elems / PE_size);
+  int n_chunks   = (nreduce + chunk_size - 1) / chunk_size;
+
+  int finish = PE_start + stride * PE_size;
+
+  for (int c = 0; c < n_chunks; c++) {
+    int offset = c * chunk_size;
+    int count  = min(chunk_size, nreduce - offset);
+
+    // For each remote PE i (rank remote_rank), send my contribution for that
+    // PE's output block into PE i's pWrk at my slot (team_rank).
+    for (int i = PE_start; i < finish; i += stride) {
+      if (i != my_pe) {
+        int remote_rank = (i - PE_start) / stride;
+        internal_putmem_wg(&pWrk[team_rank * chunk_size],
+                           reinterpret_cast<const void *>(
+                               source + remote_rank * nreduce + offset),
+                           count * sizeof(T), i, i, wf_info);
+        if (is_thread_zero_in_block()) {
+          fence();
+          int64_t flag = (int64_t)(c + 1);
+          internal_putmem(&pSync[team_rank], &flag, sizeof(*pSync), i, i, wf_info);
+        }
+      }
+    }
+
+    // Initialize dest from my own contribution to my own output block.
+    for (int j = wg_id; j < count; j += wg_size) {
+      dest[offset + j] = source[team_rank * nreduce + offset + j];
+    }
+    threadfence_system();
+    __syncthreads();
+
+    // Wait for each remote PE s to signal pWrk[s * chunk_size] is ready,
+    // then accumulate into dest.
+    for (int i = PE_start; i < finish; i += stride) {
+      if (i != my_pe) {
+        int remote_rank = (i - PE_start) / stride;
+        int64_t expected = (int64_t)(c + 1);
+        if (is_thread_zero_in_block()) {
+          wait_until(&pSync[remote_rank], ROCSHMEM_CMP_EQ, expected);
+        }
+        __syncthreads();
+        gda_compute_reduce<T, Op>(&pWrk[remote_rank * chunk_size], dest + offset,
+                                  count, wg_id, wg_size);
+        threadfence_system();
+      }
+    }
+    __syncthreads();
+  }
+
+  // Reset pSync.
+  for (int i = wg_id; i < PE_size; i += wg_size) {
+    pSync[i] = ROCSHMEM_SYNC_VALUE;
+  }
+  threadfence_system();
+  __syncthreads();
+
+  barrier_wg(team);
+  return ROCSHMEM_SUCCESS;
+}
+
 template <typename T>
 __device__ void GDAContext::internal_put_broadcast(T *dst, const T *src,
     int nelems, int pe_root, int pe_start, int stride, int pe_size,

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -574,9 +574,10 @@ __device__ int GDAContext::reduce(rocshmem_team_t team, T *dest,
  * Reduce-scatter: PE r receives the element-wise reduction of
  * source[r*nreduce .. (r+1)*nreduce - 1] across all PEs into dest[0..nreduce-1].
  *
- * Algorithm: each PE s sends source_s[r*nreduce+offset..+count] to PE r's
- * pWrk at slot s (pWrk[team_rank_s * chunk_size]).  PE r then reduces all
- * pWrk slots into dest.  Chunked when chunk_size < nreduce.
+ * Only workgroup 0 (is_block_zero_in_grid) runs the reduction algorithm;
+ * all workgroups participate in the per-chunk barrier_wg so the barrier
+ * call counts match.  This prevents concurrent accumulation races when
+ * multiple workgroups share the same team pSync/pWrk/dest buffers.
  */
 template <typename T, ROCSHMEM_OP Op>
 __device__ int GDAContext::reduce_scatter(rocshmem_team_t team, T *dest,
@@ -599,63 +600,64 @@ __device__ int GDAContext::reduce_scatter(rocshmem_team_t team, T *dest,
   int pWrk_elems = (int)(ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE * sizeof(double) / sizeof(T));
   int chunk_size = max(1, pWrk_elems / PE_size);
   int n_chunks   = (nreduce + chunk_size - 1) / chunk_size;
-
+  int64_t flag_val = 1;
   int finish = PE_start + stride * PE_size;
 
   for (int c = 0; c < n_chunks; c++) {
-    int offset = c * chunk_size;
-    int count  = min(chunk_size, nreduce - offset);
+    if (is_block_zero_in_grid()) {
+      int offset = c * chunk_size;
+      int count  = min(chunk_size, nreduce - offset);
 
-    // For each remote PE i (rank remote_rank), send my contribution for that
-    // PE's output block into PE i's pWrk at my slot (team_rank).
-    for (int i = PE_start; i < finish; i += stride) {
-      if (i != my_pe) {
-        int remote_rank = (i - PE_start) / stride;
-        internal_putmem_wg(&pWrk[team_rank * chunk_size],
-                           reinterpret_cast<const void *>(
-                               source + remote_rank * nreduce + offset),
-                           count * sizeof(T), i, i, wf_info);
-        if (is_thread_zero_in_block()) {
-          fence();
-          int64_t flag = (int64_t)(c + 1);
-          internal_putmem(&pSync[team_rank], &flag, sizeof(*pSync), i, i, wf_info);
+      // Seed dest[offset..offset+count) from my own contribution.
+      for (int j = wg_id; j < count; j += wg_size) {
+        dest[offset + j] = source[team_rank * nreduce + offset + j];
+      }
+      __syncthreads();
+
+      // Send my contribution for each remote PE's output block, then signal.
+      for (int i = PE_start; i < finish; i += stride) {
+        if (i != my_pe) {
+          int remote_rank = (i - PE_start) / stride;
+          internal_putmem_wg(&pWrk[team_rank * chunk_size],
+                             reinterpret_cast<const void *>(
+                                 source + remote_rank * nreduce + offset),
+                             count * sizeof(T), i, i, wf_info);
+          if (is_thread_zero_in_block()) {
+            fence();
+            internal_putmem(&pSync[team_rank], &flag_val, sizeof(*pSync), i, i, wf_info);
+          }
         }
       }
-    }
+      threadfence_system();
+      __syncthreads();
 
-    // Initialize dest from my own contribution to my own output block.
-    for (int j = wg_id; j < count; j += wg_size) {
-      dest[offset + j] = source[team_rank * nreduce + offset + j];
-    }
-    threadfence_system();
-    __syncthreads();
-
-    // Wait for each remote PE s to signal pWrk[s * chunk_size] is ready,
-    // then accumulate into dest.
-    for (int i = PE_start; i < finish; i += stride) {
-      if (i != my_pe) {
-        int remote_rank = (i - PE_start) / stride;
-        int64_t expected = (int64_t)(c + 1);
-        if (is_thread_zero_in_block()) {
-          wait_until(&pSync[remote_rank], ROCSHMEM_CMP_EQ, expected);
+      // Wait for each remote PE s, then accumulate into dest.
+      for (int i = PE_start; i < finish; i += stride) {
+        if (i != my_pe) {
+          int remote_rank = (i - PE_start) / stride;
+          if (is_thread_zero_in_block()) {
+            wait_until(&pSync[remote_rank], ROCSHMEM_CMP_EQ, flag_val);
+          }
+          __syncthreads();
+          gda_compute_reduce<T, Op>(&pWrk[remote_rank * chunk_size],
+                                    dest + offset, count, wg_id, wg_size);
+          threadfence_system();
         }
-        __syncthreads();
-        gda_compute_reduce<T, Op>(&pWrk[remote_rank * chunk_size], dest + offset,
-                                  count, wg_id, wg_size);
-        threadfence_system();
       }
+      __syncthreads();
+
+      // Reset pSync before reuse.
+      for (int j = wg_id; j < PE_size; j += wg_size) {
+        pSync[j] = ROCSHMEM_SYNC_VALUE;
+      }
+      threadfence_system();
+      __syncthreads();
     }
-    __syncthreads();
+
+    // All workgroups participate in the cross-PE barrier after each chunk.
+    barrier_wg(team);
   }
 
-  // Reset pSync.
-  for (int i = wg_id; i < PE_size; i += wg_size) {
-    pSync[i] = ROCSHMEM_SYNC_VALUE;
-  }
-  threadfence_system();
-  __syncthreads();
-
-  barrier_wg(team);
   return ROCSHMEM_SUCCESS;
 }
 

--- a/projects/rocshmem/src/gda/context_gda_tmpl_host.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_host.hpp
@@ -112,6 +112,12 @@ __host__ int GDAHostContext::reduce(rocshmem_team_t team, T *dest,
 }
 
 template <typename T, ROCSHMEM_OP Op>
+__host__ int GDAHostContext::reduce_scatter(rocshmem_team_t team, T *dest,
+                                            const T *source, int nreduce) {
+  return host_interface->reduce_scatter<T, Op>(team, dest, source, nreduce);
+}
+
+template <typename T, ROCSHMEM_OP Op>
 __host__ int GDAHostContext::reduce_on_stream(rocshmem_team_t team, T* dest,
                                               const T *source, int nreduce,
                                               hipStream_t stream) {

--- a/projects/rocshmem/src/host/host.hpp
+++ b/projects/rocshmem/src/host/host.hpp
@@ -253,7 +253,11 @@ class HostInterface {
   __host__ int reduce(rocshmem_team_t team, T* dest, const T* source, int nreduce);
 
   template <typename T, ROCSHMEM_OP Op>
-  __host__ int reduce_on_stream(rocshmem_team_t team, T* dest, const T* source, 
+  __host__ int reduce_scatter(rocshmem_team_t team, T* dest, const T* source,
+                              int nreduce);
+
+  template <typename T, ROCSHMEM_OP Op>
+  __host__ int reduce_on_stream(rocshmem_team_t team, T* dest, const T* source,
                                 int nreduce, hipStream_t stream);
 
   template <typename T>

--- a/projects/rocshmem/src/host/host_templates.hpp
+++ b/projects/rocshmem/src/host/host_templates.hpp
@@ -411,6 +411,25 @@ __host__ int HostInterface::reduce(rocshmem_team_t team, T* dest,
 }
 
 template <typename T, ROCSHMEM_OP Op>
+__host__ int HostInterface::reduce_scatter(rocshmem_team_t team, T* dest,
+                                           const T* source, int nreduce) {
+  LOG_API("host::reduce_scatter (dest=%p, source=%p, nreduce=%d)", dest, source, nreduce);
+
+  Team* team_obj{get_internal_team(team)};
+  MPI_Comm mpi_comm{team_obj->mpi_comm};
+
+  MPI_Op mpi_op{get_mpi_op(Op)};
+  MPI_Datatype mpi_type{get_mpi_type<T>()};
+
+  hdp_policy_->hdp_flush();
+
+  mpilib_ftable_.Reduce_scatter_block(
+      const_cast<T*>(source), dest, nreduce, mpi_type, mpi_op, mpi_comm);
+
+  return ROCSHMEM_SUCCESS;
+}
+
+template <typename T, ROCSHMEM_OP Op>
 __host__ int HostInterface::reduce_on_stream(rocshmem_team_t team,
                                               T *dest,
                                               const T *source,

--- a/projects/rocshmem/src/host/host_templates.hpp
+++ b/projects/rocshmem/src/host/host_templates.hpp
@@ -418,6 +418,11 @@ __host__ int HostInterface::reduce_scatter(rocshmem_team_t team, T* dest,
   Team* team_obj{get_internal_team(team)};
   MPI_Comm mpi_comm{team_obj->mpi_comm};
 
+  if (mpi_comm == MPI_COMM_NULL) {
+    LOGD_WARN("reduce_scatter host variant is only executable on MPI bootstrapping path");
+    return ROCSHMEM_ERROR;
+  }
+
   MPI_Op mpi_op{get_mpi_op(Op)};
   MPI_Datatype mpi_type{get_mpi_type<T>()};
 

--- a/projects/rocshmem/src/host/host_templates.hpp
+++ b/projects/rocshmem/src/host/host_templates.hpp
@@ -419,7 +419,7 @@ __host__ int HostInterface::reduce_scatter(rocshmem_team_t team, T* dest,
   MPI_Comm mpi_comm{team_obj->mpi_comm};
 
   if (mpi_comm == MPI_COMM_NULL) {
-    LOGD_WARN("reduce_scatter host variant is only executable on MPI bootstrapping path");
+    LOG_WARN("reduce_scatter host variant is only executable on MPI bootstrapping path");
     return ROCSHMEM_ERROR;
   }
 

--- a/projects/rocshmem/src/ipc/context_ipc_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.hpp
@@ -141,8 +141,8 @@ class IPCContext : public Context {
   __device__ int reduce(rocshmem_team_t team, T *dest, const T *source, int nreduce);
 
   template <typename T, ROCSHMEM_OP Op>
-  __device__ int reduce_scatter(rocshmem_team_t team, T *dest, const T *source,
-                                int nreduce);
+  __device__ int reduce_scatter_wg(rocshmem_team_t team, T *dest, const T *source,
+                                   int nreduce);
 
   template <typename T>
   __device__ void broadcast(rocshmem_team_t team, T *dest, const T *source,

--- a/projects/rocshmem/src/ipc/context_ipc_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.hpp
@@ -140,6 +140,10 @@ class IPCContext : public Context {
   template <typename T, ROCSHMEM_OP Op>
   __device__ int reduce(rocshmem_team_t team, T *dest, const T *source, int nreduce);
 
+  template <typename T, ROCSHMEM_OP Op>
+  __device__ int reduce_scatter(rocshmem_team_t team, T *dest, const T *source,
+                                int nreduce);
+
   template <typename T>
   __device__ void broadcast(rocshmem_team_t team, T *dest, const T *source,
                             int nelems, int pe_root);

--- a/projects/rocshmem/src/ipc/context_ipc_host.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_host.hpp
@@ -140,7 +140,11 @@ class IPCHostContext : public Context {
   __host__ int reduce(rocshmem_team_t team, T *dest, const T *source, int nreduce);
 
   template <typename T, ROCSHMEM_OP Op>
-  __host__ int reduce_on_stream(rocshmem_team_t team, T *dest, const T *source, 
+  __host__ int reduce_scatter(rocshmem_team_t team, T *dest, const T *source,
+                              int nreduce);
+
+  template <typename T, ROCSHMEM_OP Op>
+  __host__ int reduce_on_stream(rocshmem_team_t team, T *dest, const T *source,
                                 int nreduce, hipStream_t stream);
 
   template <typename T>

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -494,10 +494,9 @@ __device__ int IPCContext::reduce_scatter(rocshmem_team_t team, T *dest,
         pSync[j] = ROCSHMEM_SYNC_VALUE;
       }
       __syncthreads();
+      // Sync with workgroup 0 of other PEs
+      barrier_wg(team);
     }
-
-    // All workgroups participate in the cross-PE barrier after each chunk.
-    barrier_wg(team);
   }
 
   return ROCSHMEM_SUCCESS;

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -417,14 +417,10 @@ __device__ int IPCContext::reduce(rocshmem_team_t team, T *dest,
  * Reduce-scatter: PE r receives the element-wise reduction of
  * source[r*nreduce .. (r+1)*nreduce - 1] across all PEs into dest[0..nreduce-1].
  *
- * Algorithm:
- *   Each PE s sends source_s[r*nreduce + offset .. + count] to PE r's pWrk
- *   at slot s (pWrk[team_rank_s * chunk_size]).  After all PEs have written,
- *   each PE reduces its pWrk slots into dest.  Chunked when pWrk is too small.
- *
- * pSync layout: pSync[s] is the flag PE s signals on PE r after writing to
- * pWrk[s * chunk_size] on PE r.  We use value (c+1) for chunk c to allow
- * reuse without a full reset between chunks.
+ * Only workgroup 0 (is_block_zero_in_grid) runs the algorithm; all other
+ * workgroups wait at the final barrier_wg.  This prevents concurrent
+ * accumulation races when multiple workgroups share the same team
+ * pSync/pWrk/dest buffers.
  */
 template <typename T, ROCSHMEM_OP Op>
 __device__ int IPCContext::reduce_scatter(rocshmem_team_t team, T *dest,
@@ -436,8 +432,8 @@ __device__ int IPCContext::reduce_scatter(rocshmem_team_t team, T *dest,
   int stride    = team_obj->tinfo_wrt_world->stride;
   int team_rank = (my_pe - PE_start) / stride;
 
-  long *pSync = team_obj->reduce_pSync;
-  T    *pWrk  = reinterpret_cast<T *>(team_obj->pWrk);
+  long  *pSync = team_obj->reduce_pSync;
+  T     *pWrk  = reinterpret_cast<T *>(team_obj->pWrk);
 
   int wg_id   = get_flat_block_id();
   int wg_size = get_flat_block_size();
@@ -445,66 +441,65 @@ __device__ int IPCContext::reduce_scatter(rocshmem_team_t team, T *dest,
   int pWrk_elems = (int)(ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE * sizeof(double) / sizeof(T));
   int chunk_size = max(1, pWrk_elems / PE_size);
   int n_chunks   = (nreduce + chunk_size - 1) / chunk_size;
-
+  int64_t flag_val = 1;
   int finish = PE_start + stride * PE_size;
 
+  // Only workgroup 0 runs the reduction algorithm; other workgroups participate
+  // in the barriers only (same number of barrier_wg calls as WG 0).
   for (int c = 0; c < n_chunks; c++) {
-    int offset = c * chunk_size;
-    int count  = min(chunk_size, nreduce - offset);
+    if (is_block_zero_in_grid()) {
+      int offset = c * chunk_size;
+      int count  = min(chunk_size, nreduce - offset);
 
-    // For each remote PE r (rank remote_rank), send my contribution for r's
-    // output block: source[remote_rank * nreduce + offset .. + count]
-    // into PE r's pWrk at slot team_rank (pWrk[team_rank * chunk_size]).
-    for (int i = PE_start; i < finish; i += stride) {
-      if (i != my_pe) {
-        int remote_rank = (i - PE_start) / stride;
-        // Write my contribution for PE i's output block into PE i's pWrk
-        // at my slot (team_rank) so PE i knows the sender.
-        internal_putmem_wg(&pWrk[team_rank * chunk_size],
-                           reinterpret_cast<const void *>(
-                               source + remote_rank * nreduce + offset),
-                           count * sizeof(T), i);
-        if (is_thread_zero_in_block()) {
-          fence(i);
-          int64_t flag = (int64_t)(c + 1);
-          // Signal PE i that my slot is ready.
-          internal_putmem(&pSync[team_rank], &flag, sizeof(*pSync), i);
+      // Seed dest[offset..offset+count) from my own contribution.
+      for (int j = wg_id; j < count; j += wg_size) {
+        dest[offset + j] = source[team_rank * nreduce + offset + j];
+      }
+      __syncthreads();
+
+      // Send my contribution for each remote PE's output block, then signal.
+      for (int i = PE_start; i < finish; i += stride) {
+        if (i != my_pe) {
+          int remote_rank = (i - PE_start) / stride;
+          internal_putmem_wg(&pWrk[team_rank * chunk_size],
+                             reinterpret_cast<const void *>(
+                                 source + remote_rank * nreduce + offset),
+                             count * sizeof(T), i);
+          if (is_thread_zero_in_block()) {
+            fence(i);
+            internal_putmem(&pSync[team_rank], &flag_val, sizeof(*pSync), i);
+          }
         }
       }
-    }
+      threadfence_system();
+      __syncthreads();
 
-    // Initialize dest from my own contribution to my own output block.
-    for (int j = wg_id; j < count; j += wg_size) {
-      dest[offset + j] = source[team_rank * nreduce + offset + j];
-    }
-    threadfence_system();
-    __syncthreads();
-
-    // Wait for each remote PE s to signal that pWrk[s * chunk_size] is ready,
-    // then accumulate into dest.
-    for (int i = PE_start; i < finish; i += stride) {
-      if (i != my_pe) {
-        int remote_rank = (i - PE_start) / stride;
-        int64_t expected = (int64_t)(c + 1);
-        if (is_thread_zero_in_block()) {
-          wait_until(&pSync[remote_rank], ROCSHMEM_CMP_EQ, expected);
+      // Wait for each remote PE s, then accumulate into dest.
+      for (int i = PE_start; i < finish; i += stride) {
+        if (i != my_pe) {
+          int remote_rank = (i - PE_start) / stride;
+          if (is_thread_zero_in_block()) {
+            wait_until(&pSync[remote_rank], ROCSHMEM_CMP_EQ, flag_val);
+          }
+          __syncthreads();
+          ipc_compute_reduce<T, Op>(&pWrk[remote_rank * chunk_size],
+                                    dest + offset, count, wg_id, wg_size);
+          threadfence_system();
         }
-        __syncthreads();
-        ipc_compute_reduce<T, Op>(&pWrk[remote_rank * chunk_size], dest + offset,
-                                  count, wg_id, wg_size);
-        threadfence_system();
       }
+      __syncthreads();
+
+      // Reset pSync before reuse.
+      for (int j = wg_id; j < PE_size; j += wg_size) {
+        pSync[j] = ROCSHMEM_SYNC_VALUE;
+      }
+      __syncthreads();
     }
-    __syncthreads();
+
+    // All workgroups participate in the cross-PE barrier after each chunk.
+    barrier_wg(team);
   }
 
-  // Reset pSync entries for our slots on all PEs.
-  for (int i = wg_id; i < PE_size; i += wg_size) {
-    pSync[i] = ROCSHMEM_SYNC_VALUE;
-  }
-  __syncthreads();
-
-  barrier_wg(team);
   return ROCSHMEM_SUCCESS;
 }
 

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -423,8 +423,8 @@ __device__ int IPCContext::reduce(rocshmem_team_t team, T *dest,
  * pSync/pWrk/dest buffers.
  */
 template <typename T, ROCSHMEM_OP Op>
-__device__ int IPCContext::reduce_scatter(rocshmem_team_t team, T *dest,
-                                          const T *source, int nreduce) {
+__device__ int IPCContext::reduce_scatter_wg(rocshmem_team_t team, T *dest,
+                                             const T *source, int nreduce) {
   IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
 
   int PE_size   = team_obj->tinfo_wrt_world->size;

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -413,6 +413,101 @@ __device__ int IPCContext::reduce(rocshmem_team_t team, T *dest,
   return ROCSHMEM_SUCCESS;
 }
 
+/*
+ * Reduce-scatter: PE r receives the element-wise reduction of
+ * source[r*nreduce .. (r+1)*nreduce - 1] across all PEs into dest[0..nreduce-1].
+ *
+ * Algorithm:
+ *   Each PE s sends source_s[r*nreduce + offset .. + count] to PE r's pWrk
+ *   at slot s (pWrk[team_rank_s * chunk_size]).  After all PEs have written,
+ *   each PE reduces its pWrk slots into dest.  Chunked when pWrk is too small.
+ *
+ * pSync layout: pSync[s] is the flag PE s signals on PE r after writing to
+ * pWrk[s * chunk_size] on PE r.  We use value (c+1) for chunk c to allow
+ * reuse without a full reset between chunks.
+ */
+template <typename T, ROCSHMEM_OP Op>
+__device__ int IPCContext::reduce_scatter(rocshmem_team_t team, T *dest,
+                                          const T *source, int nreduce) {
+  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
+
+  int PE_size   = team_obj->tinfo_wrt_world->size;
+  int PE_start  = team_obj->tinfo_wrt_world->pe_start;
+  int stride    = team_obj->tinfo_wrt_world->stride;
+  int team_rank = (my_pe - PE_start) / stride;
+
+  long *pSync = team_obj->reduce_pSync;
+  T    *pWrk  = reinterpret_cast<T *>(team_obj->pWrk);
+
+  int wg_id   = get_flat_block_id();
+  int wg_size = get_flat_block_size();
+
+  int pWrk_elems = (int)(ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE * sizeof(double) / sizeof(T));
+  int chunk_size = max(1, pWrk_elems / PE_size);
+  int n_chunks   = (nreduce + chunk_size - 1) / chunk_size;
+
+  int finish = PE_start + stride * PE_size;
+
+  for (int c = 0; c < n_chunks; c++) {
+    int offset = c * chunk_size;
+    int count  = min(chunk_size, nreduce - offset);
+
+    // For each remote PE r (rank remote_rank), send my contribution for r's
+    // output block: source[remote_rank * nreduce + offset .. + count]
+    // into PE r's pWrk at slot team_rank (pWrk[team_rank * chunk_size]).
+    for (int i = PE_start; i < finish; i += stride) {
+      if (i != my_pe) {
+        int remote_rank = (i - PE_start) / stride;
+        // Write my contribution for PE i's output block into PE i's pWrk
+        // at my slot (team_rank) so PE i knows the sender.
+        internal_putmem_wg(&pWrk[team_rank * chunk_size],
+                           reinterpret_cast<const void *>(
+                               source + remote_rank * nreduce + offset),
+                           count * sizeof(T), i);
+        if (is_thread_zero_in_block()) {
+          fence(i);
+          int64_t flag = (int64_t)(c + 1);
+          // Signal PE i that my slot is ready.
+          internal_putmem(&pSync[team_rank], &flag, sizeof(*pSync), i);
+        }
+      }
+    }
+
+    // Initialize dest from my own contribution to my own output block.
+    for (int j = wg_id; j < count; j += wg_size) {
+      dest[offset + j] = source[team_rank * nreduce + offset + j];
+    }
+    threadfence_system();
+    __syncthreads();
+
+    // Wait for each remote PE s to signal that pWrk[s * chunk_size] is ready,
+    // then accumulate into dest.
+    for (int i = PE_start; i < finish; i += stride) {
+      if (i != my_pe) {
+        int remote_rank = (i - PE_start) / stride;
+        int64_t expected = (int64_t)(c + 1);
+        if (is_thread_zero_in_block()) {
+          wait_until(&pSync[remote_rank], ROCSHMEM_CMP_EQ, expected);
+        }
+        __syncthreads();
+        ipc_compute_reduce<T, Op>(&pWrk[remote_rank * chunk_size], dest + offset,
+                                  count, wg_id, wg_size);
+        threadfence_system();
+      }
+    }
+    __syncthreads();
+  }
+
+  // Reset pSync entries for our slots on all PEs.
+  for (int i = wg_id; i < PE_size; i += wg_size) {
+    pSync[i] = ROCSHMEM_SYNC_VALUE;
+  }
+  __syncthreads();
+
+  barrier_wg(team);
+  return ROCSHMEM_SUCCESS;
+}
+
 template <typename T>
 __device__ void IPCContext::internal_put_broadcast(
     T *dst, const T *src, int nelems, int pe_root, int pe_start,

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_host.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_host.hpp
@@ -128,7 +128,13 @@ __host__ int IPCHostContext::reduce(rocshmem_team_t team, T *dest,
 }
 
 template <typename T, ROCSHMEM_OP Op>
-__host__ int IPCHostContext::reduce_on_stream(rocshmem_team_t team, T *dest, 
+__host__ int IPCHostContext::reduce_scatter(rocshmem_team_t team, T *dest,
+                                            const T *source, int nreduce) {
+  return host_interface->reduce_scatter<T, Op>(team, dest, source, nreduce);
+}
+
+template <typename T, ROCSHMEM_OP Op>
+__host__ int IPCHostContext::reduce_on_stream(rocshmem_team_t team, T *dest,
                                               const T *source, 
                                               int nreduce, 
                                               hipStream_t stream) {

--- a/projects/rocshmem/src/mpi_instance.cpp
+++ b/projects/rocshmem/src/mpi_instance.cpp
@@ -72,9 +72,11 @@ int MPIInstance::mpilib_dl_init() {
   DLSYM_HELPER(mpilib_ftable_, MPI_, mpilib_handle_, Allgather);
   DLSYM_HELPER(mpilib_ftable_, MPI_, mpilib_handle_, Alltoall);
   DLSYM_HELPER(mpilib_ftable_, MPI_, mpilib_handle_, Allreduce);
+  DLSYM_HELPER(mpilib_ftable_, MPI_, mpilib_handle_, Reduce_scatter_block);
   DLSYM_HELPER(mpilib_ftable_, MPI_, mpilib_handle_, Bcast);
   DLSYM_HELPER(mpilib_ftable_, MPI_, mpilib_handle_, Barrier);
   DLSYM_HELPER(mpilib_ftable_, MPI_, mpilib_handle_, Iallreduce);
+  DLSYM_HELPER(mpilib_ftable_, MPI_, mpilib_handle_, Ireduce_scatter_block);
   DLSYM_HELPER(mpilib_ftable_, MPI_, mpilib_handle_, Ibarrier);
   DLSYM_HELPER(mpilib_ftable_, MPI_, mpilib_handle_, Win_create);
   DLSYM_HELPER(mpilib_ftable_, MPI_, mpilib_handle_, Win_free);

--- a/projects/rocshmem/src/mpi_instance.hpp
+++ b/projects/rocshmem/src/mpi_instance.hpp
@@ -62,12 +62,17 @@ struct mpilib_funcs_t {
   int (*Allgather)(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount, MPI_Datatype recvtype, MPI_Comm comm);
   int (*Allreduce)(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
                    MPI_Op op, MPI_Comm comm);
+  int (*Reduce_scatter_block)(const void *sendbuf, void *recvbuf, int recvcount,
+                              MPI_Datatype datatype, MPI_Op op, MPI_Comm comm);
   int (*Alltoall)(const void *sendbuf, int sendcount, MPI_Datatype sendtype, void *recvbuf, int recvcount,
                   MPI_Datatype recvtype, MPI_Comm comm);
   int (*Bcast)(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm);
   int (*Barrier)(MPI_Comm comm);
   int (*Iallreduce)(const void *sendbuf, void *recvbuf, int count, MPI_Datatype datatype,
                     MPI_Op op, MPI_Comm comm, MPI_Request *request);
+  int (*Ireduce_scatter_block)(const void *sendbuf, void *recvbuf, int recvcount,
+                               MPI_Datatype datatype, MPI_Op op, MPI_Comm comm,
+                               MPI_Request *request);
   int (*Ibarrier)(MPI_Comm comm, MPI_Request *request);
   int (*Win_create)(void *base, MPI_Aint size, int disp_unit, MPI_Info info, MPI_Comm comm, MPI_Win *win);
   int (*Win_free)(MPI_Win *win);

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
@@ -690,6 +690,11 @@ __device__ void build_queue_element(
     queue_element->datatype = datatype;
     queue_element->team_comm = team_comm;
   }
+  if (type == RO_NET_TEAM_REDUCE_SCATTER) {
+    queue_element->op = op;
+    queue_element->datatype = datatype;
+    queue_element->team_comm = team_comm;
+  }
   if (type == RO_NET_TEAM_BROADCAST) {
     queue_element->PE_root = PE_root;
     queue_element->datatype = datatype;

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
@@ -98,8 +98,8 @@ class ROContext : public Context {
                         int nreduce);
 
   template <typename T, ROCSHMEM_OP Op>
-  __device__ int reduce_scatter(rocshmem_team_t team, T *dest, const T *source,
-                                int nreduce);
+  __device__ int reduce_scatter_wg(rocshmem_team_t team, T *dest, const T *source,
+                                   int nreduce);
 
   template <typename T>
   __device__ void put(T *dest, const T *source, size_t nelems, int pe);

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
@@ -97,6 +97,10 @@ class ROContext : public Context {
   __device__ int reduce(rocshmem_team_t team, T *dest, const T *source,
                         int nreduce);
 
+  template <typename T, ROCSHMEM_OP Op>
+  __device__ int reduce_scatter(rocshmem_team_t team, T *dest, const T *source,
+                                int nreduce);
+
   template <typename T>
   __device__ void put(T *dest, const T *source, size_t nelems, int pe);
 

--- a/projects/rocshmem/src/reverse_offload/context_ro_host.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_host.hpp
@@ -167,7 +167,11 @@ class ROHostContext : public Context {
   __host__ void sync_all();
 
   template <typename T, ROCSHMEM_OP Op>
-  __host__ int reduce_on_stream(rocshmem_team_t team, T *dest, const T *source, 
+  __host__ int reduce_scatter(rocshmem_team_t team, T *dest, const T *source,
+                              int nreduce);
+
+  template <typename T, ROCSHMEM_OP Op>
+  __host__ int reduce_on_stream(rocshmem_team_t team, T *dest, const T *source,
                                 int nreduce, hipStream_t stream);
 
   __host__ void sync(rocshmem_team_t team);

--- a/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
@@ -307,6 +307,26 @@ __device__ void ROContext::amo_xor(void *dst, T value, int pe) {
   [[maybe_unused]] T ret{amo_fetch_xor(dst, value, pe)};
 }
 
+template <typename T, ROCSHMEM_OP Op>
+__device__ int ROContext::reduce_scatter(rocshmem_team_t team, T *dest,
+                                         const T *source, int nreduce) {
+  if (!is_thread_zero_in_block()) {
+    __syncthreads();
+    return ROCSHMEM_SUCCESS;
+  }
+
+  ROTeam *team_obj{reinterpret_cast<ROTeam *>(team)};
+
+  build_queue_element(RO_NET_TEAM_REDUCE_SCATTER, dest, const_cast<T *>(source),
+                      nreduce, 0, 0, 0, 0, nullptr, nullptr,
+                      (intptr_t)team_obj->mpi_comm, ro_net_win_id, block_handle,
+                      true, get_status_flag(), is_default_ctx, Op,
+                      GetROType<T>::Type);
+
+  __syncthreads();
+  return ROCSHMEM_SUCCESS;
+}
+
 template <typename T>
 __device__ void ROContext::broadcast(rocshmem_team_t team, T *dest,
                                      const T *source, int nelems, int pe_root) {

--- a/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
@@ -308,8 +308,8 @@ __device__ void ROContext::amo_xor(void *dst, T value, int pe) {
 }
 
 template <typename T, ROCSHMEM_OP Op>
-__device__ int ROContext::reduce_scatter(rocshmem_team_t team, T *dest,
-                                         const T *source, int nreduce) {
+__device__ int ROContext::reduce_scatter_wg(rocshmem_team_t team, T *dest,
+                                            const T *source, int nreduce) {
   if (!is_thread_zero_in_block()) {
     __syncthreads();
     return ROCSHMEM_SUCCESS;

--- a/projects/rocshmem/src/reverse_offload/context_ro_tmpl_host.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_tmpl_host.hpp
@@ -87,7 +87,13 @@ __host__ T ROHostContext::amo_fetch_cas(void *dst, T value, T cond, int pe) {
 }
 
 template <typename T, ROCSHMEM_OP Op>
-__host__ int ROHostContext::reduce_on_stream(rocshmem_team_t team, T *dest, 
+__host__ int ROHostContext::reduce_scatter(rocshmem_team_t team, T *dest,
+                                           const T *source, int nreduce) {
+  return host_interface->reduce_scatter<T, Op>(team, dest, source, nreduce);
+}
+
+template <typename T, ROCSHMEM_OP Op>
+__host__ int ROHostContext::reduce_on_stream(rocshmem_team_t team, T *dest,
                                              const T *source, 
                                              int nreduce, 
                                              hipStream_t stream) {

--- a/projects/rocshmem/src/reverse_offload/mpi_transport.cpp
+++ b/projects/rocshmem/src/reverse_offload/mpi_transport.cpp
@@ -156,6 +156,18 @@ void MPITransport::submitRequestsToMPI() {
               next_element.PE,
               reinterpret_cast<int64_t>(next_element.ol2.pWrk));
       break;
+    case RO_NET_TEAM_REDUCE_SCATTER:
+      team_reduce_scatter(next_element.dst, next_element.src,
+                          next_element.ol1.size,
+                          next_element.ro_net_win_id, queue_idx,
+                          (MPI_Comm)next_element.team_comm,
+                          static_cast<ROCSHMEM_OP>(next_element.op),
+                          static_cast<ro_net_types>(next_element.datatype),
+                          next_element.status, true);
+      LOG_TRACE("proxy::mpi Submitted TEAM_REDUCE_SCATTER dst %p src %p nreduce %lu team %zd",
+              next_element.dst, next_element.src, next_element.ol1.size,
+              (intptr_t)next_element.team_comm);
+      break;
     case RO_NET_TEAM_REDUCE:
       team_reduction(next_element.dst, next_element.src, next_element.ol1.size,
                      next_element.ro_net_win_id, queue_idx,
@@ -357,6 +369,24 @@ void MPITransport::team_reduction(void *dst, void *src, int size, [[maybe_unused
 
   requests.push_back({request, {status, contextId, blocking}});
 
+  outstanding[contextId]++;
+}
+
+void MPITransport::team_reduce_scatter(void *dst, void *src, int nreduce,
+                                       [[maybe_unused]] int win_id,
+                                       int contextId, MPI_Comm team,
+                                       ROCSHMEM_OP op, ro_net_types type,
+                                       volatile char *status, bool blocking) {
+  MPI_Request request{};
+
+  MPI_Op mpi_op{get_mpi_op(op)};
+  MPI_Datatype mpi_type{convertType(type)};
+  MPI_Comm comm{team};
+
+  NET_CHECK(mpilib_ftable_.Ireduce_scatter_block(
+      src, dst, nreduce, mpi_type, mpi_op, comm, &request));
+
+  requests.push_back({request, {status, contextId, blocking}});
   outstanding[contextId]++;
 }
 

--- a/projects/rocshmem/src/reverse_offload/mpi_transport.hpp
+++ b/projects/rocshmem/src/reverse_offload/mpi_transport.hpp
@@ -62,6 +62,11 @@ public:
                       ro_net_types type, volatile char *status,
                       bool blocking) override;
 
+  void team_reduce_scatter(void *dst, void *src, int nreduce, int win_id,
+                           int contextId, MPI_Comm team, ROCSHMEM_OP op,
+                           ro_net_types type, volatile char *status,
+                           bool blocking) override;
+
   void team_broadcast(void *dst, void *src, int size, int win_id,
                       int contextId, MPI_Comm team, int PE_root,
                       ro_net_types type, volatile char *status,

--- a/projects/rocshmem/src/reverse_offload/transport.hpp
+++ b/projects/rocshmem/src/reverse_offload/transport.hpp
@@ -59,6 +59,11 @@ class Transport {
                               ro_net_types type, volatile char *status,
                               bool blocking) = 0;
 
+  virtual void team_reduce_scatter(void *dst, void *src, int nreduce,
+                                   int win_id, int wg_id, MPI_Comm team,
+                                   ROCSHMEM_OP op, ro_net_types type,
+                                   volatile char *status, bool blocking) = 0;
+
   virtual void team_broadcast(void *dst, void *src, int size, int win_id,
                               int wg_id, MPI_Comm team, int PE_root,
                               ro_net_types type, volatile char *status,

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -1400,6 +1400,16 @@ __host__ int rocshmem_reduce([[maybe_unused]] rocshmem_ctx_t ctx,
               ->reduce<T, Op>(team, dest, source, nreduce);
 }
 
+template <typename T, ROCSHMEM_OP Op>
+__host__ int rocshmem_reduce_scatter([[maybe_unused]] rocshmem_ctx_t ctx,
+                                     rocshmem_team_t team, T *dest,
+                                     const T *source, int nreduce) {
+  LOG_API("host::reduce_scatter (dest=%p, source=%p, nreduce=%d)", dest, source, nreduce);
+
+  return get_internal_ctx(ROCSHMEM_HOST_CTX_DEFAULT)
+              ->reduce_scatter<T, Op>(team, dest, source, nreduce);
+}
+
 template <typename T>
 __host__ void rocshmem_wait_until(T *ivars, int cmp, T val) {
   LOG_API("host::wait_until (ivars=%p, cmp=%d, val=%g)", ivars, cmp, (double)val);
@@ -1479,6 +1489,9 @@ __host__ int rocshmem_test(T *ivars, int cmp, T val) {
       rocshmem_ctx_t ctx, T * dest, const T *source, int nreduce,             \
       int PE_start, int logPE_stride, int PE_size, T *pWrk, long *pSync);     \
   template __host__ int rocshmem_reduce<T, Op>(                               \
+      rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,    \
+      int nreduce);                                                            \
+  template __host__ int rocshmem_reduce_scatter<T, Op>(                       \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,    \
       int nreduce);
 
@@ -1638,6 +1651,11 @@ __host__ int rocshmem_test(T *ivars, int cmp, T val) {
       rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,     \
       int nreduce) {                                                          \
     return rocshmem_reduce<T, Op>(ctx, team, dest, source, nreduce);          \
+  }                                                                           \
+  __host__ int rocshmem_ctx_##TNAME##_##Op_API##_reduce_scatter(              \
+      rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,     \
+      int nreduce) {                                                          \
+    return rocshmem_reduce_scatter<T, Op>(ctx, team, dest, source, nreduce);  \
   }
 
 #define ARITH_REDUCTION_DEF_GEN(T, TNAME)                                     \

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -649,7 +649,7 @@ __device__ int rocshmem_reduce_scatter_wg(rocshmem_ctx_t ctx,
   LOGD_API("device::reduce_scatter_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nreduce=%d",
     ctx.ctx_opaque, team, dest, source, nreduce);
 
-  return get_internal_ctx(ctx)->reduce_scatter<T, Op>(team, dest, source, nreduce);
+  return get_internal_ctx(ctx)->reduce_scatter_wg<T, Op>(team, dest, source, nreduce);
 }
 
 template <typename T>

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -642,6 +642,16 @@ __device__ int rocshmem_reduce_wg(rocshmem_ctx_t ctx, rocshmem_team_t team,
   return get_internal_ctx(ctx)->reduce<T, Op>(team, dest, source, nreduce);
 }
 
+template <typename T, ROCSHMEM_OP Op>
+__device__ int rocshmem_reduce_scatter_wg(rocshmem_ctx_t ctx,
+                                          rocshmem_team_t team, T *dest,
+                                          const T *source, int nreduce) {
+  LOGD_API("device::reduce_scatter_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nreduce=%d",
+    ctx.ctx_opaque, team, dest, source, nreduce);
+
+  return get_internal_ctx(ctx)->reduce_scatter<T, Op>(team, dest, source, nreduce);
+}
+
 template <typename T>
 __device__ void rocshmem_broadcast_wg(rocshmem_ctx_t ctx,
                                        rocshmem_team_t team, T *dest,
@@ -1363,6 +1373,9 @@ __device__ int rocshmem_team_translate_pe(rocshmem_team_t src_team,
 #define REDUCTION_GEN(T, Op)                                                   \
   template __device__ int rocshmem_reduce_wg<T, Op>(                           \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,     \
+      int nreduce);                                                             \
+  template __device__ int rocshmem_reduce_scatter_wg<T, Op>(                   \
+      rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,     \
       int nreduce);
 
 /**
@@ -1584,16 +1597,30 @@ __device__ int rocshmem_team_translate_pe(rocshmem_team_t src_team,
     return rocshmem_reduce_wg<T, Op>(ctx, team, dest, source, nreduce);       \
   }
 
-#define ARITH_REDUCTION_DEF_GEN(T, TNAME)         \
-  REDUCTION_DEF_GEN(T, TNAME, sum, ROCSHMEM_SUM) \
-  REDUCTION_DEF_GEN(T, TNAME, min, ROCSHMEM_MIN) \
-  REDUCTION_DEF_GEN(T, TNAME, max, ROCSHMEM_MAX) \
-  REDUCTION_DEF_GEN(T, TNAME, prod, ROCSHMEM_PROD)
+#define REDUCE_SCATTER_DEF_GEN(T, TNAME, Op_API, Op)                          \
+  __device__ int rocshmem_ctx_##TNAME##_##Op_API##_reduce_scatter_wg(         \
+      rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,     \
+      int nreduce) {                                                          \
+    return rocshmem_reduce_scatter_wg<T, Op>(ctx, team, dest, source, nreduce); \
+  }
 
-#define BITWISE_REDUCTION_DEF_GEN(T, TNAME)       \
-  REDUCTION_DEF_GEN(T, TNAME, or, ROCSHMEM_OR)   \
-  REDUCTION_DEF_GEN(T, TNAME, and, ROCSHMEM_AND) \
-  REDUCTION_DEF_GEN(T, TNAME, xor, ROCSHMEM_XOR)
+#define ARITH_REDUCTION_DEF_GEN(T, TNAME)                 \
+  REDUCTION_DEF_GEN(T, TNAME, sum, ROCSHMEM_SUM)         \
+  REDUCTION_DEF_GEN(T, TNAME, min, ROCSHMEM_MIN)         \
+  REDUCTION_DEF_GEN(T, TNAME, max, ROCSHMEM_MAX)         \
+  REDUCTION_DEF_GEN(T, TNAME, prod, ROCSHMEM_PROD)       \
+  REDUCE_SCATTER_DEF_GEN(T, TNAME, sum, ROCSHMEM_SUM)   \
+  REDUCE_SCATTER_DEF_GEN(T, TNAME, min, ROCSHMEM_MIN)   \
+  REDUCE_SCATTER_DEF_GEN(T, TNAME, max, ROCSHMEM_MAX)   \
+  REDUCE_SCATTER_DEF_GEN(T, TNAME, prod, ROCSHMEM_PROD)
+
+#define BITWISE_REDUCTION_DEF_GEN(T, TNAME)               \
+  REDUCTION_DEF_GEN(T, TNAME, or, ROCSHMEM_OR)           \
+  REDUCTION_DEF_GEN(T, TNAME, and, ROCSHMEM_AND)         \
+  REDUCTION_DEF_GEN(T, TNAME, xor, ROCSHMEM_XOR)         \
+  REDUCE_SCATTER_DEF_GEN(T, TNAME, or, ROCSHMEM_OR)     \
+  REDUCE_SCATTER_DEF_GEN(T, TNAME, and, ROCSHMEM_AND)   \
+  REDUCE_SCATTER_DEF_GEN(T, TNAME, xor, ROCSHMEM_XOR)
 
 #define INT_REDUCTION_DEF_GEN(T, TNAME) \
   ARITH_REDUCTION_DEF_GEN(T, TNAME)     \

--- a/projects/rocshmem/src/stats.hpp
+++ b/projects/rocshmem/src/stats.hpp
@@ -103,6 +103,7 @@ enum rocshmem_stats {
   NUM_PUT_SIGNAL_NBI_WG,
   NUM_PUT_SIGNAL_NBI_WAVE,
   NUM_REDUCE,
+  NUM_REDUCE_SCATTER,
   NUM_STATS,
 };
 

--- a/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
+++ b/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
@@ -164,6 +164,7 @@ set(TEST_host_wait_until_some_vector 145)
 set(TEST_host_wait_until_all_status 146)
 set(TEST_host_wait_until_any_status 147)
 set(TEST_host_wait_until_some_status 148)
+set(TEST_teamreducescatter 149)
 
 # MPI should already be found by the parent CMakeLists.txt
 # Use standard CMake MPI variables set by find_package(MPI)
@@ -1057,6 +1058,7 @@ function(add_coll_tests)
         add_rocshmem_functional_test(NAME fcollect RANKS 3 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 32768)
         add_rocshmem_functional_test(NAME fcollect RANKS 5 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 32768)
         add_rocshmem_functional_test(NAME teamreduction RANKS 2 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 32768)
+        add_rocshmem_functional_test(NAME teamreducescatter RANKS 2 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 32768)
     end_test_group()
 
     # Team split 2D test - requires exactly 4 PEs

--- a/projects/rocshmem/tests/functional_tests/team_reduce_scatter_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_reduce_scatter_tester.cpp
@@ -1,0 +1,189 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+using namespace rocshmem;
+
+/*
+ * reduce_scatter(team, dest, source, nreduce):
+ *   - source has n_pes * nreduce elements per PE
+ *   - PE i receives the element-wise reduction of source[i*nreduce..(i+1)*nreduce-1]
+ *     from all PEs into dest[0..nreduce-1]
+ */
+
+/* Generic stub — specializations below call the actual rocSHMEM API */
+template <typename T, ROCSHMEM_OP Op>
+__device__ int wg_team_reduce_scatter([[maybe_unused]] rocshmem_ctx_t ctx,
+                                      [[maybe_unused]] rocshmem_team_t team,
+                                      [[maybe_unused]] T *dest,
+                                      [[maybe_unused]] const T *source,
+                                      [[maybe_unused]] int nreduce) {
+  return ROCSHMEM_SUCCESS;
+}
+
+#define TEAM_REDUCE_SCATTER_DEF_GEN(T, TNAME, Op_API, Op)                       \
+  template <>                                                                    \
+  __device__ int wg_team_reduce_scatter<T, Op>(rocshmem_ctx_t ctx,              \
+                                               rocshmem_team_t team, T *dest,   \
+                                               const T *source, int nreduce) {  \
+    return rocshmem_ctx_##TNAME##_##Op_API##_reduce_scatter_wg(ctx, team, dest, \
+                                                                source, nreduce);\
+  }
+
+#define TEAM_ARITH_REDUCE_SCATTER_DEF_GEN(T, TNAME)              \
+  TEAM_REDUCE_SCATTER_DEF_GEN(T, TNAME, sum, ROCSHMEM_SUM)       \
+  TEAM_REDUCE_SCATTER_DEF_GEN(T, TNAME, min, ROCSHMEM_MIN)       \
+  TEAM_REDUCE_SCATTER_DEF_GEN(T, TNAME, max, ROCSHMEM_MAX)       \
+  TEAM_REDUCE_SCATTER_DEF_GEN(T, TNAME, prod, ROCSHMEM_PROD)
+
+#define TEAM_BITWISE_REDUCE_SCATTER_DEF_GEN(T, TNAME)            \
+  TEAM_REDUCE_SCATTER_DEF_GEN(T, TNAME, or, ROCSHMEM_OR)         \
+  TEAM_REDUCE_SCATTER_DEF_GEN(T, TNAME, and, ROCSHMEM_AND)       \
+  TEAM_REDUCE_SCATTER_DEF_GEN(T, TNAME, xor, ROCSHMEM_XOR)
+
+#define TEAM_INT_REDUCE_SCATTER_DEF_GEN(T, TNAME)  \
+  TEAM_ARITH_REDUCE_SCATTER_DEF_GEN(T, TNAME)      \
+  TEAM_BITWISE_REDUCE_SCATTER_DEF_GEN(T, TNAME)
+
+#define TEAM_FLOAT_REDUCE_SCATTER_DEF_GEN(T, TNAME) \
+  TEAM_ARITH_REDUCE_SCATTER_DEF_GEN(T, TNAME)
+
+TEAM_INT_REDUCE_SCATTER_DEF_GEN(int, int)
+TEAM_INT_REDUCE_SCATTER_DEF_GEN(short, short)
+TEAM_INT_REDUCE_SCATTER_DEF_GEN(long, long)
+TEAM_INT_REDUCE_SCATTER_DEF_GEN(long long, longlong)
+TEAM_FLOAT_REDUCE_SCATTER_DEF_GEN(float, float)
+TEAM_FLOAT_REDUCE_SCATTER_DEF_GEN(double, double)
+
+rocshmem_team_t team_reduce_scatter_world_dup;
+
+/******************************************************************************
+ * DEVICE TEST KERNEL
+ *****************************************************************************/
+template <typename T1, ROCSHMEM_OP T2>
+__global__ void TeamReduceScatterTest(int loop, int skip,
+                                      long long int *start_time,
+                                      long long int *end_time, T1 *s_buf,
+                                      T1 *r_buf, size_t size,
+                                      [[maybe_unused]] TestType type,
+                                      ShmemContextType ctx_type,
+                                      rocshmem_team_t team) {
+  __shared__ rocshmem_ctx_t ctx;
+  int wg_id = get_flat_grid_id();
+
+  rocshmem_wg_team_create_ctx(team, ctx_type, &ctx);
+
+  __syncthreads();
+
+  for (int i = 0; i < loop + skip; i++) {
+    if (i == skip && hipThreadIdx_x == 0) {
+      start_time[wg_id] = wall_clock64();
+    }
+    wg_team_reduce_scatter<T1, T2>(ctx, team, r_buf, s_buf, size);
+  }
+
+  __syncthreads();
+
+  if (hipThreadIdx_x == 0) {
+    end_time[wg_id] = wall_clock64();
+  }
+
+  rocshmem_wg_ctx_destroy(&ctx);
+}
+
+/******************************************************************************
+ * HOST TESTER CLASS METHODS
+ *****************************************************************************/
+template <typename T1, ROCSHMEM_OP T2>
+TeamReduceScatterTester<T1, T2>::TeamReduceScatterTester(
+    TesterArguments args, std::function<void(T1 &, T1 &)> f1,
+    std::function<std::pair<bool, std::string>(const T1 &, const T1 &)> f2)
+    : Tester(args), init_buf{f1}, verify_buf{f2} {
+  my_pe = rocshmem_team_my_pe(ROCSHMEM_TEAM_WORLD);
+  n_pes = rocshmem_team_n_pes(ROCSHMEM_TEAM_WORLD);
+
+  // source buffer: n_pes * max_msg_size elements (on symmetric heap)
+  s_buf = (T1 *)alloc_test_buffer(n_pes * max_msg_size * sizeof(T1),
+                                  args.local_buf_type);
+  // dest buffer: max_msg_size elements (on symmetric heap)
+  r_buf = (T1 *)alloc_test_buffer(max_msg_size * sizeof(T1));
+}
+
+template <typename T1, ROCSHMEM_OP T2>
+TeamReduceScatterTester<T1, T2>::~TeamReduceScatterTester() {
+  free_test_buffer(s_buf, args.local_buf_type);
+  free_test_buffer(r_buf);
+}
+
+template <typename T1, ROCSHMEM_OP T2>
+void TeamReduceScatterTester<T1, T2>::preLaunchKernel() {
+  bw_factor = n_pes;
+
+  team_reduce_scatter_world_dup = ROCSHMEM_TEAM_INVALID;
+  rocshmem_team_split_strided(ROCSHMEM_TEAM_WORLD, 0, 1, n_pes, nullptr, 0,
+                               &team_reduce_scatter_world_dup);
+}
+
+template <typename T1, ROCSHMEM_OP T2>
+void TeamReduceScatterTester<T1, T2>::launchKernel(dim3 gridSize,
+                                                    dim3 blockSize, int loop,
+                                                    uint64_t size) {
+  size_t shared_bytes = 0;
+
+  hipLaunchKernelGGL(HIP_KERNEL_NAME(TeamReduceScatterTest<T1, T2>), gridSize,
+                     blockSize, shared_bytes, stream, loop, args.skip,
+                     start_time, end_time, s_buf, r_buf, size, _type,
+                     _shmem_context, team_reduce_scatter_world_dup);
+
+  num_msgs = loop + args.skip;
+  num_timed_msgs = loop;
+}
+
+template <typename T1, ROCSHMEM_OP T2>
+void TeamReduceScatterTester<T1, T2>::postLaunchKernel() {
+  rocshmem_team_destroy(team_reduce_scatter_world_dup);
+}
+
+template <typename T1, ROCSHMEM_OP T2>
+void TeamReduceScatterTester<T1, T2>::resetBuffers([[maybe_unused]] uint64_t size) {
+  // Each PE sets its entire source buffer to 1 so that a SUM
+  // over n_pes PEs yields n_pes in every element of dest.
+  for (uint64_t i = 0; i < (uint64_t)n_pes * max_msg_size; i++) {
+    s_buf[i] = static_cast<T1>(1);
+  }
+  for (uint64_t i = 0; i < max_msg_size; i++) {
+    r_buf[i] = static_cast<T1>(0);
+  }
+}
+
+template <typename T1, ROCSHMEM_OP T2>
+void TeamReduceScatterTester<T1, T2>::verifyResults(uint64_t size) {
+  for (uint64_t i = 0; i < size; i++) {
+    auto r = verify_buf(r_buf[i], (T1)n_pes);
+    if (r.first == false) {
+      fprintf(stderr, "Data validation error at idx %lu\n", i);
+      fprintf(stderr, "%s.\n", r.second.c_str());
+      exit(-1);
+    }
+  }
+}

--- a/projects/rocshmem/tests/functional_tests/team_reduce_scatter_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/team_reduce_scatter_tester.hpp
@@ -22,46 +22,49 @@
  * IN THE SOFTWARE.
  *****************************************************************************/
 
-#ifndef LIBRARY_SRC_REVERSE_OFFLOAD_COMMANDS_TYPES_HPP_
-#define LIBRARY_SRC_REVERSE_OFFLOAD_COMMANDS_TYPES_HPP_
+#ifndef _TEAM_REDUCE_SCATTER_TESTER_HPP_
+#define _TEAM_REDUCE_SCATTER_TESTER_HPP_
 
+#include <functional>
+#include <utility>
 
-namespace rocshmem {
+#include "tester.hpp"
 
-enum ro_net_cmds {
-  RO_NET_PUT,
-  RO_NET_P,
-  RO_NET_GET,
-  RO_NET_PUT_NBI,
-  RO_NET_GET_NBI,
-  RO_NET_AMO_FOP,
-  RO_NET_AMO_FCAS,
-  RO_NET_FENCE,
-  RO_NET_QUIET,
-  RO_NET_FINALIZE,
-  RO_NET_TEAM_REDUCE,
-  RO_NET_SYNC,
-  RO_NET_BARRIER,
-  RO_NET_TEAM_BROADCAST,
-  RO_NET_ALLTOALL,
-  RO_NET_FCOLLECT,
-  RO_NET_TEAM_REDUCE_SCATTER,
+/******************************************************************************
+ * HOST TESTER CLASS
+ *****************************************************************************/
+template <typename T1, ROCSHMEM_OP T2>
+class TeamReduceScatterTester : public Tester {
+ public:
+  explicit TeamReduceScatterTester(
+      TesterArguments args, std::function<void(T1 &, T1 &)> f1,
+      std::function<std::pair<bool, std::string>(const T1 &, const T1 &)> f2);
+  virtual ~TeamReduceScatterTester();
+
+ protected:
+  virtual void resetBuffers(uint64_t size) override;
+
+  virtual void preLaunchKernel() override;
+
+  virtual void launchKernel(dim3 gridSize, dim3 blockSize, int loop,
+                            uint64_t size) override;
+
+  virtual void postLaunchKernel() override;
+
+  virtual void verifyResults(uint64_t size) override;
+
+  T1 *s_buf;  // source: n_pes * size elements per PE
+  T1 *r_buf;  // dest:   size elements per PE
+
+ private:
+  int my_pe = 0;
+  int n_pes = 0;
+
+  std::function<void(T1 &, T1 &)> init_buf;
+  std::function<std::pair<bool, std::string>(const T1 &, const T1 &)>
+      verify_buf;
 };
 
-enum ro_net_types {
-  RO_NET_FLOAT,
-  RO_NET_CHAR,
-  RO_NET_SIGNED_CHAR,
-  RO_NET_UNSIGNED_CHAR,
-  RO_NET_DOUBLE,
-  RO_NET_INT,
-  RO_NET_LONG,
-  RO_NET_UNSIGNED_LONG,
-  RO_NET_LONG_LONG,
-  RO_NET_SHORT,
-  RO_NET_LONG_DOUBLE
-};
+#include "team_reduce_scatter_tester.cpp"
 
-}  // namespace rocshmem
-
-#endif  // LIBRARY_SRC_REVERSE_OFFLOAD_COMMANDS_TYPES_HPP_
+#endif  // _TEAM_REDUCE_SCATTER_TESTER_HPP_

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -63,6 +63,7 @@
 #include "team_ctx_primitive_tester.hpp"
 #include "team_fcollect_tester.hpp"
 #include "team_reduction_tester.hpp"
+#include "team_reduce_scatter_tester.hpp"
 #include "wavefront_primitives.hpp"
 #include "workgroup_primitives.hpp"
 #include "flood_tester.hpp"
@@ -148,6 +149,7 @@ Tester::Tester(TesterArguments args) : args(args) {
         break;
       case TeamBroadcastTestType:
       case TeamReductionTestType:
+      case TeamReduceScatterTestType:
       case TeamFCollectTestType:
       case CollectTestType:
       case TeamAllToAllTestType:
@@ -282,6 +284,22 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
           [](float& f1, float& f2) {
             f1 = 1;
             f2 = 1;
+          },
+          [](float v, float n_pes) {
+            return (v == n_pes)
+                       ? std::make_pair(true, "")
+                       : std::make_pair(false, "Got " + std::to_string(v) +
+                                                   ", Expect " +
+                                                   std::to_string(n_pes));
+          }));
+      break;
+    case TeamReduceScatterTestType:
+      test_name = "Team-based Reduce-Scatter";
+      testers.push_back(new TeamReduceScatterTester<float, ROCSHMEM_SUM>(
+          args,
+          [](float& f1, float& f2) {
+            f1 = 1;
+            f2 = 0;
           },
           [](float v, float n_pes) {
             return (v == n_pes)
@@ -966,6 +984,7 @@ bool Tester::peLaunchesKernel() {
   switch (_type) {
     case ReduceOnStreamTestType:
     case TeamReductionTestType:
+    case TeamReduceScatterTestType:
     case TeamBroadcastTestType:
     case TeamCtxInfraTestType:
     case TeamCtxInfraSingleTestType:

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -190,7 +190,9 @@
   X(HostWaitUntilSomeVector,   145)  \
   X(HostWaitUntilAllStatus,    146)  \
   X(HostWaitUntilAnyStatus,    147)  \
-  X(HostWaitUntilSomeStatus,   148)
+  X(HostWaitUntilSomeStatus,   148)  \
+  X(TeamReduceScatter,         149)
+  
 #define _ROCSHMEM_ENUM_ENTRY(name, val) name##TestType = val,
 enum TestType {
   ROCSHMEM_FOREACH_TEST_TYPE(_ROCSHMEM_ENUM_ENTRY)

--- a/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
@@ -285,6 +285,7 @@ void TesterArguments::get_arguments() {
     case TeamAllToAllvTestType:
     case TeamFCollectTestType:
     case TeamReductionTestType:
+    case TeamReduceScatterTestType:
     case TeamBroadcastTestType:
     case PingAllTestType:
     case TeamBarrierTestType:

--- a/projects/rocshmem/tests/test_categories.yaml
+++ b/projects/rocshmem/tests/test_categories.yaml
@@ -145,6 +145,7 @@ test_categories:
       - "fcollect_.*"
       - "teambroadcast_.*"
       - "teamreduction_.*"
+      - "teamreducescatter_.*"
       - "teambarrier_.*"
       - "teamwavebarrier_.*"
       - "teamwgbarrier_.*"


### PR DESCRIPTION
## Motivation

- Implements `reduce_scatter` as a new team-scoped collective across all rocSHMEM backends (IPC, GDA, RO)
- Adds device-side workgroup (`_wg`) and host-side variants with the full type/op matrix (short, int, long, longlong, float, double × sum/min/max/prod/or/and/xor)
- Adds a functional test (`team_reduce_scatter_tester`) with correctness verification
- Adds API documentation in `docs/api/coll.rst`

## API

```cpp
// Device (workgroup collective)
int rocshmem_ctx_<TYPE>_<OP>_reduce_scatter_wg(
    rocshmem_ctx_t ctx, rocshmem_team_t team,
    TYPE *dest, const TYPE *source, int nreduce);

// Host
int rocshmem_ctx_<TYPE>_<OP>_reduce_scatter(
    rocshmem_ctx_t ctx, rocshmem_team_t team,
    TYPE *dest, const TYPE *source, int nreduce);
```

Semantics: `source` has `nreduce × n_pes` elements per PE. After the operation, PE `i` holds the element-wise reduction of `source[i*nreduce .. (i+1)*nreduce - 1]` across all PEs in `dest[0 .. nreduce-1]`.

## Implementation (IPC backend)

The device-side IPC implementation uses a chunked, pSync-based algorithm that reuses the existing `reduce_pSync` and `pWrk` team buffers:

- Each PE seeds `dest` from its own source block for the current chunk.
- Each PE sends its contribution for every remote PE's output block via `internal_putmem_wg`, then signals via `pSync`.
- Each PE waits on all remote signals, then accumulates the received data into dest using `ipc_compute_reduce`
- pSync entries are reset, then all workgroups rendezvous at `barrier_wg` before the next chunk.

Only workgroup 0 runs the reduction algorithm; all other workgroups participate in the `barrier_wg` calls only, preventing concurrent accumulation races on shared team buffers.

The chunk size is derived from `ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE` to stay within the pre-allocated `pWrk` budget: `chunk_size = max(1, pWrk_elems / PE_size).`

## JIRA ID

JIRA ID: AIROCSHMEM-412

## Tests

- [x] Build with `USE_IPC=ON` and run team_reduce_scatter functional test: `mpirun -n 4 ./build/tests/functional_tests/rocshmem_functional_tests -a teamreducescatter -w 8 -z 64`
- [x] Verify correctness for sum, min, max, prod, and, or, xor ops across all integer types
- [x] Verify correctness for sum, min, max, prod across float/double
- [x] Run with multiple workgroups to confirm no races on shared pSync/pWrk buffers


