### PR TITLE
[clr] Add gfx1250 to fast-path for fp8

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp8.h
@@ -12,8 +12,8 @@
 #ifndef _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP8_H_
 #define _HIP_INCLUDE_HIP_AMD_DETAIL_HIP_FP8_H_
 
-#if (defined(__gfx942__) || defined(__gfx1200__) || defined(__gfx1201__) ||                        \
-     defined(__gfx950__)) &&                                                                       \
+#if (defined(__gfx942__) || defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__) || \
+     defined(__gfx1250__)) &&                                                                      \
     __HIP_DEVICE_COMPILE__
 #define HIP_FP8_CVT_FAST_PATH 1
 #else
@@ -23,7 +23,8 @@
 #if defined(__gfx942__) && __HIP_DEVICE_COMPILE__
 #define HIP_FP8_TYPE_OCP 0
 #define HIP_FP8_TYPE_FNUZ 1
-#elif (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__)) &&                     \
+#elif (defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx950__) ||                      \
+       defined(__gfx1250__)) &&                                                                    \
     __HIP_DEVICE_COMPILE__
 #define HIP_FP8_TYPE_OCP 1
 #define HIP_FP8_TYPE_FNUZ 0


### PR DESCRIPTION
## Motivation

gfx1250 should be in fp8 fast path

## Technical Details

gfx1250 does support fp8 convert builtins. This enables the fp8 header to use those.

## JIRA ID

Resolves ROCM-25847

## Test Plan

RCCL build time should reduce.
No other specific test are required here, we already have substantive fp8 tests, this just enables a gfx id for the fast path.

## Test Result

It does, tested it locally with/without the change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
