### PR TITLE
clr+hip+rocr: POC for HIP graph conditional nodes via vendor AQL packets

### DIFF
--- a/projects/clr/hipamd/docs/conditional_graph_nodes.md
+++ b/projects/clr/hipamd/docs/conditional_graph_nodes.md
@@ -1,0 +1,361 @@
+# HIP Graph Conditional Nodes — POC Implementation
+
+Branch: `users/agoadavr/conditional-IB-POC`
+
+## Overview
+
+This document describes the proof-of-concept (POC) implementation of HIP graph
+conditional nodes (IF and WHILE) on the AMD ROCm stack. The approach uses three
+new vendor AQL packet types to let the GPU Command Processor (CP) evaluate a
+signal-backed condition and walk a pre-built instruction buffer (IB) of kernel
+dispatch packets, without scheduler kernel involvement or driver round-trips.
+
+**Current status:** The CLR + ROCr stack compiles and instantiates conditional
+graphs end-to-end. At `hipGraphLaunch` time the CP rejects the cond_jump packet
+with `HSA_STATUS_ERROR_INVALID_PACKET_FORMAT (0x1009)` because vendor packet
+types 5 and 6 are not yet recognised by CP microcode. Runtime execution becomes
+valid once the matching CP firmware ships.
+
+---
+
+## Public API
+
+### `hipGraphConditionalHandle`
+
+```c
+typedef struct hipGraphConditionalHandle_st {
+  uint64_t device_ptr;    // GPU-visible address of the condition value cell
+  uint64_t default_value; // Value stamped into the cell at handle creation
+  uint64_t signal_handle; // Backing hsa_signal_t.handle (runtime-internal)
+} hipGraphConditionalHandle;
+```
+
+The handle is backed by a real `hsa_signal_t`. `device_ptr` is set to
+`signal_handle + offsetof(amd_signal_t, value)` (offset +8, verified by
+`static_assert`), so a kernel's `hipGraphSetConditional` store and the CP's
+signal load operate on the same memory cell.
+
+### `hipGraphConditionalHandleCreate`
+
+```c
+hipError_t hipGraphConditionalHandleCreate(
+    hipGraphConditionalHandle* pHandleOut,
+    hipGraph_t                 hGraph,
+    unsigned int               defaultLaunchValue,
+    unsigned int               flags);          // reserved, must be 0
+```
+
+Allocates a real `hsa_signal_t`, stores `defaultLaunchValue` into it, and fills
+`pHandleOut`. The signal is not yet registered with the graph for lifetime
+management (M1 limitation; fixed in the M2 lifetime work).
+
+### `hipGraphAddConditionalNode`
+
+```c
+hipError_t hipGraphAddConditionalNode(
+    hipGraphNode_t*           pGraphNode,
+    hipGraph_t                graph,
+    const hipGraphNode_t*     pDependencies,
+    size_t                    numDependencies,
+    hipGraphConditionalHandle handle,
+    hipGraphConditionalType   type,
+    unsigned int              numConditionalGraphs,
+    hipGraph_t*               phConditionalGraphs);
+```
+
+Creates a conditional node and returns `numConditionalGraphs` empty body graphs
+into `phConditionalGraphs`. The caller populates the body graphs with kernel
+nodes before calling `hipGraphInstantiate`.
+
+| `type`                   | `numConditionalGraphs` | Behaviour                          |
+|--------------------------|------------------------|------------------------------------|
+| `hipGraphCondTypeWhile`  | exactly 1              | Loop body; exits when cell == 0    |
+| `hipGraphCondTypeIf`     | 1                      | No-else IF                         |
+| `hipGraphCondTypeIf`     | 2                      | IF / ELSE (`[else_arm][if_arm]`)   |
+| `hipGraphCondTypeSwitch` | any                    | Returns `hipErrorNotSupported`     |
+
+### `hipGraphSetConditional` (device function)
+
+```c
+__device__ static inline void
+hipGraphSetConditional(hipGraphConditionalHandle handle,
+                       unsigned long long value);
+```
+
+Single volatile store to `handle.device_ptr`. No HW fence beyond the
+screlease on the enclosing kernel-dispatch packet. Body kernels call this to
+signal whether the loop should continue (`1`) or exit (`0`).
+
+---
+
+## Vendor AQL Packet Types
+
+Defined in `projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h`.
+All are 64 bytes and use `HSA_PACKET_TYPE_VENDOR_SPECIFIC` in the AQL header
+with the AMD format field encoding the subtype.
+
+| Enum value | Name | Purpose |
+|---|---|---|
+| 4 | `HSA_AMD_PACKET_TYPE_AQL_INDIRECT_BUFFER` | Generic IB dispatch (reserved; not emitted by this POC) |
+| 5 | `HSA_AMD_PACKET_TYPE_DISPATCH_IB_COND_JUMP` | Entry packet for IF/WHILE nodes |
+| 6 | `HSA_AMD_PACKET_TYPE_AQL_LOOP_BACK` | Loop-back tail packet inside a WHILE body IB |
+
+### `hsa_amd_dispatch_indirect_buffer_conditional_jump_t` (type 5)
+
+| Offset | Field | Description |
+|--------|-------|-------------|
+| +0  | `header` | Vendor packet header; BARRIER=1, scacquire=screlease=SYSTEM |
+| +4  | `reserved0` | Must be 0 |
+| +8  | `condition_signal` | `hsa_signal_t` — the cond cell read by the CP |
+| +16 | `test_value` | Value to compare against the signal |
+| +24 | `cond_op` | `hsa_signal_condition_t` (EQ/NE/LT/GTE) |
+| +28 | `fallthrough_ib_size_packets` | Packets to run when condition is FALSE |
+| +32 | `ib_base_addr` | Base address of the instruction buffer |
+| +40 | `jump_offset_packets` | Offset (in packets) to the TRUE-arm start |
+| +44 | `jump_ib_size_packets` | Packets to run when condition is TRUE |
+| +48 | `reserved1` | Must be 0 |
+| +56 | `completion_signal` | Optional completion signal (0 for in-graph use) |
+
+### `hsa_amd_aql_loop_back_t` (type 6)
+
+| Offset | Field | Description |
+|--------|-------|-------------|
+| +0  | `header` | Vendor packet header; BARRIER=1, scacquire=screlease=SYSTEM |
+| +4  | `reserved0` | Must be 0 |
+| +8  | `condition_signal` | Same signal as the enclosing cond_jump |
+| +16 | `test_value` | Same test value as the enclosing cond_jump |
+| +24 | `cond_op` | Same condition as the enclosing cond_jump |
+| +28 | `ib_size_packets` | Total IB size including this packet; CP uses it to rewind the read pointer |
+| +32 | `reserved1`–`reserved3` | Must be 0 |
+| +56 | `completion_signal` | Optional (0 for in-graph use) |
+
+---
+
+## IB Layout
+
+### WHILE
+
+```
+parent queue:
+  [ ... ]
+  [ COND_JUMP ]
+      condition_signal  = handle.signal
+      test_value        = default_value  (typically 1)
+      cond_op           = NE
+      ib_base_addr      = body_ib
+      fallthrough_pkts  = 0             (0-iteration: skip immediately)
+      jump_offset_pkts  = 0
+      jump_ib_size_pkts = N + 1         (N body kernels + 1 LOOP_BACK)
+  [ ... ]
+
+body_ib:
+  [ KERNEL_DISPATCH body[0] ]   <- body kernels call hipGraphSetConditional
+  [ KERNEL_DISPATCH body[1] ]
+  ...
+  [ KERNEL_DISPATCH body[N-1] ] <- writes 0 to cond cell when done
+  [ LOOP_BACK ]
+      ib_size_packets = N + 1
+```
+
+CP behaviour: on each LOOP_BACK the CP rewinds to `body[0]` and re-runs the
+body. The body is responsible for clearing the cond cell when the termination
+condition is met; only then does the CP exit the IB and resume the parent queue.
+
+### IF (single body)
+
+```
+parent queue:
+  [ COND_JUMP ]
+      fallthrough_pkts  = 0
+      jump_offset_pkts  = 0
+      jump_ib_size_pkts = N
+
+body_ib:
+  [ KERNEL_DISPATCH body[0] ]
+  ...
+  [ KERNEL_DISPATCH body[N-1] ]
+  -- no LOOP_BACK; CP returns to parent queue on IB exhaustion --
+```
+
+### IF / ELSE (two bodies)
+
+```
+body_ib:
+  [ KERNEL_DISPATCH else[0]  ]  <- false arm (M packets)
+  ...
+  [ KERNEL_DISPATCH else[M-1] ]
+  [ KERNEL_DISPATCH if[0]    ]  <- true arm (K packets)
+  ...
+  [ KERNEL_DISPATCH if[K-1]  ]
+
+COND_JUMP fields:
+  fallthrough_pkts  = M     (run else arm on FALSE)
+  jump_offset_pkts  = M     (skip to true arm on TRUE)
+  jump_ib_size_pkts = K     (run true arm on TRUE)
+```
+
+---
+
+## Implementation: CLR
+
+### `GraphConditionalNode` (`hip_graph_internal.hpp/.cpp`)
+
+Inherits from `GraphNode` with `hipGraphNodeTypeConditional`.
+
+**Key members:**
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `handle_` | `hipGraphConditionalHandle` | The condition signal handle |
+| `cond_type_` | `hipGraphConditionalType` | IF or WHILE |
+| `bodies_` | `vector<Graph*>` | Owned body graph(s) |
+| `ib_addr_` | `void*` | Base of the IB in device-accessible memory |
+| `ib_size_pkts_` | `size_t` | Total IB packets including LOOP_BACK |
+| `fall_pkts_` | `uint32_t` | `cond_jump.fallthrough_ib_size_packets` |
+| `jump_off_pkts_` | `uint32_t` | `cond_jump.jump_offset_packets` |
+| `jump_pkts_` | `uint32_t` | `cond_jump.jump_ib_size_packets` |
+
+**`BuildIB(kernArgMgr, devId)`** — called from `GraphExec::CaptureAQLPackets()`:
+
+1. Bootstraps a kernarg pool sized for all body kernels (sum of `GetKerArgSize()`
+   across all body nodes, plus `kKernArgChunkSize` headroom).
+2. Walks each body graph in insertion order, calling
+   `GraphNode::CaptureAndFormPacket(kernArgMgr)` on every kernel node.
+3. Zeroes `completion_signal` in each captured packet.
+4. Allocates the IB: `Device::deviceLocalAlloc` on largeBar systems,
+   `Device::hostAlloc(kKernArg segment)` fallback otherwise.
+5. `memcpy`s all captured packets into the IB, appending an
+   `hsa_amd_aql_loop_back_t` for WHILE.
+6. Sets `fall_pkts_`, `jump_off_pkts_`, `jump_pkts_` for the parent
+   `CondJumpCommand`.
+
+**`CondJumpCommand::submit(device)`** — called at each `hipGraphLaunch`:
+
+1. `hsa_signal_store_relaxed(cond_sig, default_value)` — resets the cell so a
+   previous launch's terminal value doesn't carry over.
+2. `roc::VirtualGPU::dispatchCondJumpPacket(...)` — emits the vendor packet.
+
+**Copy constructor / `clone()`:** deep-clones each body `Graph` so the
+`GraphExec` owns independent body graph instances. IB metadata is
+default-initialised; `BuildIB` is re-run on the clone's first instantiation.
+
+### `VirtualGPU::dispatchCondJumpPacket` (`rocvirtual.hpp/.cpp`)
+
+```cpp
+void dispatchCondJumpPacket(
+    hsa_signal_t cond_signal,
+    hsa_signal_value_t test_value,
+    uint64_t ib_base_addr,
+    uint32_t fall_pkts,
+    uint32_t jump_offset_pkts,
+    uint32_t jump_pkts);
+```
+
+Assembles `hsa_amd_dispatch_indirect_buffer_conditional_jump_t` with:
+- `BARRIER=1`, `scacquire=screlease=HSA_FENCE_SCOPE_SYSTEM`
+- `cond_op = HSA_SIGNAL_CONDITION_NE`, `test_value` from the handle's
+  `default_value`
+
+Reserves a slot on the HW queue via `hsa_queue_add_write_index_screlease`,
+writes the packet at the ring-buffer location, and rings the doorbell.
+
+### `GraphExec::CaptureAQLPackets` hook (`hip_graph_internal.cpp`)
+
+After capturing all regular node packets, iterates `topoOrder_` and calls
+`BuildIB(kernArgManager_, instantiateDeviceId_)` on every
+`hipGraphNodeTypeConditional` node. This ensures the kernarg pool is already
+allocated before body-kernel kernarg allocation runs inside `BuildIB`.
+
+---
+
+## Memory and Ordering
+
+| Concern | Mechanism |
+|---------|-----------|
+| IB allocation | `deviceLocalAlloc` (largeBar VRAM) or `hostAlloc(kKernArg)` (pinned) |
+| IB visibility to CP | Flagged uncached on host side; CP fetches through GFX cache |
+| Cond cell update (device) | Volatile store in `hipGraphSetConditional`; ordered by body kernel's screlease |
+| Cond cell reset (host) | `hsa_signal_store_relaxed` in `CondJumpCommand::submit` before each launch |
+| Packet ordering | BARRIER=1 + SYSTEM fences on both COND_JUMP and LOOP_BACK packets |
+
+---
+
+## Profiler / Tracing Integration
+
+The two new API entry points are wired through the full HIP tracing stack:
+
+| Layer | File |
+|-------|------|
+| Dispatch table | `hip_api_trace.hpp` — `t_hipGraphConditionalHandleCreate`, `t_hipGraphAddConditionalNode` function pointer slots; `HIP_RUNTIME_API_TABLE_STEP_VERSION` bumped to 30 |
+| ABI enforcement | `hip_api_trace.cpp` — `HIP_ENFORCE_ABI` entries at offsets 537 / 538 |
+| Profiler IDs | `hip_prof_str.h` — `HIP_API_ID_hipGraphConditionalHandleCreate = 480`, `HIP_API_ID_hipGraphAddConditionalNode = 481` |
+| Version script | `hip_hcc.map.in` — exports both symbols under `hip_7.2` |
+| Table interface | `hip_table_interface.cpp` — initialises both function pointer slots |
+
+---
+
+## Validation
+
+Three standalone harnesses (built with plain `hipcc`, not part of hip-tests)
+were used to validate the implementation:
+
+### `conditional_handle_smoke.cpp` (M1 host-side)
+
+Validates handle plumbing without launching any graph:
+
+- `device_ptr == signal_handle + 8` (Option C layout confirmed)
+- `hsa_signal_load_relaxed` reads back `defaultLaunchValue` correctly
+- `hipGraphAddConditionalNode` argument validation: null output pointer →
+  `hipErrorInvalidValue`; SWITCH → `hipErrorNotSupported`; WHILE with 2 bodies
+  → `hipErrorInvalidValue`; WHILE with 1 body → `hipSuccess`; IF with 2 bodies
+  → `hipSuccess` with distinct non-null body graphs returned
+
+### `hip_graph_set_conditional_kernel_test.cpp` (device write path)
+
+Launches `set_conditional_kernel<<<1,1>>>` which calls
+`hipGraphSetConditional(h, value)`. After `hipDeviceSynchronize`, verifies the
+updated value is observable host-side via `hsa_signal_load_relaxed`. Confirms
+the volatile store in the kernel reaches the same memory cell the host signal
+API reads.
+
+### `hip_graph_conditional_ib_test.cpp` (end-to-end IB path)
+
+Exercises `hipGraphInstantiate` + `hipGraphLaunch` for WHILE and IF nodes. All
+tests fail at `hipStreamSynchronize` with `hipErrorLaunchFailure (719)` in the
+expected pattern: the CP aborts the queue on the vendor cond_jump packet with
+`HSA_STATUS_ERROR_INVALID_PACKET_FORMAT (0x1009)` (amd_format=5). This matches
+the documented firmware boundary exactly.
+
+---
+
+## File Map
+
+| Concern | File |
+|---------|------|
+| Public API types and declarations | `projects/hip/include/hip/hip_runtime_api.h` |
+| `hipGraphSetConditional` device inline | `projects/hip/include/hip/hip_runtime_api.h` |
+| Handle creation + node creation | `projects/clr/hipamd/src/hip_graph.cpp` |
+| `GraphConditionalNode` class definition | `projects/clr/hipamd/src/hip_graph_internal.hpp` |
+| `BuildIB`, `CondJumpCommand::submit` | `projects/clr/hipamd/src/hip_graph_internal.cpp` |
+| `dispatchCondJumpPacket` | `projects/clr/rocclr/device/rocm/rocvirtual.hpp/.cpp` |
+| Vendor AQL packet types (ROCr) | `projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h` |
+| AQL packet name printer (ROCr) | `projects/rocr-runtime/runtime/hsa-runtime/core/inc/queue.h` |
+
+---
+
+## Open Items
+
+1. **CP firmware** — vendor packet types 5 and 6 must be recognised by CP
+   microcode. All CLR/ROCr changes are in place; no runtime changes are needed
+   once the firmware ships.
+2. **ROCr packet definitions** — currently removed from this branch. They
+   should land through a dedicated ROCr PR before or alongside the CP firmware.
+3. **Handle lifetime** — the backing `hsa_signal_t` is not yet destroyed when
+   the owning graph is destroyed (M1 limitation).
+4. **Non-kernel body nodes** — `BuildIB` returns `hipErrorNotSupported` for any
+   body node that is not a kernel node. Memcpy, memset, and child-graph nodes
+   are not yet supported.
+5. **IF/ELSE** — `hipGraphCondTypeIf` with 2 bodies compiles and instantiates
+   but is tagged `[!mayfail]` in tests pending CP firmware support.
+6. **`hipGraphCondTypeSwitch`** — returns `hipErrorNotSupported`; not planned
+   for the immediate follow-on.

