### PR TITLE
[rocprofiler-systems] Add redhat sysdeps workflow

### DIFF
--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -73,7 +73,8 @@ jobs:
             rocm-version: '7.0'
 
     steps:
-    - uses: actions/checkout@v6
+    - &sparse-checkout
+      uses: actions/checkout@v6
       with:
         sparse-checkout: |
           projects/rocprofiler-systems/
@@ -116,7 +117,8 @@ jobs:
           ccache-redhat-${{ github.job }}-${{ matrix.os-release }}-${{ matrix.compiler }}-${{ matrix.rocm-version }}-${{ matrix.build-type }}-
           ccache-redhat-${{ github.job }}-${{ matrix.os-release }}-${{ matrix.compiler }}-${{ matrix.rocm-version }}-
 
-    - name: Configure ccache
+    - &configure-ccache
+      name: Configure ccache
       run: |
         mkdir -p "${CCACHE_DIR}"
         ccache --max-size=1G
@@ -164,7 +166,8 @@ jobs:
           --
           -LE "network|gpu"
 
-    - name: ccache stats
+    - &ccache-stats
+      name: ccache stats
       if: always()
       run: |
         echo "=== ccache stats ==="
@@ -210,6 +213,195 @@ jobs:
       run: |
         set -v
         ./scripts/test-find-package.sh --install-dir /opt/rocprofiler-systems
