### PR TITLE
Fix a bug where closing dmabuf closes stdin

### DIFF
--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -1028,8 +1028,8 @@ void GDABackend::cleanup_ibv() {
       qp_allocator_->deallocate(bnxt_qps[i].sq_buf);
       qp_allocator_->deallocate(bnxt_qps[i].rq_buf);
 
-      close(bnxt_qps[i].sq_dmabuf_fd);
-      close(bnxt_qps[i].rq_dmabuf_fd);
+      if (bnxt_qps[i].sq_dmabuf_fd > 0) close(bnxt_qps[i].sq_dmabuf_fd);
+      if (bnxt_qps[i].rq_dmabuf_fd > 0) close(bnxt_qps[i].rq_dmabuf_fd);
 
       err = bnxt_re_dv.destroy_cq(bnxt_scqs[i].cq);
       CHECK_ZERO(err, "bnxt_re_dv_destroy_cq (SCQ)");
@@ -1043,8 +1043,8 @@ void GDABackend::cleanup_ibv() {
       err = bnxt_re_dv.umem_dereg(bnxt_rcqs[i].umem_handle);
       CHECK_ZERO(err, "bnxt_re_dv_umem_dereg (RCQ)");
 
-      close(bnxt_scqs[i].dmabuf_fd);
-      close(bnxt_rcqs[i].dmabuf_fd);
+      if (bnxt_scqs[i].dmabuf_fd > 0) close(bnxt_scqs[i].dmabuf_fd);
+      if (bnxt_rcqs[i].dmabuf_fd > 0) close(bnxt_rcqs[i].dmabuf_fd);
 
       qp_allocator_->deallocate(bnxt_scqs[i].buf);
       qp_allocator_->deallocate(bnxt_rcqs[i].buf);


### PR DESCRIPTION
## Motivation

Closing dmabuff buffer if dmabuff was not initialized would close fd 0 (stdin, a silent bug).

## Technical Details

Don't close fd0

## JIRA ID

None

## Test Plan

CI run 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
