### PR TITLE
rocr: fix unsigned underflow in P2P SDMA engine count on GPUs with <2…

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -142,8 +142,8 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
   assert(err == HSA_STATUS_SUCCESS && "hsaGetClockCounters error");
 
   num_h2d_d2h_engines_ = properties_.NumSdmaEngines > 2 ? 2 : properties_.NumSdmaEngines;
-  num_p2p_engines_ =  properties_.NumSdmaXgmiEngines ? properties_.NumSdmaXgmiEngines
-                      : std::max(0U, properties_.NumSdmaEngines - 2);
+  num_p2p_engines_ = properties_.NumSdmaXgmiEngines ? properties_.NumSdmaXgmiEngines
+                     : (properties_.NumSdmaEngines > 2 ? properties_.NumSdmaEngines - 2 : 0);
 
   const core::Isa *isa_base;
 


### PR DESCRIPTION
Fixes #7071.

`std::max(0U, NumSdmaEngines - 2)` does not clamp at zero: the unsigned subtraction wraps to `UINT32_MAX` before `std::max` sees it. On gfx1151/gfx1150 APUs with a single SDMA engine this causes `hsa_init()` to segfault.

  Replace with an explicit conditional guard so the subtraction only executes when the result is representable.

There are more details on the actual issue linked above. Fix found by @stellaraccident.