### PR TITLE
[hipfile] Add hipFileBatchIOSubmit() nullptr check

### DIFF
--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -390,6 +390,10 @@ try {
     hipFileInit();
     (void)flags; // Unused at this time.
 
+    if (iocbp == nullptr && nr > 0) {
+        return {hipFileInvalidValue, hipSuccess};
+    }
+
     std::shared_ptr<IBatchContext> batch_context = Context<DriverState>::get()->getBatchContext(batch_idp);
     batch_context->submit_operations(iocbp, nr);
 

--- a/projects/hipfile/test/amd_detail/hipfile-api.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-api.cpp
@@ -129,6 +129,21 @@ TEST_F(HipFileUnit, TestHipFileBatchIOSubmitBadArgument)
     ASSERT_EQ(result, HIPFILE_INVALID_VALUE);
 }
 
+TEST_F(HipFileUnit, TestHipFileBatchIOSubmitNullptrParams)
+{
+    hipFileBatchHandle_t           b_handle       = reinterpret_cast<hipFileBatchHandle_t>(0x12345678);
+    std::shared_ptr<MBatchContext> mock_b_context = std::make_shared<MBatchContext>();
+
+    // With nr > 0 and a nullptr iocbp, the API must reject the call before
+    // ever reaching the batch context (avoids dereferencing the nullptr).
+    EXPECT_CALL(mock_state, getBatchContext).Times(0);
+    EXPECT_CALL(*mock_b_context, submit_operations).Times(0);
+
+    auto           result          = hipFileBatchIOSubmit(b_handle, 1, nullptr, 0);
+    hipFileError_t expected_result = {hipFileInvalidValue, hipSuccess};
+    ASSERT_EQ(result, expected_result);
+}
+
 /// @brief Test hipFileIO function
 struct HipFileIoParam : public TestWithParam<IoType> {
     hipFileHandle_t                  file_handle{};


### PR DESCRIPTION
## Motivation

`hipFileBatchIOSubmit` forwards the caller's `iocbp` to `submit_operations` with no NULL check; `batch.cpp:120` dereferences `params[i]`. With `iocbp == NULL` and `nr > 0` (≤ capacity) this segfaults — uncatchable by the `catch(...)`.

## Technical Details

Adds a nullptr check to `hipFileBatchIOSubmit`.

## JIRA ID

AIHIPFILE-65

## Test Plan

CI passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
