### PR TITLE
[AILITOOLS-268] Fix amdsmi_get_gpu_vram_vendor deprecation notice

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -41,8 +41,13 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Changed
 - **Deprecated `amdsmi_get_gpu_vram_vendor()` in favor of `amdsmi_get_gpu_vram_info()`**.  
+  - The API is slated for removal in a future ROCm release. It now emits a `DeprecationWarning` from the Python interface and is implemented on top of `amdsmi_get_gpu_vram_info()`.
 
 ### Resolved Issues
+
+- **Fixed a crash in `amdsmi_get_gpu_vram_vendor()` and made `amdsmi_get_gpu_vram_info()` resilient to DRM failures**.  
+  - `amdsmi_get_gpu_vram_vendor()` now validates the output buffer and only writes it on success, fixing a null-pointer dereference on the not-supported path.
+  - `amdsmi_get_gpu_vram_info()` now reads the VRAM vendor from sysfs first and treats the DRM ioctl (VRAM type/bit width/bandwidth) as best effort, so the vendor is still returned when the DRM path is unavailable.
 
 - **Fixed AMD GPU manufacturer name display in `amd-smi static --board`**.  
   - The CLI now displays the canonical vendor name `Advanced Micro Devices, Inc. [AMD/ATI]` when the board manufacturer name is reported as the raw AMD PCI vendor ID (`0x1002`) because the host `pci.ids` lookup is unavailable. The C and Python APIs continue to return the raw value unchanged.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -41,7 +41,7 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Changed
 - **Deprecated `amdsmi_get_gpu_vram_vendor()` in favor of `amdsmi_get_gpu_vram_info()`**.  
-  - The API is slated for removal in a future ROCm release. It now emits a `DeprecationWarning` from the Python interface and is implemented on top of `amdsmi_get_gpu_vram_info()`.
+  - `amdsmi_get_gpu_vram_vendor` is slated for removal in a future ROCm release. It now emits a `DeprecationWarning` from the Python interface and functions as a wrapper of `amdsmi_get_gpu_vram_info()`.
 
 ### Resolved Issues
 

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -5032,7 +5032,7 @@ finally:
 
 ### amdsmi_get_gpu_vram_vendor
 
