### PR TITLE
[hipfile][ais-check] Improve HIP runtime detection

### DIFF
--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -12,9 +12,13 @@ If components are missing the program exits with a non-zero exit code.
 import argparse
 import ctypes
 import ctypes.util
+import glob
 import gzip
 import os
 import sys
+
+# Global list of found HIP runtime libraries
+hip_libraries = {}
 
 
 def kernel_supports_p2pdma():
@@ -46,67 +50,113 @@ def kernel_supports_p2pdma():
     return False
 
 
+def find_hip_runtimes():
+    """
+    Populate a global list of HIP runtime libraries by looking in the
+    usual places.
+    """
+
+    candidates = []
+
+    # 1. Respect runtime linker paths
+    for p in os.environ.get("LD_LIBRARY_PATH", "").split(":"):
+        if p:
+            candidates.append(os.path.join(p, "libamdhip64.so"))
+
+    # 2. Environment variables commonly set by ROCm or modules
+    for var in ("ROCM_HOME", "ROCM_PATH", "HIP_PATH"):
+        base = os.environ.get(var)
+        if base:
+            candidates += [
+                os.path.join(base, "lib", "libamdhip64.so"),
+                os.path.join(base, "lib64", "libamdhip64.so"),
+            ]
+
+    # 3. Standard ROCm install paths
+    candidates += [
+        "/opt/rocm/lib/libamdhip64.so",
+        "/opt/rocm/lib64/libamdhip64.so",
+    ]
+
+    # 4. Versioned installs (/opt/rocm-5.x, etc.)
+    for d in glob.glob("/opt/rocm*/lib*/libamdhip64.so"):
+        candidates.append(d)
+
+    # Drop any paths that don't exist
+    existing_paths = [path for path in candidates if os.path.exists(path)]
+
+    # Populate the global dictionary of paths
+    #
+    # Tell pylint to be quiet since returning the dictionary
+    # would result in uglier downstream code
+    global hip_libraries  # pylint: disable=W0603
+    hip_libraries = dict.fromkeys(existing_paths, False)
+
+
 def hip_runtime_supports_ais():
     """
     Check if hipAmdFileRead and hipAmdFileWrite are available in HIP
     """
-    hip_path = ctypes.util.find_library("amdhip64")
-    if hip_path is None:
-        return False
+    find_hip_runtimes()
 
-    hip = ctypes.CDLL(hip_path)
+    # Check for AIS functions in the list of found HIP libraries
+    for hip_path, _ in hip_libraries.items():
 
-    hipError_t = ctypes.c_int
-    hipDriverProcAddressQueryResult = ctypes.c_int
+        hip = ctypes.CDLL(hip_path)
 
-    hip.hipRuntimeGetVersion.argtypes = [ctypes.POINTER(ctypes.c_int)]
-    hip.hipRuntimeGetVersion.restype = hipError_t
+        hipError_t = ctypes.c_int
+        hipDriverProcAddressQueryResult = ctypes.c_int
 
-    hip.hipGetProcAddress.argtypes = [
-        ctypes.c_char_p,
-        ctypes.POINTER(ctypes.c_void_p),
-        ctypes.c_int,
-        ctypes.c_uint64,
-        ctypes.POINTER(hipDriverProcAddressQueryResult),
-    ]
-    hip.hipGetProcAddress.restype = hipError_t
+        hip.hipRuntimeGetVersion.argtypes = [ctypes.POINTER(ctypes.c_int)]
+        hip.hipRuntimeGetVersion.restype = hipError_t
 
-    hip.hipGetErrorString.argtypes = [hipError_t]
-    hip.hipGetErrorString.restype = ctypes.c_char_p
+        hip.hipGetProcAddress.argtypes = [
+            ctypes.c_char_p,
+            ctypes.POINTER(ctypes.c_void_p),
+            ctypes.c_int,
+            ctypes.c_uint64,
+            ctypes.POINTER(hipDriverProcAddressQueryResult),
+        ]
+        hip.hipGetProcAddress.restype = hipError_t
 
