### PR TITLE
[rocshmem] follow-up commit to the ctest commit for enabling theRock CI

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -44,8 +44,8 @@ endif()
 ###############################################################################
 
 option(PROFILE "Enable statistics and timing support" OFF)
-option(USE_RO "Enable RO conduit" ON)
-option(USE_IPC "Enable IPC support (using HIP)" OFF)
+option(USE_RO "Enable RO conduit" OFF)
+option(USE_IPC "Enable IPC support (using HIP)" ON)
 option(USE_GDA "Enable GDA conduit" OFF)
 option(USE_SDMA "Enable SDMA transport (MI300X+)" OFF)
 option(USE_THREADS "Enable workgroup threads to share network queues" OFF)

--- a/projects/rocshmem/tests/CMakeLists.txt
+++ b/projects/rocshmem/tests/CMakeLists.txt
@@ -92,6 +92,11 @@ if(BUILD_CTESTS AND (BUILD_FUNCTIONAL_TESTS OR BUILD_UNIT_TESTS))
         set(BUILD_UNIT_TESTS_SUBDIRS "# Unit tests not built")
     endif()
 
+    # Ensure USE_SLR_LAUNCHER has a default value if not set by functional_tests
+    if(NOT DEFINED USE_SLR_LAUNCHER)
+        set(USE_SLR_LAUNCHER OFF)
+    endif()
+
     # Generate and install top-level CTestTestfile.cmake
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/CTestInstallRoot.cmake.in

--- a/projects/rocshmem/tests/CTestInstallRoot.cmake.in
+++ b/projects/rocshmem/tests/CTestInstallRoot.cmake.in
@@ -11,34 +11,44 @@
 #   - Executables: ../../../../share/rocshmem/rocshmem_*_tests
 #   - Wrapper scripts: ../../../../share/rocshmem/test_wrapper.sh
 
-# Find MPI (required for all tests)
-find_program(MPIEXEC_EXECUTABLE NAMES mpiexec mpirun)
-if(NOT MPIEXEC_EXECUTABLE)
-    message(WARNING "MPI executable not found. Tests cannot run without MPI.")
-    message(WARNING "Set MPIEXEC_EXECUTABLE or ensure mpiexec/mpirun is in PATH")
-    return()
-endif()
+# Launcher mode was determined at build/configure time
+# USE_SLR_LAUNCHER is set based on whether MPI was found during configuration
+set(USE_SLR_LAUNCHER @USE_SLR_LAUNCHER@)
 
-# MPI parameters (can be overridden via CMake variables or environment)
-if(NOT DEFINED MPIEXEC_NUMPROC_FLAG)
-    set(MPIEXEC_NUMPROC_FLAG "-n")
-endif()
+if(NOT USE_SLR_LAUNCHER)
+    # MPI mode - find MPI executable
+    find_program(MPIEXEC_EXECUTABLE NAMES mpiexec mpirun)
+    if(NOT MPIEXEC_EXECUTABLE)
+        message(WARNING "MPI executable not found at install time, but tests were configured for MPI.")
+        message(WARNING "Set MPIEXEC_EXECUTABLE or ensure mpiexec/mpirun is in PATH")
+        message(WARNING "Alternatively, reconfigure with -DMPIEXEC_EXECUTABLE= to use SLR launcher")
+        return()
+    endif()
 
-# MCA parameters - read from environment or use defaults
-if(DEFINED ENV{OMPI_MCA_pml})
-    set(OMPI_MCA_PML "$ENV{OMPI_MCA_pml}")
-elseif(NOT DEFINED OMPI_MCA_PML)
-    set(OMPI_MCA_PML "ucx")
-endif()
+    # MPI parameters (can be overridden via CMake variables or environment)
+    if(NOT DEFINED MPIEXEC_NUMPROC_FLAG)
+        set(MPIEXEC_NUMPROC_FLAG "-n")
+    endif()
 
-if(DEFINED ENV{OMPI_MCA_osc})
-    set(OMPI_MCA_OSC "$ENV{OMPI_MCA_osc}")
-elseif(NOT DEFINED OMPI_MCA_OSC)
-    set(OMPI_MCA_OSC "ucx")
-endif()
+    # MCA parameters - read from environment or use defaults
+    if(DEFINED ENV{OMPI_MCA_pml})
+        set(OMPI_MCA_PML "$ENV{OMPI_MCA_pml}")
+    elseif(NOT DEFINED OMPI_MCA_PML)
+        set(OMPI_MCA_PML "ucx")
+    endif()
 
