### PR TITLE
[RCCL] Add optional device side NaN/Inf detector for RCCL reductions

### DIFF
--- a/projects/rccl/.github/workflows/rccl-nan-check.yml
+++ b/projects/rccl/.github/workflows/rccl-nan-check.yml
@@ -1,0 +1,57 @@
+# Opt-in NaN/Inf detector smoke + assertion test.
+#
+# Builds RCCL with the device-side reduction NaN detector enabled
+# (-DRCCL_ENABLE_NAN_CHECK=ON) plus the unit tests, then runs NanCheckTests,
+# which injects a NaN into an AllReduce and asserts the detector reports it.
+#
+# This is fully independent of (and must NOT pull in) any change to the default
+# thread-block size in src/include/device.h / src/include/rccl_common.h. The
+# detector lives in the shared reduction path and fires at any thread count, so
+# stock RCCL (256 threads) is exactly what we build and test here.
+#
+# NOTE: adjust `runs-on` and `container.image` to match your GPU CI runners.
+# Requires a runner with >= 2 GPUs (the test does a 2-GPU ncclCommInitAll).
+
+name: RCCL NaN Detector Test
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "src/device/nan_check.h"
+      - "src/device/common_kernel.h"
+      - "test/NanCheckTests.cpp"
+      - ".github/workflows/rccl-nan-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  nan-check:
+    name: Build (--enable-nan-check) + run NanCheckTests
+    # TODO: point at a >=2-GPU ROCm runner, e.g. linux-mi325-4gpu-ossci-rocm
+    runs-on: linux-mi325-4gpu-ossci-rocm
+    container:
+      # TODO: a ROCm image with cmake + hipcc (any rocm/dev-* works).
+      image: rocm/dev-ubuntu-24.04:7.2.3-complete
+      options: >-
+        --device /dev/kfd --device /dev/dri --group-add video
+        --ipc host --security-opt seccomp=unconfined --ulimit memlock=-1:-1
+    steps:
+      - name: Checkout RCCL
+        uses: actions/checkout@v4
+
+      - name: Build RCCL with NaN detector + unit tests
+        run: |
+          # -l : build only for the runner's local GPU arch (fast).
+          # --enable-nan-check : -DRCCL_ENABLE_NAN_CHECK=ON
+          # --tests_build      : build rccl-UnitTests (includes NanCheckTests)
+          ONLY_FUNCS="AllReduce * * Sum f32/bf16" \
+            ./install.sh -l --enable-nan-check --tests_build
+
+      - name: Run NanCheckTests
+        run: |
+          BIN=$(find "$PWD/build" -name rccl-UnitTests -type f | head -1)
+          echo "Using unit test binary: $BIN"
+          test -n "$BIN" || { echo "rccl-UnitTests not found"; exit 1; }
+          "$BIN" --gtest_filter='NanCheck.*' --gtest_color=yes

--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -95,6 +95,23 @@ option(QUIET_WARNINGS                          "Supress compiler warnings"      
 option(DWORDX4_INTRINSICS                      "Turn off compilation with dwordx4 intrinsics"  ON)
 option(ENABLE_ROCSHMEM                         "Enable rocSHMEM support in RCCL"               OFF)
 option(ENABLE_WARP_SPEED                       "Enable WARP_SPEED optimizations"               OFF)
+option(RCCL_ENABLE_NAN_CHECK                   "Enable opt-in device-side NaN/Inf detector in reductions" OFF)
+option(RCCL_NANCHECK_ABORT                     "Abort (__trap) on first NaN/Inf detected (requires RCCL_ENABLE_NAN_CHECK)" OFF)
+
+# Opt-in device-side NaN/Inf detector. Zero overhead unless explicitly enabled.
+# Requesting abort implies the detector, so turn it on rather than silently no-op.
+if(RCCL_NANCHECK_ABORT AND NOT RCCL_ENABLE_NAN_CHECK)
+  message(STATUS "RCCL_NANCHECK_ABORT requested without RCCL_ENABLE_NAN_CHECK; enabling the detector")
+  set(RCCL_ENABLE_NAN_CHECK ON)
+endif()
+if(RCCL_ENABLE_NAN_CHECK)
+  message(STATUS "RCCL device-side NaN/Inf detector ENABLED (RCCL_ENABLE_NAN_CHECK)")
+  add_compile_definitions(RCCL_ENABLE_NAN_CHECK)
+  if(RCCL_NANCHECK_ABORT)
+    message(STATUS "RCCL NaN/Inf detector will __trap() on first hit (RCCL_NANCHECK_ABORT)")
+    add_compile_definitions(RCCL_NANCHECK_ABORT)
+  endif()
+endif()
 
 # Default GPU architectures to build
 #==================================================================================================

--- a/projects/rccl/install.sh
+++ b/projects/rccl/install.sh
@@ -21,6 +21,8 @@ build_verbose=false
 clean_build=true
 dump_asm=false
 enable_code_coverage=false
+enable_nan_check=false
+enable_nan_check_abort=false
 enable_ninja=""
 install_dependencies=false
 install_library=false
@@ -62,6 +64,8 @@ function display_help()
     echo "       --disable-warp-speed    Disable WARP_SPEED kernel optimizations"
     echo "       --dump-asm              Disassemble code and dump assembly with inline code"
     echo "    -c|--enable-code-coverage  Enable code coverage"
+    echo "       --enable-nan-check      Build with opt-in device-side NaN/Inf detector in reductions (debug aid; adds overhead)"
+    echo "       --enable-nan-check-abort Same as --enable-nan-check but __trap() on first hit"
     echo "       --enable_backtrace      Build with custom backtrace support"
     echo "       --enable-mpi-tests      Enable MPI-based tests (requires --debug and MPI installation; set MPI_PATH if not in /opt/ompi)"
     echo "    -f|--fast                  Quick-build RCCL (local gpu arch only, no backtrace)"
@@ -114,7 +118,7 @@ function display_help()
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ "$?" -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,amdgpu_targets:,cmake-options:,debug,debug-fast,dependencies,device-linker,disable-roctx,disable-sym-kernels,disable-warp-speed,dump-asm,enable-code-coverage,enable_backtrace,enable-mpi-tests,fast,force-reduce-pipeline,generate-sym-kernels,help,install,jobs:,kernel-resource-use,local_gpu_only,log-trace,no_clean,no-device-linker,openmp-test-enable,package_build,prefix:,quiet-warnings,rm-legacy-include-dir,rocshmem,roctx-enable,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,amdgpu_targets:,cmake-options:,debug,debug-fast,dependencies,device-linker,disable-roctx,disable-sym-kernels,disable-warp-speed,dump-asm,enable-code-coverage,enable-nan-check,enable-nan-check-abort,enable_backtrace,enable-mpi-tests,fast,force-reduce-pipeline,generate-sym-kernels,help,install,jobs:,kernel-resource-use,local_gpu_only,log-trace,no_clean,no-device-linker,openmp-test-enable,package_build,prefix:,quiet-warnings,rm-legacy-include-dir,rocshmem,roctx-enable,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -141,6 +145,8 @@ while true; do
          --disable-warp-speed)       warp_speed_enabled=false;                                                                         shift ;;
          --dump-asm)                 dump_asm=true;                                                                                    shift ;;
     -c | --enable-code-coverage)     enable_code_coverage=true;                                                                        shift ;;