--- a/projects/clr/hipamd/include/hip/amd_detail/hip_api_trace.hpp
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_api_trace.hpp
@@ -48,7 +48,7 @@
 #define HIP_API_TABLE_STEP_VERSION 0
 #define HIP_COMPILER_API_TABLE_STEP_VERSION 0
 #define HIP_TOOLS_API_TABLE_STEP_VERSION 1
-#define HIP_RUNTIME_API_TABLE_STEP_VERSION 29
+#define HIP_RUNTIME_API_TABLE_STEP_VERSION 30
 
 // HIP API interface
 // HIP compiler dispatch functions
@@ -292,6 +292,18 @@ typedef hipError_t (*t_hipGraphAddMemsetNode)(hipGraphNode_t* pGraphNode, hipGra
 typedef hipError_t (*t_hipGraphChildGraphNodeGetGraph)(hipGraphNode_t node, hipGraph_t* pGraph);
 typedef hipError_t (*t_hipGraphClone)(hipGraph_t* pGraphClone, hipGraph_t originalGraph);
 typedef hipError_t (*t_hipGraphCreate)(hipGraph_t* pGraph, unsigned int flags);
+typedef hipError_t (*t_hipGraphConditionalHandleCreate)(hipGraphConditionalHandle* pHandleOut,
+                                                       hipGraph_t hGraph,
+                                                       unsigned int defaultLaunchValue,
+                                                       unsigned int flags);
+typedef hipError_t (*t_hipGraphAddConditionalNode)(hipGraphNode_t* pGraphNode,
+                                                  hipGraph_t graph,
+                                                  const hipGraphNode_t* pDependencies,
+                                                  size_t numDependencies,
+                                                  hipGraphConditionalHandle handle,
+                                                  hipGraphConditionalType type,
+                                                  unsigned int numConditionalGraphs,
+                                                  hipGraph_t* phConditionalGraphs);
 typedef hipError_t (*t_hipGraphDebugDotPrint)(hipGraph_t graph, const char* path,
                                               unsigned int flags);
 typedef hipError_t (*t_hipGraphDestroy)(hipGraph_t graph);
@@ -1800,6 +1812,8 @@ struct HipDispatchTable {
 
   // DO NOT EDIT ABOVE!
   // HIP_RUNTIME_API_TABLE_STEP_VERSION == 30
+  t_hipGraphConditionalHandleCreate hipGraphConditionalHandleCreate_fn;
+  t_hipGraphAddConditionalNode hipGraphAddConditionalNode_fn;
 
   // ******************************************************************************************* //
   //

--- a/projects/clr/hipamd/include/hip/amd_detail/hip_prof_str.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/hip_prof_str.h
@@ -502,7 +502,9 @@ enum hip_api_id_t {
   HIP_API_ID_hipExecutionCtxWaitEvent = 477,
   HIP_API_ID_hipLibraryGetGlobal = 478,
   HIP_API_ID_hipLibraryGetManaged = 479,
-  HIP_API_ID_LAST = 479,
+  HIP_API_ID_hipGraphConditionalHandleCreate = 480,
+  HIP_API_ID_hipGraphAddConditionalNode = 481,
+  HIP_API_ID_LAST = 481,
 
   HIP_API_ID_hipChooseDevice = HIP_API_ID_CONCAT(HIP_API_ID_,hipChooseDevice),
   HIP_API_ID_hipGetDeviceProperties = HIP_API_ID_CONCAT(HIP_API_ID_,hipGetDeviceProperties),
@@ -676,6 +678,7 @@ static inline const char* hip_api_name(const uint32_t id) {
     case HIP_API_ID_hipGetSymbolSize: return "hipGetSymbolSize";
     case HIP_API_ID_hipGraphAddBatchMemOpNode: return "hipGraphAddBatchMemOpNode";
     case HIP_API_ID_hipGraphAddChildGraphNode: return "hipGraphAddChildGraphNode";
+    case HIP_API_ID_hipGraphAddConditionalNode: return "hipGraphAddConditionalNode";
     case HIP_API_ID_hipGraphAddDependencies: return "hipGraphAddDependencies";
     case HIP_API_ID_hipGraphAddEmptyNode: return "hipGraphAddEmptyNode";
     case HIP_API_ID_hipGraphAddEventRecordNode: return "hipGraphAddEventRecordNode";
@@ -696,6 +699,7 @@ static inline const char* hip_api_name(const uint32_t id) {
     case HIP_API_ID_hipGraphBatchMemOpNodeSetParams: return "hipGraphBatchMemOpNodeSetParams";
     case HIP_API_ID_hipGraphChildGraphNodeGetGraph: return "hipGraphChildGraphNodeGetGraph";
     case HIP_API_ID_hipGraphClone: return "hipGraphClone";
+    case HIP_API_ID_hipGraphConditionalHandleCreate: return "hipGraphConditionalHandleCreate";
     case HIP_API_ID_hipGraphCreate: return "hipGraphCreate";
     case HIP_API_ID_hipGraphDebugDotPrint: return "hipGraphDebugDotPrint";
     case HIP_API_ID_hipGraphDestroy: return "hipGraphDestroy";
@@ -1149,6 +1153,7 @@ static inline uint32_t hipApiIdByName(const char* name) {
   if (strcmp("hipGetSymbolSize", name) == 0) return HIP_API_ID_hipGetSymbolSize;
   if (strcmp("hipGraphAddBatchMemOpNode", name) == 0) return HIP_API_ID_hipGraphAddBatchMemOpNode;
   if (strcmp("hipGraphAddChildGraphNode", name) == 0) return HIP_API_ID_hipGraphAddChildGraphNode;
+  if (strcmp("hipGraphAddConditionalNode", name) == 0) return HIP_API_ID_hipGraphAddConditionalNode;
   if (strcmp("hipGraphAddDependencies", name) == 0) return HIP_API_ID_hipGraphAddDependencies;
   if (strcmp("hipGraphAddEmptyNode", name) == 0) return HIP_API_ID_hipGraphAddEmptyNode;
   if (strcmp("hipGraphAddEventRecordNode", name) == 0) return HIP_API_ID_hipGraphAddEventRecordNode;
@@ -1169,6 +1174,7 @@ static inline uint32_t hipApiIdByName(const char* name) {
   if (strcmp("hipGraphBatchMemOpNodeSetParams", name) == 0) return HIP_API_ID_hipGraphBatchMemOpNodeSetParams;
   if (strcmp("hipGraphChildGraphNodeGetGraph", name) == 0) return HIP_API_ID_hipGraphChildGraphNodeGetGraph;
   if (strcmp("hipGraphClone", name) == 0) return HIP_API_ID_hipGraphClone;
+  if (strcmp("hipGraphConditionalHandleCreate", name) == 0) return HIP_API_ID_hipGraphConditionalHandleCreate;
   if (strcmp("hipGraphCreate", name) == 0) return HIP_API_ID_hipGraphCreate;
   if (strcmp("hipGraphDebugDotPrint", name) == 0) return HIP_API_ID_hipGraphDebugDotPrint;
   if (strcmp("hipGraphDestroy", name) == 0) return HIP_API_ID_hipGraphDestroy;
@@ -2189,6 +2195,19 @@ typedef struct hip_api_data_s {
       hipGraph_t childGraph;
     } hipGraphAddChildGraphNode;
     struct {
+      hipGraphNode_t* pGraphNode;
+      hipGraphNode_t pGraphNode__val;
+      hipGraph_t graph;
+      const hipGraphNode_t* pDependencies;
+      hipGraphNode_t pDependencies__val;
+      size_t numDependencies;
+      hipGraphConditionalHandle handle;
+      hipGraphConditionalType type;
+      unsigned int numConditionalGraphs;
+      hipGraph_t* phConditionalGraphs;
+      hipGraph_t phConditionalGraphs__val;
+    } hipGraphAddConditionalNode;
+    struct {
       hipGraph_t graph;
       const hipGraphNode_t* from;
       hipGraphNode_t from__val;
@@ -2369,6 +2388,13 @@ typedef struct hip_api_data_s {
       hipGraph_t pGraphClone__val;
       hipGraph_t originalGraph;
     } hipGraphClone;
+    struct {
+      hipGraphConditionalHandle* pHandleOut;
+      hipGraphConditionalHandle pHandleOut__val;
+      hipGraph_t hGraph;
+      unsigned int defaultLaunchValue;
+      unsigned int flags;
+    } hipGraphConditionalHandleCreate;
     struct {
       hipGraph_t* pGraph;
       hipGraph_t pGraph__val;
@@ -5056,6 +5082,17 @@ typedef struct hip_api_data_s {
   cb_data.args.hipGraphAddChildGraphNode.numDependencies = (size_t)numDependencies; \
   cb_data.args.hipGraphAddChildGraphNode.childGraph = (hipGraph_t)childGraph; \
 };
+// hipGraphAddConditionalNode[('hipGraphNode_t*', 'pGraphNode'), ('hipGraph_t', 'graph'), ('const hipGraphNode_t*', 'pDependencies'), ('size_t', 'numDependencies'), ('hipGraphConditionalHandle', 'handle'), ('hipGraphConditionalType', 'type'), ('unsigned int', 'numConditionalGraphs'), ('hipGraph_t*', 'phConditionalGraphs')]
+#define INIT_hipGraphAddConditionalNode_CB_ARGS_DATA(cb_data) { \
+  cb_data.args.hipGraphAddConditionalNode.pGraphNode = (hipGraphNode_t*)pGraphNode; \
+  cb_data.args.hipGraphAddConditionalNode.graph = (hipGraph_t)graph; \
+  cb_data.args.hipGraphAddConditionalNode.pDependencies = (const hipGraphNode_t*)pDependencies; \
+  cb_data.args.hipGraphAddConditionalNode.numDependencies = (size_t)numDependencies; \
+  cb_data.args.hipGraphAddConditionalNode.handle = (hipGraphConditionalHandle)handle; \
+  cb_data.args.hipGraphAddConditionalNode.type = (hipGraphConditionalType)type; \
+  cb_data.args.hipGraphAddConditionalNode.numConditionalGraphs = (unsigned int)numConditionalGraphs; \
+  cb_data.args.hipGraphAddConditionalNode.phConditionalGraphs = (hipGraph_t*)phConditionalGraphs; \
+};
 // hipGraphAddDependencies[('hipGraph_t', 'graph'), ('const hipGraphNode_t*', 'from'), ('const hipGraphNode_t*', 'to'), ('size_t', 'numDependencies')]
 #define INIT_hipGraphAddDependencies_CB_ARGS_DATA(cb_data) { \
   cb_data.args.hipGraphAddDependencies.graph = (hipGraph_t)graph; \
@@ -5212,6 +5249,13 @@ typedef struct hip_api_data_s {
 #define INIT_hipGraphClone_CB_ARGS_DATA(cb_data) { \
   cb_data.args.hipGraphClone.pGraphClone = (hipGraph_t*)pGraphClone; \
   cb_data.args.hipGraphClone.originalGraph = (hipGraph_t)originalGraph; \
+};
+// hipGraphConditionalHandleCreate[('hipGraphConditionalHandle*', 'pHandleOut'), ('hipGraph_t', 'hGraph'), ('unsigned int', 'defaultLaunchValue'), ('unsigned int', 'flags')]
+#define INIT_hipGraphConditionalHandleCreate_CB_ARGS_DATA(cb_data) { \
+  cb_data.args.hipGraphConditionalHandleCreate.pHandleOut = (hipGraphConditionalHandle*)pHandleOut; \
+  cb_data.args.hipGraphConditionalHandleCreate.hGraph = (hipGraph_t)hGraph; \
+  cb_data.args.hipGraphConditionalHandleCreate.defaultLaunchValue = (unsigned int)defaultLaunchValue; \
+  cb_data.args.hipGraphConditionalHandleCreate.flags = (unsigned int)flags; \
 };
 // hipGraphCreate[('hipGraph_t*', 'pGraph'), ('unsigned int', 'flags')]
 #define INIT_hipGraphCreate_CB_ARGS_DATA(cb_data) { \
@@ -7783,6 +7827,12 @@ static inline void hipApiArgsInit(hip_api_id_t id, hip_api_data_t* data) {
       if (data->args.hipGraphAddChildGraphNode.pGraphNode) data->args.hipGraphAddChildGraphNode.pGraphNode__val = *(data->args.hipGraphAddChildGraphNode.pGraphNode);
       if (data->args.hipGraphAddChildGraphNode.pDependencies) data->args.hipGraphAddChildGraphNode.pDependencies__val = *(data->args.hipGraphAddChildGraphNode.pDependencies);
       break;
+// hipGraphAddConditionalNode[('hipGraphNode_t*', 'pGraphNode'), ('hipGraph_t', 'graph'), ('const hipGraphNode_t*', 'pDependencies'), ('size_t', 'numDependencies'), ('hipGraphConditionalHandle', 'handle'), ('hipGraphConditionalType', 'type'), ('unsigned int', 'numConditionalGraphs'), ('hipGraph_t*', 'phConditionalGraphs')]
+    case HIP_API_ID_hipGraphAddConditionalNode:
+      if (data->args.hipGraphAddConditionalNode.pGraphNode) data->args.hipGraphAddConditionalNode.pGraphNode__val = *(data->args.hipGraphAddConditionalNode.pGraphNode);
+      if (data->args.hipGraphAddConditionalNode.pDependencies) data->args.hipGraphAddConditionalNode.pDependencies__val = *(data->args.hipGraphAddConditionalNode.pDependencies);
+      if (data->args.hipGraphAddConditionalNode.phConditionalGraphs) data->args.hipGraphAddConditionalNode.phConditionalGraphs__val = *(data->args.hipGraphAddConditionalNode.phConditionalGraphs);
+      break;
 // hipGraphAddDependencies[('hipGraph_t', 'graph'), ('const hipGraphNode_t*', 'from'), ('const hipGraphNode_t*', 'to'), ('size_t', 'numDependencies')]
     case HIP_API_ID_hipGraphAddDependencies:
       if (data->args.hipGraphAddDependencies.from) data->args.hipGraphAddDependencies.from__val = *(data->args.hipGraphAddDependencies.from);
@@ -7886,6 +7936,10 @@ static inline void hipApiArgsInit(hip_api_id_t id, hip_api_data_t* data) {
 // hipGraphClone[('hipGraph_t*', 'pGraphClone'), ('hipGraph_t', 'originalGraph')]
     case HIP_API_ID_hipGraphClone:
       if (data->args.hipGraphClone.pGraphClone) data->args.hipGraphClone.pGraphClone__val = *(data->args.hipGraphClone.pGraphClone);
+      break;
+// hipGraphConditionalHandleCreate[('hipGraphConditionalHandle*', 'pHandleOut'), ('hipGraph_t', 'hGraph'), ('unsigned int', 'defaultLaunchValue'), ('unsigned int', 'flags')]
+    case HIP_API_ID_hipGraphConditionalHandleCreate:
+      if (data->args.hipGraphConditionalHandleCreate.pHandleOut) data->args.hipGraphConditionalHandleCreate.pHandleOut__val = *(data->args.hipGraphConditionalHandleCreate.pHandleOut);
       break;
 // hipGraphCreate[('hipGraph_t*', 'pGraph'), ('unsigned int', 'flags')]
     case HIP_API_ID_hipGraphCreate:
@@ -10103,6 +10157,21 @@ static inline const char* hipApiString(hip_api_id_t id, const hip_api_data_t* da
       oss << ", childGraph="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddChildGraphNode.childGraph);
       oss << ")";
     break;
+    case HIP_API_ID_hipGraphAddConditionalNode:
+      oss << "hipGraphAddConditionalNode(";
+      if (data->args.hipGraphAddConditionalNode.pGraphNode == NULL) oss << "pGraphNode=NULL";
+      else { oss << "pGraphNode="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.pGraphNode__val); }
+      oss << ", graph="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.graph);
+      if (data->args.hipGraphAddConditionalNode.pDependencies == NULL) oss << ", pDependencies=NULL";
+      else { oss << ", pDependencies="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.pDependencies__val); }
+      oss << ", numDependencies="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.numDependencies);
+      oss << ", handle="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.handle);
+      oss << ", type="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.type);
+      oss << ", numConditionalGraphs="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.numConditionalGraphs);
+      if (data->args.hipGraphAddConditionalNode.phConditionalGraphs == NULL) oss << ", phConditionalGraphs=NULL";
+      else { oss << ", phConditionalGraphs="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddConditionalNode.phConditionalGraphs__val); }
+      oss << ")";
+    break;
     case HIP_API_ID_hipGraphAddDependencies:
       oss << "hipGraphAddDependencies(";
       oss << "graph="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphAddDependencies.graph);
