### PR TITLE
[rocjitsu] Fix scaled MFMA f8f6f4 execution

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -1347,6 +1347,29 @@ class CodeGenerator:
             and self.isa_spec.profile.generate_scaled_wmma_vop3px2
         )
 
+    def _supports_cdna_mfma_f8f6f4_vop3px2(self) -> bool:
+        return self.isa_spec.arch_name.lower() == 'cdna4'
+
+    @staticmethod
+    def _emit_cdna_mfma_f8f6f4_vop3px2_decoder_helpers() -> str:
+        return textwrap.dedent('''\
+            namespace {
+
+            bool isMfmaScaleF8f6f4Vop3px2(const MachineInst *opcode) {
+              constexpr uint32_t VOP3P_MFMA_ENC = 423;
+              constexpr uint32_t PREFIX_OP = 44;
+              auto enc0 = (opcode[0] >> 23) & 0x1FFu;
+              auto op0 = (opcode[0] >> 16) & 0x7Fu;
+              if (enc0 != VOP3P_MFMA_ENC || op0 != PREFIX_OP)
+                return false;
+              auto enc2 = (opcode[2] >> 23) & 0x1FFu;
+              auto op2 = (opcode[2] >> 16) & 0x7Fu;
+              return enc2 == VOP3P_MFMA_ENC && (op2 == 45 || op2 == 46);
+            }
+
+            } // namespace
+            ''')
+
     def _gfx1250_f8f6f4_wmma_shape(
         self, inst: Instruction
     ) -> tuple[int, int, int] | None:
@@ -7151,6 +7174,20 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                     'if (isWmmaScaleF32F8f6f4Vop3px2(opcode)) return std::make_unique<VWmmaScaleF3216x16x128F8f6f4Vop3px2>(opcode)'
                 )
             )
