### PR TITLE
kfdtest: Aggregate node failures in run_kfdtest.sh

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/run_kfdtest.sh
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/run_kfdtest.sh
@@ -239,6 +239,7 @@ runKfdTest() {
         hsaNodes=$NODE
     fi
 
+    local aggregate_fail=0
     for hsaNode in $hsaNodes; do
         nodeName=$(getNodeName $hsaNode)
         if [ "$PLATFORM" != "" ] && [ "$PLATFORM" != "$nodeName" ]; then
@@ -266,31 +267,43 @@ runKfdTest() {
                 echo "Finished node $hsaNode ($nodeName) successfully in docker container"
             else
                 echo "Testing failed for node $hsaNode ($nodeName) in docker container"
+                ((aggregate_fail+=1))
             fi
             sudo docker rm kfdtest_docker
         else
             if [ -n "$CONCURRENTNODES" ]; then
                 echo "++++ Starting parallel testing on node(s) $CONCURRENTNODES  ++++"
                 $GDB $KFDTEST "--concurrentnodes=$CONCURRENTNODES" $gtestFilter $GTEST_ARGS
+                if [ "$?" != "0" ]; then
+                    ((aggregate_fail+=1))
+                fi
                 echo "++++ Finished parallel testing on node(s) $CONCURRENTNODES  ++++"
-                exit 0;
+                exit $aggregate_fail;
             elif [ -n "$TESTNODENUM" ]; then
                 echo "++++ Starting parallel testing on $TESTNODENUM node(s) ++++"
                 $GDB $KFDTEST "--testnodenum=$TESTNODENUM" $gtestFilter $GTEST_ARGS
+                if [ "$?" != "0" ]; then
+                    ((aggregate_fail+=1))
+                fi
                 echo "++++ Finished parallel testing on $TESTNODENUM node(s) ++++"
-                exit 0;
+                exit $aggregate_fail;
             else
                 echo ""
                 echo "++++ Starting testing node $hsaNode ($nodeName) ++++"
                 $GDB $KFDTEST "--node=$hsaNode" $gtestFilter $GTEST_ARGS
+                if [ "$?" != "0" ]; then
+                    ((aggregate_fail+=1))
+                fi
                 echo "---- Finished testing node $hsaNode ($nodeName) ----"
             fi
-
         fi
 
 
     done
-
+    if [ $aggregate_fail -ne 0 ]; then
+        echo "NOTE: $aggregate_fail nodes failed at least one test"
+    fi
+    exit $aggregate_fail
 }
 
 # Prints number of GPUs present in the system


### PR DESCRIPTION
Currently the run_kfdtest.sh script will return 0 for parallel runs and single-node runs, and will only return the exit status of the last kfdtest node run. So the first 7 could fail and only the last one pass, and it would return success. Aggregate the failures and return that instead, to give a better indication of whether it passed or not

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
ISSUE ID #1234567
No JIRA for this

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
