### PR TITLE
[rocSHMEM] Add grid barrier to separate skip iterations from timed ones

### DIFF
--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -701,7 +701,7 @@ TestHeatMapRMA() {
   NOTIMEOUT=1
   NOVERIF=1
   # Batch rotation allocates volume*batch*2 = 20 GiB; use 22 GiB to leave headroom
-  ROCSHMEM_HEAP_SIZE=${ROCSHMEM_HEAP_SIZE:-$((22*1024*1024*1024))}
+  ROCSHMEM_HEAP_SIZE=$(( ROCSHMEM_HEAP_SIZE > 22*1024*1024*1024 ? ROCSHMEM_HEAP_SIZE : 22*1024*1024*1024 ))
   ##############################################################################
   #       | Name             | Ranks | Workgroups | Threads | Max Message Size #
   ##############################################################################

--- a/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
@@ -148,15 +148,14 @@ DefaultCTXPrimitiveTester::DefaultCTXPrimitiveTester(TesterArguments args)
   int max_co_resident_wgs_per_cu = 0;
   CHECK_HIP(hipOccupancyMaxActiveBlocksPerMultiprocessor(
       &max_co_resident_wgs_per_cu, DefaultCTXPrimitiveTest, args.wg_size, 0));
-  hipDeviceProp_t device_prop;
-  CHECK_HIP(hipGetDeviceProperties(&device_prop, 0));
   const int max_sustainable_wgs =
-      max_co_resident_wgs_per_cu * device_prop.multiProcessorCount;
-  if (args.num_wgs > max_sustainable_wgs) {
-    std::cout << "Warning: Number of work-groups (" << args.num_wgs
-              << ") exceeds max sustainable work-groups ("
-              << max_sustainable_wgs << "). grid_barrier may deadlock."
-              << std::endl;
+      max_co_resident_wgs_per_cu * deviceProps.multiProcessorCount;
+  if (args.num_wgs > static_cast<unsigned>(max_sustainable_wgs)) {
+    std::cout << "Warning: Requested work-groups (" << args.num_wgs
+              << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
+              << "). Capping to " << max_sustainable_wgs
+              << " to avoid grid_barrier deadlock." << std::endl;
+    args.num_wgs = max_sustainable_wgs;
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
@@ -198,7 +198,7 @@ void DefaultCTXPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,
                                              int loop, size_t size) {
   size_t shared_bytes = 0;
 
-  CHECK_HIP(hipMemset(grid_psync, 0, sizeof(int)));
+  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
   hipLaunchKernelGGL(DefaultCTXPrimitiveTest, gridSize, blockSize,
                      shared_bytes, stream, loop, args.skip, start_time,
                      end_time, source, dest, size, _type, _shmem_context,

--- a/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
@@ -145,6 +145,20 @@ DefaultCTXPrimitiveTester::DefaultCTXPrimitiveTester(TesterArguments args)
   char *remote = (char *) alloc_test_buffer(buff_size);
   CHECK_HIP(hipMalloc(&grid_psync, sizeof(int)));
 
+  int max_co_resident_wgs_per_cu = 0;
+  CHECK_HIP(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      &max_co_resident_wgs_per_cu, DefaultCTXPrimitiveTest, args.wg_size, 0));
+  hipDeviceProp_t device_prop;
+  CHECK_HIP(hipGetDeviceProperties(&device_prop, 0));
+  const int max_sustainable_wgs =
+      max_co_resident_wgs_per_cu * device_prop.multiProcessorCount;
+  if (args.num_wgs > max_sustainable_wgs) {
+    std::cout << "Warning: Number of work-groups (" << args.num_wgs
+              << ") exceeds max sustainable work-groups ("
+              << max_sustainable_wgs << "). grid_barrier may deadlock."
+              << std::endl;
+  }
+
   switch (_type) {
     case DefaultCTXPutTestType:
     case DefaultCTXPutNBITestType:
@@ -191,14 +205,14 @@ DefaultCTXPrimitiveTester::~DefaultCTXPrimitiveTester() {
 
 void DefaultCTXPrimitiveTester::resetBuffers(size_t size) {
   size_t buff_size = size * batch_size * args.wg_size * args.num_wgs;
-  CHECK_HIP(hipMemset(dest, '1', buff_size));
+  CHECK_HIP(hipMemsetAsync(dest, '1', buff_size, stream));
+  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
 }
 
 void DefaultCTXPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,
                                              int loop, size_t size) {
   size_t shared_bytes = 0;
 
-  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
   hipLaunchKernelGGL(DefaultCTXPrimitiveTest, gridSize, blockSize,
                      shared_bytes, stream, loop, args.skip, start_time,
                      end_time, source, dest, size, _type, _shmem_context,

--- a/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
@@ -36,7 +36,7 @@ __global__ void DefaultCTXPrimitiveTest(int loop, int skip,
                               long long int *end_time, char *source,
                               char *dest, size_t size, TestType type,
                               [[maybe_unused]] ShmemContextType ctx_type,
-                              int wf_size, int batch) {
+                              int wf_size, int batch, int *grid_psync) {
   int wg_id = get_flat_grid_id();
   int t_id  = get_flat_block_id();
   int wf_id = t_id / wf_size;
@@ -71,6 +71,10 @@ __global__ void DefaultCTXPrimitiveTest(int loop, int skip,
       }
       __syncthreads();
       if (i == skip) {
+        // Global barrier ensures all WGs have finished their skip-region
+        // puts before any WG starts timing, preventing skip traffic from
+        // contaminating the timed window.
+        grid_barrier(grid_psync, gridDim.x);
         // Capture the start time of each wavefront to identify the earliest one
         wf_start_time[wf_id] = wall_clock64();
       }
@@ -139,6 +143,7 @@ DefaultCTXPrimitiveTester::DefaultCTXPrimitiveTester(TesterArguments args)
   size_t buff_size = max_msg_size * batch_size * args.wg_size * args.num_wgs;
   char *local = (char *) alloc_test_buffer(buff_size, args.local_buf_type);
   char *remote = (char *) alloc_test_buffer(buff_size);
+  CHECK_HIP(hipMalloc(&grid_psync, sizeof(int)));
 
   switch (_type) {
     case DefaultCTXPutTestType:
@@ -181,6 +186,7 @@ DefaultCTXPrimitiveTester::~DefaultCTXPrimitiveTester() {
 
   free_test_buffer(local, args.local_buf_type);
   free_test_buffer(remote);
+  CHECK_HIP(hipFree(grid_psync));
 }
 
 void DefaultCTXPrimitiveTester::resetBuffers(size_t size) {
@@ -192,10 +198,11 @@ void DefaultCTXPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,
                                              int loop, size_t size) {
   size_t shared_bytes = 0;
 
+  CHECK_HIP(hipMemset(grid_psync, 0, sizeof(int)));
   hipLaunchKernelGGL(DefaultCTXPrimitiveTest, gridSize, blockSize,
                      shared_bytes, stream, loop, args.skip, start_time,
                      end_time, source, dest, size, _type, _shmem_context,
-                     wf_size, batch_size);
+                     wf_size, batch_size, grid_psync);
 
   num_msgs = (loop + args.skip) * gridSize.x * blockSize.x;
   num_timed_msgs = loop * gridSize.x * blockSize.x;

--- a/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.hpp
@@ -45,6 +45,7 @@ class DefaultCTXPrimitiveTester : public Tester {
 
   char *source = nullptr;
   char *dest = nullptr;
+  int *grid_psync = nullptr;
 };
 
 #endif

--- a/projects/rocshmem/tests/functional_tests/flood_amo_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/flood_amo_tester.cpp
@@ -205,8 +205,8 @@ FloodAmoTester::~FloodAmoTester() {
 }
 
 void FloodAmoTester::resetBuffers([[maybe_unused]] size_t size) {
-  CHECK_HIP(hipMemset(d_buf, 0, sizeof(uint64_t) * args.num_wgs));
-  CHECK_HIP(hipMemset(grid_psync, 0, 4 * sizeof(int)));
+  CHECK_HIP(hipMemsetAsync(d_buf, 0, sizeof(uint64_t) * args.num_wgs, stream));
+  CHECK_HIP(hipMemsetAsync(grid_psync, 0, 4 * sizeof(int), stream));
 }
 
 void FloodAmoTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,

--- a/projects/rocshmem/tests/functional_tests/primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/primitive_tester.cpp
@@ -148,15 +148,14 @@ PrimitiveTester::PrimitiveTester(TesterArguments args) : Tester(args) {
   int max_co_resident_wgs_per_cu = 0;
   CHECK_HIP(hipOccupancyMaxActiveBlocksPerMultiprocessor(
       &max_co_resident_wgs_per_cu, PrimitiveTest, args.wg_size, 0));
-  hipDeviceProp_t device_prop;
-  CHECK_HIP(hipGetDeviceProperties(&device_prop, 0));
   const int max_sustainable_wgs =
-      max_co_resident_wgs_per_cu * device_prop.multiProcessorCount;
-  if (args.num_wgs > max_sustainable_wgs) {
-    std::cout << "Warning: Number of work-groups (" << args.num_wgs
-              << ") exceeds max sustainable work-groups ("
-              << max_sustainable_wgs << "). grid_barrier may deadlock."
-              << std::endl;
+      max_co_resident_wgs_per_cu * deviceProps.multiProcessorCount;
+  if (args.num_wgs > static_cast<unsigned>(max_sustainable_wgs)) {
+    std::cout << "Warning: Requested work-groups (" << args.num_wgs
+              << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
+              << "). Capping to " << max_sustainable_wgs
+              << " to avoid grid_barrier deadlock." << std::endl;
+    args.num_wgs = max_sustainable_wgs;
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/primitive_tester.cpp
@@ -145,6 +145,20 @@ PrimitiveTester::PrimitiveTester(TesterArguments args) : Tester(args) {
   char *remote = (char *) alloc_test_buffer(buff_size);
   CHECK_HIP(hipMalloc(&grid_psync, sizeof(int)));
 
+  int max_co_resident_wgs_per_cu = 0;
+  CHECK_HIP(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      &max_co_resident_wgs_per_cu, PrimitiveTest, args.wg_size, 0));
+  hipDeviceProp_t device_prop;
+  CHECK_HIP(hipGetDeviceProperties(&device_prop, 0));
+  const int max_sustainable_wgs =
+      max_co_resident_wgs_per_cu * device_prop.multiProcessorCount;
+  if (args.num_wgs > max_sustainable_wgs) {
+    std::cout << "Warning: Number of work-groups (" << args.num_wgs
+              << ") exceeds max sustainable work-groups ("
+              << max_sustainable_wgs << "). grid_barrier may deadlock."
+              << std::endl;
+  }
+
   switch (_type) {
     case PutTestType:
     case PutNBITestType:
@@ -191,14 +205,14 @@ PrimitiveTester::~PrimitiveTester() {
 
 void PrimitiveTester::resetBuffers(size_t size) {
   size_t buff_size = size * batch_size * args.wg_size * args.num_wgs;
-  CHECK_HIP(hipMemset(dest, '1', buff_size));
+  CHECK_HIP(hipMemsetAsync(dest, '1', buff_size, stream));
+  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
 }
 
 void PrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
                                    size_t size) {
   size_t shared_bytes = 0;
 
-  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
   hipLaunchKernelGGL(PrimitiveTest, gridSize, blockSize, shared_bytes, stream,
                      loop, args.skip, start_time, end_time, source, dest,
                      size, _type, _shmem_context, wf_size,

--- a/projects/rocshmem/tests/functional_tests/primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/primitive_tester.cpp
@@ -35,7 +35,7 @@ __global__ void PrimitiveTest(int loop, int skip, long long int *start_time,
                               long long int *end_time, char *source,
                               char *dest, size_t size, TestType type,
                               ShmemContextType ctx_type, int wf_size,
-                              int batch) {
+                              int batch, int *grid_psync) {
   __shared__ rocshmem_ctx_t ctx;
   int wg_id = get_flat_grid_id();
   int t_id  = get_flat_block_id();
@@ -72,6 +72,10 @@ __global__ void PrimitiveTest(int loop, int skip, long long int *start_time,
       }
       __syncthreads();
       if (i == skip) {
+        // Global barrier ensures all WGs have finished their skip-region
+        // puts before any WG starts timing, preventing skip traffic from
+        // contaminating the timed window.
+        grid_barrier(grid_psync, gridDim.x);
         // Capture the start time of each wavefront to identify the earliest one
         wf_start_time[wf_id] = wall_clock64();
       }
@@ -139,6 +143,7 @@ PrimitiveTester::PrimitiveTester(TesterArguments args) : Tester(args) {
   size_t buff_size = max_msg_size * batch_size * args.wg_size * args.num_wgs;
   char *local = (char *) alloc_test_buffer(buff_size, args.local_buf_type);
   char *remote = (char *) alloc_test_buffer(buff_size);
+  CHECK_HIP(hipMalloc(&grid_psync, sizeof(int)));
 
   switch (_type) {
     case PutTestType:
@@ -181,6 +186,7 @@ PrimitiveTester::~PrimitiveTester() {
 
   free_test_buffer(local, args.local_buf_type);
   free_test_buffer(remote);
+  CHECK_HIP(hipFree(grid_psync));
 }
 
 void PrimitiveTester::resetBuffers(size_t size) {
@@ -192,10 +198,11 @@ void PrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
                                    size_t size) {
   size_t shared_bytes = 0;
 
+  CHECK_HIP(hipMemset(grid_psync, 0, sizeof(int)));
   hipLaunchKernelGGL(PrimitiveTest, gridSize, blockSize, shared_bytes, stream,
                      loop, args.skip, start_time, end_time, source, dest,
                      size, _type, _shmem_context, wf_size,
-                     batch_size);
+                     batch_size, grid_psync);
 
   num_msgs = (loop + args.skip) * gridSize.x * blockSize.x;
   num_timed_msgs = loop * gridSize.x * blockSize.x;

--- a/projects/rocshmem/tests/functional_tests/primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/primitive_tester.cpp
@@ -198,7 +198,7 @@ void PrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,
                                    size_t size) {
   size_t shared_bytes = 0;
 
-  CHECK_HIP(hipMemset(grid_psync, 0, sizeof(int)));
+  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
   hipLaunchKernelGGL(PrimitiveTest, gridSize, blockSize, shared_bytes, stream,
                      loop, args.skip, start_time, end_time, source, dest,
                      size, _type, _shmem_context, wf_size,

--- a/projects/rocshmem/tests/functional_tests/primitive_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/primitive_tester.hpp
@@ -45,6 +45,7 @@ class PrimitiveTester : public Tester {
 
   char *source = nullptr;
   char *dest = nullptr;
+  int *grid_psync = nullptr;
 };
 
 #endif

--- a/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.cpp
@@ -37,7 +37,8 @@ __global__ void TeamCtxPrimitiveTest(int loop, int skip, long long int *start_ti
                                      long long int *end_time, char *source,
                                      char *dest, size_t size, TestType type,
                                      ShmemContextType ctx_type, int wf_size,
-                                     rocshmem_team_t team, int batch) {
+                                     rocshmem_team_t team, int batch,
+                                     int *grid_psync) {
   __shared__ rocshmem_ctx_t ctx;
   int wg_id = get_flat_grid_id();
   int t_id  = get_flat_block_id();
@@ -75,6 +76,10 @@ __global__ void TeamCtxPrimitiveTest(int loop, int skip, long long int *start_ti
       }
       __syncthreads();
       if (i == skip) {
+        // Global barrier ensures all WGs have finished their skip-region
+        // puts before any WG starts timing, preventing skip traffic from
+        // contaminating the timed window.
+        grid_barrier(grid_psync, gridDim.x);
         // Capture the start time of each wavefront to identify the earliest one
         wf_start_time[wf_id] = wall_clock64();
       }
@@ -133,6 +138,7 @@ TeamCtxPrimitiveTester::TeamCtxPrimitiveTester(TesterArguments args)
   size_t buff_size = max_msg_size * batch_size * args.wg_size * args.num_wgs;
   char *local = (char *) alloc_test_buffer(buff_size, args.local_buf_type);
   char *remote = (char *) alloc_test_buffer(buff_size);
+  CHECK_HIP(hipMalloc(&grid_psync, sizeof(int)));
 
   switch (_type) {
     case TeamCtxPutTestType:
@@ -172,6 +178,7 @@ TeamCtxPrimitiveTester::~TeamCtxPrimitiveTester() {
 
   free_test_buffer(local, args.local_buf_type);
   free_test_buffer(remote);
+  CHECK_HIP(hipFree(grid_psync));
 }
 
 void TeamCtxPrimitiveTester::resetBuffers(size_t size) {
@@ -191,10 +198,11 @@ void TeamCtxPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,
                                           int loop, size_t size) {
   size_t shared_bytes = 0;
 
+  CHECK_HIP(hipMemset(grid_psync, 0, sizeof(int)));
   hipLaunchKernelGGL(TeamCtxPrimitiveTest, gridSize, blockSize, shared_bytes,
                      stream, loop, args.skip, start_time, end_time, source,
                      dest, size, _type, _shmem_context, wf_size,
-                     team_primitive_world_dup, batch_size);
+                     team_primitive_world_dup, batch_size, grid_psync);
 
   num_msgs = (loop + args.skip) * gridSize.x * blockSize.x;
   num_timed_msgs = loop * gridSize.x * blockSize.x;

--- a/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.cpp
@@ -143,15 +143,14 @@ TeamCtxPrimitiveTester::TeamCtxPrimitiveTester(TesterArguments args)
   int max_co_resident_wgs_per_cu = 0;
   CHECK_HIP(hipOccupancyMaxActiveBlocksPerMultiprocessor(
       &max_co_resident_wgs_per_cu, TeamCtxPrimitiveTest, args.wg_size, 0));
-  hipDeviceProp_t device_prop;
-  CHECK_HIP(hipGetDeviceProperties(&device_prop, 0));
   const int max_sustainable_wgs =
-      max_co_resident_wgs_per_cu * device_prop.multiProcessorCount;
-  if (args.num_wgs > max_sustainable_wgs) {
-    std::cout << "Warning: Number of work-groups (" << args.num_wgs
-              << ") exceeds max sustainable work-groups ("
-              << max_sustainable_wgs << "). grid_barrier may deadlock."
-              << std::endl;
+      max_co_resident_wgs_per_cu * deviceProps.multiProcessorCount;
+  if (args.num_wgs > static_cast<unsigned>(max_sustainable_wgs)) {
+    std::cout << "Warning: Requested work-groups (" << args.num_wgs
+              << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
+              << "). Capping to " << max_sustainable_wgs
+              << " to avoid grid_barrier deadlock." << std::endl;
+    args.num_wgs = max_sustainable_wgs;
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.cpp
@@ -198,7 +198,7 @@ void TeamCtxPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,
                                           int loop, size_t size) {
   size_t shared_bytes = 0;
 
-  CHECK_HIP(hipMemset(grid_psync, 0, sizeof(int)));
+  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
   hipLaunchKernelGGL(TeamCtxPrimitiveTest, gridSize, blockSize, shared_bytes,
                      stream, loop, args.skip, start_time, end_time, source,
                      dest, size, _type, _shmem_context, wf_size,

--- a/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.cpp
@@ -140,6 +140,20 @@ TeamCtxPrimitiveTester::TeamCtxPrimitiveTester(TesterArguments args)
   char *remote = (char *) alloc_test_buffer(buff_size);
   CHECK_HIP(hipMalloc(&grid_psync, sizeof(int)));
 
+  int max_co_resident_wgs_per_cu = 0;
+  CHECK_HIP(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      &max_co_resident_wgs_per_cu, TeamCtxPrimitiveTest, args.wg_size, 0));
+  hipDeviceProp_t device_prop;
+  CHECK_HIP(hipGetDeviceProperties(&device_prop, 0));
+  const int max_sustainable_wgs =
+      max_co_resident_wgs_per_cu * device_prop.multiProcessorCount;
+  if (args.num_wgs > max_sustainable_wgs) {
+    std::cout << "Warning: Number of work-groups (" << args.num_wgs
+              << ") exceeds max sustainable work-groups ("
+              << max_sustainable_wgs << "). grid_barrier may deadlock."
+              << std::endl;
+  }
+
   switch (_type) {
     case TeamCtxPutTestType:
     case TeamCtxPutNBITestType:
@@ -183,7 +197,8 @@ TeamCtxPrimitiveTester::~TeamCtxPrimitiveTester() {
 
 void TeamCtxPrimitiveTester::resetBuffers(size_t size) {
   size_t buff_size = size * batch_size * args.wg_size * args.num_wgs;
-  CHECK_HIP(hipMemset(dest, '1', buff_size));
+  CHECK_HIP(hipMemsetAsync(dest, '1', buff_size, stream));
+  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
 }
 
 void TeamCtxPrimitiveTester::preLaunchKernel() {
@@ -198,7 +213,6 @@ void TeamCtxPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,
                                           int loop, size_t size) {
   size_t shared_bytes = 0;
 
-  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
   hipLaunchKernelGGL(TeamCtxPrimitiveTest, gridSize, blockSize, shared_bytes,
                      stream, loop, args.skip, start_time, end_time, source,
                      dest, size, _type, _shmem_context, wf_size,

--- a/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.hpp
@@ -49,6 +49,7 @@ class TeamCtxPrimitiveTester : public Tester {
 
   char *source = nullptr;
   char *dest = nullptr;
+  int *grid_psync = nullptr;
 };
 
 #endif

--- a/projects/rocshmem/tests/functional_tests/wavefront_primitives.cpp
+++ b/projects/rocshmem/tests/functional_tests/wavefront_primitives.cpp
@@ -38,7 +38,8 @@ __global__ void WaveFrontPrimitiveTest(int loop, int skip,
                                        long long int *end_time, char *source,
                                        char *dest, size_t size, TestType type,
                                        ShmemContextType ctx_type,
-                                       int wf_size, int batch) {
+                                       int wf_size, int batch,
+                                       int *grid_psync) {
   __shared__ rocshmem_ctx_t ctx;
   int wg_id = get_flat_grid_id();
 
@@ -63,6 +64,10 @@ __global__ void WaveFrontPrimitiveTest(int loop, int skip,
       rocshmem_ctx_quiet(ctx);
       __syncthreads();
       if (i == skip) {
+        // Global barrier ensures all WGs have finished their skip-region
+        // puts before any WG starts timing, preventing skip traffic from
+        // contaminating the timed window.
+        grid_barrier(grid_psync, gridDim.x);
         if (is_thread_zero_in_wave()) {
           start_time[idx] = wall_clock64();
         }
@@ -103,6 +108,7 @@ WaveFrontPrimitiveTester::WaveFrontPrimitiveTester(TesterArguments args)
   size_t buff_size = max_msg_size * batch_size * args.num_wgs * num_warps;
   char *local = (char *) alloc_test_buffer(buff_size, args.local_buf_type);
   char *remote = (char *) alloc_test_buffer(buff_size);
+  CHECK_HIP(hipMalloc(&grid_psync, sizeof(int)));
 
   switch (_type) {
     case WAVEPutTestType:
@@ -141,6 +147,7 @@ WaveFrontPrimitiveTester::~WaveFrontPrimitiveTester() {
 
   free_test_buffer(local, args.local_buf_type);
   free_test_buffer(remote);
+  CHECK_HIP(hipFree(grid_psync));
 }
 
 void WaveFrontPrimitiveTester::resetBuffers(size_t size) {
@@ -152,10 +159,11 @@ void WaveFrontPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,
                                            int loop, size_t size) {
   size_t shared_bytes = 0;
 
+  CHECK_HIP(hipMemset(grid_psync, 0, sizeof(int)));
   hipLaunchKernelGGL(WaveFrontPrimitiveTest, gridSize, blockSize, shared_bytes,
                      stream, loop, args.skip, start_time, end_time,
                      source, dest, size, _type, _shmem_context,
-                     wf_size, batch_size);
+                     wf_size, batch_size, grid_psync);
 
   num_msgs = (loop + args.skip) * gridSize.x * num_warps;
   num_timed_msgs = loop * gridSize.x * num_warps;

--- a/projects/rocshmem/tests/functional_tests/wavefront_primitives.cpp
+++ b/projects/rocshmem/tests/functional_tests/wavefront_primitives.cpp
@@ -110,6 +110,20 @@ WaveFrontPrimitiveTester::WaveFrontPrimitiveTester(TesterArguments args)
   char *remote = (char *) alloc_test_buffer(buff_size);
   CHECK_HIP(hipMalloc(&grid_psync, sizeof(int)));
 
+  int max_co_resident_wgs_per_cu = 0;
+  CHECK_HIP(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      &max_co_resident_wgs_per_cu, WaveFrontPrimitiveTest, args.wg_size, 0));
+  hipDeviceProp_t device_prop;
+  CHECK_HIP(hipGetDeviceProperties(&device_prop, 0));
+  const int max_sustainable_wgs =
+      max_co_resident_wgs_per_cu * device_prop.multiProcessorCount;
+  if (args.num_wgs > max_sustainable_wgs) {
+    std::cout << "Warning: Number of work-groups (" << args.num_wgs
+              << ") exceeds max sustainable work-groups ("
+              << max_sustainable_wgs << "). grid_barrier may deadlock."
+              << std::endl;
+  }
+
   switch (_type) {
     case WAVEPutTestType:
     case WAVEPutNBITestType:
@@ -152,14 +166,14 @@ WaveFrontPrimitiveTester::~WaveFrontPrimitiveTester() {
 
 void WaveFrontPrimitiveTester::resetBuffers(size_t size) {
   size_t buff_size = size * batch_size * args.num_wgs * num_warps;
-  CHECK_HIP(hipMemset(dest, '1', buff_size));
+  CHECK_HIP(hipMemsetAsync(dest, '1', buff_size, stream));
+  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
 }
 
 void WaveFrontPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,
                                            int loop, size_t size) {
   size_t shared_bytes = 0;
 
-  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
   hipLaunchKernelGGL(WaveFrontPrimitiveTest, gridSize, blockSize, shared_bytes,
                      stream, loop, args.skip, start_time, end_time,
                      source, dest, size, _type, _shmem_context,

--- a/projects/rocshmem/tests/functional_tests/wavefront_primitives.cpp
+++ b/projects/rocshmem/tests/functional_tests/wavefront_primitives.cpp
@@ -159,7 +159,7 @@ void WaveFrontPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,
                                            int loop, size_t size) {
   size_t shared_bytes = 0;
 
-  CHECK_HIP(hipMemset(grid_psync, 0, sizeof(int)));
+  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
   hipLaunchKernelGGL(WaveFrontPrimitiveTest, gridSize, blockSize, shared_bytes,
                      stream, loop, args.skip, start_time, end_time,
                      source, dest, size, _type, _shmem_context,

--- a/projects/rocshmem/tests/functional_tests/wavefront_primitives.cpp
+++ b/projects/rocshmem/tests/functional_tests/wavefront_primitives.cpp
@@ -113,15 +113,14 @@ WaveFrontPrimitiveTester::WaveFrontPrimitiveTester(TesterArguments args)
   int max_co_resident_wgs_per_cu = 0;
   CHECK_HIP(hipOccupancyMaxActiveBlocksPerMultiprocessor(
       &max_co_resident_wgs_per_cu, WaveFrontPrimitiveTest, args.wg_size, 0));
-  hipDeviceProp_t device_prop;
-  CHECK_HIP(hipGetDeviceProperties(&device_prop, 0));
   const int max_sustainable_wgs =
-      max_co_resident_wgs_per_cu * device_prop.multiProcessorCount;
-  if (args.num_wgs > max_sustainable_wgs) {
-    std::cout << "Warning: Number of work-groups (" << args.num_wgs
-              << ") exceeds max sustainable work-groups ("
-              << max_sustainable_wgs << "). grid_barrier may deadlock."
-              << std::endl;
+      max_co_resident_wgs_per_cu * deviceProps.multiProcessorCount;
+  if (args.num_wgs > static_cast<unsigned>(max_sustainable_wgs)) {
+    std::cout << "Warning: Requested work-groups (" << args.num_wgs
+              << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
+              << "). Capping to " << max_sustainable_wgs
+              << " to avoid grid_barrier deadlock." << std::endl;
+    args.num_wgs = max_sustainable_wgs;
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/wavefront_primitives.hpp
+++ b/projects/rocshmem/tests/functional_tests/wavefront_primitives.hpp
@@ -45,6 +45,7 @@ class WaveFrontPrimitiveTester : public Tester {
 
   char *source = nullptr;
   char *dest = nullptr;
+  int *grid_psync = nullptr;
 };
 
 #endif

--- a/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp
+++ b/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp
@@ -109,15 +109,14 @@ WorkGroupPrimitiveTester::WorkGroupPrimitiveTester(TesterArguments args)
   int max_co_resident_wgs_per_cu = 0;
   CHECK_HIP(hipOccupancyMaxActiveBlocksPerMultiprocessor(
       &max_co_resident_wgs_per_cu, WorkGroupPrimitiveTest, args.wg_size, 0));
-  hipDeviceProp_t device_prop;
-  CHECK_HIP(hipGetDeviceProperties(&device_prop, 0));
   const int max_sustainable_wgs =
-      max_co_resident_wgs_per_cu * device_prop.multiProcessorCount;
-  if (args.num_wgs > max_sustainable_wgs) {
-    std::cout << "Warning: Number of work-groups (" << args.num_wgs
-              << ") exceeds max sustainable work-groups ("
-              << max_sustainable_wgs << "). grid_barrier may deadlock."
-              << std::endl;
+      max_co_resident_wgs_per_cu * deviceProps.multiProcessorCount;
+  if (args.num_wgs > static_cast<unsigned>(max_sustainable_wgs)) {
+    std::cout << "Warning: Requested work-groups (" << args.num_wgs
+              << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
+              << "). Capping to " << max_sustainable_wgs
+              << " to avoid grid_barrier deadlock." << std::endl;
+    args.num_wgs = max_sustainable_wgs;
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp
+++ b/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp
@@ -106,6 +106,20 @@ WorkGroupPrimitiveTester::WorkGroupPrimitiveTester(TesterArguments args)
   char *remote = (char *) alloc_test_buffer(buff_size);
   CHECK_HIP(hipMalloc(&grid_psync, sizeof(int)));
 
+  int max_co_resident_wgs_per_cu = 0;
+  CHECK_HIP(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+      &max_co_resident_wgs_per_cu, WorkGroupPrimitiveTest, args.wg_size, 0));
+  hipDeviceProp_t device_prop;
+  CHECK_HIP(hipGetDeviceProperties(&device_prop, 0));
+  const int max_sustainable_wgs =
+      max_co_resident_wgs_per_cu * device_prop.multiProcessorCount;
+  if (args.num_wgs > max_sustainable_wgs) {
+    std::cout << "Warning: Number of work-groups (" << args.num_wgs
+              << ") exceeds max sustainable work-groups ("
+              << max_sustainable_wgs << "). grid_barrier may deadlock."
+              << std::endl;
+  }
+
   switch (_type) {
     case WGPutTestType:
     case WGPutNBITestType:
@@ -148,14 +162,14 @@ WorkGroupPrimitiveTester::~WorkGroupPrimitiveTester() {
 
 void WorkGroupPrimitiveTester::resetBuffers(size_t size) {
   size_t buff_size = size * batch_size * args.num_wgs;
-  CHECK_HIP(hipMemset(dest, '1', buff_size));
+  CHECK_HIP(hipMemsetAsync(dest, '1', buff_size, stream));
+  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
 }
 
 void WorkGroupPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,
                                            int loop, size_t size) {
   size_t shared_bytes = 0;
 
-  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
   hipLaunchKernelGGL(WorkGroupPrimitiveTest, gridSize, blockSize, shared_bytes,
                      stream, loop, args.skip, start_time, end_time,
                      source, dest, size, _type, _shmem_context,

--- a/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp
+++ b/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp
@@ -155,7 +155,7 @@ void WorkGroupPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,
                                            int loop, size_t size) {
   size_t shared_bytes = 0;
 
-  CHECK_HIP(hipMemset(grid_psync, 0, sizeof(int)));
+  CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
   hipLaunchKernelGGL(WorkGroupPrimitiveTest, gridSize, blockSize, shared_bytes,
                      stream, loop, args.skip, start_time, end_time,
                      source, dest, size, _type, _shmem_context,

--- a/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp
+++ b/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp
@@ -37,7 +37,8 @@ __global__ void WorkGroupPrimitiveTest(int loop, int skip,
                                       long long int *start_time,
                                       long long int *end_time, char *source,
                                       char *dest, size_t size, TestType type,
-                                      ShmemContextType ctx_type, int batch) {
+                                      ShmemContextType ctx_type, int batch,
+                                      int *grid_psync) {
   __shared__ rocshmem_ctx_t ctx;
   int wg_id = get_flat_grid_id();
   rocshmem_wg_ctx_create(ctx_type, &ctx);
@@ -60,6 +61,10 @@ __global__ void WorkGroupPrimitiveTest(int loop, int skip,
       }
       __syncthreads();
       if (i == skip) {
+        // Global barrier ensures all WGs have finished their skip-region
+        // puts before any WG starts timing, preventing skip traffic from
+        // contaminating the timed window.
+        grid_barrier(grid_psync, gridDim.x);
         start_time[wg_id] = wall_clock64();
       }
     }
@@ -99,6 +104,7 @@ WorkGroupPrimitiveTester::WorkGroupPrimitiveTester(TesterArguments args)
   size_t buff_size = max_msg_size * batch_size * args.num_wgs;
   char *local = (char *) alloc_test_buffer(buff_size, args.local_buf_type);
   char *remote = (char *) alloc_test_buffer(buff_size);
+  CHECK_HIP(hipMalloc(&grid_psync, sizeof(int)));
 
   switch (_type) {
     case WGPutTestType:
@@ -137,6 +143,7 @@ WorkGroupPrimitiveTester::~WorkGroupPrimitiveTester() {
 
   free_test_buffer(local, args.local_buf_type);
   free_test_buffer(remote);
+  CHECK_HIP(hipFree(grid_psync));
 }
 
 void WorkGroupPrimitiveTester::resetBuffers(size_t size) {
@@ -148,10 +155,11 @@ void WorkGroupPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,
                                            int loop, size_t size) {
   size_t shared_bytes = 0;
 
+  CHECK_HIP(hipMemset(grid_psync, 0, sizeof(int)));
   hipLaunchKernelGGL(WorkGroupPrimitiveTest, gridSize, blockSize, shared_bytes,
                      stream, loop, args.skip, start_time, end_time,
                      source, dest, size, _type, _shmem_context,
-                     batch_size);
+                     batch_size, grid_psync);
 
   num_msgs = (loop + args.skip) * gridSize.x;
   num_timed_msgs = loop * gridSize.x;

--- a/projects/rocshmem/tests/functional_tests/workgroup_primitives.hpp
+++ b/projects/rocshmem/tests/functional_tests/workgroup_primitives.hpp
@@ -45,6 +45,7 @@ class WorkGroupPrimitiveTester : public Tester {
 
   char *source = nullptr;
   char *dest = nullptr;
+  int *grid_psync = nullptr;
 };
 
 #endif


### PR DESCRIPTION
## Motivation

The functional test kernels (`PrimitiveTest`, `WorkGroupPrimitiveTest`, `WaveFrontPrimitiveTest`, `TeamCtxPrimitiveTest`, `DefaultCTXPrimitiveTest`) use a skip/warmup mechanism: the first `skip` iterations are run without timing to warm up caches before the measured window begins. At iteration `i == skip`, each workgroup calls `rocshmem_ctx_quiet()` to drain its in-flight skip-region operations, then immediately records `start_time` and begins issuing timed puts/gets.

The issue is that there is no synchronization across WGs at this transition point. `rocshmem_ctx_quiet()` is per-context:  it drains only that WG's own in-flight operations. With many WGs running concurrently, the WG that completes its quiet first records `start_time` and immediately issues its first timed put into the network. At this moment, slower WGs are still draining their skip-region puts. The slower WGs will get in the way of faster WGs and affect their execution. The result is that timed traffic from the fast WG and skip-region drain ACKs from the slow WGs are simultaneously in-flight.

This causes measured bandwidth to be artificially lower as skip increases, which is the opposite of the intended behavior. The effect is most visible on large messages where transport throughput is the bottleneck.

Affected tests: All RMA benchmark tests using thread-level (`put/get`), wavefront-level (`waveput/waveget`), workgroup-level (`wgput/wgget`), team-context, and default-context primitives when run with `skip > 0` and multiple workgroups.

## Technical Details

To fix this issue, I added a `grid_barrier(grid_psync, gridDim.x)` call after the per-WG quiet and before `start_time = wall_clock64()` in all five affected kernels. This ensures every WG has fully drained its skip-region operations before any WG starts timing or issues its first timed operation. A single int counter (`grid_psync`) is allocated per tester instance and zeroed before each kernel launch.

Even with skip 0 the old code would have early quiets to affect the timing of the workgroups who have started timing. 
 
```cpp
if (offset == 0) {
  if (is_thread_zero_in_block()) {
    rocshmem_ctx_quiet(ctx);
  }
    __syncthreads();
  if (i == skip) {
    // Global barrier ensures all WGs have finished their skip-region
    // puts before any WG starts timing, preventing skip traffic from
    // contaminating the timed window.
    grid_barrier(grid_psync, gridDim.x);
    start_time[wg_id] = wall_clock64();
  }
}
```

In more detail, in this snippet, the quiet on line 3 contaminates measurements of the groups who have entered the timing block (after line 11) This is true even for skip=0. So, old code includes scheduling startup latency which increases the measured latency.

**Another fix**: correctly setting heap size in driver.sh due to heatmap tests failure because of increased batch size.

## JIRA ID

AIROCSHMEM-433

## Test Result

The functional tests and unit tests pass.