### PR TITLE
[hipfile] Add fastpath rejection counter to stats collection

### DIFF
--- a/projects/hipfile/docs/stats_collection.rst
+++ b/projects/hipfile/docs/stats_collection.rst
@@ -46,6 +46,7 @@ Stats Collected
 
 * Basic: Number of file handle registrations.
 * Basic: Number of buffer registrations.
+* Basic: Number of fastpath rejections due to failing fastpath eligibility checks (e.g., alignment, size, configuration, buffer type, or filesystem constraints).
 * Basic: Bytes read/written on the fastpath/fallback backends.
 * Basic: Bandwidth for reads/writes on the fastpath/fallback backends.
 * Basic: Latency for reads/writes on the fastpath/fallback backends.
@@ -65,6 +66,7 @@ Example output shape:
     HipFile Stats Level: 1
     File Handle Registrations: 1
     Buffer Registrations: 1
+    Fastpath Rejections: 0
 
     Total Fastpath Read Size (B): 67108864
     Average Fastpath Read Bandwidth (GiB/s): 0.776272

--- a/projects/hipfile/src/amd_detail/backend/fastpath.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fastpath.cpp
@@ -159,6 +159,9 @@ Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size,
     const auto     mem_addr{reinterpret_cast<intptr_t>(buffer->getBuffer()) + buffer_offset};
     accept_io &= dio_mem_align && !(mem_addr & (dio_mem_align - 1));
 
+    if (!accept_io) {
+        Context<StatsCollection>::get()->fastpathRejection();
+    }
     return accept_io ? 100 : -1;
 }
 

--- a/projects/hipfile/src/amd_detail/stats.cpp
+++ b/projects/hipfile/src/amd_detail/stats.cpp
@@ -363,7 +363,8 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
     }
 
     stream << "File Handle Registrations: " << stats->getFileRegistrations().load() << '\n';
-    stream << "Buffer Registrations: " << stats->getBufferRegistrations().load() << "\n\n";
+    stream << "Buffer Registrations: " << stats->getBufferRegistrations().load() << "\n";
+    stream << "Fastpath Rejections: " << stats->getFastpathRejections().load() << "\n\n";
 
     static constexpr IoType       ioTypes[]{IoType::Read, IoType::Write};
     static constexpr StatsBackend backends[]{StatsBackend::Fastpath, StatsBackend::Fallback};
@@ -540,5 +541,15 @@ StatsCollection::bufferRegistration() const noexcept
         return;
     }
     stats->getBufferRegistrations().fetch_add(1, std::memory_order_relaxed);
+}
+
+void
+StatsCollection::fastpathRejection() const noexcept
+{
+    Stats *stats{Context<IStatsServer>::get()->getStats()};
+    if (stats == nullptr || stats->getLevel() < StatsLevel::Basic) {
+        return;
+    }
+    stats->getFastpathRejections().fetch_add(1, std::memory_order_relaxed);
 }
 }

--- a/projects/hipfile/src/amd_detail/stats.h
+++ b/projects/hipfile/src/amd_detail/stats.h
@@ -169,11 +169,22 @@ public:
         return m_bufferRegistrations;
     }
 
+    std::atomic_uint64_t &getFastpathRejections() noexcept
+    {
+        return m_fastpathRejections;
+    }
+
+    const std::atomic_uint64_t &getFastpathRejections() const noexcept
+    {
+        return m_fastpathRejections;
+    }
+
 private:
     const uint64_t       m_version{PerGpuStatsT::version};
     StatsLevel           m_level{};
     std::atomic_uint64_t m_fileRegistrations{};
     std::atomic_uint64_t m_bufferRegistrations{};
+    std::atomic_uint64_t m_fastpathRejections{};
     PerGpuStatsArray     m_perGpuStats{};
 };
 
@@ -290,5 +301,6 @@ public:
     virtual void error(IoType ioType, StatsBackend backend, uint64_t bytes) const noexcept;
     virtual void fileRegistration() const noexcept;
     virtual void bufferRegistration() const noexcept;
+    virtual void fastpathRejection() const noexcept;
 };
 }

--- a/projects/hipfile/test/amd_detail/fastpath.cpp
+++ b/projects/hipfile/test/amd_detail/fastpath.cpp
@@ -81,7 +81,8 @@ public:
     shared_ptr<StrictMock<MFile>>   mfile{make_shared<StrictMock<MFile>>()};
     shared_ptr<StrictMock<MBuffer>> mbuffer{make_shared<StrictMock<MBuffer>>()};
 
