### PR TITLE
Revert clr: scratch/queue lifetime, doorbell, and host-unlock regressions (#6631, #6762, #6724)

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -76,6 +76,8 @@ bool roc::Device::isHsaInitialized_ = false;
 std::vector<hsa_agent_t> roc::Device::gpu_agents_;
 std::vector<AgentInfo> roc::Device::cpu_agents_;
 
+std::atomic<bool> Device::skipHsaShutdown_{false};
+
 address Device::mg_sync_ = nullptr;
 
 bool NullDevice::create(const amd::Isa& isa) {
@@ -222,17 +224,25 @@ Device::~Device() {
   delete xferQueue_;
   xferQueue_ = nullptr;
 
-  for (auto& it : queuePool_) {
-    for (auto qIter = it.begin(); qIter != it.end();) {
-      hsa_queue_t* queue = qIter->first;
-      auto& qInfo = qIter->second;
-      ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE, "Deleting hardware queue %p with refCount 0",
-              queue->base_address);
-      qIter = it.erase(qIter);
-      Hsa::queue_destroy(queue);
+#if defined(_WIN32)
+  if (hasSchedulerQueue_.load(std::memory_order_acquire) > 0) {
+    skipHsaShutdown_.store(true, std::memory_order_release);
+    queuePool_.clear();
+  } else
+#endif  // _WIN32
+  {
+    for (auto& it : queuePool_) {
+      for (auto qIter = it.begin(); qIter != it.end();) {
+        hsa_queue_t* queue = qIter->first;
+        auto& qInfo = qIter->second;
+        ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE, "Deleting hardware queue %p with refCount 0",
+                queue->base_address);
+        qIter = it.erase(qIter);
+        Hsa::queue_destroy(queue);
+      }
     }
+    queuePool_.clear();
   }
-  queuePool_.clear();
 
   delete blitProgram_;
 
@@ -350,6 +360,9 @@ hsa_status_t Device::loaderQueryHostAddress(const void* device, const void** hos
 
 // ================================================================================================
 bool Device::init() {
+#if defined(_WIN32)
+  skipHsaShutdown_.store(false, std::memory_order_release);
+#endif
   if (!Hsa::LoadLib()) {
     LogPrintfWarning("Failed to load rocr library!");
     return false;
@@ -532,6 +545,11 @@ extern const char* SchedulerSourceCode;
 
 void Device::tearDown() {
   NullDevice::tearDown();
+#if defined(_WIN32)
+  if (skipHsaShutdown_.load(std::memory_order_acquire)) {
+    return;
+  }
+#endif  // _WIN32
   Hsa::shut_down();
 }
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2221,28 +2221,6 @@ void* Device::hostLock(void* hostMem, size_t size, const MemorySegment memSegmen
   return deviceMemory;
 }
 
-void Device::hostUnlock(void* hostMem, size_t size) const {
-  // Nothing to unlock for a null pointer; hsa_amd_memory_unlock rejects it.
-  if (hostMem == nullptr) {
-    return;
-  }
-  // Before releasing the pin, revoke this device's GPU access to the range so
-  // the kernel-side SVM range is not left with stale GPU-access attributes once
-  // the host pages are freed.  Only the SVM-API (HMM) path needs this; the
-  // legacy userptr deregister already unmaps on its own.  Best-effort: a failed
-  // revoke must not block the unlock.
-  if (info().hmmSupported_) {
-    hsa_amd_svm_attribute_pair_t attr{HSA_AMD_SVM_ATTRIB_AGENT_NO_ACCESS,
-                                      getBackendDevice().handle};
-    hsa_status_t status = Hsa::svm_attributes_set(hostMem, size, &attr, 1);
-    if (status != HSA_STATUS_SUCCESS) {
-      ClPrint(amd::LOG_DEBUG, amd::LOG_MEM,
-              "hostUnlock: NO_ACCESS revoke failed for %p, status: %d", hostMem, status);
-    }
-  }
-  Hsa::memory_unlock(hostMem);
-}
-
 void Device::hostFree(void* ptr, size_t size) const { memFree(ptr, size); }
 
 bool Device::deviceAllowAccess(void* ptr) const {

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -509,10 +509,6 @@ class Device : public NullDevice {
   //! return a new device pointer accessible by the GPU agent.
   void* hostLock(void* hostMem, size_t size, MemorySegment memSegment) const;
 
-  //! Symmetric counterpart to hostLock(): revoke this device's GPU access to the
-  //! pinned range (SVM-API/HMM path only) and then unlock it.
-  void hostUnlock(void* hostMem, size_t size) const;
-
   //! Returns transfer engine object
   const device::BlitManager& xferMgr() const { return xferQueue()->blitMgr(); }
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -789,6 +789,12 @@ class Device : public NullDevice {
   friend void callbackQueue(hsa_status_t status, hsa_queue_t* queue, void* data);
 
  public:
+
+  //! Count of schedulerQueue_ instances per device
+  //! Windows AQL device-enqueue path.
+  std::atomic<uint32_t> hasSchedulerQueue_{0};
+  static std::atomic<bool> skipHsaShutdown_;
+
   std::atomic<uint> numOfVgpus_;  //!< Virtual gpu unique index
 
   //! Returns the valid SDMA engine bitmask for the given operation type.

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -706,7 +706,7 @@ void Buffer::destroy() {
       if (memFlags & CL_MEM_USE_HOST_PTR) {
         // unlock svm host pointer from memory pool
         if (!dev().info().hmmSupported_) {
-          dev().hostUnlock(owner()->getSvmPtr(), size());
+          Hsa::memory_unlock(owner()->getSvmPtr());
         }
         // destroy system memory
         if (!(amd::Os::releaseMemory(deviceMemory_, size()))) {
@@ -749,8 +749,7 @@ void Buffer::destroy() {
 
     if (needUnlockHostMem) {
       if (memFlags & (CL_MEM_USE_HOST_PTR | CL_MEM_ALLOC_HOST_PTR)) {
-        if (dev().agent_profile() != HSA_PROFILE_FULL)
-          dev().hostUnlock(owner()->getHostMem(), size());
+        if (dev().agent_profile() != HSA_PROFILE_FULL) Hsa::memory_unlock(owner()->getHostMem());
       }
     }
   }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1959,7 +1959,33 @@ VirtualGPU::~VirtualGPU() {
 
   delete blitMgr_;
 
-  if (tracking_created_) {
+  bool skip_fence_barrier = false;
+  if (nullptr != schedulerQueue_) {
+#if defined(_WIN32)
+    if (isSchedulerQueueThreadRunning()) {
+      schedulerQueueThreadRunning_.store(false, std::memory_order_release);
+      {
+        std::lock_guard<std::mutex> lock(scheduler_mutex_);
+        pendingSchedulerEvents_.clear();
+        scheduler_cv_.notify_one();
+      }
+      if (schedulerQueueThread_.joinable()) {
+        schedulerQueueThread_.join();
+      }
+    }
+    if (!dev().IsPm4Emulation()) {
+      roc_device_.hasSchedulerQueue_.fetch_add(1, std::memory_order_release);
+      skip_fence_barrier = true;
+    } else {
+      Hsa::queue_destroy(schedulerQueue_);
+    }
+#else
+    Hsa::queue_destroy(schedulerQueue_);
+#endif  // _WIN32
+    schedulerQueue_ = nullptr;
+  }
+
+  if (tracking_created_ && !skip_fence_barrier) {
     std::scoped_lock l(execution());
     // Dedicated queues keep their HW queue, never acquire from pool
     if (!dedicated_queue_ && gpu_queue_ == nullptr) {
@@ -1982,19 +2008,6 @@ VirtualGPU::~VirtualGPU() {
   }
 
   delete printfdbg_;
-
-  if (nullptr != schedulerQueue_) {
-#if defined(_WIN32)
-    // Stop the monitor thread before destroying the queue
-    if (schedulerQueueThread_.joinable()) {
-      schedulerQueueThreadRunning_.store(false, std::memory_order_release);
-      scheduler_cv_.notify_one();
-      schedulerQueueThread_.join();
-    }
-#endif  // _WIN32
-    Hsa::queue_destroy(schedulerQueue_);
-    schedulerQueue_ = nullptr;
-  }
 
   if (nullptr != virtualQueue_) {
     virtualQueue_->release();
@@ -3805,7 +3818,6 @@ void VirtualGPU::startSchedulerQueueThread() {
   schedulerQueueThreadRunning_.store(true, std::memory_order_release);
 
   schedulerQueueThread_ = std::thread([this]() {
-    uint64_t updated_write_index = 0;
     while (isSchedulerQueueThreadRunning()) {
 
       // Wait until scheduler events are added or thread termination
@@ -3820,12 +3832,12 @@ void VirtualGPU::startSchedulerQueueThread() {
       // Actively monitor the scheduler queue while any sync event is pending.
       bool has_active_events = true;
       while (has_active_events && isSchedulerQueueThreadRunning()) {
+        uint64_t read_index = Hsa::queue_load_read_index_scacquire(schedulerQueue_);
         uint64_t write_index = Hsa::queue_load_write_index_scacquire(schedulerQueue_);
 
-        if (write_index > updated_write_index) {
+        if (write_index > read_index) {
           // New packets in the scheduler queue, ringing the doorbell
           Hsa::signal_store_screlease(schedulerQueue_->doorbell_signal, write_index - 1);
-          updated_write_index = write_index;
         } else {
           // Yield briefly before re-checking.
           amd::Os::yield();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -567,15 +567,8 @@ class GpuAgent : public GpuAgentInt {
     *size = scratch_pool_.size();
   }
 
-  /// @brief Get a snapshot of AQL queues for core dump filtering.
-  /// Returns a copy to avoid iterator invalidation from concurrent queue destruction.
-  std::vector<core::Queue*> GetAqlQueues() const {
-    std::lock_guard<std::mutex> lock(aql_queues_lock_);
-    return aql_queues_;
-  }
-
-  /// @brief Remove a destroyed AQL queue from agent-owned tracking.
-  void UnregisterAqlQueue(core::Queue* queue);
+  /// @brief Get list of AQL queues for core dump filtering
+  const std::vector<core::Queue*>& GetAqlQueues() const { return aql_queues_; }
 
  protected:
   // Sizes are in packets.
@@ -793,7 +786,7 @@ class GpuAgent : public GpuAgentInt {
   // @brief Register signal for notification when scratch may become available.
   // @p signal is notified by OR'ing with @p value.
   bool AddScratchNotifier(hsa_signal_t signal, hsa_signal_value_t value) {
-    if (signal.handle == 0) return false;
+    if (signal.handle != 0) return false;
     scratch_notifiers_[signal] = value;
     return true;
   }
@@ -888,14 +881,11 @@ class GpuAgent : public GpuAgentInt {
   // @brief list of AQL queues owned by this agent. Indexed by queue pointer
   std::vector<core::Queue*> aql_queues_;
 
-  // @brief Protects aql_queues_ from concurrent modification/iteration.
-  mutable std::mutex aql_queues_lock_;
-
   // Sets and Tracks pending SDMA status check or request counts
   void SetCopyRequestRefCount(bool set);
   void SetCopyStatusCheckRefCount(bool set);
-  std::atomic<int> pending_copy_req_ref_;
-  std::atomic<int> pending_copy_stat_check_ref_;
+  int pending_copy_req_ref_;
+  int pending_copy_stat_check_ref_;
 
   // Tracks what SDMA blits have been used since initialization.
   uint32_t sdma_blit_used_mask_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -352,8 +352,6 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
 }
 
 AqlQueue::~AqlQueue() {
-  agent_->UnregisterAqlQueue(this);
-
   // Remove error handler synchronously.
   // Sequences error handler callbacks with queue destroy.
   dynamicScratchState |= ERROR_HANDLER_TERMINATE;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -612,15 +612,12 @@ void GpuAgent::ReserveScratch()
   if (!scratch_cache_.reserved_bytes() && reserved_sz && available > 8 * reserved_sz) {
     HSAuint64 alt_va;
     void* reserved_base = scratch_pool_.alloc(reserved_sz);
-    if (reserved_base == nullptr)
-      throw AMD::hsa_exception(HSA_STATUS_ERROR_OUT_OF_RESOURCES, "Reserve scratch memory failed.");
+    assert(reserved_base && "Could not allocate reserved memory");
 
     if (driver().MakeMemoryResident(reserved_base, reserved_sz, &alt_va) == HSA_STATUS_SUCCESS)
       scratch_cache_.reserve(reserved_sz, reserved_base);
-    else {
-      scratch_pool_.free(reserved_base);
+    else
       throw AMD::hsa_exception(HSA_STATUS_ERROR_OUT_OF_RESOURCES, "Reserve scratch memory failed.");
-    }
   }
 }
 
@@ -672,7 +669,7 @@ void GpuAgent::InitDerivedCuid() {
   }
 
   // Query the derived CUID using the device handle
-  uint32_t cuid_length = sizeof(derived_cuid_);
+  uint32_t cuid_length;
   status = amdcuid_query_device_property(handle, AMDCUID_QUERY_DERIVED_CUID,
                                          derived_cuid_, &cuid_length);
 
@@ -940,8 +937,7 @@ void GpuAgent::InitDma() {
     // since there is no graceful way to handle lazy loading when the caller needs to know
     // the status of available SDMA HW resources without a fallback.
     // Call to isSDMA should be used as a proxy error check if !blit_copy_fallback.
-    auto ret = pending_copy_stat_check_ref_.load(std::memory_order_acquire) ?
-                                              new AMD::BlitKernel(NULL) :
+    auto ret = pending_copy_stat_check_ref_ ? new AMD::BlitKernel(NULL) :
                                               CreateBlitKernel((*queue).get());
     if (ret == nullptr)
       throw AMD::hsa_exception(HSA_STATUS_ERROR_OUT_OF_RESOURCES, "Blit creation failed.");
@@ -1070,28 +1066,24 @@ hsa_status_t GpuAgent::DmaCopy(void* dst, const void* src, size_t size) {
 
 void GpuAgent::SetCopyRequestRefCount(bool set) {
   std::unique_lock<std::mutex> lock(blit_lock_);
-  while (pending_copy_stat_check_ref_.load(std::memory_order_acquire)) {
+  while (pending_copy_stat_check_ref_) {
     lock.unlock();
     os::YieldThread();
     lock.lock();
   }
-  if (!set && pending_copy_req_ref_.load(std::memory_order_relaxed))
-    pending_copy_req_ref_.fetch_sub(1, std::memory_order_release);
-  else
-    pending_copy_req_ref_.fetch_add(1, std::memory_order_release);
+  if (!set && pending_copy_req_ref_) pending_copy_req_ref_--;
+  else pending_copy_req_ref_++;
 }
 
 void GpuAgent::SetCopyStatusCheckRefCount(bool set) {
   std::unique_lock<std::mutex> lock(blit_lock_);
-  while (pending_copy_req_ref_.load(std::memory_order_acquire)) {
+  while (pending_copy_req_ref_) {
     lock.unlock();
     os::YieldThread();
     lock.lock();
   }
-  if (!set && pending_copy_stat_check_ref_.load(std::memory_order_relaxed))
-    pending_copy_stat_check_ref_.fetch_sub(1, std::memory_order_release);
-  else
-    pending_copy_stat_check_ref_.fetch_add(1, std::memory_order_release);
+  if (!set && pending_copy_stat_check_ref_) pending_copy_stat_check_ref_--;
+  else pending_copy_stat_check_ref_++;
 }
 
 // Assign direct peer gang factor to GPU
@@ -2390,9 +2382,7 @@ hsa_status_t GpuAgent::GetInfo(hsa_agent_info_t attribute, void* value) const {
 
       for (const auto& r : regions()) availableBytes += ((AMD::MemoryRegion*)(r.get()))->GetCacheSize();
 
-      const size_t free_scratch = scratch_cache_.free_bytes();
-      const size_t reserved_scratch = scratch_cache_.reserved_bytes();
-      availableBytes += free_scratch - std::min(free_scratch, reserved_scratch);
+      availableBytes += scratch_cache_.free_bytes() - scratch_cache_.reserved_bytes();
 
       *((uint64_t*)value) = availableBytes;
       break;
@@ -2617,11 +2607,7 @@ hsa_status_t GpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
   auto aql_queue = new AqlQueue(shared_queue, this, size, node_id(), scratch, event_callback, data,
                                 metadata_queue, flags);
   *queue = aql_queue;
-
-  {
-    std::lock_guard<std::mutex> lock(aql_queues_lock_);
-    aql_queues_.push_back(aql_queue);
-  }
+  aql_queues_.push_back(aql_queue);
 
   if (doorbell_queue_map_) {
     // Calculate index of the queue doorbell within the doorbell aperture.
@@ -2632,23 +2618,6 @@ hsa_status_t GpuAgent::QueueCreate(size_t size, hsa_queue_type32_t queue_type, u
 
   scratchGuard.Dismiss();
   return HSA_STATUS_SUCCESS;
-}
-
-void GpuAgent::UnregisterAqlQueue(core::Queue* queue) {
-  std::lock_guard<std::mutex> lock(aql_queues_lock_);
-  auto queue_it = std::find(aql_queues_.begin(), aql_queues_.end(), queue);
-  if (queue_it != aql_queues_.end()) {
-    aql_queues_.erase(queue_it);
-
-    // Clear the doorbell queue map entry to prevent stale pointer dereference
-    // by the trap handler after queue destruction.
-    if (doorbell_queue_map_) {
-      auto aql_queue = static_cast<AqlQueue*>(queue);
-      auto doorbell_addr = uintptr_t(aql_queue->signal_.hardware_doorbell_ptr);
-      auto doorbell_idx = (doorbell_addr >> 3) & (MAX_NUM_DOORBELLS - 1);
-      doorbell_queue_map_[doorbell_idx] = nullptr;
-    }
-  }
 }
 
 void GpuAgent::AcquireQueueMainScratch(ScratchInfo& scratch) {
@@ -2936,12 +2905,7 @@ void GpuAgent::ReleaseScratch(void* base, size_t size, bool large) {
 
 // Go through all the AQL queues and try to release scratch memory
 void GpuAgent::AsyncReclaimScratchQueues() {
-  std::vector<core::Queue*> queues;
-  {
-    std::lock_guard<std::mutex> lock(aql_queues_lock_);
-    queues = aql_queues_;
-  }
-  for (auto iter : queues) {
+  for (auto iter : aql_queues_) {
     auto aqlQueue = static_cast<AqlQueue*>(iter);
     aqlQueue->AsyncReclaimMainScratch();
     aqlQueue->AsyncReclaimAltScratch();
@@ -2953,12 +2917,7 @@ hsa_status_t GpuAgent::SetAsyncScratchThresholds(size_t use_once_limit) {
 
   scratch_limit_async_threshold_ = use_once_limit;
 
-  std::vector<core::Queue*> queues;
-  {
-    std::lock_guard<std::mutex> lock(aql_queues_lock_);
-    queues = aql_queues_;
-  }
-  for (auto iter : queues) {
+  for (auto iter : aql_queues_) {
     auto aqlQueue = static_cast<AqlQueue*>(iter);
     aqlQueue->CheckScratchLimits();
   }
@@ -3181,9 +3140,7 @@ void GpuAgent::BindTrapHandler() {
     auto doorbell_queue_map_size = MAX_NUM_DOORBELLS * sizeof(amd_queue_v2_t*);
 
     doorbell_queue_map_ = (amd_queue_v2_t**)system_allocator()(doorbell_queue_map_size, 0x1000, 0);
-    if (doorbell_queue_map_ == NULL)
-      throw AMD::hsa_exception(HSA_STATUS_ERROR_OUT_OF_RESOURCES,
-                               "Doorbell queue map allocation failed.");
+    assert(doorbell_queue_map_ != NULL && "Doorbell queue map allocation failed");
 
     memset(doorbell_queue_map_, 0, doorbell_queue_map_size);
 


### PR DESCRIPTION
## Motivation

Reverts three PRs that caused widespread **numerical correctness failures** across hipfft, rocfft, rocblas, rocthrust, hipcub, hipsparse, rocsparse, hipsparselt, rocsolver, and miopen on **gfx94X-dcgpu (gfx942)** and Windows gfx110X.

Regression observed in TheRock CI run [27176631264](https://github.com/ROCm/TheRock/actions/runs/27176631264) triggered by PR [ROCm/TheRock#5704](https://github.com/ROCm/TheRock/pull/5704) (rocm-systems bump \`1b2a555\` → \`8855e14\`). 29 test jobs failed with massive Linf/L2 errors (up to 56727× expected).

## PRs Being Reverted

### Revert "clr: Fix GPU agent scratch and queue lifetime bugs (#6631)"
\`AddScratchNotifier\` condition was **inverted** (\`handle != 0\` instead of \`handle == 0\`), causing scratch reclaim notifications to never register for valid signals. GPU kernels that spill registers rely on scratch memory; when scratch cannot be reclaimed/notified, kernels execute with stale or uninitialized scratch → silent wrong numerical results across all math libs.

### Revert "Do not ring the doorbell multiple times with same write ptr (#6762)"
Scheduler queue thread now compares \`write_index > read_index\` instead of tracking \`updated_write_index\`. This changes doorbell ring semantics and can cause incorrect packet dispatch ordering on the scheduler queue.

### Revert "clr: Revoke GPU access on host pointer unlock (#6724)"
\`hsa_amd_svm_attributes_set(NO_ACCESS)\` is called before \`hsa_amd_memory_unlock\`. If an in-flight SDMA copy is still accessing that host range, revoking GPU access mid-operation corrupts the transfer.

## Test Plan

- Verify TheRock CI passes on gfx94X-dcgpu for hipfft, rocfft, rocblas, rocthrust, hipsparse, rocsparse
- Verify Windows gfx110X tests pass (libhipcxx_hipcc, rocsparse, hipsparse)