+         --enable-nan-check)         enable_nan_check=true;                                                                            shift ;;
+         --enable-nan-check-abort)   enable_nan_check=true; enable_nan_check_abort=true;                                               shift ;;
          --enable_backtrace)         build_bfd=true;                                                                                   shift ;;
          --enable-mpi-tests)         enable_mpi_tests=true;                                                                            shift ;;
     -f | --fast)                     build_local_gpu_only=true;                                                                        shift ;;
@@ -356,6 +362,14 @@ fi
 # Enable trace debug level
 if [[ "${log_trace}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DTRACE=ON"
+fi
+
+# Enable opt-in device-side NaN/Inf detector in reductions
+if [[ "${enable_nan_check}" == true ]]; then
+    cmake_common_options="${cmake_common_options} -DRCCL_ENABLE_NAN_CHECK=ON"
+fi
+if [[ "${enable_nan_check_abort}" == true ]]; then
+    cmake_common_options="${cmake_common_options} -DRCCL_NANCHECK_ABORT=ON"
 fi
 
 # Disable ROCTX

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -50,6 +50,7 @@ set(SRC_FILES
   device/broadcast.h
   device/common.h
   device/common_kernel.h
+  device/nan_check.h
   device/op128.h
   device/primitives.h
   device/prims_ll128.h

--- a/projects/rccl/src/device/common_kernel.h
+++ b/projects/rccl/src/device/common_kernel.h
@@ -96,10 +96,6 @@ __device__ __forceinline__ static void reduceCopyPacks(
           acc[u] = ld_volatile_global<BytePerPack>(minSrcs[0]);
           if (0 < PreOpSrcs) acc[u] = applyPreOp(redFn, acc[u]);
         }
-        // RCCL NaN/Inf detector: inspect the first reduction operand as it is
-        // loaded. No-op unless built with RCCL_ENABLE_NAN_CHECK.
-        RCCL_NANCHECK(acc[u], RCCL_NANCHECK_INPUT,
-                      (threadBytesBehind + (IntBytes)u*WARP_SIZE*BytePerPack)/(IntBytes)sizeof(T));
         minSrcs[0] += WARP_SIZE*BytePerPack;
       }
     }
@@ -154,9 +150,7 @@ __device__ __forceinline__ static void reduceCopyPacks(
         acc[u] = applyPostOp(redFn, acc[u]);
     }
 
-    // RCCL NaN/Inf detector: inspect the reduced result pack before it is
-    // stored. No-op unless built with RCCL_ENABLE_NAN_CHECK. The element offset
-    // hint is this thread's byte position converted to elements of T.
+    // RCCL NaN/Inf detector: reduced result before store.
     #pragma unroll Unroll
     for (int u=0; u < Unroll; u++) {
       RCCL_NANCHECK(acc[u], RCCL_NANCHECK_OUTPUT,
@@ -246,14 +240,6 @@ __device__ __forceinline__ void loadSources(
       src += WARP_SIZE * BytePerPack;
     }
   }
-
-  // RCCL NaN/Inf detector (pipelined path input): inspect the first loaded
-  // operand. No-op unless built with RCCL_ENABLE_NAN_CHECK.
-  #pragma unroll Unroll
-  for (int u = 0; u < Unroll; u++)
-    RCCL_NANCHECK(buff[0][u], RCCL_NANCHECK_INPUT,
-                  (globalOffset + (IntBytes)u*WARP_SIZE*BytePerPack)
-                    /(IntBytes)sizeof(typename RedFn::EltType));
 }
 
 template <typename RedFn, typename DstPtrFn, typename IntBytes, int MultimemDsts, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int PreOpSrcs, int Unroll, int BytePerPack>
@@ -280,8 +266,7 @@ template <typename RedFn, typename DstPtrFn, typename IntBytes, int MultimemDsts
       buff[0][u] = applyPostOp(redFn, buff[0][u]);
   }
 
-  // RCCL NaN/Inf detector (pipelined path): inspect the reduced result pack
-  // before it is stored. No-op unless built with RCCL_ENABLE_NAN_CHECK.
+  // RCCL NaN/Inf detector: reduced result before store (pipelined path).
   #pragma unroll Unroll
   for (int u = 0; u < Unroll; u++) {
     RCCL_NANCHECK(buff[0][u], RCCL_NANCHECK_OUTPUT,
@@ -511,13 +496,9 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
           acc[u] = ld_volatile_global<BytePerPack>(minSrcs[0]);
             // coverity[dead_error_condition]
           bias[u] = ld_volatile_global<BytePerPack>(accPtr);
-          RCCL_NANCHECK(bias[u], RCCL_NANCHECK_INPUT,  // opt-in detector: bias operand
-                        (threadBytesBehind + (IntBytes)u*WARP_SIZE*BytePerPack)/(IntBytes)sizeof(T));
           accPtr += WARP_SIZE*BytePerPack;
           if (0 < PreOpSrcs) acc[u] = applyPreOp(redFn, acc[u]);
         }
-        RCCL_NANCHECK(acc[u], RCCL_NANCHECK_INPUT,  // opt-in detector: source operand
-                      (threadBytesBehind + (IntBytes)u*WARP_SIZE*BytePerPack)/(IntBytes)sizeof(T));
         minSrcs[0] += WARP_SIZE*BytePerPack;
       }
     }
@@ -571,9 +552,7 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
         acc[u] = applyPostOp(redFn, acc[u]);
     }
 
