### PR TITLE
[rocSHMEM] Add symmetric buffer registration APIs for the IPC backend

### DIFF
--- a/projects/rocshmem/CHANGELOG.md
+++ b/projects/rocshmem/CHANGELOG.md
@@ -8,6 +8,8 @@
    * `rocshmem_calloc`
    * `rocshmem_buffer_unregister_all`
    * `rocshmem_buffer_register/unregister` for GDA backend
+   * `rocshmem_buffer_register_symmetric` for IPC backend
+   * `rocshmem_buffer_unregister_symmetric` for IPC backend
    * `rocshmem_reduce_on_stream`
    * `rocshmem_team_split_2D`
 * Added tile-granular RMA operations for the IPC backend
@@ -54,6 +56,7 @@
   * `OVERRIDE_NIC_FIRMWARE_CHECK`
   * `ROCSHMEM_GDA_NUM_QPS_PER_PE_DEFAULT_CTX`
   * `ROCSHMEM_GDA_NUM_QPS_PER_PE_USR_CTX`
+  * `ROCSHMEM_MAX_SYMM_REGIONS`
 * Added VMM POSIX memory allocator (`USE_HEAP_DEVICE_VMM_POSIX`)
    * Uses HIP Virtual Memory Management (VMM) APIs for fine-grained memory control
    * Requires ROCm 7.0+ and Linux kernel 5.6+

--- a/projects/rocshmem/docs/api/memory_management.rst
+++ b/projects/rocshmem/docs/api/memory_management.rst
@@ -136,3 +136,55 @@ ROCSHMEM_BUFFER_UNREGISTER_ALL
 **Description:**
 Deregisters all buffers that were previously registered using
 `rocshmem_buffer_register`.
+
+ROCSHMEM_BUFFER_REGISTER_SYMMETRIC
+----------------------------------
+
+.. cpp:function:: __host__ void *rocshmem_buffer_register_symmetric(void *addr, size_t length);
+
+  :param addr:   Pointer to previously allocated VMM memory.
+  :param length: Length of ``addr`` in bytes.
+  :returns: The rocSHMEM-managed symmetric address on success, ``NULL``
+            otherwise.
+
+**Description:**
+Registers a user-allocated buffer so that it can be used as the remote target
+of RMA operations. Unlike :ref:`rocshmem_buffer_register`, this is a
+**collective** operation that must be called by all PEs with a buffer of the
+same ``length``.
+
+The call maps the user's buffer to a fresh rocSHMEM-managed virtual address and
+returns it. That returned address (**not** ``addr``) is the symmetric handle
+the caller must use as the target for RMA routines, and the same address must
+later be passed to :ref:`rocshmem_buffer_unregister_symmetric`.
+
+Notes:
+
+* This routine is currently restricted to memory allocated through the HIP
+  Virtual Memory Management (VMM) APIs (ROCm 7.0 or newer). Passing a non-VMM
+  pointer returns ``NULL``.
+* Each PE may supply a different underlying buffer, but all PEs must agree on
+  ``length`` and on the buffer's alignment so the region is symmetric across
+  the job.
+* The underlying buffer ranges must not overlap a region that is already
+  registered.
+
+ROCSHMEM_BUFFER_UNREGISTER_SYMMETRIC
+------------------------------------
+
+.. cpp:function:: __host__ int rocshmem_buffer_unregister_symmetric(void *addr);
+
+  :param addr:   The symmetric address returned by
+                 ``rocshmem_buffer_register_symmetric``.
+  :returns: ROCSHMEM_SUCCESS on success, ROCSHMEM_ERROR otherwise.
+
+**Description:**
+Deregisters a buffer that was previously registered using
+:ref:`rocshmem_buffer_register_symmetric`. This is a **collective** operation
+that must be called by all PEs that participated in the matching
+``rocshmem_buffer_register_symmetric`` call.
+
+The ``addr`` argument must be the rocSHMEM-managed symmetric address returned by
+``rocshmem_buffer_register_symmetric`` (not the caller's original buffer
+pointer). The call unmaps the rocSHMEM-managed virtual address; the user's
+original buffer is left untouched.

--- a/projects/rocshmem/docs/api/memory_management.rst
+++ b/projects/rocshmem/docs/api/memory_management.rst
@@ -153,7 +153,7 @@ of RMA operations. Unlike :ref:`rocshmem_buffer_register`, this is a
 **collective** operation that must be called by all PEs with a buffer of the
 same ``length``.
 
-The call maps the user's buffer to a fresh rocSHMEM-managed virtual address and
+The call maps the user's buffer to a rocSHMEM-managed virtual address and
 returns it. That returned address (**not** ``addr``) is the symmetric handle
 the caller must use as the target for RMA routines, and the same address must
 later be passed to :ref:`rocshmem_buffer_unregister_symmetric`.

--- a/projects/rocshmem/docs/api/memory_management.rst
+++ b/projects/rocshmem/docs/api/memory_management.rst
@@ -160,7 +160,7 @@ later be passed to :ref:`rocshmem_buffer_unregister_symmetric`.
 
 Notes:
 
-* This routine is currently restricted to memory allocated through the HIP
+* This routine is restricted to memory allocated through the HIP
   Virtual Memory Management (VMM) APIs (ROCm 7.0 or newer). Passing a non-VMM
   pointer returns ``NULL``.
 * Each PE may supply a different underlying buffer, but all PEs must agree on

--- a/projects/rocshmem/docs/env_variables.rst
+++ b/projects/rocshmem/docs/env_variables.rst
@@ -182,6 +182,15 @@ control the behavior of rocSHMEM.
       - ``4``
       - Maximum number of user buffer registrations for GDA
 
+    * - | ``ROCSHMEM_MAX_SYMM_REGIONS``
+        | rocSHMEM supports ``rocshmem_buffer_register_symmetric`` and
+        | ``rocshmem_buffer_unregister_symmetric`` for symmetric user buffers.
+        | This variable sets the maximum number of symmetric user buffers an
+        | application may register concurrently. It is backend-agnostic and is
+        | currently honored by the IPC backend.
+      - ``4``
+      - Maximum number of symmetric user buffer registrations
+
     * - | ``ROCSHMEM_MAX_WF_BUFFERS``
         | Maximum number of wavefront buffer arrays in default context (determines size of status, return, and atomic return buffers)
       - ``1024``

--- a/projects/rocshmem/examples/CMakeLists.txt
+++ b/projects/rocshmem/examples/CMakeLists.txt
@@ -51,7 +51,8 @@ set(EXAMPLE_SOURCES
 
 if (MPI_CXX_FOUND)
   list(APPEND EXAMPLE_SOURCES
-    rocshmem_init_attr_test.cc)
+    rocshmem_init_attr_test.cc
+    rocshmem_user_mem_symm_test.cc)
 
   add_subdirectory(LL_MoE)
 endif()

--- a/projects/rocshmem/examples/rocshmem_user_mem_symm_test.cc
+++ b/projects/rocshmem/examples/rocshmem_user_mem_symm_test.cc
@@ -1,0 +1,338 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+/*
+ * Symmetric user-buffer registration example.
+ *
+ * This mirrors rocshmem_user_mem_test.cc but exercises the *symmetric*
+ * registration APIs:
+ *
+ *   rocshmem_buffer_register_symmetric(addr, length)  -> rocSHMEM alias
+ *   rocshmem_buffer_unregister_symmetric(alias)
+ *
+ * Unlike rocshmem_buffer_register() (which registers a node-local buffer for
+ * use as the *local* side of an RMA), the symmetric variant registers a buffer
+ * so it can act as the *remote symmetric target* of RMA/collectives. The call
+ * is collective, must be passed the same length on every PE, and returns a
+ * rocSHMEM-managed virtual address (the "alias"). That returned address
+ * -- not the original buffer pointer -- is what you use as the symmetric
+ * object and what you must pass to rocshmem_buffer_unregister_symmetric().
+ *
+ * The buffer handed to the symmetric API must be HIP VMM device memory, so the
+ * example skips cleanly when either prerequisite is not met:
+ *   - The GPU supports HIP virtual memory management (queried at runtime via
+ *     hipDeviceAttributeVirtualMemoryManagementSupported).
+ *   - rocshmem_buffer_register_symmetric() returns a non-null address. A null
+ *     return simply means the current rocSHMEM build/backend does not support
+ *     symmetric registration yet.
+ *
+ * The VMM allocation below uses hipMemHandleTypePosixFileDescriptor for the
+ * requested handle type, which is the common single-node configuration.
+ *
+ * HIP VMM symmetric heaps are not compatible with MPI-*based* rocSHMEM
+ * initialization, so this example initializes via rocshmem_init_attr() over
+ * the UNIQUEID path (see rocshmem_init_attr_test.cc). MPI is used only to
+ * bootstrap and broadcast the unique id, not to initialize rocSHMEM.
+ *
+ * To run (single node):
+ *   mpirun -np 2 -x ROCSHMEM_MAX_NUM_CONTEXTS=2 ./rocshmem_user_mem_symm_test
+ */
+
+#include <rocshmem/rocshmem.hpp>
+#include <mpi.h>
+
+#include "util.h"
+
+using namespace rocshmem;
+
+__global__ void user_mem_symm_test(int *source, int *dest, size_t nelem,
+                                   rocshmem_team_t team) {
+  __shared__ rocshmem_ctx_t ctx;
+  int64_t ctx_type = 0;
+
+  rocshmem_wg_ctx_create(ctx_type, &ctx);
+
+  rocshmem_ctx_int_alltoall_wg(ctx, team, dest, source, nelem);
+
+  rocshmem_ctx_quiet(ctx);
+  __syncthreads();
+
+  rocshmem_wg_ctx_destroy(&ctx);
+}
+
+static void init_sendbuf(int *source, int nelem, int my_pe, int npes) {
+  for (int pe = 0; pe < npes; pe++) {
+    for (int i = 0; i < nelem; i++) {
+      int idx = (pe * nelem) + i;
+      source[idx] = my_pe + pe;
+    }
+  }
+}
+
+static bool check_recvbuf(int *dest, int nelem, int my_pe, int npes) {
+  bool res = true;
+
+  for (int pe = 0; pe < npes; pe++) {
+    for (int i = 0; i < nelem; i++) {
+      int idx = (pe * nelem) + i;
+      int result = my_pe + pe;
+      if (dest[idx] != result) {
+        res = false;
+#ifdef VERBOSE
+        printf("recvbuf[%d] = %d expected %d \n", i, dest[i], result);
+#endif
+      }
+    }
+  }
+
+  return res;
+}
+
+/* Query whether the GPU supports HIP virtual memory management. */
+static bool device_supports_vmm(int device_id) {
+  int supported = 0;
+  hipError_t err = hipDeviceGetAttribute(
+      &supported, hipDeviceAttributeVirtualMemoryManagementSupported,
+      device_id);
+  return (err == hipSuccess) && (supported != 0);
+}
+
+/*
+ * Allocate HIP VMM device memory suitable for symmetric registration.
+ *
+ * Performs the standard VMM sequence: create a physical handle, reserve a
+ * virtual address range, map the handle, and grant device + host access. The
+ * memory is device-resident, RDMA-capable, and uses a POSIX-fd handle type;
+ * the requested size is rounded up to the allocation granularity.
+ *
+ * The granularity-aligned size is returned via *aligned_size, since both the
+ * symmetric registration and the later unmap must use that exact length.
+ */
+static bool vmm_alloc(void **ptr, hipMemGenericAllocationHandle_t *handle,
+                      size_t size, size_t *aligned_size, int device_id) {
+  hipMemAllocationProp prop = {};
+  prop.type = hipMemAllocationTypePinned;
+  prop.location.type = hipMemLocationTypeDevice;
+  prop.location.id = device_id;
+  prop.requestedHandleTypes = hipMemHandleTypePosixFileDescriptor;
+  prop.allocFlags.gpuDirectRDMACapable = 1;
+
+  size_t granularity = 0;
+  if (hipMemGetAllocationGranularity(&granularity, &prop,
+                                     hipMemAllocationGranularityMinimum) !=
+          hipSuccess ||
+      granularity == 0) {
+    return false;
+  }
+
+  size_t alloc_size = ((size + granularity - 1) / granularity) * granularity;
+
+  if (hipMemCreate(handle, alloc_size, &prop, 0) != hipSuccess) {
+    return false;
+  }
+
+  void *va = nullptr;
+  if (hipMemAddressReserve(&va, alloc_size, 0, 0, 0) != hipSuccess) {
+    (void)hipMemRelease(*handle);
+    return false;
+  }
+
+  if (hipMemMap(va, alloc_size, 0, *handle, 0) != hipSuccess) {
+    (void)hipMemAddressFree(va, alloc_size);
+    (void)hipMemRelease(*handle);
+    return false;
+  }
+
+  hipMemAccessDesc access_desc[2];
+  access_desc[0].location.type = hipMemLocationTypeDevice;
+  access_desc[0].location.id = device_id;
+  access_desc[0].flags = hipMemAccessFlagsProtReadWrite;
+  access_desc[1].location.type = hipMemLocationTypeHost;
+  access_desc[1].location.id = 0;
+  access_desc[1].flags = hipMemAccessFlagsProtReadWrite;
+
+  if (hipMemSetAccess(va, alloc_size, access_desc, 2) != hipSuccess) {
+    (void)hipMemUnmap(va, alloc_size);
+    (void)hipMemAddressFree(va, alloc_size);
+    (void)hipMemRelease(*handle);
+    return false;
+  }
+
+  *ptr = va;
+  *aligned_size = alloc_size;
+  return true;
+}
+
+static void vmm_free(void *ptr, hipMemGenericAllocationHandle_t handle,
+                     size_t size) {
+  (void)hipMemUnmap(ptr, size);
+  (void)hipMemAddressFree(ptr, size);
+  (void)hipMemRelease(handle);
+}
+
+#define MAX_ELEM 256
+
+int main(int argc, char **argv) {
+  int nelem = MAX_ELEM;
+
+  if (argc > 1) {
+    nelem = atoi(argv[1]);
+  }
+
+  int provided;
+  MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+  if (provided != MPI_THREAD_MULTIPLE) {
+    std::cerr << "MPI_THREAD_MULTIPLE support disabled.\n";
+  }
+
+  int rank, nranks;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+
+  CHECK_HIP(hipSetDevice(get_launcher_local_rank()));
+
+  rocshmem_uniqueid_t uid;
+  rocshmem_init_attr_t attr;
+  int ret;
+
+  if (rank == 0) {
+    ret = rocshmem_get_uniqueid(&uid);
+    if (ret != ROCSHMEM_SUCCESS) {
+      std::cout << rank << ": Error in rocshmem_get_uniqueid. Aborting.\n";
+      MPI_Abort(MPI_COMM_WORLD, ret);
+    }
+  }
+
+  MPI_Bcast(&uid, sizeof(rocshmem_uniqueid_t), MPI_BYTE, 0, MPI_COMM_WORLD);
+
+  ret = rocshmem_set_attr_uniqueid_args(rank, nranks, &uid, &attr);
+  if (ret != ROCSHMEM_SUCCESS) {
+    std::cout << rank
+              << ": Error in rocshmem_set_attr_uniqueid_args. Aborting.\n";
+    MPI_Abort(MPI_COMM_WORLD, ret);
+  }
+
+  ret = rocshmem_init_attr(ROCSHMEM_INIT_WITH_UNIQUEID, &attr);
+  if (ret != ROCSHMEM_SUCCESS) {
+    std::cout << rank << ": Error in rocshmem_init_attr. Aborting.\n";
+    MPI_Abort(MPI_COMM_WORLD, ret);
+  }
+
+  int my_pe = rocshmem_my_pe();
+  int npes = rocshmem_n_pes();
+
+  int device_id = 0;
+  CHECK_HIP(hipGetDevice(&device_id));
+
+  /* Skip cleanly if the GPU does not support HIP virtual memory management. */
+  if (!device_supports_vmm(device_id)) {
+    if (my_pe == 0) {
+      std::cout << "GPU does not support HIP virtual memory management; "
+                   "skipping"
+                << std::endl;
+    }
+    rocshmem_finalize();
+    MPI_Finalize();
+    return 0;
+  }
+
+  size_t buffer_size = nelem * sizeof(int) * npes;
+
+  /*
+   * Allocate the destination as HIP VMM memory and register it symmetrically.
+   * The returned alias -- not the original VMM pointer -- is the symmetric
+   * address used by the collective and passed to the unregister call.
+   */
+  void *dest_vmm = nullptr;
+  hipMemGenericAllocationHandle_t dest_handle{};
+  size_t dest_size = 0;
+  if (!vmm_alloc(&dest_vmm, &dest_handle, buffer_size, &dest_size, device_id)) {
+    if (my_pe == 0) {
+      std::cout << "HIP VMM allocation unavailable; skipping" << std::endl;
+    }
+    rocshmem_finalize();
+    MPI_Finalize();
+    return 0;
+  }
+
+  int *dest = reinterpret_cast<int *>(
+      rocshmem_buffer_register_symmetric(dest_vmm, dest_size));
+  if (dest == nullptr) {
+    /*
+     * A null return means symmetric registration is unavailable in the current
+     * backend/build. Skip instead of failing so this example remains a valid
+     * demonstration of the API regardless of where it is run.
+     */
+    if (my_pe == 0) {
+      std::cout << "rocshmem_buffer_register_symmetric is not supported in "
+                   "this configuration; skipping"
+                << std::endl;
+    }
+    vmm_free(dest_vmm, dest_handle, dest_size);
+    rocshmem_finalize();
+    MPI_Finalize();
+    return 0;
+  }
+
+  int *source = reinterpret_cast<int *>(rocshmem_malloc(buffer_size));
+  if (source == nullptr) {
+    std::cout << "Error allocating source from symmetric heap" << std::endl;
+    rocshmem_global_exit(1);
+  }
+
+  init_sendbuf(source, nelem, my_pe, npes);
+  for (int i = 0; i < nelem * npes; i++) {
+    dest[i] = -1;
+  }
+
+  rocshmem_team_t team_reduce_world_dup;
+  team_reduce_world_dup = ROCSHMEM_TEAM_INVALID;
+  rocshmem_team_split_strided(ROCSHMEM_TEAM_WORLD, 0, 1, npes, nullptr, 0,
+                              &team_reduce_world_dup);
+
+  CHECK_HIP(hipDeviceSynchronize());
+
+  int threadsPerBlock = 256;
+  user_mem_symm_test<<<dim3(1), dim3(threadsPerBlock), 0, 0>>>(
+      source, dest, nelem, team_reduce_world_dup);
+  CHECK_HIP(hipDeviceSynchronize());
+
+  bool pass = check_recvbuf(dest, nelem, my_pe, npes);
+
+  printf("[%d] Test %s \t nelem %d %s\n", my_pe, argv[0], nelem,
+         pass ? "[PASS]" : "[FAIL]");
+
+  ret = rocshmem_buffer_unregister_symmetric(dest);
+  if (ROCSHMEM_SUCCESS != ret) {
+    std::cout << "Error unregistering symmetric user buffer" << std::endl;
+    rocshmem_global_exit(1);
+  }
+
+  vmm_free(dest_vmm, dest_handle, dest_size);
+  rocshmem_free(source);
+
+  rocshmem_finalize();
+  MPI_Finalize();
+  return 0;
+}