-    version = ctypes.c_int()
-    err = hip.hipRuntimeGetVersion(ctypes.byref(version))
-    if err != 0:
-        err_str = hip.hipGetErrorString(err).decode("utf-8")
-        print(
-            f"hipRuntimeGetVersion failed with err code {err} ({err_str})",
-            file=sys.stderr,
-        )
-        return False
+        hip.hipGetErrorString.argtypes = [hipError_t]
+        hip.hipGetErrorString.restype = ctypes.c_char_p
 
-    for symbol in [b"hipAmdFileWrite", b"hipAmdFileRead"]:
-        func_ptr = ctypes.c_void_p()
-        symbol_status = hipDriverProcAddressQueryResult()
-        err = hip.hipGetProcAddress(
-            symbol,
-            ctypes.byref(func_ptr),
-            version.value,
-            0,
-            ctypes.byref(symbol_status),
-        )
+        version = ctypes.c_int()
+        err = hip.hipRuntimeGetVersion(ctypes.byref(version))
         if err != 0:
-            if symbol_status.value != 1:
-                symbol = symbol.decode("utf-8")
-                err_str = hip.hipGetErrorString(err).decode("utf-8")
-                print(
-                    f"hipGetProcAddress({symbol}) failed with err code"
-                    f" {err} ({err_str}) and symbolStatus"
-                    f" {symbol_status.value}",
-                    file=sys.stderr,
-                )
-            return False
+            err_str = hip.hipGetErrorString(err).decode("utf-8")
+            print(
+                f"hipRuntimeGetVersion failed with err code {err} ({err_str})",
+                file=sys.stderr,
+            )
+            continue
 
-    return True
+        for symbol in [b"hipAmdFileWrite", b"hipAmdFileRead"]:
+            func_ptr = ctypes.c_void_p()
+            symbol_status = hipDriverProcAddressQueryResult()
+            err = hip.hipGetProcAddress(
+                symbol,
+                ctypes.byref(func_ptr),
+                version.value,
+                0,
+                ctypes.byref(symbol_status),
+            )
+            if err != 0:
+                if symbol_status.value != 1:
+                    symbol = symbol.decode("utf-8")
+                    err_str = hip.hipGetErrorString(err).decode("utf-8")
+                    print(
+                        f"hipGetProcAddress({symbol}) failed with err code"
+                        f" {err} ({err_str}) and symbolStatus"
+                        f" {symbol_status.value}",
+                        file=sys.stderr,
+                    )
+                continue
+
+        hip_libraries[hip_path] = True
+
+    return bool(True in hip_libraries.values())
 
 
 def amdgpu_supports_ais():
@@ -154,8 +204,17 @@ def main():
         u = os.uname()
         print()
         print(u.sysname, u.nodename, u.release, u.version, u.machine)
-        print()
 
+        print()
+        print("Found these HIP libraries:")
+        for lib, support in hip_libraries.items():
+            if support:
+                pretty_supported = "supported"
+            else:
+                pretty_supported = "NOT supported"
+            print(f"\t{lib} (AIS {pretty_supported})")
+
+        print()
         print("AIS support in:")
         for name, supported in component_support:
             print(f"\t{name:<24}: {supported}")

--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -52,8 +52,8 @@ def kernel_supports_p2pdma():
 
 def find_hip_runtimes():
     """
-    Populate a global list of HIP runtime libraries by looking in the
-    usual places.
+    Populate the global mapping of HIP runtime library paths to AIS
+    support flags by looking in the usual places.
     """
 
     # NOTE: CodeQL will be unhappy if you are not careful about paths

--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -92,7 +92,11 @@ def find_hip_runtimes():
         candidates.append(d)
 
     # Drop any paths that don't exist
-    existing_paths = [path for path in candidates if os.path.exists(path)]
+    existing_paths = [
+        path
+        for path in candidates
+        if os.path.exists(os.path.abspath(os.path.normpath(path)))
+    ]
 
     # Populate the global dictionary of paths
     #

--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -227,7 +227,7 @@ def main():
         print(u.sysname, u.nodename, u.release, u.version, u.machine)
 
         print()
