### PR TITLE
[docs/7.13.0] fix(rocprofiler-sdk): remove external_projects override so cross-project links resolve (#7118)

### DIFF
--- a/projects/rocprofiler-sdk/source/docs/conf.py
+++ b/projects/rocprofiler-sdk/source/docs/conf.py
@@ -75,7 +75,6 @@ breathe_default_project = "rocprofiler-sdk"
 doxyfile = "rocprofiler-sdk.dox"
 
 external_projects_current_project = "rocprofiler-sdk"
-external_projects = []
 
 master_doc = "index"
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.md"]


### PR DESCRIPTION
## Motivation
Cherry-pick of #7118 to `docs/7.13.0`. The "ROCm Core SDK components" cross-reference on the ROCprofiler-SDK install page renders as plain text instead of a link. `conf.py` sets `external_projects = []`, which overrides the rocm-docs-core default (`"all"`) and disables every cross-project intersphinx mapping, so `rocm:` references can't resolve. Removing the line restores the default mapping, matching rccl, rocSOLVER, and the other components.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.