@@ -10322,6 +10391,15 @@ static inline const char* hipApiString(hip_api_id_t id, const hip_api_data_t* da
       if (data->args.hipGraphClone.pGraphClone == NULL) oss << "pGraphClone=NULL";
       else { oss << "pGraphClone="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphClone.pGraphClone__val); }
       oss << ", originalGraph="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphClone.originalGraph);
+      oss << ")";
+    break;
+    case HIP_API_ID_hipGraphConditionalHandleCreate:
+      oss << "hipGraphConditionalHandleCreate(";
+      if (data->args.hipGraphConditionalHandleCreate.pHandleOut == NULL) oss << "pHandleOut=NULL";
+      else { oss << "pHandleOut="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphConditionalHandleCreate.pHandleOut__val); }
+      oss << ", hGraph="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphConditionalHandleCreate.hGraph);
+      oss << ", defaultLaunchValue="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphConditionalHandleCreate.defaultLaunchValue);
+      oss << ", flags="; roctracer::hip_support::detail::operator<<(oss, data->args.hipGraphConditionalHandleCreate.flags);
       oss << ")";
     break;
     case HIP_API_ID_hipGraphCreate:

--- a/projects/clr/hipamd/src/hip_api_trace.cpp
+++ b/projects/clr/hipamd/src/hip_api_trace.cpp
@@ -237,6 +237,18 @@ hipError_t hipGraphAddNode(hipGraphNode_t* pGraphNode, hipGraph_t graph,
 hipError_t hipGraphChildGraphNodeGetGraph(hipGraphNode_t node, hipGraph_t* pGraph);
 hipError_t hipGraphClone(hipGraph_t* pGraphClone, hipGraph_t originalGraph);
 hipError_t hipGraphCreate(hipGraph_t* pGraph, unsigned int flags);
+hipError_t hipGraphConditionalHandleCreate(hipGraphConditionalHandle* pHandleOut,
+                                           hipGraph_t hGraph,
+                                           unsigned int defaultLaunchValue,
+                                           unsigned int flags);
+hipError_t hipGraphAddConditionalNode(hipGraphNode_t* pGraphNode,
+                                      hipGraph_t graph,
+                                      const hipGraphNode_t* pDependencies,
+                                      size_t numDependencies,
+                                      hipGraphConditionalHandle handle,
+                                      hipGraphConditionalType type,
+                                      unsigned int numConditionalGraphs,
+                                      hipGraph_t* phConditionalGraphs);
 hipError_t hipGraphDebugDotPrint(hipGraph_t graph, const char* path, unsigned int flags);
 hipError_t hipGraphDestroy(hipGraph_t graph);
 hipError_t hipGraphDestroyNode(hipGraphNode_t node);
@@ -1083,6 +1095,8 @@ void UpdateDispatchTable(HipDispatchTable* ptrDispatchTable) {
   ptrDispatchTable->hipGraphChildGraphNodeGetGraph_fn = hip::hipGraphChildGraphNodeGetGraph;
   ptrDispatchTable->hipGraphClone_fn = hip::hipGraphClone;
   ptrDispatchTable->hipGraphCreate_fn = hip::hipGraphCreate;
+  ptrDispatchTable->hipGraphConditionalHandleCreate_fn = hip::hipGraphConditionalHandleCreate;
+  ptrDispatchTable->hipGraphAddConditionalNode_fn = hip::hipGraphAddConditionalNode;
   ptrDispatchTable->hipGraphDebugDotPrint_fn = hip::hipGraphDebugDotPrint;
   ptrDispatchTable->hipGraphDestroy_fn = hip::hipGraphDestroy;
   ptrDispatchTable->hipGraphDestroyNode_fn = hip::hipGraphDestroyNode;
@@ -2223,6 +2237,9 @@ HIP_ENFORCE_ABI(HipDispatchTable, hipExecutionCtxWaitEvent_fn, 534);
 // HIP_RUNTIME_API_TABLE_STEP_VERSION == 29
 HIP_ENFORCE_ABI(HipDispatchTable, hipLibraryGetGlobal_fn, 535);
 HIP_ENFORCE_ABI(HipDispatchTable, hipLibraryGetManaged_fn, 536);
+// HIP_RUNTIME_API_TABLE_STEP_VERSION == 30
+HIP_ENFORCE_ABI(HipDispatchTable, hipGraphConditionalHandleCreate_fn, 537);
+HIP_ENFORCE_ABI(HipDispatchTable, hipGraphAddConditionalNode_fn, 538);
 
 // if HIP_ENFORCE_ABI entries are added for each new function pointer in the table, the number below
 // will be +1 of the number in the last HIP_ENFORCE_ABI line. E.g.:
@@ -2230,9 +2247,9 @@ HIP_ENFORCE_ABI(HipDispatchTable, hipLibraryGetManaged_fn, 536);
 //  HIP_ENFORCE_ABI(<table>, <functor>, 8)
 //
 //  HIP_ENFORCE_ABI_VERSIONING(<table>, 9) <- 8 + 1 = 9
-HIP_ENFORCE_ABI_VERSIONING(HipDispatchTable, 537)
+HIP_ENFORCE_ABI_VERSIONING(HipDispatchTable, 539)
 
-static_assert(HIP_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && HIP_RUNTIME_API_TABLE_STEP_VERSION == 29,
+static_assert(HIP_RUNTIME_API_TABLE_MAJOR_VERSION == 0 && HIP_RUNTIME_API_TABLE_STEP_VERSION == 30,
               "If you get this error, add new HIP_ENFORCE_ABI(...) code for the new function "
               "pointers and then update this check so it is true");
 #endif

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -11,6 +11,9 @@
 #include "hip_platform.hpp"
 #include "hip_event.hpp"
 #include "hip_mempool_impl.hpp"
+#include "device/devsignal.hpp"
+#include <hsa/amd_hsa_signal.h>
+#include <cstddef>
 
 namespace hip {
 
@@ -1300,6 +1303,135 @@ hipError_t hipGraphCreate(hipGraph_t* pGraph, unsigned int flags) {
     HIP_RETURN(hipErrorInvalidValue);
   }
   *pGraph = reinterpret_cast<hipGraph_t>(new hip::Graph(hip::getCurrentDevice()));
+  HIP_RETURN(hipSuccess);
+}
+
+// M1: conditional graph handle plumbing only (Option C).
+// Allocates a real device signal whose backing `amd_signal_t::value` cell is
+// exposed to user code via `pHandleOut->device_ptr = signal_handle + 8`. A
+// device kernel can then update the cell with a single store via
+// `hipGraphSetConditional`. In M2 this same cell drives CP-evaluated
+// conditional jump / loop_back packets.
+//
+// The `+8` shortcut is locked in by a static_assert so a future ROCR layout
+// change fails the build loudly instead of silently corrupting an unrelated
+// field of `amd_signal_t`.
+hipError_t hipGraphConditionalHandleCreate(hipGraphConditionalHandle* pHandleOut,
+                                           hipGraph_t hGraph,
+                                           unsigned int defaultLaunchValue,
+                                           unsigned int flags) {
+  HIP_INIT_API(hipGraphConditionalHandleCreate, pHandleOut, hGraph, defaultLaunchValue, flags);
+  static_assert(offsetof(amd_signal_t, value) == 8,
+                "Option C: hipGraphConditionalHandle::device_ptr = signal_handle + 8 "
+                "assumes amd_signal_t::value lives at offset 8");
+  if (pHandleOut == nullptr || flags != 0) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  hip::Graph* g = reinterpret_cast<hip::Graph*>(hGraph);
+  if (!hip::Graph::isGraphValid(g)) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  hip::Device* hipDev = hip::getCurrentDevice();
+  if (hipDev == nullptr || hipDev->devices().empty()) {
+    HIP_RETURN(hipErrorInvalidDevice);
+  }
+  amd::Device* dev = hipDev->devices()[0];
+  amd::device::Signal* sig = dev->createSignal();
+  if (sig == nullptr) {
+    HIP_RETURN(hipErrorOutOfMemory);
+  }
+  if (!sig->Init(*dev, static_cast<uint64_t>(defaultLaunchValue),
+                 amd::device::Signal::WaitState::Active)) {
+    delete sig;
+    HIP_RETURN(hipErrorOutOfMemory);
+  }
+  uint64_t signal_handle = reinterpret_cast<uint64_t>(sig->getHandle());
+  pHandleOut->signal_handle = signal_handle;
+  pHandleOut->device_ptr    = signal_handle + offsetof(amd_signal_t, value);
+  pHandleOut->default_value = defaultLaunchValue;
+  // TODO(M2): register `sig` with the graph so it is destroyed in
+  // hipGraphDestroy. For M1 the smoke test is short-lived and a one-off leak
+  // here is acceptable; lifetime work is tracked under m2_lifetime in the plan.
+  HIP_RETURN(hipSuccess);
+}
+
+// M2: conditional graph node creation.  Validates the requested conditional
+// shape, allocates the body graph(s) the caller will populate, constructs a
+// hip::GraphConditionalNode owning those bodies, and inserts it into the
+// parent graph with the standard dependency wiring.
+//
+// The runtime does not capture body packets here; that happens in
+// GraphExec::Init / IB build under m2_clr_ib_build.  The host-visible
+// hipGraph_t handles written into phConditionalGraphs are owned by the
+// GraphConditionalNode (and therefore by the parent graph).
+hipError_t hipGraphAddConditionalNode(hipGraphNode_t* pGraphNode,
+                                      hipGraph_t graph,
+                                      const hipGraphNode_t* pDependencies,
+                                      size_t numDependencies,
+                                      hipGraphConditionalHandle handle,
+                                      hipGraphConditionalType type,
+                                      unsigned int numConditionalGraphs,
+                                      hipGraph_t* phConditionalGraphs) {
+  HIP_INIT_API(hipGraphAddConditionalNode, pGraphNode, graph, pDependencies, numDependencies,
+               type, numConditionalGraphs, phConditionalGraphs);
+  if (pGraphNode == nullptr || graph == nullptr || phConditionalGraphs == nullptr ||
+      numConditionalGraphs == 0 || (numDependencies > 0 && pDependencies == nullptr)) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  if (handle.signal_handle == 0 || handle.device_ptr == 0) {
+    // Caller must have populated the handle via hipGraphConditionalHandleCreate.
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  hip::Graph* g = reinterpret_cast<hip::Graph*>(graph);
+  if (!hip::Graph::isGraphValid(g)) {
+    HIP_RETURN(hipErrorInvalidValue);
+  }
+  // Validate body graph count vs. conditional type:
+  //  - WHILE                : exactly 1 body
+  //  - IF (with optional ELSE) : 1 or 2 bodies (laid out [else][if] in M2)
+  //  - SWITCH               : not yet supported
+  switch (type) {
+    case hipGraphCondTypeWhile:
+      if (numConditionalGraphs != 1) {
+        HIP_RETURN(hipErrorInvalidValue);
+      }
+      break;
+    case hipGraphCondTypeIf:
+      if (numConditionalGraphs != 1 && numConditionalGraphs != 2) {
+        HIP_RETURN(hipErrorInvalidValue);
+      }
+      break;
+    case hipGraphCondTypeSwitch:
+      HIP_RETURN(hipErrorNotSupported);
+    default:
+      HIP_RETURN(hipErrorInvalidValue);
+  }
+  hip::Device* hipDev = hip::getCurrentDevice();
+  if (hipDev == nullptr) {
+    HIP_RETURN(hipErrorInvalidDevice);
+  }
+  std::vector<hip::Graph*> bodies;
+  bodies.reserve(numConditionalGraphs);
+  for (unsigned int i = 0; i < numConditionalGraphs; ++i) {
+    hip::Graph* body = new hip::Graph(hipDev);
+    bodies.push_back(body);
+    phConditionalGraphs[i] = reinterpret_cast<hipGraph_t>(body);
+  }
+  hip::GraphNode* node = new hip::GraphConditionalNode(handle, type, std::move(bodies));
+  hipError_t status = ihipGraphAddNode(node, g,
+                                       reinterpret_cast<hip::GraphNode* const*>(pDependencies),
+                                       numDependencies, false);
+  if (status != hipSuccess) {
+    // ihipGraphAddNode does not take ownership on failure; reclaim the node
+    // (and via the destructor, the body graphs) so phConditionalGraphs entries
+    // are not left dangling.
+    delete node;
+    for (unsigned int i = 0; i < numConditionalGraphs; ++i) {
+      phConditionalGraphs[i] = nullptr;
+    }
+    HIP_RETURN(status);
+  }
+  *pGraphNode = reinterpret_cast<hipGraphNode_t>(node);
   HIP_RETURN(hipSuccess);
 }
 

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -6,6 +6,12 @@
 
 #include "hip_graph_internal.hpp"
 
+#include <cstring>
+
+#include "device/device.hpp"
+#include "device/rocm/rocdevice.hpp"
+#include "device/rocm/rocvirtual.hpp"
+
 #define CASE_STRING(X, C)                                                                          \
   case X:                                                                                          \
     case_string = #C;                                                                              \
@@ -1611,6 +1617,26 @@ hipError_t GraphExec::CaptureAQLPackets() {
     return status;
   }
 
+  // Build IB buffers for any conditional nodes in the parent graph.
+  // BuildIB walks each body Graph, captures its kernel-dispatch packets,
+  // and assembles them (plus a vendor LOOP_BACK for WHILE) into a single
+  // contiguous IB.  Done here so the kernArgManager_ pool is already
+  // available for body-kernel kernarg allocation.  Conditional nodes
+  // remain non-captureable so the segment scheduler dispatches their
+  // CondJumpCommand via the legacy CreateCommand + EnqueueCommands path.
+  for (auto* node : topoOrder_) {
+    if (node != nullptr && node->GetType() == hipGraphNodeTypeConditional) {
+      auto* cond = static_cast<GraphConditionalNode*>(node);
+      hipError_t cstatus = cond->BuildIB(kernArgManager_, instantiateDeviceId_);
+      if (cstatus != hipSuccess) {
+        ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+                "[hipGraph][cond] BuildIB failed for conditional node "
+                "(status=%d)", static_cast<int>(cstatus));
+        return cstatus;
+      }
+    }
+  }
+
   kernArgManager_->ReadBackOrFlush();
   return hipSuccess;;
 }
@@ -2760,4 +2786,307 @@ void GraphKernelArgManager::ReadBackOrFlush() {
     }
   }
 }
