### PR TITLE
[AMDSMI] Rename AINIC version label to ionic version

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -53,6 +53,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 ### Changed
 - **Deprecated `amdsmi_get_gpu_vram_vendor()` in favor of `amdsmi_get_gpu_vram_info()`**.  
 
+- **Renamed "AINIC version" to "ionic version" in `amd-smi version` output**.  
+  - The label now correctly reflects that it shows the ionic kernel driver version.
+
 ### Removed
 
 - **Removed the non-functional `--decode` flag from `amd-smi ras`**. Out-of-band CPER decoding is available via `amd-smi ras --afid --cper-file <path>` or `--afid --folder <DIR>`.

--- a/projects/amdsmi/amdsmi_cli/subcommands/version.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/version.py
@@ -131,7 +131,7 @@ class VersionCommands:
                 )
             if args.nic_version:
                 human_readable_output = (
-                    human_readable_output + f" | AINIC version: {nic_version_str}"
+                    human_readable_output + f" | ionic version: {nic_version_str}"
                 )
             # Custom human readable handling for version
             if self.logger.destination == "stdout":


### PR DESCRIPTION

## Motivation

The version command was displaying "AINIC version" but actually reports the ionic kernel driver version, not AINIC hardware version. 

## Technical Details

Updated label to match actual data source.

## JIRA ID

N/A

## Test Plan

amd-smi version

## Test Result

`$ amd-smi version`
`AMDSMI Tool: 26.5.0+e8e094445c | AMDSMI Library version: 26.5.0 | ROCm version: 7.2.3 | amdgpu version: 6.16.13 | ionic version: N/A`

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
