### PR TITLE
Revert "clr: Serialize IPC event re-recording to avoid signal re-arm race (#6786)"

### DIFF
--- a/projects/clr/hipamd/src/hip_event.cpp
+++ b/projects/clr/hipamd/src/hip_event.cpp
@@ -151,9 +151,6 @@ int64_t EventDD::time(bool getStartTs) const {
 }
 // ================================================================================================
 hipError_t Event::streamWaitCommand(amd::Command*& command, hip::Stream* stream) {
-  // Guard event_ against concurrent record/sync. Graph stream-wait nodes call
-  // this directly (not via the locked streamWait path); lock_ is recursive.
-  std::scoped_lock lock(lock_);
   const amd::Command::EventWaitList eventWaitList =
       (event_ != nullptr) ? amd::Command::EventWaitList{event_} : amd::Command::EventWaitList{};
 
@@ -189,9 +186,6 @@ hipError_t Event::streamWait(hip::Stream* stream, uint flags) {
 // ================================================================================================
 hipError_t Event::recordCommand(amd::Command*& command, amd::HostQueue* stream, uint32_t ext_flags,
                                 bool batch_flush) {
-  // Guard event state against concurrent access. Graph event-record nodes call
-  // this directly (not via the locked addMarker path); lock_ is recursive.
-  std::scoped_lock lock(lock_);
   if (command != nullptr) {
     return hipSuccess;
   }
@@ -213,9 +207,6 @@ hipError_t Event::recordCommand(amd::Command*& command, amd::HostQueue* stream, 
 
 // ================================================================================================
 hipError_t Event::enqueueRecordCommand(hip::Stream* stream, amd::Command* command) {
-  // Guard event_ release/replace against concurrent access. Graph event-record
-  // nodes call this directly (not via locked addMarker); lock_ is recursive.
-  std::scoped_lock lock(lock_);
   command->enqueue();
 
   amd::Event& new_event = command->event();

--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -61,7 +61,6 @@ bool IPCEventEmulated::createIpcEventShmemIfNeeded() {
 
 // ================================================================================================
 hipError_t IPCEventEmulated::query() {
-  std::scoped_lock lock(lock_);
   if (ipc_evt_.ipc_shmem_) {
     const int prev_read_idx = ipc_evt_.ipc_shmem_->read_index;
     const int offset = prev_read_idx % IPC_SIGNALS_PER_EVENT;
@@ -76,7 +75,6 @@ hipError_t IPCEventEmulated::query() {
 
 // ================================================================================================
 hipError_t IPCEventEmulated::synchronize() {
-  std::scoped_lock lock(lock_);
   if (ipc_evt_.ipc_shmem_) {
     int prev_read_idx = ipc_evt_.ipc_shmem_->read_index;
     if (prev_read_idx >= 0) {
@@ -92,7 +90,6 @@ hipError_t IPCEventEmulated::synchronize() {
 
 // ================================================================================================
 hipError_t IPCEventEmulated::streamWait(hip::Stream* stream, uint flags) {
-  std::scoped_lock lock(lock_);
   const int offset = ipc_evt_.ipc_shmem_->read_index;
   return ihipStreamOperation(
       reinterpret_cast<hipStream_t>(stream),
@@ -104,18 +101,12 @@ hipError_t IPCEventEmulated::streamWait(hip::Stream* stream, uint flags) {
 // ================================================================================================
 hipError_t IPCEventEmulated::recordCommand(amd::Command*& command, amd::HostQueue* stream,
                                            uint32_t flags, bool batch_flush) {
-  // Graph event-record nodes call this directly; lock_ is recursive so the
-  // normal addMarker path is unaffected.
-  std::scoped_lock lock(lock_);
   command = new amd::Marker(*stream, kMarkerDisableFlush);
   return hipSuccess;
 }
 
 // ================================================================================================
 hipError_t IPCEventEmulated::enqueueRecordCommand(hip::Stream* stream, amd::Command* command) {
-  // Guard event_/shmem against concurrent query/synchronize/streamWait. Graph
-  // event-record nodes call this directly; lock_ is recursive.
-  std::scoped_lock lock(lock_);
   createIpcEventShmemIfNeeded();
 
   // Allocate signal slot for this event
@@ -159,7 +150,6 @@ hipError_t IPCEventEmulated::enqueueRecordCommand(hip::Stream* stream, amd::Comm
 
 // ================================================================================================
 hipError_t IPCEventEmulated::GetHandle(ihipIpcEventHandle_t* handle) {
-  std::scoped_lock lock(lock_);
   if (!createIpcEventShmemIfNeeded()) {
     return hipErrorInvalidValue;
   }
@@ -174,7 +164,6 @@ hipError_t IPCEventEmulated::GetHandle(ihipIpcEventHandle_t* handle) {
 
 // ================================================================================================
 hipError_t IPCEventEmulated::OpenHandle(ihipIpcEventHandle_t* handle) {
-  std::scoped_lock lock(lock_);
   ipc_evt_.ipc_name_ = handle->shmem_name;
 
   // Map shared memory from IPC handle
@@ -245,7 +234,6 @@ IPCEvent::~IPCEvent() {
 
 // ================================================================================================
 hipError_t IPCEvent::GetHandle(ihipIpcEventHandle_t* handle) {
-  std::scoped_lock lock(lock_);
   auto status = createIpcSignalIfNeeded();
   if (status != hipSuccess) {
     return status;
@@ -262,7 +250,6 @@ hipError_t IPCEvent::GetHandle(ihipIpcEventHandle_t* handle) {
 
 // ================================================================================================
 hipError_t IPCEvent::OpenHandle(ihipIpcEventHandle_t* handle) {
-  std::scoped_lock lock(lock_);
   if (handle->type != kIpcEventHandleROCr) {
     return hipErrorInvalidValue;
   }
@@ -289,11 +276,6 @@ hipError_t IPCEvent::OpenHandle(ihipIpcEventHandle_t* handle) {
 // ================================================================================================
 hipError_t IPCEvent::recordCommand(amd::Command*& command, amd::HostQueue* stream,
                                    uint32_t flags, bool batch_flush) {
-  // Protect ipc_signal_ creation against concurrent access. Not all callers hold
-  // Event::lock() (e.g. graph event-record nodes call this directly from
-  // CreateCommand); lock_ is recursive, so the normal addMarker path is safe.
-  std::scoped_lock lock(lock_);
-
   auto status = createIpcSignalIfNeeded();
   if (status != hipSuccess) {
     return status;
@@ -307,23 +289,6 @@ hipError_t IPCEvent::recordCommand(amd::Command*& command, amd::HostQueue* strea
 
 // ================================================================================================
 hipError_t IPCEvent::enqueueRecordCommand(hip::Stream* stream, amd::Command* command) {
-  // Protect event_/ipc_signal_ against concurrent query/synchronize/streamWait.
-  // Not all callers hold Event::lock() (e.g. graph event-record nodes enqueue
-  // directly), so take it here; lock_ is recursive, so the normal addMarker path
-  // that already holds it is unaffected.
-  std::scoped_lock lock(lock_);
-
-  // A single shared IPC signal cannot represent overlapping recordings, and the
-  // consumer is attached to this exact signal (it cannot be rotated). So we must
-  // serialize re-recordings: wait for the previous record's GPU work to drain
-  // before re-arming, otherwise the absolute Reset(1) races with the prior
-  // barrier's pending decrement and a waiter can wake on the wrong recording.
-  // Skip the wait on the first record (signal still at its initial value, never
-  // decremented) — waiting there would hang forever.
-  if (event_ != nullptr) {
-    ipc_signal_->Wait(1, amd::device::Signal::Condition::Lt, UINT64_MAX);
-  }
-
   // Re-arm the signal; GPU barrier will decrement to 0 when work completes
   ipc_signal_->Reset(1);
 


### PR DESCRIPTION
## Motivation

Reverts #6786 which caused **IPC event related crashes (SIGABRT)** in hip-tests on gfx94X-dcgpu.

Regression introduced by #6786 and observed in TheRock CI run [27176631264](https://github.com/ROCm/TheRock/actions/runs/27176631264) (PR [ROCm/TheRock#5704](https://github.com/ROCm/TheRock/pull/5704)).

Failure observed in `hipGetProcAddressIpcApis` test:
```
hipGetProcAddressIpcApis.cc:127: FAILED:
  SIGABRT - Abort (abnormal termination) signal
```

## Issue PR

**#6786** — "clr: Serialize IPC event re-recording to avoid signal re-arm race"

This PR removed `scoped_lock` guards from `IPCEventEmulated::query`, `synchronize`, `streamWait`, `recordCommand`, `enqueueRecordCommand`, `GetHandle`, and `OpenHandle`. Removing these locks reintroduces concurrent access races on IPC event/signal state, leading to aborts in IPC API tests.

## Test Plan

- Verify TheRock CI passes on gfx94X-dcgpu for hip-tests (IPC APIs)
- Verify no SIGABRT in `hipGetProcAddressIpcApis`