-Description: **deprecated** Get the vram vendor string of a gpu device.
+Description: **Deprecated** (slated for removal in a future ROCm release; use `amdsmi_get_gpu_vram_info()` instead). Get the vram vendor string of a gpu device.
 
 Input parameters:
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -3640,7 +3640,8 @@ amdsmi_status_t amdsmi_get_gpu_vendor_name(amdsmi_processor_handle processor_han
 /**
  *  @brief Get the vram vendor string of a device.
  *
- *  @deprecated ::amdsmi_get_gpu_vram_info() should be used instead
+ *  @deprecated This API is slated for removal in a future ROCm release;
+ *  ::amdsmi_get_gpu_vram_info() should be used instead
  *
  *  @ingroup tagIdentQuery
  *

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -4269,8 +4269,9 @@ def amdsmi_get_gpu_id(processor_handle: processor_handle_t):
 
 
 def amdsmi_get_gpu_vram_vendor(processor_handle: processor_handle_t):
-    """Deprecated: Use amdsmi_get_gpu_vram_info() instead.\
-        Will be deprecated in Rocm 9.0.
+    """Deprecated: use amdsmi_get_gpu_vram_info() instead.
+
+    This API is slated for removal in a future ROCm release.
     """
     import warnings
 

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -2627,10 +2627,16 @@ amdsmi_status_t amdsmi_get_gpu_vendor_name(amdsmi_processor_handle processor_han
 
 amdsmi_status_t amdsmi_get_gpu_vram_vendor(amdsmi_processor_handle processor_handle, char* brand,
                                            uint32_t len) {
-  amdsmi_vram_info_t info;
+  if (brand == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
+  amdsmi_vram_info_t info = {};
   amdsmi_status_t r = amdsmi_get_gpu_vram_info(processor_handle, &info);
+  if (r != AMDSMI_STATUS_SUCCESS) {
+    return r;
+  }
   snprintf(brand, len, "%s", info.vram_vendor);
-  return (r);
+  return r;
 }
 
 amdsmi_status_t amdsmi_get_gpu_vram_info(amdsmi_processor_handle processor_handle,
@@ -2656,94 +2662,110 @@ amdsmi_status_t amdsmi_get_gpu_vram_info(amdsmi_processor_handle processor_handl
   info->vram_max_bandwidth = std::numeric_limits<decltype(info->vram_max_bandwidth)>::max();
 
   SMIGPUDEVICE_MUTEX(gpu_device->get_mutex());
-  std::string render_name = gpu_device->get_gpu_path();
-  std::string path = "/dev/dri/" + render_name;
-  if (render_name.empty()) {
-    return AMDSMI_STATUS_NOT_SUPPORTED;
-  }
 
-  ScopedFD drm_fd(path.c_str(), O_RDWR | O_CLOEXEC);
-  if (!drm_fd.valid()) {
-    ss << __PRETTY_FUNCTION__ << " | Failed to open " << path << ": " << strerror(errno)
-       << "; Returning: " << smi_amdgpu_get_status_string(AMDSMI_STATUS_FILE_ERROR, false);
-    LOG_ERROR(ss);
-    return AMDSMI_STATUS_FILE_ERROR;
-  }
-
-  amd::smi::AMDSmiLibraryLoader libdrm;
-  amdsmi_status_t status = libdrm.load(LIBDRM_AMDGPU_SONAME);
-  if (status != AMDSMI_STATUS_SUCCESS) {
-    libdrm.unload();
-    ss << __PRETTY_FUNCTION__ << " | Failed to load " LIBDRM_AMDGPU_SONAME ": " << strerror(errno)
-       << "; Returning: " << smi_amdgpu_get_status_string(status, false);
-    LOG_ERROR(ss);
-    return status;
-  }
-
-  ss << __PRETTY_FUNCTION__ << " | about to load drmCommandWrite symbol";
-  LOG_INFO(ss);
-
-  // extern int drmCommandWrite(int fd, unsigned long drmCommandIndex,
-  //                            void *data, unsigned long size);
-  typedef int (*drmCommandWrite_t)(int fd, unsigned long drmCommandIndex, void* data,
-                                   unsigned long size);
-  drmCommandWrite_t drmCommandWrite = nullptr;
-
-  // load symbol from libdrm
-  status =
-      libdrm.load_symbol(reinterpret_cast<drmCommandWrite_t*>(&drmCommandWrite), "drmCommandWrite");
-  if (status != AMDSMI_STATUS_SUCCESS) {
-    libdrm.unload();
-    ss << __PRETTY_FUNCTION__ << " | Failed to load drmCommandWrite symbol"
-       << " | Returning: " << smi_amdgpu_get_status_string(status, false);
-    LOG_ERROR(ss);
-    return status;
-  }
-  ss << __PRETTY_FUNCTION__ << " | drmCommandWrite symbol loaded successfully";
-  LOG_INFO(ss);
-
-  struct drm_amdgpu_info_device dev_info = {};
-  memset(&dev_info, 0, sizeof(struct drm_amdgpu_info_device));
-  struct drm_amdgpu_info request = {};
-  memset(&request, 0, sizeof(request));
-  request.return_pointer = reinterpret_cast<unsigned long long>(&dev_info);
-  request.return_size = sizeof(struct drm_amdgpu_info_device);
-  request.query = AMDGPU_INFO_DEV_INFO;
-  auto drm_write =
-      drmCommandWrite(drm_fd, DRM_AMDGPU_INFO, &request, sizeof(struct drm_amdgpu_info));
-  if (drm_write != 0) {
-    libdrm.unload();
-    ss << __PRETTY_FUNCTION__ << " | Issue - drm_write failed, drm_write: " << std::dec << drm_write
-       << "\n"
-       << "; Returning: " << smi_amdgpu_get_status_string(AMDSMI_STATUS_DRM_ERROR, false);
-    LOG_ERROR(ss);
-    return AMDSMI_STATUS_DRM_ERROR;
-  }
-
-  info->vram_type = amd::smi::vram_type_value(dev_info.vram_type);
-  info->vram_bit_width = dev_info.vram_bit_width;
-  libdrm.unload();
-  // if vram type is greater than the max enum set it to unknown
-  if (info->vram_type > AMDSMI_VRAM_TYPE__MAX) info->vram_type = AMDSMI_VRAM_TYPE_UNKNOWN;
-
-  // set info->vram_max_bandwidth to gpu_metrics vram_max_bandwidth if it is not set
-  amdsmi_gpu_metrics_t metric_info = {};
-  r = amdsmi_get_gpu_metrics_info(processor_handle, &metric_info);
-  if (r == AMDSMI_STATUS_SUCCESS) {
-    info->vram_max_bandwidth = metric_info.vram_max_bandwidth;
-  }
-
-  // map the vendor name to enum
+  // --- sysfs first: vendor + total size (no DRM dependency) ---
+  // The vendor string is only exposed via sysfs (mem_info_vram_vendor); the DRM
+  // ioctl carries no vendor field. Read it before attempting the ioctl so callers
+  // (e.g. amdsmi_get_gpu_vram_vendor) still get the vendor when DRM is unavailable.
   char brand[256] = {'\0'};
-  r = rsmi_wrapper(rsmi_dev_vram_vendor_get, processor_handle, 0, brand, 255);
-  if (r == AMDSMI_STATUS_SUCCESS) {
+  amdsmi_status_t vendor_status =
+      rsmi_wrapper(rsmi_dev_vram_vendor_get, processor_handle, 0, brand, 255);
+  if (vendor_status == AMDSMI_STATUS_SUCCESS) {
     for (auto& x : brand) x = static_cast<char>(toupper(x));
     snprintf(info->vram_vendor, AMDSMI_MAX_STRING_LENGTH, "%s", brand);
   }
+
   uint64_t total = 0;
-  r = rsmi_wrapper(rsmi_dev_memory_total_get, processor_handle, 0, RSMI_MEM_TYPE_VRAM, &total);
-  if (r == AMDSMI_STATUS_SUCCESS) {
+  if (rsmi_wrapper(rsmi_dev_memory_total_get, processor_handle, 0, RSMI_MEM_TYPE_VRAM, &total) ==
+      AMDSMI_STATUS_SUCCESS) {
     info->vram_size = total / (1024 * 1024);
+  }
+
+  // --- DRM ioctl fallback: vram_type + bit_width + max_bandwidth (best effort) ---
+  // Failures here are non-fatal: the function still succeeds as long as the sysfs
+  // vendor read above succeeded.
+  amdsmi_status_t drm_status = [&]() -> amdsmi_status_t {
+    std::string render_name = gpu_device->get_gpu_path();
+    std::string path = "/dev/dri/" + render_name;
+    if (render_name.empty()) {
+      return AMDSMI_STATUS_NOT_SUPPORTED;
+    }
+
+    ScopedFD drm_fd(path.c_str(), O_RDWR | O_CLOEXEC);
+    if (!drm_fd.valid()) {
+      ss << __PRETTY_FUNCTION__ << " | Failed to open " << path << ": " << strerror(errno)
+         << "; Returning: " << smi_amdgpu_get_status_string(AMDSMI_STATUS_FILE_ERROR, false);
+      LOG_ERROR(ss);
+      return AMDSMI_STATUS_FILE_ERROR;
+    }
+
+    amd::smi::AMDSmiLibraryLoader libdrm;
+    amdsmi_status_t status = libdrm.load(LIBDRM_AMDGPU_SONAME);
+    if (status != AMDSMI_STATUS_SUCCESS) {
+      libdrm.unload();
+      ss << __PRETTY_FUNCTION__ << " | Failed to load " LIBDRM_AMDGPU_SONAME ": " << strerror(errno)
+         << "; Returning: " << smi_amdgpu_get_status_string(status, false);
+      LOG_ERROR(ss);
+      return status;
+    }
+
+    ss << __PRETTY_FUNCTION__ << " | about to load drmCommandWrite symbol";
+    LOG_INFO(ss);
+
+    // extern int drmCommandWrite(int fd, unsigned long drmCommandIndex,
+    //                            void *data, unsigned long size);
+    typedef int (*drmCommandWrite_t)(int fd, unsigned long drmCommandIndex, void* data,
+                                     unsigned long size);
+    drmCommandWrite_t drmCommandWrite = nullptr;
+
+    // load symbol from libdrm
+    status = libdrm.load_symbol(reinterpret_cast<drmCommandWrite_t*>(&drmCommandWrite),
+                                "drmCommandWrite");
+    if (status != AMDSMI_STATUS_SUCCESS) {
+      libdrm.unload();
+      ss << __PRETTY_FUNCTION__ << " | Failed to load drmCommandWrite symbol"
+         << " | Returning: " << smi_amdgpu_get_status_string(status, false);
+      LOG_ERROR(ss);
+      return status;
+    }
+    ss << __PRETTY_FUNCTION__ << " | drmCommandWrite symbol loaded successfully";
+    LOG_INFO(ss);
+
+    struct drm_amdgpu_info_device dev_info = {};
+    memset(&dev_info, 0, sizeof(struct drm_amdgpu_info_device));
+    struct drm_amdgpu_info request = {};
+    memset(&request, 0, sizeof(request));
+    request.return_pointer = reinterpret_cast<unsigned long long>(&dev_info);
+    request.return_size = sizeof(struct drm_amdgpu_info_device);
+    request.query = AMDGPU_INFO_DEV_INFO;
+    auto drm_write =
+        drmCommandWrite(drm_fd, DRM_AMDGPU_INFO, &request, sizeof(struct drm_amdgpu_info));
+    if (drm_write != 0) {
+      libdrm.unload();
+      ss << __PRETTY_FUNCTION__ << " | Issue - drm_write failed, drm_write: " << std::dec
+         << drm_write << "\n"
+         << "; Returning: " << smi_amdgpu_get_status_string(AMDSMI_STATUS_DRM_ERROR, false);
+      LOG_ERROR(ss);
+      return AMDSMI_STATUS_DRM_ERROR;
+    }
+
+    info->vram_type = amd::smi::vram_type_value(dev_info.vram_type);
+    info->vram_bit_width = dev_info.vram_bit_width;
+    libdrm.unload();
+    // if vram type is greater than the max enum set it to unknown
+    if (info->vram_type > AMDSMI_VRAM_TYPE__MAX) info->vram_type = AMDSMI_VRAM_TYPE_UNKNOWN;
+
+    // set info->vram_max_bandwidth to gpu_metrics vram_max_bandwidth if it is not set
+    amdsmi_gpu_metrics_t metric_info = {};
+    if (amdsmi_get_gpu_metrics_info(processor_handle, &metric_info) == AMDSMI_STATUS_SUCCESS) {
+      info->vram_max_bandwidth = metric_info.vram_max_bandwidth;
+    }
+    return AMDSMI_STATUS_SUCCESS;
+  }();
+
+  // Succeed if at least one source provided data; otherwise surface the DRM error.
+  if (vendor_status != AMDSMI_STATUS_SUCCESS && drm_status != AMDSMI_STATUS_SUCCESS) {
+    return drm_status;
   }
 
   ss << __PRETTY_FUNCTION__ << " | info->vram_type: " << std::dec << info->vram_type << "\n"

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -2676,14 +2676,15 @@ amdsmi_status_t amdsmi_get_gpu_vram_info(amdsmi_processor_handle processor_handl
   }
 
   uint64_t total = 0;
-  if (rsmi_wrapper(rsmi_dev_memory_total_get, processor_handle, 0, RSMI_MEM_TYPE_VRAM, &total) ==
-      AMDSMI_STATUS_SUCCESS) {
+  amdsmi_status_t size_status =
+      rsmi_wrapper(rsmi_dev_memory_total_get, processor_handle, 0, RSMI_MEM_TYPE_VRAM, &total);
+  if (size_status == AMDSMI_STATUS_SUCCESS) {
     info->vram_size = total / (1024 * 1024);
   }
 
   // --- DRM ioctl fallback: vram_type + bit_width + max_bandwidth (best effort) ---
   // Failures here are non-fatal: the function still succeeds as long as the sysfs
-  // vendor read above succeeded.
+  // vendor or size read above succeeded.
   amdsmi_status_t drm_status = [&]() -> amdsmi_status_t {
     std::string render_name = gpu_device->get_gpu_path();
     std::string path = "/dev/dri/" + render_name;
@@ -2764,7 +2765,8 @@ amdsmi_status_t amdsmi_get_gpu_vram_info(amdsmi_processor_handle processor_handl
   }();
 
   // Succeed if at least one source provided data; otherwise surface the DRM error.
-  if (vendor_status != AMDSMI_STATUS_SUCCESS && drm_status != AMDSMI_STATUS_SUCCESS) {
+  if (vendor_status != AMDSMI_STATUS_SUCCESS && size_status != AMDSMI_STATUS_SUCCESS &&
+      drm_status != AMDSMI_STATUS_SUCCESS) {
     return drm_status;
   }
 


### PR DESCRIPTION
## Motivation

Follow-up to #6876, which deprecated `amdsmi_get_gpu_vram_vendor()` in favor of `amdsmi_get_gpu_vram_info()`. That PR re-pointed `amdsmi_get_gpu_vram_vendor()` at `amdsmi_get_gpu_vram_info()` but introduced two correctness bugs and an undocumented behavior change.

## Technical Details

- **Fixed a null-pointer dereference in `amdsmi_get_gpu_vram_vendor()`.** The reworked implementation called `snprintf(brand, ...)` with no null check and copied the result regardless of the return code. Existing tests pass `nullptr` on the not-supported path (`id_info_read.cc`, `ifoe_info_read.cc`), which would crash. The buffer is now null-checked and only written on success.
- **Made `amdsmi_get_gpu_vram_info()` resilient to DRM failures.** It now reads the VRAM vendor from sysfs (`mem_info_vram_vendor`) first and treats the DRM ioctl (`vram_type` / `vram_bit_width` / `vram_max_bandwidth`) as best effort. The ioctl no longer gates the call: the vendor is still returned when the DRM path is unavailable, and the function only fails when neither source yields data. The DRM ioctl carries no vendor field, so sysfs remains the sole vendor source.
- **Clarified deprecation messaging** in the header doxygen, Python docstring, and `docs/reference/amdsmi-py-api.md` to state the API is slated for removal in a future ROCm release (no hardcoded version) and to name `amdsmi_get_gpu_vram_info()` as the replacement.
- **Updated `CHANGELOG.md`** accordingly.

## JIRA ID

AILITOOLS-268

## Test Plan

- Built `libamd_smi.so` and `amdsmitst` from source under `-Werror -Wconversion` (RelWithDebInfo).
- Ran the C++ GTest cases that exercise the vendor API and the `nullptr` not-supported path on hardware (2 GPUs): `TestIdInfoRead`, `TestMutualExclusion`.

## Test Result

- Library and tests build cleanly with no new warnings.
- `TestIdInfoRead` and `TestMutualExclusion` **PASS**. `amdsmi_get_gpu_vram_vendor()` returns `SAMSUNG` on supported GPUs and `AMDSMI_STATUS_INVAL` for a `nullptr` buffer (no crash); `amdsmi_get_gpu_vram_info()` returns matching vendor data.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
