### PR TITLE
rocdbgapi: Support local to scratch address conversion

### DIFF
--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -649,6 +649,8 @@ generic_address_space_t::convert (
   else if (kind == kind_t::global)
     contiguous_bytes
       = lowered_address_space.last_address () - lowered_address + 1;
+  else if (kind == kind_t::local)
+      contiguous_bytes = wave.lds_size () - lowered_address;
   else
     dbgapi_assert_not_reached ("unsupported address space for generic.");
 

--- a/projects/rocdbgapi/src/wave.h
+++ b/projects/rocdbgapi/src/wave.h
@@ -132,6 +132,8 @@ public:
   bool is_halted () const;
   void set_halted (bool halted);
 
+  size_t lds_size () const { return m_cwsr_record->lds_size (); }
+
   /* Return the last wave stop event, or nullptr if the event is already
      processed and destroyed.  */
   const event_t *last_stop_event () const;


### PR DESCRIPTION
## Motivation

The generic_address_space_t::convert method is missing some logic to handle local to generic.  This patch adds the missing logic to compute how many bytes V the conversion is for.  That is:
- given a local address L converted to the generic address G for any e < V, convert_to_generic (L) = G => convert_to_generic (L + e) = G + e.

## Technical Details

Missing calculation for the `destination_contiguous_bytes` output argument when doing the local -> generic conversion.  Rest of the conversion is correctly handled.

## JIRA ID

AIROCGDB-605

## Test Plan

Changes tested manually for now. This will be properly exercised by ROCgdb's testsuite with upcoming changes.

## Test Result

Pass

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
