### PR TITLE
[RCCL] test_runner: add rccl-tests perf sweeps and env-var/registration coverage for MI300X

### DIFF
--- a/projects/rccl-tests/install.sh
+++ b/projects/rccl-tests/install.sh
@@ -11,6 +11,7 @@ function display_help()
     echo "    [-h|--help] Prints this help message."
     echo "    [-m|--mpi] Build RCCL-tests with MPI support. (see --mpi_home below.)"
     echo "    [-t|--test] Run unit-tests after building RCCL-Tests."
+    echo "    [--enable-device-api] Build RCCL-tests with the device API enabled (ENABLE_DEVICE_API=1)."
     echo "    [--rocm_home] Specify custom path for ROCm installation (default: /opt/rocm)"
     echo "    [--rccl_home] Specify custom path for RCCL installation (default: /opt/rocm)"
     echo "    [--mpi_home] Specify path to your MPI installation."
@@ -25,6 +26,7 @@ function display_help()
 run_tests=false
 build_release=true
 mpi_enabled=false
+device_api_enabled=false
 rocm_dir=${ROCM_PATH}
 rccl_dir=${rocm_dir}
 mpi_dir=""
@@ -40,7 +42,7 @@ gpu_targets=""
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,mpi,test,rocm_home:,rccl_home:,mpi_home:,hip_compiler:,gpu_targets: --options hmt -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,mpi,test,enable-device-api,rocm_home:,rccl_home:,mpi_home:,hip_compiler:,gpu_targets: --options hmt -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -63,6 +65,9 @@ while true; do
        shift ;;
     -t|--test)
        run_tests=true
+       shift ;;
+    --enable-device-api)
+       device_api_enabled=true
        shift ;;
     --rocm_home)
        rocm_dir=${2}
@@ -131,6 +136,12 @@ if [[ -n ${gpu_targets} ]]; then
   GPU_TARGETS="GPU_TARGETS=${gpu_targets}"
 fi
 
+DEVICE_API=""
+if ($device_api_enabled); then
+  echo "[INFO] Compiling with device API enabled (ENABLE_DEVICE_API=1)"
+  DEVICE_API="ENABLE_DEVICE_API=1"
+fi
+
 if ($mpi_enabled); then
   if [[ ${mpi_dir} == "" ]]; then
     echo "[ERROR] MPI flag enabled but path to MPI installation not specified.  See --mpi_home command line argument." >&2
@@ -138,12 +149,12 @@ if ($mpi_enabled); then
   else
     echo "[INFO] Compiling with MPI support (Using MPI from ${mpi_dir})"
     echo
-    make NCCL_HOME=${rccl_dir} CUSTOM_RCCL_LIB=${rccl_dir}/lib/librccl.so MPI=1 MPI_HOME=${mpi_dir} HIPCC=${hip_compiler} ${GPU_TARGETS} -j$(nproc)
+    make NCCL_HOME=${rccl_dir} CUSTOM_RCCL_LIB=${rccl_dir}/lib/librccl.so MPI=1 MPI_HOME=${mpi_dir} HIPCC=${hip_compiler} ${GPU_TARGETS} ${DEVICE_API} -j$(nproc)
   fi
 else
   echo "[INFO] Compiling without MPI support (MPI support requires -m and --mpi_home)"
   echo
-  make NCCL_HOME=${rccl_dir} CUSTOM_RCCL_LIB=${rccl_dir}/lib/librccl.so HIPCC=${hip_compiler} ${GPU_TARGETS} -j$(nproc)
+  make NCCL_HOME=${rccl_dir} CUSTOM_RCCL_LIB=${rccl_dir}/lib/librccl.so HIPCC=${hip_compiler} ${GPU_TARGETS} ${DEVICE_API} -j$(nproc)
 fi
 check_exit_code "$?"
 

--- a/projects/rccl-tests/install.sh
+++ b/projects/rccl-tests/install.sh
@@ -14,7 +14,8 @@ function display_help()
     echo "    [--rocm_home] Specify custom path for ROCm installation (default: /opt/rocm)"
     echo "    [--rccl_home] Specify custom path for RCCL installation (default: /opt/rocm)"
     echo "    [--mpi_home] Specify path to your MPI installation."
-    echo "    [--hip_compiler] Specify path to HIP compiler (default: /opt/rocm/llvm/bin/amdclang++)"
+    echo "    [--hip_compiler] Specify path to HIP compiler (default: \$HIP_COMPILER if set,"
+    echo "                     else /opt/rocm/llvm/bin/amdclang++)"
     echo "    [--gpu_targets] Specify GPU targets (default:gfx906,gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1102,gfx1151,gfx1200,gfx1201)"
 }
 
@@ -27,7 +28,9 @@ mpi_enabled=false
 rocm_dir=${ROCM_PATH}
 rccl_dir=${rocm_dir}
 mpi_dir=""
-hip_compiler=${rocm_dir}/llvm/bin/amdclang++
+# Default the HIP compiler from $HIP_COMPILER, else ROCm's amdclang++;
+# overridable via --hip_compiler.
+hip_compiler=${HIP_COMPILER:-${rocm_dir}/llvm/bin/amdclang++}
 gpu_targets=""
 
 # #################################################

--- a/projects/rccl/test/common/MPIHelpers.cpp
+++ b/projects/rccl/test/common/MPIHelpers.cpp
@@ -110,6 +110,46 @@ namespace
         return out;
     }
 
+    // Stable per-process label derived from the --gtest_filter argument.
+    //
+    // The per-rank stdout/stderr log file is opened once at process startup
+    // (before GTest knows which test is running) and is later looked up by name
+    // when reading it back, so the label must be constant for the whole process.
+    // The test runner launches one fully-qualified test per process, so the
+    // filter identifies that test and lets every rank's file be matched to it
+    // (e.g. `ls *<TestName>*`). Wildcard/list filters that don't map to a single
+    // test yield an empty label so the filename stays unchanged.
+    const std::string& getRunLabel()
+    {
+        static const std::string label = []() -> std::string {
+            std::string   filter;
+            std::ifstream f("/proc/self/cmdline", std::ios::binary);
+            if(f)
+            {
+                const std::string key = "--gtest_filter=";
+                std::string       arg;
+                char              c;
+                while(f.get(c))
+                {
+                    if(c == '\0')
+                    {
+                        if(arg.rfind(key, 0) == 0)
+                            filter = arg.substr(key.size());
+                        arg.clear();
+                    }
+                    else
+                    {
+                        arg += c;
+                    }
+                }
+            }
+            if(filter.empty() || filter.find_first_of("*:?") != std::string::npos)
+                return {};
+            return sanitizeForFilename(filter);
+        }();
+        return label;
+    }
+
     // Build a per-test, per-rank NCCL debug log path.
     //
     // Pattern: <logdir>/rccl_<TestSuite>.<TestName>_rank<R>_pid<P>.log
@@ -396,9 +436,15 @@ std::optional<RankLogConfig> setupRankLogging(int rank)
 
     // Rank 0 with per-rank logging: Output to BOTH console AND log file (tee behavior)
     // Print banner before redirection
+    const std::string& run_label = getRunLabel();
+    const std::string  file_glob = (run_label.empty() ? std::string{"rccl_test"}
+                                                       : "rccl_test_" + run_label)
+                                   + "_rank_*_pid*.log";
+
     TEST_INFO("Per-Rank Logging ENABLED (RCCL_MPI_LOG_ALL_RANKS=1)");
     TEST_INFO("Rank 0     : Output to BOTH console AND %s", log_filename.c_str());
     TEST_INFO("Ranks 1-N  : Output redirected to per-rank log files");
+    TEST_INFO("Rank files : %s  (each rank has its own PID)", file_glob.c_str());
     TEST_INFO("Log dir    : %s  (override: RCCL_TEST_LOG_DIR)", getLogBaseDir().c_str());
 
     // Save original stdout/stderr for tee thread
@@ -452,7 +498,9 @@ std::optional<RankLogConfig> setupRankLogging(int rank)
 
 std::string getRankLogFilePath(int rank)
 {
-    return getLogBaseDir() + "/rccl_test_rank_" + std::to_string(rank)
+    const std::string& label  = getRunLabel();
+    const std::string  prefix = label.empty() ? std::string{"rccl_test"} : "rccl_test_" + label;
+    return getLogBaseDir() + "/" + prefix + "_rank_" + std::to_string(rank)
            + "_pid" + std::to_string(::getpid()) + ".log";
 }
 

--- a/projects/rccl/test/common/MPIHelpers.hpp
+++ b/projects/rccl/test/common/MPIHelpers.hpp
@@ -212,7 +212,7 @@ inline bool isPerRankLoggingEnabled()
  *
  * Matches the filename created by setupRankLogging(). The name embeds the
  * --gtest_filter test label when it identifies a single test
- * (rccl_test_<Label>_rank<R>_pid<P>.log) so every rank's file can be matched
+ * (rccl_test_<Label>_rank_<R>_pid<P>.log) so every rank's file can be matched
  * to the test that produced it; otherwise it falls back to
  * rccl_test_rank_<R>_pid<P>.log. The file is shared by all tests in the process
  * unless callers use TestLogAssertionContext::isolate_new_output.

--- a/projects/rccl/test/common/MPIHelpers.hpp
+++ b/projects/rccl/test/common/MPIHelpers.hpp
@@ -210,9 +210,12 @@ inline bool isPerRankLoggingEnabled()
 /**
  * @brief Path to the per-rank log file used when RCCL_MPI_LOG_ALL_RANKS=1
  *
- * Matches the filename created by setupRankLogging() (current working directory).
- * The file is shared by all tests in the process unless callers use
- * TestLogAssertionContext::isolate_new_output.
+ * Matches the filename created by setupRankLogging(). The name embeds the
+ * --gtest_filter test label when it identifies a single test
+ * (rccl_test_<Label>_rank<R>_pid<P>.log) so every rank's file can be matched
+ * to the test that produced it; otherwise it falls back to
+ * rccl_test_rank_<R>_pid<P>.log. The file is shared by all tests in the process
+ * unless callers use TestLogAssertionContext::isolate_new_output.
  */
 std::string getRankLogFilePath(int rank);
 

