### PR TITLE
clr: cache read_dispatch_id to reduce queue-full DRAM reads

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1096,6 +1096,7 @@ bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address para
 // ================================================================================================
 void VirtualGPU::SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer) {
   gpu_queue_ = queue;
+  cached_read_dispatch_id_ = 0;
   metadata_preloader_.SetQueueBase(metadata_ring_buffer,
                                    roc_device_.MetadataVersionHeader());
 }
@@ -1306,9 +1307,7 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
   }
 
   // Make sure the slot is free for usage
-  while ((index - Hsa::queue_load_read_index_scacquire(gpu_queue_)) >= sw_queue_size) {
-    amd::Os::yield();
-  }
+  WaitForQueueSlot(index, sw_queue_size);
 
   // Add blocking command if the original value of read index was behind of the queue size.
   // Note: direct dispatch relies on the slot stall above to keep the forward progress
@@ -1329,24 +1328,25 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
   if (header != 0) {
     packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), header, rest);
   }
-  const auto virtual_pipe_prefix = IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)
-                                     ? [this]() -> const char* {
-                                         if (!roc_device_.settings().queue_pipe_dist_) return "";
-                                         static thread_local char buf[32];
-                                         snprintf(buf, sizeof(buf), " virtual_pipe_id=%zu,",
-                                                  gpu_queue_->id % roc_device_.NumHwPipes());
-                                         return buf;
-                                       }()
-                                     : "";
-  if (dev().settings().ext_dispatch_packet_) {
-    logAqlDispatchPacketExtended(
-        gpu_queue_, header, reinterpret_cast<hsa_amd_ext_kernel_dispatch_packet_t*>(packet),
-        Hsa::queue_load_read_index_scacquire(gpu_queue_), index, virtual_pipe_prefix);
-  } else {
-    logAqlDispatchPacket(gpu_queue_, header,
-                         reinterpret_cast<hsa_kernel_dispatch_packet_t*>(packet),
-                         Hsa::queue_load_read_index_scacquire(gpu_queue_), index,
-                         virtual_pipe_prefix);
+  // Gate the entire dispatch-packet logging path on the log level.
+  if (IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
+    char buf[32];
+    const char* virtual_pipe_prefix = "";
+    if (roc_device_.settings().queue_pipe_dist_) {
+      snprintf(buf, sizeof(buf), " virtual_pipe_id=%zu,",
+               gpu_queue_->id % roc_device_.NumHwPipes());
+      virtual_pipe_prefix = buf;
+    }
+    const uint64_t rptr = Hsa::queue_load_read_index_scacquire(gpu_queue_);
+    if (dev().settings().ext_dispatch_packet_) {
+      logAqlDispatchPacketExtended(
+          gpu_queue_, header, reinterpret_cast<hsa_amd_ext_kernel_dispatch_packet_t*>(packet),
+          rptr, index, virtual_pipe_prefix);
+    } else {
+      logAqlDispatchPacket(gpu_queue_, header,
+                           reinterpret_cast<hsa_kernel_dispatch_packet_t*>(packet),
+                           rptr, index, virtual_pipe_prefix);
+    }
   }
   // Optimization for native AQL path in Windows has problems with PM4 emulation,
   // skipping the doorbell will not wake up the AQL worker thread
@@ -1508,10 +1508,7 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
     const bool isLastChunk  = (chunkEnd == numPackets);
 
     // Yield until this chunk's physical slots are free.
-    while (((startIndex + chunkEnd - 1) - Hsa::queue_load_read_index_scacquire(gpu_queue_)) >=
-           sw_queue_size) {
-      amd::Os::yield();
-    }
+    WaitForQueueSlot(startIndex + chunkEnd - 1, sw_queue_size);
 
     // Copy this chunk's packet bodies to the queue. Handles RB wrap-around.
     const size_t chunkSlot = (startIndex + chunkStart) & queueMask;
@@ -1717,7 +1714,6 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
   }
 
   uint64_t index = Hsa::queue_add_write_index_screlease(gpu_queue_, 1);