+
+// ================================================================================================
+// GraphConditionalNode: lazy IB build + cond_jump command (M2 IB path).
+//
+// BuildIB() is called from GraphExec::CaptureAQLPackets() at instantiate time
+// after the parent's GraphKernelArgManager pool has been allocated.  It walks
+// each body Graph (POC: kernel-only, insertion-order) and captures the body's
+// AQL kernel-dispatch packets via the same machinery that the segmented
+// scheduler uses for regular nodes (GraphNode::CaptureAndFormPacket).  For
+// WHILE we append a vendor LOOP_BACK packet so the CP re-evaluates the cond
+// signal after every iteration.  The IB lives in coarse-grain VRAM on
+// largeBar systems (so the CP fetches without PCIe round-trips) and in
+// pinned host memory otherwise.
+//
+// CondJumpCommand::submit() runs at launch on the launch stream's
+// roc::VirtualGPU.  It resets the cond cell back to the handle's default
+// value (otherwise iteration N would observe value=0 left by iteration N-1)
+// and emits a single vendor cond_jump packet via the new
+// dispatchCondJumpPacket helper.  The CP follows the cond_jump into the IB,
+// runs the body, and (for WHILE) loops via LOOP_BACK until the kernel zeroes
+// the cond cell.
+
+GraphConditionalNode::~GraphConditionalNode() {
+  for (auto* body : bodies_) {
+    delete body;
+  }
+  bodies_.clear();
+  if (ib_addr_ != nullptr && ib_device_ != nullptr) {
+    ib_device_->hostFree(ib_addr_, ib_size_bytes_);
+    ib_addr_ = nullptr;
+    ib_size_bytes_ = 0;
+  }
+}
+
+hipError_t GraphConditionalNode::BuildIB(GraphKernelArgManager* kernArgMgr,
+                                        int devId) {
+  if (ib_built_) {
+    return hipSuccess;
+  }
+  if (kernArgMgr == nullptr) {
+    return hipErrorInvalidValue;
+  }
+  if (cond_type_ != hipGraphCondTypeIf && cond_type_ != hipGraphCondTypeWhile) {
+    return hipErrorNotSupported;
+  }
+  if (bodies_.empty()) {
+    return hipErrorInvalidValue;
+  }
+  if (cond_type_ == hipGraphCondTypeWhile && bodies_.size() != 1) {
+    return hipErrorInvalidValue;
+  }
+  if (cond_type_ == hipGraphCondTypeIf &&
+      bodies_.size() != 1 && bodies_.size() != 2) {
+    return hipErrorInvalidValue;
+  }
+  if (devId < 0 || static_cast<size_t>(devId) >= g_devices.size()) {
+    return hipErrorInvalidValue;
+  }
+
+  amd::Device* device = g_devices[devId]->devices()[0];
+
+  // GraphExec::GetKernelArgSizeForGraph only sums kernarg sizes for the
+  // parent graph's segments, not for kernels nested in conditional bodies.
+  // Bootstrap a kernarg pool sized for our bodies (plus a chunk of
+  // headroom) so the per-kernel CaptureAndFormPacket -> AllocKernArg path
+  // can always find a backing chunk on the first call.
+  size_t cond_kernarg_reserve = 0;
+  for (size_t bi = 0; bi < bodies_.size(); ++bi) {
+    Graph* body = bodies_[bi];
+    if (body == nullptr) {
+      return hipErrorInvalidValue;
+    }
+    for (auto* node : body->GetNodes()) {
+      if (node != nullptr && node->GetType() == hipGraphNodeTypeKernel) {
+        cond_kernarg_reserve += node->GetKerArgSize();
+      }
+    }
+  }
+  if (cond_kernarg_reserve > 0) {
+    const size_t pool_size = cond_kernarg_reserve + kKernArgChunkSize;
+    if (!kernArgMgr->AllocGraphKernargPool(pool_size, device)) {
+      ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+              "[hipGraph][cond] kernarg pool allocation of %zu bytes failed",
+              pool_size);
+      return hipErrorMemoryAllocation;
+    }
+  }
+
+  // Capture each body's kernel-dispatch packets into a local byte buffer.
+  // body_pkt_count[i] is the number of 64-byte packets emitted by body i.
+  std::vector<std::vector<uint8_t>> body_bytes(bodies_.size());
+  std::vector<size_t> body_pkt_count(bodies_.size(), 0);
+
+  for (size_t bi = 0; bi < bodies_.size(); ++bi) {
+    Graph* body = bodies_[bi];
+    if (body == nullptr) {
+      return hipErrorInvalidValue;
+    }
+    for (auto* node : body->GetNodes()) {
+      if (node == nullptr) {
+        continue;
+      }
+      if (node->GetType() != hipGraphNodeTypeKernel) {
+        ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+                "[hipGraph][cond] body graph contains non-kernel node "
+                "(type=%d); POC supports kernel-only bodies",
+                static_cast<int>(node->GetType()));
+        return hipErrorNotSupported;
+      }
+
+      std::vector<uint8_t*> nodePackets;
+      std::vector<const std::string*> nodeKernelNames;
+      hipError_t status = node->CaptureAndFormPacket(kernArgMgr, &nodePackets,
+                                                     &nodeKernelNames);
+      if (status != hipSuccess) {
+        ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+                "[hipGraph][cond] body kernel CaptureAndFormPacket failed "
+                "(status=%d)", static_cast<int>(status));
+        return status;
+      }
+      if (nodePackets.empty()) {
+        ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+                "[hipGraph][cond] body kernel produced 0 packets");
+        return hipErrorUnknown;
+      }
+      for (auto* pkt : nodePackets) {
+        // Zero the captured packet's completion_signal (offset 56) so the
+        // body kernel inside the IB does not try to signal a per-packet
+        // completion.  Aggregation (if any) is handled at the cond_jump
+        // entry packet level.
+        std::memset(pkt + 56, 0, 8);
+        body_bytes[bi].insert(body_bytes[bi].end(), pkt, pkt + 64);
+      }
+      body_pkt_count[bi] += nodePackets.size();
+    }
+  }
+
+  // Compute IB layout + cond_jump arguments per cond_type.
+  size_t total_pkts = 0;
+  size_t fall_pkts = 0;
+  size_t jump_off_pkts = 0;
+  size_t jump_pkts = 0;
+
+  if (cond_type_ == hipGraphCondTypeWhile) {
+    // Layout: [body | loop_back].  cond_jump runs body+loop_back if cond != 0;
+    // skips entirely if cond == 0 (handles 0-iteration WHILE).
+    total_pkts = body_pkt_count[0] + 1;  // +1 for trailing loop_back
+    fall_pkts = 0;
+    jump_off_pkts = 0;
+    jump_pkts = total_pkts;
+  } else {
+    if (bodies_.size() == 1) {
+      // IF (1 body).  Layout: [body].  Run body if cond != 0, skip otherwise.
+      total_pkts = body_pkt_count[0];
+      fall_pkts = 0;
+      jump_off_pkts = 0;
+      jump_pkts = body_pkt_count[0];
+    } else {
+      // IF / ELSE (2 bodies).  CUDA convention: body[0] = "if" (TRUE),
+      // body[1] = "else" (FALSE).  IB layout is [false_arm | true_arm], so
+      // jump_offset/fall point to body[1] = false_arm at the start.
+      total_pkts = body_pkt_count[0] + body_pkt_count[1];
+      fall_pkts = body_pkt_count[1];
+      jump_off_pkts = body_pkt_count[1];
+      jump_pkts = body_pkt_count[0];
+    }
+  }
+
+  if (total_pkts == 0) {
+    // Empty conditional with empty body and no loop_back -- nothing to
+    // dispatch.  Mark as built and let CondJumpCommand::submit() be a no-op.
+    ib_addr_ = nullptr;
+    ib_size_bytes_ = 0;
+    ib_size_pkts_ = 0;
+    fall_pkts_ = 0;
+    jump_off_pkts_ = 0;
+    jump_pkts_ = 0;
+    ib_built_ = true;
+    return hipSuccess;
+  }
+
+  // Allocate IB in device-accessible memory.  Mirror GraphKernelArgManager's
+  // allocation strategy: largeBar -> coarse-grain VRAM (executable kernarg
+  // pool flavor, GPU-local + host-writable on largeBar), else pinned host.
+  const size_t ib_bytes = total_pkts * 64;
+  void* ib = nullptr;
+  if (device->info().largeBar_) {
+    amd::Device::AllocationFlags flags = {};
+    flags.executable_ = true;
+    ib = device->deviceLocalAlloc(ib_bytes, flags);
+  } else {
+    ib = device->hostAlloc(ib_bytes, 64,
+                           amd::Device::MemorySegment::kKernArg);
+  }
+  if (ib == nullptr) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+            "[hipGraph][cond] IB allocation of %zu bytes failed", ib_bytes);
+    return hipErrorMemoryAllocation;
+  }
+
+  // Memcpy captured body packets, then (WHILE only) build + memcpy loop_back.
+  uint8_t* dst = static_cast<uint8_t*>(ib);
+  if (cond_type_ == hipGraphCondTypeWhile) {
+    if (!body_bytes[0].empty()) {
+      std::memcpy(dst, body_bytes[0].data(), body_bytes[0].size());
+      dst += body_bytes[0].size();
+    }
+    hsa_amd_aql_loop_back_t lb;
+    std::memset(&lb, 0, sizeof(lb));
+    constexpr uint16_t kVendorH = static_cast<uint16_t>(
+        HSA_PACKET_TYPE_VENDOR_SPECIFIC << HSA_PACKET_HEADER_TYPE);
+    constexpr uint16_t kBarrierH =
+        static_cast<uint16_t>(1 << HSA_PACKET_HEADER_BARRIER);
+    constexpr uint16_t kSysScopeH = static_cast<uint16_t>(
+        (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE) |
+        (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE));
+    lb.header.header = static_cast<uint16_t>(kVendorH | kBarrierH | kSysScopeH);
+    lb.header.AmdFormat = HSA_AMD_PACKET_TYPE_AQL_LOOP_BACK;
+    lb.condition_signal.handle = handle_.signal_handle;
+    lb.test_value = static_cast<hsa_signal_value_t>(handle_.default_value);
+    lb.cond_op = HSA_SIGNAL_CONDITION_NE;
+    lb.ib_size_packets = static_cast<uint32_t>(total_pkts);
+    lb.completion_signal.handle = 0;
+    std::memcpy(dst, &lb, sizeof(lb));
+    dst += sizeof(lb);
+  } else if (bodies_.size() == 1) {
+    if (!body_bytes[0].empty()) {
+      std::memcpy(dst, body_bytes[0].data(), body_bytes[0].size());
+      dst += body_bytes[0].size();
+    }
+  } else {
+    // IF / ELSE: memcpy false_arm (body[1]) first, then true_arm (body[0]).
+    if (!body_bytes[1].empty()) {
+      std::memcpy(dst, body_bytes[1].data(), body_bytes[1].size());
+      dst += body_bytes[1].size();
+    }
+    if (!body_bytes[0].empty()) {
+      std::memcpy(dst, body_bytes[0].data(), body_bytes[0].size());
+      dst += body_bytes[0].size();
+    }
+  }
+
+  ib_addr_ = ib;
+  ib_size_bytes_ = ib_bytes;
+  ib_size_pkts_ = total_pkts;
+  fall_pkts_ = static_cast<uint32_t>(fall_pkts);
+  jump_off_pkts_ = static_cast<uint32_t>(jump_off_pkts);
+  jump_pkts_ = static_cast<uint32_t>(jump_pkts);
+  ib_device_ = device;
+  ib_built_ = true;
+
+  ClPrint(amd::LOG_INFO, amd::LOG_CODE,
+          "[hipGraph][cond] BuildIB type=%d ib=%p bytes=%zu pkts=%zu "
+          "fall=%u jump_off=%u jump=%u",
+          static_cast<int>(cond_type_), ib_addr_, ib_size_bytes_,
+          ib_size_pkts_, fall_pkts_, jump_off_pkts_, jump_pkts_);
+  return hipSuccess;
+}
+
+GraphConditionalNode::CondJumpCommand::CondJumpCommand(
+    amd::HostQueue& queue, GraphConditionalNode& node)
+    : amd::Command(queue, CL_COMMAND_MARKER, EventWaitList{}, /*commandWaitBits=*/0,
+                   /*waitingEvent=*/nullptr),
+      node_(node) {}
+
+void GraphConditionalNode::CondJumpCommand::submit(device::VirtualDevice& device) {
+  if (!node_.IsIbBuilt()) {
+    ClPrint(amd::LOG_ERROR, amd::LOG_CODE,
+            "[hipGraph][cond] CondJumpCommand::submit() before BuildIB()");
+    setStatus(CL_INVALID_OPERATION);
+    return;
+  }
+
+  if (node_.GetIbAddr() == nullptr || node_.ib_size_pkts_ == 0) {
+    // Empty conditional: nothing to dispatch.  Treat as a no-op marker.
+    setStatus(CL_COMPLETE);
+    return;
+  }
+
+  hsa_signal_t cond_sig{};
+  cond_sig.handle = node_.GetHandle().signal_handle;
+  hsa_signal_value_t default_value = static_cast<hsa_signal_value_t>(
+      node_.GetHandle().default_value);
+
+  // Reset the cond cell to its default value before re-entering the
+  // conditional.  Required so iteration N+1 doesn't observe the value left
+  // by iteration N inside the kernel.  Relaxed is fine because the cond_jump
+  // packet itself carries SYSTEM acquire/release fences.
+  hsa_signal_store_relaxed(cond_sig, default_value);
+
+  auto& vgpu = static_cast<amd::roc::VirtualGPU&>(device);
+  vgpu.dispatchCondJumpPacket(
+      cond_sig,
+      default_value,
+      HSA_SIGNAL_CONDITION_NE,
+      reinterpret_cast<uint64_t>(node_.GetIbAddr()),
+      node_.GetFallPkts(),
+      node_.GetJumpOffPkts(),
+      node_.GetJumpPkts());
+
+  setStatus(CL_COMPLETE);
+}
+
 }  // namespace hip

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -2883,6 +2883,125 @@ class GraphEmptyNode : public GraphNode {
 };
 
 // ================================================================================================
