### PR TITLE
[rocprofiler-systems] Plumbing for MPI tests on TheRock

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -30,6 +30,9 @@ class SystemCapabilities:
     rocprofsys_site_packages: Optional[Path]
     _python_versions_hint: Optional[list[str]] = field(default=None, repr=False)
     _python_root_dirs_hint: Optional[list[Path]] = field(default=None, repr=False)
+    _base_env: dict[str, str] = field(
+        default_factory=dict, repr=False
+    )  # Will never be empty
 
     @classmethod
     def from_config(cls, config) -> SystemCapabilities:
@@ -41,6 +44,8 @@ class SystemCapabilities:
         Returns:
             A new SystemCapabilities instance with paths from config.
         """
+        base_env = config.get_fundamental_environment()
+        base_env["LD_LIBRARY_PATH"] = config.get_library_path()
         return cls(
             rocm_path=config.rocm_path,
             rocprofsys_build_dir=config.rocprofsys_build_dir,
@@ -51,6 +56,7 @@ class SystemCapabilities:
             _python_versions_hint=config._python_versions_hint,
             _python_root_dirs_hint=config._python_root_dirs_hint,
             is_installed=config.is_installed,
+            _base_env=base_env,
         )
 
     @cached_property
@@ -141,7 +147,7 @@ class SystemCapabilities:
             return False
 
         # Force OpenMPI to use UCX transport
-        ucx_env = os.environ.copy()
+        ucx_env = dict(self._base_env) if self._base_env else os.environ.copy()
         ucx_env.update(
             {
                 "OMPI_MCA_pml": "ucx",
@@ -344,6 +350,7 @@ class SystemCapabilities:
                 capture_output=True,
                 text=True,
                 timeout=10,
+                env=self._base_env,
             )
             if result.returncode != 0:
                 return None

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/config.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/config.py
@@ -224,10 +224,21 @@ class RocprofsysConfig:
             "TERM": os.environ.get("TERM", ""),
             "LANG": os.environ.get("LANG", ""),
         }
-        # To maintain a stable environment, only inherit OMPI_ and ROCPROFSYS_ env vars
+        # To maintain a stable environment, only inherit certain environment variables
         for key, value in os.environ.items():
             if key.startswith(("OMPI_", "ROCPROFSYS_")):
                 env[key] = value
+
+        # OpenMPI bakes its build-time install prefix into its binaries as
+        # string literals. When the binaries are relocated that path no
+        # longer exists, so these override the baked-in prefix at runtime.
+        for key in (
+            "OPAL_PREFIX",
+            "PRTE_PREFIX",
+            "PMIX_PREFIX",
+        ):
+            if key in os.environ:
+                env[key] = os.environ[key]
 
         # Forward sanitizer runtime options so pytest-launched binaries honor
         # the suppression files / exitcode set by the CI workflow.


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Currently, on TheRock, all MPI tests fail with:

```
--------------------------------------------------------------------------
Sorry!  You were supposed to get help about:
    prterun-exec-failed
from the file:
    /therock/output/build/third-party/openmpi/build/stage/share/openmpi/help-mpirun.txt: No such file or directory
But I couldn't find that topic in the file.  Sorry!
--------------------------------------------------------------------------
```

Open MPI bakes its build-time install prefix (/therock/output/... from the manylinux container) into its binaries as string literals. Outside the container that path doesn't exist, so plugin discovery fails (prterun-exec-failed) and even the error message can't be looked up (help-mpirun.txt: No such file or directory).

Solution: Set environment variables:

```
environ_vars["OPAL_PREFIX"] = str(THEROCK_PATH)
environ_vars["PRTE_PREFIX"] = str(THEROCK_PATH)
environ_vars["PMIX_PREFIX"] = str(THEROCK_PATH)
```

But to be able to do this on TheRock, it needs to be accepted here on `rocm-systems` side first.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Allow `capabilities` to use `fundamental_env` when using `ucx`
Add `OPAL_PREFIX`, `PRTE_PREFIX`, and `PMIX_PREFIX` to the list of fundamental environments variables.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-524 (part 1)

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Manually tested using TheRock. I cannot test in CI as I have yet to be provided the official way on how to enable `THEROCK_ENABLE_MPI` in CI builds on TheRock.

## Test Result

<!-- Briefly summarize test outcomes. -->

MPI tests pass locally. UCX is not the focus of this PR (and TheRock does not build MPI with UCX support anyways).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
