### PR TITLE
[AMD-SMI] Clean up Doxygen comments in `amdsmi.h`

### DIFF
--- a/projects/amdsmi/.claude/commands/amdsmi-update-docs.md
+++ b/projects/amdsmi/.claude/commands/amdsmi-update-docs.md
@@ -1,0 +1,44 @@
+---
+description: Create or update AMD SMI documentation
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash(git diff*), Bash(git log*)
+argument-hint: "<what to document> — e.g., 'update Python API reference for amdsmi_get_gpu_id'
+---
+
+Create or update AMD SMI documentation using the `amdsmi-update-docs` subagent.
+
+## Arguments
+
+- `$ARGUMENTS` describes what to create or update.
+
+## Process
+
+### 1. Gather context
+
+Read the relevant existing files before dispatching:
+- If updating an existing page, read it first.
+- If adding a new page, read a peer page in the same directory for structure reference.
+- If documenting a code change, run:
+
+```bash
+git diff main..HEAD -- docs/ include/ amdsmi_cli/ py-interface/
+```
+
+### 2. Identify scope
+
+Determine:
+- **File path(s)** — which file(s) to create or modify
+- **Diátaxis category** — `install/`, `how-to/`, `reference/`, `conceptual/`
+- **Toc wiring needed** — new pages require entries in `docs/sphinx/_toc.yml.in` and `docs/index.md`
+- **Breathe directives** — C++ API content should use `.. doxygen*::` directives, not hand-written signatures
+
+### 3. Dispatch the `amdsmi-update-docs` skill
+
+Use the `amdsmi-update-docs` skill with the task description and all gathered context.
+
+### 4. Confirm and report
+
+After the skill completes:
+- Confirm files exist at expected paths
+- Confirm toc wiring is present for new pages
+- Report the docs update summary
+- Make sure all internal cross-references are correct

