### PR TITLE
[AMD-SMI] Follow-up fixes for compute partition mem-alloc-mode API

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -82,12 +82,6 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Added
 
-- **Added `--sort-by-pid` flag and `amdsmi_get_gpu_process_list_by_pid()` API**.  
-  - New C API `amdsmi_get_gpu_process_list_by_pid()` aggregates process info across all GPUs and returns results keyed by PID, with per-GPU breakdowns for memory, engine usage, and occupancy.
-  - New structs: `amdsmi_proc_gpu_entry_t`, `amdsmi_proc_info_by_pid_t`.
-  - New `--sort-by-pid` CLI flag for `amd-smi process` and `amd-smi monitor --process` groups output by PID instead of GPU.
-  - New Python interface function `amdsmi_get_gpu_process_list_by_pid()`.
-
 - **Added APU metrics support (table versions 2.4 and 3.0)**.  
   - New `amdsmi_apu_metrics_t` struct accessible via `amdsmi_gpu_metrics_t.apu_metrics` pointer (non-null when APU-specific metrics are available).
   - **v2.4 metrics**:

--- a/projects/amdsmi/amdsmi_cli/subcommands/static.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/static.py
@@ -857,8 +857,8 @@ class StaticCommands:
             static_dict["partition"] = {
                 "accelerator_partition": compute_partition,
                 "memory_partition": memory_partition,
-                "compute_partition_mem_alloc_mode": mem_alloc_mode,
                 "partition_id": partition_id,
+                "compute_partition_mem_alloc_mode": mem_alloc_mode,
             }
         if "soc_pstate" in current_platform_args:
             if args.soc_pstate:

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -5589,6 +5589,7 @@ Exceptions that can be thrown by `amdsmi_get_gpu_compute_partition_mem_alloc_mod
 - `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported on this device or driver version
 - `AMDSMI_STATUS_INVAL` - Invalid parameters
 - `AMDSMI_STATUS_UNEXPECTED_DATA` - Unexpected data read from driver/sysfs
+- `AMDSMI_STATUS_FILE_ERROR` - Problem accessing the sysfs file
 
 Example:
 
