### PR TITLE
[rocjitsu] Fix gfx1250 `-march=native` builds

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -4266,6 +4266,21 @@ class CodeGenerator:
             return True
         return False
 
+    def _e32_true16_dst_reg_expr(
+        self, inst: Instruction | None, enc_name: str | None = None
+    ) -> str:
+        if inst is None or self.isa_spec.arch_name.lower() != 'gfx1250':
+            return 'inst_.vdst'
+        enc_upper = (enc_name or inst.enc_name).upper()
+        if enc_upper not in ('ENC_VOP1', 'ENC_VOP2'):
+            return 'inst_.vdst'
+        if any(
+            op.is_output and op.size == 16 and op.operand_type == 'OPR_VGPR'
+            for op in inst.operands
+        ):
+            return '(inst_.vdst & 0x7fu)'
+        return 'inst_.vdst'
+
     def _can_share_execute(
         self,
         mnemonic: str,
@@ -4891,6 +4906,9 @@ class CodeGenerator:
                                 _src_inputs[1] if len(_src_inputs) > 1 else None
                             )
                             _is_vopc = enc.enc_name.upper() == 'ENC_VOPC'
+                            _dst_reg_expr = self._e32_true16_dst_reg_expr(
+                                inst, enc.enc_name
+                            )
                             _dpp_preamble = ''
                             if _is_vopc:
                                 _dpp_preamble += (
@@ -4916,7 +4934,7 @@ class CodeGenerator:
                                     '    uint64_t ex = wf.exec();\n'
                                     '    for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)\n'
                                     '      if (ex & (1ULL << ln))\n'
-                                    '        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);\n'
+                                    f'        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + {_dst_reg_expr}, ln);\n'
                                     '  }\n'
                                 )
                             _dpp_preamble += (
@@ -4985,9 +5003,9 @@ class CodeGenerator:
                                 '    uint32_t vb = wf.vgpr_alloc().base;\n'
                                 '    for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {\n'
                                 '      if (!(ex & (1ULL << ln))) continue;\n'
-                                '      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);\n'
+                                f'      uint32_t dv = wf.cu().read_vgpr(vb + {_dst_reg_expr}, ln);\n'
                                 '      dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);\n'
-                                '      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);\n'
+                                f'      wf.cu().write_vgpr(vb + {_dst_reg_expr}, ln, dv);\n'
                                 '    }\n'
                                 '  }\n'
                             )
@@ -4998,10 +5016,10 @@ class CodeGenerator:
                                     '    uint32_t vb = wf.vgpr_alloc().base;\n'
                                     '    for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {\n'
                                     '      if (!(ex & (1ULL << ln))) continue;\n'
-                                    '      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);\n'
+                                    f'      uint32_t dv = wf.cu().read_vgpr(vb + {_dst_reg_expr}, ln);\n'
                                     '      float fv = std::bit_cast<float>(dv);\n'
                                     '      fv = std::clamp(fv, 0.0f, 1.0f);\n'
-                                    '      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));\n'
+                                    f'      wf.cu().write_vgpr(vb + {_dst_reg_expr}, ln, std::bit_cast<uint32_t>(fv));\n'
                                     '    }\n'
                                     '  }\n'
                                 )
@@ -5038,7 +5056,7 @@ class CodeGenerator:
                                     '      uint32_t vb = wf.vgpr_alloc().base;\n'
                                     '      for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {\n'
                                     '        if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))\n'
-                                    '          wf.cu().write_vgpr(vb + inst_.vdst, ln,\n'
+                                    f'          wf.cu().write_vgpr(vb + {_dst_reg_expr}, ln,\n'
                                     '              sdwa_old_dst_[ln]);\n'
                                     '      }\n'
                                     '    }\n'

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -1947,6 +1947,10 @@ class CodeGenerator:
                     dst_reg_classes,
                 )
                 lctx = LoweringContext(exec_model=sema_block.pragma, operand_map=omap)
+                if cls == 'vector_cmp':
+                    # V_CMP writes a fresh wave mask initialized to zero, so false
+                    # lanes can remain clear without emitting redundant bit clears.
+                    lctx.clear_false_lane_mask_writes = False
                 if (
                     sema_block.pragma.name == 'VECTOR'
                     and dst_ops

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -1961,17 +1961,17 @@ class CodeGenerator:
                 ):
                     lctx.vector_sgpr_once = True
                 is_gfx1250 = self.isa_spec.arch_name.lower() == 'gfx1250'
