### PR TITLE
Revert "clr: Revoke GPU access on host pointer unlock (#6724)"

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -2203,28 +2203,6 @@ void* Device::hostLock(void* hostMem, size_t size, const MemorySegment memSegmen
   return deviceMemory;
 }
 
-void Device::hostUnlock(void* hostMem, size_t size) const {
-  // Nothing to unlock for a null pointer; hsa_amd_memory_unlock rejects it.
-  if (hostMem == nullptr) {
-    return;
-  }
-  // Before releasing the pin, revoke this device's GPU access to the range so
-  // the kernel-side SVM range is not left with stale GPU-access attributes once
-  // the host pages are freed.  Only the SVM-API (HMM) path needs this; the
-  // legacy userptr deregister already unmaps on its own.  Best-effort: a failed
-  // revoke must not block the unlock.
-  if (info().hmmSupported_) {
-    hsa_amd_svm_attribute_pair_t attr{HSA_AMD_SVM_ATTRIB_AGENT_NO_ACCESS,
-                                      getBackendDevice().handle};
-    hsa_status_t status = Hsa::svm_attributes_set(hostMem, size, &attr, 1);
-    if (status != HSA_STATUS_SUCCESS) {
-      ClPrint(amd::LOG_DEBUG, amd::LOG_MEM,
-              "hostUnlock: NO_ACCESS revoke failed for %p, status: %d", hostMem, status);
-    }
-  }
-  Hsa::memory_unlock(hostMem);
-}
-
 void Device::hostFree(void* ptr, size_t size) const { memFree(ptr, size); }
 
 bool Device::deviceAllowAccess(void* ptr) const {

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -509,10 +509,6 @@ class Device : public NullDevice {
   //! return a new device pointer accessible by the GPU agent.
   void* hostLock(void* hostMem, size_t size, MemorySegment memSegment) const;
 
-  //! Symmetric counterpart to hostLock(): revoke this device's GPU access to the
-  //! pinned range (SVM-API/HMM path only) and then unlock it.
-  void hostUnlock(void* hostMem, size_t size) const;
-
   //! Returns transfer engine object
   const device::BlitManager& xferMgr() const { return xferQueue()->blitMgr(); }
 

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -706,7 +706,7 @@ void Buffer::destroy() {
       if (memFlags & CL_MEM_USE_HOST_PTR) {
         // unlock svm host pointer from memory pool
         if (!dev().info().hmmSupported_) {
-          dev().hostUnlock(owner()->getSvmPtr(), size());
+          Hsa::memory_unlock(owner()->getSvmPtr());
         }
         // destroy system memory
         if (!(amd::Os::releaseMemory(deviceMemory_, size()))) {
@@ -749,8 +749,7 @@ void Buffer::destroy() {
 
     if (needUnlockHostMem) {
       if (memFlags & (CL_MEM_USE_HOST_PTR | CL_MEM_ALLOC_HOST_PTR)) {
-        if (dev().agent_profile() != HSA_PROFILE_FULL)
-          dev().hostUnlock(owner()->getHostMem(), size());
+        if (dev().agent_profile() != HSA_PROFILE_FULL) Hsa::memory_unlock(owner()->getHostMem());
       }
     }
   }


### PR DESCRIPTION
## Motivation

Reverts PR: #6724
Fixes Issue: https://github.com/ROCm/rocm-systems/issues/6976

Reverts PR: #6724 which introduced a race condition between GPU access revocation and in-flight SDMA copies.

Regression observed in TheRock CI run [27176631264](https://github.com/ROCm/TheRock/actions/runs/27176631264) (PR [ROCm/TheRock#5704](https://github.com/ROCm/TheRock/pull/5704)). 29 test jobs failed with numerical correctness errors across math libs on gfx94X-dcgpu and Windows gfx110X.

## Root Cause

`hsa_amd_svm_attributes_set(NO_ACCESS)` is called before `hsa_amd_memory_unlock`. If an in-flight SDMA copy is still accessing that host range when GPU access is revoked, the transfer is corrupted → wrong data in library tests that use pinned host memory.

## Test Plan

- Verify TheRock CI passes on gfx94X-dcgpu for hipfft, rocfft, rocblas, rocthrust, hipsparse, rocsparse
- Verify Windows gfx110X tests pass