### PR TITLE
[rocjitsu] Fix MFMA/WMMA execution bugs in codegen and emulator

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/matrix.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/matrix.py
@@ -362,21 +362,52 @@ def gen_mfma(
                 f' src1_base, s2, extract_a, extract_b, inst_.clamp, const_acc);'
             )
         else:
-            s0b = f'amdgpu::src_base(vb, {s0}.encoding_value_)'
-            s1b = f'amdgpu::src_base(vb, {s1}.encoding_value_)'
-            # i8 MFMA (CDNA) / i8 WMMA (RDNA) share the GFX9 layout helper; the
-            # spec template needs N a multiple of the SIMD width.
-            if N % 16 == 0:
-                targ = _mma_targ(M, N, K, B, batch_optional=True)
+            has_blgp = arch in ('cdna1', 'cdna2', 'cdna3', 'cdna4')
+            if not has_blgp:
+                suffix = '4' if input_type == 'IU4' else '8'
                 L.append(
-                    f'  amdgpu::exec_i32_mfma_i8_spec<{targ}>(cu, dst, {s0b}, {s1b}, s2,'
-                    f' const_acc);'
+                    f'  auto extract_a = (inst_.neg & 0x1u) ? amdgpu::extract_i{suffix}'
+                    f' : amdgpu::extract_u{suffix};'
+                )
+                L.append(
+                    f'  auto extract_b = (inst_.neg & 0x2u) ? amdgpu::extract_i{suffix}'
+                    f' : amdgpu::extract_u{suffix};'
+                )
+                L.append(
+                    f'  amdgpu::exec_i32_mixed(cu, {M}, {N}, {K}, {B}, {in_bits}, dst,'
+                )
+                L.append(
+                    f'                        amdgpu::src_base(vb, {s0}.encoding_value_),'
+                )
+                L.append(
+                    f'                        amdgpu::src_base(vb, {s1}.encoding_value_),'
+                )
+                L.append(
+                    f'                        s2, extract_a, extract_b, const_acc, inst_.clamp);'
+                )
+            elif input_type == 'IU4':
+                L.append(
+                    f'  amdgpu::exec_i32_mixed(cu, {M}, {N}, {K}, {B}, {in_bits}, dst,'
+                )
+                L.append(
+                    f'                        amdgpu::src_base(vb, {s0}.encoding_value_),'
+                )
+                L.append(
+                    f'                        amdgpu::src_base(vb, {s1}.encoding_value_),'
+                )
+                L.append(
+                    f'                        s2, amdgpu::extract_u4, amdgpu::extract_u4, const_acc);'
                 )
             else:
+                L.append(f'  amdgpu::exec_i32_i8(cu, {M}, {N}, {K}, {B}, dst,')
                 L.append(
-                    f'  amdgpu::exec_i32_i8(cu, {M}, {N}, {K}, {B}, dst, {s0b}, {s1b}, s2,'
-                    f' const_acc);'
+                    f'                     amdgpu::src_base(vb, {s0}.encoding_value_),'
                 )
+                L.append(
+                    f'                     amdgpu::src_base(vb, {s1}.encoding_value_),'
+                )
+                L.append(f'                     s2, const_acc,')
+                L.append(f'                     inst_.cbsz, inst_.abid, inst_.blgp);')
     else:
         # F32, F16, and BF16 matrix results accumulate in f32. gfx1250 WMMA
         # uses a wave32 layout; CDNA MFMA uses the GFX9 MFMA layout helpers.