-        print("Found these HIP libraries:")
+        print("Found these HIP libraries (some may be symlinks):")
         for lib, support in hip_libraries.items():
             if support:
                 pretty_supported = "supported"

--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -17,7 +17,7 @@ import gzip
 import os
 import sys
 
-# Global list of found HIP runtime libraries
+# Global mapping of HIP runtime library paths to AIS support flags
 hip_libraries = {}
 
 
@@ -56,20 +56,29 @@ def find_hip_runtimes():
     usual places.
     """
 
+    # NOTE: CodeQL will be unhappy if you are not careful about paths
+    #       in this function
+
     candidates = []
 
     # 1. Respect runtime linker paths
     for p in os.environ.get("LD_LIBRARY_PATH", "").split(":"):
         if p:
-            candidates.append(os.path.join(p, "libamdhip64.so"))
+            # Clean up the path by removing `..`, etc. and getting
+            # an absolute path.
+            safe_p = os.path.abspath(os.path.normpath(p))
+
+            candidates.append(os.path.join(safe_p, "libamdhip64.so"))
 
     # 2. Environment variables commonly set by ROCm or modules
     for var in ("ROCM_HOME", "ROCM_PATH", "HIP_PATH"):
         base = os.environ.get(var)
         if base:
+            # Also clean up this path
+            safe_base = os.path.abspath(os.path.normpath(base))
             candidates += [
-                os.path.join(base, "lib", "libamdhip64.so"),
-                os.path.join(base, "lib64", "libamdhip64.so"),
+                os.path.join(safe_base, "lib", "libamdhip64.so"),
+                os.path.join(safe_base, "lib64", "libamdhip64.so"),
             ]
 
     # 3. Standard ROCm install paths
@@ -100,9 +109,12 @@ def hip_runtime_supports_ais():
     find_hip_runtimes()
 
     # Check for AIS functions in the list of found HIP libraries
-    for hip_path, _ in hip_libraries.items():
+    for hip_path in hip_libraries:
 
-        hip = ctypes.CDLL(hip_path)
+        try:
+            hip = ctypes.CDLL(hip_path)
+        except OSError:
+            continue
 
         hipError_t = ctypes.c_int
         hipDriverProcAddressQueryResult = ctypes.c_int
@@ -132,6 +144,9 @@ def hip_runtime_supports_ais():
             )
             continue
 
+        # Track whether all required AIS symbols are available in this library
+        supported = True
+
         for symbol in [b"hipAmdFileWrite", b"hipAmdFileRead"]:
             func_ptr = ctypes.c_void_p()
             symbol_status = hipDriverProcAddressQueryResult()
@@ -152,11 +167,13 @@ def hip_runtime_supports_ais():
                         f" {symbol_status.value}",
                         file=sys.stderr,
                     )
-                continue
+                supported = False
+                break
 
-        hip_libraries[hip_path] = True
+        if supported:
+            hip_libraries[hip_path] = True
 
-    return bool(True in hip_libraries.values())
+    return any(hip_libraries.values())
 
 
 def amdgpu_supports_ais():

--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -93,7 +93,7 @@ def find_hip_runtimes():
 
     # Drop any paths that don't exist
     existing_paths = [
-        path
+        os.path.abspath(os.path.normpath(path))
         for path in candidates
         if os.path.exists(os.path.abspath(os.path.normpath(path)))
     ]

--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -227,7 +227,7 @@ def main():
         print(u.sysname, u.nodename, u.release, u.version, u.machine)
 
         print()
-        print("Found these HIP libraries (some may be symlinks):")
+        print("Found these HIP libraries (some may be redundant symlinks):")
         for lib, support in hip_libraries.items():
             if support:
                 pretty_supported = "supported"

--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -94,7 +94,11 @@ def find_hip_runtimes():
     # 4. Versioned installs (/opt/rocm-5.x, etc.)
     candidates += glob.glob(f"/opt/rocm*/lib*/{lib_glob}")
 
-    # 5. Fall back to the ldconfig cache, which catches installs in
+    # 5. ROCm >= 7.11 versioned core installs (/opt/rocm/core-X.Y/lib),
+    #    where /opt/rocm is a real directory rather than a symlink.
+    candidates += glob.glob(f"/opt/rocm*/core-*/lib*/{lib_glob}")
+
+    # 6. Fall back to the ldconfig cache, which catches installs in
     #    non-standard prefixes registered via /etc/ld.so.conf.d
     cached = ctypes.util.find_library("amdhip64")
     if cached:
@@ -158,9 +162,11 @@ def hip_runtime_supports_ais():
         version = ctypes.c_int()
         err = hip.hipRuntimeGetVersion(ctypes.byref(version))
         if err != 0:
-            err_str = hip.hipGetErrorString(err).decode("utf-8")
+            err_bytes = hip.hipGetErrorString(err)
+            err_str = err_bytes.decode("utf-8") if err_bytes else "unknown error"
             print(
-                f"hipRuntimeGetVersion failed with err code {err} ({err_str})",
+                f"hipRuntimeGetVersion failed for {hip_path} "
+                f"with err code {err} ({err_str})",
                 file=sys.stderr,
             )
             continue
@@ -221,6 +227,12 @@ def main():
     parser.add_argument(
         "-q", "--quiet", action="store_true", help="Silence regular output"
     )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Also list the discovered HIP libraries",
+    )
     args = parser.parse_args()
 
     hip_libraries = hip_runtime_supports_ais()
@@ -236,14 +248,15 @@ def main():
         print()
         print(u.sysname, u.nodename, u.release, u.version, u.machine)
 
-        print()
-        print("Found these HIP libraries (some may be redundant symlinks):")
-        for lib, support in hip_libraries.items():
-            if support:
-                pretty_supported = "supported"
-            else:
-                pretty_supported = "NOT supported"
-            print(f"\t{lib} (AIS {pretty_supported})")
+        if args.verbose:
+            print()
+            print("Found these HIP libraries (some may be redundant symlinks):")
+            for lib, support in hip_libraries.items():
+                if support:
+                    pretty_supported = "supported"
+                else:
+                    pretty_supported = "NOT supported"
+                print(f"\t{lib} (AIS {pretty_supported})")
 
         print()
         print("AIS support in:")

--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -89,19 +89,20 @@ def find_hip_runtimes():
     # absolute) to keep CodeQL happy about env-derived paths. The directory
     # component is escaped so that glob metacharacters (*, ?, []) embedded in
     # an env var are matched literally rather than interpreted, and only the
-    # trailing lib_glob acts as a pattern.
+    # trailing lib_glob acts as a pattern. glob.glob does not guarantee an
+    # order, so each match set is sorted for deterministic probing/printing.
     for d in search_dirs:
         safe_d = os.path.abspath(os.path.normpath(d))
         if not os.path.isdir(safe_d):
             continue
-        candidates += glob.glob(os.path.join(glob.escape(safe_d), lib_glob))
+        candidates += sorted(glob.glob(os.path.join(glob.escape(safe_d), lib_glob)))
 
     # 4. Versioned installs (/opt/rocm-5.x, etc.)
-    candidates += glob.glob(f"/opt/rocm*/lib*/{lib_glob}")
+    candidates += sorted(glob.glob(f"/opt/rocm*/lib*/{lib_glob}"))
 
     # 5. ROCm >= 7.11 versioned core installs (/opt/rocm/core-X.Y/lib),
     #    where /opt/rocm is a real directory rather than a symlink.
-    candidates += glob.glob(f"/opt/rocm*/core-*/lib*/{lib_glob}")
+    candidates += sorted(glob.glob(f"/opt/rocm*/core-*/lib*/{lib_glob}"))
 
     # 6. Fall back to the ldconfig cache, which catches installs in
     #    non-standard prefixes registered via /etc/ld.so.conf.d

--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -86,10 +86,15 @@ def find_hip_runtimes():
 
     # Glob each search directory for versioned and unversioned libs.
     # Clean up each directory first (removing `..`, etc. and making it
-    # absolute) to keep CodeQL happy about env-derived paths.
+    # absolute) to keep CodeQL happy about env-derived paths. The directory
+    # component is escaped so that glob metacharacters (*, ?, []) embedded in
+    # an env var are matched literally rather than interpreted, and only the
+    # trailing lib_glob acts as a pattern.
     for d in search_dirs:
         safe_d = os.path.abspath(os.path.normpath(d))
-        candidates += glob.glob(os.path.join(safe_d, lib_glob))
+        if not os.path.isdir(safe_d):
+            continue
+        candidates += glob.glob(os.path.join(glob.escape(safe_d), lib_glob))
 
     # 4. Versioned installs (/opt/rocm-5.x, etc.)
     candidates += glob.glob(f"/opt/rocm*/lib*/{lib_glob}")
@@ -133,31 +138,34 @@ def hip_runtime_supports_ais():
     """
     hip_libraries = find_hip_runtimes()
 
