### PR TITLE
[rocprofiler-compute] improve experimental feature docs

### DIFF
--- a/projects/rocprofiler-compute/sample/membw_analysis_test_suite/README.md
+++ b/projects/rocprofiler-compute/sample/membw_analysis_test_suite/README.md
@@ -35,6 +35,9 @@ hipcc -g <hip workload> -o <output>
 ## Profiling
 
 ```bash
+# Note: --no-roof is optional and skips the
+# benchmarking that is unrelated to the our purpose
+
 # baseline profile
 rocprof-compute profile -n gl2_backpressure_baseline --membw-analysis --no-roof -- ./gl2_backpressure
 # optimized profile

--- a/projects/rocprofiler-compute/sample/membw_analysis_test_suite/ea/README.md
+++ b/projects/rocprofiler-compute/sample/membw_analysis_test_suite/ea/README.md
@@ -66,14 +66,14 @@ hipcc -g ea_hbm_read_bw.hip -o ea_hbm_read_bw
 # Profile baseline
 src/rocprof-compute profile -n ea_test_baseline \
     -b 30.13 30.14 30.15 30.16 30.17 30.18 \
-    --membw-analysis --experimental --no-roof \
+    --experimental --membw-analysis --no-roof \
     --output-directory /tmp/ea_test_baseline \
     -- ./sample/membw_analysis_test_suite/ea/ea_hbm_read_bw
 
 # Profile optimized
 src/rocprof-compute profile -n ea_test_opt \
     -b 30.13 30.14 30.15 30.16 30.17 30.18 \
-    --membw-analysis --experimental --no-roof \
+    --experimental --membw-analysis --no-roof \
     --output-directory /tmp/ea_test_opt \
     -- ./sample/membw_analysis_test_suite/ea/ea_hbm_read_bw opt
 ```
@@ -85,17 +85,17 @@ Side-by-side baseline vs. optimized comparison:
 ```bash
 src/rocprof-compute analyze \
     -p /tmp/ea_test_baseline -p /tmp/ea_test_opt \
-    -b 30.13 30.14 30.15 30.16 30.17 30.18 --membw-analysis --experimental
+    -b 30.13 30.14 30.15 30.16 30.17 30.18 --experimental --membw-analysis
 ```
 
 To analyze each run independently:
 
 ```bash
 src/rocprof-compute analyze -p /tmp/ea_test_baseline \
-    -b 30.13 30.14 30.15 30.16 30.17 30.18 --membw-analysis --experimental
+    -b 30.13 30.14 30.15 30.16 30.17 30.18 --experimental --membw-analysis
 
 src/rocprof-compute analyze -p /tmp/ea_test_opt \
-    -b 30.13 30.14 30.15 30.16 30.17 30.18 --membw-analysis --experimental
+    -b 30.13 30.14 30.15 30.16 30.17 30.18 --experimental --membw-analysis
 ```
 
 ## Validation Results (MI350X)

--- a/projects/rocprofiler-compute/sample/membw_analysis_test_suite/ea/README.md
+++ b/projects/rocprofiler-compute/sample/membw_analysis_test_suite/ea/README.md
@@ -61,6 +61,9 @@ hipcc -g ea_hbm_read_bw.hip -o ea_hbm_read_bw
 ## Profiling
 
 ```bash
+# Note: --no-roof is optional and skips the
+# benchmarking that is unrelated to the our purpose
+
 # From the rocprofiler-compute root directory:
 
 # Profile baseline

--- a/projects/rocprofiler-compute/sample/membw_analysis_test_suite/l2/README.md
+++ b/projects/rocprofiler-compute/sample/membw_analysis_test_suite/l2/README.md
@@ -1,6 +1,6 @@
 # Memory Bandwidth Analysis Test Suite
 
-HIP workloads targeting MI350 (gfx950) L1 and L2 cache/memory metrics for validation with `rocprof-compute --membw-analysis --experimental`.
+HIP workloads targeting MI350 (gfx950) L1 and L2 cache/memory metrics for validation with `rocprof-compute --experimental --membw-analysis`.
 
 ## L1 Workloads (tables 3001-3003)
 
@@ -65,41 +65,41 @@ done
 
 ```bash
 # Profile baseline
