### PR TITLE
[rocjitsu] Fix BFE width clamping and CLS off-by-one in codegen

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/scalar.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/scalar.py
@@ -607,6 +607,7 @@ def gen_scalar_bfe(dst: list[str], src: list[str], dtype: str | None) -> str:
         L.append(f'    {dst[0]}.write_scalar64(wf, 0);')
         L.append('    wf.write_scc(false);')
         L.append('  } else {')
+        L.append('    if (offset + width > 64) width = 64 - offset;')
         L.append('    uint64_t mask = width >= 64 ? ~0ULL : ((1ULL << width) - 1);')
         L.append('    uint64_t extracted = (base >> offset) & mask;')
         if dtype == 'i64':
@@ -624,6 +625,7 @@ def gen_scalar_bfe(dst: list[str], src: list[str], dtype: str | None) -> str:
         L.append(f'    {dst[0]}.write_scalar(wf, 0);')
         L.append('    wf.write_scc(false);')
         L.append('  } else {')
+        L.append('    if (offset + width > 32) width = 32 - offset;')
         L.append('    uint32_t mask = width >= 32 ? ~0u : ((1u << width) - 1);')
         L.append('    uint32_t extracted = (base >> offset) & mask;')
         if dtype == 'i32':

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -1106,7 +1106,7 @@ _INLINE_UNARY_OPS: dict[str, str] = {
     ' return s == 0 ? static_cast<uint32_t>(-1)'
     ' : static_cast<uint32_t>(std::countr_zero(s)); }}()',
     'cls': '[&]() {{ int32_t sv = static_cast<int32_t>({0});'
-    ' if (sv == 0 || sv == -1) return 32u;'
+    ' if (sv == 0 || sv == -1) return 31u;'
     ' uint32_t u = sv < 0 ? ~static_cast<uint32_t>(sv) : static_cast<uint32_t>(sv);'
     ' return static_cast<uint32_t>(std::countl_zero(u)) - 1u; }}()',
     'wqm': '[&]() {{ uint32_t s = {0}; uint32_t r = 0;'
@@ -1373,12 +1373,14 @@ _INLINE_BINARY_OPS: dict[str, str] = {
     ' uint32_t offset = field & 31u;'
     ' uint32_t width = (field >> 16) & 127u;'
     ' if (width == 0) return 0u;'
+    ' if (offset + width > 32) width = 32 - offset;'
     ' uint32_t mask = width >= 32 ? ~0u : ((1u << width) - 1u);'
     ' return (base >> offset) & mask; }}()',
     'bfe_i32': '[&]() {{ uint32_t base = {0}, field = {1};'
     ' uint32_t offset = field & 31u;'
     ' uint32_t width = (field >> 16) & 127u;'
     ' if (width == 0) return 0u;'
+    ' if (offset + width > 32) width = 32 - offset;'
     ' uint32_t mask = width >= 32 ? ~0u : ((1u << width) - 1u);'
     ' uint32_t extracted = (base >> offset) & mask;'
     ' if (width < 32 && (extracted & (1u << (width - 1))))'
@@ -1389,6 +1391,7 @@ _INLINE_BINARY_OPS: dict[str, str] = {
     ' uint32_t offset = field & 63u;'
     ' uint32_t width = (field >> 16) & 127u;'
     ' if (width == 0) return static_cast<uint64_t>(0);'
+    ' if (offset + width > 64) width = 64 - offset;'
     ' uint64_t mask = width >= 64 ? ~0ULL : ((1ULL << width) - 1ULL);'
     ' return (base >> offset) & mask; }}()',
     'bfe_i64': '[&]() {{ uint64_t base = {0};'
@@ -1396,6 +1399,7 @@ _INLINE_BINARY_OPS: dict[str, str] = {
     ' uint32_t offset = field & 63u;'
     ' uint32_t width = (field >> 16) & 127u;'
     ' if (width == 0) return static_cast<int64_t>(0);'
+    ' if (offset + width > 64) width = 64 - offset;'
     ' uint64_t mask = width >= 64 ? ~0ULL : ((1ULL << width) - 1ULL);'
     ' uint64_t extracted = (base >> offset) & mask;'
     ' if (width < 64 && (extracted & (1ULL << (width - 1))))'

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -362,8 +362,9 @@ SIMD_VOP1_UNARY: dict[str, tuple[str, str, str]] = {
         ' return out; }',
     ),
     # --- bit-scan (SWAR, no stdx primitive) -----------------------------------
-    # All return uint32_t and special-case the zero input to 0xFFFFFFFF, matching
-    # the scalar bodies (std::countl_zero / countr_zero / popcount). The VOP3
+    # All return uint32_t. Most special-case the zero input to 0xFFFFFFFF,
+    # matching the scalar bodies (std::countl_zero / countr_zero / popcount);
+    # cls_i32 instead maps the all-zero/all-one case to 31. The VOP3
     # twins share these (modifier-free integer bodies, auto-routed below). f16<->
     # f32 round-trip not involved -> not in _VOP3_UNARY_SKIP.
     #
@@ -401,7 +402,7 @@ SIMD_VOP1_UNARY: dict[str, tuple[str, str, str]] = {
         ' util::stdx::where(a == 0u, c) = 0xFFFFFFFFu;'
         ' return c; }',
     ),
-    # ffbh_i32 / cls_i32: count leading sign bits = clz of (s < 0 ? ~s : s);
+    # ffbh_i32: count leading sign bits = clz of (s < 0 ? ~s : s);
     # 0 (== all-zero or all-one source) -> 0xFFFFFFFF.
     'v_ffbh_i32_vop1': (
         'uint32_t',
@@ -419,8 +420,8 @@ SIMD_VOP1_UNARY: dict[str, tuple[str, str, str]] = {
         '[](auto a) {'
         ' util::native<uint32_t> u = a;'
         ' util::stdx::where((a & 0x80000000u) != 0u, u) = ~a;'
-        ' auto c = util::clz_u32_simd(u);'
-        ' util::stdx::where(u == 0u, c) = 0xFFFFFFFFu;'
+        ' auto c = util::clz_u32_simd(u) - 1u;'
+        ' util::stdx::where(u == 0u, c) = 31u;'
         ' return c; }',
     ),
     # v_bfrev_b32: reverse the 32 bits of src0. The scalar body loops bit-by-bit;

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_alu.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_alu.py
@@ -227,6 +227,7 @@ def gen_vector_unary(
         'ffbh_u32',
         'ffbl',
         'ffbh_i32',
+        'cls_i32',
         'bcnt',
         'mbcnt_lo',
         'mbcnt_hi',
@@ -249,6 +250,12 @@ def gen_vector_unary(
             L.append('    uint32_t abs_val = sv < 0 ? ~s : s;')
             L.append(
                 f'    {dst[0]}.write_lane(wf, lane, abs_val == 0 ? static_cast<uint32_t>(-1) : static_cast<uint32_t>(std::countl_zero(abs_val)));'
+            )
+        elif op == 'cls_i32':
+            L.append('    int32_t sv = static_cast<int32_t>(s);')
+            L.append('    uint32_t abs_val = sv < 0 ? ~s : s;')
+            L.append(
+                f'    {dst[0]}.write_lane(wf, lane, abs_val == 0 ? 31u : static_cast<uint32_t>(std::countl_zero(abs_val)) - 1);'
             )
         elif op in int_op_map:
             L.append(f'    {dst[0]}.write_lane(wf, lane, {int_op_map[op]});')

--- a/emulation/rocjitsu/lib/python/amdisa/semantics.py
+++ b/emulation/rocjitsu/lib/python/amdisa/semantics.py
@@ -725,7 +725,7 @@ _VOP1_OP_MAP = {
     # RDNA4 renamed bit-counting ops:
     'V_CLZ_I32_U32': ('vector_unary', 'ffbh_u32'),
     'V_CTZ_I32_B32': ('vector_unary', 'ffbl'),
-    'V_CLS_I32': ('vector_unary', 'ffbh_i32'),
+    'V_CLS_I32': ('vector_unary', 'cls_i32'),
     # Pipeline / system (nop in simulation):
     'V_PIPEFLUSH': ('true_nop', None),
     # Relative addressing through M0.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -759,6 +759,8 @@ inline void execute_s_bfe_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]]
     uint32_t width = (field >> 16) & 127u;
     if (width == 0)
       return 0u;
+    if (offset + width > 32)
+      width = 32 - offset;
     uint32_t mask = width >= 32 ? ~0u : ((1u << width) - 1u);
     uint32_t extracted = (base >> offset) & mask;
     if (width < 32 && (extracted & (1u << (width - 1))))
@@ -778,6 +780,8 @@ inline void execute_s_bfe_i64_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]]
     uint32_t width = (field >> 16) & 127u;
     if (width == 0)
       return static_cast<int64_t>(0);
+    if (offset + width > 64)
+      width = 64 - offset;
     uint64_t mask = width >= 64 ? ~0ULL : ((1ULL << width) - 1ULL);
     uint64_t extracted = (base >> offset) & mask;
     if (width < 64 && (extracted & (1ULL << (width - 1))))
@@ -796,6 +800,8 @@ inline void execute_s_bfe_u32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]]
     uint32_t width = (field >> 16) & 127u;
     if (width == 0)
       return 0u;
+    if (offset + width > 32)
+      width = 32 - offset;
     uint32_t mask = width >= 32 ? ~0u : ((1u << width) - 1u);
     return (base >> offset) & mask;
   }();
@@ -812,6 +818,8 @@ inline void execute_s_bfe_u64_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]]
     uint32_t width = (field >> 16) & 127u;
     if (width == 0)
       return static_cast<uint64_t>(0);
+    if (offset + width > 64)
+      width = 64 - offset;
     uint64_t mask = width >= 64 ? ~0ULL : ((1ULL << width) - 1ULL);
     return (base >> offset) & mask;
   }();
