### PR TITLE
[rocprofiler-compute] Setting sdk as default for the torchtrace coverage test

### DIFF
--- a/projects/rocprofiler-compute/tests/test_torch_trace_coverage.py
+++ b/projects/rocprofiler-compute/tests/test_torch_trace_coverage.py
@@ -28,6 +28,8 @@ except Exception:
 
 COVERAGE_TEST_CONFIG: Dict[str, Any] = {"cleanup": True}
 
+# Set default profiler
+os.environ["ROCPROF"] = "rocprofiler-sdk"
 
 @pytest.fixture
 def torch_trace_coverage_sampling(request):

--- a/projects/rocprofiler-compute/tests/test_torch_trace_coverage.py
+++ b/projects/rocprofiler-compute/tests/test_torch_trace_coverage.py
@@ -31,6 +31,7 @@ COVERAGE_TEST_CONFIG: Dict[str, Any] = {"cleanup": True}
 # Set default profiler
 os.environ["ROCPROF"] = "rocprofiler-sdk"
 
+
 @pytest.fixture
 def torch_trace_coverage_sampling(request):
     """Return ``(seed, sample_budget)`` for the coverage test."""


### PR DESCRIPTION
## Motivation
Torch trace coverage test uses `--torch-trace --iteration-multiplexing`. `--iteration-multiplexing` needs rocprofiler-sdk for the native tool. Overriding the env variable.

## Technical Details

`os.environ["ROCPROF"] = "rocprofiler-sdk"`

## JIRA ID

AIPROFCOMP-633

## Test Plan

ctest -R test_torch_trace_coverage

## Test Result

Passes when ROCPROF=rocprofv3 (by overriding) 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