+        if self._supports_cdna_mfma_f8f6f4_vop3px2():
+            class_impl.append(
+                cgen.Line(self._emit_cdna_mfma_f8f6f4_vop3px2_decoder_helpers())
+            )
+            decode_body.append(
+                cgen.Line(
+                    '  if (isMfmaScaleF8f6f4Vop3px2(opcode)) {\n'
+                    '    auto op2 = (opcode[2] >> 16) & 0x7Fu;\n'
+                    '    if (op2 == 45)\n'
+                    '      return std::make_unique<VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode + 2);\n'
+                    '    return std::make_unique<VMfmaF3232x32x64F8f6f4Vop3pMfma>(opcode + 2);\n'
+                    '  }\n'
+                )
+            )
         if self._supports_generated_vopd():
             decode_body.append(
                 cgen.Statement(
@@ -7219,6 +7256,13 @@ inline void unpack_6bit(const uint32_t dwords[6], uint8_t vals[32]) {{
                     ):
                         _pfx = 'decodeVop3pX2Prefix'
                         _dte.sub_decode_funcs[_vop3px2_opcode] = _pfx
+                        for ie in self.isa_spec.inst_encodings:
+                            for inst in ie.insts:
+                                if (
+                                    inst.name
+                                    in self.isa_spec.profile.inst_size_overrides
+                                ):
+                                    _dte.sub_decode_funcs[inst.opcode] = 'decodeInvalid'
                         _custom_decode_bodies[_pfx] = cgen.Block(
                             [
                                 cgen.Statement(

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/matrix.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/matrix.py
@@ -78,105 +78,52 @@ def gen_mfma(
     dst_bits = inst.operands[0].size if inst.operands else 0
     dst_regs = max(1, dst_bits // 32)
 
-    # SMFMAC: cross-lane matrix multiply-accumulate.
-    if 'SMFMAC' in name:
+    # SMFMAC: sparse matrix FMA with 4:2 structured sparsity.
+    # F32-result variants use cross-lane exec_smfmac_* helpers from
+    # mma_exec.h; I32-result variants fall through to the per-lane stub.
+    if 'SMFMAC' in name and result_type == 'F32':
         _SMFMAC_READ = {
             'F16': 'amdgpu::smfmac_read_f16',
             'BF16': 'amdgpu::smfmac_read_bf16',
+        }
+        _SMFMAC_FP8_READ = {
             'FP8': 'amdgpu::smfmac_read_fp8',
             'BF8': 'amdgpu::smfmac_read_bf8',
         }
-        if arch_name == 'cdna4' and input_type != 'I8':
-            L = []
-            L.append(f'  auto &cu = wf.cu();')
-            L.append(f'  uint32_t vb = wf.vgpr_alloc().base;')
+        L = []
+        L.append(f'  auto &cu = wf.cu();')
+        L.append(f'  uint32_t vb = wf.vgpr_alloc().base;')
+        has_acc_cd = arch_name in ('cdna2', 'cdna3', 'cdna4')
+        if has_acc_cd:
             L.append(
                 f'  uint32_t dst = amdgpu::dst_base(vb, {d}.encoding_value_, inst_.acc_cd);'
             )
-            L.append(f'  uint32_t s0b = amdgpu::src_base(vb, {s0}.encoding_value_);')
-            L.append(f'  uint32_t s1b = amdgpu::src_base(vb, {s1}.encoding_value_);')
-            L.append(f'  uint32_t idx = amdgpu::src_base(vb, {s2}.encoding_value_);')
-            if input_type in ('F16', 'BF16'):
-                read_fn = _SMFMAC_READ[input_type]
-                L.append(
-                    f'  amdgpu::exec_smfmac_f32_{M}x{N}x{K}_f16(cu, dst, s0b, s1b, idx, {read_fn});'
-                )
-            else:
-                parts = input_type.split('_')
-                read_a = _SMFMAC_READ.get(parts[0], 'amdgpu::smfmac_read_fp8')
-                read_b = _SMFMAC_READ.get(parts[1], 'amdgpu::smfmac_read_fp8')
-                L.append(
-                    f'  amdgpu::exec_smfmac_f32_{M}x{N}x{K}_fp8(cu, dst, s0b, s1b, idx, {read_a},'
-                )
-                L.append(f'                                        {read_b});')
-            return '\n'.join(L)
-
-        # Fallback: per-lane dot-product functional model.
-        L = []
-        L.append(
-            f'  // MFMA: {name} \u2014 {M}x{N}x{K} {input_type}\u2192{result_type}'
-        )
-        L.append(f'  // D({dst_regs} regs/lane) += A * B, functional model')
-        L.append(f'  uint64_t exec = wf.exec();')
-        L.append(f'  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {{')
-        L.append(f'    if (!(exec & (1ULL << lane)))')
-        L.append(f'      continue;')
-        L.append(f'    uint32_t a_raw = {s0}.read_lane(wf, lane);')
-        L.append(f'    uint32_t b_raw = {s1}.read_lane(wf, lane);')
+        else:
+            L.append(f'  uint32_t dst = amdgpu::dst_base(vb, {d}.encoding_value_, 1);')
+        L.append(f'  uint32_t s0b = amdgpu::src_base(vb, {s0}.encoding_value_);')
+        L.append(f'  uint32_t s1b = amdgpu::src_base(vb, {s1}.encoding_value_);')
+        L.append(f'  uint32_t idx = amdgpu::src_base(vb, {s2}.encoding_value_);')
 
         if input_type in ('F16', 'BF16'):
-            conv = 'util::f16_to_f32' if input_type == 'F16' else 'util::bf16_to_f32'
-            L.append(f'    float a0 = {conv}(static_cast<uint16_t>(a_raw));')
-            L.append(f'    float a1 = {conv}(static_cast<uint16_t>(a_raw >> 16));')
-            L.append(f'    float b0 = {conv}(static_cast<uint16_t>(b_raw));')
-            L.append(f'    float b1 = {conv}(static_cast<uint16_t>(b_raw >> 16));')
-            L.append(f'    float dot = a0 * b0 + a1 * b1;')
-            L.append(f'    float acc = std::bit_cast<float>({s2}.read_lane(wf, lane));')
+            read_fn = _SMFMAC_READ[input_type]
             L.append(
-                f'    {d}.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));'
-            )
-        elif input_type == 'I8':
-            L.append(f'    int32_t dot = 0;')
-            L.append(f'    for (int k = 0; k < 8; ++k) {{')
-            L.append(
-                f'      int8_t ae = static_cast<int8_t>((a_raw >> (k * 8)) & 0xFF);'
-            )
-            L.append(
-                f'      int8_t be = static_cast<int8_t>((b_raw >> (k * 8)) & 0xFF);'
-            )
-            L.append(f'      dot += static_cast<int32_t>(ae) * be;')
-            L.append(f'    }}')
-            L.append(
-                f'    int32_t acc0 = static_cast<int32_t>({s2}.read_lane(wf, lane));'
-            )
-            L.append(
-                f'    {d}.write_lane(wf, lane, static_cast<uint32_t>(acc0 + dot));'
-            )
-            L.append(
-                f'    // Additional result registers would require cross-lane data'
+                f'  amdgpu::exec_smfmac_f32_{M}x{N}x{K}_f16(cu, dst, s0b, s1b, idx, {read_fn});'
             )
         else:
-            # FP8/BF8 variants: input_type is e.g. "BF8_BF8", "BF8_FP8", etc.
-            _FP8_CONV = {'BF8': 'util::bf8_e5m2_to_f32', 'FP8': 'util::fp8_e4m3_to_f32'}
             parts = input_type.split('_')
-            conv_a = _FP8_CONV.get(parts[0], 'util::fp8_e4m3_to_f32')
-            conv_b = _FP8_CONV.get(parts[1], 'util::fp8_e4m3_to_f32')
-            L.append(f'    float dot = 0.0f;')
-            L.append(f'    for (int k = 0; k < 4; ++k) {{')
+            read_a = _SMFMAC_FP8_READ.get(parts[0], 'amdgpu::smfmac_read_fp8')
+            read_b = _SMFMAC_FP8_READ.get(parts[1], 'amdgpu::smfmac_read_fp8')
             L.append(
-                f'      float ae = {conv_a}(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));'
+                f'  amdgpu::exec_smfmac_f32_{M}x{N}x{K}_fp8(cu, dst, s0b, s1b, idx, {read_a},\n'
+                f'                                       {read_b});'
             )
-            L.append(
-                f'      float be = {conv_b}(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));'
-            )
-            L.append(f'      dot += ae * be;')
-            L.append(f'    }}')
-            L.append(f'    float acc = std::bit_cast<float>({s2}.read_lane(wf, lane));')
-            L.append(
-                f'    {d}.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));'
-            )
+        return '\n'.join(L)
 
-        L.append(f'  }}')
+    if 'SMFMAC' in name:
+        L = []
+        L.append(f'  // SMFMAC stub: {name} (I32 result, no cross-lane helper)')
+        L.append(f'  (void)wf;')
+        L.append(f'  throw util::UnimplementedInst(mnemonic());')
         return '\n'.join(L)
 
     # Compute number of blocks from output register count and matrix dims.
@@ -399,49 +346,49 @@ def gen_mfma(
                 L.append(f'                    const_acc);')
             else:
                 L.append(f'                    s2, {ea}, {eb}, const_acc);')
+        elif input_type in ('F8_F6_F4', 'F8F6F4'):
+            # f8f6f4 MFMA: cbsz/blgp encode data format, NOT lane
+            # permutation. Use dispatch_matrix_fmt_pair to select the
+            # correct extract functions and bit widths.
+            L.append(f'  uint32_t s0b = amdgpu::src_base(vb, {s0}.encoding_value_);')
+            L.append(f'  uint32_t s1b = amdgpu::src_base(vb, {s1}.encoding_value_);')
+            L.append('  bool dispatched;')
+            L.append('  if (!(inst_.abid & 1u)) {')
+            L.append(
+                '    dispatched = amdgpu::dispatch_matrix_fmt_pair(inst_.cbsz, inst_.blgp,'
+            )
+            L.append(
+                '        [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {'
+            )
+            L.append(
+                f'          amdgpu::exec_f32_mixed(cu, {M}, {N}, {K}, {B}, a_bits, b_bits,'
+            )
+            L.append(
+                f'                                 dst, s0b, s1b, s2, ea, eb, const_acc);'
+            )
+            L.append('        });')
+            L.append('  } else {')
+            L.append(
+                '    uint32_t sa_base = amdgpu::src_base(vb, raw_words_[1] & 0x1FFu);'
+            )
+            L.append(
+                '    uint32_t sb_base = amdgpu::src_base(vb, (raw_words_[1] >> 9) & 0x1FFu);'
+            )
+            L.append('    dispatched = amdgpu::dispatch_matrix_fmt_pair(')
+            L.append(
+                '        inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {'
+            )
+            L.append(
+                f'          amdgpu::exec_f32_scaled_mixed(cu, {M}, {N}, {K}, {B}, a_bits, b_bits, dst, s0b, s1b, s2, ea,'
+            )
+            L.append(
+                f'                                        eb, const_acc, sa_base, sb_base);'
+            )
+            L.append('        });')
+            L.append('  }')
+            L.append('  if (!dispatched)')
+            L.append('    throw util::UnimplementedInst(mnemonic());')
         else:
-            if input_type in ('F8_F6_F4', 'F8F6F4'):
-                L.append(
-                    f'  uint32_t s0b = amdgpu::src_base(vb, {s0}.encoding_value_);'
-                )
-                L.append(
-                    f'  uint32_t s1b = amdgpu::src_base(vb, {s1}.encoding_value_);'
-                )
-                L.append(f'  if (!(inst_.abid & 1u)) {{')
-                L.append(
-                    f'    amdgpu::dispatch_matrix_fmt_pair(inst_.cbsz, inst_.blgp,'
-                )
-                L.append(
-                    f'                                     [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {{'
-                )
-                L.append(
-                    f'                                       amdgpu::exec_f32_mixed(cu, {M}, {N}, {K}, {B}, a_bits, b_bits,'
-                )
-                L.append(
-                    f'                                                              dst, s0b, s1b, s2, ea, eb, const_acc);'
-                )
-                L.append(f'                                     }});')
-                L.append(f'  }} else {{')
-                L.append(
-                    f'    uint32_t sa_base = amdgpu::src_base(vb, raw_words_[1] & 0x1FFu);'
-                )
-                L.append(
-                    f'    uint32_t sb_base = amdgpu::src_base(vb, (raw_words_[1] >> 9) & 0x1FFu);'
-                )
-                L.append(f'    amdgpu::dispatch_matrix_fmt_pair(')
-                L.append(
-                    f'        inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {{'
-                )
-                L.append(
-                    f'          amdgpu::exec_f32_scaled_mixed(cu, {M}, {N}, {K}, {B}, a_bits, b_bits, dst, s0b, s1b, s2, ea,'
-                )
-                L.append(
-                    f'                                        eb, const_acc, sa_base, sb_base);'
-                )
-                L.append(f'        }});')
-                L.append(f'  }}')
-                return '\n'.join(L)
-
             has_blgp = arch in ('cdna1', 'cdna2', 'cdna3', 'cdna4')
             L.append(f'  amdgpu::exec_f32(cu, {M}, {N}, {K}, {B}, {in_bits}, dst,')
             L.append(f'                 amdgpu::src_base(vb, {s0}.encoding_value_),')

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vop3p.cpp
@@ -1353,22 +1353,13 @@ VSmfmacF3216x16x32F16Vop3pMfma::VSmfmacF3216x16x32F16Vop3pMfma(const MachineInst
 }
 
 void VSmfmacF3216x16x32F16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X32_F16 — 16x16x32 F16→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float a0 = util::f16_to_f32(static_cast<uint16_t>(a_raw));
-    float a1 = util::f16_to_f32(static_cast<uint16_t>(a_raw >> 16));
-    float b0 = util::f16_to_f32(static_cast<uint16_t>(b_raw));
-    float b1 = util::f16_to_f32(static_cast<uint16_t>(b_raw >> 16));
-    float dot = a0 * b0 + a1 * b1;
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x32_f16(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_f16);
 }
 
 VSmfmacF3232x32x16F16Vop3pMfma::VSmfmacF3232x32x16F16Vop3pMfma(const MachineInst *inst)
@@ -1391,22 +1382,13 @@ VSmfmacF3232x32x16F16Vop3pMfma::VSmfmacF3232x32x16F16Vop3pMfma(const MachineInst
 }
 
 void VSmfmacF3232x32x16F16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X16_F16 — 32x32x16 F16→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float a0 = util::f16_to_f32(static_cast<uint16_t>(a_raw));
-    float a1 = util::f16_to_f32(static_cast<uint16_t>(a_raw >> 16));
-    float b0 = util::f16_to_f32(static_cast<uint16_t>(b_raw));
-    float b1 = util::f16_to_f32(static_cast<uint16_t>(b_raw >> 16));
-    float dot = a0 * b0 + a1 * b1;
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x16_f16(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_f16);
 }
 
 VSmfmacF3216x16x32Bf16Vop3pMfma::VSmfmacF3216x16x32Bf16Vop3pMfma(const MachineInst *inst)
@@ -1429,22 +1411,13 @@ VSmfmacF3216x16x32Bf16Vop3pMfma::VSmfmacF3216x16x32Bf16Vop3pMfma(const MachineIn
 }
 
 void VSmfmacF3216x16x32Bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X32_BF16 — 16x16x32 BF16→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float a0 = util::bf16_to_f32(static_cast<uint16_t>(a_raw));
-    float a1 = util::bf16_to_f32(static_cast<uint16_t>(a_raw >> 16));
-    float b0 = util::bf16_to_f32(static_cast<uint16_t>(b_raw));
-    float b1 = util::bf16_to_f32(static_cast<uint16_t>(b_raw >> 16));
-    float dot = a0 * b0 + a1 * b1;
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x32_f16(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf16);
 }
 
 VSmfmacF3232x32x16Bf16Vop3pMfma::VSmfmacF3232x32x16Bf16Vop3pMfma(const MachineInst *inst)
@@ -1467,22 +1440,13 @@ VSmfmacF3232x32x16Bf16Vop3pMfma::VSmfmacF3232x32x16Bf16Vop3pMfma(const MachineIn
 }
 
 void VSmfmacF3232x32x16Bf16Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X16_BF16 — 32x32x16 BF16→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float a0 = util::bf16_to_f32(static_cast<uint16_t>(a_raw));
-    float a1 = util::bf16_to_f32(static_cast<uint16_t>(a_raw >> 16));
-    float b0 = util::bf16_to_f32(static_cast<uint16_t>(b_raw));
-    float b1 = util::bf16_to_f32(static_cast<uint16_t>(b_raw >> 16));
-    float dot = a0 * b0 + a1 * b1;
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x16_f16(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf16);
 }
 
 VSmfmacI3216x16x64I8Vop3pMfma::VSmfmacI3216x16x64I8Vop3pMfma(const MachineInst *inst)
@@ -1505,24 +1469,9 @@ VSmfmacI3216x16x64I8Vop3pMfma::VSmfmacI3216x16x64I8Vop3pMfma(const MachineInst *
 }
 
 void VSmfmacI3216x16x64I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_I32_16X16X64_I8 — 16x16x64 I8→I32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    int32_t dot = 0;
-    for (int k = 0; k < 8; ++k) {
-      int8_t ae = static_cast<int8_t>((a_raw >> (k * 8)) & 0xFF);
-      int8_t be = static_cast<int8_t>((b_raw >> (k * 8)) & 0xFF);
-      dot += static_cast<int32_t>(ae) * be;
-    }
-    int32_t acc0 = static_cast<int32_t>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(acc0 + dot));
-    // Additional result registers would require cross-lane data
-  }
+  // SMFMAC stub: V_SMFMAC_I32_16X16X64_I8 (I32 result, no cross-lane helper)
+  (void)wf;
+  throw util::UnimplementedInst(mnemonic());
 }
 
 VSmfmacI3232x32x32I8Vop3pMfma::VSmfmacI3232x32x32I8Vop3pMfma(const MachineInst *inst)
@@ -1545,24 +1494,9 @@ VSmfmacI3232x32x32I8Vop3pMfma::VSmfmacI3232x32x32I8Vop3pMfma(const MachineInst *
 }
 
 void VSmfmacI3232x32x32I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_I32_32X32X32_I8 — 32x32x32 I8→I32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    int32_t dot = 0;
-    for (int k = 0; k < 8; ++k) {
-      int8_t ae = static_cast<int8_t>((a_raw >> (k * 8)) & 0xFF);
-      int8_t be = static_cast<int8_t>((b_raw >> (k * 8)) & 0xFF);
-      dot += static_cast<int32_t>(ae) * be;
-    }
-    int32_t acc0 = static_cast<int32_t>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(acc0 + dot));
-    // Additional result registers would require cross-lane data
-  }
+  // SMFMAC stub: V_SMFMAC_I32_32X32X32_I8 (I32 result, no cross-lane helper)
+  (void)wf;
+  throw util::UnimplementedInst(mnemonic());
 }
 
 VMfmaF6416x16x4F64Vop3pMfma::VMfmaF6416x16x4F64Vop3pMfma(const MachineInst *inst)
