### PR TITLE
[RCCL] Enable bias (acc) AllReduce on gfx1250

### DIFF
--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -373,7 +373,7 @@ def get_arch_guard(fn):
   elif fn.proto == "LL128":
       cond = "(defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__)) && defined(ENABLE_LL128)"
   elif fn.acc == "1":
-      cond = "defined(__gfx942__) || defined(__gfx950__)"
+      cond = "defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)"
 
   return cond
 

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -906,7 +906,7 @@ bool rcclIsArchSupportedForFunc(struct ncclTaskColl* info, const char* archName)
     supported = false;
 #endif
   } else if (info->acc) {
-    supported = (IsArchMatch(archName, "gfx942") || IsArchMatch(archName, "gfx950"));
+    supported = (IsArchMatch(archName, "gfx942") || IsArchMatch(archName, "gfx950") || IsArchMatch(archName, "gfx1250"));
   }
 
   return supported;


### PR DESCRIPTION
## Motivation

`all_reduce_bias_perf` fails on gfx1250 with: `ncclPrepareTasks: unsupported architecture (gfx1250) for collective AllReduce(RING, LL, Sum, ncclFloat32, Acc=1, Pipeline=0)`. The bias/accumulate (`Acc=1`) AllReduce path was only ever enabled for gfx942 and gfx950. On gfx1250 the host validator rejects the collective and the device kernels were never generated, so the test errors out with `ncclInvalidUsage`. This PR enables the bias AllReduce path on gfx1250.

## Technical Details

The accumulate path is gated by two guards that must stay in sync:
- **Device codegen** — `src/device/generate.py` `get_arch_guard()`: the non-LL128 `acc == "1"` case compiled the kernels only under  `defined(__gfx942__) || defined(__gfx950__)`.
- **Host validator** — `src/rccl_wrap.cc` `rcclIsArchSupportedForFunc()`: the `else if (info->acc)` branch only whitelisted `gfx942`/`gfx950`. Added `gfx1250` to both guards so the host check and the generated device function tables agree. The LL128 + acc guard is intentionally left unchanged (the failing test uses the LL protocol, and LL128 on gfx1250 is not yet validated).

## JIRA ID

AICOMRCCL-1263

## Test Plan

- Run `all_reduce_bias_perf -b 8 -e 1M -f 2 -g 4 -n 5 -w 1` on gfx1250.
- Confirm the run completes without `ncclInvalidUsage` and that all `#wrong` columns report `0` across the full size range.

## Test Result

Test passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
