### PR TITLE
rocr: Fix GPU core dump EPERM on self-debugging queue suspend

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/debug.c
+++ b/projects/rocr-runtime/libhsakmt/src/debug.c
@@ -549,10 +549,12 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtDbgGetQueueDataCtx(HsaKFDContext *ctx,
 	*data = malloc(*n_entries * *entry_size);
 	if (!*data)
 		return HSAKMT_STATUS_NO_MEMORY;
-	if (suspend_queues && *n_entries)
+	if (suspend_queues && *n_entries) {
 		queue_ids = (uint32_t *)malloc(sizeof(uint32_t) * *n_entries);
-	if (!queue_ids ||
-	    dbg_trap_get_queue_data(ctx, *data, n_entries, *entry_size, queue_ids))
+		if (!queue_ids)
+			goto free_data;
+	}
+	if (dbg_trap_get_queue_data(ctx, *data, n_entries, *entry_size, queue_ids))
 		goto free_data;
 	if (queue_ids) {
 		if (dbg_trap_suspend_queues(ctx, queue_ids, *n_entries) ||

--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
@@ -385,7 +385,10 @@ struct NoteSegmentBuilder : public SegmentBuilder {
     /* Store agent_info_entry_size in PT_NOTE package */
     note_package_builder_.Write<uint32_t>(entry_size);
 
-    if (HSAKMT_CALL(hsaKmtDbgGetQueueData(&queues_ptr, &n_entries, &entry_size, true))) {
+    /* Skip queue suspension during core dump - the process is self-debugging
+       and KFD returns EPERM for self-suspend. Queue data is still captured
+       via GET_QUEUE_SNAPSHOT without suspension. */
+    if (HSAKMT_CALL(hsaKmtDbgGetQueueData(&queues_ptr, &n_entries, &entry_size, false))) {
        HSAKMT_CALL(hsaKmtDbgDisable());
        fprintf(stderr, "Failed to fetch queues snapshot.\n");
        return HSA_STATUS_ERROR;


### PR DESCRIPTION
## Motivation

GPU core dump tests (GpuCoreDump_*) fail with EPERM when the runtime attempts to suspend queues during core dump collection. The process is self-debugging, and KFD denies the SUSPEND_QUEUES ioctl because the ptrace permission check fails for a process suspending its own queues.

## Technical Details

1. amd_core_dump.cpp: Pass suspend_queues=false to hsaKmtDbgGetQueueData. Queue snapshot data is still captured via GET_QUEUE_SNAPSHOT without requiring suspension. The suspend step is unnecessary during core dump since the process is already in a fault handler context.

2. debug.c: Fix queue_ids NULL pointer logic in hsaKmtDbgGetQueueDataCtx. When suspend_queues=false, queue_ids is intentionally NULL. The original code had 'if (!queue_ids || ...)' which short-circuited to the error path even though NULL is the expected state when not suspending queues. Restructured to only check queue_ids allocation failure when suspend_queues=true.

## JIRA ID

FEAT-78989

## Test Plan

rocrtst64 --gtest_filter="rocrtstFunc.GpuCoreDump_*"

## Test Result

All 5 GpuCoreDump tests pass (previously all 5 failed with EPERM). Full rocrtst suite: 76/76 pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