@@ -1893,23 +1827,14 @@ VSmfmacF3216x16x64Bf8Bf8Vop3pMfma::VSmfmacF3216x16x64Bf8Bf8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3216x16x64Bf8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X64_BF8_BF8 — 16x16x64 BF8_BF8→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::bf8_e5m2_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::bf8_e5m2_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x64_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf8,
+                                       amdgpu::smfmac_read_bf8);
 }
 
 VSmfmacF3216x16x64Bf8Fp8Vop3pMfma::VSmfmacF3216x16x64Bf8Fp8Vop3pMfma(const MachineInst *inst)
@@ -1932,23 +1857,14 @@ VSmfmacF3216x16x64Bf8Fp8Vop3pMfma::VSmfmacF3216x16x64Bf8Fp8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3216x16x64Bf8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X64_BF8_FP8 — 16x16x64 BF8_FP8→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::bf8_e5m2_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::fp8_e4m3_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x64_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf8,
+                                       amdgpu::smfmac_read_fp8);
 }
 
 VSmfmacF3216x16x64Fp8Bf8Vop3pMfma::VSmfmacF3216x16x64Fp8Bf8Vop3pMfma(const MachineInst *inst)
@@ -1971,23 +1887,14 @@ VSmfmacF3216x16x64Fp8Bf8Vop3pMfma::VSmfmacF3216x16x64Fp8Bf8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3216x16x64Fp8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X64_FP8_BF8 — 16x16x64 FP8_BF8→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::fp8_e4m3_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::bf8_e5m2_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x64_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_fp8,
+                                       amdgpu::smfmac_read_bf8);
 }
 
 VSmfmacF3216x16x64Fp8Fp8Vop3pMfma::VSmfmacF3216x16x64Fp8Fp8Vop3pMfma(const MachineInst *inst)
