### PR TITLE
[DO NOT MERGE] CI A/B baseline — verify rocprofiler test flakiness on develop

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -4943,3 +4943,5 @@ void VirtualGPU::MetaDataPreloader::SetPacket(
   metadata->header0 = metadata_header;
 }
 }  // End of roc namespace
+
+// CI A/B baseline: intentional no-op to trigger the test matrix. No functional change. DO NOT MERGE.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/abi.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/abi.cpp
@@ -375,3 +375,5 @@ ROCP_SDK_ENFORCE_ABI(::PcSamplingExtTable, hsa_ven_amd_pcs_stop_fn, 6);
 ROCP_SDK_ENFORCE_ABI(::PcSamplingExtTable, hsa_ven_amd_pcs_flush_fn, 7);
 }  // namespace hsa
 }  // namespace rocprofiler
+
+// CI A/B baseline: intentional no-op to trigger the test matrix. No functional change. DO NOT MERGE.

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -4699,3 +4699,5 @@ hsa_status_t hsa_amd_enable_logging(uint8_t* flags, void* file);
 #endif
 
 #endif  // header guard
+
+// CI A/B baseline: intentional no-op to trigger the test matrix. No functional change. DO NOT MERGE.


### PR DESCRIPTION
**Throwaway experiment — DO NOT MERGE / DO NOT REVIEW.**

## Purpose
A/B control for #6632. That PR's `rocprofiler-sdk` (`test_kernel_trace_no_bubbles`)
and `rocprofiler-systems` (`transpose-sampling`) Linux test jobs fail deterministically
on the gfx94X TheRock CI pool. This branch is **pure develop** with only a no-op
comment added to one file in each of `rocr-runtime`, `clr`, and `rocprofiler-sdk` — just
enough to trigger the same dependent test matrix, but with **zero functional/extsem code**.

## What to look for
If `test_kernel_trace_no_bubbles` and `transpose-sampling` **still fail here**, the
failures are environment/runner/known-flaky — not caused by the external-semaphore
changes in #6632. If they **pass here**, the extsem changes are implicated.

Will be closed and the branch deleted once CI results are collected.