### PR TITLE
[rocprof-systems]: Skip gpu perf counter tests on gfx1151

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/test_transpose.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_transpose.py
@@ -342,6 +342,9 @@ class TestTransposeGPUPerfCounters(RocprofsysTest):
         num_processes,
         validation_rules_dir,
     ):
+        if "gfx1151" in gpu_info.architectures:
+            pytest.skip("transpose GPU perf counter test skipped on gfx1151")
+
         result = self.run_test(
             "sampling",
             "transpose",


### PR DESCRIPTION
## Motivation

GPU perf counter sampling tests are unreliable on gfx1151, so the test is skipped there to keep CI green without weakening coverage on supported GPUs. This is documented as a known issue in sdk tests here:
: [rocm-systems/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/input1/validate.py at cd708…](https://github.com/ROCm/rocm-systems/blob/cd7081732e2c72ab6af43878e35b801f7d39d59e/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/input1/validate.py#L82).

## Technical Details

- Add an early pytest.skip in `TestTransposeGPUPerfCounters.test` when "gfx1151" appears in `gpu_info.architectures`.
- The logic matches existing `gfx1250` and `mi300_or_later` based logic in the existing pytests.
- The dispatch counting method for sampling hardware counters are flaky on gfx1151 which is documented as AQLProfile bug in SDK validation tests.

## JIRA ID

AIPROFSYST-525

## Test Plan

Manual tests performed.

## Test Result

Tests are skipped on gfx1151 as expected.

```
360: ../../transpose-gpu-perf-counters SKIPPED (transpose GPU perf counte...)
360:
360: =========================== short test summary info ============================
360: SKIPPED [1] ../share/rocprofiler-systems/tests/pytest/test_transpose.py:346: transpose GPU perf counter test skipped on gfx1151

The following tests did not run:
        360 - transpose-gpu-perf-counters (Skipped)
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