+
+    - name: CTest Artifacts
+      if: failure()
+      continue-on-error: True
+      uses: actions/upload-artifact@v7
+      with:
+        name: ctest-${{ github.job }}-${{ strategy.job-index }}-log
+        path: |
+          projects/rocprofiler-systems/build/*.log
+
+    - name: Data Artifacts
+      if: failure()
+      continue-on-error: True
+      uses: actions/upload-artifact@v7
+      with:
+        name: data-${{ github.job }}-${{ strategy.job-index }}-files
+        path: |
+          projects/rocprofiler-systems/build/rocprofsys-tests-config/*.cfg
+          projects/rocprofiler-systems/build/rocprofsys-tests-output/**/*.txt
+          projects/rocprofiler-systems/build/rocprofsys-tests-output/**/*-instr*.json
+
+    - name: Kill Perfetto
+      if: success() || failure()
+      continue-on-error: True
+      working-directory: projects/rocprofiler-systems/
+      run: |
+        set +e
+        RUNNING_PROCS=$(pgrep trace_processor_shell)
+        if [ -n "${RUNNING_PROCS}" ]; then kill -s 9 ${RUNNING_PROCS}; fi
+
+  rhel-system-deps:
+    runs-on: ubuntu-latest
+    container:
+      image: dgaliffiamd/rocprofiler-systems:ci-rocm-7.2-rhel-${{ matrix.os-release }}
+      options: --shm-size=512m
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # RHEL 8.10's system TBB (2018.2) is older than the effective
+        # minimum (2018.6) required by the oneTBB targets
+        os-release: ['9', '10']
+        compiler: ['g++', 'amdclang++']
+        include:
+          - compiler: 'g++'
+            cc: 'gcc'
+            use-clang-omp: 'OFF'
+          - compiler: 'amdclang++'
+            cc: 'amdclang'
+            use-clang-omp: 'ON'
+
+    steps:
+    - *sparse-checkout
+
+    - name: Configure Env
+      shell: bash
+      working-directory: projects/rocprofiler-systems/
+      run:
+        echo "CC=${{ matrix.cc }}" >> $GITHUB_ENV &&
+        echo "CXX=${{ matrix.compiler }}" >> $GITHUB_ENV &&
+        echo "OS_VERSION_MAJOR=$(cat /etc/os-release | grep 'VERSION_ID' | sed 's/=/ /1' | awk '{print $NF}' | sed 's/"//g' | sed 's/\./ /g' | awk '{print $1}')" >> $GITHUB_ENV &&
+        echo "/opt/rocm/bin" >> $GITHUB_PATH &&
+        echo "/opt/rocm/llvm/bin" >> $GITHUB_PATH &&
+        echo "ROCM_PATH=/opt/rocm" >> $GITHUB_ENV &&
+        echo "LD_LIBRARY_PATH=/opt/rocm/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV &&
+        env
+
+    - name: Install Packages
+      shell: bash
+      working-directory: projects/rocprofiler-systems/
+      run: |
+          if [ $OS_VERSION_MAJOR -eq 10 ]; then
+            # TODO: Move package install to the docker.
+            dnf install -y --enablerepo=crb mpich mpich-devel
+            echo "/usr/lib64/mpich/bin" >> $GITHUB_PATH
+          fi
+
+    - name: Install System Dependency Packages
+      timeout-minutes: 25
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 #v4.0.0
+      with:
+        retry_wait_seconds: 30
+        timeout_minutes: 25
+        max_attempts: 5
+        shell: bash
+        command: |
+          # System TBB (ROCPROFSYS_BUILD_TBB=OFF) lives in CodeReady Builder (crb)
+          # on RHEL 9/10; binutils-devel provides libiberty/BFD
+          # (ROCPROFSYS_BUILD_LIBIBERTY=OFF). elfutils (libdw/libelf) is already
+          # present in the base image.
+          dnf install -y --enablerepo=crb tbb-devel
+          dnf install -y binutils-devel
+          dnf clean all
+
+    - name: Restore ccache
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.ccache
+        key: ccache-redhat-system-deps-${{ github.job }}-${{ matrix.os-release }}-${{ matrix.compiler }}-${{ github.sha }}
+        restore-keys: |
+          ccache-redhat-system-deps-${{ github.job }}-${{ matrix.os-release }}-${{ matrix.compiler }}-
+
+    - *configure-ccache
+
+    - name: Install Python Test Dependencies
+      timeout-minutes: 10
+      shell: bash
+      working-directory: projects/rocprofiler-systems/
+      run: |
+        for env_dir in /opt/conda/envs/py3.{8,9,10,11,12,13}/; do
+          if [ -d "${env_dir}" ] && [ -x "${env_dir}bin/python3" ]; then
+            echo "Installing requirements into ${env_dir}"
+            "${env_dir}bin/python3" -m pip install -r requirements.txt
+          fi
+        done
+
+    - name: Configure, Build, and Test with System Dependencies
+      timeout-minutes: 115
+      shell: bash
+      working-directory: projects/rocprofiler-systems/
+      env:
+        CMAKE_C_COMPILER_LAUNCHER: ccache
+        CMAKE_CXX_COMPILER_LAUNCHER: ccache
+      run: |
+        git config --global --add safe.directory ${GITHUB_WORKSPACE}
+        git config --global --add safe.directory ${PWD}
+        echo "CMake version: $(cmake --version | head -n 1)"
+        echo "Compiler version: $(${{ matrix.compiler }} --version | head -n 1)"
+        echo "ROCm version: 7.2"
+        echo "Testing build with SYSTEM dependencies (ROCPROFSYS_BUILD_{TBB,ELFUTILS,LIBIBERTY}=OFF; Dyninst from source)"
+        python3 ./scripts/run-ci.py -B build \
+          --name ${{ github.repository_owner }}-${{ github.ref_name }}-rhel-${{ matrix.os-release }}-system-deps-${{ matrix.compiler }} \
+          --build-jobs $(nproc) \
+          --site GitHub \
+          -- \
+          -DCMAKE_C_COMPILER=${{ matrix.cc }} \
+          -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/opt/rocprofiler-systems-dev \
+          -DROCPROFSYS_BUILD_TESTING=ON \
+          -DROCPROFSYS_USE_PYTHON=ON \
+          -DROCPROFSYS_USE_MPI_HEADERS=ON \
+          -DROCPROFSYS_CI_MPI_RUN_AS_ROOT=ON \
+          -DROCPROFSYS_BUILD_DYNINST=ON \
+          -DROCPROFSYS_BUILD_TBB=OFF \
+          -DROCPROFSYS_BUILD_ELFUTILS=OFF \
+          -DROCPROFSYS_BUILD_LIBIBERTY=OFF \
+          -DROCPROFSYS_BUILD_HIDDEN_VISIBILITY=ON \
+          -DROCPROFSYS_PYTHON_PREFIX=/opt/conda/envs \
+          -DROCPROFSYS_PYTHON_ENVS="py3.8;py3.9;py3.10;py3.11;py3.12;py3.13" \
+          -DROCPROFSYS_STRIP_LIBRARIES=OFF \
+          -DROCPROFSYS_MAX_THREADS=64 \
+          -DROCPROFSYS_DISABLE_EXAMPLES="transpose;rccl;openmp-target;openmp-vv;videodecode;jpegdecode;network" \
+          -DROCPROFSYS_BUILD_NUMBER=${{ github.run_attempt }} \
+          -DUSE_CLANG_OMP=${{ matrix.use-clang-omp }} \
+          -- \
+          -LE "network|gpu"
+
+    - *ccache-stats
+
+    - name: Check for Leftover Buffered Files
+      timeout-minutes: 5
+      working-directory: projects/rocprofiler-systems/
+      run: |
+        set -v
+        if find /tmp -maxdepth 1 -name 'buffered*' -print -quit | grep -q .; then
+          echo "Error: Found leftover buffered storage files in /tmp:"
+          ls -lh /tmp/buffered*
+          exit 1
+        else
+          echo "✓ No buffered storage files found in /tmp"
+        fi
+
+    - name: Install
+      timeout-minutes: 10
+      working-directory: projects/rocprofiler-systems/
+      run: |
+        cmake --install build --prefix /opt/rocprofiler-systems
+
+    - name: Test Install
+      timeout-minutes: 10
+      shell: bash
+      working-directory: projects/rocprofiler-systems/
+      run: |
+        set -v
+        source /opt/rocprofiler-systems/share/rocprofiler-systems/setup-env.sh
+        export PYTHON_EXECUTABLE=/opt/conda/envs/py3.8/bin/python
+        export PATH=/opt/conda/envs/py3.8/bin:${PATH}
+        ./scripts/test-install.sh --test-rocprof-sys-{instrument,avail,sample,rewrite,runtime,python}=1
 
     - name: CTest Artifacts
       if: failure()

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -1,6 +1,9 @@
 name: rocprofiler-systems RedHat Linux (GCC, Python, ROCm)
 run-name: redhat
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/projects/rocprofiler-systems/source/lib/binary/symbol.cpp
+++ b/projects/rocprofiler-systems/source/lib/binary/symbol.cpp
@@ -13,7 +13,9 @@
 #define L_LNNO_SIZE 4
 
 #include <elf.h>
