### PR TITLE
Load versioned libhsa-runtime64 instead of symlink

### DIFF
--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -189,10 +189,12 @@ static void initOnceFunc() {
    */
   char path[1024];
   char *ncclCudaPath = getenv("RCCL_ROCR_PATH");
+  // dlopen the SONAME, not the unversioned dev symlink: the .so.1 ships in
+  // every runtime tree, the bare .so only in -devel packages.
   if (ncclCudaPath == NULL)
-    snprintf(path, 1024, "%s", "libhsa-runtime64.so");
+    snprintf(path, 1024, "%s", "libhsa-runtime64.so.1");
   else
-    snprintf(path, 1024, "%s%s", ncclCudaPath, "libhsa-runtime64.so");
+    snprintf(path, 1024, "%s%s", ncclCudaPath, "libhsa-runtime64.so.1");
 
   hsaLib = dlopen(path, RTLD_LAZY);
   if (hsaLib == NULL) {


### PR DESCRIPTION
Unversioned symlinks are not shipped by design in rocm-sdk-libraries Python packages as symlinks materialize as copies. Hence, lead the versioned library instead of the unversioned symlink which is only available in devel packages.

See https://github.com/ROCm/TheRock/issues/5562 for information.