-    StrictMock<MConfiguration> mcfg{};
+    StrictMock<MConfiguration>   mcfg{};
+    StrictMock<MStatsCollection> mstats{};
 };
 
 class FastpathScoreExpectations;
@@ -91,6 +92,7 @@ public:
     StrictMock<MConfiguration>     &m_mcfg;
     shared_ptr<StrictMock<MFile>>   m_mfile;
     shared_ptr<StrictMock<MBuffer>> m_mbuffer;
+    StrictMock<MStatsCollection>   &m_stats;
 
     optional<bool>          m_fastpath_enabled;
     optional<void *>        m_buffer_addr;
@@ -101,10 +103,12 @@ public:
     optional<bool>          m_on_ext4_ordered;
     optional<bool>          m_on_xfs;
     optional<bool>          m_unsupported_file_systems;
+    optional<bool>          m_count_rejection;
 
     FastpathScoreExpectationsBuilder(StrictMock<MConfiguration> &mcfg, shared_ptr<StrictMock<MFile>> mfile,
-                                     shared_ptr<StrictMock<MBuffer>> mbuffer)
-        : m_mcfg(mcfg), m_mfile(std::move(mfile)), m_mbuffer(std::move(mbuffer))
+                                     shared_ptr<StrictMock<MBuffer>> mbuffer,
+                                     StrictMock<MStatsCollection>   &stats)
+        : m_mcfg(mcfg), m_mfile(std::move(mfile)), m_mbuffer(std::move(mbuffer)), m_stats(stats)
     {
     }
 
@@ -162,6 +166,12 @@ public:
         return *this;
     }
 
+    FastpathScoreExpectationsBuilder &countRejection(bool count_rejection)
+    {
+        m_count_rejection = count_rejection;
+        return *this;
+    }
+
     FastpathScoreExpectations build();
 };
 
@@ -191,6 +201,8 @@ public:
             .WillOnce(Return(builder.m_buffer_addr.value_or(
                 reinterpret_cast<void *>(FastpathTestBase::DEFAULT_BUFFER_ADDR))));
         EXPECT_CALL(*builder.m_mfile, dioMemAlign).WillOnce(Return(DEFAULT_MEM_ALIGN));
+        EXPECT_CALL(builder.m_stats, fastpathRejection)
+            .Times(builder.m_count_rejection.value_or(false) ? 1 : 0);
     }
 };
 
@@ -221,7 +233,7 @@ TEST_F(FastpathTest, TestDefaults)
 
 TEST_F(FastpathTest, ScoreAcceptsIoWithDefaults)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_ACCEPT);
@@ -229,7 +241,10 @@ TEST_F(FastpathTest, ScoreAcceptsIoWithDefaults)
 
 TEST_F(FastpathTest, ScoreRejectsIoIfFastpathIsDisabled)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).fastpathEnabled(false).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats)
+        .fastpathEnabled(false)
+        .countRejection(true)
+        .build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -237,7 +252,10 @@ TEST_F(FastpathTest, ScoreRejectsIoIfFastpathIsDisabled)
 
 TEST_F(FastpathTest, ScoreRejectsIoIfUnbufferedFdNotAvailable)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).unbufferedFd(nullopt).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats)
+        .unbufferedFd(nullopt)
+        .countRejection(true)
+        .build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -245,7 +263,7 @@ TEST_F(FastpathTest, ScoreRejectsIoIfUnbufferedFdNotAvailable)
 
 TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedFileOffset)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats).countRejection(true).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, -static_cast<hoff_t>(DEFAULT_OFFSET_ALIGN),
                                DEFAULT_BUFFER_OFFSET),
@@ -254,7 +272,7 @@ TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedFileOffset)
 
 TEST_F(FastpathTest, ScoreRejectsIoWithNegativeAlignedBufferOffset)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats).countRejection(true).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET,
                                -static_cast<hoff_t>(DEFAULT_MEM_ALIGN)),
@@ -265,8 +283,9 @@ TEST_F(FastpathTest, ScoreRejectsIoIfBufferAddressPlusBufferOffsetIsUnaligned)
 {
     // The DEFAULT_BUFFER_ADDR is DEFAULT_MEM_ALIGN aligned. Ensure that this
     // test's buffer is not DEFAULT_MEM_ALIGN aligned.
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer)
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats)
         .bufferAddr(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR + (DEFAULT_MEM_ALIGN >> 1)))
