### PR TITLE
[rocprofiler-systems] Fix AI NIC Phase 2 missing tracks and add diagnostics

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/base/collector.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/base/collector.hpp
@@ -176,9 +176,8 @@ struct collector
         {
             const auto   _device_id   = entry.device->get_index();
             const auto&  _device_name = entry.device->get_name();
-            const size_t _count       = m_sample_counts.count(_device_id)
-                                            ? m_sample_counts.at(_device_id)
-                                            : 0;
+            const size_t _count =
+                m_sample_counts.count(_device_id) ? m_sample_counts.at(_device_id) : 0;
             if(_count == 0)
             {
                 LOG_WARNING("No samples were collected for {} device '{}'",
@@ -186,8 +185,8 @@ struct collector
             }
             else
             {
-                LOG_DEBUG("Collected {} samples for {} device '{}'",
-                          _count, Traits::device_name, _device_name);
+                LOG_DEBUG("Collected {} samples for {} device '{}'", _count,
+                    Traits::device_name, _device_name);
             }
         }
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/base/collector.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/base/collector.hpp
@@ -186,7 +186,7 @@ struct collector
             else
             {
                 LOG_DEBUG("Collected {} samples for {} device '{}'", _count,
-                    Traits::device_name, _device_name);
+                          Traits::device_name, _device_name);
             }
         }
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/base/collector.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/base/collector.hpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <stdexcept>
 #include <vector>
@@ -146,6 +147,7 @@ struct collector
                     {
                         PerfettoApi::store_sample(_device_id, _metrics, _timestamp);
                     }
+                    m_sample_counts[_device_id]++;
                     return false;  // Keep device
                 } catch(const std::runtime_error& e)
                 {
@@ -169,6 +171,24 @@ struct collector
         {
             Traits::template post_process_perfetto<PerfettoApi>(m_device_entries,
                                                                 m_enabled_metrics);
+        }
+        for(const auto& entry : m_device_entries)
+        {
+            const auto   _device_id   = entry.device->get_index();
+            const auto&  _device_name = entry.device->get_name();
+            const size_t _count       = m_sample_counts.count(_device_id)
+                                            ? m_sample_counts.at(_device_id)
+                                            : 0;
+            if(_count == 0)
+            {
+                LOG_WARNING("No samples were collected for {} device '{}'",
+                            Traits::device_name, _device_name);
+            }
+            else
+            {
+                LOG_DEBUG("Collected {} samples for {} device '{}'",
+                          _count, Traits::device_name, _device_name);
+            }
         }
     }
 
@@ -250,6 +270,7 @@ private:
     device_entries_t m_device_entries;  ///< Devices with cached supported metrics
     std::shared_ptr<device_provider> m_device_provider;  ///< Device provider instance
     enabled_metrics_t                m_enabled_metrics;  ///< Enabled metrics
+    std::map<size_t, size_t>         m_sample_counts;    ///< Per-device sample counts
 };
 
 }  // namespace rocprofsys::pmc::collectors::base

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/cache_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/cache_policy.hpp
@@ -55,6 +55,14 @@ struct cache_policy
             { "ainic_rx_rdma_cnp_pkts", thread_id, "{}" });
         trace_cache::get_metadata_registry().add_track(
             { "ainic_tx_rdma_cnp_pkts", thread_id, "{}" });
