### PR TITLE
[rocSHMEM] Remove volatile qualifier from uncached_load call sites and function definitions (causing random breaks)

### DIFF
--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -42,52 +42,82 @@ namespace rocshmem {
 
 __device__ __forceinline__ int uncached_load_ubyte([[maybe_unused]] uint8_t* src) {
   int ret = 0;
-#if defined(__gfx90a__) || defined(__gfx1100__)
+#if defined(__gfx90a__)
+  int16_t val16;
+  asm volatile(
+      "global_load_ubyte %0 %1 off glc slc \n"
+      "s_waitcnt vmcnt(0)"
+      : "=v"(val16)
+      : "v"(src)
+      : "memory");
+  ret = static_cast<int>(val16);
+#endif
+#if defined(__gfx942__) || defined(__gfx950__)
+  int16_t val16;
+  asm volatile(
+      "global_load_ubyte %0 %1 off sc0 sc1 \n"
+      "s_waitcnt vmcnt(0)"
+      : "=v"(val16)
+      : "v"(src)
+      : "memory");
+  ret = static_cast<int>(val16);
+#endif
+#if defined(__gfx1100__)
   asm volatile(
       "global_load_ubyte %0 %1 off glc slc \n"
       "s_waitcnt vmcnt(0)"
       : "=v"(ret)
-      : "v"(src));
-#endif
-#if defined(__gfx942__) || defined(__gfx950__)
-  asm volatile(
-      "global_load_ubyte %0 %1 off sc0 sc1 \n"
-      "s_waitcnt vmcnt(0)"
-      : "=v"(ret)
-      : "v"(src));
+      : "v"(src)
+      : "memory");
 #endif
 #if defined(__gfx1201__) || defined(__gfx1250__)
   asm volatile(
       "global_load_u8 %0 %1 off scope:SCOPE_SYS \n"
       "s_wait_loadcnt 0x0"
       : "=v"(ret)
-      : "v"(src));
+      : "v"(src)
+      : "memory");
 #endif
   return ret;
 }
 
 __device__ __forceinline__ void refresh_volatile_sbyte([[maybe_unused]] volatile int *assigned_value,
                                                        [[maybe_unused]] volatile char *read_value) {
-#if defined(__gfx90a__) || defined(__gfx1100__)
+#if defined(__gfx90a__)
+  int16_t val16;
+  asm volatile(
+    "global_load_sbyte %0 %1 off glc slc\n "
+    "s_waitcnt vmcnt(0)"
+    : "=v"(val16)
+    : "v"(read_value)
+    : "memory");
+  *assigned_value = static_cast<int>(val16);
+#endif
+#if defined(__gfx942__) || defined(__gfx950__)
+  int16_t val16;
+  asm volatile(
+    "global_load_sbyte %0 %1 off sc0 sc1\n "
+    "s_waitcnt vmcnt(0)"
+    : "=v"(val16)
+    : "v"(read_value)
+    : "memory");
+  *assigned_value = static_cast<int>(val16);
+#endif
+#if defined(__gfx1100__)
   asm volatile(
     "global_load_sbyte %0 %1 off glc slc\n "
     "s_waitcnt vmcnt(0)"
     : "=v"(*assigned_value)
-    : "v"(read_value));
-#endif
-#if defined(__gfx942__) || defined(__gfx950__)
-  asm volatile(
-    "global_load_sbyte %0 %1 off sc0 sc1\n "
-    "s_waitcnt vmcnt(0)"
-    : "=v"(*assigned_value)
-    : "v"(read_value));
+    : "v"(read_value)
+    : "memory");
 #endif
 #if defined(__gfx1201__) || defined(__gfx1250__)
   asm volatile(
       "global_load_i8 %0 %1 off scope:SCOPE_SYS \n"
       "s_wait_loadcnt 0x0"
       : "=v"(*assigned_value)
-      : "v"(read_value));
+      : "v"(read_value)
+      : "memory");
 #endif
 }
 
@@ -98,87 +128,152 @@ __device__ __forceinline__ void refresh_volatile_dwordx2([[maybe_unused]] volati
     "global_load_dwordx2 %0 %1 off glc slc\n "
     "s_waitcnt vmcnt(0)"
     : "=v"(*assigned_value)
-    : "v"(read_value));
+    : "v"(read_value)
+    : "memory");
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
   asm volatile(
     "global_load_dwordx2 %0 %1 off sc0 sc1\n "
     "s_waitcnt vmcnt(0)"
     : "=v"(*assigned_value)
-    : "v"(read_value));
+    : "v"(read_value)
+    : "memory");
 #endif