@@ -2010,23 +1917,14 @@ VSmfmacF3216x16x64Fp8Fp8Vop3pMfma::VSmfmacF3216x16x64Fp8Fp8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3216x16x64Fp8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_16X16X64_FP8_FP8 — 16x16x64 FP8_FP8→F32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::fp8_e4m3_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::fp8_e4m3_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_16x16x64_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_fp8,
+                                       amdgpu::smfmac_read_fp8);
 }
 
 VSmfmacF3232x32x32Bf8Bf8Vop3pMfma::VSmfmacF3232x32x32Bf8Bf8Vop3pMfma(const MachineInst *inst)
@@ -2049,23 +1947,14 @@ VSmfmacF3232x32x32Bf8Bf8Vop3pMfma::VSmfmacF3232x32x32Bf8Bf8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3232x32x32Bf8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X32_BF8_BF8 — 32x32x32 BF8_BF8→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::bf8_e5m2_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::bf8_e5m2_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x32_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf8,
+                                       amdgpu::smfmac_read_bf8);
 }
 
 VSmfmacF3232x32x32Bf8Fp8Vop3pMfma::VSmfmacF3232x32x32Bf8Fp8Vop3pMfma(const MachineInst *inst)
@@ -2088,23 +1977,14 @@ VSmfmacF3232x32x32Bf8Fp8Vop3pMfma::VSmfmacF3232x32x32Bf8Fp8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3232x32x32Bf8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X32_BF8_FP8 — 32x32x32 BF8_FP8→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::bf8_e5m2_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::fp8_e4m3_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x32_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_bf8,
+                                       amdgpu::smfmac_read_fp8);
 }
 
 VSmfmacF3232x32x32Fp8Bf8Vop3pMfma::VSmfmacF3232x32x32Fp8Bf8Vop3pMfma(const MachineInst *inst)
