### PR TITLE
[rocprofiler-compute] Declare counter intent before HSA loads

### DIFF
--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
@@ -119,6 +119,7 @@ void on_hsa_runtime_loaded(rocprofiler_intercept_table_t /*type*/,
 
 int tool_init(rocprofiler_client_finalize_t, void* user_data)
 {
+    assert(user_data);
     std::clog << "[rocprofiler-compute] In tool init\n";
     g_sdk_wrapper->create_context(&get_client_ctx());
 

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/rocprofiler_compute_tool.cpp
@@ -104,23 +104,16 @@ void on_hsa_runtime_loaded(rocprofiler_intercept_table_t /*type*/,
                            uint64_t /*lib_instance*/,
                            void** /*tables*/,
                            uint64_t /*num_tables*/,
-                           void* user_data)
+                           void* /*user_data*/)
 {
-    // Counter collection and context start require HSA to be alive. Defer
-    // them until HSA actually loads so that LD_PRELOAD'd shells (which never
-    // touch HSA) do not initialize HSA worker threads, which would otherwise
-    // deadlock on fork() inside subshell/command-substitution.
+    // Defer start_context until HSA loads: it starts HSA worker threads, which
+    // would deadlock on fork() in non-GPU LD_PRELOAD'd shells.
     if (g_tool_shutting_down.load(std::memory_order_acquire))
         return;
 
     if (g_hsa_intercept_done.exchange(true, std::memory_order_acq_rel))
         return;
 
-    g_sdk_wrapper->configure_callback_dispatch_counting_service(get_client_ctx(),
-                                                                dispatch_callback,
-                                                                user_data,
-                                                                record_callback,
-                                                                user_data);
     g_sdk_wrapper->start_context(get_client_ctx());
 }
 
@@ -135,6 +128,18 @@ int tool_init(rocprofiler_client_finalize_t, void* user_data)
                                                       0,
                                                       tool_tracing_callback,
                                                       user_data);
+
+    // Declare counters before HSA loads so the SDK picks the legacy intercept path;
+    // queue interposition (the default) cannot collect counters.
+    auto* tool_data_ptr = static_cast<std::unique_ptr<tool_data_t>*>(user_data);
+    if (!tool_data_ptr->get()->requested_counters.empty())
+    {
+        g_sdk_wrapper->configure_callback_dispatch_counting_service(get_client_ctx(),
+                                                                    dispatch_callback,
+                                                                    user_data,
+                                                                    record_callback,
+                                                                    user_data);
+    }
     return 0;
 }
 

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
@@ -215,7 +215,7 @@ TEST_F(TestRocprofilerComputeTool, OnToolInit_CreatesContext)
 TEST_F(TestRocprofilerComputeTool, OnToolInit_ConfiguresDispatchCountingService)
 {
     const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
-    cfg->initialize(nullptr, cfg->tool_data);
+    ASSERT_EQ(cfg->initialize(nullptr, cfg->tool_data), 0);
     ASSERT_EQ(m_sdk_wrapper->get_dispatch_counting_service_info().size(), 1u);
     const auto& args = m_sdk_wrapper->get_dispatch_counting_service_info()[0];
     EXPECT_EQ(args.context, m_sdk_wrapper->get_created_contexts()[0]);

--- a/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
+++ b/projects/rocprofiler-compute/src/lib/rocprofiler_compute_tool/tests/test_rocprofiler_compute_tool.cpp
@@ -212,13 +212,10 @@ TEST_F(TestRocprofilerComputeTool, OnToolInit_CreatesContext)
     EXPECT_EQ(m_sdk_wrapper->get_created_contexts().size(), 1u);
 }
 
