### PR TITLE
RCCL: RMA Host API CE path

### DIFF
--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -285,10 +285,7 @@ ncclResult_t ncclPrepUCSync(struct ncclComm* comm, bool isComplete,
     batchParams[*opIdx].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_32;
     batchParams[*opIdx].writeValue.address  = (CUdeviceptr)peerDstPtr;
     batchParams[*opIdx].writeValue.value = waitValue;
-    // CU_STREAM_WRITE_VALUE_DEFAULT is a CUDA-specific constant with no HIP equivalent.
-    // This field must be initialized to satisfy the CUDA-compatible struct definition,
-    // but the HIP runtime does not use this flag and treats it as 0.
-    batchParams[*opIdx].writeValue.flags = 0;
+    batchParams[*opIdx].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
     (*opIdx)++;
   }
 

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -1558,6 +1558,21 @@ ncclResult_t ncclCommWindowRegister_impl(
   ncclIntruQueueEnqueue(&comm->devrState.regTaskQueue, task);
   ncclGroupCommJoin(comm, ncclGroupTaskTypeSymRegister);
 
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  // RCCL: Enqueue RMA CE init on the first window register. Matches the
+  // lazy enqueue in rmaTaskAppend (src/enqueue.cc) which fires on the first
+  // ncclPutSignal/Signal/WaitSignal. ncclRmaCeInit is collective
+  // (signals window + bootstrap barrier), so we cannot call it from the
+  // non-collective Host API entry point.
+  if (!comm->rmaState.rmaCeState.initialized &&
+      ncclIntruQueueEmpty(&comm->rmaCeInitTaskQueue)) {
+    struct ncclRmaCeInitTask* ceTask;
+    NCCLCHECKGOTO(ncclCalloc(&ceTask, 1), ret, fail);
+    ceTask->comm = comm;
+    ncclIntruQueueEnqueue(&comm->rmaCeInitTaskQueue, ceTask);
+  }
+#endif
+
 exit:
   ncclGroupErrCheck(ret);
   NCCLCHECK(ncclGroupEndInternal());

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -1841,8 +1841,7 @@ ncclResult_t ncclCommWindowRegister_impl(
   // lazy enqueue in rmaTaskAppend, which fires on the first ncclPutSignal/
   // Signal/WaitSignal. ncclRmaCeInit is collective (signals window + bootstrap
   // barrier), so we cannot call it from the non-collective Host API entry point.
-  if ((comm->symmetricSupport ? (comm->devrState.lsaSize > 1) : true) &&
-      !comm->rmaState.rmaCeState.initialized &&
+  if (!comm->rmaState.rmaCeState.initialized &&
       ncclIntruQueueEmpty(&comm->rmaCeInitTaskQueue)) {
     struct ncclRmaCeInitTask* ceTask;
     NCCLCHECKGOTO(ncclCalloc(&ceTask, 1), ret, fail);

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -152,6 +152,7 @@ ncclResult_t ncclDevrInitOnce(struct ncclComm* comm) {
   // a consecutive set of ranks.
   int lsaSize = computeLsaSize(comm);
   devr->lsaSize = lsaSize;
+  devr->nLsaTeams = comm->nRanks / devr->lsaSize;
   devr->lsaSelf = comm->rank % lsaSize;
   devr->lsaRankList = (int*)malloc(devr->lsaSize*sizeof(int));
   for (int i=0; i < devr->lsaSize; i++) {

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -1838,6 +1838,7 @@ static ncclResult_t windowDeregisterNonSym(struct ncclComm* comm,
   int teamSize = devr->ceSize;
   int teamSelf = devr->ceSelf;
   bool ipcBacked = teamSize > 1;
+  int winIdx = -1;
 
   // Decode win from winDev: IPC uses shadow pool, PROXY type-puns.
   if (ipcBacked) {
@@ -1847,6 +1848,22 @@ static ncclResult_t windowDeregisterNonSym(struct ncclComm* comm,
     win = (struct ncclDevrWindow*)winDevHost->winHost;
   } else {
     win = reinterpret_cast<struct ncclDevrWindow*>(winDev);
+  }
+
+  // Locate this window's registration. A stale handle (e.g. a second
+  // deregister of an already-freed window) is no longer in winSorted
+  for (int i = 0; i < devr->winSortedCount; i++) {
+    if (devr->winSorted[i].win == win) {
+      winIdx = i;
+      break;
+    }
+  }
+  if (winIdx < 0) {
+    WARN("ncclCommWindowDeregister: window %p is not registered (already "
+         "deregistered?)",
+         (void*)winDev);
+    ret = ncclInvalidArgument;
+    goto fail;
   }
 
   // Undo stage 2: inter-node proxy MR. rmaHostWins[0] is a reliable witness
@@ -1883,13 +1900,7 @@ static ncclResult_t windowDeregisterNonSym(struct ncclComm* comm,
   }
 
   NCCLCHECKGOTO(ncclCommDeregister(comm, win->localRegHandle), ret, fail);
-  {
-    int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted,
-                              devr->winSortedCount,
-                              reinterpret_cast<uintptr_t>(win->userPtr));
-    i -= 1;
-    listRemove(devr->winSorted, &devr->winSortedCount, i);
-  }
+  listRemove(devr->winSorted, &devr->winSortedCount, winIdx);
   free(win);
   return ncclSuccess;
 

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -1037,12 +1037,10 @@ fail:
 //       call upstream issues from symMemoryRegisterRma.
 // outWinDev is a shadow pool entry for IPC or a type-pun ncclDevrWindow*
 // for proxy-only.
-static ncclResult_t ncclDevrWindowRegisterNonSym(struct ncclComm* comm,
-                                                 void* userPtr,
-                                                 size_t userSize,
-                                                 int winFlags,
-                                                 void* localRegHandle,
-                                                 ncclWindow_t* outWinDev) {
+static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
+                                         size_t userSize, int winFlags,
+                                         void* localRegHandle,
+                                         ncclWindow_t* outWinDev) {
   struct ExchangeEntry {
     cudaIpcMemHandle_t handle;
     uint64_t hostHash;
@@ -1056,10 +1054,8 @@ static ncclResult_t ncclDevrWindowRegisterNonSym(struct ncclComm* comm,
   int lsaSize = devr->ceSize;
   int lsaSelf = devr->ceSelf;
   int* teamRankList = devr->ceRankList;
+
   bool doIpc = lsaSize > 1;
-  // Host RMA only when there are inter-node peers AND transport is available.
-  // hostRmaSupport=1 on a pure single-node setup (isOneLsaTeams short-circuit)
-  // does not imply RMA NICs/proxy state are actually wired up.
   bool doRma = comm->hostRmaSupport && (lsaSize < comm->nRanks);
 
   struct ncclDevrWindow* win = nullptr;
@@ -1092,7 +1088,7 @@ static ncclResult_t ncclDevrWindowRegisterNonSym(struct ncclComm* comm,
 
     if (CUDA_SUCCESS !=
         cuMemGetAddressRange(&allocBase, &allocSize, userPtrCu)) {
-      WARN("ncclDevrWindowRegisterNonSym: cuMemGetAddressRange failed for "
+      WARN("windowRegisterNonSym: cuMemGetAddressRange failed for "
            "userPtr=%p; falling back to nullptr window",
            userPtr);
       goto soft_fail;
@@ -1105,9 +1101,9 @@ static ncclResult_t ncclDevrWindowRegisterNonSym(struct ncclComm* comm,
 
     ExchangeEntry* mine = &peers[lsaSelf];
     cudaError_t cerr =
-        cudaIpcGetMemHandle(&mine->handle, reinterpret_cast<void*>(allocBase));
+      cudaIpcGetMemHandle(&mine->handle, reinterpret_cast<void*>(allocBase));
     if (cerr != cudaSuccess) {
-      WARN("ncclDevrWindowRegisterNonSym: cudaIpcGetMemHandle failed: %s",
+      WARN("windowRegisterNonSym: cudaIpcGetMemHandle failed: %s",
            cudaGetErrorString(cerr));
       goto soft_fail;
     }
@@ -1117,13 +1113,10 @@ static ncclResult_t ncclDevrWindowRegisterNonSym(struct ncclComm* comm,
     mine->userOffset = userOffset;
     mine->userSize = userSize;
 
-    if (ncclSuccess != bootstrapIntraNodeAllGather(comm->bootstrap,
-                                                   teamRankList,
-                                                   lsaSelf,
-                                                   lsaSize,
-                                                   peers,
-                                                   sizeof(ExchangeEntry))) {
-      WARN("ncclDevrWindowRegisterNonSym: bootstrapIntraNodeAllGather failed");
+    if (ncclSuccess !=
+        bootstrapIntraNodeAllGather(comm->bootstrap, teamRankList, lsaSelf,
+                                    lsaSize, peers, sizeof(ExchangeEntry))) {
+      WARN("windowRegisterNonSym: bootstrapIntraNodeAllGather failed");
       goto soft_fail;
     }
 
@@ -1149,13 +1142,13 @@ static ncclResult_t ncclDevrWindowRegisterNonSym(struct ncclComm* comm,
         }
       } else {
         void* peerBase = nullptr;
-        cudaError_t orErr = cudaIpcOpenMemHandle(
-            &peerBase, peers[r].handle, cudaIpcMemLazyEnablePeerAccess);
+        cudaError_t orErr =
+          cudaIpcOpenMemHandle(&peerBase, peers[r].handle,
+                               cudaIpcMemLazyEnablePeerAccess);
         if (orErr != cudaSuccess) {
-          WARN("ncclDevrWindowRegisterNonSym: cudaIpcOpenMemHandle for "
+          WARN("windowRegisterNonSym: cudaIpcOpenMemHandle for "
                "lsaRank=%d failed: %s",
-               r,
-               cudaGetErrorString(orErr));
+               r, cudaGetErrorString(orErr));
           goto soft_fail;
         }
         win->ipcPeerOpenedBases[r] = peerBase;
@@ -1168,13 +1161,13 @@ static ncclResult_t ncclDevrWindowRegisterNonSym(struct ncclComm* comm,
   // Stage 2: inter-node MR (analog of symMemoryRegisterRma).
   if (doRma) {
     if (ncclSuccess != ncclRmaProxyConnectOnce(comm)) {
-      WARN("ncclDevrWindowRegisterNonSym: ncclRmaProxyConnectOnce failed");
+      WARN("windowRegisterNonSym: ncclRmaProxyConnectOnce failed");
       goto soft_fail;
     }
-    if (ncclSuccess !=
-        ncclRmaProxyRegister(
-            comm, userPtr, userSize, win->rmaHostWins, win->rmaDevWins)) {
-      WARN("ncclDevrWindowRegisterNonSym: ncclRmaProxyRegister failed");
+    if (ncclSuccess != ncclRmaProxyRegister(comm, userPtr, userSize,
+                                            win->rmaHostWins,
+                                            win->rmaDevWins)) {
+      WARN("windowRegisterNonSym: ncclRmaProxyRegister failed");
       goto soft_fail;
     }
   }
@@ -1185,12 +1178,12 @@ static ncclResult_t ncclDevrWindowRegisterNonSym(struct ncclComm* comm,
   if (doIpc) {
     if (cudaSuccess !=
         cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking)) {
-      WARN("ncclDevrWindowRegisterNonSym: cudaStreamCreateWithFlags failed");
+      WARN("windowRegisterNonSym: cudaStreamCreateWithFlags failed");
       goto soft_fail;
     }
     if (ncclSuccess !=
         ncclShadowPoolAlloc(&devr->shadows, &winDev, &winDevHost, stream)) {
-      WARN("ncclDevrWindowRegisterNonSym: ncclShadowPoolAlloc failed");
+      WARN("windowRegisterNonSym: ncclShadowPoolAlloc failed");
       goto soft_fail;
     }
     win->vidmem = winDev;
@@ -1198,30 +1191,23 @@ static ncclResult_t ncclDevrWindowRegisterNonSym(struct ncclComm* comm,
     winDevHost->lsaRank = lsaSelf;
     winDevHost->worldRank = comm->rank;
     winDevHost->winHost = (void*)win;
-    CUDACHECKIGNORE(cudaMemcpyAsync(winDev,
-                                    winDevHost,
-                                    sizeof(*winDevHost),
-                                    cudaMemcpyHostToDevice,
-                                    stream));
+    CUDACHECKIGNORE(cudaMemcpyAsync(winDev, winDevHost, sizeof(*winDevHost),
+                                    cudaMemcpyHostToDevice, stream));
   } else {
     winDev = reinterpret_cast<struct ncclWindow_vidmem*>(win);
   }
 
   {
     uintptr_t userAddr = reinterpret_cast<uintptr_t>(userPtr);
-    int idx = listFindSortedLub(&ncclDevrWindowSorted::userAddr,
-                                devr->winSorted,
-                                devr->winSortedCount,
-                                userAddr);
+    int idx =
+      listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted,
+                        devr->winSortedCount, userAddr);
     struct ncclDevrWindowSorted winSort;
     winSort.userAddr = userAddr;
     winSort.size = userSize;
     winSort.win = win;
-    listInsert(&devr->winSorted,
-               &devr->winSortedCapacity,
-               &devr->winSortedCount,
-               idx,
-               winSort);
+    listInsert(&devr->winSorted, &devr->winSortedCapacity,
+               &devr->winSortedCount, idx, winSort);
   }
 
   if (doIpc) {
@@ -1229,14 +1215,12 @@ static ncclResult_t ncclDevrWindowRegisterNonSym(struct ncclComm* comm,
     CUDACHECKIGNORE(cudaStreamDestroy(stream));
     stream = nullptr;
     // Intra-node sync; sym path uses bootstrapBarrier post-mapping.
-    if (ncclSuccess !=
-        bootstrapIntraNodeBarrier(
-            comm->bootstrap, teamRankList, lsaSelf, lsaSize, 0xbeed)) {
-      WARN("ncclDevrWindowRegisterNonSym: bootstrapIntraNodeBarrier failed");
+    if (ncclSuccess != bootstrapIntraNodeBarrier(comm->bootstrap, teamRankList,
+                                                 lsaSelf, lsaSize, 0xbeed)) {
+      WARN("windowRegisterNonSym: bootstrapIntraNodeBarrier failed");
       // Revert listInsert before falling into shared cleanup.
       int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr,
-                                devr->winSorted,
-                                devr->winSortedCount,
+                                devr->winSorted, devr->winSortedCount,
                                 reinterpret_cast<uintptr_t>(userPtr));
       i -= 1;
       if (i >= 0) listRemove(devr->winSorted, &devr->winSortedCount, i);
@@ -1245,15 +1229,10 @@ static ncclResult_t ncclDevrWindowRegisterNonSym(struct ncclComm* comm,
   }
 
   INFO(NCCL_INIT,
-       "ncclDevrWindowRegisterNonSym: backing=%s lsaSize=%d nRanks=%d "
+       "windowRegisterNonSym: backing=%s lsaSize=%d nRanks=%d "
        "userPtr=%p size=%zu opened=%d hostRma=%d",
-       doIpc ? "IPC" : "PROXY",
-       lsaSize,
-       comm->nRanks,
-       userPtr,
-       userSize,
-       openedCount,
-       (int)doRma);
+       doIpc ? "IPC" : "PROXY", lsaSize, comm->nRanks, userPtr, userSize,
+       openedCount, (int)doRma);
 
   free(peers);
   *outWinDev = winDev;
@@ -1313,16 +1292,12 @@ ncclResult_t ncclDevrWindowRegisterInGroup(
   NCCLCHECKGOTO(ncclCommRegister(comm, userPtr, userSize, &localRegHandle), ret, fail);
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  // RCCL: when sym VMM is unavailable (no cuMem / capability gates closed),
-  // route through the non-sym helper which lays out IPC for intra-node and
-  // optional proxy/GIN MR for inter-node in one shape. Sym path below stays
-  // upstream-NCCL identical.
+  // RCCL: when sym VMM is unavailable (no cuMem), route through the non-sym
+  // helper which lays out IPC for intra-node and proxy/GIN MR for inter-node
   if (!comm->symmetricSupport) {
-    NCCLCHECKGOTO(
-        ncclDevrWindowRegisterNonSym(
-            comm, userPtr, userSize, winFlags, localRegHandle, outWinDev),
-        ret,
-        fail_locReg);
+    NCCLCHECKGOTO(windowRegisterNonSym(comm, userPtr, userSize, winFlags,
+                                       localRegHandle, outWinDev),
+                  ret, fail_locReg);
     if (*outWinDev == nullptr) {
       // Soft-fail: drop local reg so we don't leak it.
       goto fail_locReg;
@@ -1830,10 +1805,9 @@ ncclResult_t ncclCommWindowRegister_impl(
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   // RCCL: Enqueue RMA CE init on the first window register. Matches the
-  // lazy enqueue in rmaTaskAppend (src/enqueue.cc) which fires on the first
-  // ncclPutSignal/Signal/WaitSignal. ncclRmaCeInit is collective
-  // (signals window + bootstrap barrier), so we cannot call it from the
-  // non-collective Host API entry point.
+  // lazy enqueue in rmaTaskAppend, which fires on the first ncclPutSignal/
+  // Signal/WaitSignal. ncclRmaCeInit is collective (signals window + bootstrap
+  // barrier), so we cannot call it from the non-collective Host API entry point.
   if ((comm->symmetricSupport ? (comm->devrState.lsaSize > 1) : true) &&
       !comm->rmaState.rmaCeState.initialized &&
       ncclIntruQueueEmpty(&comm->rmaCeInitTaskQueue)) {
@@ -1854,10 +1828,9 @@ fail:
 }
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-// RCCL: deregister mirror of ncclDevrWindowRegisterNonSym
-static ncclResult_t
-ncclDevrWindowDeregisterNonSym(struct ncclComm* comm,
-                               struct ncclWindow_vidmem* winDev) {
+// RCCL: deregister mirror of windowRegisterNonSym
+static ncclResult_t windowDeregisterNonSym(struct ncclComm* comm,
+                                           struct ncclWindow_vidmem* winDev) {
   ncclResult_t ret = ncclSuccess;
   struct ncclDevrState* devr = &comm->devrState;
   cudaStream_t stream = nullptr;
@@ -1869,8 +1842,8 @@ ncclDevrWindowDeregisterNonSym(struct ncclComm* comm,
   // Decode win from winDev: IPC uses shadow pool, PROXY type-puns.
   if (ipcBacked) {
     struct ncclWindow_vidmem* winDevHost = nullptr;
-    NCCLCHECKGOTO(
-        ncclShadowPoolToHost(&devr->shadows, winDev, &winDevHost), ret, fail);
+    NCCLCHECKGOTO(ncclShadowPoolToHost(&devr->shadows, winDev, &winDevHost),
+                  ret, fail);
     win = (struct ncclDevrWindow*)winDevHost->winHost;
   } else {
     win = reinterpret_cast<struct ncclDevrWindow*>(winDev);
@@ -1900,10 +1873,10 @@ ncclDevrWindowDeregisterNonSym(struct ncclComm* comm,
 
   // Undo stage 3: shadow pool entry (only allocated for IPC backing).
   if (ipcBacked) {
-    CUDACHECKGOTO(
-        cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), ret, fail);
-    NCCLCHECKGOTO(
-        ncclShadowPoolFree(&devr->shadows, winDev, stream), ret, fail_stream);
+    CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking),
+                  ret, fail);
+    NCCLCHECKGOTO(ncclShadowPoolFree(&devr->shadows, winDev, stream), ret,
+                  fail_stream);
     CUDACHECKIGNORE(cudaStreamSynchronize(stream));
     CUDACHECKIGNORE(cudaStreamDestroy(stream));
     stream = nullptr;
@@ -1911,8 +1884,7 @@ ncclDevrWindowDeregisterNonSym(struct ncclComm* comm,
 
   NCCLCHECKGOTO(ncclCommDeregister(comm, win->localRegHandle), ret, fail);
   {
-    int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr,
-                              devr->winSorted,
+    int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted,
                               devr->winSortedCount,
                               reinterpret_cast<uintptr_t>(win->userPtr));
     i -= 1;
@@ -1942,7 +1914,7 @@ ncclResult_t ncclCommWindowDeregister_impl(struct ncclComm* comm, struct ncclWin
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   if (!comm->symmetricSupport) {
-    NCCLCHECKGOTO(ncclDevrWindowDeregisterNonSym(comm, winDev), ret, fail);
+    NCCLCHECKGOTO(windowDeregisterNonSym(comm, winDev), ret, fail);
     goto exit;
   }
 #endif

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -190,12 +190,22 @@ ncclResult_t ncclDevrInitOnce(struct ncclComm* comm) {
   } else {
     devr->bigSize = 1; // proxy-only: marks devrState as initialized
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-    devr->ceSize = comm->localRanks;
-    devr->ceSelf = comm->localRank;
-    devr->ceRankList = (int*)malloc(devr->ceSize * sizeof(int));
-    if (devr->ceRankList == nullptr) { ret = ncclSystemError; goto fail_lsaRankList; }
-    for (int i = 0; i < devr->ceSize; i++) {
-      devr->ceRankList[i] = comm->localRankToRank[i];
+    // RCCL: the non-sym (host API) path routes co-located peers through CE/IPC
+    // over the full node-local team, which the gcd-based consecutive LSA
+    // team above cannot represent. Reuse the lsa* fields for this team
+    free(devr->lsaRankList);
+    devr->lsaSize = comm->localRanks;
+    devr->lsaSelf = comm->localRank;
+    devr->nLsaTeams = comm->nRanks / devr->lsaSize;
+
+    devr->lsaRankList = (int*)malloc(devr->lsaSize * sizeof(int));
+    if (devr->lsaRankList == nullptr) {
+      ret = ncclSystemError;
+      goto fail_lsaRankList;
+    }
+
+    for (int i = 0; i < devr->lsaSize; i++) {
+      devr->lsaRankList[i] = comm->localRankToRank[i];
     }
 #endif
   }
@@ -234,10 +244,7 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
     while (devr->winSortedCount > 0) {
       int before = devr->winSortedCount;
       struct ncclDevrWindow* win = devr->winSorted[0].win;
-      struct ncclWindow_vidmem* winDev =
-        (devr->ceSize > 1) ? win->vidmem
-                           : reinterpret_cast<struct ncclWindow_vidmem*>(win);
-      NCCLCHECKIGNORE(windowDeregisterNonSym(comm, winDev), ret);
+      NCCLCHECKIGNORE(windowDeregisterNonSym(comm, win->vidmem), ret);
       // windowDeregisterNonSym only removes the entry on success; drop it on
       // failure too so abort-time finalize always makes progress.
       if (devr->winSortedCount >= before) {
@@ -305,10 +312,6 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
   ncclShadowPoolDestruct(&devr->shadows);
 
   free(devr->lsaRankList);
-#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  free(devr->ceRankList); // RCCL: intra-node CE team
-  devr->ceRankList = nullptr;
-#endif
   free(devr->winSorted);
   return ncclSuccess;
 }
@@ -1055,13 +1058,23 @@ fail:
 }
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+static void windowCloseIpcPeers(struct ncclComm* comm,
+                                struct ncclDevrWindow* win) {
+  if (win->ipcPeerPtrsAllocBase == nullptr) return;
+  int teamSelf = comm->devrState.lsaSelf;
+  for (int r = 0; r < win->ipcPeerCount; r++) {
+    if (r == teamSelf) continue;
+    void* peerAllocBase = win->ipcPeerPtrsAllocBase[r];
+    if (peerAllocBase == nullptr) continue;
+    CUDACHECKIGNORE(cudaIpcCloseMemHandle(peerAllocBase));
+  }
+}
+
 // RCCL: register a non-sym window. Mirrors upstream sym's two-stage shape:
 //   (1) intra-node mapping via cudaIpcOpenMemHandle peer pointers, when
-//       ceSize > 1.
+//       lsaSize > 1.
 //   (2) inter-node MR via ncclRmaProxyRegister, when hostRmaSupport. Same
 //       call upstream issues from symMemoryRegisterRma.
-// outWinDev is a shadow pool entry for IPC or a type-pun ncclDevrWindow*
-// for proxy-only.
 static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
                                          size_t userSize, int winFlags,
                                          void* localRegHandle,
@@ -1078,10 +1091,9 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
   static constexpr int kNonSymWindowBarrierTag = 0xbeed;
 
   struct ncclDevrState* devr = &comm->devrState;
-  // Non-sym path uses the CE team (all same-node ranks), not gcd lsa.
-  int teamSize = devr->ceSize;
-  int teamSelf = devr->ceSelf;
-  int* teamRankList = devr->ceRankList;
+  int teamSize = devr->lsaSize;
+  int teamSelf = devr->lsaSelf;
+  int* teamRankList = devr->lsaRankList;
 
   bool doIpc = teamSize > 1;
   bool doRma = comm->hostRmaSupport && (teamSize < comm->nRanks);
@@ -1092,7 +1104,6 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
   struct ncclWindow_vidmem* winDevHost = nullptr;
   ExchangeEntry* peers = nullptr;
   int openedCount = 0;
-
 
   win = (struct ncclDevrWindow*)malloc(sizeof(struct ncclDevrWindow));
   if (win == nullptr) goto fail;
@@ -1144,8 +1155,8 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
     }
 
     win->ipcPeerPtrs = (void**)calloc(teamSize, sizeof(void*));
-    win->ipcPeerOpenedBases = (void**)calloc(teamSize, sizeof(void*));
-    if (win->ipcPeerPtrs == nullptr || win->ipcPeerOpenedBases == nullptr) {
+    win->ipcPeerPtrsAllocBase = (void**)calloc(teamSize, sizeof(void*));
+    if (win->ipcPeerPtrs == nullptr || win->ipcPeerPtrsAllocBase == nullptr) {
       goto fail;
     }
     win->ipcPeerCount = teamSize;
@@ -1157,10 +1168,10 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
         // Same address space: self reuses userPtr; same-PID cross-thread
         // peers stay nullptr (MVP: no cross-thread peer mapping).
         if (r == teamSelf) {
-          win->ipcPeerOpenedBases[r] = reinterpret_cast<void*>(allocBase);
+          win->ipcPeerPtrsAllocBase[r] = reinterpret_cast<void*>(allocBase);
           win->ipcPeerPtrs[r] = userPtr;
         } else {
-          win->ipcPeerOpenedBases[r] = nullptr;
+          win->ipcPeerPtrsAllocBase[r] = nullptr;
           win->ipcPeerPtrs[r] = nullptr;
         }
       } else {
@@ -1174,7 +1185,7 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
                r, cudaGetErrorString(orErr));
           goto fail;
         }
-        win->ipcPeerOpenedBases[r] = peerBase;
+        win->ipcPeerPtrsAllocBase[r] = peerBase;
         win->ipcPeerPtrs[r] = (char*)peerBase + peers[r].userOffset;
         openedCount += 1;
       }
@@ -1195,35 +1206,30 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
     }
   }
 
-  // Stage 3: encode device-side handle. IPC needs a shadow pool entry so
-  // the kernel/CE resolves winHost via ncclShadowPoolToHost; proxy-only
-  // type-puns the win pointer (pre-IPC upstream layout).
-  if (doIpc) {
-    if (cudaSuccess !=
-        cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking)) {
-      WARN("windowRegisterNonSym: cudaStreamCreateWithFlags failed");
-      goto fail;
-    }
+  // Stage 3: encode the device-side handle as a shadow pool entry so the
+  // kernel/CE resolves winHost via ncclShadowPoolToHost
+  if (cudaSuccess !=
+      cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking)) {
+    WARN("windowRegisterNonSym: cudaStreamCreateWithFlags failed");
+    goto fail;
+  }
 
-    if (ncclSuccess !=
-        ncclShadowPoolAlloc(&devr->shadows, &winDev, &winDevHost, stream)) {
-      WARN("windowRegisterNonSym: ncclShadowPoolAlloc failed");
-      goto fail;
-    }
+  if (ncclSuccess !=
+      ncclShadowPoolAlloc(&devr->shadows, &winDev, &winDevHost, stream)) {
+    WARN("windowRegisterNonSym: ncclShadowPoolAlloc failed");
+    goto fail;
+  }
 
-    win->vidmem = winDev;
-    memset(winDevHost, 0, sizeof(*winDevHost));
-    winDevHost->lsaRank = teamSelf;
-    winDevHost->worldRank = comm->rank;
-    winDevHost->winHost = (void*)win;
+  win->vidmem = winDev;
+  memset(winDevHost, 0, sizeof(*winDevHost));
+  winDevHost->lsaRank = teamSelf;
+  winDevHost->worldRank = comm->rank;
+  winDevHost->winHost = (void*)win;
 
-    if (cudaSuccess != cudaMemcpyAsync(winDev, winDevHost, sizeof(*winDevHost),
-                                       cudaMemcpyHostToDevice, stream)) {
-      WARN("windowRegisterNonSym: cudaMemcpyAsync (window header) failed");
-      goto fail;
-    }
-  } else {
-    winDev = reinterpret_cast<struct ncclWindow_vidmem*>(win);
+  if (cudaSuccess != cudaMemcpyAsync(winDev, winDevHost, sizeof(*winDevHost),
+                                     cudaMemcpyHostToDevice, stream)) {
+    WARN("windowRegisterNonSym: cudaMemcpyAsync (window header) failed");
+    goto fail;
   }
 
   {
@@ -1239,10 +1245,11 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
                &devr->winSortedCount, idx, winSort);
   }
 
+  CUDACHECKIGNORE(cudaStreamSynchronize(stream));
+  CUDACHECKIGNORE(cudaStreamDestroy(stream));
+  stream = nullptr;
+
   if (doIpc) {
-    CUDACHECKIGNORE(cudaStreamSynchronize(stream));
-    CUDACHECKIGNORE(cudaStreamDestroy(stream));
-    stream = nullptr;
     // Intra-node sync; sym path uses bootstrapBarrier post-mapping.
     if (ncclSuccess != bootstrapIntraNodeBarrier(comm->bootstrap, teamRankList,
                                                  teamSelf, teamSize,
@@ -1274,19 +1281,9 @@ fail:
     if (win->rmaHostWins[0] != nullptr) {
       (void)ncclRmaProxyDeregister(comm, win->rmaHostWins);
     }
-    if (win->ipcPeerOpenedBases != nullptr) {
-      // Close only entries that came from cudaIpcOpenMemHandle.
-      for (int r = 0; r < teamSize; r++) {
-        if (r == teamSelf) continue;
-        void* b = win->ipcPeerOpenedBases[r];
-        if (b == nullptr) continue;
-        bool sameProc = peers &&
-                        (peers[r].hostHash == peers[teamSelf].hostHash) &&
-                        (peers[r].pidHash == peers[teamSelf].pidHash);
-        if (sameProc) continue;
-        CUDACHECKIGNORE(cudaIpcCloseMemHandle(b));
-      }
-    }
+
+    windowCloseIpcPeers(comm, win);
+
     // Free the shadow-pool entry if it was allocated 
     if (win->vidmem != nullptr) {
       if (stream == nullptr) {
@@ -1295,7 +1292,7 @@ fail:
       (void)ncclShadowPoolFree(&devr->shadows, win->vidmem, stream);
     }
     free(win->ipcPeerPtrs);
-    free(win->ipcPeerOpenedBases);
+    free(win->ipcPeerPtrsAllocBase);
     free(win);
   }
   if (stream != nullptr) {
@@ -1867,20 +1864,13 @@ static ncclResult_t windowDeregisterNonSym(struct ncclComm* comm,
   struct ncclDevrState* devr = &comm->devrState;
   cudaStream_t stream = nullptr;
   struct ncclDevrWindow* win = nullptr;
-  int teamSize = devr->ceSize;
-  int teamSelf = devr->ceSelf;
-  bool ipcBacked = teamSize > 1;
   int winIdx = -1;
 
-  // Decode win from winDev: IPC uses shadow pool, PROXY type-puns.
-  if (ipcBacked) {
-    struct ncclWindow_vidmem* winDevHost = nullptr;
-    NCCLCHECKGOTO(ncclShadowPoolToHost(&devr->shadows, winDev, &winDevHost),
-                  ret, fail);
-    win = (struct ncclDevrWindow*)winDevHost->winHost;
-  } else {
-    win = reinterpret_cast<struct ncclDevrWindow*>(winDev);
-  }
+  // Decode win from winDev via the shadow pool
+  struct ncclWindow_vidmem* winDevHost = nullptr;
+  NCCLCHECKGOTO(ncclShadowPoolToHost(&devr->shadows, winDev, &winDevHost),
+                ret, fail);
+  win = (struct ncclDevrWindow*)winDevHost->winHost;
 
   // Locate this window's registration. A stale handle (e.g. a second
   // deregister of an already-freed window) is no longer in winSorted
@@ -1905,31 +1895,20 @@ static ncclResult_t windowDeregisterNonSym(struct ncclComm* comm,
   }
 
   // Undo stage 1: intra-node IPC peer mappings.
-  if (win->ipcPeerOpenedBases != nullptr) {
-    for (int r = 0; r < teamSize; r++) {
-      if (r == teamSelf) continue;
-      // Same-PID peers are stored as nullptr by RegisterNonSym on purpose,
-      // so any non-null entry needs a matching cudaIpcCloseMemHandle.
-      void* b = win->ipcPeerOpenedBases[r];
-      if (b == nullptr) continue;
-      CUDACHECKIGNORE(cudaIpcCloseMemHandle(b));
-    }
-  }
+  windowCloseIpcPeers(comm, win);
   free(win->ipcPeerPtrs);
-  free(win->ipcPeerOpenedBases);
+  free(win->ipcPeerPtrsAllocBase);
   win->ipcPeerPtrs = nullptr;
-  win->ipcPeerOpenedBases = nullptr;
+  win->ipcPeerPtrsAllocBase = nullptr;
 
-  // Undo stage 3: shadow pool entry (only allocated for IPC backing).
-  if (ipcBacked) {
-    CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking),
-                  ret, fail);
-    NCCLCHECKGOTO(ncclShadowPoolFree(&devr->shadows, winDev, stream), ret,
-                  fail_stream);
-    CUDACHECKIGNORE(cudaStreamSynchronize(stream));
-    CUDACHECKIGNORE(cudaStreamDestroy(stream));
-    stream = nullptr;
-  }
+  // Undo stage 3: shadow pool entry.
+  CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking),
+                ret, fail);
+  NCCLCHECKGOTO(ncclShadowPoolFree(&devr->shadows, winDev, stream), ret,
+                fail_stream);
+  CUDACHECKIGNORE(cudaStreamSynchronize(stream));
+  CUDACHECKIGNORE(cudaStreamDestroy(stream));
+  stream = nullptr;
 
   NCCLCHECKGOTO(ncclCommDeregister(comm, win->localRegHandle), ret, fail);
   listRemove(devr->winSorted, &devr->winSortedCount, winIdx);
@@ -2197,8 +2176,8 @@ ncclResult_t ncclDevrWorldToLsaRank(struct ncclComm* comm, int peerWorldRank, in
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   if (!comm->symmetricSupport) {
     struct ncclDevrState* devr = &comm->devrState;
-    for (int i = 0; i < devr->ceSize; i++) {
-      if (devr->ceRankList[i] == peerWorldRank) {
+    for (int i = 0; i < devr->lsaSize; i++) {
+      if (devr->lsaRankList[i] == peerWorldRank) {
         *peerLsaRank = i;
         return ncclSuccess;
       }
@@ -2230,7 +2209,7 @@ ncclResult_t ncclDevrGetLsaRankPtr(struct ncclComm* comm, struct ncclDevrWindow*
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   // RCCL non-sym: a self-targeted op resolves to the local window base directly.
-  if (!comm->symmetricSupport && lsaRank == devr->ceSelf) {
+  if (!comm->symmetricSupport && lsaRank == devr->lsaSelf) {
     *outPtr = (void*)((uintptr_t)winHost->userPtr + offset);
     return ncclSuccess;
   }

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -208,6 +208,10 @@ fail_lsaRankList:
 
 static void symTeamDestroyAll(struct ncclComm* comm); // Further down
 static void symMemoryDropRef(struct ncclComm* comm, struct ncclDevrMemory* mem); // Further down
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+static ncclResult_t windowDeregisterNonSym(struct ncclComm* comm,
+                                           struct ncclWindow_vidmem* winDev); // Further down
+#endif
 
 ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
   struct ncclDevrState* devr = &comm->devrState;
@@ -223,13 +227,34 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
   // During abort or any other cases, users might not call deregister API for
   // symmetric window objects, we need to destroy all remaining window objects
   // that are not deregistered by user to avoid memory leaks here.
-  CUDACHECKIGNORE(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
-  while (devr->winSortedCount > 0) {
-    struct ncclDevrWindow* win = devr->winSorted[0].win;
-    NCCLCHECKIGNORE(symWindowDestroy(comm, win->vidmem, stream), ret);
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  // RCCL: non-sym windows aren't backed by the symmetric VMM machinery, so drain
+  // them through the matching non-sym deregister instead of symWindowDestroy.
+  if (!comm->symmetricSupport) {
+    while (devr->winSortedCount > 0) {
+      int before = devr->winSortedCount;
+      struct ncclDevrWindow* win = devr->winSorted[0].win;
+      struct ncclWindow_vidmem* winDev =
+        (devr->ceSize > 1) ? win->vidmem
+                           : reinterpret_cast<struct ncclWindow_vidmem*>(win);
+      NCCLCHECKIGNORE(windowDeregisterNonSym(comm, winDev), ret);
+      // windowDeregisterNonSym only removes the entry on success; drop it on
+      // failure too so abort-time finalize always makes progress.
+      if (devr->winSortedCount >= before) {
+        listRemove(devr->winSorted, &devr->winSortedCount, 0);
+      }
+    }
+  } else
+#endif
+  {
+    CUDACHECKIGNORE(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+    while (devr->winSortedCount > 0) {
+      struct ncclDevrWindow* win = devr->winSorted[0].win;
+      NCCLCHECKIGNORE(symWindowDestroy(comm, win->vidmem, stream), ret);
+    }
+    CUDACHECKIGNORE(cudaStreamSynchronize(stream));
+    CUDACHECKIGNORE(cudaStreamDestroy(stream));
   }
-  CUDACHECKIGNORE(cudaStreamSynchronize(stream));
-  CUDACHECKIGNORE(cudaStreamDestroy(stream));
 
 
   if (comm->symmetricSupport) {
@@ -1049,14 +1074,17 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
     size_t userSize;
   };
 
+  // Intra-node barrier tag for the non-sym window mapping handshake.
+  static constexpr int kNonSymWindowBarrierTag = 0xbeed;
+
   struct ncclDevrState* devr = &comm->devrState;
   // Non-sym path uses the CE team (all same-node ranks), not gcd lsa.
-  int lsaSize = devr->ceSize;
-  int lsaSelf = devr->ceSelf;
+  int teamSize = devr->ceSize;
+  int teamSelf = devr->ceSelf;
   int* teamRankList = devr->ceRankList;
 
-  bool doIpc = lsaSize > 1;
-  bool doRma = comm->hostRmaSupport && (lsaSize < comm->nRanks);
+  bool doIpc = teamSize > 1;
+  bool doRma = comm->hostRmaSupport && (teamSize < comm->nRanks);
 
   struct ncclDevrWindow* win = nullptr;
   cudaStream_t stream = nullptr;
@@ -1065,13 +1093,9 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
   ExchangeEntry* peers = nullptr;
   int openedCount = 0;
 
-  if (!doIpc && !doRma) {
-    *outWinDev = nullptr;
-    return ncclSuccess;
-  }
 
   win = (struct ncclDevrWindow*)malloc(sizeof(struct ncclDevrWindow));
-  if (win == nullptr) goto soft_fail;
+  if (win == nullptr) goto fail;
 
   memset(win, 0, sizeof(*win));
   win->memory = nullptr;
@@ -1088,24 +1112,23 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
 
     if (CUDA_SUCCESS !=
         cuMemGetAddressRange(&allocBase, &allocSize, userPtrCu)) {
-      WARN("windowRegisterNonSym: cuMemGetAddressRange failed for "
-           "userPtr=%p; falling back to nullptr window",
+      WARN("windowRegisterNonSym: cuMemGetAddressRange failed for userPtr=%p",
            userPtr);
-      goto soft_fail;
+      goto fail;
     }
     size_t userOffset = reinterpret_cast<uintptr_t>(userPtr) -
                         reinterpret_cast<uintptr_t>(allocBase);
 
-    peers = (ExchangeEntry*)calloc(lsaSize, sizeof(ExchangeEntry));
-    if (peers == nullptr) goto soft_fail;
+    peers = (ExchangeEntry*)calloc(teamSize, sizeof(ExchangeEntry));
+    if (peers == nullptr) goto fail;
 
-    ExchangeEntry* mine = &peers[lsaSelf];
+    ExchangeEntry* mine = &peers[teamSelf];
     cudaError_t cerr =
       cudaIpcGetMemHandle(&mine->handle, reinterpret_cast<void*>(allocBase));
     if (cerr != cudaSuccess) {
       WARN("windowRegisterNonSym: cudaIpcGetMemHandle failed: %s",
            cudaGetErrorString(cerr));
-      goto soft_fail;
+      goto fail;
     }
 
     mine->hostHash = comm->peerInfo[comm->rank].hostHash;
@@ -1114,26 +1137,26 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
     mine->userSize = userSize;
 
     if (ncclSuccess !=
-        bootstrapIntraNodeAllGather(comm->bootstrap, teamRankList, lsaSelf,
-                                    lsaSize, peers, sizeof(ExchangeEntry))) {
+        bootstrapIntraNodeAllGather(comm->bootstrap, teamRankList, teamSelf,
+                                    teamSize, peers, sizeof(ExchangeEntry))) {
       WARN("windowRegisterNonSym: bootstrapIntraNodeAllGather failed");
-      goto soft_fail;
+      goto fail;
     }
 
-    win->ipcPeerPtrs = (void**)calloc(lsaSize, sizeof(void*));
-    win->ipcPeerOpenedBases = (void**)calloc(lsaSize, sizeof(void*));
+    win->ipcPeerPtrs = (void**)calloc(teamSize, sizeof(void*));
+    win->ipcPeerOpenedBases = (void**)calloc(teamSize, sizeof(void*));
     if (win->ipcPeerPtrs == nullptr || win->ipcPeerOpenedBases == nullptr) {
-      goto soft_fail;
+      goto fail;
     }
-    win->ipcPeerCount = lsaSize;
+    win->ipcPeerCount = teamSize;
 
-    for (int r = 0; r < lsaSize; r++) {
-      bool sameProc = (peers[r].hostHash == peers[lsaSelf].hostHash) &&
-                      (peers[r].pidHash == peers[lsaSelf].pidHash);
-      if (r == lsaSelf || sameProc) {
+    for (int r = 0; r < teamSize; r++) {
+      bool sameProc = (peers[r].hostHash == peers[teamSelf].hostHash) &&
+                      (peers[r].pidHash == peers[teamSelf].pidHash);
+      if (r == teamSelf || sameProc) {
         // Same address space: self reuses userPtr; same-PID cross-thread
         // peers stay nullptr (MVP: no cross-thread peer mapping).
-        if (r == lsaSelf) {
+        if (r == teamSelf) {
           win->ipcPeerOpenedBases[r] = reinterpret_cast<void*>(allocBase);
           win->ipcPeerPtrs[r] = userPtr;
         } else {
@@ -1147,9 +1170,9 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
                                cudaIpcMemLazyEnablePeerAccess);
         if (orErr != cudaSuccess) {
           WARN("windowRegisterNonSym: cudaIpcOpenMemHandle for "
-               "lsaRank=%d failed: %s",
+               "teamRank=%d failed: %s",
                r, cudaGetErrorString(orErr));
-          goto soft_fail;
+          goto fail;
         }
         win->ipcPeerOpenedBases[r] = peerBase;
         win->ipcPeerPtrs[r] = (char*)peerBase + peers[r].userOffset;
@@ -1162,13 +1185,13 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
   if (doRma) {
     if (ncclSuccess != ncclRmaProxyConnectOnce(comm)) {
       WARN("windowRegisterNonSym: ncclRmaProxyConnectOnce failed");
-      goto soft_fail;
+      goto fail;
     }
     if (ncclSuccess != ncclRmaProxyRegister(comm, userPtr, userSize,
                                             win->rmaHostWins,
                                             win->rmaDevWins)) {
       WARN("windowRegisterNonSym: ncclRmaProxyRegister failed");
-      goto soft_fail;
+      goto fail;
     }
   }
 
@@ -1179,20 +1202,26 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
     if (cudaSuccess !=
         cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking)) {
       WARN("windowRegisterNonSym: cudaStreamCreateWithFlags failed");
-      goto soft_fail;
+      goto fail;
     }
+
     if (ncclSuccess !=
         ncclShadowPoolAlloc(&devr->shadows, &winDev, &winDevHost, stream)) {
       WARN("windowRegisterNonSym: ncclShadowPoolAlloc failed");
-      goto soft_fail;
+      goto fail;
     }
+
     win->vidmem = winDev;
     memset(winDevHost, 0, sizeof(*winDevHost));
-    winDevHost->lsaRank = lsaSelf;
+    winDevHost->lsaRank = teamSelf;
     winDevHost->worldRank = comm->rank;
     winDevHost->winHost = (void*)win;
-    CUDACHECKIGNORE(cudaMemcpyAsync(winDev, winDevHost, sizeof(*winDevHost),
-                                    cudaMemcpyHostToDevice, stream));
+
+    if (cudaSuccess != cudaMemcpyAsync(winDev, winDevHost, sizeof(*winDevHost),
+                                       cudaMemcpyHostToDevice, stream)) {
+      WARN("windowRegisterNonSym: cudaMemcpyAsync (window header) failed");
+      goto fail;
+    }
   } else {
     winDev = reinterpret_cast<struct ncclWindow_vidmem*>(win);
   }
@@ -1216,7 +1245,8 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
     stream = nullptr;
     // Intra-node sync; sym path uses bootstrapBarrier post-mapping.
     if (ncclSuccess != bootstrapIntraNodeBarrier(comm->bootstrap, teamRankList,
-                                                 lsaSelf, lsaSize, 0xbeed)) {
+                                                 teamSelf, teamSize,
+                                                 kNonSymWindowBarrierTag)) {
       WARN("windowRegisterNonSym: bootstrapIntraNodeBarrier failed");
       // Revert listInsert before falling into shared cleanup.
       int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr,
@@ -1224,25 +1254,21 @@ static ncclResult_t windowRegisterNonSym(struct ncclComm* comm, void* userPtr,
                                 reinterpret_cast<uintptr_t>(userPtr));
       i -= 1;
       if (i >= 0) listRemove(devr->winSorted, &devr->winSortedCount, i);
-      goto soft_fail;
+      goto fail;
     }
   }
 
   INFO(NCCL_INIT,
-       "windowRegisterNonSym: backing=%s lsaSize=%d nRanks=%d "
+       "windowRegisterNonSym: backing=%s teamSize=%d nRanks=%d "
        "userPtr=%p size=%zu opened=%d hostRma=%d",
-       doIpc ? "IPC" : "PROXY", lsaSize, comm->nRanks, userPtr, userSize,
-       openedCount, (int)doRma);
+       doIpc ? "IPC" : (doRma ? "PROXY" : "LOCAL"), teamSize, comm->nRanks,
+       userPtr, userSize, openedCount, (int)doRma);
 
   free(peers);
   *outWinDev = winDev;
   return ncclSuccess;
 
-soft_fail:
-  if (stream != nullptr) {
-    CUDACHECKIGNORE(cudaStreamSynchronize(stream));
-    CUDACHECKIGNORE(cudaStreamDestroy(stream));
-  }
+fail:
   if (win != nullptr) {
     // Undo proxy MR (rmaHostWins[0] is non-null only after register).
     if (win->rmaHostWins[0] != nullptr) {
@@ -1250,25 +1276,36 @@ soft_fail:
     }
     if (win->ipcPeerOpenedBases != nullptr) {
       // Close only entries that came from cudaIpcOpenMemHandle.
-      for (int r = 0; r < lsaSize; r++) {
-        if (r == lsaSelf) continue;
+      for (int r = 0; r < teamSize; r++) {
+        if (r == teamSelf) continue;
         void* b = win->ipcPeerOpenedBases[r];
         if (b == nullptr) continue;
         bool sameProc = peers &&
-                        (peers[r].hostHash == peers[lsaSelf].hostHash) &&
-                        (peers[r].pidHash == peers[lsaSelf].pidHash);
+                        (peers[r].hostHash == peers[teamSelf].hostHash) &&
+                        (peers[r].pidHash == peers[teamSelf].pidHash);
         if (sameProc) continue;
         CUDACHECKIGNORE(cudaIpcCloseMemHandle(b));
       }
+    }
+    // Free the shadow-pool entry if it was allocated 
+    if (win->vidmem != nullptr) {
+      if (stream == nullptr) {
+        CUDACHECKIGNORE(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+      }
+      (void)ncclShadowPoolFree(&devr->shadows, win->vidmem, stream);
     }
     free(win->ipcPeerPtrs);
     free(win->ipcPeerOpenedBases);
     free(win);
   }
+  if (stream != nullptr) {
+    CUDACHECKIGNORE(cudaStreamSynchronize(stream));
+    CUDACHECKIGNORE(cudaStreamDestroy(stream));
+  }
   free(peers);
   // localRegHandle is owned by caller's failure cleanup path.
   *outWinDev = nullptr;
-  return ncclSuccess;
+  return ncclSystemError;
 }
 #endif
 
@@ -1298,10 +1335,6 @@ ncclResult_t ncclDevrWindowRegisterInGroup(
     NCCLCHECKGOTO(windowRegisterNonSym(comm, userPtr, userSize, winFlags,
                                        localRegHandle, outWinDev),
                   ret, fail_locReg);
-    if (*outWinDev == nullptr) {
-      // Soft-fail: drop local reg so we don't leak it.
-      goto fail_locReg;
-    }
     return ncclSuccess;
   }
 #endif
@@ -2192,8 +2225,7 @@ ncclResult_t ncclDevrGetLsaRankPtr(struct ncclComm* comm, struct ncclDevrWindow*
 
   struct ncclDevrState* devr = &comm->devrState;
 
-  // Validate offset is within bounds
-  if (offset < 0 || offset >= winHost->size) {
+  if (offset >= winHost->size) {
     return ncclInvalidArgument;
   }
 

--- a/projects/rccl/src/dev_runtime.cc
+++ b/projects/rccl/src/dev_runtime.cc
@@ -158,6 +158,11 @@ ncclResult_t ncclDevrInitOnce(struct ncclComm* comm) {
     devr->lsaRankList[i] = comm->rank + (i - devr->lsaSelf);
   }
 
+  // RCCL: shadow pool is used by both sym VMM and IPC backings (rmaTaskAppend
+  // decodes peer windows via ncclShadowPoolToHost). Construct unconditionally;
+  // it's just a small zero-init for the hash table head, see allocator.cc.
+  ncclShadowPoolConstruct(&devr->shadows);
+
   if (comm->symmetricSupport) {
     CUmemAllocationProp memProp = {};
 #if defined(HIP_VMM_UNCACHED_MEMORY)
@@ -181,9 +186,17 @@ ncclResult_t ncclDevrInitOnce(struct ncclComm* comm) {
     INFO(NCCL_INIT, "Symmetric VA size=%ldGB", (long)devr->bigSize>>30);
 
     ncclSpaceConstruct(&devr->bigSpace);
-    ncclShadowPoolConstruct(&devr->shadows);
   } else {
     devr->bigSize = 1; // proxy-only: marks devrState as initialized
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+    devr->ceSize = comm->localRanks;
+    devr->ceSelf = comm->localRank;
+    devr->ceRankList = (int*)malloc(devr->ceSize * sizeof(int));
+    if (devr->ceRankList == nullptr) { ret = ncclSystemError; goto fail_lsaRankList; }
+    for (int i = 0; i < devr->ceSize; i++) {
+      devr->ceRankList[i] = comm->localRankToRank[i];
+    }
+#endif
   }
   return ncclSuccess;
 
@@ -258,10 +271,18 @@ ncclResult_t ncclDevrFinalize(struct ncclComm* comm) {
       CUdeviceptr flatAddr = reinterpret_cast<CUdeviceptr>(devr->lsaFlatBase);
       CUCHECK(cuMemAddressFree(flatAddr, devr->lsaSize*devr->bigSize));
     }
-    ncclShadowPoolDestruct(&devr->shadows);
     ncclSpaceDestruct(&devr->bigSpace);
   }
+
+  // RCCL: shadows is constructed unconditionally in ncclDevrInitOnce; destruct
+  // is safe whether or not it ever held pages (hbits==0 shortcuts the cleanup).
+  ncclShadowPoolDestruct(&devr->shadows);
+
   free(devr->lsaRankList);
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  free(devr->ceRankList); // RCCL: intra-node CE team
+  devr->ceRankList = nullptr;
+#endif
   free(devr->winSorted);
   return ncclSuccess;
 }
@@ -1007,6 +1028,270 @@ fail:
   return ret;
 }
 
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+// RCCL: register a non-sym window. Mirrors upstream sym's two-stage shape:
+//   (1) intra-node mapping via cudaIpcOpenMemHandle peer pointers, when
+//       ceSize > 1.
+//   (2) inter-node MR via ncclRmaProxyRegister, when hostRmaSupport. Same
+//       call upstream issues from symMemoryRegisterRma.
+// outWinDev is a shadow pool entry for IPC or a type-pun ncclDevrWindow*
+// for proxy-only.
+static ncclResult_t ncclDevrWindowRegisterNonSym(struct ncclComm* comm,
+                                                 void* userPtr,
+                                                 size_t userSize,
+                                                 int winFlags,
+                                                 void* localRegHandle,
+                                                 ncclWindow_t* outWinDev) {
+  struct ExchangeEntry {
+    cudaIpcMemHandle_t handle;
+    uint64_t hostHash;
+    uint64_t pidHash;
+    size_t userOffset; // userPtr - allocBase
+    size_t userSize;
+  };
+
+  struct ncclDevrState* devr = &comm->devrState;
+  // Non-sym path uses the CE team (all same-node ranks), not gcd lsa.
+  int lsaSize = devr->ceSize;
+  int lsaSelf = devr->ceSelf;
+  int* teamRankList = devr->ceRankList;
+  bool doIpc = lsaSize > 1;
+  // Host RMA only when there are inter-node peers AND transport is available.
+  // hostRmaSupport=1 on a pure single-node setup (isOneLsaTeams short-circuit)
+  // does not imply RMA NICs/proxy state are actually wired up.
+  bool doRma = comm->hostRmaSupport && (lsaSize < comm->nRanks);
+
+  struct ncclDevrWindow* win = nullptr;
+  cudaStream_t stream = nullptr;
+  struct ncclWindow_vidmem* winDev = nullptr;
+  struct ncclWindow_vidmem* winDevHost = nullptr;
+  ExchangeEntry* peers = nullptr;
+  int openedCount = 0;
+
+  if (!doIpc && !doRma) {
+    *outWinDev = nullptr;
+    return ncclSuccess;
+  }
+
+  win = (struct ncclDevrWindow*)malloc(sizeof(struct ncclDevrWindow));
+  if (win == nullptr) goto soft_fail;
+
+  memset(win, 0, sizeof(*win));
+  win->memory = nullptr;
+  win->userPtr = userPtr;
+  win->size = userSize;
+  win->winFlags = winFlags;
+  win->localRegHandle = localRegHandle;
+
+  // Stage 1: intra-node mapping (analog of symMemoryMapLsaTeam).
+  if (doIpc) {
+    CUdeviceptr allocBase = 0;
+    size_t allocSize = 0;
+    CUdeviceptr userPtrCu = reinterpret_cast<CUdeviceptr>(userPtr);
+
+    if (CUDA_SUCCESS !=
+        cuMemGetAddressRange(&allocBase, &allocSize, userPtrCu)) {
+      WARN("ncclDevrWindowRegisterNonSym: cuMemGetAddressRange failed for "
+           "userPtr=%p; falling back to nullptr window",
+           userPtr);
+      goto soft_fail;
+    }
+    size_t userOffset = reinterpret_cast<uintptr_t>(userPtr) -
+                        reinterpret_cast<uintptr_t>(allocBase);
+
+    peers = (ExchangeEntry*)calloc(lsaSize, sizeof(ExchangeEntry));
+    if (peers == nullptr) goto soft_fail;
+
+    ExchangeEntry* mine = &peers[lsaSelf];
+    cudaError_t cerr =
+        cudaIpcGetMemHandle(&mine->handle, reinterpret_cast<void*>(allocBase));
+    if (cerr != cudaSuccess) {
+      WARN("ncclDevrWindowRegisterNonSym: cudaIpcGetMemHandle failed: %s",
+           cudaGetErrorString(cerr));
+      goto soft_fail;
+    }
+
+    mine->hostHash = comm->peerInfo[comm->rank].hostHash;
+    mine->pidHash = comm->peerInfo[comm->rank].pidHash;
+    mine->userOffset = userOffset;
+    mine->userSize = userSize;
+
+    if (ncclSuccess != bootstrapIntraNodeAllGather(comm->bootstrap,
+                                                   teamRankList,
+                                                   lsaSelf,
+                                                   lsaSize,
+                                                   peers,
+                                                   sizeof(ExchangeEntry))) {
+      WARN("ncclDevrWindowRegisterNonSym: bootstrapIntraNodeAllGather failed");
+      goto soft_fail;
+    }
+
+    win->ipcPeerPtrs = (void**)calloc(lsaSize, sizeof(void*));
+    win->ipcPeerOpenedBases = (void**)calloc(lsaSize, sizeof(void*));
+    if (win->ipcPeerPtrs == nullptr || win->ipcPeerOpenedBases == nullptr) {
+      goto soft_fail;
+    }
+    win->ipcPeerCount = lsaSize;
+
+    for (int r = 0; r < lsaSize; r++) {
+      bool sameProc = (peers[r].hostHash == peers[lsaSelf].hostHash) &&
+                      (peers[r].pidHash == peers[lsaSelf].pidHash);
+      if (r == lsaSelf || sameProc) {
+        // Same address space: self reuses userPtr; same-PID cross-thread
+        // peers stay nullptr (MVP: no cross-thread peer mapping).
+        if (r == lsaSelf) {
+          win->ipcPeerOpenedBases[r] = reinterpret_cast<void*>(allocBase);
+          win->ipcPeerPtrs[r] = userPtr;
+        } else {
+          win->ipcPeerOpenedBases[r] = nullptr;
+          win->ipcPeerPtrs[r] = nullptr;
+        }
+      } else {
+        void* peerBase = nullptr;
+        cudaError_t orErr = cudaIpcOpenMemHandle(
+            &peerBase, peers[r].handle, cudaIpcMemLazyEnablePeerAccess);
+        if (orErr != cudaSuccess) {
+          WARN("ncclDevrWindowRegisterNonSym: cudaIpcOpenMemHandle for "
+               "lsaRank=%d failed: %s",
+               r,
+               cudaGetErrorString(orErr));
+          goto soft_fail;
+        }
+        win->ipcPeerOpenedBases[r] = peerBase;
+        win->ipcPeerPtrs[r] = (char*)peerBase + peers[r].userOffset;
+        openedCount += 1;
+      }
+    }
+  }
+
+  // Stage 2: inter-node MR (analog of symMemoryRegisterRma).
+  if (doRma) {
+    if (ncclSuccess != ncclRmaProxyConnectOnce(comm)) {
+      WARN("ncclDevrWindowRegisterNonSym: ncclRmaProxyConnectOnce failed");
+      goto soft_fail;
+    }
+    if (ncclSuccess !=
+        ncclRmaProxyRegister(
+            comm, userPtr, userSize, win->rmaHostWins, win->rmaDevWins)) {
+      WARN("ncclDevrWindowRegisterNonSym: ncclRmaProxyRegister failed");
+      goto soft_fail;
+    }
+  }
+
+  // Stage 3: encode device-side handle. IPC needs a shadow pool entry so
+  // the kernel/CE resolves winHost via ncclShadowPoolToHost; proxy-only
+  // type-puns the win pointer (pre-IPC upstream layout).
+  if (doIpc) {
+    if (cudaSuccess !=
+        cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking)) {
+      WARN("ncclDevrWindowRegisterNonSym: cudaStreamCreateWithFlags failed");
+      goto soft_fail;
+    }
+    if (ncclSuccess !=
+        ncclShadowPoolAlloc(&devr->shadows, &winDev, &winDevHost, stream)) {
+      WARN("ncclDevrWindowRegisterNonSym: ncclShadowPoolAlloc failed");
+      goto soft_fail;
+    }
+    win->vidmem = winDev;
+    memset(winDevHost, 0, sizeof(*winDevHost));
+    winDevHost->lsaRank = lsaSelf;
+    winDevHost->worldRank = comm->rank;
+    winDevHost->winHost = (void*)win;
+    CUDACHECKIGNORE(cudaMemcpyAsync(winDev,
+                                    winDevHost,
+                                    sizeof(*winDevHost),
+                                    cudaMemcpyHostToDevice,
+                                    stream));
+  } else {
+    winDev = reinterpret_cast<struct ncclWindow_vidmem*>(win);
+  }
+
+  {
+    uintptr_t userAddr = reinterpret_cast<uintptr_t>(userPtr);
+    int idx = listFindSortedLub(&ncclDevrWindowSorted::userAddr,
+                                devr->winSorted,
+                                devr->winSortedCount,
+                                userAddr);
+    struct ncclDevrWindowSorted winSort;
+    winSort.userAddr = userAddr;
+    winSort.size = userSize;
+    winSort.win = win;
+    listInsert(&devr->winSorted,
+               &devr->winSortedCapacity,
+               &devr->winSortedCount,
+               idx,
+               winSort);
+  }
+
+  if (doIpc) {
+    CUDACHECKIGNORE(cudaStreamSynchronize(stream));
+    CUDACHECKIGNORE(cudaStreamDestroy(stream));
+    stream = nullptr;
+    // Intra-node sync; sym path uses bootstrapBarrier post-mapping.
+    if (ncclSuccess !=
+        bootstrapIntraNodeBarrier(
+            comm->bootstrap, teamRankList, lsaSelf, lsaSize, 0xbeed)) {
+      WARN("ncclDevrWindowRegisterNonSym: bootstrapIntraNodeBarrier failed");
+      // Revert listInsert before falling into shared cleanup.
+      int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr,
+                                devr->winSorted,
+                                devr->winSortedCount,
+                                reinterpret_cast<uintptr_t>(userPtr));
+      i -= 1;
+      if (i >= 0) listRemove(devr->winSorted, &devr->winSortedCount, i);
+      goto soft_fail;
+    }
+  }
+
+  INFO(NCCL_INIT,
+       "ncclDevrWindowRegisterNonSym: backing=%s lsaSize=%d nRanks=%d "
+       "userPtr=%p size=%zu opened=%d hostRma=%d",
+       doIpc ? "IPC" : "PROXY",
+       lsaSize,
+       comm->nRanks,
+       userPtr,
+       userSize,
+       openedCount,
+       (int)doRma);
+
+  free(peers);
+  *outWinDev = winDev;
+  return ncclSuccess;
+
+soft_fail:
+  if (stream != nullptr) {
+    CUDACHECKIGNORE(cudaStreamSynchronize(stream));
+    CUDACHECKIGNORE(cudaStreamDestroy(stream));
+  }
+  if (win != nullptr) {
+    // Undo proxy MR (rmaHostWins[0] is non-null only after register).
+    if (win->rmaHostWins[0] != nullptr) {
+      (void)ncclRmaProxyDeregister(comm, win->rmaHostWins);
+    }
+    if (win->ipcPeerOpenedBases != nullptr) {
+      // Close only entries that came from cudaIpcOpenMemHandle.
+      for (int r = 0; r < lsaSize; r++) {
+        if (r == lsaSelf) continue;
+        void* b = win->ipcPeerOpenedBases[r];
+        if (b == nullptr) continue;
+        bool sameProc = peers &&
+                        (peers[r].hostHash == peers[lsaSelf].hostHash) &&
+                        (peers[r].pidHash == peers[lsaSelf].pidHash);
+        if (sameProc) continue;
+        CUDACHECKIGNORE(cudaIpcCloseMemHandle(b));
+      }
+    }
+    free(win->ipcPeerPtrs);
+    free(win->ipcPeerOpenedBases);
+    free(win);
+  }
+  free(peers);
+  // localRegHandle is owned by caller's failure cleanup path.
+  *outWinDev = nullptr;
+  return ncclSuccess;
+}
+#endif
+
 ncclResult_t ncclDevrWindowRegisterInGroup(
     struct ncclComm* comm,
     void* userPtr, size_t userSize, int winFlags, ncclWindow_t* outWinDev
@@ -1026,41 +1311,25 @@ ncclResult_t ncclDevrWindowRegisterInGroup(
 
   NCCLCHECKGOTO(ncclCommRegister(comm, userPtr, userSize, &localRegHandle), ret, fail);
 
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  // RCCL: when sym VMM is unavailable (no cuMem / capability gates closed),
+  // route through the non-sym helper which lays out IPC for intra-node and
+  // optional proxy/GIN MR for inter-node in one shape. Sym path below stays
+  // upstream-NCCL identical.
   if (!comm->symmetricSupport) {
-    if (comm->hostRmaSupport) {
-      INFO(NCCL_INIT, "ncclDevrWindowRegisterInGroup: proxy path userPtr=%p size=%zu", userPtr, userSize);
-      struct ncclDevrWindow* win = (struct ncclDevrWindow*)malloc(sizeof(struct ncclDevrWindow));
-      if (win == nullptr) { ret = ncclSystemError; goto fail_locReg; }
-      memset(win, 0, sizeof(*win));
-      win->memory = nullptr;
-      win->userPtr = userPtr;
-      win->size = userSize;
-      win->winFlags = winFlags;
-      win->localRegHandle = localRegHandle;
-      ncclResult_t connRet = ncclRmaProxyConnectOnce(comm);
-      INFO(NCCL_INIT, "ncclDevrWindowRegisterInGroup: ncclRmaProxyConnectOnce ret=%d", (int)connRet);
-      NCCLCHECKGOTO(connRet, ret, fail_locReg_proxywin);
-      INFO(NCCL_INIT, "ncclDevrWindowRegisterInGroup: proxy connected, registering MR");
-      NCCLCHECKGOTO(ncclRmaProxyRegister(comm, userPtr, userSize, win->rmaHostWins, win->rmaDevWins), ret, fail_locReg_proxywin);
-      INFO(NCCL_INIT, "ncclDevrWindowRegisterInGroup: MR registered, win=%p", (void*)win);
-      {
-        struct ncclDevrState* devr = &comm->devrState;
-        uintptr_t userAddr = reinterpret_cast<uintptr_t>(userPtr);
-        int idx = listFindSortedLub(&ncclDevrWindowSorted::userAddr, devr->winSorted, devr->winSortedCount, userAddr);
-        struct ncclDevrWindowSorted winSort;
-        winSort.userAddr = userAddr; winSort.size = userSize; winSort.win = win;
-        listInsert(&devr->winSorted, &devr->winSortedCapacity, &devr->winSortedCount, idx, winSort);
-      }
-      *outWinDev = reinterpret_cast<struct ncclWindow_vidmem*>(win);
-      return ncclSuccess;
-    fail_locReg_proxywin:
-      free(win);
+    NCCLCHECKGOTO(
+        ncclDevrWindowRegisterNonSym(
+            comm, userPtr, userSize, winFlags, localRegHandle, outWinDev),
+        ret,
+        fail_locReg);
+    if (*outWinDev == nullptr) {
+      // Soft-fail: drop local reg so we don't leak it.
       goto fail_locReg;
-    } else {
-      *outWinDev = reinterpret_cast<struct ncclWindow_vidmem*>(localRegHandle);
-      return ncclSuccess;
     }
+    return ncclSuccess;
   }
+#endif
+
   if (winFlags & NCCL_WIN_COLL_SYMMETRIC) {
     // Defer symmetric kernel init until at least one window with that flag exists.
     NCCLCHECKGOTO(ncclSymkInitOnce(comm), ret, fail);
@@ -1564,7 +1833,8 @@ ncclResult_t ncclCommWindowRegister_impl(
   // ncclPutSignal/Signal/WaitSignal. ncclRmaCeInit is collective
   // (signals window + bootstrap barrier), so we cannot call it from the
   // non-collective Host API entry point.
-  if (!comm->rmaState.rmaCeState.initialized &&
+  if ((comm->symmetricSupport ? (comm->devrState.lsaSize > 1) : true) &&
+      !comm->rmaState.rmaCeState.initialized &&
       ncclIntruQueueEmpty(&comm->rmaCeInitTaskQueue)) {
     struct ncclRmaCeInitTask* ceTask;
     NCCLCHECKGOTO(ncclCalloc(&ceTask, 1), ret, fail);
@@ -1582,7 +1852,86 @@ fail:
   goto exit;
 }
 
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+// RCCL: deregister mirror of ncclDevrWindowRegisterNonSym
+static ncclResult_t
+ncclDevrWindowDeregisterNonSym(struct ncclComm* comm,
+                               struct ncclWindow_vidmem* winDev) {
+  ncclResult_t ret = ncclSuccess;
+  struct ncclDevrState* devr = &comm->devrState;
+  cudaStream_t stream = nullptr;
+  struct ncclDevrWindow* win = nullptr;
+  int teamSize = devr->ceSize;
+  int teamSelf = devr->ceSelf;
+  bool ipcBacked = teamSize > 1;
+
+  // Decode win from winDev: IPC uses shadow pool, PROXY type-puns.
+  if (ipcBacked) {
+    struct ncclWindow_vidmem* winDevHost = nullptr;
+    NCCLCHECKGOTO(
+        ncclShadowPoolToHost(&devr->shadows, winDev, &winDevHost), ret, fail);
+    win = (struct ncclDevrWindow*)winDevHost->winHost;
+  } else {
+    win = reinterpret_cast<struct ncclDevrWindow*>(winDev);
+  }
+
+  // Undo stage 2: inter-node proxy MR. rmaHostWins[0] is a reliable witness
+  // because ncclRmaProxyRegister fills NCCL_GIN_MAX_CONNECTIONS handles.
+  if (win->rmaHostWins[0] != nullptr) {
+    NCCLCHECKGOTO(ncclRmaProxyDeregister(comm, win->rmaHostWins), ret, fail);
+  }
+
+  // Undo stage 1: intra-node IPC peer mappings.
+  if (win->ipcPeerOpenedBases != nullptr) {
+    for (int r = 0; r < teamSize; r++) {
+      if (r == teamSelf) continue;
+      // Same-PID peers are stored as nullptr by RegisterNonSym on purpose,
+      // so any non-null entry needs a matching cudaIpcCloseMemHandle.
+      void* b = win->ipcPeerOpenedBases[r];
+      if (b == nullptr) continue;
+      CUDACHECKIGNORE(cudaIpcCloseMemHandle(b));
+    }
+  }
+  free(win->ipcPeerPtrs);
+  free(win->ipcPeerOpenedBases);
+  win->ipcPeerPtrs = nullptr;
+  win->ipcPeerOpenedBases = nullptr;
+
+  // Undo stage 3: shadow pool entry (only allocated for IPC backing).
+  if (ipcBacked) {
+    CUDACHECKGOTO(
+        cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), ret, fail);
+    NCCLCHECKGOTO(
+        ncclShadowPoolFree(&devr->shadows, winDev, stream), ret, fail_stream);
+    CUDACHECKIGNORE(cudaStreamSynchronize(stream));
+    CUDACHECKIGNORE(cudaStreamDestroy(stream));
+    stream = nullptr;
+  }
+
+  NCCLCHECKGOTO(ncclCommDeregister(comm, win->localRegHandle), ret, fail);
+  {
+    int i = listFindSortedLub(&ncclDevrWindowSorted::userAddr,
+                              devr->winSorted,
+                              devr->winSortedCount,
+                              reinterpret_cast<uintptr_t>(win->userPtr));
+    i -= 1;
+    listRemove(devr->winSorted, &devr->winSortedCount, i);
+  }
+  free(win);
+  return ncclSuccess;
+
+fail_stream:
+  if (stream != nullptr) {
+    CUDACHECKIGNORE(cudaStreamSynchronize(stream));
+    CUDACHECKIGNORE(cudaStreamDestroy(stream));
+  }
+fail:
+  return ret;
+}
+#endif
+
 NCCL_API(ncclResult_t, ncclCommWindowDeregister, ncclComm_t comm, ncclWindow_t win);
+
 ncclResult_t ncclCommWindowDeregister_impl(struct ncclComm* comm, struct ncclWindow_vidmem* winDev) {
   ncclResult_t ret = ncclSuccess;
   int saveDev;
@@ -1590,31 +1939,12 @@ ncclResult_t ncclCommWindowDeregister_impl(struct ncclComm* comm, struct ncclWin
 
   if (winDev == nullptr) goto exit;
 
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   if (!comm->symmetricSupport) {
-    if (comm->hostRmaSupport) {
-      struct ncclDevrWindow* win = reinterpret_cast<struct ncclDevrWindow*>(winDev);
-      struct ncclDevrState* devr = &comm->devrState;
-      int winIdx = -1;
-      for (int i = 0; i < devr->winSortedCount; i++) {
-        if (devr->winSorted[i].win == win) {
-          winIdx = i;
-          break;
-        }
-      }
-      if (winIdx < 0) {
-        WARN("ncclCommWindowDeregister: window %p is not registered (already deregistered?)", (void*)winDev);
-        ret = ncclInvalidArgument;
-        goto exit;
-      }
-      NCCLCHECKGOTO(ncclRmaProxyDeregister(comm, win->rmaHostWins), ret, fail);
-      NCCLCHECKGOTO(ncclCommDeregister(comm, win->localRegHandle), ret, fail);
-      listRemove(devr->winSorted, &devr->winSortedCount, winIdx);
-      free(win);
-    } else {
-      NCCLCHECKGOTO(ncclCommDeregister(comm, winDev), ret, fail);
-    }
+    NCCLCHECKGOTO(ncclDevrWindowDeregisterNonSym(comm, winDev), ret, fail);
     goto exit;
   }
+#endif
   CUDACHECKGOTO(cudaGetDevice(&saveDev), ret, fail);
   CUDACHECKGOTO(cudaSetDevice(comm->cudaDev), ret, fail);
   CUDACHECKGOTO(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking), ret, fail_dev);
@@ -1848,6 +2178,19 @@ ncclResult_t ncclWinGetUserPtr(struct ncclComm* comm, struct ncclWindow_vidmem* 
 }
 
 ncclResult_t ncclDevrWorldToLsaRank(struct ncclComm* comm, int peerWorldRank, int* peerLsaRank) {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  if (!comm->symmetricSupport) {
+    struct ncclDevrState* devr = &comm->devrState;
+    for (int i = 0; i < devr->ceSize; i++) {
+      if (devr->ceRankList[i] == peerWorldRank) {
+        *peerLsaRank = i;
+        return ncclSuccess;
+      }
+    }
+    WARN("ncclDevrWorldToLsaRank: world rank %d is not a member of the CE team", peerWorldRank);
+    return ncclInternalError;
+  }
+#endif
   ncclTeam_t worldTeam = ncclTeamWorld(comm);
   ncclTeam_t lsaTeam = ncclTeamLsa(comm);
   if (!ncclTeamRankIsMember(lsaTeam, worldTeam, peerWorldRank)) {
@@ -1865,13 +2208,38 @@ ncclResult_t ncclDevrGetLsaRankPtr(struct ncclComm* comm, struct ncclDevrWindow*
 
   struct ncclDevrState* devr = &comm->devrState;
 
-  // Validate lsaRank is within bounds
-  if (lsaRank < 0 || lsaRank >= devr->lsaSize) {
+  // Validate offset is within bounds
+  if (offset < 0 || offset >= winHost->size) {
     return ncclInvalidArgument;
   }
 
-  // Validate offset is within bounds
-  if (offset < 0 || offset >= winHost->size) {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  // RCCL non-sym: a self-targeted op resolves to the local window base directly.
+  if (!comm->symmetricSupport && lsaRank == devr->ceSelf) {
+    *outPtr = (void*)((uintptr_t)winHost->userPtr + offset);
+    return ncclSuccess;
+  }
+
+  // RCCL: IPC-backed window has per-peer pointer table (cudaIpcOpenMemHandle
+  // cannot map into a chosen VA, so flat-VA arithmetic does not apply).
+  if (winHost->ipcPeerPtrs != nullptr) {
+    if (lsaRank < 0 || lsaRank >= winHost->ipcPeerCount) {
+      return ncclInvalidArgument;
+    }
+    void* peerBase = winHost->ipcPeerPtrs[lsaRank];
+    if (peerBase == nullptr) {
+      WARN("ncclDevrGetLsaRankPtr: no IPC mapping for lsaRank=%d (same-proc "
+           "cross-thread peer?)",
+           lsaRank);
+      return ncclInternalError;
+    }
+    *outPtr = (void*)((uintptr_t)peerBase + offset);
+    return ncclSuccess;
+  }
+#endif
+
+  // Validate lsaRank is within bounds
+  if (lsaRank < 0 || lsaRank >= devr->lsaSize) {
     return ncclInvalidArgument;
   }
 

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -3350,22 +3350,9 @@ static ncclResult_t rmaTaskAppend(
       return ncclInvalidArgument;
     }
 
-#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-    // RCCL: decode peerWin like register path; shadow pool for sym/IPC.
-    bool useShadowPool = comm->symmetricSupport || comm->devrState.ceSize > 1;
-    if (useShadowPool) {
-      struct ncclWindow_vidmem* peerWinDevHost = NULL;
-      NCCLCHECK(ncclShadowPoolToHost(&comm->devrState.shadows, info->peerWin, &peerWinDevHost));
-      peerWinHost = (struct ncclDevrWindow*)peerWinDevHost->winHost;
-    } else {
-      // hostRmaSupport path: handle is already a host pointer (type-punned in ncclDevrWindowRegisterInGroup)
-      peerWinHost = reinterpret_cast<struct ncclDevrWindow*>(info->peerWin);
-    }
-#else
     struct ncclWindow_vidmem* peerWinDevHost = NULL;
     NCCLCHECK(ncclShadowPoolToHost(&comm->devrState.shadows, info->peerWin, &peerWinDevHost));
     peerWinHost = (struct ncclDevrWindow*)peerWinDevHost->winHost;
-#endif
 
     // Validate source buffer and window
     if (srcBuff == NULL) {

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -3351,7 +3351,7 @@ static ncclResult_t rmaTaskAppend(
     }
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-    // RCCL: decode peerWin like register path; shadow pool for sym/IPC, type-pun for proxy.
+    // RCCL: decode peerWin like register path; shadow pool for sym/IPC.
     bool useShadowPool = comm->symmetricSupport || comm->devrState.ceSize > 1;
     if (useShadowPool) {
       struct ncclWindow_vidmem* peerWinDevHost = NULL;

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -3350,7 +3350,10 @@ static ncclResult_t rmaTaskAppend(
       return ncclInvalidArgument;
     }
 
-    if (comm->symmetricSupport) {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+    // RCCL: decode peerWin like register path; shadow pool for sym/IPC, type-pun for proxy.
+    bool useShadowPool = comm->symmetricSupport || comm->devrState.ceSize > 1;
+    if (useShadowPool) {
       struct ncclWindow_vidmem* peerWinDevHost = NULL;
       NCCLCHECK(ncclShadowPoolToHost(&comm->devrState.shadows, info->peerWin, &peerWinDevHost));
       peerWinHost = (struct ncclDevrWindow*)peerWinDevHost->winHost;
@@ -3358,6 +3361,11 @@ static ncclResult_t rmaTaskAppend(
       // hostRmaSupport path: handle is already a host pointer (type-punned in ncclDevrWindowRegisterInGroup)
       peerWinHost = reinterpret_cast<struct ncclDevrWindow*>(info->peerWin);
     }
+#else
+    struct ncclWindow_vidmem* peerWinDevHost = NULL;
+    NCCLCHECK(ncclShadowPoolToHost(&comm->devrState.shadows, info->peerWin, &peerWinDevHost));
+    peerWinHost = (struct ncclDevrWindow*)peerWinDevHost->winHost;
+#endif
 
     // Validate source buffer and window
     if (srcBuff == NULL) {
@@ -3368,23 +3376,21 @@ static ncclResult_t rmaTaskAppend(
       WARN("ncclPutSignal: peerWinOffset %zu is greater than peerWin size %zu", info->peerWinOffset, peerWinHost->size);
       return ncclInvalidArgument;
     }
-    if (comm->symmetricSupport) {
-      NCCLCHECK(ncclDevrFindWindow(comm, srcBuff, &srcWinHost));
-      if (srcWinHost == NULL || !(srcWinHost->winFlags & NCCL_WIN_COLL_SYMMETRIC)) {
-        WARN("ncclPutSignal: srcWinHost is not in a valid symmetric window");
-        return ncclInvalidArgument;
-      }
-      srcWinOffset = (char*)srcBuff - (char*)srcWinHost->userPtr;
-    } else {
-      // hostRmaSupport path: source buffer must be inside a registered window so
-      // the GIN proxy can resolve its MR handle.  Look it up the same way.
-      NCCLCHECK(ncclDevrFindWindow(comm, srcBuff, &srcWinHost));
-      if (srcWinHost == NULL) {
-        WARN("ncclPutSignal: srcBuff is not inside a registered ncclWindow");
-        return ncclInvalidArgument;
-      }
-      srcWinOffset = (char*)srcBuff - (char*)srcWinHost->userPtr;
+
+    // RCCL: Source buffer must be inside a registered window. The winFlags
+    // symmetric hint is enforced only on the sym VMM path (user contract:
+    // offsets symmetric across ranks); IPC and proxy do not require the flag.
+    NCCLCHECK(ncclDevrFindWindow(comm, srcBuff, &srcWinHost));
+    if (srcWinHost == NULL) {
+      WARN("ncclPutSignal: srcBuff is not inside a registered ncclWindow");
+      return ncclInvalidArgument;
     }
+    if (comm->symmetricSupport &&
+        !(srcWinHost->winFlags & NCCL_WIN_COLL_SYMMETRIC)) {
+      WARN("ncclPutSignal: srcWinHost is not in a valid symmetric window");
+      return ncclInvalidArgument;
+    }
+    srcWinOffset = (char*)srcBuff - (char*)srcWinHost->userPtr;
 
     // Relevant for symmetric window only
     bool isMultiSegment = (comm->symmetricSupport)
@@ -3432,8 +3438,18 @@ static ncclResult_t rmaTaskAppend(
     }
   }
 
-  // Check if RMA CE needs initialization
-  if (!comm->rmaState.rmaCeState.initialized && ncclIntruQueueEmpty(&comm->rmaCeInitTaskQueue)) {
+  // Check if RMA CE needs initialization. CE (Copy-Engine) handles intra-node and
+  // self-targeted ops via IPC/copy. CE init registers the signals window collectively
+  // over the WHOLE comm, so the gate must be comm-uniform or the allgather deadlocks.
+  // RCCL non-sym: self is always CE-accessible (ceRankList always contains self), so
+  // CE is always needed; init unconditionally. Sym path keeps the lsaSize>1 skip.
+#if defined(__HIP_PLATFORM_AMD__)
+  int ceInitActive = comm->symmetricSupport ? (comm->devrState.lsaSize > 1) : 1;
+#else
+  int ceInitActive = comm->devrState.lsaSize > 1;
+#endif
+  if (ceInitActive &&
+      !comm->rmaState.rmaCeState.initialized && ncclIntruQueueEmpty(&comm->rmaCeInitTaskQueue)) {
     struct ncclRmaCeInitTask* ceTask;
     NCCLCHECK(ncclCalloc(&ceTask, 1));
     ceTask->comm = comm;

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -3432,7 +3432,6 @@ static ncclResult_t rmaTaskAppend(
     }
   }
 
-#ifdef RCCL_RMA_CU_PATH_ENABLED
   // Check if RMA CE needs initialization
   if (!comm->rmaState.rmaCeState.initialized && ncclIntruQueueEmpty(&comm->rmaCeInitTaskQueue)) {
     struct ncclRmaCeInitTask* ceTask;
@@ -3441,7 +3440,6 @@ static ncclResult_t rmaTaskAppend(
     ncclIntruQueueEnqueue(&comm->rmaCeInitTaskQueue, ceTask);
     ncclGroupCommJoin(comm, ncclGroupTaskTypeSymRegister);
   }
-#endif
 
   // Must be in thread local group before tasks can be alloc'd in `comm->memScoped`.
   ncclGroupCommJoin(info->comm, ncclGroupTaskTypeCollective);

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -3438,18 +3438,9 @@ static ncclResult_t rmaTaskAppend(
     }
   }
 
-  // Check if RMA CE needs initialization. CE (Copy-Engine) handles intra-node and
-  // self-targeted ops via IPC/copy. CE init registers the signals window collectively
-  // over the WHOLE comm, so the gate must be comm-uniform or the allgather deadlocks.
-  // RCCL non-sym: self is always CE-accessible (ceRankList always contains self), so
-  // CE is always needed; init unconditionally. Sym path keeps the lsaSize>1 skip.
-#if defined(__HIP_PLATFORM_AMD__)
-  int ceInitActive = comm->symmetricSupport ? (comm->devrState.lsaSize > 1) : 1;
-#else
-  int ceInitActive = comm->devrState.lsaSize > 1;
-#endif
-  if (ceInitActive &&
-      !comm->rmaState.rmaCeState.initialized && ncclIntruQueueEmpty(&comm->rmaCeInitTaskQueue)) {
+  // Check if RMA CE needs initialization
+  if (!comm->rmaState.rmaCeState.initialized &&
+      ncclIntruQueueEmpty(&comm->rmaCeInitTaskQueue)) {
     struct ncclRmaCeInitTask* ceTask;
     NCCLCHECK(ncclCalloc(&ceTask, 1));
     ceTask->comm = comm;

--- a/projects/rccl/src/include/dev_runtime.h
+++ b/projects/rccl/src/include/dev_runtime.h
@@ -30,6 +30,12 @@ struct ncclDevrWindow {
   struct ncclComm* comm; // comm for intrusive map window <> comm look up
   void* rmaHostWins[NCCL_GIN_MAX_CONNECTIONS]; // IB MR handles per GIN connection (proxy-only path)
   ncclGinWindow_t rmaDevWins[NCCL_GIN_MAX_CONNECTIONS]; // device-side GIN window handles (proxy-only path)
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  // RCCL: intra-node IPC peer table (NULL when inactive), sized to ceSize.
+  void** ipcPeerPtrs;
+  void** ipcPeerOpenedBases;
+  int ipcPeerCount;
+#endif
 };
 
 struct ncclDevrWindowSorted;
@@ -58,6 +64,15 @@ struct ncclDevrState {
   int lsaSize;
   int* lsaRankList;
   int nLsaTeams;
+
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  // RCCL: intra-node CE team for !symmetricSupport. Co-located peers route
+  // through CE/IPC instead of the NIC proxy.
+  // Symmetric path keeps using lsa* above.
+  int ceSelf;
+  int ceSize;
+  int* ceRankList;
+#endif
 
   size_t granularity; // cuMemGetAllocationGranularity
   bool ginEnabled;

--- a/projects/rccl/src/include/dev_runtime.h
+++ b/projects/rccl/src/include/dev_runtime.h
@@ -31,9 +31,9 @@ struct ncclDevrWindow {
   void* rmaHostWins[NCCL_GIN_MAX_CONNECTIONS]; // IB MR handles per GIN connection (proxy-only path)
   ncclGinWindow_t rmaDevWins[NCCL_GIN_MAX_CONNECTIONS]; // device-side GIN window handles (proxy-only path)
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  // RCCL: intra-node IPC peer table (NULL when inactive), sized to ceSize.
+  // RCCL: intra-node IPC peer table (NULL when inactive), sized to lsaSize.
   void** ipcPeerPtrs;
-  void** ipcPeerOpenedBases;
+  void** ipcPeerPtrsAllocBase;
   int ipcPeerCount;
 #endif
 };
@@ -64,14 +64,6 @@ struct ncclDevrState {
   int lsaSize;
   int* lsaRankList;
   int nLsaTeams;
-
-#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  // RCCL: intra-node CE team for !symmetricSupport. Co-located peers route
-  // through CE/IPC. Symmetric path keeps using lsa* above.
-  int ceSelf;
-  int ceSize;
-  int* ceRankList;
-#endif
 
   size_t granularity; // cuMemGetAllocationGranularity
   bool ginEnabled;

--- a/projects/rccl/src/include/dev_runtime.h
+++ b/projects/rccl/src/include/dev_runtime.h
@@ -67,8 +67,7 @@ struct ncclDevrState {
 
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   // RCCL: intra-node CE team for !symmetricSupport. Co-located peers route
-  // through CE/IPC instead of the NIC proxy.
-  // Symmetric path keeps using lsa* above.
+  // through CE/IPC. Symmetric path keeps using lsa* above.
   int ceSelf;
   int ceSize;
   int* ceRankList;

--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -35,7 +35,8 @@ extern "C" hsa_status_t hsa_amd_portable_export_dmabuf(
 
 // HIP: implemented in rma_proxy_launch.cc (hipStreamBatchMemOp + old-HIP fallback).
 // CUDA: implemented in cudawrap.cc (cuStreamBatchMemOp).
-ncclResult_t ncclCuStreamBatchMemOp(cudaStream_t stream, unsigned int numOps, CUstreamBatchMemOpParams* batchParams);
+ncclResult_t ncclCuStreamBatchMemOp(cudaStream_t stream, unsigned int numOps,
+                                    CUstreamBatchMemOpParams* batchParams);
 typedef hsa_status_t (*PFN_hsa_amd_portable_export_dmabuf)(const void* ptr, size_t size, int* dmabuf, uint64_t* offset);
 
 #ifdef __HIP_PLATFORM_AMD__

--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -12,6 +12,15 @@
 #include <hsa/hsa_ext_amd.h>  // hsa_amd_portable_export_dmabuf (DMA-BUF export)
 #include "checks.h"
 
+#ifndef CU_STREAM_WRITE_VALUE_DEFAULT
+#define CU_STREAM_WRITE_VALUE_DEFAULT 0
+#endif
+
+// HIP: implemented in rma_proxy_launch.cc (hipStreamBatchMemOp + old-HIP fallback).
+// CUDA: implemented in cudawrap.cc (cuStreamBatchMemOp).
+ncclResult_t ncclCuStreamBatchMemOp(cudaStream_t stream, unsigned int numOps,
+                                    CUstreamBatchMemOpParams* batchParams);
+
 // Re-declare the DMA-BUF export entry as a weak reference. hsa_init,
 // hsa_system_get_info and hsa_status_string are required and resolve as hard
 // dependencies, but hsa_amd_portable_export_dmabuf is optional: older ROCr
@@ -28,15 +37,6 @@ extern "C" hsa_status_t hsa_amd_portable_export_dmabuf(
 // keeps a function-pointer indirection, because it doubles as the runtime feature
 // gate: pfn_hsa_amd_portable_export_dmabuf stays NULL when the platform does not
 // support DMA-BUF.
-
-#ifndef CU_STREAM_WRITE_VALUE_DEFAULT
-#define CU_STREAM_WRITE_VALUE_DEFAULT 0
-#endif
-
-// HIP: implemented in rma_proxy_launch.cc (hipStreamBatchMemOp + old-HIP fallback).
-// CUDA: implemented in cudawrap.cc (cuStreamBatchMemOp).
-ncclResult_t ncclCuStreamBatchMemOp(cudaStream_t stream, unsigned int numOps,
-                                    CUstreamBatchMemOpParams* batchParams);
 typedef hsa_status_t (*PFN_hsa_amd_portable_export_dmabuf)(const void* ptr, size_t size, int* dmabuf, uint64_t* offset);
 
 #ifdef __HIP_PLATFORM_AMD__

--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -28,6 +28,14 @@ extern "C" hsa_status_t hsa_amd_portable_export_dmabuf(
 // keeps a function-pointer indirection, because it doubles as the runtime feature
 // gate: pfn_hsa_amd_portable_export_dmabuf stays NULL when the platform does not
 // support DMA-BUF.
+
+#ifndef CU_STREAM_WRITE_VALUE_DEFAULT
+#define CU_STREAM_WRITE_VALUE_DEFAULT 0
+#endif
+
+// HIP: implemented in rma_proxy_launch.cc (hipStreamBatchMemOp + old-HIP fallback).
+// CUDA: implemented in cudawrap.cc (cuStreamBatchMemOp).
+ncclResult_t ncclCuStreamBatchMemOp(cudaStream_t stream, unsigned int numOps, CUstreamBatchMemOpParams* batchParams);
 typedef hsa_status_t (*PFN_hsa_amd_portable_export_dmabuf)(const void* ptr, size_t size, int* dmabuf, uint64_t* offset);
 
 #ifdef __HIP_PLATFORM_AMD__

--- a/projects/rccl/src/rma/rma.cc
+++ b/projects/rccl/src/rma/rma.cc
@@ -13,6 +13,18 @@
 #include "rma/rma.h"
 
 static bool isLsaAccessible(struct ncclComm* comm, int rank) {
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+  // RCCL: on the non-symmetric (host API) path, route any same-node peer through
+  // the CE/IPC path using the intra-node CE team
+  if (!comm->symmetricSupport) {
+    for (int i = 0; i < comm->devrState.ceSize; i++) {
+      if (comm->devrState.ceRankList[i] == rank) {
+        return true;
+      }
+    }
+    return false;
+  }
+#endif
   for (int i = 0; i < comm->devrState.lsaSize; i++) {
     if (comm->devrState.lsaRankList[i] == rank) {
       return true;

--- a/projects/rccl/src/rma/rma.cc
+++ b/projects/rccl/src/rma/rma.cc
@@ -13,18 +13,6 @@
 #include "rma/rma.h"
 
 static bool isLsaAccessible(struct ncclComm* comm, int rank) {
-#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  // RCCL: on the non-symmetric (host API) path, route any same-node peer through
-  // the CE/IPC path using the intra-node CE team
-  if (!comm->symmetricSupport) {
-    for (int i = 0; i < comm->devrState.ceSize; i++) {
-      if (comm->devrState.ceRankList[i] == rank) {
-        return true;
-      }
-    }
-    return false;
-  }
-#endif
   for (int i = 0; i < comm->devrState.lsaSize; i++) {
     if (comm->devrState.lsaRankList[i] == rank) {
       return true;

--- a/projects/rccl/src/rma/rma.cc
+++ b/projects/rccl/src/rma/rma.cc
@@ -13,13 +13,11 @@
 #include "rma/rma.h"
 
 static bool isLsaAccessible(struct ncclComm* comm, int rank) {
-#ifdef RCCL_RMA_CU_PATH_ENABLED
   for (int i = 0; i < comm->devrState.lsaSize; i++) {
     if (comm->devrState.lsaRankList[i] == rank) {
       return true;
     }
   }
-#endif
   return false;
 }
 
@@ -27,7 +25,6 @@ ncclResult_t ncclRmaWaitSignal(struct ncclComm* comm, struct ncclKernelPlan* pla
   ncclResult_t ret = ncclSuccess;
 
   // If we have both proxy and CE tasks, execute them in parallel
-#ifdef RCCL_RMA_CU_PATH_ENABLED
   if (plan->rmaArgs->nRmaTasksProxy > 0 && plan->rmaArgs->nRmaTasksCe > 0) {
     cudaStream_t ceStream = comm->rmaState.rmaCeState.ceStream;
     cudaEvent_t ceEvent = comm->rmaState.rmaCeState.ceEvent;
@@ -52,11 +49,6 @@ ncclResult_t ncclRmaWaitSignal(struct ncclComm* comm, struct ncclKernelPlan* pla
   else if (plan->rmaArgs->nRmaTasksCe > 0) {
     NCCLCHECKGOTO(ncclRmaCeWaitLaunch(comm, plan, stream), ret, fail);
   }
-#else 
-  if (plan->rmaArgs->nRmaTasksProxy > 0) {
-    NCCLCHECKGOTO(ncclRmaProxyWaitLaunch(comm, plan, stream), ret, fail);
-  }
-#endif
 
 exit:
   return ret;
@@ -69,7 +61,6 @@ ncclResult_t ncclRmaPut(struct ncclComm* comm, struct ncclKernelPlan* plan, cuda
   ncclResult_t ret = ncclSuccess;
 
   // If we have both proxy and CE tasks, execute them in parallel
-#ifdef RCCL_RMA_CU_PATH_ENABLED
   if (plan->rmaArgs->nRmaTasksProxy > 0 && plan->rmaArgs->nRmaTasksCe > 0) {
     cudaStream_t ceStream = comm->rmaState.rmaCeState.ceStream;
     cudaEvent_t ceEvent = comm->rmaState.rmaCeState.ceEvent;
@@ -94,11 +85,6 @@ ncclResult_t ncclRmaPut(struct ncclComm* comm, struct ncclKernelPlan* plan, cuda
   else if (plan->rmaArgs->nRmaTasksCe > 0) {
     NCCLCHECKGOTO(ncclRmaCePutLaunch(comm, plan, stream), ret, fail);
   }
-#else
-  if (plan->rmaArgs->nRmaTasksProxy > 0) {
-    NCCLCHECKGOTO(ncclRmaProxyPutLaunch(comm, plan, stream), ret, fail);
-  }
-#endif
 
 exit:
   return ret;
@@ -184,17 +170,13 @@ ncclResult_t scheduleRmaTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan
   plan->rmaArgs->func = firstTask->func;
   plan->rmaArgs->nRmaTasks = 0;
   plan->rmaArgs->nRmaTasksProxy = 0;
-#ifdef RCCL_RMA_CU_PATH_ENABLED
   plan->rmaArgs->nRmaTasksCe = 0;
-#endif
 
   // WaitSignal tasks
   if (firstTask->func == ncclFuncWaitSignal) {
     // Allocate temporary arrays to hold peers and nsignals for both proxy and CE paths
-#ifdef RCCL_RMA_CU_PATH_ENABLED
     int* peersCe = ncclMemoryStackAlloc<int>(&comm->memScoped, firstTask->npeers);
     int* nsignalsCe = ncclMemoryStackAlloc<int>(&comm->memScoped, firstTask->npeers);
-#endif
     NCCLCHECKGOTO(ncclCalloc(&peersProxy, firstTask->npeers), ret, fail);
     NCCLCHECKGOTO(ncclCalloc(&nsignalsProxy, firstTask->npeers), ret, fail);
 
@@ -208,11 +190,9 @@ ncclResult_t scheduleRmaTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan
 
       if (lsaAccessible) {
         // Add to CE list
-#ifdef RCCL_RMA_CU_PATH_ENABLED
         peersCe[npeersCe] = peerRank;
         nsignalsCe[npeersCe] = firstTask->nsignals[i];
         npeersCe++;
-#endif
       } else {
         // Add to Proxy list
         peersProxy[npeersProxy] = peerRank;
@@ -222,7 +202,6 @@ ncclResult_t scheduleRmaTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan
     }
 
     // Initialize the CE task if there are CE peers
-#ifdef RCCL_RMA_CU_PATH_ENABLED
     if (npeersCe > 0) {
       struct ncclTaskRma* waitSignalTaskCe = ncclMemoryPoolAlloc<struct ncclTaskRma>(&comm->memPool_ncclTaskRma, &comm->memPermanent);
       waitSignalTaskCe->func = ncclFuncWaitSignal;
@@ -236,7 +215,6 @@ ncclResult_t scheduleRmaTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan
     } else {
       plan->rmaArgs->nRmaTasksCe = 0;
     }
-#endif
 
     // Initialize the Proxy task if there are Proxy peers
     if (npeersProxy > 0) {
@@ -269,14 +247,10 @@ ncclResult_t scheduleRmaTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan
 
     plan->rmaArgs->nRmaTasks = 1;
     plan->rmaArgs->nRmaTasksProxy = lsaAccessible ? 0 : 1;
-#ifdef RCCL_RMA_CU_PATH_ENABLED
     plan->rmaArgs->nRmaTasksCe = lsaAccessible ? 1 : 0;
-#endif
 
     if (lsaAccessible) {
-#ifdef RCCL_RMA_CU_PATH_ENABLED
       ncclIntruQueueEnqueue(&plan->rmaTaskQueueCe, firstTask);
-#endif
     } else {
       ncclIntruQueueEnqueue(&plan->rmaTaskQueueProxy, firstTask);
     }
@@ -297,10 +271,8 @@ ncclResult_t scheduleRmaTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan
       // If the task can be batched, remove from context queue and add to plan
       ncclIntruQueueDequeue(ctxQueue);
       if (lsaAccessible) {
-#ifdef RCCL_RMA_CU_PATH_ENABLED
         ncclIntruQueueEnqueue(&plan->rmaTaskQueueCe, task);
         plan->rmaArgs->nRmaTasksCe++;
-#endif
       } else {
         ncclIntruQueueEnqueue(&plan->rmaTaskQueueProxy, task);
         plan->rmaArgs->nRmaTasksProxy++;
@@ -311,12 +283,7 @@ ncclResult_t scheduleRmaTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan
   }
 
   INFO(NCCL_COLL, "scheduleRmaTasksToPlan: rank=%d ctx=%d func=%d nRmaTasks=%d nRmaTasksProxy=%d nRmaTasksCe=%d",
-    comm->rank, ctx, plan->rmaArgs->func, plan->rmaArgs->nRmaTasks, plan->rmaArgs->nRmaTasksProxy,
-#ifdef RCCL_RMA_CU_PATH_ENABLED
-    plan->rmaArgs->nRmaTasksCe);
-#else 
-    -1);
-#endif
+    comm->rank, ctx, plan->rmaArgs->func, plan->rmaArgs->nRmaTasks, plan->rmaArgs->nRmaTasksProxy, plan->rmaArgs->nRmaTasksCe);
 
 exit:
   return ret;

--- a/projects/rccl/src/rma/rma.cc
+++ b/projects/rccl/src/rma/rma.cc
@@ -295,7 +295,8 @@ ncclResult_t scheduleRmaTasksToPlan(struct ncclComm* comm, struct ncclKernelPlan
   }
 
   INFO(NCCL_COLL, "scheduleRmaTasksToPlan: rank=%d ctx=%d func=%d nRmaTasks=%d nRmaTasksProxy=%d nRmaTasksCe=%d",
-    comm->rank, ctx, plan->rmaArgs->func, plan->rmaArgs->nRmaTasks, plan->rmaArgs->nRmaTasksProxy, plan->rmaArgs->nRmaTasksCe);
+       comm->rank, ctx, plan->rmaArgs->func, plan->rmaArgs->nRmaTasks, plan->rmaArgs->nRmaTasksProxy,
+       plan->rmaArgs->nRmaTasksCe);
 
 exit:
   return ret;

--- a/projects/rccl/src/rma/rma_ce.cc
+++ b/projects/rccl/src/rma/rma_ce.cc
@@ -59,6 +59,7 @@ ncclResult_t ncclRmaCeInit(struct ncclComm* comm){
       ceCtx->signalsWin = (struct ncclDevrWindow*)signalsWinDevHost->winHost;
     } else {
       ceCtx->signalsWin = (struct ncclDevrWindow*)signalsWinDev;
+      ceCtx->signalsWin->vidmem = signalsWinDev;
     }
 #else
     NCCLCHECKGOTO(ncclShadowPoolToHost(&comm->devrState.shadows, signalsWinDev, &signalsWinDevHost), ret, fail);
@@ -237,12 +238,12 @@ ncclResult_t ncclRmaCePutLaunch(struct ncclComm* comm, struct ncclKernelPlan* pl
         NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, ceCtx->signalsWin, ceCtx->signalOffset + rankSlot, peerLsaRank, &peerSignal), ret, fail);
         ceCtx->signalOpSeqs[task->peer]++;
         // [RCCL] cuStreamWriteValue64 driver entry isn't available on HIP; use a
-        // single-op batch write (flags=0; no CU_STREAM_WRITE_VALUE_DEFAULT equiv).
+        // single-op batch write
         hipStreamBatchMemOpParams writeOp[1] = {};
         writeOp[0].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_64;
         writeOp[0].writeValue.address = (CUdeviceptr)ceCtx->signalOpSeqsDev;
         writeOp[0].writeValue.value64 = ceCtx->signalOpSeqs[task->peer];
-        writeOp[0].writeValue.flags = 0;
+        writeOp[0].writeValue.flags = CU_STREAM_WRITE_VALUE_DEFAULT;
         NCCLCHECKGOTO(ncclCuStreamBatchMemOp(stream, 1, writeOp), ret, fail);
         CUDACHECKGOTO(cudaMemcpyAsync(peerSignal, ceCtx->signalOpSeqsDev, sizeof(uint64_t), cudaMemcpyDeviceToDevice, stream), ret, fail);
       } else {

--- a/projects/rccl/src/rma/rma_ce.cc
+++ b/projects/rccl/src/rma/rma_ce.cc
@@ -48,26 +48,10 @@ ncclResult_t ncclRmaCeInit(struct ncclComm* comm){
 
     NCCLCHECKGOTO(ncclMemAlloc((void**)&signalsDevBase, signalsBufSize), ret, fail);
     NCCLCHECKGOTO(ncclDevrWindowRegisterInGroup(comm, signalsDevBase, signalsBufSize, NCCL_WIN_COLL_SYMMETRIC, &signalsWinDev), ret, fail);
-
-#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-    // RCCL: decode win like rmaTaskAppend; shadow pool for sym/IPC, type-pun for proxy.
-    bool useShadowPool = comm->symmetricSupport || comm->devrState.ceSize > 1;
-    if (useShadowPool) {
-      NCCLCHECKGOTO(ncclShadowPoolToHost(&comm->devrState.shadows,
-                                         signalsWinDev, &signalsWinDevHost),
-                    ret, fail);
-      ceCtx->signalsWin = (struct ncclDevrWindow*)signalsWinDevHost->winHost;
-    } else {
-      ceCtx->signalsWin = (struct ncclDevrWindow*)signalsWinDev;
-      ceCtx->signalsWin->vidmem = signalsWinDev;
-    }
-#else
     NCCLCHECKGOTO(ncclShadowPoolToHost(&comm->devrState.shadows, signalsWinDev, &signalsWinDevHost), ret, fail);
 
     // Get the ncclDevrWindow from the winHost field
     ceCtx->signalsWin = (struct ncclDevrWindow*)signalsWinDevHost->winHost;
-#endif
-
     ceCtx->signalsDev = signalsDevBase;
     ceCtx->graphSignalsDev = signalsDevBase + nRanks + 1;
     ceCtx->graphAckDev = signalsDevBase + 2 * nRanks + 2;

--- a/projects/rccl/src/rma/rma_ce.cc
+++ b/projects/rccl/src/rma/rma_ce.cc
@@ -47,10 +47,21 @@ ncclResult_t ncclRmaCeInit(struct ncclComm* comm){
 
     NCCLCHECKGOTO(ncclMemAlloc((void**)&signalsDevBase, signalsBufSize), ret, fail);
     NCCLCHECKGOTO(ncclDevrWindowRegisterInGroup(comm, signalsDevBase, signalsBufSize, NCCL_WIN_COLL_SYMMETRIC, &signalsWinDev), ret, fail);
+#if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
+    // RCCL: decode win like rmaTaskAppend; shadow pool for sym/IPC, type-pun for proxy.
+    bool useShadowPool = comm->symmetricSupport || comm->devrState.ceSize > 1;
+    if (useShadowPool) {
+      NCCLCHECKGOTO(ncclShadowPoolToHost(&comm->devrState.shadows, signalsWinDev, &signalsWinDevHost), ret, fail);
+      ceCtx->signalsWin = (struct ncclDevrWindow*)signalsWinDevHost->winHost;
+    } else {
+      ceCtx->signalsWin = reinterpret_cast<struct ncclDevrWindow*>(signalsWinDev);
+    }
+#else
     NCCLCHECKGOTO(ncclShadowPoolToHost(&comm->devrState.shadows, signalsWinDev, &signalsWinDevHost), ret, fail);
 
     // Get the ncclDevrWindow from the winHost field
     ceCtx->signalsWin = (struct ncclDevrWindow*)signalsWinDevHost->winHost;
+#endif
     ceCtx->signalsDev = signalsDevBase;
     ceCtx->graphSignalsDev = signalsDevBase + nRanks + 1;
     ceCtx->graphAckDev = signalsDevBase + 2 * nRanks + 2;

--- a/projects/rccl/src/rma/rma_ce.cc
+++ b/projects/rccl/src/rma/rma_ce.cc
@@ -13,9 +13,9 @@
 #include "comm.h"
 #include "collectives.h"
 // [RCCL] cudawrap.h intentionally not included: its CUCHECKGOTO routes calls through
-// pfn_* CUDA driver pointers (cudawrap.cc is excluded from the RCCL build). Batch mem ops
-// go through ncclCuStreamBatchMemOp (rocmwrap.h decl, HIP impl in rma_proxy_launch.cc),
-// which calls hipStreamBatchMemOp with a per-op fallback on HIP < 71360850.
+// pfn_* CUDA driver pointers (cudawrap.cc is excluded from the RCCL build).
+// Batch mem ops go through ncclCuStreamBatchMemOp (rocmwrap.h decl, HIP impl
+// in rma_proxy_launch.cc)
 #include "rma/rma.h"
 #include "rma/rma_ce.h"
 
@@ -48,14 +48,17 @@ ncclResult_t ncclRmaCeInit(struct ncclComm* comm){
 
     NCCLCHECKGOTO(ncclMemAlloc((void**)&signalsDevBase, signalsBufSize), ret, fail);
     NCCLCHECKGOTO(ncclDevrWindowRegisterInGroup(comm, signalsDevBase, signalsBufSize, NCCL_WIN_COLL_SYMMETRIC, &signalsWinDev), ret, fail);
+
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     // RCCL: decode win like rmaTaskAppend; shadow pool for sym/IPC, type-pun for proxy.
     bool useShadowPool = comm->symmetricSupport || comm->devrState.ceSize > 1;
     if (useShadowPool) {
-      NCCLCHECKGOTO(ncclShadowPoolToHost(&comm->devrState.shadows, signalsWinDev, &signalsWinDevHost), ret, fail);
+      NCCLCHECKGOTO(ncclShadowPoolToHost(&comm->devrState.shadows,
+                                         signalsWinDev, &signalsWinDevHost),
+                    ret, fail);
       ceCtx->signalsWin = (struct ncclDevrWindow*)signalsWinDevHost->winHost;
     } else {
-      ceCtx->signalsWin = reinterpret_cast<struct ncclDevrWindow*>(signalsWinDev);
+      ceCtx->signalsWin = (struct ncclDevrWindow*)signalsWinDev;
     }
 #else
     NCCLCHECKGOTO(ncclShadowPoolToHost(&comm->devrState.shadows, signalsWinDev, &signalsWinDevHost), ret, fail);
@@ -63,6 +66,7 @@ ncclResult_t ncclRmaCeInit(struct ncclComm* comm){
     // Get the ncclDevrWindow from the winHost field
     ceCtx->signalsWin = (struct ncclDevrWindow*)signalsWinDevHost->winHost;
 #endif
+
     ceCtx->signalsDev = signalsDevBase;
     ceCtx->graphSignalsDev = signalsDevBase + nRanks + 1;
     ceCtx->graphAckDev = signalsDevBase + 2 * nRanks + 2;
@@ -301,11 +305,7 @@ ncclResult_t ncclRmaCeWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan* p
         batchParams[opIdx].waitValue.flags = CU_STREAM_WAIT_VALUE_GEQ;
         opIdx++;
       }
-      // Execute all wait operations in a single batch.
-      // [RCCL] ncclCuStreamBatchMemOp wraps hipStreamBatchMemOp with a per-op
-      // fallback on HIP < 71360850 (bare-metal AllToAllPut).
-      NCCLCHECKGOTO(
-          ncclCuStreamBatchMemOp(stream, opIdx, batchParams), ret, fail);
+      NCCLCHECKGOTO(ncclCuStreamBatchMemOp(stream, opIdx, batchParams), ret, fail);
     }
     else {
       // Graph: wait-reset-ack cycle using separate graphSignalsDev (isolated from non-graph)

--- a/projects/rccl/src/rma/rma_ce.cc
+++ b/projects/rccl/src/rma/rma_ce.cc
@@ -8,13 +8,14 @@
 #include <assert.h>
 #include "nccl.h"
 #include "alloc.h"
+#include "rocmwrap.h"
 #include "checks.h"
 #include "comm.h"
 #include "collectives.h"
 // [RCCL] cudawrap.h intentionally not included: its CUCHECKGOTO routes calls through
-// pfn_* CUDA driver pointers (cudawrap.cc is excluded from the RCCL build), which would
-// turn hipStreamBatchMemOp into an undefined pfn_hipStreamBatchMemOp. We rely on
-// rocmwrap.h's direct-HIP CUCHECKGOTO and call hipStreamBatchMemOp directly, matching ce_coll.cc.
+// pfn_* CUDA driver pointers (cudawrap.cc is excluded from the RCCL build). Batch mem ops
+// go through ncclCuStreamBatchMemOp (rocmwrap.h decl, HIP impl in rma_proxy_launch.cc),
+// which calls hipStreamBatchMemOp with a per-op fallback on HIP < 71360850.
 #include "rma/rma.h"
 #include "rma/rma_ce.h"
 
@@ -202,8 +203,7 @@ ncclResult_t ncclRmaCePutLaunch(struct ncclComm* comm, struct ncclKernelPlan* pl
       ackOps[1].writeValue.address = ackAddr;
       ackOps[1].writeValue.value64 = 0;
       ackOps[1].writeValue.flags = 0;
-      // [RCCL] direct HIP call; ncclCuStreamBatchMemOp wrapper is excluded from the RCCL build.
-      CUCHECKGOTO(hipStreamBatchMemOp(stream, 2, ackOps, 0), ret, fail);
+      NCCLCHECKGOTO(ncclCuStreamBatchMemOp(stream, 2, ackOps), ret, fail);
     }
 
     if (bytes > 0) {
@@ -233,13 +233,13 @@ ncclResult_t ncclRmaCePutLaunch(struct ncclComm* comm, struct ncclKernelPlan* pl
         NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, ceCtx->signalsWin, ceCtx->signalOffset + rankSlot, peerLsaRank, &peerSignal), ret, fail);
         ceCtx->signalOpSeqs[task->peer]++;
         // [RCCL] cuStreamWriteValue64 driver entry isn't available on HIP; use a
-        // single-op hipStreamBatchMemOp write (flags=0; no CU_STREAM_WRITE_VALUE_DEFAULT equiv).
+        // single-op batch write (flags=0; no CU_STREAM_WRITE_VALUE_DEFAULT equiv).
         hipStreamBatchMemOpParams writeOp[1] = {};
         writeOp[0].writeValue.operation = CU_STREAM_MEM_OP_WRITE_VALUE_64;
         writeOp[0].writeValue.address = (CUdeviceptr)ceCtx->signalOpSeqsDev;
         writeOp[0].writeValue.value64 = ceCtx->signalOpSeqs[task->peer];
         writeOp[0].writeValue.flags = 0;
-        CUCHECKGOTO(hipStreamBatchMemOp(stream, 1, writeOp, 0), ret, fail);
+        NCCLCHECKGOTO(ncclCuStreamBatchMemOp(stream, 1, writeOp), ret, fail);
         CUDACHECKGOTO(cudaMemcpyAsync(peerSignal, ceCtx->signalOpSeqsDev, sizeof(uint64_t), cudaMemcpyDeviceToDevice, stream), ret, fail);
       } else {
         // Graph: write signal=1 to peer's graphSignalsDev (separate from non-graph signals)
@@ -301,8 +301,11 @@ ncclResult_t ncclRmaCeWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan* p
         batchParams[opIdx].waitValue.flags = CU_STREAM_WAIT_VALUE_GEQ;
         opIdx++;
       }
-      // [RCCL] direct HIP call; ncclCuStreamBatchMemOp wrapper is excluded from the RCCL build.
-      CUCHECKGOTO(hipStreamBatchMemOp(stream, opIdx, batchParams, 0), ret, fail);
+      // Execute all wait operations in a single batch.
+      // [RCCL] ncclCuStreamBatchMemOp wraps hipStreamBatchMemOp with a per-op
+      // fallback on HIP < 71360850 (bare-metal AllToAllPut).
+      NCCLCHECKGOTO(
+          ncclCuStreamBatchMemOp(stream, opIdx, batchParams), ret, fail);
     }
     else {
       // Graph: wait-reset-ack cycle using separate graphSignalsDev (isolated from non-graph)
@@ -322,8 +325,7 @@ ncclResult_t ncclRmaCeWaitLaunch(struct ncclComm* comm, struct ncclKernelPlan* p
           signalOps[1].writeValue.address = graphSignalAddr;
           signalOps[1].writeValue.value64 = 0;
           signalOps[1].writeValue.flags = 0;
-          // [RCCL] direct HIP call; ncclCuStreamBatchMemOp wrapper is excluded from the RCCL build.
-          CUCHECKGOTO(hipStreamBatchMemOp(stream, 2, signalOps, 0), ret, fail);
+          NCCLCHECKGOTO(ncclCuStreamBatchMemOp(stream, 2, signalOps), ret, fail);
 
           void* peerAck;
           NCCLCHECKGOTO(ncclDevrGetLsaRankPtr(comm, ceCtx->signalsWin, ceCtx->graphAckOffset + comm->rank * sizeof(uint64_t), peerLsaRank, &peerAck), ret, fail);

--- a/projects/rccl/src/rma/rma_proxy.cc
+++ b/projects/rccl/src/rma/rma_proxy.cc
@@ -34,6 +34,11 @@ NCCL_PARAM(RmaProxyDumpSignal, "RMA_PROXY_DUMP_SIGNAL", -1);
 NCCL_PARAM(RmaProxyQueueSize, "RMA_PROXY_QUEUE_SIZE", -1);
 RCCL_PARAM(RmaProxyUseDMABUF, "RMA_USE_DMABUF", 0);
 
+// When set, export the DMA-BUF FD for VMM (cuMem) buffers via
+// cuMemGetHandleForAddressRange instead of hsa_amd_portable_export_dmabuf.
+// The HSA exporter cannot export cuMem/VMM allocations on some ROCm/NIC stacks
+RCCL_PARAM(DmaBufUseVmmExport, "DMABUF_USE_VMM_EXPORT", 0);
+
 
 #include <signal.h>
 static ncclRmaProxyState* ncclLastRmaProxyState;
@@ -72,6 +77,21 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
 static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
                                 bool sym_buffer) {
   if (ncclParamDmaBufEnable() == 0) return ncclInvalidUsage;
+#if HIP_VERSION >= 71260540
+  if (rcclParamDmaBufUseVmmExport()) {
+    static size_t vmmHostPageSize = ncclOsGetPageSize();
+    size_t vmmAlignedSize = length;
+    ALIGN_SIZE(vmmAlignedSize, vmmHostPageSize);
+    CUresult status =
+        cuMemGetHandleForAddressRange((void*)fd,
+                                      (CUdeviceptr)addr,
+                                      vmmAlignedSize,
+                                      CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                      0);
+    if (status == CUDA_SUCCESS) return ncclSuccess;
+    return ncclInvalidUsage;
+  }
+#endif
 #if HIP_VERSION >= 70000000
   static size_t hostPageSize = ncclOsGetPageSize();
   size_t alignedSize = length;

--- a/projects/rccl/src/rma/rma_proxy.cc
+++ b/projects/rccl/src/rma/rma_proxy.cc
@@ -34,11 +34,6 @@ NCCL_PARAM(RmaProxyDumpSignal, "RMA_PROXY_DUMP_SIGNAL", -1);
 NCCL_PARAM(RmaProxyQueueSize, "RMA_PROXY_QUEUE_SIZE", -1);
 RCCL_PARAM(RmaProxyUseDMABUF, "RMA_USE_DMABUF", 0);
 
-// When set, export the DMA-BUF FD for VMM (cuMem) buffers via
-// cuMemGetHandleForAddressRange instead of hsa_amd_portable_export_dmabuf.
-// The HSA exporter cannot export cuMem/VMM allocations on some ROCm/NIC stacks
-RCCL_PARAM(DmaBufUseVmmExport, "DMABUF_USE_VMM_EXPORT", 0);
-
 
 #include <signal.h>
 static ncclRmaProxyState* ncclLastRmaProxyState;

--- a/projects/rccl/src/rma/rma_proxy.cc
+++ b/projects/rccl/src/rma/rma_proxy.cc
@@ -205,10 +205,18 @@ static ncclResult_t ncclRmaProxyCtxAlloc(struct ncclComm* comm, ncclGin_t* ginCo
 static ncclResult_t ncclRmaProxyCtxAllocGraph(struct ncclComm* comm, ncclGin_t* ginComm, struct ncclRmaProxyCtx* rmaProxyCtx) {
   // The clean up in case of failure will be done by the ncclRmaProxyDestroyContext function invoked by the caller.
   size_t signalsBufSize = (comm->nRanks + 1) * sizeof(uint64_t);
+
+  // RCCL: Strip DMA-BUF like ncclRmaProxyCtxAlloc: cpuAccessSignals may be
+  // host memory (GDRCopy off), whose dmabuf export fails (INVALID_AGENT).
+  ncclNetProperties_t props_tmp = rmaProxyCtx->props;
+  if (rcclParamRmaProxyUseDMABUF() == 0) {
+    props_tmp.ptrSupport &= ~NCCL_PTR_DMABUF;
+  }
+
   // Allocate the CPU-accessible signal for graph capture and then register the memory region with the GIN plugin.
   NCCLCHECK(allocMemCPUAccessible(&rmaProxyCtx->cpuAccessSignals, &rmaProxyCtx->cpuAccessSignalsDev,
                                   comm->nRanks + 1, 0, &rmaProxyCtx->cpuAccessSignalsGdrHandle, comm->memManager));
-  NCCLCHECK(ncclRmaProxyRegMrSym(ginComm, rmaProxyCtx->ginCollComm, rmaProxyCtx->props, rmaProxyCtx->cpuAccessSignalsDev, signalsBufSize,
+  NCCLCHECK(ncclRmaProxyRegMrSym(ginComm, rmaProxyCtx->ginCollComm, props_tmp, rmaProxyCtx->cpuAccessSignalsDev, signalsBufSize,
                                  NCCL_PTR_CUDA, NCCL_NET_MR_FLAG_FORCE_SO,
                                  &rmaProxyCtx->cpuAccessSignalsMhandle, &rmaProxyCtx->cpuAccessSignalsGinHandle));
   // Allocate the host buffer to track the expected values of the signals

--- a/projects/rccl/src/rma/rma_proxy.cc
+++ b/projects/rccl/src/rma/rma_proxy.cc
@@ -77,21 +77,6 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
 static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
                                 bool sym_buffer) {
   if (ncclParamDmaBufEnable() == 0) return ncclInvalidUsage;
-#if HIP_VERSION >= 71260540
-  if (rcclParamDmaBufUseVmmExport()) {
-    static size_t vmmHostPageSize = ncclOsGetPageSize();
-    size_t vmmAlignedSize = length;
-    ALIGN_SIZE(vmmAlignedSize, vmmHostPageSize);
-    CUresult status =
-        cuMemGetHandleForAddressRange((void*)fd,
-                                      (CUdeviceptr)addr,
-                                      vmmAlignedSize,
-                                      CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-                                      0);
-    if (status == CUDA_SUCCESS) return ncclSuccess;
-    return ncclInvalidUsage;
-  }
-#endif
 #if HIP_VERSION >= 70000000
   static size_t hostPageSize = ncclOsGetPageSize();
   size_t alignedSize = length;

--- a/projects/rccl/src/rma/rma_proxy_launch.cc
+++ b/projects/rccl/src/rma/rma_proxy_launch.cc
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <cuda_runtime.h>
 #include <cuda.h>
+#include "rocmwrap.h"
 #include "nccl.h"
 #include "alloc.h"
 #include "checks.h"
@@ -17,10 +18,6 @@
 #include "rma/rma.h"
 #include "rma/rma_proxy.h"
 #include "dev_runtime.h"
-
-#ifndef CU_STREAM_WRITE_VALUE_DEFAULT
-#define CU_STREAM_WRITE_VALUE_DEFAULT 0
-#endif
 
 ncclResult_t ncclCuStreamBatchMemOp(hipStream_t stream, unsigned int numOps, hipStreamBatchMemOpParams* batchParams) {
   ncclResult_t ret = ncclSuccess;

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -32,7 +32,6 @@ struct ncclIbDevExtraProps {
 NCCL_PARAM(IbCastQpsPerConn, "IB_QPS_PER_CONNECTION", 2);
 extern int64_t rcclParamIbCastQpsPerP2p();
 extern int64_t rcclParamIbCastGdrFlushGpuMemNoRelaxedOrdering();
-extern int64_t rcclParamDmaBufUseVmmExport();
 
 // Calculate number of QPs based on P2P flag and device counts
 static int IbCastCalculateNqps(int isP2p, int localNdevs, int remoteNdevs, const char* funcName) {
@@ -46,31 +45,6 @@ static int IbCastCalculateNqps(int isP2p, int localNdevs, int remoteNdevs, const
   return maxNqps;
 }
 
-// Export a cuMem/VMM GPU range as a DMA-BUF FD and register the gpu-flush buffer as dmabuf MR.
-static ncclResult_t regGpuFlushDmabufCuMem(struct ncclIbGpuFlush* gpuFlush,
-                                           struct ibv_pd* pd, size_t regLen) {
-  void* const gpuAddr = gpuFlush->gpuFlushGpuMem;
-  CUresult vmmStatus =
-    cuMemGetHandleForAddressRange((void*)&gpuFlush->dmabufFd,
-                                  (CUdeviceptr)gpuAddr, regLen,
-                                  CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
-  if (vmmStatus != CUDA_SUCCESS || gpuFlush->dmabufFd < 0) {
-    WARN("Failed to export DMA BUF via cuMemGetHandleForAddressRange");
-    return ncclSystemError;
-  }
-
-  int access =
-    IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
-  ncclResult_t regRet =
-    wrap_ibv_reg_dmabuf_mr(&gpuFlush->gpuMr, pd, 0, regLen, (uint64_t)gpuAddr,
-                           gpuFlush->dmabufFd, access);
-  if (regRet != ncclSuccess) {
-    close(gpuFlush->dmabufFd);
-    gpuFlush->dmabufFd = -1;
-    return regRet;
-  }
-  return ncclSuccess;
-}
 
 #define NCCL_CTS_QP_SLOT_INVALID 0xFF
 enum ncclIbChannelType {
@@ -1525,37 +1499,32 @@ ib_recv:
     if (rComm->flushEnabled) {
       if (rcclParamIbCastGdrFlushGpuMemNoRelaxedOrdering()) {
 #if defined(HIP_UNCACHED_MEMORY)
-        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr, ncclMemPersist, hipDeviceMallocUncached), ret, fail);
+        const unsigned int gpuFlushFlags = hipDeviceMallocUncached;
 #else
-        NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr, ncclMemPersist, hipDeviceMallocFinegrained), ret, fail);
+        const unsigned int gpuFlushFlags = hipDeviceMallocFinegrained;
 #endif
+        // RCCL: allocate the GDR flush buffer directly via HIP (never cuMem/VMM)
+        // so hsa_amd_portable_export_dmabuf can export it. cuMem/VMM allocations
+        // fail to export through the HSA portable exporter on some ROCm/NIC stacks.
+        CUDACHECKGOTO(
+          hipExtMallocWithFlags((void**)&rCommDev->gpuFlush.gpuFlushGpuMem,
+                                sizeof(int), gpuFlushFlags),
+          ret, fail);
+        CUDACHECKGOTO(hipMemset(rCommDev->gpuFlush.gpuFlushGpuMem, 0,
+                                sizeof(int)),
+                      ret, fail);
+
         if (useDmaBuf) {
-          // Driver VMM range export for cuMem/VMM buffers (NCCL_CUMEM_ENABLE=1):
-          // the HSA exporter below cannot export cuMem allocations on some ROCm/NIC
-          // stacks, but cuMemGetHandleForAddressRange can. Fall back to the HSA
-          // exporter if the VMM export path is disabled or fails.
-          ncclResult_t vmmExportRet = ncclInvalidUsage;
-          if (rcclParamDmaBufUseVmmExport() && ncclCuMemEnable()) {
-            vmmExportRet =
-              regGpuFlushDmabufCuMem(&rCommDev->gpuFlush, rCommDev->base.pd,
-                                     sizeof(int));
-            if (vmmExportRet != ncclSuccess) {
-              WARN("NET/IB: VMM DMA-BUF export failed, falling back to HSA "
-                   "exporter");
-            }
+          uint64_t exportOffset = 0;
+          void *aligned_ptr = NULL;
+          size_t alignedSize = 0;
+          get_aligned_ptr_and_size(rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int) /*devicebuffersize*/, &aligned_ptr, &alignedSize);
+          hsa_status_t exportStatus = pfn_hsa_amd_portable_export_dmabuf(aligned_ptr, alignedSize, &rCommDev->gpuFlush.dmabufFd, &exportOffset);
+          if (rCommDev->gpuFlush.dmabufFd < 0 || exportStatus != HSA_STATUS_SUCCESS) {
+            WARN("Failed to export DMA BUF");
+            goto fail;
           }
-          if (vmmExportRet != ncclSuccess) {
-            uint64_t exportOffset = 0;
-            void *aligned_ptr = NULL;
-            size_t alignedSize = 0;
-            get_aligned_ptr_and_size(rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int) /*devicebuffersize*/, &aligned_ptr, &alignedSize);
-            hsa_status_t exportStatus = pfn_hsa_amd_portable_export_dmabuf(aligned_ptr, alignedSize, &rCommDev->gpuFlush.dmabufFd, &exportOffset);
-            if (rCommDev->gpuFlush.dmabufFd < 0 || exportStatus != HSA_STATUS_SUCCESS) {
-              WARN("Failed to export DMA BUF");
-              goto fail;
-            }
-            NCCLCHECKGOTO(wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, exportOffset, sizeof(int), (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem /*iova*/, rCommDev->gpuFlush.dmabufFd, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ), ret, fail);
-          }
+          NCCLCHECKGOTO(wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, exportOffset, sizeof(int), (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem /*iova*/, rCommDev->gpuFlush.dmabufFd, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ), ret, fail);
         } else {
           rCommDev->gpuFlush.dmabufFd = -1;
           NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ), ret, fail);
@@ -1668,7 +1637,7 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
       struct ncclIbRecvCommDev* commDev = comm->devs + i;
       if (comm->flushEnabled) {
         if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-          NCCLCHECK(ncclCudaFree(commDev->gpuFlush.gpuFlushGpuMem, /*manager=*/nullptr));
+          CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
           commDev->gpuFlush.gpuFlushGpuMem = nullptr;
           if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
           commDev->gpuFlush.gpuMr = nullptr;

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -61,9 +61,14 @@ static ncclResult_t regGpuFlushDmabufCuMem(struct ncclIbGpuFlush* gpuFlush,
 
   int access =
     IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
-  NCCLCHECK(wrap_ibv_reg_dmabuf_mr(&gpuFlush->gpuMr, pd, 0, regLen,
-                                   (uint64_t)gpuAddr, gpuFlush->dmabufFd,
-                                   access));
+  ncclResult_t regRet =
+    wrap_ibv_reg_dmabuf_mr(&gpuFlush->gpuMr, pd, 0, regLen, (uint64_t)gpuAddr,
+                           gpuFlush->dmabufFd, access);
+  if (regRet != ncclSuccess) {
+    close(gpuFlush->dmabufFd);
+    gpuFlush->dmabufFd = -1;
+    return regRet;
+  }
   return ncclSuccess;
 }
 

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -32,6 +32,7 @@ struct ncclIbDevExtraProps {
 NCCL_PARAM(IbCastQpsPerConn, "IB_QPS_PER_CONNECTION", 2);
 extern int64_t rcclParamIbCastQpsPerP2p();
 extern int64_t rcclParamIbCastGdrFlushGpuMemNoRelaxedOrdering();
+extern int64_t rcclParamDmaBufUseVmmExport();
 
 // Calculate number of QPs based on P2P flag and device counts
 static int IbCastCalculateNqps(int isP2p, int localNdevs, int remoteNdevs, const char* funcName) {
@@ -45,6 +46,34 @@ static int IbCastCalculateNqps(int isP2p, int localNdevs, int remoteNdevs, const
   return maxNqps;
 }
 
+#if HIP_VERSION >= 71260540
+// Export a cuMem/VMM GPU range as a DMA-BUF FD and register the gpu-flush buffer as dmabuf MR.
+static ncclResult_t IbCastRegGpuFlushDmabufCuMemRange(
+    struct ncclIbGpuFlush* gpuFlush, struct ibv_pd* pd, size_t regLen) {
+  void* const gpuAddr = gpuFlush->gpuFlushGpuMem;
+  CUresult vmmStatus =
+      cuMemGetHandleForAddressRange((void*)&gpuFlush->dmabufFd,
+                                    (CUdeviceptr)gpuAddr,
+                                    regLen,
+                                    CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                    0);
+  if (vmmStatus != CUDA_SUCCESS || gpuFlush->dmabufFd < 0) {
+    WARN("Failed to export DMA BUF via cuMemGetHandleForAddressRange");
+    return ncclSystemError;
+  }
+
+  NCCLCHECK(wrap_ibv_reg_dmabuf_mr(&gpuFlush->gpuMr,
+                                   pd,
+                                   0 /*offset*/,
+                                   regLen,
+                                   (uint64_t)gpuAddr /*iova*/,
+                                   gpuFlush->dmabufFd,
+                                   IBV_ACCESS_LOCAL_WRITE |
+                                       IBV_ACCESS_REMOTE_WRITE |
+                                       IBV_ACCESS_REMOTE_READ));
+  return ncclSuccess;
+}
+#endif
 
 #define NCCL_CTS_QP_SLOT_INVALID 0xFF
 enum ncclIbChannelType {
@@ -1504,16 +1533,30 @@ ib_recv:
         NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr, ncclMemPersist, hipDeviceMallocFinegrained), ret, fail);
 #endif
         if (useDmaBuf) {
-          uint64_t exportOffset = 0;
-          void *aligned_ptr = NULL;
-          size_t alignedSize = 0;
-          get_aligned_ptr_and_size(rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int) /*devicebuffersize*/, &aligned_ptr, &alignedSize);
-          hsa_status_t exportStatus = pfn_hsa_amd_portable_export_dmabuf(aligned_ptr, alignedSize, &rCommDev->gpuFlush.dmabufFd, &exportOffset);
-          if (rCommDev->gpuFlush.dmabufFd < 0 || exportStatus != HSA_STATUS_SUCCESS) {
-            WARN("Failed to export DMA BUF");
-            goto fail;
+#if HIP_VERSION >= 71260540
+          // Driver VMM range export for cuMem/VMM buffers (NCCL_CUMEM_ENABLE=1):
+          // the HSA exporter below cannot export cuMem allocations on some ROCm/NIC
+          // stacks, but cuMemGetHandleForAddressRange can.
+          if (rcclParamDmaBufUseVmmExport() && ncclCuMemEnable()) {
+            NCCLCHECKGOTO(IbCastRegGpuFlushDmabufCuMemRange(&rCommDev->gpuFlush,
+                                                            rCommDev->base.pd,
+                                                            sizeof(int)),
+                          ret,
+                          fail);
+          } else
+#endif
+          {
+            uint64_t exportOffset = 0;
+            void *aligned_ptr = NULL;
+            size_t alignedSize = 0;
+            get_aligned_ptr_and_size(rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int) /*devicebuffersize*/, &aligned_ptr, &alignedSize);
+            hsa_status_t exportStatus = pfn_hsa_amd_portable_export_dmabuf(aligned_ptr, alignedSize, &rCommDev->gpuFlush.dmabufFd, &exportOffset);
+            if (rCommDev->gpuFlush.dmabufFd < 0 || exportStatus != HSA_STATUS_SUCCESS) {
+              WARN("Failed to export DMA BUF");
+              goto fail;
+            }
+            NCCLCHECKGOTO(wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, exportOffset, sizeof(int), (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem /*iova*/, rCommDev->gpuFlush.dmabufFd, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ), ret, fail);
           }
-          NCCLCHECKGOTO(wrap_ibv_reg_dmabuf_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, exportOffset, sizeof(int), (uint64_t)rCommDev->gpuFlush.gpuFlushGpuMem /*iova*/, rCommDev->gpuFlush.dmabufFd, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ), ret, fail);
         } else {
           rCommDev->gpuFlush.dmabufFd = -1;
           NCCLCHECKGOTO(wrap_ibv_reg_mr(&rCommDev->gpuFlush.gpuMr, rCommDev->base.pd, rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ), ret, fail);

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -46,34 +46,26 @@ static int IbCastCalculateNqps(int isP2p, int localNdevs, int remoteNdevs, const
   return maxNqps;
 }
 
-#if HIP_VERSION >= 71260540
 // Export a cuMem/VMM GPU range as a DMA-BUF FD and register the gpu-flush buffer as dmabuf MR.
-static ncclResult_t IbCastRegGpuFlushDmabufCuMemRange(
-    struct ncclIbGpuFlush* gpuFlush, struct ibv_pd* pd, size_t regLen) {
+static ncclResult_t regGpuFlushDmabufCuMem(struct ncclIbGpuFlush* gpuFlush,
+                                           struct ibv_pd* pd, size_t regLen) {
   void* const gpuAddr = gpuFlush->gpuFlushGpuMem;
   CUresult vmmStatus =
-      cuMemGetHandleForAddressRange((void*)&gpuFlush->dmabufFd,
-                                    (CUdeviceptr)gpuAddr,
-                                    regLen,
-                                    CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-                                    0);
+    cuMemGetHandleForAddressRange((void*)&gpuFlush->dmabufFd,
+                                  (CUdeviceptr)gpuAddr, regLen,
+                                  CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
   if (vmmStatus != CUDA_SUCCESS || gpuFlush->dmabufFd < 0) {
     WARN("Failed to export DMA BUF via cuMemGetHandleForAddressRange");
     return ncclSystemError;
   }
 
-  NCCLCHECK(wrap_ibv_reg_dmabuf_mr(&gpuFlush->gpuMr,
-                                   pd,
-                                   0 /*offset*/,
-                                   regLen,
-                                   (uint64_t)gpuAddr /*iova*/,
-                                   gpuFlush->dmabufFd,
-                                   IBV_ACCESS_LOCAL_WRITE |
-                                       IBV_ACCESS_REMOTE_WRITE |
-                                       IBV_ACCESS_REMOTE_READ));
+  int access =
+    IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
+  NCCLCHECK(wrap_ibv_reg_dmabuf_mr(&gpuFlush->gpuMr, pd, 0, regLen,
+                                   (uint64_t)gpuAddr, gpuFlush->dmabufFd,
+                                   access));
   return ncclSuccess;
 }
-#endif
 
 #define NCCL_CTS_QP_SLOT_INVALID 0xFF
 enum ncclIbChannelType {
@@ -1533,19 +1525,21 @@ ib_recv:
         NCCLCHECKGOTO(ncclCudaCalloc(&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int), /*manager=*/nullptr, ncclMemPersist, hipDeviceMallocFinegrained), ret, fail);
 #endif
         if (useDmaBuf) {
-#if HIP_VERSION >= 71260540
           // Driver VMM range export for cuMem/VMM buffers (NCCL_CUMEM_ENABLE=1):
           // the HSA exporter below cannot export cuMem allocations on some ROCm/NIC
-          // stacks, but cuMemGetHandleForAddressRange can.
+          // stacks, but cuMemGetHandleForAddressRange can. Fall back to the HSA
+          // exporter if the VMM export path is disabled or fails.
+          ncclResult_t vmmExportRet = ncclInvalidUsage;
           if (rcclParamDmaBufUseVmmExport() && ncclCuMemEnable()) {
-            NCCLCHECKGOTO(IbCastRegGpuFlushDmabufCuMemRange(&rCommDev->gpuFlush,
-                                                            rCommDev->base.pd,
-                                                            sizeof(int)),
-                          ret,
-                          fail);
-          } else
-#endif
-          {
+            vmmExportRet =
+              regGpuFlushDmabufCuMem(&rCommDev->gpuFlush, rCommDev->base.pd,
+                                     sizeof(int));
+            if (vmmExportRet != ncclSuccess) {
+              WARN("NET/IB: VMM DMA-BUF export failed, falling back to HSA "
+                   "exporter");
+            }
+          }
+          if (vmmExportRet != ncclSuccess) {
             uint64_t exportOffset = 0;
             void *aligned_ptr = NULL;
             size_t alignedSize = 0;

--- a/projects/rccl/src/transport/net_ib_cast/gin.cc
+++ b/projects/rccl/src/transport/net_ib_cast/gin.cc
@@ -37,6 +37,9 @@ static ncclResult_t IbCastGinIbGdrSupport(bool* gdrSupport, bool gdaki) {
 static ncclResult_t IbCastGinIbGdrGpuSupport(bool gdaki) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   if (IbCastDmaBufSupport(0) == ncclSuccess) return ncclSuccess;
+  // RCCL: fall back to peermem/GDR when DMA-BUF is unavailable, mirroring the
+  // init-time IbCastGinIbGdrSupport() and the CUDA branch below.
+  if (IbCastGdrSupport() == ncclSuccess) return ncclSuccess;
 
   if (IbCastGdrSupport() == ncclSuccess) return ncclSuccess;
   WARN("Unable to use GIN: Peermem is not supported, and DMA-BUF is not available.");

--- a/projects/rccl/src/transport/net_ib_cast/gin.cc
+++ b/projects/rccl/src/transport/net_ib_cast/gin.cc
@@ -37,6 +37,7 @@ static ncclResult_t IbCastGinIbGdrSupport(bool* gdrSupport, bool gdaki) {
 static ncclResult_t IbCastGinIbGdrGpuSupport(bool gdaki) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   if (IbCastDmaBufSupport(0) == ncclSuccess) return ncclSuccess;
+
   if (IbCastGdrSupport() == ncclSuccess) return ncclSuccess;
   WARN("Unable to use GIN: Peermem is not supported, and DMA-BUF is not available.");
 #else

--- a/projects/rccl/src/transport/net_ib_cast/gin.cc
+++ b/projects/rccl/src/transport/net_ib_cast/gin.cc
@@ -37,10 +37,6 @@ static ncclResult_t IbCastGinIbGdrSupport(bool* gdrSupport, bool gdaki) {
 static ncclResult_t IbCastGinIbGdrGpuSupport(bool gdaki) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   if (IbCastDmaBufSupport(0) == ncclSuccess) return ncclSuccess;
-  // RCCL: fall back to peermem/GDR when DMA-BUF is unavailable, mirroring the
-  // init-time IbCastGinIbGdrSupport() and the CUDA branch below.
-  if (IbCastGdrSupport() == ncclSuccess) return ncclSuccess;
-
   if (IbCastGdrSupport() == ncclSuccess) return ncclSuccess;
   WARN("Unable to use GIN: Peermem is not supported, and DMA-BUF is not available.");
 #else


### PR DESCRIPTION
## Motivation

The host-API one-sided RMA Copy Engine (CE) path was merged in #6745 behind the `RCCL_RMA_CU_PATH_ENABLED` compile guard. This PR enables it for real so that intra-node `ncclPutSignal` / `ncclWaitSignal` traffic between co-located ranks goes peer-to-peer over the Copy Engine, while multi-node deployments keep falling back to the GIN proxy. It also adds a `hipIpc` fallback so the Host API can work without cuMem/VMM.

## Technical Details

- Drop the `RCCL_RMA_CU_PATH_ENABLED` guard in `rma.cc` / `enqueue.cc` so the CE path is always built: `ncclRmaPut` / `ncclRmaWaitSignal` launch CE and proxy tasks in parallel on two streams (`nRmaTasksCe` / `nRmaTasksProxy`), and `isLsaAccessible` routes same-node peers through the CE team on the non-symmetric path.
- `hipIpc` fallback for non-symmetric Host API windows in `dev_runtime.{cc,h}`: add a CE team (`ceSelf` / `ceSize` / `ceRankList`) and an intra-node IPC peer table (`ipcPeerPtrs` / `ipcPeerOpenedBases` / `ipcPeerCount`) on `ncclDevrWindow`. `ncclDevrWindowRegisterNonSym` maps intra-node peers via IPC and registers inter-node MRs through the proxy, so one window can carry both layers; `ncclDevrWorldToLsaRank` uses CE indexing when `!symmetricSupport`.
- CE init (collective: registers the signals window + bootstrap barrier over the whole comm) is enqueued on the first window register in `ncclDevrWindowRegisterInGroup`, since the Host API `ncclPutSignal` entry point is non-collective.

## JIRA ID

AICOMNET-196

## Test Plan

Configurations:
- Bare metal (HIP 7.0.1):
    - Tests: HostApiTest.*
        - Single node: ppn=2,4,8
        - 2 nodes: ppn=1,2,4,8
        - NCCL_CUMEM_ENABLE=0 NCCL_NET=IB-CAST NCCL_DMABUF_ENABLE=0
- ruby cluster (docker, HIP 7.13)
    - Tests: HostApiTest.*
        - Single node: ppn=2
        - 2 nodes: ppn=1
        - NCCL_CUMEM_ENABLE=0
        - NCCL_CUMEM_ENABLE=1
    - Tests: GinMPIDeviceTests.*
        - 2 nodes: ppn=1
        - GIN proxy (GIN_TYPE=2, CUMEM=1)
    - Tests: GinMPITest*
        - 2 nodes: ppn=1
        - NCCL_NET=IB-CAST
     - alltoall_perf -R 2 -D 3 (2 nodes, ppn=8)
     - alltoall_perf -R 2 -D 4 (2 nodes, ppn=8)
- dell cluster (docker, HIP 7.13):
    - Tests: HostApiTest.* 
        - Single node: ppn=2,4,8
        - NCCL_CUMEM_ENABLE=1
        - NCCL_CUMEM_ENABLE=0 NCCL_NET=IB-CAST NCCL_DMABUF_ENABLE=0
        - NCCL_CUMEM_ENABLE=1 NCCL_NET=IB-CAST NCCL_DMABUF_ENABLE=1 RCCL_RMA_USE_DMABUF=1 RCCL_DMABUF_USE_VMM_EXPORT=1

## Test Result

All tests passed. See details in AICOMNET-198

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
