### PR TITLE
hip-tests: disable CrossStreamDep_UncapturedFirstNode on Windows

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1233,7 +1233,7 @@ graph:
   Unit_hipLaunchHostFunc_CrossStreamDep_UncapturedFirstNode:
     <<: *level_2
     tags: [capture]
-    # Hangs on Windows (PAL) due to TDR timeout; passes on Linux. Disabled
+    # Hangs on Windows (PAL), hitting CI timeout; passes on Linux. Disabled
     # pending investigation of the segment scheduler's leading-batch dispatch
     # on the Windows command processor path.
     disabled: [amd_windows, amd_wsl]

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1233,6 +1233,10 @@ graph:
   Unit_hipLaunchHostFunc_CrossStreamDep_UncapturedFirstNode:
     <<: *level_2
     tags: [capture]
+    # Hangs on Windows (PAL) due to TDR timeout; passes on Linux. Disabled
+    # pending investigation of the segment scheduler's leading-batch dispatch
+    # on the Windows command processor path.
+    disabled: [amd_windows, amd_wsl]
   Unit_hipUserObjectCreate_Functional_1:
     <<: *level_2
     tags: [userobj]

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1232,9 +1232,9 @@ graph:
     tags: [capture]
   Unit_hipLaunchHostFunc_CrossStreamDep_UncapturedFirstNode:
     <<: *level_2
-    tags: [capture]
     # Hangs on Windows (PAL), hitting CI timeout; passes on Linux.
     disabled: [amd_windows, amd_wsl]
+    tags: [capture]
   Unit_hipUserObjectCreate_Functional_1:
     <<: *level_2
     tags: [userobj]

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1233,6 +1233,7 @@ graph:
   Unit_hipLaunchHostFunc_CrossStreamDep_UncapturedFirstNode:
     <<: *level_2
     # Hangs on Windows (PAL), hitting CI timeout; passes on Linux.
+    # https://github.com/ROCm/rocm-systems/issues/7148
     disabled: [amd_windows, amd_wsl]
     tags: [capture]
   Unit_hipUserObjectCreate_Functional_1:

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1233,9 +1233,7 @@ graph:
   Unit_hipLaunchHostFunc_CrossStreamDep_UncapturedFirstNode:
     <<: *level_2
     tags: [capture]
-    # Hangs on Windows (PAL), hitting CI timeout; passes on Linux. Disabled
-    # pending investigation of the segment scheduler's leading-batch dispatch
-    # on the Windows command processor path.
+    # Hangs on Windows (PAL), hitting CI timeout; passes on Linux.
     disabled: [amd_windows, amd_wsl]
   Unit_hipUserObjectCreate_Functional_1:
     <<: *level_2


### PR DESCRIPTION
## Motivation

`Unit_hipLaunchHostFunc_CrossStreamDep_UncapturedFirstNode` hangs on Windows PAL (amd_windows), hitting the 120-minute CI timeout in PR #6346's PSDB run (job 80230995906, shard 3 of 4). The test passes reliably on Linux gfx942 (~5s).

The test exercises the leading-batch dispatch path in `EnqueueSegment` where a cross-stream BARRIER_AND must be dispatched before an uncaptured first node. The hang is specific to the Windows PAL command processor path.

## Change

Disable `Unit_hipLaunchHostFunc_CrossStreamDep_UncapturedFirstNode` on `amd_windows` and `amd_wsl` in `graph.yaml` pending investigation of the leading-batch dispatch behavior on Windows.

## JIRA
<!-- pending ticket -->

Co-Authored-By: Claude <noreply@anthropic.com>