### PR TITLE
rocr: Limit queue error message prints in release builds

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -1444,15 +1444,15 @@ bool AqlQueue::ExceptionHandler(hsa_signal_value_t error_code, void* arg) {
   if (errorCode == static_cast<hsa_status_t>(HSA_STATUS_ERROR_MEMORY_FAULT)) {
     queue->MarkVMFaulted();
     core::Runtime::runtime_singleton_->SignalVMFault();
-    debug_print("Queue error - HSA_STATUS_ERROR_MEMORY_FAULT\n");
+    log_warning_n(1,"Queue error - HSA_STATUS_ERROR_MEMORY_FAULT\n");
     return exceptionHandlerDone();
   }
 
   const char* errorMsg = nullptr;
   if (HSA::hsa_status_string(errorCode, &errorMsg) == HSA_STATUS_SUCCESS && errorMsg) {
-    fprintf(stderr, "Queue error: %s\n", errorMsg);
+    log_warning_n(1, "Queue error: %s\n", errorMsg);
   } else {
-    fprintf(stderr, "Queue error: code 0x%lx\n", (unsigned long)error_code);
+    log_warning_n(1, "Queue error: code 0x%lx\n", (unsigned long)error_code);
   }
 
   // Fallback if KFD does not support GPU core dump. In this case, the core

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/utils.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/utils.h
@@ -177,20 +177,20 @@ static __forceinline unsigned long long int strtoull(const char* str,
 } while (false)
 #endif
 
-/* Limitted printing when in release mode, always prints when in debug mode*/
+/* Limited printing when in release mode, always prints when in debug mode */
 #ifdef NDEBUG
-#define log_warning_n(limit, fmt, ...)                                                             \
-  do {                                                                                             \
-    fprintf(stderr, "Warning: " fmt, ##__VA_ARGS__);                                             \
-  } while (false)
-#else
 #define log_warning_n(limit, fmt, ...)                                                             \
   do {                                                                                             \
     static std::atomic<unsigned int> count(0);                                                     \
     if (limit == 0 || count < limit) {                                                             \
-      fprintf(stderr, "Warning: " fmt, ##__VA_ARGS__);                                             \
+      fprintf(stderr, "Warning: " fmt, ##__VA_ARGS__);                                           \
       count++;                                                                                     \
     }                                                                                              \
+  } while (false)
+#else
+#define log_warning_n(limit, fmt, ...)                                                             \
+  do {                                                                                             \
+    fprintf(stderr, "Warning: " fmt, ##__VA_ARGS__);                                             \
   } while (false)
 #endif
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/utils.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/utils.h
@@ -177,6 +177,23 @@ static __forceinline unsigned long long int strtoull(const char* str,
 } while (false)
 #endif
 
+/* Limitted printing when in release mode, always prints when in debug mode*/
+#ifdef NDEBUG
+#define log_warning_n(limit, fmt, ...)                                                             \
+  do {                                                                                             \
+    fprintf(stderr, "Warning: " fmt, ##__VA_ARGS__);                                             \
+  } while (false)
+#else
+#define log_warning_n(limit, fmt, ...)                                                             \
+  do {                                                                                             \
+    static std::atomic<unsigned int> count(0);                                                     \
+    if (limit == 0 || count < limit) {                                                             \
+      fprintf(stderr, "Warning: " fmt, ##__VA_ARGS__);                                             \
+      count++;                                                                                     \
+    }                                                                                              \
+  } while (false)
+#endif
+
 #ifdef NDEBUG
 #define ifdebug if (false)
 #else


### PR DESCRIPTION
Add log_warning_n macro that limits printing in release builds but always prints in debug.

Use log_warning_n macro for queue error messages.

