### PR TITLE
[rocprofiler-compute] Catch cached imports in profile mode guard

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -695,9 +695,10 @@ class RocProfCompute:
 
     @demarcate
     def run_analysis(self) -> None:
-        # Lazy import file_io since its only used in analysis mode
-        # This will prevent analysis dependencies
-        # leakage into profile mode path
+        # Lazy import pandas and file_io since they are only used in analysis
+        # mode. This keeps analysis deps out of the profile path.
+        import pandas as pd
+
         from utils import file_io
 
         self.print_graphic()
@@ -727,10 +728,6 @@ class RocProfCompute:
         # run analysis workflow
         # -----------------------
         analyzer.sanitize()
-
-        # pandas is only used in analysis mode; import locally to keep the
-        # profile path free of it.
-        import pandas as pd
 
         # Load required SoC(s) from input
         for path_list in analyzer.get_args().path:

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -11,8 +11,6 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
-import pandas as pd
-
 import config
 from argparser import omniarg_parser
 from rocprof_compute_soc.soc_base import OmniSoC_Base
@@ -697,9 +695,11 @@ class RocProfCompute:
 
     @demarcate
     def run_analysis(self) -> None:
-        # Lazy import file_io since its only used in analysis mode
-        # This will prevent analysis dependencies
-        # leakage into profile mode path
+        # Lazy import pandas and file_io since they are only used in analysis
+        # mode. This prevents analysis dependencies leaking into the profile
+        # mode path.
+        import pandas as pd
+
         from utils import file_io
 
         self.print_graphic()

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -695,11 +695,9 @@ class RocProfCompute:
 
     @demarcate
     def run_analysis(self) -> None:
-        # Lazy import pandas and file_io since they are only used in analysis
-        # mode. This prevents analysis dependencies leaking into the profile
-        # mode path.
-        import pandas as pd
-
+        # Lazy import file_io since its only used in analysis mode
+        # This will prevent analysis dependencies
+        # leakage into profile mode path
         from utils import file_io
 
         self.print_graphic()
@@ -729,6 +727,10 @@ class RocProfCompute:
         # run analysis workflow
         # -----------------------
         analyzer.sanitize()
+
+        # pandas is only used in analysis mode; import locally to keep the
+        # profile path free of it.
+        import pandas as pd
 
         # Load required SoC(s) from input
         for path_list in analyzer.get_args().path:

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -28,25 +28,8 @@ class ProfileModeImportGuard:
     """
     Import guard enforcing stdlib-only imports in profile mode.
 
-    Uses two hooks so a violation is caught regardless of cache state:
-        - builtins.__import__ wrapper: runs for every import statement, even when
-          the target is already in sys.modules (Python checks sys.modules before
-          sys.meta_path, so a cached package would otherwise slip past).
-        - sys.meta_path finder: catches dynamic, uncached imports done via
-          importlib that bypass builtins.__import__.
-
-    Python Version Compatibility:
-        - Python 3.10+: Full enforcement (uses sys.stdlib_module_names)
-        - Python 3.8-3.9: No-op mode (enforcement disabled, warning issued)
-
-    Usage:
-        with ProfileModeImportGuard():
-            # Python 3.10+: Import checking active, non-stdlib imports raise ImportError
-            # Python 3.8-3.9: No-op, all imports allowed (with warning)
-
-    Context Manager Protocol:
-        __enter__: Registers both hooks with Python's import system
-        __exit__: Unregisters both hooks after code execution completes
+    Full enforcement on Python 3.10+ (uses sys.stdlib_module_names); no-op with
+    a warning on 3.8-3.9.
     """
 
     _real_import = None
@@ -77,13 +60,7 @@ class ProfileModeImportGuard:
     ])
 
     def __enter__(self):
-        """
-        Register both import hooks with Python's import system.
-
-        Called automatically when entering 'with' block. Installs the
-        builtins.__import__ wrapper (catches cached imports) and the
-        sys.meta_path finder (catches dynamic uncached imports).
-        """
+        """Install both import hooks (Python 3.10+ only)."""
         if sys.version_info >= (3, 10):
             sys.meta_path.insert(0, self)
             self._real_import = builtins.__import__
@@ -99,12 +76,7 @@ class ProfileModeImportGuard:
         return self
 
     def __exit__(self, _exc_type, _exc_val, _exc_tb):
-        """
-        Unregister both import hooks from Python's import system.
-
-        Called automatically when exiting 'with' block. Restores the original
-        builtins.__import__ and removes the sys.meta_path finder.
-        """
+        """Restore builtins.__import__ and remove the meta_path finder."""
         if sys.version_info >= (3, 10):
             if self._real_import is not None:
                 builtins.__import__ = self._real_import
