### PR TITLE
Reapply "AIRUNTIME-1990 - Support gl-hip and d3d-ocl image interOp" (…

### DIFF
--- a/projects/clr/hipamd/src/hip_gl.cpp
+++ b/projects/clr/hipamd/src/hip_gl.cpp
@@ -433,6 +433,7 @@ hipError_t hipGraphicsGLRegisterImage(hipGraphicsResource** resource, GLuint ima
   }
 
   GLint miplevel = 0;
+  GLint miplevels = 1;
   amd::Context& amdContext = *(hip::getCurrentDevice()->asContext());
 
   amd::GLFunctions::SetIntEnv ie(amdContext.glenv());
@@ -561,7 +562,7 @@ hipError_t hipGraphicsGLRegisterImage(hipGraphicsResource** resource, GLuint ima
       LogWarning("\"miplevel\" is not a valid mipmap level of the GL \"texture\" object");
       HIP_RETURN(hipErrorInvalidValue);
     }
-
+    miplevels = gliTexMaxLevel + 1;
     clearGLErrors(amdContext);
     amdContext.glenv()->glGetTexLevelParameteriv_(target, miplevel, GL_TEXTURE_INTERNAL_FORMAT,
                                                   (GLint*)&glInternalFormat);
@@ -670,7 +671,7 @@ hipError_t hipGraphicsGLRegisterImage(hipGraphicsResource** resource, GLuint ima
   pImageGL = new (amdContext)
       amd::ImageGL(amdContext, clType, cl_flags, clImageFormat, static_cast<size_t>(gliTexWidth),
                    static_cast<size_t>(gliTexHeight), static_cast<size_t>(gliTexDepth), glTarget,
-                   image, 0, glInternalFormat, clGLType, numSamples, target);
+                   image, miplevel, glInternalFormat, clGLType, numSamples, miplevels, target);
   if (!pImageGL->create()) {
     pImageGL->release();
     HIP_RETURN(hipErrorUnknown);

--- a/projects/clr/rocclr/cmake/ROCclr.cmake
+++ b/projects/clr/rocclr/cmake/ROCclr.cmake
@@ -93,7 +93,9 @@ if(WIN32)
   target_sources(rocclr PRIVATE
   ${ROCCLR_SRC_DIR}/platform/interop_d3d9.cpp
   ${ROCCLR_SRC_DIR}/platform/interop_d3d10.cpp
-  ${ROCCLR_SRC_DIR}/platform/interop_d3d11.cpp)
+  ${ROCCLR_SRC_DIR}/platform/interop_d3d11.cpp
+  ${ROCCLR_SRC_DIR}/device/rocm/rocd3d10interop.cpp
+  ${ROCCLR_SRC_DIR}/device/rocm/rocd3d11interop.cpp)
   target_link_libraries(rocclr PRIVATE dxguid.lib)
   target_compile_definitions(rocclr PUBLIC ATI_OS_WIN)
 else()

--- a/projects/clr/rocclr/device/pal/paldeviced3d10.cpp
+++ b/projects/clr/rocclr/device/pal/paldeviced3d10.cpp
@@ -22,7 +22,7 @@ bool Device::associateD3D10Device(void* d3d10Device) { return false; }
  * without notification. So it is safe to use a local copy of the relevant DXX extension interface
  *classes.
  **************************************************************************************************************/
-#include "DxxOpenCLInteropExt.h"
+#include "platform/DxxInteropExt.h"
 
 namespace amd::pal {
 

--- a/projects/clr/rocclr/device/pal/paldeviced3d11.cpp
+++ b/projects/clr/rocclr/device/pal/paldeviced3d11.cpp
@@ -22,7 +22,7 @@ bool Device::associateD3D11Device(void* d3d11Device) { return false; }
  * without notification. So it is safe to use a local copy of the relevant DXX extension interface
  *classes.
  **************************************************************************************************************/
-#include "DxxOpenCLInteropExt.h"
+#include "platform/DxxInteropExt.h"
 
 namespace amd::pal {
 

--- a/projects/clr/rocclr/device/pal/paldeviced3d9.cpp
+++ b/projects/clr/rocclr/device/pal/paldeviced3d9.cpp
@@ -23,7 +23,7 @@ bool Device::associateD3D9Device(void* d3d9Device) { return false; }
  * without notification. So it is safe to use a local copy of the relevant DXX extension interface
  *classes.
  **************************************************************************************************************/
-#include "DxxOpenCLInteropExt.h"
+#include "platform/DxxInteropExt.h"
 
 namespace amd::pal {
 

--- a/projects/clr/rocclr/device/rocm/rocd3d10interop.cpp
+++ b/projects/clr/rocclr/device/rocm/rocd3d10interop.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "rocdevice.hpp"
+#include "rocmemory.hpp"
+#include "rocd3d10interop.hpp"
+
+#ifdef _WIN32
+
+#include <D3D10.h>
+#include <dxgi.h>
+#include <mutex>
+#include <unordered_map>
+
+#include "platform/DxxInteropExt.h"
+#include "platform/interop_d3d10.hpp"
+
+namespace amd {
+namespace roc {
+namespace D3D10Interop {
+
+static std::unordered_map<const Device*, CachedExt> gExtCache;
+static std::mutex gExtCacheLock;
+
+bool associateD3D10Device(const Device* device, ID3D10Device* pd3d10Device) {
+  if (!device || !pd3d10Device) {
+    return false;
+  }
+
+  if (!device->hasValidLUID()) {
+    LogError("ROCr device does not have valid LUID for D3D10 interop");
+    return false;
+  }
+
+  IDXGIDevice* pDXGIDevice = nullptr;
+  HRESULT hr = pd3d10Device->QueryInterface(__uuidof(IDXGIDevice), (void**)&pDXGIDevice);
+  if (FAILED(hr) || !pDXGIDevice) {
+    LogError("Failed to query IDXGIDevice from D3D10 device");
+    return false;
+  }
+
+  IDXGIAdapter* pDXGIAdapter = nullptr;
+  hr = pDXGIDevice->GetAdapter(&pDXGIAdapter);
+  pDXGIDevice->Release();
+  if (FAILED(hr) || !pDXGIAdapter) {
+    LogError("Failed to get DXGI adapter from D3D10 device");
+    return false;
+  }
+
+  DXGI_ADAPTER_DESC adapterDesc;
+  hr = pDXGIAdapter->GetDesc(&adapterDesc);
+  pDXGIAdapter->Release();
+
+  bool canInteroperate = SUCCEEDED(hr) &&
+      (device->getDeviceLUID().HighPart == adapterDesc.AdapterLuid.HighPart) &&
+      (device->getDeviceLUID().LowPart == adapterDesc.AdapterLuid.LowPart);
+
+  if (!canInteroperate) {
+    LogError("D3D10 device and ROCr device cannot interoperate (LUID mismatch)");
+    return false;
+  }
+
+  // Create and cache AMD DXX extension objects for this device
+#if defined _WIN64
+  static constexpr CHAR dxxModuleName[13] = "atidxx64.dll";
+#else
+  static constexpr CHAR dxxModuleName[13] = "atidxx32.dll";
+#endif
+
+  HMODULE hDLL = GetModuleHandle(dxxModuleName);
+  if (!hDLL) {
+    LogError("atidxx DLL not loaded; D3D10 SRD queries will be unavailable");
+    return true;  // LUID matched; proceed without SRD support
+  }
+
+  PFNAmdDxExtCreate AmdDxExtCreate =
+      reinterpret_cast<PFNAmdDxExtCreate>(GetProcAddress(hDLL, "AmdDxExtCreate"));
+  if (!AmdDxExtCreate) {
+    return true;
+  }
+
+  IAmdDxExt* pExt = nullptr;
+  hr = AmdDxExtCreate(pd3d10Device, &pExt);
+  if (FAILED(hr) || !pExt) {
+    return true;
+  }
+
+  IAmdDxExtCLInterop* pCLExt =
+      static_cast<IAmdDxExtCLInterop*>(pExt->GetExtInterface(AmdDxExtCLInteropID));
+  if (!pCLExt) {
+    pExt->Release();
+    return true;
+  }
+
+  std::lock_guard<std::mutex> sl(gExtCacheLock);
+  gExtCache[device] = {pExt, pCLExt};
+
+  return true;
+}
+
+void dissociateD3D10Device(const Device* device) {
+  std::lock_guard<std::mutex> sl(gExtCacheLock);
+  auto it = gExtCache.find(device);
+  if (it != gExtCache.end()) {
+    if (it->second.pCLExt) it->second.pCLExt->Release();
+    if (it->second.pExt) it->second.pExt->Release();
+    gExtCache.erase(it);
+  }
+}
+
+bool Export(const Memory* memory, ID3D10Resource* d3d10Resource,
+            UINT subresource, hsa_handle_t* handle, int* offset,
+            void* srd, UINT* srdSize, hsa_interop_map_flag_t* mapFlags) {
+  if (!memory || !d3d10Resource || !handle || !offset || !mapFlags) {
+    return false;
+  }
+
+  // Use cached extension to query SRD
+  if (srd && srdSize) {
+    std::lock_guard<std::mutex> sl(gExtCacheLock);
+    auto it = gExtCache.find(&memory->dev());
+    if (it != gExtCache.end() && it->second.pCLExt) {
+      HRESULT hr = it->second.pCLExt->CLQueryResource(d3d10Resource, srd, srdSize);
+      if (FAILED(hr)) {
+        LogError("CLQueryResource failed for D3D10 resource");
+      }
+    }
+  }
+
+  IDXGIResource* pDxgiRes = nullptr;
+  HRESULT hr = d3d10Resource->QueryInterface(__uuidof(IDXGIResource), (void**)&pDxgiRes);
+  if (FAILED(hr) || !pDxgiRes) {
+    LogError("Failed to query IDXGIResource from D3D10 resource");
+    return false;
+  }
+
+  // Get legacy KMT shared handle (requires D3D10_RESOURCE_MISC_SHARED).
+  HANDLE hShared = nullptr;
+  hr = pDxgiRes->GetSharedHandle(&hShared);
+  pDxgiRes->Release();
+
+  if (FAILED(hr) || !hShared) {
+    LogError("Failed to get KMT shared handle from D3D10 resource");
+    return false;
+  }
+
+  *handle = reinterpret_cast<hsa_handle_t>(hShared);
+  *offset = 0;
+  *mapFlags = HSA_INTEROP_MAP_FLAG_KMT_HANDLE;
+  return true;
+}
+
+}  // namespace D3D10Interop
+}  // namespace roc
+}  // namespace amd
+
+#endif  // _WIN32

--- a/projects/clr/rocclr/device/rocm/rocd3d10interop.hpp
+++ b/projects/clr/rocclr/device/rocm/rocd3d10interop.hpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#ifndef ROC_D3D10_INTEROP_HPP_
+#define ROC_D3D10_INTEROP_HPP_
+
+#include "top.hpp"
+
+#ifdef _WIN32
+
+#include <d3d10.h>
+#include <dxgi.h>
+
+namespace amd {
+namespace roc {
+
+// Forward declarations
+class Device;
+class Memory;
+
+namespace D3D10Interop {
+
+/**
+ * @brief Validate D3D10 device matches ROCr GPU device
+ *
+ * Performs validation: LUID matching via DXGI adapter
+ *
+ * @param device ROCr device to validate against
+ * @param d3d10Device D3D10 device to associate
+ * @return true if devices can interoperate, false otherwise
+ */
+bool associateD3D10Device(
+    const Device* device,
+    ID3D10Device* d3d10Device
+);
+
+/**
+ * @brief Dissociate D3D10 device from ROCr device
+ *
+ * Cleanup function called during context destruction
+ *
+ * @param device ROCr device
+ */
+void dissociateD3D10Device(const Device* device);
+
+/**
+ * @brief Export D3D10 resource to HSA handle for interop
+ *
+ * Extracts shared handle from D3D10 resource and returns it
+ * as HSA handle for memory mapping
+ *
+ * @param memory ROCr memory object
+ * @param d3d10Resource D3D10 resource to export
+ * @param subresource Subresource index (for textures with mips)
+ * @param handle Output HSA handle
+ * @param offset Output offset into resource
+ * @return true if export succeeded, false otherwise
+ */
+bool Export(
+    const Memory* memory,
+    ID3D10Resource* d3d10Resource,
+    UINT subresource,
+    hsa_handle_t* handle,
+    int* offset,
+    void* srd,
+    UINT* srdSize,
+    hsa_interop_map_flag_t* mapFlags
+);
+
+}  // namespace D3D10Interop
+}  // namespace roc
+}  // namespace amd
+
+#endif  // _WIN32
+
+#endif  // ROC_D3D10_INTEROP_HPP_

--- a/projects/clr/rocclr/device/rocm/rocd3d11interop.cpp
+++ b/projects/clr/rocclr/device/rocm/rocd3d11interop.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "rocdevice.hpp"
+#include "rocmemory.hpp"
+#include "rocd3d11interop.hpp"
+
+#ifdef _WIN32
+
+#include <D3D11.h>
+#include <dxgi.h>
+#include <mutex>
+#include <unordered_map>
+
+#include "platform/DxxInteropExt.h"
+#include "platform/interop_d3d11.hpp"
+
+namespace amd {
+namespace roc {
+namespace D3D11Interop {
+
+static std::unordered_map<const Device*, CachedExt> gExtCache;
+static std::mutex gExtCacheLock;
+
+bool associateD3D11Device(const Device* device, ID3D11Device* pd3d11Device) {
+  if (!device || !pd3d11Device) {
+    return false;
+  }
+
+  if (!device->hasValidLUID()) {
+    LogError("ROCr device does not have valid LUID for D3D11 interop");
+    return false;
+  }
+
+  IDXGIDevice* pDXGIDevice = nullptr;
+  HRESULT hr = pd3d11Device->QueryInterface(__uuidof(IDXGIDevice), (void**)&pDXGIDevice);
+  if (FAILED(hr) || !pDXGIDevice) {
+    LogError("Failed to query IDXGIDevice from D3D11 device");
+    return false;
+  }
+
+  IDXGIAdapter* pDXGIAdapter = nullptr;
+  hr = pDXGIDevice->GetAdapter(&pDXGIAdapter);
+  pDXGIDevice->Release();
+  if (FAILED(hr) || !pDXGIAdapter) {
+    LogError("Failed to get DXGI adapter from D3D11 device");
+    return false;
+  }
+
+  DXGI_ADAPTER_DESC adapterDesc;
+  hr = pDXGIAdapter->GetDesc(&adapterDesc);
+  pDXGIAdapter->Release();
+
+  bool canInteroperate = SUCCEEDED(hr) &&
+      (device->getDeviceLUID().HighPart == adapterDesc.AdapterLuid.HighPart) &&
+      (device->getDeviceLUID().LowPart == adapterDesc.AdapterLuid.LowPart);
+
+  if (!canInteroperate) {
+    LogError("D3D11 device and ROCr device cannot interoperate (LUID mismatch)");
+    return false;
+  }
+
+  // Create and cache AMD DXX extension objects for this device
+#if defined _WIN64
+  static constexpr CHAR dxxModuleName[13] = "atidxx64.dll";
+#else
+  static constexpr CHAR dxxModuleName[13] = "atidxx32.dll";
+#endif
+
+  HMODULE hDLL = GetModuleHandle(dxxModuleName);
+  if (!hDLL) {
+    LogError("atidxx DLL not loaded; D3D11 SRD queries will be unavailable");
+    return true;  // LUID matched; proceed without SRD support
+  }
+
+  PFNAmdDxExtCreate11 AmdDxExtCreate11 =
+      reinterpret_cast<PFNAmdDxExtCreate11>(GetProcAddress(hDLL, "AmdDxExtCreate11"));
+  if (!AmdDxExtCreate11) {
+    return true;
+  }
+
+  IAmdDxExt* pExt = nullptr;
+  hr = AmdDxExtCreate11(pd3d11Device, &pExt);
+  if (FAILED(hr) || !pExt) {
+    return true;
+  }
+
+  IAmdDxExtCLInterop* pCLExt =
+      static_cast<IAmdDxExtCLInterop*>(pExt->GetExtInterface(AmdDxExtCLInteropID));
+  if (!pCLExt) {
+    pExt->Release();
+    return true;
+  }
+
+  std::lock_guard<std::mutex> sl(gExtCacheLock);
+  gExtCache[device] = {pExt, pCLExt};
+
+  return true;
+}
+
+void dissociateD3D11Device(const Device* device) {
+  std::lock_guard<std::mutex> sl(gExtCacheLock);
+  auto it = gExtCache.find(device);
+  if (it != gExtCache.end()) {
+    if (it->second.pCLExt) it->second.pCLExt->Release();
+    if (it->second.pExt) it->second.pExt->Release();
+    gExtCache.erase(it);
+  }
+}
+
+bool Export(const Memory* memory, ID3D11Resource* d3d11Resource,
+            UINT subresource, hsa_handle_t* handle, int* offset,
+            void* srd, UINT* srdSize, hsa_interop_map_flag_t* mapFlags,
+            size_t* sizeHint) {
+  if (!memory || !d3d11Resource || !handle || !offset || !mapFlags) {
+    return false;
+  }
+
+  // Query buffer size for D3D11 buffers so libhsakmt can handle resources
+  // whose KMD private data is opaque (no UMDKMDIF SharedHandleInfo).
+  if (sizeHint) {
+    *sizeHint = 0;
+    ID3D11Buffer* buf = nullptr;
+    if (SUCCEEDED(d3d11Resource->QueryInterface(__uuidof(ID3D11Buffer), (void**)&buf)) && buf) {
+      D3D11_BUFFER_DESC desc = {};
+      buf->GetDesc(&desc);
+      *sizeHint = desc.ByteWidth;
+      buf->Release();
+    }
+  }
+
+  // Use cached extension to query SRD
+  if (srd && srdSize) {
+    std::lock_guard<std::mutex> sl(gExtCacheLock);
+    auto it = gExtCache.find(&memory->dev());
+    if (it != gExtCache.end() && it->second.pCLExt) {
+      HRESULT hr = it->second.pCLExt->CLQueryResource11(d3d11Resource, srd, srdSize);
+      if (FAILED(hr)) {
+        LogError("CLQueryResource11 failed for D3D11 resource");
+      }
+    }
+  }
+
+  IDXGIResource* pDxgiRes = nullptr;
+  HRESULT hr = d3d11Resource->QueryInterface(__uuidof(IDXGIResource), (void**)&pDxgiRes);
+  if (FAILED(hr) || !pDxgiRes) {
+    LogError("Failed to query IDXGIResource from D3D11 resource");
+    return false;
+  }
+
+  // Get legacy KMT shared handle (requires D3D11_RESOURCE_MISC_SHARED).
+  HANDLE hShared = nullptr;
+  hr = pDxgiRes->GetSharedHandle(&hShared);
+  pDxgiRes->Release();
+
+  if (FAILED(hr) || !hShared) {
+    LogError("Failed to get KMT shared handle from D3D11 resource");
+    return false;
+  }
+
+  *handle = reinterpret_cast<hsa_handle_t>(hShared);
+  *offset = 0;
+  *mapFlags = HSA_INTEROP_MAP_FLAG_KMT_HANDLE;
+  return true;
+}
+
+}  // namespace D3D11Interop
+}  // namespace roc
+}  // namespace amd
+
+#endif  // _WIN32

--- a/projects/clr/rocclr/device/rocm/rocd3d11interop.hpp
+++ b/projects/clr/rocclr/device/rocm/rocd3d11interop.hpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#ifndef ROC_D3D11_INTEROP_HPP_
+#define ROC_D3D11_INTEROP_HPP_
+
+#include "top.hpp"
+
+#ifdef _WIN32
+
+#include <d3d11.h>
+#include <dxgi.h>
+
+namespace amd {
+namespace roc {
+
+// Forward declarations
+class Device;
+class Memory;
+
+namespace D3D11Interop {
+
+/**
+ * @brief Validate D3D11 device matches ROCr GPU device
+ *
+ * Performs validation: LUID matching via DXGI adapter
+ *
+ * @param device ROCr device to validate against
+ * @param d3d11Device D3D11 device to associate
+ * @return true if devices can interoperate, false otherwise
+ */
+bool associateD3D11Device(
+    const Device* device,
+    ID3D11Device* d3d11Device
+);
+
+/**
+ * @brief Dissociate D3D11 device from ROCr device
+ *
+ * Cleanup function called during context destruction
+ *
+ * @param device ROCr device
+ */
+void dissociateD3D11Device(const Device* device);
+
+/**
+ * @brief Export D3D11 resource to HSA handle for interop
+ *
+ * Extracts shared handle from D3D11 resource and returns it
+ * as HSA handle for memory mapping
+ *
+ * @param memory ROCr memory object
+ * @param d3d11Resource D3D11 resource to export
+ * @param subresource Subresource index (for textures with mips)
+ * @param handle Output HSA handle
+ * @param offset Output offset into resource
+ * @return true if export succeeded, false otherwise
+ */
+bool Export(
+    const Memory* memory,
+    ID3D11Resource* d3d11Resource,
+    UINT subresource,
+    hsa_handle_t* handle,
+    int* offset,
+    void* srd,
+    UINT* srdSize,
+    hsa_interop_map_flag_t* mapFlags,
+    size_t* sizeHint = nullptr
+);
+
+}  // namespace D3D11Interop
+}  // namespace roc
+}  // namespace amd
+
+#endif  // _WIN32
+
+#endif  // ROC_D3D11_INTEROP_HPP_

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -28,6 +28,13 @@
 #include "device/rocm/rocsignal.hpp"
 #include "platform/sampler.hpp"
 
+#ifdef _WIN32
+#include "device/rocm/rocd3d10interop.hpp"
+#include "device/rocm/rocd3d11interop.hpp"
+#include "platform/interop_d3d10.hpp"
+#include "platform/interop_d3d11.hpp"
+#endif
+
 #if defined(__clang__)
 #if __has_feature(address_sanitizer)
 #include "device/rocm/rocurilocator.hpp"
@@ -676,6 +683,17 @@ bool Device::create() {
     return false;
   }
   info_.pciDomainID = pci_domain_id;
+
+#ifdef _WIN32
+  // Extract adapter LUID for D3D interop validation
+  hsa_status_t luid_status = Hsa::agent_get_info(
+      bkendDevice_, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_LUID),
+      &deviceLuid_);
+  luidValid_ = luid_status == HSA_STATUS_SUCCESS;
+  if (!luidValid_) {
+    LogWarning("Could not extract LUID from HSA agent - D3D interop may not work correctly");
+  }
+#endif
 
   if (populateOCLDeviceConstants() == false) {
     LogPrintfError("populateOCLDeviceConstants failed for HSA device %s (PCI ID %x)", agent_name,
@@ -1889,30 +1907,69 @@ bool Device::amdFileWrite(amd::Os::FileDesc handle, void* devicePtr, uint64_t si
 // ================================================================================================
 bool Device::bindExternalDevice(uint flags, void* const gfxDevice[], void* gfxContext,
                                 bool validateOnly) {
-  if ((flags & amd::Context::GLDeviceKhr) == 0) return false;
+  bool success = true;
 
-  void* glDevice = gfxDevice[amd::Context::DeviceFlagIdx::GLDeviceKhrIdx];
-  if (!GlInterop::glAssociate(this, flags, gfxContext, glDevice)) {
-    LogError("Failed GlInterop::glAssociate()");
-    return false;
+#ifdef _WIN32
+  // Handle D3D10 device binding
+  if (flags & amd::Context::Flags::D3D10DeviceKhr) {
+    void* d3d10Device = gfxDevice[amd::Context::DeviceFlagIdx::D3D10DeviceKhrIdx];
+    if (!D3D10Interop::associateD3D10Device(this, static_cast<ID3D10Device*>(d3d10Device))) {
+      LogError("Failed D3D10Interop::associateD3D10Device()");
+      success = false;
+    }
   }
 
-  return true;
+  // Handle D3D11 device binding
+  if (flags & amd::Context::Flags::D3D11DeviceKhr) {
+    void* d3d11Device = gfxDevice[amd::Context::DeviceFlagIdx::D3D11DeviceKhrIdx];
+    if (!D3D11Interop::associateD3D11Device(this, static_cast<ID3D11Device*>(d3d11Device))) {
+      LogError("Failed D3D11Interop::associateD3D11Device()");
+      success = false;
+    }
+  }
+#endif  // _WIN32
+
+  // Handle GL device binding (existing code)
+  if (flags & amd::Context::Flags::GLDeviceKhr) {
+    void* glDevice = gfxDevice[amd::Context::DeviceFlagIdx::GLDeviceKhrIdx];
+    if (!GlInterop::glAssociate(this, flags, gfxContext, glDevice)) {
+      LogError("Failed GlInterop::glAssociate()");
+      success = false;
+    }
+  }
+
+  return success;
 }
 
 // ================================================================================================
 bool Device::unbindExternalDevice(uint flags, void* const gfxDevice[], void* gfxContext,
                                   bool validateOnly) {
-  if ((flags & amd::Context::GLDeviceKhr) == 0) return false;
+  bool success = true;
 
-  void* glDevice = gfxDevice[amd::Context::DeviceFlagIdx::GLDeviceKhrIdx];
-  if (glDevice != nullptr) {
-    if (!GlInterop::glDissociate(this, gfxContext, glDevice)) {
-      LogWarning("Failed GlInterop::glDissociate()");
-      return false;
+#ifdef _WIN32
+  // Handle D3D10 device cleanup
+  if (flags & amd::Context::Flags::D3D10DeviceKhr) {
+    D3D10Interop::dissociateD3D10Device(this);
+  }
+
+  // Handle D3D11 device cleanup
+  if (flags & amd::Context::Flags::D3D11DeviceKhr) {
+    D3D11Interop::dissociateD3D11Device(this);
+  }
+#endif  // _WIN32
+
+  // Handle GL device cleanup (existing code)
+  if (flags & amd::Context::Flags::GLDeviceKhr) {
+    void* glDevice = gfxDevice[amd::Context::DeviceFlagIdx::GLDeviceKhrIdx];
+    if (glDevice != nullptr) {
+      if (!GlInterop::glDissociate(this, gfxContext, glDevice)) {
+        LogWarning("Failed GlInterop::glDissociate()");
+        success = false;
+      }
     }
   }
-  return true;
+
+  return success;
 }
 
 amd::Memory* Device::findMapTarget(size_t size) const {

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -25,6 +25,7 @@
 #include "device/rocm/rocprintf.hpp"
 #include "device/rocm/rocglinterop.hpp"
 
+
 #include <atomic>
 #include <iostream>
 #include <memory>
@@ -561,6 +562,12 @@ class Device : public NullDevice {
   //! Returns the lock object for the virtual gpus list
   std::recursive_mutex& vgpusAccess() const { return vgpusAccess_; }
 
+#ifdef _WIN32
+  //! D3D interop accessors - return adapter LUID for device matching
+  const LUID& getDeviceLUID() const { return deviceLuid_; }
+  bool hasValidLUID() const { return luidValid_; }
+#endif
+
   typedef std::vector<VirtualGPU*> VirtualGPUs;
   //! Returns the list of all virtual GPUs running on this device
   const VirtualGPUs& vgpus() const { return vgpus_; }
@@ -719,6 +726,12 @@ class Device : public NullDevice {
   //! Pre-computed metadata packet version header bits
   uint32_t metadata_version_header_ = 0;
   bool metadata_version_queried_ = false;
+
+#ifdef _WIN32
+  // D3D interop device properties
+  LUID deviceLuid_;     //!< Adapter LUID for D3D interop validation
+  bool luidValid_;      //!< True if LUID was successfully extracted from HSA
+#endif
 
   struct QueueInfo {
     int refCount;             //! Reference counter. Shows how many time the queue was shared

--- a/projects/clr/rocclr/device/rocm/rocmemory.cpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.cpp
@@ -22,6 +22,13 @@
 #include "platform/interop_gl.hpp"
 #include "platform/external_memory.hpp"
 
+#ifdef _WIN32
+#include "device/rocm/rocd3d10interop.hpp"
+#include "device/rocm/rocd3d11interop.hpp"
+#include "platform/interop_d3d10.hpp"
+#include "platform/interop_d3d11.hpp"
+#endif
+
 namespace amd::roc {
 
 // RAII guard to ensure owning agent is set on successful buffer creation
@@ -203,17 +210,19 @@ void Memory::cpuUnmap(device::VirtualDevice& vDev) {
 }
 
 // ================================================================================================
-hsa_status_t Memory::interopMapBuffer(hsa_handle_t fdn, hsa_interop_map_flag_t flags) {
+hsa_status_t Memory::interopMapBuffer(hsa_handle_t fdn, hsa_interop_map_flag_t flags,
+                                      size_t size_hint) {
   hsa_agent_t agent = dev().getBackendDevice();
-  size_t size;
+  size_t size = 0;
   size_t metadata_size = 0;
   void* metadata = nullptr;
   auto fd = fdn;
-  hsa_status_t status = Hsa::interop_map_buffer(1, &agent, fd, flags, &size, &interop_deviceMemory_,
+  hsa_status_t status = Hsa::interop_map_buffer_with_size(1, &agent, fd, flags, size_hint, &size,
+                                                          &interop_deviceMemory_,
 #if IS_WINDOWS
-                                                nullptr, nullptr  // Cannot get metadata and metadata_size in Windows
+                                                          nullptr, nullptr
 #else
-                                                &metadata_size, (const void**)&metadata
+                                                          &metadata_size, (const void**)&metadata
 #endif
   );
   ClPrint(amd::LOG_DEBUG, amd::LOG_MEM, "Map Interop memory %p, size 0x%zx", interop_deviceMemory_,
@@ -261,19 +270,51 @@ bool Memory::createInteropBuffer(GLenum targetType, int miplevel) {
   amdImageDesc_->deviceID = (AmdVendor << DeviceIdVendorShift) | id;
 
 #if IS_WINDOWS
-  hsa_handle_t handle, resHandle;
-  int offset;
+  hsa_handle_t handle = 0, resHandle = 0;
+  int offset = 0;
+  hsa_interop_map_flag_t mapFlags = HSA_INTEROP_MAP_FLAG_KMT_HANDLE;
 
-  if (!GlInterop::Export(owner(), targetType, miplevel, &handle, &resHandle, &offset, amdImageDesc_->data,
-                         MaxMetadataSizeDwords * sizeof(uint32_t))) {
+  // Check if this is D3D interop (vs GL interop)
+  amd::InteropObject* interopObj = owner()->getInteropObj();
+  UINT srdSize = MaxMetadataSizeDwords * sizeof(uint32_t);
+  size_t sizeHint = 0;
+  if (interopObj->asD3D11Object()) {
+    // D3D11 interop
+    D3D11Object* d3d11Obj = interopObj->asD3D11Object();
+    if (!D3D11Interop::Export(this, d3d11Obj->getD3D11Resource(),
+                              d3d11Obj->getSubresource(), &handle, &offset,
+                              amdImageDesc_->data, &srdSize, &mapFlags, &sizeHint)) {
+      LogError("D3D11Interop::Export failed for buffer");
+      return false;
+    }
+  } else if (interopObj->asD3D10Object()) {
+    // D3D10 interop
+    D3D10Object* d3d10Obj = interopObj->asD3D10Object();
+    if (!D3D10Interop::Export(this, d3d10Obj->getD3D10Resource(),
+                              d3d10Obj->getSubresource(), &handle, &offset,
+                              amdImageDesc_->data, &srdSize, &mapFlags)) {
+      LogError("D3D10Interop::Export failed for buffer");
+      return false;
+    }
+  } else if (interopObj->asGLObject()) {
+    // GL interop
+    if (!GlInterop::Export(owner(), targetType, miplevel, &handle, &resHandle, &offset,
+                           amdImageDesc_->data, MaxMetadataSizeDwords * sizeof(uint32_t))) {
+      return false;
+    }
+  } else {
+    LogError("Unknown interop object type");
     return false;
   }
-
-  if (interopMapBuffer(handle, HSA_INTEROP_MAP_FLAG_KMT_HANDLE) != HSA_STATUS_SUCCESS) return false;
+  auto mapStatus = interopMapBuffer(handle, mapFlags, sizeHint);
+  if (mapStatus != HSA_STATUS_SUCCESS) return false;
 
   deviceMemory_ = static_cast<char*>(interop_deviceMemory_) + offset;
-  if(!GlInterop::Detach(owner(), resHandle)) {
-    LogPrintfError("GlInterop::Detach(handle %p) failed", resHandle);
+
+  if (interopObj->asGLObject()) {
+    if(!GlInterop::Detach(owner(), resHandle)) {
+      LogError("GlInterop::Detach failed");
+    }
   }
   return true;
 #else
@@ -929,7 +970,6 @@ bool Buffer::create(bool alloc_local) {
   if (owner()->isInterop()) {
     amd::InteropObject* interop = owner()->getInteropObj();
     auto ext_memory = interop->asExternalMemory();
-    amd::GLObject* glObject = interop->asGLObject();
     if (ext_memory != nullptr) {
       // Win32-KMT handles need ROCR's KMT branch in libhsakmt; the default
       // (no flag) takes the NT path and fails with STATUS_INVALID_HANDLE.
@@ -938,9 +978,9 @@ bool Buffer::create(bool alloc_local) {
           ext_memory->Type() == amd::ExternalMemory::HandleType::D3D11ResourceKmt) {
         map_flags = HSA_INTEROP_MAP_FLAG_KMT_HANDLE;
       }
-      return (success = (interopMapBuffer(ext_memory->Handle(), map_flags) == HSA_STATUS_SUCCESS));
-    } else if (glObject != nullptr) {
-      return (success = createInteropBuffer(GL_ARRAY_BUFFER, 0));
+      return interopMapBuffer(ext_memory->Handle(), map_flags) == HSA_STATUS_SUCCESS;
+    } else {
+      return createInteropBuffer(GL_ARRAY_BUFFER, 0);
     }
   }
   if (nullptr != owner()->parent()) {
@@ -1313,39 +1353,61 @@ void Image::populateImageDescriptor() {
 }
 
 bool Image::createInteropImage() {
-  auto obj = owner()->getInteropObj()->asGLObject();
-  assert(obj->getCLGLObjectType() != CL_GL_OBJECT_BUFFER &&
-         "Non-image OpenGL object used with interop image API.");
+  // Handle GL interop images
+  auto glObj = owner()->getInteropObj()->asGLObject();
+  if (glObj) {
+    assert(glObj->getCLGLObjectType() != CL_GL_OBJECT_BUFFER &&
+           "Non-image OpenGL object used with interop image API.");
 
-  GLenum glTarget = obj->getGLTarget();
-  if (glTarget == GL_TEXTURE_CUBE_MAP) {
-    glTarget = obj->getCubemapFace();
+    GLenum glTarget = glObj->getGLTarget();
+    if (glTarget == GL_TEXTURE_CUBE_MAP) {
+      glTarget = glObj->getCubemapFace();
+    }
+
+    if (!createInteropBuffer(glTarget, glObj->getGLMipLevel())) {
+      assert(false && "Failed to map GL image buffer.");
+      return false;
+    }
   }
-
-  if (!createInteropBuffer(glTarget, obj->getGLMipLevel())) {
-    assert(false && "Failed to map image buffer.");
+#ifdef _WIN32
+  // Handle D3D interop images (D3D11/D3D10 supported)
+  else if (owner()->getInteropObj()->asD3D11Object() || owner()->getInteropObj()->asD3D10Object()) {
+    // For D3D, we use targetType=0 and miplevel from D3D object
+    // The createInteropBuffer will detect D3D object type and handle appropriately
+    if (!createInteropBuffer(0, 0)) {
+      assert(false && "Failed to map D3D image buffer.");
+      return false;
+    }
+  }
+#endif
+  else {
+    LogError("Interop image is neither GL nor D3D object");
     return false;
   }
 
   originalDeviceMemory_ = deviceMemory_;
 
-  if (obj->getGLTarget() == GL_TEXTURE_BUFFER) {
+  // Handle GL-specific texture buffer case
+  if (glObj && glObj->getGLTarget() == GL_TEXTURE_BUFFER) {
     hsa_status_t err = Hsa::image_create(dev().getBackendDevice(), &imageDescriptor_,
                                          originalDeviceMemory_, permission_, &hsaImageObject_);
     return (err == HSA_STATUS_SUCCESS);
   }
 
+  // For D3D and other GL textures, use metadata descriptor
   image_metadata desc;
   if (!desc.create(amdImageDesc_)) {
     return false;
   }
 
-  if (!desc.setMipLevel(obj->getGLMipLevel())) {
+  // Set mip level if GL object
+  if (glObj && !desc.setMipLevel(glObj->getGLMipLevel())) {
     return false;
   }
 
-  if (obj->getGLTarget() == GL_TEXTURE_CUBE_MAP) {
-    desc.setFace(obj->getCubemapFace(), dev().isa().versionMajor());
+  // Set cubemap face if GL cubemap
+  if (glObj && glObj->getGLTarget() == GL_TEXTURE_CUBE_MAP) {
+    desc.setFace(glObj->getCubemapFace(), dev().isa().versionMajor());
   }
 
   hsa_status_t err =
@@ -1529,36 +1591,33 @@ bool Image::createView(const Memory& parent) {
         }
       }
     }
-  } else if (kind_ == MEMORY_KIND_INTEROP) {
-    amdImageDesc_ = static_cast<Image*>(parent.owner()->getDeviceMemory(dev()))->amdImageDesc_;
-    status = Hsa::image_create(dev().getBackendDevice(), &imageDescriptor_, amdImageDesc_,
-                               deviceMemory_, permission_, &hsaImageObject_);
-  } else {
-    if (ancestor->asImage()->getMipLevels() > 1 && imageDescriptor_.mipmap_levels == 1) {
-      // This is on leveled image of mipmap image ancestor
+  } else if (ancestor->asImage()->getMipLevels() > 1 && imageDescriptor_.mipmap_levels == 1) {
+      // This is on leveled image of mipmap image, including leveled view of interop mipmap.
       amd::Memory* parentOwner = parent.owner();
       auto* ancestor_image = static_cast<Image*>(ancestor->getDeviceMemory(dev()));
       if (ancestor == parentOwner) {
         // This is leveled image
-        status = Hsa::image_get_mipmap_level(dev().getBackendDevice(),
-                                           &ancestor_image->hsaImageObject_,
-                                           owner()->asImage()->getBaseMipLevel(),
-                                           nullptr, &hsaImageObject_);
+        status = Hsa::image_get_mipmap_level(
+            dev().getBackendDevice(), &ancestor_image->hsaImageObject_,
+            owner()->asImage()->getBaseMipLevel(), nullptr, &hsaImageObject_);
       } else if (ancestor == parentOwner->parent()) {
         // This is format changed view on leveled image
-        status = Hsa::image_get_mipmap_level(dev().getBackendDevice(),
-                                           &ancestor_image->hsaImageObject_,
-                                           parentOwner->asImage()->getBaseMipLevel(),
-                                           &imageDescriptor_, &hsaImageObject_);
+        status = Hsa::image_get_mipmap_level(
+            dev().getBackendDevice(), &ancestor_image->hsaImageObject_,
+            parentOwner->asImage()->getBaseMipLevel(), &imageDescriptor_, &hsaImageObject_);
       } else {
         // This is an impossible view on leveled image
         status = HSA_STATUS_ERROR_INVALID_REGION;
       }
-    } else {
-      // This is a view on regular image or mipmap image.
-      status = Hsa::image_create(dev().getBackendDevice(), &imageDescriptor_, deviceMemory_,
+  } else if (kind_ == MEMORY_KIND_INTEROP) {
+    // This is a view on interop regular image or mipmap image.
+    amdImageDesc_ = static_cast<Image*>(parent.owner()->getDeviceMemory(dev()))->amdImageDesc_;
+    status = Hsa::image_create(dev().getBackendDevice(), &imageDescriptor_, amdImageDesc_,
+                               deviceMemory_, permission_, &hsaImageObject_);
+  } else {
+    // This is a view on regular image or mipmap image.
+    status = Hsa::image_create(dev().getBackendDevice(), &imageDescriptor_, deviceMemory_,
                                  permission_, &hsaImageObject_);
-    }
   }
 
   if (status != HSA_STATUS_SUCCESS) {

--- a/projects/clr/rocclr/device/rocm/rocmemory.hpp
+++ b/projects/clr/rocclr/device/rocm/rocmemory.hpp
@@ -133,7 +133,8 @@ class Memory : public device::Memory {
 
   // Map interop buffer
   hsa_status_t interopMapBuffer(hsa_handle_t fdn,
-                                hsa_interop_map_flag_t flags = HSA_INTEROP_MAP_FLAG_NONE);
+                                hsa_interop_map_flag_t flags = HSA_INTEROP_MAP_FLAG_NONE,
+                                size_t size_hint = 0);
 
   // Place interop object into HSA's flat address space
   bool createInteropBuffer(GLenum targetType, int miplevel);

--- a/projects/clr/rocclr/device/rocm/rocrctx.cpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.cpp
@@ -82,8 +82,10 @@ bool Hsa::LoadLib() {
   GET_ROCR_SYMBOL(hsa_amd_agents_allow_access)
   GET_ROCR_SYMBOL(hsa_amd_memory_unlock)
   GET_ROCR_SYMBOL(hsa_amd_interop_map_buffer)
+  GET_ROCR_SYMBOL(hsa_amd_interop_map_buffer_with_size)
   GET_ROCR_SYMBOL(hsa_amd_interop_unmap_buffer)
   GET_ROCR_SYMBOL(hsa_amd_image_create)
+  GET_ROCR_SYMBOL(hsa_amd_image_create_v2)
   GET_ROCR_SYMBOL(hsa_amd_pointer_info)
   GET_ROCR_SYMBOL(hsa_amd_ipc_memory_create)
   GET_ROCR_SYMBOL(hsa_amd_ipc_memory_attach)
@@ -132,6 +134,7 @@ bool Hsa::LoadLib() {
   GET_ROCR_SYMBOL(hsa_ext_sampler_destroy)
   GET_ROCR_SYMBOL(hsa_ext_image_create_with_layout)
   GET_ROCR_SYMBOL(hsa_ext_image_mipmap_array_get_level)
+
   is_ready_ = true;
   return true;
 }

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -91,8 +91,10 @@ struct RocrEntryPoints {
   decltype(hsa_amd_agents_allow_access)* hsa_amd_agents_allow_access_;
   decltype(hsa_amd_memory_unlock)* hsa_amd_memory_unlock_;
   decltype(hsa_amd_interop_map_buffer)* hsa_amd_interop_map_buffer_;
+  decltype(hsa_amd_interop_map_buffer_with_size)* hsa_amd_interop_map_buffer_with_size_;
   decltype(hsa_amd_interop_unmap_buffer)* hsa_amd_interop_unmap_buffer_;
   decltype(hsa_amd_image_create)* hsa_amd_image_create_;
+  decltype(hsa_amd_image_create_v2)* hsa_amd_image_create_v2_;
   decltype(hsa_amd_pointer_info)* hsa_amd_pointer_info_;
   decltype(hsa_amd_ipc_memory_create)* hsa_amd_ipc_memory_create_;
   decltype(hsa_amd_ipc_memory_attach)* hsa_amd_ipc_memory_attach_;
@@ -395,6 +397,14 @@ class Hsa : public amd::AllStatic {
     return ROCR_DYN(hsa_amd_interop_map_buffer)(num_agents, agents, interop_handle, flags, size, ptr,
                                                 metadata_size, metadata);
   }
+  static hsa_status_t interop_map_buffer_with_size(uint32_t num_agents, hsa_agent_t* agents,
+                                                   hsa_handle_t interop_handle, uint32_t flags,
+                                                   size_t size_hint, size_t* size, void** ptr,
+                                                   size_t* metadata_size, const void** metadata) {
+    return ROCR_DYN(hsa_amd_interop_map_buffer_with_size)(num_agents, agents, interop_handle,
+                                                          flags, size_hint, size, ptr,
+                                                          metadata_size, metadata);
+  }
   static hsa_status_t interop_unmap_buffer(void* ptr) {
     return ROCR_DYN(hsa_amd_interop_unmap_buffer)(ptr);
   }
@@ -550,10 +560,8 @@ class Hsa : public amd::AllStatic {
     const hsa_amd_image_descriptor_t* image_layout,
     const void* image_data, hsa_access_permission_t access_permission,
     hsa_ext_image_t* image) {
-    assert(image_descriptor->mipmap_levels == 1);
-    return ROCR_DYN(hsa_amd_image_create)(agent,
-                   reinterpret_cast<const hsa_ext_image_descriptor_t*>(image_descriptor),
-                   image_layout, image_data, access_permission, image);
+    return ROCR_DYN(hsa_amd_image_create_v2)(agent,
+                   image_descriptor, image_layout, image_data, access_permission, image);
   }
   static hsa_status_t image_data_get_info(
     hsa_agent_t agent, const hsa_ext_image_descriptor_v2_t* image_descriptor,

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -194,6 +194,16 @@ bool Settings::create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, b
     sdma_indirect_supported_ = true;
   }
 
+#if defined(_WIN32)
+  if (gfxipMajor >= 11) {
+    // Due to driver limitation,
+    // D3D10/11 sharing extensions are only supported on GFX11 or later,
+    // and D3D9 sharing extension is not supported on any hardware as it is deprecated.
+    enableExtension(ClKhrD3d10Sharing);
+    enableExtension(ClKhrD3d11Sharing);
+  }
+#endif
+
   // Override current device settings
   override();
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -23,6 +23,13 @@
 
 #include <fstream>
 #include <limits>
+
+#ifdef _WIN32
+#include "device/rocm/rocd3d10interop.hpp"
+#include "device/rocm/rocd3d11interop.hpp"
+#include "platform/interop_d3d10.hpp"
+#include "platform/interop_d3d11.hpp"
+#endif
 #include <memory>
 #include <string>
 #include <thread>
@@ -5012,6 +5019,15 @@ void VirtualGPU::submitAcquireExtObjects(amd::AcquireExtObjectsCommand& vcmd) {
 
   profilingBegin(vcmd);
   addSystemScope();
+
+  for (auto& mem : vcmd.getMemList()) {
+    amd::InteropObject* interop = mem->getInteropObj();
+    if (!interop) continue;
+    // Copy data from the original D3D resource to the shared intermediate resource
+    // (no-op for GL and for resources that are already directly shared)
+    interop->copyOrigToShared();
+  }
+
   profilingEnd();
 }
 
@@ -5020,6 +5036,14 @@ void VirtualGPU::submitReleaseExtObjects(amd::ReleaseExtObjectsCommand& vcmd) {
   // Make sure VirtualGPU has an exclusive access to the resources
   std::scoped_lock lock(execution());
   profilingBegin(vcmd);
+
+  for (auto& mem : vcmd.getMemList()) {
+    amd::InteropObject* interop = mem->getInteropObj();
+    if (!interop) continue;
+    // Copy data from the shared intermediate resource back to the original D3D resource
+    interop->copySharedToOrig();
+  }
+
   profilingEnd();
 }
 

--- a/projects/clr/rocclr/platform/DxxInteropExt.h
+++ b/projects/clr/rocclr/platform/DxxInteropExt.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-#ifndef __DXXOPENCLINTEROPEXT_H__
-#define __DXXOPENCLINTEROPEXT_H__
+#ifndef __DXXINTEROPEXT_H__
+#define __DXXINTEROPEXT_H__
 
 // Abstract extension interface class
 // Each extension interface (e.g. OpenCL Interop extension) will derive from this class
@@ -67,9 +67,11 @@ class IAmdDxExtCLInterop : public IAmdDxExtInterface {
 
   virtual HRESULT CLAcquireResource(ID3D10Resource* pResource, UINT* gpuIdBitmask) = 0;
   virtual HRESULT CLReleaseResource(ID3D10Resource* pResource, UINT* gpuIdBitmask) = 0;
+  virtual HRESULT CLQueryResource(ID3D10Resource* pResource, VOID* pSrd, UINT* pSrdSize) = 0;
 
   virtual HRESULT CLAcquireResource11(ID3D11Resource* pResource, UINT* gpuIdBitmask) = 0;
   virtual HRESULT CLReleaseResource11(ID3D11Resource* pResource, UINT* gpuIdBitmask) = 0;
+  virtual HRESULT CLQueryResource11(ID3D11Resource* pResource, VOID* pSrd, UINT* pSrdSize) = 0;
 
   virtual HRESULT CLAcquireResource9(IDirect3DSurface9* pResource, UINT* gpuIdBitmask) = 0;
   virtual HRESULT CLReleaseResource9(IDirect3DSurface9* pResource, UINT* gpuIdBitmask) = 0;
@@ -85,5 +87,10 @@ typedef HRESULT(__cdecl* PFNAmdDxExtCreate11)(ID3D11Device* pDevice, IAmdDxExt**
 
 HRESULT __cdecl AmdDxExtCreate9(IDirect3DDevice9Ex* pDevice, IAmdDxExt** ppExt);
 typedef HRESULT(__cdecl* PFNAmdDxExtCreate9)(IDirect3DDevice9Ex* pDevice, IAmdDxExt** ppExt);
+
+struct CachedExt {
+  IAmdDxExt* pExt = nullptr;
+  IAmdDxExtCLInterop* pCLExt = nullptr;
+};
 
 #endif

--- a/projects/clr/rocclr/platform/interop_d3d11.cpp
+++ b/projects/clr/rocclr/platform/interop_d3d11.cpp
@@ -13,7 +13,6 @@
 
 #include <cstring>
 #include <utility>
-
 namespace amd {
 
 size_t D3D11Object::getResourceByteSize() {
@@ -340,7 +339,9 @@ int D3D11Object::initD3D11Object(const Context& amdContext, ID3D11Resource* pRes
 
 bool D3D11Object::copyOrigToShared() {
   // Don't copy if there is no orig
-  if (nullptr == getD3D11ResOrig()) return true;
+  if (nullptr == getD3D11ResOrig()) {
+    return true;
+  }
 
   ID3D11Device* d3dDev;
   pD3D11Res_->GetDevice(&d3dDev);

--- a/projects/hip-tests/catch/config/configs/unit/gl_interop.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/gl_interop.yaml
@@ -96,3 +96,12 @@ gl_interop:
   Unit_hipGL_ContextSwitch_MultipleDestructionCycles: *level_2
   Unit_hipGL_ContextSwitch_DeviceListTypes: *level_2
   Unit_hipGL_ContextSwitch_FirstOperationInitialization: *level_2
+  Unit_GLHIPImageData_Positive_GLWrite_HIPRead_Gradient: *level_2
+  Unit_GLHIPImageData_Positive_GLWrite_HIPRead_SolidColor: *level_2
+  Unit_GLHIPImageData_Positive_HIPWrite_GLRead_SolidColor: *level_2
+  Unit_GLHIPImageData_Positive_HIPWrite_GLRead_UniquePerPixel: *level_2
+  Unit_GLHIPImageData_Positive_Mipmap_GLWrite_HIPRead_PerLevel: *level_2
+  Unit_GLHIPImageData_Positive_Mipmap_HIPWrite_GLRead_HigherLevels: *level_2
+  Unit_GLHIPImageData_Positive_Mipmap_RoundTrip_InvertLevel2: *level_2
+  Unit_GLHIPImageData_Positive_RoundTrip_CoordTransform: *level_2
+  Unit_GLHIPImageData_Positive_RoundTrip_InvertChannels: *level_2

--- a/projects/hip-tests/catch/unit/gl_interop/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/gl_interop/CMakeLists.txt
@@ -5,6 +5,7 @@
 set(TEST_SRC
     hipGLGetDevices.cc
     hipGLContextSwitch.cc
+    hipGLImageDataVerification.cc
     hipGraphicsGLRegisterBuffer.cc
     hipGraphicsGLRegisterImage.cc
     hipGraphicsMapResources.cc
@@ -70,7 +71,46 @@ endif()
 
 # GLEW is required on Windows for OpenGL extension access
 # On Linux, extensions are available via native headers
-find_package(GLEW)
+# Handle GLEW - env vars first, then find_package
+set(USE_ENV_GLEW FALSE)
+if (DEFINED ENV{GLEW_SHARED_LIBRARY_RELEASE} AND
+    DEFINED ENV{GLEW_INCLUDE_DIR})
+  if (NOT "$ENV{GLEW_SHARED_LIBRARY_RELEASE}" STREQUAL "" AND
+      NOT "$ENV{GLEW_INCLUDE_DIR}" STREQUAL "")
+    if (EXISTS "$ENV{GLEW_SHARED_LIBRARY_RELEASE}" AND
+        EXISTS "$ENV{GLEW_INCLUDE_DIR}")
+      set(USE_ENV_GLEW TRUE)
+    else()
+      message(WARNING "GLEW env vars invalid, using find_package")
+    endif()
+  endif()
+endif()
+
+if (USE_ENV_GLEW)
+  message(STATUS "Using GLEW from environment variables")
+  message(STATUS "  GLEW_SHARED_LIBRARY_RELEASE: $ENV{GLEW_SHARED_LIBRARY_RELEASE}")
+  message(STATUS "  GLEW_INCLUDE_DIR: $ENV{GLEW_INCLUDE_DIR}")
+
+  set(GLEW_SHARED_LIBRARY_RELEASE "$ENV{GLEW_SHARED_LIBRARY_RELEASE}"
+      CACHE FILEPATH "Path to GLEW library")
+  set(GLEW_INCLUDE_DIR "$ENV{GLEW_INCLUDE_DIR}"
+      CACHE PATH "Path to GLEW include directory")
+  set(GLEW_FOUND TRUE)
+  add_library(GLEW::GLEW UNKNOWN IMPORTED)
+  set_target_properties(GLEW::GLEW PROPERTIES
+      IMPORTED_LOCATION "${GLEW_SHARED_LIBRARY_RELEASE}"
+      INTERFACE_INCLUDE_DIRECTORIES "${GLEW_INCLUDE_DIR}"
+  )
+else()
+  message(STATUS "Searching for GLEW via find_package...")
+  find_package(GLEW)
+  message(STATUS "GLEW_FOUND: ${GLEW_FOUND}")
+  if (NOT GLEW_FOUND)
+    message(STATUS "GLEW not found.")
+    message(STATUS "Do you add -DGLEW_INCLUDE_DIR=path-to-include -DGLEW_SHARED_LIBRARY_RELEASE=path-to-x64/glew32.lib to CMake?")
+  endif()
+endif()
+
 if(WIN32 AND NOT GLEW_FOUND)
   message(STATUS "GLEW required on Windows but not found, "
                  "GL interop tests not enabled.")

--- a/projects/hip-tests/catch/unit/gl_interop/hipGLImageDataVerification.cc
+++ b/projects/hip-tests/catch/unit/gl_interop/hipGLImageDataVerification.cc
@@ -1,0 +1,755 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*
+ * Image data verification tests for GL-HIP interop.
+ *
+ * These tests verify that pixel data written on one side of the interop
+ * boundary (GL or HIP) is faithfully readable on the other side.  The
+ * pattern for every test is:
+ *
+ *   1. Populate a GL texture on the CPU side via glTexImage2D.
+ *   2. Register + map the texture for HIP access.
+ *   3. Read or write the hipArray backing the texture (via surface object
+ *      or hipMemcpy2D*Array).
+ *   4. Unmap + unregister, then read back via glGetTexImage.
+ *   5. Compare host-side expected values against the readback.
+ *
+ * All pixel formats use GL_RGBA8UI (4 × uint8) to keep the arithmetic
+ * simple and to match the GLImageObject fixture defined in
+ * gl_interop_common.hh.
+ *
+ * Mipmap tests use a base level of 64×64 with two additional mip levels
+ * (32×32 and 16×16) so that mipLevel indices 0, 1, and 2 are all valid.
+ */
+
+#include <hip_test_common.hh>
+#include <hip/hip_runtime_api.h>
+#include <hip/hip_gl_interop.h>
+
+#include "gl_interop_common.hh"
+
+#include <cstdint>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Device kernels
+// ---------------------------------------------------------------------------
+
+/* Read every texel of a surface and copy it to a flat device buffer. */
+__global__ void kernel_read_surface(hipSurfaceObject_t surf, uint32_t* out,
+                                    unsigned int width, unsigned int height) {
+#if !__HIP_NO_IMAGE_SUPPORT
+  unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+  unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= width || y >= height) return;
+
+  uchar4 px;
+  surf2Dread(&px, surf, x * sizeof(uchar4), y);
+
+  out[y * width + x] = (static_cast<uint32_t>(px.w) << 24) |
+                       (static_cast<uint32_t>(px.z) << 16) |
+                       (static_cast<uint32_t>(px.y) << 8) |
+                        static_cast<uint32_t>(px.x);
+#endif
+}
+
+/* Write a solid color to every texel. */
+__global__ void kernel_fill_surface(hipSurfaceObject_t surf, uint8_t r,
+                                    uint8_t g, uint8_t b, uint8_t a,
+                                    unsigned int width, unsigned int height) {
+#if !__HIP_NO_IMAGE_SUPPORT
+  unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+  unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= width || y >= height) return;
+
+  surf2Dwrite(make_uchar4(r, g, b, a), surf, x * sizeof(uchar4), y);
+#endif
+}
+
+/* Invert all four channels (255 - value) of every texel. */
+__global__ void kernel_invert_surface(hipSurfaceObject_t surf,
+                                      unsigned int width, unsigned int height) {
+#if !__HIP_NO_IMAGE_SUPPORT
+  unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+  unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= width || y >= height) return;
+
+  uchar4 px;
+  surf2Dread(&px, surf, x * sizeof(uchar4), y);
+  px.x = 255u - px.x;
+  px.y = 255u - px.y;
+  px.z = 255u - px.z;
+  px.w = 255u - px.w;
+  surf2Dwrite(px, surf, x * sizeof(uchar4), y);
+#endif
+}
+
+/* Write R=x, G=y, B=x^y, A=0xFF unique-per-pixel to every texel. */
+__global__ void kernel_write_unique_surface(hipSurfaceObject_t surf,
+                                            unsigned int width,
+                                            unsigned int height) {
+#if !__HIP_NO_IMAGE_SUPPORT
+  unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+  unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= width || y >= height) return;
+  surf2Dwrite(make_uchar4(static_cast<uint8_t>(x & 0xFF),
+                          static_cast<uint8_t>(y & 0xFF),
+                          static_cast<uint8_t>((x ^ y) & 0xFF), 0xFF),
+              surf, x * sizeof(uchar4), y);
+#endif
+}
+
+/* Add (x+y) mod 256 to the R, G, B channels; leave alpha unchanged. */
+__global__ void kernel_transform_surface(hipSurfaceObject_t surf,
+                                         unsigned int width,
+                                         unsigned int height) {
+#if !__HIP_NO_IMAGE_SUPPORT
+  unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+  unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+  if (x >= width || y >= height) return;
+
+  uchar4 px;
+  surf2Dread(&px, surf, x * sizeof(uchar4), y);
+  uint8_t delta = static_cast<uint8_t>((x + y) & 0xFF);
+  px.x = static_cast<uint8_t>(px.x + delta);
+  px.y = static_cast<uint8_t>(px.y + delta);
+  px.z = static_cast<uint8_t>(px.z + delta);
+  surf2Dwrite(px, surf, x * sizeof(uchar4), y);
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static constexpr unsigned int kWidth    = 64;
+static constexpr unsigned int kHeight   = 64;
+static constexpr unsigned int kNumPixels = kWidth * kHeight;
+
+/* Number of mip levels used by the mipmap tests (base + 2 reduced levels). */
+static constexpr int kMipLevels = 3;
+
+/* Width/height of mip level i relative to the base (kWidth, kHeight). */
+static unsigned int mip_dim(unsigned int base, int level) {
+  unsigned int d = base >> level;
+  return d < 1u ? 1u : d;
+}
+
+/* Pack four uint8 RGBA channels into a uint32 (R in lowest byte). */
+static uint32_t pack_rgba(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
+  return (static_cast<uint32_t>(a) << 24) | (static_cast<uint32_t>(b) << 16) |
+         (static_cast<uint32_t>(g) << 8)  |  static_cast<uint32_t>(r);
+}
+
+/*
+ * Create a GL_RGBA8UI texture with the given base-level pixel data.
+ * min_filter is set to GL_NEAREST_MIPMAP_NEAREST when num_levels > 1 so
+ * that GL accepts multiple mip levels.  Caller owns the returned name.
+ */
+static GLuint make_gl_texture(unsigned int width, unsigned int height,
+                               const std::vector<uint32_t>& pixels,
+                               int num_levels = 1) {
+  GLuint tex = 0;
+  glGenTextures(1, &tex);
+  glBindTexture(GL_TEXTURE_2D, tex);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  GLint min_filter = (num_levels > 1) ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST;
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, min_filter);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, num_levels - 1);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8UI_EXT,
+               static_cast<GLsizei>(width), static_cast<GLsizei>(height),
+               0, GL_RGBA_INTEGER_EXT, GL_UNSIGNED_BYTE, pixels.data());
+  REQUIRE(glGetError() == GL_NO_ERROR);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  return tex;
+}
+
+/*
+ * Upload pixel data for one mip level of an existing GL texture.
+ * level 0 = base, level 1 = half size, etc.
+ */
+static void upload_mip_level(GLuint tex, int level,
+                              unsigned int width, unsigned int height,
+                              const std::vector<uint32_t>& pixels) {
+  glBindTexture(GL_TEXTURE_2D, tex);
+  glTexImage2D(GL_TEXTURE_2D, level, GL_RGBA8UI_EXT,
+               static_cast<GLsizei>(width), static_cast<GLsizei>(height),
+               0, GL_RGBA_INTEGER_EXT, GL_UNSIGNED_BYTE, pixels.data());
+  REQUIRE(glGetError() == GL_NO_ERROR);
+  glBindTexture(GL_TEXTURE_2D, 0);
+}
+
+/* Download one mip level of a GL texture into a flat packed-RGBA vector. */
+static std::vector<uint32_t> read_gl_mip_level(GLuint tex, int level,
+                                                unsigned int width,
+                                                unsigned int height) {
+  std::vector<uint32_t> result(width * height, 0);
+  glBindTexture(GL_TEXTURE_2D, tex);
+  glGetTexImage(GL_TEXTURE_2D, level, GL_RGBA_INTEGER_EXT,
+                GL_UNSIGNED_BYTE, result.data());
+  REQUIRE(glGetError() == GL_NO_ERROR);
+  glBindTexture(GL_TEXTURE_2D, 0);
+  return result;
+}
+
+/* Convenience wrapper for level 0. */
+static std::vector<uint32_t> read_gl_texture(GLuint tex,
+                                              unsigned int width,
+                                              unsigned int height) {
+  return read_gl_mip_level(tex, 0, width, height);
+}
+
+/* Build a hipSurfaceObject_t from a mapped hipArray_t.
+ * Requires hipGraphicsRegisterFlagsSurfaceLoadStore at registration time. */
+static hipSurfaceObject_t make_surface(hipArray_t array) {
+  hipResourceDesc res_desc{};
+  res_desc.resType = hipResourceTypeArray;
+  res_desc.res.array.array = array;
+  hipSurfaceObject_t surf = 0;
+  HIP_CHECK(hipCreateSurfaceObject(&surf, &res_desc));
+  return surf;
+}
+
+/* Compute a 2-D grid/block covering w × h threads with 16×16 blocks. */
+static void dispatch2d(dim3& grid, dim3& block,
+                        unsigned int w, unsigned int h) {
+  block = dim3(16, 16, 1);
+  grid  = dim3((w + 15u) / 16u, (h + 15u) / 16u, 1u);
+}
+
+// ---------------------------------------------------------------------------
+// Tests: GL → HIP (read texture written by GL, verify in HIP)
+// ---------------------------------------------------------------------------
+
+/*
+ * Upload a solid color to a GL texture from the CPU, map it for HIP, read
+ * every pixel via a surface kernel into a device buffer, copy to host,
+ * and verify all pixels match the expected color.
+ */
+HIP_TEST_CASE(Unit_GLHIPImageData_Positive_GLWrite_HIPRead_SolidColor) {
+  CHECK_IMAGE_SUPPORT;
+  GLContextScopeGuard gl_context;
+  hipGetLastError(); // reset previous err
+  const uint8_t R = 0xDE, G = 0xAD, B = 0xBE, A = 0xEF;
+  const uint32_t expected_pixel = pack_rgba(R, G, B, A);
+
+  std::vector<uint32_t> host_pixels(kNumPixels, expected_pixel);
+  GLuint tex = make_gl_texture(kWidth, kHeight, host_pixels);
+
+  hipGraphicsResource* resource = nullptr;
+  HIP_CHECK(hipGraphicsGLRegisterImage(&resource, tex, GL_TEXTURE_2D,
+                                       hipGraphicsRegisterFlagsSurfaceLoadStore));
+  HIP_CHECK(hipGraphicsMapResources(1, &resource, 0));
+
+  hipArray_t array = nullptr;
+  HIP_CHECK(hipGraphicsSubResourceGetMappedArray(&array, resource, 0, 0));
+
+  hipSurfaceObject_t surf = make_surface(array);
+
+  uint32_t* d_out = nullptr;
+  HIP_CHECK(hipMalloc(&d_out, kNumPixels * sizeof(uint32_t)));
+  HIP_CHECK(hipMemset(d_out, 0, kNumPixels * sizeof(uint32_t)));
+
+  dim3 grid, block;
+  dispatch2d(grid, block, kWidth, kHeight);
+  kernel_read_surface<<<grid, block>>>(surf, d_out, kWidth, kHeight);
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipDeviceSynchronize());
+
+  std::vector<uint32_t> hip_pixels(kNumPixels, 0);
+  HIP_CHECK(hipMemcpy(hip_pixels.data(), d_out,
+                      kNumPixels * sizeof(uint32_t),
+                      hipMemcpyDeviceToHost));
+
+  HIP_CHECK(hipDestroySurfaceObject(surf));
+  HIP_CHECK(hipFree(d_out));
+  HIP_CHECK(hipGraphicsUnmapResources(1, &resource, 0));
+  HIP_CHECK(hipGraphicsUnregisterResource(resource));
+  glDeleteTextures(1, &tex);
+
+  for (unsigned int i = 0; i < kNumPixels; ++i) {
+    REQUIRE(hip_pixels[i] == expected_pixel);
+  }
+}
+
+/*
+ * Upload an (x, y) coordinate-encoded pattern to a GL texture from the CPU
+ * (R=x, G=y, B=x^y, A=0xFF), map it for HIP, read every pixel via a surface
+ * kernel, and verify the values match the original encoding.
+ */
+HIP_TEST_CASE(Unit_GLHIPImageData_Positive_GLWrite_HIPRead_Gradient) {
+  CHECK_IMAGE_SUPPORT;
+  GLContextScopeGuard gl_context;
+
+  std::vector<uint32_t> host_pixels(kNumPixels);
+  for (unsigned int y = 0; y < kHeight; ++y) {
+    for (unsigned int x = 0; x < kWidth; ++x) {
+      host_pixels[y * kWidth + x] =
+          pack_rgba(static_cast<uint8_t>(x & 0xFF),
+                    static_cast<uint8_t>(y & 0xFF),
+                    static_cast<uint8_t>((x ^ y) & 0xFF), 0xFF);
+    }
+  }
+
+  GLuint tex = make_gl_texture(kWidth, kHeight, host_pixels);
+
+  hipGraphicsResource* resource = nullptr;
+  HIP_CHECK(hipGraphicsGLRegisterImage(&resource, tex, GL_TEXTURE_2D,
+                                       hipGraphicsRegisterFlagsSurfaceLoadStore));
+  HIP_CHECK(hipGraphicsMapResources(1, &resource, 0));
+
+  hipArray_t array = nullptr;
+  HIP_CHECK(hipGraphicsSubResourceGetMappedArray(&array, resource, 0, 0));
+
+  hipSurfaceObject_t surf = make_surface(array);
+
+  uint32_t* d_out = nullptr;
+  HIP_CHECK(hipMalloc(&d_out, kNumPixels * sizeof(uint32_t)));
+  HIP_CHECK(hipMemset(d_out, 0, kNumPixels * sizeof(uint32_t)));
+
+  dim3 grid, block;
+  dispatch2d(grid, block, kWidth, kHeight);
+  kernel_read_surface<<<grid, block>>>(surf, d_out, kWidth, kHeight);
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipDeviceSynchronize());
+
+  std::vector<uint32_t> hip_pixels(kNumPixels, 0);
+  HIP_CHECK(hipMemcpy(hip_pixels.data(), d_out,
+                      kNumPixels * sizeof(uint32_t),
+                      hipMemcpyDeviceToHost));
+
+  HIP_CHECK(hipDestroySurfaceObject(surf));
+  HIP_CHECK(hipFree(d_out));
+  HIP_CHECK(hipGraphicsUnmapResources(1, &resource, 0));
+  HIP_CHECK(hipGraphicsUnregisterResource(resource));
+  glDeleteTextures(1, &tex);
+
+  for (unsigned int i = 0; i < kNumPixels; ++i) {
+    REQUIRE(hip_pixels[i] == host_pixels[i]);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: HIP → GL (write from HIP, read back via GL)
+// ---------------------------------------------------------------------------
+
+/*
+ * Start with a zeroed GL texture, map it for HIP with SurfaceLoadStore,
+ * fill every pixel with a known solid color from a HIP kernel, unmap,
+ * read back via glGetTexImage, and verify every pixel matches.
+ */
+HIP_TEST_CASE(Unit_GLHIPImageData_Positive_HIPWrite_GLRead_SolidColor) {
+  CHECK_IMAGE_SUPPORT;
+  GLContextScopeGuard gl_context;
+
+  const uint8_t R = 0x42, G = 0x13, B = 0x57, A = 0xFF;
+  const uint32_t expected_pixel = pack_rgba(R, G, B, A);
+
+  std::vector<uint32_t> zeroes(kNumPixels, 0);
+  GLuint tex = make_gl_texture(kWidth, kHeight, zeroes);
+
+  hipGraphicsResource* resource = nullptr;
+  HIP_CHECK(hipGraphicsGLRegisterImage(&resource, tex, GL_TEXTURE_2D,
+                                       hipGraphicsRegisterFlagsSurfaceLoadStore));
+  HIP_CHECK(hipGraphicsMapResources(1, &resource, 0));
+
+  hipArray_t array = nullptr;
+  HIP_CHECK(hipGraphicsSubResourceGetMappedArray(&array, resource, 0, 0));
+
+  hipSurfaceObject_t surf = make_surface(array);
+
+  dim3 grid, block;
+  dispatch2d(grid, block, kWidth, kHeight);
+  kernel_fill_surface<<<grid, block>>>(surf, R, G, B, A, kWidth, kHeight);
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipDeviceSynchronize());
+
+  HIP_CHECK(hipDestroySurfaceObject(surf));
+  HIP_CHECK(hipGraphicsUnmapResources(1, &resource, 0));
+  HIP_CHECK(hipGraphicsUnregisterResource(resource));
+
+  std::vector<uint32_t> gl_pixels = read_gl_texture(tex, kWidth, kHeight);
+  glDeleteTextures(1, &tex);
+
+  for (unsigned int i = 0; i < kNumPixels; ++i) {
+    REQUIRE(gl_pixels[i] == expected_pixel);
+  }
+}
+
+/*
+ * Build a per-pixel unique image on the host (R=x, G=y, B=x^y, A=0xFF),
+ * upload it to the hipArray backing a GL texture via a surface write kernel,
+ * unmap, read back from GL via glGetTexImage, and verify every pixel.
+ */
+HIP_TEST_CASE(Unit_GLHIPImageData_Positive_HIPWrite_GLRead_UniquePerPixel) {
+  CHECK_IMAGE_SUPPORT;
+  GLContextScopeGuard gl_context;
+
+  std::vector<uint32_t> zeroes(kNumPixels, 0);
+  GLuint tex = make_gl_texture(kWidth, kHeight, zeroes);
+
+  hipGraphicsResource* resource = nullptr;
+  HIP_CHECK(hipGraphicsGLRegisterImage(&resource, tex, GL_TEXTURE_2D,
+                                       hipGraphicsRegisterFlagsSurfaceLoadStore));
+  HIP_CHECK(hipGraphicsMapResources(1, &resource, 0));
+
+  hipArray_t array = nullptr;
+  HIP_CHECK(hipGraphicsSubResourceGetMappedArray(&array, resource, 0, 0));
+
+  std::vector<uint32_t> expected(kNumPixels);
+  for (unsigned int y = 0; y < kHeight; ++y) {
+    for (unsigned int x = 0; x < kWidth; ++x) {
+      expected[y * kWidth + x] =
+          pack_rgba(static_cast<uint8_t>(x & 0xFF),
+                    static_cast<uint8_t>(y & 0xFF),
+                    static_cast<uint8_t>((x ^ y) & 0xFF), 0xFF);
+    }
+  }
+
+  hipSurfaceObject_t surf = make_surface(array);
+
+  dim3 grid, block;
+  dispatch2d(grid, block, kWidth, kHeight);
+  kernel_write_unique_surface<<<grid, block>>>(surf, kWidth, kHeight);
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipDeviceSynchronize());
+
+  HIP_CHECK(hipDestroySurfaceObject(surf));
+  HIP_CHECK(hipGraphicsUnmapResources(1, &resource, 0));
+  HIP_CHECK(hipGraphicsUnregisterResource(resource));
+
+  std::vector<uint32_t> gl_pixels = read_gl_texture(tex, kWidth, kHeight);
+  glDeleteTextures(1, &tex);
+
+  for (unsigned int i = 0; i < kNumPixels; ++i) {
+    REQUIRE(gl_pixels[i] == expected[i]);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: round-trip (GL write → HIP modify → GL read)
+// ---------------------------------------------------------------------------
+
+/*
+ * Upload a known image from the CPU to GL, map it in HIP with
+ * SurfaceLoadStore, run the invert kernel (all four channels: 255 - value),
+ * unmap, read back from GL, and verify every pixel equals the per-channel
+ * bitwise complement of the original.
+ */
+HIP_TEST_CASE(Unit_GLHIPImageData_Positive_RoundTrip_InvertChannels) {
+  CHECK_IMAGE_SUPPORT;
+  GLContextScopeGuard gl_context;
+
+  std::vector<uint32_t> original(kNumPixels);
+  for (unsigned int i = 0; i < kNumPixels; ++i) {
+    uint8_t v = static_cast<uint8_t>(i & 0xFF);
+    original[i] = pack_rgba(v,
+                             static_cast<uint8_t>(v + 32),
+                             static_cast<uint8_t>(v + 64),
+                             static_cast<uint8_t>(v + 96));
+  }
+
+  GLuint tex = make_gl_texture(kWidth, kHeight, original);
+
+  hipGraphicsResource* resource = nullptr;
+  HIP_CHECK(hipGraphicsGLRegisterImage(&resource, tex, GL_TEXTURE_2D,
+                                       hipGraphicsRegisterFlagsSurfaceLoadStore));
+  HIP_CHECK(hipGraphicsMapResources(1, &resource, 0));
+
+  hipArray_t array = nullptr;
+  HIP_CHECK(hipGraphicsSubResourceGetMappedArray(&array, resource, 0, 0));
+
+  hipSurfaceObject_t surf = make_surface(array);
+
+  dim3 grid, block;
+  dispatch2d(grid, block, kWidth, kHeight);
+  kernel_invert_surface<<<grid, block>>>(surf, kWidth, kHeight);
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipDeviceSynchronize());
+
+  HIP_CHECK(hipDestroySurfaceObject(surf));
+  HIP_CHECK(hipGraphicsUnmapResources(1, &resource, 0));
+  HIP_CHECK(hipGraphicsUnregisterResource(resource));
+
+  std::vector<uint32_t> gl_pixels = read_gl_texture(tex, kWidth, kHeight);
+  glDeleteTextures(1, &tex);
+
+  for (unsigned int i = 0; i < kNumPixels; ++i) {
+    REQUIRE(gl_pixels[i] == (original[i] ^ 0xFFFFFFFFu));
+  }
+}
+
+/*
+ * Upload a uniform base color (all RGB channels = 10, A = 0xAA) from the
+ * CPU to GL, map it in HIP, apply the coordinate transform kernel
+ * (RGB += (x+y) mod 256, alpha unchanged), unmap, read back from GL,
+ * and verify each pixel.
+ */
+HIP_TEST_CASE(Unit_GLHIPImageData_Positive_RoundTrip_CoordTransform) {
+  CHECK_IMAGE_SUPPORT;
+  GLContextScopeGuard gl_context;
+
+  const uint8_t base = 10;
+  std::vector<uint32_t> original(kNumPixels,
+                                  pack_rgba(base, base, base, 0xAA));
+
+  GLuint tex = make_gl_texture(kWidth, kHeight, original);
+
+  hipGraphicsResource* resource = nullptr;
+  HIP_CHECK(hipGraphicsGLRegisterImage(&resource, tex, GL_TEXTURE_2D,
+                                       hipGraphicsRegisterFlagsSurfaceLoadStore));
+  HIP_CHECK(hipGraphicsMapResources(1, &resource, 0));
+
+  hipArray_t array = nullptr;
+  HIP_CHECK(hipGraphicsSubResourceGetMappedArray(&array, resource, 0, 0));
+
+  hipSurfaceObject_t surf = make_surface(array);
+
+  dim3 grid, block;
+  dispatch2d(grid, block, kWidth, kHeight);
+  kernel_transform_surface<<<grid, block>>>(surf, kWidth, kHeight);
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipDeviceSynchronize());
+
+  HIP_CHECK(hipDestroySurfaceObject(surf));
+  HIP_CHECK(hipGraphicsUnmapResources(1, &resource, 0));
+  HIP_CHECK(hipGraphicsUnregisterResource(resource));
+
+  std::vector<uint32_t> gl_pixels = read_gl_texture(tex, kWidth, kHeight);
+  glDeleteTextures(1, &tex);
+
+  for (unsigned int y = 0; y < kHeight; ++y) {
+    for (unsigned int x = 0; x < kWidth; ++x) {
+      uint8_t delta        = static_cast<uint8_t>((x + y) & 0xFF);
+      uint8_t expected_rgb = static_cast<uint8_t>(base + delta);
+      REQUIRE(gl_pixels[y * kWidth + x] ==
+              pack_rgba(expected_rgb, expected_rgb, expected_rgb, 0xAA));
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests: mipmap levels > 0
+//
+// The texture is created with kMipLevels levels (base 64×64, mip1 32×32,
+// mip2 16×16).  Each mip level is uploaded separately so that
+// hipGraphicsSubResourceGetMappedArray can be called with mipLevel > 0.
+// ---------------------------------------------------------------------------
+
+/*
+ * Upload distinct solid colors to each mip level from the CPU, register the
+ * texture, and for each mip level: map → GetMappedArray(mipLevel) → read via
+ * surface kernel → unmap → verify the color matches the level-specific value.
+ *
+ * This confirms that mipLevel indexing selects the correct sub-resource.
+ */
+HIP_TEST_CASE(Unit_GLHIPImageData_Positive_Mipmap_GLWrite_HIPRead_PerLevel) {
+  CHECK_IMAGE_SUPPORT;
+  GLContextScopeGuard gl_context;
+
+  /* One distinct color per mip level so cross-level aliasing is detectable. */
+  const uint32_t level_color[kMipLevels] = {
+    pack_rgba(0xFF, 0x00, 0x00, 0xFF),  /* level 0 — red   */
+    pack_rgba(0x00, 0xFF, 0x00, 0xFF),  /* level 1 — green */
+    pack_rgba(0x00, 0x00, 0xFF, 0xFF),  /* level 2 — blue  */
+  };
+
+  /* Create the base level and set the mip count. */
+  std::vector<uint32_t> base_pixels(kNumPixels, level_color[0]);
+  GLuint tex = make_gl_texture(kWidth, kHeight, base_pixels, kMipLevels);
+
+  /* Upload levels 1 and 2. */
+  for (int lvl = 1; lvl < kMipLevels; ++lvl) {
+    unsigned int w = mip_dim(kWidth, lvl);
+    unsigned int h = mip_dim(kHeight, lvl);
+    std::vector<uint32_t> pixels(w * h, level_color[lvl]);
+    upload_mip_level(tex, lvl, w, h, pixels);
+  }
+
+  hipGraphicsResource* resource = nullptr;
+  HIP_CHECK(hipGraphicsGLRegisterImage(&resource, tex, GL_TEXTURE_2D,
+                                       hipGraphicsRegisterFlagsSurfaceLoadStore));
+
+  for (int lvl = 0; lvl < kMipLevels; ++lvl) {
+    unsigned int w = mip_dim(kWidth, lvl);
+    unsigned int h = mip_dim(kHeight, lvl);
+
+    HIP_CHECK(hipGraphicsMapResources(1, &resource, 0));
+
+    hipArray_t array = nullptr;
+    HIP_CHECK(hipGraphicsSubResourceGetMappedArray(&array, resource, 0, lvl));
+
+    hipSurfaceObject_t surf = make_surface(array);
+
+    uint32_t* d_out = nullptr;
+    HIP_CHECK(hipMalloc(&d_out, w * h * sizeof(uint32_t)));
+    HIP_CHECK(hipMemset(d_out, 0, w * h * sizeof(uint32_t)));
+
+    dim3 grid, block;
+    dispatch2d(grid, block, w, h);
+    kernel_read_surface<<<grid, block>>>(surf, d_out, w, h);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+
+    std::vector<uint32_t> hip_pixels(w * h, 0);
+    HIP_CHECK(hipMemcpy(hip_pixels.data(), d_out,
+                        w * h * sizeof(uint32_t), hipMemcpyDeviceToHost));
+
+    HIP_CHECK(hipDestroySurfaceObject(surf));
+    HIP_CHECK(hipFree(d_out));
+    HIP_CHECK(hipGraphicsUnmapResources(1, &resource, 0));
+
+    for (unsigned int i = 0; i < w * h; ++i) {
+      REQUIRE(hip_pixels[i] == level_color[lvl]);
+    }
+  }
+
+  HIP_CHECK(hipGraphicsUnregisterResource(resource));
+  glDeleteTextures(1, &tex);
+}
+
+/*
+ * For each mip level > 0 (32×32 and 16×16): start with a zeroed GL texture,
+ * map the specific mip level in HIP, fill it with a level-specific color via
+ * a surface kernel, unmap, read back via glGetTexImage at that mip level,
+ * and verify the written color.  The base level (0) is left zeroed to confirm
+ * the kernel only touches the targeted level.
+ */
+HIP_TEST_CASE(Unit_GLHIPImageData_Positive_Mipmap_HIPWrite_GLRead_HigherLevels) {
+  CHECK_IMAGE_SUPPORT;
+  GLContextScopeGuard gl_context;
+  unsigned int w = 0;
+  unsigned int h = 0;
+
+  const uint32_t fill_color[kMipLevels] = {
+    pack_rgba(0x11, 0x22, 0x33, 0xFF),  /* level 0 (base, left as-is) */
+    pack_rgba(0xAA, 0xBB, 0xCC, 0xFF),  /* level 1 — written by HIP   */
+    pack_rgba(0xDD, 0xEE, 0xFF, 0xFF),  /* level 2 — written by HIP   */
+  };
+
+  /* Create the texture with all levels zeroed initially. */
+  std::vector<uint32_t> base_pixels(kNumPixels, fill_color[0]);
+  GLuint tex = make_gl_texture(kWidth, kHeight, base_pixels, kMipLevels);
+
+  for (int lvl = 1; lvl < kMipLevels; ++lvl) {
+    w = mip_dim(kWidth, lvl);
+    h = mip_dim(kHeight, lvl);
+    std::vector<uint32_t> zeroes(w * h, 0);
+    upload_mip_level(tex, lvl, w, h, zeroes);
+  }
+
+  hipGraphicsResource* resource = nullptr;
+  HIP_CHECK(hipGraphicsGLRegisterImage(&resource, tex, GL_TEXTURE_2D,
+                                       hipGraphicsRegisterFlagsSurfaceLoadStore));
+  HIP_CHECK(hipGraphicsMapResources(1, &resource, 0));
+
+  /* Write each non-base mip level from HIP and verify via GL. */
+  for (int lvl = 1; lvl < kMipLevels; ++lvl) {
+    w = mip_dim(kWidth, lvl);
+    h = mip_dim(kHeight, lvl);
+
+    hipArray_t array = nullptr;
+    HIP_CHECK(hipGraphicsSubResourceGetMappedArray(&array, resource, 0, lvl));
+
+    hipSurfaceObject_t surf = make_surface(array);
+
+    uint8_t r = static_cast<uint8_t>(fill_color[lvl] & 0xFF);
+    uint8_t g = static_cast<uint8_t>((fill_color[lvl] >>  8) & 0xFF);
+    uint8_t b = static_cast<uint8_t>((fill_color[lvl] >> 16) & 0xFF);
+    uint8_t a = static_cast<uint8_t>((fill_color[lvl] >> 24) & 0xFF);
+
+    dim3 grid, block;
+    dispatch2d(grid, block, w, h);
+    kernel_fill_surface<<<grid, block>>>(surf, r, g, b, a, w, h);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+    HIP_CHECK(hipDestroySurfaceObject(surf));
+  }
+
+  HIP_CHECK(hipGraphicsUnmapResources(1, &resource, 0));
+
+  /* Verify */
+  for (int lvl = 0; lvl < kMipLevels; ++lvl) {
+    w = mip_dim(kWidth, lvl);
+    h = mip_dim(kHeight, lvl);
+    /* Read back this mip level from GL and verify. */
+    std::vector<uint32_t> gl_pixels = read_gl_mip_level(tex, lvl, w, h);
+    for (unsigned int i = 0, size = w * h; i < size; ++i) {
+      REQUIRE(gl_pixels[i] == fill_color[lvl]);
+    }
+  }
+
+  HIP_CHECK(hipGraphicsUnregisterResource(resource));
+  glDeleteTextures(1, &tex);
+}
+
+/*
+ * Round-trip for mip level 2 (16×16): upload a gradient to GL at level 2,
+ * map it in HIP, run the invert kernel (all four channels: 255 - value),
+ * unmap, read back from GL at level 2, and verify the per-channel complement.
+ */
+HIP_TEST_CASE(Unit_GLHIPImageData_Positive_Mipmap_RoundTrip_InvertLevel2) {
+  CHECK_IMAGE_SUPPORT;
+  GLContextScopeGuard gl_context;
+
+  const int kTargetLevel = 2;
+  const unsigned int w = mip_dim(kWidth, kTargetLevel);
+  const unsigned int h = mip_dim(kHeight, kTargetLevel);
+
+  /* Base level: arbitrary solid color (not touched by the test). */
+  std::vector<uint32_t> base_pixels(kNumPixels,
+                                     pack_rgba(0x10, 0x20, 0x30, 0xFF));
+  GLuint tex = make_gl_texture(kWidth, kHeight, base_pixels, kMipLevels);
+
+  /* Level 2: per-pixel gradient. */
+  std::vector<uint32_t> mip1_original(w * h);
+  for (unsigned int y = 0; y < h; ++y) {
+    for (unsigned int x = 0; x < w; ++x) {
+      mip1_original[y * w + x] =
+          pack_rgba(static_cast<uint8_t>(x * 255u / (w - 1)),
+                    static_cast<uint8_t>(y * 255u / (h - 1)),
+                    static_cast<uint8_t>((x + y) & 0xFF), 0x80);
+    }
+  }
+  upload_mip_level(tex, kTargetLevel, w, h, mip1_original);
+
+  /* Level 1: arbitrary filler so the texture is complete. */
+  unsigned int w2 = mip_dim(kWidth, 1), h2 = mip_dim(kHeight, 1);
+  std::vector<uint32_t> mip2(w2 * h2, pack_rgba(0xAA, 0xBB, 0xCC, 0xFF));
+  upload_mip_level(tex, 1, w2, h2, mip2);
+
+  hipGraphicsResource* resource = nullptr;
+  HIP_CHECK(hipGraphicsGLRegisterImage(&resource, tex, GL_TEXTURE_2D,
+                                       hipGraphicsRegisterFlagsSurfaceLoadStore));
+  HIP_CHECK(hipGraphicsMapResources(1, &resource, 0));
+
+  hipArray_t array = nullptr;
+  HIP_CHECK(hipGraphicsSubResourceGetMappedArray(&array, resource, 0,
+                                                 kTargetLevel));
+
+  hipSurfaceObject_t surf = make_surface(array);
+
+  dim3 grid, block;
+  dispatch2d(grid, block, w, h);
+  kernel_invert_surface<<<grid, block>>>(surf, w, h);
+  HIP_CHECK(hipGetLastError());
+  HIP_CHECK(hipDeviceSynchronize());
+
+  HIP_CHECK(hipDestroySurfaceObject(surf));
+  HIP_CHECK(hipGraphicsUnmapResources(1, &resource, 0));
+  HIP_CHECK(hipGraphicsUnregisterResource(resource));
+
+  std::vector<uint32_t> gl_mip1 = read_gl_mip_level(tex, kTargetLevel, w, h);
+  glDeleteTextures(1, &tex);
+
+  for (unsigned int i = 0; i < w * h; ++i) {
+    REQUIRE(gl_mip1[i] == (mip1_original[i] ^ 0xFFFFFFFFu));
+  }
+}

--- a/projects/rocdbgapi/src/hsa/hsa_ext_amd.h
+++ b/projects/rocdbgapi/src/hsa/hsa_ext_amd.h
@@ -72,14 +72,9 @@
  * - 1.19 - hsa_amd_agent_preload
  * - 1.20 - Memory batch discard API: hsa_amd_svm_discard_batch_async
  * - 1.21 - hsa_amd_signal_get_event_id
- * - 1.22 - hsa_amd_queue_get_info: per-queue VM fault state queries
- * - 1.23 - hsa_amd_agent_info_t: HSA_AMD_AGENT_INFO_MAX_DATA_PREFETCH_REGIONS
- * - 1.24 - hsa_amd_external_semaphore_handle_open/hsa_amd_external_semaphore_handle_close
- * - 1.25 - hsa_amd_vmem_export_fabric_handle, hsa_amd_vmem_import_fabric_handle
- * - 1.26 - hsa_amd_image_create_v2, hsa_amd_interop_map_buffer_with_size
  */
 #define HSA_AMD_INTERFACE_VERSION_MAJOR 1
-#define HSA_AMD_INTERFACE_VERSION_MINOR 26
+#define HSA_AMD_INTERFACE_VERSION_MINOR 21
 
 #ifdef __cplusplus
 extern "C" {

--- a/projects/rocdbgapi/src/hsa/hsa_ext_amd.h
+++ b/projects/rocdbgapi/src/hsa/hsa_ext_amd.h
@@ -72,9 +72,14 @@
  * - 1.19 - hsa_amd_agent_preload
  * - 1.20 - Memory batch discard API: hsa_amd_svm_discard_batch_async
  * - 1.21 - hsa_amd_signal_get_event_id
+ * - 1.22 - hsa_amd_queue_get_info: per-queue VM fault state queries
+ * - 1.23 - hsa_amd_agent_info_t: HSA_AMD_AGENT_INFO_MAX_DATA_PREFETCH_REGIONS
+ * - 1.24 - hsa_amd_external_semaphore_handle_open/hsa_amd_external_semaphore_handle_close
+ * - 1.25 - hsa_amd_vmem_export_fabric_handle, hsa_amd_vmem_import_fabric_handle
+ * - 1.26 - hsa_amd_image_create_v2, hsa_amd_interop_map_buffer_with_size
  */
 #define HSA_AMD_INTERFACE_VERSION_MAJOR 1
-#define HSA_AMD_INTERFACE_VERSION_MINOR 21
+#define HSA_AMD_INTERFACE_VERSION_MINOR 26
 
 #ifdef __cplusplus
 extern "C" {

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/enum_string.hpp
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/cxx/enum_string.hpp
@@ -428,6 +428,10 @@ ROCPROFILER_ENUM_LABEL(ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_queue_create);
 ROCPROFILER_ENUM_LABEL(ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_queue_signal_external_semaphore);
 ROCPROFILER_ENUM_LABEL(ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_queue_wait_external_semaphore);
 #    endif
+#    if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x12
+ROCPROFILER_ENUM_LABEL(ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_image_create_v2);
+ROCPROFILER_ENUM_LABEL(ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_interop_map_buffer_with_size);
+#    endif
 #endif
 
 #if HSA_AMD_EXT_API_TABLE_MAJOR_VERSION == 0x01
@@ -469,6 +473,8 @@ static_assert(ROCPROFILER_HSA_AMD_EXT_API_ID_LAST == 86);
 static_assert(ROCPROFILER_HSA_AMD_EXT_API_ID_LAST == 87);
 #    elif HSA_AMD_EXT_API_TABLE_STEP_VERSION == 0x11
 static_assert(ROCPROFILER_HSA_AMD_EXT_API_ID_LAST == 89);
+#    elif HSA_AMD_EXT_API_TABLE_STEP_VERSION == 0x12
+static_assert(ROCPROFILER_HSA_AMD_EXT_API_ID_LAST == 91);
 #    else
 #        if !defined(ROCPROFILER_UNSAFE_NO_VERSION_CHECK) &&                                       \
             (defined(ROCPROFILER_CI) && ROCPROFILER_CI > 0)

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hsa/amd_ext_api_id.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hsa/amd_ext_api_id.h
@@ -156,6 +156,10 @@ typedef enum rocprofiler_hsa_amd_ext_api_id_t  // NOLINT(performance-enum-size)
     ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_queue_signal_external_semaphore,
     ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_queue_wait_external_semaphore,
 #    endif
+#    if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x12
+    ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_image_create_v2,
+    ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_interop_map_buffer_with_size,
+#    endif
 #endif
 
     ROCPROFILER_HSA_AMD_EXT_API_ID_LAST,

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hsa/api_args.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hsa/api_args.h
@@ -1573,15 +1573,15 @@ typedef union rocprofiler_hsa_api_args_t
     } hsa_amd_image_create_v2;
     struct
     {
-        uint32_t         num_agents;
-        hsa_agent_t*     agents;
-        hsa_handle_t     interop_handle;
-        uint32_t         flags;
-        size_t           size_hint;
-        size_t*          size;
-        void**           ptr;
-        size_t*          metadata_size;
-        const void**     metadata;
+        uint32_t     num_agents;
+        hsa_agent_t* agents;
+        hsa_handle_t interop_handle;
+        uint32_t     flags;
+        size_t       size_hint;
+        size_t*      size;
+        void**       ptr;
+        size_t*      metadata_size;
+        const void** metadata;
     } hsa_amd_interop_map_buffer_with_size;
 #    endif
 #endif

--- a/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hsa/api_args.h
+++ b/projects/rocprofiler-sdk/source/include/rocprofiler-sdk/hsa/api_args.h
@@ -1533,7 +1533,6 @@ typedef union rocprofiler_hsa_api_args_t
         hsa_amd_vmem_alloc_handle_t handle;
         uint64_t                    flags;
     } hsa_amd_vmem_export_fabric_handle;
-
     struct
     {
         hsa_fabric_handle_t          fabric_handle;
@@ -1555,13 +1554,35 @@ typedef union rocprofiler_hsa_api_args_t
         hsa_amd_external_semaphore_t sem;
         uint64_t                     value;
     } hsa_amd_queue_signal_external_semaphore;
-
     struct
     {
         hsa_queue_t*                 queue;
         hsa_amd_external_semaphore_t sem;
         uint64_t                     value;
     } hsa_amd_queue_wait_external_semaphore;
+#    endif
+#    if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x12
+    struct
+    {
+        hsa_agent_t                          agent;
+        const hsa_ext_image_descriptor_v2_t* image_descriptor;
+        const hsa_amd_image_descriptor_t*    image_layout;
+        const void*                          image_data;
+        hsa_access_permission_t              access_permission;
+        hsa_ext_image_t*                     image;
+    } hsa_amd_image_create_v2;
+    struct
+    {
+        uint32_t         num_agents;
+        hsa_agent_t*     agents;
+        hsa_handle_t     interop_handle;
+        uint32_t         flags;
+        size_t           size_hint;
+        size_t*          size;
+        void**           ptr;
+        size_t*          metadata_size;
+        const void**     metadata;
+    } hsa_amd_interop_map_buffer_with_size;
 #    endif
 #endif
 } rocprofiler_hsa_api_args_t;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/abi.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/abi.cpp
@@ -77,6 +77,8 @@ ROCP_SDK_ENFORCE_ABI_VERSIONING(::AmdExtTable, 87);
 ROCP_SDK_ENFORCE_ABI_VERSIONING(::AmdExtTable, 88);
 #elif HSA_AMD_EXT_API_TABLE_STEP_VERSION == 0x11
 ROCP_SDK_ENFORCE_ABI_VERSIONING(::AmdExtTable, 90);
+#elif HSA_AMD_EXT_API_TABLE_STEP_VERSION == 0x12
+ROCP_SDK_ENFORCE_ABI_VERSIONING(::AmdExtTable, 92);
 #else
 INTERNAL_CI_ROCP_SDK_ENFORCE_ABI_VERSIONING(::AmdExtTable, 0);
 #endif
@@ -347,6 +349,10 @@ ROCP_SDK_ENFORCE_ABI(::AmdExtTable, hsa_amd_queue_create_fn, 87);
 #if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x11
 ROCP_SDK_ENFORCE_ABI(::AmdExtTable, hsa_amd_queue_signal_external_semaphore_fn, 88);
 ROCP_SDK_ENFORCE_ABI(::AmdExtTable, hsa_amd_queue_wait_external_semaphore_fn, 89);
+#endif
+#if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x12
+ROCP_SDK_ENFORCE_ABI(::AmdExtTable, hsa_amd_image_create_v2_fn, 90);
+ROCP_SDK_ENFORCE_ABI(::AmdExtTable, hsa_amd_interop_map_buffer_with_size_fn, 91);
 #endif
 
 ROCP_SDK_ENFORCE_ABI(::ImageExtTable, hsa_ext_image_get_capability_fn, 1);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/details/fmt.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/details/fmt.hpp
@@ -459,4 +459,39 @@ struct formatter<hsa_amd_memory_copy_op_t>
     }
 };
 #endif
+#if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x12
+template <>
+struct formatter<hsa_ext_image_descriptor_v2_t>
+{
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx)
+    {
+        return ctx.begin();
+    }
+
+    template <typename FormatContext>
+    auto format(hsa_ext_image_descriptor_v2_t const& h, FormatContext& ctx) const
+    {
+        static const char* geometry[] = {"HSA_EXT_IMAGE_GEOMETRY_1D",
+                                         "HSA_EXT_IMAGE_GEOMETRY_2D",
+                                         "HSA_EXT_IMAGE_GEOMETRY_3D",
+                                         "HSA_EXT_IMAGE_GEOMETRY_1DA",
+                                         "HSA_EXT_IMAGE_GEOMETRY_2DA",
+                                         "HSA_EXT_IMAGE_GEOMETRY_1DB",
+                                         "HSA_EXT_IMAGE_GEOMETRY_2DDEPTH",
+                                         "HSA_EXT_IMAGE_GEOMETRY_2DADEPTH"};
+        return fmt::format_to(ctx.out(),
+                              "{{format=[channel_order={}, channel_type={}], array_size={}, "
+                              "depth={}, height={}, width={}, mipmap_levels={}, geometry={}}}",
+                              h.format.channel_order,
+                              h.format.channel_type,
+                              h.array_size,
+                              h.depth,
+                              h.height,
+                              h.width,
+                              h.mipmap_levels,
+                              geometry[h.geometry]);
+    }
+};
+#endif
 }  // namespace fmt

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/details/ostream.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/details/ostream.hpp
@@ -786,67 +786,6 @@ operator<<(std::ostream& out, const hsa_ext_image_descriptor_t& v)
 }
 
 inline static std::ostream&
-operator<<(std::ostream& out, const hsa_ext_image_descriptor_v2_t& v)
-{
-    std::operator<<(out, '{');
-    HSA_depth_max_cnt++;
-    if(HSA_depth_max == -1 || HSA_depth_max_cnt <= HSA_depth_max)
-    {
-        if(std::string_view{"hsa_ext_image_descriptor_v2_t::format"}.find(HSA_structs_regex) !=
-           std::string_view::npos)
-        {
-            rocprofiler::hsa::detail::operator<<(out, "format=");
-            rocprofiler::hsa::detail::operator<<(out, v.format);
-            rocprofiler::hsa::detail::operator<<(out, ", ");
-        }
-        if(std::string_view{"hsa_ext_image_descriptor_v2_t::array_size"}.find(HSA_structs_regex) !=
-           std::string_view::npos)
-        {
-            rocprofiler::hsa::detail::operator<<(out, "array_size=");
-            rocprofiler::hsa::detail::operator<<(out, v.array_size);
-            rocprofiler::hsa::detail::operator<<(out, ", ");
-        }
-        if(std::string_view{"hsa_ext_image_descriptor_v2_t::depth"}.find(HSA_structs_regex) !=
-           std::string_view::npos)
-        {
-            rocprofiler::hsa::detail::operator<<(out, "depth=");
-            rocprofiler::hsa::detail::operator<<(out, v.depth);
-            rocprofiler::hsa::detail::operator<<(out, ", ");
-        }
-        if(std::string_view{"hsa_ext_image_descriptor_v2_t::height"}.find(HSA_structs_regex) !=
-           std::string_view::npos)
-        {
-            rocprofiler::hsa::detail::operator<<(out, "height=");
-            rocprofiler::hsa::detail::operator<<(out, v.height);
-            rocprofiler::hsa::detail::operator<<(out, ", ");
-        }
-        if(std::string_view{"hsa_ext_image_descriptor_v2_t::width"}.find(HSA_structs_regex) !=
-           std::string_view::npos)
-        {
-            rocprofiler::hsa::detail::operator<<(out, "width=");
-            rocprofiler::hsa::detail::operator<<(out, v.width);
-            rocprofiler::hsa::detail::operator<<(out, ", ");
-        }
-        if(std::string_view{"hsa_ext_image_descriptor_v2_t::mipmap_levels"}.find(HSA_structs_regex) !=
-           std::string_view::npos)
-        {
-            rocprofiler::hsa::detail::operator<<(out, "mipmap_levels=");
-            rocprofiler::hsa::detail::operator<<(out, v.mipmap_levels);
-            rocprofiler::hsa::detail::operator<<(out, ", ");
-        }
-        if(std::string_view{"hsa_ext_image_descriptor_v2_t::geometry"}.find(HSA_structs_regex) !=
-           std::string_view::npos)
-        {
-            rocprofiler::hsa::detail::operator<<(out, "geometry=");
-            rocprofiler::hsa::detail::operator<<(out, v.geometry);
-        }
-    };
-    HSA_depth_max_cnt--;
-    std::operator<<(out, '}');
-    return out;
-}
-
-inline static std::ostream&
 operator<<(std::ostream& out, const hsa_ext_image_data_info_t& v)
 {
     std::operator<<(out, '{');
@@ -1800,13 +1739,6 @@ operator<<(std::ostream& out, const hsa_ext_image_format_t& v)
 
 inline static std::ostream&
 operator<<(std::ostream& out, const hsa_ext_image_descriptor_t& v)
-{
-    rocprofiler::hsa::detail::operator<<(out, v);
-    return out;
-}
-
-inline static std::ostream&
-operator<<(std::ostream& out, const hsa_ext_image_descriptor_v2_t& v)
 {
     rocprofiler::hsa::detail::operator<<(out, v);
     return out;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/details/ostream.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/details/ostream.hpp
@@ -786,6 +786,67 @@ operator<<(std::ostream& out, const hsa_ext_image_descriptor_t& v)
 }
 
 inline static std::ostream&
+operator<<(std::ostream& out, const hsa_ext_image_descriptor_v2_t& v)
+{
+    std::operator<<(out, '{');
+    HSA_depth_max_cnt++;
+    if(HSA_depth_max == -1 || HSA_depth_max_cnt <= HSA_depth_max)
+    {
+        if(std::string_view{"hsa_ext_image_descriptor_v2_t::format"}.find(HSA_structs_regex) !=
+           std::string_view::npos)
+        {
+            rocprofiler::hsa::detail::operator<<(out, "format=");
+            rocprofiler::hsa::detail::operator<<(out, v.format);
+            rocprofiler::hsa::detail::operator<<(out, ", ");
+        }
+        if(std::string_view{"hsa_ext_image_descriptor_v2_t::array_size"}.find(HSA_structs_regex) !=
+           std::string_view::npos)
+        {
+            rocprofiler::hsa::detail::operator<<(out, "array_size=");
+            rocprofiler::hsa::detail::operator<<(out, v.array_size);
+            rocprofiler::hsa::detail::operator<<(out, ", ");
+        }
+        if(std::string_view{"hsa_ext_image_descriptor_v2_t::depth"}.find(HSA_structs_regex) !=
+           std::string_view::npos)
+        {
+            rocprofiler::hsa::detail::operator<<(out, "depth=");
+            rocprofiler::hsa::detail::operator<<(out, v.depth);
+            rocprofiler::hsa::detail::operator<<(out, ", ");
+        }
+        if(std::string_view{"hsa_ext_image_descriptor_v2_t::height"}.find(HSA_structs_regex) !=
+           std::string_view::npos)
+        {
+            rocprofiler::hsa::detail::operator<<(out, "height=");
+            rocprofiler::hsa::detail::operator<<(out, v.height);
+            rocprofiler::hsa::detail::operator<<(out, ", ");
+        }
+        if(std::string_view{"hsa_ext_image_descriptor_v2_t::width"}.find(HSA_structs_regex) !=
+           std::string_view::npos)
+        {
+            rocprofiler::hsa::detail::operator<<(out, "width=");
+            rocprofiler::hsa::detail::operator<<(out, v.width);
+            rocprofiler::hsa::detail::operator<<(out, ", ");
+        }
+        if(std::string_view{"hsa_ext_image_descriptor_v2_t::mipmap_levels"}.find(HSA_structs_regex) !=
+           std::string_view::npos)
+        {
+            rocprofiler::hsa::detail::operator<<(out, "mipmap_levels=");
+            rocprofiler::hsa::detail::operator<<(out, v.mipmap_levels);
+            rocprofiler::hsa::detail::operator<<(out, ", ");
+        }
+        if(std::string_view{"hsa_ext_image_descriptor_v2_t::geometry"}.find(HSA_structs_regex) !=
+           std::string_view::npos)
+        {
+            rocprofiler::hsa::detail::operator<<(out, "geometry=");
+            rocprofiler::hsa::detail::operator<<(out, v.geometry);
+        }
+    };
+    HSA_depth_max_cnt--;
+    std::operator<<(out, '}');
+    return out;
+}
+
+inline static std::ostream&
 operator<<(std::ostream& out, const hsa_ext_image_data_info_t& v)
 {
     std::operator<<(out, '{');
@@ -1739,6 +1800,13 @@ operator<<(std::ostream& out, const hsa_ext_image_format_t& v)
 
 inline static std::ostream&
 operator<<(std::ostream& out, const hsa_ext_image_descriptor_t& v)
+{
+    rocprofiler::hsa::detail::operator<<(out, v);
+    return out;
+}
+
+inline static std::ostream&
+operator<<(std::ostream& out, const hsa_ext_image_descriptor_v2_t& v)
 {
     rocprofiler::hsa::detail::operator<<(out, v);
     return out;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/hsa.def.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/hsa.def.cpp
@@ -628,6 +628,18 @@ HSA_API_INFO_DEFINITION_V(ROCPROFILER_HSA_TABLE_ID_AmdExt,
                           sem,
                           value)
 #        endif
+#        if HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x12
+HSA_API_INFO_DEFINITION_V(ROCPROFILER_HSA_TABLE_ID_AmdExt,
+                          ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_image_create_v2,
+                          hsa_amd_image_create_v2,
+                          hsa_amd_image_create_v2_fn,
+                          agent, image_descriptor, image_layout, image_data, access_permission, image)
+HSA_API_INFO_DEFINITION_V(ROCPROFILER_HSA_TABLE_ID_AmdExt,
+                          ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_interop_map_buffer_with_size,
+                          hsa_amd_interop_map_buffer_with_size,
+                          hsa_amd_interop_map_buffer_with_size_fn,
+                          num_agents, agents, interop_handle, flags, size_hint, size, ptr, metadata_size, metadata)
+#        endif
 #    endif
 
 #elif defined(ROCPROFILER_LIB_ROCPROFILER_HSA_ASYNC_COPY_CPP_IMPL) &&                              \

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/hsa.def.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/hsa.def.cpp
@@ -633,12 +633,25 @@ HSA_API_INFO_DEFINITION_V(ROCPROFILER_HSA_TABLE_ID_AmdExt,
                           ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_image_create_v2,
                           hsa_amd_image_create_v2,
                           hsa_amd_image_create_v2_fn,
-                          agent, image_descriptor, image_layout, image_data, access_permission, image)
+                          agent,
+                          image_descriptor,
+                          image_layout,
+                          image_data,
+                          access_permission,
+                          image)
 HSA_API_INFO_DEFINITION_V(ROCPROFILER_HSA_TABLE_ID_AmdExt,
                           ROCPROFILER_HSA_AMD_EXT_API_ID_hsa_amd_interop_map_buffer_with_size,
                           hsa_amd_interop_map_buffer_with_size,
                           hsa_amd_interop_map_buffer_with_size_fn,
-                          num_agents, agents, interop_handle, flags, size_hint, size, ptr, metadata_size, metadata)
+                          num_agents,
+                          agents,
+                          interop_handle,
+                          flags,
+                          size_hint,
+                          size,
+                          ptr,
+                          metadata_size,
+                          metadata)
 #        endif
 #    endif
 

--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmttypes.h
@@ -639,10 +639,11 @@ typedef struct _HsaMemMapFlags
 
 typedef struct _HsaGraphicsResourceInfo {
     void       *MemoryAddress;      // For use in hsaKmtMapMemoryToGPU(Nodes)
-    HSAuint64  SizeInBytes;         // Buffer size
+    HSAuint64  SizeInBytes;         // Buffer size (OUT)
     const void *Metadata;           // Pointer to metadata owned by Thunk
     HSAuint32  MetadataSizeInBytes; // Size of metadata
     HSAuint32  NodeId;              // GPU exported the buffer
+    HSAuint64  SizeHintInBytes;     // Caller-provided size hint for foreign (non-ROCr) resources (IN, 0 if unknown)
 } HsaGraphicsResourceInfo;
 
 typedef enum _HSA_CACHING_TYPE

--- a/projects/rocr-runtime/libhsakmt/src/dxg/librocdxg.h
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/librocdxg.h
@@ -300,7 +300,8 @@ uint32_t get_vgpr_size_per_cu(HSA_ENGINE_ID id);
 bool is_ipc_sysmemfd(uint64_t fd);
 
 HSAKMT_STATUS import_dmabuf_fd(uint64_t DMABufFd, uint32_t NodeId, bool alloc_va, bool is_ipc_memfd,
-                               wsl::thunk::GpuMemoryHandle* GpuMemHandle, bool is_kmt_handle);
+                               wsl::thunk::GpuMemoryHandle* GpuMemHandle, bool is_kmt_handle,
+                               uint64_t size_hint = 0);
 
 bool hsakmt_hsa_loader_init();
 

--- a/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/memory.cpp
@@ -555,7 +555,8 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtRegisterGraphicsHandleToNodesExt(HSAuint64 Graphic
   wsl::thunk::GpuMemoryHandle mem_handle;
 
   ret = import_dmabuf_fd(GraphicsResourceHandle, NodeArray[0], RegisterFlags.ui32.requiresVAddr,
-                         false, &mem_handle, RegisterFlags.ui32.kmtHandle);
+                         false, &mem_handle, RegisterFlags.ui32.kmtHandle,
+                         GraphicsResourceInfo->SizeHintInBytes);
   if (ret != HSAKMT_STATUS_SUCCESS) {
     pr_err("hsaKmtRegisterGraphicsHandleToNodesExt: import_dmabuf_fd failed, "
            "GraphicsResourceHandle: %" PRIu64 ", NodeId: %u\n",
@@ -610,7 +611,8 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtExportDMABufHandle(void *MemoryAddress,
 
 
 HSAKMT_STATUS import_dmabuf_fd(uint64_t DMABufFd, uint32_t NodeId, bool alloc_va, bool is_ipc_memfd,
-                               wsl::thunk::GpuMemoryHandle* GpuMemHandle, bool is_kmt_handle) {
+                               wsl::thunk::GpuMemoryHandle* GpuMemHandle, bool is_kmt_handle,
+                               uint64_t size_hint) {
   CHECK_DXG_OPEN();
 
   *GpuMemHandle = nullptr;
@@ -620,6 +622,7 @@ HSAKMT_STATUS import_dmabuf_fd(uint64_t DMABufFd, uint32_t NodeId, bool alloc_va
   create_info.dmabuf_fd = DMABufFd;
   create_info.flags.alloc_va = alloc_va;
   create_info.flags.kmt_handle_importer = is_kmt_handle ? 1 : 0;
+  create_info.size = size_hint;
 
 #if defined(__linux__)
   if (is_ipc_memfd) {

--- a/projects/rocr-runtime/libhsakmt/src/dxg/wddm/gpu_memory.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/wddm/gpu_memory.cpp
@@ -603,7 +603,8 @@ ErrorCode GpuMemory::OpenResourceFromNTHandle(HANDLE buffer_handle, D3DKMT_HANDL
   const size_t data_size = sizeof(D3DKMT_OPENRESOURCEFROMNTHANDLE) +
       query_args.PrivateRuntimeDataSize + query_args.TotalPrivateDriverDataSize +
       query_args.ResourcePrivateDriverDataSize +
-      sizeof(D3DDDI_OPENALLOCATIONINFO2) * query_args.NumAllocations;
+      sizeof(D3DDDI_OPENALLOCATIONINFO2) * query_args.NumAllocations +
+      Wkmi::GetProxyResourceInfoSize();  // extra room for pTotalPrivateDriverDataBuffer proxy info
   D3DKMT_OPENRESOURCEFROMNTHANDLE* open_resource =
       reinterpret_cast<D3DKMT_OPENRESOURCEFROMNTHANDLE*>(calloc(1, data_size));
 
@@ -728,11 +729,17 @@ ErrorCode GpuMemory::ImportPhysicalAllocHandle(const GpuMemoryCreateInfo& create
     desc_.size = shared_info_ptr->size;
     desc_.client_size = shared_info_ptr->client_size;
     desc_.domain = shared_info_ptr->domain;
-    desc_.flags.reserved = shared_info_ptr->flags;
+    // Copy only cross-process-meaningful fields from shared_info; do not restore
+    // the exporter's process-local GpuMemoryDescFlags wholesale, as that would
+    // corrupt importer-side flag state (e.g. is_shared, is_queue_referenced).
     desc_.mem_flags = shared_info_ptr->mem_flags;
     desc_.adapter_luid = shared_info_ptr->adapter_luid;
-    is_phymem_created = 1;
 
+    if (desc_.size == 0) {
+      pr_err("import failed: could not determine allocation size from shared handle\n");
+      return ErrorCode::InvalidateParams;
+    }
+    is_phymem_created = 1;
     desc_.flags.is_va_required = create_info.flags.alloc_va;
     if (desc_.flags.is_va_required) {
       desc_.flags.is_imported_vram_ipc = 1;
@@ -758,20 +765,28 @@ ErrorCode GpuMemory::ImportPhysicalAllocHandle(const GpuMemoryCreateInfo& create
       return ErrorCode::InvalidateParams;
     }
 
-    if (open_resource->PrivateRuntimeDataSize > 0)
+    if (open_resource->PrivateRuntimeDataSize == sizeof(SharedHandleInfo))
       shared_info = *static_cast<SharedHandleInfo*>(open_resource->pPrivateRuntimeData);
 
     if (open_resource->NumAllocations > 1)
       alloc_handles_ptr_ = new WinAllocationHandle[open_resource->NumAllocations];
 
-    // Update shared_info if OpenResourceFromKMTHandle skips populating it.
-    if (open_resource->PrivateRuntimeDataSize == 0) {
+    // Update shared_info if not populated by a ROCr-created SharedHandleInfo.
+    if (open_resource->PrivateRuntimeDataSize != sizeof(SharedHandleInfo)) {
       for (auto alloc_index = 0U; alloc_index < open_resource->NumAllocations; alloc_index++) {
         const auto* const pPrivateDriverData =
             open_resource->pOpenAllocationInfo[alloc_index].pPrivateDriverData;
         auto alloc_size = Wkmi::GetMemoryAllocationSize(pPrivateDriverData);
         shared_info_ptr->size += alloc_size;
         shared_info_ptr->client_size += alloc_size;
+      }
+      // If wkmi returned zero size the private data is not in UMDKMDIF format (e.g. a
+      // D3D11_USAGE_DYNAMIC constant buffer). Fall back to the caller-supplied size and
+      // treat as system memory — CPU-accessible D3D11 resources are always GTT-backed.
+      if (shared_info_ptr->size == 0 && create_info.size != 0) {
+        shared_info_ptr->size = create_info.size;
+        shared_info_ptr->client_size = create_info.size;
+        shared_info_ptr->domain = Wkmi::AllocDomain::kSystem;
       }
     }
 
@@ -790,20 +805,26 @@ ErrorCode GpuMemory::ImportPhysicalAllocHandle(const GpuMemoryCreateInfo& create
       return ErrorCode::InvalidateParams;
     }
 
-    if (open_resource->PrivateRuntimeDataSize > 0)
+    if (open_resource->PrivateRuntimeDataSize == sizeof(SharedHandleInfo))
       shared_info = *static_cast<SharedHandleInfo*>(open_resource->pPrivateRuntimeData);
 
     if (open_resource->NumAllocations > 1)
       alloc_handles_ptr_ = new WinAllocationHandle[open_resource->NumAllocations];
 
-    // Update shared_info if OpenResourceFromNtHandle skips populating it.
-    if (open_resource->PrivateRuntimeDataSize == 0) {
+    // Update shared_info if not populated by a ROCr-created SharedHandleInfo.
+    if (open_resource->PrivateRuntimeDataSize != sizeof(SharedHandleInfo)) {
       for (auto alloc_index = 0U; alloc_index < open_resource->NumAllocations; alloc_index++) {
         const auto* const pPrivateDriverData =
             open_resource->pOpenAllocationInfo2[alloc_index].pPrivateDriverData;
         auto alloc_size = Wkmi::GetMemoryAllocationSize(pPrivateDriverData);
         shared_info_ptr->size += alloc_size;
         shared_info_ptr->client_size += alloc_size;
+      }
+      // Same fallback as the KMT path: foreign D3D11 resource with non-UMDKMDIF private data.
+      if (shared_info_ptr->size == 0 && create_info.size != 0) {
+        shared_info_ptr->size = create_info.size;
+        shared_info_ptr->client_size = create_info.size;
+        shared_info_ptr->domain = Wkmi::AllocDomain::kSystem;
       }
     }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
@@ -1116,6 +1116,13 @@ hsa_status_t HSA_API hsa_amd_interop_map_buffer(uint32_t num_agents, hsa_agent_t
                                                     ptr, metadata_size, metadata);
 }
 
+hsa_status_t HSA_API hsa_amd_interop_map_buffer_with_size(
+    uint32_t num_agents, hsa_agent_t* agents, hsa_handle_t interop_handle, uint32_t flags,
+    size_t size_hint, size_t* size, void** ptr, size_t* metadata_size, const void** metadata) {
+  return amdExtTable->hsa_amd_interop_map_buffer_with_size_fn(
+      num_agents, agents, interop_handle, flags, size_hint, size, ptr, metadata_size, metadata);
+}
+
 // Mirrors Amd Extension Apis
 hsa_status_t HSA_API hsa_amd_interop_unmap_buffer(void* ptr) {
   return amdExtTable->hsa_amd_interop_unmap_buffer_fn(ptr);
@@ -1131,6 +1138,18 @@ hsa_status_t HSA_API hsa_amd_image_create(
   hsa_ext_image_t *image) {
   return amdExtTable->hsa_amd_image_create_fn(agent, image_descriptor,
                           image_layout, image_data, access_permission, image);
+}
+
+// Mirrors Amd Extension Apis
+hsa_status_t HSA_API hsa_amd_image_create_v2(
+  hsa_agent_t agent,
+  const hsa_ext_image_descriptor_v2_t* image_descriptor,
+  const hsa_amd_image_descriptor_t* image_layout,
+  const void* image_data,
+  hsa_access_permission_t access_permission,
+  hsa_ext_image_t* image) {
+  return amdExtTable->hsa_amd_image_create_v2_fn(agent, image_descriptor,
+                           image_layout, image_data, access_permission, image);
 }
 
 // Mirrors Amd Extension Apis

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
@@ -236,6 +236,16 @@ hsa_status_t hsa_amd_interop_map_buffer(uint32_t num_agents,
                                         size_t* metadata_size,
                                         const void** metadata);
 
+hsa_status_t hsa_amd_interop_map_buffer_with_size(uint32_t num_agents,
+                                                  hsa_agent_t* agents,
+                                                  hsa_handle_t interop_handle,
+                                                  uint32_t flags,
+                                                  size_t size_hint,
+                                                  size_t* size,
+                                                  void** ptr,
+                                                  size_t* metadata_size,
+                                                  const void** metadata);
+
 // Mirrors Amd Extension Apis
 hsa_status_t hsa_amd_interop_unmap_buffer(void* ptr);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_interface.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_interface.h
@@ -112,7 +112,8 @@ class ExtensionEntryPoints {
   void InitAmdExtTable();
 
   // Update Amd Ext table for Api related to Images
-  void UpdateAmdExtTable(decltype(::hsa_amd_image_create)* func_ptr);
+  void UpdateAmdExtTable(decltype(::hsa_amd_image_create)* func_ptr,
+                         decltype(::hsa_amd_image_create_v2)* func_v2_ptr);
 
   DISALLOW_COPY_AND_ASSIGN(ExtensionEntryPoints);
 };

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/runtime.h
@@ -374,7 +374,7 @@ class Runtime {
                                      hsa_amd_signal_handler handler, void* arg);
 
   hsa_status_t InteropMap(uint32_t num_agents, Agent** agents, hsa_handle_t handle,
-                          hsa_interop_map_flag_t flags, size_t* size, void** ptr,
+                          hsa_interop_map_flag_t flags, size_t size_hint, size_t* size, void** ptr,
                           size_t* metadata_size, const void** metadata);
 
   hsa_status_t InteropUnmap(void* ptr);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
@@ -87,7 +87,7 @@ void HsaApiTable::Init() {
   // they can add preprocessor macros on the new functions
 
   constexpr size_t expected_core_api_table_size = 1016;
-  constexpr size_t expected_amd_ext_table_size = 730;
+  constexpr size_t expected_amd_ext_table_size = 744;
   constexpr size_t expected_image_ext_table_size = 128;
   constexpr size_t expected_finalizer_ext_table_size = 64;
   constexpr size_t expected_tools_table_size = 64;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
@@ -87,7 +87,7 @@ void HsaApiTable::Init() {
   // they can add preprocessor macros on the new functions
 
   constexpr size_t expected_core_api_table_size = 1016;
-  constexpr size_t expected_amd_ext_table_size = 728;
+  constexpr size_t expected_amd_ext_table_size = 730;
   constexpr size_t expected_image_ext_table_size = 128;
   constexpr size_t expected_finalizer_ext_table_size = 64;
   constexpr size_t expected_tools_table_size = 64;
@@ -393,7 +393,7 @@ void HsaApiTable::UpdateCore() {
 
 // Update Api table for Amd Extensions.
 // @note: Current implementation will initialize the
-// member variable hsa_amd_image_create_fn while loading
+// member variables hsa_amd_image_create_fn and hsa_amd_image_create_v2_fn while loading
 // Image extension library
 void HsaApiTable::UpdateAmdExts() {
 
@@ -430,6 +430,7 @@ void HsaApiTable::UpdateAmdExts() {
   amd_ext_api.hsa_amd_memory_unlock_fn = AMD::hsa_amd_memory_unlock;
   amd_ext_api.hsa_amd_memory_fill_fn = AMD::hsa_amd_memory_fill;
   amd_ext_api.hsa_amd_interop_map_buffer_fn = AMD::hsa_amd_interop_map_buffer;
+  amd_ext_api.hsa_amd_interop_map_buffer_with_size_fn = AMD::hsa_amd_interop_map_buffer_with_size;
   amd_ext_api.hsa_amd_interop_unmap_buffer_fn = AMD::hsa_amd_interop_unmap_buffer;
   amd_ext_api.hsa_amd_pointer_info_fn = AMD::hsa_amd_pointer_info;
   amd_ext_api.hsa_amd_pointer_info_set_userdata_fn = AMD::hsa_amd_pointer_info_set_userdata;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -1461,8 +1461,17 @@ hsa_status_t hsa_amd_agent_memory_pool_get_info(
 }
 
 hsa_status_t hsa_amd_interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents,
-                                        hsa_handle_t interop_handle, uint32_t flags, size_t* size,
-                                        void** ptr, size_t* metadata_size, const void** metadata) {
+                                       hsa_handle_t interop_handle, uint32_t flags, size_t* size,
+                                       void** ptr, size_t* metadata_size, const void** metadata) {
+  return AMD::hsa_amd_interop_map_buffer_with_size(num_agents, agents, interop_handle, flags,
+                                               size_t{0},  // size_hint = 0 for legacy API
+                                               size, ptr, metadata_size, metadata);
+}
+
+hsa_status_t hsa_amd_interop_map_buffer_with_size(uint32_t num_agents, hsa_agent_t* agents,
+                                                   hsa_handle_t interop_handle, uint32_t flags,
+                                                   size_t size_hint, size_t* size, void** ptr,
+                                                   size_t* metadata_size, const void** metadata) {
   static const int tinyArraySize = 8;
   TRY;
   IS_OPEN();
@@ -1489,8 +1498,8 @@ hsa_status_t hsa_amd_interop_map_buffer(uint32_t num_agents, hsa_agent_t* agents
   }
 
   auto ret = core::Runtime::runtime_singleton_->InteropMap(
-      num_agents, core_agents, interop_handle, static_cast<hsa_interop_map_flag_t>(flags), size,
-      ptr, metadata_size, metadata);
+      num_agents, core_agents, interop_handle, static_cast<hsa_interop_map_flag_t>(flags),
+      size_hint, size, ptr, metadata_size, metadata);
 
   return ret;
   CATCH;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_interface.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_interface.cpp
@@ -121,20 +121,31 @@ void ExtensionEntryPoints::InitPcSamplingExtTable() {
 void ExtensionEntryPoints::InitAmdExtTable() {
   hsa_api_table().amd_ext_api.hsa_amd_image_create_fn = hsa_ext_null;
   hsa_internal_api_table().amd_ext_api.hsa_amd_image_create_fn = hsa_ext_null;
+  hsa_api_table().amd_ext_api.hsa_amd_image_create_v2_fn = hsa_ext_null;
+  hsa_internal_api_table().amd_ext_api.hsa_amd_image_create_v2_fn = hsa_ext_null;
 }
 
 // Update Amd Ext table for Api related to Images.
 // @note: Interface should be updated when Amd Ext table
 // begins hosting Api's from other extension libraries
-void ExtensionEntryPoints::UpdateAmdExtTable(decltype(::hsa_amd_image_create)* func_ptr) {
+void ExtensionEntryPoints::UpdateAmdExtTable(decltype(::hsa_amd_image_create)* func_ptr,
+                                             decltype(::hsa_amd_image_create_v2)* func_v2_ptr) {
   assert(hsa_api_table().amd_ext_api.hsa_amd_image_create_fn ==
              (decltype(hsa_amd_image_create)*)hsa_ext_null &&
              "Duplicate load of extension import.");
   assert(hsa_internal_api_table().amd_ext_api.hsa_amd_image_create_fn ==
              (decltype(hsa_amd_image_create)*)hsa_ext_null &&
              "Duplicate load of extension import.");
+  assert(hsa_api_table().amd_ext_api.hsa_amd_image_create_v2_fn ==
+             (decltype(hsa_amd_image_create_v2)*)hsa_ext_null &&
+             "Duplicate load of extension import.");
+  assert(hsa_internal_api_table().amd_ext_api.hsa_amd_image_create_v2_fn ==
+             (decltype(hsa_amd_image_create_v2)*)hsa_ext_null &&
+             "Duplicate load of extension import.");
   hsa_api_table().amd_ext_api.hsa_amd_image_create_fn = func_ptr;
   hsa_internal_api_table().amd_ext_api.hsa_amd_image_create_fn = func_ptr;
+  hsa_api_table().amd_ext_api.hsa_amd_image_create_v2_fn = func_v2_ptr;
+  hsa_internal_api_table().amd_ext_api.hsa_amd_image_create_v2_fn = func_v2_ptr;
 }
 
 void ExtensionEntryPoints::UnloadImage() {
@@ -185,7 +196,8 @@ bool ExtensionEntryPoints::LoadImage() {
 
   // Bind to Image implementation api's
   decltype(::hsa_amd_image_create)* func;
-  rocr::image::LoadImage(&image_api, &func);
+  decltype(::hsa_amd_image_create_v2)* func_v2;
+  rocr::image::LoadImage(&image_api, &func, &func_v2);
 
   // Initialize Version of Api Table
   image_api.version.major_id = HSA_IMAGE_API_TABLE_MAJOR_VERSION;
@@ -197,7 +209,7 @@ bool ExtensionEntryPoints::LoadImage() {
                                     core::HsaApiTable::HSA_EXT_IMAGE_API_TABLE_ID);
 
   // Update Amd Ext Api table Api that deals with Images
-  UpdateAmdExtTable(func);
+  UpdateAmdExtTable(func, func_v2);
 #endif
   return true;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -915,10 +915,11 @@ hsa_status_t Runtime::SetAsyncSignalHandler(hsa_signal_t signal,
 }
 
 hsa_status_t Runtime::InteropMap(uint32_t num_agents, Agent** agents, hsa_handle_t handle,
-                                 hsa_interop_map_flag_t flags, size_t* size, void** ptr,
-                                 size_t* metadata_size, const void** metadata) {
+                                 hsa_interop_map_flag_t flags, size_t size_hint, size_t* size,
+                                 void** ptr, size_t* metadata_size, const void** metadata) {
   constexpr int tinyArraySize = 8;
-  HsaGraphicsResourceInfo info;
+  HsaGraphicsResourceInfo info{};
+  info.SizeHintInBytes = size_hint;
 
   HSAuint32 short_nodes[tinyArraySize];
   HSAuint32* nodes = short_nodes;

--- a/projects/rocr-runtime/runtime/hsa-runtime/hsacore.dll.def
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hsacore.dll.def
@@ -163,8 +163,10 @@ EXPORTS
   hsa_amd_memory_pool_can_migrate
   hsa_amd_memory_migrate
   hsa_amd_interop_map_buffer
+  hsa_amd_interop_map_buffer_with_size
   hsa_amd_interop_unmap_buffer
   hsa_amd_image_create
+  hsa_amd_image_create_v2
   hsa_ext_image_get_capability
   hsa_ext_image_data_get_info
   hsa_ext_image_create

--- a/projects/rocr-runtime/runtime/hsa-runtime/hsacore.so.def
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hsacore.so.def
@@ -200,8 +200,10 @@ global:
 	hsa_amd_memory_pool_can_migrate;
 	hsa_amd_memory_migrate;
 	hsa_amd_interop_map_buffer;
+	hsa_amd_interop_map_buffer_with_size;
 	hsa_amd_interop_unmap_buffer;
 	hsa_amd_image_create;
+	hsa_amd_image_create_v2;
 	hsa_ext_image_get_capability;
 	hsa_ext_image_data_get_info;
 	hsa_ext_image_create;

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/hsa_ext_image.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/hsa_ext_image.cpp
@@ -580,7 +580,8 @@ hsa_status_t HSA_API hsa_ext_image_mipmap_array_get_level(hsa_agent_t agent,
 }
 
 void LoadImage(core::ImageExtTableInternal* image_api,
-               decltype(::hsa_amd_image_create)** interface_api) {
+               decltype(::hsa_amd_image_create)** interface_api,
+               decltype(::hsa_amd_image_create_v2)** interface_v2_api) {
   image_api->hsa_ext_image_get_capability_fn = hsa_ext_image_get_capability;
 
   image_api->hsa_ext_image_data_get_info_fn = hsa_ext_image_data_get_info;
@@ -618,6 +619,7 @@ void LoadImage(core::ImageExtTableInternal* image_api,
   image_api->hsa_ext_image_mipmap_array_get_level_fn = hsa_ext_image_mipmap_array_get_level;
 
   *interface_api = hsa_amd_image_create;
+  *interface_v2_api = hsa_amd_image_create_v2;
 }
 
 void ReleaseImageRsrcs() { ImageRuntime::DestroySingleton(); }

--- a/projects/rocr-runtime/runtime/hsa-runtime/image/inc/hsa_ext_image_impl.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/image/inc/hsa_ext_image_impl.h
@@ -123,9 +123,16 @@ hsa_status_t hsa_amd_image_create(hsa_agent_t agent,
                                   const void* image_data, hsa_access_permission_t access_permission,
                                   hsa_ext_image_t* image);
 
+hsa_status_t hsa_amd_image_create_v2(hsa_agent_t agent,
+                                  const hsa_ext_image_descriptor_v2_t* image_descriptor,
+                                  const hsa_amd_image_descriptor_t* image_layout,
+                                  const void* image_data, hsa_access_permission_t access_permission,
+                                  hsa_ext_image_t* image);
+
 // Update Api table with func pointers that implement functionality
 void LoadImage(core::ImageExtTableInternal* image_api,
-               decltype(::hsa_amd_image_create)** interface_api);
+               decltype(::hsa_amd_image_create)** interface_api,
+               decltype(::hsa_amd_image_create_v2)** interface_v2_api);
 
 // Release resources acquired by Image implementation
 void ReleaseImageRsrcs();

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace.h
@@ -286,6 +286,8 @@ struct AmdExtTable {
   decltype(hsa_amd_queue_create)* hsa_amd_queue_create_fn;
   decltype(hsa_amd_queue_signal_external_semaphore)* hsa_amd_queue_signal_external_semaphore_fn;
   decltype(hsa_amd_queue_wait_external_semaphore)*   hsa_amd_queue_wait_external_semaphore_fn;
+  decltype(hsa_amd_image_create_v2)* hsa_amd_image_create_v2_fn;
+  decltype(hsa_amd_interop_map_buffer_with_size)* hsa_amd_interop_map_buffer_with_size_fn;
 };
 
 // Table to export HSA Core Runtime Apis

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace_version.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace_version.h
@@ -58,7 +58,7 @@
 // Step Ids of the Api tables exported by Hsa Core Runtime
 #define HSA_API_TABLE_STEP_VERSION                  0x01
 #define HSA_CORE_API_TABLE_STEP_VERSION             0x00
-#define HSA_AMD_EXT_API_TABLE_STEP_VERSION          0x11
+#define HSA_AMD_EXT_API_TABLE_STEP_VERSION          0x12
 #define HSA_FINALIZER_API_TABLE_STEP_VERSION        0x00
 #define HSA_IMAGE_API_TABLE_STEP_VERSION            0x01
 // Rocprofiler just checks HSA_MAGE_EXT_API_TABLE_STEP_VERSION

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -80,9 +80,10 @@
  * - 1.26 - hsa_amd_queue_create: batch queue creation with descriptor
  * - 1.27 - hsa_amd_queue_signal_external_semaphore, hsa_amd_queue_wait_external_semaphore
  * - 1.28 - hsa_amd_agent_info_t: HSA_AMD_AGENT_INFO_HOST_ALLOC_DMABUF_SUPPORTED
+ * - 1.29 - hsa_amd_image_create_v2, hsa_amd_interop_map_buffer_with_size
  */
 #define HSA_AMD_INTERFACE_VERSION_MAJOR 1
-#define HSA_AMD_INTERFACE_VERSION_MINOR 28
+#define HSA_AMD_INTERFACE_VERSION_MINOR 29
 
 #ifdef __cplusplus
 extern "C" {
@@ -1597,7 +1598,7 @@ typedef struct hsa_amd_image_descriptor_s {
  *
  * @param agent[in] Agent on which to create the image
  *
- * @param[in] image_descriptor[in] Vendor specific image format
+ * @param[in] image_descriptor Vendor specific image format
  *
  * @param[in] image_data Pointer to image backing store
  *
@@ -1623,6 +1624,42 @@ hsa_status_t HSA_API hsa_amd_image_create(
     hsa_access_permission_t access_permission,
     hsa_ext_image_t *image
 );
+
+/**
+ * @brief Creates an image from an opaque vendor specific image format.
+ * Does not modify data at image_data.  Intended initially for
+ * accessing interop images.
+ *
+ * @param agent[in] Agent on which to create the image
+ *
+ * @param[in] image_descriptor Vendor specific image format
+ *
+ * @param[in] image_layout Opaque vendor-specific image layout descriptor (may be NULL
+ *                         when image metadata is not available from an interop source)
+ *
+ * @param[in] image_data Pointer to image backing store
+ *
+ * @param[in] access_permission Access permissions for the image object
+ *
+ * @param[out] image Created image object.
+ *
+ * @retval HSA_STATUS_SUCCESS Image created successfully
+ *
+ * @retval HSA_STATUS_ERROR_NOT_INITIALIZED if HSA is not initialized
+ *
+ * @retval HSA_STATUS_ERROR_OUT_OF_RESOURCES if there is a failure in allocating
+ * necessary resources
+ *
+ * @retval HSA_STATUS_ERROR_INVALID_ARGUMENT Bad or mismatched descriptor,
+ * null image_data, or mismatched access_permission.
+ */
+hsa_status_t HSA_API hsa_amd_image_create_v2(
+    hsa_agent_t agent,
+    const hsa_ext_image_descriptor_v2_t* image_descriptor,
+    const hsa_amd_image_descriptor_t* image_layout,
+    const void* image_data,
+    hsa_access_permission_t access_permission,
+    hsa_ext_image_t* image);
 
 /**
  * @brief Query image limits.
@@ -2897,6 +2934,55 @@ hsa_status_t HSA_API hsa_amd_interop_map_buffer(uint32_t num_agents, hsa_agent_t
                                                 hsa_handle_t interop_handle, uint32_t flags,
                                                 size_t* size, void** ptr, size_t* metadata_size,
                                                 const void** metadata);
+
+/**
+ * @brief Maps an interop object into the HSA flat address space with a
+ * caller-supplied size hint and establishes memory residency.
+ * The metadata pointer is valid during the lifetime of the
+ * map (until hsa_amd_interop_unmap_buffer is called).
+ * Multiple calls to hsa_amd_interop_map_buffer with the same interop_handle
+ * result in multiple mappings with potentially different addresses and
+ * different metadata pointers.  Concurrent operations on these addresses are
+ * not coherent.  Memory must be fenced to system scope to ensure consistency,
+ * between mappings and with any views of this buffer in the originating
+ * software stack.
+ * It is identical to hsa_amd_interop_map_buffer except that @p size_hint provides
+ * the known byte size of the resource to the runtime.  Use this variant when
+ * the resource was created by a foreign API (e.g. D3D11 USAGE_DYNAMIC constant
+ * buffer) whose KMD private data does not encode the allocation size in a
+ * format the runtime can parse.  Pass 0 when the size is unknown and will be deduced.
+ *
+ * @param[in] num_agents Number of agents which require access to the memory
+ *
+ * @param[in] agents List of accessing agents.
+ *
+ * @param[in] interop_handle interop buffer handle (FD on Linux and HANDLE on
+ * Windows)
+ *
+ * @param [in] flags Reserved, must be 0
+ *
+ * @param [in] size_hint the hinted size of the buffer.
+ *
+ * @param[out] size Size in bytes of the mapped object
+ *
+ * @param[out] ptr Base address of the mapped object
+ *
+ * @param[out] metadata_size Size of metadata in bytes, may be NULL
+ *
+ * @param[out] metadata Pointer to metadata, may be NULL
+ *
+ * @retval HSA_STATUS_SUCCESS if successfully mapped
+ *
+ * @retval HSA_STATUS_ERROR_NOT_INITIALIZED if HSA is not initialized
+ *
+ * @retval HSA_STATUS_ERROR_OUT_OF_RESOURCES if there is a failure in allocating
+ * necessary resources
+ *
+ * @retval HSA_STATUS_ERROR_INVALID_ARGUMENT all other errors
+ */
+hsa_status_t HSA_API hsa_amd_interop_map_buffer_with_size(
+    uint32_t num_agents, hsa_agent_t* agents, hsa_handle_t interop_handle, uint32_t flags,
+    size_t size_hint, size_t* size, void** ptr, size_t* metadata_size, const void** metadata);
 
 /**
  * @brief Removes a previously mapped interop object from HSA's flat address space.


### PR DESCRIPTION
…#7281)

This reverts commit 1c5a2276a631082cf53b18fcc36cf2ff4f08deb4.

Fix rocprofile issue in 
commit 2dc63484fe78ad6b611e6b763ac50290faf0ab9c
Author: Tao Sang <Tao.Sang@amd.com>
Date:   Mon Jun 15 15:54:07 2026 -0400

    AIRUNTIME-1990 - Support gl-hip and d3d-ocl image interOp (#5838)


## Motivation

Fix rocprofiler issue in 2dc63484fe78ad6b611e6b763ac50290faf0ab9c

## Technical Details

Update formats in rocprofiler

## JIRA ID

AIRUNTIME-1990 

## Test Plan

hip-gl, d3d-cl interOp

## Test Result
pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
