### PR TITLE
gfx1151 hipInfo issue on rocr backend

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -143,7 +143,7 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
 
   num_h2d_d2h_engines_ = properties_.NumSdmaEngines > 2 ? 2 : properties_.NumSdmaEngines;
   num_p2p_engines_ =  properties_.NumSdmaXgmiEngines ? properties_.NumSdmaXgmiEngines
-                      : std::max(0U, properties_.NumSdmaEngines - 2);
+                      : (properties_.NumSdmaEngines > 2 ? properties_.NumSdmaEngines - 2 : 0);
 
   const core::Isa *isa_base;
 


### PR DESCRIPTION
## Motivation
gfx1151 hipInfo and other apps crash because the sdma engine size is 1 for APU. 
earlier commit introduces the unsigned integer underflow . 

## Technical Details
PR #6593 introduced an unsigned integer underflow bug at line 146. When NumSdmaEngines < 2 (e.g., 1 on Strix Halo), the expression properties_.NumSdmaEngines - 2 underflows to 4294967295 in unsigned arithmetic, causing a massive vector allocation that crashes.

## JIRA ID
AIRUNTIME-2317

## Test Plan
hipInfo and hip-tests works on rocr backend for both dGPU and APUs

## Test Result
hipInfo and hip-tests works on rocr backend for both dGPU and APUs

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