-rocprof-compute profile -n <name>_baseline --membw-analysis --experimental --no-roof -- ./<workload>
+rocprof-compute profile -n <name>_baseline --experimental --membw-analysis --no-roof -- ./<workload>
 
 # Profile optimized
-rocprof-compute profile -n <name>_optimized --membw-analysis --experimental --no-roof -- ./<workload> opt
+rocprof-compute profile -n <name>_optimized --experimental --membw-analysis --no-roof -- ./<workload> opt
 ```
 
 ### Examples
 
 ```bash
 # HBM read stress
-rocprof-compute profile -n hbm_read_baseline --membw-analysis --experimental --no-roof -- ./l2_hbm_read_bw_stress
-rocprof-compute profile -n hbm_read_optimized --membw-analysis --experimental --no-roof -- ./l2_hbm_read_bw_stress opt
+rocprof-compute profile -n hbm_read_baseline --experimental --membw-analysis --no-roof -- ./l2_hbm_read_bw_stress
+rocprof-compute profile -n hbm_read_optimized --experimental --membw-analysis --no-roof -- ./l2_hbm_read_bw_stress opt
 
 # Cache thrash
-rocprof-compute profile -n thrash_baseline --membw-analysis --experimental --no-roof -- ./l2_cache_thrash
-rocprof-compute profile -n thrash_optimized --membw-analysis --experimental --no-roof -- ./l2_cache_thrash opt
+rocprof-compute profile -n thrash_baseline --experimental --membw-analysis --no-roof -- ./l2_cache_thrash
+rocprof-compute profile -n thrash_optimized --experimental --membw-analysis --no-roof -- ./l2_cache_thrash opt
 
 # Coherence (fine-grained mode)
-rocprof-compute profile -n coherence_fg --membw-analysis --experimental --no-roof -- ./l2_coherence_traffic
-rocprof-compute profile -n coherence_nc --membw-analysis --experimental --no-roof -- ./l2_coherence_traffic nc
-rocprof-compute profile -n coherence_opt --membw-analysis --experimental --no-roof -- ./l2_coherence_traffic opt
+rocprof-compute profile -n coherence_fg --experimental --membw-analysis --no-roof -- ./l2_coherence_traffic
+rocprof-compute profile -n coherence_nc --experimental --membw-analysis --no-roof -- ./l2_coherence_traffic nc
+rocprof-compute profile -n coherence_opt --experimental --membw-analysis --no-roof -- ./l2_coherence_traffic opt
 
 # IO stress (host-pinned vs device-local)
-rocprof-compute profile -n io_baseline --membw-analysis --experimental --no-roof -- ./l2_io_stress
-rocprof-compute profile -n io_optimized --membw-analysis --experimental --no-roof -- ./l2_io_stress opt
+rocprof-compute profile -n io_baseline --experimental --membw-analysis --no-roof -- ./l2_io_stress
+rocprof-compute profile -n io_optimized --experimental --membw-analysis --no-roof -- ./l2_io_stress opt
 
 # Multi-GPU (requires 2 GPUs)
-rocprof-compute profile -n fabric_read --membw-analysis --experimental --no-roof -- ./l2_multigpu_fabric read
-rocprof-compute profile -n fabric_write --membw-analysis --experimental --no-roof -- ./l2_multigpu_fabric write
+rocprof-compute profile -n fabric_read --experimental --membw-analysis --no-roof -- ./l2_multigpu_fabric read
+rocprof-compute profile -n fabric_write --experimental --membw-analysis --no-roof -- ./l2_multigpu_fabric write
 ```
 
 ## Analyzing
 
 ```bash