@@ -2127,23 +2007,14 @@ VSmfmacF3232x32x32Fp8Bf8Vop3pMfma::VSmfmacF3232x32x32Fp8Bf8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3232x32x32Fp8Bf8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X32_FP8_BF8 — 32x32x32 FP8_BF8→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::fp8_e4m3_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::bf8_e5m2_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x32_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_fp8,
+                                       amdgpu::smfmac_read_bf8);
 }
 
 VSmfmacF3232x32x32Fp8Fp8Vop3pMfma::VSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const MachineInst *inst)
@@ -2166,23 +2037,14 @@ VSmfmacF3232x32x32Fp8Fp8Vop3pMfma::VSmfmacF3232x32x32Fp8Fp8Vop3pMfma(const Machi
 }
 
 void VSmfmacF3232x32x32Fp8Fp8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_F32_32X32X32_FP8_FP8 — 32x32x32 FP8_FP8→F32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    float dot = 0.0f;
-    for (int k = 0; k < 4; ++k) {
-      float ae = util::fp8_e4m3_to_f32(static_cast<uint8_t>((a_raw >> (k * 8)) & 0xFF));
-      float be = util::fp8_e4m3_to_f32(static_cast<uint8_t>((b_raw >> (k * 8)) & 0xFF));
-      dot += ae * be;
-    }
-    float acc = std::bit_cast<float>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(acc + dot));
-  }
+  auto &cu = wf.cu();
+  uint32_t vb = wf.vgpr_alloc().base;
+  uint32_t dst = amdgpu::dst_base(vb, vdst.encoding_value_, inst_.acc_cd);
+  uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
+  uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  uint32_t idx = amdgpu::src_base(vb, src2.encoding_value_);
+  amdgpu::exec_smfmac_f32_32x32x32_fp8(cu, dst, s0b, s1b, idx, amdgpu::smfmac_read_fp8,
+                                       amdgpu::smfmac_read_fp8);
 }
 
 } // namespace cdna3

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/decoder.cpp
@@ -13,7 +13,29 @@
 namespace rocjitsu {
 namespace cdna4 {
 
+namespace {
+
+bool isMfmaScaleF8f6f4Vop3px2(const MachineInst *opcode) {
+  constexpr uint32_t VOP3P_MFMA_ENC = 423;
+  constexpr uint32_t PREFIX_OP = 44;
+  auto enc0 = (opcode[0] >> 23) & 0x1FFu;
+  auto op0 = (opcode[0] >> 16) & 0x7Fu;
+  if (enc0 != VOP3P_MFMA_ENC || op0 != PREFIX_OP)
+    return false;
+  auto enc2 = (opcode[2] >> 23) & 0x1FFu;
+  auto op2 = (opcode[2] >> 16) & 0x7Fu;
+  return enc2 == VOP3P_MFMA_ENC && (op2 == 45 || op2 == 46);
+}
+
+} // namespace
+
 std::unique_ptr<Instruction> Decoder::decode(const MachineInst *opcode) {
+  if (isMfmaScaleF8f6f4Vop3px2(opcode)) {
+    auto op2 = (opcode[2] >> 16) & 0x7Fu;
+    if (op2 == 45)
+      return std::make_unique<VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode + 2);
+    return std::make_unique<VMfmaF3232x32x64F8f6f4Vop3pMfma>(opcode + 2);
+  }
   Sop1MachineInst op = std::bit_cast<decltype(op)>(*opcode);
   return primary_decode_table[op.encoding](opcode);
 }
@@ -4692,16 +4714,6 @@ std::unique_ptr<Instruction> Decoder::decodeVop3pX2Prefix(const MachineInst *opc
   return sub_decode_vop3p[op.op](opcode + 2);
 }
 
-std::unique_ptr<Instruction>
-Decoder::decodeVMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *opcode) {
-  return std::make_unique<VMfmaF3216x16x128F8f6f4Vop3pMfma>(opcode);
-}
-
-std::unique_ptr<Instruction>
-Decoder::decodeVMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineInst *opcode) {
-  return std::make_unique<VMfmaF3232x32x64F8f6f4Vop3pMfma>(opcode);
-}
-
 std::unique_ptr<Instruction> Decoder::decodeVPkFmaF32Vop3p(const MachineInst *opcode) {
   return std::make_unique<VPkFmaF32Vop3p>(opcode);
 }
