### PR TITLE
[rocjitsu] Remove duplicate .cache from .gitignore

### DIFF
--- a/emulation/rocjitsu/.gitignore
+++ b/emulation/rocjitsu/.gitignore
@@ -28,6 +28,7 @@ third_party
 Testing
 tmp
 .cache
+CMakePresets.json
 
 # python
 .venv
@@ -39,6 +40,3 @@ __pycache__
 
 # agents
 .claude
-
-CMakePresets.json
-.cache/


### PR DESCRIPTION
## Motivation
We had a duplicate .cache/ entry in .gitignore

## Technical Details
Removes the duplicate .cache/ entry from .gitignore.

## JIRA ID
N/A

## Test Plan
N/A

## Test Result
N/A

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
