### PR TITLE
fix(CI): Disable hipgraph-bubbles-test for gfx1151

### DIFF
--- a/projects/rocprofiler-sdk/tests/rocprofv3/hip-graph-bubbles-test/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/hip-graph-bubbles-test/CMakeLists.txt
@@ -10,6 +10,14 @@ project(
 
 find_package(rocprofiler-sdk REQUIRED)
 
+# These tests currently fail only on gfx1151. Detect the system architecture and disable
+# the tests there, while leaving them enabled elsewhere.
+rocprofiler_sdk_get_gfx_architectures(rocprofiler-sdk-hip-graph-bubbles-gfx-info ECHO)
+set(HIP_GRAPH_BUBBLES_DISABLED OFF)
+if("gfx1151" IN_LIST rocprofiler-sdk-hip-graph-bubbles-gfx-info)
+    set(HIP_GRAPH_BUBBLES_DISABLED ON)
+endif()
+
 set(HIP_GRAPH_BUBBLES_ENVIRONMENT)
 if(DEFINED ENV{ROCM_PATH} AND EXISTS "$ENV{ROCM_PATH}/lib/rocm_sysdeps/lib")
     list(APPEND HIP_GRAPH_BUBBLES_ENVIRONMENT
@@ -32,7 +40,7 @@ function(add_hip_graph_bubbles_kernel_trace_test SUFFIX NUM_KERNELS NUM_ITERATIO
         DEPENDS hip-graph-bubbles
         TIMEOUT ${TIMEOUT_SECS}
         LABELS "integration-tests"
-        DISABLED ON
+        DISABLED "${HIP_GRAPH_BUBBLES_DISABLED}"
         ENVIRONMENT ${HIP_GRAPH_BUBBLES_ENVIRONMENT}
         FIXTURES_SETUP ${TEST_NAME}
         FAIL_REGULAR_EXPRESSION
@@ -54,7 +62,7 @@ function(add_hip_graph_bubbles_kernel_trace_test SUFFIX NUM_KERNELS NUM_ITERATIO
              ${NUM_ITERATIONS}
         TIMEOUT ${TIMEOUT_SECS}
         LABELS "integration-tests"
-        DISABLED ON
+        DISABLED "${HIP_GRAPH_BUBBLES_DISABLED}"
         FIXTURES_REQUIRED ${TEST_NAME})
 endfunction()
 

--- a/projects/rocprofiler-sdk/tests/rocprofv3/hip-graph-bubbles-test/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/hip-graph-bubbles-test/CMakeLists.txt
@@ -32,6 +32,7 @@ function(add_hip_graph_bubbles_kernel_trace_test SUFFIX NUM_KERNELS NUM_ITERATIO
         DEPENDS hip-graph-bubbles
         TIMEOUT ${TIMEOUT_SECS}
         LABELS "integration-tests"
+        DISABLED ON
         ENVIRONMENT ${HIP_GRAPH_BUBBLES_ENVIRONMENT}
         FIXTURES_SETUP ${TEST_NAME}
         FAIL_REGULAR_EXPRESSION
@@ -53,6 +54,7 @@ function(add_hip_graph_bubbles_kernel_trace_test SUFFIX NUM_KERNELS NUM_ITERATIO
              ${NUM_ITERATIONS}
         TIMEOUT ${TIMEOUT_SECS}
         LABELS "integration-tests"
+        DISABLED ON
         FIXTURES_REQUIRED ${TEST_NAME})
 endfunction()
 


### PR DESCRIPTION
## Motivation

Current CI has repeated failures for hip-graph-bubbles test for gfx1151 despite manual testing showing no performance degradation 

## Technical Details

Removed hip-graph-bubbles for gfx1151

## JIRA ID

JIRA ID : AIPROFSDK-883

## Test Plan



## Test Result



## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