-  uint64_t read = Hsa::queue_load_read_index_relaxed(gpu_queue_);
 
   setFenceDirty(true);
   auto cache_state = extractAqlBits(packetHeader, HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE,
@@ -1737,7 +1733,7 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
     setFenceDirty(false);
   }
 
-  while ((index - Hsa::queue_load_read_index_scacquire(gpu_queue_)) >= queueMask);
+  WaitForQueueSlot(index, queueMask);
   hsa_barrier_and_packet_t* aql_loc =
       &(reinterpret_cast<hsa_barrier_and_packet_t*>(gpu_queue_->base_address))[index & queueMask];
   *aql_loc = barrier_packet_;
@@ -1745,16 +1741,17 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
   packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), packetHeader, 0);
 
   Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
-  logAqlBarrierPacket(gpu_queue_, packetHeader, &barrier_packet_, read, index,
-                      IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)
-                        ? [this]() -> const char* {
-                            if (!roc_device_.settings().queue_pipe_dist_) return "";
-                            static thread_local char buf[32];
-                            snprintf(buf, sizeof(buf), " virtual_pipe_id=%zu,",
-                                     gpu_queue_->id % roc_device_.NumHwPipes());
-                            return buf;
-                          }()
-                        : "");
+  if (IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
+    char buf[32];
+    const char* virtual_pipe_prefix = "";
+    if (roc_device_.settings().queue_pipe_dist_) {
+      snprintf(buf, sizeof(buf), " virtual_pipe_id=%zu,",
+               gpu_queue_->id % roc_device_.NumHwPipes());
+      virtual_pipe_prefix = buf;
+    }
+    logAqlBarrierPacket(gpu_queue_, packetHeader, &barrier_packet_,
+                        Hsa::queue_load_read_index_relaxed(gpu_queue_), index, virtual_pipe_prefix);
+  }
 
   // Clear dependent signals for the next packet
   barrier_packet_.dep_signal[0] = hsa_signal_t{};
@@ -1818,11 +1815,10 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
   }
 
   uint64_t index = Hsa::queue_add_write_index_screlease(gpu_queue_, 1);
-  uint64_t read = Hsa::queue_load_read_index_relaxed(gpu_queue_);
 
   TrackQueueProgress(barrier_value_packet_, index);
 
-  while ((index - Hsa::queue_load_read_index_scacquire(gpu_queue_)) >= queueMask);
+  WaitForQueueSlot(index, queueMask);
   hsa_amd_barrier_value_packet_t* aql_loc = &(reinterpret_cast<hsa_amd_barrier_value_packet_t*>(
       gpu_queue_->base_address))[index & queueMask];
   *aql_loc = barrier_value_packet_;
@@ -1830,16 +1826,18 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
   packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), packetHeader, rest);
   Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
 
-  logAqlBarrierValuePacket(gpu_queue_, packetHeader, &barrier_value_packet_, read, index,
-                           IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)
-                             ? [this]() -> const char* {
-                                 if (!roc_device_.settings().queue_pipe_dist_) return "";
-                                 static thread_local char buf[32];
-                                 snprintf(buf, sizeof(buf), " virtual_pipe_id=%zu,",
-                                          gpu_queue_->id % roc_device_.NumHwPipes());
-                                 return buf;
-                               }()
-                             : "");
+  if (IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
+    char buf[32];
+    const char* virtual_pipe_prefix = "";
+    if (roc_device_.settings().queue_pipe_dist_) {
+      snprintf(buf, sizeof(buf), " virtual_pipe_id=%zu,",
+               gpu_queue_->id % roc_device_.NumHwPipes());
+      virtual_pipe_prefix = buf;
+    }
+    logAqlBarrierValuePacket(gpu_queue_, packetHeader, &barrier_value_packet_,
+                             Hsa::queue_load_read_index_relaxed(gpu_queue_), index,
+                             virtual_pipe_prefix);
+  }
   // Clear dependent signals for the next packet
   barrier_value_packet_.signal = hsa_signal_t{};
 }
