### PR TITLE
[RCCL-Tests] Add gfx1250 to hip_fp8 path

### DIFF
--- a/projects/rccl-tests/src/rccl_float8.h
+++ b/projects/rccl-tests/src/rccl_float8.h
@@ -23,7 +23,10 @@
 #ifndef ROCBLAS_FLOAT8_H
 #define ROCBLAS_FLOAT8_H
 
+#include <cmath>
 #include <stdint.h>
+#include <ostream>
+#include <type_traits>
 #include <hip/hip_version.h>
 
 #if __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))

--- a/projects/rccl-tests/src/rccl_float8.h
+++ b/projects/rccl-tests/src/rccl_float8.h
@@ -94,8 +94,8 @@ inline std::ostream& operator<<(std::ostream& os, const __hip_fp8_e5m2_fnuz& bf8
 
 extern bool rccl_float8_useFnuz;
 
-// For older versions of ROCm that do not include hip_fp8.h,
-// we provide a local version of the header file as a fallback.
+// For ROCm versions or target architectures that do not support hip_fp8.h,
+// we provide a local implementation as a fallback.
 #else
 
 #define HIP_HOST_DEVICE __host__ __device__

--- a/projects/rccl-tests/src/rccl_float8.h
+++ b/projects/rccl-tests/src/rccl_float8.h
@@ -40,14 +40,17 @@ typedef struct
 } rccl_bfloat8;
 
 // __cplusplus < 201103L || (!defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__))
-#elif HIP_VERSION >= 60300000
+
+#elif HIP_VERSION >= 60300000 && \
+      (!__HIP_DEVICE_COMPILE__ || \
+       defined(__gfx942__)  || defined(__gfx950__)  || \
+       defined(__gfx1100__) || defined(__gfx1101__) || \
+       defined(__gfx1200__) || defined(__gfx1201__) || \
+       defined(__gfx1250__))
 
 #include <hip/hip_fp8.h>
 
-#if   __HIP_DEVICE_COMPILE__ && (defined(__gfx950__) || defined(__gfx1200__) || defined(__gfx1201__) ||  (defined(__gfx1100__) || defined(__gfx1101__)))//HIP_FP8_TYPE_OCP is enabled.
-typedef __hip_fp8_e4m3 rccl_float8;
-typedef __hip_fp8_e5m2 rccl_bfloat8;
-#elif __HIP_DEVICE_COMPILE__ && (defined(__gfx942__))
+#if __HIP_DEVICE_COMPILE__ && (defined(__gfx942__))
 typedef __hip_fp8_e4m3_fnuz rccl_float8;
 typedef __hip_fp8_e5m2_fnuz rccl_bfloat8;
 #else
@@ -90,6 +93,7 @@ inline std::ostream& operator<<(std::ostream& os, const __hip_fp8_e5m2_fnuz& bf8
 #endif
 
 extern bool rccl_float8_useFnuz;
+
 // For older versions of ROCm that do not include hip_fp8.h,
 // we provide a local version of the header file as a fallback.
 #else


### PR DESCRIPTION
## Motivation

Add gfx1250 to the hip_fp8 architecture allow-list (same as RCCL)

## Technical Details

Technically covered in https://github.com/ROCm/rocm-systems/pull/4942, but this PR can potentially impact perf. As a result, separating enablement.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
