### PR TITLE
(fix) [rhdc] Fix command injection via LIBDIR_MAX_DEPTH

### DIFF
--- a/projects/rocm-core/rdhc/rdhc.py
+++ b/projects/rocm-core/rdhc/rdhc.py
@@ -15,6 +15,7 @@ import shutil
 from enum import Enum
 from pathlib import Path
 
+
 # Check for required packages before importing them
 def check_required_packages():
     """Check if required Python packages are installed"""
@@ -116,9 +117,11 @@ def generate_table_report(results):
                 test_name,
                 description,
                 result["status"],
-                result["reason"][:50] + "..."
-                if len(result["reason"]) > 50
-                else result["reason"],
+                (
+                    result["reason"][:50] + "..."
+                    if len(result["reason"]) > 50
+                    else result["reason"]
+                ),
             ]
         )
 
@@ -772,16 +775,32 @@ class ROCMHealthCheck:
 
         max_depth = os.environ.get("LIBDIR_MAX_DEPTH", "")
         self.logger.debug(f"-- Env LIBDIR_MAX_DEPTH = {max_depth}")
-        max_depth_arg = f"-maxdepth {max_depth}" if max_depth else ""
+        if max_depth:
+            try:
+                depth_value = int(max_depth.strip())
+                if depth_value < 0:
+                    raise ValueError
+            except ValueError:
+                self.logger.error(
+                    f"!!! LIBDIR_MAX_DEPTH must be a non-negative integer: {max_depth}"
+                )
+                return (
+                    TestStatus.FAIL.value,
+                    "LIBDIR_MAX_DEPTH must be a non-negative integer.",
+                )
+            # Normalize to a canonical base-10 integer string
+            max_depth = str(depth_value)
 
         if not os.path.exists(rocm_lib_path):
             self.logger.error(f"!!! ROCm library path not found: {rocm_lib_path}")
             return TestStatus.FAIL.value, "ROCm library path not found."
 
         # Get list of libraries in the ROCm path
-        stdout, stderr, ret_code = run_command(
-            f"find {rocm_lib_path} {max_depth_arg} -name '*.so*'", shell=True
-        )
+        find_cmd = ["find", rocm_lib_path]
+        if max_depth:
+            find_cmd += ["-maxdepth", max_depth]
+        find_cmd += ["-name", "*.so*"]
+        stdout, stderr, ret_code = run_command(find_cmd, shell=False)
         if ret_code != 0:
             self.logger.error(
                 f"--Error finding libraries in {rocm_lib_path}: \n{stderr}"
@@ -863,15 +882,15 @@ class ROCMHealthCheck:
                     rplib.startswith(real_rocm_lib_path)
                     or rplib.startswith(rocm_lib_path)
                 ):
-                    wrong_path_warnings[
-                        lib
-                    ] = f"Library symlink pointing to ->{rplib} ; outside of ROCm library path {rocm_lib_path}."
+                    wrong_path_warnings[lib] = (
+                        f"Library symlink pointing to ->{rplib} ; outside of ROCm library path {rocm_lib_path}."
+                    )
                     self.logger.debug(
                         f"!!! Library symlink {lib}->{rplib} ; pointing outside of ROCm library path {rocm_lib_path}."
                     )
                 continue
 
-            stdout, stderr, ret_code = run_command(f"ldd {lib}", shell=True)
+            stdout, stderr, ret_code = run_command(["ldd", "--", lib], shell=False)
             # Check if its not a dynamic library
             if "not a dynamic executable" in stderr:
                 continue