+//
+// Conditional graph node (HIP graph IF / WHILE).  Owns 1 (WHILE / IF-no-else)
+// or 2 (IF/ELSE) empty body graphs that the caller populates after node
+// creation.  The runtime reads the bodies at GraphExec::Init time to build
+// the per-conditional indirect buffer (see m2_clr_ib_build), and at
+// GraphExec::Run time emits a single vendor cond_jump AQL packet on the
+// launch stream's HW queue (see m2_clr_packet_emit + m2_clr_launch_reset).
+//
+// The CreateCommand override currently emits an amd::Marker as a stand-in so
+// segment scheduling and dependency edges work end-to-end while the IB / packet
+// emission path is still under construction.
+//
+// Lifetime: parent graph owns the GraphConditionalNode, which owns the body
+// hip::Graph objects; ~GraphConditionalNode() deletes the bodies.  The
+// underlying hsa_signal_t in the handle is owned by hipGraphConditionalHandle
+// and freed under m2_lifetime.
+class GraphConditionalNode : public GraphNode {
+ protected:
+  // Copy ctor: deep-clones the body graphs so the GraphExec returned by
+  // hipGraphInstantiate has its own independent body Graph hierarchy.  The
+  // hipGraphConditionalHandle (cond signal) and the conditional type are POD
+  // and shared by value.  IB metadata stays at its default-initialised state
+  // (ib_built_ == false) so the clone's first BuildIB() will materialise a
+  // fresh IB on the GraphExec's kernArgManager pool rather than aliasing the
+  // original's IB allocation.
+  GraphConditionalNode(const GraphConditionalNode& rhs)
+      : GraphNode(rhs),
+        handle_(rhs.handle_),
+        cond_type_(rhs.cond_type_) {
+    bodies_.reserve(rhs.bodies_.size());
+    for (auto* body : rhs.bodies_) {
+      auto* newBody = new Graph(body->Device(), body);
+      body->clone(newBody, /*cloneNodes=*/true);
+      bodies_.push_back(newBody);
+    }
+  }
+
+ public:
+  // Custom amd::Command emitted at graph launch.  submit() resets the cond
+  // signal to its default and rings out one vendor cond_jump AQL packet on
+  // the launch stream's HW queue.  Defined out-of-line in
+  // hip_graph_internal.cpp because submit() needs HSA + rocvirtual headers.
+  class CondJumpCommand : public amd::Command {
+   public:
+    CondJumpCommand(amd::HostQueue& queue, GraphConditionalNode& node);
+    void submit(device::VirtualDevice& device) final;
+
+   private:
+    GraphConditionalNode& node_;
+  };
+
+  GraphConditionalNode(hipGraphConditionalHandle handle,
+                       hipGraphConditionalType cond_type,
+                       std::vector<Graph*> bodies)
+      : GraphNode(hipGraphNodeTypeConditional, "solid", "diamond", "CONDITIONAL"),
+        handle_(handle),
+        cond_type_(cond_type),
+        bodies_(std::move(bodies)) {}
+
+  ~GraphConditionalNode() override;
+
+  GraphConditionalNode& operator=(const GraphConditionalNode&) = delete;
+
+  GraphNode* clone() const override { return new GraphConditionalNode(*this); }
+
+  hipError_t SetParams(GraphNode* node) override {
+    // No mutable parameters yet -- the handle and conditional type are fixed
+    // at node creation time.  Body graphs are mutated by the user via the
+    // hipGraph_t handles returned from hipGraphAddConditionalNode.
+    (void)node;
+    return hipSuccess;
+  }
+
+  // Walks each body Graph, captures kernel-dispatch packets via
+  // GraphNode::CaptureAndFormPacket(kernArgMgr), and assembles a contiguous
+  // IB in coarse-grain VRAM (or pinned host memory on non-largeBar systems).
+  // For WHILE, an hsa_amd_aql_loop_back_t is appended so the CP re-evaluates
+  // the cond signal at the tail of every iteration.  POC: bodies must contain
+  // only kernel nodes.  Idempotent across launches; first call wins.
+  hipError_t BuildIB(GraphKernelArgManager* kernArgMgr, int devId);
+
+  hipError_t CreateCommand(hip::Stream* stream) override {
+    hipError_t status = GraphNode::CreateCommand(stream);
+    if (status != hipSuccess) {
+      return status;
+    }
+    commands_.reserve(1);
+    commands_.emplace_back(new CondJumpCommand(*stream, *this));
+    return hipSuccess;
+  }
+
+  const hipGraphConditionalHandle& GetHandle() const { return handle_; }
+  hipGraphConditionalType GetCondType() const { return cond_type_; }
+  const std::vector<Graph*>& GetBodies() const { return bodies_; }
+
+  // Used by CondJumpCommand::submit().
+  void* GetIbAddr() const { return ib_addr_; }
+  uint32_t GetFallPkts() const { return fall_pkts_; }
+  uint32_t GetJumpOffPkts() const { return jump_off_pkts_; }
+  uint32_t GetJumpPkts() const { return jump_pkts_; }
+  bool IsIbBuilt() const { return ib_built_; }
+
+ private:
+  hipGraphConditionalHandle handle_;
+  hipGraphConditionalType cond_type_;
+  std::vector<Graph*> bodies_;  //!< Owned; deleted in destructor.
+
+  // IB metadata, populated by BuildIB() at instantiate time.
+  void* ib_addr_ = nullptr;        //!< Base of the IB in device-accessible memory.
+  size_t ib_size_bytes_ = 0;       //!< Allocation size for ib_addr_, used by hostFree.
+  size_t ib_size_pkts_ = 0;        //!< Total IB packets including loop_back (WHILE).
+  uint32_t fall_pkts_ = 0;         //!< cond_jump.fallthrough_ib_size_packets
+  uint32_t jump_off_pkts_ = 0;     //!< cond_jump.jump_offset_packets
+  uint32_t jump_pkts_ = 0;         //!< cond_jump.jump_ib_size_packets
+  amd::Device* ib_device_ = nullptr;  //!< Device that allocated ib_addr_.
+  bool ib_built_ = false;
+};
+
+// ================================================================================================
 class GraphMemAllocNode final : public GraphNode {
   hipMemAllocNodeParams node_params_;  // Node parameters for memory allocation
   amd::Memory* va_ = nullptr;          // Memory object, which holds a virtual address

--- a/projects/clr/hipamd/src/hip_hcc.map.in
+++ b/projects/clr/hipamd/src/hip_hcc.map.in
@@ -660,6 +660,8 @@ global:
     hipKernelSetAttribute;
     hipKernelGetFunction;
     hipMemPrefetchBatchAsync;
+    hipGraphConditionalHandleCreate;
+    hipGraphAddConditionalNode;
 local:
     *;
 } hip_7.1;