-rocprof-compute analyze -p <path to profiled result> --membw-analysis --experimental
+rocprof-compute analyze -p <path to profiled result> --experimental --membw-analysis
 ```
 
 ## Hardware Requirements

--- a/projects/rocprofiler-compute/sample/membw_analysis_test_suite/l2/README.md
+++ b/projects/rocprofiler-compute/sample/membw_analysis_test_suite/l2/README.md
@@ -64,6 +64,9 @@ done
 ## Profiling
 
 ```bash
+# Note: --no-roof is optional and skips the
+# benchmarking that is unrelated to the our purpose
+
 # Profile baseline
 rocprof-compute profile -n <name>_baseline --experimental --membw-analysis --no-roof -- ./<workload>
 

--- a/projects/rocprofiler-compute/sample/membw_analysis_test_suite/l2/VERIFICATION_REPORT.md
+++ b/projects/rocprofiler-compute/sample/membw_analysis_test_suite/l2/VERIFICATION_REPORT.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-03-27
 **System:** 2x MI350X GPUs (gfx950), 256 CUs, 128 TCC channels, 4 MB L2 per XCD (8 XCDs)
-**Tool:** `src/rocprof-compute analyze -p <path> -b 30 --membw-analysis --experimental`
+**Tool:** `src/rocprof-compute analyze -p <path> -b 30 --experimental --membw-analysis`
 **Profiling data:** `/tmp/l2_profile_results/`
 
 ## Hardware Spec Cross-Reference (MI350 TCC Perfmon List)

--- a/projects/rocprofiler-compute/sample/membw_analysis_test_suite/l2/l2_multigpu_fabric.hip
+++ b/projects/rocprofiler-compute/sample/membw_analysis_test_suite/l2/l2_multigpu_fabric.hip
@@ -25,14 +25,14 @@
 //
 // Run (profile GPU 0 while it accesses GPU 1's memory):
 //   # Read from remote:
-//   rocprof-compute profile -n fabric_read --membw-analysis --experimental --no-roof -- ./l2_multigpu_fabric read
+//   rocprof-compute profile -n fabric_read --experimental --membw-analysis --no-roof -- ./l2_multigpu_fabric read
 //   # Write to remote:
-//   rocprof-compute profile -n fabric_write --membw-analysis --experimental --no-roof -- ./l2_multigpu_fabric write
+//   rocprof-compute profile -n fabric_write --experimental --membw-analysis --no-roof -- ./l2_multigpu_fabric write
 //   # Read+Write:
-//   rocprof-compute profile -n fabric_rw --membw-analysis --experimental --no-roof -- ./l2_multigpu_fabric
+//   rocprof-compute profile -n fabric_rw --experimental --membw-analysis --no-roof -- ./l2_multigpu_fabric
 //
 // Analyze:
-//   rocprof-compute analyze -p <profiled_result_path> --membw-analysis --experimental
+//   rocprof-compute analyze -p <profiled_result_path> --experimental --membw-analysis
 
 #include <hip/hip_runtime.h>
 #include <iostream>

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -171,7 +171,7 @@ class RocProfCompute:
                         "Block 30 (Memory Bandwidth Analysis) is an experimental "
                         "feature.\n"
                         f'To use "-b {block_input}", you must also specify: '
-                        "--membw-analysis --experimental"
+                        "--experimental --membw-analysis"
                     )
             # Block 21 (PC sampling) is profile-only; analyze auto-detects it
             # from the profiling config yaml.
@@ -180,7 +180,7 @@ class RocProfCompute:
                     console_error(
                         "Block 21 (PC Sampling) is an experimental feature.\n"
                         f'To use "-b {block_input}", you must also specify: '
-                        "--pc-sampling --experimental"
+                        "--experimental --pc-sampling"
                     )
 
         # When --pc-sampling is set, inject "21" into filter_blocks so the


### PR DESCRIPTION
## Motivation

In user-facing doc/output, the ordering of `--experimental` and the respective feature is inconsistent.

## Technical Details

Cosmetic changes only.
Always have `--experimental` before the respective feature: `--experimental --<feature>`

## JIRA ID

N/A

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