@@ -973,7 +981,7 @@ inline void execute_s_cls_i32_sop1([[maybe_unused]] Inst &inst, [[maybe_unused]]
   uint32_t result = [&]() {
     int32_t sv = static_cast<int32_t>(inst.ssrc0.read_scalar(wf));
     if (sv == 0 || sv == -1)
-      return 32u;
+      return 31u;
     uint32_t u = sv < 0 ? ~static_cast<uint32_t>(sv) : static_cast<uint32_t>(sv);
     return static_cast<uint32_t>(std::countl_zero(u)) - 1u;
   }();
@@ -987,7 +995,7 @@ inline void execute_s_cls_i32_i64_sop1([[maybe_unused]] Inst &inst,
   int64_t result = [&]() {
     int32_t sv = static_cast<int32_t>(static_cast<int64_t>(inst.ssrc0.read_scalar64(wf)));
     if (sv == 0 || sv == -1)
-      return 32u;
+      return 31u;
     uint32_t u = sv < 0 ? ~static_cast<uint32_t>(sv) : static_cast<uint32_t>(sv);
     return static_cast<uint32_t>(std::countl_zero(u)) - 1u;
   }();
@@ -3663,8 +3671,8 @@ inline void execute_v_cls_i32_vop1([[maybe_unused]] Inst &inst, [[maybe_unused]]
   ROCJITSU_TRY_SIMD_VOP1_UNARY(uint32_t, uint32_t, [](auto a) {
     util::native<uint32_t> u = a;
     util::stdx::where((a & 0x80000000u) != 0u, u) = ~a;
-    auto c = util::clz_u32_simd(u);
-    util::stdx::where(u == 0u, c) = 0xFFFFFFFFu;
+    auto c = util::clz_u32_simd(u) - 1u;
+    util::stdx::where(u == 0u, c) = 31u;
     return c;
   });
   uint64_t exec = wf.exec();
@@ -3674,7 +3682,7 @@ inline void execute_v_cls_i32_vop1([[maybe_unused]] Inst &inst, [[maybe_unused]]
     inst.vdst.write_lane(wf, lane, [&]() {
       auto s = static_cast<int32_t>(inst.src0.read_lane(wf, lane));
       uint32_t a = s < 0 ? ~static_cast<uint32_t>(s) : static_cast<uint32_t>(s);
-      return a == 0 ? static_cast<uint32_t>(-1) : static_cast<uint32_t>(std::countl_zero(a));
+      return a == 0 ? 31u : static_cast<uint32_t>(std::countl_zero(a)) - 1;
     }());
   }
 }
@@ -3684,8 +3692,8 @@ inline void execute_v_cls_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   ROCJITSU_TRY_SIMD_VOP1_UNARY(uint32_t, uint32_t, [](auto a) {
     util::native<uint32_t> u = a;
     util::stdx::where((a & 0x80000000u) != 0u, u) = ~a;
-    auto c = util::clz_u32_simd(u);
-    util::stdx::where(u == 0u, c) = 0xFFFFFFFFu;
+    auto c = util::clz_u32_simd(u) - 1u;
+    util::stdx::where(u == 0u, c) = 31u;
     return c;
   });
   uint64_t exec = wf.exec();
@@ -3695,7 +3703,7 @@ inline void execute_v_cls_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
     inst.vdst.write_lane(wf, lane, [&]() {
       auto s = static_cast<int32_t>(inst.src0.read_lane(wf, lane));
       uint32_t a = s < 0 ? ~static_cast<uint32_t>(s) : static_cast<uint32_t>(s);
-      return a == 0 ? static_cast<uint32_t>(-1) : static_cast<uint32_t>(std::countl_zero(a));
+      return a == 0 ? 31u : static_cast<uint32_t>(std::countl_zero(a)) - 1;
     }());
   }
 }


### PR DESCRIPTION
## Motivation
Fixes a few small bugs in some instructions for bit field extraction and count leading sign.

## Technical Details
BFE (bit field extract): when offset+width exceeds the register size, the ISA spec clamps width to (size - offset). The codegen was missing this clamp, causing incorrect extraction and sign extension for edge- case offset/width pairs. Fixed in scalar.py, sema_lower.py (all 4 BFE variants: u32/i32/u64/i64), and regenerated execute_shared.h.

CLS (count leading sign): should return 31 for inputs 0 and -1 (all 32 bits match the sign bit → 31 leading sign bits). The sema_lower.py scalar lambda returned 32; the simd_codegen.py SIMD lambda was missing the -1 adjustment from clz and returned 0xFFFFFFFF for the zero case. Both fixed and regenerated.

## JIRA ID
N/A

## Test Plan
Run all CI tests

## Test Result
All CI tests: PASSED

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.