-message(STATUS "MPI executable: ${MPIEXEC_EXECUTABLE}")
-message(STATUS "MPI MCA parameters: pml=${OMPI_MCA_PML}, osc=${OMPI_MCA_OSC}")
+    if(DEFINED ENV{OMPI_MCA_osc})
+        set(OMPI_MCA_OSC "$ENV{OMPI_MCA_osc}")
+    elseif(NOT DEFINED OMPI_MCA_OSC)
+        set(OMPI_MCA_OSC "ucx")
+    endif()
+
+    message(STATUS "MPI executable: ${MPIEXEC_EXECUTABLE}")
+    message(STATUS "MPI MCA parameters: pml=${OMPI_MCA_PML}, osc=${OMPI_MCA_OSC}")
+else()
+    # SLR mode - no MPI required
+    message(STATUS "Using SLR (Simple Local Runtime) launcher - MPI not required")
+endif()
 
 # Subdirectories containing test definitions
 @BUILD_FUNCTIONAL_TESTS_SUBDIRS@

--- a/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
+++ b/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
@@ -286,8 +286,11 @@ set(ALL_TEST_VARIANT_NAMES default_stream)
 function(generate_variant_combinations global_variants test_variants output_var)
     set(ALL_COMBINATIONS "")
 
-    # Always include base variant (no global variants, no test variants)
-    list(APPEND ALL_COMBINATIONS "base")
+    # When using SLR launcher, skip base variant (no difference from uuid variant in SLR mode)
+    # Only include base variant for MPI mode
+    if(NOT USE_SLR_LAUNCHER)
+        list(APPEND ALL_COMBINATIONS "base")
+    endif()
 
     # Add global-only variants
     foreach(global_var ${global_variants})

--- a/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
+++ b/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
@@ -215,6 +215,10 @@ function(write_install_test_definition TEST_NAME TEST_COMMAND TEST_LABELS TEST_T
             # Executable is at: <install>/share/rocshmem/rocshmem_functional_tests
             # Relative from working dir: ../../../../share/rocshmem/rocshmem_functional_tests
             list(APPEND INSTALL_CMD_PARTS "../../../../share/rocshmem/rocshmem_functional_tests")
+        elseif("${part}" STREQUAL "${CMAKE_COMMAND}")
+            # Replace build-host cmake path with portable system env
+            # This prevents build-host absolute paths from leaking into install files
+            list(APPEND INSTALL_CMD_PARTS "env")
         elseif("${part}" STREQUAL "${MPIEXEC_EXECUTABLE}")
             # Use the MPI executable found at configure time (absolute path)
             list(APPEND INSTALL_CMD_PARTS "${MPIEXEC_EXECUTABLE}")
@@ -615,8 +619,9 @@ function(_add_single_rocshmem_test)
     # Build test command - choose launcher based on MPI availability
     if(USE_SLR_LAUNCHER)
         # SLR mode: Direct execution with ROCSHMEM_SLR_NP environment variable
+        # Use system env instead of cmake -E env for portability (build-host cmake path doesn't leak into install)
         set(TEST_COMMAND
-            ${CMAKE_COMMAND} -E env "ROCSHMEM_SLR_NP=${TEST_RANKS}"
+            env "ROCSHMEM_SLR_NP=${TEST_RANKS}"
             "ROCSHMEM_MAX_NUM_CONTEXTS=${TEST_WORKGROUPS}"
             "ROCSHMEM_HEAP_SIZE=6442450944"
         )

--- a/projects/rocshmem/tests/test_categories.yaml
+++ b/projects/rocshmem/tests/test_categories.yaml
@@ -21,8 +21,13 @@ test_categories:
       - "device_bitcode_.*"
 
       # Baseline RMA tests (single workgroup configuration)
-      - "put_n2_w8_z1_1048576B"
-      - "get_n2_w8_z1_1048576B"
+      # Matches both base variant (MPI) and uuid variant (SLR)
+      - "put_n2_w8_z1_1048576B(_uuid)?"
+      - "get_n2_w8_z1_1048576B(_uuid)?"
+
+      # Workgroup-level RMA tests (basic, any thread count for GPU portability)
+      - "wgput_n2_w1_z.*_1048576B(_uuid)?"
+      - "wgget_n2_w1_z.*_1048576B(_uuid)?"
 
       # Context-specific RMA tests
       - "defaultctxput_.*"


### PR DESCRIPTION
## Motivation

This commit makes four changes:
 - the non-MPI path for theRock CI categories didn't work from the installation directory. This commit fixes this issue.
 - for the non-MPI test path, we do not need to distinguish between the 'base' and the 'uuid' category. Only execute the uuid tests.
 - the default backend was hardcoded to be RO, unless explicitly set by the user. Change the default to IPC.
 - minor adjustments to the tests executed in the quick category.

## JIRA ID

AIROCSHMEM- 399

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