@@ -5629,8 +5630,9 @@ Exceptions that can be thrown by `amdsmi_set_gpu_compute_partition_mem_alloc_mod
 #### Possible Library Exceptions
 
 - `AMDSMI_STATUS_NOT_SUPPORTED` - Feature not supported on this device or driver version
-- `AMDSMI_STATUS_PERMISSION` - Permission Denied (requires sudo)
+- `AMDSMI_STATUS_NO_PERM` - Permission Denied (requires sudo)
 - `AMDSMI_STATUS_INVAL` - Invalid parameters
+- `AMDSMI_STATUS_FILE_ERROR` - Problem accessing the sysfs file
 
 Example:
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6884,6 +6884,7 @@ amdsmi_status_t amdsmi_set_gpu_compute_partition(amdsmi_processor_handle process
  *  @retval ::AMDSMI_STATUS_SUCCESS call was successful
  *  @retval ::AMDSMI_STATUS_INVAL the provided arguments are not valid
  *  @retval ::AMDSMI_STATUS_UNEXPECTED_DATA data provided to function is not valid
+ *  @retval ::AMDSMI_STATUS_FILE_ERROR problem accessing the sysfs file
  *  @retval ::AMDSMI_STATUS_NOT_SUPPORTED installed software or hardware does not
  *  support this function
  */
@@ -6913,13 +6914,15 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition_mem_alloc_mode(
  *  updated to.
  *
  *  @retval ::AMDSMI_STATUS_SUCCESS call was successful
- *  @retval ::AMDSMI_STATUS_PERMISSION function requires admin/sudo privileges
+ *  @retval ::AMDSMI_STATUS_NO_PERM function requires admin/sudo privileges
  *  @retval ::AMDSMI_STATUS_INVAL the provided arguments are not valid
+ *  @retval ::AMDSMI_STATUS_FILE_ERROR problem accessing the sysfs file
  *  @retval ::AMDSMI_STATUS_NOT_SUPPORTED installed software or hardware does not
  *  support this function
  */
 amdsmi_status_t amdsmi_set_gpu_compute_partition_mem_alloc_mode(
     amdsmi_processor_handle processor_handle, amdsmi_compute_partition_mem_alloc_mode_t mode);
+
 /** @} End tagComputePartition */
 
 /*****************************************************************************/

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -6069,9 +6069,9 @@ rsmi_status_t rsmi_dev_compute_partition_mem_alloc_mode_set(
   REQUIRE_ROOT_ACCESS
 
   // Unlike rsmi_dev_compute_partition_set, do not read-before-write here.
-  // The mem-alloc-mode sysfs attribute is a cheap, idempotent store with no
-  // hardware reconfigure side effects, so an unconditional write is correct
-  // and avoids a TOCTOU window between the read and write under DEVICE_MUTEX.
+  // The mem-alloc-mode sysfs attribute is a cheap store; writing the same value
+  // again is a no-op with no hardware reconfigure side effects, so an unconditional
+  // write is correct and avoids a TOCTOU window between the read and write.
   std::string newModeStr;
   switch (mode) {
     case RSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING:

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -6068,6 +6068,10 @@ rsmi_status_t rsmi_dev_compute_partition_mem_alloc_mode_set(
   LOG_TRACE(ss);
   REQUIRE_ROOT_ACCESS
 
+  // Unlike rsmi_dev_compute_partition_set, do not read-before-write here.
+  // The mem-alloc-mode sysfs attribute is a cheap, idempotent store with no
+  // hardware reconfigure side effects, so an unconditional write is correct
+  // and avoids a TOCTOU window between the read and write under DEVICE_MUTEX.
   std::string newModeStr;
   switch (mode) {
     case RSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING:

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -3026,6 +3026,9 @@ amdsmi_status_t amdsmi_set_gpu_compute_partition(
 amdsmi_status_t amdsmi_get_gpu_compute_partition_mem_alloc_mode(
     amdsmi_processor_handle processor_handle, amdsmi_compute_partition_mem_alloc_mode_t* mode) {
   AMDSMI_CHECK_INIT();
+  if (mode == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
   std::ostringstream ss;
   auto status = rsmi_wrapper(rsmi_dev_compute_partition_mem_alloc_mode_get, processor_handle, 0,
                              reinterpret_cast<rsmi_compute_partition_mem_alloc_mode_t*>(mode));
@@ -3038,6 +3041,10 @@ amdsmi_status_t amdsmi_get_gpu_compute_partition_mem_alloc_mode(
 amdsmi_status_t amdsmi_set_gpu_compute_partition_mem_alloc_mode(
     amdsmi_processor_handle processor_handle, amdsmi_compute_partition_mem_alloc_mode_t mode) {
   AMDSMI_CHECK_INIT();
+  if (mode != AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING &&
+      mode != AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL) {
+    return AMDSMI_STATUS_INVAL;
+  }
   return rsmi_wrapper(rsmi_dev_compute_partition_mem_alloc_mode_set, processor_handle, 0,
                       static_cast<rsmi_compute_partition_mem_alloc_mode_t>(mode));
 }

--- a/projects/amdsmi/tests/amd_smi_test/functional/computepartition_memallocmode_read_write.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/computepartition_memallocmode_read_write.cc
@@ -61,7 +61,7 @@ void TestComputePartitionMemAllocModeReadWrite::Close() {
   TestBase::Close();
 }
 
-static const std::string memAllocModeString(amdsmi_compute_partition_mem_alloc_mode_t mode) {
+static std::string memAllocModeString(amdsmi_compute_partition_mem_alloc_mode_t mode) {
   switch (mode) {
     case AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING:
       return "CAPPING";
@@ -81,7 +81,8 @@ void TestComputePartitionMemAllocModeReadWrite::Run(void) {
     return;
   }
 
-  // Invalid input tests (device-independent)
+  // Invalid argument tests (run only when at least one device exists;
+  // the handle is validated by SetUp).
   ret = amdsmi_get_gpu_compute_partition_mem_alloc_mode(processor_handles_[0], nullptr);
   EXPECT_EQ(ret, AMDSMI_STATUS_INVAL);
 
@@ -182,5 +183,10 @@ void TestComputePartitionMemAllocModeReadWrite::Run(void) {
         amdsmi_set_gpu_compute_partition_mem_alloc_mode(processor_handles_[dv_ind], original_mode);
     DISPLAY_AMDSMI_STATUS(isVerbose, __FILE__, __LINE__, ret, AMDSMI_STATUS_SUCCESS);
     EXPECT_EQ(ret, AMDSMI_STATUS_SUCCESS);
+    if (ret != AMDSMI_STATUS_SUCCESS) {
+      std::cerr << "\t**WARNING: failed to restore device " << dv_ind
+                << " to original compute_partition_mem_alloc_mode = "
+                << memAllocModeString(original_mode) << "; device left in modified state.\n";
+    }
   }
 }

--- a/projects/amdsmi/tests/python_unittest/common.py
+++ b/projects/amdsmi/tests/python_unittest/common.py
@@ -618,6 +618,15 @@ class Common:
                 (member.name, amdsmi.AmdSmiMemoryPartitionType(member.value), cond)
             )
 
+        self.compute_partition_mem_alloc_mode_types = []
+        for member in amdsmi.AmdSmiComputePartitionMemAllocModeType:
+            cond = self.PASS
+            if member.name in ["INVALID"]:
+                cond = self.FAIL
+            self.compute_partition_mem_alloc_mode_types.append(
+                (member.name, amdsmi.AmdSmiComputePartitionMemAllocModeType(member.value), cond)
+            )
+
         self.freq_inds = []
         for member in amdsmi.AmdSmiFreqInd:
             cond = self.PASS

--- a/projects/amdsmi/tests/python_unittest/unit_tests.py
+++ b/projects/amdsmi/tests/python_unittest/unit_tests.py
@@ -1529,6 +1529,15 @@ class TestAmdSmiPython(unittest.TestCase):
         )
         return
 
+    def test_set_gpu_compute_partition_mem_alloc_mode(self):
+        self.common.print_func_name("")
+
+        self.common.Test_Per_GPU_With_One_Enum(
+            amdsmi_set_gpu_compute_partition_mem_alloc_mode=amdsmi.amdsmi_set_gpu_compute_partition_mem_alloc_mode,
+            compute_partition_mem_alloc_mode=self.common.compute_partition_mem_alloc_mode_types,
+        )
+        return
+
     def test_set_gpu_memory_partition_mode(self):
         self.common.print_func_name("")
 


### PR DESCRIPTION
## Motivation

Follow-up to PR #5147 which added the compute partition memory allocation mode API and CLI. This PR addresses issues found in code review.

## Technical Details

**Docs / header** (`include/amd_smi/amdsmi.h`, `docs/reference/amdsmi-py-api.md`):
- `AMDSMI_STATUS_PERMISSION` in the setter's `@retval` and Python API reference was wrong — the correct constant is `AMDSMI_STATUS_NO_PERM`
- Added missing `AMDSMI_STATUS_FILE_ERROR` to both getter and setter `@retval` lists (sysfs failures propagate through `ErrnoToRsmiStatus`)
- Added missing blank line before the doxygen `@}` group close marker

**CLI field order** (`amdsmi_cli/subcommands/static.py`):
- `compute_partition_mem_alloc_mode` was placed before `partition_id` in the output dict, contradicting the documented order in `docs/how-to/amdsmi-cli-tool.md`; swapped to match

**CHANGELOG** (`CHANGELOG.md`):
- A `--sort-by-pid` block was accidentally re-added to the 7.13.0 section by the merge commit in #5147; removed

**Public API hardening** (`src/amd_smi/amd_smi.cc`, `rocm_smi/src/rocm_smi.cc`):
- Getter now rejects `nullptr` mode pointer with `AMDSMI_STATUS_INVAL` at the public layer
- Setter now rejects out-of-range enum values at the public layer before the `static_cast`
- Added inline comment explaining why the setter writes unconditionally (avoids TOCTOU on a cheap sysfs attribute, unlike `rsmi_dev_compute_partition_set`)

**Tests** (`tests/amd_smi_test/functional/computepartition_memallocmode_read_write.cc`, `tests/python_unittest/`):
- Added `test_set_gpu_compute_partition_mem_alloc_mode` Python unit test (setter was only covered by CLI integration tests)
- Added `compute_partition_mem_alloc_mode_types` enum list to `common.py` for the above
- C++ test now prints a stderr warning with the device number when the post-test mode restore fails
- Fixed misleading `// Invalid input tests (device-independent)` comment — calls use `processor_handles_[0]` and require the device guard
- Removed redundant `const` on by-value return from `memAllocModeString()`

## JIRA ID

N/A

## Test Plan

- Pre-commit passes on all changed files
- Incremental build of `amd_smi` static lib + `amdsmitst` binary — clean, 0 new warnings
- No hardware test required: changes are docs, field ordering, null/range guards, comments, and tests

## Test Result

Build clean. Pre-commit clean.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.