### PR TITLE
[RCCL] Remove forced AINIC GDR flush disable in IB-CAST

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -16,7 +16,7 @@ NCCL_PARAM(IbCastTimeout, "IB_TIMEOUT", 20);
 NCCL_PARAM(IbCastRetryCnt, "IB_RETRY_CNT", 7);
 NCCL_PARAM(IbCastPkey, "IB_PKEY", 0);
 NCCL_PARAM(IbCastUseInline, "IB_USE_INLINE", 0);
-NCCL_PARAM(IbCastGdrFlushDisable, "GDR_FLUSH_DISABLE", 0);
+NCCL_PARAM(IbCastGdrFlushDisable, "GDR_FLUSH_DISABLE", 1);
 NCCL_PARAM(IbCastSl, "IB_SL", -1);
 NCCL_PARAM(IbCastTc, "IB_TC", -1);
 NCCL_PARAM(IbCastFifoTc, "IB_FIFO_TC", -1);

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -518,8 +518,7 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       // for AINIC IbUseInline is enabled by default always
       IbCastUseInline = true;
       // for AINIC GDR flush is disabled by default
-      IbCastGdrFlushDisable = 1;
-  
+
       INFO(NCCL_INIT|NCCL_NET, "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
            "IB Use Inline: enabled; GDR Flush: disabled", IbCastUseInline ? "Enabled": "Disabled",
            IbCastOffloadEnabled ? "Enabled": "Disabled");

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -517,7 +517,6 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       }
       // for AINIC IbUseInline is enabled by default always
       IbCastUseInline = true;
-      // for AINIC GDR flush is disabled by default
 
       INFO(NCCL_INIT|NCCL_NET, "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
            "IB Use Inline: enabled; GDR Flush: disabled", IbCastUseInline ? "Enabled": "Disabled",


### PR DESCRIPTION
Default NCCL_GDR_FLUSH_DISABLE to 1 so GDR flush stays off on AINIC, while allowing users to override via NCCL_GDR_FLUSH_DISABLE=0.

## Motivation

AINIC may need additional flush to avoid data corruption during large scale training: NCCL_GDR_FLUSH_DISABLE=0
RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING=0

## Technical Details

Default NCCL_GDR_FLUSH_DISABLE to 1 so GDR flush stays off on AINIC, while allowing users to override via NCCL_GDR_FLUSH_DISABLE=0.

## JIRA ID

ROCM-25457 

## Test Plan

Large scale end to end verification

## Test Result

Pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