-                has_true16_vop3_src = any(
+                has_true16_src = any(
                     opnd.is_input and opnd.size == 16 for opnd in src_operands
                 )
-                has_true16_vop3_dst = any(
+                has_true16_dst = any(
                     opnd.is_output and opnd.size == 16 for opnd in dst_operands
                 )
                 is_true16_vop3 = (
                     is_gfx1250
                     and is_vop3
                     and dst_operands
-                    and (has_true16_vop3_src or has_true16_vop3_dst)
+                    and (has_true16_src or has_true16_dst)
                 )
                 if is_true16_vop3:
                     for src_idx, opnd in enumerate(src_operands):
@@ -1979,7 +1979,7 @@ class CodeGenerator:
                             lctx.true16_src_selects[src_idx] = (
                                 f'inst_.opsel & 0x{1 << src_idx:x}u'
                             )
-                    if has_true16_vop3_dst:
+                    if has_true16_dst:
                         lctx.true16_dst_select = 'inst_.opsel & 0x8u'
                 elif (
                     is_gfx1250
@@ -2001,6 +2001,14 @@ class CodeGenerator:
                             '((inst_.src0 - 256) & 0x7fu), lane) '
                             ': src0.read_lane(wf, lane))'
                         )
+                elif (
+                    is_gfx1250
+                    and enc_name.upper() in ('ENC_VOP1', 'ENC_VOP2')
+                    and has_true16_dst
+                    and cls != 'vector_swap'
+                ):
+                    lctx.true16_dst_select = 'inst_.vdst & 0x80u'
+                    lctx.true16_dst_reg = 'inst_.vdst & 0x7fu'
                 if cls == 'vector_cndmask' and is_vop3 and len(src_ops) >= 3:
                     lctx.vcc_read = f'{src_ops[2]}.read_scalar64(wf)'
                 if cls == 'vector_add_co':
@@ -4248,6 +4256,10 @@ class CodeGenerator:
             and any(op.size == 16 for op in inst.operands)
         ):
             return True
+        if enc_upper in ('ENC_VOP1', 'ENC_VOP2') and any(
+            op.is_output and op.size == 16 for op in inst.operands
+        ):
+            return True
         if enc_upper == 'ENC_VOP3' and any(
             (op.is_input or op.is_output) and op.size == 16 for op in inst.operands
         ):
@@ -4294,6 +4306,20 @@ class CodeGenerator:
                 if arch in info.isa_names and len(info.isa_names) >= 2:
                     return True
         return False
+
+    def _can_force_shared_simd_probe(
+        self, inst: Instruction | None, enc_name: str | None = None
+    ) -> bool:
+        if inst is None or self._requires_arch_local_execute(inst, enc_name):
+            return False
+
+        from amdisa.codegen.execute.simd_codegen import simd_probe_arch_portable
+
+        enc_key = (enc_name or inst.enc_name).lower().replace('enc_', '')
+        return simd_probe_arch_portable(
+            f'{inst.mnemonic}_{enc_key}',
+            self.isa_spec.profile.vop3p_opsel_fields,
+        )
 
     def gen_insts(self) -> None:
         """Generate instruction classes deriving from encoding classes.
@@ -5050,14 +5076,8 @@ class CodeGenerator:
                         # read the literal through an ISA-divergent member, so a
                         # single shared body can't serve every ISA — those are
                         # left to the genuine shared plan.
-                        from amdisa.codegen.execute.simd_codegen import (
-                            simd_probe_arch_portable as _simd_probe_arch_portable,
-                        )
-
-                        _enc_key_for_probe = enc.enc_name.lower().replace('enc_', '')
-                        _portable_probe = _simd_probe_arch_portable(
-                            f'{inst.mnemonic}_{_enc_key_for_probe}',
-                            self.isa_spec.profile.vop3p_opsel_fields,
+                        _portable_probe = self._can_force_shared_simd_probe(
+                            inst, enc.enc_name
                         )
                         if body_throws:
                             exec_impl = cgen.Line(
@@ -5320,21 +5340,12 @@ class CodeGenerator:
                 # any instruction in this encoding delegates to a template.
                 # Portable SIMD probes can delegate even outside --multi mode,
                 # so this cannot be gated solely on shared_plan.
-                from amdisa.codegen.execute.simd_codegen import (
-                    simd_probe_arch_portable as _simd_probe_arch_portable,
-                )
-
-                enc_key = enc.enc_name.lower().replace('enc_', '')
-
                 def _delegates_to_shared(i: Instruction) -> bool:
                     if not self.semantics or i.name not in self.semantics.instructions:
                         return False
                     return self._can_share_execute(
                         i.mnemonic, i, enc.enc_name
-                    ) or _simd_probe_arch_portable(
-                        f'{i.mnemonic}_{enc_key}',
-                        self.isa_spec.profile.vop3p_opsel_fields,
-                    )
+                    ) or self._can_force_shared_simd_probe(i, enc.enc_name)
 
                 has_shared = any(_delegates_to_shared(i) for i in all_insts)
                 if has_shared:

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -255,6 +255,8 @@ def _vcc_init_expr(ctx: LoweringContext) -> str:
 
 
 def _write_vcc_mask_to_explicit_dst(dst: str) -> str:
+    # Keep this wave32/wave64 mask-width rule in sync with simd_glue.h and
+    # vector_cmp.py.
     return (
         f'if (wf.wf_size() <= 32)\n'
         f'    {dst}.write_scalar(wf, static_cast<uint32_t>(vcc));\n'
@@ -892,6 +894,11 @@ def _lower_instoperand_read(node: SemaNode, ctx: LoweringContext) -> str:
             and ctx.true16_dst_select is not None
             and ((node.ty and node.ty.size == 16) or binding.bit_width == 16)
         ):
+            if ctx.true16_dst_reg is not None:
+                value = (
+                    'wf.cu().read_vgpr(wf.vgpr_alloc().base + '
+                    f'({ctx.true16_dst_reg}), lane)'
+                )
             return f'(({ctx.true16_dst_select}) != 0 ? ({value} >> 16) : {value})'
         if tag != 'D' and idx in ctx.true16_src_selects:
             select = ctx.true16_src_selects[idx]

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -121,6 +121,7 @@ class LoweringContext:
     true16_dst_reg: str | None = None
     true16_src_raw: str | None = None
     vector_sgpr_once: bool = False
+    clear_false_lane_mask_writes: bool = True
 
 
 _INFIX_OPS: dict[SemaNodeKind, str] = {
@@ -321,6 +322,7 @@ def _lower_stmt(node: SemaNode, ctx: LoweringContext) -> list[str]:
             true16_dst_reg=ctx.true16_dst_reg,
             true16_src_raw=ctx.true16_src_raw,
             vector_sgpr_once=ctx.vector_sgpr_once,
+            clear_false_lane_mask_writes=ctx.clear_false_lane_mask_writes,
         )
         lines.extend(_lower_stmt(node.children[1], inner_ctx))
         lines.append(f'{_indent(ctx)}}}')
@@ -393,12 +395,18 @@ def _lower_assign(node: SemaNode, ctx: LoweringContext) -> list[str]:
             idx = _lower_expr(lhs_node.children[1], ctx)
             rhs = _lower_expr(rhs_node, ctx)
             ind = _indent(ctx)
-            return [
+            lines = [
                 f'{ind}if ({rhs})',
                 f'{ind}  {ctx.vcc_var} |= (1ULL << {idx});',
-                f'{ind}else',
-                f'{ind}  {ctx.vcc_var} &= ~(1ULL << {idx});',
             ]
+            if ctx.clear_false_lane_mask_writes:
+                lines.extend(
+                    [
+                        f'{ind}else',
+                        f'{ind}  {ctx.vcc_var} &= ~(1ULL << {idx});',
+                    ]
+                )
+            return lines
         if arr.kind == SemaNodeKind.ID and arr.id_name in ('MEM', 'LDS'):
             idx = _lower_expr(lhs_node.children[1], ctx)
             rhs = _lower_expr(rhs_node, ctx)
@@ -446,6 +454,7 @@ def _lower_if(node: SemaNode, ctx: LoweringContext) -> list[str]:
         true16_dst_reg=ctx.true16_dst_reg,
         true16_src_raw=ctx.true16_src_raw,
         vector_sgpr_once=ctx.vector_sgpr_once,
+        clear_false_lane_mask_writes=ctx.clear_false_lane_mask_writes,
     )
 
     if len(children) == 2:
@@ -496,6 +505,7 @@ def _lower_for(node: SemaNode, ctx: LoweringContext) -> list[str]:
         true16_dst_reg=ctx.true16_dst_reg,
         true16_src_raw=ctx.true16_src_raw,
         vector_sgpr_once=ctx.vector_sgpr_once,
+        clear_false_lane_mask_writes=ctx.clear_false_lane_mask_writes,
     )
 
     init_str = (

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -74,15 +74,15 @@ class OperandMap:
             # Prefer the operand's own declared bit size so mixed-width
             # instructions (e.g. the f64<->32-bit conversions, where one side is
             # 64-bit and the other 32-bit) get the correct per-operand lane
-            # width instead of a single instruction-level dtype width. Only the
-            # 64-bit case matters for read_lane64/write_lane64 selection; every
-            # narrower size (8/16/32) reads/writes through the 32-bit path.
+            # width instead of a single instruction-level dtype width. 64-bit
+            # selects read_lane64/write_lane64; 16-bit is also preserved so
+            # true16 lowering can merge the selected half of a 32-bit lane.
             if explicit_width is not None:
-                return 64 if explicit_width == 64 else 32
+                return explicit_width
             size = op_widths.get(name) if op_widths else None
             if size is None:
                 return width
-            return 64 if size == 64 else 32
+            return size
 
         src_reg_classes = src_reg_classes or {}
         dst_reg_classes = dst_reg_classes or {}
@@ -254,16 +254,25 @@ def _vcc_init_expr(ctx: LoweringContext) -> str:
     return '0'
 
 
+def _write_vcc_mask_to_explicit_dst(dst: str) -> str:
+    return (
+        f'if (wf.wf_size() <= 32)\n'
+        f'    {dst}.write_scalar(wf, static_cast<uint32_t>(vcc));\n'
+        f'  else\n'
+        f'    {dst}.write_scalar64(wf, vcc);'
+    )
+
+
 def _vcc_write_stmt(ctx: LoweringContext) -> str:
     """Return the C++ statement to write back the vcc local variable."""
     if ctx.vcc_dst and ctx.vcc_dst != '__vcc__':
-        return f'{ctx.vcc_dst}.write_scalar64(wf, vcc);'
+        return _write_vcc_mask_to_explicit_dst(ctx.vcc_dst)
     if ctx.vcc_dst == '__vcc__':
         return 'wf.set_vcc(vcc);'
     if ctx.operand_map:
         dst = ctx.operand_map.dst(0)
         if dst:
-            return f'{dst.name}.write_scalar64(wf, vcc);'
+            return _write_vcc_mask_to_explicit_dst(dst.name)
     return 'wf.set_vcc(vcc);'
 
 
@@ -511,6 +520,23 @@ def _lower_declare(node: SemaNode, ctx: LoweringContext) -> list[str]:
     return []
 
 
+def _lower_less_greater_once(node: SemaNode, ctx: LoweringContext) -> str | None:
+    if node.kind != SemaNodeKind.LOR or len(node.children) != 2:
+        return None
+
+    left, right = node.children
+    if {left.kind, right.kind} != {SemaNodeKind.LT, SemaNodeKind.GT}:
+        return None
+    if len(left.children) != 2 or len(right.children) != 2:
+        return None
+    if left.children != right.children:
+        return None
+
+    lhs = _lower_expr(left.children[0], ctx)
+    rhs = _lower_expr(left.children[1], ctx)
+    return f'([&]() {{ auto a = {lhs}; auto b = {rhs}; return (a < b) || (a > b); }}())'
+
+
 def _lower_expr(node: SemaNode, ctx: LoweringContext) -> str:
     """Lower an expression node to a C++ expression string."""
     kind = node.kind
@@ -522,6 +548,8 @@ def _lower_expr(node: SemaNode, ctx: LoweringContext) -> str:
         return _lower_id(node, ctx)
 
     if kind in _INFIX_OPS:
+        if (expr := _lower_less_greater_once(node, ctx)) is not None:
+            return expr
         lhs = _lower_expr(node.children[0], ctx)
         rhs = _lower_expr(node.children[1], ctx)
         op = _INFIX_OPS[kind]
@@ -859,6 +887,12 @@ def _lower_instoperand_read(node: SemaNode, ctx: LoweringContext) -> str:
         if binding.bit_width == 64:
             return f'{name}.read_lane64(wf, lane)'
         value = f'{name}.read_lane(wf, lane)'
+        if (
+            tag == 'D'
+            and ctx.true16_dst_select is not None
+            and ((node.ty and node.ty.size == 16) or binding.bit_width == 16)
+        ):
+            return f'(({ctx.true16_dst_select}) != 0 ? ({value} >> 16) : {value})'
         if tag != 'D' and idx in ctx.true16_src_selects:
             select = ctx.true16_src_selects[idx]
             return f'(({select}) != 0 ? ({value} >> 16) : {value})'
@@ -978,7 +1012,9 @@ def _lower_dst_write(
             if binding.bit_width == 64:
                 return [f'{_indent(ctx)}{name}.write_scalar64(wf, {rhs});']
             return [f'{_indent(ctx)}{name}.write_scalar(wf, {rhs});']
-        if lhs_ty and lhs_ty.size == 16 and ctx.true16_dst_select is not None:
+        if ctx.true16_dst_select is not None and (
+            (lhs_ty and lhs_ty.size == 16) or binding.bit_width == 16
+        ):
             selected_rhs = rhs
             if ctx.true16_src_raw is not None or ctx.true16_src_select is not None:
                 true16_rhs = ctx.true16_src_raw or raw_rhs

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_cmp.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_cmp.py
@@ -144,7 +144,6 @@ def gen_vector_cmp_class(
         L.append('    if (match) result |= (1ULL << lane);')
     else:
         L.append('    if (match) vcc |= (1ULL << lane);')
-        L.append('    else vcc &= ~(1ULL << lane);')
     L.append('  }')
     if is_cmpx:
         if cmpx_writes_vcc:
@@ -293,16 +292,12 @@ def gen_vector_cmp(
     L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
     L.append('    if (!(exec & (1ULL << lane))) continue;')
 
-    if op == 'f':
-        L.append('    vcc &= ~(1ULL << lane);')
-    elif op == 't':
+    if op == 't':
         L.append('    vcc |= (1ULL << lane);')
-    else:
+    elif op != 'f':
         cond = _cmp_condition(src, op, dtype, is_vop3, L, has_abs)
         L.append(f'    if ({cond})')
         L.append('      vcc |= (1ULL << lane);')
-        L.append('    else')
-        L.append('      vcc &= ~(1ULL << lane);')
     L.append('  }')
     if dst:
         # VOP3: write to explicit destination (sdst/vdst SGPR pair).

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_cmp.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_cmp.py
@@ -14,6 +14,13 @@ from amdisa.codegen.execute.vop3_modifiers import (
 )
 
 
+def _write_mask_to_explicit_dst(lines: list[str], dst: str, value: str) -> None:
+    lines.append('  if (wf.wf_size() <= 32)')
+    lines.append(f'    {dst}.write_scalar(wf, static_cast<uint32_t>({value}));')
+    lines.append('  else')
+    lines.append(f'    {dst}.write_scalar64(wf, {value});')
+
+
 def gen_vector_cmp_class(
     dst: list[str],
     src: list[str],
@@ -142,7 +149,7 @@ def gen_vector_cmp_class(
             L.append('  wf.set_vcc(result);')
         L.append('  wf.set_exec(result);')
     elif dst:
-        L.append(f'  {dst[0]}.write_scalar64(wf, vcc);')
+        _write_mask_to_explicit_dst(L, dst[0], 'vcc')
     else:
         L.append('  wf.set_vcc(vcc);')
     return '\n'.join(L)
@@ -297,7 +304,7 @@ def gen_vector_cmp(
     L.append('  }')
     if dst:
         # VOP3: write to explicit destination (sdst/vdst SGPR pair).
-        L.append(f'  {dst[0]}.write_scalar64(wf, vcc);')
+        _write_mask_to_explicit_dst(L, dst[0], 'vcc')
     else:
         # VOPC: write to VCC.
         L.append('  wf.set_vcc(vcc);')

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_cmp.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_cmp.py
@@ -15,6 +15,8 @@ from amdisa.codegen.execute.vop3_modifiers import (
 
 
 def _write_mask_to_explicit_dst(lines: list[str], dst: str, value: str) -> None:
+    # Keep this wave32/wave64 mask-width rule in sync with simd_glue.h and
+    # sema_lower.py.
     lines.append('  if (wf.wf_size() <= 32)')
     lines.append(f'    {dst}.write_scalar(wf, static_cast<uint32_t>({value}));')
     lines.append('  else')

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -64,6 +64,13 @@ def test_vector_cmp_writes_explicit_sdst_mask():
     assert 'wf.set_vcc(vcc)' not in body
 
 
+def test_vector_cmp_omits_redundant_mask_clears():
+    body = gen_vector_cmp(['sdst'], ['src0', 'src1'], 'eq', 'u32', is_vop3=True)
+
+    assert 'uint64_t vcc = 0;' in body
+    assert 'vcc &= ~(1ULL << lane)' not in body
+
+
 def test_vector_cmp_class_writes_explicit_sdst_mask():
     body = gen_vector_cmp_class(
         ['sdst'], ['src0', 'src1'], 'f32', is_cmpx=False, is_vop3=True
@@ -73,6 +80,15 @@ def test_vector_cmp_class_writes_explicit_sdst_mask():
     assert 'sdst.write_scalar(wf, static_cast<uint32_t>(vcc))' in body
     assert 'sdst.write_scalar64(wf, vcc)' in body
     assert 'wf.set_vcc(vcc)' not in body
+
+
+def test_vector_cmp_class_omits_redundant_mask_clears():
+    body = gen_vector_cmp_class(
+        ['sdst'], ['src0', 'src1'], 'f32', is_cmpx=False, is_vop3=True
+    )
+
+    assert 'uint64_t vcc = 0;' in body
+    assert 'vcc &= ~(1ULL << lane)' not in body
 
 
 def test_div_scale_uses_signed_tiny_exponent_threshold():

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -8,6 +8,10 @@ from amdisa.codegen.execute.vector_special import (
     gen_vector_div_scale,
     gen_vector_movrel,
 )
+from amdisa.codegen.execute.vector_cmp import (
+    gen_vector_cmp,
+    gen_vector_cmp_class,
+)
 from amdisa.isa_profile import Gfx1250Profile, Rdna4Profile
 
 
@@ -43,6 +47,26 @@ def test_movrel_uses_wavefront_resolver_with_vgpr_msb_indexing():
 def test_div_scale_writes_explicit_sdst_mask():
     body = gen_vector_div_scale(
         ['vdst', 'sdst'], ['src0', 'src1', 'src2'], 'f32', is_vop3=True
+    )
+
+    assert 'if (wf.wf_size() <= 32)' in body
+    assert 'sdst.write_scalar(wf, static_cast<uint32_t>(vcc))' in body
+    assert 'sdst.write_scalar64(wf, vcc)' in body
+    assert 'wf.set_vcc(vcc)' not in body
+
+
+def test_vector_cmp_writes_explicit_sdst_mask():
+    body = gen_vector_cmp(['sdst'], ['src0', 'src1'], 't', 'u32', is_vop3=True)
+
+    assert 'if (wf.wf_size() <= 32)' in body
+    assert 'sdst.write_scalar(wf, static_cast<uint32_t>(vcc))' in body
+    assert 'sdst.write_scalar64(wf, vcc)' in body
+    assert 'wf.set_vcc(vcc)' not in body
+
+
+def test_vector_cmp_class_writes_explicit_sdst_mask():
+    body = gen_vector_cmp_class(
+        ['sdst'], ['src0', 'src1'], 'f32', is_cmpx=False, is_vop3=True
     )
 
     assert 'if (wf.wf_size() <= 32)' in body
@@ -134,8 +158,8 @@ def test_gfx1250_vopd_template_uses_dx9_zero_and_fma(tmp_path):
 
     assert 'case 3:\n              case 7:' not in cpp
     assert 'if (lhs == 0.0f || rhs == 0.0f)' in cpp
-    fma_start = cpp.index('case 19: {')
-    fma_case = cpp[fma_start : cpp.index('case 20:', fma_start)]
+    fma_start = cpp.index('case kVopdFmaF32: {')
+    fma_case = cpp[fma_start : cpp.index('case kVopdSubNcU32:', fma_start)]
     assert 'std::fma(std::bit_cast<float>(src0),' in fma_case
     assert 'std::bit_cast<float>(src1),' in fma_case
     assert 'std::bit_cast<float>(src2))' in fma_case

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -760,8 +760,10 @@ class TestDeriveVectorUnary:
 
         cpp = gen_vector_cvt_pk(['vdst'], ['src0'], sem.semantic_class, sem.operation)
         assert helper in cpp
-        assert 'raw & 0xFFu' in cpp
-        assert '(raw >> 8) & 0xFFu' in cpp
+        assert 'src_hi' in cpp
+        assert 'packed & 0xFFFFu' in cpp
+        assert 'half & 0xFFu' in cpp
+        assert '(half >> 8) & 0xFFu' in cpp
         assert write_fn in cpp
         assert ('util::f32_to_f16' in cpp) == needs_f16
         assert 'src1' not in cpp
@@ -786,7 +788,11 @@ class TestDeriveVectorUnary:
         src = ['src0', 'src1'] if needs_src1 else ['src0']
         cpp = gen_vector_cvt_pk(['vdst'], src, sem.semantic_class, sem.operation)
         assert helper in cpp
-        assert 'lo | (hi << 8)' in cpp
+        assert 'static_cast<uint32_t>(lo)' in cpp
+        assert 'static_cast<uint32_t>(hi) << 8' in cpp
+        assert 'word_hi' in cpp
+        assert 'packed << 16' in cpp
+        assert 'packed & 0xFFFFu' in cpp
         assert 'write_lane' in cpp
         assert ('src1' in cpp) == needs_src1
         assert ('util::f16_to_f32' in cpp) == needs_f16
@@ -868,7 +874,7 @@ class TestDeriveVectorUnary:
         assert read_helper in cpp
         assert encode_helper in cpp
         assert 'pack_scaled_dst(index' in cpp
-        assert 'read_scaled_input(index) * scale' in cpp
+        assert 'read_scaled_input(index) / scale' in cpp
         assert 'Isa::resolved_vgpr_offset' in cpp
 
 

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_lower.py
@@ -141,6 +141,43 @@ class TestLowerVectorAdd:
         result = lower_sema_block(block)
         assert 'std::fma(' in result
 
+    def test_vector_explicit_vcc_dst_preserves_high_sgpr_on_wave32(self):
+        body = SemaNode(
+            SemaNodeKind.ASSIGN,
+            children=(
+                _cast(_dst(0), SemaType.U32),
+                SemaNode(
+                    SemaNodeKind.CALL,
+                    call_name='add_co',
+                    ty=SemaType.U32,
+                    children=(
+                        SemaNode(SemaNodeKind.ID, id_name='add_co'),
+                        _cast(_src(0), SemaType.U32),
+                        _cast(_src(1), SemaType.U32),
+                    ),
+                ),
+            ),
+        )
+        block = SemaBlock('V_ADD_CO_U32', ExecModel.VECTOR, body)
+        omap = OperandMap(
+            src_bindings={
+                0: OperandBinding('src0', RegClass.VGPR, 32),
+                1: OperandBinding('src1', RegClass.VGPR, 32),
+            },
+            dst_bindings={0: OperandBinding('vdst', RegClass.VGPR, 32)},
+        )
+        ctx = LoweringContext(
+            exec_model=ExecModel.VECTOR,
+            operand_map=omap,
+            vcc_dst='sdst',
+        )
+
+        result = lower_sema_block(block, ctx)
+
+        assert 'if (wf.wf_size() <= 32)' in result
+        assert 'sdst.write_scalar(wf, static_cast<uint32_t>(vcc))' in result
+        assert 'sdst.write_scalar64(wf, vcc)' in result
+
     def test_vector_block_can_write_scalar_destination(self):
         body = SemaNode(
             SemaNodeKind.ASSIGN,
@@ -190,6 +227,45 @@ class TestLowerVectorAdd:
         assert 'for (uint32_t lane = 0' not in result
         assert 'src0.read_scalar(wf)' in result
         assert 'vdst.write_scalar(wf' in result
+
+    def test_less_greater_compare_reads_operands_once(self):
+        s0 = _cast(_src(0), SemaType.F32)
+        s1 = _cast(_src(1), SemaType.F32)
+        body = SemaNode(
+            SemaNodeKind.ASSIGN,
+            children=(
+                SemaNode(
+                    SemaNodeKind.ARRAYDEREF,
+                    children=(
+                        SemaNode(SemaNodeKind.ID, id_name='VCC'),
+                        SemaNode(SemaNodeKind.ID, id_name='laneId'),
+                    ),
+                ),
+                SemaNode(
+                    SemaNodeKind.LOR,
+                    ty=SemaType.U1,
+                    children=(
+                        SemaNode(SemaNodeKind.LT, ty=SemaType.U1, children=(s0, s1)),
+                        SemaNode(SemaNodeKind.GT, ty=SemaType.U1, children=(s0, s1)),
+                    ),
+                ),
+            ),
+        )
+        block = SemaBlock('V_CMP_LG_F32', ExecModel.VECTOR, body)
+        omap = OperandMap(
+            src_bindings={
+                0: OperandBinding('src0', RegClass.VGPR, 32),
+                1: OperandBinding('src1', RegClass.VGPR, 32),
+            },
+        )
+
+        result = lower_sema_block(
+            block, LoweringContext(exec_model=ExecModel.VECTOR, operand_map=omap)
+        )
+
+        assert 'return (a < b) || (a > b);' in result
+        assert result.count('src0.read_lane(wf, lane)') == 1
+        assert result.count('src1.read_lane(wf, lane)') == 1
 
     def test_true16_destination_select_merges_half(self):
         b16 = SemaType('B', 16)
@@ -325,6 +401,45 @@ class TestLowerVectorAdd:
             in result
         )
         assert 'std::cos' in result
+
+    def test_true16_destination_read_selects_matching_half(self):
+        f16 = SemaType('F', 16)
+        dst_read = SemaNode(
+            SemaNodeKind.INSTOPERAND,
+            ty=f16,
+            children=(
+                SemaNode(SemaNodeKind.ID, id_name='D'),
+                SemaNode(SemaNodeKind.LIT, lit_value='0'),
+            ),
+        )
+        body = SemaNode(
+            SemaNodeKind.ASSIGN,
+            children=(
+                _cast(_dst(0), f16),
+                SemaNode(
+                    SemaNodeKind.ADD,
+                    ty=SemaType.F32,
+                    children=(
+                        _cast(_src(0), f16),
+                        _cast(dst_read, f16),
+                    ),
+                ),
+            ),
+        )
+        block = SemaBlock('V_FMAC_F16', ExecModel.VECTOR, body)
+        omap = OperandMap(
+            src_bindings={0: OperandBinding('src0', RegClass.VGPR, 16)},
+            dst_bindings={0: OperandBinding('vdst', RegClass.VGPR, 16)},
+        )
+        ctx = LoweringContext(
+            exec_model=ExecModel.VECTOR,
+            operand_map=omap,
+            true16_dst_select='inst_.opsel & 0x8u',
+        )
+
+        result = lower_sema_block(block, ctx)
+
+        assert '((inst_.opsel & 0x8u) != 0 ? (vdst.read_lane(wf, lane) >> 16)' in result
 
 
 class TestLowerCast:

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_lower.py
@@ -435,11 +435,16 @@ class TestLowerVectorAdd:
             exec_model=ExecModel.VECTOR,
             operand_map=omap,
             true16_dst_select='inst_.opsel & 0x8u',
+            true16_dst_reg='inst_.vdst & 0x7fu',
         )
 
         result = lower_sema_block(block, ctx)
 
-        assert '((inst_.opsel & 0x8u) != 0 ? (vdst.read_lane(wf, lane) >> 16)' in result
+        assert (
+            '((inst_.opsel & 0x8u) != 0 ? '
+            '(wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane) >> 16)'
+            in result
+        )
 
 
 class TestLowerCast:

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_lower.py
@@ -267,6 +267,46 @@ class TestLowerVectorAdd:
         assert result.count('src0.read_lane(wf, lane)') == 1
         assert result.count('src1.read_lane(wf, lane)') == 1
 
+    def test_zero_initialized_vcc_mask_omits_false_lane_clear(self):
+        body = SemaNode(
+            SemaNodeKind.ASSIGN,
+            children=(
+                SemaNode(
+                    SemaNodeKind.ARRAYDEREF,
+                    children=(
+                        SemaNode(SemaNodeKind.ID, id_name='VCC'),
+                        SemaNode(SemaNodeKind.ID, id_name='laneId'),
+                    ),
+                ),
+                SemaNode(
+                    SemaNodeKind.EQ,
+                    ty=SemaType.U1,
+                    children=(
+                        _cast(_src(0), SemaType.U32),
+                        _cast(_src(1), SemaType.U32),
+                    ),
+                ),
+            ),
+        )
+        block = SemaBlock('V_CMP_EQ_U32', ExecModel.VECTOR, body)
+        omap = OperandMap(
+            src_bindings={
+                0: OperandBinding('src0', RegClass.VGPR, 32),
+                1: OperandBinding('src1', RegClass.VGPR, 32),
+            },
+        )
+        ctx = LoweringContext(
+            exec_model=ExecModel.VECTOR,
+            operand_map=omap,
+            clear_false_lane_mask_writes=False,
+        )
+
+        result = lower_sema_block(block, ctx)
+
+        assert 'uint64_t vcc = 0;' in result
+        assert 'vcc |= (1ULL << lane);' in result
+        assert 'vcc &= ~(1ULL << lane);' not in result
+
     def test_true16_destination_select_merges_half(self):
         b16 = SemaType('B', 16)
         body = SemaNode(

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_vector_special_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_vector_special_codegen.py
@@ -69,7 +69,10 @@ def test_arch_local_execute_bodies_are_not_shared():
 
 def test_gfx1250_true16_execute_bodies_are_arch_local():
     codegen = object.__new__(CodeGenerator)
-    codegen.isa_spec = SimpleNamespace(arch_name='gfx1250')
+    codegen.isa_spec = SimpleNamespace(
+        arch_name='gfx1250',
+        profile=SimpleNamespace(vop3p_opsel_fields=('opsel', 'opsel_hi')),
+    )
     mov_b16 = Instruction(
         'V_MOV_B16',
         'ENC_VOP1',
@@ -89,6 +92,48 @@ def test_gfx1250_true16_execute_bodies_are_arch_local():
             Operand('src1', 16, 'OPR_SRC', True, False, False, False, 2),
         ],
     )
+    add_f16 = Instruction(
+        'V_ADD_F16',
+        'ENC_VOP2',
+        0,
+        [
+            Operand('vdst', 16, 'OPR_VGPR', False, True, False, False, 0),
+            Operand('src0', 16, 'OPR_SRC', True, False, False, False, 1),
+            Operand('vsrc1', 16, 'OPR_VGPR', True, False, False, False, 2),
+        ],
+    )
+    not_b16 = Instruction(
+        'V_NOT_B16',
+        'ENC_VOP1',
+        0,
+        [
+            Operand('vdst', 16, 'OPR_VGPR', False, True, False, False, 0),
+            Operand('src0', 16, 'OPR_SRC', True, False, False, False, 1),
+        ],
+    )
 
     assert codegen._requires_arch_local_execute(mov_b16, 'ENC_VOP1')
+    assert codegen._requires_arch_local_execute(not_b16, 'ENC_VOP1')
+    assert codegen._requires_arch_local_execute(add_f16, 'ENC_VOP2')
     assert codegen._requires_arch_local_execute(or_b16, 'ENC_VOP3')
+    assert not codegen._can_force_shared_simd_probe(mov_b16, 'ENC_VOP1')
+
+
+def test_gfx1250_non_true16_simd_probe_can_still_be_shared():
+    codegen = object.__new__(CodeGenerator)
+    codegen.isa_spec = SimpleNamespace(
+        arch_name='gfx1250',
+        profile=SimpleNamespace(vop3p_opsel_fields=('opsel', 'opsel_hi')),
+    )
+    mov_b32 = Instruction(
+        'V_MOV_B32',
+        'ENC_VOP1',
+        0,
+        [
+            Operand('vdst', 32, 'OPR_VGPR', False, True, False, False, 0),
+            Operand('src0', 32, 'OPR_SRC', True, False, False, False, 1),
+        ],
+    )
+
+    assert not codegen._requires_arch_local_execute(mov_b32, 'ENC_VOP1')
+    assert codegen._can_force_shared_simd_probe(mov_b32, 'ENC_VOP1')

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_vector_special_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_vector_special_codegen.py
@@ -137,3 +137,33 @@ def test_gfx1250_non_true16_simd_probe_can_still_be_shared():
 
     assert not codegen._requires_arch_local_execute(mov_b32, 'ENC_VOP1')
     assert codegen._can_force_shared_simd_probe(mov_b32, 'ENC_VOP1')
+
+
+def test_gfx1250_true16_e32_dst_reg_uses_physical_vgpr():
+    codegen = object.__new__(CodeGenerator)
+    codegen.isa_spec = SimpleNamespace(arch_name='gfx1250')
+    fmac_f16 = Instruction(
+        'V_FMAC_F16',
+        'ENC_VOP2',
+        0,
+        [
+            Operand('vdst', 16, 'OPR_VGPR', False, True, False, False, 0),
+            Operand('src0', 16, 'OPR_SRC', True, False, False, False, 1),
+            Operand('vsrc1', 16, 'OPR_VGPR', True, False, False, False, 2),
+        ],
+    )
+    add_f32 = Instruction(
+        'V_ADD_F32',
+        'ENC_VOP2',
+        0,
+        [
+            Operand('vdst', 32, 'OPR_VGPR', False, True, False, False, 0),
+            Operand('src0', 32, 'OPR_SRC', True, False, False, False, 1),
+            Operand('vsrc1', 32, 'OPR_VGPR', True, False, False, False, 2),
+        ],
+    )
+
+    assert codegen._e32_true16_dst_reg_expr(fmac_f16, 'ENC_VOP2') == (
+        '(inst_.vdst & 0x7fu)'
+    )
+    assert codegen._e32_true16_dst_reg_expr(add_f32, 'ENC_VOP2') == 'inst_.vdst'

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop1.cpp
@@ -1116,7 +1116,7 @@ void VCvtF16F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -1191,7 +1191,7 @@ void VCvtF16F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -1202,9 +1202,9 @@ void VCvtF16F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -3322,7 +3322,7 @@ void VMovB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -3404,7 +3404,7 @@ void VMovB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -3415,9 +3415,9 @@ void VMovB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -3721,7 +3721,7 @@ void VTanhF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -3797,7 +3797,7 @@ void VTanhF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -3808,9 +3808,9 @@ void VTanhF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -3819,10 +3819,10 @@ void VTanhF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -7706,7 +7706,7 @@ void VTanhBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -7782,7 +7782,7 @@ void VTanhBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -7793,9 +7793,9 @@ void VTanhBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -7960,7 +7960,7 @@ void VCvtF16U16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -8035,7 +8035,7 @@ void VCvtF16U16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -8046,9 +8046,9 @@ void VCvtF16U16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -8093,7 +8093,7 @@ void VCvtF16I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -8168,7 +8168,7 @@ void VCvtF16I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -8179,9 +8179,9 @@ void VCvtF16I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -8226,7 +8226,7 @@ void VCvtU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -8307,7 +8307,7 @@ void VCvtU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -8318,9 +8318,9 @@ void VCvtU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -8365,7 +8365,7 @@ void VCvtI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -8448,7 +8448,7 @@ void VCvtI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -8459,9 +8459,9 @@ void VCvtI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -8506,7 +8506,7 @@ void VRcpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -8582,7 +8582,7 @@ void VRcpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -8593,9 +8593,9 @@ void VRcpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -8604,10 +8604,10 @@ void VRcpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -8652,7 +8652,7 @@ void VSqrtF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -8728,7 +8728,7 @@ void VSqrtF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -8739,9 +8739,9 @@ void VSqrtF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -8750,10 +8750,10 @@ void VSqrtF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -8798,7 +8798,7 @@ void VRsqF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -8874,7 +8874,7 @@ void VRsqF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -8885,9 +8885,9 @@ void VRsqF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -8896,10 +8896,10 @@ void VRsqF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -8944,7 +8944,7 @@ void VLogF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -9020,7 +9020,7 @@ void VLogF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -9031,9 +9031,9 @@ void VLogF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -9042,10 +9042,10 @@ void VLogF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -9090,7 +9090,7 @@ void VExpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -9166,7 +9166,7 @@ void VExpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -9177,9 +9177,9 @@ void VExpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -9188,10 +9188,10 @@ void VExpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -9236,7 +9236,7 @@ void VFrexpMantF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -9315,7 +9315,7 @@ void VFrexpMantF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -9326,9 +9326,9 @@ void VFrexpMantF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -9337,10 +9337,10 @@ void VFrexpMantF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -9385,7 +9385,7 @@ void VFrexpExpI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -9465,7 +9465,7 @@ void VFrexpExpI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -9476,9 +9476,9 @@ void VFrexpExpI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -9487,10 +9487,10 @@ void VFrexpExpI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -9535,7 +9535,7 @@ void VFloorF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -9590,7 +9590,7 @@ void VFloorF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     {
       uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(
-          std::floor(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+          util::floor_scalar(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
       uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
       uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
                                                     : ((old_dst & 0xffff0000u) | src_half);
@@ -9610,7 +9610,7 @@ void VFloorF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -9621,9 +9621,9 @@ void VFloorF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -9632,10 +9632,10 @@ void VFloorF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -9680,7 +9680,7 @@ void VCeilF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -9735,7 +9735,7 @@ void VCeilF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     {
       uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(
-          std::ceil(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+          util::ceil_scalar(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
       uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
       uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
                                                     : ((old_dst & 0xffff0000u) | src_half);
@@ -9755,7 +9755,7 @@ void VCeilF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -9766,9 +9766,9 @@ void VCeilF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -9777,10 +9777,10 @@ void VCeilF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -9825,7 +9825,7 @@ void VTruncF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -9880,7 +9880,7 @@ void VTruncF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     {
       uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(
-          std::trunc(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+          util::trunc_scalar(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
       uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
       uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
                                                     : ((old_dst & 0xffff0000u) | src_half);
@@ -9900,7 +9900,7 @@ void VTruncF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -9911,9 +9911,9 @@ void VTruncF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -9922,10 +9922,10 @@ void VTruncF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -9970,7 +9970,7 @@ void VRndneF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -10045,7 +10045,7 @@ void VRndneF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -10056,9 +10056,9 @@ void VRndneF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -10067,10 +10067,10 @@ void VRndneF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -10115,7 +10115,7 @@ void VFractF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -10192,7 +10192,7 @@ void VFractF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -10203,9 +10203,9 @@ void VFractF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -10214,10 +10214,10 @@ void VFractF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -10262,7 +10262,7 @@ void VSinF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -10338,7 +10338,7 @@ void VSinF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -10349,9 +10349,9 @@ void VSinF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -10360,10 +10360,10 @@ void VSinF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -10408,7 +10408,7 @@ void VCosF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -10484,7 +10484,7 @@ void VCosF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -10495,9 +10495,9 @@ void VCosF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -10506,10 +10506,10 @@ void VCosF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -10591,7 +10591,7 @@ void VCvtNormI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -10671,7 +10671,7 @@ void VCvtNormI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -10682,9 +10682,9 @@ void VCvtNormI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -10693,10 +10693,10 @@ void VCvtNormI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -10741,7 +10741,7 @@ void VCvtNormU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -10821,7 +10821,7 @@ void VCvtNormU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -10832,9 +10832,9 @@ void VCvtNormU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -10843,10 +10843,10 @@ void VCvtNormU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -11016,7 +11016,7 @@ void VSwapB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -11086,7 +11086,7 @@ void VSwapB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -11096,9 +11096,9 @@ void VSwapB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -11180,7 +11180,7 @@ void VNotB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -11255,7 +11255,7 @@ void VNotB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -11266,9 +11266,9 @@ void VNotB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -12530,7 +12530,7 @@ void VCvtF16Fp8Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -12606,7 +12606,7 @@ void VCvtF16Fp8Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -12617,9 +12617,9 @@ void VCvtF16Fp8Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -12628,10 +12628,10 @@ void VCvtF16Fp8Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -12675,7 +12675,7 @@ void VCvtF16Bf8Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -12751,7 +12751,7 @@ void VCvtF16Bf8Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -12762,9 +12762,9 @@ void VCvtF16Bf8Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -12773,10 +12773,10 @@ void VCvtF16Bf8Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -12821,7 +12821,7 @@ void VRcpBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -12897,7 +12897,7 @@ void VRcpBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -12908,9 +12908,9 @@ void VRcpBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -12955,7 +12955,7 @@ void VSqrtBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -13031,7 +13031,7 @@ void VSqrtBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -13042,9 +13042,9 @@ void VSqrtBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -13089,7 +13089,7 @@ void VRsqBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -13165,7 +13165,7 @@ void VRsqBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -13176,9 +13176,9 @@ void VRsqBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -13223,7 +13223,7 @@ void VLogBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -13299,7 +13299,7 @@ void VLogBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -13310,9 +13310,9 @@ void VLogBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -13357,7 +13357,7 @@ void VExpBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -13433,7 +13433,7 @@ void VExpBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -13444,9 +13444,9 @@ void VExpBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -13491,7 +13491,7 @@ void VSinBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -13567,7 +13567,7 @@ void VSinBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -13578,9 +13578,9 @@ void VSinBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }
@@ -13625,7 +13625,7 @@ void VCosBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -13701,7 +13701,7 @@ void VCosBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -13712,9 +13712,9 @@ void VCosBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop1.cpp
@@ -1165,7 +1165,19 @@ void VCvtF16F32Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_f16_f32_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          util::f32_to_f16(std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -3359,7 +3371,26 @@ void VMovB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_mov_b16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>((
+          ((inst_.src0 >= 256 && inst_.src0 <= 511) ? ((inst_.src0 - 256) & 0x80u) : 0u) != 0
+              ? (((inst_.src0 >= 256 && inst_.src0 <= 511)
+                      ? wf.cu().read_vgpr(wf.vgpr_alloc().base + ((inst_.src0 - 256) & 0x7fu), lane)
+                      : src0.read_lane(wf, lane)) >>
+                 16)
+              : ((inst_.src0 >= 256 && inst_.src0 <= 511)
+                     ? wf.cu().read_vgpr(wf.vgpr_alloc().base + ((inst_.src0 - 256) & 0x7fu), lane)
+                     : src0.read_lane(wf, lane)))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -3743,9 +3774,15 @@ void VTanhF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane,
-                    util::f32_to_f16(amdgpu::transcendental::tanh_f32(
-                        util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))))));
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_f16(amdgpu::transcendental::tanh_f32(
+              util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
   }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
@@ -7722,9 +7759,15 @@ void VTanhBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane,
-                    util::f32_to_bf16(amdgpu::transcendental::tanh_f32(
-                        util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))))));
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_bf16(amdgpu::transcendental::tanh_f32(
+              util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
   }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
@@ -7966,7 +8009,19 @@ void VCvtF16U16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_f16_u16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          util::f32_to_f16(static_cast<float>(static_cast<uint16_t>(src0.read_lane(wf, lane))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -8087,7 +8142,19 @@ void VCvtF16I16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_f16_i16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(
+          static_cast<float>(static_cast<int16_t>(src0.read_lane(wf, lane) & 0xFFFF)))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -8208,7 +8275,25 @@ void VCvtU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_u16_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>([&]() -> uint32_t {
+        float s = util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)));
+        if (std::isnan(s) || s < 0.0f)
+          return 0u;
+        if (s >= 65536.0f)
+          return static_cast<uint32_t>(UINT16_MAX);
+        return static_cast<uint32_t>(static_cast<uint16_t>(s));
+      }()));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -8329,7 +8414,27 @@ void VCvtI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_i16_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>([&]() -> uint32_t {
+        float s = util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)));
+        if (std::isnan(s))
+          return 0u;
+        if (s >= 32768.0f)
+          return static_cast<uint32_t>(static_cast<uint16_t>(INT16_MAX));
+        if (s < -32768.0f)
+          return static_cast<uint32_t>(static_cast<uint16_t>(INT16_MIN));
+        return static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(s)));
+      }()));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -8450,7 +8555,20 @@ void VRcpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_rcp_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_f16(amdgpu::transcendental::rcp_f32(
+              util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -8583,7 +8701,20 @@ void VSqrtF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_sqrt_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_f16(amdgpu::transcendental::sqrt_f32(
+              util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -8716,7 +8847,20 @@ void VRsqF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_rsq_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_f16(amdgpu::transcendental::rsq_f32(
+              util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -8849,7 +8993,20 @@ void VLogF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_log_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_f16(amdgpu::transcendental::log_f32(
+              util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -8982,7 +9139,20 @@ void VExpF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_exp_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_f16(amdgpu::transcendental::exp_f32(
+              util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -9115,7 +9285,23 @@ void VFrexpMantF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_frexp_mant_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        int e;
+        return std::frexp(
+            static_cast<float>(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))),
+            &e);
+      }())));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -9248,7 +9434,24 @@ void VFrexpExpI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_frexp_exp_i16_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float s = util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)));
+        int exp = 0;
+        if (s != 0.0f && !std::isnan(s) && !std::isinf(s))
+          std::frexp(s, &exp);
+        return static_cast<uint32_t>(exp);
+      }())));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -9381,7 +9584,19 @@ void VFloorF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_floor_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(
+          std::floor(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -9514,7 +9729,19 @@ void VCeilF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_ceil_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(
+          std::ceil(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -9647,7 +9874,19 @@ void VTruncF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_trunc_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(
+          std::trunc(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -9780,7 +10019,19 @@ void VRndneF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_rndne_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(
+          std::nearbyint(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -9913,7 +10164,21 @@ void VFractF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_fract_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        auto v = util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)));
+        return v - std::floor(v);
+      }())));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -10046,7 +10311,20 @@ void VSinF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_sin_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_f16(amdgpu::transcendental::sin_f32(
+              util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -10179,7 +10457,20 @@ void VCosF16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cos_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_f16(amdgpu::transcendental::cos_f32(
+              util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -10349,7 +10640,24 @@ void VCvtNormI16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_norm_i16_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>([&]() -> uint32_t {
+        float s = util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)));
+        if (std::isnan(s))
+          return 0u;
+        float scaled = std::clamp(s * 32767.0f, -32768.0f, 32767.0f);
+        return static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(scaled)));
+      }()));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -10482,7 +10790,24 @@ void VCvtNormU16F16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_cvt_norm_u16_f16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>([&]() -> uint32_t {
+        float s = util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)));
+        if (std::isnan(s))
+          return 0u;
+        float scaled = std::clamp(s * 65535.0f, 0.0f, 65535.0f);
+        return static_cast<uint32_t>(static_cast<uint16_t>(scaled));
+      }()));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -10904,7 +11229,19 @@ void VNotB16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   }
   if (dpp_src0_)
     src0.set_delegate(dpp_src0_.get());
-  amdgpu::execute_v_not_b16_vop1(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          static_cast<uint32_t>(static_cast<uint16_t>((~src0.read_lane(wf, lane))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -12246,9 +12583,15 @@ void VCvtF16Fp8Vop1::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane,
-                    static_cast<uint32_t>(util::f32_to_f16(
-                        util::fp8_e4m3_to_f32(static_cast<uint8_t>(src0.read_lane(wf, lane))))));
+    {
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(util::f32_to_f16(
+              util::fp8_e4m3_to_f32(static_cast<uint8_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
   }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
@@ -12385,9 +12728,15 @@ void VCvtF16Bf8Vop1::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane,
-                    static_cast<uint32_t>(util::f32_to_f16(
-                        util::bf8_e5m2_to_f32(static_cast<uint8_t>(src0.read_lane(wf, lane))))));
+    {
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(util::f32_to_f16(
+              util::bf8_e5m2_to_f32(static_cast<uint8_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
   }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
@@ -12525,9 +12874,15 @@ void VRcpBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane,
-                    util::f32_to_bf16(amdgpu::transcendental::rcp_f32(
-                        util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))))));
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_bf16(amdgpu::transcendental::rcp_f32(
+              util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
   }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
@@ -12653,9 +13008,15 @@ void VSqrtBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane,
-                    util::f32_to_bf16(amdgpu::transcendental::sqrt_f32(
-                        util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))))));
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_bf16(amdgpu::transcendental::sqrt_f32(
+              util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
   }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
@@ -12781,9 +13142,15 @@ void VRsqBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane,
-                    util::f32_to_bf16(amdgpu::transcendental::rsq_f32(
-                        util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))))));
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_bf16(amdgpu::transcendental::rsq_f32(
+              util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
   }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
@@ -12909,9 +13276,15 @@ void VLogBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane,
-                    util::f32_to_bf16(amdgpu::transcendental::log_f32(
-                        util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))))));
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_bf16(amdgpu::transcendental::log_f32(
+              util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
   }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
@@ -13037,9 +13410,15 @@ void VExpBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane,
-                    util::f32_to_bf16(amdgpu::transcendental::exp_f32(
-                        util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))))));
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_bf16(amdgpu::transcendental::exp_f32(
+              util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
   }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
@@ -13165,9 +13544,15 @@ void VSinBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane,
-                    util::f32_to_bf16(amdgpu::transcendental::sin_f32(
-                        util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))))));
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_bf16(amdgpu::transcendental::sin_f32(
+              util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
   }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
@@ -13293,9 +13678,15 @@ void VCosBf16Vop1::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane,
-                    util::f32_to_bf16(amdgpu::transcendental::cos_f32(
-                        util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))))));
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(util::f32_to_bf16(amdgpu::transcendental::cos_f32(
+              util::bf16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
   }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop2.cpp
@@ -5717,7 +5717,20 @@ void VMinNumF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     src0.set_delegate(dpp_src0_.get());
   if (dpp_src1_)
     vsrc1.set_delegate(dpp_src1_.get());
-  amdgpu::execute_v_min_num_f16_vop2(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(
+          std::fmin(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))),
+                    util::f16_to_f32(static_cast<uint16_t>(vsrc1.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -5856,7 +5869,20 @@ void VMaxNumF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     src0.set_delegate(dpp_src0_.get());
   if (dpp_src1_)
     vsrc1.set_delegate(dpp_src1_.get());
-  amdgpu::execute_v_max_num_f16_vop2(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(
+          std::fmax(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))),
+                    util::f16_to_f32(static_cast<uint16_t>(vsrc1.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -5995,7 +6021,20 @@ void VAddF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     src0.set_delegate(dpp_src0_.get());
   if (dpp_src1_)
     vsrc1.set_delegate(dpp_src1_.get());
-  amdgpu::execute_v_add_f16_vop2(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          util::f32_to_f16((util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))) +
+                            util::f16_to_f32(static_cast<uint16_t>(vsrc1.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -6134,7 +6173,20 @@ void VSubF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     src0.set_delegate(dpp_src0_.get());
   if (dpp_src1_)
     vsrc1.set_delegate(dpp_src1_.get());
-  amdgpu::execute_v_sub_f16_vop2(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          util::f32_to_f16((util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))) -
+                            util::f16_to_f32(static_cast<uint16_t>(vsrc1.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -6273,7 +6325,20 @@ void VSubrevF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     src0.set_delegate(dpp_src0_.get());
   if (dpp_src1_)
     vsrc1.set_delegate(dpp_src1_.get());
-  amdgpu::execute_v_subrev_f16_vop2(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          util::f32_to_f16((util::f16_to_f32(static_cast<uint16_t>(vsrc1.read_lane(wf, lane))) -
+                            util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -6412,7 +6477,20 @@ void VMulF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     src0.set_delegate(dpp_src0_.get());
   if (dpp_src1_)
     vsrc1.set_delegate(dpp_src1_.get());
-  amdgpu::execute_v_mul_f16_vop2(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          util::f32_to_f16((util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))) *
+                            util::f16_to_f32(static_cast<uint16_t>(vsrc1.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -6552,7 +6630,23 @@ void VFmacF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     src0.set_delegate(dpp_src0_.get());
   if (dpp_src1_)
     vsrc1.set_delegate(dpp_src1_.get());
-  amdgpu::execute_v_fmac_f16_vop2(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(
+          std::fma(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))),
+                   util::f16_to_f32(static_cast<uint16_t>(vsrc1.read_lane(wf, lane))),
+                   util::f16_to_f32(static_cast<uint16_t>(((inst_.vdst & 0x80u) != 0
+                                                               ? (vdst.read_lane(wf, lane) >> 16)
+                                                               : vdst.read_lane(wf, lane))))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
@@ -6997,7 +7091,20 @@ void VLdexpF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     src0.set_delegate(dpp_src0_.get());
   if (dpp_src1_)
     vsrc1.set_delegate(dpp_src1_.get());
-  amdgpu::execute_v_ldexp_f16_vop2(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(
+          std::ldexp(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))),
+                     static_cast<int32_t>(static_cast<int16_t>(vsrc1.read_lane(wf, lane)))))));
+      uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
+      uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      wf.cu().write_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane, merged);
+    }
+  }
   if (inst_.src0 == amdgpu::SRC_DPP) {
     uint64_t dpp_write_mask = 0;
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop2.cpp
@@ -5666,7 +5666,7 @@ void VMinNumF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -5744,7 +5744,7 @@ void VMinNumF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -5756,9 +5756,9 @@ void VMinNumF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -5767,10 +5767,10 @@ void VMinNumF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -5818,7 +5818,7 @@ void VMaxNumF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -5896,7 +5896,7 @@ void VMaxNumF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -5908,9 +5908,9 @@ void VMaxNumF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -5919,10 +5919,10 @@ void VMaxNumF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -5970,7 +5970,7 @@ void VAddF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -6048,7 +6048,7 @@ void VAddF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -6060,9 +6060,9 @@ void VAddF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -6071,10 +6071,10 @@ void VAddF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -6122,7 +6122,7 @@ void VSubF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -6200,7 +6200,7 @@ void VSubF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -6212,9 +6212,9 @@ void VSubF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -6223,10 +6223,10 @@ void VSubF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -6274,7 +6274,7 @@ void VSubrevF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -6352,7 +6352,7 @@ void VSubrevF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -6364,9 +6364,9 @@ void VSubrevF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -6375,10 +6375,10 @@ void VSubrevF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -6426,7 +6426,7 @@ void VMulF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -6504,7 +6504,7 @@ void VMulF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -6516,9 +6516,9 @@ void VMulF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -6527,10 +6527,10 @@ void VMulF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -6579,7 +6579,7 @@ void VFmacF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -6635,12 +6635,13 @@ void VFmacF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(
-          std::fma(util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))),
-                   util::f16_to_f32(static_cast<uint16_t>(vsrc1.read_lane(wf, lane))),
-                   util::f16_to_f32(static_cast<uint16_t>(((inst_.vdst & 0x80u) != 0
-                                                               ? (vdst.read_lane(wf, lane) >> 16)
-                                                               : vdst.read_lane(wf, lane))))))));
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(std::fma(
+          util::f16_to_f32(static_cast<uint16_t>(src0.read_lane(wf, lane))),
+          util::f16_to_f32(static_cast<uint16_t>(vsrc1.read_lane(wf, lane))),
+          util::f16_to_f32(static_cast<uint16_t>(
+              ((inst_.vdst & 0x80u) != 0
+                   ? (wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane) >> 16)
+                   : wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane))))))));
       uint32_t old_dst = wf.cu().read_vgpr(wf.vgpr_alloc().base + (inst_.vdst & 0x7fu), lane);
       uint32_t merged = ((inst_.vdst & 0x80u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
                                                     : ((old_dst & 0xffff0000u) | src_half);
@@ -6660,7 +6661,7 @@ void VFmacF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -6672,9 +6673,9 @@ void VFmacF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -6683,10 +6684,10 @@ void VFmacF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -6740,7 +6741,7 @@ void VFmamkF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -6813,7 +6814,7 @@ void VFmamkF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -6825,9 +6826,9 @@ void VFmamkF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -6836,10 +6837,10 @@ void VFmamkF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -6893,7 +6894,7 @@ void VFmaakF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -6966,7 +6967,7 @@ void VFmaakF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -6978,9 +6979,9 @@ void VFmaakF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -6989,10 +6990,10 @@ void VFmaakF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }
@@ -7040,7 +7041,7 @@ void VLdexpF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     uint64_t ex = wf.exec();
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln)
       if (ex & (1ULL << ln))
-        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+        sdwa_old_dst_[ln] = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
   }
   if (inst_.src0 == amdgpu::SRC_DPP)
     amdgpu::dpp::apply_dpp(src_operands_[0], dpp_ctrl_, dpp_row_mask_, dpp_bank_mask_,
@@ -7118,7 +7119,7 @@ void VLdexpF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
       uint32_t vb = wf.vgpr_alloc().base;
       for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
         if ((ex & (1ULL << ln)) && !(dpp_write_mask & (1ULL << ln)))
-          wf.cu().write_vgpr(vb + inst_.vdst, ln, sdwa_old_dst_[ln]);
+          wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, sdwa_old_dst_[ln]);
       }
     }
   }
@@ -7130,9 +7131,9 @@ void VLdexpF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       dv = amdgpu::sdwa::sdwa_dst_merge(dv, sdwa_old_dst_[ln], sdwa_dst_sel_, sdwa_dst_unused_);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, dv);
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, dv);
     }
   }
   if (sdwa_clamp_) {
@@ -7141,10 +7142,10 @@ void VLdexpF16Vop2::execute_impl(amdgpu::Wavefront &wf) {
     for (uint32_t ln = 0; ln < wf.wf_size(); ++ln) {
       if (!(ex & (1ULL << ln)))
         continue;
-      uint32_t dv = wf.cu().read_vgpr(vb + inst_.vdst, ln);
+      uint32_t dv = wf.cu().read_vgpr(vb + (inst_.vdst & 0x7fu), ln);
       float fv = std::bit_cast<float>(dv);
       fv = std::clamp(fv, 0.0f, 1.0f);
-      wf.cu().write_vgpr(vb + inst_.vdst, ln, std::bit_cast<uint32_t>(fv));
+      wf.cu().write_vgpr(vb + (inst_.vdst & 0x7fu), ln, std::bit_cast<uint32_t>(fv));
     }
   }
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu.cpp
@@ -912,7 +912,43 @@ VRcpF16Vop3::VRcpF16Vop3(const MachineInst *inst)
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
-void VRcpF16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rcp_f16_vop3(*this, wf); }
+void VRcpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = amdgpu::transcendental::rcp_f32([&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
     : Vop3("v_sqrt_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSqrtF16Vop3>()),
@@ -938,7 +974,41 @@ VSqrtF16Vop3::VSqrtF16Vop3(const MachineInst *inst)
 }
 
 void VSqrtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_sqrt_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = amdgpu::transcendental::sqrt_f32([&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
@@ -964,7 +1034,43 @@ VRsqF16Vop3::VRsqF16Vop3(const MachineInst *inst)
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
-void VRsqF16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_rsq_f16_vop3(*this, wf); }
+void VRsqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = amdgpu::transcendental::rsq_f32([&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
     : Vop3("v_log_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VLogF16Vop3>()),
@@ -989,7 +1095,43 @@ VLogF16Vop3::VLogF16Vop3(const MachineInst *inst)
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
-void VLogF16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_log_f16_vop3(*this, wf); }
+void VLogF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = amdgpu::transcendental::log_f32([&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
     : Vop3("v_exp_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VExpF16Vop3>()),
@@ -1014,7 +1156,43 @@ VExpF16Vop3::VExpF16Vop3(const MachineInst *inst)
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
-void VExpF16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_exp_f16_vop3(*this, wf); }
+void VExpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = amdgpu::transcendental::exp_f32([&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
     : Vop3("v_floor_f16", reinterpret_cast<const OpEncoding *>(inst),
@@ -1041,7 +1219,41 @@ VFloorF16Vop3::VFloorF16Vop3(const MachineInst *inst)
 }
 
 void VFloorF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_floor_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = std::floor([&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
@@ -1068,7 +1280,41 @@ VCeilF16Vop3::VCeilF16Vop3(const MachineInst *inst)
 }
 
 void VCeilF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_ceil_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = std::ceil([&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
@@ -1096,7 +1342,41 @@ VTruncF16Vop3::VTruncF16Vop3(const MachineInst *inst)
 }
 
 void VTruncF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_trunc_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = std::trunc([&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
@@ -1124,7 +1404,41 @@ VRndneF16Vop3::VRndneF16Vop3(const MachineInst *inst)
 }
 
 void VRndneF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_rndne_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = std::nearbyint([&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
@@ -1152,7 +1466,44 @@ VFractF16Vop3::VFractF16Vop3(const MachineInst *inst)
 }
 
 void VFractF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_fract_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = [&]() {
+            auto v = [&]() {
+              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                             : src0.read_lane(wf, lane))));
+              if (inst_.abs & (1u << 0))
+                sv = std::fabs(sv);
+              if (inst_.neg & (1u << 0))
+                sv = -sv;
+              return sv;
+            }();
+            return v - std::floor(v);
+          }();
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VSinF16Vop3::VSinF16Vop3(const MachineInst *inst)
@@ -1300,7 +1651,22 @@ VNotB16Vop3::VNotB16Vop3(const MachineInst *inst)
   src0.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src0);
 }
 
-void VNotB16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_not_b16_vop3(*this, wf); }
+void VNotB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
+          static_cast<uint16_t>((~((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                             : src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VRcpBf16Vop3::VRcpBf16Vop3(const MachineInst *inst)
     : Vop3("v_rcp_bf16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VRcpBf16Vop3>()),
@@ -3304,7 +3670,53 @@ VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
-void VAddF16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_add_f16_vop3(*this, wf); }
+void VAddF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = ([&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }() +
+                     [&]() {
+                       float sv = util::f16_to_f32(static_cast<uint16_t>(
+                           ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                      : src1.read_lane(wf, lane))));
+                       if (inst_.abs & (1u << 1))
+                         sv = std::fabs(sv);
+                       if (inst_.neg & (1u << 1))
+                         sv = -sv;
+                       return sv;
+                     }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
     : Vop3("v_sub_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VSubF16Vop3>()),
@@ -3343,7 +3755,53 @@ VSubF16Vop3::VSubF16Vop3(const MachineInst *inst)
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
-void VSubF16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_sub_f16_vop3(*this, wf); }
+void VSubF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = ([&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }() -
+                     [&]() {
+                       float sv = util::f16_to_f32(static_cast<uint16_t>(
+                           ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                      : src1.read_lane(wf, lane))));
+                       if (inst_.abs & (1u << 1))
+                         sv = std::fabs(sv);
+                       if (inst_.neg & (1u << 1))
+                         sv = -sv;
+                       return sv;
+                     }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
     : Vop3("v_subrev_f16", reinterpret_cast<const OpEncoding *>(inst),
@@ -3384,7 +3842,51 @@ VSubrevF16Vop3::VSubrevF16Vop3(const MachineInst *inst)
 }
 
 void VSubrevF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_subrev_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = ([&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                 : src1.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 1))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 1))
+              sv = -sv;
+            return sv;
+          }() -
+                     [&]() {
+                       float sv = util::f16_to_f32(static_cast<uint16_t>(
+                           ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                      : src0.read_lane(wf, lane))));
+                       if (inst_.abs & (1u << 0))
+                         sv = std::fabs(sv);
+                       if (inst_.neg & (1u << 0))
+                         sv = -sv;
+                       return sv;
+                     }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
@@ -3424,7 +3926,53 @@ VMulF16Vop3::VMulF16Vop3(const MachineInst *inst)
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
-void VMulF16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_mul_f16_vop3(*this, wf); }
+void VMulF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = ([&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }() *
+                     [&]() {
+                       float sv = util::f16_to_f32(static_cast<uint16_t>(
+                           ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                      : src1.read_lane(wf, lane))));
+                       if (inst_.abs & (1u << 1))
+                         sv = std::fabs(sv);
+                       if (inst_.neg & (1u << 1))
+                         sv = -sv;
+                       return sv;
+                     }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VFmacF16Vop3::VFmacF16Vop3(const MachineInst *inst)
     : Vop3("v_fmac_f16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VFmacF16Vop3>()),
@@ -3465,7 +4013,55 @@ VFmacF16Vop3::VFmacF16Vop3(const MachineInst *inst)
 }
 
 void VFmacF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_fmac_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = std::fma(
+              [&]() {
+                float sv = util::f16_to_f32(static_cast<uint16_t>(
+                    ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                               : src0.read_lane(wf, lane))));
+                if (inst_.abs & (1u << 0))
+                  sv = std::fabs(sv);
+                if (inst_.neg & (1u << 0))
+                  sv = -sv;
+                return sv;
+              }(),
+              [&]() {
+                float sv = util::f16_to_f32(static_cast<uint16_t>(
+                    ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                               : src1.read_lane(wf, lane))));
+                if (inst_.abs & (1u << 1))
+                  sv = std::fabs(sv);
+                if (inst_.neg & (1u << 1))
+                  sv = -sv;
+                return sv;
+              }(),
+              util::f16_to_f32(static_cast<uint16_t>(((inst_.opsel & 0x8u) != 0
+                                                          ? (vdst.read_lane(wf, lane) >> 16)
+                                                          : vdst.read_lane(wf, lane)))));
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
@@ -3507,7 +4103,45 @@ VLdexpF16Vop3::VLdexpF16Vop3(const MachineInst *inst)
 }
 
 void VLdexpF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_ldexp_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = std::ldexp(
+              [&]() {
+                float sv = util::f16_to_f32(static_cast<uint16_t>(
+                    ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                               : src0.read_lane(wf, lane))));
+                if (inst_.abs & (1u << 0))
+                  sv = std::fabs(sv);
+                if (inst_.neg & (1u << 0))
+                  sv = -sv;
+                return sv;
+              }(),
+              static_cast<int32_t>(
+                  static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                  : src1.read_lane(wf, lane)))));
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VDivFixupF32Vop3::VDivFixupF32Vop3(const MachineInst *inst)
@@ -3927,7 +4561,60 @@ VDivFixupF16Vop3::VDivFixupF16Vop3(const MachineInst *inst)
 }
 
 void VDivFixupF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_div_fixup_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float p = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float b = std::bit_cast<float>(src1.read_lane(wf, lane));
+    float c = std::bit_cast<float>(src2.read_lane(wf, lane));
+    if (inst_.abs & (1u << 0))
+      p = std::fabs(p);
+    if (inst_.neg & (1u << 0))
+      p = -p;
+    if (inst_.abs & (1u << 1))
+      b = std::fabs(b);
+    if (inst_.neg & (1u << 1))
+      b = -b;
+    if (inst_.abs & (1u << 2))
+      c = std::fabs(c);
+    if (inst_.neg & (1u << 2))
+      c = -c;
+    float result;
+    if (std::isnan(c))
+      result = c;
+    else if (std::isnan(b))
+      result = b;
+    else if (c == 0.0f && b == 0.0f)
+      result = std::numeric_limits<float>::quiet_NaN();
+    else if (std::isinf(c) && std::isinf(b))
+      result = std::numeric_limits<float>::quiet_NaN();
+    else if (b == 0.0f) {
+      result = std::copysign(
+          std::numeric_limits<float>::infinity(),
+          std::bit_cast<float>(std::bit_cast<uint32_t>(b) ^ std::bit_cast<uint32_t>(c)));
+    } else if (c == 0.0f)
+      result = std::copysign(
+          0.0f, std::bit_cast<float>(std::bit_cast<uint32_t>(b) ^ std::bit_cast<uint32_t>(c)));
+    else if (std::isinf(c)) {
+      result = std::copysign(
+          std::numeric_limits<float>::infinity(),
+          std::bit_cast<float>(std::bit_cast<uint32_t>(b) ^ std::bit_cast<uint32_t>(c)));
+    } else if (std::isinf(b))
+      result = std::copysign(
+          0.0f, std::bit_cast<float>(std::bit_cast<uint32_t>(b) ^ std::bit_cast<uint32_t>(c)));
+    else
+      result = p;
+    if (inst_.omod == 1)
+      result *= 2.0f;
+    else if (inst_.omod == 2)
+      result *= 4.0f;
+    else if (inst_.omod == 3)
+      result *= 0.5f;
+    if (inst_.clamp)
+      result = std::clamp(result, 0.0f, 1.0f);
+    vdst.write_lane(wf, lane, std::bit_cast<uint32_t>(result));
+  }
 }
 
 VSExpF32Vop3::VSExpF32Vop3(const MachineInst *inst)
@@ -4351,7 +5038,23 @@ VAddNcU16Vop3::VAddNcU16Vop3(const MachineInst *inst)
 }
 
 void VAddNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_add_nc_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane))) +
+               static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
@@ -4393,7 +5096,23 @@ VSubNcU16Vop3::VSubNcU16Vop3(const MachineInst *inst)
 }
 
 void VSubNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_sub_nc_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane))) -
+               static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
@@ -4435,7 +5154,25 @@ VMulLoU16Vop3::VMulLoU16Vop3(const MachineInst *inst)
 }
 
 void VMulLoU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_mul_lo_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              static_cast<uint16_t>(static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0
+                                                               ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane)))) *
+              static_cast<uint16_t>(static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0
+                                                               ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane))))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
@@ -4475,7 +5212,25 @@ VMaxU16Vop3::VMaxU16Vop3(const MachineInst *inst)
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
-void VMaxU16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_max_u16_vop3(*this, wf); }
+void VMaxU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(std::max(
+              static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))),
+              static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
     : Vop3("v_max_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMaxI16Vop3>()),
@@ -4514,7 +5269,25 @@ VMaxI16Vop3::VMaxI16Vop3(const MachineInst *inst)
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
-void VMaxI16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_max_i16_vop3(*this, wf); }
+void VMaxI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(std::max(
+              static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                              : src0.read_lane(wf, lane))),
+              static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
     : Vop3("v_min_u16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinU16Vop3>()),
@@ -4553,7 +5326,25 @@ VMinU16Vop3::VMinU16Vop3(const MachineInst *inst)
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
-void VMinU16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_min_u16_vop3(*this, wf); }
+void VMinU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(std::min(
+              static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))),
+              static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
     : Vop3("v_min_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMinI16Vop3>()),
@@ -4592,7 +5383,25 @@ VMinI16Vop3::VMinI16Vop3(const MachineInst *inst)
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
-void VMinI16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_min_i16_vop3(*this, wf); }
+void VMinI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(std::min(
+              static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                              : src0.read_lane(wf, lane))),
+              static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
     : Vop3("v_add_nc_i16", reinterpret_cast<const OpEncoding *>(inst),
@@ -4633,7 +5442,23 @@ VAddNcI16Vop3::VAddNcI16Vop3(const MachineInst *inst)
 }
 
 void VAddNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_add_nc_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))) +
+               static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane)))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
@@ -4675,7 +5500,23 @@ VSubNcI16Vop3::VSubNcI16Vop3(const MachineInst *inst)
 }
 
 void VSubNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_sub_nc_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))) -
+               static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane)))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMinU64Vop3::VMinU64Vop3(const MachineInst *inst)
@@ -5368,7 +6209,25 @@ VLshlrevB16Vop3::VLshlrevB16Vop3(const MachineInst *inst)
 }
 
 void VLshlrevB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_lshlrev_b16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane)))
+               << (static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0
+                                              ? (src0.read_lane(wf, lane) >> 16)
+                                              : src0.read_lane(wf, lane))) &
+                   15u))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
@@ -5410,7 +6269,24 @@ VLshrrevB16Vop3::VLshrrevB16Vop3(const MachineInst *inst)
 }
 
 void VLshrrevB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_lshrrev_b16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))) >>
+               (static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))) &
+                15u))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
@@ -5452,7 +6328,28 @@ VAshrrevI16Vop3::VAshrrevI16Vop3(const MachineInst *inst)
 }
 
 void VAshrrevI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_ashrrev_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>([&]() {
+            auto v = static_cast<int16_t>(
+                static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))));
+            return static_cast<uint32_t>(static_cast<uint16_t>(
+                v >>
+                (static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))) &
+                 15u)));
+          }())))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VLshrrevB64Vop3::VLshrrevB64Vop3(const MachineInst *inst)
@@ -5660,7 +6557,25 @@ VAndB16Vop3::VAndB16Vop3(const MachineInst *inst)
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
-void VAndB16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_and_b16_vop3(*this, wf); }
+void VAndB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane))) &
+               static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VOrB16Vop3::VOrB16Vop3(const MachineInst *inst)
     : Vop3("v_or_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VOrB16Vop3>()),
@@ -5699,7 +6614,25 @@ VOrB16Vop3::VOrB16Vop3(const MachineInst *inst)
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
-void VOrB16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_or_b16_vop3(*this, wf); }
+void VOrB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane))) |
+               static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VXorB16Vop3::VXorB16Vop3(const MachineInst *inst)
     : Vop3("v_xor_b16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXorB16Vop3>()),
@@ -5738,7 +6671,25 @@ VXorB16Vop3::VXorB16Vop3(const MachineInst *inst)
   src1.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src1);
 }
 
-void VXorB16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_xor_b16_vop3(*this, wf); }
+void VXorB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane))) ^
+               static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VMinimumF32Vop3::VMinimumF32Vop3(const MachineInst *inst)
     : Vop3("v_minimum_f32", reinterpret_cast<const OpEncoding *>(inst),

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu.cpp
@@ -1226,7 +1226,7 @@ void VFloorF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     {
       uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
         float v = [&]() {
-          float v = std::floor([&]() {
+          float v = util::floor_scalar([&]() {
             float sv = util::f16_to_f32(
                 static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
                                                                  : src0.read_lane(wf, lane))));
@@ -1287,7 +1287,7 @@ void VCeilF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     {
       uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
         float v = [&]() {
-          float v = std::ceil([&]() {
+          float v = util::ceil_scalar([&]() {
             float sv = util::f16_to_f32(
                 static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
                                                                  : src0.read_lane(wf, lane))));
@@ -1349,7 +1349,7 @@ void VTruncF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     {
       uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
         float v = [&]() {
-          float v = std::trunc([&]() {
+          float v = util::trunc_scalar([&]() {
             float sv = util::f16_to_f32(
                 static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
                                                                  : src0.read_lane(wf, lane))));
@@ -3588,7 +3588,52 @@ VMinNumF16Vop3::VMinNumF16Vop3(const MachineInst *inst)
 }
 
 void VMinNumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_min_num_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = std::fmin(
+              [&]() {
+                float sv = util::f16_to_f32(static_cast<uint16_t>(
+                    ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                               : src0.read_lane(wf, lane))));
+                if (inst_.abs & (1u << 0))
+                  sv = std::fabs(sv);
+                if (inst_.neg & (1u << 0))
+                  sv = -sv;
+                return sv;
+              }(),
+              [&]() {
+                float sv = util::f16_to_f32(static_cast<uint16_t>(
+                    ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                               : src1.read_lane(wf, lane))));
+                if (inst_.abs & (1u << 1))
+                  sv = std::fabs(sv);
+                if (inst_.neg & (1u << 1))
+                  sv = -sv;
+                return sv;
+              }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMaxNumF16Vop3::VMaxNumF16Vop3(const MachineInst *inst)
@@ -3630,7 +3675,52 @@ VMaxNumF16Vop3::VMaxNumF16Vop3(const MachineInst *inst)
 }
 
 void VMaxNumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_max_num_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = std::fmax(
+              [&]() {
+                float sv = util::f16_to_f32(static_cast<uint16_t>(
+                    ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                               : src0.read_lane(wf, lane))));
+                if (inst_.abs & (1u << 0))
+                  sv = std::fabs(sv);
+                if (inst_.neg & (1u << 0))
+                  sv = -sv;
+                return sv;
+              }(),
+              [&]() {
+                float sv = util::f16_to_f32(static_cast<uint16_t>(
+                    ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                               : src1.read_lane(wf, lane))));
+                if (inst_.abs & (1u << 1))
+                  sv = std::fabs(sv);
+                if (inst_.neg & (1u << 1))
+                  sv = -sv;
+                return sv;
+              }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VAddF16Vop3::VAddF16Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_cmp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_cmp.cpp
@@ -57,7 +57,39 @@ VCmpLtF16Vop3::VCmpLtF16Vop3(const MachineInst *inst)
 }
 
 void VCmpLtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_lt_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if (([&]() {
+          float sv = util::f16_to_f32(
+              static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }() <
+         [&]() {
+           float sv = util::f16_to_f32(
+               static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))));
+           if (inst_.abs & (1u << 1))
+             sv = std::fabs(sv);
+           if (inst_.neg & (1u << 1))
+             sv = -sv;
+           return sv;
+         }()))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
@@ -98,7 +130,39 @@ VCmpEqF16Vop3::VCmpEqF16Vop3(const MachineInst *inst)
 }
 
 void VCmpEqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_eq_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if (([&]() {
+          float sv = util::f16_to_f32(
+              static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }() ==
+         [&]() {
+           float sv = util::f16_to_f32(
+               static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))));
+           if (inst_.abs & (1u << 1))
+             sv = std::fabs(sv);
+           if (inst_.neg & (1u << 1))
+             sv = -sv;
+           return sv;
+         }()))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
@@ -139,7 +203,39 @@ VCmpLeF16Vop3::VCmpLeF16Vop3(const MachineInst *inst)
 }
 
 void VCmpLeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_le_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if (([&]() {
+          float sv = util::f16_to_f32(
+              static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }() <=
+         [&]() {
+           float sv = util::f16_to_f32(
+               static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))));
+           if (inst_.abs & (1u << 1))
+             sv = std::fabs(sv);
+           if (inst_.neg & (1u << 1))
+             sv = -sv;
+           return sv;
+         }()))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
@@ -180,7 +276,39 @@ VCmpGtF16Vop3::VCmpGtF16Vop3(const MachineInst *inst)
 }
 
 void VCmpGtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_gt_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if (([&]() {
+          float sv = util::f16_to_f32(
+              static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }() >
+         [&]() {
+           float sv = util::f16_to_f32(
+               static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))));
+           if (inst_.abs & (1u << 1))
+             sv = std::fabs(sv);
+           if (inst_.neg & (1u << 1))
+             sv = -sv;
+           return sv;
+         }()))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
@@ -221,7 +349,42 @@ VCmpLgF16Vop3::VCmpLgF16Vop3(const MachineInst *inst)
 }
 
 void VCmpLgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_lg_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if (([&]() {
+          auto a = [&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }();
+          auto b = [&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                 : src1.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 1))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 1))
+              sv = -sv;
+            return sv;
+          }();
+          return (a < b) || (a > b);
+        }()))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
@@ -262,7 +425,39 @@ VCmpGeF16Vop3::VCmpGeF16Vop3(const MachineInst *inst)
 }
 
 void VCmpGeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_ge_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if (([&]() {
+          float sv = util::f16_to_f32(
+              static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }() >=
+         [&]() {
+           float sv = util::f16_to_f32(
+               static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))));
+           if (inst_.abs & (1u << 1))
+             sv = std::fabs(sv);
+           if (inst_.neg & (1u << 1))
+             sv = -sv;
+           return sv;
+         }()))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
@@ -302,7 +497,39 @@ VCmpOF16Vop3::VCmpOF16Vop3(const MachineInst *inst)
 }
 
 void VCmpOF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_o_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((!std::isnan([&]() {
+          float sv = util::f16_to_f32(
+              static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }()) &&
+         !std::isnan([&]() {
+           float sv = util::f16_to_f32(
+               static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))));
+           if (inst_.abs & (1u << 1))
+             sv = std::fabs(sv);
+           if (inst_.neg & (1u << 1))
+             sv = -sv;
+           return sv;
+         }())))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
@@ -342,7 +569,39 @@ VCmpUF16Vop3::VCmpUF16Vop3(const MachineInst *inst)
 }
 
 void VCmpUF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_u_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((std::isnan([&]() {
+           float sv = util::f16_to_f32(
+               static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane))));
+           if (inst_.abs & (1u << 0))
+             sv = std::fabs(sv);
+           if (inst_.neg & (1u << 0))
+             sv = -sv;
+           return sv;
+         }()) ||
+         std::isnan([&]() {
+           float sv = util::f16_to_f32(
+               static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))));
+           if (inst_.abs & (1u << 1))
+             sv = std::fabs(sv);
+           if (inst_.neg & (1u << 1))
+             sv = -sv;
+           return sv;
+         }())))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
@@ -383,7 +642,39 @@ VCmpNgeF16Vop3::VCmpNgeF16Vop3(const MachineInst *inst)
 }
 
 void VCmpNgeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_nge_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((!([&]() {
+          float sv = util::f16_to_f32(
+              static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }() >=
+           [&]() {
+             float sv = util::f16_to_f32(
+                 static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                  : src1.read_lane(wf, lane))));
+             if (inst_.abs & (1u << 1))
+               sv = std::fabs(sv);
+             if (inst_.neg & (1u << 1))
+               sv = -sv;
+             return sv;
+           }())))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
@@ -424,7 +715,42 @@ VCmpNlgF16Vop3::VCmpNlgF16Vop3(const MachineInst *inst)
 }
 
 void VCmpNlgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_nlg_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((!([&]() {
+          auto a = [&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }();
+          auto b = [&]() {
+            float sv = util::f16_to_f32(
+                static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                 : src1.read_lane(wf, lane))));
+            if (inst_.abs & (1u << 1))
+              sv = std::fabs(sv);
+            if (inst_.neg & (1u << 1))
+              sv = -sv;
+            return sv;
+          }();
+          return (a < b) || (a > b);
+        }())))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
@@ -465,7 +791,39 @@ VCmpNgtF16Vop3::VCmpNgtF16Vop3(const MachineInst *inst)
 }
 
 void VCmpNgtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_ngt_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((!([&]() {
+          float sv = util::f16_to_f32(
+              static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }() >
+           [&]() {
+             float sv = util::f16_to_f32(
+                 static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                  : src1.read_lane(wf, lane))));
+             if (inst_.abs & (1u << 1))
+               sv = std::fabs(sv);
+             if (inst_.neg & (1u << 1))
+               sv = -sv;
+             return sv;
+           }())))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
@@ -506,7 +864,39 @@ VCmpNleF16Vop3::VCmpNleF16Vop3(const MachineInst *inst)
 }
 
 void VCmpNleF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_nle_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((!([&]() {
+          float sv = util::f16_to_f32(
+              static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }() <=
+           [&]() {
+             float sv = util::f16_to_f32(
+                 static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                  : src1.read_lane(wf, lane))));
+             if (inst_.abs & (1u << 1))
+               sv = std::fabs(sv);
+             if (inst_.neg & (1u << 1))
+               sv = -sv;
+             return sv;
+           }())))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
@@ -547,7 +937,39 @@ VCmpNeqF16Vop3::VCmpNeqF16Vop3(const MachineInst *inst)
 }
 
 void VCmpNeqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_neq_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if (([&]() {
+          float sv = util::f16_to_f32(
+              static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }() !=
+         [&]() {
+           float sv = util::f16_to_f32(
+               static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))));
+           if (inst_.abs & (1u << 1))
+             sv = std::fabs(sv);
+           if (inst_.neg & (1u << 1))
+             sv = -sv;
+           return sv;
+         }()))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
@@ -588,7 +1010,39 @@ VCmpNltF16Vop3::VCmpNltF16Vop3(const MachineInst *inst)
 }
 
 void VCmpNltF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_nlt_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((!([&]() {
+          float sv = util::f16_to_f32(
+              static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))));
+          if (inst_.abs & (1u << 0))
+            sv = std::fabs(sv);
+          if (inst_.neg & (1u << 0))
+            sv = -sv;
+          return sv;
+        }() <
+           [&]() {
+             float sv = util::f16_to_f32(
+                 static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                  : src1.read_lane(wf, lane))));
+             if (inst_.abs & (1u << 1))
+               sv = std::fabs(sv);
+             if (inst_.neg & (1u << 1))
+               sv = -sv;
+             return sv;
+           }())))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpLtF32Vop3::VCmpLtF32Vop3(const MachineInst *inst)
@@ -1773,7 +2227,23 @@ VCmpLtI16Vop3::VCmpLtI16Vop3(const MachineInst *inst)
 }
 
 void VCmpLtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_lt_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                         : src0.read_lane(wf, lane))) <
+         static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                         : src1.read_lane(wf, lane)))))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
@@ -1814,7 +2284,23 @@ VCmpEqI16Vop3::VCmpEqI16Vop3(const MachineInst *inst)
 }
 
 void VCmpEqI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_eq_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                         : src0.read_lane(wf, lane))) ==
+         static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                         : src1.read_lane(wf, lane)))))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
@@ -1855,7 +2341,23 @@ VCmpLeI16Vop3::VCmpLeI16Vop3(const MachineInst *inst)
 }
 
 void VCmpLeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_le_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                         : src0.read_lane(wf, lane))) <=
+         static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                         : src1.read_lane(wf, lane)))))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
@@ -1896,7 +2398,23 @@ VCmpGtI16Vop3::VCmpGtI16Vop3(const MachineInst *inst)
 }
 
 void VCmpGtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_gt_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                         : src0.read_lane(wf, lane))) >
+         static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                         : src1.read_lane(wf, lane)))))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
@@ -1937,7 +2455,23 @@ VCmpNeI16Vop3::VCmpNeI16Vop3(const MachineInst *inst)
 }
 
 void VCmpNeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_ne_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                         : src0.read_lane(wf, lane))) !=
+         static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                         : src1.read_lane(wf, lane)))))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
@@ -1978,7 +2512,23 @@ VCmpGeI16Vop3::VCmpGeI16Vop3(const MachineInst *inst)
 }
 
 void VCmpGeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_ge_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                         : src0.read_lane(wf, lane))) >=
+         static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                         : src1.read_lane(wf, lane)))))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
@@ -2019,7 +2569,23 @@ VCmpLtU16Vop3::VCmpLtU16Vop3(const MachineInst *inst)
 }
 
 void VCmpLtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_lt_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                          : src0.read_lane(wf, lane))) <
+         static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                          : src1.read_lane(wf, lane)))))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
@@ -2060,7 +2626,23 @@ VCmpEqU16Vop3::VCmpEqU16Vop3(const MachineInst *inst)
 }
 
 void VCmpEqU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_eq_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                          : src0.read_lane(wf, lane))) ==
+         static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                          : src1.read_lane(wf, lane)))))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
@@ -2101,7 +2683,23 @@ VCmpLeU16Vop3::VCmpLeU16Vop3(const MachineInst *inst)
 }
 
 void VCmpLeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_le_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                          : src0.read_lane(wf, lane))) <=
+         static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                          : src1.read_lane(wf, lane)))))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
@@ -2142,7 +2740,23 @@ VCmpGtU16Vop3::VCmpGtU16Vop3(const MachineInst *inst)
 }
 
 void VCmpGtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_gt_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                          : src0.read_lane(wf, lane))) >
+         static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                          : src1.read_lane(wf, lane)))))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
@@ -2183,7 +2797,23 @@ VCmpNeU16Vop3::VCmpNeU16Vop3(const MachineInst *inst)
 }
 
 void VCmpNeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_ne_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                          : src0.read_lane(wf, lane))) !=
+         static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                          : src1.read_lane(wf, lane)))))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
@@ -2224,7 +2854,23 @@ VCmpGeU16Vop3::VCmpGeU16Vop3(const MachineInst *inst)
 }
 
 void VCmpGeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_ge_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    if ((static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                          : src0.read_lane(wf, lane))) >=
+         static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                          : src1.read_lane(wf, lane)))))
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpLtI32Vop3::VCmpLtI32Vop3(const MachineInst *inst)
@@ -3249,7 +3895,55 @@ VCmpClassF16Vop3::VCmpClassF16Vop3(const MachineInst *inst)
 }
 
 void VCmpClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cmp_class_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  uint64_t vcc = 0;
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint16_t s0_raw = static_cast<uint16_t>(src0.read_lane(wf, lane));
+    if (inst_.abs & (1u << 0))
+      s0_raw &= 0x7FFFu;
+    if (inst_.neg & (1u << 0))
+      s0_raw ^= 0x8000u;
+    uint32_t mask = src1.read_lane(wf, lane);
+    bool match = false;
+    uint16_t f16_exp = (s0_raw >> 10) & 0x1F;
+    uint16_t f16_mant = s0_raw & 0x3FF;
+    bool f16_sign = (s0_raw & 0x8000) != 0;
+    bool is_nan = (f16_exp == 0x1F) && (f16_mant != 0);
+    bool is_inf = (f16_exp == 0x1F) && (f16_mant == 0);
+    bool is_zero = (f16_exp == 0) && (f16_mant == 0);
+    bool is_denorm = (f16_exp == 0) && (f16_mant != 0);
+    bool is_normal = (f16_exp >= 1) && (f16_exp <= 30);
+    if ((mask & 0x001) && is_nan && (s0_raw & 0x0200) == 0)
+      match = true;
+    if ((mask & 0x002) && is_nan && (s0_raw & 0x0200) != 0)
+      match = true;
+    if ((mask & 0x004) && is_inf && f16_sign)
+      match = true;
+    if ((mask & 0x008) && is_normal && f16_sign)
+      match = true;
+    if ((mask & 0x010) && is_denorm && f16_sign)
+      match = true;
+    if ((mask & 0x020) && is_zero && f16_sign)
+      match = true;
+    if ((mask & 0x040) && is_zero && !f16_sign)
+      match = true;
+    if ((mask & 0x080) && is_denorm && !f16_sign)
+      match = true;
+    if ((mask & 0x100) && is_normal && !f16_sign)
+      match = true;
+    if ((mask & 0x200) && is_inf && !f16_sign)
+      match = true;
+    if (match)
+      vcc |= (1ULL << lane);
+    else
+      vcc &= ~(1ULL << lane);
+  }
+  if (wf.wf_size() <= 32)
+    vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    vdst.write_scalar64(wf, vcc);
 }
 
 VCmpClassF32Vop3::VCmpClassF32Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_cmp.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_cmp.cpp
@@ -83,8 +83,6 @@ void VCmpLtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -156,8 +154,6 @@ void VCmpEqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -229,8 +225,6 @@ void VCmpLeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -302,8 +296,6 @@ void VCmpGtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -378,8 +370,6 @@ void VCmpLgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
           return (a < b) || (a > b);
         }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -451,8 +441,6 @@ void VCmpGeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -523,8 +511,6 @@ void VCmpOF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
            return sv;
          }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -595,8 +581,6 @@ void VCmpUF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
            return sv;
          }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -668,8 +652,6 @@ void VCmpNgeF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -744,8 +726,6 @@ void VCmpNlgF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
           return (a < b) || (a > b);
         }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -817,8 +797,6 @@ void VCmpNgtF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -890,8 +868,6 @@ void VCmpNleF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -963,8 +939,6 @@ void VCmpNeqF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -1036,8 +1010,6 @@ void VCmpNltF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -2237,8 +2209,6 @@ void VCmpLtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
          static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
                                                          : src1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -2294,8 +2264,6 @@ void VCmpEqI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
          static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
                                                          : src1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -2351,8 +2319,6 @@ void VCmpLeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
          static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
                                                          : src1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -2408,8 +2374,6 @@ void VCmpGtI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
          static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
                                                          : src1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -2465,8 +2429,6 @@ void VCmpNeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
          static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
                                                          : src1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -2522,8 +2484,6 @@ void VCmpGeI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
          static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
                                                          : src1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -2579,8 +2539,6 @@ void VCmpLtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
          static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
                                                           : src1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -2636,8 +2594,6 @@ void VCmpEqU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
          static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
                                                           : src1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -2693,8 +2649,6 @@ void VCmpLeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
          static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
                                                           : src1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -2750,8 +2704,6 @@ void VCmpGtU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
          static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
                                                           : src1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -2807,8 +2759,6 @@ void VCmpNeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
          static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
                                                           : src1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -2864,8 +2814,6 @@ void VCmpGeU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
          static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
                                                           : src1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -3937,8 +3885,6 @@ void VCmpClassF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
       match = true;
     if (match)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     vdst.write_scalar(wf, static_cast<uint32_t>(vcc));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_cvt.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_cvt.cpp
@@ -891,7 +891,45 @@ VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
 }
 
 void VFrexpMantF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_frexp_mant_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = [&]() {
+            int e;
+            return std::frexp(static_cast<float>([&]() {
+                                float sv = util::f16_to_f32(static_cast<uint16_t>(
+                                    ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane))));
+                                if (inst_.abs & (1u << 0))
+                                  sv = std::fabs(sv);
+                                if (inst_.neg & (1u << 0))
+                                  sv = -sv;
+                                return sv;
+                              }()),
+                              &e);
+          }();
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
@@ -919,7 +957,47 @@ VFrexpExpI16F16Vop3::VFrexpExpI16F16Vop3(const MachineInst *inst)
 }
 
 void VFrexpExpI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_frexp_exp_i16_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = [&]() {
+            float s = [&]() {
+              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                             : src0.read_lane(wf, lane))));
+              if (inst_.abs & (1u << 0))
+                sv = std::fabs(sv);
+              if (inst_.neg & (1u << 0))
+                sv = -sv;
+              return sv;
+            }();
+            int exp = 0;
+            if (s != 0.0f && !std::isnan(s) && !std::isinf(s))
+              std::frexp(s, &exp);
+            return static_cast<uint32_t>(exp);
+          }();
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VCvtNormI16F16Vop3::VCvtNormI16F16Vop3(const MachineInst *inst)
@@ -5208,7 +5286,22 @@ VCvtPkNormI16F16Vop3::VCvtPkNormI16F16Vop3(const MachineInst *inst)
 }
 
 void VCvtPkNormI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_norm_i16_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    auto cvt_u16 = [](float f) -> uint16_t {
+      if (std::isnan(f))
+        return 0;
+      return static_cast<uint16_t>(std::clamp(f * 65535.0f, 0.0f, 65535.0f));
+    };
+    uint16_t lo = cvt_u16(s0);
+    uint16_t hi = cvt_u16(s1);
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(hi) << 16) | (static_cast<uint32_t>(lo) & 0xFFFF));
+  }
 }
 
 VCvtPkNormU16F16Vop3::VCvtPkNormU16F16Vop3(const MachineInst *inst)
@@ -5250,7 +5343,22 @@ VCvtPkNormU16F16Vop3::VCvtPkNormU16F16Vop3(const MachineInst *inst)
 }
 
 void VCvtPkNormU16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_pk_norm_u16_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    float s0 = std::bit_cast<float>(src0.read_lane(wf, lane));
+    float s1 = std::bit_cast<float>(src1.read_lane(wf, lane));
+    auto cvt_u16 = [](float f) -> uint16_t {
+      if (std::isnan(f))
+        return 0;
+      return static_cast<uint16_t>(std::clamp(f * 65535.0f, 0.0f, 65535.0f));
+    };
+    uint16_t lo = cvt_u16(s0);
+    uint16_t hi = cvt_u16(s1);
+    vdst.write_lane(wf, lane,
+                    (static_cast<uint32_t>(hi) << 16) | (static_cast<uint32_t>(lo) & 0xFFFF));
+  }
 }
 
 VCvtPkNormI16F32Vop3::VCvtPkNormI16F32Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_cvt.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_cvt.cpp
@@ -212,7 +212,19 @@ VCvtF16F32Vop3::VCvtF16F32Vop3(const MachineInst *inst)
 }
 
 void VCvtF16F32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_f16_f32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          util::f32_to_f16(std::bit_cast<float>(static_cast<uint32_t>(src0.read_lane(wf, lane))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
@@ -240,7 +252,15 @@ VCvtF32F16Vop3::VCvtF32F16Vop3(const MachineInst *inst)
 }
 
 void VCvtF32F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_f32_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    vdst.write_lane(wf, lane,
+                    std::bit_cast<uint32_t>(util::f16_to_f32(static_cast<uint16_t>(
+                        ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                   : src0.read_lane(wf, lane))))));
+  }
 }
 
 VCvtNearestI32F32Vop3::VCvtNearestI32F32Vop3(const MachineInst *inst)
@@ -688,7 +708,21 @@ VCvtF16U16Vop3::VCvtF16U16Vop3(const MachineInst *inst)
 }
 
 void VCvtF16U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_f16_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(static_cast<float>(
+              static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
@@ -716,7 +750,22 @@ VCvtF16I16Vop3::VCvtF16I16Vop3(const MachineInst *inst)
 }
 
 void VCvtF16I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_f16_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16(static_cast<float>(
+              static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                              : src0.read_lane(wf, lane)) &
+                                   0xFFFF)))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
@@ -744,7 +793,27 @@ VCvtU16F16Vop3::VCvtU16F16Vop3(const MachineInst *inst)
 }
 
 void VCvtU16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_u16_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>([&]() -> uint32_t {
+        float s = util::f16_to_f32(
+            static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                             : src0.read_lane(wf, lane))));
+        if (std::isnan(s) || s < 0.0f)
+          return 0u;
+        if (s >= 65536.0f)
+          return static_cast<uint32_t>(UINT16_MAX);
+        return static_cast<uint32_t>(static_cast<uint16_t>(s));
+      }()));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
@@ -772,7 +841,29 @@ VCvtI16F16Vop3::VCvtI16F16Vop3(const MachineInst *inst)
 }
 
 void VCvtI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_i16_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>([&]() -> uint32_t {
+        float s = util::f16_to_f32(
+            static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                             : src0.read_lane(wf, lane))));
+        if (std::isnan(s))
+          return 0u;
+        if (s >= 32768.0f)
+          return static_cast<uint32_t>(static_cast<uint16_t>(INT16_MAX));
+        if (s < -32768.0f)
+          return static_cast<uint32_t>(static_cast<uint16_t>(INT16_MIN));
+        return static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(s)));
+      }()));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VFrexpMantF16Vop3::VFrexpMantF16Vop3(const MachineInst *inst)
@@ -860,15 +951,21 @@ void VCvtNormI16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane, [&]() -> uint32_t {
-      float s = util::f16_to_f32(
-          static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
-                                                           : src0.read_lane(wf, lane))));
-      if (std::isnan(s))
-        return 0u;
-      float scaled = std::clamp(s * 32767.0f, -32768.0f, 32767.0f);
-      return static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(scaled)));
-    }());
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>([&]() -> uint32_t {
+        float s = util::f16_to_f32(
+            static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                             : src0.read_lane(wf, lane))));
+        if (std::isnan(s))
+          return 0u;
+        float scaled = std::clamp(s * 32767.0f, -32768.0f, 32767.0f);
+        return static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(scaled)));
+      }()));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
   }
 }
 
@@ -901,15 +998,21 @@ void VCvtNormU16F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane, [&]() -> uint32_t {
-      float s = util::f16_to_f32(
-          static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
-                                                           : src0.read_lane(wf, lane))));
-      if (std::isnan(s))
-        return 0u;
-      float scaled = std::clamp(s * 65535.0f, 0.0f, 65535.0f);
-      return static_cast<uint32_t>(static_cast<uint16_t>(scaled));
-    }());
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>([&]() -> uint32_t {
+        float s = util::f16_to_f32(
+            static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                             : src0.read_lane(wf, lane))));
+        if (std::isnan(s))
+          return 0u;
+        float scaled = std::clamp(s * 65535.0f, 0.0f, 65535.0f);
+        return static_cast<uint32_t>(static_cast<uint16_t>(scaled));
+      }()));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
   }
 }
 
@@ -938,7 +1041,16 @@ VCvtI32I16Vop3::VCvtI32I16Vop3(const MachineInst *inst)
 }
 
 void VCvtI32I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_i32_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    vdst.write_lane(wf, lane,
+                    static_cast<uint32_t>(static_cast<int32_t>(static_cast<int16_t>(
+                        ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                   : src0.read_lane(wf, lane)) &
+                        0xFFFF))));
+  }
 }
 
 VCvtU32U16Vop3::VCvtU32U16Vop3(const MachineInst *inst)
@@ -966,7 +1078,15 @@ VCvtU32U16Vop3::VCvtU32U16Vop3(const MachineInst *inst)
 }
 
 void VCvtU32U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cvt_u32_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    vdst.write_lane(
+        wf, lane,
+        (((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16) : src0.read_lane(wf, lane)) &
+         0xFFFFu));
+  }
 }
 
 VCvtF32Fp8Vop3::VCvtF32Fp8Vop3(const MachineInst *inst)
@@ -1252,9 +1372,15 @@ void VCvtF16Fp8Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane,
-                    static_cast<uint32_t>(util::f32_to_f16(
-                        util::fp8_e4m3_to_f32(static_cast<uint8_t>(src0.read_lane(wf, lane))))));
+    {
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(util::f32_to_f16(
+              util::fp8_e4m3_to_f32(static_cast<uint8_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
   }
 }
 
@@ -1287,9 +1413,15 @@ void VCvtF16Bf8Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane,
-                    static_cast<uint32_t>(util::f32_to_f16(
-                        util::bf8_e5m2_to_f32(static_cast<uint8_t>(src0.read_lane(wf, lane))))));
+    {
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(util::f32_to_f16(
+              util::bf8_e5m2_to_f32(static_cast<uint8_t>(src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
   }
 }
 
@@ -5027,7 +5159,14 @@ VPackB32F16Vop3::VPackB32F16Vop3(const MachineInst *inst)
 }
 
 void VPackB32F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_pack_b32_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t s0 = src0.read_lane(wf, lane) & 0xFFFF;
+    uint32_t s1 = src1.read_lane(wf, lane) & 0xFFFF;
+    vdst.write_lane(wf, lane, s0 | (s1 << 16));
+  }
 }
 
 VCvtPkNormI16F16Vop3::VCvtPkNormI16F16Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_data.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_data.cpp
@@ -983,7 +983,25 @@ VCndmaskB16Vop3::VCndmaskB16Vop3(const MachineInst *inst)
 }
 
 void VCndmaskB16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_cndmask_b16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
+          static_cast<uint16_t>(((src2.read_scalar64(wf) >> lane) & 1)
+                                    ? static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0
+                                                                 ? (src1.read_lane(wf, lane) >> 16)
+                                                                 : src1.read_lane(wf, lane)))
+                                    : static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0
+                                                                 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane)))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VPermlaneBcastB32Vop3::VPermlaneBcastB32Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_ternary.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_ternary.cpp
@@ -1350,7 +1350,63 @@ VMin3NumF16Vop3::VMin3NumF16Vop3(const MachineInst *inst)
 }
 
 void VMin3NumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_min3_num_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v =
+              std::fmin(std::fmin(
+                            [&]() {
+                              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                             : src0.read_lane(wf, lane))));
+                              if (inst_.abs & (1u << 0))
+                                sv = std::fabs(sv);
+                              if (inst_.neg & (1u << 0))
+                                sv = -sv;
+                              return sv;
+                            }(),
+                            [&]() {
+                              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                             : src1.read_lane(wf, lane))));
+                              if (inst_.abs & (1u << 1))
+                                sv = std::fabs(sv);
+                              if (inst_.neg & (1u << 1))
+                                sv = -sv;
+                              return sv;
+                            }()),
+                        [&]() {
+                          float sv = util::f16_to_f32(static_cast<uint16_t>(
+                              ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                         : src2.read_lane(wf, lane))));
+                          if (inst_.abs & (1u << 2))
+                            sv = std::fabs(sv);
+                          if (inst_.neg & (1u << 2))
+                            sv = -sv;
+                          return sv;
+                        }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMax3NumF16Vop3::VMax3NumF16Vop3(const MachineInst *inst)
@@ -1406,7 +1462,63 @@ VMax3NumF16Vop3::VMax3NumF16Vop3(const MachineInst *inst)
 }
 
 void VMax3NumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_max3_num_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v =
+              std::fmax(std::fmax(
+                            [&]() {
+                              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                             : src0.read_lane(wf, lane))));
+                              if (inst_.abs & (1u << 0))
+                                sv = std::fabs(sv);
+                              if (inst_.neg & (1u << 0))
+                                sv = -sv;
+                              return sv;
+                            }(),
+                            [&]() {
+                              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                             : src1.read_lane(wf, lane))));
+                              if (inst_.abs & (1u << 1))
+                                sv = std::fabs(sv);
+                              if (inst_.neg & (1u << 1))
+                                sv = -sv;
+                              return sv;
+                            }()),
+                        [&]() {
+                          float sv = util::f16_to_f32(static_cast<uint16_t>(
+                              ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                         : src2.read_lane(wf, lane))));
+                          if (inst_.abs & (1u << 2))
+                            sv = std::fabs(sv);
+                          if (inst_.neg & (1u << 2))
+                            sv = -sv;
+                          return sv;
+                        }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMinimum3F32Vop3::VMinimum3F32Vop3(const MachineInst *inst)
@@ -1574,7 +1686,67 @@ VMinimum3F16Vop3::VMinimum3F16Vop3(const MachineInst *inst)
 }
 
 void VMinimum3F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_minimum3_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = [&]() {
+            auto a = [&]() {
+              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                             : src0.read_lane(wf, lane))));
+              if (inst_.abs & (1u << 0))
+                sv = std::fabs(sv);
+              if (inst_.neg & (1u << 0))
+                sv = -sv;
+              return sv;
+            }();
+            auto b = [&]() {
+              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                             : src1.read_lane(wf, lane))));
+              if (inst_.abs & (1u << 1))
+                sv = std::fabs(sv);
+              if (inst_.neg & (1u << 1))
+                sv = -sv;
+              return sv;
+            }();
+            auto c = [&]() {
+              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                             : src2.read_lane(wf, lane))));
+              if (inst_.abs & (1u << 2))
+                sv = std::fabs(sv);
+              if (inst_.neg & (1u << 2))
+                sv = -sv;
+              return sv;
+            }();
+            if (std::isnan(a) || std::isnan(b) || std::isnan(c))
+              return std::numeric_limits<decltype(a)>::quiet_NaN();
+            auto ab = (a == b) ? (std::signbit(a) ? a : b) : (a < b ? a : b);
+            return (ab == c) ? (std::signbit(ab) ? ab : c) : (ab < c ? ab : c);
+          }();
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMaximum3F16Vop3::VMaximum3F16Vop3(const MachineInst *inst)
@@ -1630,7 +1802,67 @@ VMaximum3F16Vop3::VMaximum3F16Vop3(const MachineInst *inst)
 }
 
 void VMaximum3F16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_maximum3_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = [&]() {
+            auto a = [&]() {
+              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                             : src0.read_lane(wf, lane))));
+              if (inst_.abs & (1u << 0))
+                sv = std::fabs(sv);
+              if (inst_.neg & (1u << 0))
+                sv = -sv;
+              return sv;
+            }();
+            auto b = [&]() {
+              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                             : src1.read_lane(wf, lane))));
+              if (inst_.abs & (1u << 1))
+                sv = std::fabs(sv);
+              if (inst_.neg & (1u << 1))
+                sv = -sv;
+              return sv;
+            }();
+            auto c = [&]() {
+              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                             : src2.read_lane(wf, lane))));
+              if (inst_.abs & (1u << 2))
+                sv = std::fabs(sv);
+              if (inst_.neg & (1u << 2))
+                sv = -sv;
+              return sv;
+            }();
+            if (std::isnan(a) || std::isnan(b) || std::isnan(c))
+              return std::numeric_limits<decltype(a)>::quiet_NaN();
+            auto ab = (a == b) ? (std::signbit(a) ? b : a) : (a > b ? a : b);
+            return (ab == c) ? (std::signbit(ab) ? c : ab) : (ab > c ? ab : c);
+          }();
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMed3NumF32Vop3::VMed3NumF32Vop3(const MachineInst *inst)
@@ -3902,7 +4134,63 @@ VMinmaxNumF16Vop3::VMinmaxNumF16Vop3(const MachineInst *inst)
 }
 
 void VMinmaxNumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_minmax_num_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v =
+              std::fmax(std::fmin(
+                            [&]() {
+                              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                             : src0.read_lane(wf, lane))));
+                              if (inst_.abs & (1u << 0))
+                                sv = std::fabs(sv);
+                              if (inst_.neg & (1u << 0))
+                                sv = -sv;
+                              return sv;
+                            }(),
+                            [&]() {
+                              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                             : src1.read_lane(wf, lane))));
+                              if (inst_.abs & (1u << 1))
+                                sv = std::fabs(sv);
+                              if (inst_.neg & (1u << 1))
+                                sv = -sv;
+                              return sv;
+                            }()),
+                        [&]() {
+                          float sv = util::f16_to_f32(static_cast<uint16_t>(
+                              ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                         : src2.read_lane(wf, lane))));
+                          if (inst_.abs & (1u << 2))
+                            sv = std::fabs(sv);
+                          if (inst_.neg & (1u << 2))
+                            sv = -sv;
+                          return sv;
+                        }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMaxminNumF16Vop3::VMaxminNumF16Vop3(const MachineInst *inst)
@@ -3958,7 +4246,63 @@ VMaxminNumF16Vop3::VMaxminNumF16Vop3(const MachineInst *inst)
 }
 
 void VMaxminNumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_maxmin_num_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v =
+              std::fmin(std::fmax(
+                            [&]() {
+                              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                             : src0.read_lane(wf, lane))));
+                              if (inst_.abs & (1u << 0))
+                                sv = std::fabs(sv);
+                              if (inst_.neg & (1u << 0))
+                                sv = -sv;
+                              return sv;
+                            }(),
+                            [&]() {
+                              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                             : src1.read_lane(wf, lane))));
+                              if (inst_.abs & (1u << 1))
+                                sv = std::fabs(sv);
+                              if (inst_.neg & (1u << 1))
+                                sv = -sv;
+                              return sv;
+                            }()),
+                        [&]() {
+                          float sv = util::f16_to_f32(static_cast<uint16_t>(
+                              ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                         : src2.read_lane(wf, lane))));
+                          if (inst_.abs & (1u << 2))
+                            sv = std::fabs(sv);
+                          if (inst_.neg & (1u << 2))
+                            sv = -sv;
+                          return sv;
+                        }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMinimummaximumF32Vop3::VMinimummaximumF32Vop3(const MachineInst *inst)
@@ -4126,7 +4470,67 @@ VMinimummaximumF16Vop3::VMinimummaximumF16Vop3(const MachineInst *inst)
 }
 
 void VMinimummaximumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_minimummaximum_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = [&]() {
+            auto a = [&]() {
+              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                             : src0.read_lane(wf, lane))));
+              if (inst_.abs & (1u << 0))
+                sv = std::fabs(sv);
+              if (inst_.neg & (1u << 0))
+                sv = -sv;
+              return sv;
+            }();
+            auto b = [&]() {
+              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                             : src1.read_lane(wf, lane))));
+              if (inst_.abs & (1u << 1))
+                sv = std::fabs(sv);
+              if (inst_.neg & (1u << 1))
+                sv = -sv;
+              return sv;
+            }();
+            auto c = [&]() {
+              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                             : src2.read_lane(wf, lane))));
+              if (inst_.abs & (1u << 2))
+                sv = std::fabs(sv);
+              if (inst_.neg & (1u << 2))
+                sv = -sv;
+              return sv;
+            }();
+            if (std::isnan(a) || std::isnan(b) || std::isnan(c))
+              return std::numeric_limits<decltype(a)>::quiet_NaN();
+            auto ab = (a == b) ? (std::signbit(a) ? a : b) : (a < b ? a : b);
+            return (ab == c) ? (std::signbit(ab) ? c : ab) : (ab > c ? ab : c);
+          }();
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMaximumminimumF16Vop3::VMaximumminimumF16Vop3(const MachineInst *inst)
@@ -4182,7 +4586,67 @@ VMaximumminimumF16Vop3::VMaximumminimumF16Vop3(const MachineInst *inst)
 }
 
 void VMaximumminimumF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_maximumminimum_f16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = [&]() {
+            auto a = [&]() {
+              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                             : src0.read_lane(wf, lane))));
+              if (inst_.abs & (1u << 0))
+                sv = std::fabs(sv);
+              if (inst_.neg & (1u << 0))
+                sv = -sv;
+              return sv;
+            }();
+            auto b = [&]() {
+              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                             : src1.read_lane(wf, lane))));
+              if (inst_.abs & (1u << 1))
+                sv = std::fabs(sv);
+              if (inst_.neg & (1u << 1))
+                sv = -sv;
+              return sv;
+            }();
+            auto c = [&]() {
+              float sv = util::f16_to_f32(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                             : src2.read_lane(wf, lane))));
+              if (inst_.abs & (1u << 2))
+                sv = std::fabs(sv);
+              if (inst_.neg & (1u << 2))
+                sv = -sv;
+              return sv;
+            }();
+            if (std::isnan(a) || std::isnan(b) || std::isnan(c))
+              return std::numeric_limits<decltype(a)>::quiet_NaN();
+            auto ab = (a == b) ? (std::signbit(a) ? b : a) : (a > b ? a : b);
+            return (ab == c) ? (std::signbit(ab) ? ab : c) : (ab < c ? ab : c);
+          }();
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VAshrPkI8I32Vop3::VAshrPkI8I32Vop3(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_ternary.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_ternary.cpp
@@ -558,7 +558,19 @@ VAlignbitB32Vop3::VAlignbitB32Vop3(const MachineInst *inst)
 }
 
 void VAlignbitB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_alignbit_b32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    vdst.write_lane(wf, lane, [&]() {
+      auto a = src0.read_lane(wf, lane);
+      auto b = src1.read_lane(wf, lane);
+      auto c =
+          ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16) : src2.read_lane(wf, lane));
+      uint64_t val = (static_cast<uint64_t>(a) << 32) | b;
+      return static_cast<uint32_t>(val >> (c & 31u));
+    }());
+  }
 }
 
 VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
@@ -614,7 +626,19 @@ VAlignbyteB32Vop3::VAlignbyteB32Vop3(const MachineInst *inst)
 }
 
 void VAlignbyteB32Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_alignbyte_b32_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    vdst.write_lane(wf, lane, [&]() {
+      auto a = src0.read_lane(wf, lane);
+      auto b = src1.read_lane(wf, lane);
+      auto c =
+          ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16) : src2.read_lane(wf, lane));
+      uint64_t val = (static_cast<uint64_t>(a) << 32) | b;
+      return static_cast<uint32_t>(val >> ((c & 3u) * 8u));
+    }());
+  }
 }
 
 VMin3I32Vop3::VMin3I32Vop3(const MachineInst *inst)
@@ -1999,7 +2023,27 @@ VMadU16Vop3::VMadU16Vop3(const MachineInst *inst)
   src2.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src2);
 }
 
-void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_mad_u16_vop3(*this, wf); }
+void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              ((static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane))) *
+                static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                 : src1.read_lane(wf, lane)))) +
+               static_cast<uint16_t>(((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                                : src2.read_lane(wf, lane))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VXadU32Vop3::VXadU32Vop3(const MachineInst *inst)
     : Vop3("v_xad_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VXadU32Vop3>()),
@@ -2217,7 +2261,64 @@ VFmaF16Vop3::VFmaF16Vop3(const MachineInst *inst)
   src2.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src2);
 }
 
-void VFmaF16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_fma_f16_vop3(*this, wf); }
+void VFmaF16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(util::f32_to_f16([&]() {
+        float v = [&]() {
+          float v = std::fma(
+              [&]() {
+                float sv = util::f16_to_f32(static_cast<uint16_t>(
+                    ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                               : src0.read_lane(wf, lane))));
+                if (inst_.abs & (1u << 0))
+                  sv = std::fabs(sv);
+                if (inst_.neg & (1u << 0))
+                  sv = -sv;
+                return sv;
+              }(),
+              [&]() {
+                float sv = util::f16_to_f32(static_cast<uint16_t>(
+                    ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                               : src1.read_lane(wf, lane))));
+                if (inst_.abs & (1u << 1))
+                  sv = std::fabs(sv);
+                if (inst_.neg & (1u << 1))
+                  sv = -sv;
+                return sv;
+              }(),
+              [&]() {
+                float sv = util::f16_to_f32(static_cast<uint16_t>(
+                    ((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                               : src2.read_lane(wf, lane))));
+                if (inst_.abs & (1u << 2))
+                  sv = std::fabs(sv);
+                if (inst_.neg & (1u << 2))
+                  sv = -sv;
+                return sv;
+              }());
+          if (inst_.omod == 1)
+            v *= 2.0f;
+          else if (inst_.omod == 2)
+            v *= 4.0f;
+          else if (inst_.omod == 3)
+            v *= 0.5f;
+          return v;
+        }();
+        if (inst_.clamp)
+          v = std::clamp(v, 0.0f, 1.0f);
+        return v;
+      }())));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
     : Vop3("v_min3_i16", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VMin3I16Vop3>()),
@@ -2271,7 +2372,26 @@ VMin3I16Vop3::VMin3I16Vop3(const MachineInst *inst)
 }
 
 void VMin3I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_min3_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(std::min(
+              std::min(
+                  static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                  : src0.read_lane(wf, lane))),
+                  static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                  : src1.read_lane(wf, lane)))),
+              static_cast<int16_t>(((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                              : src2.read_lane(wf, lane)))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
@@ -2326,7 +2446,27 @@ VMin3U16Vop3::VMin3U16Vop3(const MachineInst *inst)
 }
 
 void VMin3U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_min3_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(std::min(
+              std::min(static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0
+                                                  ? (src0.read_lane(wf, lane) >> 16)
+                                                  : src0.read_lane(wf, lane))),
+                       static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0
+                                                  ? (src1.read_lane(wf, lane) >> 16)
+                                                  : src1.read_lane(wf, lane)))),
+              static_cast<uint16_t>(((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                               : src2.read_lane(wf, lane))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
@@ -2381,7 +2521,26 @@ VMax3I16Vop3::VMax3I16Vop3(const MachineInst *inst)
 }
 
 void VMax3I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_max3_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(std::max(
+              std::max(
+                  static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                  : src0.read_lane(wf, lane))),
+                  static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                  : src1.read_lane(wf, lane)))),
+              static_cast<int16_t>(((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                              : src2.read_lane(wf, lane)))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
@@ -2436,7 +2595,27 @@ VMax3U16Vop3::VMax3U16Vop3(const MachineInst *inst)
 }
 
 void VMax3U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_max3_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(std::max(
+              std::max(static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0
+                                                  ? (src0.read_lane(wf, lane) >> 16)
+                                                  : src0.read_lane(wf, lane))),
+                       static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0
+                                                  ? (src1.read_lane(wf, lane) >> 16)
+                                                  : src1.read_lane(wf, lane)))),
+              static_cast<uint16_t>(((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                               : src2.read_lane(wf, lane))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
@@ -2491,7 +2670,30 @@ VMed3I16Vop3::VMed3I16Vop3(const MachineInst *inst)
 }
 
 void VMed3I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_med3_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>([&]() {
+            auto a =
+                static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane)));
+            auto b =
+                static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane)));
+            auto c =
+                static_cast<int16_t>(((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                                : src2.read_lane(wf, lane)));
+            return std::max(std::min(std::max(a, b), c), std::min(a, b));
+          }())))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
@@ -2546,7 +2748,30 @@ VMed3U16Vop3::VMed3U16Vop3(const MachineInst *inst)
 }
 
 void VMed3U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_med3_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>([&]() {
+            auto a =
+                static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane)));
+            auto b =
+                static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                 : src1.read_lane(wf, lane)));
+            auto c =
+                static_cast<uint16_t>(((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                                 : src2.read_lane(wf, lane)));
+            return std::max(std::min(std::max(a, b), c), std::min(a, b));
+          }()))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
 }
 
 VLshlAddU64Vop3::VLshlAddU64Vop3(const MachineInst *inst)
@@ -2656,7 +2881,27 @@ VMadI16Vop3::VMadI16Vop3(const MachineInst *inst)
   src2.set_vgpr_msb_role(amdgpu::VgprMsbRole::Src2);
 }
 
-void VMadI16Vop3::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_v_mad_i16_vop3(*this, wf); }
+void VMadI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    {
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              ((static_cast<int16_t>(((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane))) *
+                static_cast<int16_t>(((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane)))) +
+               static_cast<int16_t>(((inst_.opsel & 0x4u) != 0 ? (src2.read_lane(wf, lane) >> 16)
+                                                               : src2.read_lane(wf, lane)))))))));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
+  }
+}
 
 VAdd3U32Vop3::VAdd3U32Vop3(const MachineInst *inst)
     : Vop3("v_add3_u32", reinterpret_cast<const OpEncoding *>(inst), make_exec_fn<VAdd3U32Vop3>()),
@@ -2931,7 +3176,15 @@ VMadU32U16Vop3::VMadU32U16Vop3(const MachineInst *inst)
 }
 
 void VMadU32U16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_mad_u32_u16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    uint32_t s0 = src0.read_lane(wf, lane) & 0xFFFFu;
+    uint32_t s1 = src1.read_lane(wf, lane) & 0xFFFFu;
+    uint32_t s2 = src2.read_lane(wf, lane);
+    vdst.write_lane(wf, lane, s0 * s1 + s2);
+  }
 }
 
 VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
@@ -2987,7 +3240,15 @@ VMadI32I16Vop3::VMadI32I16Vop3(const MachineInst *inst)
 }
 
 void VMadI32I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
-  amdgpu::execute_v_mad_i32_i16_vop3(*this, wf);
+  uint64_t exec = wf.exec();
+  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
+    if (!(exec & (1ULL << lane)))
+      continue;
+    int32_t s0 = static_cast<int16_t>(src0.read_lane(wf, lane) & 0xFFFF);
+    int32_t s1 = static_cast<int16_t>(src1.read_lane(wf, lane) & 0xFFFF);
+    int32_t s2 = static_cast<int32_t>(src2.read_lane(wf, lane));
+    vdst.write_lane(wf, lane, static_cast<uint32_t>(s0 * s1 + s2));
+  }
 }
 
 VAddMaxI32Vop3::VAddMaxI32Vop3(const MachineInst *inst)
@@ -3981,16 +4242,22 @@ void VAshrPkI8I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane, [&]() -> uint32_t {
-      uint32_t shift = static_cast<uint32_t>(src2.read_lane(wf, lane)) & 31u;
-      auto pack = [&](uint32_t src) -> uint32_t {
-        int32_t shifted = static_cast<int32_t>(src) >> shift;
-        int32_t clamped =
-            std::clamp(shifted, static_cast<int32_t>(-128), static_cast<int32_t>(127));
-        return static_cast<uint32_t>(clamped) & 0xffu;
-      };
-      return pack(src0.read_lane(wf, lane)) | (pack(src1.read_lane(wf, lane)) << 8);
-    }());
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>([&]() -> uint32_t {
+        uint32_t shift = static_cast<uint32_t>(src2.read_lane(wf, lane)) & 31u;
+        auto pack = [&](uint32_t src) -> uint32_t {
+          int32_t shifted = static_cast<int32_t>(src) >> shift;
+          int32_t clamped =
+              std::clamp(shifted, static_cast<int32_t>(-128), static_cast<int32_t>(127));
+          return static_cast<uint32_t>(clamped) & 0xffu;
+        };
+        return pack(src0.read_lane(wf, lane)) | (pack(src1.read_lane(wf, lane)) << 8);
+      }()));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
   }
 }
 
@@ -4051,15 +4318,21 @@ void VAshrPkU8I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    vdst.write_lane(wf, lane, [&]() -> uint32_t {
-      uint32_t shift = static_cast<uint32_t>(src2.read_lane(wf, lane)) & 31u;
-      auto pack = [&](uint32_t src) -> uint32_t {
-        int32_t shifted = static_cast<int32_t>(src) >> shift;
-        int32_t clamped = std::clamp(shifted, static_cast<int32_t>(0), static_cast<int32_t>(255));
-        return static_cast<uint32_t>(clamped);
-      };
-      return pack(src0.read_lane(wf, lane)) | (pack(src1.read_lane(wf, lane)) << 8);
-    }());
+    {
+      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>([&]() -> uint32_t {
+        uint32_t shift = static_cast<uint32_t>(src2.read_lane(wf, lane)) & 31u;
+        auto pack = [&](uint32_t src) -> uint32_t {
+          int32_t shifted = static_cast<int32_t>(src) >> shift;
+          int32_t clamped = std::clamp(shifted, static_cast<int32_t>(0), static_cast<int32_t>(255));
+          return static_cast<uint32_t>(clamped);
+        };
+        return pack(src0.read_lane(wf, lane)) | (pack(src1.read_lane(wf, lane)) << 8);
+      }()));
+      uint32_t old_dst = vdst.read_lane(wf, lane);
+      uint32_t merged = ((inst_.opsel & 0x8u) != 0) ? ((old_dst & 0x0000ffffu) | (src_half << 16))
+                                                    : ((old_dst & 0xffff0000u) | src_half);
+      vdst.write_lane(wf, lane, merged);
+    }
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -1136,40 +1136,47 @@ inline void execute_s_cmp_le_u32_sopc([[maybe_unused]] Inst &inst, [[maybe_unuse
 
 template <typename Inst>
 inline void execute_s_cmp_lg_f16_sopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  wf.write_scc(((util::f16_to_f32(static_cast<uint16_t>(inst.ssrc0.read_scalar(wf))) <
-                 util::f16_to_f32(static_cast<uint16_t>(inst.ssrc1.read_scalar(wf)))) ||
-                (util::f16_to_f32(static_cast<uint16_t>(inst.ssrc0.read_scalar(wf))) >
-                 util::f16_to_f32(static_cast<uint16_t>(inst.ssrc1.read_scalar(wf))))));
+  wf.write_scc(([&]() {
+    auto a = util::f16_to_f32(static_cast<uint16_t>(inst.ssrc0.read_scalar(wf)));
+    auto b = util::f16_to_f32(static_cast<uint16_t>(inst.ssrc1.read_scalar(wf)));
+    return (a < b) || (a > b);
+  }()));
 }
 
 template <typename Inst>
 inline void execute_s_cmp_lg_f32_sopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  wf.write_scc(((std::bit_cast<float>(inst.ssrc0.read_scalar(wf)) <
-                 std::bit_cast<float>(inst.ssrc1.read_scalar(wf))) ||
-                (std::bit_cast<float>(inst.ssrc0.read_scalar(wf)) >
-                 std::bit_cast<float>(inst.ssrc1.read_scalar(wf)))));
+  wf.write_scc(([&]() {
+    auto a = std::bit_cast<float>(inst.ssrc0.read_scalar(wf));
+    auto b = std::bit_cast<float>(inst.ssrc1.read_scalar(wf));
+    return (a < b) || (a > b);
+  }()));
 }
 
 template <typename Inst>
 inline void execute_s_cmp_lg_i32_sopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  wf.write_scc(((static_cast<int32_t>(inst.ssrc0.read_scalar(wf)) <
-                 static_cast<int32_t>(inst.ssrc1.read_scalar(wf))) ||
-                (static_cast<int32_t>(inst.ssrc0.read_scalar(wf)) >
-                 static_cast<int32_t>(inst.ssrc1.read_scalar(wf)))));
+  wf.write_scc(([&]() {
+    auto a = static_cast<int32_t>(inst.ssrc0.read_scalar(wf));
+    auto b = static_cast<int32_t>(inst.ssrc1.read_scalar(wf));
+    return (a < b) || (a > b);
+  }()));
 }
 
 template <typename Inst>
 inline void execute_s_cmp_lg_u32_sopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  wf.write_scc(((inst.ssrc0.read_scalar(wf) < inst.ssrc1.read_scalar(wf)) ||
-                (inst.ssrc0.read_scalar(wf) > inst.ssrc1.read_scalar(wf))));
+  wf.write_scc(([&]() {
+    auto a = inst.ssrc0.read_scalar(wf);
+    auto b = inst.ssrc1.read_scalar(wf);
+    return (a < b) || (a > b);
+  }()));
 }
 
 template <typename Inst>
 inline void execute_s_cmp_lg_u64_sopc([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  wf.write_scc(((static_cast<uint64_t>(inst.ssrc0.read_scalar64(wf)) <
-                 static_cast<uint64_t>(inst.ssrc1.read_scalar64(wf))) ||
-                (static_cast<uint64_t>(inst.ssrc0.read_scalar64(wf)) >
-                 static_cast<uint64_t>(inst.ssrc1.read_scalar64(wf)))));
+  wf.write_scc(([&]() {
+    auto a = static_cast<uint64_t>(inst.ssrc0.read_scalar64(wf));
+    auto b = static_cast<uint64_t>(inst.ssrc1.read_scalar64(wf));
+    return (a < b) || (a > b);
+  }()));
 }
 
 template <typename Inst>
@@ -1254,19 +1261,21 @@ inline void execute_s_cmp_nle_f32_sopc([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_s_cmp_nlg_f16_sopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  wf.write_scc((!((util::f16_to_f32(static_cast<uint16_t>(inst.ssrc0.read_scalar(wf))) <
-                   util::f16_to_f32(static_cast<uint16_t>(inst.ssrc1.read_scalar(wf)))) ||
-                  (util::f16_to_f32(static_cast<uint16_t>(inst.ssrc0.read_scalar(wf))) >
-                   util::f16_to_f32(static_cast<uint16_t>(inst.ssrc1.read_scalar(wf)))))));
+  wf.write_scc((!([&]() {
+    auto a = util::f16_to_f32(static_cast<uint16_t>(inst.ssrc0.read_scalar(wf)));
+    auto b = util::f16_to_f32(static_cast<uint16_t>(inst.ssrc1.read_scalar(wf)));
+    return (a < b) || (a > b);
+  }())));
 }
 
 template <typename Inst>
 inline void execute_s_cmp_nlg_f32_sopc([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  wf.write_scc((!((std::bit_cast<float>(inst.ssrc0.read_scalar(wf)) <
-                   std::bit_cast<float>(inst.ssrc1.read_scalar(wf))) ||
-                  (std::bit_cast<float>(inst.ssrc0.read_scalar(wf)) >
-                   std::bit_cast<float>(inst.ssrc1.read_scalar(wf))))));
+  wf.write_scc((!([&]() {
+    auto a = std::bit_cast<float>(inst.ssrc0.read_scalar(wf));
+    auto b = std::bit_cast<float>(inst.ssrc1.read_scalar(wf));
+    return (a < b) || (a > b);
+  }())));
 }
 
 template <typename Inst>
@@ -2737,7 +2746,10 @@ inline void execute_v_add_co_ci_u32_vop3([[maybe_unused]] Inst &inst,
       return static_cast<uint32_t>(w);
     }());
   }
-  inst.sdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.sdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.sdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -2785,7 +2797,10 @@ inline void execute_v_add_co_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
       return static_cast<uint32_t>(w);
     }());
   }
-  inst.sdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.sdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.sdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -3171,7 +3186,10 @@ inline void execute_v_addc_co_u32_vop3([[maybe_unused]] Inst &inst,
       return static_cast<uint32_t>(w);
     }());
   }
-  inst.sdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.sdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.sdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -3814,7 +3832,10 @@ inline void execute_v_cmp_class_f16_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -3955,7 +3976,10 @@ inline void execute_v_cmp_class_f32_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4092,7 +4116,10 @@ inline void execute_v_cmp_class_f64_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4191,7 +4218,10 @@ inline void execute_v_cmp_eq_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4241,7 +4271,10 @@ inline void execute_v_cmp_eq_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4289,7 +4322,10 @@ inline void execute_v_cmp_eq_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4326,7 +4362,10 @@ inline void execute_v_cmp_eq_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4363,7 +4402,10 @@ inline void execute_v_cmp_eq_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4397,7 +4439,10 @@ inline void execute_v_cmp_eq_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4432,7 +4477,10 @@ inline void execute_v_cmp_eq_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4465,7 +4513,10 @@ inline void execute_v_cmp_eq_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4498,7 +4549,10 @@ inline void execute_v_cmp_eq_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4531,7 +4585,10 @@ inline void execute_v_cmp_f_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4565,7 +4622,10 @@ inline void execute_v_cmp_f_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4597,7 +4657,10 @@ inline void execute_v_cmp_f_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4632,7 +4695,10 @@ inline void execute_v_cmp_f_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4667,7 +4733,10 @@ inline void execute_v_cmp_f_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4700,7 +4769,10 @@ inline void execute_v_cmp_f_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4733,7 +4805,10 @@ inline void execute_v_cmp_f_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4766,7 +4841,10 @@ inline void execute_v_cmp_f_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4799,7 +4877,10 @@ inline void execute_v_cmp_f_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4846,7 +4927,10 @@ inline void execute_v_cmp_ge_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4896,7 +4980,10 @@ inline void execute_v_cmp_ge_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4944,7 +5031,10 @@ inline void execute_v_cmp_ge_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -4981,7 +5071,10 @@ inline void execute_v_cmp_ge_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5018,7 +5111,10 @@ inline void execute_v_cmp_ge_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5052,7 +5148,10 @@ inline void execute_v_cmp_ge_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5087,7 +5186,10 @@ inline void execute_v_cmp_ge_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5120,7 +5222,10 @@ inline void execute_v_cmp_ge_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5153,7 +5258,10 @@ inline void execute_v_cmp_ge_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5201,7 +5309,10 @@ inline void execute_v_cmp_gt_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5250,7 +5361,10 @@ inline void execute_v_cmp_gt_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5298,7 +5412,10 @@ inline void execute_v_cmp_gt_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5335,7 +5452,10 @@ inline void execute_v_cmp_gt_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5372,7 +5492,10 @@ inline void execute_v_cmp_gt_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5406,7 +5529,10 @@ inline void execute_v_cmp_gt_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5441,7 +5567,10 @@ inline void execute_v_cmp_gt_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5474,7 +5603,10 @@ inline void execute_v_cmp_gt_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5507,7 +5639,10 @@ inline void execute_v_cmp_gt_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5555,7 +5690,10 @@ inline void execute_v_cmp_le_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5605,7 +5743,10 @@ inline void execute_v_cmp_le_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5653,7 +5794,10 @@ inline void execute_v_cmp_le_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5690,7 +5834,10 @@ inline void execute_v_cmp_le_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5727,7 +5874,10 @@ inline void execute_v_cmp_le_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5761,7 +5911,10 @@ inline void execute_v_cmp_le_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5796,7 +5949,10 @@ inline void execute_v_cmp_le_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5829,7 +5985,10 @@ inline void execute_v_cmp_le_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5862,7 +6021,10 @@ inline void execute_v_cmp_le_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5890,43 +6052,33 @@ inline void execute_v_cmp_lg_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    if ((([&]() {
-           float sv = util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)));
-           if (inst.inst_.abs & (1u << 0))
-             sv = std::fabs(sv);
-           if (inst.inst_.neg & (1u << 0))
-             sv = -sv;
-           return sv;
-         }() <
-          [&]() {
+    if (([&]() {
+          auto a = [&]() {
+            float sv = util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)));
+            if (inst.inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst.inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }();
+          auto b = [&]() {
             float sv = util::f16_to_f32(static_cast<uint16_t>(inst.src1.read_lane(wf, lane)));
             if (inst.inst_.abs & (1u << 1))
               sv = std::fabs(sv);
             if (inst.inst_.neg & (1u << 1))
               sv = -sv;
             return sv;
-          }()) ||
-         ([&]() {
-           float sv = util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)));
-           if (inst.inst_.abs & (1u << 0))
-             sv = std::fabs(sv);
-           if (inst.inst_.neg & (1u << 0))
-             sv = -sv;
-           return sv;
-         }() >
-          [&]() {
-            float sv = util::f16_to_f32(static_cast<uint16_t>(inst.src1.read_lane(wf, lane)));
-            if (inst.inst_.abs & (1u << 1))
-              sv = std::fabs(sv);
-            if (inst.inst_.neg & (1u << 1))
-              sv = -sv;
-            return sv;
-          }())))
+          }();
+          return (a < b) || (a > b);
+        }()))
       vcc |= (1ULL << lane);
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -5940,10 +6092,11 @@ inline void execute_v_cmp_lg_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    if (((util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) <
-          util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)))) ||
-         (util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) >
-          util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))))
+    if (([&]() {
+          auto a = util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)));
+          auto b = util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)));
+          return (a < b) || (a > b);
+        }()))
       vcc |= (1ULL << lane);
     else
       vcc &= ~(1ULL << lane);
@@ -5959,43 +6112,33 @@ inline void execute_v_cmp_lg_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    if ((([&]() {
-           float sv = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
-           if (inst.inst_.abs & (1u << 0))
-             sv = std::fabs(sv);
-           if (inst.inst_.neg & (1u << 0))
-             sv = -sv;
-           return sv;
-         }() <
-          [&]() {
+    if (([&]() {
+          auto a = [&]() {
+            float sv = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
+            if (inst.inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst.inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }();
+          auto b = [&]() {
             float sv = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
             if (inst.inst_.abs & (1u << 1))
               sv = std::fabs(sv);
             if (inst.inst_.neg & (1u << 1))
               sv = -sv;
             return sv;
-          }()) ||
-         ([&]() {
-           float sv = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
-           if (inst.inst_.abs & (1u << 0))
-             sv = std::fabs(sv);
-           if (inst.inst_.neg & (1u << 0))
-             sv = -sv;
-           return sv;
-         }() >
-          [&]() {
-            float sv = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
-            if (inst.inst_.abs & (1u << 1))
-              sv = std::fabs(sv);
-            if (inst.inst_.neg & (1u << 1))
-              sv = -sv;
-            return sv;
-          }())))
+          }();
+          return (a < b) || (a > b);
+        }()))
       vcc |= (1ULL << lane);
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6006,10 +6149,11 @@ inline void execute_v_cmp_lg_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    if (((std::bit_cast<float>(inst.src0.read_lane(wf, lane)) <
-          std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane))) ||
-         (std::bit_cast<float>(inst.src0.read_lane(wf, lane)) >
-          std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane)))))
+    if (([&]() {
+          auto a = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
+          auto b = std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane));
+          return (a < b) || (a > b);
+        }()))
       vcc |= (1ULL << lane);
     else
       vcc &= ~(1ULL << lane);
@@ -6025,43 +6169,33 @@ inline void execute_v_cmp_lg_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    if ((([&]() {
-           double sv = std::bit_cast<double>(inst.src0.read_lane64(wf, lane));
-           if (inst.inst_.abs & (1u << 0))
-             sv = std::fabs(sv);
-           if (inst.inst_.neg & (1u << 0))
-             sv = -sv;
-           return sv;
-         }() <
-          [&]() {
+    if (([&]() {
+          auto a = [&]() {
+            double sv = std::bit_cast<double>(inst.src0.read_lane64(wf, lane));
+            if (inst.inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst.inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }();
+          auto b = [&]() {
             double sv = std::bit_cast<double>(inst.src1.read_lane64(wf, lane));
             if (inst.inst_.abs & (1u << 1))
               sv = std::fabs(sv);
             if (inst.inst_.neg & (1u << 1))
               sv = -sv;
             return sv;
-          }()) ||
-         ([&]() {
-           double sv = std::bit_cast<double>(inst.src0.read_lane64(wf, lane));
-           if (inst.inst_.abs & (1u << 0))
-             sv = std::fabs(sv);
-           if (inst.inst_.neg & (1u << 0))
-             sv = -sv;
-           return sv;
-         }() >
-          [&]() {
-            double sv = std::bit_cast<double>(inst.src1.read_lane64(wf, lane));
-            if (inst.inst_.abs & (1u << 1))
-              sv = std::fabs(sv);
-            if (inst.inst_.neg & (1u << 1))
-              sv = -sv;
-            return sv;
-          }())))
+          }();
+          return (a < b) || (a > b);
+        }()))
       vcc |= (1ULL << lane);
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6072,10 +6206,11 @@ inline void execute_v_cmp_lg_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    if (((std::bit_cast<double>(inst.src0.read_lane64(wf, lane)) <
-          std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane))) ||
-         (std::bit_cast<double>(inst.src0.read_lane64(wf, lane)) >
-          std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane)))))
+    if (([&]() {
+          auto a = std::bit_cast<double>(inst.src0.read_lane64(wf, lane));
+          auto b = std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane));
+          return (a < b) || (a > b);
+        }()))
       vcc |= (1ULL << lane);
     else
       vcc &= ~(1ULL << lane);
@@ -6111,7 +6246,10 @@ inline void execute_v_cmp_lt_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6160,7 +6298,10 @@ inline void execute_v_cmp_lt_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6208,7 +6349,10 @@ inline void execute_v_cmp_lt_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6245,7 +6389,10 @@ inline void execute_v_cmp_lt_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6282,7 +6429,10 @@ inline void execute_v_cmp_lt_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6316,7 +6466,10 @@ inline void execute_v_cmp_lt_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6351,7 +6504,10 @@ inline void execute_v_cmp_lt_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6384,7 +6540,10 @@ inline void execute_v_cmp_lt_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6417,7 +6576,10 @@ inline void execute_v_cmp_lt_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6454,7 +6616,10 @@ inline void execute_v_cmp_ne_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6491,7 +6656,10 @@ inline void execute_v_cmp_ne_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6525,7 +6693,10 @@ inline void execute_v_cmp_ne_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6560,7 +6731,10 @@ inline void execute_v_cmp_ne_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6593,7 +6767,10 @@ inline void execute_v_cmp_ne_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6626,7 +6803,10 @@ inline void execute_v_cmp_ne_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6675,7 +6855,10 @@ inline void execute_v_cmp_neq_f16_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6727,7 +6910,10 @@ inline void execute_v_cmp_neq_f32_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6777,7 +6963,10 @@ inline void execute_v_cmp_neq_f64_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6827,7 +7016,10 @@ inline void execute_v_cmp_nge_f16_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6879,7 +7071,10 @@ inline void execute_v_cmp_nge_f32_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6929,7 +7124,10 @@ inline void execute_v_cmp_nge_f64_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -6979,7 +7177,10 @@ inline void execute_v_cmp_ngt_f16_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7031,7 +7232,10 @@ inline void execute_v_cmp_ngt_f32_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7081,7 +7285,10 @@ inline void execute_v_cmp_ngt_f64_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7131,7 +7338,10 @@ inline void execute_v_cmp_nle_f16_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7183,7 +7393,10 @@ inline void execute_v_cmp_nle_f32_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7233,7 +7446,10 @@ inline void execute_v_cmp_nle_f64_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7263,43 +7479,33 @@ inline void execute_v_cmp_nlg_f16_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    if ((!(([&]() {
-             float sv = util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)));
-             if (inst.inst_.abs & (1u << 0))
-               sv = std::fabs(sv);
-             if (inst.inst_.neg & (1u << 0))
-               sv = -sv;
-             return sv;
-           }() <
-            [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(inst.src1.read_lane(wf, lane)));
-              if (inst.inst_.abs & (1u << 1))
-                sv = std::fabs(sv);
-              if (inst.inst_.neg & (1u << 1))
-                sv = -sv;
-              return sv;
-            }()) ||
-           ([&]() {
-             float sv = util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)));
-             if (inst.inst_.abs & (1u << 0))
-               sv = std::fabs(sv);
-             if (inst.inst_.neg & (1u << 0))
-               sv = -sv;
-             return sv;
-           }() >
-            [&]() {
-              float sv = util::f16_to_f32(static_cast<uint16_t>(inst.src1.read_lane(wf, lane)));
-              if (inst.inst_.abs & (1u << 1))
-                sv = std::fabs(sv);
-              if (inst.inst_.neg & (1u << 1))
-                sv = -sv;
-              return sv;
-            }()))))
+    if ((!([&]() {
+          auto a = [&]() {
+            float sv = util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)));
+            if (inst.inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst.inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }();
+          auto b = [&]() {
+            float sv = util::f16_to_f32(static_cast<uint16_t>(inst.src1.read_lane(wf, lane)));
+            if (inst.inst_.abs & (1u << 1))
+              sv = std::fabs(sv);
+            if (inst.inst_.neg & (1u << 1))
+              sv = -sv;
+            return sv;
+          }();
+          return (a < b) || (a > b);
+        }())))
       vcc |= (1ULL << lane);
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7314,10 +7520,11 @@ inline void execute_v_cmp_nlg_f16_vopc([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    if ((!((util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) <
-            util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)))) ||
-           (util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) >
-            util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)))))))
+    if ((!([&]() {
+          auto a = util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)));
+          auto b = util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)));
+          return (a < b) || (a > b);
+        }())))
       vcc |= (1ULL << lane);
     else
       vcc &= ~(1ULL << lane);
@@ -7334,43 +7541,33 @@ inline void execute_v_cmp_nlg_f32_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    if ((!(([&]() {
-             float sv = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
-             if (inst.inst_.abs & (1u << 0))
-               sv = std::fabs(sv);
-             if (inst.inst_.neg & (1u << 0))
-               sv = -sv;
-             return sv;
-           }() <
-            [&]() {
-              float sv = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
-              if (inst.inst_.abs & (1u << 1))
-                sv = std::fabs(sv);
-              if (inst.inst_.neg & (1u << 1))
-                sv = -sv;
-              return sv;
-            }()) ||
-           ([&]() {
-             float sv = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
-             if (inst.inst_.abs & (1u << 0))
-               sv = std::fabs(sv);
-             if (inst.inst_.neg & (1u << 0))
-               sv = -sv;
-             return sv;
-           }() >
-            [&]() {
-              float sv = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
-              if (inst.inst_.abs & (1u << 1))
-                sv = std::fabs(sv);
-              if (inst.inst_.neg & (1u << 1))
-                sv = -sv;
-              return sv;
-            }()))))
+    if ((!([&]() {
+          auto a = [&]() {
+            float sv = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
+            if (inst.inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst.inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }();
+          auto b = [&]() {
+            float sv = std::bit_cast<float>(inst.src1.read_lane(wf, lane));
+            if (inst.inst_.abs & (1u << 1))
+              sv = std::fabs(sv);
+            if (inst.inst_.neg & (1u << 1))
+              sv = -sv;
+            return sv;
+          }();
+          return (a < b) || (a > b);
+        }())))
       vcc |= (1ULL << lane);
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7382,10 +7579,11 @@ inline void execute_v_cmp_nlg_f32_vopc([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    if ((!((std::bit_cast<float>(inst.src0.read_lane(wf, lane)) <
-            std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane))) ||
-           (std::bit_cast<float>(inst.src0.read_lane(wf, lane)) >
-            std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane))))))
+    if ((!([&]() {
+          auto a = std::bit_cast<float>(inst.src0.read_lane(wf, lane));
+          auto b = std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane));
+          return (a < b) || (a > b);
+        }())))
       vcc |= (1ULL << lane);
     else
       vcc &= ~(1ULL << lane);
@@ -7402,43 +7600,33 @@ inline void execute_v_cmp_nlg_f64_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    if ((!(([&]() {
-             double sv = std::bit_cast<double>(inst.src0.read_lane64(wf, lane));
-             if (inst.inst_.abs & (1u << 0))
-               sv = std::fabs(sv);
-             if (inst.inst_.neg & (1u << 0))
-               sv = -sv;
-             return sv;
-           }() <
-            [&]() {
-              double sv = std::bit_cast<double>(inst.src1.read_lane64(wf, lane));
-              if (inst.inst_.abs & (1u << 1))
-                sv = std::fabs(sv);
-              if (inst.inst_.neg & (1u << 1))
-                sv = -sv;
-              return sv;
-            }()) ||
-           ([&]() {
-             double sv = std::bit_cast<double>(inst.src0.read_lane64(wf, lane));
-             if (inst.inst_.abs & (1u << 0))
-               sv = std::fabs(sv);
-             if (inst.inst_.neg & (1u << 0))
-               sv = -sv;
-             return sv;
-           }() >
-            [&]() {
-              double sv = std::bit_cast<double>(inst.src1.read_lane64(wf, lane));
-              if (inst.inst_.abs & (1u << 1))
-                sv = std::fabs(sv);
-              if (inst.inst_.neg & (1u << 1))
-                sv = -sv;
-              return sv;
-            }()))))
+    if ((!([&]() {
+          auto a = [&]() {
+            double sv = std::bit_cast<double>(inst.src0.read_lane64(wf, lane));
+            if (inst.inst_.abs & (1u << 0))
+              sv = std::fabs(sv);
+            if (inst.inst_.neg & (1u << 0))
+              sv = -sv;
+            return sv;
+          }();
+          auto b = [&]() {
+            double sv = std::bit_cast<double>(inst.src1.read_lane64(wf, lane));
+            if (inst.inst_.abs & (1u << 1))
+              sv = std::fabs(sv);
+            if (inst.inst_.neg & (1u << 1))
+              sv = -sv;
+            return sv;
+          }();
+          return (a < b) || (a > b);
+        }())))
       vcc |= (1ULL << lane);
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7450,10 +7638,11 @@ inline void execute_v_cmp_nlg_f64_vopc([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    if ((!((std::bit_cast<double>(inst.src0.read_lane64(wf, lane)) <
-            std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane))) ||
-           (std::bit_cast<double>(inst.src0.read_lane64(wf, lane)) >
-            std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane))))))
+    if ((!([&]() {
+          auto a = std::bit_cast<double>(inst.src0.read_lane64(wf, lane));
+          auto b = std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane));
+          return (a < b) || (a > b);
+        }())))
       vcc |= (1ULL << lane);
     else
       vcc &= ~(1ULL << lane);
@@ -7490,7 +7679,10 @@ inline void execute_v_cmp_nlt_f16_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7542,7 +7734,10 @@ inline void execute_v_cmp_nlt_f32_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7592,7 +7787,10 @@ inline void execute_v_cmp_nlt_f64_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7642,7 +7840,10 @@ inline void execute_v_cmp_o_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7694,7 +7895,10 @@ inline void execute_v_cmp_o_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7744,7 +7948,10 @@ inline void execute_v_cmp_o_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7778,7 +7985,10 @@ inline void execute_v_cmp_t_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7809,7 +8019,10 @@ inline void execute_v_cmp_t_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7840,7 +8053,10 @@ inline void execute_v_cmp_t_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7874,7 +8090,10 @@ inline void execute_v_cmp_t_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7909,7 +8128,10 @@ inline void execute_v_cmp_t_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7941,7 +8163,10 @@ inline void execute_v_cmp_t_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -7974,7 +8199,10 @@ inline void execute_v_cmp_t_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -8007,7 +8235,10 @@ inline void execute_v_cmp_t_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -8040,7 +8271,10 @@ inline void execute_v_cmp_t_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -8073,7 +8307,10 @@ inline void execute_v_cmp_tru_f16_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -8109,7 +8346,10 @@ inline void execute_v_cmp_tru_f32_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -8143,7 +8383,10 @@ inline void execute_v_cmp_tru_f64_vop3([[maybe_unused]] Inst &inst,
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -8192,7 +8435,10 @@ inline void execute_v_cmp_u_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -8244,7 +8490,10 @@ inline void execute_v_cmp_u_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -8294,7 +8543,10 @@ inline void execute_v_cmp_u_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
     else
       vcc &= ~(1ULL << lane);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.vdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -19480,7 +19732,10 @@ inline void execute_v_sub_co_ci_u32_vop3([[maybe_unused]] Inst &inst,
       return static_cast<uint32_t>(a - b - c);
     }());
   }
-  inst.sdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.sdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.sdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -19520,7 +19775,10 @@ inline void execute_v_sub_co_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
       return a - b;
     }());
   }
-  inst.sdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.sdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.sdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -19836,7 +20094,10 @@ inline void execute_v_subb_co_u32_vop3([[maybe_unused]] Inst &inst,
       return static_cast<uint32_t>(a - b - c);
     }());
   }
-  inst.sdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.sdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.sdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -19894,7 +20155,10 @@ inline void execute_v_subbrev_co_u32_vop3([[maybe_unused]] Inst &inst,
       return static_cast<uint32_t>(a - b - c);
     }());
   }
-  inst.sdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.sdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.sdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -19945,7 +20209,10 @@ inline void execute_v_subrev_co_ci_u32_vop3([[maybe_unused]] Inst &inst,
       return static_cast<uint32_t>(a - b - c);
     }());
   }
-  inst.sdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.sdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.sdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>
@@ -19987,7 +20254,10 @@ inline void execute_v_subrev_co_u32_vop3([[maybe_unused]] Inst &inst,
       return a - b;
     }());
   }
-  inst.sdst.write_scalar64(wf, vcc);
+  if (wf.wf_size() <= 32)
+    inst.sdst.write_scalar(wf, static_cast<uint32_t>(vcc));
+  else
+    inst.sdst.write_scalar64(wf, vcc);
 }
 
 template <typename Inst>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -3829,8 +3829,6 @@ inline void execute_v_cmp_class_f16_vop3([[maybe_unused]] Inst &inst,
       match = true;
     if (match)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -3904,8 +3902,6 @@ inline void execute_v_cmp_class_f16_vopc([[maybe_unused]] Inst &inst,
       match = true;
     if (match)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -3973,8 +3969,6 @@ inline void execute_v_cmp_class_f32_vop3([[maybe_unused]] Inst &inst,
       match = true;
     if (match)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4041,8 +4035,6 @@ inline void execute_v_cmp_class_f32_vopc([[maybe_unused]] Inst &inst,
       match = true;
     if (match)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4113,8 +4105,6 @@ inline void execute_v_cmp_class_f64_vop3([[maybe_unused]] Inst &inst,
       match = true;
     if (match)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4184,8 +4174,6 @@ inline void execute_v_cmp_class_f64_vopc([[maybe_unused]] Inst &inst,
       match = true;
     if (match)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4215,8 +4203,6 @@ inline void execute_v_cmp_eq_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4237,8 +4223,6 @@ inline void execute_v_cmp_eq_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) ==
          util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4268,8 +4252,6 @@ inline void execute_v_cmp_eq_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4288,8 +4270,6 @@ inline void execute_v_cmp_eq_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((std::bit_cast<float>(inst.src0.read_lane(wf, lane)) ==
          std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4319,8 +4299,6 @@ inline void execute_v_cmp_eq_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4339,8 +4317,6 @@ inline void execute_v_cmp_eq_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((std::bit_cast<double>(inst.src0.read_lane64(wf, lane)) ==
          std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4359,8 +4335,6 @@ inline void execute_v_cmp_eq_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int16_t>(inst.src0.read_lane(wf, lane)) ==
          static_cast<int16_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4382,8 +4356,6 @@ inline void execute_v_cmp_eq_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int16_t>(inst.src0.read_lane(wf, lane)) ==
          static_cast<int16_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4399,8 +4371,6 @@ inline void execute_v_cmp_eq_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int32_t>(inst.src0.read_lane(wf, lane)) ==
          static_cast<int32_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4419,8 +4389,6 @@ inline void execute_v_cmp_eq_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int32_t>(inst.src0.read_lane(wf, lane)) ==
          static_cast<int32_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4436,8 +4404,6 @@ inline void execute_v_cmp_eq_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int64_t>(inst.src0.read_lane64(wf, lane)) ==
          static_cast<int64_t>(inst.src1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4456,8 +4422,6 @@ inline void execute_v_cmp_eq_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int64_t>(inst.src0.read_lane64(wf, lane)) ==
          static_cast<int64_t>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4474,8 +4438,6 @@ inline void execute_v_cmp_eq_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) ==
          static_cast<uint16_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4494,8 +4456,6 @@ inline void execute_v_cmp_eq_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) ==
          static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4510,8 +4470,6 @@ inline void execute_v_cmp_eq_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     if ((inst.src0.read_lane(wf, lane) == inst.src1.read_lane(wf, lane)))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4529,8 +4487,6 @@ inline void execute_v_cmp_eq_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     if ((inst.src0.read_lane(wf, lane) == inst.vsrc1.read_lane(wf, lane)))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4546,8 +4502,6 @@ inline void execute_v_cmp_eq_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)) ==
          static_cast<uint64_t>(inst.src1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4566,8 +4520,6 @@ inline void execute_v_cmp_eq_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)) ==
          static_cast<uint64_t>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4582,8 +4534,6 @@ inline void execute_v_cmp_f_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4603,8 +4553,6 @@ inline void execute_v_cmp_f_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4619,8 +4567,6 @@ inline void execute_v_cmp_f_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4638,8 +4584,6 @@ inline void execute_v_cmp_f_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4654,8 +4598,6 @@ inline void execute_v_cmp_f_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4673,8 +4615,6 @@ inline void execute_v_cmp_f_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4692,8 +4632,6 @@ inline void execute_v_cmp_f_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4714,8 +4652,6 @@ inline void execute_v_cmp_f_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4730,8 +4666,6 @@ inline void execute_v_cmp_f_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4749,8 +4683,6 @@ inline void execute_v_cmp_f_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4766,8 +4698,6 @@ inline void execute_v_cmp_f_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4785,8 +4715,6 @@ inline void execute_v_cmp_f_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4802,8 +4730,6 @@ inline void execute_v_cmp_f_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4822,8 +4748,6 @@ inline void execute_v_cmp_f_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4838,8 +4762,6 @@ inline void execute_v_cmp_f_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4857,8 +4779,6 @@ inline void execute_v_cmp_f_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4874,8 +4794,6 @@ inline void execute_v_cmp_f_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4893,8 +4811,6 @@ inline void execute_v_cmp_f_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (0)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4924,8 +4840,6 @@ inline void execute_v_cmp_ge_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4946,8 +4860,6 @@ inline void execute_v_cmp_ge_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) >=
          util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -4977,8 +4889,6 @@ inline void execute_v_cmp_ge_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -4997,8 +4907,6 @@ inline void execute_v_cmp_ge_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((std::bit_cast<float>(inst.src0.read_lane(wf, lane)) >=
          std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5028,8 +4936,6 @@ inline void execute_v_cmp_ge_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5048,8 +4954,6 @@ inline void execute_v_cmp_ge_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((std::bit_cast<double>(inst.src0.read_lane64(wf, lane)) >=
          std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5068,8 +4972,6 @@ inline void execute_v_cmp_ge_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int16_t>(inst.src0.read_lane(wf, lane)) >=
          static_cast<int16_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5091,8 +4993,6 @@ inline void execute_v_cmp_ge_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int16_t>(inst.src0.read_lane(wf, lane)) >=
          static_cast<int16_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5108,8 +5008,6 @@ inline void execute_v_cmp_ge_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int32_t>(inst.src0.read_lane(wf, lane)) >=
          static_cast<int32_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5128,8 +5026,6 @@ inline void execute_v_cmp_ge_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int32_t>(inst.src0.read_lane(wf, lane)) >=
          static_cast<int32_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5145,8 +5041,6 @@ inline void execute_v_cmp_ge_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int64_t>(inst.src0.read_lane64(wf, lane)) >=
          static_cast<int64_t>(inst.src1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5165,8 +5059,6 @@ inline void execute_v_cmp_ge_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int64_t>(inst.src0.read_lane64(wf, lane)) >=
          static_cast<int64_t>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5183,8 +5075,6 @@ inline void execute_v_cmp_ge_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) >=
          static_cast<uint16_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5203,8 +5093,6 @@ inline void execute_v_cmp_ge_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) >=
          static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5219,8 +5107,6 @@ inline void execute_v_cmp_ge_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     if ((inst.src0.read_lane(wf, lane) >= inst.src1.read_lane(wf, lane)))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5238,8 +5124,6 @@ inline void execute_v_cmp_ge_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     if ((inst.src0.read_lane(wf, lane) >= inst.vsrc1.read_lane(wf, lane)))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5255,8 +5139,6 @@ inline void execute_v_cmp_ge_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)) >=
          static_cast<uint64_t>(inst.src1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5275,8 +5157,6 @@ inline void execute_v_cmp_ge_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)) >=
          static_cast<uint64_t>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5306,8 +5186,6 @@ inline void execute_v_cmp_gt_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5327,8 +5205,6 @@ inline void execute_v_cmp_gt_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) >
          util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5358,8 +5234,6 @@ inline void execute_v_cmp_gt_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5378,8 +5252,6 @@ inline void execute_v_cmp_gt_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((std::bit_cast<float>(inst.src0.read_lane(wf, lane)) >
          std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5409,8 +5281,6 @@ inline void execute_v_cmp_gt_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5429,8 +5299,6 @@ inline void execute_v_cmp_gt_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((std::bit_cast<double>(inst.src0.read_lane64(wf, lane)) >
          std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5449,8 +5317,6 @@ inline void execute_v_cmp_gt_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int16_t>(inst.src0.read_lane(wf, lane)) >
          static_cast<int16_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5472,8 +5338,6 @@ inline void execute_v_cmp_gt_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int16_t>(inst.src0.read_lane(wf, lane)) >
          static_cast<int16_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5489,8 +5353,6 @@ inline void execute_v_cmp_gt_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int32_t>(inst.src0.read_lane(wf, lane)) >
          static_cast<int32_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5509,8 +5371,6 @@ inline void execute_v_cmp_gt_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int32_t>(inst.src0.read_lane(wf, lane)) >
          static_cast<int32_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5526,8 +5386,6 @@ inline void execute_v_cmp_gt_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int64_t>(inst.src0.read_lane64(wf, lane)) >
          static_cast<int64_t>(inst.src1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5546,8 +5404,6 @@ inline void execute_v_cmp_gt_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int64_t>(inst.src0.read_lane64(wf, lane)) >
          static_cast<int64_t>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5564,8 +5420,6 @@ inline void execute_v_cmp_gt_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) >
          static_cast<uint16_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5584,8 +5438,6 @@ inline void execute_v_cmp_gt_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) >
          static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5600,8 +5452,6 @@ inline void execute_v_cmp_gt_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     if ((inst.src0.read_lane(wf, lane) > inst.src1.read_lane(wf, lane)))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5619,8 +5469,6 @@ inline void execute_v_cmp_gt_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     if ((inst.src0.read_lane(wf, lane) > inst.vsrc1.read_lane(wf, lane)))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5636,8 +5484,6 @@ inline void execute_v_cmp_gt_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)) >
          static_cast<uint64_t>(inst.src1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5656,8 +5502,6 @@ inline void execute_v_cmp_gt_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)) >
          static_cast<uint64_t>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5687,8 +5531,6 @@ inline void execute_v_cmp_le_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5709,8 +5551,6 @@ inline void execute_v_cmp_le_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) <=
          util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5740,8 +5580,6 @@ inline void execute_v_cmp_le_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5760,8 +5598,6 @@ inline void execute_v_cmp_le_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((std::bit_cast<float>(inst.src0.read_lane(wf, lane)) <=
          std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5791,8 +5627,6 @@ inline void execute_v_cmp_le_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5811,8 +5645,6 @@ inline void execute_v_cmp_le_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((std::bit_cast<double>(inst.src0.read_lane64(wf, lane)) <=
          std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5831,8 +5663,6 @@ inline void execute_v_cmp_le_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int16_t>(inst.src0.read_lane(wf, lane)) <=
          static_cast<int16_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5854,8 +5684,6 @@ inline void execute_v_cmp_le_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int16_t>(inst.src0.read_lane(wf, lane)) <=
          static_cast<int16_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5871,8 +5699,6 @@ inline void execute_v_cmp_le_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int32_t>(inst.src0.read_lane(wf, lane)) <=
          static_cast<int32_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5891,8 +5717,6 @@ inline void execute_v_cmp_le_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int32_t>(inst.src0.read_lane(wf, lane)) <=
          static_cast<int32_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5908,8 +5732,6 @@ inline void execute_v_cmp_le_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int64_t>(inst.src0.read_lane64(wf, lane)) <=
          static_cast<int64_t>(inst.src1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5928,8 +5750,6 @@ inline void execute_v_cmp_le_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int64_t>(inst.src0.read_lane64(wf, lane)) <=
          static_cast<int64_t>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5946,8 +5766,6 @@ inline void execute_v_cmp_le_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) <=
          static_cast<uint16_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -5966,8 +5784,6 @@ inline void execute_v_cmp_le_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) <=
          static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -5982,8 +5798,6 @@ inline void execute_v_cmp_le_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     if ((inst.src0.read_lane(wf, lane) <= inst.src1.read_lane(wf, lane)))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6001,8 +5815,6 @@ inline void execute_v_cmp_le_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     if ((inst.src0.read_lane(wf, lane) <= inst.vsrc1.read_lane(wf, lane)))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6018,8 +5830,6 @@ inline void execute_v_cmp_le_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)) <=
          static_cast<uint64_t>(inst.src1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6038,8 +5848,6 @@ inline void execute_v_cmp_le_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)) <=
          static_cast<uint64_t>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6072,8 +5880,6 @@ inline void execute_v_cmp_lg_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
           return (a < b) || (a > b);
         }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6098,8 +5904,6 @@ inline void execute_v_cmp_lg_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
           return (a < b) || (a > b);
         }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6132,8 +5936,6 @@ inline void execute_v_cmp_lg_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
           return (a < b) || (a > b);
         }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6155,8 +5957,6 @@ inline void execute_v_cmp_lg_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
           return (a < b) || (a > b);
         }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6189,8 +5989,6 @@ inline void execute_v_cmp_lg_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
           return (a < b) || (a > b);
         }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6212,8 +6010,6 @@ inline void execute_v_cmp_lg_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
           return (a < b) || (a > b);
         }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6243,8 +6039,6 @@ inline void execute_v_cmp_lt_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6264,8 +6058,6 @@ inline void execute_v_cmp_lt_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) <
          util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6295,8 +6087,6 @@ inline void execute_v_cmp_lt_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6315,8 +6105,6 @@ inline void execute_v_cmp_lt_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((std::bit_cast<float>(inst.src0.read_lane(wf, lane)) <
          std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6346,8 +6134,6 @@ inline void execute_v_cmp_lt_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6366,8 +6152,6 @@ inline void execute_v_cmp_lt_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((std::bit_cast<double>(inst.src0.read_lane64(wf, lane)) <
          std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6386,8 +6170,6 @@ inline void execute_v_cmp_lt_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int16_t>(inst.src0.read_lane(wf, lane)) <
          static_cast<int16_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6409,8 +6191,6 @@ inline void execute_v_cmp_lt_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int16_t>(inst.src0.read_lane(wf, lane)) <
          static_cast<int16_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6426,8 +6206,6 @@ inline void execute_v_cmp_lt_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int32_t>(inst.src0.read_lane(wf, lane)) <
          static_cast<int32_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6446,8 +6224,6 @@ inline void execute_v_cmp_lt_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int32_t>(inst.src0.read_lane(wf, lane)) <
          static_cast<int32_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6463,8 +6239,6 @@ inline void execute_v_cmp_lt_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int64_t>(inst.src0.read_lane64(wf, lane)) <
          static_cast<int64_t>(inst.src1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6483,8 +6257,6 @@ inline void execute_v_cmp_lt_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int64_t>(inst.src0.read_lane64(wf, lane)) <
          static_cast<int64_t>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6501,8 +6273,6 @@ inline void execute_v_cmp_lt_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) <
          static_cast<uint16_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6521,8 +6291,6 @@ inline void execute_v_cmp_lt_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) <
          static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6537,8 +6305,6 @@ inline void execute_v_cmp_lt_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     if ((inst.src0.read_lane(wf, lane) < inst.src1.read_lane(wf, lane)))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6556,8 +6322,6 @@ inline void execute_v_cmp_lt_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     if ((inst.src0.read_lane(wf, lane) < inst.vsrc1.read_lane(wf, lane)))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6573,8 +6337,6 @@ inline void execute_v_cmp_lt_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)) <
          static_cast<uint64_t>(inst.src1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6593,8 +6355,6 @@ inline void execute_v_cmp_lt_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)) <
          static_cast<uint64_t>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6613,8 +6373,6 @@ inline void execute_v_cmp_ne_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int16_t>(inst.src0.read_lane(wf, lane)) !=
          static_cast<int16_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6636,8 +6394,6 @@ inline void execute_v_cmp_ne_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int16_t>(inst.src0.read_lane(wf, lane)) !=
          static_cast<int16_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6653,8 +6409,6 @@ inline void execute_v_cmp_ne_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int32_t>(inst.src0.read_lane(wf, lane)) !=
          static_cast<int32_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6673,8 +6427,6 @@ inline void execute_v_cmp_ne_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int32_t>(inst.src0.read_lane(wf, lane)) !=
          static_cast<int32_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6690,8 +6442,6 @@ inline void execute_v_cmp_ne_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int64_t>(inst.src0.read_lane64(wf, lane)) !=
          static_cast<int64_t>(inst.src1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6710,8 +6460,6 @@ inline void execute_v_cmp_ne_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<int64_t>(inst.src0.read_lane64(wf, lane)) !=
          static_cast<int64_t>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6728,8 +6476,6 @@ inline void execute_v_cmp_ne_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) !=
          static_cast<uint16_t>(inst.src1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6748,8 +6494,6 @@ inline void execute_v_cmp_ne_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) !=
          static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6764,8 +6508,6 @@ inline void execute_v_cmp_ne_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     if ((inst.src0.read_lane(wf, lane) != inst.src1.read_lane(wf, lane)))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6783,8 +6525,6 @@ inline void execute_v_cmp_ne_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     if ((inst.src0.read_lane(wf, lane) != inst.vsrc1.read_lane(wf, lane)))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6800,8 +6540,6 @@ inline void execute_v_cmp_ne_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)) !=
          static_cast<uint64_t>(inst.src1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6820,8 +6558,6 @@ inline void execute_v_cmp_ne_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unuse
     if ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)) !=
          static_cast<uint64_t>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6852,8 +6588,6 @@ inline void execute_v_cmp_neq_f16_vop3([[maybe_unused]] Inst &inst,
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6875,8 +6609,6 @@ inline void execute_v_cmp_neq_f16_vopc([[maybe_unused]] Inst &inst,
     if ((util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) !=
          util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6907,8 +6639,6 @@ inline void execute_v_cmp_neq_f32_vop3([[maybe_unused]] Inst &inst,
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6928,8 +6658,6 @@ inline void execute_v_cmp_neq_f32_vopc([[maybe_unused]] Inst &inst,
     if ((std::bit_cast<float>(inst.src0.read_lane(wf, lane)) !=
          std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -6960,8 +6688,6 @@ inline void execute_v_cmp_neq_f64_vop3([[maybe_unused]] Inst &inst,
            return sv;
          }()))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -6981,8 +6707,6 @@ inline void execute_v_cmp_neq_f64_vopc([[maybe_unused]] Inst &inst,
     if ((std::bit_cast<double>(inst.src0.read_lane64(wf, lane)) !=
          std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7013,8 +6737,6 @@ inline void execute_v_cmp_nge_f16_vop3([[maybe_unused]] Inst &inst,
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7036,8 +6758,6 @@ inline void execute_v_cmp_nge_f16_vopc([[maybe_unused]] Inst &inst,
     if ((!(util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) >=
            util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7068,8 +6788,6 @@ inline void execute_v_cmp_nge_f32_vop3([[maybe_unused]] Inst &inst,
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7089,8 +6807,6 @@ inline void execute_v_cmp_nge_f32_vopc([[maybe_unused]] Inst &inst,
     if ((!(std::bit_cast<float>(inst.src0.read_lane(wf, lane)) >=
            std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7121,8 +6837,6 @@ inline void execute_v_cmp_nge_f64_vop3([[maybe_unused]] Inst &inst,
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7142,8 +6856,6 @@ inline void execute_v_cmp_nge_f64_vopc([[maybe_unused]] Inst &inst,
     if ((!(std::bit_cast<double>(inst.src0.read_lane64(wf, lane)) >=
            std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7174,8 +6886,6 @@ inline void execute_v_cmp_ngt_f16_vop3([[maybe_unused]] Inst &inst,
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7197,8 +6907,6 @@ inline void execute_v_cmp_ngt_f16_vopc([[maybe_unused]] Inst &inst,
     if ((!(util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) >
            util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7229,8 +6937,6 @@ inline void execute_v_cmp_ngt_f32_vop3([[maybe_unused]] Inst &inst,
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7250,8 +6956,6 @@ inline void execute_v_cmp_ngt_f32_vopc([[maybe_unused]] Inst &inst,
     if ((!(std::bit_cast<float>(inst.src0.read_lane(wf, lane)) >
            std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7282,8 +6986,6 @@ inline void execute_v_cmp_ngt_f64_vop3([[maybe_unused]] Inst &inst,
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7303,8 +7005,6 @@ inline void execute_v_cmp_ngt_f64_vopc([[maybe_unused]] Inst &inst,
     if ((!(std::bit_cast<double>(inst.src0.read_lane64(wf, lane)) >
            std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7335,8 +7035,6 @@ inline void execute_v_cmp_nle_f16_vop3([[maybe_unused]] Inst &inst,
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7358,8 +7056,6 @@ inline void execute_v_cmp_nle_f16_vopc([[maybe_unused]] Inst &inst,
     if ((!(util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) <=
            util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7390,8 +7086,6 @@ inline void execute_v_cmp_nle_f32_vop3([[maybe_unused]] Inst &inst,
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7411,8 +7105,6 @@ inline void execute_v_cmp_nle_f32_vopc([[maybe_unused]] Inst &inst,
     if ((!(std::bit_cast<float>(inst.src0.read_lane(wf, lane)) <=
            std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7443,8 +7135,6 @@ inline void execute_v_cmp_nle_f64_vop3([[maybe_unused]] Inst &inst,
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7464,8 +7154,6 @@ inline void execute_v_cmp_nle_f64_vopc([[maybe_unused]] Inst &inst,
     if ((!(std::bit_cast<double>(inst.src0.read_lane64(wf, lane)) <=
            std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7499,8 +7187,6 @@ inline void execute_v_cmp_nlg_f16_vop3([[maybe_unused]] Inst &inst,
           return (a < b) || (a > b);
         }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7526,8 +7212,6 @@ inline void execute_v_cmp_nlg_f16_vopc([[maybe_unused]] Inst &inst,
           return (a < b) || (a > b);
         }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7561,8 +7245,6 @@ inline void execute_v_cmp_nlg_f32_vop3([[maybe_unused]] Inst &inst,
           return (a < b) || (a > b);
         }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7585,8 +7267,6 @@ inline void execute_v_cmp_nlg_f32_vopc([[maybe_unused]] Inst &inst,
           return (a < b) || (a > b);
         }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7620,8 +7300,6 @@ inline void execute_v_cmp_nlg_f64_vop3([[maybe_unused]] Inst &inst,
           return (a < b) || (a > b);
         }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7644,8 +7322,6 @@ inline void execute_v_cmp_nlg_f64_vopc([[maybe_unused]] Inst &inst,
           return (a < b) || (a > b);
         }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7676,8 +7352,6 @@ inline void execute_v_cmp_nlt_f16_vop3([[maybe_unused]] Inst &inst,
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7699,8 +7373,6 @@ inline void execute_v_cmp_nlt_f16_vopc([[maybe_unused]] Inst &inst,
     if ((!(util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) <
            util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7731,8 +7403,6 @@ inline void execute_v_cmp_nlt_f32_vop3([[maybe_unused]] Inst &inst,
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7752,8 +7422,6 @@ inline void execute_v_cmp_nlt_f32_vopc([[maybe_unused]] Inst &inst,
     if ((!(std::bit_cast<float>(inst.src0.read_lane(wf, lane)) <
            std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7784,8 +7452,6 @@ inline void execute_v_cmp_nlt_f64_vop3([[maybe_unused]] Inst &inst,
              return sv;
            }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7805,8 +7471,6 @@ inline void execute_v_cmp_nlt_f64_vopc([[maybe_unused]] Inst &inst,
     if ((!(std::bit_cast<double>(inst.src0.read_lane64(wf, lane)) <
            std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7837,8 +7501,6 @@ inline void execute_v_cmp_o_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
            return sv;
          }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7860,8 +7522,6 @@ inline void execute_v_cmp_o_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if ((!std::isnan(util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)))) &&
          !std::isnan(util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7892,8 +7552,6 @@ inline void execute_v_cmp_o_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
            return sv;
          }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7913,8 +7571,6 @@ inline void execute_v_cmp_o_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if ((!std::isnan(std::bit_cast<float>(inst.src0.read_lane(wf, lane))) &&
          !std::isnan(std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7945,8 +7601,6 @@ inline void execute_v_cmp_o_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
            return sv;
          }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -7966,8 +7620,6 @@ inline void execute_v_cmp_o_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if ((!std::isnan(std::bit_cast<double>(inst.src0.read_lane64(wf, lane))) &&
          !std::isnan(std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -7982,8 +7634,6 @@ inline void execute_v_cmp_t_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8000,8 +7650,6 @@ inline void execute_v_cmp_t_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -8016,8 +7664,6 @@ inline void execute_v_cmp_t_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8034,8 +7680,6 @@ inline void execute_v_cmp_t_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -8050,8 +7694,6 @@ inline void execute_v_cmp_t_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8068,8 +7710,6 @@ inline void execute_v_cmp_t_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -8087,8 +7727,6 @@ inline void execute_v_cmp_t_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8109,8 +7747,6 @@ inline void execute_v_cmp_t_i16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -8125,8 +7761,6 @@ inline void execute_v_cmp_t_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8144,8 +7778,6 @@ inline void execute_v_cmp_t_i32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -8160,8 +7792,6 @@ inline void execute_v_cmp_t_i64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8179,8 +7809,6 @@ inline void execute_v_cmp_t_i64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -8196,8 +7824,6 @@ inline void execute_v_cmp_t_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8216,8 +7842,6 @@ inline void execute_v_cmp_t_u16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -8232,8 +7856,6 @@ inline void execute_v_cmp_t_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8251,8 +7873,6 @@ inline void execute_v_cmp_t_u32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -8268,8 +7888,6 @@ inline void execute_v_cmp_t_u64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8287,8 +7905,6 @@ inline void execute_v_cmp_t_u64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -8304,8 +7920,6 @@ inline void execute_v_cmp_tru_f16_vop3([[maybe_unused]] Inst &inst,
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8326,8 +7940,6 @@ inline void execute_v_cmp_tru_f16_vopc([[maybe_unused]] Inst &inst,
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -8343,8 +7955,6 @@ inline void execute_v_cmp_tru_f32_vop3([[maybe_unused]] Inst &inst,
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8363,8 +7973,6 @@ inline void execute_v_cmp_tru_f32_vopc([[maybe_unused]] Inst &inst,
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -8380,8 +7988,6 @@ inline void execute_v_cmp_tru_f64_vop3([[maybe_unused]] Inst &inst,
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8400,8 +8006,6 @@ inline void execute_v_cmp_tru_f64_vopc([[maybe_unused]] Inst &inst,
       continue;
     if (1)
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -8432,8 +8036,6 @@ inline void execute_v_cmp_u_f16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
            return sv;
          }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8455,8 +8057,6 @@ inline void execute_v_cmp_u_f16_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if ((std::isnan(util::f16_to_f32(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)))) ||
          std::isnan(util::f16_to_f32(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -8487,8 +8087,6 @@ inline void execute_v_cmp_u_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
            return sv;
          }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8508,8 +8106,6 @@ inline void execute_v_cmp_u_f32_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if ((std::isnan(std::bit_cast<float>(inst.src0.read_lane(wf, lane))) ||
          std::isnan(std::bit_cast<float>(inst.vsrc1.read_lane(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }
@@ -8540,8 +8136,6 @@ inline void execute_v_cmp_u_f64_vop3([[maybe_unused]] Inst &inst, [[maybe_unused
            return sv;
          }())))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   if (wf.wf_size() <= 32)
     inst.vdst.write_scalar(wf, static_cast<uint32_t>(vcc));
@@ -8561,8 +8155,6 @@ inline void execute_v_cmp_u_f64_vopc([[maybe_unused]] Inst &inst, [[maybe_unused
     if ((std::isnan(std::bit_cast<double>(inst.src0.read_lane64(wf, lane))) ||
          std::isnan(std::bit_cast<double>(inst.vsrc1.read_lane64(wf, lane)))))
       vcc |= (1ULL << lane);
-    else
-      vcc &= ~(1ULL << lane);
   }
   wf.set_vcc(vcc);
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -35,6 +35,14 @@ using float32_t = float;
 /// flip at runtime.
 inline bool simd_force_scalar() { return util::force_scalar(); }
 
+template <typename Op>
+inline void write_wave_mask_scalar(const Op &op, Wavefront &wf, uint64_t mask) {
+  if (wf.wf_size() <= 32)
+    op.write_scalar(wf, static_cast<uint32_t>(mask));
+  else
+    op.write_scalar64(wf, mask);
+}
+
 /// In-vector VOP3 source modifier (f32), bit-exact with the scalar lambda the
 /// generated bodies emit per source: `abs` first (`std::fabs`), then `neg`
 /// (`-x`). `abs`/`neg` are the raw VOP3 modifier fields; the bit for source
@@ -1195,7 +1203,7 @@ template <typename Inst, typename CmpOp>
         cmp_bits |= (1ULL << i);
     vcc = (vcc & ~(chunk << base)) | ((cmp_bits & chunk) << base);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  write_wave_mask_scalar(inst.vdst, wf, vcc);
   return true;
 }
 
@@ -1249,7 +1257,7 @@ template <typename Inst, typename CmpOp>
         cmp_bits |= (1ULL << i);
     vcc = (vcc & ~(chunk << base)) | ((cmp_bits & chunk) << base);
   }
-  inst.vdst.write_scalar64(wf, vcc);
+  write_wave_mask_scalar(inst.vdst, wf, vcc);
   return true;
 }
 
@@ -1393,7 +1401,7 @@ template <typename T, typename Inst, typename CmpOp>
         cmp_bits |= (1ULL << i);
     dst = (dst & ~(chunk << base)) | ((cmp_bits & chunk) << base);
   }
-  inst.vdst.write_scalar64(wf, dst);
+  write_wave_mask_scalar(inst.vdst, wf, dst);
   return true;
 }
 
@@ -1439,7 +1447,7 @@ template <typename T, typename Inst, typename CmpOp>
         cmp_bits |= (1ULL << i);
     dst = (dst & ~(chunk << base)) | ((cmp_bits & chunk) << base);
   }
-  inst.vdst.write_scalar64(wf, dst);
+  write_wave_mask_scalar(inst.vdst, wf, dst);
   return true;
 }
 
@@ -1488,7 +1496,7 @@ template <typename Inst, typename CmpOp>
         cmp_bits |= (1ULL << i);
     dst = (dst & ~(chunk << base)) | ((cmp_bits & chunk) << base);
   }
-  inst.vdst.write_scalar64(wf, dst);
+  write_wave_mask_scalar(inst.vdst, wf, dst);
   return true;
 }
 
@@ -1539,7 +1547,7 @@ template <typename Inst, typename CmpOp>
         cmp_bits |= (1ULL << i);
     dst = (dst & ~(chunk << base)) | ((cmp_bits & chunk) << base);
   }
-  inst.vdst.write_scalar64(wf, dst);
+  write_wave_mask_scalar(inst.vdst, wf, dst);
   return true;
 }
 
@@ -1591,7 +1599,7 @@ template <typename Inst, typename CmpOp>
         cmp_bits |= (1ULL << i);
     dst = (dst & ~(chunk << base)) | ((cmp_bits & chunk) << base);
   }
-  inst.vdst.write_scalar64(wf, dst);
+  write_wave_mask_scalar(inst.vdst, wf, dst);
   return true;
 }
 
@@ -2481,8 +2489,9 @@ template <typename Inst, typename MadOp>
 
 /// VOP3 carry-OUT binary fast path (v_add_co/sub_co/subrev_co_u32). No carry-in
 /// (the SimdCarry functor's third arg is a zero vector); the per-lane carry-out
-/// is merged into a copy of the current VCC and written to the SGPR-pair `sdst`
-/// (not the fixed VCC) — exactly the scalar body's `inst.sdst.write_scalar64`.
+/// is written to the SGPR-pair `sdst` (not the fixed VCC). In wave32, explicit
+/// scalar mask destinations write only the low SGPR and preserve the high SGPR;
+/// wave64 writes the full pair.
 /// `sdst` is an SGPR operand, so it does not participate in the simd_capable
 /// gate; src0/src1/vdst do. (These VOP3 forms carry no `src2` member, so the
 /// carry-in path lives in the separate _cin glue below.)
@@ -2517,7 +2526,7 @@ template <typename Inst, typename CarryOp>
         carry_bits |= (1ULL << i);
     carry_out = (carry_out & ~(chunk << base)) | ((carry_bits & chunk) << base);
   }
-  inst.sdst.write_scalar64(wf, carry_out);
+  write_wave_mask_scalar(inst.sdst, wf, carry_out);
   return true;
 }
 template <typename Inst, typename CarryOp>
@@ -2528,7 +2537,8 @@ template <typename Inst, typename CarryOp>
 /// VOP3 carry-IN binary fast path (v_addc_co/subb_co/subbrev_co_u32). Same as
 /// the _co glue but the per-lane carry-in is read from the SGPR-pair `src2`
 /// (these forms have a src2 member) and expanded to a 0/1-per-lane vector;
-/// carry-out goes to `sdst`. src2/sdst are SGPR operands (not gated).
+/// carry-out goes to `sdst` with the same wave32/wave64 width rule as _co.
+/// src2/sdst are SGPR operands (not gated).
 template <typename Inst, typename CarryOp>
   requires(util::has_stdx_simd)
 [[nodiscard]] inline bool try_execute_binary_vop3_cin_simd(Inst &inst, Wavefront &wf,
@@ -2565,7 +2575,7 @@ template <typename Inst, typename CarryOp>
         carry_bits |= (1ULL << i);
     carry_out = (carry_out & ~(chunk << base)) | ((carry_bits & chunk) << base);
   }
-  inst.sdst.write_scalar64(wf, carry_out);
+  write_wave_mask_scalar(inst.sdst, wf, carry_out);
   return true;
 }
 template <typename Inst, typename CarryOp>
@@ -2579,10 +2589,20 @@ template <typename Inst, typename CarryOp>
 /// high half (low half preserved). Selected by the per-mnemonic glue probe.
 enum class FmaMixDst { F32, F16_LO, F16_HI };
 
-/// VOP3P fma_mix / mad_mix SIMD fast path. Six ops share one body because
-/// the scalar reference computes `a * b + c` (plain `*+`, not std::fma) for
-/// all six and differs only in (a) the f16-vs-f32 widening shape per source
-/// and (b) the f16-lo/f16-hi/f32 narrowing shape on the destination.
+inline util::native<float> fma_mix_mul_add(util::native<float> a, util::native<float> b,
+                                           util::native<float> c) {
+#if defined(__FMA__) || defined(__ARM_FEATURE_FMA)
+  return util::stdx::fma(a, b, c);
+#else
+  return a * b + c;
+#endif
+}
+
+/// VOP3P fma_mix / mad_mix SIMD fast path. Six ops share one body because all
+/// six differ only in (a) the f16-vs-f32 widening shape per source and (b) the
+/// f16-lo/f16-hi/f32 narrowing shape on the destination. When the host compiler
+/// enables FMA contraction for the scalar `a * b + c` reference, the SIMD path
+/// uses `stdx::fma`; otherwise it keeps the same separate multiply/add shape.
 ///
 /// Per-source data fetch is gated by `op_sel_hi` (src0/src1) and
 /// `op_sel_hi_2` (src2): when the bit is 0 the source is read as f32; when
@@ -2635,7 +2655,7 @@ template <FmaMixDst DstMode, typename Inst>
     F a = load_src(inst.src0, op_sel_hi & 1u, op_sel & 1u, neg & 1u);
     F b = load_src(inst.src1, (op_sel_hi >> 1) & 1u, (op_sel >> 1) & 1u, (neg >> 1) & 1u);
     F c = load_src(inst.src2, op_sel_hi_2, (op_sel >> 2) & 1u, (neg >> 2) & 1u);
-    F r = a * b + c;
+    F r = fma_mix_mul_add(a, b, c);
     if (clamp) {
       util::stdx::where(r < kZero, r) = kZero;
       util::stdx::where(r > kOne, r) = kOne;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -2623,7 +2623,9 @@ template <FmaMixDst DstMode, typename Inst>
 #if defined(__clang__) && defined(__FMA__)
   if constexpr (DstMode == FmaMixDst::F32) {
     // Clang contracts native SIMD a*b+c on FMA hosts for this shape while the
-    // generated scalar bodies remain bit-exact with separate multiply/add.
+    // generated scalar bodies remain bit-exact with separate multiply/add. The
+    // f16 destination modes stay enabled: they narrow to f16 and are covered by
+    // the fma_mix SIMD-vs-scalar tests rather than by this raw-f32 bit path.
     return false;
   }
 #endif

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -37,6 +37,8 @@ inline bool simd_force_scalar() { return util::force_scalar(); }
 
 template <typename Op>
 inline void write_wave_mask_scalar(const Op &op, Wavefront &wf, uint64_t mask) {
+  // Keep this wave32/wave64 mask-width rule in sync with the Python emitters
+  // in sema_lower.py and vector_cmp.py.
   if (wf.wf_size() <= 32)
     op.write_scalar(wf, static_cast<uint32_t>(mask));
   else
@@ -2591,18 +2593,15 @@ enum class FmaMixDst { F32, F16_LO, F16_HI };
 
 inline util::native<float> fma_mix_mul_add(util::native<float> a, util::native<float> b,
                                            util::native<float> c) {
-#if defined(__FMA__) || defined(__ARM_FEATURE_FMA)
-  return util::stdx::fma(a, b, c);
-#else
   return a * b + c;
-#endif
 }
 
 /// VOP3P fma_mix / mad_mix SIMD fast path. Six ops share one body because all
 /// six differ only in (a) the f16-vs-f32 widening shape per source and (b) the
-/// f16-lo/f16-hi/f32 narrowing shape on the destination. When the host compiler
-/// enables FMA contraction for the scalar `a * b + c` reference, the SIMD path
-/// uses `stdx::fma`; otherwise it keeps the same separate multiply/add shape.
+/// f16-lo/f16-hi/f32 narrowing shape on the destination. The generated scalar
+/// bodies use `a * b + c`, so this keeps the SIMD path in the same expression
+/// shape instead of forcing a fused stdx::fma and shifting finite results by an
+/// ulp on some hosts.
 ///
 /// Per-source data fetch is gated by `op_sel_hi` (src0/src1) and
 /// `op_sel_hi_2` (src2): when the bit is 0 the source is read as f32; when
@@ -2621,6 +2620,13 @@ template <FmaMixDst DstMode, typename Inst>
   if (simd_force_scalar() || !inst.src0.simd_capable() || !inst.src1.simd_capable() ||
       !inst.src2.simd_capable() || !inst.vdst.simd_capable())
     return false;
+#if defined(__clang__) && defined(__FMA__)
+  if constexpr (DstMode == FmaMixDst::F32) {
+    // Clang contracts native SIMD a*b+c on FMA hosts for this shape while the
+    // generated scalar bodies remain bit-exact with separate multiply/add.
+    return false;
+  }
+#endif
   using T = float32_t;
   const uint32_t op_sel = inst.inst_.op_sel;
   const uint32_t op_sel_hi = inst.inst_.op_sel_hi;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_ioctl_utils.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_ioctl_utils.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_KMD_LINUX_KFD_IOCTL_UTILS_H_
+#define ROCJITSU_KMD_LINUX_KFD_IOCTL_UTILS_H_
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "linux/uapi/kfd_ioctl.h"
+RJ_DIAGNOSTIC_POP
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace rocjitsu {
+
+constexpr size_t ioctl_arg_size(unsigned long request) { return _IOC_SIZE(request); }
+
+constexpr unsigned long ioctl_without_size(unsigned long request) {
+  return request & ~(_IOC_SIZEMASK << _IOC_SIZESHIFT);
+}
+
+constexpr unsigned long ioctl_with_size(unsigned long request, size_t size) {
+  return ioctl_without_size(request) |
+         ((static_cast<unsigned long>(size) & _IOC_SIZEMASK) << _IOC_SIZESHIFT);
+}
+
+constexpr bool is_svm_ioctl(unsigned long request) {
+  return ioctl_without_size(request) == ioctl_without_size(AMDKFD_IOC_SVM);
+}
+
+inline bool svm_ioctl_required_size(uint32_t nattr, size_t &required_size) {
+  constexpr size_t base_size = sizeof(kfd_ioctl_svm_args);
+  constexpr size_t attr_size = sizeof(kfd_ioctl_svm_attribute);
+  constexpr auto max_nattr = (std::numeric_limits<size_t>::max() - base_size) / attr_size;
+  if (static_cast<size_t>(nattr) > max_nattr)
+    return false;
+  required_size = base_size + static_cast<size_t>(nattr) * attr_size;
+  return true;
+}
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_KMD_LINUX_KFD_IOCTL_UTILS_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -258,6 +258,9 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
 
   size_t arg_size = ioctl_arg_size(request);
   if (is_svm_ioctl(request)) {
+    // SVM has a flexible attrs[] tail, so ROCR encodes the actual byte size in
+    // the ioctl request. The attributes are inline payload, not embedded client
+    // pointers, so RPC only needs the larger buffer size validated here.
     if (arg_size < sizeof(kfd_ioctl_svm_args))
       return -EINVAL;
     auto *svm_args = static_cast<const kfd_ioctl_svm_args *>(arg);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -5,13 +5,8 @@
 /// @brief Client-side RPC stub for the rocjitsu daemon.
 
 #include "rocjitsu/kmd/linux/remote_driver.h"
+#include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
 #include "rocjitsu/kmd/linux/rpc.h"
-
-#include "rocjitsu/base/rj_compiler.h"
-RJ_DIAGNOSTIC_PUSH
-RJ_DIAGNOSTIC_IGNORE_PEDANTIC
-#include "linux/uapi/kfd_ioctl.h"
-RJ_DIAGNOSTIC_POP
 
 #include <cassert>
 #include <cerrno>
@@ -38,14 +33,14 @@ RJ_DIAGNOSTIC_POP
 namespace rocjitsu {
 namespace {
 
-constexpr size_t ioctl_arg_size(unsigned long request) { return _IOC_SIZE(request); }
-
 constexpr bool has_embedded_pointers(unsigned long request) {
+  if (is_svm_ioctl(request))
+    return true;
+
   switch (request) {
   case AMDKFD_IOC_WAIT_EVENTS:
   case AMDKFD_IOC_MAP_MEMORY_TO_GPU:
   case AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU:
-  case AMDKFD_IOC_SVM:
   case AMDKFD_IOC_GET_PROCESS_APERTURES_NEW:
     return true;
   default:
@@ -265,6 +260,14 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
   std::lock_guard<std::mutex> lock(rpc_mutex_);
 
   size_t arg_size = ioctl_arg_size(request);
+  if (is_svm_ioctl(request)) {
+    if (arg_size < sizeof(kfd_ioctl_svm_args))
+      return -EINVAL;
+    auto *svm_args = static_cast<const kfd_ioctl_svm_args *>(arg);
+    size_t required_size = 0;
+    if (!svm_ioctl_required_size(svm_args->nattr, required_size) || arg_size < required_size)
+      return -EINVAL;
+  }
 
   // Save original embedded pointers before serialization. The daemon rewrites
   // these to point at its own buffer; we must restore the client-side originals
@@ -316,14 +319,6 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
       buf.resize(inline_offset + inline_size);
       std::memcpy(buf.data() + inline_offset,
                   reinterpret_cast<const void *>(map_args->device_ids_array_ptr), inline_size);
-      break;
-    }
-    case AMDKFD_IOC_SVM: {
-      auto *svm_args = reinterpret_cast<kfd_ioctl_svm_args *>(args_base);
-      size_t inline_size = svm_args->nattr * sizeof(kfd_ioctl_svm_attribute);
-      size_t inline_offset = buf.size();
-      buf.resize(inline_offset + inline_size);
-      std::memcpy(buf.data() + inline_offset, svm_args + 1, inline_size);
       break;
     }
     case AMDKFD_IOC_GET_PROCESS_APERTURES_NEW: {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -34,9 +34,6 @@ namespace rocjitsu {
 namespace {
 
 constexpr bool has_embedded_pointers(unsigned long request) {
-  if (is_svm_ioctl(request))
-    return true;
-
   switch (request) {
   case AMDKFD_IOC_WAIT_EVENTS:
   case AMDKFD_IOC_MAP_MEMORY_TO_GPU:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocjitsu/kmd/linux/simulated_driver.h"
+#include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
 #include "rocjitsu/vm/amdgpu/command_processor.h"
 
 #include "rocjitsu/base/rj_compiler.h"
@@ -533,6 +534,9 @@ int SimulatedDriver::ioctl(uint32_t process_id, unsigned long request, void *arg
 }
 
 static const char *ioctl_name(unsigned long req) {
+  if (is_svm_ioctl(req))
+    return "SVM";
+
   switch (req) {
   case AMDKFD_IOC_GET_VERSION:
     return "GET_VERSION";
@@ -585,6 +589,9 @@ static const char *ioctl_name(unsigned long req) {
 
 int SimulatedDriver::dispatch_ioctl(KfdProcess &proc, unsigned long request, void *arg) {
   util::Logger::cp("IOCTL pid=", proc.process_id(), " ", ioctl_name(request));
+  if (is_svm_ioctl(request))
+    return svm_ioctl(proc, arg);
+
   switch (request) {
   case AMDKFD_IOC_GET_VERSION:
     return get_version_ioctl(arg);
@@ -663,8 +670,6 @@ int SimulatedDriver::dispatch_ioctl(KfdProcess &proc, unsigned long request, voi
     return ipc_export_handle_ioctl(proc, arg);
   case AMDKFD_IOC_IPC_IMPORT_HANDLE:
     return ipc_import_handle_ioctl(proc, arg);
-  case AMDKFD_IOC_SVM:
-    return svm_ioctl(proc, arg);
   default:
     util::Logger::debug_print("rocjitsu: unhandled ioctl 0x", std::hex, request);
     return 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
@@ -534,10 +534,10 @@ int SimulatedDriver::ioctl(uint32_t process_id, unsigned long request, void *arg
 }
 
 static const char *ioctl_name(unsigned long req) {
-  if (is_svm_ioctl(req))
-    return "SVM";
-
-  switch (req) {
+  // SVM requests carry a variable attrs[] tail, so the size bits may differ
+  // from the fixed UAPI macro while the ioctl number/type still match.
+  unsigned long dispatch_req = is_svm_ioctl(req) ? AMDKFD_IOC_SVM : req;
+  switch (dispatch_req) {
   case AMDKFD_IOC_GET_VERSION:
     return "GET_VERSION";
   case AMDKFD_IOC_GET_CLOCK_COUNTERS:
@@ -582,6 +582,8 @@ static const char *ioctl_name(unsigned long req) {
     return "SET_MEM_POLICY";
   case AMDKFD_IOC_AVAILABLE_MEMORY:
     return "AVAIL_MEMORY";
+  case AMDKFD_IOC_SVM:
+    return "SVM";
   default:
     return "UNKNOWN";
   }
@@ -589,10 +591,11 @@ static const char *ioctl_name(unsigned long req) {
 
 int SimulatedDriver::dispatch_ioctl(KfdProcess &proc, unsigned long request, void *arg) {
   util::Logger::cp("IOCTL pid=", proc.process_id(), " ", ioctl_name(request));
-  if (is_svm_ioctl(request))
-    return svm_ioctl(proc, arg);
 
-  switch (request) {
+  // Match SVM by ioctl number/type but keep dispatch in the normal switch. The
+  // caller-provided size is still available in request for RPC-side validation.
+  unsigned long dispatch_request = is_svm_ioctl(request) ? AMDKFD_IOC_SVM : request;
+  switch (dispatch_request) {
   case AMDKFD_IOC_GET_VERSION:
     return get_version_ioctl(arg);
   case AMDKFD_IOC_GET_CLOCK_COUNTERS:
@@ -670,6 +673,8 @@ int SimulatedDriver::dispatch_ioctl(KfdProcess &proc, unsigned long request, voi
     return ipc_export_handle_ioctl(proc, arg);
   case AMDKFD_IOC_IPC_IMPORT_HANDLE:
     return ipc_import_handle_ioctl(proc, arg);
+  case AMDKFD_IOC_SVM:
+    return svm_ioctl(proc, arg);
   default:
     util::Logger::debug_print("rocjitsu: unhandled ioctl 0x", std::hex, request);
     return 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -295,6 +295,15 @@ void CommandProcessor::startup() {
     completion_->set_interrupt_callback(interrupt_cb_);
 }
 
+void CommandProcessor::shutdown() {
+  stop_doorbell_monitor();
+  if (is_primary_ && engine()) {
+    engine()->primary_release();
+    is_primary_ = false;
+  }
+  completion_.reset();
+}
+
 void CommandProcessor::register_queue(HwQueue queue) {
   util::Logger::cp([&](auto &os) {
     os << std::format("{}: REGISTER_QUEUE id={} pid={} ring={:#x} size={} rptr={:#x} wptr={:#x} "

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1313,6 +1313,21 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
   auto resolve = [&](uint64_t va) -> void * {
     return resolve_sdma_ptr(memory_, va, queue.process_id);
   };
+  auto write_read_ptr = [&] {
+    uint64_t rptr_val = rpos * sizeof(uint32_t);
+    auto *read_ptr = static_cast<uint64_t *>(resolve(queue.read_ptr_va));
+    if (read_ptr &&
+        (queue.read_ptr_va & GpuMemory::PAGE_MASK) + sizeof(rptr_val) <= GpuMemory::PAGE_SIZE &&
+        reinterpret_cast<uintptr_t>(read_ptr) % alignof(uint64_t) == 0) {
+      std::atomic_ref<uint64_t>(*read_ptr).store(rptr_val, std::memory_order_release);
+      return;
+    }
+    write_gpu_block(queue.read_ptr_va, &rptr_val, sizeof(rptr_val), queue.process_id);
+  };
+  auto reschedule_current_packet = [&] {
+    write_read_ptr();
+    engine()->schedule_event_now(&doorbell_event_);
+  };
 
   while (rpos < wpos) {
     uint32_t header = dw(0);
@@ -1346,44 +1361,65 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
           uint64_t wait_ref = static_cast<uint64_t>(dw(4)) | (static_cast<uint64_t>(dw(5)) << 32);
           uint64_t wait_mask = static_cast<uint64_t>(dw(6)) | (static_cast<uint64_t>(dw(7)) << 32);
           if (wait_addr > 0x1000) {
+            auto *wait_ptr = static_cast<uint64_t *>(resolve(wait_addr));
+            if (!wait_ptr) {
+              reschedule_current_packet();
+              return;
+            }
             uint64_t wait_value =
-                std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(wait_addr))
-                    .load(std::memory_order_acquire);
+                std::atomic_ref<uint64_t>(*wait_ptr).load(std::memory_order_acquire);
             if (!sdma_compare_u64(wait_func, wait_value & wait_mask, wait_ref)) {
-              if (queue.host_accessible) {
-                std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(queue.read_ptr_va))
-                    .store(rpos * sizeof(uint32_t), std::memory_order_release);
-              }
-              engine()->schedule_event_now(&doorbell_event_);
+              reschedule_current_packet();
               return;
             }
           }
         }
 
-        uint32_t count = (dw(COPY_BASE) & 0x3FFFFFFF) + 1;
-        uint64_t src = static_cast<uint64_t>(dw(COPY_BASE + 2)) |
-                       (static_cast<uint64_t>(dw(COPY_BASE + 3)) << 32);
-        uint64_t dst = static_cast<uint64_t>(dw(COPY_BASE + 4)) |
-                       (static_cast<uint64_t>(dw(COPY_BASE + 5)) << 32);
+        int64_t *signal_ptr = nullptr;
+        uint64_t signal_addr = 0;
+        uint64_t signal_data = 0;
+        bool signal_decrement = false;
+        if (has_signal) {
+          uint32_t signal_op = dw(SIGNAL_BASE) & 0x7F;
+          signal_addr = (static_cast<uint64_t>(dw(SIGNAL_BASE + 1) & ~0x7u)) |
+                        (static_cast<uint64_t>(dw(SIGNAL_BASE + 2)) << 32);
+          signal_data = static_cast<uint64_t>(dw(SIGNAL_BASE + 3)) |
+                        (static_cast<uint64_t>(dw(SIGNAL_BASE + 4)) << 32);
 
-        std::memcpy(reinterpret_cast<void *>(dst), reinterpret_cast<const void *>(src), count);
+          if (signal_addr > 0x1000 && signal_op == 0x70) {
+            signal_ptr = static_cast<int64_t *>(resolve(signal_addr));
+            if (!signal_ptr) {
+              reschedule_current_packet();
+              return;
+            }
+            signal_decrement = true;
+          }
+        }
+
+        uint32_t count = (dw(COPY_BASE) & 0x3FFFFFFF) + 1;
+        uint64_t src_va = static_cast<uint64_t>(dw(COPY_BASE + 2)) |
+                          (static_cast<uint64_t>(dw(COPY_BASE + 3)) << 32);
+        uint64_t dst_va = static_cast<uint64_t>(dw(COPY_BASE + 4)) |
+                          (static_cast<uint64_t>(dw(COPY_BASE + 5)) << 32);
+        auto *src_ptr = resolve(src_va);
+        auto *dst_ptr = resolve(dst_va);
+        if (!src_ptr || !dst_ptr) {
+          reschedule_current_packet();
+          return;
+        }
+
+        std::memcpy(dst_ptr, src_ptr, count);
 
         for (auto *l2 : l2_caches_)
-          l2->invalidate_range(dst, count);
+          l2->invalidate_range(dst_va, count);
         for (auto *cu : cus_)
           cu->l1_vector().invalidate_all();
 
-        if (has_signal) {
-          uint32_t signal_op = dw(SIGNAL_BASE) & 0x7F;
-          uint64_t signal_addr = (static_cast<uint64_t>(dw(SIGNAL_BASE + 1) & ~0x7u)) |
-                                 (static_cast<uint64_t>(dw(SIGNAL_BASE + 2)) << 32);
-          uint64_t signal_data = static_cast<uint64_t>(dw(SIGNAL_BASE + 3)) |
-                                 (static_cast<uint64_t>(dw(SIGNAL_BASE + 4)) << 32);
-
-          if (signal_addr > 0x1000 && signal_op == 0x70) {
-            std::atomic_ref<int64_t>(*reinterpret_cast<int64_t *>(signal_addr))
-                .fetch_sub(static_cast<int64_t>(signal_data), std::memory_order_release);
-          }
+        if (signal_decrement) {
+          std::atomic_ref<int64_t>(*signal_ptr)
+              .fetch_sub(static_cast<int64_t>(signal_data), std::memory_order_release);
+          for (auto *l2 : l2_caches_)
+            l2->invalidate_range(signal_addr, sizeof(int64_t));
         }
 
         pkt_dwords = sdma::COPY_LINEAR_WAITSIGNAL_GFX1250_SIZE;
@@ -1401,27 +1437,29 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
                        " count=", count, " (", count / 1024, " KB)");
       auto *src_ptr = resolve(src_va);
       auto *dst_ptr = resolve(dst_va);
-      if (src_ptr && dst_ptr) {
-        if (header & (1u << 28)) {
-          uint64_t dst2_va = static_cast<uint64_t>(dw(7)) | (static_cast<uint64_t>(dw(8)) << 32);
-          auto *dst2_ptr = resolve(dst2_va);
-          std::memcpy(dst_ptr, src_ptr, count);
-          for (auto *l2 : l2_caches_)
-            l2->invalidate_range(dst_va, count);
-          if (dst2_ptr) {
-            std::memcpy(dst2_ptr, src_ptr, count);
-            for (auto *l2 : l2_caches_)
-              l2->invalidate_range(dst2_va, count);
-          }
-          pkt_dwords = 9;
-        } else {
-          std::memcpy(dst_ptr, src_ptr, count);
-          for (auto *l2 : l2_caches_)
-            l2->invalidate_range(dst_va, count);
-          pkt_dwords = sdma::COPY_LINEAR_SIZE;
+      if (!src_ptr || !dst_ptr) {
+        reschedule_current_packet();
+        return;
+      }
+      if (header & (1u << 28)) {
+        uint64_t dst2_va = static_cast<uint64_t>(dw(7)) | (static_cast<uint64_t>(dw(8)) << 32);
+        auto *dst2_ptr = resolve(dst2_va);
+        if (!dst2_ptr) {
+          reschedule_current_packet();
+          return;
         }
+        std::memcpy(dst_ptr, src_ptr, count);
+        for (auto *l2 : l2_caches_)
+          l2->invalidate_range(dst_va, count);
+        std::memcpy(dst2_ptr, src_ptr, count);
+        for (auto *l2 : l2_caches_)
+          l2->invalidate_range(dst2_va, count);
+        pkt_dwords = 9;
       } else {
-        pkt_dwords = (header & (1u << 28)) ? 9 : sdma::COPY_LINEAR_SIZE;
+        std::memcpy(dst_ptr, src_ptr, count);
+        for (auto *l2 : l2_caches_)
+          l2->invalidate_range(dst_va, count);
+        pkt_dwords = sdma::COPY_LINEAR_SIZE;
       }
       break;
     }
@@ -1475,14 +1513,14 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         uint64_t ref = static_cast<uint64_t>(dw(3)) | (static_cast<uint64_t>(dw(4)) << 32);
         uint64_t mask = static_cast<uint64_t>(dw(5)) | (static_cast<uint64_t>(dw(6)) << 32);
         if (addr > 0x1000) {
-          auto *ptr = reinterpret_cast<uint64_t *>(addr);
+          auto *ptr = static_cast<uint64_t *>(resolve(addr));
+          if (!ptr) {
+            reschedule_current_packet();
+            return;
+          }
           uint64_t val = std::atomic_ref<uint64_t>(*ptr).load(std::memory_order_acquire);
           if (!sdma_compare_u64(func, val & mask, ref)) {
-            if (queue.host_accessible) {
-              std::atomic_ref<uint64_t>(*reinterpret_cast<uint64_t *>(queue.read_ptr_va))
-                  .store(rpos * sizeof(uint32_t), std::memory_order_release);
-            }
-            engine()->schedule_event_now(&doorbell_event_);
+            reschedule_current_packet();
             return;
           }
         }
@@ -1500,6 +1538,10 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         // Register poll / HDP flush — no-op in functional sim.
       } else if (addr_va > 0x1000) {
         auto *ptr = static_cast<uint32_t *>(resolve(addr_va));
+        if (!ptr) {
+          reschedule_current_packet();
+          return;
+        }
         auto compare = [func](uint32_t val, uint32_t reference) -> bool {
           switch (func) {
           case 0:
@@ -1520,15 +1562,9 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
             return true;
           }
         };
-        uint32_t val = ptr ? std::atomic_ref<uint32_t>(*ptr).load(std::memory_order_acquire) : 0;
+        uint32_t val = std::atomic_ref<uint32_t>(*ptr).load(std::memory_order_acquire);
         if (!compare(val & mask, ref)) {
-          {
-            uint64_t rptr_val = rpos * sizeof(uint32_t);
-            auto *rp_src = reinterpret_cast<const uint8_t *>(&rptr_val);
-            for (uint32_t b = 0; b < sizeof(rptr_val); ++b)
-              memory_->write8(queue.read_ptr_va + b, rp_src[b], queue.process_id);
-          }
-          engine()->schedule_event_now(&doorbell_event_);
+          reschedule_current_packet();
           return;
         }
       }
@@ -1652,12 +1688,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
     rpos += pkt_dwords;
   }
 
-  {
-    uint64_t rptr_val = rpos * sizeof(uint32_t);
-    auto *src = reinterpret_cast<const uint8_t *>(&rptr_val);
-    for (uint32_t b = 0; b < sizeof(rptr_val); ++b)
-      memory_->write8(queue.read_ptr_va + b, src[b], queue.process_id);
-  }
+  write_read_ptr();
 }
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1324,6 +1324,10 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
     }
     write_gpu_block(queue.read_ptr_va, &rptr_val, sizeof(rptr_val), queue.process_id);
   };
+  // Publish the unchanged read pointer before retrying a wait/poll packet or an
+  // SDMA packet whose translated VA is not ready yet. The queue owner still sees
+  // the packet as pending, and the doorbell reschedule gives later mappings or
+  // signal writes a chance to make the same packet executable.
   auto reschedule_current_packet = [&] {
     write_read_ptr();
     engine()->schedule_event_now(&doorbell_event_);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1325,18 +1325,30 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
   auto write_read_ptr = [&] {
     uint64_t rptr_val = rpos * sizeof(uint32_t);
     auto *read_ptr = static_cast<uint64_t *>(resolve(queue.read_ptr_va));
-    if (read_ptr &&
-        (queue.read_ptr_va & GpuMemory::PAGE_MASK) + sizeof(rptr_val) <= GpuMemory::PAGE_SIZE &&
-        reinterpret_cast<uintptr_t>(read_ptr) % alignof(uint64_t) == 0) {
-      std::atomic_ref<uint64_t>(*read_ptr).store(rptr_val, std::memory_order_release);
-      return;
+    if (read_ptr) {
+      // Queue read pointers should be naturally aligned and contained in one
+      // page. Keep runtime guards before atomic_ref anyway so malformed tests
+      // or future queue types do not turn the fallback path into UB.
+      bool contained_in_page =
+          (queue.read_ptr_va & GpuMemory::PAGE_MASK) + sizeof(rptr_val) <= GpuMemory::PAGE_SIZE;
+      bool aligned = reinterpret_cast<uintptr_t>(read_ptr) % alignof(uint64_t) == 0;
+      assert(contained_in_page && "SDMA read pointer must not cross a page boundary");
+      assert(aligned && "SDMA read pointer must be naturally aligned");
+      if (contained_in_page && aligned) {
+        std::atomic_ref<uint64_t>(*read_ptr).store(rptr_val, std::memory_order_release);
+        return;
+      }
     }
+    // Fallback for queues whose read pointer cannot be resolved to a directly
+    // writable host pointer in this process.
     write_gpu_block(queue.read_ptr_va, &rptr_val, sizeof(rptr_val), queue.process_id);
   };
   // Publish the unchanged read pointer before retrying a wait/poll packet or an
   // SDMA packet whose translated VA is not ready yet. The queue owner still sees
   // the packet as pending, and the doorbell reschedule gives later mappings or
-  // signal writes a chance to make the same packet executable.
+  // signal writes a chance to make the same packet executable. Callers must
+  // return from process_sdma_ring() immediately after this helper so a later
+  // read-pointer update cannot accidentally advance past the deferred packet.
   auto reschedule_current_packet = [&] {
     write_read_ptr();
     engine()->schedule_event_now(&doorbell_event_);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1266,6 +1266,7 @@ constexpr uint8_t SUBOP_POLL_MEM_64B = 5;
 
 // Packet sizes in dwords.
 constexpr uint32_t COPY_LINEAR_SIZE = 7;
+constexpr uint32_t COPY_LINEAR_BROADCAST_SIZE = 9;
 constexpr uint32_t FENCE_SIZE = 4;
 constexpr uint32_t TRAP_SIZE = 2;
 constexpr uint32_t POLL_REGMEM_SIZE = 6;
@@ -1277,6 +1278,7 @@ constexpr uint32_t GCR_GFX1250_SIZE = 6;
 constexpr uint32_t COPY_LINEAR_WAITSIGNAL_GFX1250_SIZE = 19;
 constexpr uint32_t FENCE_64B_GFX1250_SIZE = 5;
 constexpr uint32_t POLL_MEM_64B_GFX1250_SIZE = 8;
+constexpr uint32_t COPY_LINEAR_BROADCAST_FLAG = 1u << 27;
 // NOP_BASE_SIZE intentionally omitted — NOP is handled inline.
 } // namespace sdma
 
@@ -1466,7 +1468,12 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         reschedule_current_packet();
         return;
       }
-      if (header & (1u << 28)) {
+      // GFX12.5 COPY_LINEAR uses bit 28 for NPD metadata. The two-destination
+      // broadcast form is marked by bit 27 and extends the packet with DW7/DW8.
+      bool is_broadcast_copy = uses_gfx1250_sdma_packets()
+                                   ? (header & sdma::COPY_LINEAR_BROADCAST_FLAG) != 0
+                                   : (header & (1u << 28)) != 0;
+      if (is_broadcast_copy) {
         uint64_t dst2_va = static_cast<uint64_t>(dw(7)) | (static_cast<uint64_t>(dw(8)) << 32);
         auto *dst2_ptr = resolve(dst2_va);
         if (!dst2_ptr) {
@@ -1479,7 +1486,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         std::memcpy(dst2_ptr, src_ptr, count);
         for (auto *l2 : l2_caches_)
           l2->invalidate_range(dst2_va, count);
-        pkt_dwords = 9;
+        pkt_dwords = sdma::COPY_LINEAR_BROADCAST_SIZE;
       } else {
         std::memcpy(dst_ptr, src_ptr, count);
         for (auto *l2 : l2_caches_)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -138,6 +138,7 @@ public:
   }
 
   void startup() override;
+  void shutdown() override;
   bool step() override;
   simdojo::Event *doorbell_event() { return &doorbell_event_; }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
@@ -6,6 +6,7 @@
 #include "util/log.h"
 
 #include <algorithm>
+#include <atomic>
 #include <bit>
 #include <cassert>
 #include <cstring>
@@ -17,9 +18,10 @@ void L2Cache::send_backing(uint64_t addr, uint8_t *data, uint32_t size, simdojo:
                            uint32_t vmid) {
   if (backing_memory_) {
     if (op == simdojo::MessageOp::WRITE) {
-      static uint64_t wb_count = 0;
-      if (++wb_count <= 3)
-        util::Logger::vm("L2 writeback(backing) #", wb_count, " addr=0x", std::hex, addr,
+      static std::atomic<uint64_t> wb_count{0};
+      const uint64_t count = wb_count.fetch_add(1, std::memory_order_relaxed) + 1;
+      if (count <= 3)
+        util::Logger::vm("L2 writeback(backing) #", count, " addr=0x", std::hex, addr,
                          " size=", std::dec, size);
       for (uint32_t i = 0; i < size; ++i)
         backing_memory_->write8(addr + i, data[i], vmid);

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -394,6 +394,7 @@ native<Float> round_fixup_simd(native<Float> a, Round round) {
 #if defined(__clang__) || defined(__GNUC__)
   constexpr bool kQuietNan = true;
 #else
+  static_assert(QuietNan, "round_fixup_simd needs a compiler-specific signaling-NaN policy");
   constexpr bool kQuietNan = QuietNan;
 #endif
   F nan_result;

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -359,9 +359,10 @@ inline native<uint32_t> f32_to_f16_simd(native<float> val) {
 /// (b) mangle the payload/quiet bit of a NaN input instead of returning it
 /// unchanged. The scalar generated bodies these SIMD fast paths must match use
 /// the compiler's scalar std:: functions. Clang lowers signaling NaNs to quiet
-/// NaNs here. GCC does that when it lowers to SSE4.1 round instructions, and for
-/// nearbyint otherwise. The NaN repair is selected per operation and target
-/// feature instead of hardcoding one libc policy. We run the stdx intrinsic for
+/// NaNs here, and GCC scalar wrappers below quiet them explicitly so the scalar
+/// and SIMD paths keep the same lane bits. The NaN repair is selected per
+/// operation and compiler policy instead of hardcoding one libc policy. We run
+/// the stdx intrinsic for
 /// the finite, nonzero-result lanes and then repair the two edge cases by blend:
 ///   - NaN input lane: return the scalar-compiler-matching NaN bits.
 ///   - zero-magnitude result lane: copy the input's sign bit onto the +0 the
@@ -369,7 +370,7 @@ inline native<uint32_t> f32_to_f16_simd(native<float> val) {
 ///     a zero result, so this is exactly the sign of the *input*).
 /// Bit-identical to the scalar reference at every native width.
 template <class Float, bool QuietNan, class Round>
-inline native<Float> round_fixup_simd(native<Float> a, Round round) {
+native<Float> round_fixup_simd(native<Float> a, Round round) {
   using F = native<Float>;
   using U = std::conditional_t<sizeof(Float) == 4, native<uint32_t>, native<uint64_t>>;
   using Bits = typename U::value_type;
@@ -388,10 +389,9 @@ inline native<Float> round_fixup_simd(native<Float> a, Round round) {
   const F signed_zero = std::bit_cast<F>(ai & U(kSign));
   stdx::where(r == F(Float(0)), r) = signed_zero;
   // NaN input: repair to the scalar path for this compiler and operation.
-  // Clang quiets sNaNs for these scalar std:: calls. GCC also quiets them when
-  // SSE4.1 round instructions are enabled (for example under -march=native on
-  // hosts with SSE4.1); otherwise it preserves floor/ceil/trunc input bits.
-#if defined(__clang__) || defined(__SSE4_1__)
+  // Clang quiets sNaNs for these scalar std:: calls. GCC's scalar wrappers
+  // below quiet explicitly, so the SIMD repair follows that same policy.
+#if defined(__clang__) || defined(__GNUC__)
   constexpr bool kQuietNan = true;
 #else
   constexpr bool kQuietNan = QuietNan;

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -358,22 +358,23 @@ inline native<uint32_t> f32_to_f16_simd(native<float> val) {
 /// zero-magnitude result (e.g. trunc(-0.3) yields +0.0 instead of -0.0) and
 /// (b) mangle the payload/quiet bit of a NaN input instead of returning it
 /// unchanged. The scalar generated bodies these SIMD fast paths must match use
-/// the libc functions, which preserve sign-of-zero and pass NaNs through
-/// verbatim. So we run the stdx intrinsic for the finite, nonzero-result lanes
-/// and then repair the two edge cases by blend:
-///   - NaN input lane: return the input bits unchanged.
+/// the compiler's scalar std:: functions. Clang lowers signaling NaNs to quiet
+/// NaNs here. GCC does that when it lowers to SSE4.1 round instructions, and for
+/// nearbyint otherwise. The NaN repair is selected per operation and target
+/// feature instead of hardcoding one libc policy. We run the stdx intrinsic for
+/// the finite, nonzero-result lanes and then repair the two edge cases by blend:
+///   - NaN input lane: return the scalar-compiler-matching NaN bits.
 ///   - zero-magnitude result lane: copy the input's sign bit onto the +0 the
 ///     intrinsic produced (IEEE-754 round-to-integer keeps the operand sign on
 ///     a zero result, so this is exactly the sign of the *input*).
 /// Bit-identical to the scalar reference at every native width.
-template <class Float, class Round> native<Float> round_fixup_simd(native<Float> a, Round round) {
+template <class Float, bool QuietNan, class Round>
+inline native<Float> round_fixup_simd(native<Float> a, Round round) {
   using F = native<Float>;
   using U = std::conditional_t<sizeof(Float) == 4, native<uint32_t>, native<uint64_t>>;
   using Bits = typename U::value_type;
   static_assert(sizeof(Bits) == sizeof(Float));
   constexpr Bits kSign = Bits(1) << (sizeof(Bits) * 8 - 1);
-  // Quiet bit = MSB of the mantissa (bit 22 for f32, bit 51 for f64).
-  constexpr Bits kQuiet = Bits(1) << (sizeof(Float) == 4 ? 22 : 51);
 
   const U ai = std::bit_cast<U>(a);
   F r = round(a);
@@ -386,39 +387,51 @@ template <class Float, class Round> native<Float> round_fixup_simd(native<Float>
   // narrow widths. `r == 0` matches both +0 and -0 lanes.
   const F signed_zero = std::bit_cast<F>(ai & U(kSign));
   stdx::where(r == F(Float(0)), r) = signed_zero;
-  // NaN input -> canonical quiet NaN (sign + payload preserved, quiet bit set),
-  // exactly what scalar `std::trunc/ceil/floor/nearbyint` produce: qNaN passes
-  // through unchanged and sNaN is quieted. The stdx intrinsic instead clears the
-  // quiet bit at narrow widths, so blend the bit-correct value in explicitly.
-  const F quieted = std::bit_cast<F>(ai | U(kQuiet));
-  stdx::where(stdx::isnan(a), r) = quieted;
+  // NaN input: repair to the scalar path for this compiler and operation.
+  // Clang quiets sNaNs for these scalar std:: calls. GCC also quiets them when
+  // SSE4.1 round instructions are enabled (for example under -march=native on
+  // hosts with SSE4.1); otherwise it preserves floor/ceil/trunc input bits.
+#if defined(__clang__) || defined(__SSE4_1__)
+  constexpr bool kQuietNan = true;
+#else
+  constexpr bool kQuietNan = QuietNan;
+#endif
+  F nan_result;
+  if constexpr (kQuietNan) {
+    // Quiet bit = MSB of the mantissa (bit 22 for f32, bit 51 for f64).
+    constexpr Bits kQuiet = Bits(1) << (sizeof(Float) == 4 ? 22 : 51);
+    nan_result = std::bit_cast<F>(ai | U(kQuiet));
+  } else {
+    nan_result = std::bit_cast<F>(ai);
+  }
+  stdx::where(stdx::isnan(a), r) = nan_result;
   return r;
 }
 
 inline native<float> trunc_simd(native<float> a) {
-  return round_fixup_simd<float>(a, [](native<float> x) { return stdx::trunc(x); });
+  return round_fixup_simd<float, false>(a, [](native<float> x) { return stdx::trunc(x); });
 }
 inline native<float> ceil_simd(native<float> a) {
-  return round_fixup_simd<float>(a, [](native<float> x) { return stdx::ceil(x); });
+  return round_fixup_simd<float, false>(a, [](native<float> x) { return stdx::ceil(x); });
 }
 inline native<float> floor_simd(native<float> a) {
-  return round_fixup_simd<float>(a, [](native<float> x) { return stdx::floor(x); });
+  return round_fixup_simd<float, false>(a, [](native<float> x) { return stdx::floor(x); });
 }
 inline native<float> rndne_simd(native<float> a) {
-  return round_fixup_simd<float>(a, [](native<float> x) { return stdx::nearbyint(x); });
+  return round_fixup_simd<float, true>(a, [](native<float> x) { return stdx::nearbyint(x); });
 }
 
 inline native<double> trunc_simd(native<double> a) {
-  return round_fixup_simd<double>(a, [](native<double> x) { return stdx::trunc(x); });
+  return round_fixup_simd<double, false>(a, [](native<double> x) { return stdx::trunc(x); });
 }
 inline native<double> ceil_simd(native<double> a) {
-  return round_fixup_simd<double>(a, [](native<double> x) { return stdx::ceil(x); });
+  return round_fixup_simd<double, false>(a, [](native<double> x) { return stdx::ceil(x); });
 }
 inline native<double> floor_simd(native<double> a) {
-  return round_fixup_simd<double>(a, [](native<double> x) { return stdx::floor(x); });
+  return round_fixup_simd<double, false>(a, [](native<double> x) { return stdx::floor(x); });
 }
 inline native<double> rndne_simd(native<double> a) {
-  return round_fixup_simd<double>(a, [](native<double> x) { return stdx::nearbyint(x); });
+  return round_fixup_simd<double, true>(a, [](native<double> x) { return stdx::nearbyint(x); });
 }
 
 /// Scalar round-to-integer matching the round_fixup_simd / AMD-hardware NaN

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -10,6 +10,8 @@
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/vimage.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/vop1.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/vop2.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/vop3.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
@@ -77,8 +79,10 @@ constexpr uint32_t kGfx1250SimdsPerCu = 4;
 constexpr uint32_t kGfx1250MaxWavesPerSimd = 20;
 constexpr uint32_t kGfx1250WaveSlotsPerCu = kGfx1250SimdsPerCu * kGfx1250MaxWavesPerSimd;
 constexpr uint32_t kGfx1250LdsSizeKb = 160;
+constexpr uint32_t kSdmaOpCopy = 1;
 constexpr uint32_t kSdmaOpFence = 5;
 constexpr uint32_t kSdmaOpPollRegmem = 8;
+constexpr uint32_t kSdmaSubopCopyLinear = 0;
 constexpr uint32_t kSdmaSubopFence64 = 2;
 constexpr uint32_t kSdmaSubopPollMem64 = 5;
 
@@ -182,10 +186,87 @@ private:
   std::array<uint64_t, 1> doorbells_{};
 };
 
+class TranslatedSdmaQueueForTest {
+public:
+  explicit TranslatedSdmaQueueForTest(Gfx1250Sim &sim) : sim_(sim), process_(kProcessId) {
+    sim_.memory->register_process(kProcessId, &process_.page_table_, &process_.page_table_mutex_);
+    process_.map_pages(kRingVa, ring_.data(), ring_.size() * sizeof(ring_[0]));
+    process_.map_pages(kQueueStateVa, queue_state_.data(),
+                       queue_state_.size() * sizeof(queue_state_[0]));
+    process_.map_pages(kSrcVa, src_.data(), src_.size());
+    process_.map_pages(kDstVa, dst_.data(), dst_.size());
+    process_.map_pages(kSignalVa, signal_.data(), signal_.size() * sizeof(signal_[0]));
+    process_.map_pages(kPollVa, poll_.data(), poll_.size() * sizeof(poll_[0]));
+
+    amdgpu::HwQueue queue{};
+    queue.process_id = kProcessId;
+    queue.queue_id = kQueueId;
+    queue.ring_base_va = kRingVa;
+    queue.ring_size = static_cast<uint32_t>(ring_.size() * sizeof(ring_[0]));
+    queue.read_ptr_va = kQueueStateVa;
+    queue.write_ptr_va = kQueueStateVa + sizeof(queue_state_[0]);
+    queue.doorbell_base = doorbells_.data();
+    queue.doorbell_offset = 0;
+    queue.host_accessible = true;
+    queue.is_sdma = true;
+    sim_.cp()->register_queue(std::move(queue));
+  }
+
+  ~TranslatedSdmaQueueForTest() {
+    sim_.cp()->unregister_queue(kQueueId, kProcessId);
+    sim_.memory->unregister_process(kProcessId);
+  }
+
+  uint32_t *ring() { return ring_.data(); }
+  uint8_t *src() { return src_.data(); }
+  uint8_t *dst() { return dst_.data(); }
+  int64_t &signal_value() { return signal_[0]; }
+  uint64_t &poll_value() { return poll_[0]; }
+
+  uint64_t src_va() const { return kSrcVa; }
+  uint64_t dst_va() const { return kDstVa; }
+  uint64_t signal_va() const { return kSignalVa; }
+  uint64_t poll_va() const { return kPollVa; }
+
+  void submit(uint32_t dwords) {
+    uint64_t write_idx = static_cast<uint64_t>(dwords) * sizeof(uint32_t);
+    std::atomic_ref<uint64_t>(queue_state_[1]).store(write_idx, std::memory_order_release);
+    std::atomic_ref<uint64_t>(doorbells_[0]).store(write_idx, std::memory_order_release);
+    sim_.engine->schedule_event_now(sim_.cp()->doorbell_event());
+  }
+
+  uint64_t read_idx() const {
+    return std::atomic_ref<const uint64_t>(queue_state_[0]).load(std::memory_order_acquire);
+  }
+
+private:
+  static constexpr uint32_t kProcessId = 1251;
+  static constexpr uint32_t kQueueId = 1251;
+  static constexpr uint64_t kRingVa = 0x1000'0000'0000ULL;
+  static constexpr uint64_t kQueueStateVa = 0x1000'0000'1000ULL;
+  static constexpr uint64_t kSrcVa = 0x1000'0000'2000ULL;
+  static constexpr uint64_t kDstVa = 0x1000'0000'3000ULL;
+  static constexpr uint64_t kSignalVa = 0x1000'0000'4000ULL;
+  static constexpr uint64_t kPollVa = 0x1000'0000'5000ULL;
+
+  Gfx1250Sim &sim_;
+  KfdProcess process_;
+  alignas(4096) std::array<uint32_t, 1024> ring_{};
+  alignas(4096) std::array<uint64_t, 512> queue_state_{};
+  alignas(4096) std::array<uint8_t, 4096> src_{};
+  alignas(4096) std::array<uint8_t, 4096> dst_{};
+  alignas(4096) std::array<int64_t, 512> signal_{};
+  alignas(4096) std::array<uint64_t, 512> poll_{};
+  std::array<uint64_t, 1> doorbells_{};
+};
+
+void write_sdma_qword_va(uint32_t *packet, uint32_t lo_dw, uint32_t hi_dw, uint64_t va) {
+  packet[lo_dw] = static_cast<uint32_t>(va) & ~0x7u;
+  packet[hi_dw] = static_cast<uint32_t>(va >> 32);
+}
+
 void write_sdma_qword_address(uint32_t *packet, uint32_t lo_dw, uint32_t hi_dw, const void *addr) {
-  auto value = reinterpret_cast<uintptr_t>(addr);
-  packet[lo_dw] = static_cast<uint32_t>(value) & ~0x7u;
-  packet[hi_dw] = static_cast<uint32_t>(value >> 32);
+  write_sdma_qword_va(packet, lo_dw, hi_dw, reinterpret_cast<uintptr_t>(addr));
 }
 
 void step_until_halted(simdojo::SimulationEngine &engine, amdgpu::ComputeUnitCore &cu,
@@ -517,6 +598,182 @@ TEST(Gfx1250SdmaTest, Fence64WritesFull64BitValue) {
   EXPECT_EQ(std::atomic_ref<uint64_t>(value).load(std::memory_order_acquire), kFenceValue);
 }
 
+TEST(Gfx1250SdmaTest, CopyWaitSignalResolvesTranslatedAddresses) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kCopyBytes = 128;
+  queue.signal_value() = 5;
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    queue.src()[i] = static_cast<uint8_t>(i ^ 0x5a);
+    queue.dst()[i] = 0;
+  }
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8) | (1u << 31);
+  packet[8] = kCopyBytes - 1;
+  write_sdma_qword_va(packet, 10, 11, queue.src_va());
+  write_sdma_qword_va(packet, 12, 13, queue.dst_va());
+  packet[14] = 0x70;
+  write_sdma_qword_va(packet, 15, 16, queue.signal_va());
+  packet[17] = 1;
+  packet[18] = 0;
+
+  queue.submit(19);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 19u * sizeof(uint32_t));
+  EXPECT_EQ(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0);
+  EXPECT_EQ(queue.signal_value(), 4);
+}
+
+TEST(Gfx1250SdmaTest, CopyWaitSignalUnresolvedWaitAddressDoesNotAdvance) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kCopyBytes = 128;
+  constexpr uint64_t kUnmappedWaitVa = 0x2000'0000'0000ULL;
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    queue.src()[i] = static_cast<uint8_t>(i ^ 0xa5);
+    queue.dst()[i] = 0;
+  }
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8) | (1u << 30);
+  packet[1] = 3;
+  write_sdma_qword_va(packet, 2, 3, kUnmappedWaitVa);
+  packet[4] = 0;
+  packet[5] = 0;
+  packet[6] = 0xFFFFFFFFu;
+  packet[7] = 0xFFFFFFFFu;
+  packet[8] = kCopyBytes - 1;
+  write_sdma_qword_va(packet, 10, 11, queue.src_va());
+  write_sdma_qword_va(packet, 12, 13, queue.dst_va());
+
+  queue.submit(19);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 0u);
+  EXPECT_NE(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0);
+}
+
+TEST(Gfx1250SdmaTest, CopyWaitSignalUnresolvedDstDoesNotAdvanceOrSignal) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kCopyBytes = 128;
+  constexpr uint64_t kUnmappedDstVa = 0x2000'0000'2000ULL;
+  queue.signal_value() = 5;
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    queue.src()[i] = static_cast<uint8_t>(i ^ 0x3c);
+    queue.dst()[i] = 0;
+  }
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8) | (1u << 31);
+  packet[8] = kCopyBytes - 1;
+  write_sdma_qword_va(packet, 10, 11, queue.src_va());
+  write_sdma_qword_va(packet, 12, 13, kUnmappedDstVa);
+  packet[14] = 0x70;
+  write_sdma_qword_va(packet, 15, 16, queue.signal_va());
+  packet[17] = 1;
+  packet[18] = 0;
+
+  queue.submit(19);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 0u);
+  EXPECT_NE(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0);
+  EXPECT_EQ(queue.signal_value(), 5);
+}
+
+TEST(Gfx1250SdmaTest, CopyWaitSignalUnresolvedSignalDoesNotAdvanceOrCopy) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kCopyBytes = 128;
+  constexpr uint64_t kUnmappedSignalVa = 0x2000'0000'4000ULL;
+  queue.signal_value() = 5;
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    queue.src()[i] = static_cast<uint8_t>(i ^ 0x69);
+    queue.dst()[i] = 0;
+  }
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8) | (1u << 31);
+  packet[8] = kCopyBytes - 1;
+  write_sdma_qword_va(packet, 10, 11, queue.src_va());
+  write_sdma_qword_va(packet, 12, 13, queue.dst_va());
+  packet[14] = 0x70;
+  write_sdma_qword_va(packet, 15, 16, kUnmappedSignalVa);
+  packet[17] = 1;
+  packet[18] = 0;
+
+  queue.submit(19);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 0u);
+  EXPECT_NE(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0);
+  EXPECT_EQ(queue.signal_value(), 5);
+}
+
+TEST(Gfx1250SdmaTest, CopyLinearUnresolvedDstDoesNotAdvance) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kCopyBytes = 128;
+  constexpr uint64_t kUnmappedDstVa = 0x2000'0000'3000ULL;
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    queue.src()[i] = static_cast<uint8_t>(i ^ 0xc3);
+    queue.dst()[i] = 0;
+  }
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8);
+  packet[1] = kCopyBytes - 1;
+  write_sdma_qword_va(packet, 3, 4, queue.src_va());
+  write_sdma_qword_va(packet, 5, 6, kUnmappedDstVa);
+
+  queue.submit(7);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 0u);
+  EXPECT_NE(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0);
+}
+
+TEST(Gfx1250SdmaTest, PollMem64ResolvesTranslatedAddress) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  queue.poll_value() = 1;
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpPollRegmem | (kSdmaSubopPollMem64 << 8) | (3u << 28);
+  write_sdma_qword_va(packet, 1, 2, queue.poll_va());
+  packet[3] = 0;
+  packet[4] = 0;
+  packet[5] = 0xFFFFFFFFu;
+  packet[6] = 0xFFFFFFFFu;
+  packet[7] = 0;
+
+  queue.submit(8);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 0u);
+
+  std::atomic_ref<uint64_t>(queue.poll_value()).store(0, std::memory_order_release);
+  sim.engine->schedule_event_now(sim.cp()->doorbell_event());
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 8u * sizeof(uint32_t));
+}
+
+TEST(Gfx1250SdmaTest, PollMem64UnresolvedAddressDoesNotAdvance) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint64_t kUnmappedPollVa = 0x2000'0000'1000ULL;
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpPollRegmem | (kSdmaSubopPollMem64 << 8) | (3u << 28);
+  write_sdma_qword_va(packet, 1, 2, kUnmappedPollVa);
+  packet[3] = 0;
+  packet[4] = 0;
+  packet[5] = 0xFFFFFFFFu;
+  packet[6] = 0xFFFFFFFFu;
+  packet[7] = 0;
+
+  queue.submit(8);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 0u);
+}
+
 TEST(Gfx1250ExecutionTest, DivScaleWritesExplicitSdstMask) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
@@ -579,6 +836,141 @@ TEST(Gfx1250ExecutionTest, DivScaleWritesExplicitSdstMask) {
   EXPECT_EQ(read_wave_sgpr(*cu, *wf, 2), 0x12345679u);
   EXPECT_EQ(read_wave_sgpr(*cu, *wf, 3), 0xfefefefeu);
   EXPECT_EQ(read_vgpr(6), 0x5f800000u);
+}
+
+TEST(Gfx1250ExecutionTest, VMovB16HighVdstMergesIntoLowPhysicalVgpr) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, kGfx1250Wave32VgprAllocation);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1u);
+
+  constexpr uint32_t kLane = 0;
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  cu->write_vgpr(vgpr_base + 1, kLane, 0xAAAA5555u);
+  cu->write_vgpr(vgpr_base + 129, kLane, 0xDEADBEEFu);
+
+  const std::array<uint32_t, 1> words = {0x7F023880u}; // v_mov_b16_e32 v1.h, 0
+  gfx1250::VMovB16Vop1 high_half_mov(words.data());
+  high_half_mov.execute_impl(*wf);
+
+  EXPECT_EQ(cu->read_vgpr(vgpr_base + 1, kLane), 0x00005555u);
+  EXPECT_EQ(cu->read_vgpr(vgpr_base + 129, kLane), 0xDEADBEEFu);
+}
+
+TEST(Gfx1250ExecutionTest, VNotB16HighVdstMergesIntoLowPhysicalVgpr) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, kGfx1250Wave32VgprAllocation);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1u);
+
+  constexpr uint32_t kLane = 0;
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  cu->write_vgpr(vgpr_base + 0, kLane, 0x000000FFu);
+  cu->write_vgpr(vgpr_base + 1, kLane, 0xAAAA5555u);
+  cu->write_vgpr(vgpr_base + 129, kLane, 0xDEADBEEFu);
+
+  const std::array<uint32_t, 1> words = {0x7F02D300u}; // v_not_b16_e32 v1.h, v0.l
+  gfx1250::VNotB16Vop1 high_half_not(words.data());
+  high_half_not.execute_impl(*wf);
+
+  EXPECT_EQ(cu->read_vgpr(vgpr_base + 1, kLane), 0xFF005555u);
+  EXPECT_EQ(cu->read_vgpr(vgpr_base + 129, kLane), 0xDEADBEEFu);
+}
+
+TEST(Gfx1250ExecutionTest, VAddF16HighVdstMergesIntoLowPhysicalVgpr) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, kGfx1250Wave32VgprAllocation);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1u);
+
+  constexpr uint32_t kLane = 0;
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  cu->write_vgpr(vgpr_base + 0, kLane, 0x00003C00u);
+  cu->write_vgpr(vgpr_base + 1, kLane, 0xAAAA5555u);
+  cu->write_vgpr(vgpr_base + 2, kLane, 0x00003C00u);
+  cu->write_vgpr(vgpr_base + 129, kLane, 0xDEADBEEFu);
+
+  const std::array<uint32_t, 1> words = {0x65020500u}; // v_add_f16_e32 v1.h, v0.l, v2.l
+  gfx1250::VAddF16Vop2 high_half_add(words.data());
+  high_half_add.execute_impl(*wf);
+
+  EXPECT_EQ(cu->read_vgpr(vgpr_base + 1, kLane), 0x40005555u);
+  EXPECT_EQ(cu->read_vgpr(vgpr_base + 129, kLane), 0xDEADBEEFu);
+}
+
+TEST(Gfx1250ExecutionTest, VFmacF16Vop3HighVdstUsesHighHalfAddend) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, kGfx1250Wave32VgprAllocation);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1u);
+
+  constexpr uint32_t kLane = 0;
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  cu->write_vgpr(vgpr_base + 0, kLane, 0x00003C00u);
+  cu->write_vgpr(vgpr_base + 1, kLane, 0x40003C00u);
+  cu->write_vgpr(vgpr_base + 2, kLane, 0x00003C00u);
+
+  const std::array<uint32_t, 2> words = {
+      0xD5364001u, // v_fmac_f16 v1.h, v0.l, v2.l
+      0x02020500u,
+  };
+  gfx1250::VFmacF16Vop3 high_half_fmac(words.data());
+  high_half_fmac.execute_impl(*wf);
+
+  EXPECT_EQ(cu->read_vgpr(vgpr_base + 1, kLane), 0x42003C00u);
+}
+
+TEST(Gfx1250ExecutionTest, VMadU32LiteralTimesScalarAddsVector) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1u);
+
+  constexpr uint32_t kLane = 0;
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  write_wave_sgpr(*cu, *wf, 3, 1);
+  cu->write_vgpr(vgpr_base + 4, kLane, 0x24u);
+
+  const std::array<uint32_t, 3> words = {
+      0xD6350004u, // v_mad_u32 v4, 0x48, s3, v4
+      0x041006FFu,
+      0x00000048u,
+  };
+  gfx1250::VMadU32Vop3 mad(words.data());
+  mad.execute_impl(*wf);
+
+  EXPECT_EQ(cu->read_vgpr(vgpr_base + 4, kLane), 0x6Cu);
+}
+
+TEST(Gfx1250ExecutionTest, VCmpGtU32Wave32ExplicitSdstPreservesHighSgpr) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0x3u);
+
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  cu->write_vgpr(vgpr_base + 4, 0, 3u);
+  cu->write_vgpr(vgpr_base + 4, 1, 5u);
+  write_wave_sgpr(*cu, *wf, 2, 0xaaaaaaaau);
+  write_wave_sgpr(*cu, *wf, 3, 0xfefefefeu);
+  wf->set_vcc(0x12345678u);
+
+  const std::array<uint32_t, 2> words = {
+      0xD44C0002u, // v_cmp_gt_u32_e64 s2, 4, v4
+      0x02020884u,
+  };
+  gfx1250::VCmpGtU32Vop3 cmp(words.data());
+  cmp.execute_impl(*wf);
+
+  EXPECT_EQ(read_wave_sgpr(*cu, *wf, 2), 0x1u);
+  EXPECT_EQ(read_wave_sgpr(*cu, *wf, 3), 0xfefefefeu);
+  EXPECT_EQ(wf->vcc(), 0x12345678u);
 }
 
 TEST(Gfx1250ExecutionTest, TensorDmaD2CopiesGlobalAndLds) {

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -924,6 +924,28 @@ TEST(Gfx1250ExecutionTest, VFmacF16Vop3HighVdstUsesHighHalfAddend) {
   EXPECT_EQ(cu->read_vgpr(vgpr_base + 1, kLane), 0x42003C00u);
 }
 
+TEST(Gfx1250ExecutionTest, VFmacF16Vop2HighVdstUsesHighHalfAddend) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, kGfx1250Wave32VgprAllocation);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1u);
+
+  constexpr uint32_t kLane = 0;
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  cu->write_vgpr(vgpr_base + 0, kLane, 0x00003C00u);
+  cu->write_vgpr(vgpr_base + 1, kLane, 0x40003C00u);
+  cu->write_vgpr(vgpr_base + 2, kLane, 0x00003C00u);
+  cu->write_vgpr(vgpr_base + 129, kLane, 0x3C003C00u);
+
+  const std::array<uint32_t, 1> words = {0x6D020500u}; // v_fmac_f16_e32 v1.h, v0.l, v2.l
+  gfx1250::VFmacF16Vop2 high_half_fmac(words.data());
+  high_half_fmac.execute_impl(*wf);
+
+  EXPECT_EQ(cu->read_vgpr(vgpr_base + 1, kLane), 0x42003C00u);
+  EXPECT_EQ(cu->read_vgpr(vgpr_base + 129, kLane), 0x3C003C00u);
+}
+
 TEST(Gfx1250ExecutionTest, VMadU32LiteralTimesScalarAddsVector) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -731,6 +731,27 @@ TEST(Gfx1250SdmaTest, CopyLinearUnresolvedDstDoesNotAdvance) {
   EXPECT_NE(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0);
 }
 
+TEST(Gfx1250SdmaTest, CopyLinearNpdBitDoesNotDecodeAsBroadcast) {
+  Gfx1250Sim sim;
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kCopyBytes = 128;
+  for (uint32_t i = 0; i < kCopyBytes; ++i) {
+    queue.src()[i] = static_cast<uint8_t>(i ^ 0x4d);
+    queue.dst()[i] = 0;
+  }
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpCopy | (kSdmaSubopCopyLinear << 8) | (1u << 28);
+  packet[1] = kCopyBytes - 1;
+  write_sdma_qword_va(packet, 3, 4, queue.src_va());
+  write_sdma_qword_va(packet, 5, 6, queue.dst_va());
+
+  queue.submit(7);
+  ASSERT_TRUE(sim.engine->step());
+  EXPECT_EQ(queue.read_idx(), 7u * sizeof(uint32_t));
+  EXPECT_EQ(std::memcmp(queue.dst(), queue.src(), kCopyBytes), 0);
+}
+
 TEST(Gfx1250SdmaTest, PollMem64ResolvesTranslatedAddress) {
   Gfx1250Sim sim;
   TranslatedSdmaQueueForTest queue(sim);

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "rocjitsu/config/config_loader.h"
+#include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
 #include "rocjitsu/kmd/linux/simulated_driver.h"
 #include "rocjitsu/vm/virtual_machine.h"
 
@@ -129,14 +130,15 @@ TEST_F(KfdIoctlTest, SvmSetAndGetAttributes) {
   attrs[1].type = KFD_IOCTL_SVM_ATTR_SET_FLAGS;
   attrs[1].value = KFD_IOCTL_SVM_FLAG_GPU_EXEC;
 
-  int rc = driver_->ioctl(AMDKFD_IOC_SVM, svm_args);
+  unsigned long svm_request = rocjitsu::ioctl_with_size(AMDKFD_IOC_SVM, buffer.size());
+  int rc = driver_->ioctl(svm_request, svm_args);
   EXPECT_EQ(rc, 0);
 
   svm_args->op = KFD_IOCTL_SVM_OP_GET_ATTR;
   attrs[0].value = 0;
   attrs[1].value = 0;
 
-  rc = driver_->ioctl(AMDKFD_IOC_SVM, svm_args);
+  rc = driver_->ioctl(svm_request, svm_args);
   EXPECT_EQ(rc, 0);
   EXPECT_EQ(attrs[0].value, kGpuId);
   EXPECT_EQ(attrs[1].value, KFD_IOCTL_SVM_FLAG_GPU_EXEC);


### PR DESCRIPTION
## Motivation

This showed up on e2e tests with rocjitsu compiled with `-march=native` on clang-23.

## Technical Details

* Fix march-native SIMD fast-path mismatches for rounding NaN behavior and fma-mix lowering.
* Make gfx1250 scalar mask writes wave32-aware and keep generated compare bodies local where they depend on gfx1250 behavior.
* Lower gfx1250 16-bit VOP1/VOP2 destination writes through the selected half, including destination addend reads for FMAC true16 forms.
* Treat unresolved gfx1250 SDMA wait/poll memory addresses as not-ready so the command processor reschedules without advancing.
* Fix a TSan race in L2Cache::send_backing() by making the debug writeback counter atomic.
* Fix the SDMA teardown race by adding CommandProcessor::shutdown() to stop the doorbell monitor before releasing the primary engine/completion state.

Regenerated the affected gfx1250 ISA sources from the generator.

## JIRA ID

N/A

## Test Plan

Run unit tests and IREE e2e tests.

## Test Result

All pass.
Generator output is clean -- no diff.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