-    // RCCL NaN/Inf detector: inspect the reduced result before store. No-op
-    // unless built with RCCL_ENABLE_NAN_CHECK. (The d==0 dst additionally folds
-    // in the bias operand, which is checked as INPUT above.)
+    // RCCL NaN/Inf detector: reduced result before store (bias path).
     #pragma unroll Unroll
     for (int u=0; u < Unroll; u++)
       RCCL_NANCHECK(acc[u], RCCL_NANCHECK_OUTPUT,

--- a/projects/rccl/src/device/common_kernel.h
+++ b/projects/rccl/src/device/common_kernel.h
@@ -11,6 +11,7 @@
 #include "device.h"
 #include "op128.h"
 #include "reduce_kernel.h"
+#include "nan_check.h" // opt-in (RCCL_ENABLE_NAN_CHECK) device-side NaN/Inf detector; no-op otherwise
 #include <cstdio>
 #include <cstdint>
 
@@ -95,6 +96,10 @@ __device__ __forceinline__ static void reduceCopyPacks(
           acc[u] = ld_volatile_global<BytePerPack>(minSrcs[0]);
           if (0 < PreOpSrcs) acc[u] = applyPreOp(redFn, acc[u]);
         }
+        // RCCL NaN/Inf detector: inspect the first reduction operand as it is
+        // loaded. No-op unless built with RCCL_ENABLE_NAN_CHECK.
+        RCCL_NANCHECK(acc[u], RCCL_NANCHECK_INPUT,
+                      (threadBytesBehind + (IntBytes)u*WARP_SIZE*BytePerPack)/(IntBytes)sizeof(T));
         minSrcs[0] += WARP_SIZE*BytePerPack;
       }
     }
@@ -147,6 +152,15 @@ __device__ __forceinline__ static void reduceCopyPacks(
       #pragma unroll Unroll
       for (int u=0; u < Unroll; u++)
         acc[u] = applyPostOp(redFn, acc[u]);
+    }
+
+    // RCCL NaN/Inf detector: inspect the reduced result pack before it is
+    // stored. No-op unless built with RCCL_ENABLE_NAN_CHECK. The element offset
+    // hint is this thread's byte position converted to elements of T.
+    #pragma unroll Unroll
+    for (int u=0; u < Unroll; u++) {
+      RCCL_NANCHECK(acc[u], RCCL_NANCHECK_OUTPUT,
+                    (threadBytesBehind + (IntBytes)u*WARP_SIZE*BytePerPack)/(IntBytes)sizeof(T));
     }
 
     #pragma unroll Unroll
@@ -232,6 +246,14 @@ __device__ __forceinline__ void loadSources(
       src += WARP_SIZE * BytePerPack;
     }
   }
+
+  // RCCL NaN/Inf detector (pipelined path input): inspect the first loaded
+  // operand. No-op unless built with RCCL_ENABLE_NAN_CHECK.
+  #pragma unroll Unroll
+  for (int u = 0; u < Unroll; u++)
+    RCCL_NANCHECK(buff[0][u], RCCL_NANCHECK_INPUT,
+                  (globalOffset + (IntBytes)u*WARP_SIZE*BytePerPack)
+                    /(IntBytes)sizeof(typename RedFn::EltType));
 }
 
 template <typename RedFn, typename DstPtrFn, typename IntBytes, int MultimemDsts, int MinSrcs, int MaxSrcs, int MinDsts, int MaxDsts, int PreOpSrcs, int Unroll, int BytePerPack>
@@ -256,6 +278,15 @@ template <typename RedFn, typename DstPtrFn, typename IntBytes, int MultimemDsts
     #pragma unroll Unroll
     for (int u = 0; u < Unroll; u++)
       buff[0][u] = applyPostOp(redFn, buff[0][u]);
+  }
+
+  // RCCL NaN/Inf detector (pipelined path): inspect the reduced result pack
+  // before it is stored. No-op unless built with RCCL_ENABLE_NAN_CHECK.
+  #pragma unroll Unroll
+  for (int u = 0; u < Unroll; u++) {
+    RCCL_NANCHECK(buff[0][u], RCCL_NANCHECK_OUTPUT,
+                  (tailThreadBytesBehind + (IntBytes)u*WARP_SIZE*BytePerPack)
+                    /(IntBytes)sizeof(typename RedFn::EltType));
   }
 
   #pragma unroll Unroll
@@ -480,9 +511,13 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
           acc[u] = ld_volatile_global<BytePerPack>(minSrcs[0]);
             // coverity[dead_error_condition]
           bias[u] = ld_volatile_global<BytePerPack>(accPtr);
+          RCCL_NANCHECK(bias[u], RCCL_NANCHECK_INPUT,  // opt-in detector: bias operand
+                        (threadBytesBehind + (IntBytes)u*WARP_SIZE*BytePerPack)/(IntBytes)sizeof(T));
           accPtr += WARP_SIZE*BytePerPack;
           if (0 < PreOpSrcs) acc[u] = applyPreOp(redFn, acc[u]);
         }
+        RCCL_NANCHECK(acc[u], RCCL_NANCHECK_INPUT,  // opt-in detector: source operand
+                      (threadBytesBehind + (IntBytes)u*WARP_SIZE*BytePerPack)/(IntBytes)sizeof(T));
         minSrcs[0] += WARP_SIZE*BytePerPack;
       }
     }
@@ -535,6 +570,14 @@ __device__ __forceinline__ void reduceCopyPacksWithBias(
       for (int u=0; u < Unroll; u++)
         acc[u] = applyPostOp(redFn, acc[u]);
     }
