### PR TITLE
[AMD-SMI] Bump esmi_ib_library tag to 5.2.1.1

### DIFF
--- a/projects/amdsmi/CMakeLists.txt
+++ b/projects/amdsmi/CMakeLists.txt
@@ -260,7 +260,7 @@ set(ROCM_INC_DIR "${PROJECT_SOURCE_DIR}/rocm_smi/include/rocm_smi")
 set(SHR_MUTEX_DIR "${PROJECT_SOURCE_DIR}/third_party/shared_mutex")
 if(ENABLE_ESMI_LIB)
     # Supported esmi library version tag
-    set(current_esmi_tag "esmi_pkg_ver-5.1.1")
+    set(current_esmi_tag "esmi_pkg_ver-5.2.1.1")
 
     if(NOT EXISTS ${PROJECT_SOURCE_DIR}/esmi_ib_library/src)
         # TODO: use ExternalProject_Add instead or a submodule


### PR DESCRIPTION
## Summary
Bumps the supported esmi library version tag in `projects/amdsmi/CMakeLists.txt` from `esmi_pkg_ver-5.1.1` to `esmi_pkg_ver-5.2.1.1`.

| esmi file | lines | reaches amd-smi? |
|-----------|-------|------------------|
| `tools/e_smi_tool.c` | 1251 | No - amd-smi never builds the standalone tool |
| `include/asm/amd_hsmp.h` | 150 | No - amd-smi force-overwrites this with its own `include/amd_smi/impl/amd_hsmp.h` |
| `include/e_smi/e_smi.h` | 130 | Yes - purely additive |
| `src/e_smi.c` | 138 | Yes - additive functions + one bugfix |

What actually changes under amd-smi:
- **Additive API** in `e_smi.h`: `esmi_number_of_physicalcores_in_socket_get`, `esmi_dimm_power_consumption_data_get`, `esmi_dimm_thermal_sensor_data_get`, `esmi_metrics_table_F1A_M50_M5F_get`, one appended status enum `ESMI_METRICS_TABLE_NOT_SUPPORTED`, and a `const`-hardening of `freqlimitsrcnames`. All backward compatible.
- **Bugfix** in `detect_packages()`: socket count now rounds up and guards against a `malloc(0)`/out-of-bounds write when sockets==0.

## Compatibility
The new `e_smi.c` references only HSMP message IDs that already exist in amd-smi's overriding `amd_hsmp.h`, so the build's header override stays consistent. Functionally a near no-op