### PR TITLE
[hipfile] Use local variable in find_library loop

### DIFF
--- a/projects/hipfile/cmake/AISAddLibraries.cmake
+++ b/projects/hipfile/cmake/AISAddLibraries.cmake
@@ -42,11 +42,11 @@ function(ais_add_libraries)
 
     # Add dependencies on external libraries
     foreach(lib IN LISTS arg_LIBS)
-        find_library(LIBRARY_PATH NAMES ${lib})
-        if(NOT LIBRARY_PATH)
+        find_library(${arg_NAME}_${lib}_LIBRARY NAMES ${lib})
+        if(NOT ${arg_NAME}_${lib}_LIBRARY)
             message(FATAL_ERROR "lib${lib} not found")
         endif()
-        target_link_libraries(${arg_NAME} PRIVATE ${LIBRARY_PATH})
+        target_link_libraries(${arg_NAME} PRIVATE ${${arg_NAME}_${lib}_LIBRARY})
     endforeach()
 
     if(BUILD_TESTING)


### PR DESCRIPTION
## Motivation

In PR #7172, Copilot noted that we use CMake's find_library() in a loop with a variable that is cached, which is a problem when there are multiple libraries.

## Technical Details

This fix uses a per-target, per-library local variable instead.

## JIRA ID

AIHIPFILE-65

## Test Plan

CI passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
