### PR TITLE
Fix CPU affinity not being restored after comm init

### DIFF
--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2085,7 +2085,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   TRACE(NCCL_INIT, "rank %d nranks %d - DONE", rank, nranks);
 
 exit:
-  if (ncclOsCpuCount(comm->cpuAffinity)) ncclOsSetAffinity(comm->cpuAffinity);
+  if (ncclOsCpuCount(comm->cpuAffinity)) ncclOsSetAffinity(affinitySave);
   /* If split resource is shared, we are not able to unlink the proxy ops pool here since the child comm can
    * attach the proxy ops pool of parent at any time; otherwise, unlink it here to make sure the pool will be
    * properly cleaned up. */


### PR DESCRIPTION
Rank's process affinity is permanently narrowed to the GPU-local subset, silently overwriting the Slurm --cpu-bind allocation.

## Motivation

Mitigate regressions observed while using CPU bind.

## Technical Details
In the recent PR the affinity restore at the end of initTransportsRank to re-apply comm->cpuAffinity (the temporary GPU-local mask used for NUMA-local init allocations) instead of the saved affinitySave. This left the rank's process affinity permanently narrowed to the GPU-local subset, silently overwriting the Slurm --cpu-bind allocation.

## JIRA ID



## Test Plan



## Test Result



## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
