### PR TITLE
[RCCL] Fix ncclCommGrow hang when growing to 8-rank single-node comm

### DIFF
--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -2415,7 +2415,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   }
 
   NCCLCHECKGOTO(latency_profiler::collTraceInit(comm), res, fail);
-  if (!job->parent && comm->nNodes == 1 && comm->nRanks == 8) {
+  if (!job->parent && !job->isGrow && comm->nNodes == 1 && comm->nRanks == 8) {
   	NCCLCHECKGOTO(ncclDdaIpcCommInit(comm), res, fail);
   }
   // update communicator state


### PR DESCRIPTION
## Motivation

ncclCommGrow hangs and times out when growing a communicator to exactly 8 ranks on a single node, blocking the elastic-grow feature. This PR fixes the deadlock so a grow to a full 8-GPU communicator completes reliably.

## Technical Details

DDA IPC init (ncclDdaIpcCommInit) was gated only on `!job->parent`, so during a grow the new joining rank (no parent) entered it while existing ranks (with a parent) skipped it, deadlocking the collective bootstrapAllGather inside. The fix adds `!job->isGrow` to the gate in ncclCommInitRankFunc (src/init.cc) so all ranks consistently skip DDA during a grow, leaving fresh init and split paths unchanged.

## JIRA ID

Resolves AICOMRCCL-1262.

## Test Plan

Ran the MPI unit test `GrowMPITest.*` with 8 ranks on a single MI300X node, which reproduced the hang prior to the change.

## Test Result

The previously hanging test now completes init on all 8 ranks and passes the AllReduce verification, with no 300s timeout.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