+    hipError_t = ctypes.c_int
+    hipDriverProcAddressQueryResult = ctypes.c_int
+
     # Check for AIS functions in the list of found HIP libraries
     for hip_path in hip_libraries:
 
         try:
             hip = ctypes.CDLL(hip_path)
-        except OSError:
+
+            # Resolving these symbols can raise AttributeError on a HIP runtime
+            # too old to export them (e.g. hipGetProcAddress). Treat such a
+            # library as simply not AIS-capable rather than crashing.
+            hip.hipRuntimeGetVersion.argtypes = [ctypes.POINTER(ctypes.c_int)]
+            hip.hipRuntimeGetVersion.restype = hipError_t
+
+            hip.hipGetProcAddress.argtypes = [
+                ctypes.c_char_p,
+                ctypes.POINTER(ctypes.c_void_p),
+                ctypes.c_int,
+                ctypes.c_uint64,
+                ctypes.POINTER(hipDriverProcAddressQueryResult),
+            ]
+            hip.hipGetProcAddress.restype = hipError_t
+
+            hip.hipGetErrorString.argtypes = [hipError_t]
+            hip.hipGetErrorString.restype = ctypes.c_char_p
+        except (OSError, AttributeError):
             continue
-
-        hipError_t = ctypes.c_int
-        hipDriverProcAddressQueryResult = ctypes.c_int
-
-        hip.hipRuntimeGetVersion.argtypes = [ctypes.POINTER(ctypes.c_int)]
-        hip.hipRuntimeGetVersion.restype = hipError_t
-
-        hip.hipGetProcAddress.argtypes = [
-            ctypes.c_char_p,
-            ctypes.POINTER(ctypes.c_void_p),
-            ctypes.c_int,
-            ctypes.c_uint64,
-            ctypes.POINTER(hipDriverProcAddressQueryResult),
-        ]
-        hip.hipGetProcAddress.restype = hipError_t
-
-        hip.hipGetErrorString.argtypes = [hipError_t]
-        hip.hipGetErrorString.restype = ctypes.c_char_p
 
         version = ctypes.c_int()
         err = hip.hipRuntimeGetVersion(ctypes.byref(version))
