### PR TITLE
fix(rocr): Fix compile warnings

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -396,8 +396,8 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
     uint8_t minor_;
   };
 
-  struct metadata_prefetch_pkt_version dispatch_version_;
-  struct metadata_prefetch_pkt_version barrier_version_;
+  class metadata_prefetch_pkt_version dispatch_version_;
+  class metadata_prefetch_pkt_version barrier_version_;
 
   // Shared event used for queue errors
   static __forceinline HsaEvent*& queue_event() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -396,8 +396,8 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
     uint8_t minor_;
   };
 
-  class metadata_prefetch_pkt_version dispatch_version_;
-  class metadata_prefetch_pkt_version barrier_version_;
+  metadata_prefetch_pkt_version dispatch_version_;
+  metadata_prefetch_pkt_version barrier_version_;
 
   // Shared event used for queue errors
   static __forceinline HsaEvent*& queue_event() {


### PR DESCRIPTION
## Summary

Fix C++ compile warnings in ROCr runtime. No functional change.

## JIRA ID

JIRA ID : ROCM-26177

## Test plan

- [ ] Build libhsa-runtime64 on Linux; confirm no new warnings or errors.