@@ -480,6 +511,16 @@ def gen_mfma(
             L.append('  }')
             L.append('  if (!dispatched)')
             L.append('    throw util::UnimplementedInst(mnemonic());')
+        elif result_type in ('F16', 'BF16') and arch in (
+            'rdna3',
+            'rdna3_5',
+            'rdna4',
+        ):
+            exec_fn = 'exec_f16_gfx9' if result_type == 'F16' else 'exec_bf16_gfx9'
+            L.append(f'  amdgpu::{exec_fn}(cu, {M}, {N}, {K}, {B}, {in_bits}, dst,')
+            L.append(f'                 amdgpu::src_base(vb, {s0}.encoding_value_),')
+            L.append(f'                 amdgpu::src_base(vb, {s1}.encoding_value_),')
+            L.append(f'                 s2, {ea}, {eb}, const_acc);')
         else:
             # CDNA1-4 VOP3P_MFMA encoding has cbsz/abid/blgp fields for A-matrix
             # broadcast and B-matrix lane permutation; RDNA WMMA does not, so
@@ -490,13 +531,13 @@ def gen_mfma(
             blgp = 'inst_.blgp' if has_blgp else '0u'
             s0b = f'amdgpu::src_base(vb, {s0}.encoding_value_)'
             s1b = f'amdgpu::src_base(vb, {s1}.encoding_value_)'
-            if N % 16 == 0 and input_type in _F8_FIXED:
+            if N % 16 == 0 and input_type in _F8_FIXED and has_blgp:
                 a_fp8, b_fp8 = _f8_bools(input_type)
                 L.append(
                     f'  amdgpu::exec_f32_mfma_f8_spec<{M}, {N}, {K}, {a_fp8}, {b_fp8}>('
                     f'cu, dst, {s0b}, {s1b}, s2, const_acc, {cbsz}, {abid}, {blgp});'
                 )
-            elif N % 16 == 0 and input_type in _MFMA_F32_SPEC:
+            elif N % 16 == 0 and input_type in _MFMA_F32_SPEC and has_blgp:
                 fam = _MFMA_F32_SPEC[input_type]
                 targ = _mma_targ(M, N, K, B, batch_optional=(fam != 'f32'))
                 L.append(

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/vop3p.cpp
@@ -916,9 +916,9 @@ void VMfmaI3232x32x4i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                              const_acc);
+  amdgpu::exec_i32_i8(cu, 32, 32, 4, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI3216x16x4i8Vop3pMfma::VMfmaI3216x16x4i8Vop3pMfma(const MachineInst *inst)
@@ -947,9 +947,9 @@ void VMfmaI3216x16x4i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                              const_acc);
+  amdgpu::exec_i32_i8(cu, 16, 16, 4, 4, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI324x4x4i8Vop3pMfma::VMfmaI324x4x4i8Vop3pMfma(const MachineInst *inst)
@@ -979,7 +979,8 @@ void VMfmaI324x4x4i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
   amdgpu::exec_i32_i8(cu, 4, 4, 4, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI3232x32x8i8Vop3pMfma::VMfmaI3232x32x8i8Vop3pMfma(const MachineInst *inst)
@@ -1008,9 +1009,9 @@ void VMfmaI3232x32x8i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<32, 32, 8>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                           amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                           const_acc);
+  amdgpu::exec_i32_i8(cu, 32, 32, 8, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI3216x16x16i8Vop3pMfma::VMfmaI3216x16x16i8Vop3pMfma(const MachineInst *inst)
@@ -1039,9 +1040,9 @@ void VMfmaI3216x16x16i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                            const_acc);
+  amdgpu::exec_i32_i8(cu, 16, 16, 16, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaF3232x32x2bf16Vop3pMfma::VMfmaF3232x32x2bf16Vop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/vop3p.cpp
@@ -991,9 +991,9 @@ void VMfmaI3232x32x4i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                              const_acc);
+  amdgpu::exec_i32_i8(cu, 32, 32, 4, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI3216x16x4i8Vop3pMfma::VMfmaI3216x16x4i8Vop3pMfma(const MachineInst *inst)
@@ -1022,9 +1022,9 @@ void VMfmaI3216x16x4i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                              const_acc);
+  amdgpu::exec_i32_i8(cu, 16, 16, 4, 4, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI324x4x4i8Vop3pMfma::VMfmaI324x4x4i8Vop3pMfma(const MachineInst *inst)
@@ -1054,7 +1054,8 @@ void VMfmaI324x4x4i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
   amdgpu::exec_i32_i8(cu, 4, 4, 4, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI3232x32x8i8Vop3pMfma::VMfmaI3232x32x8i8Vop3pMfma(const MachineInst *inst)
@@ -1083,9 +1084,9 @@ void VMfmaI3232x32x8i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<32, 32, 8>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                           amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                           const_acc);
+  amdgpu::exec_i32_i8(cu, 32, 32, 8, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI3216x16x16i8Vop3pMfma::VMfmaI3216x16x16i8Vop3pMfma(const MachineInst *inst)
@@ -1114,9 +1115,9 @@ void VMfmaI3216x16x16i8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                            const_acc);
+  amdgpu::exec_i32_i8(cu, 16, 16, 16, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaF3232x32x4bf161kVop3pMfma::VMfmaF3232x32x4bf161kVop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/vop3p.cpp
@@ -1053,9 +1053,9 @@ void VMfmaI3232x32x42bI8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                              const_acc);
+  amdgpu::exec_i32_i8(cu, 32, 32, 4, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI3216x16x44bI8Vop3pMfma::VMfmaI3216x16x44bI8Vop3pMfma(const MachineInst *inst)
@@ -1084,9 +1084,9 @@ void VMfmaI3216x16x44bI8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                              const_acc);
+  amdgpu::exec_i32_i8(cu, 16, 16, 4, 4, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI324x4x416bI8Vop3pMfma::VMfmaI324x4x416bI8Vop3pMfma(const MachineInst *inst)
@@ -1116,7 +1116,8 @@ void VMfmaI324x4x416bI8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
   amdgpu::exec_i32_i8(cu, 4, 4, 4, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI3232x32x16I8Vop3pMfma::VMfmaI3232x32x16I8Vop3pMfma(const MachineInst *inst)
@@ -1145,9 +1146,9 @@ void VMfmaI3232x32x16I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<32, 32, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                            const_acc);
+  amdgpu::exec_i32_i8(cu, 32, 32, 16, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI3216x16x32I8Vop3pMfma::VMfmaI3216x16x32I8Vop3pMfma(const MachineInst *inst)
@@ -1176,9 +1177,9 @@ void VMfmaI3216x16x32I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 32>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                            const_acc);
+  amdgpu::exec_i32_i8(cu, 16, 16, 32, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaF3232x32x42bBf16Vop3pMfma::VMfmaF3232x32x42bBf16Vop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/vop3p.cpp
@@ -964,9 +964,9 @@ void VMfmaI3216x16x64I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 64>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                            const_acc);
+  amdgpu::exec_i32_i8(cu, 16, 16, 64, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaF3232x32x16Bf16Vop3pMfma::VMfmaF3232x32x16Bf16Vop3pMfma(const MachineInst *inst)
@@ -1026,9 +1026,9 @@ void VMfmaI3232x32x32I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<32, 32, 32>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                            const_acc);
+  amdgpu::exec_i32_i8(cu, 32, 32, 32, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VSmfmacF3216x16x64Bf16Vop3pMfma::VSmfmacF3216x16x64Bf16Vop3pMfma(const MachineInst *inst)
@@ -1677,9 +1677,9 @@ void VMfmaI3232x32x42bI8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<32, 32, 4, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                              const_acc);
+  amdgpu::exec_i32_i8(cu, 32, 32, 4, 2, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI3216x16x44bI8Vop3pMfma::VMfmaI3216x16x44bI8Vop3pMfma(const MachineInst *inst)
@@ -1708,9 +1708,9 @@ void VMfmaI3216x16x44bI8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 4, 4>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                              const_acc);
+  amdgpu::exec_i32_i8(cu, 16, 16, 4, 4, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI324x4x416bI8Vop3pMfma::VMfmaI324x4x416bI8Vop3pMfma(const MachineInst *inst)
@@ -1740,7 +1740,8 @@ void VMfmaI324x4x416bI8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
   amdgpu::exec_i32_i8(cu, 4, 4, 4, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc);
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VSmfmacF3232x32x64Fp8Fp8Vop3pMfma::VSmfmacF3232x32x64Fp8Fp8Vop3pMfma(const MachineInst *inst)
@@ -1860,9 +1861,9 @@ void VMfmaI3232x32x16I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<32, 32, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                            const_acc);
+  amdgpu::exec_i32_i8(cu, 32, 32, 16, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VMfmaI3216x16x32I8Vop3pMfma::VMfmaI3216x16x32I8Vop3pMfma(const MachineInst *inst)
@@ -1891,9 +1892,9 @@ void VMfmaI3216x16x32I8Vop3pMfma::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 32>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                            amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                            const_acc);
+  amdgpu::exec_i32_i8(cu, 16, 16, 32, 1, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, inst_.cbsz,
+                      inst_.abid, inst_.blgp);
 }
 
 VSmfmacF3216x16x64F16Vop3pMfma::VSmfmacF3216x16x64F16Vop3pMfma(const MachineInst *inst)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3p.cpp
@@ -828,9 +828,9 @@ void VWmmaF3216x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                                const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
+                   amdgpu::extract_f16, const_acc);
 }
 
 VWmmaF3216x16x16Bf16Vop3p::VWmmaF3216x16x16Bf16Vop3p(const MachineInst *inst)
@@ -868,9 +868,9 @@ void VWmmaF3216x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16, 2>(
-      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
+                   amdgpu::extract_bf16, const_acc);
 }
 
 VWmmaF1616x16x16F16Vop3p::VWmmaF1616x16x16F16Vop3p(const MachineInst *inst)
@@ -908,9 +908,9 @@ void VWmmaF1616x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                                const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f16_gfx9(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                        amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
+                        amdgpu::extract_f16, const_acc);
 }
 
 VWmmaBf1616x16x16Bf16Vop3p::VWmmaBf1616x16x16Bf16Vop3p(const MachineInst *inst)
@@ -948,9 +948,9 @@ void VWmmaBf1616x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16, 2>(
-      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
+  amdgpu::exec_bf16_gfx9(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                         amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
+                         amdgpu::extract_bf16, const_acc);
 }
 
 VWmmaI3216x16x16Iu8Vop3p::VWmmaI3216x16x16Iu8Vop3p(const MachineInst *inst)
