### PR TITLE
[hipfile] Fix UBSan enum check on param validation

### DIFF
--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -10,12 +10,14 @@
 #include "hipfile.h"
 #include "state.h"
 
+#include <bit>
 #include <cstddef>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -66,18 +68,31 @@ BatchOperation::BatchOperation(std::unique_ptr<const hipFileIOParams_t> params,
         throw std::invalid_argument(msg.str());
     }
 
+    // These enums have no fixed underlying type, so loading an out-of-range
+    // value (e.g. one passed in by a misbehaving caller) is UB and trips
+    // UBSan's enum check. Read the raw bits as a signed integer of the same
+    // width instead: this dodges the enum load and keeps a -1 mismatch
+    // readable regardless of the underlying type's implementation-defined
+    // signedness (a value-preserving widen would render -1 as a huge unsigned
+    // number when the underlying type is unsigned).
+    using opcode_raw_t    = std::make_signed_t<std::underlying_type_t<hipFileOpcode_t>>;
+    using mode_raw_t      = std::make_signed_t<std::underlying_type_t<hipFileBatchMode_t>>;
+    const auto opcode_raw = std::bit_cast<opcode_raw_t>(io_params->opcode);
+    const auto mode_raw   = std::bit_cast<mode_raw_t>(io_params->mode);
+
     // Check OpCode
-    if (io_params->opcode != hipFileBatchRead && io_params->opcode != hipFileBatchWrite) {
+    if (opcode_raw != static_cast<opcode_raw_t>(hipFileBatchRead) &&
+        opcode_raw != static_cast<opcode_raw_t>(hipFileBatchWrite)) {
         std::stringstream msg;
-        msg << "Bad opcode specified. Value: " << io_params->opcode;
+        msg << "Bad opcode specified. Value: " << opcode_raw;
         msg << ". Cookie: " << io_params->cookie;
         throw std::invalid_argument(msg.str());
     }
 
     // Check Batch Mode
-    if (io_params->mode != hipFileBatch) {
+    if (mode_raw != static_cast<mode_raw_t>(hipFileBatch)) {
         std::stringstream msg;
-        msg << "Invalid Batch mode specified. Value: " << io_params->mode;
+        msg << "Invalid Batch mode specified. Value: " << mode_raw;
         msg << ". Cookie: " << io_params->cookie;
         throw std::invalid_argument(msg.str());
     }


### PR DESCRIPTION
## Motivation

Tests intentionally pass invalid enum values into the batch API to verify
they are rejected. The opcode and mode fields are unscoped enums with no
fixed underlying type, so loading an out-of-range value is undefined
behavior and trips UBSan's enum check before our own validation can run.

## Technical Details

Read the raw bits of each field as a signed integer of the same width via
std::bit_cast (C++20), dodging the enum load entirely. Validation compares
against the enum constants cast to that same integer type to avoid
mixed-type comparisons. A signed reinterpretation (rather than a
value-preserving widen) keeps a -1 mismatch readable in error messages
regardless of the underlying type's implementation-defined signedness,
which would otherwise render -1 as a large unsigned value.

## JIRA ID

AIHIPFILE-154

## Test Plan

Manual sanitizer verification

## Test Result

Passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