@@ -113,30 +85,16 @@ class ProfileModeImportGuard:
                 sys.meta_path.remove(self)
 
     def _guarded_import(self, name, *args, **kwargs):
-        """
-        Hook 1: replaces builtins.__import__ for the with block.
-
-        Runs for every import statement before the sys.modules lookup, so it
-        catches forbidden imports even when the package is already cached.
-        Only absolute imports (level == 0) are checked here: a relative import's
-        name is unresolved and always lands inside its already-checked parent
-        package, and hook 2 sees the fully-resolved submodule name anyway.
-        Delegates to the real importer once the check passes.
-        """
+        """Hook 1: builtins.__import__ wrapper; catches cached imports."""
+        # Relative imports (level > 0) resolve within their already-checked
+        # parent; hook 2 catches the resolved submodule, so only check absolute.
         level = args[3] if len(args) > 3 else kwargs.get("level", 0)
         if level == 0:
             self._raise_if_forbidden(name)
         return self._real_import(name, *args, **kwargs)
 
     def find_spec(self, fullname, path, target=None):
-        """
-        Hook 2: PEP 451 sys.meta_path finder.
-
-        Python consults meta_path only on a cache miss, so this covers dynamic
-        uncached imports (e.g. importlib.import_module) that bypass
-        builtins.__import__. Returns None for allowed modules to let normal
-        resolution proceed.
-        """
+        """Hook 2: meta_path finder; catches dynamic uncached imports."""
         self._raise_if_forbidden(fullname)
         return None
 

--- a/projects/rocprofiler-compute/tests/conftest.py
+++ b/projects/rocprofiler-compute/tests/conftest.py
@@ -1,6 +1,7 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
+import builtins
 import importlib.util
 import os
 import random
@@ -25,7 +26,14 @@ rocprof_compute_script_path = str(rocprof_compute_script_path)
 
 class ProfileModeImportGuard:
     """
-    Import guard using sys.meta_path to enforce stdlib-only imports in profile mode.
+    Import guard enforcing stdlib-only imports in profile mode.
+
+    Uses two hooks so a violation is caught regardless of cache state:
+        - builtins.__import__ wrapper: runs for every import statement, even when
+          the target is already in sys.modules (Python checks sys.modules before
+          sys.meta_path, so a cached package would otherwise slip past).
+        - sys.meta_path finder: catches dynamic, uncached imports done via
+          importlib that bypass builtins.__import__.
 
     Python Version Compatibility:
         - Python 3.10+: Full enforcement (uses sys.stdlib_module_names)
@@ -37,9 +45,11 @@ class ProfileModeImportGuard:
             # Python 3.8-3.9: No-op, all imports allowed (with warning)
 
     Context Manager Protocol:
-        __enter__: Registers guard with Python's import system (sys.meta_path)
-        __exit__: Unregisters guard after code execution completes
+        __enter__: Registers both hooks with Python's import system
+        __exit__: Unregisters both hooks after code execution completes
     """