@@ -988,9 +988,11 @@ void VWmmaI3216x16x16Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                               const_acc);
+  auto extract_a = (inst_.neg & 0x1u) ? amdgpu::extract_i8 : amdgpu::extract_u8;
+  auto extract_b = (inst_.neg & 0x2u) ? amdgpu::extract_i8 : amdgpu::extract_u8;
+  amdgpu::exec_i32_mixed(cu, 16, 16, 16, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                         amdgpu::src_base(vb, src1.encoding_value_), s2, extract_a, extract_b,
+                         const_acc, inst_.clamp);
 }
 
 VWmmaI3216x16x16Iu4Vop3p::VWmmaI3216x16x16Iu4Vop3p(const MachineInst *inst)
@@ -1028,9 +1030,11 @@ void VWmmaI3216x16x16Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                               const_acc);
+  auto extract_a = (inst_.neg & 0x1u) ? amdgpu::extract_i4 : amdgpu::extract_u4;
+  auto extract_b = (inst_.neg & 0x2u) ? amdgpu::extract_i4 : amdgpu::extract_u4;
+  amdgpu::exec_i32_mixed(cu, 16, 16, 16, 2, 4, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                         amdgpu::src_base(vb, src1.encoding_value_), s2, extract_a, extract_b,
+                         const_acc, inst_.clamp);
 }
 
 } // namespace rdna3

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3p.cpp
@@ -828,9 +828,9 @@ void VWmmaF3216x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                                const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
+                   amdgpu::extract_f16, const_acc);
 }
 
 VWmmaF3216x16x16Bf16Vop3p::VWmmaF3216x16x16Bf16Vop3p(const MachineInst *inst)
@@ -868,9 +868,9 @@ void VWmmaF3216x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16, 2>(
-      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
+                   amdgpu::extract_bf16, const_acc);
 }
 
 VWmmaF1616x16x16F16Vop3p::VWmmaF1616x16x16F16Vop3p(const MachineInst *inst)
@@ -908,9 +908,9 @@ void VWmmaF1616x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                                const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f16_gfx9(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                        amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
+                        amdgpu::extract_f16, const_acc);
 }
 
 VWmmaBf1616x16x16Bf16Vop3p::VWmmaBf1616x16x16Bf16Vop3p(const MachineInst *inst)
@@ -948,9 +948,9 @@ void VWmmaBf1616x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16, 2>(
-      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
+  amdgpu::exec_bf16_gfx9(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                         amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
+                         amdgpu::extract_bf16, const_acc);
 }
 
 VWmmaI3216x16x16Iu8Vop3p::VWmmaI3216x16x16Iu8Vop3p(const MachineInst *inst)
@@ -988,9 +988,11 @@ void VWmmaI3216x16x16Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                               const_acc);
+  auto extract_a = (inst_.neg & 0x1u) ? amdgpu::extract_i8 : amdgpu::extract_u8;
+  auto extract_b = (inst_.neg & 0x2u) ? amdgpu::extract_i8 : amdgpu::extract_u8;
+  amdgpu::exec_i32_mixed(cu, 16, 16, 16, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                         amdgpu::src_base(vb, src1.encoding_value_), s2, extract_a, extract_b,
+                         const_acc, inst_.clamp);
 }
 
 VWmmaI3216x16x16Iu4Vop3p::VWmmaI3216x16x16Iu4Vop3p(const MachineInst *inst)
@@ -1028,9 +1030,11 @@ void VWmmaI3216x16x16Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                               const_acc);
+  auto extract_a = (inst_.neg & 0x1u) ? amdgpu::extract_i4 : amdgpu::extract_u4;
+  auto extract_b = (inst_.neg & 0x2u) ? amdgpu::extract_i4 : amdgpu::extract_u4;
+  amdgpu::exec_i32_mixed(cu, 16, 16, 16, 2, 4, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                         amdgpu::src_base(vb, src1.encoding_value_), s2, extract_a, extract_b,
+                         const_acc, inst_.clamp);
 }
 
 } // namespace rdna3_5

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3p.cpp
@@ -1746,9 +1746,9 @@ void VWmmaF3216x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                                const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
+                   amdgpu::extract_f16, const_acc);
 }
 
 VWmmaF3216x16x16Bf16Vop3p::VWmmaF3216x16x16Bf16Vop3p(const MachineInst *inst)
@@ -1786,9 +1786,9 @@ void VWmmaF3216x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16, 2>(
-      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 16, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
+                   amdgpu::extract_bf16, const_acc);
 }
 
 VWmmaF1616x16x16F16Vop3p::VWmmaF1616x16x16F16Vop3p(const MachineInst *inst)
@@ -1826,9 +1826,9 @@ void VWmmaF1616x16x16F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f16_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                             const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f16_gfx9(cu, 16, 16, 16, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                        amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
+                        amdgpu::extract_f16, const_acc);
 }
 
 VWmmaBf1616x16x16Bf16Vop3p::VWmmaBf1616x16x16Bf16Vop3p(const MachineInst *inst)
@@ -1866,9 +1866,9 @@ void VWmmaBf1616x16x16Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 16>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                              const_acc, 0u, 0u, 0u);
+  amdgpu::exec_bf16_gfx9(cu, 16, 16, 16, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                         amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
+                         amdgpu::extract_bf16, const_acc);
 }
 
 VWmmaI3216x16x16Iu8Vop3p::VWmmaI3216x16x16Iu8Vop3p(const MachineInst *inst)
@@ -1906,9 +1906,11 @@ void VWmmaI3216x16x16Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                               const_acc);
+  auto extract_a = (inst_.neg & 0x1u) ? amdgpu::extract_i8 : amdgpu::extract_u8;
+  auto extract_b = (inst_.neg & 0x2u) ? amdgpu::extract_i8 : amdgpu::extract_u8;
+  amdgpu::exec_i32_mixed(cu, 16, 16, 16, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                         amdgpu::src_base(vb, src1.encoding_value_), s2, extract_a, extract_b,
+                         const_acc, inst_.clamp);
 }
 
 VWmmaI3216x16x16Iu4Vop3p::VWmmaI3216x16x16Iu4Vop3p(const MachineInst *inst)
@@ -1946,9 +1948,11 @@ void VWmmaI3216x16x16Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 16, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                               const_acc);
+  auto extract_a = (inst_.neg & 0x1u) ? amdgpu::extract_i4 : amdgpu::extract_u4;
+  auto extract_b = (inst_.neg & 0x2u) ? amdgpu::extract_i4 : amdgpu::extract_u4;
+  amdgpu::exec_i32_mixed(cu, 16, 16, 16, 2, 4, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                         amdgpu::src_base(vb, src1.encoding_value_), s2, extract_a, extract_b,
+                         const_acc, inst_.clamp);
 }
 
 VWmmaF3216x16x16Fp8Fp8Vop3p::VWmmaF3216x16x16Fp8Fp8Vop3p(const MachineInst *inst)
@@ -1986,9 +1990,9 @@ void VWmmaF3216x16x16Fp8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f8_spec<16, 16, 16, true, true>(
-      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 16, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
+                   amdgpu::extract_fp8, const_acc);
 }
 
 VWmmaF3216x16x16Fp8Bf8Vop3p::VWmmaF3216x16x16Fp8Bf8Vop3p(const MachineInst *inst)
