### PR TITLE
Adding cluster ID, misc fixes for AM and partial tokens

### DIFF
--- a/projects/rocprof-trace-decoder/include/rocprof_trace_decoder/trace_decoder_types.h
+++ b/projects/rocprof-trace-decoder/include/rocprof_trace_decoder/trace_decoder_types.h
@@ -89,7 +89,8 @@ typedef struct rocprofiler_thread_trace_decoder_occupancy_t
     uint32_t pipe_id      : 4;
     uint32_t is_ext       : 1; ///< Is workgroup_id valid?
     uint32_t workgroup_id : 7;
-    uint32_t _rsvd        : 16;
+    uint32_t cluster_id   : 5; ///< 0 = not in a cluster; only valid on wavestart
+    uint32_t _rsvd        : 11;
 } rocprofiler_thread_trace_decoder_occupancy_t;
 
 /**
@@ -168,7 +169,8 @@ typedef struct rocprofiler_thread_trace_decoder_wave_t
 
     uint8_t dispatcher;   ///< [0:3] PIPE_ID, [4:6] ME_ID
     uint8_t workgroup_id; ///< Workgroup ID
-    uint16_t reserved;    ///< Reserved
+    uint8_t cluster_id;  ///< 0 = not in a cluster
+    uint8_t reserved;    ///< Reserved
     uint64_t size;        ///< Size of this struct
 
     int64_t begin_time; ///< Wave begin time. Should match occupancy event wave start.

--- a/projects/rocprof-trace-decoder/include/rocprof_trace_decoder/trace_decoder_types.h
+++ b/projects/rocprof-trace-decoder/include/rocprof_trace_decoder/trace_decoder_types.h
@@ -275,8 +275,8 @@ typedef union rocprofiler_thread_trace_decoder_event_payload_t
     uint64_t code_object_id;
     struct
     {
-        int cluster_id;
-        int barrier_id;
+        int32_t cluster_id;
+        int32_t barrier_id;
     } cluster_barrier;
 } rocprofiler_thread_trace_decoder_event_payload_t;
 

--- a/projects/rocprof-trace-decoder/include/rocprof_trace_decoder/trace_decoder_types.h
+++ b/projects/rocprof-trace-decoder/include/rocprof_trace_decoder/trace_decoder_types.h
@@ -169,8 +169,8 @@ typedef struct rocprofiler_thread_trace_decoder_wave_t
 
     uint8_t dispatcher;   ///< [0:3] PIPE_ID, [4:6] ME_ID
     uint8_t workgroup_id; ///< Workgroup ID
-    uint8_t cluster_id;  ///< 0 = not in a cluster
-    uint8_t reserved;    ///< Reserved
+    uint8_t cluster_id;   ///< 0 = not in a cluster
+    uint8_t reserved;     ///< Reserved
     uint64_t size;        ///< Size of this struct
 
     int64_t begin_time; ///< Wave begin time. Should match occupancy event wave start.
@@ -247,15 +247,15 @@ typedef enum rocprofiler_thread_trace_decoder_event_type_t
     ROCPROF_TRACE_DECODER_EVENT_DISPATCH_END,
     ROCPROF_TRACE_DECODER_EVENT_CACHE_FLUSH,
     ROCPROF_TRACE_DECODER_EVENT_PACKET_LOSS,
-    ROCPROF_TRACE_DECODER_EVENT_CODE_OBJECT_LOAD,   ///< Payload is the ID
-    ROCPROF_TRACE_DECODER_EVENT_CODE_OBJECT_UNLOAD, ///< Payload is the ID
+    ROCPROF_TRACE_DECODER_EVENT_CODE_OBJECT_LOAD,   ///< ID = payload.code_object_id
+    ROCPROF_TRACE_DECODER_EVENT_CODE_OBJECT_UNLOAD, ///< ID = payload.code_object_id
     ROCPROF_TRACE_DECODER_EVENT_TT_STALL_BEGIN,
     ROCPROF_TRACE_DECODER_EVENT_TT_STALL_END,
     ROCPROF_TRACE_DECODER_EVENT_TT_FLUSH,
     ROCPROF_TRACE_DECODER_EVENT_DIDT_STALL_BEGIN,
     ROCPROF_TRACE_DECODER_EVENT_DIDT_STALL_END,
-    ROCPROF_TRACE_DECODER_EVENT_CLUSTER_BEGIN, ///< Payload is the ID
-    ROCPROF_TRACE_DECODER_EVENT_CLUSTER_END,   ///< Payload is the ID
+    ROCPROF_TRACE_DECODER_EVENT_CLUSTER_BARRIER, ///< IDs = cluster_barrier.{cluster_id, barrier_id}
+    ROCPROF_TRACE_DECODER_EVENT_RESERVED,
     ROCPROF_TRACE_DECODER_EVENT_GC_RINSE,
     ROCPROF_TRACE_DECODER_EVENT_SPM_SAMPLE,
     ROCPROF_TRACE_DECODER_EVENT_LAST
@@ -269,6 +269,17 @@ typedef enum rocprofiler_thread_trace_decoder_event_flags_t
     ROCPROF_TRACE_DECODER_EVENT_FLAGS_LAST = ROCPROF_TRACE_DECODER_EVENT_FLAGS_BOP,
 } rocprofiler_thread_trace_decoder_event_flags_t;
 
+typedef union rocprofiler_thread_trace_decoder_event_payload_t
+{
+    uint64_t raw;
+    uint64_t code_object_id;
+    struct
+    {
+        int cluster_id;
+        int barrier_id;
+    } cluster_barrier;
+} rocprofiler_thread_trace_decoder_event_payload_t;
+
 typedef struct rocprofiler_thread_trace_decoder_event_t
 {
     uint64_t size; ///< Size of this struct
@@ -277,7 +288,7 @@ typedef struct rocprofiler_thread_trace_decoder_event_t
     uint8_t me_id;
     uint8_t pipe_id;
     uint16_t flags;
-    uint64_t payload;
+    rocprofiler_thread_trace_decoder_event_payload_t payload;
     uint64_t byte_offset; ///< Byte offset within the trace data
 } rocprofiler_thread_trace_decoder_event_t;
 

--- a/projects/rocprof-trace-decoder/source/gfx10/gfx10token.h
+++ b/projects/rocprof-trace-decoder/source/gfx10/gfx10token.h
@@ -283,10 +283,7 @@ union misc_fields
     };
     uint8_t raw;
 
-    void tt5_shift()
-    {
-        raw = (raw & 0x3) | ((raw & 0x7C) << 1);
-    }
+    void tt5_shift() { raw = (raw & 0x3) | ((raw & 0x7C) << 1); }
 };
 
 union misc_type

--- a/projects/rocprof-trace-decoder/source/gfx10/gfx10token.h
+++ b/projects/rocprof-trace-decoder/source/gfx10/gfx10token.h
@@ -274,7 +274,7 @@ union misc_fields
     {
         uint8_t spm_or_pl        : 1; // PL on gfx10, SPM on gfx11
         uint8_t gc_rinse         : 1;
-        uint8_t reserved         : 1;
+        uint8_t reserved         : 1; // Absent in tt >= 5, handled in tt5_shift
         uint8_t save_context     : 1;
         uint8_t tt_stall_start   : 1;
         uint8_t tt_stall_end     : 1;
@@ -282,6 +282,11 @@ union misc_fields
         uint8_t DIDT_stall_end   : 1;
     };
     uint8_t raw;
+
+    void tt5_shift()
+    {
+        raw = (raw & 0x3) | ((raw & 0x7C) << 1);
+    }
 };
 
 union misc_type

--- a/projects/rocprof-trace-decoder/source/gfx10/gfx10token.h
+++ b/projects/rocprof-trace-decoder/source/gfx10/gfx10token.h
@@ -425,8 +425,7 @@ union reg_init_type
     std::stringstream print() const
     {
         std::stringstream ss;
-        ss << "pipe:" << pipe << " type:" << type << " context:" << context << std::hex << " data:0x" << data
-           << " data2:0x" << data2 << std::dec;
+        ss << "pipe:" << pipe << " type:" << type << std::hex << " data:0x" << data << std::dec;
         return ss;
     }
     const char* typestr() const { return "REG_INIT"; };

--- a/projects/rocprof-trace-decoder/source/gfx10/gfx10wave.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx10/gfx10wave.cpp
@@ -232,9 +232,10 @@ wave_t::wave_t(
     bool exbarw,
     uint8_t me,
     uint8_t pipe,
-    uint8_t wg
+    uint8_t wg,
+    uint8_t cluster
 ) :
-WaveDataInternal(target_wgp, tg_simd, slot, token.time, addr, exbarw, me, pipe, wg)
+WaveDataInternal(target_wgp, tg_simd, slot, token.time, addr, exbarw, me, pipe, wg, cluster)
 {
     this->last_state_cycle = token.time;
     this->cur_state = WaveslotState::WS_IDLE;

--- a/projects/rocprof-trace-decoder/source/gfx10/gfx10wave.h
+++ b/projects/rocprof-trace-decoder/source/gfx10/gfx10wave.h
@@ -44,7 +44,8 @@ struct wave_t : public WaveDataInternal
         bool exbarw,
         uint8_t me = 0,
         uint8_t pipe = 0,
-        uint8_t wg = 0
+        uint8_t wg = 0,
+        uint8_t cluster = 0
     );
 
     int64_t last_state_cycle = 0;
@@ -94,6 +95,9 @@ protected:
 
     int dprate = 1;
     int derate = 1;
+
+    uint8_t active_cluster_id = 0;
+    bool cluster_end_pending = false;
 
     gfx10::CSRegisterHandler csregister;
     PipeArray64 wave_start_addr{};

--- a/projects/rocprof-trace-decoder/source/gfx10/rdna_sqtt.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx10/rdna_sqtt.cpp
@@ -74,6 +74,17 @@ void RDNASQTParser::sqtt_simd_analysis(CppReturnInfo& info, TokenGenerator& _gen
         stitch.sendOccupancy(occupancy);
     };
 
+    auto consume_launch_cluster = [&]() -> uint8_t
+    {
+        auto cluster_id = active_cluster_id;
+        if (cluster_end_pending)
+        {
+            active_cluster_id = 0;
+            cluster_end_pending = false;
+        }
+        return cluster_id;
+    };
+
     while (generator.nextValid())
     {
         Token token = generator.next();
@@ -92,9 +103,18 @@ void RDNASQTParser::sqtt_simd_analysis(CppReturnInfo& info, TokenGenerator& _gen
                     mi400::misc_type misc{.raw = token.contents};
                     DEBUGPRINT(misc);
                     fields.raw = (uint8_t) misc.fields;
+                    fields.tt5_shift();
 
-                    if (misc.CLF) generate_event(ROCPROF_TRACE_DECODER_EVENT_CLUSTER_BEGIN, misc.CLID);
-                    if (misc.CLL) generate_event(ROCPROF_TRACE_DECODER_EVENT_CLUSTER_END, misc.CLID);
+                    if (misc.CLF)
+                    {
+                        active_cluster_id = static_cast<uint8_t>(misc.CLID);
+                        cluster_end_pending = false;
+                    }
+                    if (misc.CLL)
+                    {
+                        active_cluster_id = static_cast<uint8_t>(misc.CLID);
+                        cluster_end_pending = true;
+                    }
                 }
                 else
                 {
@@ -280,6 +300,7 @@ void RDNASQTParser::sqtt_simd_analysis(CppReturnInfo& info, TokenGenerator& _gen
                         token.time - 1, start.SACU(), start.simd, start.wid, 0, 0, 0, 0, 0
                     });
                 }
+                auto cluster_id = consume_launch_cluster();
                 running_waves[start.getGPULocation()] = wave_addr;
 
                 occupancy.push_back(
@@ -292,7 +313,8 @@ void RDNASQTParser::sqtt_simd_analysis(CppReturnInfo& info, TokenGenerator& _gen
                      (uint64_t) start.me,
                      (uint64_t) start.pipe,
                      start.isExt,
-                     (uint64_t) start.wgid}
+                     (uint64_t) start.wgid,
+                     cluster_id}
                 );
                 if (double_buffer && occupancy.size() >= MAX_ACCUM_RECORDS) send_occupancy();
 
@@ -314,7 +336,8 @@ void RDNASQTParser::sqtt_simd_analysis(CppReturnInfo& info, TokenGenerator& _gen
                         exclude_barrier_wait,
                         (uint8_t) start.me,
                         (uint8_t) start.pipe,
-                        (uint8_t) start.wgid
+                        (uint8_t) start.wgid,
+                        cluster_id
                     ));
                 }
                 break;

--- a/projects/rocprof-trace-decoder/source/gfx12/gfx12token.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx12/gfx12token.cpp
@@ -97,8 +97,6 @@ gfx10::Token TokenGenerator::next()
     // Safe reads when the buffer is not padded. TODO: Avoid duplication.
     while (bufferValid_unsafe())
     {
-        if (bits_toread + bit_ptr > 8 * BUFFER_SIZE) break;
-
         readOne_safe();
 
         if (bIsExt && (current & 1)) // Handle wave_start_ext
@@ -109,13 +107,15 @@ gfx10::Token TokenGenerator::next()
 
         auto& info = lookupbits.lookup(current);
         RdnaType type = (RdnaType) info.type;
+        bits_toread = info.length;
+        if (bit_ptr + bits_toread > 8 * BUFFER_SIZE + 64) break;
+
         if (type == RdnaType::NOP)
         {
             bits_toread = 4;
             continue;
         }
 
-        bits_toread = info.length;
         bIsExt = type == WAVE_START_EXT;
 
         int64_t real = 0;

--- a/projects/rocprof-trace-decoder/source/gfx12/gfx12token.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx12/gfx12token.cpp
@@ -97,7 +97,7 @@ gfx10::Token TokenGenerator::next()
     // Safe reads when the buffer is not padded. TODO: Avoid duplication.
     while (bufferValid_unsafe())
     {
-        if (bits_toread + bit_ptr > 8*BUFFER_SIZE) break;
+        if (bits_toread + bit_ptr > 8 * BUFFER_SIZE) break;
 
         readOne_safe();
 
@@ -147,7 +147,7 @@ gfx10::Token TokenGenerator::next()
     }
 
     current = 0;
-    bit_ptr = 8*BUFFER_SIZE;
+    bit_ptr = 8 * BUFFER_SIZE;
     return Token{0, 0, RdnaType::TIMESTAMP};
 }
 

--- a/projects/rocprof-trace-decoder/source/gfx12/gfx12token.cpp
+++ b/projects/rocprof-trace-decoder/source/gfx12/gfx12token.cpp
@@ -97,6 +97,8 @@ gfx10::Token TokenGenerator::next()
     // Safe reads when the buffer is not padded. TODO: Avoid duplication.
     while (bufferValid_unsafe())
     {
+        if (bits_toread + bit_ptr > 8*BUFFER_SIZE) break;
+
         readOne_safe();
 
         if (bIsExt && (current & 1)) // Handle wave_start_ext
@@ -144,6 +146,8 @@ gfx10::Token TokenGenerator::next()
         return token;
     }
 
+    current = 0;
+    bit_ptr = 8*BUFFER_SIZE;
     return Token{0, 0, RdnaType::TIMESTAMP};
 }
 

--- a/projects/rocprof-trace-decoder/source/mi400/mi400token.cpp
+++ b/projects/rocprof-trace-decoder/source/mi400/mi400token.cpp
@@ -117,7 +117,7 @@ gfx10::Token TokenGenerator::next()
     // Duplicated for performance reasons. Avoiding duplication leads to worse performance.
     while (byte_ptr < BUFFER_SIZE || current)
     {
-        if (bits_toread/8 + byte_ptr > BUFFER_SIZE) break;
+        if (bits_toread / 8 + byte_ptr > BUFFER_SIZE) break;
 
         readOne_safe400();
 

--- a/projects/rocprof-trace-decoder/source/mi400/mi400token.cpp
+++ b/projects/rocprof-trace-decoder/source/mi400/mi400token.cpp
@@ -117,8 +117,6 @@ gfx10::Token TokenGenerator::next()
     // Duplicated for performance reasons. Avoiding duplication leads to worse performance.
     while (byte_ptr < BUFFER_SIZE || current)
     {
-        if (bits_toread / 8 + byte_ptr > BUFFER_SIZE) break;
-
         readOne_safe400();
 
         if (bIsExt && (current & 1)) // Handle wave_start_ext
@@ -130,6 +128,8 @@ gfx10::Token TokenGenerator::next()
         auto& info = lookupbits.lookup(current);
         RdnaType type = (RdnaType) info.type;
         bits_toread = info.length;
+        if (byte_ptr * 8 + bits_toread > 8 * BUFFER_SIZE + 64) break;
+
         if (type == RdnaType::NOP || bits_toread == 0)
         {
             bits_toread = 8;

--- a/projects/rocprof-trace-decoder/source/mi400/mi400token.cpp
+++ b/projects/rocprof-trace-decoder/source/mi400/mi400token.cpp
@@ -128,7 +128,6 @@ gfx10::Token TokenGenerator::next()
         auto& info = lookupbits.lookup(current);
         RdnaType type = (RdnaType) info.type;
         bits_toread = info.length;
-        if (byte_ptr * 8 + bits_toread > 8 * BUFFER_SIZE + 64) break;
 
         if (type == RdnaType::NOP || bits_toread == 0)
         {

--- a/projects/rocprof-trace-decoder/source/mi400/mi400token.cpp
+++ b/projects/rocprof-trace-decoder/source/mi400/mi400token.cpp
@@ -117,6 +117,8 @@ gfx10::Token TokenGenerator::next()
     // Duplicated for performance reasons. Avoiding duplication leads to worse performance.
     while (byte_ptr < BUFFER_SIZE || current)
     {
+        if (bits_toread/8 + byte_ptr > BUFFER_SIZE) break;
+
         readOne_safe400();
 
         if (bIsExt && (current & 1)) // Handle wave_start_ext
@@ -173,6 +175,8 @@ gfx10::Token TokenGenerator::next()
         return token;
     }
 
+    current = 0;
+    byte_ptr = BUFFER_SIZE;
     bit_ptr = byte_ptr * 8;
     return Token{0, 0, RdnaType::TIMESTAMP};
 }

--- a/projects/rocprof-trace-decoder/source/mi400/mi400token.h
+++ b/projects/rocprof-trace-decoder/source/mi400/mi400token.h
@@ -115,7 +115,7 @@ union misc_type
     {
         uint64_t header : 7;
         uint64_t tm     : 3;
-        uint64_t fields : 8;
+        uint64_t fields : 7;
         uint64_t CLF    : 1;
         uint64_t CLL    : 1;
         uint64_t CLID   : 4;

--- a/projects/rocprof-trace-decoder/source/quick_scan_export.cpp
+++ b/projects/rocprof-trace-decoder/source/quick_scan_export.cpp
@@ -285,7 +285,7 @@ template <bool EmitEvents> rocprofiler_thread_trace_decoder_status_t process_eve
                     ev.me_id = static_cast<uint8_t>(r.me);
                     ev.pipe_id = static_cast<uint8_t>(r.pipe);
                     ev.flags = ROCPROF_TRACE_DECODER_EVENT_FLAGS_NONE;
-                    ev.payload = 0;
+                    ev.payload.raw = 0;
                     ev.byte_offset = static_cast<uint64_t>(tok.offset) + header_skip;
                     auto status = trace_callback(ROCPROFILER_THREAD_TRACE_DECODER_RECORD_EVENT, &ev, 1, userdata);
                     if (status != ROCPROFILER_THREAD_TRACE_DECODER_STATUS_SUCCESS) return status;
@@ -375,7 +375,7 @@ template <bool EmitEvents> rocprofiler_thread_trace_decoder_status_t process_eve
             ev.pipe_id = static_cast<uint8_t>(event.pipe);
             ev.flags = ROCPROF_TRACE_DECODER_EVENT_FLAGS_PER_PIPE;
             if (event.bop) ev.flags |= ROCPROF_TRACE_DECODER_EVENT_FLAGS_BOP;
-            ev.payload = 0;
+            ev.payload.raw = 0;
             ev.byte_offset = static_cast<uint64_t>(tok.offset);
             auto status = trace_callback(ROCPROFILER_THREAD_TRACE_DECODER_RECORD_EVENT, &ev, 1, userdata);
             if (status != ROCPROFILER_THREAD_TRACE_DECODER_STATUS_SUCCESS) return status;

--- a/projects/rocprof-trace-decoder/source/rocprof_trace_decoder.cpp
+++ b/projects/rocprof-trace-decoder/source/rocprof_trace_decoder.cpp
@@ -41,6 +41,22 @@
 #    include "rocprof_trace_decoder/cxx/code_printing.hpp"
 #endif
 
+static_assert(
+    sizeof(((rocprofiler_thread_trace_decoder_event_payload_t*) nullptr)->cluster_barrier) == 8,
+    "Unexpected rocprofiler_thread_trace_decoder_event_payload_t.cluster_barrier size"
+);
+static_assert(
+    sizeof(rocprofiler_thread_trace_decoder_event_payload_t) == 8,
+    "Unexpected rocprofiler_thread_trace_decoder_event_payload_t size"
+);
+static_assert(
+    sizeof(rocprofiler_thread_trace_decoder_event_t) == 40, "Unexpected rocprofiler_thread_trace_decoder_event_t size"
+);
+static_assert(
+    sizeof(rocprofiler_thread_trace_decoder_dispatch_t) == 80,
+    "Unexpected rocprofiler_thread_trace_decoder_dispatch_t size"
+);
+
 #define RADT(x) ROCPROFILER_THREAD_TRACE_DECODER_RECORD_##x
 
 // ============================================================================

--- a/projects/rocprof-trace-decoder/source/stitch/stitch.cpp
+++ b/projects/rocprof-trace-decoder/source/stitch/stitch.cpp
@@ -112,11 +112,7 @@ std::pair<size_t, barrier_list_t> Stitcher::stitchWave(class WaveDataInternal& w
             inst_index++;
             continue;
         }
-#ifndef ARCH_MODEL
         else if (bValid(inst.pc))
-#else
-        else if (bValid(inst.pc) || inst_index == 0)
-#endif
         {
             inst_index++;
             next = nullptr;
@@ -151,6 +147,15 @@ std::pair<size_t, barrier_list_t> Stitcher::stitchWave(class WaveDataInternal& w
                 return {0, barrier_gap};
             }
             continue;
+        }
+        else if (inst_index == 0)
+        {
+            // AM
+            try {
+                next = pctranslator->getcode(inst.pc);
+            } catch(...) {};
+
+            if (!next) return {0, barrier_gap};
         }
 
         line = std::move(next);
@@ -414,10 +419,4 @@ void Stitcher::stitch(WaveDataInternal& wave)
 Stitcher::Stitcher(
     std::shared_ptr<ICodeServicer> service, rocprof_trace_decoder_trace_callback_t _callback, void* _cbdata
 ) :
-codeobj_service(service), callback(_callback), cbdata(_cbdata)
-{
-#ifndef ARCH_MODEL
-    raw_code.push_back(std::make_shared<assemblyLine>());
-    raw_code.at(0)->line = "; Begin ASM";
-#endif
-}
+codeobj_service(service), callback(_callback), cbdata(_cbdata) {}

--- a/projects/rocprof-trace-decoder/source/stitch/stitch.cpp
+++ b/projects/rocprof-trace-decoder/source/stitch/stitch.cpp
@@ -151,9 +151,12 @@ std::pair<size_t, barrier_list_t> Stitcher::stitchWave(class WaveDataInternal& w
         else if (inst_index == 0)
         {
             // AM
-            try {
+            try
+            {
                 next = pctranslator->getcode(inst.pc);
-            } catch(...) {};
+            }
+            catch (...)
+            {};
 
             if (!next) return {0, barrier_gap};
         }
@@ -419,4 +422,5 @@ void Stitcher::stitch(WaveDataInternal& wave)
 Stitcher::Stitcher(
     std::shared_ptr<ICodeServicer> service, rocprof_trace_decoder_trace_callback_t _callback, void* _cbdata
 ) :
-codeobj_service(service), callback(_callback), cbdata(_cbdata) {}
+codeobj_service(service), callback(_callback), cbdata(_cbdata)
+{}

--- a/projects/rocprof-trace-decoder/source/stitch/stitch.cpp
+++ b/projects/rocprof-trace-decoder/source/stitch/stitch.cpp
@@ -148,7 +148,7 @@ std::pair<size_t, barrier_list_t> Stitcher::stitchWave(class WaveDataInternal& w
             }
             continue;
         }
-        else if (inst_index == 0)
+        else if (gfxip >= 12 && inst_index == 0)
         {
             // AM
             try
@@ -158,13 +158,13 @@ std::pair<size_t, barrier_list_t> Stitcher::stitchWave(class WaveDataInternal& w
             catch (...)
             {};
 
-            if (!next) return {0, barrier_gap};
+            if (!next || next->line.empty()) return {0, barrier_gap};
         }
 
         line = std::move(next);
         next = nullptr;
 
-        if (!line || inst.category == WaveInstCategory::WAVE_NOT_FINISHED) break;
+        if (!line || line->line.empty() || inst.category == WaveInstCategory::WAVE_NOT_FINISHED) break;
 
         try
         {

--- a/projects/rocprof-trace-decoder/source/stitch/stitch.hpp
+++ b/projects/rocprof-trace-decoder/source/stitch/stitch.hpp
@@ -181,7 +181,7 @@ public:
         event.me_id = me & 1;
         event.pipe_id = pipe;
         event.flags = 0;
-        event.payload = payload;
+        event.payload.raw = payload;
         if (per_pipe) event.flags |= ROCPROF_TRACE_DECODER_EVENT_FLAGS_PER_PIPE;
         if (bop) event.flags |= ROCPROF_TRACE_DECODER_EVENT_FLAGS_BOP;
         callback(ROCPROFILER_THREAD_TRACE_DECODER_RECORD_EVENT, &event, 1, cbdata);

--- a/projects/rocprof-trace-decoder/source/trace_parser.hpp
+++ b/projects/rocprof-trace-decoder/source/trace_parser.hpp
@@ -82,7 +82,8 @@ struct occupancy_info_t : public rocprofiler_thread_trace_decoder_occupancy_t
         uint64_t me,
         uint64_t pipe,
         uint64_t is_ext,
-        uint64_t wg
+        uint64_t wg,
+        uint64_t cluster = 0
     )
     {
         this->pc = pc;
@@ -96,6 +97,7 @@ struct occupancy_info_t : public rocprofiler_thread_trace_decoder_occupancy_t
         this->pipe_id = pipe & 0xF;
         this->is_ext = is_ext;
         this->workgroup_id = wg & 0x7F;
+        this->cluster_id = cluster & 0x1F;
         this->_rsvd = 0;
     }
     occupancy_info_t(
@@ -108,7 +110,8 @@ struct occupancy_info_t : public rocprofiler_thread_trace_decoder_occupancy_t
         uint64_t me,
         uint64_t pipe,
         uint64_t is_ext,
-        uint64_t wg
+        uint64_t wg,
+        uint64_t cluster = 0
     )
     {
         this->pc = pc;
@@ -122,6 +125,7 @@ struct occupancy_info_t : public rocprofiler_thread_trace_decoder_occupancy_t
         this->pipe_id = pipe & 0xF;
         this->is_ext = is_ext;
         this->workgroup_id = wg & 0x7F;
+        this->cluster_id = cluster & 0x1F;
         this->_rsvd = 0;
     }
 };
@@ -165,7 +169,8 @@ struct WaveDataInternal : public rocprofiler_thread_trace_decoder_wave_t
         bool exbarw,
         uint8_t me = 0,
         uint8_t pipe = 0,
-        uint8_t wg = 0
+        uint8_t wg = 0,
+        uint8_t cluster = 0
     )
     {
         this->cu = (uint8_t) cu;
@@ -175,6 +180,7 @@ struct WaveDataInternal : public rocprofiler_thread_trace_decoder_wave_t
 
         this->dispatcher = (uint8_t) (((me & 0x7) << 4) | (pipe & 0xF));
         this->workgroup_id = wg;
+        this->cluster_id = cluster;
         this->reserved = 0;
         this->size = sizeof(rocprofiler_thread_trace_decoder_wave_t);
 

--- a/projects/rocprof-trace-decoder/test/unit/stitch_test.cpp
+++ b/projects/rocprof-trace-decoder/test/unit/stitch_test.cpp
@@ -69,14 +69,6 @@ protected:
     }
 };
 
-TEST_F(StitcherTest, ConstructorInitializesRawCode)
-{
-    Stitcher stitcher(mock_service, test_callback, &cbdata);
-
-    ASSERT_FALSE(stitcher.raw_code.empty());
-    EXPECT_EQ(stitcher.raw_code[0]->line, "; Begin ASM");
-}
-
 TEST_F(StitcherTest, SetGfxipSetsValueAndCallsCallback)
 {
     Stitcher stitcher(mock_service, test_callback, &cbdata);


### PR DESCRIPTION
## Motivation

This PR:
* Adds cluster ID to occupancy records
* Fixes misc token field encodings for gfx1250
* Fixes incorrect token decoding when the buffer stops in the middle of a token (sometimes happens in double buffering).
* Removes the necessity of a compiler flag for AM
* Adds cluster barrier to API (implementation to follow).

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AIPROFSDK-838
AIPROFSDK-830
AIPROFSDK-768
ROCM-24668

## Test Plan

Tested locally, unit tests to maintain behavior will follow.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