+
+    _real_import = None
 
     # Project modules that are allowed (non-stdlib)
     ALLOWED_PROJECT_MODULES = frozenset([
@@ -68,14 +78,16 @@ class ProfileModeImportGuard:
 
     def __enter__(self):
         """
-        Register import guard with Python's import system.
+        Register both import hooks with Python's import system.
 
-        Called automatically when entering 'with' block.
-        Adds this object to sys.meta_path so Python calls our find_spec()
-        for every import during the with block.
+        Called automatically when entering 'with' block. Installs the
+        builtins.__import__ wrapper (catches cached imports) and the
+        sys.meta_path finder (catches dynamic uncached imports).
         """
         if sys.version_info >= (3, 10):
             sys.meta_path.insert(0, self)
+            self._real_import = builtins.__import__
+            builtins.__import__ = self._guarded_import
         else:
             print(
                 "\n" + "=" * 70 + "\n"
@@ -88,36 +100,63 @@ class ProfileModeImportGuard:
 
     def __exit__(self, _exc_type, _exc_val, _exc_tb):
         """
-        Unregister import guard from Python's import system.
+        Unregister both import hooks from Python's import system.
 
-        Called automatically when exiting 'with' block.
-        Removes this object from sys.meta_path, disabling import checking.
+        Called automatically when exiting 'with' block. Restores the original
+        builtins.__import__ and removes the sys.meta_path finder.
         """
-        if sys.version_info >= (3, 10) and self in sys.meta_path:
-            sys.meta_path.remove(self)
+        if sys.version_info >= (3, 10):
+            if self._real_import is not None:
+                builtins.__import__ = self._real_import
+                self._real_import = None
+            if self in sys.meta_path:
+                sys.meta_path.remove(self)
+
+    def _guarded_import(self, name, *args, **kwargs):
+        """
+        Hook 1: replaces builtins.__import__ for the with block.
+
+        Runs for every import statement before the sys.modules lookup, so it
+        catches forbidden imports even when the package is already cached.
+        Only absolute imports (level == 0) are checked here: a relative import's
+        name is unresolved and always lands inside its already-checked parent
+        package, and hook 2 sees the fully-resolved submodule name anyway.
+        Delegates to the real importer once the check passes.
+        """
+        level = args[3] if len(args) > 3 else kwargs.get("level", 0)
+        if level == 0:
+            self._raise_if_forbidden(name)
+        return self._real_import(name, *args, **kwargs)
 
     def find_spec(self, fullname, path, target=None):
         """
-        PEP 451 import hook - called automatically by Python during imports.
+        Hook 2: PEP 451 sys.meta_path finder.
 
-        Python's import system calls this method for every import statement.
-        We check if the module is allowed, and raise ImportError if not.
+        Python consults meta_path only on a cache miss, so this covers dynamic
+        uncached imports (e.g. importlib.import_module) that bypass
+        builtins.__import__. Returns None for allowed modules to let normal
+        resolution proceed.
         """
+        self._raise_if_forbidden(fullname)
+        return None
+
+    def _raise_if_forbidden(self, fullname):
+        """Raise ImportError if the top-level package is not allowed."""
         top_level = fullname.split(".")[0]
 
         # Check stdlib
         if top_level in sys.stdlib_module_names:
-            return None
+            return
 
         # Check ROCm modules
         if top_level in self.ALLOWED_ROCM_MODULES:
-            return None
+            return
 
         # Check project modules (validate origin to prevent third-party modules
         # with same name, e.g., "utils" from site-packages)
         if top_level in self.ALLOWED_PROJECT_MODULES:
             if self._is_from_project(top_level):
-                return None
+                return
 
         # Forbidden module
         raise ImportError(

--- a/projects/rocprofiler-compute/tests/test_import_guard.py
+++ b/projects/rocprofiler-compute/tests/test_import_guard.py
@@ -69,24 +69,41 @@ def test_import_guard_blocks_non_stdlib():
             "ProfileModeImportGuard requires Python 3.10+ (sys.stdlib_module_names)"
         )
 
-    # Test blocking non-stdlib imports
-    # Note: Must clear from sys.modules first since import hooks only
-    # run for uncached modules
     test_packages = ["pandas", "yaml", "numpy"]
 
     for package in test_packages:
-        # Clear from cache if present
-        if package in sys.modules:
-            del sys.modules[package]
-
         # Should block the import
         with pytest.raises(ImportError, match="PROFILE MODE DEPENDENCY VIOLATION"):
             with ProfileModeImportGuard():
                 __import__(package)
 
         # Verify error message mentions the forbidden package
-        if package in sys.modules:
-            del sys.modules[package]
         with pytest.raises(ImportError, match=package):
             with ProfileModeImportGuard():
                 __import__(package)
+
+
+def test_import_guard_catches_already_cached_package():
+    """Verify the guard flags a forbidden import even when the package is
+    already in sys.modules.
+
+    Python checks sys.modules before sys.meta_path, so a meta_path finder alone
+    never sees a cached import. pandas is cached for the whole session (conftest
+    imports it via common.py at collection), which is exactly the real scenario:
+    a profile-mode `import pandas` must still be caught.
+    """
+    from conftest import ProfileModeImportGuard
+
+    if sys.version_info < (3, 10):
+        pytest.skip(
+            "ProfileModeImportGuard requires Python 3.10+ (sys.stdlib_module_names)"
+        )
+
+    # Ensure the package is cached, then confirm the guard still raises.
+    import pandas  # noqa: F401
+
+    assert "pandas" in sys.modules
+
+    with pytest.raises(ImportError, match="PROFILE MODE DEPENDENCY VIOLATION"):
+        with ProfileModeImportGuard():
+            import pandas as pd  # noqa: F401, F811

--- a/projects/rocprofiler-compute/tests/test_import_guard.py
+++ b/projects/rocprofiler-compute/tests/test_import_guard.py
@@ -9,11 +9,6 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason="ProfileModeImportGuard requires Python 3.10+ (sys.stdlib_module_names)",
-)
-
 
 def test_import_guard_allows_stdlib_and_project():
     """Verify ProfileModeImportGuard allows stdlib and project imports."""

--- a/projects/rocprofiler-compute/tests/test_import_guard.py
+++ b/projects/rocprofiler-compute/tests/test_import_guard.py
@@ -8,12 +8,11 @@ import sys
 from pathlib import Path
 
 import pytest
+from conftest import ProfileModeImportGuard
 
 
 def test_import_guard_allows_stdlib_and_project():
     """Verify ProfileModeImportGuard allows stdlib and project imports."""
-    from conftest import ProfileModeImportGuard
-
     with ProfileModeImportGuard():
         # 1. Stdlib imports (must succeed - these are always available)
         import argparse
@@ -34,8 +33,6 @@ def test_import_guard_allows_stdlib_and_project():
 
 def test_import_guard_allows_rocm_modules():
     """Verify ProfileModeImportGuard allows ROCm system libraries."""
-    from conftest import ProfileModeImportGuard
-
     # Add amdsmi to sys.path (same as profile code does)
     amdsmi_path = Path(os.getenv("ROCM_PATH", "/opt/rocm")) / "share/amd_smi"
     if not amdsmi_path.exists():
@@ -62,8 +59,6 @@ def test_import_guard_allows_rocm_modules():
 
 def test_import_guard_blocks_non_stdlib():
     """Verify ProfileModeImportGuard blocks non-stdlib imports."""
-    from conftest import ProfileModeImportGuard
-
     test_packages = ["pandas", "yaml", "numpy"]
 
     for package in test_packages:
@@ -80,8 +75,6 @@ def test_import_guard_blocks_non_stdlib():
 
 def test_import_guard_catches_already_cached_package():
     """Guard must flag a forbidden import even when it is already cached."""
-    from conftest import ProfileModeImportGuard
-
     # pandas is cached session-wide (conftest imports it via common.py); a
     # meta_path finder alone never sees a cached import.
     assert "pandas" in sys.modules

--- a/projects/rocprofiler-compute/tests/test_import_guard.py
+++ b/projects/rocprofiler-compute/tests/test_import_guard.py
@@ -9,6 +9,11 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="ProfileModeImportGuard requires Python 3.10+ (sys.stdlib_module_names)",
+)
+
 
 def test_import_guard_allows_stdlib_and_project():
     """Verify ProfileModeImportGuard allows stdlib and project imports."""
@@ -64,11 +69,6 @@ def test_import_guard_blocks_non_stdlib():
     """Verify ProfileModeImportGuard blocks non-stdlib imports."""
     from conftest import ProfileModeImportGuard
 
-    if sys.version_info < (3, 10):
-        pytest.skip(
-            "ProfileModeImportGuard requires Python 3.10+ (sys.stdlib_module_names)"
-        )
-
     test_packages = ["pandas", "yaml", "numpy"]
 
     for package in test_packages:
@@ -84,26 +84,12 @@ def test_import_guard_blocks_non_stdlib():
 
 
 def test_import_guard_catches_already_cached_package():
-    """Verify the guard flags a forbidden import even when the package is
-    already in sys.modules.
-
-    Python checks sys.modules before sys.meta_path, so a meta_path finder alone
-    never sees a cached import. pandas is cached for the whole session (conftest
-    imports it via common.py at collection), which is exactly the real scenario:
-    a profile-mode `import pandas` must still be caught.
-    """
+    """Guard must flag a forbidden import even when it is already cached."""
     from conftest import ProfileModeImportGuard
 
-    if sys.version_info < (3, 10):
-        pytest.skip(
-            "ProfileModeImportGuard requires Python 3.10+ (sys.stdlib_module_names)"
-        )
-
-    # Ensure the package is cached, then confirm the guard still raises.
-    import pandas  # noqa: F401
-
+    # pandas is cached session-wide (conftest imports it via common.py); a
+    # meta_path finder alone never sees a cached import.
     assert "pandas" in sys.modules
-
     with pytest.raises(ImportError, match="PROFILE MODE DEPENDENCY VIOLATION"):
         with ProfileModeImportGuard():
-            import pandas as pd  # noqa: F401, F811
+            __import__("pandas")


### PR DESCRIPTION
## Motivation

The profile-mode import guard could not detect a forbidden import when the
package was already cached in sys.modules. pandas is imported at collection
time (via common.py), so the guard was effectively blind to profile-mode
pandas usage.

Bugfix: PR #6319 added a module-level pandas import to rocprof_compute_base.py,
pulling pandas into the profile mode path. This guard gap is why it went
undetected.

## Technical Details

- ProfileModeImportGuard now uses two hooks sharing one allow/deny check:
  - a builtins.__import__ wrapper that runs for every import statement
    before the sys.modules lookup, so cached imports are caught (absolute
    imports only; relative imports stay within their checked parent).
  - the existing sys.meta_path finder, kept for dynamic uncached imports.
  - original builtins.__import__ restored on exit.
- rocprof_compute_base.py: remove module-level pandas import (added in #6319);
  import pandas locally inside the analyze-only run_analysis path.
- test_import_guard.py: add a test asserting the guard flags an
  already-cached forbidden import.

## JIRA ID

## Test Plan

- pytest tests/test_import_guard.py

## Test Result

- [x] ruff check clean on changed files
- [x] pytest tests/test_import_guard.py (4 passed)
- [x] pytest tests/test_utils.py (268 passed)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.