### PR TITLE
rocr: Fix get_hwreg_size_per_cu() in older devices

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/queues.c
+++ b/projects/rocr-runtime/libhsakmt/src/queues.c
@@ -112,15 +112,16 @@ static uint32_t get_hwreg_size_per_cu(const HsaNodeProperties *node, uint32_t gf
 	HSAuint32 num_waves_per_simd = node->MaxWavesPerSIMD;
 	HSAuint32 bytes_per_wave = 128;
 
+	if (gfxv < GFX_VERSION_GFX1250) {
+		return 0x1000;
+	}
+
 	if (gfxv == GFX_VERSION_GFX1250) {
 		bytes_per_wave = 512;  // per HW design; GFX_SHARED__HWREG_SPACE_USED
 	}
 
 	hwreg_size_bytes = num_waves_per_simd * simd_per_cu * bytes_per_wave;
 
-	assert(hwreg_size_bytes == (
-		gfxv == GFX_VERSION_GFX1250 ?	0x8000 :
-										0x1000));
 	return hwreg_size_bytes;
 }
 


### PR DESCRIPTION
For older devices use a hardcoded value.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
