### PR TITLE
[rocprofiler-register] Guard optional access before string_view construction

### DIFF
--- a/projects/rocprofiler-register/source/lib/rocprofiler-register/rocprofiler_register.cpp
+++ b/projects/rocprofiler-register/source/lib/rocprofiler-register/rocprofiler_register.cpp
@@ -667,8 +667,9 @@ is_attachment_library_registered()
 {
     for(const auto& itr : registered)
     {
-        if(itr.has_value() && std::string_view{ itr->common_name } ==
-                                  supported_library_trait<ROCP_REG_ROCATTACH>::common_name)
+        if(itr.has_value() &&
+           std::string_view{ itr->common_name } ==
+               supported_library_trait<ROCP_REG_ROCATTACH>::common_name)
         {
             return true;
         }

--- a/projects/rocprofiler-register/source/lib/rocprofiler-register/rocprofiler_register.cpp
+++ b/projects/rocprofiler-register/source/lib/rocprofiler-register/rocprofiler_register.cpp
@@ -667,8 +667,8 @@ is_attachment_library_registered()
 {
     for(const auto& itr : registered)
     {
-        if(std::string_view{ itr->common_name } ==
-           supported_library_trait<ROCP_REG_ROCATTACH>::common_name)
+        if(itr.has_value() && std::string_view{ itr->common_name } ==
+                                  supported_library_trait<ROCP_REG_ROCATTACH>::common_name)
         {
             return true;
         }


### PR DESCRIPTION
## Motivation

Fix a potential attach-time segfault in `is_attachment_library_registered()`.

The crash can occur when checking whether the rocattach library is already registered. If the registration lookup returns an empty `std::optional`, the previous code dereferenced it before constructing a `std::string_view`, which is undefined behavior.

## Technical Details

Add a `has_value()` check before accessing `itr->common_name`.

Previously, this code could dereference an empty std::optional: `std::string_view{itr->common_name}`

Since constructing a `std::string_view` from a `const char*` computes the string length, an invalid `common_name` access can lead to a segfault in `strlen`.

## JIRA ID

ROCM-20556

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