--- a/projects/rocm-core/rdhc/test_rdhc.py
+++ b/projects/rocm-core/rdhc/test_rdhc.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Unit tests for rdhc.py"""
+
+import importlib
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
+if MODULE_DIR not in sys.path:
+    sys.path.insert(0, MODULE_DIR)
+
+
+def _ensure_optional_deps():
+    """Stub optional third-party deps so importing rdhc never sys.exit()s.
+
+    rdhc.py calls check_required_packages() at import time and exits if
+    prettytable/yaml are missing. CI installs them via requirements.txt, but
+    stubbing keeps the tests runnable in a bare environment too.
+    """
+    if "prettytable" not in sys.modules:
+        try:
+            import prettytable  # noqa: F401
+        except ImportError:
+            stub = types.ModuleType("prettytable")
+            stub.PrettyTable = type("PrettyTable", (), {})
+            sys.modules["prettytable"] = stub
+    if "yaml" not in sys.modules:
+        try:
+            import yaml  # noqa: F401
+        except ImportError:
+            sys.modules["yaml"] = types.ModuleType("yaml")
+
+
+_ensure_optional_deps()
+rdhc = importlib.import_module("rdhc")
+
+
+class LibDepthValidationTest(unittest.TestCase):
+    """Covers LIBDIR_MAX_DEPTH validation and safe find/ldd invocation."""
+
+    def setUp(self):
+        self.hc = rdhc.ROCMHealthCheck(rocm_path="/opt/rocm")
+
+    def _run(self, env_value, find_stdout="", find_ret=0):
+        """Invoke test_check_lib_dependencies with a patched environment.
+
+        Returns (result, calls) where calls is the list of every
+        (command, shell) pair passed to run_command. The find invocation is
+        always the first entry. find is stubbed so no real filesystem/command
+        is touched; os.path.exists returns True so we reach the find call.
+        """
+        calls = []
+
+        def fake_run_command(command, shell=False):
+            calls.append((command, shell))
+            # First call is find; any later call (ldd) returns "not dynamic".
+            if len(calls) == 1:
+                return find_stdout, "", find_ret
+            return "", "not a dynamic executable", 0
+
+        env = {} if env_value is None else {"LIBDIR_MAX_DEPTH": env_value}
+        with mock.patch.dict(os.environ, env, clear=False):
+            if env_value is None:
+                os.environ.pop("LIBDIR_MAX_DEPTH", None)
+            with mock.patch.object(
+                rdhc, "run_command", side_effect=fake_run_command
+            ), mock.patch.object(rdhc.os.path, "exists", return_value=True):
+                result = self.hc.test_check_lib_dependencies()
+        return result, calls
+
+    def test_invalid_non_numeric_fails(self):
+        (status, msg), calls = self._run("3; rm -rf /")
+        self.assertEqual(status, rdhc.TestStatus.FAIL.value)
+        self.assertIn("non-negative integer", msg)
+        # Rejected before any command was run.
+        self.assertEqual(calls, [])
+
+    def test_negative_value_fails(self):
+        (status, _msg), calls = self._run("-1")
+        self.assertEqual(status, rdhc.TestStatus.FAIL.value)
+        self.assertEqual(calls, [])
+
+    def test_non_ascii_digits_normalized_to_ascii(self):
+        # Arabic-Indic digit three: int() parses it and str() normalizes to
+        # ASCII "3", so find receives a safe base-10 integer string.
+        _result, calls = self._run("٣", find_stdout="")
+        find_cmd, shell = calls[0]
+        self.assertEqual(shell, False)
+        self.assertEqual(find_cmd[find_cmd.index("-maxdepth") + 1], "3")
+
+    def test_whitespace_value_normalized(self):
+        # Whitespace should be accepted and normalized, not rejected.
+        _result, calls = self._run(" 3 ", find_stdout="")
+        find_cmd, shell = calls[0]
+        self.assertEqual(shell, False)
+        self.assertIsInstance(find_cmd, list)
+        self.assertIn("-maxdepth", find_cmd)
+        self.assertEqual(find_cmd[find_cmd.index("-maxdepth") + 1], "3")
+
+    def test_find_uses_argv_list_without_shell(self):
+        _result, calls = self._run(None, find_stdout="")
+        find_cmd, shell = calls[0]
+        self.assertIsInstance(find_cmd, list)
+        self.assertEqual(find_cmd[0], "find")
+        self.assertEqual(shell, False)
+        # No -maxdepth when the env var is unset.
+        self.assertNotIn("-maxdepth", find_cmd)
+
+
+class LddInvocationTest(unittest.TestCase):
+    """The ldd call must use an argv list with shell=False and a -- guard."""
+
+    def setUp(self):
+        self.hc = rdhc.ROCMHealthCheck(rocm_path="/opt/rocm")
+
+    def test_ldd_called_with_argv_and_dashdash(self):
+        malicious = "/opt/rocm/lib/evil; touch pwned.so"
+        captured = {}
+
+        def fake_run_command(command, shell=False):
+            captured["command"] = command
+            captured["shell"] = shell
+            return "\tnot a dynamic executable", "not a dynamic executable", 0
+
+        with mock.patch.object(
+            rdhc, "run_command", side_effect=fake_run_command
+        ), mock.patch.object(
+            rdhc.os.path, "exists", return_value=True
+        ), mock.patch.object(
+            rdhc.os.path, "islink", return_value=False
+        ):
+            self.hc._check_rocm_libs_dependency([malicious], "/opt/rocm/lib")
+
+        self.assertEqual(captured["shell"], False)
+        self.assertEqual(captured["command"], ["ldd", "--", malicious])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
check_libraries() interpolated the LIBDIR_MAX_DEPTH environment variable into a find command run with shell=True, allowing arbitrary command execution as root via sudo -E. Validate the value as a non-negative integer and invoke find with an argv list and shell=False.

JIRA ID: SWSPLAT-24266

