### PR TITLE
[AMD-SMI] Clarify amdsmi_get_processor_info documentation

### DIFF
--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -167,15 +167,14 @@ finally:
 
 ### amdsmi_get_processor_info
 
-**Note: CURRENTLY HARDCODED TO RETURN EMPTY VALUES**
-
-Description: Return processor name. Available regardless of whether the library
-was built with ESMI support.
+Description: Return a string identifier for the processor: its index as a decimal
+string (for example `"0"`, `"1"`, `"2"`), which is its zero-based position in the
+library's processor list, the same order used by `amdsmi_get_processor_handles`.
 
 Input parameters:
 `processor_handle` processor handle
 
-Output: Processor name
+Output: Processor index as a string
 
 Exceptions that can be thrown by `amdsmi_get_processor_info` function:
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -3327,23 +3327,24 @@ amdsmi_status_t amdsmi_get_processor_type(amdsmi_processor_handle processor_hand
                                           amdsmi_processor_type_t* processor_type);
 
 /**
- *  @brief Get information about the given processor
+ *  @brief Get a string identifier for the given processor.
  *
  *  @ingroup tagProcDiscovery
  *
- *  @platform{gpu_bm_linux} @platform{host} @platform{cpu_bm} @platform{guest_1vf}
- *  @platform{guest_mvf} @platform{guest_windows}
+ *  @platform{gpu_bm_linux} @platform{cpu_bm} @platform{guest_1vf}
+ *  @platform{guest_mvf}
  *
- *  @details This function retrieves processor information. The @p processor_handle must
- *  be provided to retrieve the processor ID. The implementation depends only on
- *  ::amdsmi_get_processor_type and is available regardless of whether the library was
- *  built with ENABLE_ESMI_LIB.
+ *  @details This function writes the processor's index into @p name as a decimal
+ *  string (for example "0", "1", "2"). The index is the processor's zero-based
+ *  position in the library's processor list, the same order used by
+ *  ::amdsmi_get_processor_handles. A valid @p processor_handle must be provided.
  *
  *  @param[in] processor_handle a processor handle
  *
- *  @param[in] len the length of the caller provided buffer @p name.
+ *  @param[in] len The length of the caller-provided buffer @p name.
  *
- *  @param[out] name The id of the processor.
+ *  @param[out] name Buffer that receives the processor index as a decimal string.
+ *  Must not be NULL.
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -1181,6 +1181,19 @@ def amdsmi_get_socket_info(socket_handle):
 
 
 def amdsmi_get_processor_info(processor_handle):
+    """
+    Get a string identifier for the given processor. Wraps the same named function call.
+
+    The returned string is the processor's index as a string (for example
+    "0", "1", "2"): its zero-based position in the library's processor list, the
+    same order used by ``amdsmi_get_processor_handles``.
+
+    Parameters:
+        `processor_handle`: Handle of the processor to query.
+
+    Returns:
+        `str`: The processor index as a string.
+    """
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
     processor_info = ctypes.create_string_buffer(128)


### PR DESCRIPTION
## Summary

Documentation-only change. `amdsmi_get_processor_info()` writes the processor's zero-based index in the library's processor list (same order as `amdsmi_get_processor_handles`) into the caller's buffer as a decimal string (e.g. `"0"`, `"1"`, `"2"`). The existing docs were misleading:

- The header doxygen said it returns generic "processor information" / "the id of the processor" and incorrectly stated the implementation depends on `amdsmi_get_processor_type`.
- The Python API reference wrongly claimed it is "CURRENTLY HARDCODED TO RETURN EMPTY VALUES" and returns a "processor name".
- The Python interface had no docstring at all.

## Changes

- `include/amd_smi/amdsmi.h` — rewrote the `@brief`/`@details` and `@param` text for `amdsmi_get_processor_info` to describe what is actually written.
- `py-interface/amdsmi_interface.py` — added a docstring matching the file's existing style.
- `docs/reference/amdsmi-py-api.md` — removed the false "HARDCODED TO RETURN EMPTY VALUES" note and the "processor name" description.

## Test Plan

No functional change. Pre-commit passes (clang-format, ruff, codespell, etc.).