- #if defined(__gfx1201__) || defined(__gfx1250__)
+#if defined(__gfx1201__) || defined(__gfx1250__)
   asm volatile(
       "global_load_b64 %0 %1 off scope:SCOPE_SYS \n"
       "s_wait_loadcnt 0x0"
       : "=v"(*assigned_value)
-      : "v"(read_value));
+      : "v"(read_value)
+      : "memory");
 #endif
 }
 
-/* Ignore the warning about deprecated volatile.
- * The only usage of volatile is to force the compiler to generate
- * the assembly instruction. If volatile is omitted, the compiler
- * will NOT generate the non-temporal load or the waitcnt.
- */
-// clang-format off
-NOWARN(-Wdeprecated-volatile,
-  template <typename T> __device__ __forceinline__ T uncached_load([[maybe_unused]] T* src) {
-    T ret{};
-    switch (sizeof(T)) {
-      case 4:
-#if defined(__gfx90a__) || defined(__gfx1100__)
-        asm volatile(
-            "global_load_dword %0 %1 off glc slc \n"
-            "s_waitcnt vmcnt(0)"
-            : "=v"(ret)
-            : "v"(src));
+template <typename T>
+__device__ __forceinline__ T uncached_load([[maybe_unused]] T* src) {
+  T ret{};
+  switch (sizeof(T)) {
+    case 2:
+#if defined(__gfx90a__)
+      asm volatile(
+          "global_load_ushort %0 %1 off glc slc \n"
+          "s_waitcnt vmcnt(0)"
+          : "=v"(ret)
+          : "v"(src)
+          : "memory");
+#endif
+#if defined(__gfx1100__)
+      int32_t val32;
+      asm volatile(
+          "global_load_ushort %0 %1 off glc slc \n"
+          "s_waitcnt vmcnt(0)"
+          : "=v"(val32)
+          : "v"(src)
+          : "memory");
+      ret = static_cast<int16_t>(val32);
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-        asm volatile(
-            "global_load_dword %0 %1 off sc0 sc1 \n"
-            "s_waitcnt vmcnt(0)"
-            : "=v"(ret)
-            : "v"(src));
+      asm volatile(
+          "global_load_ushort %0 %1 off sc0 sc1 \n"
+          "s_waitcnt vmcnt(0)"
+          : "=v"(ret)
+          : "v"(src)
+          : "memory");
 #endif
 #if defined(__gfx1201__) || defined(__gfx1250__)
-        asm volatile(
-            "global_load_b32 %0 %1 off scope:SCOPE_SYS \n"
-            "s_wait_loadcnt 0x0"
-            : "=v"(ret)
-            : "v"(src));
+      int32_t val32;
+      asm volatile(
+          "global_load_u16 %0 %1 off scope:SCOPE_SYS \n"
+          "s_wait_loadcnt 0x0"
+          : "=v"(val32)
+          : "v"(src)
+          : "memory");
+      ret = static_cast<int16_t>(val32);
 #endif
-        break;
-      case 8:
+      break;
+    case 4:
 #if defined(__gfx90a__) || defined(__gfx1100__)
-        asm volatile(
-            "global_load_dwordx2 %0 %1 off glc slc \n"
-            "s_waitcnt vmcnt(0)"
-            : "=v"(ret)
-            : "v"(src));
+      asm volatile(
+          "global_load_dword %0 %1 off glc slc \n"
+          "s_waitcnt vmcnt(0)"
+          : "=v"(ret)
+          : "v"(src)
+          : "memory");
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
-        asm volatile(
-            "global_load_dwordx2 %0 %1 off sc0 sc1 \n"
-            "s_waitcnt vmcnt(0)"
-            : "=v"(ret)
-            : "v"(src));
+      asm volatile(
+          "global_load_dword %0 %1 off sc0 sc1 \n"
+          "s_waitcnt vmcnt(0)"
+          : "=v"(ret)
+          : "v"(src)
+          : "memory");
 #endif
 #if defined(__gfx1201__) || defined(__gfx1250__)
-        asm volatile(
-            "global_load_b64 %0 %1 off scope:SCOPE_SYS \n"
-            "s_wait_loadcnt 0x0"
-            : "=v"(ret)
-            : "v"(src));
+      asm volatile(
+          "global_load_b32 %0 %1 off scope:SCOPE_SYS \n"
+          "s_wait_loadcnt 0x0"
+          : "=v"(ret)
+          : "v"(src)
+          : "memory");
 #endif
-        break;
-      default:
-        break;
-    }
-    return ret;
+      break;
+    case 8:
+#if defined(__gfx90a__) || defined(__gfx1100__)
+      asm volatile(
+          "global_load_dwordx2 %0 %1 off glc slc \n"
+          "s_waitcnt vmcnt(0)"
+          : "=v"(ret)
+          : "v"(src)
+          : "memory");
+#endif
+#if defined(__gfx942__) || defined(__gfx950__)
+      asm volatile(
+          "global_load_dwordx2 %0 %1 off sc0 sc1 \n"
+          "s_waitcnt vmcnt(0)"
+          : "=v"(ret)
+          : "v"(src)
+          : "memory");
+#endif
+#if defined(__gfx1201__) || defined(__gfx1250__)
+      asm volatile(
+          "global_load_b64 %0 %1 off scope:SCOPE_SYS \n"
+          "s_wait_loadcnt 0x0"
+          : "=v"(ret)
+          : "v"(src)
+          : "memory");
+#endif
+      break;
+    case 16:
+#if defined(__gfx90a__) || defined(__gfx1100__)
+      asm volatile(
+          "global_load_dwordx4 %0 %1 off glc slc \n"
+          "s_waitcnt vmcnt(0)"
+          : "=v"(ret)
+          : "v"(src)
+          : "memory");
+#endif
+#if defined(__gfx942__) || defined(__gfx950__)
+      asm volatile(
+          "global_load_dwordx4 %0 %1 off sc0 sc1 \n"
+          "s_waitcnt vmcnt(0)"
+          : "=v"(ret)
+          : "v"(src)
+          : "memory");
+#endif
+#if defined(__gfx1201__) || defined(__gfx1250__)
+      asm volatile(
+          "global_load_b128 %0 %1 off scope:SCOPE_SYS \n"
+          "s_wait_loadcnt 0x0"
+          : "=v"(ret)
+          : "v"(src)
+          : "memory");
+#endif
+      break;
+    default:
+      break;
   }
-)
-// clang-format on
+  return ret;
+}
 
 __device__ __forceinline__ void __roc_flush() {
 #if not defined USE_HDP_FLUSH

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -151,12 +151,56 @@ __device__ __forceinline__ void refresh_volatile_dwordx2([[maybe_unused]] volati
 
 template <typename T>
 __device__ __forceinline__ T uncached_load([[maybe_unused]] T* src) {
-  static_assert(sizeof(T) == 2 || sizeof(T) == 4 || 
-                sizeof(T) == 8 || sizeof(T) == 16, 
-                "uncached_load only supports 2/4/8/16-byte types");
+  static_assert(sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 ||
+                sizeof(T) == 8 || sizeof(T) == 16,
+                "uncached_load only supports 1/2/4/8/16-byte types");
   T ret{};
   switch (sizeof(T)) {
-    case 2:
+    case 1: {
+#if defined(__gfx90a__)
+    
+      int16_t val16;
+      asm volatile(
+          "global_load_ubyte %0 %1 off glc slc \n"
+          "s_waitcnt vmcnt(0)"
+          : "=v"(val16)
+          : "v"(src)
+          : "memory");
+      ret = static_cast<T>(val16);
+#endif
+#if defined(__gfx942__) || defined(__gfx950__)
+      int16_t val16;
+      asm volatile(
+          "global_load_ubyte %0 %1 off sc0 sc1 \n"
+          "s_waitcnt vmcnt(0)"
+          : "=v"(val16)
+          : "v"(src)
+          : "memory");
+      ret = static_cast<T>(val16);
+#endif
+#if defined(__gfx1100__)
+      int32_t val32;
+      asm volatile(
+          "global_load_ubyte %0 %1 off glc slc \n"
+          "s_waitcnt vmcnt(0)"
+          : "=v"(val32)
+          : "v"(src)
+          : "memory");
+      ret = static_cast<T>(val32);
+#endif
+#if defined(__gfx1201__) || defined(__gfx1250__)
+      int32_t val32;
+      asm volatile(
+          "global_load_u8 %0 %1 off scope:SCOPE_SYS \n"
+          "s_wait_loadcnt 0x0"
+          : "=v"(val32)
+          : "v"(src)
+          : "memory");
+      ret = static_cast<T>(val32);
+#endif
+      break;
+    }
+    case 2: {
 #if defined(__gfx90a__)
       asm volatile(
           "global_load_ushort %0 %1 off glc slc \n"
@@ -194,7 +238,8 @@ __device__ __forceinline__ T uncached_load([[maybe_unused]] T* src) {
       ret = static_cast<T>(val32);
 #endif
       break;
-    case 4:
+    }
+    case 4: {
 #if defined(__gfx90a__) || defined(__gfx1100__)
       asm volatile(
           "global_load_dword %0 %1 off glc slc \n"
@@ -220,7 +265,8 @@ __device__ __forceinline__ T uncached_load([[maybe_unused]] T* src) {
           : "memory");
 #endif
       break;
-    case 8:
+    }
+    case 8: {
 #if defined(__gfx90a__) || defined(__gfx1100__)
       asm volatile(
           "global_load_dwordx2 %0 %1 off glc slc \n"
@@ -246,7 +292,8 @@ __device__ __forceinline__ T uncached_load([[maybe_unused]] T* src) {
           : "memory");
 #endif
       break;
-    case 16:
+    }
+    case 16: {
 #if defined(__gfx90a__) || defined(__gfx1100__)
       asm volatile(
           "global_load_dwordx4 %0 %1 off glc slc \n"
@@ -272,6 +319,7 @@ __device__ __forceinline__ T uncached_load([[maybe_unused]] T* src) {
           : "memory");
 #endif
       break;
+    }
     default:
       break;
   }

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -151,6 +151,9 @@ __device__ __forceinline__ void refresh_volatile_dwordx2([[maybe_unused]] volati
 
 template <typename T>
 __device__ __forceinline__ T uncached_load([[maybe_unused]] T* src) {
+  static_assert(sizeof(T) == 2 || sizeof(T) == 4 || 
+                sizeof(T) == 8 || sizeof(T) == 16, 
+                "uncached_load only supports 2/4/8/16-byte types");
   T ret{};
   switch (sizeof(T)) {
     case 2:
@@ -170,7 +173,7 @@ __device__ __forceinline__ T uncached_load([[maybe_unused]] T* src) {
           : "=v"(val32)
           : "v"(src)
           : "memory");
-      ret = static_cast<int16_t>(val32);
+      ret = static_cast<T>(val32);
 #endif
 #if defined(__gfx942__) || defined(__gfx950__)
       asm volatile(
@@ -188,7 +191,7 @@ __device__ __forceinline__ T uncached_load([[maybe_unused]] T* src) {
           : "=v"(val32)
           : "v"(src)
           : "memory");
-      ret = static_cast<int16_t>(val32);
+      ret = static_cast<T>(val32);
 #endif
       break;
     case 4:

--- a/projects/rocshmem/src/context_tmpl_device.hpp
+++ b/projects/rocshmem/src/context_tmpl_device.hpp
@@ -426,35 +426,34 @@ template <typename T>
 __device__ __forceinline__ int Context::test(T *ivars, int cmp,
                                              T val) {
   int ret = 0;
-  volatile T *vol_ivars = reinterpret_cast<T *>(ivars);
   switch (cmp) {
     case ROCSHMEM_CMP_EQ:
-      if (uncached_load(vol_ivars) == val) {
+      if (uncached_load(ivars) == val) {
         ret = 1;
       }
       break;
     case ROCSHMEM_CMP_NE:
-      if (uncached_load(vol_ivars) != val) {
+      if (uncached_load(ivars) != val) {
         ret = 1;
       }
       break;
     case ROCSHMEM_CMP_GT:
-      if (uncached_load(vol_ivars) > val) {
+      if (uncached_load(ivars) > val) {
         ret = 1;
       }
       break;
     case ROCSHMEM_CMP_GE:
-      if (uncached_load(vol_ivars) >= val) {
+      if (uncached_load(ivars) >= val) {
         ret = 1;
       }
       break;
     case ROCSHMEM_CMP_LT:
-      if (uncached_load(vol_ivars) < val) {
+      if (uncached_load(ivars) < val) {
         ret = 1;
       }
       break;
     case ROCSHMEM_CMP_LE:
-      if (uncached_load(vol_ivars) <= val) {
+      if (uncached_load(ivars) <= val) {
         ret = 1;
       }
       break;

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -682,8 +682,8 @@ __device__ void GDAContext::alltoallv_copy(rocshmem_team_t team, T *dest,
   for (int j = tid; j < pe_size; j+= step_size) {
     int dest_pe = team_obj->get_pe_in_world(j);
 
-    long *vol_ivars = &pSync[alltoall_pSync_offset + dest_pe];
-    while (uncached_load(vol_ivars) != 1) { }
+    long *sync_flags = &pSync[alltoall_pSync_offset + dest_pe];
+    while (uncached_load(sync_flags) != 1) { }
 
     qps[dest_pe].quiet_single();
 
@@ -771,8 +771,8 @@ __device__ void GDAContext::alltoallv_get(rocshmem_team_t team, T *dest,
     char* amo_dst = ((char*)&pSync[alltoall_pSync_offset + my_pe_in_team] + base_heap_offset);
     qps[dest_pe].atomic_nofetch_single(amo_dst, 1);
 
-    long *vol_ivars = &pSync[alltoall_pSync_offset + dest_pe];
-    while (uncached_load(vol_ivars) != 1) { }
+    long *sync_flags = &pSync[alltoall_pSync_offset + dest_pe];
+    while (uncached_load(sync_flags) != 1) { }
 
     qps[dest_pe].quiet_single();
 
@@ -846,8 +846,8 @@ __device__ void GDAContext::alltoall_linear_thread_puts(rocshmem_team_t team,
   for (int j = tid; j < pe_size; j+= step_size) {
     int dest_pe = team_obj->get_pe_in_world(j);
 
-    long *vol_ivars = &pSync[alltoall_pSync_offset + dest_pe];
-    while (uncached_load(vol_ivars) != 1) { }
+    long *sync_flags = &pSync[alltoall_pSync_offset + dest_pe];
+    while (uncached_load(sync_flags) != 1) { }
 
     qps[dest_pe].quiet_single();
 

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -682,7 +682,7 @@ __device__ void GDAContext::alltoallv_copy(rocshmem_team_t team, T *dest,
   for (int j = tid; j < pe_size; j+= step_size) {
     int dest_pe = team_obj->get_pe_in_world(j);
 
-    volatile long *vol_ivars = &pSync[alltoall_pSync_offset + dest_pe];
+    long *vol_ivars = &pSync[alltoall_pSync_offset + dest_pe];
     while (uncached_load(vol_ivars) != 1) { }
 
     qps[dest_pe].quiet_single();
@@ -752,7 +752,7 @@ __device__ void GDAContext::alltoallv_get(rocshmem_team_t team, T *dest,
 
     /* Wait for Ctrl Message */
     uint64_t ctrl_value;
-    volatile uint64_t *vol_ctrl = &tmp_buf[dest_pe];
+    uint64_t *vol_ctrl = &tmp_buf[dest_pe];
 
     do {
       ctrl_value = uncached_load(vol_ctrl);
@@ -771,7 +771,7 @@ __device__ void GDAContext::alltoallv_get(rocshmem_team_t team, T *dest,
     char* amo_dst = ((char*)&pSync[alltoall_pSync_offset + my_pe_in_team] + base_heap_offset);
     qps[dest_pe].atomic_nofetch_single(amo_dst, 1);
 
-    volatile long *vol_ivars = &pSync[alltoall_pSync_offset + dest_pe];
+    long *vol_ivars = &pSync[alltoall_pSync_offset + dest_pe];
     while (uncached_load(vol_ivars) != 1) { }
 
     qps[dest_pe].quiet_single();
@@ -846,7 +846,7 @@ __device__ void GDAContext::alltoall_linear_thread_puts(rocshmem_team_t team,
   for (int j = tid; j < pe_size; j+= step_size) {
     int dest_pe = team_obj->get_pe_in_world(j);
 
-    volatile long *vol_ivars = &pSync[alltoall_pSync_offset + dest_pe];
+    long *vol_ivars = &pSync[alltoall_pSync_offset + dest_pe];
     while (uncached_load(vol_ivars) != 1) { }
 
     qps[dest_pe].quiet_single();

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -544,7 +544,7 @@ __device__ void IPCContext::alltoall_linear_thread_puts(rocshmem_team_t team,
   for (int j = tid; j < pe_size; j+= step_size) {
     int dest_pe = team_obj->get_pe_in_world(j);
 
-    volatile long *vol_ivars = &pSync[alltoall_pSync_offset + dest_pe];
+    long *vol_ivars = &pSync[alltoall_pSync_offset + dest_pe];
     while (uncached_load(vol_ivars) != 1) { }
 
     //quiet(dest_pe);// needed to quiet add when it is nbi in gda, it is not nbi in ipc

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -544,8 +544,8 @@ __device__ void IPCContext::alltoall_linear_thread_puts(rocshmem_team_t team,
   for (int j = tid; j < pe_size; j+= step_size) {
     int dest_pe = team_obj->get_pe_in_world(j);
 
-    long *vol_ivars = &pSync[alltoall_pSync_offset + dest_pe];
-    while (uncached_load(vol_ivars) != 1) { }
+    long *sync_flag = &pSync[alltoall_pSync_offset + dest_pe];
+    while (uncached_load(sync_flag) != 1) { }
 
     //quiet(dest_pe);// needed to quiet add when it is nbi in gda, it is not nbi in ipc
 


### PR DESCRIPTION
## Motivation

Across several call sites in `context_tmpl_device.hpp`, `context_gda_tmpl_device.hpp`, and `context_ipc_tmpl_device.hpp`, local pointer variables are declared volatile before being passed to `uncached_load`. The intent was to prevent the compiler from caching the loaded value across loop iterations. 

The volatile qualifier on the pointer variables provides no memory-ordering or cache-bypass guarantees in the GPU execution model. Only the `asm volatile` + `"memory"` clobber matters. 

Moreover, this line is a potential bug:
`volatile T *vol_ivars = reinterpret_cast<T *>(ivars);`

`reinterpret_cast<T *>` drops the volatile modifier from `ivars`, and defining this as a new variable does not guarantee that the compiler prevent this from getting cached or reorder on the new GPU compilers. I double checked this with ROCm 7.4.2, and with this extra cast and modifer, the function `uncached_load` performs a bunch of unnecessary flat stores/loads in spite of doing a global load. 

```
flat_store_dwordx2 v[2:3], v[0:1] sc0 sc1
s_waitcnt vmcnt(0)
;;#ASMSTART
global_load_dwordx2 v[6:7] v[4:5] off sc0 sc1 
s_waitcnt vmcnt(0)
;;#ASMEND
flat_store_dwordx2 v[2:3], v[6:7] sc0 sc1
s_waitcnt vmcnt(0)
flat_load_dwordx2 v[6:7], v[2:3] sc0 sc1
s_waitcnt vmcnt(0) lgkmcnt(0)
```

This is completely performance degrading, and moreover I’m not even sure this is intended to begin with. With the fix (removing the volatile keyword and add memory clobber to the asm box) the same function compiles to:

```
;;#ASMSTART
global_load_dwordx2 v[2:3] v[0:1] off sc0 sc1 
s_waitcnt vmcnt(0)
;;#ASMEND
```

On systems with ROCm 7.2.4 and lower this has been “working”. But with the new changes to the IPC backend and how we are forcing cache bypassing in other parts of the code, this has started to fail almost every time.

```
### Creating Test:	All-to-All Team-based Reduction	B=ipc PE=2 W=1 Z=64 ###
# Volume (B)   Msg Size (B)   # of timed Msgs        Latency (us)    Bandwidth (GB/s)    Msg Rate (Msg/s)
1              1              10                             8.88                0.00           112612.61
2              2              10                             8.68                0.00           115260.49
4              4              10                             8.70                0.00           114942.53
8              8              10                             8.84                0.00           113122.17
16             16             10                             8.59                0.00           116387.34
32             32             10                             8.66                0.01           115526.80
64             64             10                             9.51                0.01           105130.36
128            128            10                             9.02                0.03           110815.60
256            256            10                             9.92                0.05           100806.45
512            512            10                            12.27                0.08            81486.31
Memory access fault by GPU node-2 (Agent handle: 0x583d758a33f0) on address (nil). Reason: Unknown.
Memory access fault by GPU node-3 (Agent handle: 0x5efd26778140) on address (nil). Reason: Unknown.
```

**GDA** is also implemented with the same ideas, which could potentially fail.

## JIRA ID

AIROCSHMEM-434

## Test Result

Functional tests and unit tests pass