### PR TITLE
[AMD-SMI] Add AI NIC simulation support for hardware-free testing

### DIFF
--- a/projects/amdsmi/example/CMakeLists.txt
+++ b/projects/amdsmi/example/CMakeLists.txt
@@ -96,6 +96,14 @@ target_include_directories(${SMI_AINIC_EXAMPLE_EXE} PRIVATE ${ROCM_DIR}/include 
 target_link_libraries(${SMI_AINIC_EXAMPLE_EXE} PRIVATE ${_AMDSMI_LINK_TARGET})
 target_link_directories(${SMI_AINIC_EXAMPLE_EXE} PRIVATE ${ROCM_DIR}/lib)
 
+# amd_smi_ainic_info: standalone AI NIC info tool.
+# Uses only public <amd_smi/amdsmi.h> — no internal headers.
+# Works against real hardware and against a simulated sysfs tree
+# (set SMI_NIC_SYSFS_ROOT; see run_simulated_ainic.sh).
+set(SMI_AINIC_INFO_EXE "amd_smi_ainic_info")
+add_executable(${SMI_AINIC_INFO_EXE} "amd_smi_ainic_example.cc")
+target_link_libraries(${SMI_AINIC_INFO_EXE} PRIVATE ${_AMDSMI_LINK_TARGET})
+
 set(SMI_FABRIC_EXAMPLE_EXE "amd_smi_fabric_ex")
 add_executable(${SMI_FABRIC_EXAMPLE_EXE} "amd_smi_fabric_example.cc")
 target_link_libraries(${SMI_FABRIC_EXAMPLE_EXE} PRIVATE ${_AMDSMI_LINK_TARGET})

--- a/projects/amdsmi/example/amd_smi_ainic_example.cc
+++ b/projects/amdsmi/example/amd_smi_ainic_example.cc
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * amd_smi_ainic_example.cc
+ *
+ * Developer tool: discover all AI NIC (Pensando Pollara) devices visible to
+ * amd-smi and print every piece of information the public API exposes.
+ *
+ * Uses ONLY the public header <amd_smi/amdsmi.h> — no internal headers —
+ * so it works both on systems with real hardware and against a simulated
+ * sysfs tree (set SMI_NIC_SYSFS_ROOT before running; see run_simulated_ainic.sh).
+ *
+ * Build: compiled as part of the amdsmi example CMake target amd_smi_ainic_info.
+ */
+
+#include <amd_smi/amdsmi.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static const char* SEP = "  ";
+
+static void print_section(const char* title) {
+  std::cout << "\n" << SEP << "--- " << title << " ---\n";
+}
+
+static void print_field(const char* name, const char* value) {
+  std::cout << SEP << SEP << std::left << std::setw(28) << name << ": " << value << "\n";
+}
+
+static void print_field(const char* name, uint64_t value, bool hex = false) {
+  std::cout << SEP << SEP << std::left << std::setw(28) << name << ": ";
+  if (hex) {
+    std::cout << "0x" << std::hex << value << std::dec;
+  } else {
+    std::cout << value;
+  }
+  std::cout << "\n";
+}
+
+static void print_field(const char* name, uint32_t value, bool hex = false) {
+  print_field(name, static_cast<uint64_t>(value), hex);
+}
+
+static void print_field(const char* name, uint16_t value, bool hex = false) {
+  print_field(name, static_cast<uint64_t>(value), hex);
+}
+
+static void print_field(const char* name, uint8_t value) {
+  print_field(name, static_cast<uint64_t>(value));
+}
+
+// ---------------------------------------------------------------------------
+// Per-device display functions
+// ---------------------------------------------------------------------------
+
+static void show_asic_info(amdsmi_processor_handle handle) {
+  amdsmi_nic_asic_info_t info{};
+  if (amdsmi_get_nic_asic_info(handle, &info) != AMDSMI_STATUS_SUCCESS) {
+    std::cout << SEP << SEP << "(ASIC info unavailable)\n";
+    return;
+  }
+  print_section("ASIC");
+  print_field("Vendor name", info.vendor_name);
+  print_field("Product name", info.product_name);
+  print_field("Part number", info.part_number);
+  print_field("Serial number", info.serial_number);
+  print_field("Vendor ID", info.vendor_id, /*hex=*/true);
+  print_field("Subvendor ID", info.subvendor_id, /*hex=*/true);
+  print_field("Device ID", info.device_id, /*hex=*/true);
+  print_field("Subsystem ID", info.subsystem_id, /*hex=*/true);
+  print_field("Revision", info.revision);
+  print_field("Permanent addr", info.permanent_address);
+}
+
+static void show_bus_info(amdsmi_processor_handle handle) {
+  amdsmi_nic_bus_info_t info{};
+  if (amdsmi_get_nic_bus_info(handle, &info) != AMDSMI_STATUS_SUCCESS) {
+    std::cout << SEP << SEP << "(bus info unavailable)\n";
+    return;
+  }
+  print_section("PCIe Bus");
+  std::cout << SEP << SEP << std::left << std::setw(28) << "BDF"
+            << ": " << std::setfill('0') << std::hex << std::setw(4) << info.bdf.domain_number
+            << ":" << std::setw(2) << (unsigned)info.bdf.bus_number << ":" << std::setw(2)
+            << (unsigned)info.bdf.device_number << "." << std::setw(1)
+            << (unsigned)info.bdf.function_number << std::dec << std::setfill(' ') << "\n";
+  print_field("Max PCIe width (lanes)", info.max_pcie_width);
+  print_field("Max PCIe speed (GT/s)", info.max_pcie_speed);
+  print_field("PCIe interface version", info.pcie_interface_version);
+  print_field("Slot type", info.slot_type);
+}
+
+static void show_driver_info(amdsmi_processor_handle handle) {
+  amdsmi_nic_driver_info_t info{};
+  if (amdsmi_get_nic_driver_info(handle, &info) != AMDSMI_STATUS_SUCCESS) {
+    std::cout << SEP << SEP << "(driver info unavailable)\n";
+    return;
+  }
+  print_section("Driver");
+  print_field("Driver name", info.name);
+  print_field("Driver version", info.version);
+}
+
+static void show_numa_info(amdsmi_processor_handle handle) {
+  amdsmi_nic_numa_info_t info{};
+  if (amdsmi_get_nic_numa_info(handle, &info) != AMDSMI_STATUS_SUCCESS) {
+    std::cout << SEP << SEP << "(NUMA info unavailable)\n";
+    return;
+  }
+  print_section("NUMA");
+  print_field("NUMA node", info.node);
+  print_field("CPU affinity", info.affinity);
+}
+
+static void show_port_info(amdsmi_processor_handle handle) {
+  amdsmi_nic_port_info_t info{};
+  if (amdsmi_get_nic_port_info(handle, &info) != AMDSMI_STATUS_SUCCESS) {
+    std::cout << SEP << SEP << "(port info unavailable)\n";
+    return;
+  }
+  print_section("Ports");
+  std::cout << SEP << SEP << info.num_ports << " port(s)\n";
+  for (uint32_t i = 0; i < info.num_ports; ++i) {
+    const amdsmi_nic_port_t& p = info.ports[i];
+    std::cout << SEP << SEP << "  [port " << i << "]\n";
+    auto pf = [&](const char* name, const char* val) {
+      std::cout << SEP << SEP << "    " << std::left << std::setw(26) << name << ": " << val
+                << "\n";
+    };
+    auto pfn = [&](const char* name, uint64_t val) {
+      std::cout << SEP << SEP << "    " << std::left << std::setw(26) << name << ": " << val
+                << "\n";
+    };
+    pf("netdev", p.netdev);
+    pf("type", p.type);
+    pf("MAC address", p.mac_address);
+    pf("link state", p.link_state);
+    pf("autoneg", p.autoneg);
+    pf("pause autoneg", p.pause_autoneg);
+    pf("pause rx", p.pause_rx);
+    pf("pause tx", p.pause_tx);
+    pfn("port number", p.port_num);
+    pfn("ifindex", p.ifindex);
+    pfn("carrier", p.carrier);
+    pfn("MTU", p.mtu);
+    pfn("link speed", p.link_speed);
+    pfn("active FEC", p.active_fec);
+  }
+}
+
+static void show_rdma_info(amdsmi_processor_handle handle) {
+  amdsmi_nic_rdma_devices_info_t info{};
+  if (amdsmi_get_nic_rdma_dev_info(handle, &info) != AMDSMI_STATUS_SUCCESS) {
+    std::cout << SEP << SEP << "(RDMA info unavailable)\n";
+    return;
+  }
+  print_section("RDMA Devices");
+  std::cout << SEP << SEP << info.num_rdma_dev << " RDMA device(s)\n";
+
+  for (uint8_t d = 0; d < info.num_rdma_dev; ++d) {
+    const amdsmi_nic_rdma_dev_info_t& dev = info.rdma_dev_info[d];
+    std::cout << SEP << SEP << "  [rdma_dev " << (int)d << ": " << dev.rdma_dev << "]\n";
+    auto df = [&](const char* name, const char* val) {
+      std::cout << SEP << SEP << "    " << std::left << std::setw(26) << name << ": " << val
+                << "\n";
+    };
+    df("node GUID", dev.node_guid);
+    df("node type", dev.node_type);
+    df("sys image GUID", dev.sys_image_guid);
+    df("firmware version", dev.fw_ver);
+    std::cout << SEP << SEP << "    " << dev.num_rdma_ports << " RDMA port(s)\n";
+
+    for (uint8_t p = 0; p < dev.num_rdma_ports; ++p) {
+      const amdsmi_nic_rdma_port_info_t& port = dev.rdma_port_info[p];
+      std::cout << SEP << SEP << "      [rdma port " << (int)p << "]\n";
+      auto pf = [&](const char* name, const char* val) {
+        std::cout << SEP << SEP << "        " << std::left << std::setw(22) << name << ": " << val
+                  << "\n";
+      };
+      auto pfn = [&](const char* name, uint64_t val) {
+        std::cout << SEP << SEP << "        " << std::left << std::setw(22) << name << ": " << val
+                  << "\n";
+      };
+      pf("netdev", port.netdev);
+      pf("state", port.state);
+      pfn("rdma port", port.rdma_port);
+      pfn("max MTU", port.max_mtu);
+      pfn("active MTU", port.active_mtu);
+
+      // Fetch live RDMA statistics
+      uint32_t num_stats = 0;
+      amdsmi_status_t s = amdsmi_get_nic_rdma_port_statistics(handle, p, &num_stats, nullptr);
+      if (s == AMDSMI_STATUS_SUCCESS && num_stats > 0) {
+        std::vector<amdsmi_nic_stat_t> stats(num_stats);
+        s = amdsmi_get_nic_rdma_port_statistics(handle, p, &num_stats, stats.data());
+        if (s == AMDSMI_STATUS_SUCCESS) {
+          std::cout << SEP << SEP << "        --- hw_counters (" << num_stats << ") ---\n";
+          for (uint32_t k = 0; k < num_stats; ++k) {
+            std::cout << SEP << SEP << "        " << std::left << std::setw(36) << stats[k].name
+                      << ": " << stats[k].value << "\n";
+          }
+        }
+      } else {
+        std::cout << SEP << SEP << "        (RDMA statistics unavailable)\n";
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main discovery loop
+// ---------------------------------------------------------------------------
+
+static void show_all_nic_devices() {
+  uint32_t soc_count = 0;
+  amdsmi_status_t status = amdsmi_get_socket_handles(&soc_count, nullptr);
+  if (status != AMDSMI_STATUS_SUCCESS) {
+    std::cerr << "amdsmi_get_socket_handles failed: " << (int)status << "\n";
+    return;
+  }
+
+  if (soc_count == 0) {
+    std::cout << "No sockets found.\n";
+    return;
+  }
+
+  std::vector<amdsmi_socket_handle> sockets(soc_count);
+  status = amdsmi_get_socket_handles(&soc_count, sockets.data());
+  if (status != AMDSMI_STATUS_SUCCESS) {
+    std::cerr << "amdsmi_get_socket_handles (data) failed: " << (int)status << "\n";
+    return;
+  }
+
+  uint32_t total_nics = 0;
+  for (uint32_t si = 0; si < soc_count; ++si) {
+    uint32_t nic_count = 0;
+    status = amdsmi_get_processor_handles_by_type(sockets[si], AMDSMI_PROCESSOR_TYPE_AMD_NIC,
+                                                  nullptr, &nic_count);
+    if (status != AMDSMI_STATUS_SUCCESS || nic_count == 0) continue;
+
+    std::vector<amdsmi_processor_handle> handles(nic_count);
+    status = amdsmi_get_processor_handles_by_type(sockets[si], AMDSMI_PROCESSOR_TYPE_AMD_NIC,
+                                                  handles.data(), &nic_count);
+    if (status != AMDSMI_STATUS_SUCCESS) continue;
+
+    for (uint32_t ni = 0; ni < nic_count; ++ni) {
+      std::cout << "\n=== AI NIC device " << total_nics << " (socket " << si << ", device " << ni
+                << ") ===\n";
+      show_asic_info(handles[ni]);
+      show_bus_info(handles[ni]);
+      show_driver_info(handles[ni]);
+      show_numa_info(handles[ni]);
+      show_port_info(handles[ni]);
+      show_rdma_info(handles[ni]);
+      ++total_nics;
+    }
+  }
+
+  std::cout << "\nTotal AI NIC devices found: " << total_nics << "\n";
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+int main() {
+  const char* sysfs_root = std::getenv("SMI_NIC_SYSFS_ROOT");
+  if (sysfs_root && sysfs_root[0] != '\0') {
+    std::cout << "SMI_NIC_SYSFS_ROOT = " << sysfs_root << "  (simulation mode)\n";
+  } else {
+    std::cout << "SMI_NIC_SYSFS_ROOT not set  (real hardware mode)\n";
+  }
+
+  amdsmi_status_t status = amdsmi_init(AMDSMI_INIT_AMD_NICS);
+  if (status != AMDSMI_STATUS_SUCCESS) {
+    std::cerr << "amdsmi_init(AMDSMI_INIT_AMD_NICS) failed: " << (int)status << "\n";
+    return 1;
+  }
+  std::cout << "amd-smi initialized\n";
+
+  show_all_nic_devices();
+
+  amdsmi_shut_down();
+  std::cout << "\namd-smi shut down\n";
+  return 0;
+}

--- a/projects/amdsmi/example/run_simulated_ainic.sh
+++ b/projects/amdsmi/example/run_simulated_ainic.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# run_simulated_ainic.sh — manual developer test for AI NIC simulation.
+#
+# Creates a fake sysfs tree, starts the NIC simulator in the background,
+# then runs amd_smi_ainic_info once so you can see the output.
+#
+# Usage:
+#   ./run_simulated_ainic.sh [path/to/amd_smi_ainic_info]
+#
+# If the binary path is not given, the script looks for amd_smi_ainic_info
+# in the PATH and in common build directories relative to the repo root.
+#
+# Requirements: python3 must be available.
+#
+# Environment variables (optional):
+#   NIC_SIM_INTERVAL  — simulator update interval in seconds (default: 0.1)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Resolve script and repo locations
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# This script lives at projects/amdsmi/example/; simulation scripts are at
+# projects/amdsmi/tests/ai-nic-sim/
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+SIM_DIR="${REPO_ROOT}/projects/amdsmi/tests/ai-nic-sim"
+
+FAKE_SYSFS_PY="${SIM_DIR}/fake_sysfs.py"
+NIC_SIM_PY="${SIM_DIR}/nic_simulator.py"
+
+# ---------------------------------------------------------------------------
+# Locate the amd_smi_ainic_info binary
+# ---------------------------------------------------------------------------
+if [[ $# -ge 1 ]]; then
+    BINARY="$1"
+else
+    BINARY=""
+    for candidate in \
+        "$(command -v amd_smi_ainic_info 2>/dev/null || true)" \
+        "${REPO_ROOT}/build/projects/amdsmi/example/amd_smi_ainic_info" \
+        "${REPO_ROOT}/build-release/projects/amdsmi/example/amd_smi_ainic_info" \
+        "${SCRIPT_DIR}/build/amd_smi_ainic_info"
+    do
+        if [[ -x "${candidate}" ]]; then
+            BINARY="${candidate}"
+            break
+        fi
+    done
+
+    if [[ -z "${BINARY}" ]]; then
+        echo "ERROR: amd_smi_ainic_info not found."
+        echo "  Build it with CMake first, then either:"
+        echo "    $0 /path/to/amd_smi_ainic_info"
+        echo "  or put it in PATH."
+        exit 1
+    fi
+fi
+
+if [[ ! -x "${BINARY}" ]]; then
+    echo "ERROR: '${BINARY}' is not an executable file."
+    exit 1
+fi
+
+echo "Binary : ${BINARY}"
+
+# ---------------------------------------------------------------------------
+# Validate Python helpers
+# ---------------------------------------------------------------------------
+for f in "${FAKE_SYSFS_PY}" "${NIC_SIM_PY}"; do
+    if [[ ! -f "${f}" ]]; then
+        echo "ERROR: Required Python script not found: ${f}"
+        exit 1
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Create the fake sysfs tree
+# ---------------------------------------------------------------------------
+FAKE_ROOT="$(mktemp -d /tmp/ainic-sim-sysfs.XXXXXX)"
+echo "Fake sysfs : ${FAKE_ROOT}"
+python3 "${FAKE_SYSFS_PY}" "${FAKE_ROOT}" > /dev/null
+
+HW_COUNTERS_DIR="${FAKE_ROOT}/sys/devices/pci0000:e0/0000:e2:00.0/0000:e2:00.1/infiniband/rocep226s0/ports/1/hw_counters"
+
+# ---------------------------------------------------------------------------
+# Start the NIC simulator in the background
+# ---------------------------------------------------------------------------
+NIC_SIM_INTERVAL="${NIC_SIM_INTERVAL:-0.1}"
+echo "Starting NIC simulator (interval=${NIC_SIM_INTERVAL}s) ..."
+python3 "${NIC_SIM_PY}" "${HW_COUNTERS_DIR}" --interval "${NIC_SIM_INTERVAL}" &
+SIM_PID=$!
+
+cleanup() {
+    echo ""
+    echo "Stopping NIC simulator (pid ${SIM_PID}) ..."
+    kill "${SIM_PID}" 2>/dev/null || true
+    wait "${SIM_PID}" 2>/dev/null || true
+    echo "Removing fake sysfs: ${FAKE_ROOT}"
+    rm -rf "${FAKE_ROOT}"
+}
+trap cleanup EXIT
+
+# Give the simulator a moment to write the first tick
+sleep 0.3
+
+# ---------------------------------------------------------------------------
+# Run amd_smi_ainic_info with the fake sysfs root
+# ---------------------------------------------------------------------------
+echo ""
+echo "Running: SMI_NIC_SYSFS_ROOT=${FAKE_ROOT} ${BINARY}"
+echo "============================================================"
+SMI_NIC_SYSFS_ROOT="${FAKE_ROOT}" "${BINARY}"
+echo "============================================================"

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -1192,6 +1192,14 @@ amdsmi_status_t amdsmi_get_nic_fw_info(amdsmi_processor_handle processor_handle,
 }
 #endif  // BRCM_NIC
 
+static const std::string& nic_sysfs_root() {
+  static const std::string root = [] {
+    const char* env = std::getenv("SMI_NIC_SYSFS_ROOT");
+    return env ? std::string(env) : std::string("");
+  }();
+  return root;
+}
+
 amdsmi_status_t amdsmi_get_nic_rdma_port_statistics(amdsmi_processor_handle processor_handle,
                                                     uint32_t rdma_port_index, uint32_t* num_stats,
                                                     amdsmi_nic_stat_t* stats) {
@@ -1241,9 +1249,10 @@ amdsmi_status_t amdsmi_get_nic_rdma_port_statistics(amdsmi_processor_handle proc
   std::string rdmadev(nic_info.rdma_dev.rdma_dev_info[0].rdma_dev);
   int port_num = nic_info.rdma_dev.rdma_dev_info[0].rdma_port_info[rdma_port_index].rdma_port;
 
-  std::string directory_path = "/sys/class/net/" + netdev + "/device/infiniband/" + rdmadev +
-                               "/subsystem/" + rdmadev + "/subsystem/" + rdmadev + "/ports/" +
-                               std::to_string(port_num) + "/hw_counters/";
+  std::string directory_path = nic_sysfs_root() + "/sys/class/net/" + netdev +
+                               "/device/infiniband/" + rdmadev + "/subsystem/" + rdmadev +
+                               "/subsystem/" + rdmadev + "/ports/" + std::to_string(port_num) +
+                               "/hw_counters/";
   if (!std::filesystem::exists(directory_path)) {
     ss << __PRETTY_FUNCTION__ << " | Directory does not exist: " << directory_path;
     LOG_ERROR(ss);

--- a/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/inc/smi_sysfs.h
+++ b/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/inc/smi_sysfs.h
@@ -27,6 +27,20 @@
 #include <variant>
 #include <vector>
 
+/**
+ * @brief Return the sysfs root prefix.
+ *
+ * Normally empty (""), which means all paths start directly at "/sys/...".
+ * When the environment variable SMI_NIC_SYSFS_ROOT is set, its value is
+ * prepended to every sysfs path, allowing a fake sysfs tree to be used
+ * for simulation and testing without real hardware.
+ *
+ * Example:
+ *   SMI_NIC_SYSFS_ROOT=/tmp/fake-sysfs
+ *   -> "/sys/class/net" becomes "/tmp/fake-sysfs/sys/class/net"
+ */
+const std::string& smi_sysfs_root();
+
 class SmiSysfsReader {
  public:
   using SysfsValue = std::variant<int, std::string>;

--- a/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/src/smi_nic.cpp
+++ b/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/src/smi_nic.cpp
@@ -562,7 +562,8 @@ std::optional<uint8_t> SmiNic::numa_node() const {
 }
 
 std::optional<std::string> SmiNic::numa_affinity(uint8_t node) const {
-  std::string path = "/sys/devices/system/node/node" + std::to_string(node) + "/cpulist";
+  std::string path =
+      smi_sysfs_root() + "/sys/devices/system/node/node" + std::to_string(node) + "/cpulist";
   return get_sysfs_data<std::string>(path);
 }
 

--- a/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/src/smi_nic_interface.cpp
+++ b/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/src/smi_nic_interface.cpp
@@ -169,7 +169,10 @@ smi_nic_status_t smi_get_nic_driver_info(smi_nic_ctx_t ctx, uint64_t device,
 
   int ret = smi_ethtool_ioctl(ports[0].interface(), &drvinfo);
   if (ret != 0) {
-    return SMI_NIC_STATUS_ERROR;
+    // ethtool unavailable (e.g. simulation or missing driver) — return empty info
+    std::snprintf(info->name, SMI_NIC_MAX_STRING_LENGTH, "%s", "N/A");
+    std::snprintf(info->version, SMI_NIC_MAX_STRING_LENGTH, "%s", "N/A");
+    return SMI_NIC_STATUS_SUCCESS;
   }
 
   std::snprintf(info->name, SMI_NIC_MAX_STRING_LENGTH, "%s", drvinfo.driver);

--- a/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/src/smi_nic_subsystem.cpp
+++ b/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/src/smi_nic_subsystem.cpp
@@ -87,10 +87,10 @@ bool SmiNicSubsystemPensando::driver_loaded(const std::string& bdf, DriverType d
 
   switch (driver_type) {
     case DriverType::IONIC:
-      driver_dir = "/sys/bus/pci/drivers/ionic";
+      driver_dir = smi_sysfs_root() + "/sys/bus/pci/drivers/ionic";
       break;
     case DriverType::IONIC_RDMA:
-      driver_dir = "/sys/bus/auxiliary/drivers/ionic_rdma.rdma";
+      driver_dir = smi_sysfs_root() + "/sys/bus/auxiliary/drivers/ionic_rdma.rdma";
       break;
     default:
       return false;

--- a/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/src/smi_nic_system.cpp
+++ b/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/src/smi_nic_system.cpp
@@ -56,7 +56,9 @@ uint64_t parse_bdf(const std::string& bdf) {
   }
 }
 
-SmiNicSystem::SmiNicSystem() : net_path_("/sys/class/net"), pci_path_("/sys/bus/pci/devices") {
+SmiNicSystem::SmiNicSystem()
+    : net_path_(smi_sysfs_root() + "/sys/class/net"),
+      pci_path_(smi_sysfs_root() + "/sys/bus/pci/devices") {
   register_subsystem(std::make_unique<SmiNicSubsystemPensando>());
   // TODO: broadcom
   // register_subsystem(std::make_unique<SmiNicSubsystemBroadcom>());

--- a/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/src/smi_sysfs.cpp
+++ b/projects/amdsmi/src/nic/ai-nic/amdsmi_unified/src/smi_sysfs.cpp
@@ -23,9 +23,18 @@
 #include "smi_sysfs.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <sstream>
+
+const std::string& smi_sysfs_root() {
+  static const std::string root = [] {
+    const char* env = std::getenv("SMI_NIC_SYSFS_ROOT");
+    return env ? std::string(env) : std::string("");
+  }();
+  return root;
+}
 
 SmiSysfsReader::SysfsStatus SmiSysfsReader::readAll(const std::string& filepath,
                                                     std::vector<SysfsValue>& content) {

--- a/projects/amdsmi/tests/ai-nic-sim/AINIC_SIMULATION.md
+++ b/projects/amdsmi/tests/ai-nic-sim/AINIC_SIMULATION.md
@@ -1,0 +1,430 @@
+# AI NIC Simulation
+
+This document explains how to build, run, and test the AMD AI NIC (Pensando Pollara)
+simulation on a machine **without physical AI NIC hardware**, including inside a
+container.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [How it works](#how-it-works)
+3. [Repository layout](#repository-layout)
+4. [Build instructions](#build-instructions)
+5. [Manual test (quick sanity check)](#manual-test-quick-sanity-check)
+6. [Automated pytest suite](#automated-pytest-suite)
+7. [Full rocprofiler-systems end-to-end test](#full-rocprofiler-systems-end-to-end-test)
+8. [Container quick-start recipe](#container-quick-start-recipe)
+
+---
+
+## Overview
+
+AMD AI NIC cards (Pensando Pollara) expose their metrics through the Linux
+**sysfs** pseudo-filesystem at paths like:
+
+```
+/sys/bus/pci/devices/<bdf>/
+/sys/class/net/<iface>/
+/sys/class/infiniband/<ib_dev>/ports/<n>/hw_counters/
+```
+
+The `amdsmi` library reads these paths at device-discovery time and on every
+metrics collection call.  Because the paths are **hardcoded** in the original
+code, running on a machine without the hardware (e.g. a CI container) makes
+any test of the collection pipeline impossible.
+
+The simulation adds:
+
+* A **configurable sysfs root** (`SMI_NIC_SYSFS_ROOT` env var) — every sysfs
+  path in amdsmi is prefixed with this value instead of the real `/`.
+* A **fake sysfs tree** (`fake_sysfs.py`) — a Python script that builds a
+  minimal but complete tree that satisfies all amdsmi traversals.
+* A **NIC simulator** (`nic_simulator.py`) — a background process that
+  periodically increments the `hw_counters` files so the sampled values are
+  non-zero and rising, just like a real card under load.
+* A **manual info tool** (`amd_smi_ainic_info`) — a C++ binary that calls
+  every public amdsmi NIC API once and prints the result; useful for a quick
+  human-readable sanity check.
+* A **developer script** (`run_simulated_ainic.sh`) — sets everything up and
+  runs `amd_smi_ainic_info` in one shot.
+* **pytest tests** — three automated tests that cover sysfs structure,
+  simulator behaviour, and the full amdsmi read path.
+
+---
+
+## How it works
+
+### `SMI_NIC_SYSFS_ROOT`
+
+Every C++ file that previously used a hardcoded `/sys/...` path now calls
+`smi_sysfs_root()` (declared in `smi_sysfs.h`, implemented in `smi_sysfs.cpp`).
+That helper reads `SMI_NIC_SYSFS_ROOT` from the environment:
+
+* If unset (or empty) → returns `""` → paths are `/sys/...` (real hardware).
+* If set to `/tmp/ainic-sim-sysfs.XYZ` → paths become
+  `/tmp/ainic-sim-sysfs.XYZ/sys/...` (fake tree).
+
+Modified files:
+
+| File | Change |
+|------|--------|
+| `src/nic/ai-nic/amdsmi_unified/inc/smi_sysfs.h` | Declares `smi_sysfs_root()` |
+| `src/nic/ai-nic/amdsmi_unified/src/smi_sysfs.cpp` | Implements `smi_sysfs_root()` |
+| `src/nic/ai-nic/amdsmi_unified/src/smi_nic_system.cpp` | Uses root for `net_path_` and `pci_path_` |
+| `src/nic/ai-nic/amdsmi_unified/src/smi_nic.cpp` | Uses root for NUMA node path |
+| `src/nic/ai-nic/amdsmi_unified/src/smi_nic_subsystem.cpp` | Uses root for driver paths |
+| `src/amd_smi/amd_smi.cc` | Uses root for `hw_counters` lookup via class/net |
+| `src/nic/ai-nic/amdsmi_unified/src/smi_nic_interface.cpp` | `smi_get_nic_driver_info`: treat ethtool failure as non-fatal (returns "N/A" instead of error) |
+
+### Fake sysfs tree
+
+`fake_sysfs.py::create(root)` builds this layout under `root/`:
+
+```
+sys/
+├── bus/
+│   ├── pci/
+│   │   ├── devices/
+│   │   │   ├── 0000:e2:00.0 -> ../../../devices/pci0000:e0/0000:e2:00.0
+│   │   │   └── 0000:e2:00.1 -> ../../../devices/pci0000:e0/0000:e2:00.0/0000:e2:00.1
+│   │   └── drivers/ionic/
+│   │       └── 0000:e2:00.1 -> (symlink, for driver_loaded() check)
+│   └── auxiliary/drivers/ionic_rdma.rdma/
+│       └── ionic_rdma.rdma.0 -> (symlink, for RDMA driver_loaded() check)
+├── class/
+│   ├── net/enp226s0/
+│   │   ├── address, carrier, mtu, operstate, speed, ifindex, ...
+│   │   ├── statistics/{rx_bytes, tx_bytes}
+│   │   └── device -> ../../../devices/pci0000:e0/0000:e2:00.0/0000:e2:00.1
+│   └── infiniband/rocep226s0 -> (symlink to real IB device dir)
+├── devices/
+│   ├── pci0000:e0/
+│   │   └── 0000:e2:00.0/          ← Pensando PCIe bridge (vendor=0x1dd8 dev=0x0008)
+│   │       ├── vendor, device, subsystem_vendor, subsystem_device, revision, ...
+│   │       └── 0000:e2:00.1/      ← Pensando port (vendor=0x1dd8 dev=0x1002)
+│   │           ├── vendor, device, numa_node, ...
+│   │           ├── ionic_rdma.rdma.0/  (auxiliary device for driver check)
+│   │           └── infiniband/rocep226s0/
+│   │               ├── node_guid, node_type, sys_image_guid, fw_ver
+│   │               └── ports/1/
+│   │                   ├── state, max_mtu, active_mtu
+│   │                   └── hw_counters/
+│   │                       ├── rx_rdma_ucast_bytes   ← simulator writes here
+│   │                       ├── tx_rdma_ucast_bytes
+│   │                       └── ... (10 counters total)
+│   └── system/node/node0/cpulist
+```
+
+### NIC simulator
+
+`nic_simulator.py` runs in the background, reading each counter file and
+writing `value + delta` every `--interval` seconds (default 0.1 s).
+It exits cleanly on `SIGTERM` / `SIGINT`.
+
+```
+python3 nic_simulator.py <hw_counters_dir> [--interval 0.1]
+```
+
+---
+
+## Repository layout
+
+```
+projects/amdsmi/
+├── example/
+│   ├── amd_smi_ainic_example.cc   ← manual info tool source
+│   ├── CMakeLists.txt             ← builds amd_smi_ainic_info target
+│   └── run_simulated_ainic.sh     ← one-shot developer test script
+└── src/
+    ├── amd_smi/amd_smi.cc
+    └── nic/ai-nic/amdsmi_unified/
+        ├── inc/smi_sysfs.h
+        └── src/
+            ├── smi_sysfs.cpp
+            ├── smi_nic_system.cpp
+            ├── smi_nic.cpp
+            ├── smi_nic_subsystem.cpp
+            └── smi_nic_interface.cpp
+
+projects/rocprofiler-systems/tests/pytest/
+├── conftest.py           ← registers ainic_sim pytest mark
+├── fake_sysfs.py         ← builds the fake sysfs tree
+├── nic_simulator.py      ← background counter updater
+└── test_ainic_sim.py     ← pytest test suite (4 tests)
+```
+
+---
+
+## Build instructions
+
+### Prerequisites (Ubuntu 22.04 container)
+
+```bash
+apt-get install -y \
+    build-essential cmake git \
+    libnl-3-dev libnl-genl-3-dev libmnl-dev \
+    python3 python3-pip
+pip3 install pytest
+```
+
+### Build amdsmi only (fastest — sufficient for manual testing)
+
+```bash
+cd /path/to/rocm-systems
+
+cmake -S projects/amdsmi \
+      -B projects/amdsmi/build \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DROCM_DIR=/opt/rocm
+
+cmake --build projects/amdsmi/build \
+      --target amd_smi_ainic_info \
+      -j$(nproc)
+```
+
+The binary will be at:
+
+```
+projects/amdsmi/build/example/amd_smi_ainic_info
+```
+
+### Build rocprofiler-systems (required for full end-to-end test)
+
+```bash
+cmake -S projects/rocprofiler-systems \
+      -B projects/rocprofiler-systems/build \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -Damdsmi_DIR=projects/amdsmi/build \
+      -DROCM_DIR=/opt/rocm
+
+cmake --build projects/rocprofiler-systems/build \
+      --target rocprof-sys-sample \
+      -j$(nproc)
+```
+
+---
+
+## Manual test (quick sanity check)
+
+The `run_simulated_ainic.sh` script does everything in one command:
+
+```bash
+cd projects/amdsmi/example
+
+./run_simulated_ainic.sh /path/to/amd_smi_ainic_info
+# or, if the binary is in PATH or a standard build dir:
+./run_simulated_ainic.sh
+```
+
+It will:
+1. Create a temp fake sysfs tree.
+2. Start the NIC simulator in the background.
+3. Run `amd_smi_ainic_info` with `SMI_NIC_SYSFS_ROOT` set.
+4. Print all discovered AI NIC parameters (ASIC, bus, driver, NUMA, ports,
+   RDMA devices, and live hw_counters).
+5. Kill the simulator and clean up on exit.
+
+Expected output excerpt:
+
+```
+SMI_NIC_SYSFS_ROOT = /tmp/ainic-sim-sysfs.XXXXX  (simulation mode)
+amd-smi initialized
+
+=== AI NIC device 0 (socket 0, device 0) ===
+
+  --- ASIC ---
+  Vendor name                  : N/A
+  Product name                 : N/A
+  ...
+
+  --- RDMA Devices ---
+  1 RDMA device(s)
+    [rdma_dev 0: rocep226s0]
+      node GUID                  : 0xaabbccddeeff0011
+      ...
+        --- hw_counters (10) ---
+        rx_rdma_ucast_bytes              : 42
+        tx_rdma_ucast_bytes              : 42
+        ...
+
+Total AI NIC devices found: 1
+amd-smi shut down
+```
+
+---
+
+## Automated pytest suite
+
+```bash
+cd projects/rocprofiler-systems/tests/pytest
+
+# Run all four tests (3 pass/skip, 1 requires build):
+python3 -m pytest test_ainic_sim.py -v
+
+# Run only the two infrastructure tests (no binary needed):
+python3 -m pytest test_ainic_sim.py -v -k "sysfs or simulator"
+
+# Run the amdsmi direct test (needs amd_smi_ainic_info on PATH):
+export PATH=$PATH:/path/to/projects/amdsmi/build/example
+python3 -m pytest test_ainic_sim.py::TestAINICSim::test_amdsmi_reads_simulated_nic_counters -v
+```
+
+### What each test does
+
+| Test | Needs | Validates |
+|------|-------|-----------|
+| `test_fake_sysfs_structure` | nothing | Symlinks, file contents, and directory layout of the fake sysfs tree |
+| `test_nic_simulator_increments_counters` | nothing | Simulator actually increments `hw_counter` files over time |
+| `test_amdsmi_reads_simulated_nic_counters` | `amd_smi_ainic_info` binary | Our patched amdsmi discovers the device, reads RDMA counters, and returns non-zero values while the simulator runs |
+| `test_rocprof_sys_sample_collects_nic_metrics` | dev build + `AINIC_TEST_ROCPROF=1` | Full rocprofiler-systems pipeline collects NIC metrics from the simulation |
+
+### Enabling the rocprof-sys-sample test
+
+This test requires a `rocprof-sys-sample` binary built against the patched
+amdsmi (the installed system version does not support `SMI_NIC_SYSFS_ROOT`):
+
+```bash
+export AINIC_TEST_ROCPROF=1
+export PATH=/path/to/rocprofiler-systems/build/bin:$PATH
+python3 -m pytest test_ainic_sim.py -v
+```
+
+---
+
+## Full rocprofiler-systems end-to-end test
+
+Once both projects are built (see [Build instructions](#build-instructions)):
+
+```bash
+export SMI_NIC_SYSFS_ROOT=$(mktemp -d)
+python3 -c "
+import sys
+sys.path.insert(0, 'projects/rocprofiler-systems/tests/pytest')
+import fake_sysfs
+from pathlib import Path
+fake_sysfs.create(Path('$SMI_NIC_SYSFS_ROOT'))
+"
+
+HW=$SMI_NIC_SYSFS_ROOT/sys/devices/pci0000:e0/0000:e2:00.0/0000:e2:00.1/infiniband/rocep226s0/ports/1/hw_counters
+python3 projects/rocprofiler-systems/tests/pytest/nic_simulator.py "$HW" &
+SIM=$!
+
+SMI_NIC_SYSFS_ROOT=$SMI_NIC_SYSFS_ROOT \
+  AINIC_TEST_ROCPROF=1 \
+  PATH=projects/rocprofiler-systems/build/bin:$PATH \
+  python3 -m pytest projects/rocprofiler-systems/tests/pytest/test_ainic_sim.py -v
+
+kill $SIM
+rm -rf "$SMI_NIC_SYSFS_ROOT"
+```
+
+---
+
+## Container quick-start recipe
+
+This is the complete procedure to go from a clean Ubuntu 22.04 container to a
+passing AI NIC simulation test, assuming the rocm-systems repository is mounted
+at `/mnt`.
+
+```bash
+# 1. Install build dependencies
+apt-get update && apt-get install -y \
+    build-essential cmake git ninja-build \
+    libnl-3-dev libnl-genl-3-dev libmnl-dev \
+    python3 python3-pip
+pip3 install pytest
+
+# 2. Build amdsmi (only the info binary, fast build)
+cmake -S /mnt/projects/amdsmi \
+      -B /tmp/amdsmi-build \
+      -GNinja \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DROCM_DIR=/opt/rocm
+
+ninja -C /tmp/amdsmi-build amd_smi_ainic_info
+
+# 3. Quick manual sanity check
+cd /mnt/projects/amdsmi/example
+./run_simulated_ainic.sh /tmp/amdsmi-build/example/amd_smi_ainic_info
+
+# 4. Run the automated tests
+export PATH=$PATH:/tmp/amdsmi-build/example
+cd /mnt/projects/rocprofiler-systems/tests/pytest
+python3 -m pytest test_ainic_sim.py -v
+```
+
+Expected result: **3 PASSED, 1 SKIPPED** (the rocprof-sys-sample test is
+skipped until `AINIC_TEST_ROCPROF=1` and a dev build are available).
+
+---
+
+## Running `test_ainic_perf.py` without hardware
+
+`test_ainic_perf.py` tests full end-to-end AI NIC performance sampling via
+`rocprof-sys-sample`.  It was originally written for systems with real Pensando
+Pollara hardware, but it now supports simulation via `SMI_NIC_SYSFS_ROOT`.
+
+### Prerequisites
+
+* A dev build of **rocprofiler-systems** that links against the patched amdsmi
+  (the one with `SMI_NIC_SYSFS_ROOT` support and the non-fatal ethtool path).
+* `wget` must be on the `PATH` (the test uses it as the profiled workload).
+* The `setup_ainic_sim.sh` script (in the same directory as the tests).
+
+### Workflow: two terminals
+
+**Terminal 1 — start the simulation** (keep it running for the duration of the tests):
+
+```bash
+cd projects/rocprofiler-systems/tests/pytest
+./setup_ainic_sim.sh
+```
+
+The script prints a line like:
+
+```
+    export SMI_NIC_SYSFS_ROOT=/tmp/ainic-sim-12345
+```
+
+**Terminal 2 — run the tests:**
+
+```bash
+# Copy the export line from Terminal 1:
+export SMI_NIC_SYSFS_ROOT=/tmp/ainic-sim-12345
+export ROCPROFSYS_BUILD_DIR=/mnt/projects/rocprofiler-systems/build/debug
+
+cd projects/rocprofiler-systems/tests/pytest
+pytest -m ainic test_ainic_perf.py -v
+```
+
+The `ainic_perf_env` fixture automatically forwards `SMI_NIC_SYSFS_ROOT` into
+the `rocprof-sys-sample` child process so that amdsmi uses the fake sysfs.
+The `ainic_available` session fixture skips the test automatically if neither
+real hardware nor `SMI_NIC_SYSFS_ROOT` is set.
+
+### What the test validates
+
+| Check | How |
+|-------|-----|
+| 10 AI NIC Perfetto counter tracks written | `assert_perfetto()` with `AINIC_PERFETTO_COUNTER_NAMES` |
+| 10 AI NIC track names in ROCpd SQLite DB | queries `rocpd_string_*` tables for `ainic_*` strings |
+
+### Simulation vs real hardware
+
+| | Simulation | Real hardware |
+|---|---|---|
+| `SMI_NIC_SYSFS_ROOT` | set to fake sysfs root | unset |
+| Counter source | `nic_simulator.py` (increments files every 50 ms) | Pensando Pollara NIC |
+| Workload | `wget` download (2 files) | same |
+| Expected result | PASSED (counters non-zero) | PASSED (counters non-zero) |
+
+> **Tip:** The download URLs in the test point to real release artifacts. In an
+> air-gapped environment, replace them with any HTTP endpoint that takes several
+> seconds to respond (e.g. a local Python HTTP server serving a large file).
+
+> **Note:** `ROCPROFSYS_USE_PROCESS_SAMPLING` must be `ON` (which is the default
+> in the fixture) because `ROCPROFSYS_USE_AINIC` is in the `process_sampling`
+> category.  Setting process sampling to `OFF` silently disables AINIC even
+> when `ROCPROFSYS_USE_AINIC=ON`.

--- a/projects/amdsmi/tests/ai-nic-sim/fake_sysfs.py
+++ b/projects/amdsmi/tests/ai-nic-sim/fake_sysfs.py
@@ -1,0 +1,182 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+fake_sysfs.py — build a minimal fake sysfs tree that fools amdsmi into
+thinking one AMD Pensando Pollara (AI NIC) card is present.
+
+Directory layout mirrors real Linux sysfs.  Symlinks are created to
+satisfy every traversal that amdsmi_unified and amd_smi.cc perform:
+
+  - SmiNicSubsystemPensando::discover()   reads pci_path for vendor/device IDs
+  - SmiNicSubsystem::resolve_bdf()        follows class/net/<iface>/device symlink
+  - SmiNicSubsystemPensando::downstream_port()  canonicalises pci symlink
+  - SmiNicSubsystemPensando::driver_loaded()    checks pci/drivers/ionic and
+                                                auxiliary/drivers/ionic_rdma.rdma
+  - SmiNicPort::discover_infiniband()     reads <pci_bdf>/infiniband/...
+  - SmiInfiniBandPort::collect_hw_counters()  reads ports/<N>/hw_counters/*
+  - amdsmi_get_nic_rdma_port_statistics() re-reads hw_counters on every call
+    via: class/net/<iface>/device/infiniband/<ib>/subsystem/<ib>/subsystem/<ib>/ports/<N>/hw_counters/
+
+Usage (command line):
+    python3 fake_sysfs.py <SIM_ROOT>
+
+Prints the hw_counters directory path to stdout so callers can capture it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Simulated hardware identifiers
+# ---------------------------------------------------------------------------
+
+BRIDGE_BDF = "0000:e2:00.0"  # Pensando PCIe bridge (vendor=0x1dd8, device=0x0008)
+PORT_BDF = "0000:e2:00.1"  # Pensando Ethernet/IB port (vendor=0x1dd8, device=0x1002)
+IFACE = "enp226s0"  # Linux net interface name
+IB_DEV = "rocep226s0"  # InfiniBand device name
+IB_PORT = "1"  # InfiniBand port number (directory name under ports/)
+
+VENDOR_ID_HEX = "0x1dd8"
+BRIDGE_DEV_HEX = "0x0008"
+PORT_DEV_HEX = "0x1002"
+
+HW_COUNTERS = [
+    "rx_rdma_ucast_bytes",
+    "tx_rdma_ucast_bytes",
+    "rx_rdma_ucast_pkts",
+    "tx_rdma_ucast_pkts",
+    "rx_rdma_cnp_pkts",
+    "tx_rdma_cnp_pkts",
+    "tx_rdma_ack_timeout",
+    "resp_tx_pkt_seq_err",
+    "req_rx_pkt_seq_err",
+    "req_rx_impl_nak_seq_err",
+]
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _symlink(link: Path, target: str) -> None:
+    """Create symlink, replacing any existing one."""
+    link.parent.mkdir(parents=True, exist_ok=True)
+    if link.is_symlink() or link.exists():
+        link.unlink()
+    link.symlink_to(target)
+
+
+def create(root: Path) -> Path:
+    """
+    Populate *root* with the fake sysfs tree and return the path to the
+    hw_counters directory (the one the simulator will keep updating).
+    """
+    root = root.resolve()
+
+    bridge_dev = root / "sys/devices/pci0000:e0" / BRIDGE_BDF
+    bridge_dev.mkdir(parents=True, exist_ok=True)
+    _write(bridge_dev / "vendor", VENDOR_ID_HEX)
+    _write(bridge_dev / "device", BRIDGE_DEV_HEX)
+    _write(bridge_dev / "subsystem_vendor", VENDOR_ID_HEX)
+    _write(bridge_dev / "subsystem_device", "0x0000")
+    _write(bridge_dev / "revision", "0x00")
+    _write(bridge_dev / "class", "0x060400")
+    _write(bridge_dev / "max_link_width", "16")
+    _write(bridge_dev / "max_link_speed", "16")
+    _write(bridge_dev / "numa_node", "0")
+
+    port_dev = bridge_dev / PORT_BDF
+    port_dev.mkdir(parents=True, exist_ok=True)
+    _write(port_dev / "vendor", VENDOR_ID_HEX)
+    _write(port_dev / "device", PORT_DEV_HEX)
+    _write(port_dev / "subsystem_vendor", VENDOR_ID_HEX)
+    _write(port_dev / "subsystem_device", "0x0000")
+    _write(port_dev / "revision", "0x00")
+    _write(port_dev / "numa_node", "0")
+
+    ib_dev_dir = port_dev / "infiniband" / IB_DEV
+    ib_dev_dir.mkdir(parents=True, exist_ok=True)
+    _write(ib_dev_dir / "node_guid", "0xaabbccddeeff0011")
+    _write(ib_dev_dir / "node_type", "1: CA")
+    _write(ib_dev_dir / "sys_image_guid", "0xaabbccddeeff0011")
+    _write(ib_dev_dir / "fw_ver", "1.15.0")
+
+    ib_port_dir = ib_dev_dir / "ports" / IB_PORT
+    ib_port_dir.mkdir(parents=True, exist_ok=True)
+    _write(ib_port_dir / "state", "4: ACTIVE")
+    _write(ib_port_dir / "max_mtu", "4096")
+    _write(ib_port_dir / "active_mtu", "4096")
+
+    hw_counters_dir = ib_port_dir / "hw_counters"
+    hw_counters_dir.mkdir(parents=True, exist_ok=True)
+    for counter in HW_COUNTERS:
+        _write(hw_counters_dir / counter, "0")
+
+    rdma_aux_dev = port_dev / "ionic_rdma.rdma.0"
+    rdma_aux_dev.mkdir(parents=True, exist_ok=True)
+
+    net_iface_dir = root / "sys/class/net" / IFACE
+    net_iface_dir.mkdir(parents=True, exist_ok=True)
+    _write(net_iface_dir / "address", "aa:bb:cc:dd:ee:ff")
+    _write(net_iface_dir / "dev_port", "0")
+    _write(net_iface_dir / "type", "32")
+    _write(net_iface_dir / "ifindex", "5")
+    _write(net_iface_dir / "carrier", "1")
+    _write(net_iface_dir / "mtu", "4096")
+    _write(net_iface_dir / "operstate", "up")
+    _write(net_iface_dir / "speed", "100000")
+    stats_dir = net_iface_dir / "statistics"
+    stats_dir.mkdir(exist_ok=True)
+    _write(stats_dir / "rx_bytes", "0")
+    _write(stats_dir / "tx_bytes", "0")
+    _symlink(net_iface_dir / "device", "../../../devices/pci0000:e0/" + BRIDGE_BDF + "/" + PORT_BDF)
+
+    ib_class_dir = root / "sys/class/infiniband"
+    ib_class_dir.mkdir(parents=True, exist_ok=True)
+    _symlink(
+        ib_class_dir / IB_DEV,
+        "../../devices/pci0000:e0/" + BRIDGE_BDF + "/" + PORT_BDF + "/infiniband/" + IB_DEV,
+    )
+    _symlink(ib_dev_dir / "subsystem", "../../../../../../class/infiniband")
+
+    pci_dev_dir = root / "sys/bus/pci/devices"
+    pci_dev_dir.mkdir(parents=True, exist_ok=True)
+    _symlink(pci_dev_dir / BRIDGE_BDF, "../../../devices/pci0000:e0/" + BRIDGE_BDF)
+    _symlink(pci_dev_dir / PORT_BDF, "../../../devices/pci0000:e0/" + BRIDGE_BDF + "/" + PORT_BDF)
+
+    ionic_driver_dir = root / "sys/bus/pci/drivers/ionic"
+    ionic_driver_dir.mkdir(parents=True, exist_ok=True)
+    _symlink(
+        ionic_driver_dir / PORT_BDF, "../../../../devices/pci0000:e0/" + BRIDGE_BDF + "/" + PORT_BDF
+    )
+
+    rdma_driver_dir = root / "sys/bus/auxiliary/drivers/ionic_rdma.rdma"
+    rdma_driver_dir.mkdir(parents=True, exist_ok=True)
+    _symlink(
+        rdma_driver_dir / "ionic_rdma.rdma.0",
+        "../../../../devices/pci0000:e0/" + BRIDGE_BDF + "/" + PORT_BDF + "/ionic_rdma.rdma.0",
+    )
+
+    _write(root / "sys/devices/system/node/node0/cpulist", "0-63")
+
+    return hw_counters_dir
+
+
+def main() -> None:
+    if len(sys.argv) != 2 or sys.argv[1] in ("-h", "--help"):
+        print(f"Usage: {sys.argv[0]} <SIM_ROOT>", file=sys.stderr)
+        print("  Creates a fake AI NIC sysfs tree under SIM_ROOT and", file=sys.stderr)
+        print("  prints the hw_counters directory path to stdout.", file=sys.stderr)
+        sys.exit(0 if sys.argv[1:] == ["--help"] else 1)
+
+    hw_counters_dir = create(Path(sys.argv[1]))
+    print(hw_counters_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/amdsmi/tests/ai-nic-sim/nic_simulator.py
+++ b/projects/amdsmi/tests/ai-nic-sim/nic_simulator.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+nic_simulator.py — simulate live AI NIC traffic by incrementing hw_counter
+files at a fixed interval.
+
+Usage:
+    python3 nic_simulator.py <hw_counters_dir> [--interval SECONDS]
+
+Where <hw_counters_dir> is the path to the hw_counters directory created by
+fake_sysfs.create().
+
+The process runs until it receives SIGTERM or SIGINT (Ctrl-C).
+"""
+
+from __future__ import annotations
+
+import argparse
+import signal
+import sys
+import time
+from pathlib import Path
+
+INCREMENTS: dict[str, int] = {
+    "rx_rdma_ucast_bytes": 1_000_000,
+    "tx_rdma_ucast_bytes": 800_000,
+    "rx_rdma_ucast_pkts": 1_000,
+    "tx_rdma_ucast_pkts": 800,
+    "rx_rdma_cnp_pkts": 5,
+    "tx_rdma_cnp_pkts": 3,
+    "tx_rdma_ack_timeout": 1,
+    "resp_tx_pkt_seq_err": 1,
+    "req_rx_pkt_seq_err": 1,
+    "req_rx_impl_nak_seq_err": 1,
+}
+
+
+def _read_counter(path: Path) -> int:
+    try:
+        return int(path.read_text().strip())
+    except (ValueError, OSError):
+        return 0
+
+
+def _write_counter(path: Path, value: int) -> None:
+    try:
+        path.write_text(str(value) + "\n")
+    except OSError as exc:
+        print(f"[nic_simulator] Warning: could not write {path}: {exc}", file=sys.stderr)
+
+
+def run(hw_counters_dir: Path, interval: float) -> None:
+    running = True
+
+    def _stop(sig, frame):  # noqa: ANN001
+        nonlocal running
+        running = False
+
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+
+    print(f"[nic_simulator] started (dir={hw_counters_dir}, interval={interval}s)", flush=True)
+
+    while running:
+        for counter_name, delta in INCREMENTS.items():
+            path = hw_counters_dir / counter_name
+            if path.exists() and delta > 0:
+                _write_counter(path, _read_counter(path) + delta)
+        time.sleep(interval)
+
+    print("[nic_simulator] stopped", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simulate AI NIC hw_counters")
+    parser.add_argument("hw_counters_dir", type=Path, help="Path to the hw_counters directory")
+    parser.add_argument(
+        "--interval", type=float, default=0.05, help="Update interval in seconds (default: 0.05)"
+    )
+    args = parser.parse_args()
+
+    if not args.hw_counters_dir.is_dir():
+        print(f"ERROR: {args.hw_counters_dir} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    run(args.hw_counters_dir, args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/amdsmi/tests/ai-nic-sim/setup_ainic_sim.sh
+++ b/projects/amdsmi/tests/ai-nic-sim/setup_ainic_sim.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+#
+# setup_ainic_sim.sh — set up AI NIC simulation for manual testing.
+#
+# Creates a fake sysfs tree under /tmp/ainic-sim-<PID>, starts the NIC
+# counter simulator, then prints the SMI_NIC_SYSFS_ROOT export command.
+#
+# Run this in a SEPARATE terminal, then run your test in another terminal:
+#
+#   Terminal 1:
+#       cd projects/amdsmi/tests/ai-nic-sim
+#       ./setup_ainic_sim.sh
+#       # copy the  export SMI_NIC_SYSFS_ROOT=...  line it prints
+#
+#   Terminal 2:
+#       export SMI_NIC_SYSFS_ROOT=<path from Terminal 1>
+#       SMI_NIC_SYSFS_ROOT=... /path/to/amd_smi_ainic_info
+#       # or run pytest:
+#       pytest projects/amdsmi/tests/ai-nic-sim/
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SIM_ROOT="/tmp/ainic-sim-$$"
+
+cleanup() {
+    echo ""
+    echo "[setup_ainic_sim] Stopping simulator and cleaning up ..."
+    if [[ -n "${SIM_PID:-}" ]] && kill -0 "$SIM_PID" 2>/dev/null; then
+        kill "$SIM_PID"
+        wait "$SIM_PID" 2>/dev/null || true
+    fi
+    rm -rf "$SIM_ROOT"
+    echo "[setup_ainic_sim] Done."
+}
+trap cleanup EXIT INT TERM
+
+echo "[setup_ainic_sim] Creating fake sysfs under $SIM_ROOT ..."
+HW_COUNTERS_DIR=$(python3 "$SCRIPT_DIR/fake_sysfs.py" "$SIM_ROOT")
+echo "[setup_ainic_sim] hw_counters dir: $HW_COUNTERS_DIR"
+
+echo "[setup_ainic_sim] Starting NIC counter simulator ..."
+python3 "$SCRIPT_DIR/nic_simulator.py" "$HW_COUNTERS_DIR" &
+SIM_PID=$!
+echo "[setup_ainic_sim] Simulator PID: $SIM_PID"
+
+echo ""
+echo "============================================================"
+echo "  AI NIC simulation is ACTIVE."
+echo ""
+echo "  In your test terminal, run:"
+echo ""
+echo "    export SMI_NIC_SYSFS_ROOT=$SIM_ROOT"
+echo ""
+echo "  Then run a test, e.g.:"
+echo ""
+echo "    /path/to/amd_smi_ainic_info"
+echo "    pytest projects/amdsmi/tests/ai-nic-sim/"
+echo "============================================================"
+echo ""
+echo "[setup_ainic_sim] Press Ctrl-C to stop."
+
+while kill -0 "$SIM_PID" 2>/dev/null; do
+    sleep 2
+done
+
+echo "[setup_ainic_sim] Simulator exited unexpectedly."
+exit 1

--- a/projects/amdsmi/tests/ai-nic-sim/test_ainic_sim.py
+++ b/projects/amdsmi/tests/ai-nic-sim/test_ainic_sim.py
@@ -1,0 +1,241 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+test_ainic_sim.py — simulation-based pytest test for the amd-smi AI NIC API.
+
+The test creates a fake sysfs tree that looks like a Pensando Pollara NIC,
+starts a background simulator that increments the hw_counter files, then
+runs amd_smi_ainic_info (the example binary built from amd_smi_ainic_example.cc)
+with SMI_NIC_SYSFS_ROOT pointing at the fake tree.
+
+Assertions:
+  1. amd_smi_ainic_info exits with return code 0.
+  2. Exactly one AI NIC device is reported.
+  3. The expected RDMA hw_counter names appear in the output.
+  4. At least one RDMA counter has a non-zero value (proves the simulator's
+     updates were picked up during the run).
+
+No real Pensando Pollara hardware is required.
+
+Run:
+    pytest projects/amdsmi/tests/ai-nic-sim/test_ainic_sim.py -v
+
+The amd_smi_ainic_info binary must be built first:
+    cmake -B build && cmake --build build --target amd_smi_ainic_info
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_HERE = Path(__file__).parent
+_FAKE_SYSFS_PY = _HERE / "fake_sysfs.py"
+_NIC_SIM_PY = _HERE / "nic_simulator.py"
+
+sys.path.insert(0, str(_HERE))
+import fake_sysfs  # noqa: E402
+
+
+def _find_ainic_info_binary() -> Path | None:
+    """Search common build locations for the amd_smi_ainic_info binary."""
+    from shutil import which
+
+    found = which("amd_smi_ainic_info")
+    if found:
+        return Path(found)
+
+    # projects/amdsmi/tests/ai-nic-sim  →  parents[4] = repo root
+    repo_root = _HERE.parents[3]
+    candidates = [
+        repo_root / "build" / "projects" / "amdsmi" / "example" / "amd_smi_ainic_info",
+        repo_root / "build-release" / "projects" / "amdsmi" / "example" / "amd_smi_ainic_info",
+        repo_root / "projects" / "amdsmi" / "example" / "build" / "amd_smi_ainic_info",
+    ]
+    for c in candidates:
+        if c.is_file() and os.access(c, os.X_OK):
+            return c
+    return None
+
+
+_BINARY = _find_ainic_info_binary()
+
+# ---------------------------------------------------------------------------
+# Session-scoped fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def fake_sysfs_root(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Create the fake sysfs tree once per test session."""
+    root = tmp_path_factory.mktemp("fake-sysfs")
+    fake_sysfs.create(root)
+    return root
+
+
+@pytest.fixture(scope="session")
+def hw_counters_dir(fake_sysfs_root: Path) -> Path:
+    """Return the hw_counters directory inside the fake sysfs tree."""
+    return (
+        fake_sysfs_root
+        / "sys/devices/pci0000:e0"
+        / fake_sysfs.BRIDGE_BDF
+        / fake_sysfs.PORT_BDF
+        / "infiniband"
+        / fake_sysfs.IB_DEV
+        / "ports"
+        / fake_sysfs.IB_PORT
+        / "hw_counters"
+    )
+
+
+@pytest.fixture(scope="session")
+def nic_simulator(hw_counters_dir: Path):
+    """Start the NIC simulator subprocess; stop it after the session."""
+    proc = subprocess.Popen(
+        [sys.executable, str(_NIC_SIM_PY), str(hw_counters_dir), "--interval", "0.05"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    time.sleep(0.2)
+    assert proc.poll() is None, "nic_simulator failed to start"
+    yield proc
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAINICSim:
+    """Simulation-based tests for the amd-smi AI NIC API."""
+
+    def test_fake_sysfs_structure(self, fake_sysfs_root: Path, hw_counters_dir: Path) -> None:
+        """Verify the fake sysfs tree has the expected structure."""
+        # PCI bus device symlinks
+        assert (fake_sysfs_root / "sys/bus/pci/devices" / fake_sysfs.BRIDGE_BDF).is_symlink()
+        assert (fake_sysfs_root / "sys/bus/pci/devices" / fake_sysfs.PORT_BDF).is_symlink()
+
+        # Bridge PCI IDs
+        bridge_dev = fake_sysfs_root / "sys/devices/pci0000:e0" / fake_sysfs.BRIDGE_BDF
+        assert (bridge_dev / "vendor").read_text().strip() == fake_sysfs.VENDOR_ID_HEX
+        assert (bridge_dev / "device").read_text().strip() == fake_sysfs.BRIDGE_DEV_HEX
+
+        # Port PCI IDs
+        port_dev = bridge_dev / fake_sysfs.PORT_BDF
+        assert (port_dev / "vendor").read_text().strip() == fake_sysfs.VENDOR_ID_HEX
+        assert (port_dev / "device").read_text().strip() == fake_sysfs.PORT_DEV_HEX
+
+        # All hw_counter files present
+        assert hw_counters_dir.is_dir()
+        for counter in fake_sysfs.HW_COUNTERS:
+            assert (hw_counters_dir / counter).exists(), f"Missing counter: {counter}"
+
+        # Net interface and device symlink
+        net_iface = fake_sysfs_root / "sys/class/net" / fake_sysfs.IFACE
+        assert net_iface.is_dir()
+        assert (net_iface / "device").is_symlink()
+
+        # downstream_port() check: canonical port path must contain BRIDGE_BDF
+        port_link = fake_sysfs_root / "sys/bus/pci/devices" / fake_sysfs.PORT_BDF
+        assert f"/{fake_sysfs.BRIDGE_BDF}/" in str(port_link.resolve()), (
+            f"downstream_port() check would fail: '{fake_sysfs.BRIDGE_BDF}' "
+            f"not in '{port_link.resolve()}'"
+        )
+
+    def test_nic_simulator_increments_counters(
+        self, nic_simulator: subprocess.Popen, hw_counters_dir: Path
+    ) -> None:
+        """Verify the NIC simulator is actually incrementing hw_counter values."""
+        counter_path = hw_counters_dir / "rx_rdma_ucast_bytes"
+        before = int(counter_path.read_text().strip())
+        time.sleep(0.3)
+        after = int(counter_path.read_text().strip())
+        assert after > before, (
+            f"rx_rdma_ucast_bytes did not increase: before={before}, after={after}"
+        )
+
+    @pytest.mark.skipif(
+        _BINARY is None,
+        reason="amd_smi_ainic_info not found — build amdsmi first "
+        "(cmake --build <build_dir> --target amd_smi_ainic_info)",
+    )
+    def test_amdsmi_reads_simulated_nic(
+        self, fake_sysfs_root: Path, nic_simulator: subprocess.Popen
+    ) -> None:
+        """
+        Run amd_smi_ainic_info with the fake sysfs and verify:
+          - exits 0
+          - reports exactly 1 AI NIC device
+          - lists RDMA hw_counter names
+          - at least one RDMA counter value is non-zero
+        """
+        env = os.environ.copy()
+        env["SMI_NIC_SYSFS_ROOT"] = str(fake_sysfs_root)
+
+        result = subprocess.run([str(_BINARY)], env=env, capture_output=True, text=True, timeout=15)
+
+        assert result.returncode == 0, (
+            f"amd_smi_ainic_info failed (exit {result.returncode})\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+        output = result.stdout
+
+        # Exactly 1 AI NIC device discovered
+        assert "Total AI NIC devices found: 1" in output, (
+            f"Expected exactly 1 AI NIC device.\nstdout:\n{output}"
+        )
+
+        # RDMA counter names appear in the output
+        expected_counters = [
+            "rx_rdma_ucast_bytes",
+            "tx_rdma_ucast_bytes",
+            "rx_rdma_ucast_pkts",
+            "tx_rdma_ucast_pkts",
+            "rx_rdma_cnp_pkts",
+            "tx_rdma_cnp_pkts",
+            "tx_rdma_ack_timeout",
+            "resp_tx_pkt_seq_err",
+            "req_rx_pkt_seq_err",
+            "req_rx_impl_nak_seq_err",
+        ]
+        missing = [c for c in expected_counters if c not in output]
+        assert not missing, f"RDMA counter names missing from output: {missing}\nstdout:\n{output}"
+
+        # At least one counter value is non-zero
+        nonzero = False
+        for line in output.splitlines():
+            for counter in expected_counters:
+                if counter in line and ":" in line:
+                    try:
+                        value = int(line.split(":")[-1].strip())
+                        if value > 0:
+                            nonzero = True
+                            break
+                    except ValueError:
+                        pass
+            if nonzero:
+                break
+
+        assert nonzero, (
+            "All RDMA counter values are zero — the simulator may not have "
+            "been running long enough or its updates were not picked up.\n"
+            f"stdout:\n{output}"
+        )


### PR DESCRIPTION
## Summary

Add hardware-free simulation support for AI NIC (Pensando Pollara) testing in amd-smi, so the AI NIC code path can be exercised on any machine without physical hardware.

- Introduce `SMI_NIC_SYSFS_ROOT` environment variable support in the amdsmi AI NIC implementation, allowing the sysfs root to be overridden at runtime
- Add a fake sysfs tree builder and a live counter simulator so a realistic NIC environment can be constructed in a temp directory
- Add a pytest test under `projects/amdsmi/tests/ai-nic-sim/` that runs the full amdsmi discovery and statistics path against the simulated tree
- Add `amd_smi_ainic_example.cc` — a developer tool that enumerates AI NIC devices and prints all public-API information, usable on real hardware or in simulation

## Changes

- **`projects/amdsmi/src/nic/ai-nic/amdsmi_unified/inc/smi_sysfs.h`** and **`src/smi_sysfs.cpp`** — read `SMI_NIC_SYSFS_ROOT` at init time and prepend it to every sysfs path lookup, enabling full path override for simulation
- **`projects/amdsmi/src/nic/ai-nic/amdsmi_unified/src/smi_nic.cpp`**, **`smi_nic_interface.cpp`**, **`smi_nic_subsystem.cpp`**, **`smi_nic_system.cpp`** — thread the sysfs-root override through device discovery, BDF resolution, driver checks, InfiniBand enumeration, and `hw_counters` reads
- **`projects/amdsmi/src/amd_smi/amd_smi.cc`** — propagate the override into the top-level socket/processor enumeration path
- **`projects/amdsmi/example/amd_smi_ainic_example.cc`** — new developer tool (`amd_smi_ainic_info` binary) that prints ASIC, PCIe, driver, NUMA, port, and live RDMA statistics for every detected AI NIC; works on real hardware or with `SMI_NIC_SYSFS_ROOT` set
- **`projects/amdsmi/example/CMakeLists.txt`** — add `amd_smi_ainic_info` build target
- **`projects/amdsmi/example/run_simulated_ainic.sh`** — developer convenience script: builds the fake sysfs tree, starts the counter simulator, runs `amd_smi_ainic_info`, and cleans up on exit
- **`projects/amdsmi/tests/ai-nic-sim/fake_sysfs.py`** — constructs a minimal fake sysfs tree (PCI bridge/port devices, InfiniBand device, `hw_counters` files, `class/net` and driver symlinks) that satisfies every traversal in amdsmi's AI NIC code; also callable as `python3 fake_sysfs.py <SIM_ROOT>`
- **`projects/amdsmi/tests/ai-nic-sim/nic_simulator.py`** — daemon that increments all 10 RDMA `hw_counter` files at a configurable rate so counter reads return non-zero values
- **`projects/amdsmi/tests/ai-nic-sim/setup_ainic_sim.sh`** — keep-alive script for manual two-terminal testing; prints the `export SMI_NIC_SYSFS_ROOT=…` line to copy into the test terminal
- **`projects/amdsmi/tests/ai-nic-sim/test_ainic_sim.py`** — pytest test that creates the fake sysfs tree, runs the NIC simulator, invokes `amd_smi_ainic_info`, and asserts: exit code 0, exactly 1 AI NIC device found, all 10 RDMA counter names present, at least one counter value non-zero
- **`projects/amdsmi/tests/ai-nic-sim/AINIC_SIMULATION.md`** — documentation for the two-terminal simulation workflow

## Verification

- `test_ainic_sim.py` run inside a container with amdsmi built from this branch: all three test cases pass (`test_fake_sysfs_structure`, `test_nic_simulator_increments_counters`, `test_amdsmi_reads_simulated_nic`)
- `run_simulated_ainic.sh` executed manually: `amd_smi_ainic_info` reports 1 AI NIC device with all 10 RDMA counters showing non-zero values
- No real Pensando Pollara hardware required for any of the above