+        .countRejection(true)
         .build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET,
@@ -276,7 +295,10 @@ TEST_F(FastpathTest, ScoreRejectsIoIfBufferAddressPlusBufferOffsetIsUnaligned)
 
 TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsRegularAndOnExt4Ordered)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(true).onExt4Ordered(true).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats)
+        .isRegularFile(true)
+        .onExt4Ordered(true)
+        .build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_ACCEPT);
@@ -284,7 +306,7 @@ TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsRegularAndOnExt4Ordered)
 
 TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsRegularAndOnXfs)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(true).onXfs(true).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats).isRegularFile(true).onXfs(true).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_ACCEPT);
@@ -292,10 +314,11 @@ TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsRegularAndOnXfs)
 
 TEST_F(FastpathTest, ScoreRejectsIoIfFileIsRegularAndNotOnExt4OrderedNorXfs)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer)
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats)
         .isRegularFile(true)
         .onExt4Ordered(false)
         .onXfs(false)
+        .countRejection(true)
         .build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
@@ -304,7 +327,7 @@ TEST_F(FastpathTest, ScoreRejectsIoIfFileIsRegularAndNotOnExt4OrderedNorXfs)
 
 TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsRegularNotOnExt4OrderedNorXfsIfUnsupportedFileSystemsIsTrue)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer)
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats)
         .isRegularFile(true)
         .onExt4Ordered(false)
         .onXfs(false)
@@ -317,7 +340,10 @@ TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsRegularNotOnExt4OrderedNorXfsIfUnsupp
 
 TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsBlockDevice)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(false).isBlockDevice(true).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats)
+        .isRegularFile(false)
+        .isBlockDevice(true)
+        .build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_ACCEPT);
@@ -325,7 +351,11 @@ TEST_F(FastpathTest, ScoreAcceptsIoIfFileIsBlockDevice)
 
 TEST_F(FastpathTest, ScoreRejectsIoIfFileIsNotRegularFileOrBlockDevice)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).isRegularFile(false).isBlockDevice(false).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats)
+        .isRegularFile(false)
+        .isBlockDevice(false)
+        .countRejection(true)
+        .build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -335,7 +365,7 @@ struct FastpathSupportedHipMemoryParam : public FastpathTestBase, public TestWit
 
 TEST_P(FastpathSupportedHipMemoryParam, Score)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).bufferType(GetParam()).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats).bufferType(GetParam()).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_ACCEPT);
@@ -347,7 +377,10 @@ struct FastpathUnsupportedHipMemoryParam : public FastpathTestBase, public TestW
 
 TEST_P(FastpathUnsupportedHipMemoryParam, Score)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).bufferType(GetParam()).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats)
+        .bufferType(GetParam())
+        .countRejection(true)
+        .build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -360,7 +393,7 @@ struct FastpathAlignedIoSizesParam : public FastpathTestBase, public TestWithPar
 
 TEST_P(FastpathAlignedIoSizesParam, Score)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, GetParam(), DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_ACCEPT);
@@ -374,7 +407,7 @@ struct FastpathUnalignedIoSizesParam : public FastpathTestBase, public TestWithP
 
 TEST_P(FastpathUnalignedIoSizesParam, Score)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats).countRejection(true).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, GetParam(), DEFAULT_FILE_OFFSET, DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -388,7 +421,7 @@ struct FastpathAlignedFileOffsetsParam : public FastpathTestBase, public TestWit
 
 TEST_P(FastpathAlignedFileOffsetsParam, Score)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats).countRejection(GetParam() < 0).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, GetParam(), DEFAULT_BUFFER_OFFSET),
               GetParam() >= 0 ? SCORE_ACCEPT : SCORE_REJECT);
@@ -404,7 +437,7 @@ struct FastpathUnalignedFileOffsetsParam : public FastpathTestBase, public TestW
 
 TEST_P(FastpathUnalignedFileOffsetsParam, Score)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats).countRejection(true).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, GetParam(), DEFAULT_BUFFER_OFFSET),
               SCORE_REJECT);