--- a/projects/clr/hipamd/src/hip_table_interface.cpp
+++ b/projects/clr/hipamd/src/hip_table_interface.cpp
@@ -902,6 +902,29 @@ hipError_t hipGraphCreate(hipGraph_t* pGraph, unsigned int flags) {
   return hip::GetHipDispatchTable()->hipGraphCreate_fn(pGraph, flags);
   CATCH;
 }
+hipError_t hipGraphConditionalHandleCreate(hipGraphConditionalHandle* pHandleOut,
+                                           hipGraph_t hGraph,
+                                           unsigned int defaultLaunchValue,
+                                           unsigned int flags) {
+  TRY;
+  return hip::GetHipDispatchTable()->hipGraphConditionalHandleCreate_fn(
+      pHandleOut, hGraph, defaultLaunchValue, flags);
+  CATCH;
+}
+hipError_t hipGraphAddConditionalNode(hipGraphNode_t* pGraphNode,
+                                      hipGraph_t graph,
+                                      const hipGraphNode_t* pDependencies,
+                                      size_t numDependencies,
+                                      hipGraphConditionalHandle handle,
+                                      hipGraphConditionalType type,
+                                      unsigned int numConditionalGraphs,
+                                      hipGraph_t* phConditionalGraphs) {
+  TRY;
+  return hip::GetHipDispatchTable()->hipGraphAddConditionalNode_fn(
+      pGraphNode, graph, pDependencies, numDependencies, handle, type,
+      numConditionalGraphs, phConditionalGraphs);
+  CATCH;
+}
 hipError_t hipGraphDebugDotPrint(hipGraph_t graph, const char* path, unsigned int flags) {
   TRY;
   return hip::GetHipDispatchTable()->hipGraphDebugDotPrint_fn(graph, path, flags);

--- a/projects/clr/rocclr/device/blitcl.cpp
+++ b/projects/clr/rocclr/device/blitcl.cpp
@@ -202,6 +202,15 @@ const char* BlitLinearSourceCode = BLIT_KERNELS(
       __amd_batchMemOp(params, count);
     });
 
