### PR TITLE
ROCM-25953 Allow string and dict cmake options in test tool configs

### DIFF
--- a/projects/rccl/tools/scripts/test_runner/lib/schema.json
+++ b/projects/rccl/tools/scripts/test_runner/lib/schema.json
@@ -1,0 +1,273 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "rccl-test-runner-config",
+  "title": "RCCL Test Runner Configuration",
+  "description": "Schema for RCCL test runner JSON configuration files",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+
+    "system_configurations": {
+      "description": "Human-readable metadata about this configuration",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name":        { "type": "string" },
+        "description": { "type": "string" }
+      }
+    },
+
+    "paths": {
+      "description": "Filesystem paths used by the runner. Values support ${VAR}, $VAR, and ${VAR:-default} expansion.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "workdir":         { "type": "string", "description": "RCCL source and build root (default: $PWD)" },
+        "rocm_path":       { "type": "string", "description": "ROCm installation prefix (default: /opt/rocm)" },
+        "mpi_path":        { "type": "string", "description": "MPI installation prefix" },
+        "test_binary_dir": { "type": "string", "description": "Directory containing test binaries; overrides the default build_dir/test/" }
+      }
+    },
+
+    "env_variables": {
+      "$ref": "#/$defs/env_variables_map",
+      "description": "Global environment variables applied to every test run"
+    },
+
+    "auto_detect_hosts": {
+      "type": "boolean",
+      "description": "When true, auto-detect MPI hosts from SLURM_NODELIST or similar"
+    },
+
+    "mpi_args": {
+      "description": "Per-system-profile extra mpirun arguments (keyed by profile name, e.g. 'mellanox', 'ainic', 'thor2')",
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+
+    "system_env_variables": {
+      "description": "Per-system-profile environment variable overrides (keyed by profile name)",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/env_variables_map" }
+    },
+
+    "build_configuration": {
+      "description": "Controls how librccl.so and test binaries are built via install.sh",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "install_flags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "install.sh command-line flags, e.g. ['--debug', '-t', '-l', '--no_clean']"
+        },
+        "cmake_options": {
+          "description": "Additional CMake options. Either a string ('-DFOO=BAR -DBAZ=1') or an object whose keys become -DKEY=VAL entries.",
+          "oneOf": [
+            { "type": "string" },
+            {
+              "type": "object",
+              "additionalProperties": { "type": ["string", "number", "boolean"] }
+            }
+          ]
+        },
+        "env_variables": {
+          "$ref": "#/$defs/env_variables_map",
+          "description": "Environment variables set only during the build step"
+        },
+        "parallel_jobs": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of parallel compile jobs passed to install.sh via -j"
+        },
+        "generator": {
+          "type": "string",
+          "description": "CMake generator, e.g. 'Unix Makefiles' or 'Ninja'"
+        }
+      }
+    },
+
+    "test_configurations": {
+      "description": "Named test configuration blocks. Each key is a configuration name referenced by test_suites or via 'extends'.",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/test_configuration" }
+    },
+
+    "test_suites": {
+      "description": "Ordered list of test suites to execute",
+      "type": "array",
+      "items": { "$ref": "#/$defs/test_suite" }
+    }
+  },
+
+  "$defs": {
+
+    "env_variables_map": {
+      "description": "Key/value pairs of environment variables. Values are always strings (use '' to unset).",
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+
+    "test_defaults": {
+      "description": "Fields that can appear at the test_configuration level as defaults and be overridden per-test",
+      "type": "object",
+      "properties": {
+        "is_gtest": {
+          "type": "boolean",
+          "description": "True → GTest binary using --gtest_filter; false → plain executable with direct args. Default: true."
+        },
+        "binary": {
+          "type": "string",
+          "description": "Test binary name or path. Relative names are resolved under build_dir/test/ (or test_binary_dir if set). Supports ~ and $VAR expansion."
+        },
+        "num_ranks": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Total MPI ranks. 1 → no mpirun wrapper."
+        },
+        "num_nodes": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of nodes across which ranks are distributed"
+        },
+        "num_gpus": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "GPUs per node; controls --map-by ppr:{num_gpus}:node for multi-node runs. Default: 8."
+        },
+        "timeout": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Timeout in seconds. 0 = unlimited."
+        }
+      }
+    },
+
+    "test_configuration": {
+      "description": "A named test configuration. May extend another configuration and define a list of tests.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "extends": {
+          "description": "Name (or list of names) of parent configuration(s) to inherit from",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" }, "minItems": 1 }
+          ]
+        },
+        "is_gtest":    { "$ref": "#/$defs/test_defaults/properties/is_gtest" },
+        "binary":      { "$ref": "#/$defs/test_defaults/properties/binary" },
+        "num_ranks":   { "$ref": "#/$defs/test_defaults/properties/num_ranks" },
+        "num_nodes":   { "$ref": "#/$defs/test_defaults/properties/num_nodes" },
+        "num_gpus":    { "$ref": "#/$defs/test_defaults/properties/num_gpus" },
+        "timeout":     { "$ref": "#/$defs/test_defaults/properties/timeout" },
+        "env_variables": {
+          "$ref": "#/$defs/env_variables_map",
+          "description": "Environment variables applied to every test in this configuration (merged on top of global env_variables)"
+        },
+        "rerun_env_variables": {
+          "$ref": "#/$defs/env_variables_map",
+          "description": "Additional environment variables merged in when a failed test is rerun (requires --rerun-failed)"
+        },
+        "args": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Extra command-line arguments appended to the test binary invocation. Lists are de-duplicated and appended when configs are merged via 'extends'."
+        },
+        "mpi_args": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Extra mpirun arguments for tests in this configuration. Lists are de-duplicated and appended when configs are merged via 'extends'."
+        },
+        "_comment": {
+          "type": "string",
+          "description": "Informal annotation for this configuration block (not interpreted by the runner)"
+        },
+        "tests": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/test_item" },
+          "description": "Individual test cases belonging to this configuration"
+        }
+      }
+    },
+
+    "test_item": {
+      "description": "A single test case within a test_configuration",
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique test identifier used for --test-name filtering (supports glob patterns)"
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description shown in output and logs"
+        },
+        "is_gtest":    { "$ref": "#/$defs/test_defaults/properties/is_gtest" },
+        "binary":      { "$ref": "#/$defs/test_defaults/properties/binary" },
+        "test_binary_dir": {
+          "type": "string",
+          "description": "Per-test override of the directory in which binary is looked up"
+        },
+        "test_filter": {
+          "type": "string",
+          "description": "For GTest binaries: passed as --gtest_filter=<value>. For non-GTest: passed as a plain argument."
+        },
+        "command_args": {
+          "type": "string",
+          "description": "Additional command-line arguments appended after the binary (and after test_filter for non-GTest)"
+        },
+        "num_ranks":   { "$ref": "#/$defs/test_defaults/properties/num_ranks" },
+        "num_nodes":   { "$ref": "#/$defs/test_defaults/properties/num_nodes" },
+        "num_gpus":    { "$ref": "#/$defs/test_defaults/properties/num_gpus" },
+        "timeout":     { "$ref": "#/$defs/test_defaults/properties/timeout" },
+        "env_variables": {
+          "$ref": "#/$defs/env_variables_map",
+          "description": "Test-specific environment variables (highest priority, merged on top of all other levels)"
+        },
+        "rerun_env_variables": {
+          "$ref": "#/$defs/env_variables_map",
+          "description": "Per-test additional environment variables used only on rerun"
+        }
+      }
+    },
+
+    "test_suite": {
+      "description": "A suite entry that binds a test_configuration to a named run with optional overrides",
+      "type": "object",
+      "required": ["name", "config"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable suite name used for --suite-name filtering"
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional longer description of what this suite exercises"
+        },
+        "config": {
+          "type": "string",
+          "description": "Name of the test_configuration to use for this suite"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "When false the suite is skipped unless targeted by --suite-name. Default: true."
+        },
+        "is_gtest":  { "$ref": "#/$defs/test_defaults/properties/is_gtest" },
+        "binary":    { "$ref": "#/$defs/test_defaults/properties/binary" },
+        "num_ranks": { "$ref": "#/$defs/test_defaults/properties/num_ranks" },
+        "num_nodes": { "$ref": "#/$defs/test_defaults/properties/num_nodes" },
+        "num_gpus":  { "$ref": "#/$defs/test_defaults/properties/num_gpus" },
+        "timeout":   { "$ref": "#/$defs/test_defaults/properties/timeout" },
+        "env_variables": {
+          "$ref": "#/$defs/env_variables_map",
+          "description": "Suite-level environment variable overrides (between configuration-level and test-level in priority)"
+        }
+      }
+    }
+
+  }
+}