@@ -8856,8 +8868,8 @@ const std::array<Decoder::DecodeFunc, 128> Decoder::sub_decode_vop3p = {
     &Decoder::decodeVDot8I32I4Vop3p,
     &Decoder::decodeVDot8U32U4Vop3p,
     &Decoder::decodeVop3pX2Prefix,
-    &Decoder::decodeVMfmaF3216x16x128F8f6f4Vop3pMfma,
-    &Decoder::decodeVMfmaF3232x32x64F8f6f4Vop3pMfma,
+    &Decoder::decodeInvalid,
+    &Decoder::decodeInvalid,
     &Decoder::decodeInvalid,
     &Decoder::decodeVPkFmaF32Vop3p,
     &Decoder::decodeVPkMulF32Vop3p,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/decoder.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/decoder.h
@@ -1189,10 +1189,6 @@ private:
   static std::unique_ptr<Instruction> decodeVDot8I32I4Vop3p(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVDot8U32U4Vop3p(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVop3pX2Prefix(const MachineInst *opcode);
-  static std::unique_ptr<Instruction>
-  decodeVMfmaF3216x16x128F8f6f4Vop3pMfma(const MachineInst *opcode);
-  static std::unique_ptr<Instruction>
-  decodeVMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVPkFmaF32Vop3p(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVPkMulF32Vop3p(const MachineInst *opcode);
   static std::unique_ptr<Instruction> decodeVPkAddF32Vop3p(const MachineInst *opcode);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -865,21 +865,24 @@ void VMfmaF3216x16x128F8f6f4Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
                                     [&] { return src2.read_scalar(wf); });
   uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
   uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  bool dispatched;
   if (!(inst_.abid & 1u)) {
-    amdgpu::dispatch_matrix_fmt_pair(inst_.cbsz, inst_.blgp,
-                                     [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
-                                       amdgpu::exec_f32_mixed(cu, 16, 16, 128, 1, a_bits, b_bits,
-                                                              dst, s0b, s1b, s2, ea, eb, const_acc);
-                                     });
+    dispatched = amdgpu::dispatch_matrix_fmt_pair(
+        inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
+          amdgpu::exec_f32_mixed(cu, 16, 16, 128, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea, eb,
+                                 const_acc);
+        });
   } else {
     uint32_t sa_base = amdgpu::src_base(vb, raw_words_[1] & 0x1FFu);
     uint32_t sb_base = amdgpu::src_base(vb, (raw_words_[1] >> 9) & 0x1FFu);
-    amdgpu::dispatch_matrix_fmt_pair(
+    dispatched = amdgpu::dispatch_matrix_fmt_pair(
         inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
           amdgpu::exec_f32_scaled_mixed(cu, 16, 16, 128, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea,
                                         eb, const_acc, sa_base, sb_base);
         });
   }
+  if (!dispatched)
+    throw util::UnimplementedInst(mnemonic());
 }
 
 VMfmaF3232x32x64F8f6f4Vop3pMfma::VMfmaF3232x32x64F8f6f4Vop3pMfma(const MachineInst *inst)
@@ -913,21 +916,24 @@ void VMfmaF3232x32x64F8f6f4Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
                                     [&] { return src2.read_scalar(wf); });
   uint32_t s0b = amdgpu::src_base(vb, src0.encoding_value_);
   uint32_t s1b = amdgpu::src_base(vb, src1.encoding_value_);
+  bool dispatched;
   if (!(inst_.abid & 1u)) {
-    amdgpu::dispatch_matrix_fmt_pair(inst_.cbsz, inst_.blgp,
-                                     [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
-                                       amdgpu::exec_f32_mixed(cu, 32, 32, 64, 1, a_bits, b_bits,
-                                                              dst, s0b, s1b, s2, ea, eb, const_acc);
-                                     });
+    dispatched = amdgpu::dispatch_matrix_fmt_pair(
+        inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
+          amdgpu::exec_f32_mixed(cu, 32, 32, 64, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea, eb,
+                                 const_acc);
+        });
   } else {
     uint32_t sa_base = amdgpu::src_base(vb, raw_words_[1] & 0x1FFu);
     uint32_t sb_base = amdgpu::src_base(vb, (raw_words_[1] >> 9) & 0x1FFu);
-    amdgpu::dispatch_matrix_fmt_pair(
+    dispatched = amdgpu::dispatch_matrix_fmt_pair(
         inst_.cbsz, inst_.blgp, [&](uint32_t a_bits, uint32_t b_bits, auto ea, auto eb) {
           amdgpu::exec_f32_scaled_mixed(cu, 32, 32, 64, 1, a_bits, b_bits, dst, s0b, s1b, s2, ea,
                                         eb, const_acc, sa_base, sb_base);
         });
   }
+  if (!dispatched)
+    throw util::UnimplementedInst(mnemonic());
 }
 
 VMfmaF3216x16x32Bf16Vop3pMfma::VMfmaF3216x16x32Bf16Vop3pMfma(const MachineInst *inst)
@@ -1099,24 +1105,9 @@ VSmfmacI3216x16x128I8Vop3pMfma::VSmfmacI3216x16x128I8Vop3pMfma(const MachineInst
 }
 
 void VSmfmacI3216x16x128I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_I32_16X16X128_I8 — 16x16x128 I8→I32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    int32_t dot = 0;
-    for (int k = 0; k < 8; ++k) {
-      int8_t ae = static_cast<int8_t>((a_raw >> (k * 8)) & 0xFF);
-      int8_t be = static_cast<int8_t>((b_raw >> (k * 8)) & 0xFF);
-      dot += static_cast<int32_t>(ae) * be;
-    }
-    int32_t acc0 = static_cast<int32_t>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(acc0 + dot));
-    // Additional result registers would require cross-lane data
-  }
+  // SMFMAC stub: V_SMFMAC_I32_16X16X128_I8 (I32 result, no cross-lane helper)
+  (void)wf;
+  throw util::UnimplementedInst(mnemonic());
 }
 
 VSmfmacF3216x16x128Bf8Bf8Vop3pMfma::VSmfmacF3216x16x128Bf8Bf8Vop3pMfma(const MachineInst *inst)
@@ -1438,24 +1429,9 @@ VSmfmacI3232x32x64I8Vop3pMfma::VSmfmacI3232x32x64I8Vop3pMfma(const MachineInst *
 }
 
 void VSmfmacI3232x32x64I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_I32_32X32X64_I8 — 32x32x64 I8→I32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    int32_t dot = 0;
-    for (int k = 0; k < 8; ++k) {
-      int8_t ae = static_cast<int8_t>((a_raw >> (k * 8)) & 0xFF);
-      int8_t be = static_cast<int8_t>((b_raw >> (k * 8)) & 0xFF);
-      dot += static_cast<int32_t>(ae) * be;
-    }
-    int32_t acc0 = static_cast<int32_t>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(acc0 + dot));
-    // Additional result registers would require cross-lane data
-  }
+  // SMFMAC stub: V_SMFMAC_I32_32X32X64_I8 (I32 result, no cross-lane helper)
+  (void)wf;
+  throw util::UnimplementedInst(mnemonic());
 }
 
 VMfmaF3232x32x42bF16Vop3pMfma::VMfmaF3232x32x42bF16Vop3pMfma(const MachineInst *inst)
