### PR TITLE
[hipfile] Handle NULL pointers from mnt_fs_get_fstype()

### DIFF
--- a/projects/hipfile/src/amd_detail/mountinfo.cpp
+++ b/projects/hipfile/src/amd_detail/mountinfo.cpp
@@ -85,19 +85,19 @@ LibMountHelper::getMountInfo(dev_t dev) const
     MountInfo mountinfo{};
 
     const char *fstype{libmount->mnt_fs_get_fstype(mnt_fs)};
-    if (!strcmp(fstype, "ext4")) {
+    if (fstype && !strcmp(fstype, "ext4")) {
         mountinfo.type = FilesystemType::ext4;
 
         char *value;
         switch (libmount->mnt_fs_get_option(mnt_fs, "data", &value, nullptr)) {
             case 0: // option found
-                if (!strcmp(value, "ordered")) {
+                if (value && !strcmp(value, "ordered")) {
                     mountinfo.options.ext4.journaling_mode = ExtJournalingMode::ordered;
                 }
-                else if (!strcmp(value, "journal")) {
+                else if (value && !strcmp(value, "journal")) {
                     mountinfo.options.ext4.journaling_mode = ExtJournalingMode::journal;
                 }
-                else if (!strcmp(value, "writeback")) {
+                else if (value && !strcmp(value, "writeback")) {
                     mountinfo.options.ext4.journaling_mode = ExtJournalingMode::writeback;
                 }
                 else {
@@ -112,7 +112,7 @@ LibMountHelper::getMountInfo(dev_t dev) const
                 throw std::runtime_error("libmount: Could not get mount option: data");
         }
     }
-    else if (!strcmp(fstype, "xfs")) {
+    else if (fstype && !strcmp(fstype, "xfs")) {
         mountinfo.type = FilesystemType::xfs;
     }
     else {

--- a/projects/hipfile/test/amd_detail/mountinfo.cpp
+++ b/projects/hipfile/test/amd_detail/mountinfo.cpp
@@ -125,7 +125,8 @@ TEST_P(LibMountHelperFilesystemTypeParam, GetMountInfoHandlesFilesystemType)
 INSTANTIATE_TEST_SUITE_P(
     LibMountHelperFilesystemType, LibMountHelperFilesystemTypeParam,
     Values(
-        std::make_tuple("autofs", FilesystemType::other), std::make_tuple("beegfs", FilesystemType::other),
+        std::make_tuple(nullptr, FilesystemType::other), std::make_tuple("autofs", FilesystemType::other),
+        std::make_tuple("beegfs", FilesystemType::other),
         std::make_tuple("binfmt_misc", FilesystemType::other), std::make_tuple("bpf", FilesystemType::other),
         std::make_tuple("btrfs", FilesystemType::other), std::make_tuple("cgroup2", FilesystemType::other),
         std::make_tuple("configfs", FilesystemType::other), std::make_tuple("debugfs", FilesystemType::other),
@@ -179,6 +180,7 @@ TEST_P(LibMountHelperExt4FilesystemTypeParam, GetMountInfoHandlesExt4FilesystemT
 
 INSTANTIATE_TEST_SUITE_P(LibMountHelperExt4FilesystemType, LibMountHelperExt4FilesystemTypeParam,
                          Values(std::make_tuple(1, nullptr, ExtJournalingMode::ordered),
+                                std::make_tuple(0, nullptr, ExtJournalingMode::unknown),
                                 std::make_tuple(0, "ordered", ExtJournalingMode::ordered),
                                 std::make_tuple(0, "journal", ExtJournalingMode::journal),
                                 std::make_tuple(0, "writeback", ExtJournalingMode::writeback),


### PR DESCRIPTION
## Motivation

NULL pointers returned from mnt_fs_get_fstype() are passed to string functions, which can cause crashes.

## Technical Details

The fix involves checking for NULL pointers before string operations.

## JIRA ID

N/A

## Test Plan

CI passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