--- a/projects/rccl/tools/scripts/test_runner/lib/test_config.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_config.py
@@ -14,6 +14,14 @@ from copy import deepcopy
 from pathlib import Path
 from types import MappingProxyType
 
+try:
+    import jsonschema
+    _JSONSCHEMA_AVAILABLE = True
+except ImportError:
+    _JSONSCHEMA_AVAILABLE = False
+
+_SCHEMA_PATH = Path(__file__).parent / "schema.json"
+
 # Set default WORKDIR to rccl root directory if not already defined
 # This file is at: rccl/tools/scripts/test_runner/lib/test_config.py
 # rccl root is 5 directories up
@@ -45,6 +53,9 @@ class TestConfigProcessor:
         with open(config_file, 'r') as file:
             config_data = json.load(file)
 
+        # Validate against the JSON schema
+        self._validate_schema(config_data, config_file)
+
         # Expand environment variables in paths section
         if "paths" in config_data:
             config_data["paths"] = self._expand_env_vars_in_dict(config_data["paths"])
@@ -52,6 +63,36 @@ class TestConfigProcessor:
         # Make the configuration immutable (frozen)
         self.config = MappingProxyType(config_data)
         self.config_file = config_file
+
+    @staticmethod
+    def _validate_schema(config_data, config_file):
+        """
+        Validate config_data against the bundled JSON schema.
+
+        Raises ValueError listing all schema violations if the config is
+        invalid.  Emits a warning and continues if jsonschema is not
+        installed or the schema file is missing.
+        """
+        if not _JSONSCHEMA_AVAILABLE:
+            print("WARNING: 'jsonschema' package not installed — skipping config validation. "
+                  "Install it with: pip install jsonschema")
+            return
+
+        if not _SCHEMA_PATH.exists():
+            print(f"WARNING: Schema file not found at {_SCHEMA_PATH} — skipping config validation.")
+            return
+
+        with open(_SCHEMA_PATH) as f:
+            schema = json.load(f)
+
+        validator = jsonschema.Draft7Validator(schema)
+        errors = sorted(validator.iter_errors(config_data), key=str)
+        if errors:
+            lines = [f"Configuration file '{config_file}' failed schema validation:"]
+            for e in errors:
+                path = " -> ".join(str(p) for p in e.absolute_path)
+                lines.append(f"  {path + ': ' if path else ''}{e.message}")
+            raise ValueError("\n".join(lines))
 
     def _expand_env_var(self, value):
         """

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -470,7 +470,8 @@ class TestExecutor:
 
         The build_configuration in the JSON config specifies:
         - install_flags: List of install.sh command-line flags
-        - cmake_options: Optional string of additional CMake options (passed via --cmake-options)
+        - cmake_options: Optional CMake options, either a string (e.g. "-DFOO=BAR") or a
+          dict (e.g. {"FOO": "BAR"}); dicts are converted to "-DKEY=VAL" form (passed via --cmake-options)
         - env_variables: Environment variables to set during the build
         - parallel_jobs: Number of parallel compilation jobs (passed via -j)
 
@@ -498,6 +499,8 @@ class TestExecutor:
 
         install_flags = list(self.build_config.get("install_flags", []))
         cmake_options = self.build_config.get("cmake_options", "")
+        if isinstance(cmake_options, dict):
+            cmake_options = " ".join(f"-D{k}={v}" for k, v in cmake_options.items())
         build_env_vars = self.build_config.get("env_variables", {})
         parallel_jobs = self.build_config.get("parallel_jobs")
 


### PR DESCRIPTION
## Motivation

The ci-precheckin.json file uses a dictionary for it's cmake_options configuration, while all others use a string. This causes an error when attempting to use this configuration without a pre-built RCCL: 
```
   ERROR: unsupported operand type(s) for +=: 'dict' and 'str'
   Traceback (most recent call last):
     File ".../test_runner.py", line 62, in main
       if not executor.build_rccl():
              ^^^^^^^^^^^^^^^^^^^^^
     File ".../lib/test_executor.py", line 509, in build_rccl
       cmake_options += " -DENABLE_MPI_TESTS=OFF"
   TypeError: unsupported operand type(s) for +=: 'dict' and 'str'
   Exiting: Unhandled exception occurred
```

This isn't a problem on CI because it builds RCCL in a separate step and never users the cmake_options. 

## Technical Details

This allows the cmake_options to be either a string or a dictionary. It adds a JSON schema for test tool config files, and validation of the config file against the schema when the tool loads the config.

## JIRA ID

ROCM-25953

## Test Plan

Run the tests in CI.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