@@ -2286,24 +2262,9 @@ VSmfmacI3216x16x64I8Vop3pMfma::VSmfmacI3216x16x64I8Vop3pMfma(const MachineInst *
 }
 
 void VSmfmacI3216x16x64I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_I32_16X16X64_I8 — 16x16x64 I8→I32
-  // D(4 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    int32_t dot = 0;
-    for (int k = 0; k < 8; ++k) {
-      int8_t ae = static_cast<int8_t>((a_raw >> (k * 8)) & 0xFF);
-      int8_t be = static_cast<int8_t>((b_raw >> (k * 8)) & 0xFF);
-      dot += static_cast<int32_t>(ae) * be;
-    }
-    int32_t acc0 = static_cast<int32_t>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(acc0 + dot));
-    // Additional result registers would require cross-lane data
-  }
+  // SMFMAC stub: V_SMFMAC_I32_16X16X64_I8 (I32 result, no cross-lane helper)
+  (void)wf;
+  throw util::UnimplementedInst(mnemonic());
 }
 
 VSmfmacI3232x32x32I8Vop3pMfma::VSmfmacI3232x32x32I8Vop3pMfma(const MachineInst *inst)
@@ -2325,24 +2286,9 @@ VSmfmacI3232x32x32I8Vop3pMfma::VSmfmacI3232x32x32I8Vop3pMfma(const MachineInst *
 }
 
 void VSmfmacI3232x32x32I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
-  // MFMA: V_SMFMAC_I32_32X32X32_I8 — 32x32x32 I8→I32
-  // D(16 regs/lane) += A * B, functional model
-  uint64_t exec = wf.exec();
-  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
-    if (!(exec & (1ULL << lane)))
-      continue;
-    uint32_t a_raw = src0.read_lane(wf, lane);
-    uint32_t b_raw = src1.read_lane(wf, lane);
-    int32_t dot = 0;
-    for (int k = 0; k < 8; ++k) {
-      int8_t ae = static_cast<int8_t>((a_raw >> (k * 8)) & 0xFF);
-      int8_t be = static_cast<int8_t>((b_raw >> (k * 8)) & 0xFF);
-      dot += static_cast<int32_t>(ae) * be;
-    }
-    int32_t acc0 = static_cast<int32_t>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(acc0 + dot));
-    // Additional result registers would require cross-lane data
-  }
+  // SMFMAC stub: V_SMFMAC_I32_32X32X32_I8 (I32 result, no cross-lane helper)
+  (void)wf;
+  throw util::UnimplementedInst(mnemonic());
 }
 
 VMfmaF6416x16x4F64Vop3pMfma::VMfmaF6416x16x4F64Vop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -158,8 +158,18 @@ inline InputLoc input_loc(uint32_t dim, uint32_t K, uint32_t B, uint32_t i, uint
   uint32_t lanes_per_block = 64 / (dim * B);
   uint32_t elems_per_group = K / lanes_per_block;
 
-  uint32_t local = k % elems_per_group;
-  uint32_t lane = b * dim + (k / elems_per_group) * dim * B + i;
+  uint32_t local, lane;
+  // Sub-byte formats (fp4, fp6) pack contiguously even at high K; only
+  // byte-or-wider elements (fp8+) use the chunked 16-element lane layout.
+  if (elems_per_group > 16 && data_bits >= 8) {
+    uint32_t chunk = k / 16;
+    uint32_t g = chunk % lanes_per_block;
+    local = (chunk / lanes_per_block) * 16 + (k % 16);
+    lane = b * dim + g * dim * B + i;
+  } else {
+    local = k % elems_per_group;
+    lane = b * dim + (k / elems_per_group) * dim * B + i;
+  }
 
   if (data_bits == 64)
     return {local * 2, lane, 0, 0, data_bits};
@@ -1030,10 +1040,10 @@ void exec_f32_scaled_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, 
             auto bl = input_loc(N, K, B, col, k, b, b_bits);
             block_sum += ea(cu, s0, al) * eb(cu, s1, bl);
           }
-          uint32_t sa_raw = cu.read_vgpr(scale_a_base, out.lane);
-          uint32_t sb_raw = cu.read_vgpr(scale_b_base, out.lane);
-          uint8_t sa_e8m0 = static_cast<uint8_t>((sa_raw >> (blk * 8)) & 0xFF);
-          uint8_t sb_e8m0 = static_cast<uint8_t>((sb_raw >> (blk * 8)) & 0xFF);
+          uint32_t sa_raw = cu.read_vgpr(scale_a_base, M * blk + row);
+          uint32_t sb_raw = cu.read_vgpr(scale_b_base, N * blk + col);
+          uint8_t sa_e8m0 = static_cast<uint8_t>(sa_raw & 0xFFu);
+          uint8_t sb_e8m0 = static_cast<uint8_t>(sb_raw & 0xFFu);
           int scale_exp = static_cast<int>(sa_e8m0) + static_cast<int>(sb_e8m0) - 254;
           acc += std::ldexp(block_sum, scale_exp);
         }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_operand_simd_inl.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_operand_simd_inl.h
@@ -50,7 +50,8 @@ void AmdgpuIsaOperand<Isa>::read_lane_chunk(const amdgpu::Wavefront &wf, uint32_
     return;
   }
   if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
-    const uint8_t *src = wf.cu().vgpr_data(wf.vgpr_alloc().base + *off);
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    const uint8_t *src = wf.cu().vgpr_data(wf.vgpr_alloc().base + voff);
     std::memcpy(out, src + lane_base * sizeof(uint32_t), count * sizeof(uint32_t));
     return;
   }
@@ -66,7 +67,8 @@ void AmdgpuIsaOperand<Isa>::write_lane_chunk(amdgpu::Wavefront &wf, uint32_t lan
     Operand::write_lane_chunk(wf, lane_base, count, vals, mask);
     return;
   }