@@ -422,7 +455,7 @@ struct FastpathAlignedBufferOffsetsParam : public FastpathTestBase, public TestW
 
 TEST_P(FastpathAlignedBufferOffsetsParam, Score)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats).countRejection(GetParam() < 0).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, GetParam()),
               GetParam() >= 0 ? SCORE_ACCEPT : SCORE_REJECT);
@@ -439,7 +472,7 @@ struct FastpathUnalignedBufferOffsetsParam : public FastpathTestBase, public Tes
 
 TEST_P(FastpathUnalignedBufferOffsetsParam, Score)
 {
-    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer).build();
+    FastpathScoreExpectationsBuilder(mcfg, mfile, mbuffer, mstats).countRejection(true).build();
 
     ASSERT_EQ(Fastpath().score(mfile, mbuffer, DEFAULT_IO_SIZE, DEFAULT_FILE_OFFSET, GetParam()),
               SCORE_REJECT);
@@ -455,8 +488,7 @@ INSTANTIATE_TEST_SUITE_P(FastpathTest, FastpathUnalignedBufferOffsetsParam,
 
 struct FastpathIoParam : public FastpathTestBase, public TestWithParam<IoType> {
 
-    StrictMock<MHip>             mhip;
-    StrictMock<MStatsCollection> mstats;
+    StrictMock<MHip> mhip;
 
     // Setup expectations on the mocks called to validate IO arguments
     void expect_validate()

--- a/projects/hipfile/test/amd_detail/mstats.h
+++ b/projects/hipfile/test/amd_detail/mstats.h
@@ -34,5 +34,6 @@ public:
                 (const, noexcept, override));
     MOCK_METHOD(void, fileRegistration, (), (const, noexcept, override));
     MOCK_METHOD(void, bufferRegistration, (), (const, noexcept, override));
+    MOCK_METHOD(void, fastpathRejection, (), (const, noexcept, override));
 };
 }

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -116,6 +116,21 @@ TEST_F(HipFileStats, StatsCollectionBufferRegistration)
     ASSERT_EQ(2, stats.getBufferRegistrations().load());
 }
 
+TEST_F(HipFileStats, StatsCollectionFastpathRejection)
+{
+    Stats                    stats{};
+    StrictMock<MStatsServer> mstats{};
+    EXPECT_CALL(mstats, getStats).WillRepeatedly(testing::Return(&stats));
+    stats.setLevel(StatsLevel::Basic);
+    Context<StatsCollection>::get()->fastpathRejection();
+    ASSERT_EQ(1, stats.getFastpathRejections().load());
+    Context<StatsCollection>::get()->fastpathRejection();
+    ASSERT_EQ(2, stats.getFastpathRejections().load());
+    stats.setLevel(StatsLevel::Disabled);
+    Context<StatsCollection>::get()->fastpathRejection();
+    ASSERT_EQ(2, stats.getFastpathRejections().load());
+}
+
 TEST_F(HipFileStats, StatsContainer)
 {
     StrictMock<MSys>           msys{};
@@ -178,6 +193,7 @@ TEST_F(HipFileStats, GenerateReportV1)
         .buckets[0]                = 4;
     stats.getBufferRegistrations() = 10;
     stats.getFileRegistrations()   = 20;
+    stats.getFastpathRejections()  = 30;
     StatsClient::generateReportV1(os, &stats);
     std::string str{os.str()};
     ASSERT_GT(std::string::npos, str.find("Total Fastpath Read Size (B): 2"));
@@ -190,6 +206,7 @@ TEST_F(HipFileStats, GenerateReportV1)
     ASSERT_GT(std::string::npos, str.find("Total Fallback Write Errors: 4"));
     ASSERT_GT(std::string::npos, str.find("Buffer Registrations: 10"));
     ASSERT_GT(std::string::npos, str.find("File Handle Registrations: 20"));
+    ASSERT_GT(std::string::npos, str.find("Fastpath Rejections: 30"));
 }
 
 TEST_F(HipFileStats, GenerateReportV1TwoGpus)


### PR DESCRIPTION
## Motivation

This is one of the counters we agreed to provide to the RocProfiler team.

## Technical Details

Similar to the file and buffer registration counters on the stats side. The instrumentation is done in Fastpath::score() where the count is incremented if the IO is rejected.

## JIRA ID

AIHIPFILE-99

## Test Plan

Use aiscp running under ais-stats to copy a file on both a supported and unsupported volume and compare ais-stats output.

## Test Result

fastpath rejection counted correctly

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