+// Local workaround (DEV ENV ONLY): the system /opt/rocm device runtime
+// bitcode (opencl.bc) on this branch only ships __amd_streamOpsWrite and
+// __amd_streamOpsWait; __amd_streamOpsIncrement and __amd_streamOpsDecrement
+// are not yet provided.  To keep the develop CLR's BlitManager init from
+// failing on stale ROCm installs, the wrapper kernels below stub out the
+// missing extern calls (no-op).  Anyone exercising
+// hipExtStreamWriteValue{Increment,Decrement} on this build will get a no-op
+// instead of a runtime crash; revert this once the device runtime catches up
+// and the externs are available again.
 const char* HipExtraSourceCode = BLIT_KERNELS(
     __kernel void __amd_rocclr_streamOpsWrite(__global uint* ptrInt, __global ulong* ptrUlong,
                                               ulong value) {
@@ -210,12 +219,12 @@ const char* HipExtraSourceCode = BLIT_KERNELS(
 
     __kernel void __amd_rocclr_streamOpsIncrement(__global uint* ptrInt, __global ulong* ptrUlong,
                                                   ulong value) {
-      __amd_streamOpsIncrement(ptrInt, ptrUlong, value);
+      (void)ptrInt; (void)ptrUlong; (void)value;
     }
 
     __kernel void __amd_rocclr_streamOpsDecrement(__global uint* ptrInt, __global ulong* ptrUlong,
                                                   ulong value) {
-      __amd_streamOpsDecrement(ptrInt, ptrUlong, value);
+      (void)ptrInt; (void)ptrUlong; (void)value;
     }
 
     __kernel void __amd_rocclr_streamOpsWait(__global uint* ptrInt, __global ulong* ptrUlong,
@@ -238,12 +247,12 @@ const char* HipExtraSourceCodeNoGWS = BLIT_KERNELS(
 
     __kernel void __amd_rocclr_streamOpsIncrement(__global uint* ptrInt, __global ulong* ptrUlong,
                                                   ulong value) {
-      __amd_streamOpsIncrement(ptrInt, ptrUlong, value);
+      (void)ptrInt; (void)ptrUlong; (void)value;
     }
 
     __kernel void __amd_rocclr_streamOpsDecrement(__global uint* ptrInt, __global ulong* ptrUlong,
                                                   ulong value) {
-      __amd_streamOpsDecrement(ptrInt, ptrUlong, value);
+      (void)ptrInt; (void)ptrUlong; (void)value;
     }
 
     __kernel void __amd_rocclr_streamOpsWait(__global uint* ptrInt, __global ulong* ptrUlong,

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1841,6 +1841,75 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
 }
 
 // ================================================================================================
+// HIP graph conditional node entry packet.  Mirrors dispatchBarrierValuePacket
+// but emits a vendor HSA_AMD_PACKET_TYPE_DISPATCH_IB_COND_JUMP instead.
+//
+// The CP is expected to:
+//   - read cond_signal.value (the cond cell at amd_signal_t +8)
+//   - compare it against test_value with cond_op
+//   - if TRUE, fetch jump_pkts packets from
+//       ib_base_addr + jump_offset_pkts * 64
+//   - if FALSE, fetch fallthrough_pkts packets from ib_base_addr
+//   - then resume from this queue
+//
+// barrier=1 + SYSTEM acquire/release on the header ensures any prior packet
+// (including a kernel that wrote the cond cell) has retired and its store is
+// visible to the CP before the cond load.
+void VirtualGPU::dispatchCondJumpPacket(hsa_signal_t cond_signal,
+                                        hsa_signal_value_t test_value,
+                                        hsa_signal_condition32_t cond_op,
+                                        uint64_t ib_base_addr,
+                                        uint32_t fallthrough_pkts,
+                                        uint32_t jump_offset_pkts,
+                                        uint32_t jump_pkts) {
+  const uint32_t queueSize = gpu_queue_->size;
+  const uint32_t queueMask = queueSize - 1;
+
+  // Header bits: VENDOR_SPECIFIC + barrier + SYSTEM acquire/release fences.
+  // Identical scope choice as barrier_value to make any prior write to the
+  // cond cell visible to the CP load.
+  constexpr uint16_t kVendorSpecificHBits =
+      (HSA_PACKET_TYPE_VENDOR_SPECIFIC << HSA_PACKET_HEADER_TYPE);
+  constexpr uint16_t kBarrierHBits = (1 << HSA_PACKET_HEADER_BARRIER);
+  constexpr uint16_t kSystemScopeHBits =
+      (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCACQUIRE_FENCE_SCOPE) |
+      (HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE);
+  const uint16_t header = kVendorSpecificHBits | kBarrierHBits | kSystemScopeHBits;
+  const uint16_t rest = HSA_AMD_PACKET_TYPE_DISPATCH_IB_COND_JUMP;
+
+  // Build the packet body on the stack first; the slot starts as INVALID and
+  // we publish the real header last via release-store.
+  hsa_amd_dispatch_indirect_buffer_conditional_jump_t pkt;
+  std::memset(&pkt, 0, sizeof(pkt));
+  pkt.condition_signal = cond_signal;
+  pkt.test_value = test_value;
+  pkt.cond_op = cond_op;
+  pkt.fallthrough_ib_size_packets = fallthrough_pkts;
+  pkt.ib_base_addr = ib_base_addr;
+  pkt.jump_offset_packets = jump_offset_pkts;
+  pkt.jump_ib_size_packets = jump_pkts;
+  pkt.completion_signal = hsa_signal_t{0};
+
+  setFenceDirty(true);
+
+  uint64_t index = Hsa::queue_add_write_index_screlease(gpu_queue_, 1);
+  while ((index - Hsa::queue_load_read_index_scacquire(gpu_queue_)) >= queueMask);
+
+  auto* aql_loc = &(reinterpret_cast<hsa_amd_dispatch_indirect_buffer_conditional_jump_t*>(
+      gpu_queue_->base_address))[index & queueMask];
+  *aql_loc = pkt;
+  packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), header, rest);
+  Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
+
+  ClPrint(amd::LOG_INFO, amd::LOG_AQL,
+          "[cond_jump] queue=%p index=%lu ib=0x%lx jump_off=%u jump_pkts=%u "
+          "fall_pkts=%u cond_sig=0x%lx test=%ld cond_op=%u",
+          gpu_queue_, index, ib_base_addr, jump_offset_pkts, jump_pkts,
+          fallthrough_pkts, cond_signal.handle, static_cast<long>(test_value),
+          cond_op);
+}
+
+// ================================================================================================
 void VirtualGPU::ResetQueueStates() {
   // Release all memory dependencies
   memoryDependency().clear();

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -653,6 +653,24 @@ class VirtualGPU : public device::VirtualDevice {
                                   hsa_signal_condition32_t cond = HSA_SIGNAL_CONDITION_EQ,
                                   bool skipTs = false,
                                   hsa_signal_t completionSignal = hsa_signal_t{0});
+
+ public:
+  //! Emit one vendor cond_jump (HSA_AMD_PACKET_TYPE_DISPATCH_IB_COND_JUMP) on
+  //! gpu_queue_ pointing at @a ib_base_addr.  The CP loads
+  //! @a cond_signal.value, evaluates it against @a test_value with @a cond_op,
+  //! and either runs @a fallthrough_pkts starting at ib_base_addr (FALSE) or
+  //! runs @a jump_pkts starting at ib_base_addr + jump_offset_pkts*64 (TRUE).
+  //! Used by HIP graph IF / WHILE conditional nodes; see
+  //! [hipamd/src/hip_graph_internal.hpp] GraphConditionalNode.
+  void dispatchCondJumpPacket(hsa_signal_t cond_signal,
+                              hsa_signal_value_t test_value,
+                              hsa_signal_condition32_t cond_op,
+                              uint64_t ib_base_addr,
+                              uint32_t fallthrough_pkts,
+                              uint32_t jump_offset_pkts,
+                              uint32_t jump_pkts);
+
+ private:
   void initializeDispatchPacket(hsa_kernel_dispatch_packet_t* packet, amd::NDRangeContainer& sizes);
 
   void resetKernArgPool() { managed_kernarg_buffer_.ResetPool(); }

--- a/projects/hip-tests/catch/unit/graph/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/graph/CMakeLists.txt
@@ -196,3 +196,17 @@ hip_add_exe_to_target(NAME GraphsTest2
                       TEST_TARGET_NAME build_tests)
 
 add_dependencies(build_tests add_Kernel.code)
+
+if(HIP_PLATFORM MATCHES "amd")
+  set(CONDITIONAL_TEST_SRC
+    hipGraphConditionalNode.cc
+  )
+  set(_clr_install "${CMAKE_SOURCE_DIR}/../clr/build/install")
+  if(EXISTS "${_clr_install}/include/hip/hip_runtime_api.h")
+    set(_cond_hip_path_opt "--hip-path=${_clr_install}")
+  endif()
+  hip_add_exe_to_target(NAME GraphsConditionalTest
+                        TEST_SRC ${CONDITIONAL_TEST_SRC}
+                        TEST_TARGET_NAME build_tests
+                        COMPILE_OPTIONS ${_cond_hip_path_opt})
+endif()

--- a/projects/hip-tests/catch/unit/graph/hipGraphConditionalNode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphConditionalNode.cc
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Tests for hipGraphConditionalNode — WHILE and IF conditional types.
+ *
+ * Validates:
+ *   - hipGraphConditionalHandleCreate / hipGraphAddConditionalNode APIs
+ *   - hipGraphSetConditional device function
+ *   - GPU-side WHILE loop correctness across iteration counts
+ *   - GPU-side WHILE with multiple body kernels
+ *   - GPU-side IF branch selection
+ *   - Zero-iteration WHILE (condition starts false)
+ */
+
+#include <hip_test_common.hh>
+
+// Body kernel: increments counter, accumulates, sets condition
+static __global__ void whileBodyKernel(hipGraphConditionalHandle handle,
+                                       int* counter, const int* limit,
+                                       float* accum) {
+  *counter += 1;
+  *accum += 1.0f;
+  hipGraphSetConditional(handle, (*counter < *limit) ? 1 : 0);
+}
+
+// Work kernel for multi-kernel body tests
+static __global__ void workKernel(float* accum) {
+  *accum += 0.5f;
+}
+
+// Condition-setting kernel (last in multi-kernel body)
+static __global__ void condSetKernel(hipGraphConditionalHandle handle,
+                                     int* counter, const int* limit) {
+  *counter += 1;
+  hipGraphSetConditional(handle, (*counter < *limit) ? 1 : 0);
+}
+
+// IF body kernels
+static __global__ void ifTrueKernel(int* output) { *output = 42; }
+static __global__ void ifFalseKernel(int* output) { *output = -1; }
+
+// Helper: build and run a WHILE graph, verify results
+static void runWhileTest(int numIters, int numBodyKernels = 1) {
+  int *d_counter, *d_limit;
+  float *d_accum;
+
+  HIP_CHECK(hipMalloc(&d_counter, sizeof(int)));
+  HIP_CHECK(hipMalloc(&d_limit, sizeof(int)));
+  HIP_CHECK(hipMalloc(&d_accum, sizeof(float)));
+
+  HIP_CHECK(hipMemcpy(d_limit, &numIters, sizeof(int), hipMemcpyHostToDevice));
+
+  hipGraph_t graph;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  hipGraphConditionalHandle handle;
+  HIP_CHECK(hipGraphConditionalHandleCreate(&handle, graph, 1, 0));
+
+  hipGraph_t bodyGraph = nullptr;
+  HIP_CHECK(hipGraphCreate(&bodyGraph, 0));
+
+  hipGraphNode_t condNode;
+  HIP_CHECK(hipGraphAddConditionalNode(&condNode, graph, nullptr, 0,
+                                        handle, hipGraphCondTypeWhile, 1,
+                                        &bodyGraph));
+
+  hipGraphNode_t prevNode = nullptr;
+  for (int k = 0; k < numBodyKernels; k++) {
+    hipKernelNodeParams kp = {};
+    kp.gridDim = dim3(1);
+    kp.blockDim = dim3(1);
+    hipGraphNode_t kNode;
+
+    if (numBodyKernels == 1) {
+      kp.func = reinterpret_cast<void*>(whileBodyKernel);
+      void* args[] = {&handle, &d_counter, &d_limit, &d_accum};
+      kp.kernelParams = args;
+      HIP_CHECK(hipGraphAddKernelNode(&kNode, bodyGraph,
+                                       prevNode ? &prevNode : nullptr,
+                                       prevNode ? 1 : 0, &kp));
+    } else if (k < numBodyKernels - 1) {
+      kp.func = reinterpret_cast<void*>(workKernel);
+      void* args[] = {&d_accum};
+      kp.kernelParams = args;
+      HIP_CHECK(hipGraphAddKernelNode(&kNode, bodyGraph,
+                                       prevNode ? &prevNode : nullptr,
+                                       prevNode ? 1 : 0, &kp));
+    } else {
+      kp.func = reinterpret_cast<void*>(condSetKernel);
+      void* args[] = {&handle, &d_counter, &d_limit};
+      kp.kernelParams = args;
+      HIP_CHECK(hipGraphAddKernelNode(&kNode, bodyGraph,
+                                       prevNode ? &prevNode : nullptr,
+                                       prevNode ? 1 : 0, &kp));
+    }
+    prevNode = kNode;
+  }
+
+  hipGraphExec_t exec;
+  HIP_CHECK(hipGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  // Run 3 times to verify reusability
+  for (int run = 0; run < 3; run++) {
+    int zero = 0;
+    float fzero = 0.0f;
+    HIP_CHECK(hipMemcpy(d_counter, &zero, sizeof(int), hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(d_accum, &fzero, sizeof(float), hipMemcpyHostToDevice));
+
+    HIP_CHECK(hipGraphLaunch(exec, stream));
+    HIP_CHECK(hipStreamSynchronize(stream));
+
+    int h_counter = 0;
+    float h_accum = 0.0f;
+    HIP_CHECK(hipMemcpy(&h_counter, d_counter, sizeof(int), hipMemcpyDeviceToHost));
+    HIP_CHECK(hipMemcpy(&h_accum, d_accum, sizeof(float), hipMemcpyDeviceToHost));
+
+    REQUIRE(h_counter == numIters);
+    if (numBodyKernels == 1) {
+      REQUIRE(h_accum == Catch::Approx(static_cast<float>(numIters)).epsilon(0.001));
+    }
+  }
+
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipGraphExecDestroy(exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_counter));
+  HIP_CHECK(hipFree(d_limit));
+  HIP_CHECK(hipFree(d_accum));
+}
+
+TEST_CASE("Unit_hipGraphConditionalNode_While_10iter") {
+  runWhileTest(10);
+}
+
+TEST_CASE("Unit_hipGraphConditionalNode_While_100iter") {
+  runWhileTest(100);
+}
+
+TEST_CASE("Unit_hipGraphConditionalNode_While_1000iter") {
+  runWhileTest(1000);
+}
+
+TEST_CASE("Unit_hipGraphConditionalNode_While_ZeroIter") {
+  int *d_counter, *d_limit;
+  float *d_accum;
+
+  HIP_CHECK(hipMalloc(&d_counter, sizeof(int)));
+  HIP_CHECK(hipMalloc(&d_limit, sizeof(int)));
+  HIP_CHECK(hipMalloc(&d_accum, sizeof(float)));
+
+  int zero = 0;
+  float fzero = 0.0f;
+  HIP_CHECK(hipMemcpy(d_counter, &zero, sizeof(int), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(d_limit, &zero, sizeof(int), hipMemcpyHostToDevice));
+  HIP_CHECK(hipMemcpy(d_accum, &fzero, sizeof(float), hipMemcpyHostToDevice));
+
+  hipGraph_t graph;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  // defaultValue = 0 → never enter the loop
+  hipGraphConditionalHandle handle;
+  HIP_CHECK(hipGraphConditionalHandleCreate(&handle, graph, 0, 0));
+
+  hipGraph_t bodyGraph = nullptr;
+  HIP_CHECK(hipGraphCreate(&bodyGraph, 0));
+
+  hipGraphNode_t condNode;
+  HIP_CHECK(hipGraphAddConditionalNode(&condNode, graph, nullptr, 0,
+                                        handle, hipGraphCondTypeWhile, 1,
+                                        &bodyGraph));
+
+  hipKernelNodeParams kp = {};
+  kp.func = reinterpret_cast<void*>(whileBodyKernel);
+  kp.gridDim = dim3(1);
+  kp.blockDim = dim3(1);
+  void* args[] = {&handle, &d_counter, &d_limit, &d_accum};
+  kp.kernelParams = args;
+  hipGraphNode_t kNode;
+  HIP_CHECK(hipGraphAddKernelNode(&kNode, bodyGraph, nullptr, 0, &kp));
+
+  hipGraphExec_t exec;
+  HIP_CHECK(hipGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  HIP_CHECK(hipGraphLaunch(exec, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  int h_counter = -1;
+  float h_accum = -1.0f;
+  HIP_CHECK(hipMemcpy(&h_counter, d_counter, sizeof(int), hipMemcpyDeviceToHost));
+  HIP_CHECK(hipMemcpy(&h_accum, d_accum, sizeof(float), hipMemcpyDeviceToHost));
+
+  REQUIRE(h_counter == 0);
+  REQUIRE(h_accum == 0.0f);
+
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipGraphExecDestroy(exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_counter));
+  HIP_CHECK(hipFree(d_limit));
+  HIP_CHECK(hipFree(d_accum));
+}
+
+TEST_CASE("Unit_hipGraphConditionalNode_While_MultiBody_3kernels") {
+  runWhileTest(100, 3);
+}
+
+TEST_CASE("Unit_hipGraphConditionalNode_While_MultiBody_5kernels") {
+  runWhileTest(100, 5);
+}
+
+// IF conditional type is not yet fully implemented in the runtime.
+// These tests are disabled until hipGraphCondTypeIf support is added.
+TEST_CASE("Unit_hipGraphConditionalNode_If_TrueBranch",
+          "[!mayfail]") {
+  int* d_output;
+  HIP_CHECK(hipMalloc(&d_output, sizeof(int)));
+
+  int zero = 0;
+  HIP_CHECK(hipMemcpy(d_output, &zero, sizeof(int), hipMemcpyHostToDevice));
+
+  hipGraph_t graph;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  // defaultValue = 1 → take the true branch
+  hipGraphConditionalHandle handle;
+  HIP_CHECK(hipGraphConditionalHandleCreate(&handle, graph, 1, 0));
+
+  hipGraph_t bodyGraph = nullptr;
+  HIP_CHECK(hipGraphCreate(&bodyGraph, 0));
+
+  hipGraphNode_t condNode;
+  HIP_CHECK(hipGraphAddConditionalNode(&condNode, graph, nullptr, 0,
+                                        handle, hipGraphCondTypeIf, 1,
+                                        &bodyGraph));
+
+  hipKernelNodeParams kp = {};
+  kp.func = reinterpret_cast<void*>(ifTrueKernel);
+  kp.gridDim = dim3(1);
+  kp.blockDim = dim3(1);
+  void* args[] = {&d_output};
+  kp.kernelParams = args;
+  hipGraphNode_t kNode;
+  HIP_CHECK(hipGraphAddKernelNode(&kNode, bodyGraph, nullptr, 0, &kp));
+
+  hipGraphExec_t exec;
+  HIP_CHECK(hipGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  HIP_CHECK(hipGraphLaunch(exec, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  int h_output = 0;
+  HIP_CHECK(hipMemcpy(&h_output, d_output, sizeof(int), hipMemcpyDeviceToHost));
+  REQUIRE(h_output == 42);
+
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipGraphExecDestroy(exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_output));
+}
+
+TEST_CASE("Unit_hipGraphConditionalNode_If_FalseBranch",
+          "[!mayfail]") {
+  int* d_output;
+  HIP_CHECK(hipMalloc(&d_output, sizeof(int)));
+
+  int zero = 0;
+  HIP_CHECK(hipMemcpy(d_output, &zero, sizeof(int), hipMemcpyHostToDevice));
+
+  hipGraph_t graph;
+  HIP_CHECK(hipGraphCreate(&graph, 0));
+
+  // defaultValue = 0 → take the false/skip branch
+  hipGraphConditionalHandle handle;
+  HIP_CHECK(hipGraphConditionalHandleCreate(&handle, graph, 0, 0));
+
+  hipGraph_t bodyGraph = nullptr;
+  HIP_CHECK(hipGraphCreate(&bodyGraph, 0));
+
+  hipGraphNode_t condNode;
+  HIP_CHECK(hipGraphAddConditionalNode(&condNode, graph, nullptr, 0,
+                                        handle, hipGraphCondTypeIf, 1,
+                                        &bodyGraph));
+
+  hipKernelNodeParams kp = {};
+  kp.func = reinterpret_cast<void*>(ifTrueKernel);
+  kp.gridDim = dim3(1);
+  kp.blockDim = dim3(1);
+  void* args[] = {&d_output};
+  kp.kernelParams = args;
+  hipGraphNode_t kNode;
+  HIP_CHECK(hipGraphAddKernelNode(&kNode, bodyGraph, nullptr, 0, &kp));
+
+  hipGraphExec_t exec;
+  HIP_CHECK(hipGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  HIP_CHECK(hipGraphLaunch(exec, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  int h_output = -1;
+  HIP_CHECK(hipMemcpy(&h_output, d_output, sizeof(int), hipMemcpyDeviceToHost));
+  // Body should NOT have run, output stays 0
+  REQUIRE(h_output == 0);
+
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipGraphExecDestroy(exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipFree(d_output));
+}

--- a/projects/hip/include/hip/hip_runtime_api.h
+++ b/projects/hip/include/hip/hip_runtime_api.h
@@ -1568,8 +1568,44 @@ typedef enum hipGraphNodeType {
   hipGraphNodeTypeMemcpyFromSymbol = 12,   ///< MemcpyFromSymbol node
   hipGraphNodeTypeMemcpyToSymbol = 13,     ///< MemcpyToSymbol node
   hipGraphNodeTypeBatchMemOp = 14,         ///< BatchMemOp node
+  hipGraphNodeTypeConditional = 15,        ///< Conditional (IF / WHILE) node
   hipGraphNodeTypeCount
 } hipGraphNodeType;
+
+/**
+ * Conditional graph handle (M1: handle plumbing only; node support is M2).
+ *
+ * On the AMD path the handle is backed by a real `hsa_signal_t` (Option C):
+ *   `device_ptr   == signal_handle + offsetof(amd_signal_t, value)`
+ * so that a single device-side store via `hipGraphSetConditional` updates
+ * the same cell the GPU CP firmware reads in M2 conditional packets.
+ *
+ * - `device_ptr`: GPU-visible address of the value cell. Kernels write here
+ *   via `hipGraphSetConditional`.
+ * - `default_value`: initial value the runtime stamps into the cell at
+ *   handle-create time and (in M2) at every `hipGraphLaunch`.
+ * - `signal_handle`: opaque `hsa_signal_t.handle` used by the runtime to
+ *   address the underlying signal in M2. Not consumed by user code.
+ */
+typedef struct hipGraphConditionalHandle_st {
+  uint64_t device_ptr;       ///< Device-visible address of the conditional value cell
+  uint64_t default_value;    ///< Initial value of the cell at handle creation
+  uint64_t signal_handle;    ///< Backing hsa_signal_t.handle (runtime-internal)
+} hipGraphConditionalHandle;
+
+/**
+ * @brief Type of conditional graph node.
+ *
+ * Mirrors CUDA's conditional node taxonomy.  AMD currently implements
+ * IF and WHILE via three vendor AQL packets (cond_jump entry packet plus
+ * an optional loop_back tail).  SWITCH is reserved and currently returns
+ * #hipErrorNotSupported from #hipGraphAddConditionalNode.
+ */
+typedef enum hipGraphConditionalType {
+  hipGraphCondTypeIf = 0,        ///< Conditional IF node (1 or 2 body graphs)
+  hipGraphCondTypeWhile = 1,     ///< Conditional WHILE node (1 body graph)
+  hipGraphCondTypeSwitch = 2,    ///< Conditional SWITCH node (not yet supported)
+} hipGraphConditionalType;
 
 typedef void (*hipHostFn_t)(void* userData);
 typedef struct hipHostNodeParams {
@@ -8436,6 +8472,74 @@ hipError_t hipThreadExchangeStreamCaptureMode(hipStreamCaptureMode* mode);
 hipError_t hipGraphCreate(hipGraph_t* pGraph, unsigned int flags);
 
 /**
+ * @brief Creates a conditional graph handle (M1: handle plumbing only).
+ *
+ * Allocates a runtime-managed cell whose address is exposed via
+ * `pHandleOut->device_ptr` so that a kernel can update the cell by calling
+ * `hipGraphSetConditional`. In M2 the same cell will be polled by the GPU
+ * CP firmware to drive conditional graph nodes (IF / WHILE).
+ *
+ * In M1, `hGraph` is validated but the handle is not yet registered with the
+ * graph for destruction; the backing signal is leaked at process exit. This
+ * is sufficient for the M1 smoke test and is fixed in the M2 lifetime work.
+ *
+ * @param [out] pHandleOut         - Conditional handle to fill in.
+ * @param [in]  hGraph             - Graph that will own this handle (validated only in M1).
+ * @param [in]  defaultLaunchValue - Initial value of the cell.
+ * @param [in]  flags              - Reserved, must be 0.
+ *
+ * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorOutOfMemory,
+ *          #hipErrorInvalidDevice
+ */
+hipError_t hipGraphConditionalHandleCreate(hipGraphConditionalHandle* pHandleOut,
+                                           hipGraph_t hGraph,
+                                           unsigned int defaultLaunchValue,
+                                           unsigned int flags);
+
+/**
+ * @brief Adds a conditional (IF / WHILE) node to a graph.
+ *
+ * The node owns @a numConditionalGraphs empty body graph(s) returned via
+ * @a phConditionalGraphs that the caller then populates.  At
+ * @ref hipGraphInstantiate time the runtime captures the body graph(s)
+ * into one indirect-buffer per conditional, and at @ref hipGraphLaunch the
+ * runtime resets @a handle's value to its `default_value` and emits a
+ * vendor cond_jump AQL packet so the GPU CP picks the right arm or loop
+ * count (M2).
+ *
+ * Body graph counts:
+ *  - @ref hipGraphCondTypeWhile  : exactly 1.
+ *  - @ref hipGraphCondTypeIf     : 1 (no-else IF) or 2 (IF / ELSE, laid out
+ *                                  as `[else_body][if_body]` in the IB).
+ *  - @ref hipGraphCondTypeSwitch : not currently supported -- returns
+ *                                  #hipErrorNotSupported.
+ *
+ * @param [out] pGraphNode           Created conditional node.
+ * @param [in]  graph                Parent graph.
+ * @param [in]  pDependencies        Dependencies of the new node, may be NULL.
+ * @param [in]  numDependencies      Number of dependencies.
+ * @param [in]  handle               Conditional handle previously created via
+ *                                   @ref hipGraphConditionalHandleCreate.
+ * @param [in]  type                 Conditional node type
+ *                                   (@ref hipGraphConditionalType).
+ * @param [in]  numConditionalGraphs Number of body graphs to create
+ *                                   (1 for WHILE, 1 or 2 for IF).
+ * @param [out] phConditionalGraphs  Caller-provided array of size
+ *                                   @a numConditionalGraphs into which the
+ *                                   runtime writes new empty body graphs.
+ *
+ * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorNotSupported
+ */
+hipError_t hipGraphAddConditionalNode(hipGraphNode_t* pGraphNode,
+                                      hipGraph_t graph,
+                                      const hipGraphNode_t* pDependencies,
+                                      size_t numDependencies,
+                                      hipGraphConditionalHandle handle,
+                                      hipGraphConditionalType type,
+                                      unsigned int numConditionalGraphs,
+                                      hipGraph_t* phConditionalGraphs);
+
+/**
  * @brief Destroys a graph
  *
  * @param [in] graph - instance of graph to destroy.
@@ -10093,6 +10197,15 @@ template <typename T> static hipError_t __host__ inline hipOccupancyMaxPotential
   (void)flags;
   return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, reinterpret_cast<const void*>(f),
                                            dynSharedMemPerBlk, blockSizeLimit);
+}
+
+// Device-side helper to update the conditional cell from a kernel.
+// Single global store at the address the runtime exposed via
+// `hipGraphConditionalHandleCreate`. In M2 the GPU CP firmware reads this
+// same cell to drive conditional graph nodes.
+__device__ static inline void
+hipGraphSetConditional(hipGraphConditionalHandle handle, unsigned long long value) {
+  *reinterpret_cast<volatile unsigned long long*>(handle.device_ptr) = value;
 }
 #endif  // defined(__clang__) && defined(__HIP__)
 


### PR DESCRIPTION
Adds an end-to-end proof-of-concept that lets HIP graphs express WHILE loops and IF branches by having the GPU command processor walk an instruction buffer (IB) of pre-built kernel-dispatch packets, gated by a new vendor AQL packet that consumes a hsa_signal_t value as the loop condition.

ROCr (vendor packet ABI):
* Add three 64-byte vendor AQL packet formats in hsa_ext_amd.h:
    HSA_AMD_PACKET_TYPE_AQL_INDIRECT_BUFFER          (4)
    HSA_AMD_PACKET_TYPE_DISPATCH_IB_COND_JUMP        (5)
    HSA_AMD_PACKET_TYPE_AQL_LOOP_BACK                (6)
  with static_asserts for size and alignment.
* Extend AqlPacket::string() (core/inc/queue.h) so logs print the new
  formats by name.

HIP API surface:
* Declare hipGraphAddConditionalNode and hipGraphConditionalType (hipGraphCondTypeIf / While / Switch) in hip_runtime_api.h, plus the matching hipGraphNodeTypeConditional enum.
* Wire hipGraphConditionalHandleCreate + hipGraphAddConditionalNode through HipDispatchTable, hip_api_trace, hip_table_interface, the hcc.map version script, and hip_prof_str.h profiler IDs.

CLR conditional node implementation:
* hip_graph_internal.{hpp,cpp}: GraphConditionalNode owns the cond signal handle, the conditional type and the body Graph(s).  Adds BuildIB() which during hipGraphInstantiate (a) bootstraps a GraphKernelArgManager pool large enough for every kernel in the body graphs, (b) calls CaptureAndFormPacket on each body kernel node, (c) zeroes the captured completion signals, (d) lays the packets out in a contiguous device-accessible IB (VRAM via deviceLocalAlloc, fallback to pinned host) and (e) for WHILE appends a hand-built hsa_amd_aql_loop_back_t.  IF/ELSE arrange [false_arm][true_arm].
* CondJumpCommand (nested in GraphConditionalNode): legacy command path that resets the cond cell to default_value via hsa_signal_store_relaxed and dispatches the cond_jump packet.
* GraphExec::CaptureAQLPackets calls BuildIB on every conditional node after the regular packet capture pass and before kernarg flush.
* Real GraphConditionalNode copy ctor + clone() so hipGraphInstantiate's internal Graph::clone deep-copies the body Graph hierarchy into the GraphExec instead of asserting.

CLR queue helper:
* roc::VirtualGPU::dispatchCondJumpPacket assembles hsa_amd_dispatch_indirect_buffer_conditional_jump_t with the right scacquire/screlease fence scopes, reserves the slot, writes the packet and rings the doorbell.

Status / open items:
* The CLR + ROCr side compiles and instantiates conditional graphs end to end.  At hipGraphLaunch the cond_jump packet is emitted on the HW queue and is rejected by the CP firmware on this part with HSA_STATUS_ERROR_INVALID_PACKET_FORMAT (0x1009) -- vendor types 5 and 6 are not yet recognised by CP microcode.  This is expected for the POC; runtime execution will become valid once the matching CP firmware ships.

DEV-ENV-ONLY workarounds (must NOT be merged to develop as-is):
* projects/clr/rocclr/device/rocm/rocrctx.hpp temporarily hard-codes the HSA include paths to this workspace's ROCr install (/home/amd/anusha_latest_clr/...).  Required because the system /opt/rocm hsa headers don't yet have the new vendor packet types.
* projects/clr/rocclr/device/blitcl.cpp stubs the __amd_rocclr_streamOpsIncrement / Decrement bodies to no-op so BlitManager init doesn't fail against the stale opencl.bc shipped in /opt/rocm.

Smoke / validation harness lives outside this repo at the workspace root: hip_graph_conditional_ib_test.cpp, adapted from projects/hip-tests/catch/unit/graph/hipGraphConditionalNode.cc on users/agodavar/conditionalGraphsPOC.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
