### PR TITLE
[hipfile] Validate pointer range in temporary Buffer constructor

### DIFF
--- a/projects/hipfile/src/amd_detail/buffer.cpp
+++ b/projects/hipfile/src/amd_detail/buffer.cpp
@@ -85,7 +85,19 @@ Buffer::Buffer(const void *_buffer, const PassKey<BufferMap> &)
     gpu_id = _attrs.device;
 
     HipMemAddressRange range{Context<Hip>::get()->hipMemGetAddressRange(buffer)};
-    length = range.size - (reinterpret_cast<uintptr_t>(buffer) - reinterpret_cast<uintptr_t>(range.base));
+    uintptr_t          uptr = reinterpret_cast<uintptr_t>(buffer);
+    uintptr_t          base = reinterpret_cast<uintptr_t>(range.base);
+
+    if (uptr < base) {
+        throw InvalidPointerRange();
+    }
+
+    uintptr_t offset = uptr - base;
+    if (offset >= range.size) {
+        throw InvalidPointerRange();
+    }
+
+    length = range.size - offset;
 }
 
 void *

--- a/projects/hipfile/test/amd_detail/buffer.cpp
+++ b/projects/hipfile/test/amd_detail/buffer.cpp
@@ -329,4 +329,28 @@ TEST_F(HipFileBuffer, get_buffer_throws_on_getPointerAttributes_error)
     ASSERT_THROW(Context<DriverState>::get()->getBuffer(nonnull_ptr), Hip::RuntimeError);
 }
 
+TEST_F(HipFileBuffer, get_buffer_pointer_before_address_range_base_throws)
+{
+    StrictMock<MHip>   mhip;
+    void              *buffer = reinterpret_cast<void *>(0x1FFF);
+    HipMemAddressRange range{reinterpret_cast<void *>(0x2000), 0x100};
+    EXPECT_CALL(mhip, hipMemGetAddressRange).WillOnce(testing::Return(range));
+    hipPointerAttribute_t attrs{};
+    attrs.type = hipMemoryTypeDevice;
+    EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
+    ASSERT_THROW(Context<DriverState>::get()->getBuffer(buffer), InvalidPointerRange);
+}
+
+TEST_F(HipFileBuffer, get_buffer_pointer_at_offset_past_end_throws)
+{
+    StrictMock<MHip>   mhip;
+    void              *buffer = reinterpret_cast<void *>(0x2100);
+    HipMemAddressRange range{reinterpret_cast<void *>(0x2000), 0x100};
+    EXPECT_CALL(mhip, hipMemGetAddressRange).WillOnce(testing::Return(range));
+    hipPointerAttribute_t attrs{};
+    attrs.type = hipMemoryTypeDevice;
+    EXPECT_CALL(mhip, hipPointerGetAttributes).WillOnce(testing::Return(attrs));
+    ASSERT_THROW(Context<DriverState>::get()->getBuffer(buffer), InvalidPointerRange);
+}
+
 HIPFILE_WARN_NO_GLOBAL_CTOR_ON


### PR DESCRIPTION
## Motivation

The temporary-buffer constructor used for unregistered pointers derived its length as range.size - (buffer - range.base) without guarding the subtraction. When range.base > buffer, the uintptr_t subtraction underflowed to a huge length that later passed paramsValid, permitting an out-of-bounds device hipMemcpy.

## Technical Details

Guard the offset computation with base/size checks, throwing InvalidPointerRange when the pointer falls outside its allocation.

## JIRA ID

N/A

## Test Plan

CI passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
