### PR TITLE
[hipFile] removed working directory from the disabled tests

### DIFF
--- a/projects/hipfile/examples/basics/CMakeLists.txt
+++ b/projects/hipfile/examples/basics/CMakeLists.txt
@@ -124,8 +124,14 @@ if(BUILD_TESTING)
             LABELS "system;hipfile;basics"
         )
         if(mode_name STREQUAL "managed" OR mode_name STREQUAL "pinned")
+            # Disabled modes never run, but ctest still chdir's into a test's
+            # WORKING_DIRECTORY to report it — and the fixture scratch dir is
+            # already cleaned up by then (disabled tests don't keep the fixture
+            # alive). Point them at the always-present build dir so reporting
+            # them doesn't emit a spurious "Failed to change working directory".
             set_tests_properties(basics_various-mem-rw_${mode_name} PROPERTIES
                 DISABLED TRUE
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             )
         endif()
     endforeach()


### PR DESCRIPTION
## Motivation

cleanup on how the test results present themselves on disabled examples

## Technical Details

removed the working directory that gets cleaned up by ctest for 2 tests 
basics_various-mem-rw_managed
basics_various-mem-rw_pinned

## JIRA ID
AIHIPFILE-135

## Test Plan

CI. This is a CI test augmentation

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
