### PR TITLE
[rocDecode] Fix integer underflow in MPEG-4 first-frame demux

### DIFF
--- a/projects/rocdecode/utils/video_demuxer.h
+++ b/projects/rocdecode/utils/video_demuxer.h
@@ -31,6 +31,7 @@ extern "C" {
     #endif
 }
 
+#include <cstdint>
 #include <cstring>
 #include <ctime>
 #include <time.h>
@@ -224,15 +225,22 @@ class VideoDemuxer {
                 if (is_mpeg4_ && (frame_count_ == 0)) {
                     int ext_data_size = av_fmt_input_ctx_->streams[av_stream_]->codecpar->extradata_size;
                     if (ext_data_size > 0) {
-                        data_with_header_ = (uint8_t *)av_malloc(ext_data_size + packet_->size - 3 * sizeof(uint8_t));
+                        if (packet_->size < 3 ||
+                            (size_t)ext_data_size > SIZE_MAX - (size_t)(packet_->size - 3)) {
+                            DemuxCriticalLog("malformed first MPEG-4 packet!");
+                            return false;
+                        }
+                        size_t payload = (size_t)packet_->size - 3;
+                        size_t total = (size_t)ext_data_size + payload;
+                        data_with_header_ = (uint8_t *)av_malloc(total);
                         if (!data_with_header_) {
                             DemuxCriticalLog("av_malloc failed!");
                             return false;
                         }
                         memcpy(data_with_header_, av_fmt_input_ctx_->streams[av_stream_]->codecpar->extradata, ext_data_size);
-                        memcpy(data_with_header_ + ext_data_size, packet_->data + 3, packet_->size - 3 * sizeof(uint8_t));
+                        memcpy(data_with_header_ + ext_data_size, packet_->data + 3, payload);
                         *video = data_with_header_;
-                        *video_size = ext_data_size + packet_->size - 3 * sizeof(uint8_t);
+                        *video_size = total;
                     }
                 } else {
                     *video = packet_->data;

--- a/projects/rocprofiler-systems/examples/videodecode/video_demuxer.h
+++ b/projects/rocprofiler-systems/examples/videodecode/video_demuxer.h
@@ -33,6 +33,8 @@ extern "C"
 }
 
 #include <rocdecode/rocdecode.h>
+#include <cstdint>
+#include <cstring>
 
 /*!
  * \file
@@ -246,8 +248,15 @@ public:
                     av_fmt_input_ctx_->streams[av_stream_]->codecpar->extradata_size;
                 if(ext_data_size > 0)
                 {
-                    data_with_header_ = (uint8_t*) av_malloc(
-                        ext_data_size + packet_->size - 3 * sizeof(uint8_t));
+                    if(packet_->size < 3 ||
+                       (size_t) ext_data_size > SIZE_MAX - (size_t) (packet_->size - 3))
+                    {
+                        std::cerr << "ERROR: malformed first MPEG-4 packet!" << std::endl;
+                        return false;
+                    }
+                    size_t payload    = (size_t) packet_->size - 3;
+                    size_t total      = (size_t) ext_data_size + payload;
+                    data_with_header_ = (uint8_t*) av_malloc(total);
                     if(!data_with_header_)
                     {
                         std::cerr << "ERROR: av_malloc failed!" << std::endl;
@@ -256,10 +265,9 @@ public:
                     memcpy(data_with_header_,
                            av_fmt_input_ctx_->streams[av_stream_]->codecpar->extradata,
                            ext_data_size);
-                    memcpy(data_with_header_ + ext_data_size, packet_->data + 3,
-                           packet_->size - 3 * sizeof(uint8_t));
+                    memcpy(data_with_header_ + ext_data_size, packet_->data + 3, payload);
                     *video      = data_with_header_;
-                    *video_size = ext_data_size + packet_->size - 3 * sizeof(uint8_t);
+                    *video_size = total;
                 }
             }
             else

--- a/projects/rocprofiler-systems/examples/videodecode/video_demuxer.h
+++ b/projects/rocprofiler-systems/examples/videodecode/video_demuxer.h
@@ -32,9 +32,9 @@ extern "C"
 #endif
 }
 
-#include <rocdecode/rocdecode.h>
 #include <cstdint>
 #include <cstring>
+#include <rocdecode/rocdecode.h>
 
 /*!
  * \file


### PR DESCRIPTION
A first MPEG-4 video packet shorter than 3 bytes makes packet_->size - 3 negative; after unsigned promotion the size math wraps, allowing a small av_malloc followed by a ~2^64-byte memcpy that smashes the heap (DoS / heap corruption). Reject packets shorter than 3 bytes and the extradata sum that would overflow SIZE_MAX, and compute sizes in checked size_t.

Fixes: SWSPLAT-24275 (CWE-191/CWE-787)