### PR TITLE
[rocprofiler-compute] Sync .github workflows with rocprofiler-compute-develop

### DIFF
--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -146,7 +146,7 @@ jobs:
           apt-get update
           apt-get install -y /tmp/amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
           apt-get update
-          apt install -y amd-smi-lib libdw-dev hip-dev
+          apt install -y amd-smi-lib libdw-dev hip-dev pkg-config
           echo "✅ amdgpu and ROCm dependencies Installed!"
 
       - name: Install Latest Nightly ROCm

--- a/.github/workflows/rocprofiler-compute-formatting.yml
+++ b/.github/workflows/rocprofiler-compute-formatting.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # required for --from-ref/--to-ref
+          submodules: recursive
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
 

--- a/.github/workflows/rocprofiler-compute-rhel-8.yml
+++ b/.github/workflows/rocprofiler-compute-rhel-8.yml
@@ -70,6 +70,7 @@ jobs:
           yum -y install cmake3
           yum -y install which
           yum -y install glibc-langpack-en
+          yum -y install elfutils-devel pkgconf-pkg-config
 
       - name: Install ROCm Packages
         timeout-minutes: 30

--- a/.github/workflows/rocprofiler-compute-tarball.yml
+++ b/.github/workflows/rocprofiler-compute-tarball.yml
@@ -77,6 +77,7 @@ jobs:
           apt-get install -y /tmp/amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
           apt-get update
           apt install -y rocm-dev
+          apt install -y libdw-dev pkg-config
           echo "✅ ROCm Dependencies Installed!"
       - name: Install Python
         uses: actions/setup-python@v5
@@ -128,6 +129,7 @@ jobs:
           apt-get install -y /tmp/amdgpu-install_${ROCM_MAJOR}.${ROCM_MINOR}.${ROCM_VERSN}-1_all.deb
           apt-get update
           apt install -y rocm-dev
+          apt install -y libdw-dev pkg-config
           echo "✅ ROCm Dependencies Installed!"
       - name: Python dependency installs
         run: |

--- a/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-compute-ubuntu-jammy.yml
@@ -50,7 +50,7 @@ jobs:
           apt-get install -y git
           apt-get install -y python3-pip
           apt-get install -y cmake
-          apt-get install -y libdw1
+          apt-get install -y libdw-dev pkg-config
 
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Motivation

Bring the rocprofiler-compute workflow files on `develop` in sync with `rocprofiler-compute-develop` so both branches build with the same dependencies.

## Technical Details

- Add `pkg-config` to the apt install step in the continuous-integration workflow.
- Add `libdw-dev` / `elfutils-devel` and `pkg-config` install steps to the rhel-8, tarball, and ubuntu-jammy workflows.
- Add `submodules: recursive` to the formatting workflow checkout.

## JIRA ID

N/A

## Test Plan

CI runs the updated workflows on this PR.

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.