--- a/projects/rocshmem/examples/rocshmem_user_mem_symm_test.cc
+++ b/projects/rocshmem/examples/rocshmem_user_mem_symm_test.cc
@@ -25,19 +25,16 @@
 /*
  * Symmetric user-buffer registration example.
  *
- * This mirrors rocshmem_user_mem_test.cc but exercises the *symmetric*
- * registration APIs:
+ * This example exercises the symmetric user-buffer registration APIs:
  *
- *   rocshmem_buffer_register_symmetric(addr, length)  -> rocSHMEM alias
- *   rocshmem_buffer_unregister_symmetric(alias)
+ *   rocshmem_buffer_register_symmetric(addr, length)
+ *   rocshmem_buffer_unregister_symmetric(addr)
  *
- * Unlike rocshmem_buffer_register() (which registers a node-local buffer for
- * use as the *local* side of an RMA), the symmetric variant registers a buffer
- * so it can act as the *remote symmetric target* of RMA/collectives. The call
- * is collective, must be passed the same length on every PE, and returns a
- * rocSHMEM-managed virtual address (the "alias"). That returned address
- * -- not the original buffer pointer -- is what you use as the symmetric
- * object and what you must pass to rocshmem_buffer_unregister_symmetric().
+ * Registering a user buffer symmetrically lets it be used as the remote target
+ * of RMA and collective operations. The call is collective and must be passed
+ * the same length on every PE. It returns the address to use as the symmetric
+ * object for subsequent operations, which is also the address passed back to
+ * rocshmem_buffer_unregister_symmetric().
  *
  * The buffer handed to the symmetric API must be HIP VMM device memory, so the
  * example skips cleanly when either prerequisite is not met:
@@ -61,6 +58,8 @@
 
 #include <rocshmem/rocshmem.hpp>
 #include <mpi.h>
+
+#include <vector>
 
 #include "util.h"
 
@@ -100,7 +99,8 @@ static bool check_recvbuf(int *dest, int nelem, int my_pe, int npes) {
       if (dest[idx] != result) {
         res = false;
 #ifdef VERBOSE
-        printf("recvbuf[%d] = %d expected %d \n", i, dest[i], result);
+        std::cout << "recvbuf[" << i << "] = " << dest[i] << " expected "
+                  << result << std::endl;
 #endif
       }
     }
@@ -191,6 +191,55 @@ static void vmm_free(void *ptr, hipMemGenericAllocationHandle_t handle,
   (void)hipMemRelease(handle);
 }
 
+/*
+ * Register dest_buf symmetrically, run an all-to-all into the returned address,
+ * verify the result, and unregister. If registration is not supported for the
+ * given memory, the case is reported and skipped so the example stays portable
+ * across backends.
+ */
+static bool run_symm_variant(const char *label, void *dest_buf,
+                             size_t dest_size, int *source, int nelem,
+                             int my_pe, int npes, rocshmem_team_t team,
+                             const char *prog) {
+  int *dest = reinterpret_cast<int *>(
+      rocshmem_buffer_register_symmetric(dest_buf, dest_size));
+  if (dest == nullptr) {
+    if (my_pe == 0) {
+      std::cout << label
+                << ": rocshmem_buffer_register_symmetric is not supported for "
+                   "this memory in the current configuration; skipping"
+                << std::endl;
+    }
+    return true;
+  }
+
+  size_t nbytes = static_cast<size_t>(nelem) * npes * sizeof(int);
+
+  /* Initialize the destination to -1 (0xff bytes) before any remote writes. */
+  CHECK_HIP(hipMemset(dest, 0xff, nbytes));
+  rocshmem_barrier_all();
+
+  user_mem_symm_test<<<dim3(1), dim3(256), 0, 0>>>(source, dest, nelem, team);
+  CHECK_HIP(hipDeviceSynchronize());
+
+  std::vector<int> host(static_cast<size_t>(nelem) * npes);
+  CHECK_HIP(hipMemcpy(host.data(), dest, nbytes, hipMemcpyDeviceToHost));
+  bool pass = check_recvbuf(host.data(), nelem, my_pe, npes);
+
+  std::cout << "[" << my_pe << "] Test " << prog << " (" << label
+            << ") \t nelem " << nelem << " " << (pass ? "[PASS]" : "[FAIL]")
+            << std::endl;
+
+  int ret = rocshmem_buffer_unregister_symmetric(dest);
+  if (ROCSHMEM_SUCCESS != ret) {
+    std::cout << label << ": Error unregistering symmetric user buffer"
+              << std::endl;
+    rocshmem_global_exit(1);
+  }
+
+  return pass;
+}
+
 #define MAX_ELEM 256
 
 int main(int argc, char **argv) {
@@ -245,91 +294,48 @@ int main(int argc, char **argv) {
   int device_id = 0;
   CHECK_HIP(hipGetDevice(&device_id));
 
-  /* Skip cleanly if the GPU does not support HIP virtual memory management. */
-  if (!device_supports_vmm(device_id)) {
-    if (my_pe == 0) {
-      std::cout << "GPU does not support HIP virtual memory management; "
-                   "skipping"
-                << std::endl;
-    }
-    rocshmem_finalize();
-    MPI_Finalize();
-    return 0;
-  }
-
   size_t buffer_size = nelem * sizeof(int) * npes;
 
-  /*
-   * Allocate the destination as HIP VMM memory and register it symmetrically.
-   * The returned alias -- not the original VMM pointer -- is the symmetric
-   * address used by the collective and passed to the unregister call.
-   */
-  void *dest_vmm = nullptr;
-  hipMemGenericAllocationHandle_t dest_handle{};
-  size_t dest_size = 0;
-  if (!vmm_alloc(&dest_vmm, &dest_handle, buffer_size, &dest_size, device_id)) {
-    if (my_pe == 0) {
-      std::cout << "HIP VMM allocation unavailable; skipping" << std::endl;
-    }
-    rocshmem_finalize();
-    MPI_Finalize();
-    return 0;
-  }
-
-  int *dest = reinterpret_cast<int *>(
-      rocshmem_buffer_register_symmetric(dest_vmm, dest_size));
-  if (dest == nullptr) {
-    /*
-     * A null return means symmetric registration is unavailable in the current
-     * backend/build. Skip instead of failing so this example remains a valid
-     * demonstration of the API regardless of where it is run.
-     */
-    if (my_pe == 0) {
-      std::cout << "rocshmem_buffer_register_symmetric is not supported in "
-                   "this configuration; skipping"
-                << std::endl;
-    }
-    vmm_free(dest_vmm, dest_handle, dest_size);
-    rocshmem_finalize();
-    MPI_Finalize();
-    return 0;
-  }
-
+  /* Shared all-to-all source, used by every variant. */
   int *source = reinterpret_cast<int *>(rocshmem_malloc(buffer_size));
   if (source == nullptr) {
     std::cout << "Error allocating source from symmetric heap" << std::endl;
     rocshmem_global_exit(1);
   }
-
   init_sendbuf(source, nelem, my_pe, npes);
-  for (int i = 0; i < nelem * npes; i++) {
-    dest[i] = -1;
-  }
 
-  rocshmem_team_t team_reduce_world_dup;
-  team_reduce_world_dup = ROCSHMEM_TEAM_INVALID;
+  rocshmem_team_t team_reduce_world_dup = ROCSHMEM_TEAM_INVALID;
   rocshmem_team_split_strided(ROCSHMEM_TEAM_WORLD, 0, 1, npes, nullptr, 0,
                               &team_reduce_world_dup);
 
-  CHECK_HIP(hipDeviceSynchronize());
+  /* Variant 1: plain hipMalloc device memory. */
+  int *dest_hip = nullptr;
+  CHECK_HIP(hipMalloc(&dest_hip, buffer_size));
+  run_symm_variant("hipMalloc", dest_hip, buffer_size, source, nelem, my_pe,
+                   npes, team_reduce_world_dup, argv[0]);
+  CHECK_HIP(hipFree(dest_hip));
 
-  int threadsPerBlock = 256;
-  user_mem_symm_test<<<dim3(1), dim3(threadsPerBlock), 0, 0>>>(
-      source, dest, nelem, team_reduce_world_dup);
-  CHECK_HIP(hipDeviceSynchronize());
+  rocshmem_barrier_all();
 
-  bool pass = check_recvbuf(dest, nelem, my_pe, npes);
-
-  printf("[%d] Test %s \t nelem %d %s\n", my_pe, argv[0], nelem,
-         pass ? "[PASS]" : "[FAIL]");
-
-  ret = rocshmem_buffer_unregister_symmetric(dest);
-  if (ROCSHMEM_SUCCESS != ret) {
-    std::cout << "Error unregistering symmetric user buffer" << std::endl;
-    rocshmem_global_exit(1);
+  /* Variant 2: HIP VMM device memory (only attempted if the GPU supports it). */
+  if (device_supports_vmm(device_id)) {
+    void *dest_vmm = nullptr;
+    hipMemGenericAllocationHandle_t dest_handle{};
+    size_t dest_size = 0;
+    if (vmm_alloc(&dest_vmm, &dest_handle, buffer_size, &dest_size,
+                  device_id)) {
+      run_symm_variant("VMM", dest_vmm, dest_size, source, nelem, my_pe, npes,
+                       team_reduce_world_dup, argv[0]);
+      vmm_free(dest_vmm, dest_handle, dest_size);
+    } else if (my_pe == 0) {
+      std::cout << "VMM: HIP VMM allocation unavailable; skipping" << std::endl;
+    }
+  } else if (my_pe == 0) {
+    std::cout << "VMM: GPU does not support HIP virtual memory management; "
+                 "skipping"
+              << std::endl;
   }
 
-  vmm_free(dest_vmm, dest_handle, dest_size);
   rocshmem_free(source);
 
   rocshmem_finalize();

--- a/projects/rocshmem/include/rocshmem/rocshmem.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem.hpp
@@ -317,6 +317,41 @@ __host__ int rocshmem_buffer_unregister(void *addr);
 __host__ void rocshmem_buffer_unregister_all();
 
 /**
+ * @brief Registers a symmetric user buffer so it can be used as the remote
+ * target of RMA operations.
+ *
+ * Unlike rocshmem_buffer_register(), this is a *collective* operation that
+ * must be called by all PEs with a buffer of the same length. The call maps
+ * the user's buffer to a fresh rocSHMEM-managed virtual address and returns
+ * it; that returned address (not @p addr) is what the caller must use as the
+ * symmetric target for RMA routines and must pass to
+ * rocshmem_buffer_unregister_symmetric().
+ *
+ * @note This routine is currently restricted to memory allocated through the
+ *       HIP Virtual Memory Management (VMM) APIs (ROCm 7.0 or newer). Passing
+ *       a non-VMM pointer returns nullptr.
+ *
+ * @param[in] addr   Pointer to previously allocated VMM memory.
+ * @param[in] length Length of addr in bytes.
+ *
+ * @return The rocSHMEM-managed symmetric address on success, nullptr otherwise.
+ */
+__host__ void *rocshmem_buffer_register_symmetric(void *addr, size_t length);
+
+/**
+ * @brief Deregisters a previously registered symmetric user buffer.
+ *
+ * This is a collective operation that must be called by all PEs that
+ * participated in the matching rocshmem_buffer_register_symmetric() call.
+ *
+ * @param[in] addr The symmetric address returned by
+ *                 rocshmem_buffer_register_symmetric().
+ *
+ * @return ROCSHMEM_SUCCESS on success, ROCSHMEM_ERROR otherwise.
+ */
+__host__ int rocshmem_buffer_unregister_symmetric(void *addr);
+
+/**
  * @brief Query for the number of PEs.
  *
  * @return Number of PEs.

--- a/projects/rocshmem/src/backend_bc.cpp
+++ b/projects/rocshmem/src/backend_bc.cpp
@@ -114,6 +114,8 @@ void Backend::init(void) {
       hipHostMalloc(reinterpret_cast<void**>(&done_init), sizeof(uint8_t)));
 
   psync_allocator_ = get_default_allocator();
+
+  max_symm_regions_ = envvar::max_symm_regions;
 }
 
 void Backend::init_mpi_once(MPI_Comm comm) {
@@ -412,6 +414,123 @@ int Backend::buffer_unregister(void *addr) {
 
 void Backend::buffer_unregister_all() {
   user_buffer_regions.clear();
+}
+
+int Backend::buffer_register_symmetric(void *addr, size_t length,
+                                       void **registered_addr) {
+#if HIP_VERSION >= 70000000
+  if (registered_addr == nullptr) {
+    return ROCSHMEM_ERROR;
+  }
+
+  HIPAllocator *alloc = heap.get_allocator();
+
+  /*
+   * Symmetric registration is restricted to HIP VMM device memory. Validate
+   * the buffer against the heap's own allocator (mirrors NVSHMEM's per-buffer
+   * checks): this rejects non-VMM heaps, null/zero/granularity-misaligned
+   * sizes, non-VMM pointers, memory on the wrong device, and handle-type
+   * mismatches.
+   */
+  if (!alloc->ValidateVMMRegistration(addr, length, hip_dev_id)) {
+    return ROCSHMEM_ERROR;
+  }
+
+  /* Enforce the configured maximum number of symmetric registrations. */
+  if (symm_buffer_regions.size() >= max_symm_regions_) {
+    return ROCSHMEM_ERROR;
+  }
+
+  /*
+   * Overlap detection is performed against the user's *original* address
+   * range. Aliases are freshly reserved virtual addresses and never overlap,
+   * so checking them would be meaningless.
+   */
+  uintptr_t orig_start = reinterpret_cast<uintptr_t>(addr);
+
+  // Check for overflow when computing end address
+  if (orig_start > UINTPTR_MAX - length) {
+    return ROCSHMEM_ERROR;
+  }
+
+  uintptr_t orig_end = orig_start + length;
+
+  // Find first entry with base >= our base
+  auto it = symm_orig_regions.lower_bound(orig_start);
+
+  // Check entry at or after our base for overlap
+  if (it != symm_orig_regions.end() && it->first < orig_end) {
+    return ROCSHMEM_ERROR;
+  }
+
+  // Check entry just before our base for overlap
+  if (it != symm_orig_regions.begin()) {
+    auto prev = std::prev(it);
+    uintptr_t prev_end = prev->first + prev->second;
+    if (prev_end > orig_start) {
+      return ROCSHMEM_ERROR;
+    }
+  }
+
+  /*
+   * Map the user's buffer to a fresh rocSHMEM-owned virtual address. This
+   * alias refers to the same physical memory but at a distinct address that
+   * the caller uses for RMA and unregistration.
+   */
+  void *alias = nullptr;
+  if (alloc->MapLocalAlias(addr, length, &alias) != hipSuccess) {
+    return ROCSHMEM_ERROR;
+  }
+
+  uintptr_t alias_start = reinterpret_cast<uintptr_t>(alias);
+  symm_buffer_regions[alias_start] = SymmRegion{length, orig_start};
+  symm_orig_regions[orig_start] = length;
+  *registered_addr = alias;
+  return ROCSHMEM_SUCCESS;
+#else
+  (void)addr;
+  (void)length;
+  (void)registered_addr;
+  return ROCSHMEM_ERROR;
+#endif
+}
+
+int Backend::buffer_unregister_symmetric(void *addr) {
+#if HIP_VERSION >= 70000000
+  if (addr == nullptr) {
+    return ROCSHMEM_ERROR;
+  }
+
+  uintptr_t base = reinterpret_cast<uintptr_t>(addr);
+
+  auto it = symm_buffer_regions.find(base);
+  if (it == symm_buffer_regions.end()) {
+    return ROCSHMEM_ERROR;
+  }
+
+  /* Release the rocSHMEM-owned alias mapping created at registration. */
+  (void)heap.get_allocator()->UnmapLocalAlias(addr, it->second.length);
+
+  /* Drop the original-range entry used for overlap detection. */
+  symm_orig_regions.erase(it->second.orig_base);
+
+  symm_buffer_regions.erase(it);
+  return ROCSHMEM_SUCCESS;
+#else
+  (void)addr;
+  return ROCSHMEM_ERROR;
+#endif
+}
+
+void Backend::symm_allgather(void* inout, size_t bytes_per_pe) {
+  if (backend_comm != MPI_COMM_NULL) {
+    NET_CHECK(mpilib_ftable_.Allgather(MPI_IN_PLACE, bytes_per_pe, MPI_CHAR,
+                                       inout, bytes_per_pe, MPI_CHAR,
+                                       backend_comm));
+  } else {
+    assert(backend_bootstr != nullptr);
+    backend_bootstr->allGather(inout, bytes_per_pe);
+  }
 }
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/backend_bc.hpp
+++ b/projects/rocshmem/src/backend_bc.hpp
@@ -362,15 +362,14 @@ class Backend {
 
  protected:
   /**
-<<<<<<< HEAD
    * @brief Alignment for regions carved from a backend's work/sync pool.
    *
    * The barrier_sync and pSync pools are accessed with 64-bit atomics, which
    * require 8-byte alignment.
    */
   static constexpr size_t wrk_sync_pool_alignment{alignof(int64_t)};
-=======
-   * @brief Maximum number of concurrent symmetric buffer registrations.
+
+  /* @brief Maximum number of concurrent symmetric buffer registrations.
    *
    * Configured via ROCSHMEM_MAX_SYMM_REGIONS (see envvar::max_symm_regions)
    * and shared by every backend that supports symmetric registration.
@@ -386,7 +385,6 @@ class Backend {
    * Shared helper for backends exchanging registration handles.
    */
   void symm_allgather(void *inout, size_t bytes_per_pe);
->>>>>>> 11214334fe (Add common backend symmetric registration bookkeeping)
 
   /**
    * @brief Required to support static inheritance for device calls.

--- a/projects/rocshmem/src/backend_bc.hpp
+++ b/projects/rocshmem/src/backend_bc.hpp
@@ -33,6 +33,7 @@
  * It is the top-level interface for these resources.
  */
 
+#include <cstdint>
 #include <map>
 #include <vector>
 
@@ -199,6 +200,33 @@ class Backend {
   std::map<uintptr_t, size_t> user_buffer_regions;
 
   /**
+   * @brief Per-symmetric-registration record kept on the host.
+   */
+  struct SymmRegion {
+    size_t length{0};       // registered length in bytes
+    uintptr_t orig_base{0}; // user's original buffer base address
+  };
+
+  /**
+   * @brief Symmetric registrations keyed by the rocSHMEM-managed alias address.
+   *
+   * The alias is the address returned to (and used by) the caller; it is the
+   * key for unregistration and the base that needs unmapping at cleanup. The
+   * stored orig_base ties the alias back to the user's original buffer so its
+   * entry in symm_orig_regions can be removed on unregister.
+   */
+  std::map<uintptr_t, SymmRegion> symm_buffer_regions;
+
+  /**
+   * @brief User original buffer ranges keyed by original base address.
+   *
+   * Used to reject overlapping registrations of the same underlying buffer.
+   * Aliases are freshly reserved virtual addresses and never overlap, so
+   * overlap detection must be performed against the original addresses.
+   */
+  std::map<uintptr_t, size_t> symm_orig_regions;
+
+  /**
    * @brief Register a user buffer.
    */
   virtual int buffer_register(void *addr, size_t length);
@@ -212,6 +240,33 @@ class Backend {
    * @brief Unregister all previously registered user buffers.
    */
   virtual void buffer_unregister_all();
+
+  /**
+   * @brief Register a symmetric user buffer (collective).
+   *
+   * The base implementation performs the common host-side work: argument
+   * validation, mapping the user's buffer to a fresh rocSHMEM-owned virtual
+   * address (the "alias"), capacity enforcement (ROCSHMEM_MAX_SYMM_REGIONS),
+   * duplicate detection, and recording the registration (keyed by the alias)
+   * in symm_buffer_regions. The alias is returned via @p registered_addr and
+   * is the address the caller must use for RMA and for unregistration.
+   *
+   * @param[in]  addr            User's VMM allocation to register
+   * @param[in]  length          Length in bytes
+   * @param[out] registered_addr Filled with the rocSHMEM-managed alias address
+   */
+  virtual int buffer_register_symmetric(void *addr, size_t length,
+                                        void **registered_addr);
+
+  /**
+   * @brief Unregister a symmetric user buffer (collective).
+   *
+   * The base implementation removes the registration from
+   * symm_buffer_regions. Backends override to release transport-specific
+   * resources and call Backend::buffer_unregister_symmetric for the common
+   * portion.
+   */
+  virtual int buffer_unregister_symmetric(void *addr);
 
   /**
    * @brief High level device stats that do not depend on backend type.
@@ -307,12 +362,31 @@ class Backend {
 
  protected:
   /**
+<<<<<<< HEAD
    * @brief Alignment for regions carved from a backend's work/sync pool.
    *
    * The barrier_sync and pSync pools are accessed with 64-bit atomics, which
    * require 8-byte alignment.
    */
   static constexpr size_t wrk_sync_pool_alignment{alignof(int64_t)};
+=======
+   * @brief Maximum number of concurrent symmetric buffer registrations.
+   *
+   * Configured via ROCSHMEM_MAX_SYMM_REGIONS (see envvar::max_symm_regions)
+   * and shared by every backend that supports symmetric registration.
+   */
+  size_t max_symm_regions_{0};
+
+  /**
+   * @brief Collective all-gather of fixed-size per-PE blobs.
+   *
+   * @p inout points to a contiguous array of num_pes elements, each
+   * @p bytes_per_pe long. The calling PE's slot (index my_pe) must already be
+   * populated on entry. Works with either the MPI or TCP bootstrap transport.
+   * Shared helper for backends exchanging registration handles.
+   */
+  void symm_allgather(void *inout, size_t bytes_per_pe);
+>>>>>>> 11214334fe (Add common backend symmetric registration bookkeeping)
 
   /**
    * @brief Required to support static inheritance for device calls.

--- a/projects/rocshmem/src/envvar.cpp
+++ b/projects/rocshmem/src/envvar.cpp
@@ -146,6 +146,10 @@ namespace envvar {
     const var<size_t> max_wavefront_buffers("MAX_WF_BUFFERS",
       "Maximum number of wavefront buffer arrays in default context (determines size of status, return, and atomic return buffers)",
       1024);
+    const var<size_t> max_symm_regions("MAX_SYMM_REGIONS",
+      "Maximum number of symmetric user buffers an application can register "
+      "with rocshmem_buffer_register_symmetric. The default value is 4",
+      4);
   }  // inline namespace _base
 
   namespace bootstrap {

--- a/projects/rocshmem/src/envvar.hpp
+++ b/projects/rocshmem/src/envvar.hpp
@@ -524,6 +524,15 @@ namespace envvar {
 
     extern const var<std::string> requested_nic;
     extern const var<std::string> hca_list;
+
+    /**
+     * @brief Maximum number of symmetric user buffers that can be registered
+     * with rocshmem_buffer_register_symmetric.
+     *
+     * Backend-agnostic; currently consumed by the IPC backend and intended to
+     * be honored by other backends as they gain symmetric-registration support.
+     */
+    extern const var<size_t> max_symm_regions;
   }  // inline namespace _base
 
   namespace bootstrap {

--- a/projects/rocshmem/src/gda/backend_gda.cpp
+++ b/projects/rocshmem/src/gda/backend_gda.cpp
@@ -273,6 +273,8 @@ void GDABackend::setup_ipc() {
     ipcImpl.ipcHostInit(my_pe, heap_bases, backend_comm);
   else
     ipcImpl.ipcHostInit(my_pe, heap_bases, backend_bootstr);
+
+  ipcImpl.heap_size = heap.get_size();
 }
 
 void GDABackend::cleanup_ipc() {

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -34,6 +34,8 @@
 #include "ipc_team.hpp"
 #include "mpi_instance.hpp"
 #include "log.hpp"
+#include "memory/default_allocator.hpp"
+#include "memory/hip_allocator_vmm_common.hpp"
 
 namespace rocshmem {
 
@@ -112,6 +114,8 @@ IPCBackend::IPCBackend(TcpBootstrap *bootstrap):  Backend(bootstrap) {
 void IPCBackend::init() {
   ROCSHMEM_HOST_CTX_DEFAULT.ctx_opaque = default_host_ctx.get();
 
+  setup_symm_registration();
+
   setup_wrk_sync_buffers();
 
   rocshmem_collective_init();
@@ -142,6 +146,7 @@ IPCBackend::~IPCBackend() {
    * and team world
    */
   teams_destroy();
+  cleanup_symm_registration();
   cleanup_wrk_sync_buffer();
 
   // Close IPC handles for remote heap bases
@@ -503,6 +508,294 @@ void IPCBackend::setup_fence_buffer() {
   /* Must be carved last (see init()); do not add pool regions after this. */
   fence_pool = reinterpret_cast<int *>(wrk_sync_pool_top_);
   wrk_sync_pool_top_ += sizeof(int) * num_pes;
+}
+
+void IPCBackend::setup_symm_registration() {
+#if HIP_VERSION >= 70000000
+  /*
+   * Allocate the device-visible symmetric-registration table in
+   * host+device accessible (fine-grained) memory. The pointer is shared by
+   * all contexts via IpcImpl::initFrom so registrations are observed without
+   * re-propagation.
+   */
+  int capacity = static_cast<int>(max_symm_regions_);
+  if (capacity <= 0) {
+    capacity = 1;
+  }
+
+  IpcSymmTable *table{nullptr};
+  CHECK_HIP(hipMalloc(reinterpret_cast<void **>(&table), sizeof(IpcSymmTable)));
+  assert(table);
+  CHECK_HIP(hipMemset(table, 0, sizeof(IpcSymmTable)));
+
+  IpcSymmRegion *regions{nullptr};
+  CHECK_HIP(hipMalloc(reinterpret_cast<void **>(&regions),
+                      sizeof(IpcSymmRegion) * capacity));
+  assert(regions);
+  CHECK_HIP(hipMemset(regions, 0, sizeof(IpcSymmRegion) * capacity));
+
+  IpcSymmTable host_table{};
+  host_table.count = 0;
+  host_table.capacity = capacity;
+  host_table.regions = regions;
+  CHECK_HIP(hipMemcpy(table, &host_table, sizeof(IpcSymmTable),
+                      hipMemcpyHostToDevice));
+  ipcImpl.symm_table = table;
+#else
+  ipcImpl.symm_table = nullptr;
+#endif
+}
+
+void IPCBackend::cleanup_symm_registration() {
+#if HIP_VERSION >= 70000000
+  /*
+   * Unregister anything the user left registered. buffer_unregister_symmetric
+   * mutates ipc_symm_records_, so iterate over a snapshot of the keys.
+   */
+  std::vector<uintptr_t> addrs;
+  addrs.reserve(ipc_symm_records_.size());
+  for (auto &kv : ipc_symm_records_) {
+    addrs.push_back(kv.first);
+  }
+  for (auto a : addrs) {
+    buffer_unregister_symmetric(reinterpret_cast<void *>(a));
+  }
+
+  if (ipcImpl.symm_table != nullptr) {
+    /*
+     * The table is in device memory; stage it on the host to recover the
+     * regions pointer before freeing.
+     */
+    IpcSymmTable host_table{};
+    CHECK_HIP(hipMemcpy(&host_table, ipcImpl.symm_table, sizeof(IpcSymmTable),
+                        hipMemcpyDeviceToHost));
+    if (host_table.regions != nullptr) {
+      CHECK_HIP(hipFree(host_table.regions));
+    }
+    CHECK_HIP(hipFree(ipcImpl.symm_table));
+    ipcImpl.symm_table = nullptr;
+  }
+#endif
+}
+
+int IPCBackend::buffer_register_symmetric([[maybe_unused]] void *addr,
+                                          [[maybe_unused]] size_t length,
+                                          [[maybe_unused]] void **registered_addr) {
+#if HIP_VERSION >= 70000000
+  if (registered_addr == nullptr) {
+    return ROCSHMEM_ERROR;
+  }
+
+  IpcSymmTable *table = ipcImpl.symm_table;
+  if (table == nullptr) {
+    return ROCSHMEM_ERROR;
+  }
+
+  HIPAllocator *alloc = heap.get_allocator();
+
+  /*
+   * Common host-side work: VMM/per-buffer validation, mapping the user's
+   * buffer to a fresh rocSHMEM-owned alias address, capacity/overlap checks,
+   * and recording in symm_buffer_regions (keyed by the alias). The alias is
+   * the address the caller uses for RMA and unregistration; it is also the
+   * local base published into the device translation table.
+   */
+  void *alias = nullptr;
+  if (Backend::buffer_register_symmetric(addr, length, &alias) !=
+      ROCSHMEM_SUCCESS) {
+    return ROCSHMEM_ERROR;
+  }
+
+  /*
+   * Symmetric size check: registration is collective, so every PE must call
+   * with the same length. All-gather the sizes and compare.
+   */
+  {
+    std::vector<size_t> sizes(num_pes, 0);
+    sizes[my_pe] = length;
+    symm_allgather(sizes.data(), sizeof(size_t));
+    for (int i = 0; i < num_pes; i++) {
+      if (sizes[i] != length) {
+        Backend::buffer_unregister_symmetric(alias);
+        return ROCSHMEM_ERROR;
+      }
+    }
+  }
+
+  /* The alias is the symmetric address; key all IPC bookkeeping by it. */
+  uintptr_t key = reinterpret_cast<uintptr_t>(alias);
+
+  size_t handle_size = alloc->GetIpcHandleSize();
+
+  HIPIpcHandleVec *vec = alloc->AllocateIpcHandleVec(num_pes);
+
+  /* Export an IPC handle for my buffer (the original allocation). */
+  if (alloc->GetIpcHandleFromPtr(addr, length,
+                                 vec->GetHandleVecElem(my_pe)) != hipSuccess) {
+    delete vec;
+    Backend::buffer_unregister_symmetric(alias);
+    return ROCSHMEM_ERROR;
+  }
+
+  /* Preserve my local handle bytes so the export can be released later. */
+  std::vector<char> local_handle(handle_size);
+  std::memcpy(local_handle.data(), vec->GetHandleVecElem(my_pe), handle_size);
+
+  /* Collective exchange of IPC handles (common base helper). */
+  symm_allgather(vec->GetHandleVecElem(0), handle_size);
+
+  /*
+   * Build the array of peer-mapped base addresses on the host. The device
+   * reads this array in ipcPeerPtr, so a device-memory copy is published
+   * below; the host copy is retained for teardown (CloseIpcHandle).
+   */
+  std::vector<char *> host_peer_bases(num_pes, nullptr);
+
+  for (int i = 0; i < num_pes; i++) {
+    if (i == my_pe) {
+      /* Local accesses through the symmetric address resolve to the alias. */
+      host_peer_bases[i] = reinterpret_cast<char *>(alias);
+      continue;
+    }
+    void *p{nullptr};
+    if (alloc->OpenIpcHandle(&p, vec->GetHandleVecElem(i)) != hipSuccess) {
+      /* Close the peer mappings opened so far, then unwind. */
+      for (int j = 0; j < i; j++) {
+        if (j == my_pe) {
+          continue;
+        }
+        (void)alloc->CloseIpcHandle(host_peer_bases[j]);
+      }
+      (void)alloc->CloseExportedHandle(local_handle.data());
+      delete vec;
+      Backend::buffer_unregister_symmetric(alias);
+      return ROCSHMEM_ERROR;
+    }
+    host_peer_bases[i] = reinterpret_cast<char *>(p);
+  }
+
+  delete vec;
+
+  /* Publish the peer-base array into device memory for ipcPeerPtr. */
+  char **peer_bases{nullptr};
+  CHECK_HIP(hipMalloc(reinterpret_cast<void **>(&peer_bases),
+                      num_pes * sizeof(char *)));
+  CHECK_HIP(hipMemcpy(peer_bases, host_peer_bases.data(),
+                      num_pes * sizeof(char *), hipMemcpyHostToDevice));
+
+  /*
+   * Publish the region into the device-visible table. The table lives in
+   * device memory, so read/update it through host staging copies rather than
+   * dereferencing the device pointer from the host.
+   */
+  IpcSymmTable host_table{};
+  CHECK_HIP(hipMemcpy(&host_table, table, sizeof(IpcSymmTable),
+                      hipMemcpyDeviceToHost));
+  int slot = host_table.count;
+
+  /*
+   * Guard the device-table bound. The base class already enforces
+   * max_symm_regions_ (== table capacity), so this should never trigger; it
+   * protects the regions[] write from overflow if the host/device bookkeeping
+   * ever diverges. Roll back the IPC-specific state acquired above.
+   */
+  if (slot >= host_table.capacity) {
+    for (int i = 0; i < num_pes; i++) {
+      if (i == my_pe) {
+        continue;
+      }
+      (void)alloc->CloseIpcHandle(host_peer_bases[i]);
+    }
+    (void)hipFree(peer_bases);
+    (void)alloc->CloseExportedHandle(local_handle.data());
+    Backend::buffer_unregister_symmetric(alias);
+    return ROCSHMEM_ERROR;
+  }
+
+  IpcSymmRegion host_region{};
+  host_region.local_base = key;
+  host_region.length = length;
+  host_region.peer_bases = peer_bases;
+  CHECK_HIP(hipMemcpy(&host_table.regions[slot], &host_region,
+                      sizeof(IpcSymmRegion), hipMemcpyHostToDevice));
+
+  host_table.count = slot + 1;
+  CHECK_HIP(hipMemcpy(table, &host_table, sizeof(IpcSymmTable),
+                      hipMemcpyHostToDevice));
+
+  /* Record IPC-specific bookkeeping for unregister. */
+  IpcSymmRecord rec;
+  rec.slot = slot;
+  rec.dev_peer_bases = peer_bases;
+  rec.peer_bases = std::move(host_peer_bases);
+  rec.local_handle = std::move(local_handle);
+  ipc_symm_records_[key] = std::move(rec);
+
+  *registered_addr = alias;
+  return ROCSHMEM_SUCCESS;
+#else
+  return ROCSHMEM_ERROR;
+#endif
+}
+
+int IPCBackend::buffer_unregister_symmetric([[maybe_unused]] void *addr) {
+#if HIP_VERSION >= 70000000
+  if (addr == nullptr || ipcImpl.symm_table == nullptr) {
+    return ROCSHMEM_ERROR;
+  }
+
+  uintptr_t key = reinterpret_cast<uintptr_t>(addr);
+  auto it = ipc_symm_records_.find(key);
+  if (it == ipc_symm_records_.end()) {
+    return ROCSHMEM_ERROR;
+  }
+
+  HIPAllocator *alloc = heap.get_allocator();
+  IpcSymmTable *table = ipcImpl.symm_table;
+
+  int slot = it->second.slot;
+  std::vector<char *> &peer_bases = it->second.peer_bases;
+
+  /* Close peer mappings and release our exported handle. */
+  for (int i = 0; i < num_pes; i++) {
+    if (i == my_pe) {
+      continue;
+    }
+    CHECK_HIP(alloc->CloseIpcHandle(peer_bases[i]));
+  }
+  (void)alloc->CloseExportedHandle(it->second.local_handle.data());
+
+  /*
+   * Compact the device table by moving the last region into the freed slot.
+   * The table is in device memory, so stage the header on the host and perform
+   * the region move with a device-to-device copy.
+   */
+  IpcSymmTable host_table{};
+  CHECK_HIP(hipMemcpy(&host_table, table, sizeof(IpcSymmTable),
+                      hipMemcpyDeviceToHost));
+  int last = host_table.count - 1;
+  if (slot != last) {
+    CHECK_HIP(hipMemcpy(&host_table.regions[slot], &host_table.regions[last],
+                        sizeof(IpcSymmRegion), hipMemcpyDeviceToDevice));
+    for (auto &kv : ipc_symm_records_) {
+      if (kv.second.slot == last) {
+        kv.second.slot = slot;
+        break;
+      }
+    }
+  }
+  host_table.count = last;
+  CHECK_HIP(hipMemcpy(table, &host_table, sizeof(IpcSymmTable),
+                      hipMemcpyHostToDevice));
+
+  CHECK_HIP(hipFree(it->second.dev_peer_bases));
+  ipc_symm_records_.erase(it);
+
+  /* Common host-side bookkeeping. */
+  return Backend::buffer_unregister_symmetric(addr);
+#else
+  return ROCSHMEM_ERROR;
+#endif
 }
 
 void IPCBackend::rocshmem_collective_init() {

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -594,21 +594,49 @@ int IPCBackend::buffer_register_symmetric([[maybe_unused]] void *addr,
   HIPAllocator *alloc = heap.get_allocator();
 
   /*
-   * Common host-side work: VMM/per-buffer validation, mapping the user's
-   * buffer to a fresh rocSHMEM-owned alias address, capacity/overlap checks,
-   * and recording in symm_buffer_regions (keyed by the alias). The alias is
-   * the address the caller uses for RMA and unregistration; it is also the
-   * local base published into the device translation table.
+   * Registration is collective and exchanges data via symm_allgather below. If
+   * a PE returned early on a local error, it would drop out of those collectives
+   * and either deadlock the remaining PEs or leave the symmetric region
+   * published on some PEs but not others.
+   *
+   * To keep all PEs on the same path, every step that can fail locally records
+   * a success flag, allgathers it, and proceeds only if all PEs succeeded.
+   * Otherwise all PEs roll back their partial state and return an error
+   * together.
+   */
+  auto all_pes_succeeded = [&](int local_success) {
+    std::vector<int> pe_success(num_pes, 0);
+    pe_success[my_pe] = local_success;
+    symm_allgather(pe_success.data(), sizeof(int));
+    for (int i = 0; i < num_pes; i++) {
+      if (!pe_success[i]) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  /*
+   * Stage 1: per-PE host-side setup. Validates the user buffer (VMM/per-buffer
+   * checks), maps it to a rocSHMEM-owned alias, runs capacity/overlap
+   * checks, and records it keyed by the alias. The alias is the address the
+   * caller uses for RMA and unregistration, and the local base published into
+   * the device translation table.
    */
   void *alias = nullptr;
-  if (Backend::buffer_register_symmetric(addr, length, &alias) !=
-      ROCSHMEM_SUCCESS) {
+  int register_ok = (Backend::buffer_register_symmetric(addr, length, &alias) ==
+                     ROCSHMEM_SUCCESS) ? 1 : 0;
+  if (!all_pes_succeeded(register_ok)) {
+    if (register_ok) {
+      Backend::buffer_unregister_symmetric(alias);
+    }
     return ROCSHMEM_ERROR;
   }
 
   /*
    * Symmetric size check: registration is collective, so every PE must call
-   * with the same length. All-gather the sizes and compare.
+   * with the same length. All-gather the sizes and compare. Every PE inspects
+   * the same gathered vector, so a mismatch makes all PEs unwind together.
    */
   {
     std::vector<size_t> sizes(num_pes, 0);
@@ -629,15 +657,23 @@ int IPCBackend::buffer_register_symmetric([[maybe_unused]] void *addr,
 
   HIPIpcHandleVec *vec = alloc->AllocateIpcHandleVec(num_pes);
 
-  /* Export an IPC handle for my buffer (the original allocation). */
-  if (alloc->GetIpcHandleFromPtr(addr, length,
-                                 vec->GetHandleVecElem(my_pe)) != hipSuccess) {
+  /*
+   * Stage 2: export this PE's IPC handle for its buffer (the original
+   * allocation). This runs before the collective handle exchange, so its
+   * outcome is made collective to avoid deadlocking the allgather below.
+   */
+  int export_ok = (alloc->GetIpcHandleFromPtr(addr, length,
+                       vec->GetHandleVecElem(my_pe)) == hipSuccess) ? 1 : 0;
+  if (!all_pes_succeeded(export_ok)) {
+    if (export_ok) {
+      (void)alloc->CloseExportedHandle(vec->GetHandleVecElem(my_pe));
+    }
     delete vec;
     Backend::buffer_unregister_symmetric(alias);
     return ROCSHMEM_ERROR;
   }
 
-  /* Preserve my local handle bytes so the export can be released later. */
+  /* Keep this PE's handle bytes so the export can be released later. */
   std::vector<char> local_handle(handle_size);
   std::memcpy(local_handle.data(), vec->GetHandleVecElem(my_pe), handle_size);
 
@@ -645,12 +681,13 @@ int IPCBackend::buffer_register_symmetric([[maybe_unused]] void *addr,
   symm_allgather(vec->GetHandleVecElem(0), handle_size);
 
   /*
-   * Build the array of peer-mapped base addresses on the host. The device
-   * reads this array in ipcPeerPtr, so a device-memory copy is published
+   * Stage 3: build the array of peer-mapped base addresses on the host. The
+   * device reads this array in ipcPeerPtr, so a device-memory copy is published
    * below; the host copy is retained for teardown (CloseIpcHandle).
    */
   std::vector<char *> host_peer_bases(num_pes, nullptr);
 
+  int open_ok = 1;
   for (int i = 0; i < num_pes; i++) {
     if (i == my_pe) {
       /* Local accesses through the symmetric address resolve to the alias. */
@@ -659,19 +696,40 @@ int IPCBackend::buffer_register_symmetric([[maybe_unused]] void *addr,
     }
     void *p{nullptr};
     if (alloc->OpenIpcHandle(&p, vec->GetHandleVecElem(i)) != hipSuccess) {
-      /* Close the peer mappings opened so far, then unwind. */
+      /* Close the peer mappings this PE opened so far. */
       for (int j = 0; j < i; j++) {
         if (j == my_pe) {
           continue;
         }
         (void)alloc->CloseIpcHandle(host_peer_bases[j]);
+        host_peer_bases[j] = nullptr;
       }
-      (void)alloc->CloseExportedHandle(local_handle.data());
-      delete vec;
-      Backend::buffer_unregister_symmetric(alias);
-      return ROCSHMEM_ERROR;
+      open_ok = 0;
+      break;
     }
     host_peer_bases[i] = reinterpret_cast<char *>(p);
+  }
+
+  /*
+   * Opening peer mappings is the last per-PE step that can fail. There is no
+   * further collective communication, but a per-PE early return would publish
+   * the region on some PEs and not others. Agree on the outcome so all PEs
+   * either keep the region or unwind it.
+   */
+  if (!all_pes_succeeded(open_ok)) {
+    if (open_ok) {
+      /* This PE mapped every peer; close the mappings it opened. */
+      for (int i = 0; i < num_pes; i++) {
+        if (i == my_pe) {
+          continue;
+        }
+        (void)alloc->CloseIpcHandle(host_peer_bases[i]);
+      }
+    }
+    (void)alloc->CloseExportedHandle(local_handle.data());
+    delete vec;
+    Backend::buffer_unregister_symmetric(alias);
+    return ROCSHMEM_ERROR;
   }
 
   delete vec;

--- a/projects/rocshmem/src/ipc/backend_ipc.cpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.cpp
@@ -381,6 +381,7 @@ void IPCBackend::initIPC() {
 
   ipcImpl.ipcHostInit(my_pe, heap_bases,
                       backend_comm);
+  ipcImpl.heap_size = heap.get_size();
 }
 
 void IPCBackend::initIPC(TcpBootstrap *bootstr) {
@@ -388,6 +389,7 @@ void IPCBackend::initIPC(TcpBootstrap *bootstr) {
 
   ipcImpl.ipcHostInit(my_pe, heap_bases,
                       bootstr);
+  ipcImpl.heap_size = heap.get_size();
 }
 
 void IPCBackend::global_exit(int status) {

--- a/projects/rocshmem/src/ipc/backend_ipc.hpp
+++ b/projects/rocshmem/src/ipc/backend_ipc.hpp
@@ -25,6 +25,9 @@
 #ifndef LIBRARY_SRC_IPC_BACKEND_HPP_
 #define LIBRARY_SRC_IPC_BACKEND_HPP_
 
+#include <map>
+#include <vector>
+
 #include "backend_bc.hpp"
 #include "containers/free_list_impl.hpp"
 #include "hdp_proxy.hpp"
@@ -107,6 +110,21 @@ class IPCBackend : public Backend {
    * @copydoc Backend::team_destroy(rocshmem_team_t)
    */
   void team_destroy(rocshmem_team_t team) override;
+
+  /**
+   * @copydoc Backend::buffer_register_symmetric
+   *
+   * Collective. Restricted to VMM allocations.
+   */
+  int buffer_register_symmetric(void *addr, size_t length,
+                                void **registered_addr) override;
+
+  /**
+   * @copydoc Backend::buffer_unregister_symmetric
+   *
+   * Collective.
+   */
+  int buffer_unregister_symmetric(void *addr) override;
 
   /**
    * @brief Accessor for work/sync bases
@@ -308,6 +326,35 @@ class IPCBackend : public Backend {
    * work/sync buffer.
   */
   void cleanup_wrk_sync_buffer();
+
+  /**
+   * @brief Allocate the device-visible symmetric-registration table.
+   */
+  void setup_symm_registration();
+
+  /**
+   * @brief Unregister all symmetric buffers and free the registration table.
+   */
+  void cleanup_symm_registration();
+
+  /**
+   * @brief IPC-specific per-registration state.
+   *
+   * The common base/length bookkeeping lives in Backend::symm_buffer_regions;
+   * this map holds the transport-specific state needed to tear a registration
+   * down, keyed by the registered buffer's base address.
+   */
+  struct IpcSymmRecord {
+    int slot{-1};                       // index into the device symm_table
+    char** dev_peer_bases{nullptr};     // device array[num_pes] (published to table)
+    std::vector<char*> peer_bases{};    // host copy[num_pes] (for CloseIpcHandle)
+    std::vector<char> local_handle{};   // exported IPC handle (for cleanup)
+  };
+
+  /**
+   * @brief Host-side map of IPC-specific symmetric registration state.
+   */
+  std::map<uintptr_t, IpcSymmRecord> ipc_symm_records_{};
 
   /**
    * @brief

--- a/projects/rocshmem/src/ipc/context_ipc_device.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.cpp
@@ -51,30 +51,27 @@ __host__ IPCContext::IPCContext(Backend *b, unsigned int ctx_id)
 
 __device__ void IPCContext::putmem(void *dest, const void *source, size_t nelems,
                                   int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
+  char *remote = ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
   ipcImpl_.ipcCopy<MemcpyKind::PutBlocking>(
-      ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems, pe);
+      remote, const_cast<void *>(source), nelems, pe);
 }
 
 __device__ void IPCContext::getmem(void *dest, const void *source, size_t nelems,
                                   int pe) {
-  const char *src_typed = reinterpret_cast<const char *>(source);
-  uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[constmem.my_pe];
-  ipcImpl_.ipcCopy<MemcpyKind::GetBlocking>(
-      dest, ipcImpl_.ipc_bases[pe] + L_offset, nelems, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(source, constmem.my_pe, pe);
+  ipcImpl_.ipcCopy<MemcpyKind::GetBlocking>(dest, remote, nelems, pe);
 }
 
 __device__ void IPCContext::putmem_nbi(void *dest, const void *source,
                                       size_t nelems, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
-  ipcImpl_.ipcCopy<MemcpyKind::Put>(ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
+  ipcImpl_.ipcCopy<MemcpyKind::Put>(remote, const_cast<void *>(source), nelems, pe);
 }
 
 __device__ void IPCContext::getmem_nbi(void *dest, const void *source,
                                       size_t nelems, int pe) {
-  const char *src_typed = reinterpret_cast<const char *>(source);
-  uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[constmem.my_pe];
-  ipcImpl_.ipcCopy<MemcpyKind::Get>(dest, ipcImpl_.ipc_bases[pe] + L_offset, nelems, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(source, constmem.my_pe, pe);
+  ipcImpl_.ipcCopy<MemcpyKind::Get>(dest, remote, nelems, pe);
 }
 
 __device__ void IPCContext::fence() {
@@ -95,69 +92,59 @@ __device__ void IPCContext::pe_quiet(size_t pe) {
 }
 
 __device__ void *IPCContext::shmem_ptr(const void *dest, int pe) {
-  void *ret = nullptr;
-  void *dst = const_cast<void *>(dest);
-  uint64_t L_offset = reinterpret_cast<char *>(dst) - ipcImpl_.ipc_bases[constmem.my_pe];
-  ret = ipcImpl_.ipc_bases[pe] + L_offset;
-  return ret;
+  return ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
 }
 
 __device__ void IPCContext::putmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
+  char *remote = ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
   ipcImpl_.ipcCopy_wg<MemcpyKind::PutBlocking>(
-      ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems, pe);
+      remote, const_cast<void *>(source), nelems, pe);
   __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::getmem_wg(void *dest, const void *source,
                                      size_t nelems, int pe) {
-  const char *src_typed = reinterpret_cast<const char *>(source);
-  uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[constmem.my_pe];
-  ipcImpl_.ipcCopy_wg<MemcpyKind::GetBlocking>(
-      dest, ipcImpl_.ipc_bases[pe] + L_offset, nelems, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(source, constmem.my_pe, pe);
+  ipcImpl_.ipcCopy_wg<MemcpyKind::GetBlocking>(dest, remote, nelems, pe);
   __builtin_amdgcn_s_barrier();
 }
 
 __device__ void IPCContext::putmem_nbi_wg(void *dest, const void *source,
                                          size_t nelems, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
-  ipcImpl_.ipcCopy_wg<MemcpyKind::Put>(ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
+  ipcImpl_.ipcCopy_wg<MemcpyKind::Put>(remote, const_cast<void *>(source), nelems, pe);
 }
 
 __device__ void IPCContext::getmem_nbi_wg(void *dest, const void *source,
                                          size_t nelems, int pe) {
-  const char *src_typed = reinterpret_cast<const char *>(source);
-  uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[constmem.my_pe];
-  ipcImpl_.ipcCopy_wg<MemcpyKind::Get>(dest, ipcImpl_.ipc_bases[pe] + L_offset, nelems, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(source, constmem.my_pe, pe);
+  ipcImpl_.ipcCopy_wg<MemcpyKind::Get>(dest, remote, nelems, pe);
 }
 
 __device__ void IPCContext::putmem_wave(void *dest, const void *source,
                                        size_t nelems, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
+  char *remote = ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
   ipcImpl_.ipcCopy_wave<MemcpyKind::PutBlocking>(
-      ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems, pe);
+      remote, const_cast<void *>(source), nelems, pe);
 }
 
 __device__ void IPCContext::getmem_wave(void *dest, const void *source,
                                        size_t nelems, int pe) {
-  const char *src_typed = reinterpret_cast<const char *>(source);
-  uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[constmem.my_pe];
-  ipcImpl_.ipcCopy_wave<MemcpyKind::GetBlocking>(
-      dest, ipcImpl_.ipc_bases[pe] + L_offset, nelems, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(source, constmem.my_pe, pe);
+  ipcImpl_.ipcCopy_wave<MemcpyKind::GetBlocking>(dest, remote, nelems, pe);
 }
 
 __device__ void IPCContext::putmem_nbi_wave(void *dest, const void *source,
                                            size_t nelems, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
-  ipcImpl_.ipcCopy_wave<MemcpyKind::Put>(ipcImpl_.ipc_bases[pe] + L_offset, const_cast<void *>(source), nelems, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe);
+  ipcImpl_.ipcCopy_wave<MemcpyKind::Put>(remote, const_cast<void *>(source), nelems, pe);
 }
 
 __device__ void IPCContext::getmem_nbi_wave(void *dest, const void *source,
                                            size_t nelems, int pe) {
-  const char *src_typed = reinterpret_cast<const char *>(source);
-  uint64_t L_offset = const_cast<char *>(src_typed) - ipcImpl_.ipc_bases[constmem.my_pe];
-  ipcImpl_.ipcCopy_wave<MemcpyKind::Get>(dest, ipcImpl_.ipc_bases[pe] + L_offset, nelems, pe);
+  char *remote = ipcImpl_.ipcPeerPtr(source, constmem.my_pe, pe);
+  ipcImpl_.ipcCopy_wave<MemcpyKind::Get>(dest, remote, nelems, pe);
 }
 
 __device__ void IPCContext::internal_putmem(void *dest, const void *source,

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -76,88 +76,69 @@ __device__ void IPCContext::get_nbi(T *dest, const T *source, size_t nelems, int
 // Atomics
 template <typename T>
 __device__ void IPCContext::amo_add(void *dest, T value, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
-  ipcImpl_.ipcAMOAdd(reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), value);
+  ipcImpl_.ipcAMOAdd(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
 }
 
 template <typename T>
 __device__ void IPCContext::amo_set(void *dest, T value, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
-  ipcImpl_.ipcAMOSet(reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), value);
+  ipcImpl_.ipcAMOSet(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
 }
 
 template <typename T>
 __device__ T IPCContext::amo_swap(void *dest, T value, int pe) {
-  uint64_t L_offset =
-      reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
   return ipcImpl_.ipcAMOSwap(
-      reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), value);
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
 }
 
 template <typename T>
 __device__ T IPCContext::amo_fetch_and(void *dest, T value, int pe) {
-  uint64_t L_offset =
-      reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
   return ipcImpl_.ipcAMOFetchAnd(
-      reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), value);
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
 }
 
 template <typename T>
 __device__ void IPCContext::amo_and(void *dest, T value, int pe) {
-  uint64_t L_offset =
-      reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
   ipcImpl_.ipcAMOAnd(
-      reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), value);
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
 }
 
 template <typename T>
 __device__ T IPCContext::amo_fetch_or(void *dest, T value, int pe) {
-  uint64_t L_offset =
-      reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
   return ipcImpl_.ipcAMOFetchOr(
-      reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), value);
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
 }
 
 template <typename T>
 __device__ void IPCContext::amo_or(void *dest, T value, int pe) {
-  uint64_t L_offset =
-      reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
   ipcImpl_.ipcAMOOr(
-      reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), value);
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
 }
 
 template <typename T>
 __device__ T IPCContext::amo_fetch_xor(void *dest, T value, int pe) {
-  uint64_t L_offset =
-      reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
   return ipcImpl_.ipcAMOFetchXor(
-      reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), value);
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
 }
 
 template <typename T>
 __device__ void IPCContext::amo_xor(void *dest, T value, int pe) {
-  uint64_t L_offset =
-      reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
   ipcImpl_.ipcAMOXor(
-      reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), value);
+      reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
 }
 
 template <typename T>
 __device__ void IPCContext::amo_cas(void *dest, T value, T cond, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
-  ipcImpl_.ipcAMOCas(reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), cond, value);
+  ipcImpl_.ipcAMOCas(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), cond, value);
 }
 
 template <typename T>
 __device__ T IPCContext::amo_fetch_add(void *dest, T value, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
-  return ipcImpl_.ipcAMOFetchAdd(reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), value);
+  return ipcImpl_.ipcAMOFetchAdd(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), value);
 }
 
 template <typename T>
 __device__ T IPCContext::amo_fetch_cas(void *dest, T value, T cond, int pe) {
-  uint64_t L_offset = reinterpret_cast<char *>(dest) - ipcImpl_.ipc_bases[constmem.my_pe];
-  return ipcImpl_.ipcAMOFetchCas(reinterpret_cast<T *>(ipcImpl_.ipc_bases[pe] + L_offset), cond, value);
+  return ipcImpl_.ipcAMOFetchCas(reinterpret_cast<T *>(ipcImpl_.ipcPeerPtr(dest, constmem.my_pe, pe)), cond, value);
 }
 
 // Collectives

--- a/projects/rocshmem/src/ipc_policy.hpp
+++ b/projects/rocshmem/src/ipc_policy.hpp
@@ -85,6 +85,15 @@ class IpcOnImpl {
 
   char **ipc_bases{nullptr};
 
+  /**
+   * @brief Size in bytes of the local symmetric heap.
+   *
+   * The heap occupies [ipc_bases[my_pe], ipc_bases[my_pe] + heap_size).
+   * ipcPeerPtr() uses this to recognize heap addresses (the common case) and
+   * translate them directly, before searching the registered-buffer table.
+   */
+  size_t heap_size{0};
+
   int *pes_with_ipc_avail{nullptr};
 
   /**
@@ -150,6 +159,7 @@ class IpcOnImpl {
 
   void initFrom(const IpcOnImpl &other) {
     ipc_bases = other.ipc_bases;
+    heap_size = other.heap_size;
     shm_size = other.shm_size;
     shm_rank = other.shm_rank;
     pes_with_ipc_avail = other.pes_with_ipc_avail;
@@ -159,9 +169,9 @@ class IpcOnImpl {
   /**
    * @brief Return the address of a symmetric object on a target PE.
    *
-   * If sym_addr falls within a symmetrically-registered user buffer, the
-   * translation uses that region's peer base. Otherwise it falls back to the
-   * symmetric heap (ipc_bases).
+   * The common case is an address in the symmetric heap, which is translated
+   * directly from the local heap base. Only addresses outside the heap are
+   * matched against the symmetrically-registered user buffers.
    *
    * @param[in] sym_addr Symmetric address (valid in the local address space)
    * @param[in] my_pe    Local PE id (index into ipc_bases for the local base)
@@ -171,6 +181,18 @@ class IpcOnImpl {
   __device__ __forceinline__ char *ipcPeerPtr(const void *sym_addr, int my_pe,
                                                int pe) {
     uintptr_t addr = reinterpret_cast<uintptr_t>(sym_addr);
+    uintptr_t heap_base = reinterpret_cast<uintptr_t>(ipc_bases[my_pe]);
+
+    /*
+     * Common case: the address lives in the symmetric heap. Translate it
+     * directly and skip the registered-buffer search. The single unsigned
+     * compare also rejects addresses below the heap base (they wrap large).
+     */
+    if (addr - heap_base < heap_size) {
+      return ipc_bases[pe] + (addr - heap_base);
+    }
+
+    /* Otherwise it may belong to a symmetrically-registered user buffer. */
     if (symm_table != nullptr) {
       int n = symm_table->count;
       for (int i = 0; i < n; ++i) {
@@ -180,8 +202,9 @@ class IpcOnImpl {
         }
       }
     }
-    uint64_t offset = addr - reinterpret_cast<uintptr_t>(ipc_bases[my_pe]);
-    return ipc_bases[pe] + offset;
+
+    /* Not a heap address and not in any registered region: invalid input. */
+    return nullptr;
   }
 
   void assignSdmaChannel([[maybe_unused]] unsigned int ctx_id) {}
@@ -472,6 +495,8 @@ class IpcOffImpl {
   uint32_t shm_size{0};
 
   char **ipc_bases{nullptr};
+
+  size_t heap_size{0};
 
   int *pes_with_ipc_avail{nullptr};
 

--- a/projects/rocshmem/src/ipc_policy.hpp
+++ b/projects/rocshmem/src/ipc_policy.hpp
@@ -44,6 +44,36 @@ namespace rocshmem {
 class Backend;
 class Context;
 
+/**
+ * @brief A single symmetrically-registered user buffer (VMM memory).
+ *
+ * peer_bases is a device-resident array (indexed by local PE) holding the
+ * address at which the registering PE's buffer is mapped in each peer's
+ * address space.
+ */
+struct IpcSymmRegion {
+  uintptr_t local_base;   // this PE's registered buffer base address
+  size_t    length;       // registered length in bytes
+  char**    peer_bases;   // device array[shm_size] of peer-mapped bases
+};
+
+/**
+ * @brief Device-visible table of symmetric IPC registrations.
+ *
+ * Allocated once in host+device accessible memory; its contents are mutated
+ * by (collective) register/unregister calls. The pointer is shared by all
+ * contexts so updates are observed without re-propagation.
+ *
+ * @c regions points to a device-visible array of @c capacity entries. The
+ * capacity is configured at init time via the ROCSHMEM_MAX_SYMM_REGIONS
+ * environment variable (see envvar::max_symm_regions).
+ */
+struct IpcSymmTable {
+  int count;
+  int capacity;
+  IpcSymmRegion *regions;
+};
+
 class IpcOnImpl {
  protected:
   using HEAP_BASES_T = std::vector<char *, StdAllocatorHIP<char *>>;
@@ -56,6 +86,11 @@ class IpcOnImpl {
   char **ipc_bases{nullptr};
 
   int *pes_with_ipc_avail{nullptr};
+
+  /**
+   * @brief Device-visible table of symmetric user-buffer registrations.
+   */
+  IpcSymmTable *symm_table{nullptr};
 
   /**
    * @brief Fast O(1) IPC availability check.
@@ -118,6 +153,35 @@ class IpcOnImpl {
     shm_size = other.shm_size;
     shm_rank = other.shm_rank;
     pes_with_ipc_avail = other.pes_with_ipc_avail;
+    symm_table = other.symm_table;
+  }
+
+  /**
+   * @brief Return the address of a symmetric object on a target PE.
+   *
+   * If sym_addr falls within a symmetrically-registered user buffer, the
+   * translation uses that region's peer base. Otherwise it falls back to the
+   * symmetric heap (ipc_bases).
+   *
+   * @param[in] sym_addr Symmetric address (valid in the local address space)
+   * @param[in] my_pe    Local PE id (index into ipc_bases for the local base)
+   * @param[in] pe       Target PE id
+   * @return Address of the corresponding data in PE 'pe'
+   */
+  __device__ __forceinline__ char *ipcPeerPtr(const void *sym_addr, int my_pe,
+                                               int pe) {
+    uintptr_t addr = reinterpret_cast<uintptr_t>(sym_addr);
+    if (symm_table != nullptr) {
+      int n = symm_table->count;
+      for (int i = 0; i < n; ++i) {
+        IpcSymmRegion &r = symm_table->regions[i];
+        if (addr >= r.local_base && addr < r.local_base + r.length) {
+          return r.peer_bases[pe] + (addr - r.local_base);
+        }
+      }
+    }
+    uint64_t offset = addr - reinterpret_cast<uintptr_t>(ipc_bases[my_pe]);
+    return ipc_bases[pe] + offset;
   }
 
   void assignSdmaChannel([[maybe_unused]] unsigned int ctx_id) {}
@@ -411,8 +475,16 @@ class IpcOffImpl {
 
   int *pes_with_ipc_avail{nullptr};
 
+  IpcSymmTable *symm_table{nullptr};
+
   int ipc_first_pe{0};
   int ipc_stride{0};
+
+  __device__ __forceinline__ char *ipcPeerPtr([[maybe_unused]] const void *sym_addr,
+                                               [[maybe_unused]] int my_pe,
+                                               [[maybe_unused]] int pe) {
+    return nullptr;
+  }
 
   __host__ void ipcHostInit(int my_pe, const HEAP_BASES_T &heap_bases,
                             MPI_Comm thread_comm) {}

--- a/projects/rocshmem/src/memory/heap_memory.hpp
+++ b/projects/rocshmem/src/memory/heap_memory.hpp
@@ -50,6 +50,11 @@ namespace rocshmem {
     virtual __host__ __device__ size_t get_size() = 0;
 
     AllocatorType type_;
+
+    /**
+     * @brief Allocation granularity (bytes) of the backing allocator.
+     */
+    size_t granularity_{1};
   };
 
 
@@ -83,6 +88,7 @@ class HeapMemoryType : public HeapMemory {
 
     // Get allocator type from the base class without unsafe casting
     type_ = allocator_.get_type();
+    granularity_ = allocator_.get_granularity();
   }
 
   /**

--- a/projects/rocshmem/src/memory/hip_allocator.hpp
+++ b/projects/rocshmem/src/memory/hip_allocator.hpp
@@ -33,6 +33,7 @@
 
 #include "rocshmem/rocshmem_config.h"  // NOLINT(build/include_subdir)
 #include "memory_allocator.hpp"
+#include "hip_allocator_vmm_common.hpp"
 
 #include <hip/hip_runtime_api.h>
 #include <hip/hip_version.h>
@@ -142,6 +143,209 @@ class HIPAllocator : public MemoryAllocator {
     return sizeof(hipIpcMemHandle_t);
   }
 
+#if HIP_VERSION >= 70000000
+  /**
+   * @brief HIP VMM handle type used by this allocator's symmetric heap.
+   *
+   * Returns hipMemHandleTypeNone for non-VMM allocators. The VMM allocators
+   * override this so callers can verify that a user buffer's requested handle
+   * type matches the one used by the symmetric heap.
+   */
+  virtual hipMemAllocationHandleType GetVMMHandleType() const
+  {
+    return hipMemHandleTypeNone;
+  }
+
+  /**
+   * @brief Validate that a user buffer can be registered as symmetric.
+   *
+   * Performs the single-PE checks required before a buffer can be registered
+   * as a symmetric region: non-zero and granularity-aligned size, allocated
+   * via the HIP VMM APIs, device memory residing on the given device, and a
+   * requested handle type matching this allocator's.
+   *
+   * Non-VMM allocators report hipMemHandleTypeNone and therefore reject all
+   * registrations.
+   *
+   * @param[in] ptr        Pointer to validate
+   * @param[in] size       Registered length in bytes
+   * @param[in] device_id  This PE's device ordinal
+   * @return true if all local checks pass, false otherwise
+   */
+  bool ValidateVMMRegistration(const void *ptr, size_t size, int device_id) const
+  {
+    /* Non-VMM allocators cannot back symmetric registrations. */
+    hipMemAllocationHandleType handle_type = GetVMMHandleType();
+    if (handle_type == hipMemHandleTypeNone) {
+      return false;
+    }
+
+    /* Non-zero size. */
+    if (ptr == nullptr || size == 0) {
+      return false;
+    }
+
+    /* Granularity-aligned size. */
+    size_t granularity = get_granularity();
+    if (granularity == 0) {
+      granularity = 1;
+    }
+    if (size % granularity != 0) {
+      return false;
+    }
+
+    /*
+     * Allocated via HIP VMM: hipMemRetainAllocationHandle only succeeds for
+     * memory created with hipMemCreate/hipMemMap.
+     */
+    hipMemGenericAllocationHandle_t handle;
+    if (hipMemRetainAllocationHandle(&handle, const_cast<void *>(ptr)) !=
+        hipSuccess) {
+      return false;
+    }
+
+    hipMemAllocationProp prop = {};
+    hipError_t err = hipMemGetAllocationPropertiesFromHandle(&prop, handle);
+    (void)hipMemRelease(handle);
+    if (err != hipSuccess) {
+      return false;
+    }
+
+    /* Right memory type: must be device (VMM) memory. */
+    if (prop.location.type != hipMemLocationTypeDevice) {
+      return false;
+    }
+
+    /* Right device: device memory must live on this PE's device. */
+    if (prop.location.id != device_id) {
+      return false;
+    }
+
+    /* Matching handle type: must match this allocator's symmetric heap. */
+    if (prop.requestedHandleTypes != handle_type) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * @brief Map an existing VMM allocation to a fresh, distinct virtual address.
+   *
+   * Retains the generic allocation handle backing @p dev_ptr and maps the same
+   * physical memory at a newly reserved virtual address. The alias refers to
+   * the same data as @p dev_ptr but at a different address owned by rocSHMEM.
+   * Used so symmetric registration can return a rocSHMEM-managed address
+   * distinct from the user's pointer.
+   *
+   * @param[in]  dev_ptr VMM allocation to alias
+   * @param[in]  length  Length in bytes (granularity-aligned)
+   * @param[out] alias   Filled with the newly mapped virtual address
+   * @return hipSuccess, or an error (hipErrorNotSupported for non-VMM allocators)
+   */
+  hipError_t MapLocalAlias(void *dev_ptr, size_t length, void **alias)
+  {
+    if (GetVMMHandleType() == hipMemHandleTypeNone) {
+      return hipErrorNotSupported;
+    }
+    if (dev_ptr == nullptr || alias == nullptr || length == 0) {
+      return hipErrorInvalidValue;
+    }
+
+    hipMemGenericAllocationHandle_t handle;
+    hipError_t err = hipMemRetainAllocationHandle(&handle, dev_ptr);
+    if (err != hipSuccess) {
+      return err;
+    }
+
+    void *va = nullptr;
+    err = hipMemAddressReserve(&va, length, 0, 0, 0);
+    if (err != hipSuccess) {
+      (void)hipMemRelease(handle);
+      return err;
+    }
+
+    err = hipMemMap(va, length, 0, handle, 0);
+    if (err != hipSuccess) {
+      (void)hipMemAddressFree(va, length);
+      (void)hipMemRelease(handle);
+      return err;
+    }
+
+    int device_id = 0;
+    err = hipGetDevice(&device_id);
+    if (err == hipSuccess) {
+      hipMemAccessDesc access_desc[2];
+      access_desc[0].location.type = hipMemLocationTypeDevice;
+      access_desc[0].location.id = device_id;
+      access_desc[0].flags = hipMemAccessFlagsProtReadWrite;
+      access_desc[1].location.type = hipMemLocationTypeHost;
+      access_desc[1].location.id = 0;
+      access_desc[1].flags = hipMemAccessFlagsProtReadWrite;
+      err = hipMemSetAccess(va, length, access_desc, 2);
+    }
+    if (err != hipSuccess) {
+      (void)hipMemUnmap(va, length);
+      (void)hipMemAddressFree(va, length);
+      (void)hipMemRelease(handle);
+      return err;
+    }
+
+    /* The mapping holds its own reference; drop ours from the retain above. */
+    (void)hipMemRelease(handle);
+
+    *alias = va;
+    return hipSuccess;
+  }
+
+  /**
+   * @brief Unmap and free a virtual address alias created by MapLocalAlias().
+   *
+   * @param[in] alias  Alias virtual address returned by MapLocalAlias()
+   * @param[in] length Length in bytes used when the alias was created
+   * @return hipSuccess or the first error encountered
+   */
+  hipError_t UnmapLocalAlias(void *alias, size_t length)
+  {
+    if (alias == nullptr || length == 0) {
+      return hipErrorInvalidValue;
+    }
+    hipError_t err = hipMemUnmap(alias, length);
+    hipError_t free_err = hipMemAddressFree(alias, length);
+    return (err != hipSuccess) ? err : free_err;
+  }
+#endif
+
+  /**
+   * @brief Export an IPC handle for an arbitrary (caller-owned) pointer.
+   *
+   * Unlike GetIpcHandle(), this does not require the pointer to have been
+   * produced by this allocator. It is used to register user-supplied
+   * symmetric buffers. Only implemented by the VMM allocators.
+   *
+   * @param[in]  dev_ptr Pointer to the (VMM) allocation to export
+   * @param[in]  length  Length of the region in bytes
+   * @param[out] handle  Filled with the shareable IPC handle
+   */
+  virtual hipError_t GetIpcHandleFromPtr(void * /*dev_ptr*/, size_t /*length*/,
+                                         void * /*handle*/)
+  {
+    return hipErrorNotSupported;
+  }
+
+  /**
+   * @brief Release a handle previously produced by GetIpcHandleFromPtr().
+   *
+   * For POSIX-fd based handles this closes the exported file descriptor.
+   * Default implementation is a no-op.
+   *
+   * @param[in] handle Handle previously filled by GetIpcHandleFromPtr()
+   */
+  virtual hipError_t CloseExportedHandle(void * /*handle*/)
+  {
+    return hipSuccess;
+  }
+
   virtual HIPIpcHandleVec* AllocateIpcHandleVec(int num_elems)
   {
     HIPIpcHandleLegacyVec* vec = new HIPIpcHandleLegacyVec();
@@ -217,6 +421,13 @@ class HIPAllocatorVMMPosixFd : public HIPAllocator {
   size_t GetIpcHandleSize() override;
   HIPIpcHandleVec* AllocateIpcHandleVec(int num_elems) override;
   hipError_t GetDmabufHandle(void *dev_ptr, size_t size, int *dmabuf_fd, uint64_t *dmabuf_offset) override;
+  hipError_t GetIpcHandleFromPtr(void *dev_ptr, size_t length, void *handle) override;
+  hipError_t CloseExportedHandle(void *handle) override;
+
+  hipMemAllocationHandleType GetVMMHandleType() const override
+  {
+    return hipMemHandleTypePosixFileDescriptor;
+  }
 };
 
 // Forward declarations for fabric handle support (part of future HIP releases)
@@ -285,6 +496,12 @@ class HIPAllocatorVMMFabric : public HIPAllocator {
   size_t GetIpcHandleSize() override;
   HIPIpcHandleVec* AllocateIpcHandleVec(int num_elems) override;
   hipError_t GetDmabufHandle(void *dev_ptr, size_t size, int *dmabuf_fd, uint64_t *dmabuf_offset) override;
+  hipError_t GetIpcHandleFromPtr(void *dev_ptr, size_t length, void *handle) override;
+
+  hipMemAllocationHandleType GetVMMHandleType() const override
+  {
+    return hipMemHandleTypeFabric;
+  }
 };
 #endif
 

--- a/projects/rocshmem/src/memory/hip_allocator.hpp
+++ b/projects/rocshmem/src/memory/hip_allocator.hpp
@@ -195,8 +195,32 @@ class HIPAllocator : public MemoryAllocator {
     }
 
     /*
-     * Allocated via HIP VMM: hipMemRetainAllocationHandle only succeeds for
-     * memory created with hipMemCreate/hipMemMap.
+     * Confirm the pointer is HIP VMM memory before doing anything else.
+     * hipMemRetainAllocationHandle can fault on non-VMM pointers (e.g.
+     * hipMalloc or host memory), whereas hipMemGetAccess fails gracefully with
+     * an error, so use it as a safe gate.
+     */
+    hipMemLocation location = {};
+    location.type = hipMemLocationTypeDevice;
+    location.id = device_id;
+    unsigned long long access_flags = 0;
+    if (hipMemGetAccess(&access_flags, &location, const_cast<void *>(ptr)) !=
+        hipSuccess) {
+      return false;
+    }
+
+    /*
+     * This PE's device must have read/write access to the buffer; RMA
+     * (puts/gets) would otherwise fault. VMM memory can be mapped without
+     * hipMemSetAccess having been called for this device, in which case the
+     * call above still succeeds but reports no access.
+     */
+    if (access_flags != hipMemAccessFlagsProtReadWrite) {
+      return false;
+    }
+
+    /*
+     * Now safe to retain the backing VMM handle to inspect its properties.
      */
     hipMemGenericAllocationHandle_t handle;
     if (hipMemRetainAllocationHandle(&handle, const_cast<void *>(ptr)) !=
@@ -208,11 +232,6 @@ class HIPAllocator : public MemoryAllocator {
     hipError_t err = hipMemGetAllocationPropertiesFromHandle(&prop, handle);
     (void)hipMemRelease(handle);
     if (err != hipSuccess) {
-      return false;
-    }
-
-    /* Right memory type: must be device (VMM) memory. */
-    if (prop.location.type != hipMemLocationTypeDevice) {
       return false;
     }
 

--- a/projects/rocshmem/src/memory/hip_allocator.hpp
+++ b/projects/rocshmem/src/memory/hip_allocator.hpp
@@ -412,6 +412,11 @@ class HIPAllocatorVMMPosixFd : public HIPAllocator {
   static hipError_t VMMAlloc(void** ptr, size_t size);
   static hipError_t VMMFree(void* ptr);
 
+  // Export a generic VMM handle to a POSIX shareable fd and fill the IPC handle
+  // struct. The exported fd is returned via out_fd.
+  hipError_t ExportToPosixHandle(hipMemGenericAllocationHandle_t generic_handle,
+                                 size_t size, void *handle, int *out_fd);
+
  public:
   HIPAllocatorVMMPosixFd();
 
@@ -486,6 +491,11 @@ class HIPAllocatorVMMFabric : public HIPAllocator {
 
   static hipError_t VMMAlloc(void** ptr, size_t size);
   static hipError_t VMMFree(void* ptr);
+
+  // Export a generic VMM handle to a fabric handle and fill the IPC handle
+  // struct.
+  hipError_t ExportToFabricHandle(hipMemGenericAllocationHandle_t generic_handle,
+                                  size_t size, void *handle);
 
  public:
   HIPAllocatorVMMFabric();

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_common.hpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_common.hpp
@@ -53,7 +53,7 @@ struct VMMCommonAllocationInfo {
  */
 inline size_t VMMQueryGranularity(hipMemAllocationHandleType handle_type) {
   hipMemAllocationProp prop = {};
-#if HIP_VERSION < 7020000
+#if HIP_VERSION < 70200000
   prop.type = hipMemAllocationTypePinned;
 #else
   prop.type = hipMemAllocationTypeUncached;
@@ -94,7 +94,7 @@ inline hipError_t VMMAllocCommon(void** ptr, size_t size, hipMemAllocationHandle
   hipMemGenericAllocationHandle_t handle;
   hipMemAllocationProp prop = {};
 
-#if HIP_VERSION < 7020000
+#if HIP_VERSION < 70200000
   prop.type = hipMemAllocationTypePinned;
 #else
   prop.type = hipMemAllocationTypeUncached;

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_common.hpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_common.hpp
@@ -41,6 +41,44 @@ struct VMMCommonAllocationInfo {
 };
 
 /**
+ * @brief Query the minimum HIP VMM allocation granularity for this device.
+ *
+ * The property used for the query must match the one used at allocation time
+ * (see VMMAllocCommon), since granularity can depend on the requested handle
+ * type and allocation flags.
+ *
+ * @param handle_type Handle type the allocations will request (e.g.
+ *                    hipMemHandleTypePosixFileDescriptor or hipMemHandleTypeFabric)
+ * @return Minimum allocation granularity in bytes, or 0 on failure.
+ */
+inline size_t VMMQueryGranularity(hipMemAllocationHandleType handle_type) {
+  hipMemAllocationProp prop = {};
+#if HIP_VERSION < 7020000
+  prop.type = hipMemAllocationTypePinned;
+#else
+  prop.type = hipMemAllocationTypeUncached;
+#endif
+  prop.location.type = hipMemLocationTypeDevice;
+
+  int device_id = 0;
+  if (hipGetDevice(&device_id) != hipSuccess) {
+    return 0;
+  }
+  prop.location.id = device_id;
+  prop.requestedHandleTypes = handle_type;
+
+  // Match VMMAllocCommon: allocations are made RDMA-capable.
+  prop.allocFlags.gpuDirectRDMACapable = 1;
+
+  size_t granularity = 0;
+  if (hipMemGetAllocationGranularity(&granularity, &prop,
+                                     hipMemAllocationGranularityMinimum) != hipSuccess) {
+    return 0;
+  }
+  return granularity;
+}
+
+/**
  * Common VMM allocation helper
  *
  * @param ptr Output pointer for allocated memory

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_fabric.cpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_fabric.cpp
@@ -23,6 +23,7 @@
  *****************************************************************************/
 
 #include "hip_allocator.hpp"
+#include "log.hpp"
 #include "hip_allocator_vmm_common.hpp"
 
 #if HIP_VERSION >= 70000000
@@ -115,6 +116,10 @@ HIPAllocatorVMMFabric::HIPAllocatorVMMFabric()
             device_id);
     abort();
   }
+
+  // Cache the VMM allocation granularity for this allocator.
+  size_t granularity = VMMQueryGranularity(hipMemHandleTypeFabric);
+  mem_granularity_ = (granularity != 0) ? granularity : 1;
 }
 
 hipError_t HIPAllocatorVMMFabric::GetIpcHandle(void *dev_ptr, void *handle)
@@ -254,6 +259,49 @@ hipError_t HIPAllocatorVMMFabric::CloseIpcHandle(void *dev_ptr)
 
   // Remove from tracking map
   imported_allocations_.erase(it);
+
+  return hipSuccess;
+}
+
+hipError_t HIPAllocatorVMMFabric::GetIpcHandleFromPtr(void *dev_ptr, size_t length, void *handle)
+{
+  if (dev_ptr == nullptr || handle == nullptr || length == 0) {
+    return hipErrorInvalidValue;
+  }
+
+  // Retain the generic allocation handle backing this VMM pointer so we can
+  // export it without relying on this allocator's internal tracking.
+  hipMemGenericAllocationHandle_t generic_handle;
+  hipError_t err = hipMemRetainAllocationHandle(&generic_handle, dev_ptr);
+  if (err != hipSuccess) {
+    return err;
+  }
+
+  hipMemFabricHandle_t fabricHandle;
+  err = hipMemExportToShareableHandle(&fabricHandle, generic_handle,
+                                      hipMemHandleTypeFabric, 0);
+
+  /*
+   * Drop our retained reference regardless of the export outcome. On success
+   * the exported handle keeps the underlying memory alive for importers; a
+   * release failure only leaks a reference, so warn rather than fail.
+   */
+  hipError_t rel_err = hipMemRelease(generic_handle);
+  if (rel_err != hipSuccess) {
+    LOG_WARN("hipMemRelease failed in GetIpcHandleFromPtr: %s",
+             hipGetErrorString(rel_err));
+  }
+
+  // Report any export failure once cleanup is done.
+  if (err != hipSuccess) {
+    return err;
+  }
+
+  HIPIpcMemHandleFabric_t* ipc_handle = reinterpret_cast<HIPIpcMemHandleFabric_t*>(handle);
+  ipc_handle->fabric_handle = fabricHandle;
+  /* length is already granularity-aligned (validated at registration). */
+  ipc_handle->size = length;
+  ipc_handle->offset = 0;
 
   return hipSuccess;
 }

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_fabric.cpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_fabric.cpp
@@ -122,6 +122,24 @@ HIPAllocatorVMMFabric::HIPAllocatorVMMFabric()
   mem_granularity_ = (granularity != 0) ? granularity : 1;
 }
 
+hipError_t HIPAllocatorVMMFabric::ExportToFabricHandle(
+    hipMemGenericAllocationHandle_t generic_handle, size_t size, void *handle)
+{
+  hipMemFabricHandle_t fabricHandle;
+  hipError_t err = hipMemExportToShareableHandle(&fabricHandle, generic_handle,
+                                                 hipMemHandleTypeFabric, 0);
+  if (err != hipSuccess) {
+    return err;
+  }
+
+  HIPIpcMemHandleFabric_t* ipc_handle = reinterpret_cast<HIPIpcMemHandleFabric_t*>(handle);
+  ipc_handle->fabric_handle = fabricHandle;
+  ipc_handle->size = size;
+  ipc_handle->offset = 0;
+
+  return hipSuccess;
+}
+
 hipError_t HIPAllocatorVMMFabric::GetIpcHandle(void *dev_ptr, void *handle)
 {
   if (dev_ptr == nullptr || handle == nullptr) {
@@ -134,26 +152,7 @@ hipError_t HIPAllocatorVMMFabric::GetIpcHandle(void *dev_ptr, void *handle)
     return hipErrorInvalidValue;
   }
 
-  VMMFabricAllocationInfo& info = it->second;
-  HIPIpcMemHandleFabric_t* ipc_handle = reinterpret_cast<HIPIpcMemHandleFabric_t*>(handle);
-
-  // Export the VMM handle to a fabric handle
-  hipMemFabricHandle_t fabricHandle;
-  hipError_t err = hipMemExportToShareableHandle(&fabricHandle, info.handle,
-                                                 hipMemHandleTypeFabric, 0);
-  if (err != hipSuccess) {
-    return err;
-  }
-
-  // Store the fabric handle in the IPC handle structure
-  ipc_handle->fabric_handle = fabricHandle;
-  ipc_handle->size = info.size;
-  ipc_handle->offset = 0;
-
-  // Cache the fabric_id in our allocation info for later use
-  info.fabric_id = fabricHandle;
-
-  return hipSuccess;
+  return ExportToFabricHandle(it->second.handle, it->second.size, handle);
 }
 
 hipError_t HIPAllocatorVMMFabric::OpenIpcHandle(void **dev_ptr, void *handle)
@@ -277,9 +276,8 @@ hipError_t HIPAllocatorVMMFabric::GetIpcHandleFromPtr(void *dev_ptr, size_t leng
     return err;
   }
 
-  hipMemFabricHandle_t fabricHandle;
-  err = hipMemExportToShareableHandle(&fabricHandle, generic_handle,
-                                      hipMemHandleTypeFabric, 0);
+  // length is already granularity-aligned (validated at registration).
+  err = ExportToFabricHandle(generic_handle, length, handle);
 
   /*
    * Drop our retained reference regardless of the export outcome. On success
@@ -292,18 +290,7 @@ hipError_t HIPAllocatorVMMFabric::GetIpcHandleFromPtr(void *dev_ptr, size_t leng
              hipGetErrorString(rel_err));
   }
 
-  // Report any export failure once cleanup is done.
-  if (err != hipSuccess) {
-    return err;
-  }
-
-  HIPIpcMemHandleFabric_t* ipc_handle = reinterpret_cast<HIPIpcMemHandleFabric_t*>(handle);
-  ipc_handle->fabric_handle = fabricHandle;
-  /* length is already granularity-aligned (validated at registration). */
-  ipc_handle->size = length;
-  ipc_handle->offset = 0;
-
-  return hipSuccess;
+  return err;
 }
 
 size_t HIPAllocatorVMMFabric::GetIpcHandleSize()

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_posix.cpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_posix.cpp
@@ -145,6 +145,26 @@ HIPAllocatorVMMPosixFd::HIPAllocatorVMMPosixFd() : HIPAllocator(VMMAlloc, VMMFre
   mem_granularity_ = (granularity != 0) ? granularity : 1;
 }
 
+hipError_t HIPAllocatorVMMPosixFd::ExportToPosixHandle(
+    hipMemGenericAllocationHandle_t generic_handle, size_t size, void *handle,
+    int *out_fd)
+{
+  int fd;
+  hipError_t err = hipMemExportToShareableHandle(
+      &fd, generic_handle, hipMemHandleTypePosixFileDescriptor, 0);
+  if (err != hipSuccess) {
+    return err;
+  }
+
+  HIPIpcMemHandlePosix_t* posix_handle = reinterpret_cast<HIPIpcMemHandlePosix_t*>(handle);
+  posix_handle->fd = static_cast<uint64_t>(fd);
+  posix_handle->pid = static_cast<uint32_t>(getpid());
+  posix_handle->size = size;
+  *out_fd = fd;
+
+  return hipSuccess;
+}
+
 hipError_t HIPAllocatorVMMPosixFd::GetIpcHandle(void *dev_ptr, void *handle)
 {
   if (dev_ptr == nullptr || handle == nullptr) {
@@ -157,29 +177,25 @@ hipError_t HIPAllocatorVMMPosixFd::GetIpcHandle(void *dev_ptr, void *handle)
     return hipErrorInvalidValue;
   }
 
-  HIPIpcMemHandlePosix_t* posix_handle = reinterpret_cast<HIPIpcMemHandlePosix_t*>(handle);
-  hipError_t err;
-
-  // Check if we already exported this allocation
-  int fd;
+  // Reuse a previously exported fd if available; the underlying handle does
+  // not change for the lifetime of this allocation.
   if (it->second.exported_fd != -1) {
-    // Reuse existing fd
-    fd = it->second.exported_fd;
-  } else {
-    // Export the VMM handle to a shareable file descriptor
-    err = hipMemExportToShareableHandle(&fd, it->second.handle,
-                                        hipMemHandleTypePosixFileDescriptor, 0);
-    if (err != hipSuccess) {
-      return err;
-    }
-    // Store the fd so we can close it later
-    it->second.exported_fd = fd;
+    HIPIpcMemHandlePosix_t* posix_handle = reinterpret_cast<HIPIpcMemHandlePosix_t*>(handle);
+    posix_handle->fd = static_cast<uint64_t>(it->second.exported_fd);
+    posix_handle->pid = static_cast<uint32_t>(getpid());
+    posix_handle->size = it->second.size;
+    return hipSuccess;
   }
 
-  // Get current process ID and fill handle
-  posix_handle->fd = static_cast<uint64_t>(fd);
-  posix_handle->pid = static_cast<uint32_t>(getpid());
-  posix_handle->size = it->second.size;
+  // First export for this allocation: export and cache the fd so we can close
+  // it later in Deallocate().
+  int fd;
+  hipError_t err = ExportToPosixHandle(it->second.handle, it->second.size,
+                                       handle, &fd);
+  if (err != hipSuccess) {
+    return err;
+  }
+  it->second.exported_fd = fd;
 
   return hipSuccess;
 }
@@ -350,9 +366,9 @@ hipError_t HIPAllocatorVMMPosixFd::GetIpcHandleFromPtr(void *dev_ptr, size_t len
     return err;
   }
 
+  // length is already granularity-aligned (validated at registration).
   int fd;
-  err = hipMemExportToShareableHandle(&fd, generic_handle,
-                                      hipMemHandleTypePosixFileDescriptor, 0);
+  err = ExportToPosixHandle(generic_handle, length, handle, &fd);
 
   // Drop our retained reference regardless of the export outcome. On success
   // the exported fd keeps the underlying memory alive for importers; a release
@@ -363,18 +379,7 @@ hipError_t HIPAllocatorVMMPosixFd::GetIpcHandleFromPtr(void *dev_ptr, size_t len
              hipGetErrorString(rel_err));
   }
 
-  // Report any export failure once cleanup is done.
-  if (err != hipSuccess) {
-    return err;
-  }
-
-  HIPIpcMemHandlePosix_t* posix_handle = reinterpret_cast<HIPIpcMemHandlePosix_t*>(handle);
-  posix_handle->fd = static_cast<uint64_t>(fd);
-  posix_handle->pid = static_cast<uint32_t>(getpid());
-  /* length is already granularity-aligned (validated at registration). */
-  posix_handle->size = length;
-
-  return hipSuccess;
+  return err;
 }
 
 hipError_t HIPAllocatorVMMPosixFd::CloseExportedHandle(void *handle)

--- a/projects/rocshmem/src/memory/hip_allocator_vmm_posix.cpp
+++ b/projects/rocshmem/src/memory/hip_allocator_vmm_posix.cpp
@@ -139,6 +139,10 @@ HIPAllocatorVMMPosixFd::HIPAllocatorVMMPosixFd() : HIPAllocator(VMMAlloc, VMMFre
                     "The USE_HEAP_DEVICE_VMM_POSIX allocator requires a GPU with VMM support. "
                     "Please use a different memory allocator.", device_id);
   }
+
+  // Cache the VMM allocation granularity for this allocator.
+  size_t granularity = VMMQueryGranularity(hipMemHandleTypePosixFileDescriptor);
+  mem_granularity_ = (granularity != 0) ? granularity : 1;
 }
 
 hipError_t HIPAllocatorVMMPosixFd::GetIpcHandle(void *dev_ptr, void *handle)
@@ -327,6 +331,64 @@ hipError_t HIPAllocatorVMMPosixFd::CloseIpcHandle(void *dev_ptr)
   // Remove from tracking map
   imported_allocations_.erase(it);
 
+  return hipSuccess;
+}
+
+hipError_t HIPAllocatorVMMPosixFd::GetIpcHandleFromPtr(void *dev_ptr, size_t length, void *handle)
+{
+  if (dev_ptr == nullptr || handle == nullptr || length == 0) {
+    return hipErrorInvalidValue;
+  }
+
+  // Retain the generic allocation handle backing this VMM pointer. This only
+  // succeeds for VMM allocations (the caller is expected to have validated
+  // this), and gives us a handle we can export without relying on this
+  // allocator's internal allocation tracking.
+  hipMemGenericAllocationHandle_t generic_handle;
+  hipError_t err = hipMemRetainAllocationHandle(&generic_handle, dev_ptr);
+  if (err != hipSuccess) {
+    return err;
+  }
+
+  int fd;
+  err = hipMemExportToShareableHandle(&fd, generic_handle,
+                                      hipMemHandleTypePosixFileDescriptor, 0);
+
+  // Drop our retained reference regardless of the export outcome. On success
+  // the exported fd keeps the underlying memory alive for importers; a release
+  // failure only leaks a reference, so warn rather than fail.
+  hipError_t rel_err = hipMemRelease(generic_handle);
+  if (rel_err != hipSuccess) {
+    LOG_WARN("hipMemRelease failed in GetIpcHandleFromPtr: %s",
+             hipGetErrorString(rel_err));
+  }
+
+  // Report any export failure once cleanup is done.
+  if (err != hipSuccess) {
+    return err;
+  }
+
+  HIPIpcMemHandlePosix_t* posix_handle = reinterpret_cast<HIPIpcMemHandlePosix_t*>(handle);
+  posix_handle->fd = static_cast<uint64_t>(fd);
+  posix_handle->pid = static_cast<uint32_t>(getpid());
+  /* length is already granularity-aligned (validated at registration). */
+  posix_handle->size = length;
+
+  return hipSuccess;
+}
+
+hipError_t HIPAllocatorVMMPosixFd::CloseExportedHandle(void *handle)
+{
+  if (handle == nullptr) {
+    return hipErrorInvalidValue;
+  }
+
+  HIPIpcMemHandlePosix_t* posix_handle = reinterpret_cast<HIPIpcMemHandlePosix_t*>(handle);
+  int fd = static_cast<int>(posix_handle->fd);
+  if (fd != -1) {
+    close(fd);
+    posix_handle->fd = static_cast<uint64_t>(-1);
+  }
   return hipSuccess;
 }
 

--- a/projects/rocshmem/src/memory/memory_allocator.hpp
+++ b/projects/rocshmem/src/memory/memory_allocator.hpp
@@ -125,6 +125,17 @@ class MemoryAllocator {
    */
   AllocatorType get_type() const { return type_; }
 
+  /**
+   * @brief Get the memory allocation granularity
+   *
+   * For VMM allocators this is the minimum allocation granularity reported by
+   * HIP (often a 2 MiB page); for other allocators it defaults to 1 (no
+   * granularity constraint).
+   *
+   * @return Allocation granularity in bytes
+   */
+  size_t get_granularity() const { return mem_granularity_; }
+
  public:
  protected:
   /**
@@ -136,6 +147,14 @@ class MemoryAllocator {
    * @brief Type of allocator for runtime identification
    */
   AllocatorType type_{AllocatorTypeCoarsegrained};
+
+  /**
+   * @brief Memory allocation granularity in bytes
+   *
+   * Defaults to 1 (no granularity constraint). VMM allocators set this to the
+   * HIP minimum allocation granularity at construction time.
+   */
+  size_t mem_granularity_{1};
 
  private:
   /**

--- a/projects/rocshmem/src/memory/single_heap.cpp
+++ b/projects/rocshmem/src/memory/single_heap.cpp
@@ -36,8 +36,8 @@ HIPAllocator *default_allocator_{nullptr};
 
 SingleHeap::SingleHeap() {
 
-  HIPAllocator *allocator = get_default_allocator();
-  heap_mem_ = new HeapMemoryType(*allocator, envvar::heap_size.get_value());
+  allocator_ = get_default_allocator();
+  heap_mem_ = new HeapMemoryType(*allocator_, envvar::heap_size.get_value());
   assert(heap_mem_ != nullptr);
 
   strat_ = new DLAllocatorStrategy<HeapMemoryType>(static_cast<HeapMemoryType *>(heap_mem_));
@@ -81,5 +81,11 @@ size_t SingleHeap::get_size() { return heap_mem_->get_size(); }
 size_t SingleHeap::get_used() { return strat_->get_used(); }
 
 size_t SingleHeap::get_avail() { return get_size() - get_used(); }
+
+AllocatorType SingleHeap::get_type() { return heap_mem_->type_; }
+
+size_t SingleHeap::get_granularity() { return heap_mem_->granularity_; }
+
+HIPAllocator *SingleHeap::get_allocator() { return allocator_; }
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/memory/single_heap.hpp
+++ b/projects/rocshmem/src/memory/single_heap.hpp
@@ -131,6 +131,27 @@ class SingleHeap {
    */
   size_t get_avail();
 
+  /**
+   * @brief Accessor for the allocator type backing the heap
+   *
+   * @return AllocatorType used to allocate the heap memory
+   */
+  AllocatorType get_type();
+
+  /**
+   * @brief Accessor for the allocation granularity of the heap allocator
+   *
+   * @return Allocation granularity in bytes
+   */
+  size_t get_granularity();
+
+  /**
+   * @brief Accessor for the allocator used to back the heap memory
+   *
+   * @return Pointer to the HIPAllocator that allocated the heap
+   */
+  HIPAllocator *get_allocator();
+
  private:
   /**
    * @brief Heap memory object
@@ -140,6 +161,10 @@ class SingleHeap {
    * @brief Allocation strategy object
    */
   ShmemAllocatorStrategy *strat_{nullptr};
+  /**
+   * @brief Allocator used to back the heap memory
+   */
+  HIPAllocator *allocator_{nullptr};
 };
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/memory/symmetric_heap.hpp
+++ b/projects/rocshmem/src/memory/symmetric_heap.hpp
@@ -138,6 +138,31 @@ class SymmetricHeap {
   auto get_size() { return single_heap_.get_size(); }
 
   /**
+   * @brief Accessor for the allocator type backing the symmetric heap
+   */
+  AllocatorType get_type() { return single_heap_.get_type(); }
+
+  /**
+   * @brief Accessor for the allocation granularity of the symmetric heap
+   */
+  size_t get_granularity() { return single_heap_.get_granularity(); }
+
+  /**
+   * @brief Accessor for the allocator used to back the symmetric heap
+   */
+  HIPAllocator *get_allocator() { return single_heap_.get_allocator(); }
+
+  /**
+   * @brief Whether the symmetric heap is backed by HIP VMM memory
+   *
+   * @return true if the heap allocator is a VMM allocator (POSIX fd or fabric)
+   */
+  bool is_vmm() {
+    auto type = single_heap_.get_type();
+    return type == AllocatorTypeVMMPosix || type == AllocatorTypeVMMFabric;
+  }
+
+  /**
    * @brief Accessor method for heap_window_info_
    */
   auto get_window_info() { return remote_heap_info_->get_window_info(); }

--- a/projects/rocshmem/src/rocshmem.cpp
+++ b/projects/rocshmem/src/rocshmem.cpp
@@ -610,6 +610,21 @@ __host__ void rocshmem_buffer_unregister_all() {
   backend->buffer_unregister_all();
 }
 
+__host__ void *rocshmem_buffer_register_symmetric(void *addr, size_t length) {
+  VERIFY_BACKEND();
+  void *registered_addr = nullptr;
+  if (backend->buffer_register_symmetric(addr, length, &registered_addr) !=
+      ROCSHMEM_SUCCESS) {
+    return nullptr;
+  }
+  return registered_addr;
+}
+
+__host__ int rocshmem_buffer_unregister_symmetric(void *addr) {
+  VERIFY_BACKEND();
+  return backend->buffer_unregister_symmetric(addr);
+}
+
 [[maybe_unused]] __host__ void rocshmem_free(void *ptr) {
   VERIFY_BACKEND();
 


### PR DESCRIPTION
## Motivation

- rocSHMEM only allowed RMA against memory carved from its own symmetric heap.This PR adds support for registering user-allocated buffers as symmetric regions so they can be used directly as RMA targets, via the new `rocshmem_buffer_register_symmetric` / `rocshmem_buffer_unregister_symmetric` APIs. The feature is currently implemented for the IPC backend and restricted to HIP VMM memory (ROCm 7.0+).

## Technical Details

- Add `ROCSHMEM_MAX_SYMM_REGIONS` (default 4) to cap concurrent symmetric registrations; backend-agnostic.
- Expose allocator type, allocation granularity, and the backing allocator through the heap classes, and add VMM allocator helpers (`ValidateVMMRegistration`, `MapLocalAlias`/`UnmapLocalAlias`, `GetIpcHandleFromPtr`, `CloseExportedHandle`).
- Add common symmetric registration bookkeeping in the base `Backend`: VMM validation, capacity and overlap checks, mapping the buffer to a fresh rocSHMEM-owned alias address (returned to the caller), and an allgather
  helper.
- Add device-side `ipcPeerPtr` translation backed by a device-visible symmetric registration table; route IPC put/get/atomic and `shmem_ptr` through it (falls back to heap-offset translation when no region matches).
- Implement the IPC backend registration path: collective IPC handle exchange, peer base mapping, device-table publish/compaction, and teardown.
- Add the public APIs: `rocshmem_buffer_register_symmetric` returns the rocSHMEM-managed symmetric address; `rocshmem_buffer_unregister_symmetric` takes that returned address. Documented in the API reference.

## JIRA ID
- AIROCSHMEM-411

## Test Plan
- Build the `rocshmem` library after each commit to confirm each is compilable.
- Run a multi-PE IPC test that registers a VMM buffer with `rocshmem_buffer_register_symmetric`, performs put/get/atomics against the returned symmetric address, and unregisters it.

## Test Result
- Library builds successfully
- Runtime validation on ROCm 7.0+ hardware pending.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.