### PR TITLE
rocrtst: Make hsa_amd_memory APIs symmetric and Skip VirtMemory VA-alias subtest under ASAN

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -1519,6 +1519,17 @@ void VirtMemoryTestBasic::TestVirtAddressAlias(void) {
     PrintMemorySubtestHeader("VA Alias Access Test");
   }
 
+#ifdef ROCRTST_ASAN
+  // The ASAN interceptors do not support multiple VA mappings of one handle,
+  // so skip this subtest under ASAN (bug to be filed to compiler-rt).
+  if (verbosity() > 0) {
+    std::cout << "    Skipping VA alias test under ASAN (vmem aliasing unsupported by interceptors)"
+              << std::endl;
+    std::cout << kSubTestSeparator << std::endl;
+  }
+  return;
+#endif
+
   bool supp = false;
   ASSERT_SUCCESS(hsa_system_get_info(HSA_AMD_SYSTEM_INFO_VIRTUAL_MEM_API_SUPPORTED, (void*)&supp));
   if (!supp) {

--- a/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/virtual_memory.cc
@@ -882,9 +882,9 @@ void VirtMemoryTestBasic::GPUAccessToCPUMemoryTest(hsa_agent_t cpuAgent, hsa_age
     EXPECT_SUCCESS(hsa_amd_vmem_address_free(dev_data, sizeof(*dev_data)));
   }
 
-  if (host_data) hsa_memory_free(host_data);
+  if (host_data) hsa_amd_memory_pool_free(host_data);
   if (kernArgsVirt) {
-    hsa_memory_free(kernArgsVirt);
+    hsa_amd_memory_pool_free(kernArgsVirt);
   }
   if (signal.handle) {
     hsa_signal_destroy(signal);
@@ -1137,9 +1137,9 @@ void VirtMemoryTestBasic::GPUAccessToGPUMemoryTest(hsa_agent_t cpuAgent, hsa_age
     EXPECT_SUCCESS(hsa_amd_vmem_address_free(dev_data, sizeof(*dev_data)));
   }
 
-  if (host_data) hsa_memory_free(host_data);
+  if (host_data) hsa_amd_memory_pool_free(host_data);
   if (kernArgsVirt) {
-    hsa_memory_free(kernArgsVirt);
+    hsa_amd_memory_pool_free(kernArgsVirt);
   }
   if (signal.handle) {
     hsa_signal_destroy(signal);
@@ -1505,9 +1505,9 @@ void VirtMemoryTestBasic::TestVirtAddressAlias(hsa_agent_t cpuAgent, hsa_agent_t
   ASSERT_SUCCESS(hsa_amd_vmem_address_free(addr1, alloc_size));
   ASSERT_SUCCESS(hsa_amd_vmem_address_free(addr2, alloc_size));
 
-  if (host_data) hsa_memory_free(host_data);
-  if (dummy_data) hsa_memory_free(dummy_data);
-  if (kernArgs) hsa_memory_free(kernArgs);
+  if (host_data) hsa_amd_memory_pool_free(host_data);
+  if (dummy_data) hsa_amd_memory_pool_free(dummy_data);
+  if (kernArgs) hsa_amd_memory_pool_free(kernArgs);
   if (signal.handle) hsa_signal_destroy(signal);
   if (queue) hsa_queue_destroy(queue);
 }


### PR DESCRIPTION
1. `hsa_amd_memory_` APIs are intercepted by ASAN, so we use them.
2. TestVirtAddressAlias reserves two VAs and maps both to a single vmem
handle. The ASAN device-allocator interceptors do not model one handle
aliased to multiple VAs, so freeing the second VA in cleanup hits a
stale region descriptor:
```
  CHECK failed: sanitizer_allocator_device.h:185
  "nearest_chunk >= h->map_beg" (map_beg=0xaaaa..)
  in asan_hsa_amd_vmem_address_free -> DeviceAllocatorT::GetBlockBegin
```
The functional path passes ("VA alias test PASSED"); the crash is purely
in ASAN cleanup and is heap-layout dependent (passes in isolation, fails
randomly in combined runs). Guard the subtest with #ifdef ROCRTST_ASAN
until the upstream compiler-rt bug is fixed.