+        trace_cache::get_metadata_registry().add_track(
+            { "ainic_tx_rdma_ack_timeout", thread_id, "{}" });
+        trace_cache::get_metadata_registry().add_track(
+            { "ainic_resp_tx_pkt_seq_err", thread_id, "{}" });
+        trace_cache::get_metadata_registry().add_track(
+            { "ainic_req_rx_pkt_seq_err", thread_id, "{}" });
+        trace_cache::get_metadata_registry().add_track(
+            { "ainic_req_rx_impl_nak_seq_err", thread_id, "{}" });
     }
 
     /**

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
@@ -160,8 +160,9 @@ struct nic_traits
             }
             else
             {
-                LOG_DEBUG("NIC device [{}] ({}) excluded by ROCPROFSYS_SAMPLING_AINICS filter",
-                          device->get_index(), device->get_name());
+                LOG_DEBUG(
+                    "NIC device [{}] ({}) excluded by ROCPROFSYS_SAMPLING_AINICS filter",
+                    device->get_index(), device->get_name());
             }
         }
 
@@ -171,8 +172,8 @@ struct nic_traits
         return entries;
     }
 
-    static void warn_invalid_names(const nic_device_filter&      filter,
-                                   const std::set<std::string>&  available_names)
+    static void warn_invalid_names(const nic_device_filter&     filter,
+                                   const std::set<std::string>& available_names)
     {
         if(filter.mode != device_selection_mode::SPECIFIC) return;
         if(available_names.empty())
@@ -184,10 +185,9 @@ struct nic_traits
         {
             if(available_names.find(requested) == available_names.end())
             {
-                LOG_WARNING(
-                    "Requested AI NIC device '{}' not found. "
-                    "Available device(s): [{}]",
-                    requested, fmt::join(available_names, ", "));
+                LOG_WARNING("Requested AI NIC device '{}' not found. "
+                            "Available device(s): [{}]",
+                            requested, fmt::join(available_names, ", "));
             }
         }
     }

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
@@ -12,7 +12,10 @@
 
 #include <cstdint>
 #include <memory>
+#include <set>
 #include <vector>
+
+#include <spdlog/fmt/fmt.h>
 
 namespace rocprofsys::pmc::collectors::nic
 {
@@ -123,9 +126,20 @@ struct nic_traits
 
         auto devices = provider->template get_nic_devices<device_t, driver_t>();
 
+        LOG_DEBUG("Discovered {} AI NIC device(s) via AMD SMI", devices.size());
+
+        std::set<std::string> available_names;
+        for(const auto& device : devices)
+            available_names.insert(device->get_name());
+
         for(auto& device : devices)
         {
-            if(!device->is_supported()) continue;
+            if(!device->is_supported())
+            {
+                LOG_DEBUG("NIC device [{}] ({}) has no supported RDMA metrics, skipping",
+                          device->get_index(), device->get_name());
+                continue;
+            }
 
             bool should_include = false;
             switch(filter.mode)
@@ -139,14 +153,43 @@ struct nic_traits
 
             if(should_include)
             {
+                LOG_INFO("NIC device [{}] ({}) enabled for AI NIC PMC sampling",
+                         device->get_index(), device->get_name());
                 auto supported = device->get_supported_metrics();
                 entries.push_back(device_entry{ std::move(device), supported });
             }
+            else
+            {
+                LOG_DEBUG("NIC device [{}] ({}) excluded by ROCPROFSYS_SAMPLING_AINICS filter",
+                          device->get_index(), device->get_name());
+            }
         }
 
+        warn_invalid_names(filter, available_names);
         register_nic_agents(entries);
 
         return entries;
+    }
+
+    static void warn_invalid_names(const nic_device_filter&      filter,
+                                   const std::set<std::string>&  available_names)
+    {
+        if(filter.mode != device_selection_mode::SPECIFIC) return;
+        if(available_names.empty())
+        {
+            LOG_WARNING("No AI NIC devices were discovered.");
+            return;
+        }
+        for(const auto& requested : filter.names)
+        {
+            if(available_names.find(requested) == available_names.end())
+            {
+                LOG_WARNING(
+                    "Requested AI NIC device '{}' not found. "
+                    "Available device(s): [{}]",
+                    requested, fmt::join(available_names, ", "));
+            }
+        }
     }
 
     static void register_nic_agents(const std::vector<device_entry>& entries)

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -1371,14 +1371,14 @@ def _generate_rocprofsys_config_header() -> list[str]:
         _row("Ptrace scope:", cap.ptrace_scope),
         _row("Is inside docker:", rocprof_config.capabilities.is_inside_docker),
         _row("PAPI available:", cap.papi_availability),
-        _row("Default NIC:", cap.default_nic),
         _row("AI NIC devices:", cap.ai_nic_devices),
+        _row("Default NIC:", cap.default_nic),
         *(
             lambda evts: (
-                [_subrow("PAPI NIC events:", evts[0])]
-                + [_subrow("", e) for e in evts[1:]]
+                [_row("PAPI NIC events:", evts[0])]
+                + [_row("", e) for e in evts[1:]]
                 if evts
-                else [_subrow("PAPI NIC events:", "None")]
+                else [_row("PAPI NIC events:", "None")]
             )
         )(cap.papi_nic_events.split() if cap.papi_nic_events else []),
         "-" * 70,

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -290,6 +290,7 @@ def pytest_configure(config: pytest.Config) -> None:
         "no_docker",
         "shmem",
         "nic",
+        "ainic",
     ]
 
     # Informational markers, only used for test labeling
@@ -569,6 +570,10 @@ def pytest_collection_modifyitems(config, items) -> None:
             _msg = nic_unavailable_reason(rocprof_config)
             if _msg is not None:
                 item.add_marker(pytest.mark.skip(reason=_msg))
+        if "ainic" in item.keywords:
+            _msg = ainic_unavailable_reason(rocprof_config)
+            if _msg is not None:
+                item.add_marker(pytest.mark.skip(reason=_msg))
         if "kfd" in item.keywords or "unified_memory" in item.keywords:
             _msg = kfd_unavailable_reason(rocprof_config)
             if _msg is not None:
@@ -797,6 +802,19 @@ def nic_unavailable_reason(rocprof_config: RocprofsysConfig) -> Optional[str]:
     if caps.papi_nic_events is not None and caps.perf_event_paranoid <= 2:
         return None
     return "Requires PAPI network events and perf_event_paranoid <= 2 to be available"
+
+
+def ainic_unavailable_reason(rocprof_config: RocprofsysConfig) -> Optional[str]:
+    """Check if AI NIC tracking is available.
+
+    Requires ``amd-smi static`` to report at least one NETDEV entry.
+    """
+    if not rocprof_config.capabilities.ai_nic_devices:
+        return (
+            "No AI NIC devices found "
+            "(amd-smi static reports no NETDEV entries)"
+        )
+    return None
 
 
 def kfd_unavailable_reason(rocprof_config: RocprofsysConfig) -> Optional[str]:

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -811,7 +811,6 @@ def ainic_unavailable_reason(rocprof_config: RocprofsysConfig) -> Optional[str]:
     """
     if not rocprof_config.capabilities.ai_nic_devices:
         return "No AI NIC devices found (amd-smi static reports no NETDEV entries)"
-        )
     return None
 
 

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -1372,6 +1372,7 @@ def _generate_rocprofsys_config_header() -> list[str]:
         _row("Is inside docker:", rocprof_config.capabilities.is_inside_docker),
         _row("PAPI available:", cap.papi_availability),
         _row("Default NIC:", cap.default_nic),
+        _row("AI NIC devices:", cap.ai_nic_devices),
         *(
             lambda evts: (
                 [_subrow("PAPI NIC events:", evts[0])]

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -810,9 +810,7 @@ def ainic_unavailable_reason(rocprof_config: RocprofsysConfig) -> Optional[str]:
     Requires ``amd-smi static`` to report at least one NETDEV entry.
     """
     if not rocprof_config.capabilities.ai_nic_devices:
-        return (
-            "No AI NIC devices found "
-            "(amd-smi static reports no NETDEV entries)"
+        return "No AI NIC devices found (amd-smi static reports no NETDEV entries)"
         )
     return None
 

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -135,7 +135,7 @@ class SystemCapabilities:
                 if "netdev" in line.lower():
                     colon_idx = line.find(":")
                     if colon_idx != -1:
-                        name = line[colon_idx + 1:].strip()
+                        name = line[colon_idx + 1 :].strip()
                         if name and name not in seen:
                             seen.add(name)
                             devices.append(name)

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -108,6 +108,42 @@ class SystemCapabilities:
             return None
 
     @cached_property
+    def ai_nic_devices(self) -> list[str]:
+        """Get the unique AI NIC device names reported by AMD SMI.
+
+        Runs ``amd-smi static`` and extracts every distinct NETDEV value.
+        Returns an empty list when AMD SMI is unavailable or reports no NICs.
+
+        Example output line from ``amd-smi static``:
+        ``NETDEV: enp137s0np0``
+        """
+        amd_smi = shutil.which("amd-smi")
+        if not amd_smi:
+            return []
+        try:
+            result = subprocess.run(
+                [amd_smi, "static"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if result.returncode != 0:
+                return []
+            seen: set[str] = set()
+            devices: list[str] = []
+            for line in result.stdout.splitlines():
+                if "netdev" in line.lower():
+                    colon_idx = line.find(":")
+                    if colon_idx != -1:
+                        name = line[colon_idx + 1:].strip()
+                        if name and name not in seen:
+                            seen.add(name)
+                            devices.append(name)
+            return devices
+        except (subprocess.SubprocessError, OSError, subprocess.TimeoutExpired):
+            return []
+
+    @cached_property
     def papi_nic_events(self) -> Optional[str]:
         """Get the list of all events that we want PAPI to record.
 

--- a/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MIT
 
 """
-AI NIC tests using AMD SMI Phase 2 RDMA metrics (amdsmi_get_nic_rdma_dev_info).
+AI NIC tests using AMD SMI RDMA metrics (amdsmi_get_nic_rdma_dev_info).
 
-These tests verify that rocprofiler-systems correctly collects all 10 AI NIC
+These tests verify that rocprofiler-systems correctly collects all AI NIC
 RDMA counters per device and writes them to both the Perfetto (.proto) trace
 and the ROCpd (.db) database.
 
@@ -47,7 +47,7 @@ AINIC_PERFETTO_COUNTER_NAMES = [
 
 
 @pytest.fixture
-def ainic_perf_env(rocprof_config) -> dict[str, str]:
+def ainic_perf_env() -> dict[str, str]:
     """Environment variables for AI NIC performance tests."""
     env = {
         "ROCPROFSYS_USE_PID": "OFF",
@@ -99,13 +99,9 @@ class TestAINIC(RocprofsysTest):
     @pytest.mark.rocpd("ainic_perf_env")
     def test_performance_tracks(
         self,
-        rocprof_config,
         ainic_perf_env,
         ainic_download_url_1,
         ainic_download_url_2,
-        test_output_dir,
-        subtests,
-        record_subtest_failure,
         ainic_rocpd_rules,
     ):
         target = shutil.which("wget")

--- a/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
@@ -26,20 +26,6 @@ pytestmark = [pytest.mark.ainic, pytest.mark.network]
 # Constants
 # =============================================================================
 
-# The 10 AI NIC RDMA track names written to the ROCpd (.db) database.
-AINIC_ROCPD_TRACK_NAMES = [
-    "ainic_rx_rdma_ucast_bytes",
-    "ainic_tx_rdma_ucast_bytes",
-    "ainic_rx_rdma_ucast_pkts",
-    "ainic_tx_rdma_ucast_pkts",
-    "ainic_rx_rdma_cnp_pkts",
-    "ainic_tx_rdma_cnp_pkts",
-    "ainic_tx_rdma_ack_timeout",
-    "ainic_resp_tx_pkt_seq_err",
-    "ainic_req_rx_pkt_seq_err",
-    "ainic_req_rx_impl_nak_seq_err",
-]
-
 # Substrings used to match the 10 Perfetto counter track names via LIKE.
 # Full name format: "NIC [<device_id>] <METRIC> (S)"
 AINIC_PERFETTO_COUNTER_NAMES = [

--- a/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
@@ -15,7 +15,6 @@ The test is skipped automatically when no AI NIC devices are present on the syst
 from __future__ import annotations
 
 import os
-import sqlite3
 import pytest
 import shutil
 from pathlib import Path
@@ -74,7 +73,6 @@ def ainic_perf_env(rocprof_config) -> dict[str, str]:
         "ROCPROFSYS_USE_AMD_SMI": "ON",
         "ROCPROFSYS_USE_AINIC": "ON",
         "ROCPROFSYS_SAMPLING_AINICS": "all",
-        "ROCPROFSYS_USE_ROCPD": "ON",
         "ROCPROFSYS_SAMPLING_DELAY": "0.05",
     }
     sysfs_root = os.environ.get("SMI_NIC_SYSFS_ROOT", "")
@@ -95,38 +93,11 @@ def ainic_download_url_2() -> str:
     return "https://github.com/ROCm/rocprofiler-systems/releases/download/rocm-6.4.3/rocprofiler-systems-1.0.2-rhel-9.4-PAPI-OMPT-Python3.sh"
 
 
-# =============================================================================
-# Private helpers
-# =============================================================================
-
-
-def _get_ainic_tracks_from_rocpd(db_path: Path) -> set[str]:
-    """Return the set of AI NIC track names found in the ROCpd SQLite database.
-
-    Track names are stored in ``rocpd_string_{upid}`` tables. We query every
-    such table for strings that start with ``ainic_``.
-    """
-    conn = sqlite3.connect(str(db_path))
-    try:
-        cursor = conn.cursor()
-        cursor.execute(
-            "SELECT name FROM sqlite_master "
-            "WHERE type IN ('table', 'view') AND name LIKE 'rocpd_string_%'"
-        )
-        string_tables = [row[0] for row in cursor.fetchall()]
-
-        found: set[str] = set()
-        for table in string_tables:
-            try:
-                cursor.execute(
-                    f"SELECT DISTINCT string FROM {table} WHERE string LIKE 'ainic_%'"
-                )
-                found.update(row[0] for row in cursor.fetchall())
-            except sqlite3.Error:
-                pass
-        return found
-    finally:
-        conn.close()
+@pytest.fixture
+def ainic_rocpd_rules(validation_rules_dir) -> list[Path]:
+    """Validation rules for AI NIC RDMA track presence in ROCpd database."""
+    rules_dir = validation_rules_dir / "ainic"
+    return [rules_dir / "ainic-rdma-rules.json"]
 
 
 # =============================================================================
@@ -140,7 +111,8 @@ class TestAINIC(RocprofsysTest):
     PERFETTO_PASS_REGEX = [r"perfetto-trace\.proto validated"]
     PERFETTO_FAIL_REGEX = [r"Failure validating.*perfetto-trace\.proto"]
 
-    def test_performance(
+    @pytest.mark.rocpd("ainic_perf_env")
+    def test_performance_tracks(
         self,
         rocprof_config,
         ainic_perf_env,
@@ -149,6 +121,7 @@ class TestAINIC(RocprofsysTest):
         test_output_dir,
         subtests,
         record_subtest_failure,
+        ainic_rocpd_rules,
     ):
         target = shutil.which("wget")
         if not target:
@@ -179,20 +152,8 @@ class TestAINIC(RocprofsysTest):
         )
 
         # Validate ROCpd .db: all 10 AI NIC track names must be present
-        subtest_name = "ROCpd AI NIC track validation"
-        with subtests.test(subtest_name):
-            rocpd_file = result.rocpd_file
-            if rocpd_file is None:
-                record_subtest_failure(subtest_name)
-                pytest.fail("ROCpd database (.db) was not created")
-
-            found_tracks = _get_ainic_tracks_from_rocpd(rocpd_file)
-            missing = [t for t in AINIC_ROCPD_TRACK_NAMES if t not in found_tracks]
-            if missing:
-                record_subtest_failure(subtest_name)
-                pytest.fail(
-                    f"Missing AI NIC tracks in ROCpd database:\n"
-                    f"  Missing : {missing}\n"
-                    f"  Found   : {sorted(found_tracks)}\n"
-                    f"  Database: {rocpd_file}"
-                )
+        self.assert_rocpd(
+            result,
+            subtest_name="ROCpd AI NIC track validation",
+            rules_files=ainic_rocpd_rules,
+        )

--- a/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
@@ -50,7 +50,6 @@ AINIC_PERFETTO_COUNTER_NAMES = [
 def ainic_perf_env(rocprof_config) -> dict[str, str]:
     """Environment variables for AI NIC performance tests."""
     env = {
-        "ROCPROFSYS_TRACE_LEGACY": "ON",
         "ROCPROFSYS_USE_PID": "OFF",
         "ROCPROFSYS_LOG_LEVEL": "trace",
         "ROCPROFSYS_USE_PROCESS_SAMPLING": "ON",

--- a/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
@@ -1,0 +1,198 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+AI NIC tests using AMD SMI Phase 2 RDMA metrics (amdsmi_get_nic_rdma_dev_info).
+
+These tests verify that rocprofiler-systems correctly collects all 10 AI NIC
+RDMA counters per device and writes them to both the Perfetto (.proto) trace
+and the ROCpd (.db) database.
+
+AI NIC devices are discovered at runtime via ``amd-smi static | grep -i netdev``.
+The test is skipped automatically when no AI NIC devices are present on the system.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import pytest
+import shutil
+from pathlib import Path
+from conftest import RocprofsysTest
+
+pytestmark = [pytest.mark.ainic, pytest.mark.network]
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+# The 10 AI NIC RDMA track names written to the ROCpd (.db) database.
+AINIC_ROCPD_TRACK_NAMES = [
+    "ainic_rx_rdma_ucast_bytes",
+    "ainic_tx_rdma_ucast_bytes",
+    "ainic_rx_rdma_ucast_pkts",
+    "ainic_tx_rdma_ucast_pkts",
+    "ainic_rx_rdma_cnp_pkts",
+    "ainic_tx_rdma_cnp_pkts",
+    "ainic_tx_rdma_ack_timeout",
+    "ainic_resp_tx_pkt_seq_err",
+    "ainic_req_rx_pkt_seq_err",
+    "ainic_req_rx_impl_nak_seq_err",
+]
+
+# Substrings used to match the 10 Perfetto counter track names via LIKE.
+# Full name format: "NIC [<device_id>] <METRIC> (S)"
+AINIC_PERFETTO_COUNTER_NAMES = [
+    "RX RDMA Bytes",
+    "TX RDMA Bytes",
+    "RX RDMA Packets",
+    "TX RDMA Packets",
+    "RX CNP Packets",
+    "TX CNP Packets",
+    "TX ACK TIMEOUT",
+    "RESP TX PKT SEQ ERR",
+    "REQ RX PKT SEQ ERR",
+    "REQ RX IMPL NAK SEQ ERR",
+]
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def ainic_perf_env(rocprof_config) -> dict[str, str]:
+    """Environment variables for AI NIC performance tests."""
+    env = {
+        "ROCPROFSYS_TRACE_LEGACY": "ON",
+        "ROCPROFSYS_USE_PID": "OFF",
+        "ROCPROFSYS_LOG_LEVEL": "trace",
+        "ROCPROFSYS_USE_PROCESS_SAMPLING": "ON",
+        "ROCPROFSYS_SAMPLING_FREQ": "50",
+        "ROCPROFSYS_SAMPLING_CPUS": "none",
+        "ROCPROFSYS_USE_AMD_SMI": "ON",
+        "ROCPROFSYS_USE_AINIC": "ON",
+        "ROCPROFSYS_SAMPLING_AINICS": "all",
+        "ROCPROFSYS_USE_ROCPD": "ON",
+        "ROCPROFSYS_SAMPLING_DELAY": "0.05",
+    }
+    sysfs_root = os.environ.get("SMI_NIC_SYSFS_ROOT", "")
+    if sysfs_root:
+        env["SMI_NIC_SYSFS_ROOT"] = sysfs_root
+    return env
+
+
+@pytest.fixture
+def ainic_download_url_1() -> str:
+    """Download URL for the first file to download."""
+    return "https://github.com/ROCm/rocprofiler-systems/releases/download/rocm-6.4.1/rocprofiler-systems-1.0.1-ubuntu-22.04-ROCm-60400-PAPI-OMPT-Python3.sh"
+
+
+@pytest.fixture
+def ainic_download_url_2() -> str:
+    """Download URL for the second file to download."""
+    return "https://github.com/ROCm/rocprofiler-systems/releases/download/rocm-6.4.3/rocprofiler-systems-1.0.2-rhel-9.4-PAPI-OMPT-Python3.sh"
+
+
+# =============================================================================
+# Private helpers
+# =============================================================================
+
+
+def _get_ainic_tracks_from_rocpd(db_path: Path) -> set[str]:
+    """Return the set of AI NIC track names found in the ROCpd SQLite database.
+
+    Track names are stored in ``rocpd_string_{upid}`` tables. We query every
+    such table for strings that start with ``ainic_``.
+    """
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type IN ('table', 'view') AND name LIKE 'rocpd_string_%'"
+        )
+        string_tables = [row[0] for row in cursor.fetchall()]
+
+        found: set[str] = set()
+        for table in string_tables:
+            try:
+                cursor.execute(
+                    f"SELECT DISTINCT string FROM {table} WHERE string LIKE 'ainic_%'"
+                )
+                found.update(row[0] for row in cursor.fetchall())
+            except sqlite3.Error:
+                pass
+        return found
+    finally:
+        conn.close()
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+class TestAINIC(RocprofsysTest):
+    """Tests for AI NIC performance using AMD SMI Phase 2 RDMA metrics."""
+
+    PERFETTO_PASS_REGEX = [r"perfetto-trace\.proto validated"]
+    PERFETTO_FAIL_REGEX = [r"Failure validating.*perfetto-trace\.proto"]
+
+    def test_performance(
+        self,
+        rocprof_config,
+        ainic_perf_env,
+        ainic_download_url_1,
+        ainic_download_url_2,
+        test_output_dir,
+        subtests,
+        record_subtest_failure,
+    ):
+        target = shutil.which("wget")
+        if not target:
+            pytest.skip("wget not found")
+
+        download_cmd = [
+            "--no-check-certificate",
+            ainic_download_url_1,
+            ainic_download_url_2,
+            "-O",
+            str(test_output_dir / "rocprofiler-systems.test.bin"),
+        ]
+        result = self.run_test(
+            "sampling",
+            target,
+            run_args=download_cmd,
+            env=ainic_perf_env,
+        )
+
+        self.assert_regex(result)
+
+        # Validate Perfetto .proto: all 10 AI NIC counter track substrings must match
+        self.assert_perfetto(
+            result,
+            counter_names=AINIC_PERFETTO_COUNTER_NAMES,
+            pass_regex=self.PERFETTO_PASS_REGEX,
+            fail_regex=self.PERFETTO_FAIL_REGEX,
+        )
+
+        # Validate ROCpd .db: all 10 AI NIC track names must be present
+        subtest_name = "ROCpd AI NIC track validation"
+        with subtests.test(subtest_name):
+            rocpd_file = result.rocpd_file
+            if rocpd_file is None:
+                record_subtest_failure(subtest_name)
+                pytest.fail("ROCpd database (.db) was not created")
+
+            found_tracks = _get_ainic_tracks_from_rocpd(rocpd_file)
+            missing = [t for t in AINIC_ROCPD_TRACK_NAMES if t not in found_tracks]
+            if missing:
+                record_subtest_failure(subtest_name)
+                pytest.fail(
+                    f"Missing AI NIC tracks in ROCpd database:\n"
+                    f"  Missing : {missing}\n"
+                    f"  Found   : {sorted(found_tracks)}\n"
+                    f"  Database: {rocpd_file}"
+                )

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/ainic/ainic-rdma-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/ainic/ainic-rdma-rules.json
@@ -1,0 +1,81 @@
+{
+    "required_tables": [
+        {
+            "name_prefix": "rocpd_string_",
+            "min_rows": 1,
+            "required_columns": ["string"],
+            "validation_queries": [
+                {
+                    "description": "Check for ainic_rx_rdma_ucast_bytes track name",
+                    "error_message": "Did not find ainic_rx_rdma_ucast_bytes in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_rx_rdma_ucast_bytes'"
+                },
+                {
+                    "description": "Check for ainic_tx_rdma_ucast_bytes track name",
+                    "error_message": "Did not find ainic_tx_rdma_ucast_bytes in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_tx_rdma_ucast_bytes'"
+                },
+                {
+                    "description": "Check for ainic_rx_rdma_ucast_pkts track name",
+                    "error_message": "Did not find ainic_rx_rdma_ucast_pkts in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_rx_rdma_ucast_pkts'"
+                },
+                {
+                    "description": "Check for ainic_tx_rdma_ucast_pkts track name",
+                    "error_message": "Did not find ainic_tx_rdma_ucast_pkts in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_tx_rdma_ucast_pkts'"
+                },
+                {
+                    "description": "Check for ainic_rx_rdma_cnp_pkts track name",
+                    "error_message": "Did not find ainic_rx_rdma_cnp_pkts in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_rx_rdma_cnp_pkts'"
+                },
+                {
+                    "description": "Check for ainic_tx_rdma_cnp_pkts track name",
+                    "error_message": "Did not find ainic_tx_rdma_cnp_pkts in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_tx_rdma_cnp_pkts'"
+                },
+                {
+                    "description": "Check for ainic_tx_rdma_ack_timeout track name",
+                    "error_message": "Did not find ainic_tx_rdma_ack_timeout in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_tx_rdma_ack_timeout'"
+                },
+                {
+                    "description": "Check for ainic_resp_tx_pkt_seq_err track name",
+                    "error_message": "Did not find ainic_resp_tx_pkt_seq_err in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_resp_tx_pkt_seq_err'"
+                },
+                {
+                    "description": "Check for ainic_req_rx_pkt_seq_err track name",
+                    "error_message": "Did not find ainic_req_rx_pkt_seq_err in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_req_rx_pkt_seq_err'"
+                },
+                {
+                    "description": "Check for ainic_req_rx_impl_nak_seq_err track name",
+                    "error_message": "Did not find ainic_req_rx_impl_nak_seq_err in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_req_rx_impl_nak_seq_err'"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The AI NIC PMC collector (AMD Pensando Pollara, Phase 2 RDMA metrics) had two silent correctness problems:

1. `cache_policy.hpp` only registered 6 of the 10 AI NIC track names in `initialize_tracks_metadata()`. The four error/timeout counters (`ainic_tx_rdma_ack_timeout`, `ainic_resp_tx_pkt_seq_err`, `ainic_req_rx_pkt_seq_err`, `ainic_req_rx_impl_nak_seq_err`) were never written to the ROCpd database, with no warning.
2. There was no runtime observability into whether AI NIC devices were actually found, filtered, or producing samples — making it difficult to diagnose "no data" failures.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
### Bug fix — `cache_policy.hpp`:

- Add four missing `add_track()` calls in `initialize_tracks_metadata()` for the error/timeout counters introduced in Phase 2.

### End-to-end test — `test_ainic_perf.py`:

- New pytest test (`-m ainic`) that runs `rocprof-sys-sample` over a network workload and validates all 10 RDMA counters appear in both the Perfetto trace and the ROCpd database.
- Supports simulation mode via `SMI_NIC_SYSFS_ROOT`; skips automatically when neither real hardware nor simulation is active.
- `conftest.py`: register `ainic` pytest marker and `ainic_unavailable_reason()` skip helper.
- `capabilities.py`: add `ai_nic_devices` cached property (queries `amd-smi static`).

### Runtime diagnostics — `nic_traits.hpp`:

- `LOG_DEBUG`: total devices discovered via AMD SMI, each device skipped (no RDMA support), each device excluded by `ROCPROFSYS_SAMPLING_AINICS` filter.
- `LOG_INFO`: each device successfully enrolled for PMC sampling.
- `LOG_WARNING`: requested device name not found (with list of available names); no devices discovered at all (mode `SPECIFIC` only).

### Runtime diagnostics — `base/collector.hpp`:

- Track per-device successful sample count in `m_sample_counts` (incremented in `sample()`).
- In `post_process()`, emit `LOG_WARNING` for any enrolled device that collected zero samples; `LOG_DEBUG` with the exact count otherwise.
- Applies generically to NIC, GPU, and CPU collectors.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Run `pytest -m ainic tests/pytest/test_ainic_perf.py -v` with optionally `SMI_NIC_SYSFS_ROOT` pointing to a running
NIC simulator — all 10 RDMA counters must appear in both ROCpd and Perfetto outputs.
- On a system without AI NICs and without `SMI_NIC_SYSFS_ROOT` set, the test must be skipped automatically.
- No regression in the existing ctest suite.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