--- a/projects/amdsmi/.claude/skills/amdsmi-update-docs/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-update-docs/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: amdsmi-update-docs
+description: "Create and update AMD SMI documentation. Use when: writing docs, adding a new page, updating API reference, fixing doc content, wiring toctree."
+---
+
+# Update AMD SMI docs
+
+Creates and updates documentation for AMD SMI.
+
+## When to use
+
+- Adding a new how-to, conceptual, install, or reference page
+- Updating existing docs after an API change or CLI change
+- Wiring a new page into `_toc.yml.in` for discoverability
+- Adding or updating Doxygen comments in `amdsmi.h`
+- Fixing style issues
+
+## Guidelines
+
+### Style preferences
+
+Apply these on every page you create or touch:
+
+- [Google developer documentation style guide](https://developers.google.com/style)
+
+  Rules include:
+
+  - **Sentence-case headings**: capitalize only the first word and proper nouns.
+  - **Parallel structures**: list parallel concepts in a grammatically and stylistically parallel way.
+  - **Front-load**: lead with the most important idea.
+  - **Accessibility**: use inclusive language.
+
+- **Markdown**
+  - Most `.md` files under `docs/` use [MyST-flavored Markdown](https://myst-parser.readthedocs.io/en/latest/) through [Sphinx](https://www.sphinx-doc.org/en/master/usage/markdown.html).
+  - For `.md` files not intended to be processed by Sphinx, like READMEs typically read in GitHub previews, use [GitHub-flavored Markdown](https://github.github.com/gfm/).
+  - Use [Pygments](https://pygments.org/languages/) language identifiers on all fenced code blocks.
+
+#### Content architecture
+
+Follow [Diátaxis](https://diataxis.fr/) best practices when structuring documentation.
+This approach identifies four needs that users have - tutorials, how-to guides,
+technical reference and conceptual explanation.
+
+| Content type                          | Directory     | Ask:                                        |
+|:--------------------------------------|:--------------|:--------------------------------------------|
+| Install, uninstall, build steps       | `install/`    | "How do I set it up?"                       |
+| Step-by-step recommended usage        | `how-to/`     | "How do I do X?"                            |
+| API reference, CLI reference, options | `reference/`  | "What does this do / what are the options?" |
+| Background, concepts, design          | `conceptual/` | "Why does this work this way?"              |
+
+When unsure, prefer `how-to/` for procedural content and `conceptual/` for explanatory content.
+
+#### Page template
+
+Use a logical structure for new pages. Adjust sections to fit the content type. For example:
+
+```markdown
+---
+myst:
+  html_meta:
+    "description lang=en": "<one-sentence description>"
+    "keywords": "amdsmi, <topic keywords that don't already appear on the page>"
+---
+
+# <Sentence-case title>
+
+<One-paragraph orientation: what this page covers and who it is for.>
+
+## Prerequisites
+
+<List of requirements before the user starts.>
+
+## <Main sections>
+
+<Content.>
+
+## Further reading
+
+- [<Title>](<path>)
+```
+
+### Cross-references and linking
+
+Use these directives to link to API constructs auto-documented by Doxygen. If
+a public API name changes, update all documentation references to it to use the
+new name.
+
+- Use [Sphinx C domain references](https://www.sphinx-doc.org/en/master/usage/domains/c.html#the-c-domain) to refer to APIs.
+
+  ```
+  {c:func}`amdsmi_init`
+  {c:type}`amdsmi_status_t`
+  ```
+
+  You can also refer to groups of APIs categorized using the `@defgroup` Doxygen marker in `amdsmi.h`.
+
+  ```
+  {ref}`anchor text <tagInitShutdown>`
+  ```
+
+- Use normal Markdown references to refer to Python APIs in `docs/reference/amdsmi-py-api.md`.
+
+## Process
+
+1. **Read first** — read the target file before editing; read a peer page for structure reference when creating.
+2. **Create or update** the file(s) needed.
+3. **Wire into toc** — add or update entries in `docs/sphinx/_toc.yml.in` and `docs/index.md` for any new pages.
+4. **Apply style rules** — sentence-case headings, Pygments code block identifiers, correct naming conventions.
+5. **Report** what was created/changed and what requires a Sphinx build to verify.
+
+## Output
+
+After completing the work, report:
+
+```
+## Docs update summary
+
+**Created:** [file list]
+**Modified:** [file list]
+**Toc wired:** yes / no — [entry added]
+**Open items:** [anything the user must supply, e.g., missing content]
+```

--- a/projects/amdsmi/docs/CLAUDE.md
+++ b/projects/amdsmi/docs/CLAUDE.md
@@ -1,0 +1,1 @@
+@../.claude/skills/amdsmi-update-docs/SKILL.md

--- a/projects/amdsmi/docs/how-to/amdsmi-cpp-lib.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cpp-lib.md
@@ -1,15 +1,15 @@
 ---
 myst:
   html_meta:
-    "description lang=en": "Get started with the AMD SMI C++ library. Basic usage and examples."
+    "description lang=en": "Get started with the AMD SMI C/C++ library. Basic usage and examples."
     "keywords": "api, smi, lib, c++, system, management, interface, ROCm"
 ---
 
-# AMD SMI C++ library usage and examples
+# AMD SMI C/C++ library overview
 
 This section presents a brief overview and some basic examples on the AMD SMI
 library's usage. Whether you are developing applications for performance
-monitoring, system diagnostics, or resource allocation, the AMD SMI C++ library
+monitoring, system diagnostics, or resource allocation, the AMD SMI library
 serves as a valuable tool for leveraging the full potential of AMD hardware in
 your projects.
 
@@ -50,29 +50,29 @@ For MI200 GPUs, multiple GCDs may reside within a single socket, so a single soc
 own several processor handles. GPU socket IDs are derived from the device's BDF, whereas
 CPU socket IDs correspond to the physical CPU package.
 
-To identify the sockets in a system, use the `amdsmi_get_socket_handles()`
+To identify the sockets in a system, use the {c:func}`amdsmi_get_socket_handles()`
 function, which returns a list of socket handles. These handles can then be used
-with `amdsmi_get_processor_handles()` to query devices within each socket. The
+with {c:func}`amdsmi_get_processor_handles()` to query devices within each socket. The
 device handle is used to differentiate between detected devices; however, it's
 important to note that a device handle may change after restarting the
 application, so it should not be considered a persistent identifier across
 processes.
 
-The list of socket handles obtained from `amdsmi_get_socket_handles()` can
+The list of socket handles obtained from {c:func}`amdsmi_get_socket_handles()` can
 also be used to query the CPUs in each socket by calling
-`amdsmi_get_processor_handles_by_type()`. This function can then be called again
+{c:func}`amdsmi_get_processor_handles_by_type()`. This function can then be called again
 to query the cores within each CPU.
 
 (cpp_hello_amdsmi)=
 ## Hello AMD SMI
 
-An application using AMD SMI must call `amdsmi_init()` to initialize the AMI SMI
+An application using AMD SMI must call {c:func}`amdsmi_init()` to initialize the AMI SMI
 library before all other calls. This call initializes the internal data
 structures required for subsequent AMD SMI operations. In the call, a flag can
 be passed to indicate if the application is interested in a specific device
 type.
 
-`amdsmi_shut_down()` must be the last call to properly close connection to
+{c:func}`amdsmi_shut_down()` must be the last call to properly close connection to
 driver and make sure that any resources held by AMD SMI are released.
 
 1. A simple "Hello World" type program that displays the temperature of detected

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -3144,10 +3144,9 @@ typedef struct {
  *  Singleton Design, requires the same number of inits as shutdowns.
  *
  *  The @p init_flags decides which type of processor
- *  can be discovered by ::amdsmi_get_socket_handles(). AMDSMI_INIT_AMD_GPUS returns
- *  sockets with AMD GPUS, and AMDSMI_INIT_AMD_GPUS | AMDSMI_INIT_AMD_CPUS returns
- *  sockets with either AMD GPUS or CPUS.
- *  Both AMDSMI_INIT_AMD_GPUS and AMDSMI_INIT_AMD_CPUS flags are supported.
+ *  can be discovered by ::amdsmi_get_socket_handles(). ::AMDSMI_INIT_AMD_GPUS returns
+ *  sockets with AMD GPUs, and ::AMDSMI_INIT_AMD_APUS returns sockets with either AMD GPUs or CPUs.
+ *  ::AMDSMI_INIT_ALL_PROCESSORS initializes all supported processor types.
  *
  *  @param[in] init_flags Bit flags that tell SMI how to initialize. Values of
  *  ::amdsmi_init_flags_t may be OR'd together and passed through @p init_flags
@@ -3189,9 +3188,9 @@ amdsmi_status_t amdsmi_shut_down(void);
  *  @platform{gpu_bm_linux} @platform{host} @platform{cpu_bm} @platform{guest_1vf}
  *  @platform{guest_mvf} @platform{guest_windows}
  *
- *  @details Depends on what flag is passed to ::amdsmi_init.  AMDSMI_INIT_AMD_GPUS
- *  returns sockets with AMD GPUS, and AMDSMI_INIT_AMD_GPUS | AMDSMI_INIT_AMD_CPUS returns
- *  sockets with either AMD GPUS or CPUS.
+ *  @details Depends on what flag is passed to ::amdsmi_init. ::AMDSMI_INIT_AMD_GPUS
+ *  returns sockets with AMD GPUs, and ::AMDSMI_INIT_AMD_APUS returns sockets with either
+ *  AMD GPUs or CPUs.
  *  The socket handles can be used to query the processor handles in that socket, which
  *  will be used in other APIs to get processor detail information or telemetries.
  *

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -721,7 +721,7 @@ typedef enum {
   AMDSMI_FW_ID_CP_PM4,      //!< Compute Processor Packet Processor 4 (processing command packets)
   AMDSMI_FW_ID_RLC_P,       //!< Rasterizier and L2 Cache Partition
   AMDSMI_FW_ID_SEC_POLICY_STAGE2,     //!< Security Policy Stage 2 (security features)
-  AMDSMI_FW_ID_REG_ACCESS_WHITELIST,  //!< Register Access Whitelist (Prevent unathorizied access)
+  AMDSMI_FW_ID_REG_ACCESS_WHITELIST,  //!< Register Access Whitelist (Prevent unauthorized access)
   AMDSMI_FW_ID_IMU_DRAM,              //!< Input/Output Memory Management Unit - Dynamic RAM
   AMDSMI_FW_ID_IMU_IRAM,              //!< Input/Output Memory Management Unit - Instruction RAM
   AMDSMI_FW_ID_SDMA_TH0,              //!< System Direct Memory Access - Thread Handler 0
@@ -1016,7 +1016,7 @@ typedef enum {
 } amdsmi_card_form_factor_t;
 
 /**
- * @brief pcie information
+ * @brief PCIe information
  *
  * @cond @tag{gpu_bm_linux} @tag{host} @tag{guest_windows} @endcond
  */
@@ -1148,7 +1148,7 @@ typedef struct {
   uint32_t oam_id;                   //!< Corresponds to socket number, 0xFFFFFFFF if not supported
   uint32_t num_of_compute_units;     //!< 0xFFFFFFFF if not supported
   uint64_t target_graphics_version;  //!< 0xFFFFFFFFFFFFFFFF if not supported
-  uint32_t subsystem_id;             //!> The subsystem ID
+  uint32_t subsystem_id;             //!< The subsystem ID
   uint64_t flags;                    //!< Chip flags
   uint32_t reserved[18];
 } amdsmi_asic_info_t;
@@ -2078,7 +2078,7 @@ typedef struct {
 } amdsmi_freq_volt_region_t;
 
 /**
- * @brief OD Vold Curve
+ * @brief OD Volt Curve
  * ::AMDSMI_NUM_VOLTAGE_CURVE_POINTS number of ::amdsmi_od_vddc_point_t's
  *
  * @cond @tag{gpu_bm_linux} @endcond
@@ -3193,7 +3193,7 @@ amdsmi_status_t amdsmi_shut_down(void);
  *  returns sockets with AMD GPUS, and AMDSMI_INIT_AMD_GPUS | AMDSMI_INIT_AMD_CPUS returns
  *  sockets with either AMD GPUS or CPUS.
  *  The socket handles can be used to query the processor handles in that socket, which
- *  will be used in other APIs to get processor detail information or telemtries.
+ *  will be used in other APIs to get processor detail information or telemetries.
  *
  *  @param[in,out] socket_count As input, the value passed
  *  through this parameter is the number of ::amdsmi_socket_handle that
@@ -3601,7 +3601,7 @@ amdsmi_status_t amdsmi_get_gpu_revision(amdsmi_processor_handle processor_handle
                                         uint16_t* revision);
 
 /**
- *  @brief Get the name string for a give vendor ID
+ *  @brief Get the name string for a given vendor ID
  *
  *  @ingroup tagIdentQuery
  *
@@ -4970,7 +4970,7 @@ amdsmi_status_t amdsmi_get_gpu_partition_metrics_info(amdsmi_processor_handle pr
  *
  *  @param[in] processor_handle a processor handle
  *
- *  @param[inout] pm_metrics A pointerto an array to hold multiple PM metrics. On success,
+ *  @param[inout] pm_metrics A pointer to an array to hold multiple PM metrics. On success,
  *  the library will allocate memory of pm_metrics and write metrics to this array.
  *  The caller must free this memory after usage to avoid memory leak.
  *
@@ -5010,7 +5010,7 @@ amdsmi_status_t amdsmi_get_gpu_pm_metrics_info(amdsmi_processor_handle processor
  *
  *  @param[in] reg_type The register type
  *
- *  @param[inout] reg_metrics A pointerto an array to hold multiple register metrics. On success,
+ *  @param[inout] reg_metrics A pointer to an array to hold multiple register metrics. On success,
  *  the library will allocate memory of reg_metrics and write metrics to this array.
  *  The caller must free this memory after usage to avoid memory leak.
  *

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -3252,11 +3252,7 @@ amdsmi_status_t amdsmi_get_socket_info(amdsmi_socket_handle socket_handle, size_
  *  @note Sockets are not supported on the @platform{host}.
  *
  *  @note On the @platform{host} this function currently supports only AMD GPUs. To enumerate other
- * devices, such as AMD NICs, use amdsmi_get_processor_handles_by_type().
- *
- *  The number of processor count is returned through @p processor_count
- *  if @p processor_handles is NULL. Then the number of @p processor_count can be pass
- *  as input to retrieval all processors on the socket to @p processor_handles.
+ *  devices, such as AMD NICs, use amdsmi_get_processor_handles_by_type().
  *
  *  @param[in] socket_handle The socket to query
  *

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -371,10 +371,12 @@ typedef enum {
 typedef amdsmi_processor_type_t processor_type_t;
 
 /**
- * @brief Error codes returned by amdsmi functions
+ * @brief Status codes returned by amdsmi functions.
  *
+ * @internal
  * Please avoid status codes that are multiples of 256 (256, 512, etc..)
  * Return values in the shell get modulo 256 applied, meaning any multiple of 256 ends up as 0
+ * @endinternal
  *
  * @cond @tag{gpu_bm_linux} @tag{host} @tag{cpu_bm} @tag{guest_windows} @endcond
  */


### PR DESCRIPTION
## Motivation

Clean up Doxygen comments in `amdsmi.h` for more readable API documentation.

- Fix typos
- ~~Fix references to non-existent things (e.g., `AMDSMI_STATUS_PERMISSION` should be `AMDSMI_STATUS_NO_PERM`)~~ Nvm, already addressed in #7337.
- Fix white-space issues that cause Doxygen to display docs incorrectly
  <details>
  <summary>Example</summary>
  <img width="1417" height="1032" alt="image" src="https://github.com/user-attachments/assets/137c300a-7911-46d3-8ff9-5fe81567692a" />
  </details>
- Mark some comments as `@internal`
- Add Claude skill to assist with documentation style

Clean up is needed regardless of https://github.com/ROCm/rocm-systems/pull/6578

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
