### PR TITLE
[rocshmem] update broadcast operation

### DIFF
--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -577,15 +577,21 @@ __device__ void GDAContext::internal_put_broadcast(T *dst, const T *src,
   if (constmem.my_pe == pe_root) {
     int finish = pe_start + stride * pe_size;
     for (int i = pe_start; i < finish; i += stride) {
+      if (constmem.my_pe != i)
         internal_putmem_nbi_wg(dst, src, nelems * sizeof(T), i, i, wf_info);
     }
+    memcpy_wg<MemcpyKind::Put>(dst, const_cast<T *>(src), nelems * sizeof(T));
   }
 }
 
 template <typename T>
 __device__ void GDAContext::internal_get_broadcast(T *dst, const T *src,
     int nelems, int pe_root, ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
+  if (constmem.my_pe == pe_root) {
+    memcpy_wg<MemcpyKind::Put>(dst, const_cast<T *>(src), nelems * sizeof(T));
+  } else {
     internal_getmem_wg(dst, src, nelems * sizeof(T), pe_root, pe_root, wf_info);
+  }
 }
 
 template <typename T>

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -577,9 +577,7 @@ __device__ void GDAContext::internal_put_broadcast(T *dst, const T *src,
   if (constmem.my_pe == pe_root) {
     int finish = pe_start + stride * pe_size;
     for (int i = pe_start; i < finish; i += stride) {
-      if (i != constmem.my_pe) {
         internal_putmem_nbi_wg(dst, src, nelems * sizeof(T), i, i, wf_info);
-      }
     }
   }
 }