@@ -2026,9 +2030,9 @@ void VWmmaF3216x16x16Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f8_spec<16, 16, 16, true, false>(
-      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 16, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
+                   amdgpu::extract_bf8, const_acc);
 }
 
 VWmmaF3216x16x16Bf8Fp8Vop3p::VWmmaF3216x16x16Bf8Fp8Vop3p(const MachineInst *inst)
@@ -2066,9 +2070,9 @@ void VWmmaF3216x16x16Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f8_spec<16, 16, 16, false, true>(
-      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 16, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
+                   amdgpu::extract_fp8, const_acc);
 }
 
 VWmmaF3216x16x16Bf8Bf8Vop3p::VWmmaF3216x16x16Bf8Bf8Vop3p(const MachineInst *inst)
@@ -2106,9 +2110,9 @@ void VWmmaF3216x16x16Bf8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f8_spec<16, 16, 16, false, false>(
-      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 16, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
+                   amdgpu::extract_bf8, const_acc);
 }
 
 VWmmaI3216x16x32Iu4Vop3p::VWmmaI3216x16x32Iu4Vop3p(const MachineInst *inst)
@@ -2146,9 +2150,11 @@ void VWmmaI3216x16x32Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 32, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                               const_acc);
+  auto extract_a = (inst_.neg & 0x1u) ? amdgpu::extract_i4 : amdgpu::extract_u4;
+  auto extract_b = (inst_.neg & 0x2u) ? amdgpu::extract_i4 : amdgpu::extract_u4;
+  amdgpu::exec_i32_mixed(cu, 16, 16, 32, 2, 4, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                         amdgpu::src_base(vb, src1.encoding_value_), s2, extract_a, extract_b,
+                         const_acc, inst_.clamp);
 }
 
 VSwmmacF3216x16x32F16Vop3p::VSwmmacF3216x16x32F16Vop3p(const MachineInst *inst)
@@ -2186,9 +2192,9 @@ void VSwmmacF3216x16x32F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f16_spec<16, 16, 32, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                                amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                                const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 32, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
+                   amdgpu::extract_f16, const_acc);
 }
 
 VSwmmacF3216x16x32Bf16Vop3p::VSwmmacF3216x16x32Bf16Vop3p(const MachineInst *inst)
@@ -2226,9 +2232,9 @@ void VSwmmacF3216x16x32Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 32, 2>(
-      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 32, 2, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
+                   amdgpu::extract_bf16, const_acc);
 }
 
 VSwmmacF1616x16x32F16Vop3p::VSwmmacF1616x16x32F16Vop3p(const MachineInst *inst)
@@ -2266,9 +2272,9 @@ void VSwmmacF1616x16x32F16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f16_spec<16, 16, 32>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                             amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                             const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f16_gfx9(cu, 16, 16, 32, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                        amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_f16,
+                        amdgpu::extract_f16, const_acc);
 }
 
 VSwmmacBf1616x16x32Bf16Vop3p::VSwmmacBf1616x16x32Bf16Vop3p(const MachineInst *inst)
@@ -2306,9 +2312,9 @@ void VSwmmacBf1616x16x32Bf16Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_bf16_spec<16, 16, 32>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                              amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                              const_acc, 0u, 0u, 0u);
+  amdgpu::exec_bf16_gfx9(cu, 16, 16, 32, 1, 16, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                         amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf16,
+                         amdgpu::extract_bf16, const_acc);
 }
 
 VSwmmacI3216x16x32Iu8Vop3p::VSwmmacI3216x16x32Iu8Vop3p(const MachineInst *inst)
@@ -2346,9 +2352,11 @@ void VSwmmacI3216x16x32Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 32, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                               const_acc);
+  auto extract_a = (inst_.neg & 0x1u) ? amdgpu::extract_i8 : amdgpu::extract_u8;
+  auto extract_b = (inst_.neg & 0x2u) ? amdgpu::extract_i8 : amdgpu::extract_u8;
+  amdgpu::exec_i32_mixed(cu, 16, 16, 32, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                         amdgpu::src_base(vb, src1.encoding_value_), s2, extract_a, extract_b,
+                         const_acc, inst_.clamp);
 }
 
 VSwmmacI3216x16x32Iu4Vop3p::VSwmmacI3216x16x32Iu4Vop3p(const MachineInst *inst)
@@ -2386,9 +2394,11 @@ void VSwmmacI3216x16x32Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 32, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                               const_acc);
+  auto extract_a = (inst_.neg & 0x1u) ? amdgpu::extract_i4 : amdgpu::extract_u4;
+  auto extract_b = (inst_.neg & 0x2u) ? amdgpu::extract_i4 : amdgpu::extract_u4;
+  amdgpu::exec_i32_mixed(cu, 16, 16, 32, 2, 4, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                         amdgpu::src_base(vb, src1.encoding_value_), s2, extract_a, extract_b,
+                         const_acc, inst_.clamp);
 }
 
 VSwmmacI3216x16x64Iu4Vop3p::VSwmmacI3216x16x64Iu4Vop3p(const MachineInst *inst)
@@ -2426,9 +2436,11 @@ void VSwmmacI3216x16x64Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_i32_mfma_i8_spec<16, 16, 64, 2>(cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-                                               amdgpu::src_base(vb, src1.encoding_value_), s2,
-                                               const_acc);
+  auto extract_a = (inst_.neg & 0x1u) ? amdgpu::extract_i4 : amdgpu::extract_u4;
+  auto extract_b = (inst_.neg & 0x2u) ? amdgpu::extract_i4 : amdgpu::extract_u4;
+  amdgpu::exec_i32_mixed(cu, 16, 16, 64, 2, 4, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                         amdgpu::src_base(vb, src1.encoding_value_), s2, extract_a, extract_b,
+                         const_acc, inst_.clamp);
 }
 
 VSwmmacF3216x16x32Fp8Fp8Vop3p::VSwmmacF3216x16x32Fp8Fp8Vop3p(const MachineInst *inst)
@@ -2466,9 +2478,9 @@ void VSwmmacF3216x16x32Fp8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, true, true>(
-      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 32, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
+                   amdgpu::extract_fp8, const_acc);
 }
 
 VSwmmacF3216x16x32Fp8Bf8Vop3p::VSwmmacF3216x16x32Fp8Bf8Vop3p(const MachineInst *inst)
@@ -2506,9 +2518,9 @@ void VSwmmacF3216x16x32Fp8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, true, false>(
-      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 32, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_fp8,
+                   amdgpu::extract_bf8, const_acc);
 }
 
 VSwmmacF3216x16x32Bf8Fp8Vop3p::VSwmmacF3216x16x32Bf8Fp8Vop3p(const MachineInst *inst)
@@ -2546,9 +2558,9 @@ void VSwmmacF3216x16x32Bf8Fp8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, false, true>(
-      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 32, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
+                   amdgpu::extract_fp8, const_acc);
 }
 
 VSwmmacF3216x16x32Bf8Bf8Vop3p::VSwmmacF3216x16x32Bf8Bf8Vop3p(const MachineInst *inst)
@@ -2586,9 +2598,9 @@ void VSwmmacF3216x16x32Bf8Bf8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
   uint32_t const_acc;
   uint32_t s2 = amdgpu::resolve_acc(vb, dst, src2.encoding_value_, const_acc,
                                     [&] { return src2.read_scalar(wf); });