--- a/projects/rccl/tools/scripts/test_runner/README.md
+++ b/projects/rccl/tools/scripts/test_runner/README.md
@@ -109,6 +109,7 @@ The test runner supports the following environment variables to customize behavi
 | `RCCL_BUILD_DIR` | Alternative name for `RCCL_LIB_PATH`. Either variable can be used. | `/path/to/rccl/build` |
 | `RCCL_TEST_MPI_HOSTFILE` | Path to MPI hostfile for multi-node tests. | `~/.mpi_hostfile` |
 | `RCCL_MPI_LOG_ALL_RANKS` | Set to `1` to capture stdout/stderr from every MPI rank into `rccl_test_rank_<N>.log` in the working directory (rank 0 is tee'd to console + file; ranks 1-N go to file only). Useful for debugging failures on non-zero ranks. | `RCCL_MPI_LOG_ALL_RANKS=1` |
+| `RCCL_TEST_GPUS_PER_NODE` | Override the detected number of GPUs per node (used for `"auto"` sizing and GPU-count skipping). See [GPU Count Detection](#gpu-count-detection-and-auto-sizing). | `4` |
 
 ### Configuration Path Variables
 
@@ -329,12 +330,13 @@ Used for custom validation scripts or any non-GTest executables.
 | `binary` | Yes | string | Test binary name (relative to build/test/) |
 | `test_filter` | Optional | string | Test filter (GTest filter syntax for gtest, plain argument for non-gtest) |
 | `command_args` | Optional | string | Additional command-line arguments |
-| `num_ranks` | Optional | integer | Number of MPI ranks (default: 1) |
+| `num_ranks` | Optional | integer or `"auto"` | Number of MPI ranks (default: 1). `"auto"` = detected GPUs/node × `num_nodes` (use all GPUs). See [GPU Count Detection](#gpu-count-detection-and-auto-sizing). |
 | `num_nodes` | Optional | integer | Number of nodes (default: 1) |
-| `num_gpus` | Optional | integer | GPUs per node - controls rank distribution (default: 8) |
+| `num_gpus` | Optional | integer or `"auto"` | GPUs per node - controls rank distribution. `"auto"` (also the default when omitted) = detected GPUs/node. |
 | `timeout` | Optional | integer | Timeout in seconds (0 = unlimited) |
 | `env_variables` | Optional | object | Test-specific environment variables |
 | `rerun_env_variables` | Optional | object | Additional environment variables for failed test reruns (merged with env_variables) |
+| `mpi_args` | Optional | string or list | Extra `mpirun`/MCA arguments appended to the base MPI arguments (MPI tests only). See [Custom MPI Arguments](#custom-mpi-arguments). |
 
 ### Configuration Inheritance
 
@@ -678,6 +680,171 @@ Create `~/.mpi_hostfile` with node names (one per line):
 node01 slots=8
 node02 slots=8
 ```
+
+## GPU Count Detection and Auto-Sizing
+
+To make configurations portable across nodes with different GPU counts (e.g. 4-GPU vs 8-GPU nodes), the runner can detect how many GPUs a node has and size/skip tests accordingly.
+
+### Detection
+
+The GPUs-per-node count is detected once, using this priority:
+
+1. `RCCL_TEST_GPUS_PER_NODE` environment variable (explicit override)
+2. Visible-device masks: `HIP_VISIBLE_DEVICES`, `ROCR_VISIBLE_DEVICES`, or `CUDA_VISIBLE_DEVICES` (counts the listed IDs)
+3. `rocminfo` GPU-agent count
+
+If none of these yield a value, detection returns "unknown" and the runner falls back to defaults (treating `"auto"` as 8) and disables GPU-count-based skipping.
+
+### `"auto"` values
+
+Both `num_gpus` and `num_ranks` accept the literal string `"auto"`:
+
+- `num_gpus: "auto"` → resolves to the detected GPUs per node. **This is also the default when `num_gpus` is omitted.**
+- `num_ranks: "auto"` → resolves to `num_gpus × num_nodes` (i.e. use *all* GPUs across all nodes).
+
+Example — a single-node test that always uses every GPU on the node:
+
+```json
+{
+  "implicit_launch_order": {
+    "is_gtest": true,
+    "binary": "rccl-UnitTestsMPI",
+    "num_ranks": "auto",
+    "num_nodes": 1,
+    "tests": [ { "name": "MultiCommunicatorChain", "test_filter": "..." } ]
+  }
+}
+```
+
+On an 8-GPU node this runs with 8 ranks; on a 4-GPU node, 4 ranks — no config change required.
+
+### Automatic skipping on insufficient GPUs
+
+When the GPU count is known, a test is automatically **SKIPPED** (not failed) if the node does not have enough GPUs:
+
+- **Single-node** tests: skipped when `num_ranks` > detected GPUs/node.
+- **Multi-node** tests: skipped when `num_gpus` (ranks per node) > detected GPUs/node.
+
+This lets fixed-size tests (e.g. an 8-rank test whose gtest filters require exactly 8 ranks) live in one shared config and simply self-skip on smaller nodes, instead of failing. Use `RCCL_TEST_GPUS_PER_NODE` to force a specific value (or to re-enable skipping in environments where detection fails).
+
+## Custom MPI Arguments
+
+For MPI tests (`num_ranks > 1`), the runner builds the `mpirun` command line as:
+
+```
+mpirun -np <ranks> <host args> <map-by args> <mpi_args> ./<binary> ...
+```
+
+The `<mpi_args>` portion is resolved from the `mpi_args` field, which can be
+specified at multiple levels. **Every `mpi_args` value may be either a string or
+a list of strings** (lists are joined with spaces), so both of these are
+equivalent:
+
+```json
+"mpi_args": "--bind-to none --oversubscribe"
+"mpi_args": ["--bind-to none", "--oversubscribe"]
+```
+
+### Resolution and Merge Order
+
+There are two categories of `mpi_args`:
+
+1. **Base arguments** — *replace* the built-in defaults. The base is chosen with
+   this priority:
+   1. Top-level `mpi_args` dict entry matching the active `--system`
+   2. Top-level `mpi_args` string/list (applies to all systems)
+   3. Built-in defaults (`--mca btl ^vader,openib --mca pml ucx --bind-to none`
+      for Open MPI, `-bind-to none` for MPICH)
+2. **Additive arguments** — *appended* on top of the base, regardless of
+   `--system`:
+   - Test-suite-level `mpi_args`
+   - Individual test-level `mpi_args`
+
+Final command arguments are:
+
+```
+<base args>  <suite mpi_args>  <test mpi_args>
+```
+
+> **Note:** Because base arguments *replace* the defaults, a top-level
+> `mpi_args` should include any default flags you still want (e.g.
+> `--bind-to none`). Suite- and test-level `mpi_args` are purely additive and do
+> not remove anything.
+
+### Per-System Arguments (top-level dict)
+
+Use a dict keyed by system name and select it with `--system`:
+
+```json
+{
+  "mpi_args": {
+    "mellanox": "--mca oob_tcp_if_include eth1 --mca btl ^vader,openib --bind-to none",
+    "thor2":    "--oversubscribe --mca plm_rsh_agent srun --mca btl ^openib --bind-to none"
+  }
+}
+```
+
+```bash
+python test_runner.py --config net_ib_transport.json --system mellanox
+```
+
+If `--system` is not given (or has no matching key), the built-in defaults are
+used as the base.
+
+### Global Arguments (top-level string/list)
+
+Apply the same base arguments to every MPI test:
+
+```json
+{
+  "mpi_args": ["--mca pml ucx", "--bind-to none", "--oversubscribe"]
+}
+```
+
+### Suite- and Test-Level Arguments (additive)
+
+These are appended to the base and work regardless of `--system`:
+
+```json
+{
+  "test_suites": [
+    {
+      "name": "Oversubscribed_Suite",
+      "config": "perf_tests",
+      "mpi_args": "--oversubscribe"
+    }
+  ],
+  "test_configurations": {
+    "perf_tests": {
+      "tests": [
+        {
+          "name": "AllReduce_Perf",
+          "is_gtest": false,
+          "binary": "all_reduce_perf",
+          "command_args": "-b 8 -e 128M -f 2",
+          "num_ranks": 2,
+          "mpi_args": "--mca btl_tcp_if_include eth0"
+        }
+      ]
+    }
+  }
+}
+```
+
+For the example above (no `--system`, no top-level `mpi_args`), the AllReduce
+test runs with:
+
+```
+mpirun -np 2 <host args> --mca btl ^vader,openib --mca pml ucx --bind-to none --oversubscribe --mca btl_tcp_if_include eth0 ./all_reduce_perf ...
+```
+
+(base defaults + suite `--oversubscribe` + test `--mca btl_tcp_if_include eth0`)
+
+### Inheritance
+
+When using the `extends` directive, list-form `mpi_args` are appended and
+de-duplicated across parent/child configurations (see
+[Configuration Inheritance](#configuration-inheritance)).
 
 ## Advanced Features
 
@@ -1210,6 +1377,7 @@ These override the paths specified in the JSON configuration file:
 |----------|-------------|---------|
 | `RCCL_TEST_MPI_HOSTFILE` | Path to MPI hostfile for multi-node tests | `export RCCL_TEST_MPI_HOSTFILE=~/.mpi_hostfile` |
 | `RCCL_MPI_LOG_ALL_RANKS` | Set to `1` to redirect each MPI rank's stdout/stderr to `rccl_test_rank_<N>.log` (rank 0 is also tee'd to the console). Useful when debugging failures on non-zero ranks or when tests read per-rank log files for assertions. | `export RCCL_MPI_LOG_ALL_RANKS=1` |
+| `RCCL_TEST_GPUS_PER_NODE` | Override the detected GPUs-per-node count used for `"auto"` rank/GPU sizing and for skipping tests that need more GPUs than the node has. See [GPU Count Detection](#gpu-count-detection-and-auto-sizing). | `export RCCL_TEST_GPUS_PER_NODE=4` |
 
 **Note**: `RCCL_TEST_MPI_HOSTFILE` falls back to `~/.mpi_hostfile` if not set. For SLURM environments, hostfile is auto-generated from `SLURM_NODELIST`.
 

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -24,7 +24,10 @@
     "source_dir": "${RCCL_TESTS_DIR:-$HOME/code/rocm-sparse/projects/rccl-tests}",
     "install_script": "install.sh",
     "install_flags": [
-      "--mpi"
+      "--mpi",
+      "--enable-device-api",
+      "--gpu_targets",
+      "gfx942"
     ],
     "rccl_home": "${RCCL_HOME:-${WORKDIR}/build/debug}",
     "parallel_jobs": 64,
@@ -2454,6 +2457,53 @@
           }
         }
       ]
+    },
+    "device_api_symmetric": {
+      "extends": "perf_base",
+      "command_args": "-b 8 -e 1G -f 2 -g 1 -n 5 -w 2 -c 1 -R 2",
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1",
+        "HSA_FORCE_FINE_GRAIN_PCIE": "1"
+      },
+      "tests": [
+        { "name": "DeviceAPI_Symmetric_Broadcast", "description": "Symmetric-memory window (-R 2) device-API path on broadcast", "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/broadcast_perf" },
+        { "name": "DeviceAPI_Symmetric_Reduce",    "description": "Symmetric-memory window (-R 2) device-API path on reduce",    "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_perf" },
+        { "name": "DeviceAPI_Symmetric_SendRecv",  "description": "Symmetric-memory window (-R 2) device-API path on sendrecv",  "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf" },
+        { "name": "DeviceAPI_Symmetric_Scatter",   "description": "Symmetric-memory window (-R 2) device-API path on scatter",   "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/scatter_perf" },
+        { "name": "DeviceAPI_Symmetric_Gather",    "description": "Symmetric-memory window (-R 2) device-API path on gather",    "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/gather_perf" }
+      ]
+    },
+    "device_api_lsa": {
+      "extends": "perf_base",
+      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_reduce_perf",
+      "command_args": "-b 8 -e 1G -f 2 -g 1 -n 5 -w 2 -c 1",
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1",
+        "HSA_FORCE_FINE_GRAIN_PCIE": "1"
+      },
+      "tests": [
+        { "name": "DeviceAPI_LSA_D1", "description": "LSA device-API all_reduce, symmetric window + multimem depth 1 (-R 2 -D 1)", "command_args": "-R 2 -D 1" },
+        { "name": "DeviceAPI_LSA_D2", "description": "LSA device-API all_reduce, symmetric window + multimem depth 2 (-R 2 -D 2)", "command_args": "-R 2 -D 2" }
+      ]
+    },
+    "device_api_gin": {
+      "extends": "perf_base",
+      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/alltoall_perf",
+      "command_args": "-b 8 -e 1G -f 2 -g 1 -n 5 -w 2 -c 1",
+      "env_variables": {
+        "NCCL_CUMEM_ENABLE": "1",
+        "HSA_FORCE_FINE_GRAIN_PCIE": "1",
+        "NCCL_GIN_TYPE": "2",
+        "HSA_NO_SCRATCH_RECLAIM": "1",
+        "NCCL_ENV_PLUGIN": "none",
+        "RCCL_ENABLE_INTRANET": "1"
+      },
+      "tests": [
+        { "name": "DeviceAPI_GIN_D3", "description": "GIN device-API alltoall, symmetric window + multimem depth 3 (-R 2 -D 3), DMABUF enabled", "command_args": "-R 2 -D 3", "env_variables": { "NCCL_DMABUF_ENABLE": "1" } },
+        { "name": "DeviceAPI_GIN_D4", "description": "GIN device-API alltoall, symmetric window + multimem depth 4 (-R 2 -D 4), DMABUF enabled", "command_args": "-R 2 -D 4", "env_variables": { "NCCL_DMABUF_ENABLE": "1" } },
+        { "name": "DeviceAPI_GIN_D3_NoDmabuf", "description": "GIN device-API alltoall, symmetric window + multimem depth 3 (-R 2 -D 3), NCCL_DMABUF_ENABLE NOT set", "command_args": "-R 2 -D 3" },
+        { "name": "DeviceAPI_GIN_D4_NoDmabuf", "description": "GIN device-API alltoall, symmetric window + multimem depth 4 (-R 2 -D 4), NCCL_DMABUF_ENABLE NOT set", "command_args": "-R 2 -D 4" }
+      ]
     }
   },
   "test_suites": [
@@ -2971,6 +3021,24 @@
       "name": "rccl-tests - Registration Matrix (DMABUF enabled)",
       "description": "rccl-tests buffer registration matrix with DMABUF on (NCCL_DMABUF_ENABLE=1): local+legacy, local+cumem, graph+local+legacy, graph+local+cumem (NCCL_LOCAL_REGISTER, NCCL_GRAPH_REGISTER, NCCL_LEGACY_CUDA_REGISTER, NCCL_CUMEM_ENABLE; rccl-tests -R 1 and -G 2 flags)",
       "config": "registration_matrix",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Device API - Symmetric Memory",
+      "description": "Symmetric-memory window device-API path (rccl-tests -R 2) across broadcast/reduce/sendrecv/scatter/gather (NCCL_CUMEM_ENABLE, HSA_FORCE_FINE_GRAIN_PCIE). Requires rccl-tests built with --enable-device-api.",
+      "config": "device_api_symmetric",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Device API - LSA",
+      "description": "LSA device-API all_reduce sweeping multimem depth (rccl-tests -R 2 -D 1 / -D 2). Requires rccl-tests built with --enable-device-api.",
+      "config": "device_api_lsa",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Device API - GIN",
+      "description": "GIN device-API alltoall sweeping multimem depth (rccl-tests -R 2 -D 3 / -D 4) with GIN env (NCCL_DMABUF_ENABLE, NCCL_GIN_TYPE=2, HSA_NO_SCRATCH_RECLAIM, NCCL_ENV_PLUGIN=none, RCCL_ENABLE_INTRANET). Requires rccl-tests built with --enable-device-api.",
+      "config": "device_api_gin",
       "enabled": true
     }
   ]

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -30,7 +30,6 @@
       "gfx942"
     ],
     "rccl_home": "${RCCL_HOME:-${WORKDIR}/build/debug}",
-    "parallel_jobs": 64,
     "env_variables": {}
   },
   "test_configurations": {

--- a/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
+++ b/projects/rccl/tools/scripts/test_runner/configs/mi300x_mellanox_ib.json
@@ -1,7 +1,7 @@
 {
   "system_configurations": {
     "name": "RCCL-Tests-MI300X-Mellanox-IB",
-    "description": "Comprehensive RCCL Test Configuration - All Tests"
+    "description": "Comprehensive RCCL Test Configuration - All gtest unit/MPI tests plus rccl-tests perf binaries sweeping RCCL environment variables."
   },
   "paths": {
     "workdir": "${WORKDIR:-$PWD}",
@@ -18,6 +18,17 @@
     "install_flags": ["--debug", "-t", "-l", "--log-trace", "--enable-code-coverage", "--enable-mpi-tests", "--no_clean"],
     "cmake_options": "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DEMIT_LLVM_IR=ON -DBITCODE_LIB_ARCH=gfx942",
     "parallel_jobs": 64
+  },
+  "rccl_tests_build_configuration": {
+    "enabled": true,
+    "source_dir": "${RCCL_TESTS_DIR:-$HOME/code/rocm-sparse/projects/rccl-tests}",
+    "install_script": "install.sh",
+    "install_flags": [
+      "--mpi"
+    ],
+    "rccl_home": "${RCCL_HOME:-${WORKDIR}/build/debug}",
+    "parallel_jobs": 64,
+    "env_variables": {}
   },
   "test_configurations": {
     "default": {
@@ -1973,6 +1984,476 @@
           "test_filter": "ALL"
         }
       ]
+    },
+    "perf_base": {
+      "is_gtest": false,
+      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_reduce_perf",
+      "num_ranks": 8,
+      "num_nodes": 1,
+      "num_gpus": 8,
+      "timeout": 1500,
+      "command_args": "-b 8 -e 1G -f 2 -g 1 -n 3 -w 2 -c 1 -d all -o all",
+      "env_variables": {}
+    },
+    "perf_bf16_base": {
+      "extends": "perf_base",
+      "timeout": 1500,
+      "command_args": "-b 1K -e 1G -f 1024 -g 1 -n 5 -w 2 -c 1 -d bfloat16"
+    },
+    "default_collectives": {
+      "extends": "perf_base",
+      "command_args": "-g 1 -n 5 -w 2 -c 1 -d all",
+      "tests": [
+        { "name": "AllReduce_1KiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_reduce_perf",     "command_args": "-b 1K -e 1K -o all" },
+        { "name": "AllReduce_64MiB",     "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_reduce_perf",     "command_args": "-b 64M -e 64M -o all" },
+        { "name": "AllReduce_1GiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_reduce_perf",     "command_args": "-b 1G -e 1G -o all" },
+        { "name": "Reduce_1KiB",         "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_perf",         "command_args": "-b 1K -e 1K -o all" },
+        { "name": "Reduce_64MiB",        "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_perf",         "command_args": "-b 64M -e 64M -o all" },
+        { "name": "Reduce_1GiB",         "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_perf",         "command_args": "-b 1G -e 1G -o all" },
+        { "name": "ReduceScatter_1KiB",  "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_scatter_perf", "command_args": "-b 1K -e 1K -o all" },
+        { "name": "ReduceScatter_64MiB", "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_scatter_perf", "command_args": "-b 64M -e 64M -o all" },
+        { "name": "ReduceScatter_1GiB",  "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_scatter_perf", "command_args": "-b 1G -e 1G -o all" },
+        { "name": "AllGather_1KiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_gather_perf",     "command_args": "-b 1K -e 1K" },
+        { "name": "AllGather_64MiB",     "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_gather_perf",     "command_args": "-b 64M -e 64M" },
+        { "name": "AllGather_1GiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_gather_perf",     "command_args": "-b 1G -e 1G" },
+        { "name": "Broadcast_1KiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/broadcast_perf",      "command_args": "-b 1K -e 1K" },
+        { "name": "Broadcast_64MiB",     "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/broadcast_perf",      "command_args": "-b 64M -e 64M" },
+        { "name": "Broadcast_1GiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/broadcast_perf",      "command_args": "-b 1G -e 1G" },
+        { "name": "AllToAll_1KiB",       "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/alltoall_perf",       "command_args": "-b 1K -e 1K" },
+        { "name": "AllToAll_64MiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/alltoall_perf",       "command_args": "-b 64M -e 64M" },
+        { "name": "AllToAll_1GiB",       "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/alltoall_perf",       "command_args": "-b 1G -e 1G" },
+        { "name": "Scatter_1KiB",        "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/scatter_perf",        "command_args": "-b 1K -e 1K" },
+        { "name": "Scatter_64MiB",       "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/scatter_perf",        "command_args": "-b 64M -e 64M" },
+        { "name": "Scatter_1GiB",        "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/scatter_perf",        "command_args": "-b 1G -e 1G" },
+        { "name": "Gather_1KiB",         "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/gather_perf",         "command_args": "-b 1K -e 1K" },
+        { "name": "Gather_64MiB",        "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/gather_perf",         "command_args": "-b 64M -e 64M" },
+        { "name": "Gather_1GiB",         "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/gather_perf",         "command_args": "-b 1G -e 1G" },
+        { "name": "SendRecv_1KiB",       "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf",       "command_args": "-b 1K -e 1K" },
+        { "name": "SendRecv_64MiB",      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf",       "command_args": "-b 64M -e 64M" },
+        { "name": "SendRecv_1GiB",       "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf",       "command_args": "-b 1G -e 1G" }
+      ]
+    },
+    "tuning_algo_proto": {
+      "extends": "perf_bf16_base",
+      "command_args": "-b 1K -e 1G -f 1024 -g 1 -n 5 -w 2 -c 1 -d all",
+      "tests": [
+        {
+          "name": "Tuning_Ring_Simple",
+          "description": "Ring algo + SIMPLE proto, combined with NCCL_THREAD_THRESHOLDS / NCCL_NTHREADS / NCCL_PAT_ENABLE / NCCL_NET_OVERHEAD tuning knobs",
+          "command_args": "-o all",
+          "env_variables": {
+            "NCCL_ALGO": "Ring",
+            "NCCL_PROTO": "Simple",
+            "NCCL_THREAD_THRESHOLDS": "8192,8192,8192",
+            "NCCL_NTHREADS": "256",
+            "NCCL_PAT_ENABLE": "1",
+            "NCCL_NET_OVERHEAD": "1000"
+          }
+        },
+        {
+          "name": "Tuning_Tree_LL",
+          "description": "Tree algo + LL proto path (NCCL_ALGO/NCCL_PROTO are single-valued, so kept separate from Ring/Simple)",
+          "command_args": "-o all",
+          "env_variables": {
+            "NCCL_ALGO": "Tree",
+            "NCCL_PROTO": "LL"
+          }
+        },
+        {
+          "name": "Tuning_Proto_LL128",
+          "description": "LL128 proto + LL128 thread count override",
+          "command_args": "-o all",
+          "env_variables": {
+            "NCCL_PROTO": "LL128",
+            "NCCL_LL128_NTHREADS": "640"
+          }
+        }
+      ]
+    },
+    "enqueue_thresholds": {
+      "extends": "perf_bf16_base",
+      "tests": [
+        {
+          "name": "Enqueue_GraphRegister_On",
+          "description": "NCCL_GRAPH_REGISTER on + L1 carveout, combined with RCCL_INTRANET_THRESHOLD / RCCL_ENABLE_INTRANET",
+          "command_args": "-o all",
+          "env_variables": {
+            "NCCL_GRAPH_REGISTER": "1",
+            "NCCL_L1_SHARED_MEMORY_CARVEOUT": "0",
+            "RCCL_INTRANET_THRESHOLD": "4194304",
+            "RCCL_ENABLE_INTRANET": "1"
+          }
+        },
+        {
+          "name": "Enqueue_GraphRegister_Off",
+          "description": "NCCL_GRAPH_REGISTER off (conflicts with the on value, kept separate)",
+          "command_args": "-o all",
+          "env_variables": {
+            "NCCL_GRAPH_REGISTER": "0"
+          }
+        },
+        {
+          "name": "Enqueue_P2P_Thresholds",
+          "description": "NCCL_P2P_LL_THRESHOLD + RCCL_P2P_NET_THRESHOLD + NCCL_CHUNK_SIZE (sendrecv binary, kept separate)",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf",
+          "env_variables": {
+            "NCCL_P2P_LL_THRESHOLD": "16384",
+            "RCCL_P2P_NET_THRESHOLD": "65536",
+            "NCCL_CHUNK_SIZE": "262144"
+          }
+        }
+      ]
+    },
+    "channels_rings": {
+      "extends": "perf_bf16_base",
+      "tests": [
+        {
+          "name": "Channels_Rings_Combined",
+          "description": "Combined NCCL_MIN/MAX_NRINGS, NCCL_MIN/MAX_NCHANNELS, NCCL_UNPACK_DOUBLE_NCHANNELS (all independent knobs)",
+          "command_args": "-o all",
+          "env_variables": {
+            "NCCL_MIN_NRINGS": "4",
+            "NCCL_MAX_NRINGS": "8",
+            "NCCL_MIN_NCHANNELS": "2",
+            "NCCL_MAX_NCHANNELS": "16",
+            "NCCL_UNPACK_DOUBLE_NCHANNELS": "0"
+          }
+        },
+        {
+          "name": "Channels_P2P_NChannels",
+          "description": "NCCL_MIN_P2P_NCHANNELS / NCCL_MAX_P2P_NCHANNELS (alltoall binary, kept separate)",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/alltoall_perf",
+          "env_variables": {
+            "NCCL_MIN_P2P_NCHANNELS": "2",
+            "NCCL_MAX_P2P_NCHANNELS": "8"
+          }
+        }
+      ]
+    },
+    "paths_topo": {
+      "extends": "perf_bf16_base",
+      "tests": [
+        {
+          "name": "Paths_Topo_Combined",
+          "description": "Combined NCCL_NET_GDR_LEVEL, NCCL_PXN_DISABLE, NCCL_NET_DISABLE_INTRA, NCCL_NET_GDR_READ, NCCL_NVB_DISABLE, NCCL_IGNORE_DISABLED_P2P, NCCL_CROSS_NIC, NCCL_P2P_PXN_LEVEL (all independent path/topology knobs)",
+          "command_args": "-o all",
+          "env_variables": {
+            "NCCL_NET_GDR_LEVEL": "SYS",
+            "NCCL_PXN_DISABLE": "0",
+            "NCCL_NET_DISABLE_INTRA": "0",
+            "NCCL_NET_GDR_READ": "1",
+            "NCCL_NVB_DISABLE": "1",
+            "NCCL_IGNORE_DISABLED_P2P": "1",
+            "NCCL_CROSS_NIC": "1",
+            "NCCL_P2P_PXN_LEVEL": "0"
+          }
+        }
+      ]
+    },
+    "model_matching": {
+      "extends": "perf_bf16_base",
+      "tests": [
+        {
+          "name": "Rome_Dump_Reversal",
+          "description": "Combined RCCL_DISABLE_RAIL_TREES, RCCL_MODEL_REVERSAL_DISABLE, RCCL_DUMP_ROME_MODEL_FILE, NCCL_GRAPH_DUMP_FILE (model active so the dumps are populated)",
+          "command_args": "-o all",
+          "env_variables": {
+            "RCCL_DISABLE_RAIL_TREES": "1",
+            "RCCL_MODEL_REVERSAL_DISABLE": "1",
+            "RCCL_DUMP_ROME_MODEL_FILE": "rccl_rome_model.xml",
+            "NCCL_GRAPH_DUMP_FILE": "rccl_graph.xml"
+          }
+        },
+        {
+          "name": "Rome_ModelMatchingDisable",
+          "description": "RCCL_MODEL_MATCHING_DISABLE (kept separate: it suppresses the Rome model so it must not run with the dump test)",
+          "command_args": "-o all",
+          "env_variables": {
+            "RCCL_MODEL_MATCHING_DISABLE": "1"
+          }
+        }
+      ]
+    },
+    "ib_transport": {
+      "extends": "perf_bf16_base",
+      "env_variables": {
+        "NCCL_IB_DISABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "IB_Combined",
+          "description": "Combined IB knobs: PKEY, MERGE_VFS, WARN_RAIL_LOCAL, PCI_RELAXED_ORDERING, RETURN_ASYNC_EVENTS, TC, SL, SPLIT_DATA_ON_QPS, QPS_PER_CONNECTION, GID_INDEX, TIMEOUT, RETRY_CNT, GDR_FLUSH_DISABLE, FORCE_ENABLE_GDRDMA (all independent)",
+          "command_args": "-o all",
+          "env_variables": {
+            "NCCL_IB_PKEY": "0",
+            "NCCL_IB_MERGE_VFS": "0",
+            "NCCL_IB_WARN_RAIL_LOCAL": "1",
+            "NCCL_IB_PCI_RELAXED_ORDERING": "1",
+            "NCCL_IB_RETURN_ASYNC_EVENTS": "1",
+            "NCCL_IB_TC": "96",
+            "NCCL_IB_SL": "0",
+            "NCCL_IB_SPLIT_DATA_ON_QPS": "1",
+            "NCCL_IB_QPS_PER_CONNECTION": "2",
+            "NCCL_IB_GID_INDEX": "3",
+            "NCCL_IB_TIMEOUT": "22",
+            "NCCL_IB_RETRY_CNT": "7",
+            "NCCL_GDR_FLUSH_DISABLE": "1",
+            "RCCL_FORCE_ENABLE_GDRDMA": "1"
+          }
+        }
+      ]
+    },
+    "ibvwrap_retry": {
+      "extends": "perf_bf16_base",
+      "env_variables": {
+        "NCCL_IB_DISABLE": "0"
+      },
+      "tests": [
+        {
+          "name": "IBV_MQP_Retry",
+          "description": "Combined NCCL_IB_MQP_RETRY_ALL + NCCL_IB_MQP_RETRY_SLEEP_MSEC + NCCL_IB_MQP_RETRY_CNT",
+          "command_args": "-o all",
+          "env_variables": {
+            "NCCL_IB_MQP_RETRY_ALL": "1",
+            "NCCL_IB_MQP_RETRY_SLEEP_MSEC": "200",
+            "NCCL_IB_MQP_RETRY_CNT": "20"
+          }
+        }
+      ]
+    },
+    "socket_transport": {
+      "extends": "perf_bf16_base",
+      "env_variables": {
+        "NCCL_IB_DISABLE": "1",
+        "NCCL_NET": "Socket"
+      },
+      "tests": [
+        {
+          "name": "Socket_Combined",
+          "description": "Combined NCCL_SOCKET_RETRY_CNT + NCCL_SOCKET_RETRY_SLEEP_MSEC + NCCL_NSOCKS_PERTHREAD + NCCL_SOCKET_NTHREADS",
+          "command_args": "-o all",
+          "env_variables": {
+            "NCCL_SOCKET_RETRY_CNT": "50",
+            "NCCL_SOCKET_RETRY_SLEEP_MSEC": "200",
+            "NCCL_NSOCKS_PERTHREAD": "4",
+            "NCCL_SOCKET_NTHREADS": "2"
+          }
+        }
+      ]
+    },
+    "shm_transport": {
+      "extends": "perf_bf16_base",
+      "num_ranks": 2,
+      "num_gpus": 2,
+      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf",
+      "tests": [
+        {
+          "name": "SHM_CudaMemcpy_SendSide",
+          "description": "SHM enabled + NCCL_SHM_USE_CUDA_MEMCPY send-side locality/mode",
+          "env_variables": {
+            "NCCL_SHM_DISABLE": "0",
+            "NCCL_SHM_USE_CUDA_MEMCPY": "1",
+            "NCCL_SHM_MEMCPY_MODE": "1",
+            "NCCL_SHM_LOCALITY": "1"
+          }
+        },
+        {
+          "name": "SHM_CudaMemcpy_RecvSide",
+          "description": "receive-side memcpy mode/locality (MEMCPY_MODE single-valued, kept separate from send-side)",
+          "env_variables": {
+            "NCCL_SHM_USE_CUDA_MEMCPY": "1",
+            "NCCL_SHM_MEMCPY_MODE": "2",
+            "NCCL_SHM_LOCALITY": "2"
+          }
+        },
+        {
+          "name": "SHM_Disable",
+          "description": "NCCL_SHM_DISABLE forces alternate transport selection (conflicts with SHM-enabled tests)",
+          "env_variables": {
+            "NCCL_SHM_DISABLE": "1"
+          }
+        }
+      ]
+    },
+    "p2p_transport": {
+      "extends": "perf_bf16_base",
+      "num_ranks": 2,
+      "num_gpus": 2,
+      "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/sendrecv_perf",
+      "tests": [
+        {
+          "name": "P2P_Combined",
+          "description": "Combined NCCL_P2P_DIRECT_DISABLE + NCCL_P2P_USE_CUDA_MEMCPY + NCCL_P2P_LEVEL",
+          "env_variables": {
+            "NCCL_P2P_DIRECT_DISABLE": "1",
+            "NCCL_P2P_USE_CUDA_MEMCPY": "1",
+            "NCCL_P2P_LEVEL": "SYS"
+          }
+        }
+      ]
+    },
+    "gdr_copy": {
+      "extends": "perf_bf16_base",
+      "tests": [
+        {
+          "name": "GdrCopy_Combined",
+          "description": "Combined NCCL_GDRCOPY_ENABLE/FIFO/SYNC/FLUSH + RCCL_NET_HDP_FLUSH",
+          "command_args": "-o all",
+          "env_variables": {
+            "NCCL_GDRCOPY_ENABLE": "1",
+            "NCCL_GDRCOPY_FIFO_ENABLE": "1",
+            "NCCL_GDRCOPY_SYNC_ENABLE": "1",
+            "NCCL_GDRCOPY_FLUSH_ENABLE": "1",
+            "RCCL_NET_HDP_FLUSH": "1"
+          }
+        }
+      ]
+    },
+    "bootstrap_oob": {
+      "extends": "perf_bf16_base",
+      "tests": [
+        {
+          "name": "Bootstrap_Combined",
+          "description": "Combined NCCL_OOB_NET_ENABLE + NCCL_OOB_NET_IFNAME + NCCL_UID_STAGGER_RATE + NCCL_UID_STAGGER_THRESHOLD",
+          "command_args": "-o all",
+          "env_variables": {
+            "NCCL_OOB_NET_ENABLE": "1",
+            "NCCL_OOB_NET_IFNAME": "eth0",
+            "NCCL_UID_STAGGER_RATE": "5000",
+            "NCCL_UID_STAGGER_THRESHOLD": "128"
+          }
+        }
+      ]
+    },
+    "debug_observability": {
+      "extends": "perf_bf16_base",
+      "tests": [
+        {
+          "name": "Debug_Combined",
+          "description": "Combined NCCL_DEBUG=INFO + NCCL_DEBUG_SUBSYS + NCCL_DEBUG_FILE + NCCL_SET_THREAD_NAME + RCCL_LOG_ROCTX + NCCL_GRAPH_MIXING_SUPPORT + RCCL_ENABLE_SIGNALHANDLER",
+          "command_args": "-o all",
+          "env_variables": {
+            "NCCL_DEBUG": "INFO",
+            "NCCL_DEBUG_SUBSYS": "INIT,COLL,NET,TUNING",
+            "NCCL_DEBUG_FILE": "rccl_debug.%h.%p.log",
+            "NCCL_SET_THREAD_NAME": "1",
+            "RCCL_LOG_ROCTX": "1",
+            "NCCL_GRAPH_MIXING_SUPPORT": "1",
+            "RCCL_ENABLE_SIGNALHANDLER": "1"
+          }
+        }
+      ]
+    },
+    "init_runtime": {
+      "extends": "perf_bf16_base",
+      "tests": [
+        {
+          "name": "Init_Combined",
+          "description": "Combined RCCL_KERNEL_COLL_TRACE_ENABLE/THREAD + NCCL_MIN/MAX_CTAS + HSA_FORCE_FINE_GRAIN_PCIE + NCCL_BUFFSIZE + NCCL_NCHANNELS_PER_NET_PEER + NCCL_LAUNCH_MODE",
+          "command_args": "-o all",
+          "env_variables": {
+            "RCCL_KERNEL_COLL_TRACE_ENABLE": "1",
+            "RCCL_KERNEL_COLL_TRACE_THREAD_ENABLE": "1",
+            "NCCL_MIN_CTAS": "1",
+            "NCCL_MAX_CTAS": "16",
+            "HSA_FORCE_FINE_GRAIN_PCIE": "1",
+            "NCCL_BUFFSIZE": "8388608",
+            "NCCL_NCHANNELS_PER_NET_PEER": "2",
+            "NCCL_LAUNCH_MODE": "GROUP"
+          }
+        }
+      ]
+    },
+    "collective_variants": {
+      "extends": "perf_bf16_base",
+      "tests": [
+        {
+          "name": "Coll_PivotAlltoall",
+          "description": "RCCL_ALL_TO_ALL_PIVOT_ENABLE + RCCL_PIVOT_ALLTOALL_ENABLE off",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/alltoall_perf",
+          "env_variables": {
+            "RCCL_ALL_TO_ALL_PIVOT_ENABLE": "1",
+            "RCCL_PIVOT_ALLTOALL_ENABLE": "0"
+          }
+        },
+        {
+          "name": "Coll_LL128_Force",
+          "description": "RCCL_LL128_FORCE_ENABLE forces LL128 proto",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/all_gather_perf",
+          "env_variables": {
+            "RCCL_LL128_FORCE_ENABLE": "1"
+          }
+        },
+        {
+          "name": "Coll_P2pNetDisable",
+          "description": "RCCL_P2P_NET_DISABLE toggled off (default 1)",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/reduce_scatter_perf",
+          "command_args": "-o all",
+          "env_variables": {
+            "RCCL_P2P_NET_DISABLE": "0"
+          }
+        },
+        {
+          "name": "Coll_Broadcast_Output_Trees",
+          "description": "RCCL_OUTPUT_TREES diagnostic dump on broadcast path",
+          "binary": "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build/broadcast_perf",
+          "env_variables": {
+            "RCCL_OUTPUT_TREES": "1"
+          }
+        }
+      ]
+    },
+    "registration_matrix": {
+      "extends": "perf_bf16_base",
+      "env_variables": {
+        "NCCL_DMABUF_ENABLE": "1"
+      },
+      "tests": [
+        {
+          "name": "Reg_Local_Legacy_DMABUF",
+          "description": "Local registration + legacy CUDA register, no graph (-R 1), DMABUF enabled",
+          "command_args": "-R 1 -o all",
+          "env_variables": {
+            "NCCL_LEGACY_CUDA_REGISTER": "1",
+            "NCCL_LOCAL_REGISTER": "1",
+            "NCCL_GRAPH_REGISTER": "0",
+            "NCCL_CUMEM_ENABLE": "0"
+          }
+        },
+        {
+          "name": "Reg_Local_Cumem_DMABUF",
+          "description": "Local registration + CUMEM, no graph (-R 1), DMABUF enabled",
+          "command_args": "-R 1 -o all",
+          "env_variables": {
+            "NCCL_LEGACY_CUDA_REGISTER": "0",
+            "NCCL_LOCAL_REGISTER": "1",
+            "NCCL_GRAPH_REGISTER": "0",
+            "NCCL_CUMEM_ENABLE": "1"
+          }
+        },
+        {
+          "name": "Reg_Graph_Local_Legacy_DMABUF",
+          "description": "Graph + local registration + legacy CUDA register (-R 1 -G 2), DMABUF enabled",
+          "command_args": "-R 1 -G 2 -o all",
+          "env_variables": {
+            "NCCL_LEGACY_CUDA_REGISTER": "1",
+            "NCCL_LOCAL_REGISTER": "1",
+            "NCCL_GRAPH_REGISTER": "1",
+            "NCCL_CUMEM_ENABLE": "0"
+          }
+        },
+        {
+          "name": "Reg_Graph_Local_Cumem_DMABUF",
+          "description": "Graph + local registration + CUMEM (-R 1 -G 2), DMABUF enabled",
+          "command_args": "-R 1 -G 2 -o all",
+          "env_variables": {
+            "NCCL_LEGACY_CUDA_REGISTER": "0",
+            "NCCL_LOCAL_REGISTER": "1",
+            "NCCL_GRAPH_REGISTER": "1",
+            "NCCL_CUMEM_ENABLE": "1"
+          }
+        }
+      ]
     }
   },
   "test_suites": [
@@ -2388,6 +2869,108 @@
       "name": "IR Device Tests",
       "description": "librccl_device.bc (IR) device-API tests via pytest harness; builds artifacts on demand and self-skips when prerequisites are missing",
       "config": "ir_device",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Default Collectives",
+      "description": "All collectives (all_reduce, reduce, reduce_scatter, all_gather, broadcast, alltoall, scatter, gather, sendrecv) at three message sizes (1 KiB, 64 MiB, 1 GiB), all datatypes (-d all), and all operations (-o all) for reduction collectives",
+      "config": "default_collectives",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Tuning / Algo / Proto",
+      "description": "rccl-tests perf sweep of NCCL_ALGO, NCCL_PROTO, NCCL_THREAD_THRESHOLDS, NCCL_LL128_NTHREADS, NCCL_PAT_ENABLE, NCCL_NET_OVERHEAD, NCCL_NTHREADS",
+      "config": "tuning_algo_proto",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Enqueue Thresholds",
+      "description": "rccl-tests perf sweep of NCCL_GRAPH_REGISTER, NCCL_P2P_LL_THRESHOLD, RCCL_P2P_NET_THRESHOLD, NCCL_CHUNK_SIZE, NCCL_L1_SHARED_MEMORY_CARVEOUT, RCCL_INTRANET_THRESHOLD",
+      "config": "enqueue_thresholds",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Channels / Rings",
+      "description": "rccl-tests perf sweep of NCCL_MIN/MAX_NRINGS, NCCL_MIN/MAX_NCHANNELS, NCCL_UNPACK_DOUBLE_NCHANNELS, NCCL_MIN/MAX_P2P_NCHANNELS",
+      "config": "channels_rings",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Paths / Topology",
+      "description": "rccl-tests perf sweep of NCCL_NET_GDR_LEVEL, NCCL_PXN_DISABLE, NCCL_NET_DISABLE_INTRA, NCCL_NET_GDR_READ, NCCL_NVB_DISABLE, NCCL_IGNORE_DISABLED_P2P, NCCL_CROSS_NIC, NCCL_P2P_PXN_LEVEL",
+      "config": "paths_topo",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Rome Model Matching",
+      "description": "rccl-tests perf sweep of RCCL_MODEL_MATCHING_DISABLE, RCCL_DISABLE_RAIL_TREES, RCCL_MODEL_REVERSAL_DISABLE, RCCL_DUMP_ROME_MODEL_FILE, NCCL_GRAPH_DUMP_FILE",
+      "config": "model_matching",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - IB Transport",
+      "description": "rccl-tests perf sweep of NCCL_IB_PKEY, NCCL_IB_MERGE_VFS, NCCL_IB_WARN_RAIL_LOCAL, NCCL_IB_PCI_RELAXED_ORDERING, NCCL_IB_RETURN_ASYNC_EVENTS, NCCL_IB_TC, NCCL_IB_SL, NCCL_IB_SPLIT_DATA_ON_QPS, NCCL_IB_QPS_PER_CONNECTION, NCCL_IB_GID_INDEX, NCCL_IB_TIMEOUT, NCCL_IB_RETRY_CNT, NCCL_GDR_FLUSH_DISABLE, RCCL_FORCE_ENABLE_GDRDMA - requires IB hardware",
+      "config": "ib_transport",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - IB MQP Retry (ibvwrap)",
+      "description": "rccl-tests perf sweep of NCCL_IB_MQP_RETRY_ALL, NCCL_IB_MQP_RETRY_CNT, NCCL_IB_MQP_RETRY_SLEEP_MSEC - requires IB hardware",
+      "config": "ibvwrap_retry",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Socket Transport",
+      "description": "rccl-tests perf sweep of NCCL_SOCKET_RETRY_CNT, NCCL_SOCKET_RETRY_SLEEP_MSEC, NCCL_NSOCKS_PERTHREAD, NCCL_SOCKET_NTHREADS",
+      "config": "socket_transport",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - SHM Transport",
+      "description": "rccl-tests perf sweep of NCCL_SHM_DISABLE, NCCL_SHM_USE_CUDA_MEMCPY, NCCL_SHM_MEMCPY_MODE, NCCL_SHM_LOCALITY",
+      "config": "shm_transport",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - P2P Transport",
+      "description": "rccl-tests perf sweep of NCCL_P2P_DIRECT_DISABLE, NCCL_P2P_USE_CUDA_MEMCPY, NCCL_P2P_LEVEL",
+      "config": "p2p_transport",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - GDR Copy / HDP Flush",
+      "description": "rccl-tests perf sweep of NCCL_GDRCOPY_ENABLE, NCCL_GDRCOPY_FIFO_ENABLE, NCCL_GDRCOPY_SYNC_ENABLE, NCCL_GDRCOPY_FLUSH_ENABLE, RCCL_NET_HDP_FLUSH",
+      "config": "gdr_copy",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Bootstrap / OOB Net",
+      "description": "rccl-tests perf sweep of NCCL_OOB_NET_ENABLE, NCCL_OOB_NET_IFNAME, NCCL_UID_STAGGER_RATE, NCCL_UID_STAGGER_THRESHOLD",
+      "config": "bootstrap_oob",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Debug / Observability",
+      "description": "rccl-tests perf sweep of NCCL_DEBUG, NCCL_DEBUG_SUBSYS, NCCL_DEBUG_FILE, NCCL_SET_THREAD_NAME, RCCL_LOG_ROCTX, NCCL_GRAPH_MIXING_SUPPORT, RCCL_ENABLE_SIGNALHANDLER",
+      "config": "debug_observability",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Init / Runtime",
+      "description": "rccl-tests perf sweep of RCCL_KERNEL_COLL_TRACE_ENABLE, RCCL_KERNEL_COLL_TRACE_THREAD_ENABLE, NCCL_MIN_CTAS, NCCL_MAX_CTAS, HSA_FORCE_FINE_GRAIN_PCIE, NCCL_BUFFSIZE, NCCL_NCHANNELS_PER_NET_PEER, NCCL_LAUNCH_MODE",
+      "config": "init_runtime",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Collective Variants",
+      "description": "rccl-tests perf sweep across alltoall/allgather/reducescatter/broadcast (RCCL_ALL_TO_ALL_PIVOT_ENABLE, RCCL_PIVOT_ALLTOALL_ENABLE, RCCL_LL128_FORCE_ENABLE, RCCL_P2P_NET_DISABLE, RCCL_OUTPUT_TREES)",
+      "config": "collective_variants",
+      "enabled": true
+    },
+    {
+      "name": "rccl-tests - Registration Matrix (DMABUF enabled)",
+      "description": "rccl-tests buffer registration matrix with DMABUF on (NCCL_DMABUF_ENABLE=1): local+legacy, local+cumem, graph+local+legacy, graph+local+cumem (NCCL_LOCAL_REGISTER, NCCL_GRAPH_REGISTER, NCCL_LEGACY_CUDA_REGISTER, NCCL_CUMEM_ENABLE; rccl-tests -R 1 and -G 2 flags)",
+      "config": "registration_matrix",
       "enabled": true
     }
   ]

--- a/projects/rccl/tools/scripts/test_runner/lib/schema.json
+++ b/projects/rccl/tools/scripts/test_runner/lib/schema.json
@@ -267,7 +267,7 @@
         },
         "command_args": {
           "type": "string",
-          "description": "Shared base command-line arguments for this configuration. A test's own 'command_args' is appended to this base at execution time (see test_executor.run_test); it is intentionally not inherited via 'extends'."
+          "description": "Shared base command-line arguments for this configuration. A test's own 'command_args' is appended to this base at execution time (see test_executor.run_test). Inherited via 'extends': a child that omits command_args takes the parent's value."
         },
         "_comment": {
           "type": "string",

--- a/projects/rccl/tools/scripts/test_runner/lib/schema.json
+++ b/projects/rccl/tools/scripts/test_runner/lib/schema.json
@@ -125,11 +125,6 @@
           "type": "string",
           "description": "RCCL install/build prefix to link rccl-tests against. Default: the RCCL build_dir."
         },
-        "parallel_jobs": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Number of parallel compile jobs."
-        },
         "env_variables": {
           "$ref": "#/$defs/env_variables_map",
           "description": "Environment variables set only during the rccl-tests build step"

--- a/projects/rccl/tools/scripts/test_runner/lib/schema.json
+++ b/projects/rccl/tools/scripts/test_runner/lib/schema.json
@@ -40,9 +40,14 @@
     },
 
     "mpi_args": {
-      "description": "Per-system-profile extra mpirun arguments (keyed by profile name, e.g. 'mellanox', 'ainic', 'thor2')",
-      "type": "object",
-      "additionalProperties": { "type": "string" }
+      "description": "Base mpirun arguments that replace the built-in defaults. May be a string or list of strings applied to all tests, OR an object keyed by --system profile name (e.g. 'mellanox', 'ainic', 'thor2') whose values are strings or lists of strings.",
+      "oneOf": [
+        { "$ref": "#/$defs/mpi_args_value" },
+        {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/$defs/mpi_args_value" }
+        }
+      ]
     },
 
     "system_env_variables": {
@@ -87,6 +92,51 @@
       }
     },
 
+    "rccl_tests_build_configuration": {
+      "description": "Controls how the rccl-tests perf binaries (all_reduce_perf, etc.) are built. Absent section => step skipped.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Set to false to skip building rccl-tests. Default: true when the section is present."
+        },
+        "source_dir": {
+          "type": "string",
+          "description": "Path to the rccl-tests checkout. Supports ~ and $VAR expansion. Default: $workdir/rccl-tests."
+        },
+        "install_script": {
+          "type": "string",
+          "description": "Name of the build script inside source_dir. Default: 'install.sh'."
+        },
+        "build_command": {
+          "description": "Explicit build command (string run via shell, or argv array). Overrides install_script + install_flags.",
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
+        },
+        "install_flags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Flags passed to install_script, e.g. ['--mpi']. Supports ~ and $VAR expansion."
+        },
+        "rccl_home": {
+          "type": "string",
+          "description": "RCCL install/build prefix to link rccl-tests against. Default: the RCCL build_dir."
+        },
+        "parallel_jobs": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of parallel compile jobs."
+        },
+        "env_variables": {
+          "$ref": "#/$defs/env_variables_map",
+          "description": "Environment variables set only during the rccl-tests build step"
+        }
+      }
+    },
+
     "test_configurations": {
       "description": "Named test configuration blocks. Each key is a configuration name referenced by test_suites or via 'extends'.",
       "type": "object",
@@ -108,6 +158,14 @@
       "additionalProperties": { "type": "string" }
     },
 
+    "mpi_args_value": {
+      "description": "Extra mpirun arguments expressed as either a single string ('--bind-to none --oversubscribe') or a list of strings (['--bind-to none', '--oversubscribe']).",
+      "oneOf": [
+        { "type": "string" },
+        { "type": "array", "items": { "type": "string" } }
+      ]
+    },
+
     "test_defaults": {
       "description": "Fields that can appear at the test_configuration level as defaults and be overridden per-test",
       "type": "object",
@@ -121,9 +179,11 @@
           "description": "Test binary name or path. Relative names are resolved under build_dir/test/ (or test_binary_dir if set). Supports ~ and $VAR expansion."
         },
         "num_ranks": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "Total MPI ranks. 1 → no mpirun wrapper."
+          "description": "Total MPI ranks. 1 → no mpirun wrapper. The string \"auto\" resolves to (detected GPUs per node × num_nodes), i.e. use all GPUs.",
+          "oneOf": [
+            { "type": "integer", "minimum": 1 },
+            { "type": "string", "enum": ["auto"] }
+          ]
         },
         "num_nodes": {
           "type": "integer",
@@ -131,9 +191,11 @@
           "description": "Number of nodes across which ranks are distributed"
         },
         "num_gpus": {
-          "type": "integer",
-          "minimum": 1,
-          "description": "GPUs per node; controls --map-by ppr:{num_gpus}:node for multi-node runs. Default: 8."
+          "description": "GPUs per node; controls --map-by ppr:{num_gpus}:node for multi-node runs. The string \"auto\" (also the default when omitted) resolves to the detected GPUs per node.",
+          "oneOf": [
+            { "type": "integer", "minimum": 1 },
+            { "type": "string", "enum": ["auto"] }
+          ]
         },
         "timeout": {
           "type": "integer",
@@ -205,9 +267,12 @@
           "description": "Extra command-line arguments appended to the test binary invocation. Lists are de-duplicated and appended when configs are merged via 'extends'."
         },
         "mpi_args": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": "Extra mpirun arguments for tests in this configuration. Lists are de-duplicated and appended when configs are merged via 'extends'."
+          "$ref": "#/$defs/mpi_args_value",
+          "description": "Extra mpirun arguments for tests in this configuration, appended after the base mpi_args. Accepts a string or list of strings; lists are de-duplicated and appended when configs are merged via 'extends'."
+        },
+        "command_args": {
+          "type": "string",
+          "description": "Shared base command-line arguments for this configuration. A test's own 'command_args' is appended to this base at execution time (see test_executor.run_test); it is intentionally not inherited via 'extends'."
         },
         "_comment": {
           "type": "string",
@@ -266,6 +331,10 @@
         "rerun_env_variables": {
           "$ref": "#/$defs/env_variables_map",
           "description": "Per-test additional environment variables used only on rerun"
+        },
+        "mpi_args": {
+          "$ref": "#/$defs/mpi_args_value",
+          "description": "Per-test extra mpirun arguments (MPI tests only), appended after the base and suite/configuration mpi_args. Accepts a string or list of strings."
         }
       }
     },
@@ -307,6 +376,10 @@
         "env_variables": {
           "$ref": "#/$defs/env_variables_map",
           "description": "Suite-level environment variable overrides (between configuration-level and test-level in priority)"
+        },
+        "mpi_args": {
+          "$ref": "#/$defs/mpi_args_value",
+          "description": "Suite-level extra mpirun arguments, appended after the base and configuration mpi_args (and before per-test mpi_args). Accepts a string or list of strings."
         }
       }
     }

--- a/projects/rccl/tools/scripts/test_runner/lib/test_config.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_config.py
@@ -438,7 +438,7 @@ class TestConfigProcessor:
                 "description": suite.get("description", ""),
                 "num_nodes": suite.get("num_nodes", 1),
                 "num_ranks": suite.get("num_ranks", 1),
-                "num_gpus": suite.get("num_gpus", 8),
+                "num_gpus": suite.get("num_gpus", "auto"),
                 "enabled": suite.get("enabled", True)
             }
 

--- a/projects/rccl/tools/scripts/test_runner/lib/test_config.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_config.py
@@ -22,12 +22,78 @@ except ImportError:
 
 _SCHEMA_PATH = Path(__file__).parent / "schema.json"
 
-# Set default WORKDIR to rccl root directory if not already defined
+# Compute canonical project roots so builds work regardless of the caller's $PWD.
 # This file is at: rccl/tools/scripts/test_runner/lib/test_config.py
-# rccl root is 5 directories up
+#   parents[4] -> the rccl root (".../projects/rccl")
+# rccl-tests is a sibling checkout of rccl (".../projects/rccl-tests"), so it is
+# resolved relative to the rccl root, NOT relative to $PWD (running the test
+# runner from the rccl directory would otherwise look for a non-existent
+# rccl/rccl-tests). Both can be overridden via the environment.
+_rccl_root = Path(__file__).resolve().parents[4]
 if "WORKDIR" not in os.environ:
-    _rccl_root = Path(__file__).resolve().parents[4]
     os.environ["WORKDIR"] = str(_rccl_root)
+if "RCCL_TESTS_DIR" not in os.environ:
+    os.environ["RCCL_TESTS_DIR"] = str(_rccl_root.parent / "rccl-tests")
+
+
+def expand_env_vars(value):
+    """
+    Expand environment variables in a string with bash-style default support.
+
+    Supports ${VAR}, $VAR, and ${VAR:-default} (including nested expansion in
+    the default value). Unlike os.path.expandvars, this honors the ":-" default
+    syntax. Unset ${VAR}/$VAR references are left intact.
+
+    This is a module-level function so it can be reused outside the config
+    processor (e.g. when the executor resolves test binary paths).
+
+    Args:
+        value: String that may contain environment variables
+
+    Returns:
+        str: String with environment variables expanded
+
+    Examples:
+        "${HOME}/code" -> "/home/user/code"
+        "$ROCM_PATH/bin" -> "/opt/rocm/bin"
+        "${UNDEFINED:-/default}" -> "/default" (bash-style default)
+        "${RCCL_TESTS_DIR:-$PWD/rccl-tests}/build" -> expands $PWD in the default
+    """
+    if not isinstance(value, str):
+        return value
+
+    # Replace ${VAR:-default} patterns (default value is recursively expanded).
+    def replace_with_default(match):
+        var_name = match.group(1)
+        default_value = match.group(2)
+        result = os.environ.get(var_name)
+        if result is None:
+            result = expand_env_vars(default_value)
+        return result
+
+    # All three forms are expanded together, repeatedly, until the string
+    # stabilizes. This resolves arbitrarily nested references such as
+    # "${RCCL_HOME:-${WORKDIR}/build/debug}" or
+    # "${RCCL_HOME:-${WORKDIR:-$PWD}/build/debug}": the inner ${WORKDIR}/$PWD is
+    # resolved on one pass, which turns the outer default brace-free so the
+    # ${VAR:-default} pattern can match it on the next pass. The default group
+    # excludes braces ([^{}]*) so the innermost default is always matched first.
+    # Unset references collapse to themselves, so iteration reaches a fixed
+    # point; the range() bound just guards against pathological input.
+    default_pattern = re.compile(r'\$\{([A-Za-z_][A-Za-z0-9_]*):-([^{}]*)\}')
+    braced_pattern = re.compile(r'\$\{([A-Za-z_][A-Za-z0-9_]*)\}')
+    bare_pattern = re.compile(r'\$([A-Za-z_][A-Za-z0-9_]*)')
+    resolve = lambda m: os.environ.get(m.group(1), m.group(0))
+
+    for _ in range(10):
+        new_value = default_pattern.sub(replace_with_default, value)
+        new_value = braced_pattern.sub(resolve, new_value)
+        new_value = bare_pattern.sub(resolve, new_value)
+        if new_value == value:
+            break
+        value = new_value
+
+    return value
 
 
 class TestConfigProcessor:
@@ -114,33 +180,7 @@ class TestConfigProcessor:
             "${UNDEFINED:-/default}" -> "/default" (bash-style default)
             "${WORKDIR:-$HOME/code}" -> expands $HOME in default if WORKDIR not set
         """
-        if not isinstance(value, str):
-            return value
-
-        # Pattern to match ${VAR}, ${VAR:-default}, or $VAR
-        # First, handle ${VAR:-default} pattern
-        def replace_with_default(match):
-            var_name = match.group(1)
-            default_value = match.group(2)
-            # Get the env var, or use default
-            result = os.environ.get(var_name)
-            if result is None:
-                # Recursively expand env vars in the default value
-                result = self._expand_env_var(default_value)
-            return result
-
-        # Replace ${VAR:-default} patterns
-        value = re.sub(r'\$\{([A-Za-z_][A-Za-z0-9_]*):-([^}]*)\}', replace_with_default, value)
-
-        # Replace ${VAR} patterns
-        value = re.sub(r'\$\{([A-Za-z_][A-Za-z0-9_]*)\}',
-                      lambda m: os.environ.get(m.group(1), m.group(0)), value)
-
-        # Replace $VAR patterns (but not ${ to avoid double replacement)
-        value = re.sub(r'\$([A-Za-z_][A-Za-z0-9_]*)',
-                      lambda m: os.environ.get(m.group(1), m.group(0)), value)
-
-        return value
+        return expand_env_vars(value)
 
     def _expand_env_vars_in_dict(self, data):
         """
@@ -342,7 +382,7 @@ class TestConfigProcessor:
                 "binary": combined_config.get("binary"),
                 "num_ranks": combined_config.get("num_ranks"),
                 "num_nodes": combined_config.get("num_nodes"),
-                "num_gpus": combined_config.get("num_gpus", 8),
+                "num_gpus": combined_config.get("num_gpus", "auto"),
                 "timeout": combined_config.get("timeout"),
                 "is_pytest": combined_config.get("is_pytest"),
                 "test_dir": combined_config.get("test_dir"),
@@ -379,6 +419,18 @@ class TestConfigProcessor:
             tests = combined_config.get("tests", [])
             if tests and merged_defaults:
                 combined_config["tests"] = self._apply_test_defaults(tests, merged_defaults)
+
+            # Propagate suite-entry-level mpi_args (additive, appended after any
+            # config-level mpi_args). Accepts a string or list at either level.
+            suite_mpi_args = suite.get("mpi_args")
+            if suite_mpi_args is not None:
+                def _as_list(value):
+                    if value is None:
+                        return []
+                    return list(value) if isinstance(value, (list, tuple)) else [value]
+                combined_config["mpi_args"] = (
+                    _as_list(combined_config.get("mpi_args")) + _as_list(suite_mpi_args)
+                )
 
             # Add suite-specific details
             combined_config["suite_details"] = {
@@ -429,6 +481,16 @@ class TestConfigProcessor:
             dict: Build configuration with CMake options, environment variables, etc.
         """
         return self.config.get("build_configuration", {})
+
+    def get_rccl_tests_build_config(self):
+        """
+        Get the rccl-tests build configuration settings.
+
+        Returns:
+            dict: rccl-tests build configuration (source_dir, install_flags,
+                  parallel_jobs, env_variables, etc.). Empty dict if not present.
+        """
+        return self.config.get("rccl_tests_build_configuration", {})
 
     def validate_config(self):
         """

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -779,10 +779,17 @@ class TestExecutor:
         build_env_vars = cfg.get("env_variables", {})
 
         # Build the command: explicit build_command wins, otherwise install.sh + flags.
+        # build_command may be a shell string or an argv array (per schema). An argv
+        # array must run without a shell; a string runs through the shell. In both
+        # forms expand env vars / ~ for consistency with the other resolved paths.
         build_command = cfg.get("build_command")
         if build_command:
-            cmd = build_command
-            use_shell = True
+            if isinstance(build_command, (list, tuple)):
+                cmd = [_expand(arg) for arg in build_command]
+                use_shell = False
+            else:
+                cmd = _expand(build_command)
+                use_shell = True
         else:
             install_script = os.path.join(source_dir, cfg.get("install_script", "install.sh"))
             if not os.path.isfile(install_script):
@@ -2024,7 +2031,7 @@ class TestExecutor:
         ignore_regex = (
             ".*tuner_v.*|.*profiler_v.*|.*net_v.*|.*_deps.*|ext.*|"
             ".*coll_net.*|.*nvls.*|.*nvml.*|.*nvtx.*|test/|.*gtest.*|"
-            ".*gensrc/*|.*rccl-tests.*"
+            ".*gensrc.*|.*rccl-tests.*"
         )
 
         if self.args.verbose:

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -427,17 +427,20 @@ class TestExecutor:
         """
         Number of GPUs available on a node (lazy, detected once).
 
-        Returns 0 when the count cannot be determined, in which case callers
-        should fall back to defaults and skip GPU-count-based skipping.
+        Returns 0 when the count cannot be determined, in which case "auto"
+        sizing falls back to 8 GPUs/node and GPU-count-based skipping is disabled.
         """
         if not self._gpus_per_node_detected:
             self._gpus_per_node = self._detect_gpus_per_node()
             self._gpus_per_node_detected = True
-            if self.args.verbose:
-                if self._gpus_per_node:
+            if self._gpus_per_node:
+                if self.args.verbose:
                     print(f"Detected GPUs per node: {self._gpus_per_node}")
-                else:
-                    print("Could not detect GPU count; using defaults (no GPU-count skipping)")
+            else:
+                # Unconditional: silent fallback to 8 ranks on a smaller node is
+                # very hard to debug, so always surface the detection failure.
+                print("WARNING: could not detect GPU count; 'auto' sizing falls "
+                      "back to 8 GPUs/node and GPU-count skipping is disabled")
         return self._gpus_per_node
 
     def _detect_gpus_per_node(self):
@@ -800,8 +803,8 @@ class TestExecutor:
             # rccl-tests/install.sh parses args with getopt (short opts: hmt) and
             # parallelizes internally with -j$(nproc); it does NOT accept a -j flag.
             # It also ignores NCCL_HOME/RCCL_HOME/MPI_HOME from the environment, so
-            # the RCCL and MPI locations must be passed as explicit flags (only
-            # ROCM_PATH is read from the env).
+            # the RCCL and MPI locations must be passed as explicit flags (it does
+            # read ROCM_PATH and HIP_COMPILER from the env, but not those homes).
             if rccl_home and "--rccl_home" not in install_flags:
                 install_flags += ["--rccl_home", rccl_home]
             if rocm_path and "--rocm_home" not in install_flags:
@@ -994,18 +997,30 @@ class TestExecutor:
         # Use test_filter for all test types
         test_filter = test_config.get("test_filter", "*")
 
-        num_nodes = int(test_config.get("num_nodes", 1))
         # num_gpus / num_ranks support the literal "auto" (and num_gpus defaults to
         # "auto" when omitted): "auto" resolves to the detected GPUs per node so
-        # tests adapt to whatever hardware they run on.
+        # tests adapt to whatever hardware they run on. Bad/overridden values that
+        # bypass schema validation fail this single test rather than aborting the
+        # whole run.
         detected_gpus = self.gpus_per_node
-        num_gpus = self._resolve_gpu_count(test_config.get("num_gpus", "auto"), detected_gpus)
-        raw_ranks = test_config.get("num_ranks", 1)
-        if isinstance(raw_ranks, str) and raw_ranks.strip().lower() == "auto":
-            # All GPUs across all nodes
-            num_ranks = num_gpus * num_nodes
-        else:
-            num_ranks = int(raw_ranks)
+        try:
+            num_nodes = int(test_config.get("num_nodes", 1))
+            num_gpus = self._resolve_gpu_count(test_config.get("num_gpus", "auto"), detected_gpus)
+            raw_ranks = test_config.get("num_ranks", 1)
+            if isinstance(raw_ranks, str) and raw_ranks.strip().lower() == "auto":
+                # All GPUs across all nodes
+                num_ranks = num_gpus * num_nodes
+            else:
+                num_ranks = int(raw_ranks)
+        except (ValueError, TypeError) as e:
+            msg = f"Invalid num_nodes/num_gpus/num_ranks for test '{test_name}': {e}"
+            print(f"ERROR: {msg}")
+            return {
+                "name": test_name,
+                "result": TestResult.RESULT_FAILED.value,
+                "duration": 0,
+                "error": msg,
+            }
         timeout = test_config.get("timeout", 0)
         env_vars = test_config.get("env_variables", {})
 
@@ -1087,6 +1102,27 @@ class TestExecutor:
                     "result": TestResult.RESULT_SKIPPED.value,
                     "duration": 0,
                     "error": "mpirun not available"
+                }
+
+        # GPU-count skip: when the per-node GPU count is known, a test that needs
+        # more GPUs than the node provides is SKIPPED (not failed) so fixed-size
+        # tests can live in a shared config and self-skip on smaller nodes. For
+        # single-node tests the requirement is num_ranks; for multi-node it is the
+        # per-node rank count (num_gpus). Detection failure (detected_gpus == 0)
+        # disables this check. See README "Automatic skipping on insufficient GPUs".
+        if detected_gpus > 0:
+            gpus_needed = num_ranks if num_nodes <= 1 else num_gpus
+            if gpus_needed > detected_gpus:
+                msg = (
+                    f"SKIP: test needs {gpus_needed} GPU(s)/node, "
+                    f"node has {detected_gpus}"
+                )
+                print(msg)
+                return {
+                    "name": test_name,
+                    "result": TestResult.RESULT_SKIPPED.value,
+                    "duration": 0,
+                    "error": msg,
                 }
 
         # Multi-node tests: skip if hostfile / SLURM provides fewer hosts than required

--- a/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
+++ b/projects/rccl/tools/scripts/test_runner/lib/test_executor.py
@@ -7,11 +7,13 @@ Test Executor Module
 Handles test execution, build processes, and result tracking
 """
 
+import glob
 import json
 import os
 import re
 import shlex
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -21,6 +23,13 @@ import copy
 import xml.etree.ElementTree as ET
 from enum import IntEnum, Enum
 from pathlib import Path
+
+# Bash-style env-var expander (supports ${VAR:-default}); shared with the config
+# processor so binary/path resolution honors the same syntax used elsewhere.
+try:
+    from lib.test_config import expand_env_vars
+except ImportError:
+    from test_config import expand_env_vars
 
 # Make stdout unbuffered to prevent output ordering issues with subprocesses
 sys.stdout.reconfigure(line_buffering=True)
@@ -261,6 +270,7 @@ class TestExecutor:
                 available = list(system_env.keys()) if isinstance(system_env, dict) else []
                 print(f"WARNING: No system_env_variables for '{system}'. Available: {available}")
         self.build_config = config_processor.get_build_config()
+        self.rccl_tests_build_config = config_processor.get_rccl_tests_build_config()
 
         # Setup directories
         self.setup_directories()
@@ -275,6 +285,10 @@ class TestExecutor:
 
         # Detect MPI hosts: auto-detect from SLURM if "auto_detect_hosts" is true in config, otherwise use hostfile
         self.mpi_hosts = self._detect_mpi_hosts()
+
+        # GPUs-per-node is detected lazily on first use (see gpus_per_node property)
+        self._gpus_per_node = 0
+        self._gpus_per_node_detected = False
 
         # Test tracking
         self.test_results = []
@@ -408,6 +422,68 @@ class TestExecutor:
 
         return {}
 
+    @property
+    def gpus_per_node(self):
+        """
+        Number of GPUs available on a node (lazy, detected once).
+
+        Returns 0 when the count cannot be determined, in which case callers
+        should fall back to defaults and skip GPU-count-based skipping.
+        """
+        if not self._gpus_per_node_detected:
+            self._gpus_per_node = self._detect_gpus_per_node()
+            self._gpus_per_node_detected = True
+            if self.args.verbose:
+                if self._gpus_per_node:
+                    print(f"Detected GPUs per node: {self._gpus_per_node}")
+                else:
+                    print("Could not detect GPU count; using defaults (no GPU-count skipping)")
+        return self._gpus_per_node
+
+    def _detect_gpus_per_node(self):
+        """
+        Detect the number of GPUs usable on a node.
+
+        Priority:
+          1. RCCL_TEST_GPUS_PER_NODE env override
+          2. Visible-device masks (HIP/ROCR/CUDA_VISIBLE_DEVICES)
+          3. rocminfo GPU agent count
+
+        Returns:
+            int: GPU count, or 0 if it cannot be determined.
+        """
+        override = os.environ.get('RCCL_TEST_GPUS_PER_NODE', '').strip()
+        if override.isdigit() and int(override) > 0:
+            return int(override)
+
+        for var in ('HIP_VISIBLE_DEVICES', 'ROCR_VISIBLE_DEVICES', 'CUDA_VISIBLE_DEVICES'):
+            mask = os.environ.get(var)
+            if mask:
+                ids = [tok for tok in mask.split(',') if tok.strip() != '']
+                if ids:
+                    return len(ids)
+
+        rocm_path = self.paths.get('rocm_path', '/opt/rocm')
+        rocminfo = os.path.join(rocm_path, 'bin', 'rocminfo')
+        if not os.path.isfile(rocminfo):
+            rocminfo = shutil.which('rocminfo')
+        if rocminfo:
+            try:
+                result = subprocess.run(
+                    [rocminfo], capture_output=True, text=True, timeout=15
+                )
+                if result.returncode == 0:
+                    count = sum(
+                        1 for line in result.stdout.splitlines()
+                        if 'Device Type:' in line and 'GPU' in line
+                    )
+                    if count > 0:
+                        return count
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+                pass
+
+        return 0
+
     def check_environment(self):
         """
         Check that required environment and tools are available
@@ -418,7 +494,7 @@ class TestExecutor:
         errors = []
 
         # Check ROCm
-        rocm_path = self.paths.get("rocm_path", "/opt/rocm")
+        rocm_path = self._rocm_root()
         if not os.path.isdir(rocm_path):
             errors.append(f"ROCm not found at {rocm_path}")
 
@@ -533,7 +609,7 @@ class TestExecutor:
         print("="*80)
 
         workdir = self.paths.get("workdir", os.getcwd())
-        rocm_path = self.paths.get("rocm_path", "/opt/rocm")
+        rocm_path = self._rocm_root()
         mpi_path = self.paths.get("mpi_path", "")
 
         install_flags = list(self.build_config.get("install_flags", []))
@@ -635,6 +711,142 @@ class TestExecutor:
             print(f"ERROR: Build failed with exception: {e}")
             return False
 
+    def build_rccl_tests(self):
+        """
+        Build rccl-tests (the perf binaries: all_reduce_perf, all_gather_perf, ...)
+        using its own build system, mirroring build_rccl().
+
+        The rccl_tests_build_configuration in the JSON config specifies:
+        - enabled:        Set to false to skip this step entirely (default true if the
+                          section is present; absent section => skipped).
+        - source_dir:     Path to the rccl-tests checkout (env vars/~ expanded).
+        - install_script: Build script relative to source_dir (default "install.sh").
+        - install_flags:  List of flags passed to the build script (e.g. ["--mpi"]).
+        - build_command:  Optional full shell command that overrides install_script/
+                          install_flags (run with cwd=source_dir).
+        - rccl_home:      Path to the RCCL install/build to link against. Defaults to
+                          the RCCL build_dir produced by build_rccl(). Exported as both
+                          NCCL_HOME and RCCL_HOME for the build.
+        - env_variables:  Extra environment variables to set during the build.
+
+        Returns:
+            bool: True if the build succeeded or was intentionally skipped.
+        """
+        cfg = self.rccl_tests_build_config
+
+        # No section => nothing to build (backward compatible with existing configs).
+        if not cfg:
+            return True
+
+        if not cfg.get("enabled", True):
+            if self.args.verbose:
+                print("SKIP: rccl-tests build disabled (rccl_tests_build_configuration.enabled=false)")
+            return True
+
+        if self.args.no_build:
+            if self.args.verbose:
+                print("SKIP: rccl-tests build skipped (--no-build)")
+            return True
+
+        print("="*80)
+        print("BUILDING rccl-tests")
+        print("="*80)
+
+        workdir = self.paths.get("workdir", os.getcwd())
+        rocm_path = self._rocm_root()
+        mpi_path = self.paths.get("mpi_path", "")
+
+        # Use the bash-aware expander so ${VAR:-default} (e.g. the computed
+        # RCCL_TESTS_DIR with a fallback) resolves; os.path.expandvars cannot
+        # handle the ":-" default syntax and would leave the path literal.
+        def _expand(p):
+            return os.path.expanduser(expand_env_vars(str(p)))
+
+        source_dir = _expand(cfg.get("source_dir", os.path.join(workdir, "rccl-tests")))
+        if not os.path.isdir(source_dir):
+            print(f"ERROR: rccl-tests source directory not found: {source_dir}")
+            print("       Set rccl_tests_build_configuration.source_dir or the "
+                  "RCCL_TESTS_DIR environment variable.")
+            return False
+
+        # RCCL to link against: explicit rccl_home, else the RCCL build_dir we built.
+        rccl_home = _expand(cfg.get("rccl_home", self.build_dir))
+
+        # Expand env vars / ~ in each flag so values like
+        # "--hip_compiler ${HIP_COMPILER:-$HOME/.local/llvm/bin/amdclang++}"
+        # resolve before being passed to install.sh (argv is not shell-expanded).
+        install_flags = [_expand(f) for f in cfg.get("install_flags", [])]
+        build_env_vars = cfg.get("env_variables", {})
+
+        # Build the command: explicit build_command wins, otherwise install.sh + flags.
+        build_command = cfg.get("build_command")
+        if build_command:
+            cmd = build_command
+            use_shell = True
+        else:
+            install_script = os.path.join(source_dir, cfg.get("install_script", "install.sh"))
+            if not os.path.isfile(install_script):
+                print(f"ERROR: rccl-tests build script not found: {install_script}")
+                print("       Provide rccl_tests_build_configuration.build_command or "
+                      "install_script.")
+                return False
+            # rccl-tests/install.sh parses args with getopt (short opts: hmt) and
+            # parallelizes internally with -j$(nproc); it does NOT accept a -j flag.
+            # It also ignores NCCL_HOME/RCCL_HOME/MPI_HOME from the environment, so
+            # the RCCL and MPI locations must be passed as explicit flags (only
+            # ROCM_PATH is read from the env).
+            if rccl_home and "--rccl_home" not in install_flags:
+                install_flags += ["--rccl_home", rccl_home]
+            if rocm_path and "--rocm_home" not in install_flags:
+                install_flags += ["--rocm_home", rocm_path]
+            mpi_requested = any(f in ("--mpi", "-m") for f in install_flags)
+            if mpi_requested and mpi_path and "--mpi_home" not in install_flags:
+                install_flags += ["--mpi_home", mpi_path]
+            cmd = [install_script] + install_flags
+            use_shell = False
+
+        # Setup environment: point rccl-tests at the RCCL we just built.
+        env = os.environ.copy()
+        env['ROCM_PATH'] = rocm_path
+        if mpi_path:
+            env['MPI_PATH'] = mpi_path
+            env['MPI_HOME'] = mpi_path
+        env['NCCL_HOME'] = rccl_home
+        env['RCCL_HOME'] = rccl_home
+        for key, value in build_env_vars.items():
+            env[key] = str(value)
+
+        if self.args.verbose:
+            print(f"Source directory: {source_dir}")
+            print(f"ROCm path:        {rocm_path}")
+            print(f"MPI path:         {mpi_path}")
+            print(f"RCCL home:        {rccl_home}")
+            print(f"Command:          {cmd if use_shell else ' '.join(cmd)}")
+            if build_env_vars:
+                print("Build environment variables:")
+                for key, value in build_env_vars.items():
+                    print(f"  {key}={value}")
+
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=source_dir,
+                env=env,
+                shell=use_shell,
+                capture_output=False
+            )
+
+            if result.returncode != 0:
+                print("ERROR: rccl-tests build failed")
+                return False
+
+            print("rccl-tests build completed successfully")
+            return True
+
+        except Exception as e:
+            print(f"ERROR: rccl-tests build failed with exception: {e}")
+            return False
+
     def _resolve_binary_path(self, binary, test_config):
         """
         Resolve the test binary path using multiple strategies:
@@ -652,7 +864,7 @@ class TestExecutor:
         """
         # Strategy 1: Check if binary is already an absolute path
         if os.path.isabs(binary):
-            expanded_path = os.path.expandvars(binary)
+            expanded_path = expand_env_vars(binary)
             resolved = os.path.expanduser(expanded_path)
             if self.args.verbose:
                 print(f"  Binary resolved via absolute path: {resolved}")
@@ -660,7 +872,7 @@ class TestExecutor:
 
         # Strategy 2: Expand environment variables in binary path
         if '$' in binary or '~' in binary:
-            expanded_path = os.path.expandvars(binary)
+            expanded_path = expand_env_vars(binary)
             expanded_path = os.path.expanduser(expanded_path)
             # If after expansion it becomes absolute, use it
             if os.path.isabs(expanded_path):
@@ -674,7 +886,7 @@ class TestExecutor:
         test_binary_dir = test_config.get("test_binary_dir", "")
         if test_binary_dir:
             # Expand environment variables in test_binary_dir
-            test_binary_dir = os.path.expandvars(test_binary_dir)
+            test_binary_dir = expand_env_vars(test_binary_dir)
             test_binary_dir = os.path.expanduser(test_binary_dir)
             resolved = os.path.join(test_binary_dir, binary)
             if self.args.verbose:
@@ -685,7 +897,7 @@ class TestExecutor:
         if "test_binary_dir" in self.paths:
             test_binary_dir = self.paths["test_binary_dir"]
             # Expand environment variables in test_binary_dir
-            test_binary_dir = os.path.expandvars(test_binary_dir)
+            test_binary_dir = expand_env_vars(test_binary_dir)
             test_binary_dir = os.path.expanduser(test_binary_dir)
             resolved = os.path.join(test_binary_dir, binary)
             if self.args.verbose:
@@ -697,6 +909,64 @@ class TestExecutor:
         if self.args.verbose:
             print(f"  Binary resolved via default build_dir/test: {resolved}")
         return resolved
+
+    def _terminate_process_group(self, proc):
+        """Tear down the entire process group of ``proc`` (SIGTERM, then SIGKILL).
+
+        Tests are launched with ``start_new_session=True`` so the shell, mpirun,
+        orted and all spawned ranks share one process group (pgid == proc.pid).
+        Signalling the group -- rather than just ``proc`` -- guarantees a timed-out
+        or interrupted MPI job does not leave orphaned ranks holding the GPUs.
+        """
+        try:
+            pgid = os.getpgid(proc.pid)
+        except (ProcessLookupError, OSError):
+            return  # already gone
+
+        for sig in (signal.SIGTERM, signal.SIGKILL):
+            try:
+                os.killpg(pgid, sig)
+            except (ProcessLookupError, OSError):
+                return  # group already gone
+            try:
+                # Give the group a short grace period to exit on SIGTERM before
+                # escalating to SIGKILL.
+                proc.wait(timeout=10)
+                return
+            except subprocess.TimeoutExpired:
+                continue
+        # Reap to avoid a zombie even if it ignored SIGKILL (should not happen).
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+
+    @staticmethod
+    def _normalize_mpi_args(value):
+        """
+        Normalize an "mpi_args" config value into a single argument string.
+
+        Accepts a string (returned trimmed) or a list of strings (joined with
+        spaces). Returns "" for None/empty values so callers can skip it.
+        """
+        if value is None:
+            return ""
+        if isinstance(value, (list, tuple)):
+            return " ".join(str(item).strip() for item in value if str(item).strip())
+        return str(value).strip()
+
+    @staticmethod
+    def _resolve_gpu_count(value, detected):
+        """
+        Resolve a num_gpus value into a concrete integer.
+
+        "auto" (or None) resolves to the detected GPU count, or 8 when detection
+        failed (detected == 0), preserving the historical default. Numeric values
+        are returned as-is.
+        """
+        if value is None or (isinstance(value, str) and value.strip().lower() == "auto"):
+            return detected if detected else 8
+        return int(value)
 
     def run_test(self, test_config, suite_config):
         """
@@ -717,14 +987,28 @@ class TestExecutor:
         # Use test_filter for all test types
         test_filter = test_config.get("test_filter", "*")
 
-        num_ranks = test_config.get("num_ranks", 1)
-        num_nodes = test_config.get("num_nodes", 1)
-        num_gpus = test_config.get("num_gpus", 8)  # GPUs per node (default: 8)
+        num_nodes = int(test_config.get("num_nodes", 1))
+        # num_gpus / num_ranks support the literal "auto" (and num_gpus defaults to
+        # "auto" when omitted): "auto" resolves to the detected GPUs per node so
+        # tests adapt to whatever hardware they run on.
+        detected_gpus = self.gpus_per_node
+        num_gpus = self._resolve_gpu_count(test_config.get("num_gpus", "auto"), detected_gpus)
+        raw_ranks = test_config.get("num_ranks", 1)
+        if isinstance(raw_ranks, str) and raw_ranks.strip().lower() == "auto":
+            # All GPUs across all nodes
+            num_ranks = num_gpus * num_nodes
+        else:
+            num_ranks = int(raw_ranks)
         timeout = test_config.get("timeout", 0)
         env_vars = test_config.get("env_variables", {})
 
-        # Support custom command arguments for non-gtest or specialized tests
-        custom_args = test_config.get("command_args", "")
+        # Support custom command arguments for non-gtest or specialized tests.
+        # The suite-level "command_args" is a shared base; a test's own
+        # "command_args" is appended to it, so a test can add flags
+        # (e.g. "-R 1 -G 2") without restating the shared base args.
+        base_args = suite_config.get("command_args", "")
+        test_args = test_config.get("command_args", "")
+        custom_args = f"{base_args} {test_args}".strip()
 
         # Merge environment variables
         merged_env = {
@@ -830,7 +1114,7 @@ class TestExecutor:
         # LD_LIBRARY_PATH from the JSON config is consumed here (not in the
         # merged_env loop below) so that build_dir always stays first.
         mpi_path  = self.paths.get("mpi_path", "")
-        rocm_path = self.paths.get("rocm_path", "/opt/rocm")
+        rocm_path = self._rocm_root()
 
         ld_library_path_parts = [self.build_dir]
         test_ld = merged_env.get('LD_LIBRARY_PATH')
@@ -861,6 +1145,13 @@ class TestExecutor:
             if key != 'LD_LIBRARY_PATH':
                 env[key] = str(value)
 
+        # Executable to invoke. Use the fully-resolved absolute path (not
+        # "./<binary>") so out-of-tree binaries work: gtest binaries live in
+        # cwd=<build_dir>/test, but rccl-tests perf binaries live under the
+        # rccl-tests build dir. test_binary_path was resolved above and verified
+        # to exist; shlex.quote handles any spaces.
+        exe = shlex.quote(test_binary_path)
+
         # Build command based on test type
         if num_ranks == 1:
             # Non-MPI test - prepend environment variables to the command.
@@ -875,16 +1166,16 @@ class TestExecutor:
             if is_gtest:
                 # GTest-based test - use --gtest_filter syntax
                 if test_filter == "ALL" or test_filter == "*":
-                    cmd = f"{env_prefix}./{binary}"
+                    cmd = f"{env_prefix}{exe}"
                 else:
-                    cmd = f"{env_prefix}./{binary} --gtest_filter={test_filter}"
+                    cmd = f"{env_prefix}{exe} --gtest_filter={test_filter}"
 
                 # Add custom arguments if provided
                 if custom_args:
                     cmd += f" {custom_args}"
             else:
                 # Non-gtest test (perf, custom, etc.) - run binary with args
-                cmd = f"{env_prefix}./{binary}"
+                cmd = f"{env_prefix}{exe}"
                 if custom_args:
                     cmd += f" {custom_args}"
 
@@ -915,21 +1206,32 @@ class TestExecutor:
                 host_arg = ""
                 map_by_arg = ""
 
-            # MCA params priority: --system profile lookup > test-level "mpi_args" string > default
+            # Resolve the mpirun/MCA arguments. Each "mpi_args" value may be a
+            # string or a list of strings (lists are joined with spaces).
+            #
+            # The BASE set replaces the built-in defaults, with this priority:
+            #   1. top-level "mpi_args" dict entry for the active --system
+            #   2. top-level "mpi_args" string/list (applies to all systems)
+            #   3. built-in default_args
+            #
+            # Suite-level and test-level "mpi_args" are then APPENDED on top of
+            # the base, so they add flags regardless of --system.
             default_mca = self.mpi_config["default_args"]
             system = getattr(self.args, 'system', '') or ''
-            mpi_args_config = self.config_processor.config.get("mpi_args", {})
+            top_level_config = self.config_processor.config.get("mpi_args", "")
 
-            if system:
-                if isinstance(mpi_args_config, dict) and system in mpi_args_config:
-                    mca_params = mpi_args_config[system]
-                else:
-                    mca_params = default_mca
-            elif isinstance(mpi_args_config, str) and mpi_args_config:
-                mca_params = mpi_args_config
+            if isinstance(top_level_config, dict):
+                base_args = self._normalize_mpi_args(top_level_config.get(system)) if system else ""
             else:
-                config_mpi_args = test_config.get("mpi_args", "")
-                mca_params = config_mpi_args if config_mpi_args else default_mca
+                base_args = self._normalize_mpi_args(top_level_config)
+
+            if not base_args:
+                base_args = default_mca
+
+            suite_args = self._normalize_mpi_args(suite_config.get("mpi_args"))
+            test_args = self._normalize_mpi_args(test_config.get("mpi_args"))
+
+            mca_params = " ".join(p for p in (base_args, suite_args, test_args) if p)
 
             mpi_args = (
                 f"-np {num_ranks} "
@@ -959,15 +1261,15 @@ class TestExecutor:
             if is_gtest:
                 # GTest-based test - use --gtest_filter syntax
                 if test_filter == "ALL" or test_filter == "*":
-                    cmd = f"{mpi_cmd} {mpi_args} ./{binary}"
+                    cmd = f"{mpi_cmd} {mpi_args} {exe}"
                 else:
-                    cmd = f"{mpi_cmd} {mpi_args} ./{binary} --gtest_filter={test_filter}"
+                    cmd = f"{mpi_cmd} {mpi_args} {exe} --gtest_filter={test_filter}"
 
                 if custom_args:
                     cmd += f" {custom_args}"
             else:
                 # Non-gtest test (perf, custom, etc.) - run binary with args
-                cmd = f"{mpi_cmd} {mpi_args} ./{binary}"
+                cmd = f"{mpi_cmd} {mpi_args} {exe}"
                 if custom_args:
                     cmd += f" {custom_args}"
 
@@ -987,37 +1289,43 @@ class TestExecutor:
 
         # Inherit stdout/stderr (no PIPE capture). For gtest, --gtest_output=json:…
         # (temp file, removed in finally) supplies reliable SKIPPED vs PASSED on exit 0.
+        #
+        # Launch the test in its own session (start_new_session=True) so the
+        # shell AND every descendant -- mpirun, orted, and the spawned ranks /
+        # perf binaries -- share a single process group we can signal as a unit.
+        # subprocess.run(timeout=...) only SIGKILLs the immediate /bin/sh child,
+        # leaving mpirun and all of its ranks running (and holding the GPUs),
+        # which is exactly the orphaned-process behaviour seen on timeout.
         start_time = time.time()
-        run_kwargs = {
-            "shell": True,
-            "cwd": os.path.join(self.build_dir, "test"),
-            "env": env,
-            "capture_output": False,
-        }
-        if timeout > 0:
-            run_kwargs["timeout"] = timeout
+        proc = subprocess.Popen(
+            cmd,
+            shell=True,
+            cwd=os.path.join(self.build_dir, "test"),
+            env=env,
+            start_new_session=True,
+        )
         try:
             try:
-                result = subprocess.run(cmd, **run_kwargs)
-            except subprocess.TimeoutExpired as e:
+                returncode = proc.wait(timeout=timeout if timeout > 0 else None)
+            except subprocess.TimeoutExpired:
                 duration = time.time() - start_time
-                parts = []
-                if getattr(e, "stdout", None):
-                    parts.append(e.stdout)
-                if getattr(e, "stderr", None):
-                    parts.append(e.stderr)
-                combined = "".join(parts)
-                if combined:
-                    print(combined, end="" if combined.endswith("\n") else "\n")
                 print(f"\n  Result: {TestResult.RESULT_TIMEOUT.value} after {timeout} seconds")
+                print("  Killing process group (mpirun and all ranks)...")
+                self._terminate_process_group(proc)
                 return {
                     "name": test_name,
                     "result": TestResult.RESULT_TIMEOUT.value,
                     "duration": duration,
                     "error": f"Test timed out after {timeout} seconds",
                 }
+            except KeyboardInterrupt:
+                # Make sure Ctrl-C tears down the whole MPI job, not just the shell.
+                print("\n  Interrupted -- killing process group (mpirun and all ranks)...")
+                self._terminate_process_group(proc)
+                raise
             except Exception as e:
                 duration = time.time() - start_time
+                self._terminate_process_group(proc)
                 print(f"\n  ERROR: {e}")
                 return {
                     "name": test_name,
@@ -1029,12 +1337,12 @@ class TestExecutor:
             duration = time.time() - start_time
 
             if is_gtest:
-                rc = result.returncode if result.returncode is not None else -1
+                rc = returncode if returncode is not None else -1
                 test_result = infer_gtest_result_from_json_file(gtest_json_path or "", rc)
             else:
-                if result.returncode == ExitCode.EXIT_SUCCESS:
+                if returncode == ExitCode.EXIT_SUCCESS:
                     test_result = TestResult.RESULT_PASSED.value
-                elif result.returncode == ExitCode.EXIT_TIMEOUT:
+                elif returncode == ExitCode.EXIT_TIMEOUT:
                     test_result = TestResult.RESULT_TIMEOUT.value
                 else:
                     test_result = TestResult.RESULT_FAILED.value
@@ -1045,7 +1353,7 @@ class TestExecutor:
                 "name": test_name,
                 "result": test_result,
                 "duration": duration,
-                "exit_code": int(result.returncode) if result.returncode is not None else -1,
+                "exit_code": int(returncode) if returncode is not None else -1,
             }
         finally:
             if gtest_json_path:
@@ -1153,7 +1461,7 @@ class TestExecutor:
         # from the JSON env (mirrors the gtest/MPI path), then rocm/mpi libs.
         # RCCL_BUILD defaults to build_dir; remaining config env is applied as-is.
         env = os.environ.copy()
-        rocm_path = self.paths.get("rocm_path", "/opt/rocm")
+        rocm_path = self._rocm_root()
         mpi_path = self.paths.get("mpi_path", "")
         test_ld = merged_env.get("LD_LIBRARY_PATH")
         ld_parts = [self.build_dir]
@@ -1273,9 +1581,11 @@ class TestExecutor:
                 skipped_count += 1
                 continue
 
-            # Skip MPI tests when --skip-mpi-check is set
+            # Skip MPI tests when --skip-mpi-check is set ("auto" implies multi-rank)
             test_ranks = test.get("num_ranks", suite_config.get("num_ranks", 1))
-            if self.args.skip_mpi_check and test_ranks > 1:
+            is_auto_ranks = isinstance(test_ranks, str) and test_ranks.strip().lower() == "auto"
+            is_mpi_test = is_auto_ranks or (not isinstance(test_ranks, str) and test_ranks > 1)
+            if self.args.skip_mpi_check and is_mpi_test:
                 skipped_count += 1
                 if self.args.verbose:
                     print(f"  SKIP: '{test_name}' requires {test_ranks} ranks (--skip-mpi-check)")
@@ -1433,6 +1743,124 @@ class TestExecutor:
             print(f"Total Time:    {self._format_duration(rerun_time_seconds)}")
             print("="*120)
 
+    def _rccl_tests_build_dir(self):
+        """Resolve the rccl-tests build directory (``<source_dir>/build``).
+
+        Mirrors the path logic in ``build_rccl_tests`` so coverage discovery and
+        the build use the same location. Env vars and ``~`` are expanded with the
+        bash-aware expander (``${VAR:-default}`` support). Returns None when
+        rccl-tests is not configured.
+        """
+        cfg = self.rccl_tests_build_config
+        if not cfg:
+            return None
+        workdir = self.paths.get("workdir", os.getcwd())
+        source_dir = cfg.get("source_dir", os.path.join(workdir, "rccl-tests"))
+        source_dir = os.path.expanduser(expand_env_vars(str(source_dir)))
+        return os.path.join(source_dir, "build")
+
+    # LLVM tool layout under a ROCm root, most-specific first.
+    _LLVM_BIN_SUBDIRS = (("lib", "llvm", "bin"), ("llvm", "bin"), ("bin",))
+
+    def _candidate_rocm_roots(self):
+        """Ordered, de-duplicated list of ROCm roots to consider, most-trusted first.
+
+        A `module load rocm/...` sets ROCM_PATH/HIP_PATH to a versioned tree
+        (e.g. /cluster/.../rocm-7.13.0...) and puts its compiler on PATH, while the
+        configured rocm_path may still be the bare ${ROCM_PATH:-/opt/rocm} default.
+        """
+        roots = []
+
+        def add(root):
+            if root:
+                root = os.path.normpath(root)
+                if root not in roots:
+                    roots.append(root)
+
+        # 1. Explicitly configured rocm_path (paths.rocm_path / --rocm_home).
+        add(self.paths.get("rocm_path"))
+        # 2. The loaded module's environment.
+        for env_var in ("ROCM_PATH", "ROCM_HOME", "HIP_PATH"):
+            add(os.environ.get(env_var))
+        # 3. The root inferred from a ROCm compiler/tool on PATH. The module may add
+        #    <root>/bin or <root>/lib/llvm/bin to PATH; map either back to <root>.
+        for binname in ("amdclang++", "hipcc", "rocminfo", "rocm_agent_enumerator"):
+            binpath = shutil.which(binname)
+            if not binpath:
+                continue
+            bindir = os.path.dirname(os.path.realpath(binpath))
+            add(os.path.dirname(bindir))  # <root>/bin -> <root>
+            add(os.path.dirname(os.path.dirname(os.path.dirname(bindir))))  # <root>/lib/llvm/bin -> <root>
+        # 4. Last-resort default.
+        add("/opt/rocm")
+        return roots
+
+    def _rocm_root(self):
+        """Single source of truth for the ROCm toolchain root, shared by build, test,
+        and coverage so all three phases use an identical toolchain.
+
+        The build compiles RCCL with <root>/.../amdclang++ and coverage MUST read the
+        profraw files with the matching <root>/lib/llvm/bin/llvm-profdata, so the same
+        root has to drive every phase. A root is preferred only if it actually contains
+        the LLVM toolchain (llvm-profdata present); this lets a stale `/opt/rocm`
+        default yield to the loaded module. Cached after first resolution.
+        """
+        cached = getattr(self, "_rocm_root_cache", None)
+        if cached:
+            return cached
+
+        candidates = self._candidate_rocm_roots()
+
+        def has_llvm_toolchain(root):
+            return any(os.path.isfile(os.path.join(root, *sub, "llvm-profdata"))
+                       for sub in self._LLVM_BIN_SUBDIRS)
+
+        # Prefer the first root with a complete LLVM toolchain (matches the compiler
+        # and provides the coverage tools); otherwise the first existing directory.
+        chosen = next((r for r in candidates if has_llvm_toolchain(r)), None)
+        if chosen is None:
+            chosen = next((r for r in candidates if os.path.isdir(r)), None)
+        if chosen is None:
+            chosen = self.paths.get("rocm_path") or "/opt/rocm"
+
+        self._rocm_root_cache = chosen
+        if getattr(self.args, "verbose", False):
+            print(f"Resolved ROCm toolchain root: {chosen}")
+        return chosen
+
+    def _resolve_llvm_tool(self, name):
+        """Resolve an LLVM tool (e.g. llvm-profdata, llvm-cov) from the SAME ROCm root
+        used to build and run, so the profile format matches the compiler.
+
+        Order:
+          1. Explicit config override in self.paths (key == tool name).
+          2. The resolved ROCm root (_rocm_root) — preferred over a bare PATH hit so a
+             different LLVM on PATH cannot shadow the build's toolchain.
+          3. PATH lookup via shutil.which as a final fallback.
+        Raises FileNotFoundError with a clear, searched-path message if not found.
+        """
+        override = self.paths.get(name)
+        if override and os.path.isfile(override):
+            return override
+
+        searched = []
+        rocm_root = self._rocm_root()
+        for sub in self._LLVM_BIN_SUBDIRS:
+            candidate = os.path.join(rocm_root, *sub, name)
+            searched.append(candidate)
+            if os.path.isfile(candidate):
+                return candidate
+
+        found = shutil.which(name)
+        if found:
+            return found
+
+        raise FileNotFoundError(
+            f"{name} not found under the resolved ROCm root ({rocm_root}) or on PATH. "
+            f"Searched: {', '.join(searched)}. "
+            f"Load a ROCm module or set rocm_path/--rocm_home."
+        )
+
     def generate_coverage_report(self):
         """Generate code coverage report.
 
@@ -1453,14 +1881,28 @@ class TestExecutor:
         import glob
         import shutil
 
-        # Tests run with cwd=<build_dir>/test, so profraw files are written
-        # there. A recursive glob also picks up any files written elsewhere
-        # under the build tree (e.g. by ad-hoc runs).
-        profraw_files = glob.glob(os.path.join(self.build_dir, "**/*.profraw"), recursive=True)
+        # Tests run with cwd=<build_dir>/test, so RCCL profraw files are written
+        # there. The rccl-tests perf binaries are instrumented separately and
+        # their profraw files live under the rccl-tests build tree, so search
+        # both roots. A recursive glob also picks up files written elsewhere
+        # under either tree (e.g. by ad-hoc runs).
+        profraw_search_roots = [self.build_dir]
+        rccl_tests_build_dir = self._rccl_tests_build_dir()
+        if rccl_tests_build_dir:
+            profraw_search_roots.append(rccl_tests_build_dir)
+
+        profraw_files = []
+        for root in profraw_search_roots:
+            profraw_files.extend(
+                glob.glob(os.path.join(root, "**/*.profraw"), recursive=True)
+            )
+        # De-duplicate in case the roots overlap or are nested.
+        profraw_files = sorted({os.path.abspath(p) for p in profraw_files})
 
         if not profraw_files:
-            print("ERROR: No .profraw files found under the build directory:")
-            print(f"           {self.build_dir}")
+            print("ERROR: No .profraw files found under the build directories:")
+            for root in profraw_search_roots:
+                print(f"           {root}")
             if self.args.skip_tests:
                 print()
                 print("--coverage-report --skip-tests was requested, so this run did")
@@ -1497,10 +1939,15 @@ class TestExecutor:
             for profraw in glob.glob(os.path.join(rawfiles_dir, "*.profraw")):
                 f.write(f"{profraw}\n")
 
-        # Get ROCm path for LLVM tools
-        rocm_path = self.paths.get("rocm_path", "/opt/rocm")
-        llvm_profdata = os.path.join(rocm_path, "lib", "llvm", "bin", "llvm-profdata")
-        llvm_cov = os.path.join(rocm_path, "lib", "llvm", "bin", "llvm-cov")
+        # Resolve LLVM tools from the same ROCm root used to build/run so the
+        # profraw format matches the compiler that produced it.
+        rocm_path = self._rocm_root()
+        try:
+            llvm_profdata = self._resolve_llvm_tool("llvm-profdata")
+            llvm_cov = self._resolve_llvm_tool("llvm-cov")
+        except FileNotFoundError as e:
+            print(f"ERROR: {e}")
+            return
 
         if self.args.verbose:
             print(f"ROCm path:      {rocm_path}")
@@ -1557,6 +2004,15 @@ class TestExecutor:
                 if self.args.verbose:
                     print(f"Found binary: {binary_path}")
 
+        # Add rccl-tests perf binaries so their host coverage mapping is attributed.
+        if rccl_tests_build_dir and os.path.isdir(rccl_tests_build_dir):
+            perf_binaries = sorted(glob.glob(os.path.join(rccl_tests_build_dir, "*_perf")))
+            for perf_binary in perf_binaries:
+                if os.path.isfile(perf_binary):
+                    object_files.extend(["--object", perf_binary])
+                    if self.args.verbose:
+                        print(f"Found perf binary: {perf_binary}")
+
         if not object_files:
             print("WARNING: No object files found for coverage report")
             return
@@ -1567,7 +2023,8 @@ class TestExecutor:
         # Ignore patterns for non-relevant files
         ignore_regex = (
             ".*tuner_v.*|.*profiler_v.*|.*net_v.*|.*_deps.*|ext.*|"
-            ".*coll_net.*|.*nvls.*|.*nvml.*|.*nvtx.*|test/|.*gtest.*"
+            ".*coll_net.*|.*nvls.*|.*nvml.*|.*nvtx.*|test/|.*gtest.*|"
+            ".*gensrc/*|.*rccl-tests.*"
         )
 
         if self.args.verbose:

--- a/projects/rccl/tools/scripts/test_runner/test_runner.py
+++ b/projects/rccl/tools/scripts/test_runner/test_runner.py
@@ -64,6 +64,13 @@ def main():
                 if args.verbose:
                     print("Exiting: RCCL build failed")
                 sys.exit(1)
+            # Build rccl-tests (perf binaries) if the config provides a
+            # rccl_tests_build_configuration section; no-op otherwise.
+            if not executor.build_rccl_tests():
+                print("ERROR: rccl-tests build failed")
+                if args.verbose:
+                    print("Exiting: rccl-tests build failed")
+                sys.exit(1)
         else:
                 print("SKIP: Build step skipped (--no-build)")
 


### PR DESCRIPTION
## Motivation

Bring RCCL performance testing (rccl-tests) into the test_runner framework so that a single RCCL build can drive a consolidated host + device coverage report on MI300X. Previously the perf binaries were not wired into the coverage configs, and there was no automated way to sweep the highest-impact RCCL environment variables or exercise the buffer-registration code paths as part of the standard test flow.

## Technical Details

- test_executor.py / test_config.py / schema.json:
  - Add build_rccl_tests() driven by a new rccl_tests_build_configuration section, wired into the run flow immediately after the RCCL build and skipped with --no-build.
  - Point rccl-tests at the freshly built RCCL via NCCL_HOME / RCCL_HOME.
  - Treat suite-level command_args as a base and append each test's command_args.
  - Fix path handling: compute RCCL_TESTS_DIR as the rccl-tests sibling root, invoke the resolved absolute binary, and bash-expand ${VAR:-default} (including nested defaults) when resolving build/source paths.
- mi300x_mellanox_ib_rccl_tests.json (new): Standalone config driving the rccl-tests perf binaries. Sweeps the highest-coverage RCCL env vars grouped by subsystem, and adds a DMABUF-enabled buffer-registration matrix (local/graph × legacy/cumem). Dump/debug artifacts are written to the test working dir instead of /tmp.
- mi300x_mellanox_ib.json: Merge the rccl-tests perf suites (all-datatype/op sweeps, registration matrix) into the main MI300X coverage config so one RCCL build feeds a single consolidated host + device coverage report.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

- Ran the test_runner against mi300x_mellanox_ib_rccl_tests.json on MI300X with Mellanox IB, exercising the env-var sweeps and the DMABUF buffer-registration matrix (local/graph × legacy/cumem).
- Ran the consolidated mi300x_mellanox_ib.json config end-to-end to confirm a single RCCL build produces one combined host + device coverage report.
- Verified --no-build correctly skips both the RCCL and rccl-tests builds.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