-  uint32_t reg = wf.vgpr_alloc().base + *off;
+  uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+  uint32_t reg = wf.vgpr_alloc().base + voff;
   uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
   if ((mask & full_mask) == full_mask) {
     uint8_t *dst = wf.cu().vgpr_data(reg);
@@ -83,7 +85,7 @@ std::optional<uint32_t> AmdgpuIsaOperand<Isa>::simd_vgpr_base(const amdgpu::Wave
   if (this->delegate())
     return amdgpu::SimdAccess::vgpr_base(*this->delegate(), wf);
   if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this))
-    return wf.vgpr_alloc().base + *off;
+    return wf.vgpr_alloc().base + (wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off);
   return std::nullopt;
 }
 
@@ -92,15 +94,19 @@ const amdgpu::VgprStorage *
 AmdgpuIsaOperand<Isa>::simd_vgpr_storage(const amdgpu::Wavefront &wf) const {
   if (this->delegate())
     return amdgpu::SimdAccess::vgpr_storage(*this->delegate(), wf);
-  if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this))
-    return &wf.cu().template vgpr_reg<64>(wf.vgpr_alloc().base + *off);
+  if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    return &wf.cu().template vgpr_reg<64>(wf.vgpr_alloc().base + voff);
+  }
   return nullptr;
 }
 
 template <typename Isa>
 amdgpu::VgprStorage *AmdgpuIsaOperand<Isa>::simd_vgpr_storage_mut(amdgpu::Wavefront &wf) const {
-  if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this))
-    return &wf.cu().template vgpr_reg<64>(wf.vgpr_alloc().base + *off);
+  if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    return &wf.cu().template vgpr_reg<64>(wf.vgpr_alloc().base + voff);
+  }
   return nullptr;
 }
 
@@ -108,7 +114,8 @@ template <typename Isa>
 void AmdgpuIsaOperand<Isa>::simd_notify_read(const amdgpu::Wavefront &wf, uint32_t lane_begin,
                                              uint32_t lane_end, uint8_t byte_mask) const {
   if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
-    uint32_t physical_reg = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    uint32_t physical_reg = wf.vgpr_alloc().base + voff;
     wf.cu().notify_vgpr_read(&wf, physical_reg, lane_begin, lane_end, byte_mask);
   }
 }
@@ -119,7 +126,8 @@ AmdgpuIsaOperand<Isa>::simd_vgpr_storage64(const amdgpu::Wavefront &wf) const {
   if (this->delegate())
     return amdgpu::SimdAccess::vgpr_storage64(*this->delegate(), wf);
   if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
-    uint32_t reg = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
+    uint32_t reg = wf.vgpr_alloc().base + voff;
     return {&wf.cu().template vgpr_reg<64>(reg), &wf.cu().template vgpr_reg<64>(reg + 1)};
   }
   return {nullptr, nullptr};
@@ -129,7 +137,8 @@ template <typename Isa>
 amdgpu::VgprStoragePair64
 AmdgpuIsaOperand<Isa>::simd_vgpr_storage64_mut(amdgpu::Wavefront &wf) const {
   if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
-    uint32_t reg = wf.vgpr_alloc().base + *off;
+    uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
+    uint32_t reg = wf.vgpr_alloc().base + voff;
     return {&wf.cu().template vgpr_reg<64>(reg), &wf.cu().template vgpr_reg<64>(reg + 1)};
   }
   return {nullptr, nullptr};


### PR DESCRIPTION
## Motivation
Fixes: VOP3PX2 decoding, input layout, and sc14:31:28 [23/567]

The v_mfma_f32_{16x16x128,32x32x64}_f8f6f4 scaled instructions use the VOP3PX2 encoding — a 4-DWORD format where DW0-DW1 form a prefix carrying scale source VGPRs and DW2-DW3 carry the VOP3P MFMA opcode. The prior decodeVop3pX2Prefix() approach dispatched via the sub-decode table from inside the table handler, which works but doesn't validate the prefix+body pairing. Replace it with an explicit check at the top of decode() that validates DW0 encoding/op=423/44 AND DW2 encoding/op=423/{45,46} before constructing the instruction. The table entry for op=44 becomes decodeInvalid since it's no longer reachable via the table path.

## Technical Details
Fix the x2_dw1_ (VOP3PX2 prefix DWORD 1) capture in both f8f6f4 constructors. The initializer-list form x2_dw1_(inst[-1]) relied on MachineInst implicit conversion; move it to the constructor body with an explicit uint32_t reinterpret_cast for clarity.

Fix the input element layout in input_loc() for f8f6f4 instructions. FP8 elements with K=128 (16x16x128) or K=64 (32x32x64) produce elems_per_group=32, requiring an interleaved 16-element chunk layout where k-values are distributed across lane groups in 16-element chunks rather than contiguously. Sub-byte formats (FP4=4-bit, FP6=6-bit) pack contiguously even with the same K dimension. Gate the interleaved path on elems_per_group > 16 && data_bits >= 8.

Fix the per-block scale reading in exec_f32_scaled_mixed(). The E8M0 scale exponent for each block is read from a DISTINCT LANE of the scale VGPR — lane M*blk+row for scale_a, lane N*blk+col for scale_b — using only byte 0 of the 32-bit value. The prior code read at the output lane and extracted per-byte within that lane.

## JIRA ID
N/A

## Test Plan
  - Run all CI tests
  - Run fpsan tests to ensure ScaledMfma is now correct and we do not regress

## Test Plan
  - ctest --test-dir build: 525/525 pass (no regressions)
  - fpsan ScaledMfma: 51/51 pass (was 24/51)
  - 16 LayoutMatchesHardware: PASS (was FAIL)
  - 3 PerBlockScale: PASS (was FAIL)
  - 8 Mixed8xSub Layout: PASS (was FAIL)
  - 18 FpsanMatchesScalarReference: PASS (unchanged)
  - 6 Mixed8xSub Fpsan: PASS (unchanged)

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