@@ -184,7 +192,11 @@ def hip_runtime_supports_ais():
                 0,
                 ctypes.byref(symbol_status),
             )
-            if err != 0:
+            # A symbol is only present if the call succeeded, the query result
+            # is HIP_GET_PROC_ADDRESS_SUCCESS (0), and a non-null pointer came
+            # back. Checking all three avoids false positives across HIP
+            # implementations.
+            if err != 0 or symbol_status.value != 0 or not func_ptr.value:
                 supported = False
                 break
 
@@ -224,10 +236,11 @@ def main():
     """
 
     parser = argparse.ArgumentParser()
-    parser.add_argument(
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument(
         "-q", "--quiet", action="store_true", help="Silence regular output"
     )
-    parser.add_argument(
+    output_group.add_argument(
         "-v",
         "--verbose",
         action="store_true",
@@ -250,7 +263,7 @@ def main():
 
         if args.verbose:
             print()
-            print("Found these HIP libraries (some may be redundant symlinks):")
+            print("Found these HIP libraries (some may refer to the same library):")
             for lib, support in hip_libraries.items():
                 if support:
                     pretty_supported = "supported"

--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -17,9 +17,6 @@ import gzip
 import os
 import sys
 
-# Global mapping of HIP runtime library paths to AIS support flags
-hip_libraries = {}
-
 
 def kernel_supports_p2pdma():
     """