-  amdgpu::exec_f32_mfma_f8_spec<16, 16, 32, false, false>(
-      cu, dst, amdgpu::src_base(vb, src0.encoding_value_),
-      amdgpu::src_base(vb, src1.encoding_value_), s2, const_acc, 0u, 0u, 0u);
+  amdgpu::exec_f32(cu, 16, 16, 32, 2, 8, dst, amdgpu::src_base(vb, src0.encoding_value_),
+                   amdgpu::src_base(vb, src1.encoding_value_), s2, amdgpu::extract_bf8,
+                   amdgpu::extract_bf8, const_acc);
 }
 
 } // namespace rdna4

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -613,6 +613,45 @@ void wmma_simd_matmul(uint32_t M, uint32_t N, uint32_t K, uint32_t W, uint32_t s
   }
 }
 
+/// Adjust a GFX9 InputLoc for wave32 physical VGPR addressing.
+///
+/// The GFX9 MFMA layout uses 64 virtual lanes. On wave64 this maps directly
+/// to physical registers. On wave32, each logical VGPR spans two physical
+/// VGPRs. Without stride adjustment, read_vgpr(base+V, lane>=32) aliases
+/// with read_vgpr(base+V+1, lane%32), corrupting data from the next logical
+/// VGPR. The fix strides the logical VGPR offset by 2 on wave32.
+inline InputLoc physicalize_loc(const InputLoc &loc, uint32_t wf_size) {
+  if (wf_size >= 64)
+    return loc;
+  const uint32_t stride = 64 / wf_size;
+  return {loc.vgpr_offset * stride + loc.lane / wf_size, loc.lane % wf_size, loc.sub_element,
+          loc.bit_offset, loc.data_bits};
+}
+
+/// Adjust a GFX9 OutputLoc for wave32 physical VGPR addressing.
+inline OutputLoc physicalize_out(const OutputLoc &loc, uint32_t wf_size) {
+  if (wf_size >= 64)
+    return loc;
+  const uint32_t stride = 64 / wf_size;
+  return {loc.reg * stride + loc.lane / wf_size, loc.lane % wf_size};
+}
+
+/// Adjust a GFX9 PackedOutputLoc for wave32 physical VGPR addressing.
+inline PackedOutputLoc physicalize_packed_out(const PackedOutputLoc &loc, uint32_t wf_size) {
+  if (wf_size >= 64)
+    return loc;
+  const uint32_t stride = 64 / wf_size;
+  return {loc.reg * stride + loc.lane / wf_size, loc.lane % wf_size, loc.sub_element};
+}
+
+/// Map f32 output position to packed 16-bit output position using GFX9 layout.
+/// Two consecutive f32 register positions pack into one 32-bit VGPR as two
+/// 16-bit sub-elements: reg/2 holds the VGPR offset, reg%2 the sub-element.
+inline PackedOutputLoc output_loc_16(uint32_t M, uint32_t N, uint32_t i, uint32_t j, uint32_t b) {
+  auto f32 = output_loc_32(M, N, i, j, b);
+  return {f32.reg / 2, f32.lane, f32.reg % 2};
+}
+
 /// Generic MFMA execute for f32 output: D = C + A x B.
 ///
 /// All inputs are read before any outputs are written to avoid WAR hazards
@@ -626,6 +665,7 @@ void exec_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_
                     uint32_t a_bits, uint32_t b_bits, uint32_t dst, uint32_t s0, uint32_t s1,
                     uint32_t s2, ExtractA ea, ExtractB eb, uint32_t const_acc = ACC_FROM_VGPR,
                     uint32_t cbsz = 0, uint32_t abid = 0, uint32_t blgp = 0) {
+  const uint32_t wf = cu.wf_size();
   struct Result {
     uint32_t reg;
     uint32_t lane;
@@ -641,7 +681,7 @@ void exec_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_
       for (uint32_t row = 0; row < M; ++row) {
         for (uint32_t col = 0; col < N; ++col) {
           // AMD convention: i=row (register dimension), j=col (lane dimension).
-          auto out = output_loc_32(M, N, row, col, b);
+          auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
           float acc = (const_acc != ACC_FROM_VGPR)
                           ? std::bit_cast<float>(const_acc)
                           : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
@@ -654,8 +694,8 @@ void exec_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_
             // Apply blgp lane permutation to B input.
             if (blgp != 0)
               bl.lane = permute_b_lane(bl.lane, blgp);
-            float a_val = ea(cu, s0, al);
-            float b_val = eb(cu, s1, bl);
+            float a_val = ea(cu, s0, physicalize_loc(al, wf));
+            float b_val = eb(cu, s1, physicalize_loc(bl, wf));
             acc += a_val * b_val;
           }
           results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(acc)});
@@ -700,7 +740,7 @@ void exec_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_
       for (uint32_t b = 0; b < B; ++b) {
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t col = 0; col < N; ++col) {
-            auto out = output_loc_32(M, N, row, col, b);
+            auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
             Cbuf[row * stride + col] =
                 (const_acc != ACC_FROM_VGPR)
                     ? std::bit_cast<float>(const_acc)
@@ -711,19 +751,19 @@ void exec_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_
             auto al = input_loc(M, K, B, row, k, b, a_bits);
             if (cbsz != 0)
               al.lane = permute_a_lane(al.lane, cbsz, abid);
-            Abuf[row * K + k] = ea(cu, s0, al);
+            Abuf[row * K + k] = ea(cu, s0, physicalize_loc(al, wf));
           }
         for (uint32_t k = 0; k < K; ++k)
           for (uint32_t col = 0; col < N; ++col) {
             auto bl = input_loc(N, K, B, col, k, b, b_bits);
             if (blgp != 0)
               bl.lane = permute_b_lane(bl.lane, blgp);
-            Bbuf[k * stride + col] = eb(cu, s1, bl);
+            Bbuf[k * stride + col] = eb(cu, s1, physicalize_loc(bl, wf));
           }
         wmma_simd_matmul<float>(M, N, K, W, stride, Abuf, Bbuf, Cbuf);
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t col = 0; col < N; ++col) {
-            auto out = output_loc_32(M, N, row, col, b);
+            auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
             results.push_back(
                 {out.reg, out.lane, std::bit_cast<uint32_t>(Cbuf[row * stride + col])});
           }
@@ -794,6 +834,165 @@ constexpr size_t WMMA_SIMD_MAX_C = 1024;       // max M*stride
 static_assert((WMMA_SIMD_MAX_AB + WMMA_SIMD_MAX_BSTRIDE + WMMA_SIMD_MAX_C) * sizeof(float) <=
                   48 * 1024,
               "WMMA SIMD staging buffers exceed the 48 KiB stack budget");