-// Older elf.h versions may not define the newer RELR relocation format
+// The RELR (relative-relocation) types were added to glibc's <elf.h> in glibc 2.36.
+// Older glibc versions (e.g. RHEL 8/9) lack them, but they are referenced by the
+// binutils headers below, so define the typedefs here to avoid compile errors.
 #ifndef SHT_RELR
 typedef Elf32_Word  Elf32_Relr;
 typedef Elf64_Xword Elf64_Relr;

--- a/projects/rocprofiler-systems/source/lib/binary/symbol.cpp
+++ b/projects/rocprofiler-systems/source/lib/binary/symbol.cpp
@@ -12,6 +12,13 @@
 #define PACKAGE     "rocprofiler-systems"
 #define L_LNNO_SIZE 4
 
+#include <elf.h>
+// Older elf.h versions may not define the newer RELR relocation format
+#ifndef SHT_RELR
+typedef Elf32_Word  Elf32_Relr;
+typedef Elf64_Xword Elf64_Relr;
+#endif
+
 #include <bfd.h>
 #include <coff/external.h>
 #include <coff/internal.h>


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Add a workflow that builds `rocprofiler-systems` using existing sysdeps.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Added missing `elf.h` include. Also define `RELR` as older RHEL `elf.h` headers may not have these defined. These defines are referenced by the binutils header, so we need to define them to avoid compilation error.

Specifically, RELR was introduced in glibc 2.36. RHEL8/9 do not have these:
https://gist.github.com/richardlau/6a01d7829cc33ddab35269dacc127680

RHEL 8.10 is excluded, the system TBB is too old. It would have to be built from source.
```
        # RHEL 8.10's system TBB (2018.2) is older than the effective
        # minimum (2018.6) required by the oneTBB targets
```

Also add:
```
permissions:
  contents: read
```
to the top of the workflow file (security bot flagged this, and other workflows do this).

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-537

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Four new workflows:
 - 2 on RHEL 9, one with LLVM, the other with GNU
 - 2 on RHEL 10, one with LLVM, the other with GNU

## Test Result

<!-- Briefly summarize test outcomes. -->

New workflows pass:
 - https://github.com/ROCm/rocm-systems/actions/runs/27420992081/job/81046227908?pr=7095
 - https://github.com/ROCm/rocm-systems/actions/runs/27420992081/job/81046227619?pr=7095
 - https://github.com/ROCm/rocm-systems/actions/runs/27420992081/job/81046227622?pr=7095
 - https://github.com/ROCm/rocm-systems/actions/runs/27420992081/job/81046227900?pr=7095

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
