### PR TITLE
libhsakmt: Map errno to specific status codes in queue creation

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -806,8 +806,16 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtCreateQueueV2Ctx(
 	err = hsakmt_ioctl(ctx->fd, AMDKFD_IOC_CREATE_QUEUE, &args);
 
 	if (err == -1) {
+		int saved_errno = errno;
 		free_queue(ctx, q);
-		return HSAKMT_STATUS_ERROR;
+      	
+		/* Return specific error code based on errno */
+      	if (saved_errno == ENOMEM)
+			return HSAKMT_STATUS_NO_MEMORY;
+      	else if (saved_errno == EINVAL)
+			return HSAKMT_STATUS_INVALID_PARAMETER;
+      	else
+			return HSAKMT_STATUS_ERROR;
 	}
 
 	q->queue_id = args.queue_id;


### PR DESCRIPTION
## Motivation
When AMDKFD_IOC_CREATE_QUEUE ioctl fails, hsaKmtCreateQueueV2Ctx
currently returns generic HSAKMT_STATUS_ERROR regardless of errno.
This prevents ROCr/HIP from distinguishing resource exhaustion
(ENOMEM) from invalid parameters (EINVAL), causing silent failures
and NULL doorbell pointer dereferences.

for example under doorbell pool exhaustion (256+ concurrent processes),
applications receive no error from hipSetDevice() but SIGSEGV when
accessing the NULL doorbell pointer.

This enables proper error propagation: thunk → ROCr (HSA_STATUS_ERROR_
OUT_OF_RESOURCES) → HIP (hipErrorOutOfMemory) → application.