+
+/// GFX9-layout packed 16-bit output execution: D = C + A x B, result packed f16/bf16.
+/// Uses GFX9 input_loc for inputs and output_loc_16 (derived from output_loc_32)
+/// for outputs. The accumulator is read/written in packed 16-bit format.
+template <typename ExtractA, typename ExtractB, typename ReadAcc, typename PackResult>
+void exec_packed16_gfx9(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B,
+                        uint32_t in_bits, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
+                        ExtractA ea, ExtractB eb, ReadAcc read_acc, PackResult pack_result,
+                        uint32_t const_acc = ACC_FROM_VGPR) {
+  const uint32_t wf = cu.wf_size();
+  struct Result {
+    uint32_t reg;
+    uint32_t lane;
+    uint32_t sub_element;
+    uint16_t val;
+  };
+  std::vector<Result> results;
+  results.reserve(M * N * B);
+  for (uint32_t b = 0; b < B; ++b) {
+    for (uint32_t row = 0; row < M; ++row) {
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = physicalize_packed_out(output_loc_16(M, N, row, col, b), wf);
+        float acc = (const_acc != ACC_FROM_VGPR)
+                        ? std::bit_cast<float>(const_acc)
+                        : read_acc(cu, s2 + out.reg, out.lane, out.sub_element);
+        for (uint32_t k = 0; k < K; ++k) {
+          auto al = physicalize_loc(input_loc(M, K, B, row, k, b, in_bits), wf);
+          auto bl = physicalize_loc(input_loc(N, K, B, col, k, b, in_bits), wf);
+          acc += ea(cu, s0, al) * eb(cu, s1, bl);
+        }
+        results.push_back({out.reg, out.lane, out.sub_element, pack_result(acc)});
+      }
+    }
+  }
+
+  // Determine physical VGPR count for the packed output.
+  uint32_t max_reg = 0;
+  for (const auto &r : results)
+    if (r.reg > max_reg)
+      max_reg = r.reg;
+  uint32_t dst_regs = max_reg + 1;
+
+  std::vector<uint32_t> words(dst_regs * wf, 0);
+  std::vector<uint8_t> masks(dst_regs * wf, 0);
+  for (const auto &r : results) {
+    uint32_t idx = r.reg * wf + r.lane;
+    uint32_t shift = r.sub_element * 16;
+    words[idx] = (words[idx] & ~(0xFFFFu << shift)) | (static_cast<uint32_t>(r.val) << shift);
+    masks[idx] |= 1u << r.sub_element;
+  }
+  for (uint32_t reg = 0; reg < dst_regs; ++reg) {
+    for (uint32_t lane = 0; lane < wf; ++lane) {
+      uint32_t idx = reg * wf + lane;
+      uint32_t word = words[idx];
+      if (masks[idx] != 0x3u) {
+        uint32_t old = cu.read_vgpr(dst + reg, lane);
+        if ((masks[idx] & 0x1u) == 0)
+          word = (word & 0xFFFF0000u) | (old & 0x0000FFFFu);
+        if ((masks[idx] & 0x2u) == 0)
+          word = (word & 0x0000FFFFu) | (old & 0xFFFF0000u);
+      }
+      cu.write_vgpr(dst + reg, lane, word);
+    }
+  }
+}
+
+/// Convenience wrappers for GFX9 packed f16/bf16 output.
+template <typename ExtractA, typename ExtractB>
+void exec_f16_gfx9(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B,
+                   uint32_t in_bits, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
+                   ExtractA ea, ExtractB eb, uint32_t const_acc = ACC_FROM_VGPR) {
+  exec_packed16_gfx9(
+      cu, M, N, K, B, in_bits, dst, s0, s1, s2, ea, eb,
+      [](amdgpu::ComputeUnitCore &c, uint32_t base, uint32_t lane, uint32_t sub) -> float {
+        uint32_t raw = c.read_vgpr(base, lane);
+        return util::f16_to_f32(static_cast<uint16_t>((raw >> (sub * 16)) & 0xFFFF));
+      },
+      [](float v) -> uint16_t { return util::f32_to_f16(v); }, const_acc);
+}
+
+template <typename ExtractA, typename ExtractB>
+void exec_bf16_gfx9(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B,
+                    uint32_t in_bits, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
+                    ExtractA ea, ExtractB eb, uint32_t const_acc = ACC_FROM_VGPR) {
+  exec_packed16_gfx9(
+      cu, M, N, K, B, in_bits, dst, s0, s1, s2, ea, eb,
+      [](amdgpu::ComputeUnitCore &c, uint32_t base, uint32_t lane, uint32_t sub) -> float {
+        uint32_t raw = c.read_vgpr(base, lane);
+        return util::bf16_to_f32(static_cast<uint16_t>((raw >> (sub * 16)) & 0xFFFF));
+      },
+      [](float v) -> uint16_t { return util::f32_to_bf16(v); }, const_acc);
+}
+
+inline uint32_t pack_i32_acc(int64_t acc, bool clamp) {
+  if (clamp) {
+    acc = std::clamp(acc, static_cast<int64_t>(std::numeric_limits<int32_t>::min()),
+                     static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
+  }
+  return static_cast<uint32_t>(acc);
+}
+
+/// GFX9-layout i32 output with configurable input bit-width and extractors.
+/// When clamp=false, accumulates in uint32_t (defined wrapping, matching
+/// hardware). When clamp=true, accumulates in int64_t and saturates to
+/// int32_t range via pack_i32_acc.
+template <typename ExtractA, typename ExtractB>
+void exec_i32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B,
+                    uint32_t in_bits, uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
+                    ExtractA ea, ExtractB eb, uint32_t const_acc = ACC_FROM_VGPR,
+                    bool clamp = false, uint32_t cbsz = 0, uint32_t abid = 0, uint32_t blgp = 0) {
+  const uint32_t wf = cu.wf_size();
+  struct Result {
+    uint32_t reg;
+    uint32_t lane;
+    uint32_t val;
+  };
+  std::vector<Result> results;
+  results.reserve(M * N * B);
+  for (uint32_t b = 0; b < B; ++b) {
+    for (uint32_t row = 0; row < M; ++row) {
+      for (uint32_t col = 0; col < N; ++col) {
+        auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
+        auto products = [&](uint32_t k) {
+          auto al = input_loc(M, K, B, row, k, b, in_bits);
+          auto bl = input_loc(N, K, B, col, k, b, in_bits);
+          if (cbsz != 0)
+            al.lane = permute_a_lane(al.lane, cbsz, abid);
+          if (blgp != 0)
+            bl.lane = permute_b_lane(bl.lane, blgp);
+          return std::pair{ea(cu, s0, physicalize_loc(al, wf)),
+                           eb(cu, s1, physicalize_loc(bl, wf))};
+        };
+        uint32_t val;
+        if (clamp) {
+          int64_t acc = (const_acc != ACC_FROM_VGPR)
+                            ? static_cast<int64_t>(static_cast<int32_t>(const_acc))
+                            : static_cast<int64_t>(
+                                  static_cast<int32_t>(cu.read_vgpr(s2 + out.reg, out.lane)));
+          for (uint32_t k = 0; k < K; ++k) {
+            auto [a, b_val] = products(k);
+            acc += static_cast<int64_t>(a) * static_cast<int64_t>(b_val);
+          }
+          val = pack_i32_acc(acc, true);
+        } else {
+          uint32_t acc =
+              (const_acc != ACC_FROM_VGPR) ? const_acc : cu.read_vgpr(s2 + out.reg, out.lane);
+          for (uint32_t k = 0; k < K; ++k) {
+            auto [a, b_val] = products(k);
+            acc += static_cast<uint32_t>(a * b_val);
+          }
+          val = acc;
+        }
+        results.push_back({out.reg, out.lane, val});
+      }
+    }
+  }
+  for (const auto &r : results)
+    cu.write_vgpr(dst + r.reg, r.lane, r.val);
+}
 
 template <typename ExtractA, typename ExtractB>
 void exec_wmma_f32_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K,
