### PR TITLE
[AMD-SMI] Locate libamd_smi.so via rocm_sdk for TheRock wheels

### DIFF
--- a/projects/amdsmi/docs/install/install.md
+++ b/projects/amdsmi/docs/install/install.md
@@ -209,7 +209,7 @@ Installing multiple versions of ROCm on the same system can result in the `amd-s
    python3 -m pip install --user .
    ```
 
-   If using TheRock nightlies wheel, after installing ROCm Core SDK, run the following:
+   If using TheRock nightly wheel, after installing ROCm Core SDK, run the following:
    ```
    # To find out which site-packages rocm-sdk-core is installed at, run: pip show rocm-sdk-core
    cd <site-packages>/_rocm_sdk_core/share/amd_smi

--- a/projects/amdsmi/docs/install/install.md
+++ b/projects/amdsmi/docs/install/install.md
@@ -209,6 +209,13 @@ Installing multiple versions of ROCm on the same system can result in the `amd-s
    python3 -m pip install --user .
    ```
 
+   If using TheRock nightlies wheel, after installing ROCm Core SDK, run the following:
+   ```
+   # To find out which site-packages rocm-sdk-core is installed at, run: pip show rocm-sdk-core
+   cd <site-packages>/_rocm_sdk_core/share/amd_smi
+   pip install .
+   ```
+
    > **Note:** `sudo` may be required. On some systems, use `--break-system-packages` if pip installation fails.
 
 3. You should now have the AMD SMI Python library in your Python path:

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -194,7 +194,7 @@ def find_smi_library():
         rocm_sdk_libamd_smi_path = rocm_sdk.find_libraries("amd_smi")
         if rocm_sdk_libamd_smi_path and len(rocm_sdk_libamd_smi_path) > 0:
             possible_locations.append(rocm_sdk_libamd_smi_path[0])
-    except:  # If rocm_sdk is not installed or library is not found, skip
+    except ModuleNotFoundError:  # If rocm_sdk is not installed or library is not found, skip
         pass
     # 2.
     rocm_path = os.getenv("ROCM_HOME", os.getenv("ROCM_PATH"))

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -192,9 +192,9 @@ def find_smi_library():
     try:
         import rocm_sdk
         rocm_sdk_libamd_smi_path = rocm_sdk.find_libraries("amd_smi")
-        if rocm_sdk_libamd_smi_path and len(rocm_sdk_libamd_smi_path) > 0:
+        if rocm_sdk_libamd_smi_path:
             possible_locations.append(rocm_sdk_libamd_smi_path[0])
-    except ModuleNotFoundError:  # If rocm_sdk is not installed or library is not found, skip
+    except (ModuleNotFoundError, FileNotFoundError):  # If rocm_sdk is not installed or library is not found, skip
         pass
     # 2.
     rocm_path = os.getenv("ROCM_HOME", os.getenv("ROCM_PATH"))
@@ -5017,13 +5017,14 @@ __all__ = \
     'amdsmi_board_info_t', 'amdsmi_cache_property_type_t',
     'amdsmi_card_form_factor_t', 'amdsmi_clean_gpu_local_data',
     'amdsmi_clk_info_t', 'amdsmi_clk_limit_type_t',
-    'amdsmi_clk_type_t', 'amdsmi_compute_partition_type_t',
-    'amdsmi_container_types_t', 'amdsmi_counter_command_t',
-    'amdsmi_counter_value_t', 'amdsmi_cper_guid_t',
-    'amdsmi_cper_hdr_t', 'amdsmi_cper_notify_type_t',
-    'amdsmi_cper_sev_t', 'amdsmi_cper_timestamp_t',
-    'amdsmi_cper_valid_bits_t', 'amdsmi_cpu_apb_disable',
-    'amdsmi_cpu_apb_enable', 'amdsmi_cpu_info_t', 'amdsmi_cpu_util_t',
+    'amdsmi_clk_type_t', 'amdsmi_compute_partition_mem_alloc_mode_t',
+    'amdsmi_compute_partition_type_t', 'amdsmi_container_types_t',
+    'amdsmi_counter_command_t', 'amdsmi_counter_value_t',
+    'amdsmi_cper_guid_t', 'amdsmi_cper_hdr_t',
+    'amdsmi_cper_notify_type_t', 'amdsmi_cper_sev_t',
+    'amdsmi_cper_timestamp_t', 'amdsmi_cper_valid_bits_t',
+    'amdsmi_cpu_apb_disable', 'amdsmi_cpu_apb_enable',
+    'amdsmi_cpu_info_t', 'amdsmi_cpu_util_t',
     'amdsmi_cpusocket_handle', 'amdsmi_ddr_bw_metrics_t',
     'amdsmi_dev_perf_level_t', 'amdsmi_dimm_power_t',
     'amdsmi_dimm_thermal_t', 'amdsmi_dpm_level_t',

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -171,13 +171,15 @@ from pathlib import Path
 #    `amdsmi_wrapper.py` is located in
 #    `_rocm_sdk_core/share/amd_smi/amdsmi`, libraries are in
 #    `_rocm_sdk_core/lib`.
-# 1. ROCM_HOME/ROCM_PATH environment variables
+# 1. From TheRock rocm_sdk_core package:
+#    `site-packages/_rocm_sdk_core/lib`.
+# 2. ROCM_HOME/ROCM_PATH environment variables
 #    - ROCM_HOME/lib
 #    - ROCM_PATH/lib (usually set to /opt/rocm/)
-# 2. Decided by the linker
+# 3. Decided by the linker
 #    - LD_LIBRARY_PATH env var
 #    - defined path in /etc/ld.so.conf.d/
-# 3. Relative to amdsmi_wrapper.py
+# 4. Relative to amdsmi_wrapper.py
 #    - parent directory
 #    - current directory
 def find_smi_library():
@@ -187,12 +189,20 @@ def find_smi_library():
     libamd_smi_path = Path(__file__).resolve().parent.parent.parent.parent / "lib/libamd_smi.so.26"
     possible_locations.append(libamd_smi_path)
     # 1.
+    try:
+        import rocm_sdk
+        rocm_sdk_libamd_smi_path = rocm_sdk.find_libraries("amd_smi")
+        if rocm_sdk_libamd_smi_path and len(rocm_sdk_libamd_smi_path) > 0:
+            possible_locations.append(rocm_sdk_libamd_smi_path[0])
+    except:  # If rocm_sdk is not installed or library is not found, skip
+        pass
+    # 2.
     rocm_path = os.getenv("ROCM_HOME", os.getenv("ROCM_PATH"))
     if rocm_path:
         possible_locations.append(os.path.join(rocm_path, "lib/libamd_smi.so"))
-    # 2.
-    possible_locations.append("libamd_smi.so")
     # 3.
+    possible_locations.append("libamd_smi.so")
+    # 4.
     libamd_smi_parent_dir = Path(__file__).resolve().parent / "libamd_smi.so"
     libamd_smi_cwd = Path.cwd() / "libamd_smi.so"
     possible_locations.append(libamd_smi_parent_dir)

--- a/projects/amdsmi/tools/generator.py
+++ b/projects/amdsmi/tools/generator.py
@@ -188,13 +188,15 @@ def main():
 #    `amdsmi_wrapper.py` is located in
 #    `_rocm_sdk_core/share/amd_smi/amdsmi`, libraries are in
 #    `_rocm_sdk_core/lib`.
-# 1. ROCM_HOME/ROCM_PATH environment variables
+# 1. From TheRock rocm_sdk_core package:
+#    `site-packages/_rocm_sdk_core/lib`.
+# 2. ROCM_HOME/ROCM_PATH environment variables
 #    - ROCM_HOME/lib
 #    - ROCM_PATH/lib (usually set to /opt/rocm/)
-# 2. Decided by the linker
+# 3. Decided by the linker
 #    - LD_LIBRARY_PATH env var
 #    - defined path in /etc/ld.so.conf.d/
-# 3. Relative to amdsmi_wrapper.py
+# 4. Relative to amdsmi_wrapper.py
 #    - parent directory
 #    - current directory
 def find_smi_library():
@@ -204,12 +206,20 @@ def find_smi_library():
     libamd_smi_path = Path(__file__).resolve().parent.parent.parent.parent / "lib/libamd_smi.so.26"
     possible_locations.append(libamd_smi_path)
     # 1.
+    try:
+        import rocm_sdk
+        rocm_sdk_libamd_smi_path = rocm_sdk.find_libraries("amd_smi")
+        if rocm_sdk_libamd_smi_path:
+            possible_locations.append(rocm_sdk_libamd_smi_path[0])
+    except (ModuleNotFoundError, FileNotFoundError):  # If rocm_sdk is not installed or library is not found, skip
+        pass
+    # 2.
     rocm_path = os.getenv("ROCM_HOME", os.getenv("ROCM_PATH"))
     if rocm_path:
         possible_locations.append(os.path.join(rocm_path, "lib/{library_name}"))
-    # 2.
-    possible_locations.append("{library_name}")
     # 3.
+    possible_locations.append("{library_name}")
+    # 4.
     libamd_smi_parent_dir = Path(__file__).resolve().parent / "{library_name}"
     libamd_smi_cwd = Path.cwd() / "{library_name}"
     possible_locations.append(libamd_smi_parent_dir)


### PR DESCRIPTION
## Motivation

Part of https://github.com/ROCm/ROCm/issues/6340

This change adds using TheRock `rocm_sdk.find_libraries` to locate `libamd_smi.so.*`. 
This change is required for separate Python binding installation to work with TheRock wheel installation.

## Technical Details

Update .so finding logic with `rocm_sdk.find_libraries` call.

## JIRA ID

N/A

## Test Plan

1. Install TheRock multi-arch SDK & core wheels.
2. `cd <site-packages>/_rocm_sdk_core/share/amd_smi` & `pip install .`
Before: `import amdsmi` will error with .so not found (Or includes the wrong .so from system installation)
After: `import amdsmi` finds and use the correct .so from TheRock wheel.

## Test Result

Test pass with multi-arch whl.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
