### PR TITLE
Load versioned libamd_smi SONAME instead of symlink

### DIFF
--- a/projects/rccl/src/misc/amdsmi_wrap.cc
+++ b/projects/rccl/src/misc/amdsmi_wrap.cc
@@ -48,6 +48,18 @@ RCCL_PARAM(UseAmdSmiLib, "USE_AMD_SMI_LIB", 0); // Opt-in environment variable f
 #include <dlfcn.h>
 #define RCCL_AMDSMI_FN(name, rettype, arglist) rettype(*pfn_##name)arglist = nullptr;
 
+// dlopen the versioned SONAME (in every runtime tree), not the unversioned dev
+// symlink (devel / /opt/rocm only). The major comes from the amdsmi header,
+// which feeds its SOVERSION, so it tracks bumps. No header (AMDSMI_DIRECT==0):
+// fall back to the unversioned name.
+#if AMDSMI_DIRECT && defined(AMDSMI_LIB_VERSION_MAJOR)
+#define RCCL_AMDSMI_STR2(v) #v
+#define RCCL_AMDSMI_STR(v) RCCL_AMDSMI_STR2(v)
+#define RCCL_AMDSMI_LIBNAME "libamd_smi.so." RCCL_AMDSMI_STR(AMDSMI_LIB_VERSION_MAJOR)
+#else
+#define RCCL_AMDSMI_LIBNAME "libamd_smi.so"
+#endif
+
 
 namespace {
   // Core AMD SMI functions
@@ -152,9 +164,11 @@ ncclResult_t amd_smi_init() {
 
   if (rcclParamUseAmdSmiLib()) {
     if (pfn_amdsmi_init == nullptr) {
-      static void *libhandle = dlopen("libamd_smi.so", RTLD_NOW);
+      // RCCL_AMDSMI_LIBNAME resolves to the versioned SONAME when built against
+      // the amdsmi headers, otherwise the unversioned name (see above).
+      static void *libhandle = dlopen(RCCL_AMDSMI_LIBNAME, RTLD_NOW);
       if (libhandle == nullptr) {
-        WARN("Failed to open libamd_smi.so");
+        WARN("Failed to open %s", RCCL_AMDSMI_LIBNAME);
         amdSmiInitResult = ncclInternalError;
         return ncclInternalError;
       }

--- a/projects/rccl/src/misc/amdsmi_wrap.cc
+++ b/projects/rccl/src/misc/amdsmi_wrap.cc
@@ -49,9 +49,9 @@ RCCL_PARAM(UseAmdSmiLib, "USE_AMD_SMI_LIB", 0); // Opt-in environment variable f
 #define RCCL_AMDSMI_FN(name, rettype, arglist) rettype(*pfn_##name)arglist = nullptr;
 
 // dlopen the versioned SONAME (in every runtime tree), not the unversioned dev
-// symlink (devel / /opt/rocm only). The major comes from the amdsmi header,
-// which feeds its SOVERSION, so it tracks bumps. No header (AMDSMI_DIRECT==0):
-// fall back to the unversioned name.
+// symlink (devel packages and /opt/rocm installs only). The major comes from
+// the amdsmi header, which feeds its SOVERSION, so it tracks bumps. No header
+// (AMDSMI_DIRECT==0): fall back to the unversioned name.
 #if AMDSMI_DIRECT && defined(AMDSMI_LIB_VERSION_MAJOR)
 #define RCCL_AMDSMI_STR2(v) #v
 #define RCCL_AMDSMI_STR(v) RCCL_AMDSMI_STR2(v)
@@ -168,7 +168,7 @@ ncclResult_t amd_smi_init() {
       // the amdsmi headers, otherwise the unversioned name (see above).
       static void *libhandle = dlopen(RCCL_AMDSMI_LIBNAME, RTLD_NOW);
       if (libhandle == nullptr) {
-        WARN("Failed to open %s", RCCL_AMDSMI_LIBNAME);
+        WARN("Failed to open %s: %s", RCCL_AMDSMI_LIBNAME, dlerror());
         amdSmiInitResult = ncclInternalError;
         return ncclInternalError;
       }


### PR DESCRIPTION
RCCL dlopen'd the unversioned "libamd_smi.so", which is a link-time dev symlink that ships only in development packages (e.g. rocm-sdk-devel) and /opt/rocm installs. In a /opt/rocm-less wheel deployment the runtime tree carries only the versioned SONAME, so the unversioned lookup fails.

dlopen the SONAME instead. When built against the amdsmi headers (AMDSMI_DIRECT), derive the major from AMDSMI_LIB_VERSION_MAJOR, the same value amdsmi feeds into its library SOVERSION, so it tracks version bumps without a hardcoded major. Without the headers there is no major to derive, so fall back to the unversioned name.