@@ -587,9 +585,7 @@ __device__ void GDAContext::internal_put_broadcast(T *dst, const T *src,
 template <typename T>
 __device__ void GDAContext::internal_get_broadcast(T *dst, const T *src,
     int nelems, int pe_root, ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
-  if (constmem.my_pe != pe_root) {
     internal_getmem_wg(dst, src, nelems * sizeof(T), pe_root, pe_root, wf_info);
-  }
 }
 
 template <typename T>

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -420,9 +420,7 @@ __device__ void IPCContext::internal_put_broadcast(
   if (my_pe == pe_root) {
     int finish = pe_start + stride * pe_size;
     for (int i = pe_start; i < finish; i += stride) {
-      if (i != my_pe) {
         put_nbi_wg(dst, src, nelems, i);
-      }
     }
   }
 }
@@ -430,9 +428,7 @@ __device__ void IPCContext::internal_put_broadcast(
 template <typename T>
 __device__ void IPCContext::internal_get_broadcast(
   T *dst, const T *src, int nelems, int pe_root) {  // NOLINT(runtime/int)
-  if (my_pe != pe_root) {
     get_wg(dst, src, nelems, pe_root);
-  }
 }
 
 template <typename T>

--- a/projects/rocshmem/src/reverse_offload/mpi_transport.cpp
+++ b/projects/rocshmem/src/reverse_offload/mpi_transport.cpp
@@ -385,14 +385,12 @@ void MPITransport::team_broadcast(void *dst, void *src, int size, int win_id,
   MPI_Datatype mpi_type{convertType(type)};
   MPI_Request req;
 
-  if (rank != root){
-    NET_CHECK(mpilib_ftable_.Rget(reinterpret_cast<char *>(dst), size, mpi_type, world_ranks[root],
-                       bp->heap_window_info[win_id]->get_offset(reinterpret_cast<char *>(src)),
-                       size, mpi_type, bp->heap_window_info[win_id]->get_win(), &req));
+  NET_CHECK(mpilib_ftable_.Rget(reinterpret_cast<char *>(dst), size, mpi_type, world_ranks[root],
+                      bp->heap_window_info[win_id]->get_offset(reinterpret_cast<char *>(src)),
+                      size, mpi_type, bp->heap_window_info[win_id]->get_win(), &req));
 
-      requests.push_back({req, {nullptr, contextId, false}});
-      outstanding[contextId]++;
-  }
+  requests.push_back({req, {nullptr, contextId, false}});
+  outstanding[contextId]++;
 
   NET_CHECK(mpilib_ftable_.Win_flush_all(bp->heap_window_info[win_id]->get_win()));
   barrier(contextId, nullptr, false, comm, false);

--- a/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
@@ -203,30 +203,21 @@ void TeamBroadcastTester<T1>::verifyResults(size_t size) {
   int idx = 0;
   T1 expected;
 
-  /**
-   * The verification routine here requires that the
-   * PE_root value is 0 which denotes that the
-   * sending processing element is rank 0.
-   *
-   * The difference in expected values arises from
-   * the specification for broadcast where the
-   * PE_root processing element does not copy the
-   * contents from its own source to dest during
-   * the broadcast.
-   */
+  // verify correctness. All PE's (including root) recieve source buffer
+  // data in dest buffer
   for (unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
     for (int i = 0; i < num_elems; i++) {
       idx = wg_id * num_elems + i;
       if constexpr (std::is_same<T1, char>::value ||
                     std::is_same<T1, signed char>::value ||
                     std::is_same<T1, unsigned char>::value) {
-        expected = static_cast<T1>('a' + wg_id + (my_pe ? n_pes : 0));
+        expected = static_cast<T1>('a' + wg_id + n_pes);
       }
       else if constexpr (std::is_floating_point<T1>::value) {
-        expected = static_cast<T1>(3.14 + wg_id + (my_pe ? n_pes : 0));
+        expected = static_cast<T1>(3.14 + wg_id + n_pes);
       }
       else if constexpr (std::is_integral<T1>::value) {
-        expected = static_cast<T1>(wg_id + (my_pe ? n_pes : 0));
+        expected = static_cast<T1>(wg_id + n_pes);
       }
       if (dest_buf[idx] != expected) {
         std::cerr << "Data validation error at idx " << idx << std::endl;

--- a/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_broadcast_tester.cpp
@@ -203,8 +203,8 @@ void TeamBroadcastTester<T1>::verifyResults(size_t size) {
   int idx = 0;
   T1 expected;
 
-  // verify correctness. All PE's (including root) recieve source buffer
-  // data in dest buffer
+  // Verify correctness: all PEs (including root) receive source 
+  // buffer data in dest buffer
   for (unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
     for (int i = 0; i < num_elems; i++) {
       idx = wg_id * num_elems + i;

--- a/projects/rocshmem/tests/functional_tests/team_broadcastmem_on_stream_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_broadcastmem_on_stream_tester.cpp
@@ -203,19 +203,10 @@ void TeamBroadcastmemOnStreamTester::launchKernel([[maybe_unused]] dim3 gridSize
 }
 
 void TeamBroadcastmemOnStreamTester::verifyResults(size_t size) {
-  // Verify correctness: after broadcast, non-root PEs receive the broadcast
-  // data Root PE's dest buffer is NOT modified (per OpenSHMEM/rocSHMEM spec)
+  // Verify correctness: after broadcast, all PEs receive the broadcast data
   for (int wg_id = 0; wg_id < num_teams; wg_id++) {
     int idx = wg_id * size;
-    int expected_value;
-
-    if (my_pe == pe_root) {
-      // Root PE's dest buffer should remain unchanged (0xAA)
-      expected_value = 0xAA;
-    } else {
-      // Non-root PEs should have received the broadcast value
-      expected_value = (pe_root + 1) * 100 + wg_id;
-    }
+    int expected_value = (pe_root + 1) * 100 + wg_id;
 
     for (size_t k = 0; k < size; k++) {
       if (static_cast<unsigned char>(dest_buf[idx + k]) !=


### PR DESCRIPTION
## Motivation

Update broadcast operation to adhere to OpenSHMEM specification version 1.6.

## Technical Details

- The root PE's destination buffer must be updated with the source buffer data. 
- Update functional test verification to check root PE destination buffer received the expected data.

## JIRA ID


## Test Plan

- Use functional test to verify correctness

## Test Result

[x] Functional tests ran as expected

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