@@ -4135,6 +4133,10 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
   bool isGraphCapture = command_ != nullptr && command_->getPktCapturingState();
 
   ClPrint(amd::LOG_INFO, amd::LOG_KERN2, "ShaderName : %s", gpuKernel.getDemangledName().c_str());
+  ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN,
+          "argSize = %u, KernargSegmentByteSize = %u, KernargSegmentAlignment = %u",
+          std::min(gpuKernel.KernargSegmentByteSize(), signature.paramsSize()),
+          gpuKernel.KernargSegmentByteSize(), gpuKernel.KernargSegmentAlignment());
 
   amd::NDRange local_size(sizes.local());
   address hidden_arguments = const_cast<address>(parameters);
@@ -4333,12 +4335,6 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
                                             gpuKernel.KernargSegmentAlignment(), dev().index());
       command_->SetKernelName(gpuKernel.getDemangledName());
     } else {
-      ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN,
-              "Kernel name = %s, argSize = %zu, "
-              "KernargSegmentByteSize = %lu "
-              "KernargSegmentAlignment = %lu",
-              gpuKernel.getDemangledName().c_str(), argSize,
-              gpuKernel.KernargSegmentByteSize(), gpuKernel.KernargSegmentAlignment());
       argBuffer = reinterpret_cast<address>(
           allocKernArg(gpuKernel.KernargSegmentByteSize(), gpuKernel.KernargSegmentAlignment()));
     }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -753,6 +753,23 @@ class VirtualGPU : public device::VirtualDevice {
   //! one and retaining the new one. No-op if cmd or hw_event is null.
   static void AttachHwEvent(amd::Command* cmd, void* hw_event);
 
+  //! Spin-wait until queue has space for a packet at \p write_index.
+  //! Uses cached_read_dispatch_id_ to avoid DRAM traffic on the fast path;
+  //! only re-reads the hardware read_dispatch_id when the cached value
+  //! indicates the queue might be full.
+  void WaitForQueueSlot(uint64_t write_index, uint32_t capacity) {
+    if ((write_index - cached_read_dispatch_id_) < capacity) {
+      return;
+    }
+    do {
+      cached_read_dispatch_id_ = Hsa::queue_load_read_index_scacquire(gpu_queue_);
+      if ((write_index - cached_read_dispatch_id_) < capacity) {
+        return;
+      }
+      amd::Os::yield();
+    } while (true);
+  }
+
   //! Queue state flags
   union {
     struct {
@@ -780,6 +797,10 @@ class VirtualGPU : public device::VirtualDevice {
   hsa_barrier_and_packet_t barrier_packet_ {};
   hsa_amd_barrier_value_packet_t barrier_value_packet_ {};
 
+  uint64_t cached_read_dispatch_id_ = 0;  //!< Cached read_dispatch_id to avoid DRAM reads
+                                          //!< when queue is not full. GPU updates to
+                                          //!< amd_queue_t.read_dispatch_id probe-invalidate
+                                          //!< CPU caches; this local copy stays in L1/L2.
   uint32_t skippedDispatches_;  //!< Count of consecutive dispatches that skipped the doorbell flush.
   uint32_t dispatch_id_;  //!< This variable must be updated atomically.
   Device& roc_device_;    //!< roc device object


### PR DESCRIPTION
clr: cache read_dispatch_id to reduce queue-full DRAM reads

The hardware read_dispatch_id lives in amd_queue_t and is updated by the
GPU. Each GPU update probe-invalidates the CPU's copy of that cache line,
so every subsequent CPU read in the queue-full spin loops misses cache and
goes to DRAM. Add a per-VirtualGPU cached copy and a WaitForQueueSlot()
helper that only re-reads the hardware index when the cached value
indicates the queue might be full. Reset the cached value when the queue is
(re)assigned.

Also gate the AQL dispatch- and barrier-packet debug logging on the log
level, so the hardware read index is only loaded when logging is enabled,
and consolidate the redundant kernel-name / kernarg debug prints.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
