### PR TITLE
fix(rsmi_init): Do not complain loudly when no device is found

### DIFF
--- a/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
+++ b/projects/amdsmi/rocm_smi/include/rocm_smi/rocm_smi.h
@@ -1817,6 +1817,8 @@ typedef struct {
  *  to modify how RSMI initializes.
  *
  *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_NOT_SUPPORTED ROCm/KFD is not present on this system.
+ *  @retval ::RSMI_STATUS_INIT_ERROR initialization failed for other reasons.
  */
 rsmi_status_t rsmi_init(uint64_t init_flags);
 

--- a/projects/amdsmi/rocm_smi/src/rocm_smi.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi.cc
@@ -455,8 +455,7 @@ rsmi_status_t rsmi_init(uint64_t flags) {
       smi.Initialize(flags);
     } catch (const amd::smi::rsmi_exception& e) {
       smi.Cleanup();
-      if (e.error_code() == RSMI_INITIALIZATION_ERROR &&
-          !strcmp(e.what(), "Failed to initialize rocm_smi library (KFD node discovery).")) {
+      if (e.error_code() == RSMI_STATUS_NOT_SUPPORTED) {
         // This system does not actually have ROCM drivers set up
         // We were probably just called through dependency, just report the
         // error and log without complaining loudly.

--- a/projects/amdsmi/rocm_smi/src/rocm_smi_main.cc
+++ b/projects/amdsmi/rocm_smi/src/rocm_smi_main.cc
@@ -279,6 +279,11 @@ void RocmSMI::Initialize(uint64_t flags) {
   // internal data structures.
   ret = DiscoverAmdgpuDevices();
   if (ret != 0) {
+    if (ret == 2) {
+      // DiscoverAmdgpuDevices returns 2 when GetLargestNodeNumber failed with ENOENT
+      throw amd::smi::rsmi_exception(RSMI_STATUS_NOT_SUPPORTED,
+                                     "DiscoverAmdgpuDevices() did not detect a supported device.");
+    }
     throw amd::smi::rsmi_exception(RSMI_INITIALIZATION_ERROR, "DiscoverAmdgpuDevices() failed.");
   }
 
@@ -311,6 +316,10 @@ void RocmSMI::Initialize(uint64_t flags) {
 
   std::map<uint64_t, std::shared_ptr<KFDNode>> tmp_map;
   i_ret = DiscoverKFDNodes(&tmp_map);
+  if (i_ret == ENOENT) {
+    throw amd::smi::rsmi_exception(RSMI_STATUS_NOT_SUPPORTED,
+                                   "Failed to initialize rocm_smi library (KFD node discovery).");
+  }
   if (i_ret != 0) {
     throw amd::smi::rsmi_exception(RSMI_INITIALIZATION_ERROR,
                                    "Failed to initialize rocm_smi library (KFD node discovery).");
@@ -1051,12 +1060,16 @@ uint32_t GetLargestNodeNumber(const std::string& path = "/sys/class/kfd/kfd/topo
   // Open the directory
   DIR* dir = opendir(path.c_str());
   if (!dir) {
+    int error = errno;
     // Return UINT32_MAX on error
-    ss << __PRETTY_FUNCTION__ << " | Failed to open directory: " << path << " | errno = " << errno
-       << " | error = " << strerror(errno);
+    ss << __PRETTY_FUNCTION__ << " | Failed to open directory: " << path << " | errno = " << error
+       << " | error = " << strerror(error);
     // std::cout << ss.str() << std::endl;
     LOG_ERROR(ss);
-    return UINT32_MAX;
+    if (error == ENOENT)
+      return UINT32_MAX - 1;
+    else
+      return UINT32_MAX;
   }
 
   struct dirent* entry;
@@ -1099,6 +1112,12 @@ uint32_t RocmSMI::DiscoverAmdgpuDevices(void) {
      << " kfd nodes";
   // std::cout << ss.str() << std::endl;
   LOG_DEBUG(ss);
+  if (max_nodes == UINT32_MAX - 1) {
+    ss << __PRETTY_FUNCTION__ << " | Failed to get kfd directory";
+    // std::cout << ss.str() << std::endl;
+    LOG_ERROR(ss);
+    return 2;
+  }
   if (max_nodes == UINT32_MAX) {
     ss << __PRETTY_FUNCTION__ << " | Failed to get largest node number";
     // std::cout << ss.str() << std::endl;

--- a/projects/rocm-smi-lib/include/rocm_smi/rocm_smi.h
+++ b/projects/rocm-smi-lib/include/rocm_smi/rocm_smi.h
@@ -1339,6 +1339,8 @@ typedef struct {
  *  to modify how RSMI initializes.
  *
  *  @retval ::RSMI_STATUS_SUCCESS is returned upon successful call.
+ *  @retval ::RSMI_STATUS_NOT_SUPPORTED ROCm/KFD is not present on this system.
+ *  @retval ::RSMI_STATUS_INIT_ERROR initialization failed for other reasons.
  */
 rsmi_status_t rsmi_init(uint64_t init_flags);
 

--- a/projects/rocm-smi-lib/src/rocm_smi_main.cc
+++ b/projects/rocm-smi-lib/src/rocm_smi_main.cc
@@ -309,7 +309,13 @@ void RocmSMI::Initialize(uint64_t flags) {
   // internal data structures.
   ret = DiscoverAmdgpuDevices();
   if (ret != 0) {
-    throw amd::smi::rsmi_exception(RSMI_INITIALIZATION_ERROR, "DiscoverAmdgpuDevices() failed.");
+    if (ret == 2) {
+        // DiscoverAmdgpuDevices returns 2 when GetLargestNodeNumber failed with ENOENT
+        throw amd::smi::rsmi_exception(RSMI_STATUS_NOT_SUPPORTED,
+                                       "DiscoverAmdgpuDevices() did not detect a supported device.");
+    }
+    throw amd::smi::rsmi_exception(RSMI_INITIALIZATION_ERROR,
+                                   "DiscoverAmdgpuDevices() failed.");
   }
 
   ss << __PRETTY_FUNCTION__ << " | about to sort by BDF..." << std::endl;
@@ -343,6 +349,10 @@ void RocmSMI::Initialize(uint64_t flags) {
 
   std::map<uint64_t, std::shared_ptr<KFDNode>> tmp_map;
   i_ret = DiscoverKFDNodes(&tmp_map);
+  if (i_ret == ENOENT) {
+    throw amd::smi::rsmi_exception(RSMI_STATUS_NOT_SUPPORTED,
+                                   "Failed to initialize rocm_smi library (KFD node discovery).");
+  }
   if (i_ret != 0) {
     throw amd::smi::rsmi_exception(RSMI_INITIALIZATION_ERROR,
                                    "Failed to initialize rocm_smi library (KFD node discovery).");
@@ -812,12 +822,16 @@ uint32_t GetLargestNodeNumber(const std::string& path = "/sys/class/kfd/kfd/topo
   // Open the directory
   DIR* dir = opendir(path.c_str());
   if (!dir) {
+    int error = errno;
     // Return UINT32_MAX on error
-    ss << __PRETTY_FUNCTION__ << " | Failed to open directory: " << path << " | errno = " << errno
-       << " | error = " << strerror(errno);
+    ss << __PRETTY_FUNCTION__ << " | Failed to open directory: " << path << " | errno = " << error
+       << " | error = " << strerror(error);
     // std::cout << ss.str() << std::endl;
     LOG_ERROR(ss);
-    return UINT32_MAX;
+    if (error == ENOENT)
+      return UINT32_MAX-1;
+    else
+      return UINT32_MAX;
   }
 
   struct dirent* entry;
@@ -860,6 +874,12 @@ uint32_t RocmSMI::DiscoverAmdgpuDevices(void) {
      << " kfd nodes";
   // std::cout << ss.str() << std::endl;
   LOG_DEBUG(ss);
+  if (max_nodes == UINT32_MAX-1) {
+    ss << __PRETTY_FUNCTION__ << " | Failed to get kfd directory";
+    // std::cout << ss.str() << std::endl;
+    LOG_ERROR(ss);
+    return 2;
+  }
   if (max_nodes == UINT32_MAX) {
     ss << __PRETTY_FUNCTION__ << " | Failed to get largest node number";
     // std::cout << ss.str() << std::endl;


### PR DESCRIPTION
This is a follow-up for ROCm/amdsmi#74, to generalize to various initialization cases which show the stack or device is simply not available.

## Motivation

Just like for https://github.com/ROCm/amdsmi/pull/74: “When librocm-smi is pulled through a dependency, we may end up on a system without actual hardware supported by ROCM, and rsmi_init() failing is actually expected, we do want to frighten the user in such a case.

The situation that triggered this is that I was considering to enable ROCm support by default in hwloc shipped by Debian. On all systems that don't have rocm-supported hardware, we would always get Exception caught: rsmi_init. without any way for hwloc to avoid it. We really cannot have this by default in Debian, so unless we have a way to avoid this warning, I cannot enable ROCm by default in hwloc in Debian.”

Fixes: #8612

## Technical Details

This is a variant of https://github.com/ROCm/rocm-systems/pull/7250 which generalizes the approach by using the `RSMI_STATUS_NOT_SUPPORTED` error code to identify errors which are just reporting that the stack / a device is not available.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