@@ -38,9 +35,7 @@ def kernel_supports_p2pdma():
             with opener(path, "rt") as f:
                 configs_found = True
                 for line in f:
-                    if line.startswith("CONFIG_PCI_P2PDMA=y") or line.startswith(
-                        "CONFIG_PCI_P2PDMA=m"
-                    ):
+                    if line.startswith("CONFIG_PCI_P2PDMA=y"):
                         return True
         except OSError:
             continue
@@ -52,65 +47,87 @@ def kernel_supports_p2pdma():
 
 def find_hip_runtimes():
     """
-    Populate the global mapping of HIP runtime library paths to AIS
-    support flags by looking in the usual places.
+    Return a mapping of HIP runtime library paths to AIS support flags
+    (all initially False) by looking in the usual places.
     """
 
     # NOTE: CodeQL will be unhappy if you are not careful about paths
     #       in this function
 
-    candidates = []
+    # Match both the unversioned symlink (shipped in the -dev package)
+    # and the versioned runtime libraries (e.g. libamdhip64.so.6), which
+    # are all that exist on runtime-only installs.
+    lib_glob = "libamdhip64.so*"
+
+    # Directories to search for HIP runtime libraries
+    search_dirs = []
 
     # 1. Respect runtime linker paths
     for p in os.environ.get("LD_LIBRARY_PATH", "").split(":"):
         if p:
-            # Clean up the path by removing `..`, etc. and getting
-            # an absolute path.
-            safe_p = os.path.abspath(os.path.normpath(p))
-
-            candidates.append(os.path.join(safe_p, "libamdhip64.so"))
+            search_dirs.append(p)
 
     # 2. Environment variables commonly set by ROCm or modules
     for var in ("ROCM_HOME", "ROCM_PATH", "HIP_PATH"):
         base = os.environ.get(var)
         if base:
-            # Also clean up this path
-            safe_base = os.path.abspath(os.path.normpath(base))
-            candidates += [
-                os.path.join(safe_base, "lib", "libamdhip64.so"),
-                os.path.join(safe_base, "lib64", "libamdhip64.so"),
+            search_dirs += [
+                os.path.join(base, "lib"),
+                os.path.join(base, "lib64"),
             ]
 
     # 3. Standard ROCm install paths
-    candidates += [
-        "/opt/rocm/lib/libamdhip64.so",
-        "/opt/rocm/lib64/libamdhip64.so",
+    search_dirs += [
+        "/opt/rocm/lib",
+        "/opt/rocm/lib64",
     ]
+
+    candidates = []
+
+    # Glob each search directory for versioned and unversioned libs.
+    # Clean up each directory first (removing `..`, etc. and making it
+    # absolute) to keep CodeQL happy about env-derived paths.
+    for d in search_dirs:
+        safe_d = os.path.abspath(os.path.normpath(d))
+        candidates += glob.glob(os.path.join(safe_d, lib_glob))
 
     # 4. Versioned installs (/opt/rocm-5.x, etc.)
-    for d in glob.glob("/opt/rocm*/lib*/libamdhip64.so"):
-        candidates.append(d)
+    candidates += glob.glob(f"/opt/rocm*/lib*/{lib_glob}")
 
-    # Drop any paths that don't exist
-    existing_paths = [
-        os.path.abspath(os.path.normpath(path))
-        for path in candidates
-        if os.path.exists(os.path.abspath(os.path.normpath(path)))
-    ]
+    # 5. Fall back to the ldconfig cache, which catches installs in
+    #    non-standard prefixes registered via /etc/ld.so.conf.d
+    cached = ctypes.util.find_library("amdhip64")
+    if cached:
+        candidates.append(cached)
 
-    # Populate the global dictionary of paths
+    # Resolve, dedup, and drop paths that don't exist.
     #
-    # Tell pylint to be quiet since returning the dictionary
-    # would result in uglier downstream code
-    global hip_libraries  # pylint: disable=W0603
-    hip_libraries = dict.fromkeys(existing_paths, False)
+    # Absolute paths are canonicalized with realpath so that symlinks
+    # (the unversioned .so pointing at a versioned one, or several rocm
+    # directories pointing at a single install) collapse to one entry.
+    # find_library may return a bare soname with no path to check, but
+    # CDLL can still load it by name, so it is kept as-is.
+    resolved = []
+    for path in candidates:
+        if os.path.isabs(path):
+            real = os.path.realpath(path)
+            if os.path.exists(real):
+                resolved.append(real)
+        else:
+            resolved.append(path)
+
+    # dict.fromkeys dedups while preserving insertion order.
+    return dict.fromkeys(resolved, False)
 
 
 def hip_runtime_supports_ais():
     """
-    Check if hipAmdFileRead and hipAmdFileWrite are available in HIP
+    Check if hipAmdFileRead and hipAmdFileWrite are available in HIP.
+
+    Returns the mapping of discovered HIP library paths to a bool
+    indicating whether that library supports AIS.
     """
-    find_hip_runtimes()
+    hip_libraries = find_hip_runtimes()
 
     # Check for AIS functions in the list of found HIP libraries
     for hip_path in hip_libraries:
@@ -162,22 +179,13 @@ def hip_runtime_supports_ais():
                 ctypes.byref(symbol_status),
             )
             if err != 0:
-                if symbol_status.value != 1:
-                    symbol = symbol.decode("utf-8")
-                    err_str = hip.hipGetErrorString(err).decode("utf-8")
-                    print(
-                        f"hipGetProcAddress({symbol}) failed with err code"
-                        f" {err} ({err_str}) and symbolStatus"
-                        f" {symbol_status.value}",
-                        file=sys.stderr,
-                    )
                 supported = False
                 break
 
         if supported:
             hip_libraries[hip_path] = True
 
-    return any(hip_libraries.values())
+    return hip_libraries
 
 
 def amdgpu_supports_ais():
@@ -215,9 +223,11 @@ def main():
     )
     args = parser.parse_args()
 
+    hip_libraries = hip_runtime_supports_ais()
+
     component_support = [
         ("Kernel P2PDMA support", kernel_supports_p2pdma()),
-        ("HIP runtime", hip_runtime_supports_ais()),
+        ("HIP runtime", any(hip_libraries.values())),
         ("amdgpu", amdgpu_supports_ais()),
     ]
 


### PR DESCRIPTION
## Motivation

The ais-check doesn't do a very good job at identifying all the
HIP runtimes on a system. We need to improve the output to make
it easier for users to determine if their system is capable of
using hipFile.

## Technical Details

Broaden how ais-check locates HIP runtime libraries so it works on
runtime-only installs and non-standard prefixes, and report what was
found.

- Search multiple locations (LD_LIBRARY_PATH, ROCM_HOME/ROCM_PATH/
  HIP_PATH, standard and versioned /opt/rocm paths) and glob for both
  the unversioned symlink and versioned libraries (libamdhip64.so*),
  which are all that exist on runtime-only installs.
- Fall back to the ldconfig cache (ctypes.util.find_library) to catch
  installs registered via /etc/ld.so.conf.d.
- Canonicalize paths with realpath and dedup so redundant symlinks
  collapse to a single entry.
- Probe every discovered library for the AIS symbols instead of only
  the first one found, returning a path->support mapping.
- Print the discovered HIP libraries and their AIS support in verbose
  mode.
- Tighten P2PDMA detection to require CONFIG_PCI_P2PDMA=y.
- Drop the noisy per-symbol hipGetProcAddress error output and the
  module-level global in favor of returning the mapping.
- Keep CodeQL happy by sanitizing env-derived paths before use.

## JIRA ID

AIHIPFILE-156

## Test Plan

Manual verification of output

## Test Result

Looks good

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
