### PR TITLE
[rocprofiler-compute] Init all src/ submodules in README setup

### DIFF
--- a/projects/rocprofiler-compute/README.md
+++ b/projects/rocprofiler-compute/README.md
@@ -34,13 +34,13 @@ git checkout develop
 
 cd projects/rocprofiler-compute
 
-# Initialize vendored dependencies
-git submodule update --init --recursive -- src/vendored/
+# Initialize submodule dependencies (vendored Python deps and src/lib/external C++ libs)
+git submodule update --init --recursive -- src/
 
 python3 -m pip install -r requirements.txt
 ```
 
-**Note**: When working from source, vendored dependencies (like PyYAML) are included as git submodules. If you see import errors about missing vendored modules, run `git submodule update --init --recursive -- src/vendored/`.
+**Note**: When working from source, submodules live under `src/` (vendored Python dependencies like PyYAML in `src/vendored/`, and C++ libraries like googletest, fmt, and json in `src/lib/external/`). If you see import errors about missing vendored modules or missing C++ externals during a build, run `git submodule update --init --recursive -- src/`.
 
 ### Development dependencies
 


### PR DESCRIPTION
## Motivation

The source-setup instructions only initialized git submodules under `src/vendored/`, but `src/lib/external/` also contains submodules (googletest, fmt, json). Widen the instruction to init all of `src/` so a fresh source checkout has every submodule.

## Technical Details

- Change the README setup command to `git submodule update --init --recursive -- src/`.
- Update the source-build note to mention both vendored Python deps (`src/vendored/`) and C++ libraries (`src/lib/external/`).

## JIRA ID

N/A

## Test Plan

Fresh sparse-checkout, run the documented command, confirm both src/vendored and src/lib/external submodules populate.

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.