+
+    // RCCL NaN/Inf detector: inspect the reduced result before store. No-op
+    // unless built with RCCL_ENABLE_NAN_CHECK. (The d==0 dst additionally folds
+    // in the bias operand, which is checked as INPUT above.)
+    #pragma unroll Unroll
+    for (int u=0; u < Unroll; u++)
+      RCCL_NANCHECK(acc[u], RCCL_NANCHECK_OUTPUT,
+                    (threadBytesBehind + (IntBytes)u*WARP_SIZE*BytePerPack)/(IntBytes)sizeof(T));
 
     #pragma unroll Unroll
     for (int d=0; d < MinDsts; d++) {

--- a/projects/rccl/src/device/nan_check.h
+++ b/projects/rccl/src/device/nan_check.h
@@ -1,0 +1,202 @@
+/*************************************************************************
+ * Modifications Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Opt-in, compile-time-gated device-side NaN/Inf detector for RCCL reductions.
+//
+// Enable with `-DRCCL_ENABLE_NAN_CHECK=ON` (see top-level CMakeLists.txt and
+// install.sh `--enable-nan-check`). When the macro RCCL_ENABLE_NAN_CHECK is NOT
+// defined, every helper/macro here expands to nothing, so there is truly zero
+// overhead in a normal build.
+//
+// The detector inspects the operands/results that flow through the reduction
+// combine point in common_kernel.h (BytePack<N> packs). For floating-point
+// element types it tests each lane with isnan()/isinf(); on a hit it bumps a
+// global device counter and emits a single, rate-limited device printf with
+// enough context (INPUT vs OUTPUT, the offending value, the element offset, and
+// blockIdx/threadIdx so the rank+channel can be inferred host-side).
+//
+// Non-floating-point element types are a no-op (NaN/Inf only exist for floats).
+
+#ifndef RCCL_NAN_CHECK_H_
+#define RCCL_NAN_CHECK_H_
+
+#ifdef RCCL_ENABLE_NAN_CHECK
+
+#include "op128.h"
+#include "reduce_kernel.h"   // for IsFloatingPoint<T>
+#include <hip/hip_runtime.h>
+#include <cstdint>
+#include <cstdio>
+#include <type_traits>
+
+#include "rccl_float8.h"
+
+// What is being inspected at the reduction combine point.
+enum rcclNanCheckKind {
+  RCCL_NANCHECK_INPUT  = 0,   // an operand loaded into the reduction
+  RCCL_NANCHECK_OUTPUT = 1    // the reduced result about to be stored
+};
+
+// Global device counters. The first counts every detected element (so the host
+// can tell whether anything was seen at all). The second gates the printf so a
+// pathological run cannot flood stdout.
+//
+// These are file-local (`static __device__`) so the header can be included by
+// every device translation unit without causing duplicate-symbol errors at
+// device-link time. Rate-limiting is therefore per-translation-unit, which is
+// fine for a debugging aid.
+static __device__ unsigned long long rcclNanCheckHitCount   = 0;
+static __device__ unsigned int       rcclNanCheckPrintCount = 0;
+
+// Maximum number of device printf lines emitted across the whole kernel launch.
+#ifndef RCCL_NANCHECK_MAX_PRINTS
+#define RCCL_NANCHECK_MAX_PRINTS 32
+#endif
+
+// Scalar test for one floating-point element. Promote sub-fp32 types to float so
+// isnan/isinf are well-defined for all supported element types.
+template<typename T>
+__device__ __forceinline__ bool rcclNanCheckScalar(T v) {
+  float f = (float)v;
+  return isnan(f) || isinf(f);
+}
+template<>
+__device__ __forceinline__ bool rcclNanCheckScalar<float>(float v) {
+  return isnan(v) || isinf(v);
+}
+template<>
+__device__ __forceinline__ bool rcclNanCheckScalar<double>(double v) {
+  return isnan(v) || isinf(v);
+}
+
+// Report one offending element. Rate-limited and (optionally) aborts.
+// MUST be noinline: it carries a device printf (varargs). If inlined into the
+// heavily-unrolled hot reduce path at every check site (x lanes x Unroll), it
+// makes amdclang -O3 compilation explode (single-kernel compiles ran >20 min).
+// Out-of-line, each check site is just a cheap isnan branch + a call.
+template<typename T>
+__device__ __attribute__((noinline)) void rcclNanCheckReport(
+    T v, int kind, long long eltOffset) {
+  atomicAdd(&rcclNanCheckHitCount, 1ull);
+  unsigned int idx = atomicAdd(&rcclNanCheckPrintCount, 1u);
+  if (idx < RCCL_NANCHECK_MAX_PRINTS) {
+    // %g works once we promote to float/double; rank+channel are recovered
+    // host-side from the (block,thread) coordinates plus the launch grid.
+    printf("[RCCL NaN/Inf] %s value=%g eltOffset=%lld block=(%d,%d,%d) thread=(%d,%d,%d)\n",
+           kind == RCCL_NANCHECK_OUTPUT ? "OUTPUT" : "INPUT",
+           (double)(float)v, eltOffset,
+           blockIdx.x, blockIdx.y, blockIdx.z,
+           threadIdx.x, threadIdx.y, threadIdx.z);
+  }
+#ifdef RCCL_NANCHECK_ABORT
+  __trap();
+#endif
+}
+
+// Extract element `e` (of type T) from a BytePack<Bytes> as a BytePack<sizeof(T)>.
+// We copy the raw bytes via the always-present u8[] member, which works for every
+// pack size (BytePack<0> is excluded by the EltPerPack>0 guard below) and avoids
+// depending on differently-named sub-pack members across pack sizes.
+template<typename T, int Bytes>
+__device__ __forceinline__ BytePack<sizeof(T)> rcclNanCheckElt(
+    BytePack<Bytes> pack, int e) {
+  BytePack<sizeof(T)> out;
+  #pragma unroll
+  for (int i = 0; i < (int)sizeof(T); i++) {
+    out.u8[i] = pack.u8[e*(int)sizeof(T) + i];
+  }
+  return out;
+}
+
+// Core: iterate the EltPerPack lanes of a BytePack and test each as type T.
+// `eltBase` is the element-index of lane 0 (best-effort location hint).
+template<typename T, int Bytes>
+__device__ __forceinline__ void rcclNanCheckPack(
+    BytePack<Bytes> pack, int kind, long long eltBase) {
+  constexpr int EltPerPack = Bytes / sizeof(T);
+  // Guard the empty-pack case (e.g. BytePack<0>) so the body, and therefore
+  // rcclNanCheckElt's member access, is never instantiated for it.
+  if constexpr (EltPerPack > 0) {
+    #pragma unroll
+    for (int e = 0; e < EltPerPack; e++) {
+      T v = fromPack<T>(rcclNanCheckElt<T, Bytes>(pack, e));
+      if (rcclNanCheckScalar<T>(v)) {
+        rcclNanCheckReport<T>(v, kind, eltBase + e);
+      }
+    }
+  }
+}
+
+// Dispatcher keyed on whether the reduction's element type is floating point.
+// Non-float element types compile to nothing.
+template<typename Fn, int Bytes, bool IsFloat>
+struct rcclNanCheckDispatch {
+  __device__ __forceinline__ static void run(BytePack<Bytes>, int, long long) {}
+};
+template<typename Fn, int Bytes>
+struct rcclNanCheckDispatch<Fn, Bytes, true> {
+  __device__ __forceinline__ static void run(
+      BytePack<Bytes> pack, int kind, long long eltBase) {
+    rcclNanCheckPack<typename Fn::EltType, Bytes>(pack, kind, eltBase);
+  }
+};
+
+// Entry point used at the insertion site. `Fn` is the redop functor (FuncSum<T>
+// etc.), so Fn::EltType gives us the scalar element type.
+template<typename Fn, int Bytes>
+__device__ __forceinline__ void rcclNanCheck(
+    BytePack<Bytes> pack, int kind, long long eltBase) {
+  rcclNanCheckDispatch<Fn, Bytes,
+    IsFloatingPoint<typename Fn::EltType>::value>::run(pack, kind, eltBase);
+}
+
+// --- Word variant for the LL / LL128 reduce paths --------------------------
+// LL (prims_ll.h) and LL128 (prims_ll128.h) hold reduced data in 64-bit words
+// (uint64_t), not BytePack<>. Reinterpret the 8 bytes as a pack of T and test
+// each lane. Non-float T compiles to nothing.
+template<typename T, bool IsFloat>
+struct rcclNanCheckWordDispatch {
+  __device__ __forceinline__ static void run(unsigned long long, int, long long) {}
+};
+template<typename T>
+struct rcclNanCheckWordDispatch<T, true> {
+  __device__ __forceinline__ static void run(
+      unsigned long long w, int kind, long long eltBase) {
+    constexpr int n = (int)(sizeof(unsigned long long) / sizeof(T));
+    if constexpr (n > 0) {
+      T vals[n];
+      __builtin_memcpy(vals, &w, n * sizeof(T));
+      #pragma unroll
+      for (int i = 0; i < n; i++) {
+        if (rcclNanCheckScalar<T>(vals[i]))
+          rcclNanCheckReport<T>(vals[i], kind, eltBase + i);
+      }
+    }
+  }
+};
+template<typename T>
+__device__ __forceinline__ void rcclNanCheckWord(
+    unsigned long long w, int kind, long long eltBase) {
+  rcclNanCheckWordDispatch<T, IsFloatingPoint<T>::value>::run(w, kind, eltBase);
+}
+
+// Convenience macros for the insertion sites.
+// RCCL_NANCHECK:      RedFn/BytePerPack in scope (common_kernel.h, Simple path).
+// RCCL_NANCHECK_WORD: element type T in scope (prims_ll.h / prims_ll128.h).
+#define RCCL_NANCHECK(pack, kind, eltBase) \
+  rcclNanCheck<RedFn, BytePerPack>((pack), (kind), (long long)(eltBase))
+#define RCCL_NANCHECK_WORD(word, kind, eltBase) \
+  rcclNanCheckWord<T>((unsigned long long)(word), (kind), (long long)(eltBase))
+
+#else // !RCCL_ENABLE_NAN_CHECK
+
+// Zero-overhead no-op when the detector is disabled.
+#define RCCL_NANCHECK(pack, kind, eltBase) do {} while (0)
+#define RCCL_NANCHECK_WORD(word, kind, eltBase) do {} while (0)
+
+#endif // RCCL_ENABLE_NAN_CHECK
+
+#endif // RCCL_NAN_CHECK_H_

--- a/projects/rccl/src/device/nan_check.h
+++ b/projects/rccl/src/device/nan_check.h
@@ -183,6 +183,23 @@ __device__ __forceinline__ void rcclNanCheckWord(
   rcclNanCheckWordDispatch<T, IsFloatingPoint<T>::value>::run(w, kind, eltBase);
 }
 
+// --- Reduce combine-point hook ---------------------------------------------
+// Called from applyReduce() so Simple-path reduction operands are INPUT-checked
+// without instrumenting each load site in common_kernel.h. eltOffset is -1 (not
+// available here). Restricted to BytePack<N> (Simple + bias fold): the LL/LL128
+// paths reduce raw words whose flag/shuffled slots would false-positive, so they
+// keep their own flag-guarded RCCL_NANCHECK_WORD checks.
+template<typename Fn, typename Pack>
+__device__ __forceinline__ void rcclNanCheckReduceInput(Pack a, Pack b) {
+  if constexpr (!std::is_integral<Pack>::value) {
+    constexpr int Bytes = (int)BytePackOf<Pack>::Size;
+    using Disp = rcclNanCheckDispatch<Fn, Bytes,
+                   IsFloatingPoint<typename Fn::EltType>::value>;
+    Disp::run(toPack(a), RCCL_NANCHECK_INPUT, (long long)-1);
+    Disp::run(toPack(b), RCCL_NANCHECK_INPUT, (long long)-1);
+  }
+}
+
 // Convenience macros for the insertion sites.
 // RCCL_NANCHECK:      RedFn/BytePerPack in scope (common_kernel.h, Simple path).
 // RCCL_NANCHECK_WORD: element type T in scope (prims_ll.h / prims_ll128.h).
@@ -190,12 +207,16 @@ __device__ __forceinline__ void rcclNanCheckWord(
   rcclNanCheck<RedFn, BytePerPack>((pack), (kind), (long long)(eltBase))
 #define RCCL_NANCHECK_WORD(word, kind, eltBase) \
   rcclNanCheckWord<T>((unsigned long long)(word), (kind), (long long)(eltBase))
+// Used inside applyReduce(); `fn` is the redop functor in scope there.
+#define RCCL_NANCHECK_REDUCE_INPUTS(fn, a, b) \
+  rcclNanCheckReduceInput<decltype(fn)>((a), (b))
 
 #else // !RCCL_ENABLE_NAN_CHECK
 
 // Zero-overhead no-op when the detector is disabled.
 #define RCCL_NANCHECK(pack, kind, eltBase) do {} while (0)
 #define RCCL_NANCHECK_WORD(word, kind, eltBase) do {} while (0)
+#define RCCL_NANCHECK_REDUCE_INPUTS(fn, a, b) do {} while (0)
 
 #endif // RCCL_ENABLE_NAN_CHECK
 

--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -414,6 +414,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
       if (RECV) {
         readLLBeginAll<1>(offset, line);
         peerData = readLL(offset, 0);
+        RCCL_NANCHECK_WORD(peerData, RCCL_NANCHECK_INPUT, (long long)offset*EltPerLine);  // opt-in NaN/Inf detector (offset is a fifo line, scale to elements)
       }
       if (SRC) {
         data = dl.loadFinish();
@@ -431,6 +432,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
       }
 
       if (postOp) data = applyPostOp(redOp, data);
+      RCCL_NANCHECK_WORD(data, RCCL_NANCHECK_OUTPUT, (long long)offset*EltPerLine);  // opt-in NaN/Inf detector (reduced result; offset is a fifo line, scale to elements)
 
       // Send : inter-node, then intra-node, then local
       if (SEND) {

--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -414,11 +414,12 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
       if (RECV) {
         readLLBeginAll<1>(offset, line);
         peerData = readLL(offset, 0);
-        RCCL_NANCHECK_WORD(peerData, RCCL_NANCHECK_INPUT, (long long)offset*EltPerLine);  // opt-in NaN/Inf detector (offset is a fifo line, scale to elements)
+        RCCL_NANCHECK_WORD(peerData, RCCL_NANCHECK_INPUT, (long long)offset*EltPerLine);  // peer operand
       }
       if (SRC) {
         data = dl.loadFinish();
         if (SrcBuf == Input) data = applyPreOp(redOp, data);
+        RCCL_NANCHECK_WORD(data, RCCL_NANCHECK_INPUT, (long long)offset*EltPerLine);  // local source operand
       }
       if (RECV) {
         data = !SRC ? peerData : applyReduce(redOp, peerData, data);
@@ -427,12 +428,13 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
         // coverity[dead_error_line]
         for (int i=1; i < MaxRecv && i < fan.nrecv(); i++) {
           peerData = readLLFinish(offset, line, i);
+          RCCL_NANCHECK_WORD(peerData, RCCL_NANCHECK_INPUT, (long long)offset*EltPerLine);  // additional peer operand
           data = applyReduce(redOp, peerData, data);
         }
       }
 
       if (postOp) data = applyPostOp(redOp, data);
-      RCCL_NANCHECK_WORD(data, RCCL_NANCHECK_OUTPUT, (long long)offset*EltPerLine);  // opt-in NaN/Inf detector (reduced result; offset is a fifo line, scale to elements)
+      RCCL_NANCHECK_WORD(data, RCCL_NANCHECK_OUTPUT, (long long)offset*EltPerLine);  // opt-in detector: reduced result (offset = fifo line scaled to elements)
 
       // Send : inter-node, then intra-node, then local
       if (SEND) {

--- a/projects/rccl/src/device/prims_ll128.h
+++ b/projects/rccl/src/device/prims_ll128.h
@@ -308,6 +308,21 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
       }
     }
 
+#ifdef RCCL_ENABLE_NAN_CHECK
+    // opt-in NaN/Inf detector on the reduced LL128 result words. v[u] is data;
+    // on flagThread v[u+1] is replaced by the flag at store time, so skip it.
+    // The reported offset is the fifo wire-word index of the value (v[u] stores
+    // to ll128Offset + u*WARP_SIZE), not a user-buffer element index: the LL128
+    // wire layout interleaves flag words, so there is no cheap element mapping
+    // here. The value + (block,thread) coordinates are the actionable signal.
+    #pragma unroll
+    for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
+      RCCL_NANCHECK_WORD(v[u], RCCL_NANCHECK_OUTPUT, (long long)ll128Offset + u*WARP_SIZE);
+      if (!flagThread)
+        RCCL_NANCHECK_WORD(v[u+1], RCCL_NANCHECK_OUTPUT, (long long)ll128Offset + u*WARP_SIZE + 1);
+    }
+#endif
+
 #if RCCL_USE_WBINVL1_VOL
     if (tid == 0) __builtin_amdgcn_buffer_wbinvl1();
 #endif

--- a/projects/rccl/src/device/prims_ll128.h
+++ b/projects/rccl/src/device/prims_ll128.h
@@ -258,6 +258,13 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
             v[u+1] = applyPreOp(redOp, v[u+1]);
         }
       }
+      // opt-in detector: local source operand (skip flag slot on flagThread).
+      #pragma unroll
+      for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
+        RCCL_NANCHECK_WORD(v[u], RCCL_NANCHECK_INPUT, (long long)ll128Offset + u*WARP_SIZE);
+        if (!flagThread)
+          RCCL_NANCHECK_WORD(v[u+1], RCCL_NANCHECK_INPUT, (long long)ll128Offset + u*WARP_SIZE + 1);
+      }
     }
 
     /************************ Recv rest *********************/
@@ -265,6 +272,10 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
       { // Consume data from first recv
         #pragma unroll
         for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
+          // opt-in detector: peer operand (skip flag slot on flagThread).
+          RCCL_NANCHECK_WORD(vr[u], RCCL_NANCHECK_INPUT, (long long)ll128Offset + u*WARP_SIZE);
+          if (!flagThread)
+            RCCL_NANCHECK_WORD(vr[u+1], RCCL_NANCHECK_INPUT, (long long)ll128Offset + u*WARP_SIZE + 1);
           v[u]   = SRC ? applyReduce(redOp, vr[u], v[u]) : vr[u];
           v[u+1] = SRC ? applyReduce(redOp, vr[u+1], v[u+1]) : vr[u+1];
         }
@@ -293,6 +304,10 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
 
         #pragma unroll
         for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
+          // opt-in detector: additional peer operand (skip flag slot on flagThread).
+          RCCL_NANCHECK_WORD(vr[u], RCCL_NANCHECK_INPUT, (long long)ll128Offset + u*WARP_SIZE);
+          if (!flagThread)
+            RCCL_NANCHECK_WORD(vr[u+1], RCCL_NANCHECK_INPUT, (long long)ll128Offset + u*WARP_SIZE + 1);
           v[u]   = applyReduce(redOp, vr[u], v[u]);
           v[u+1] = applyReduce(redOp, vr[u+1], v[u+1]);
         }