-TEST_F(TestRocprofilerComputeTool, OnHsaInterceptCallback_ConfiguresDispatchCountingService)
+TEST_F(TestRocprofilerComputeTool, OnToolInit_ConfiguresDispatchCountingService)
 {
     const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
     cfg->initialize(nullptr, cfg->tool_data);
-    ASSERT_EQ(m_sdk_wrapper->get_hsa_intercept_registration_info().size(), 1u);
-    const auto reg = m_sdk_wrapper->get_hsa_intercept_registration_info()[0];
-    reg.callback(ROCPROFILER_HSA_TABLE, 0, 0, nullptr, 0, reg.user_data);
     ASSERT_EQ(m_sdk_wrapper->get_dispatch_counting_service_info().size(), 1u);
     const auto& args = m_sdk_wrapper->get_dispatch_counting_service_info()[0];
     EXPECT_EQ(args.context, m_sdk_wrapper->get_created_contexts()[0]);
@@ -263,15 +260,27 @@ TEST_F(TestRocprofilerComputeTool, OnFiniWithNonEmptyCountersAndKernelFiltering_
     EXPECT_EQ(m_counters_writer->get_write_counters_info()[0].kernel_id, std::vector{kernel_id0});
 }
 
-// Regression guard for the HSA-init-in-shell-then-fork deadlock: tool_init
-// must not call into HSA-touching SDK services. Counter collection setup and
-// context activation must only happen via the HSA intercept callback.
-TEST_F(TestRocprofilerComputeTool, ToolInit_DoesNotStartContextOrConfigureCountingService)
+// Counter intent is declared in tool_init so the SDK queue-interposition gate
+// sees it before HSA loads. The HSA-touching start_context must stay deferred
+// to the intercept callback (regression guard for the fork deadlock when the
+// tool is preloaded into non-GPU processes).
+TEST_F(TestRocprofilerComputeTool, ToolInit_ConfiguresCountingServiceButDoesNotStartContext)
 {
     const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
     ASSERT_EQ(cfg->initialize(nullptr, cfg->tool_data), 0);
+    EXPECT_EQ(m_sdk_wrapper->get_dispatch_counting_service_info().size(), 1u);
     EXPECT_TRUE(m_sdk_wrapper->get_started_contexts().empty());
+}
+
+// Without requested counters there is nothing to collect, so tool_init must not
+// configure the counting service.
+TEST_F(TestRocprofilerComputeTool, ToolInit_WithoutRequestedCounters_DoesNotConfigureCountingService)
+{
+    m_input_parameters->set_requested_counters("");
+    const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
+    ASSERT_EQ(cfg->initialize(nullptr, cfg->tool_data), 0);
     EXPECT_TRUE(m_sdk_wrapper->get_dispatch_counting_service_info().empty());
+    EXPECT_TRUE(m_sdk_wrapper->get_started_contexts().empty());
 }
 
 TEST_F(TestRocprofilerComputeTool, RocprofilerConfigure_RegistersHsaInterceptCallback)
@@ -282,7 +291,7 @@ TEST_F(TestRocprofilerComputeTool, RocprofilerConfigure_RegistersHsaInterceptCal
     EXPECT_EQ(m_sdk_wrapper->get_hsa_intercept_registration_info()[0].user_data, cfg->tool_data);
 }
 
-TEST_F(TestRocprofilerComputeTool, HsaInterceptCallback_StartsContextAndConfiguresCountingService)
+TEST_F(TestRocprofilerComputeTool, HsaInterceptCallback_StartsContext)
 {
     const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
     ASSERT_EQ(cfg->initialize(nullptr, cfg->tool_data), 0);
@@ -290,13 +299,12 @@ TEST_F(TestRocprofilerComputeTool, HsaInterceptCallback_StartsContextAndConfigur
     const auto reg = m_sdk_wrapper->get_hsa_intercept_registration_info()[0];
     reg.callback(ROCPROFILER_HSA_TABLE, 0, 0, nullptr, 0, reg.user_data);
     EXPECT_EQ(m_sdk_wrapper->get_started_contexts().size(), 1u);
-    EXPECT_EQ(m_sdk_wrapper->get_dispatch_counting_service_info().size(), 1u);
     compare_counter_config_ids(m_sdk_wrapper->get_created_contexts(),
                                m_sdk_wrapper->get_started_contexts());
 }
 
-// The SDK may fire the HSA intercept callback more than once. Counter setup
-// and context start must run exactly once per process.
+// The SDK may fire the HSA intercept callback more than once. Context start
+// must run exactly once per process.
 TEST_F(TestRocprofilerComputeTool, HsaInterceptCallback_IsIdempotent)
 {
     const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
@@ -306,11 +314,10 @@ TEST_F(TestRocprofilerComputeTool, HsaInterceptCallback_IsIdempotent)
     reg.callback(ROCPROFILER_HSA_TABLE, 0, 0, nullptr, 0, reg.user_data);
     reg.callback(ROCPROFILER_HSA_TABLE, 0, 0, nullptr, 0, reg.user_data);
     EXPECT_EQ(m_sdk_wrapper->get_started_contexts().size(), 1u);
-    EXPECT_EQ(m_sdk_wrapper->get_dispatch_counting_service_info().size(), 1u);
 }
 
-// If HSA loads after tool_fini has run, the callback must not dereference
-// the freed tool_data pointer it captured at registration time.
+// If HSA loads after tool_fini has run, the callback must not start a context
+// or dereference the freed tool_data pointer it captured at registration time.
 TEST_F(TestRocprofilerComputeTool, HsaInterceptCallback_AfterToolFini_IsNoOp)
 {
     const auto cfg = rocprofiler_configure(1, "", 1, &m_client_id);
@@ -320,7 +327,6 @@ TEST_F(TestRocprofilerComputeTool, HsaInterceptCallback_AfterToolFini_IsNoOp)
     const auto reg = m_sdk_wrapper->get_hsa_intercept_registration_info()[0];
     reg.callback(ROCPROFILER_HSA_TABLE, 0, 0, nullptr, 0, reg.user_data);
     EXPECT_TRUE(m_sdk_wrapper->get_started_contexts().empty());
-    EXPECT_TRUE(m_sdk_wrapper->get_dispatch_counting_service_info().empty());
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Motivation

Bugfix: restore native counter collection, which stopped collecting counters after the rocprofiler-sdk [Queue Interposition change (#5219)](https://github.com/ROCm/rocm-systems/pull/5219).

Problem: At HSA-table registration the SDK now picks once, based on which contexts have already declared counter collection, between the legacy queue-intercept path and the new tracing-only interposition path. The native tool declares its counter context lazily, after HSA loads, to avoid starting HSA worker threads in non-GPU processes (which can deadlock on fork). It therefore declared too late: the SDK saw no counter context, chose interposition, and collected nothing.

Solution: Declare the counter context in tool_init, before HSA loads, so the SDK sees it and installs the legacy intercept path that counters require. The HSA-touching context start stays deferred, so non-GPU fork-safety is unchanged.

## Technical Details

- Move the counter-service configuration (configure_callback_dispatch_counting_service) from on_hsa_runtime_loaded to tool_init, gated on requested counters.
- Keep start_context in on_hsa_runtime_loaded as the only HSA-touching step, preserving fork-safety for non-GPU preloaded processes.
- Update unit tests for the moved configuration and add a no-requested-counters gate case.

## JIRA ID

## Test Plan

- Profile a GPU workload against a rocprofiler-sdk build that defaults to queue interposition.
- Confirm the raw counter CSV is populated and the "No GPU kernel data collected" warning is absent.
- Repeat against an older rocprofiler-sdk to confirm no regression.
- Run the tool unit tests (test-rocprofiler-compute-tool).

## Test Result

Verified on MI300X (gfx942): with the queue-interposition SDK the counter CSV now populates and the "No GPU kernel data collected" warning is gone; the older SDK still works. Tool unit tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.