### PR TITLE
[RCCL] Validate ncclBarrierSession LSA

### DIFF
--- a/projects/rccl/src/include/nccl_device/impl/gin__funcs.h
+++ b/projects/rccl/src/include/nccl_device/impl/gin__funcs.h
@@ -1029,7 +1029,11 @@ NCCL_DEVICE_INLINE void ncclGin_BackendMask<beMask>::waitSignalFollowShadow(Coop
   uint32_t steps = 0;
   coop.sync();
   uint64_t before64 = this->_signalShadows[signal];
+#if defined(__HIP_PLATFORM_AMD__)
+  uint64_t after64 = 0;  // must be zero-initialized, else non-root threads broadcast an indeterminate value and hang
+#else
   uint64_t after64;
+#endif
   if (coop.thread_rank() == 0) {
     uint64_t* ptr = ncclGinCall<ncclGinApi_GetSignalPtr>(this->_makeCtx(), signal);
     #pragma unroll 1

--- a/projects/rccl/test/device/GinDeviceTests.cpp
+++ b/projects/rccl/test/device/GinDeviceTests.cpp
@@ -12,6 +12,7 @@
 // references ncclGinCtx / ncclGinDescriptorSmem; their primary declarations
 // live in gin_device_common.h, which must be included first.
 #include "nccl_device/coop.h"
+#include "nccl_device/impl/core__funcs.h" 
 #include "nccl_device/gin/gin_device_host_common.h"
 #include "nccl_device/gin/gin_device_common.h"
 #include "nccl_device/gin/proxy/gin_proxy.h"

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -2015,10 +2015,6 @@ __global__ void multiContextConsumerKernel(
 // slot + per-context signal. Confirms every contextId has a working
 // proxy ring + IB QP and that there's no cross-context contamination.
 TEST_F(GinMPIDeviceTests, MultiContext_AllFourRoute) {
-  // Needs >1 GIN context; the bundled v12 IB-proxy plugin is single-context
-  // (rejects contextId != 0, gin_v12.cc), so this can't pass on it.
-  GTEST_SKIP() << "Multi-context GIN unsupported by single-context v12 IB-proxy plugin";
-
   if (auto reason = ginProxyTestSkipReason(); !reason.empty())
     GTEST_SKIP() << reason;
 
@@ -2164,10 +2160,6 @@ __global__ void multiContextNpo2ConsumerKernel(
 }
 
 TEST_F(GinMPIDeviceTests, MultiContext_NonPowerOf2) {
-  // Needs >1 GIN context; the bundled v12 IB-proxy plugin is single-context
-  // (rejects contextId != 0, gin_v12.cc), so this can't pass on it.
-  GTEST_SKIP() << "Multi-context GIN unsupported by single-context v12 IB-proxy plugin";
-
   if (auto reason = ginProxyTestSkipReason(); !reason.empty())
     GTEST_SKIP() << reason;
 
@@ -2965,6 +2957,12 @@ TEST_F(GinMPIDeviceTests, RailConnection_Create) {
     GTEST_SKIP() << reason;
   if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/2))
     GTEST_SKIP() << "Requires exactly 2 ranks";
+
+  // ginIsRailed reflects the communicator's connection mode (RAIL only when the
+  // system cannot cross NICs). Opt in by disabling cross-NIC: NCCL_CROSS_NIC=0.
+  const char* crossNic = std::getenv("NCCL_CROSS_NIC");
+  if (!crossNic || std::strcmp(crossNic, "0") != 0)
+    GTEST_SKIP() << "RAIL connection requires NCCL_CROSS_NIC=0 (rail-only mode)";
 
   ASSERT_EQ(ncclSuccess, createTestCommunicator());
   ncclComm_t comm = getActiveCommunicator();

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -1019,6 +1019,177 @@ TEST_F(GinMPIDeviceTests, Barrier_TwoRanks) {
 }
 
 // ---------------------------------------------------------------------------
+// ncclBarrierSession (unified hybrid LSA+GIN barrier, barrier.h). The two
+// tests below exercise it directly, separate from the alltoall kernels that
+// use it incidentally:
+//   BarrierSession_LsaOnly  -- the LSA-only subset (ncclTeamTagLsa ctor, no
+//                              ncclGin); builds/runs without the GIN stack.
+//   BarrierSession_Hybrid   -- the world-team ctor that composes the inner
+//                              LSA barrier with the outer rail-GIN barrier.
+// ---------------------------------------------------------------------------
+
+// Collective over the LSA (intra-node) team. Validates the LSA-only subset of
+// ncclBarrierSession: the ncclTeamTagLsa convenience ctor takes no ncclGin, so
+// this path builds and runs even when GIN is absent. Each round every rank
+// stamps the iteration number into its own slot of every LSA peer's window,
+// barriers, then verifies all peers' stamps for this round are visible in its
+// own buffer. The release sync publishes our writes + provides arrival; the
+// acquire sync before the next round gates the overwrite on all peers having
+// read. A broken barrier (no arrival guarantee, or missing release/acquire
+// ordering) leaves a stale slot, recorded in dErr; a broken epoch deadlocks.
+__global__ void barrierSessionLsaKernel(
+    ncclWindow_t win, size_t off, int iters, int* dErr,
+    struct ncclDevComm devComm) {
+  ncclBarrierSession<ncclCoopCta> bar{
+      ncclCoopCta(), ncclTeamTagLsa(), devComm, /*index=*/blockIdx.x};
+  ncclTeam lsa = ncclTeamLsa(devComm);
+  int* myBuf = static_cast<int*>(ncclGetLocalPointer(win, off));
+  for (int it = 1; it <= iters; ++it) {
+    if (threadIdx.x == 0) {
+      for (int p = 0; p < lsa.nRanks; ++p) {
+        int* peer = static_cast<int*>(ncclGetLsaPointer(win, off, p));
+        peer[lsa.rank] = it;
+      }
+    }
+    // Publish our writes to LSA peers and arrive.
+    bar.sync(ncclCoopCta(), cuda::memory_order_release, ncclGinFenceLevel::Relaxed);
+    if (threadIdx.x == 0) {
+      for (int p = 0; p < lsa.nRanks; ++p) {
+        if (myBuf[p] != it) atomicExch(dErr, it);
+      }
+    }
+    // Gate the next round's overwrites on all peers having read this round.
+    bar.sync(ncclCoopCta(), cuda::memory_order_acquire, ncclGinFenceLevel::Relaxed);
+  }
+}
+
+// Exercises the LSA-only subset in isolation. Needs only symmetric memory and
+// >=2 LSA peers; it does NOT require the GIN proxy, so it is gated only on
+// cuMem (not the full GIN prerequisites).
+TEST_F(GinMPIDeviceTests, BarrierSession_LsaOnly) {
+  if (auto reason = cuMemReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
+    GTEST_SKIP() << "Requires 2-8 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int nRanks = -1;
+  ncclCommCount(comm, &nRanks);
+  ASSERT_GE(nRanks, 2);
+  ASSERT_LE(nRanks, 8);
+
+  // Only the inner LSA barrier pool is needed; no GIN signal/counter/force so
+  // GIN stays inactive and the ncclTeamTagLsa path is what gets validated.
+  ncclDevCommRequirements reqs = defaultGinReqs();
+  reqs.lsaBarrierCount = 1;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  // One int slot per possible LSA peer (<= nRanks). Symmetric window so peers
+  // can store into our buffer via ncclGetLsaPointer.
+  constexpr int kIters = 16;
+  const size_t  bytes  = static_cast<size_t>(nRanks) * sizeof(int);
+  void* dBuf = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess, ncclMemAlloc(&dBuf, bytes));
+  auto memCleanup = makeScopeGuard([&]() {
+    if (dBuf) (void)ncclMemFree(dBuf);
+  });
+
+  ncclWindow_t win = nullptr;
+  ASSERT_MPI_EQ(ncclSuccess,
+      ncclCommWindowRegister(comm, dBuf, bytes, &win, NCCL_WIN_COLL_SYMMETRIC));
+  auto winCleanup = makeScopeGuard([&]() {
+    if (win) (void)ncclCommWindowDeregister(comm, win);
+  });
+
+  // Device-side error flag: set to the failing iteration if a peer's write
+  // was not visible after the barrier.
+  int* dErr = nullptr;
+  ASSERT_MPI_EQ(hipSuccess, hipMalloc(&dErr, sizeof(int)));
+  auto errCleanup = makeScopeGuard([&]() {
+    if (dErr) (void)hipFree(dErr);
+  });
+  ASSERT_MPI_EQ(hipSuccess, hipMemset(dErr, 0, sizeof(int)));
+  ASSERT_MPI_EQ(hipSuccess, hipMemset(dBuf, 0, bytes));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Collective: every rank runs the same kernel on its node's LSA team.
+  barrierSessionLsaKernel<<<1, 64, 0, stream>>>(win, /*off=*/0, kIters, dErr, devComm);
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  int hErr = 0;
+  ASSERT_MPI_EQ(hipSuccess, hipMemcpy(&hErr, dErr, sizeof(int), hipMemcpyDeviceToHost));
+  ASSERT_EQ(0, hErr) << "LSA barrier failed to make a peer's write visible at iteration " << hErr;
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// Collective over the world team: composes the inner LSA barrier with the
+// outer rail-GIN barrier (ncclTeamTagWorld ctor). Mirrors Barrier_TwoRanks'
+// "completion == success" philosophy -- a broken inner or outer epoch
+// deadlocks at iter 1 -- but routes through both substrates. On single node
+// the outer rail arm degenerates; multi-node it crosses rails.
+__global__ void barrierSessionHybridKernel(int iters, struct ncclDevComm devComm) {
+  ncclGin gin{devComm, /*ginContext=*/0};
+  ncclBarrierSession<ncclCoopCta> bar{
+      ncclCoopCta(), ncclTeamTagWorld(), gin, /*index=*/blockIdx.x};
+  for (int i = 0; i < iters; i++) {
+    bar.sync(ncclCoopCta(), cuda::memory_order_relaxed, ncclGinFenceLevel::Relaxed);
+  }
+}
+
+TEST_F(GinMPIDeviceTests, BarrierSession_Hybrid) {
+  if (auto reason = ginProxyTestSkipReason(); !reason.empty())
+    GTEST_SKIP() << reason;
+
+  if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
+    GTEST_SKIP() << "Requires 2-8 ranks";
+
+  ASSERT_EQ(ncclSuccess, createTestCommunicator());
+  ncclComm_t  comm   = getActiveCommunicator();
+  hipStream_t stream = getActiveStream();
+
+  int nRanks = -1;
+  ncclCommCount(comm, &nRanks);
+  ASSERT_GE(nRanks, 2);
+  ASSERT_LE(nRanks, 8);
+
+  constexpr int kIters = 16;
+
+  // World-team barrier needs both pools: lsaBarrierCount for the inner LSA
+  // arm, railGinBarrierCount for the outer rail-GIN arm. ginForceEnable is
+  // required so GIN actually activates (ginHandles[] populated) on a single
+  // node -- without it the outer barrier's waitSignal dereferences a NULL
+  // proxy ctx and faults (see Barrier_TwoRanks).
+  ncclDevCommRequirements reqs = defaultGinReqs();
+  reqs.lsaBarrierCount     = 1;
+  reqs.railGinBarrierCount = 1;
+  reqs.ginForceEnable      = true;
+  ncclDevComm devComm{};
+  ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));
+  auto devCommCleanup = makeScopeGuard([&]() {
+    (void)ncclDevCommDestroy(comm, &devComm);
+  });
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // All ranks run the same collective barrier loop; completion means every
+  // round's inner LSA + outer rail-GIN epochs stayed in lockstep.
+  barrierSessionHybridKernel<<<1, 32, 0, stream>>>(kIters, devComm);
+  ASSERT_MPI_EQ(hipSuccess, hipStreamSynchronize(stream));
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+// ---------------------------------------------------------------------------
 // SignalAdd_AndShadow
 //   Walks the signal-shadow API family end-to-end. SignalAdd (variable add)
 //   takes a different proxy host path than SignalInc (+1):
@@ -1847,6 +2018,10 @@ __global__ void multiContextConsumerKernel(
 // slot + per-context signal. Confirms every contextId has a working
 // proxy ring + IB QP and that there's no cross-context contamination.
 TEST_F(GinMPIDeviceTests, MultiContext_AllFourRoute) {
+  // Needs >1 GIN context; the bundled v12 IB-proxy plugin is single-context
+  // (rejects contextId != 0, gin_v12.cc), so this can't pass on it.
+  GTEST_SKIP() << "Multi-context GIN unsupported by single-context v12 IB-proxy plugin";
+
   if (auto reason = ginProxyTestSkipReason(); !reason.empty())
     GTEST_SKIP() << reason;
 
@@ -1992,6 +2167,10 @@ __global__ void multiContextNpo2ConsumerKernel(
 }
 
 TEST_F(GinMPIDeviceTests, MultiContext_NonPowerOf2) {
+  // Needs >1 GIN context; the bundled v12 IB-proxy plugin is single-context
+  // (rejects contextId != 0, gin_v12.cc), so this can't pass on it.
+  GTEST_SKIP() << "Multi-context GIN unsupported by single-context v12 IB-proxy plugin";
+
   if (auto reason = ginProxyTestSkipReason(); !reason.empty())
     GTEST_SKIP() << reason;
 

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -2812,9 +2812,6 @@ TEST_F(GinMPIDeviceTests, MultiContext_Exclusive) {
   ASSERT_EQ(kNumContexts, (int)devComm.ginContextCount)
       << "exclusive allocation returned " << (int)devComm.ginContextCount;
 
-  // 2.30 dropped ncclDevComm.ginContextBase; contexts are addressed 0-based via
-  // ginContextCount. Exclusivity is exercised by the producer/consumer kernels below.
-
   std::vector<uint8_t> hostSrc(kBufBytes, 0), hostDst(kBufBytes, 0);
   for (int b = 0; b < kNumContexts; b++)
     std::fill_n(hostSrc.begin() + b * kSlotStride, kTransferBytes,

--- a/projects/rccl/test/transport/GinDeviceMPITests.cpp
+++ b/projects/rccl/test/transport/GinDeviceMPITests.cpp
@@ -51,16 +51,22 @@ std::string cuMemReason() {
   return "";
 }
 
+// Number of MPI ranks co-located on this rank's node.
+int nodeLocalRanks() {
+  MPI_Comm nodeComm;
+  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &nodeComm);
+  int n = 0;
+  MPI_Comm_size(nodeComm, &n);
+  MPI_Comm_free(&nodeComm);
+  return n;
+}
+
 // Single-node runs need intranet mode -- otherwise the topology pruner
 // removes the NET node and GIN has no path to bind.
 std::string intranetReason() {
-  MPI_Comm nodeComm;
-  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &nodeComm);
-  int nodeSize = 0, worldSize = 0;
-  MPI_Comm_size(nodeComm, &nodeSize);
+  int worldSize = 0;
   MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
-  MPI_Comm_free(&nodeComm);
-  if (nodeSize != worldSize) return "";
+  if (nodeLocalRanks() != worldSize) return "";
   const char* intra = std::getenv("RCCL_ENABLE_INTRANET");
   if (!intra || std::strcmp(intra, "1") != 0)
     return "Intranet mode required for single-node run (RCCL_ENABLE_INTRANET=1)";
@@ -69,13 +75,9 @@ std::string intranetReason() {
 
 // Skip if all ranks share a node -- IB would silently loopback.
 std::string crossNodeReason() {
-  MPI_Comm nodeComm;
-  MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &nodeComm);
-  int nodeSize = 0, worldSize = 0;
-  MPI_Comm_size(nodeComm, &nodeSize);
+  int worldSize = 0;
   MPI_Comm_size(MPI_COMM_WORLD, &worldSize);
-  MPI_Comm_free(&nodeComm);
-  if (nodeSize == worldSize)
+  if (nodeLocalRanks() == worldSize)
     return "Cross-node test requires ranks on >=2 physical nodes";
   return "";
 }
@@ -1018,25 +1020,15 @@ TEST_F(GinMPIDeviceTests, Barrier_TwoRanks) {
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-// ---------------------------------------------------------------------------
-// ncclBarrierSession (unified hybrid LSA+GIN barrier, barrier.h). The two
-// tests below exercise it directly, separate from the alltoall kernels that
-// use it incidentally:
-//   BarrierSession_LsaOnly  -- the LSA-only subset (ncclTeamTagLsa ctor, no
-//                              ncclGin); builds/runs without the GIN stack.
-//   BarrierSession_Hybrid   -- the world-team ctor that composes the inner
-//                              LSA barrier with the outer rail-GIN barrier.
-// ---------------------------------------------------------------------------
+// Direct tests for ncclBarrierSession (barrier.h), separate from the alltoall
+// kernels that use it incidentally: BarrierSession_LsaOnly (LSA-only subset,
+// ncclTeamTagLsa, no GIN) and BarrierSession_Hybrid (world-team: inner LSA +
+// outer rail-GIN).
 
-// Collective over the LSA (intra-node) team. Validates the LSA-only subset of
-// ncclBarrierSession: the ncclTeamTagLsa convenience ctor takes no ncclGin, so
-// this path builds and runs even when GIN is absent. Each round every rank
-// stamps the iteration number into its own slot of every LSA peer's window,
-// barriers, then verifies all peers' stamps for this round are visible in its
-// own buffer. The release sync publishes our writes + provides arrival; the
-// acquire sync before the next round gates the overwrite on all peers having
-// read. A broken barrier (no arrival guarantee, or missing release/acquire
-// ordering) leaves a stale slot, recorded in dErr; a broken epoch deadlocks.
+// LSA-team collective for the LSA-only subset. Each round every rank stamps the
+// iteration into its slot of each peer's window, barriers, then checks all
+// peers' stamps are visible. acq_rel publishes our writes and acquires theirs;
+// a broken barrier leaves a stale slot in dErr (or deadlocks on a broken epoch).
 __global__ void barrierSessionLsaKernel(
     ncclWindow_t win, size_t off, int iters, int* dErr,
     struct ncclDevComm devComm) {
@@ -1051,8 +1043,9 @@ __global__ void barrierSessionLsaKernel(
         peer[lsa.rank] = it;
       }
     }
-    // Publish our writes to LSA peers and arrive.
-    bar.sync(ncclCoopCta(), cuda::memory_order_release, ncclGinFenceLevel::Relaxed);
+    // Publish our writes to LSA peers and acquire theirs (acq_rel so the loads
+    // below are ordered after every peer's store, not relaxed).
+    bar.sync(ncclCoopCta(), cuda::memory_order_acq_rel, ncclGinFenceLevel::Relaxed);
     if (threadIdx.x == 0) {
       for (int p = 0; p < lsa.nRanks; ++p) {
         if (myBuf[p] != it) atomicExch(dErr, it);
@@ -1063,15 +1056,19 @@ __global__ void barrierSessionLsaKernel(
   }
 }
 
-// Exercises the LSA-only subset in isolation. Needs only symmetric memory and
-// >=2 LSA peers; it does NOT require the GIN proxy, so it is gated only on
-// cuMem (not the full GIN prerequisites).
+// Exercises the LSA-only subset in isolation. Needs symmetric memory and >=2
+// ranks co-located on a node; it does NOT require the GIN proxy, so it gates on
+// cuMem + a node-local size check rather than the full GIN prerequisites.
 TEST_F(GinMPIDeviceTests, BarrierSession_LsaOnly) {
   if (auto reason = cuMemReason(); !reason.empty())
     GTEST_SKIP() << reason;
 
   if (!validateTestPrerequisites(/*min_processes=*/2, /*max_processes=*/8))
     GTEST_SKIP() << "Requires 2-8 ranks";
+
+  // Needs >=2 co-located ranks; otherwise the LSA team is size 1 (vacuous).
+  if (nodeLocalRanks() < 2)
+    GTEST_SKIP() << "Requires >=2 ranks co-located on a node for a non-trivial LSA team";
 
   ASSERT_EQ(ncclSuccess, createTestCommunicator());
   ncclComm_t  comm   = getActiveCommunicator();
@@ -1082,9 +1079,9 @@ TEST_F(GinMPIDeviceTests, BarrierSession_LsaOnly) {
   ASSERT_GE(nRanks, 2);
   ASSERT_LE(nRanks, 8);
 
-  // Only the inner LSA barrier pool is needed; no GIN signal/counter/force so
-  // GIN stays inactive and the ncclTeamTagLsa path is what gets validated.
-  ncclDevCommRequirements reqs = defaultGinReqs();
+  // LSA-only path: start from the plain initializer (GIN disabled) and ask only
+  // for the inner LSA barrier pool, so ncclDevCommCreate does not activate GIN.
+  ncclDevCommRequirements reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
   reqs.lsaBarrierCount = 1;
   ncclDevComm devComm{};
   ASSERT_MPI_EQ(ncclSuccess, ncclDevCommCreate(comm, &reqs, &devComm));

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -2521,7 +2521,6 @@
         "NCCL_GIN_TYPE": "2",
         "NCCL_GIN_ENABLE": "1",
         "NCCL_CUMEM_ENABLE": "1",
-        "NCCL_DMABUF_ENABLE": "1",
         "NCCL_ENV_PLUGIN": "none"
       },
       "tests": [
@@ -2559,7 +2558,6 @@
       "timeout": 300,
       "env_variables": {
         "NCCL_CUMEM_ENABLE": "1",
-        "NCCL_DMABUF_ENABLE": "1",
         "NCCL_ENV_PLUGIN": "none"
       },
       "tests": [
@@ -2579,6 +2577,28 @@
         }
       ]
     },
+    "gin_reducescatter_sym": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_GIN_TYPE": "2",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_ENV_PLUGIN": "none"
+      },
+      "tests": [
+        {
+          "name": "GIN_ReduceScatter_Symmetric",
+          "description": "Symmetric-memory ReduceScatter (RailA2A_LsaLD) sum + avg; requires >=2 ranks/node across >=2 nodes",
+          "test_filter": "GinMPIDeviceTests.ReduceScatter_Symmetric*"
+        }
+      ]
+    },
     "gin_negative": {
       "extends": "default",
       "is_gtest": true,
@@ -2591,7 +2611,6 @@
         "NCCL_GIN_TYPE": "2",
         "NCCL_GIN_ENABLE": "1",
         "NCCL_CUMEM_ENABLE": "1",
-        "NCCL_DMABUF_ENABLE": "1",
         "NCCL_ENV_PLUGIN": "none"
       },
       "tests": [
@@ -3167,6 +3186,12 @@
       "name": "GIN BarrierSession - LSA + Hybrid",
       "description": "ncclBarrierSession LSA-only and hybrid LSA+GIN barrier with 2 ranks/node",
       "config": "gin_barrier_session",
+      "enabled": true
+    },
+    {
+      "name": "GIN ReduceScatter - Symmetric",
+      "description": "Symmetric-memory ReduceScatter (RailA2A_LsaLD) sum + avg with 2 ranks/node across 2 nodes",
+      "config": "gin_reducescatter_sym",
       "enabled": true
     },
     {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -2528,7 +2528,7 @@
         {
           "name": "GIN_DeviceMPI_AllTests",
           "description": "GIN proxy device-side MPI tests over IB across two nodes",
-          "test_filter": "GinMPIDeviceTests.*:-GinMPIDeviceTests.SignalAdd_AndShadow",
+          "test_filter": "GinMPIDeviceTests.*",
           "timeout": 600
         },
         {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -2520,7 +2520,6 @@
       "env_variables": {
         "NCCL_GIN_TYPE": "2",
         "NCCL_GIN_ENABLE": "1",
-        "NCCL_GIN_NCONTEXTS": "4",
         "NCCL_CUMEM_ENABLE": "1",
         "NCCL_DMABUF_ENABLE": "1",
         "NCCL_ENV_PLUGIN": "none"
@@ -2528,9 +2527,25 @@
       "tests": [
         {
           "name": "GIN_DeviceMPI_AllTests",
-          "description": "GIN proxy device-side MPI tests (put/signal/counter/barrier/alltoall) over IB across two nodes; LSA-only, multi-context, and negative opt-in tests self-skip in this layout",
-          "test_filter": "GinMPIDeviceTests.*",
+          "description": "GIN proxy device-side MPI tests over IB across two nodes",
+          "test_filter": "GinMPIDeviceTests.*:-GinMPIDeviceTests.SignalAdd_AndShadow",
           "timeout": 600
+        },
+        {
+          "name": "GIN_MultiContext_NonPowerOf2",
+          "description": "Multi-context GIN with a non-power-of-2 context count (NCCL_GIN_NCONTEXTS=3)",
+          "test_filter": "GinMPIDeviceTests.MultiContext_NonPowerOf2",
+          "env_variables": {
+            "NCCL_GIN_NCONTEXTS": "3"
+          }
+        },
+        {
+          "name": "GIN_RailConnection_Create",
+          "description": "RAIL GIN connection type; requires rail-only mode (NCCL_CROSS_NIC=0)",
+          "test_filter": "GinMPIDeviceTests.RailConnection_Create",
+          "env_variables": {
+            "NCCL_CROSS_NIC": "0"
+          }
         }
       ]
     },
@@ -2545,7 +2560,6 @@
       "env_variables": {
         "NCCL_GIN_TYPE": "2",
         "NCCL_GIN_ENABLE": "1",
-        "NCCL_GIN_NCONTEXTS": "4",
         "NCCL_CUMEM_ENABLE": "1",
         "NCCL_DMABUF_ENABLE": "1",
         "NCCL_ENV_PLUGIN": "none"
@@ -2569,7 +2583,6 @@
       "env_variables": {
         "NCCL_GIN_TYPE": "2",
         "NCCL_GIN_ENABLE": "1",
-        "NCCL_GIN_NCONTEXTS": "4",
         "NCCL_CUMEM_ENABLE": "1",
         "NCCL_DMABUF_ENABLE": "1",
         "NCCL_ENV_PLUGIN": "none"

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -2508,6 +2508,98 @@
         { "name": "DeviceAPI_GIN_D3_NoDmabuf", "description": "GIN device-API alltoall, symmetric window + multimem depth 3 (-R 2 -D 3), NCCL_DMABUF_ENABLE NOT set", "command_args": "-R 2 -D 3" },
         { "name": "DeviceAPI_GIN_D4_NoDmabuf", "description": "GIN device-API alltoall, symmetric window + multimem depth 4 (-R 2 -D 4), NCCL_DMABUF_ENABLE NOT set", "command_args": "-R 2 -D 4" }
       ]
+    },
+    "gin_device_mpi": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 600,
+      "env_variables": {
+        "NCCL_GIN_TYPE": "2",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_NCONTEXTS": "4",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_ENV_PLUGIN": "none"
+      },
+      "tests": [
+        {
+          "name": "GIN_DeviceMPI_AllTests",
+          "description": "GIN proxy device-side MPI tests (put/signal/counter/barrier/alltoall) over IB across two nodes; LSA-only, multi-context, and negative opt-in tests self-skip in this layout",
+          "test_filter": "GinMPIDeviceTests.*",
+          "timeout": 600
+        }
+      ]
+    },
+    "gin_barrier_session": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 4,
+      "num_nodes": 2,
+      "num_gpus": 2,
+      "timeout": 300,
+      "env_variables": {
+        "NCCL_GIN_TYPE": "2",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_NCONTEXTS": "4",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_ENV_PLUGIN": "none"
+      },
+      "tests": [
+        {
+          "name": "GIN_BarrierSession_LsaAndHybrid",
+          "description": "ncclBarrierSession LSA-only + hybrid (LSA+GIN) with 2 ranks/node so the inner LSA team is non-trivial and the outer rail-GIN arm crosses nodes",
+          "test_filter": "GinMPIDeviceTests.BarrierSession_*"
+        }
+      ]
+    },
+    "gin_negative": {
+      "extends": "default",
+      "is_gtest": true,
+      "binary": "rccl-UnitTestsMPI",
+      "num_ranks": 2,
+      "num_nodes": 2,
+      "num_gpus": 1,
+      "timeout": 180,
+      "env_variables": {
+        "NCCL_GIN_TYPE": "2",
+        "NCCL_GIN_ENABLE": "1",
+        "NCCL_GIN_NCONTEXTS": "4",
+        "NCCL_CUMEM_ENABLE": "1",
+        "NCCL_DMABUF_ENABLE": "1",
+        "NCCL_ENV_PLUGIN": "none"
+      },
+      "tests": [
+        {
+          "name": "GIN_Disable_Error",
+          "description": "Negative path: ncclDevCommCreate must reject GIN bring-up when NCCL_GIN_ENABLE=0",
+          "test_filter": "GinMPIDeviceTests.Disable_Error",
+          "env_variables": {
+            "NCCL_GIN_ENABLE": "0"
+          }
+        },
+        {
+          "name": "GIN_Invalid_SignalPool",
+          "description": "Oversized GIN signal pool is silently clamped; basic put round-trip still works",
+          "test_filter": "GinMPIDeviceTests.Invalid_SignalPool",
+          "env_variables": {
+            "NCCL_GIN_SIGNAL_POOL_SIZE": "0x40000000"
+          }
+        },
+        {
+          "name": "GIN_Invalid_CounterPool",
+          "description": "Oversized GIN counter pool is silently clamped; basic put round-trip still works",
+          "test_filter": "GinMPIDeviceTests.Invalid_CounterPool",
+          "env_variables": {
+            "NCCL_GIN_COUNTER_POOL_SIZE": "0x40000000"
+          }
+        }
+      ]
     }
   },
   "test_suites": [
@@ -3043,6 +3135,24 @@
       "name": "rccl-tests - Device API - GIN",
       "description": "GIN device-API alltoall sweeping multimem depth (rccl-tests -R 2 -D 3 / -D 4) with GIN env (NCCL_DMABUF_ENABLE, NCCL_GIN_TYPE=2, HSA_NO_SCRATCH_RECLAIM, NCCL_ENV_PLUGIN=none, RCCL_ENABLE_INTRANET). Requires rccl-tests built with --enable-device-api.",
       "config": "device_api_gin",
+      "enabled": true
+    },
+    {
+      "name": "GIN Device MPI - Proxy Tests",
+      "description": "GIN proxy device-side MPI tests (put/signal/counter/barrier/alltoall) over IB across two nodes",
+      "config": "gin_device_mpi",
+      "enabled": true
+    },
+    {
+      "name": "GIN BarrierSession - LSA + Hybrid",
+      "description": "ncclBarrierSession LSA-only and hybrid LSA+GIN barrier with 2 ranks/node",
+      "config": "gin_barrier_session",
+      "enabled": true
+    },
+    {
+      "name": "GIN Negative / Pool Limits",
+      "description": "GIN disabled-path rejection and oversized signal/counter pool clamp opt-in tests",
+      "config": "gin_negative",
       "enabled": true
     }
   ]

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -2558,17 +2558,24 @@
       "num_gpus": 2,
       "timeout": 300,
       "env_variables": {
-        "NCCL_GIN_TYPE": "2",
-        "NCCL_GIN_ENABLE": "1",
         "NCCL_CUMEM_ENABLE": "1",
         "NCCL_DMABUF_ENABLE": "1",
         "NCCL_ENV_PLUGIN": "none"
       },
       "tests": [
         {
-          "name": "GIN_BarrierSession_LsaAndHybrid",
-          "description": "ncclBarrierSession LSA-only + hybrid (LSA+GIN) with 2 ranks/node so the inner LSA team is non-trivial and the outer rail-GIN arm crosses nodes",
-          "test_filter": "GinMPIDeviceTests.BarrierSession_*"
+          "name": "GIN_BarrierSession_LsaOnly",
+          "description": "ncclBarrierSession LSA-only: intra-node symmetric-memory barrier (no GIN), with 2 ranks/node so the LSA team is non-trivial",
+          "test_filter": "GinMPIDeviceTests.BarrierSession_LsaOnly"
+        },
+        {
+          "name": "GIN_BarrierSession_Hybrid",
+          "description": "ncclBarrierSession hybrid: inner LSA composed with outer rail-GIN barrier; the rail arm crosses nodes",
+          "test_filter": "GinMPIDeviceTests.BarrierSession_Hybrid",
+          "env_variables": {
+            "NCCL_GIN_TYPE": "2",
+            "NCCL_GIN_ENABLE": "1"
+          }
         }
       ]
     },


### PR DESCRIPTION
## Motivation

Validate ncclBarrierSession (the NCCL 2.28.7 hybrid LSA+GIN barrier) 

## Technical Details

- Add `BarrierSession_LsaOnly` - exercises the LSA-only subset via the `ncclTeamTagLsa` constructor (no GIN required).
- Add `BarrierSession_Hybrid` - exercises the world-team constructor that composes the inner LSA barrier with the outer rail-GIN barrier.

## JIRA ID

AICOMRCCL-1174

## Test Plan

```
MPI_PATH=/ompi/ompi-4.1.8/install ./install.sh -l -t --debug --enable-mpi-tests

export LD_LIBRARY_PATH=$PWD/build/debug:$LD_LIBRARY_PATH
MPI_PATH=/ompi-4.1.8/install mpirun -np 8   --mca pml ucx --mca btl ^vader,openib   -x NCCL_CUMEM_ENABLE=1 build/debug/test/rccl-UnitTestsMPI --gtest_filter='GinMPIDeviceTests.BarrierSession_LsaOnly'

MPI_PATH=/ompi/ompi-4.1.8/install mpirun -np 2   --mca pml ucx --mca btl ^vader,openib   -x NCCL_CUMEM_ENABLE=1 -x NCCL_GIN_TYPE=2 -x RCCL_ENABLE_INTRANET=1  build/debug/test/rccl-UnitTestsMPI --gtest_filter='GinMPIDeviceTests.BarrierSession_Hybrid'
```
## Test Result

<img width="622" height="183" alt="image" src="https://github.com/user-attachments/assets/75c1197f-d6f9-46c5-bdb6-9e4e5c3cd6ac" />

<img width="622" height="183" alt="image" src="https://github.com/user-attachments/assets/d1c208e7-59e7-4f9a-bc14-fe08d4e08505" />


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
