### PR TITLE
CLR: Fix free-memory accounting for VM-heap mem pools (VA reservations vs physical commits)

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -719,9 +719,9 @@ void Buffer::destroy() {
       }
     }
 
-    // Not counted on alloc, so don't add it back on free.
+    // Not counted on alloc (e.g. arena and VA ranges), so don't add it back on free.
     if ((deviceMemory_ != nullptr) && (dev().settings().apuSystem_ || !isFineGrain) &&
-        !(memFlags & CL_MEM_VA_RANGE_AMD)) {
+        (kind_ != MEMORY_KIND_ARENA) && !(memFlags & CL_MEM_VA_RANGE_AMD)) {
       const_cast<Device&>(dev()).updateFreeMemory(size(), true);
     }
 

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -679,6 +679,10 @@ void Buffer::destroy() {
     if (memFlags & ROCCLR_MEM_PHYMEM) {
       // If this is physical memory, dont call hsa free function, since device mem was never created
       dev().deviceVmemRelease(owner()->getUserData().hsa_handle);
+      // Free what we counted on alloc. Imported memory was never counted.
+      if (!(memFlags & ROCCLR_MEM_INTERPROCESS)) {
+        const_cast<Device&>(dev()).updateFreeMemory(size(), true);
+      }
       return;
     }
 
@@ -827,6 +831,11 @@ bool Buffer::create(bool alloc_local) {
     }
 
     owner()->setSvmPtr(reinterpret_cast<void*>(owner()->getUserData().hsa_handle));
+
+    // Real device memory, so count it. Imported memory isn't ours, so skip it.
+    if (!(memFlags & ROCCLR_MEM_INTERPROCESS)) {
+      const_cast<Device&>(dev()).updateFreeMemory(size(), false);
+    }
 
     return (success = true);
   }

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -715,7 +715,9 @@ void Buffer::destroy() {
       }
     }
 
-    if ((deviceMemory_ != nullptr) && (dev().settings().apuSystem_ || !isFineGrain)) {
+    // Not counted on alloc, so don't add it back on free.
+    if ((deviceMemory_ != nullptr) && (dev().settings().apuSystem_ || !isFineGrain) &&
+        !(memFlags & CL_MEM_VA_RANGE_AMD)) {
       const_cast<Device&>(dev()).updateFreeMemory(size(), true);
     }
 
@@ -917,8 +919,9 @@ bool Buffer::create(bool alloc_local) {
       }
     }
 
+    // VA ranges only reserve addresses, not real memory, so don't count them.
     if ((deviceMemory_ != nullptr) && (dev().settings().apuSystem_ || !isFineGrain) &&
-        (kind_ != MEMORY_KIND_ARENA)) {
+        (kind_ != MEMORY_KIND_ARENA) && !(memFlags & CL_MEM_VA_RANGE_AMD)) {
       const_cast<Device&>(dev()).updateFreeMemory(size(), false);
     }
 


### PR DESCRIPTION
## Problem

Memory tests fail with "out of memory" even though the GPU has plenty free. A small 32 MiB allocation gets `hipErrorOutOfMemory` while the device still reports ~7.7 GiB free.

## Cause

The HIP memory pool first reserves a few large address ranges (sized as fractions of total memory, ~1/2/5/8 GiB) and later carves small allocations out of them.

These reservations are virtual address space only they don't use real GPU memory. But the runtime was subtracting their full size from its free-memory counter. If the reservation is bigger than the tracked free memory,  the counter underflows and clamps to zero:

```
Free memory set to zero ... requested size = 0x140000000, freeMem_ = 0x13b5ee000
```

After that, every allocation is rejected even though the GPU has memory left.

## Fix

Two small changes that together make the accounting correct:

1. **Don't count address reservations.** A VA range (`CL_MEM_VA_RANGE_AMD`) is just addresses, so it no longer touches the free-memory counter. This is what fixes the false OOMs.
2. **Do count the real memory.** The physical pages the pool actually commits (`ROCCLR_MEM_PHYMEM`) were never tracked. Now they are, with matching updates on alloc and free. Imported (interprocess) handles aren't ours, so they stay uncounted.
