### PR TITLE
[hipFile] Avoid disabling all backends upon conflicting environment variables

### DIFF
--- a/projects/hipfile/src/amd_detail/configuration.cpp
+++ b/projects/hipfile/src/amd_detail/configuration.cpp
@@ -36,8 +36,8 @@ Configuration::fallback() const noexcept
         if (force_compat && !allow_compat) {
             // TODO: replace with logging
             fprintf(stderr, "hipFile: HIPFILE_FORCE_COMPAT_MODE=1 and HIPFILE_ALLOW_COMPAT_MODE=0 "
-                   "would disable all I/O backends; enabling the fallback path to avoid "
-                   "failing all I/O.\n");
+                            "would disable all I/O backends; enabling the fallback path to avoid "
+                            "failing all I/O.\n");
             return true;
         }
         return allow_compat;

--- a/projects/hipfile/src/amd_detail/configuration.cpp
+++ b/projects/hipfile/src/amd_detail/configuration.cpp
@@ -34,7 +34,7 @@ Configuration::fallback() const noexcept
         bool force_compat = Environment::force_compat_mode().value_or(false);
         bool allow_compat = Environment::allow_compat_mode().value_or(true);
         if (force_compat && !allow_compat) {
-            printf("hipFile: HIPFILE_FORCE_COMPAT_MODE=1 and HIPFILE_ALLOW_COMPAT_MODE=0 "
+            fprintf(stderr, "hipFile: HIPFILE_FORCE_COMPAT_MODE=1 and HIPFILE_ALLOW_COMPAT_MODE=0 "
                    "would disable all I/O backends; enabling the fallback path to avoid "
                    "failing all I/O.\n");
             return true;

--- a/projects/hipfile/src/amd_detail/configuration.cpp
+++ b/projects/hipfile/src/amd_detail/configuration.cpp
@@ -35,7 +35,7 @@ Configuration::fallback() const noexcept
         bool allow_compat = Environment::allow_compat_mode().value_or(true);
         if (force_compat && !allow_compat) {
             // TODO: replace with logging
-            fprintf(stderr, "hipFile: HIPFILE_FORCE_COMPAT_MODE=1 and HIPFILE_ALLOW_COMPAT_MODE=0 "
+            fprintf(stderr, "hipFile: HIPFILE_FORCE_COMPAT_MODE=true and HIPFILE_ALLOW_COMPAT_MODE=false "
                             "would disable all I/O backends; enabling the fallback path to avoid "
                             "failing all I/O.\n");
             return true;

--- a/projects/hipfile/src/amd_detail/configuration.cpp
+++ b/projects/hipfile/src/amd_detail/configuration.cpp
@@ -7,6 +7,7 @@
 #include "environment.h"
 #include "hip.h"
 
+#include <cstdio>
 #include <optional>
 
 using namespace hipFile;
@@ -29,7 +30,17 @@ Configuration::fastpath(bool enabled) noexcept
 bool
 Configuration::fallback() const noexcept
 {
-    static bool fallback_env{Environment::allow_compat_mode().value_or(true)};
+    static bool fallback_env{[] {
+        bool force_compat = Environment::force_compat_mode().value_or(false);
+        bool allow_compat = Environment::allow_compat_mode().value_or(true);
+        if (force_compat && !allow_compat) {
+            printf("hipFile: HIPFILE_FORCE_COMPAT_MODE=1 and HIPFILE_ALLOW_COMPAT_MODE=0 "
+                   "would disable all I/O backends; enabling the fallback path to avoid "
+                   "failing all I/O.\n");
+            return true;
+        }
+        return allow_compat;
+    }()};
     return m_fallback_override.value_or(fallback_env);
 }
 

--- a/projects/hipfile/src/amd_detail/configuration.cpp
+++ b/projects/hipfile/src/amd_detail/configuration.cpp
@@ -34,6 +34,7 @@ Configuration::fallback() const noexcept
         bool force_compat = Environment::force_compat_mode().value_or(false);
         bool allow_compat = Environment::allow_compat_mode().value_or(true);
         if (force_compat && !allow_compat) {
+            // TODO: replace with logging
             fprintf(stderr, "hipFile: HIPFILE_FORCE_COMPAT_MODE=1 and HIPFILE_ALLOW_COMPAT_MODE=0 "
                    "would disable all I/O backends; enabling the fallback path to avoid "
                    "failing all I/O.\n");

--- a/projects/hipfile/test/amd_detail/configuration.cpp
+++ b/projects/hipfile/test/amd_detail/configuration.cpp
@@ -181,7 +181,7 @@ TEST_F(HipFileConfiguration, OverrideDisabledFallbackBackend)
 
 TEST_F(HipFileConfiguration, FallbackForcedOnWhenForceCompatTrueAndAllowCompatFalse)
 {
-    // FORCE_COMPAT_MODE=1 + ALLOW_COMPAT_MODE=0 would disable both backends.
+    // HIPFILE_FORCE_COMPAT_MODE=true + HIPFILE_ALLOW_COMPAT_MODE=false would disable both backends.
     // The guard must force the fallback path back on.
     expect_configuration_fallback("true", "false");
     ASSERT_TRUE(Configuration().fallback());

--- a/projects/hipfile/test/amd_detail/configuration.cpp
+++ b/projects/hipfile/test/amd_detail/configuration.cpp
@@ -37,8 +37,11 @@ struct HipFileConfiguration : public Test {
             .WillOnce(Return(hipAmdFileWrite));
     }
 
-    void expect_configuration_fallback(const char *hipfile_allow_compat_mode)
+    void expect_configuration_fallback(const char *hipfile_force_compat_mode,
+                                       const char *hipfile_allow_compat_mode)
     {
+        EXPECT_CALL(msys, getenv(StrEq(hipFile::Environment::FORCE_COMPAT_MODE)))
+            .WillOnce(Return(const_cast<char *>(hipfile_force_compat_mode)));
         EXPECT_CALL(msys, getenv(StrEq(hipFile::Environment::ALLOW_COMPAT_MODE)))
             .WillOnce(Return(const_cast<char *>(hipfile_allow_compat_mode)));
     }
@@ -134,26 +137,26 @@ TEST_F(HipFileConfiguration, CantOverrideDisabledFastpathBackendIfHipAmdFileWrit
 
 TEST_F(HipFileConfiguration, FallbackEnabledIfAllowCompatModeEnvironmentVariableIsNotSet)
 {
-    expect_configuration_fallback(nullptr);
+    expect_configuration_fallback(nullptr, nullptr);
     ASSERT_TRUE(Configuration().fallback());
 }
 
 TEST_F(HipFileConfiguration, FallbackEnabledIfAllowCompatModeEnvironmentVariableIsInvalid)
 {
-    expect_configuration_fallback("not-a-bool");
+    expect_configuration_fallback(nullptr, "not-a-bool");
     ASSERT_TRUE(Configuration().fallback());
 }
 
 TEST_F(HipFileConfiguration, FallbackEnabledIfAllowCompatModeEnvironmentVariableIsTrue)
 {
-    expect_configuration_fallback("true");
+    expect_configuration_fallback(nullptr, "true");
     ASSERT_TRUE(Configuration().fallback());
 }
 
 TEST_F(HipFileConfiguration, OverrideEnabledFallbackBackend)
 {
     Configuration config{};
-    expect_configuration_fallback(nullptr);
+    expect_configuration_fallback(nullptr, nullptr);
     ASSERT_TRUE(config.fallback());
 
     config.fallback(false);
@@ -162,14 +165,14 @@ TEST_F(HipFileConfiguration, OverrideEnabledFallbackBackend)
 
 TEST_F(HipFileConfiguration, FallbackDisabledIfAllowCompatModeEnvironmentVariableIsFalse)
 {
-    expect_configuration_fallback("false");
+    expect_configuration_fallback(nullptr, "false");
     ASSERT_FALSE(Configuration().fallback());
 }
 
 TEST_F(HipFileConfiguration, OverrideDisabledFallbackBackend)
 {
     Configuration config{};
-    expect_configuration_fallback("false");
+    expect_configuration_fallback(nullptr, "false");
     ASSERT_FALSE(config.fallback());
 
     config.fallback(true);

--- a/projects/hipfile/test/amd_detail/configuration.cpp
+++ b/projects/hipfile/test/amd_detail/configuration.cpp
@@ -179,6 +179,21 @@ TEST_F(HipFileConfiguration, OverrideDisabledFallbackBackend)
     ASSERT_TRUE(config.fallback());
 }
 
+TEST_F(HipFileConfiguration, FallbackForcedOnWhenForceCompatTrueAndAllowCompatFalse)
+{
+    // FORCE_COMPAT_MODE=1 + ALLOW_COMPAT_MODE=0 would disable both backends.
+    // The guard must force the fallback path back on.
+    expect_configuration_fallback("true", "false");
+    ASSERT_TRUE(Configuration().fallback());
+}
+
+TEST_F(HipFileConfiguration, FallbackEnabledWhenForceCompatTrueAndAllowCompatTrue)
+{
+    // FORCE=true + ALLOW=true: forced fallback, unchanged behavior.
+    expect_configuration_fallback("true", "true");
+    ASSERT_TRUE(Configuration().fallback());
+}
+
 TEST_F(HipFileConfiguration, StatsLevelEnvironmentVariableIsNotSet)
 {
     expect_configuration_statslevel(nullptr);


### PR DESCRIPTION
## Motivation

When the user passes both `HIPFILE_FORCE_COMPAT_MODE=1` and `HIPFILE_ALLOW_COMPAT_MODE=0`, they can inadvertently disable both the fastpath and fallback backend. This causes all IO to fail. We want to handle this gracefully, and warn the user, and use the fallback backend.

## Technical Details

This is what our competitor does.

I used fprintf to warn the user. In the future, this should be replaced with a logging system, I left a code comment,

I see there also exists the following where the user can programmatically set configuration parameters:

https://github.com/ROCm/rocm-systems/blob/daed9987560fa127e5c749df644015ee49e6891b/projects/hipfile/include/hipfile.h#L942-L955

but `hipFileSetParameterBool` currently returns "Not Implemented". Should I do anything about this at this point in time?

## JIRA ID

AIHIPFILE-212

## Test Plan

Run all tests.

## Test Result

Tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