@@ -309,12 +324,8 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
     }
 
 #ifdef RCCL_ENABLE_NAN_CHECK
-    // opt-in NaN/Inf detector on the reduced LL128 result words. v[u] is data;
-    // on flagThread v[u+1] is replaced by the flag at store time, so skip it.
-    // The reported offset is the fifo wire-word index of the value (v[u] stores
-    // to ll128Offset + u*WARP_SIZE), not a user-buffer element index: the LL128
-    // wire layout interleaves flag words, so there is no cheap element mapping
-    // here. The value + (block,thread) coordinates are the actionable signal.
+    // opt-in detector: reduced result (skip flag slot on flagThread). Offset is
+    // the fifo wire-word index, not a user element index (LL128 interleaves flags).
     #pragma unroll
     for (int u=0; u<ELEMS_PER_THREAD; u+=2) {
       RCCL_NANCHECK_WORD(v[u], RCCL_NANCHECK_OUTPUT, (long long)ll128Offset + u*WARP_SIZE);

--- a/projects/rccl/src/device/reduce_kernel.h
+++ b/projects/rccl/src/device/reduce_kernel.h
@@ -35,6 +35,10 @@ struct IsFloatingPoint<float>: std::true_type {};
 template<>
 struct IsFloatingPoint<double>: std::true_type {};
 
+// Opt-in NaN/Inf detector (no-op unless RCCL_ENABLE_NAN_CHECK). Included after
+// IsFloatingPoint/op128 so applyReduce can hook the Simple-path combine point.
+#include "nan_check.h"
+
 ////////////////////////////////////////////////////////////////////////////////
 // The reduction function classes. All classes must:
 //  1. Expose the `EltType` typedef.
@@ -172,6 +176,7 @@ __device__ __forceinline__ BytePack<BytePackOf<PackA>::Size*sizeof(B)/sizeof(A)>
 
 template<typename Fn, typename Pack>
 __device__ __forceinline__ Pack applyReduce(Fn fn, Pack a, Pack b) {
+  RCCL_NANCHECK_REDUCE_INPUTS(fn, a, b);  // opt-in detector: Simple-path operands
   return fromPack<Pack>(
     Apply_Reduce_MaybeEmpty<Fn, BytePackOf<Pack>::Size/sizeof(typename Fn::EltType)>
       ::reduce(fn, toPack(a), toPack(b))

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -172,6 +172,7 @@ if(BUILD_TESTS)
     BroadcastTests.cpp
     GatherTests.cpp
     GroupCallTests.cpp
+    NanCheckTests.cpp
     NonBlockingTests.cpp
     ReduceScatterTests.cpp
     ReduceTests.cpp

--- a/projects/rccl/test/NanCheckTests.cpp
+++ b/projects/rccl/test/NanCheckTests.cpp
@@ -1,0 +1,192 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Validates the opt-in device-side NaN/Inf detector (RCCL_ENABLE_NAN_CHECK).
+// We inject a NaN into one rank's AllReduce input and assert the detector's
+// device-side report ("[RCCL NaN/Inf] ...") is emitted.
+//
+// Why a subprocess: HIP device printf is flushed to the stdout fd the runtime
+// caches at init, so gtest's per-test CaptureStdout (which redirects fd 1 later)
+// does NOT capture it. RCCL's reduce kernels are compiled device-only, so there
+// is also no host-registered symbol for hipMemcpyFromSymbol. The reliable
+// signal is the device printf itself, captured by running the collective in a
+// fresh child process whose stdout is a pipe from the start. We re-exec this
+// same test binary filtered to the helper test, so no extra binary is needed
+// and the detector requires no changes.
+
+#include <gtest/gtest.h>
+#include <rccl/rccl.h>
+#include <hip/hip_runtime.h>
+
+#include <unistd.h>
+
+#include <cmath>
+#include <cstdio>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "common/StandaloneUtils.hpp"   // HIPCALL, NCCLCHECK
+
+namespace RcclUnitTesting
+{
+#ifdef RCCL_ENABLE_NAN_CHECK
+
+  // Runs a 2-GPU AllReduce(sum) with a NaN injected into GPU 0's input.
+  // Returns: 0 on success (NaN propagated), 1 on logic error, 77 to indicate skip.
+  static int RunNanAllReduce()
+  {
+    int numDevices = 0;
+    if (hipGetDeviceCount(&numDevices) != hipSuccess || numDevices < 2) return 77;
+
+    const int    ngpu = 2;
+    const size_t N    = 1 << 20;
+    std::vector<ncclComm_t> comms(ngpu);
+    if (ncclCommInitAll(comms.data(), ngpu, /*devlist=*/nullptr) != ncclSuccess) return 1;
+
+    std::vector<float>       host(N, 1.0f);
+    std::vector<float*>      sbuf(ngpu, nullptr), rbuf(ngpu, nullptr);
+    std::vector<hipStream_t> st(ngpu);
+    for (int i = 0; i < ngpu; i++) {
+      if (hipSetDevice(i) != hipSuccess) return 1;
+      hipStreamCreate(&st[i]);
+      hipMalloc(&sbuf[i], N * sizeof(float));
+      hipMalloc(&rbuf[i], N * sizeof(float));
+      hipMemcpy(sbuf[i], host.data(), N * sizeof(float), hipMemcpyHostToDevice);
+    }
+    const size_t kIdx = 123456;
+    float nan = std::nanf("");
+    hipSetDevice(0);
+    hipMemcpy(&sbuf[0][kIdx], &nan, sizeof(float), hipMemcpyHostToDevice);
+
+    ncclGroupStart();
+    for (int i = 0; i < ngpu; i++)
+      ncclAllReduce(sbuf[i], rbuf[i], N, ncclFloat, ncclSum, comms[i], st[i]);
+    ncclGroupEnd();
+    for (int i = 0; i < ngpu; i++) { hipSetDevice(i); hipStreamSynchronize(st[i]); hipDeviceSynchronize(); }
+
+    float result = 0.0f;
+    hipSetDevice(1);
+    hipMemcpy(&result, &rbuf[1][kIdx], sizeof(float), hipMemcpyDeviceToHost);
+
+    for (int i = 0; i < ngpu; i++) { hipSetDevice(i); hipFree(sbuf[i]); hipFree(rbuf[i]); hipStreamDestroy(st[i]); }
+    for (int i = 0; i < ngpu; i++) ncclCommDestroy(comms[i]);
+    return std::isnan(result) ? 0 : 1;
+  }
+
+  // Helper "test": just runs the collective so its device printf hits this
+  // process's stdout. Invoked in-process by the suite and re-exec'd as a child
+  // by the assertion test below.
+  TEST(NanCheck, HelperRunCollectiveWithNaN)
+  {
+    int rc = RunNanAllReduce();
+    if (rc == 77) GTEST_SKIP() << "This test requires at least 2 GPUs.";
+    EXPECT_EQ(rc, 0) << "Injected NaN did not propagate through AllReduce.";
+  }
+
+  // Drives the bias / accumulate reduce path (reduceCopyPacksWithBias, USE_ACC=1)
+  // via the RCCL ncclAllReduceWithBias extension, with a NaN in GPU 0's input.
+  static int RunNanAllReduceWithBias()
+  {
+    int numDevices = 0;
+    if (hipGetDeviceCount(&numDevices) != hipSuccess || numDevices < 2) return 77;
+
+    const int    ngpu = 2;
+    const size_t N    = 1 << 20;
+    std::vector<ncclComm_t> comms(ngpu);
+    if (ncclCommInitAll(comms.data(), ngpu, /*devlist=*/nullptr) != ncclSuccess) return 1;
+
+    std::vector<float>       host(N, 1.0f);
+    std::vector<float*>      sbuf(ngpu, nullptr), rbuf(ngpu, nullptr), abuf(ngpu, nullptr);
+    std::vector<hipStream_t> st(ngpu);
+    for (int i = 0; i < ngpu; i++) {
+      if (hipSetDevice(i) != hipSuccess) return 1;
+      hipStreamCreate(&st[i]);
+      hipMalloc(&sbuf[i], N * sizeof(float));
+      hipMalloc(&rbuf[i], N * sizeof(float));
+      hipMalloc(&abuf[i], N * sizeof(float));            // bias / accumulator buffer
+      hipMemcpy(sbuf[i], host.data(), N * sizeof(float), hipMemcpyHostToDevice);
+      hipMemcpy(abuf[i], host.data(), N * sizeof(float), hipMemcpyHostToDevice);
+    }
+    const size_t kIdx = 123456;
+    float nan = std::nanf("");
+    hipSetDevice(0);
+    hipMemcpy(&sbuf[0][kIdx], &nan, sizeof(float), hipMemcpyHostToDevice);
+
+    ncclGroupStart();
+    for (int i = 0; i < ngpu; i++)
+      ncclAllReduceWithBias(sbuf[i], rbuf[i], N, ncclFloat, ncclSum, comms[i], st[i], abuf[i]);
+    ncclGroupEnd();
+    for (int i = 0; i < ngpu; i++) { hipSetDevice(i); hipStreamSynchronize(st[i]); hipDeviceSynchronize(); }
+
+    float result = 0.0f;
+    hipSetDevice(1);
+    hipMemcpy(&result, &rbuf[1][kIdx], sizeof(float), hipMemcpyDeviceToHost);
+
+    for (int i = 0; i < ngpu; i++) { hipSetDevice(i); hipFree(sbuf[i]); hipFree(rbuf[i]); hipFree(abuf[i]); hipStreamDestroy(st[i]); }
+    for (int i = 0; i < ngpu; i++) ncclCommDestroy(comms[i]);
+    return std::isnan(result) ? 0 : 1;
+  }
+
+  TEST(NanCheck, HelperRunBiasCollectiveWithNaN)
+  {
+    int rc = RunNanAllReduceWithBias();
+    if (rc == 77) GTEST_SKIP() << "This test requires at least 2 GPUs.";
+    EXPECT_EQ(rc, 0) << "Injected NaN did not propagate through AllReduceWithBias.";
+  }
+
+  // Re-exec this binary filtered to a helper test in a child process (optionally
+  // forcing a protocol) and return the child's combined stdout/stderr. A fresh
+  // child is required because HIP device printf only reaches the stdout fd the
+  // runtime cached at process start (gtest's CaptureStdout cannot intercept it).
+  static std::string RunHelper(const char* filter, const char* proto)
+  {
+    char self[4096] = {0};
+    ssize_t n = readlink("/proc/self/exe", self, sizeof(self) - 1);
+    if (n <= 0) return "";
+    self[n] = '\0';
+
+    std::string cmd;
+    if (proto) cmd += std::string("NCCL_PROTO=") + proto + " ";
+    cmd += "'" + std::string(self) + "' --gtest_filter='" + filter + "' --gtest_color=no 2>&1";
+    FILE* p = popen(cmd.c_str(), "r");
+    if (!p) return "";
+    std::string out;
+    char buf[4096];
+    size_t r;
+    while ((r = fread(buf, 1, sizeof(buf), p)) > 0) out.append(buf, r);
+    pclose(p);
+    return out;
+  }
+
+  static void ExpectDetects(const char* filter, const char* proto, const char* what)
+  {
+    int numDevices = 0;
+    if (hipGetDeviceCount(&numDevices) != hipSuccess || numDevices < 2)
+      GTEST_SKIP() << "This test requires at least 2 GPUs.";
+    std::string out = RunHelper(filter, proto);
+    std::cout << out;   // surface in CI logs
+    EXPECT_NE(out.find("[RCCL NaN/Inf]"), std::string::npos)
+        << "Detector did not report the injected NaN for " << what
+        << ". Child output:\n" << out;
+  }
+
+  // Simple / LL / LL128 reduce paths (common_kernel.h, prims_ll.h, prims_ll128.h).
+  TEST(NanCheck, AllReduceDetectsInjectedNaN_Simple) { ExpectDetects("NanCheck.HelperRunCollectiveWithNaN", "Simple", "AllReduce/Simple"); }
+  TEST(NanCheck, AllReduceDetectsInjectedNaN_LL)     { ExpectDetects("NanCheck.HelperRunCollectiveWithNaN", "LL", "AllReduce/LL"); }
+  TEST(NanCheck, AllReduceDetectsInjectedNaN_LL128)  { ExpectDetects("NanCheck.HelperRunCollectiveWithNaN", "LL128", "AllReduce/LL128"); }
+  // Bias / accumulate reduce path (reduceCopyPacksWithBias).
+  TEST(NanCheck, AllReduceWithBiasDetectsInjectedNaN) { ExpectDetects("NanCheck.HelperRunBiasCollectiveWithNaN", nullptr, "AllReduceWithBias"); }
+
+#else  // !RCCL_ENABLE_NAN_CHECK
+
+  TEST(NanCheck, DISABLED_AllReduceDetectsInjectedNaN)
+  {
+    GTEST_SKIP() << "Built without RCCL_ENABLE_NAN_CHECK; the NaN detector is a no-op.";
+  }
+
+#endif
+}  // namespace RcclUnitTesting


### PR DESCRIPTION
Adds an optional device side detector that flags NaN or Inf in RCCL reductions.

## Motivation

When a NaN or Inf shows up in a reduction it is hard to tell where it entered. This adds a build time switch that catches it right at the reduce step and prints the value, element offset and block/thread coords so you can trace it. It is off by default so normal builds are unaffected.

## Technical Details

New header src/device/nan_check.h with the check, gated by RCCL_ENABLE_NAN_CHECK (build with --enable-nan-check, or --enable-nan-check-abort to trap on the first hit). It is wired into every reduce path: Simple (common_kernel.h), the pipelined helper (loadSources and reduceAndStore), the bias path (reduceCopyPacksWithBias), and LL and LL128 (prims_ll.h, prims_ll128.h). Integer types are a no op since only floats have NaN or Inf. The default thread count is unchanged.

## JIRA ID

ROCM-25455

## Test Plan

NanCheckTests injects a NaN into a 2 GPU AllReduce and checks the detector fires, one test per protocol (Simple, LL, LL128) plus the bias path through ncclAllReduceWithBias. A CI workflow builds with the flag and runs them.

## Test Result

All NanCheck tests pass and the detector reports the injected NaN on every reduce path.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