@@ -1939,13 +2138,14 @@ void exec_f32_scaled(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32
     uint32_t lane;
     uint32_t val;
   };
+  const uint32_t wf = cu.wf_size();
   std::vector<Result> results;
   results.reserve(M * N * B);
   uint32_t num_blocks = (K + BLOCK_K - 1) / BLOCK_K;
 
   // Per-block E8M0 scale factor for output (row,col,b) in K-block blk.
   auto scale_exp_for = [&](uint32_t row, uint32_t col, uint32_t b, uint32_t blk) -> int {
-    auto out = output_loc_32(M, N, row, col, b);
+    auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
     uint32_t sa_raw = cu.read_vgpr(scale_a_base, out.lane);
     uint32_t sb_raw = cu.read_vgpr(scale_b_base, out.lane);
     uint8_t sa_e8m0 = static_cast<uint8_t>((sa_raw >> (blk * 8)) & 0xFF);
@@ -1957,7 +2157,7 @@ void exec_f32_scaled(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32
     for (uint32_t b = 0; b < B; ++b) {
       for (uint32_t row = 0; row < M; ++row) {
         for (uint32_t col = 0; col < N; ++col) {
-          auto out = output_loc_32(M, N, row, col, b);
+          auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
           float acc = (const_acc != ACC_FROM_VGPR)
                           ? std::bit_cast<float>(const_acc)
                           : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
@@ -1972,7 +2172,8 @@ void exec_f32_scaled(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32
                 al.lane = permute_a_lane(al.lane, cbsz, abid);
               if (blgp != 0)
                 bl.lane = permute_b_lane(bl.lane, blgp);
-              block_sum += ea(cu, s0, al) * eb(cu, s1, bl);
+              block_sum +=
+                  ea(cu, s0, physicalize_loc(al, wf)) * eb(cu, s1, physicalize_loc(bl, wf));
             }
             acc += std::ldexp(block_sum, scale_exp_for(row, col, b, blk));
           }
@@ -2012,18 +2213,18 @@ void exec_f32_scaled(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32
             auto al = input_loc(M, K, B, row, k, b, in_bits);
             if (cbsz != 0)
               al.lane = permute_a_lane(al.lane, cbsz, abid);
-            Abuf[row * K + k] = ea(cu, s0, al);
+            Abuf[row * K + k] = ea(cu, s0, physicalize_loc(al, wf));
           }
         for (uint32_t k = 0; k < K; ++k)
           for (uint32_t col = 0; col < N; ++col) {
             auto bl = input_loc(N, K, B, col, k, b, in_bits);
             if (blgp != 0)
               bl.lane = permute_b_lane(bl.lane, blgp);
-            Bbuf[k * stride + col] = eb(cu, s1, bl);
+            Bbuf[k * stride + col] = eb(cu, s1, physicalize_loc(bl, wf));
           }
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t col = 0; col < N; ++col) {
-            auto out = output_loc_32(M, N, row, col, b);
+            auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
             Cacc[row * N + col] = (const_acc != ACC_FROM_VGPR)
                                       ? std::bit_cast<float>(const_acc)
                                       : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
@@ -2056,7 +2257,7 @@ void exec_f32_scaled(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32
         }
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t col = 0; col < N; ++col) {
-            auto out = output_loc_32(M, N, row, col, b);
+            auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
             results.push_back({out.reg, out.lane, std::bit_cast<uint32_t>(Cacc[row * N + col])});
           }
       }
@@ -2077,6 +2278,7 @@ void exec_f32_scaled_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, 
                            uint32_t s1, uint32_t s2, ExtractA ea, ExtractB eb, uint32_t const_acc,
                            uint32_t scale_a_base, uint32_t scale_b_base) {
   constexpr uint32_t BLOCK_K = 32;
+  const uint32_t wf = cu.wf_size();
   struct Result {
     uint32_t reg;
     uint32_t lane;
@@ -2088,7 +2290,7 @@ void exec_f32_scaled_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, 
   for (uint32_t b = 0; b < B; ++b) {
     for (uint32_t row = 0; row < M; ++row) {
       for (uint32_t col = 0; col < N; ++col) {
-        auto out = output_loc_32(M, N, row, col, b);
+        auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
         float acc = (const_acc != ACC_FROM_VGPR)
                         ? std::bit_cast<float>(const_acc)
                         : std::bit_cast<float>(cu.read_vgpr(s2 + out.reg, out.lane));
@@ -2099,7 +2301,7 @@ void exec_f32_scaled_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, 
           for (uint32_t k = k_start; k < k_end; ++k) {
             auto al = input_loc(M, K, B, row, k, b, a_bits);
             auto bl = input_loc(N, K, B, col, k, b, b_bits);
-            block_sum += ea(cu, s0, al) * eb(cu, s1, bl);
+            block_sum += ea(cu, s0, physicalize_loc(al, wf)) * eb(cu, s1, physicalize_loc(bl, wf));
           }
           uint32_t sa_raw = cu.read_vgpr(scale_a_base, M * blk + row);
           uint32_t sb_raw = cu.read_vgpr(scale_b_base, N * blk + col);
@@ -2119,7 +2321,9 @@ void exec_f32_scaled_mixed(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, 
 /// MFMA execute for i32 output with i8 input: D = C + A x B.
 inline void exec_i32_i8(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t K, uint32_t B,
                         uint32_t dst, uint32_t s0, uint32_t s1, uint32_t s2,
-                        uint32_t const_acc = ACC_FROM_VGPR) {
+                        uint32_t const_acc = ACC_FROM_VGPR, uint32_t cbsz = 0, uint32_t abid = 0,
+                        uint32_t blgp = 0) {
+  const uint32_t wf = cu.wf_size();
   struct Result {
     uint32_t reg;
     uint32_t lane;
@@ -2132,17 +2336,20 @@ inline void exec_i32_i8(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uin
     for (uint32_t b = 0; b < B; ++b) {
       for (uint32_t row = 0; row < M; ++row) {
         for (uint32_t col = 0; col < N; ++col) {
-          // AMD convention: i=row (register dimension), j=col (lane dimension).
-          auto out = output_loc_32(M, N, row, col, b);
-          int32_t acc = (const_acc != ACC_FROM_VGPR)
-                            ? static_cast<int32_t>(const_acc)
-                            : static_cast<int32_t>(cu.read_vgpr(s2 + out.reg, out.lane));
+          auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
+          uint32_t acc =
+              (const_acc != ACC_FROM_VGPR) ? const_acc : cu.read_vgpr(s2 + out.reg, out.lane);
           for (uint32_t k = 0; k < K; ++k) {
             auto al = input_loc(M, K, B, row, k, b, 8);
             auto bl = input_loc(N, K, B, col, k, b, 8);
-            acc += extract_i8(cu, s0, al) * extract_i8(cu, s1, bl);
+            if (cbsz != 0)
+              al.lane = permute_a_lane(al.lane, cbsz, abid);
+            if (blgp != 0)
+              bl.lane = permute_b_lane(bl.lane, blgp);
+            acc += static_cast<uint32_t>(extract_i8(cu, s0, physicalize_loc(al, wf)) *
+                                         extract_i8(cu, s1, physicalize_loc(bl, wf)));
           }
-          results.push_back({out.reg, out.lane, static_cast<uint32_t>(acc)});
+          results.push_back({out.reg, out.lane, acc});
         }
       }
     }
@@ -2173,7 +2380,7 @@ inline void exec_i32_i8(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uin
       for (uint32_t b = 0; b < B; ++b) {
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t col = 0; col < N; ++col) {
-            auto out = output_loc_32(M, N, row, col, b);
+            auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
             Cbuf[row * stride + col] =
                 (const_acc != ACC_FROM_VGPR)
                     ? static_cast<int32_t>(const_acc)
@@ -2182,12 +2389,16 @@ inline void exec_i32_i8(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uin
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t k = 0; k < K; ++k) {
             auto al = input_loc(M, K, B, row, k, b, 8);
-            Abuf[row * K + k] = extract_i8(cu, s0, al);
+            if (cbsz != 0)
+              al.lane = permute_a_lane(al.lane, cbsz, abid);
+            Abuf[row * K + k] = extract_i8(cu, s0, physicalize_loc(al, wf));
           }
         for (uint32_t k = 0; k < K; ++k)
           for (uint32_t col = 0; col < N; ++col) {
             auto bl = input_loc(N, K, B, col, k, b, 8);
-            Bbuf[k * stride + col] = extract_i8(cu, s1, bl);
+            if (blgp != 0)
+              bl.lane = permute_b_lane(bl.lane, blgp);
+            Bbuf[k * stride + col] = extract_i8(cu, s1, physicalize_loc(bl, wf));
           }
         for (uint32_t row = 0; row < M; ++row) {
           uint32_t col = 0;
@@ -2203,15 +2414,15 @@ inline void exec_i32_i8(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uin
             c.copy_to(&Cbuf[row * stride + col], util::stdx::vector_aligned);
           }
           for (; col < N; ++col) {
-            int32_t acc = Cbuf[row * stride + col];
+            uint32_t acc = static_cast<uint32_t>(Cbuf[row * stride + col]);
             for (uint32_t k = 0; k < K; ++k)
-              acc += Abuf[row * K + k] * Bbuf[k * stride + col];
-            Cbuf[row * stride + col] = acc;
+              acc += static_cast<uint32_t>(Abuf[row * K + k] * Bbuf[k * stride + col]);
+            Cbuf[row * stride + col] = static_cast<int32_t>(acc);
           }
         }
         for (uint32_t row = 0; row < M; ++row)
           for (uint32_t col = 0; col < N; ++col) {
-            auto out = output_loc_32(M, N, row, col, b);
+            auto out = physicalize_out(output_loc_32(M, N, row, col, b), wf);
             results.push_back({out.reg, out.lane, static_cast<uint32_t>(Cbuf[row * stride + col])});
           }
       }
@@ -2222,14 +2433,6 @@ inline void exec_i32_i8(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uin
 
   for (const auto &r : results)
     cu.write_vgpr(dst + r.reg, r.lane, r.val);
-}
-
-inline uint32_t pack_i32_acc(int64_t acc, bool clamp) {
-  if (clamp) {
-    acc = std::clamp(acc, static_cast<int64_t>(std::numeric_limits<int32_t>::min()),
-                     static_cast<int64_t>(std::numeric_limits<int32_t>::max()));
-  }
-  return static_cast<uint32_t>(acc);
 }
 
 template <typename ExtractA, typename ExtractB>
@@ -2997,7 +3200,8 @@ void exec_f32_mfma_f32_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t 
              const_acc, cbsz, abid, blgp);
     return;
   } else {
-    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16) {
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16 ||
+        cu.wf_size() != 64) {
       exec_f32(cu, M, N, K, BATCH, in_bits, dst, s0, s1, s2, amdgpu::extract_f32,
                amdgpu::extract_f32, const_acc, cbsz, abid, blgp);
       return;
@@ -3071,7 +3275,8 @@ void exec_f32_mfma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t 
              const_acc, cbsz, abid, blgp);
     return;
   } else {
-    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16) {
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16 ||
+        cu.wf_size() != 64) {
       exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_f16, amdgpu::extract_f16,
                const_acc, cbsz, abid, blgp);
       return;
@@ -3159,7 +3364,8 @@ void exec_f32_mfma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t
              const_acc, cbsz, abid, blgp);
     return;
   } else {
-    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16) {
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16 ||
+        cu.wf_size() != 64) {
       exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, amdgpu::extract_bf16, amdgpu::extract_bf16,
                const_acc, cbsz, abid, blgp);
       return;
@@ -3248,7 +3454,8 @@ void exec_f32_mfma_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s
     exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, ea, eb, const_acc, cbsz, abid, blgp);
     return;
   } else {
-    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16) {
+    if (util::force_scalar() || cbsz != 0 || blgp != 0 || util::native<float>::size() != 16 ||
+        cu.wf_size() != 64) {
       exec_f32(cu, M, N, K, B, in_bits, dst, s0, s1, s2, ea, eb, const_acc, cbsz, abid, blgp);
       return;
     }
@@ -3335,7 +3542,7 @@ void exec_i32_mfma_i8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s
     exec_i32_i8(cu, M, N, K, B, dst, s0, s1, s2, const_acc);
     return;
   } else {
-    if (util::force_scalar() || util::native<float>::size() != 16) {
+    if (util::force_scalar() || util::native<float>::size() != 16 || cu.wf_size() != 64) {
       exec_i32_i8(cu, M, N, K, B, dst, s0, s1, s2, const_acc);
       return;
     }


### PR DESCRIPTION
## Motivation
A few bugs were uncovered by the new CTS for the ISA execution. This PR fixes them.

## Technical Details
Fix four emulator bugs:
- CDNA i8 MFMA ignores cbsz/abid/blgp lane permutation modifiers
- CDNA bf16 non-1k 32x32x4 uses wrong block count (B=2 vs correct B=1)
- RDNA3/3.5/4 WMMA f16/bf16 output written as f32 instead of packed 16-bit
- RDNA3/3.5/4 WMMA iu4 uses 8-bit extraction instead of 4-bit

Additional fix applied following code review:
- GFX9 wave32 physicalization (`physicalize_loc`, `physicalize_out`, `physicalize_packed_out`) now applied to **both** the scalar and SIMD fast paths in `exec_f32_mixed`, `exec_f32_scaled`, and `exec_i32_i8`. Previously only the scalar paths were corrected, leaving the SIMD paths to alias lanes 32+ into the wrong physical VGPR on wave32.

All fixes applied through the codegen pipeline (matrix.py) with regenerated vop3p.cpp for all affected ISAs.

## JIRA ID
N/A

## Test Plan
Run all CI tests, run CTS suite (not yet merged)

## Test Result
CI tests: PASSED
CTS: PASSED

## Submission Checklist
- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.