### PR TITLE
Fix test failures in ASAN builds

### DIFF
--- a/projects/hip-tests/catch/multiproc/childMalloc.cc
+++ b/projects/hip-tests/catch/multiproc/childMalloc.cc
@@ -56,6 +56,7 @@ bool testMallocFromChild() {
     // send the value on the write-descriptor:
     write(fd[1], &testResult, sizeof(testResult));
 
+    hipFree(A_d);
     // close the write descriptor:
     close(fd[1]);
     exit(0);

--- a/projects/hip-tests/catch/unit/device/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/device/CMakeLists.txt
@@ -51,6 +51,11 @@ set_source_files_properties(getDeviceCount_exe.cc PROPERTIES LANGUAGE ${GPGPU_LA
 set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS getDeviceCount)
 target_link_libraries(getDeviceCount ${GPGPU_LINKER_LIBRARIES})
 
+add_executable(hipSetValidDevicesMultiProc EXCLUDE_FROM_ALL hipSetValidDevicesMultiProc_Exe.cc)
+set_source_files_properties(hipSetValidDevicesMultiProc_Exe.cc PROPERTIES LANGUAGE ${GPGPU_LANGUAGE})
+set_property(GLOBAL APPEND PROPERTY G_INSTALL_EXE_TARGETS hipSetValidDevicesMultiProc)
+target_link_libraries(hipSetValidDevicesMultiProc ${GPGPU_LINKER_LIBRARIES})
+
 add_executable(chkUUIDFrmChildProc_Exe EXCLUDE_FROM_ALL chkUUIDFrmChildProc_Exe.cc)
 add_executable(chkUUIDInGrandChild_Exe EXCLUDE_FROM_ALL chkUUIDInGrandChild_Exe.cc)
 add_executable(setuuidGetDevCount EXCLUDE_FROM_ALL setuuidGetDevCount_Exe.cc)
@@ -100,7 +105,7 @@ endif()
 hip_add_exe_to_target(NAME DeviceTest
                       TEST_SRC ${TEST_SRC}
                       TEST_TARGET_NAME build_tests)
-add_dependencies(build_tests getDeviceCount chkUUIDFrmChildProc_Exe chkUUIDInGrandChild_Exe setuuidGetDevCount multipleUUID setEnvInChildProc uuidList)
+add_dependencies(build_tests getDeviceCount hipSetValidDevicesMultiProc chkUUIDFrmChildProc_Exe chkUUIDInGrandChild_Exe setuuidGetDevCount multipleUUID setEnvInChildProc uuidList)
 #Disabled below two executable due to the defect ticket SWDEV-467665
 if(0)
 add_dependencies(build_tests passUUIDToGrandChild_Exe ResetUUIDInChild_Exe)

--- a/projects/hip-tests/catch/unit/device/hipSetValidDevices.cc
+++ b/projects/hip-tests/catch/unit/device/hipSetValidDevices.cc
@@ -291,8 +291,9 @@ HIP_TEST_CASE(Unit_hipSetValidDevices_Positive_Cases) {
  * ------------------------
  *  - This test case checks the behavior of hipSetValidDevices
  *  - in multi process scenario, check the current device at start in
- *  - Parant and child process and set different devices in child and parent
+ *  - Parent and child process and set different devices in child and parent
  *  - using hipSetValidDevices and validate.
+ *  - The child runs as a separately spawned process (hipSetValidDevicesMultiProc)
  * Test source
  * ------------------------
  *  - unit/device/hipSetValidDevices.cc
@@ -306,34 +307,25 @@ HIP_TEST_CASE(Unit_hipSetValidDevices_MultiProcess) {
     HIP_SKIP_TEST(HipTest::SkipReason::kFewerThanTwoGpus);
   }
 
-  auto pid = fork();
-  REQUIRE(pid >= 0);
+  // Spawn the child process first so it initializes the runtime independently and
+  // runs concurrently with the parent's own hipSetValidDevices path.
+  hip::SpawnProc proc("hipSetValidDevicesMultiProc", true);
+  REQUIRE(proc.spawn() == 0);
 
-  if (pid != 0) {  // Parent process
-    REQUIRE(getCurrentDevice() == 0);
+  // Parent process path.
+  REQUIRE(getCurrentDevice() == 0);
 
-    int length = 2;
-    int deviceArr[2] = {1, 0};
-    HIP_CHECK(hipSetValidDevices(deviceArr, length));
+  int length = 2;
+  int deviceArr[2] = {1, 0};
+  HIP_CHECK(hipSetValidDevices(deviceArr, length));
 
-    REQUIRE(getCurrentDevice() == 1);
-    performOperations();
+  REQUIRE(getCurrentDevice() == 1);
+  performOperations();
 
-    int status;
-    REQUIRE(wait(&status) >= 0);
-
-  } else {  // Child process
-    REQUIRE(getCurrentDevice() == 0);
-
-    int length = 2;
-    int device_arr_c[2] = {0, 1};
-    HIP_CHECK(hipSetValidDevices(device_arr_c, length));
-
-    REQUIRE(getCurrentDevice() == 0);
-    performOperations();
-
-    exit(0);
-  }
+  // The child must complete its own validation and exit cleanly.
+  int childExit = proc.wait();
+  INFO("Child process output:\n" << proc.getOutput());
+  REQUIRE(childExit == 0);
 }
 #endif
 

--- a/projects/hip-tests/catch/unit/device/hipSetValidDevicesMultiProc_Exe.cc
+++ b/projects/hip-tests/catch/unit/device/hipSetValidDevicesMultiProc_Exe.cc
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+// Child process used by Unit_hipSetValidDevices_MultiProcess.
+
+// This runs as a freshly exec'd process, so that the HIP runtime is initialized
+// cleanly in this process. The parent test process spawns it, runs its own
+// hipSetValidDevices path concurrently, and asserts that this process exits
+// with status 0.
+
+// Returns 0 on success, 1 on identifying the failing step otherwise.
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+
+#define N 1024
+
+static __global__ void doubleKernel(int* arr, size_t arrSize) {
+  size_t offset = blockDim.x * blockIdx.x + threadIdx.x;
+  size_t stride = blockDim.x * gridDim.x;
+
+  for (size_t i = offset; i < arrSize; i += stride) {
+    arr[i] += arr[i];
+  }
+}
+
+static int performOperations() {
+  int hostMem[N];
+  for (int i = 0; i < N; i++) {
+    hostMem[i] = 5;
+  }
+
+  int rc = 0;
+  int* devMem = nullptr;
+  if (hipMalloc(&devMem, N * sizeof(int)) != hipSuccess) return 1;
+
+  if (hipMemcpy(devMem, hostMem, N * sizeof(int), hipMemcpyHostToDevice) != hipSuccess) {
+    rc = 1;
+    goto cleanup;
+  }
+
+  doubleKernel<<<1, N>>>(devMem, N);
+
+  if (hipMemcpy(hostMem, devMem, N * sizeof(int), hipMemcpyDeviceToHost) != hipSuccess) {
+    rc = 1;
+    goto cleanup;
+  }
+
+  for (int i = 0; i < N; i++) {
+    if (hostMem[i] != 10) {
+      rc = 1;
+      goto cleanup;
+    }
+  }
+
+  cleanup:
+    if (devMem != nullptr && hipFree(devMem) != hipSuccess) {
+     rc = 1;
+    }
+    return rc;
+}
+
+int main() {
+  int device = -1;
+  if (hipGetDevice(&device) != hipSuccess || device != 0) {
+    printf("child: expected current device 0, got %d\n", device);
+    return 1;
+  }
+
+  int deviceArr[2] = {0, 1};
+  if (hipSetValidDevices(deviceArr, 2) != hipSuccess) {
+    printf("child: hipSetValidDevices failed\n");
+    return 1;
+  }
+
+  if (hipGetDevice(&device) != hipSuccess || device != 0) {
+    printf("child: expected current device 0 after set, got %d\n", device);
+    return 1;
+  }
+
+  int rc = performOperations();
+  if (rc != 0) {
+    printf("child: performOperations failed with code %d\n", rc);
+    return rc;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Motivation

To fix the tests ChildMalloc and Unit_hipSetValidDevices_MultiProcess in ASAN builds

## Technical Details

"ChildMalloc" test doesnt do a hipFree after hipMalloc causing leaks
"Unit_hipSetValidDevices_MultiProcess" seems to initialize HIP in parent process and later forks a child and does hipMalloc. But actually HIP runtime fails in the child if initialization happened before fork. So the test had to be rewritten to avoid this and also to catch the child process status correctly. 

## JIRA ID

ROCM-25866, ROCM-25871

## Test Plan

These tests should pass without any errors reported by ASAN

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
