### PR TITLE
[ROCr] Allow the comgr hotswap tool to load via HSA_TOOLS_LIB

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -2714,7 +2714,14 @@ void Runtime::LoadTools() {
               getpid(), rocp_reg_status, rocprofiler_register_error_string(rocp_reg_status));
     }
 
-    bool allow_v1_registration = false;
+    // rocprofiler-register (v3) provides tracing only; the comgr hotswap tool must
+    // intercept and modify HSA calls (it wraps hsa_code_object_reader_create_from_memory),
+    // which requires the v1 HSA_TOOLS_LIB path. Allow v1 registration specifically for
+    // that first-party tool so it loads via HSA_TOOLS_LIB alone, without re-enabling v1
+    // for other tools. General v1 behavior is otherwise unchanged.
+    static constexpr const char* kHotswapToolLib = "libamd_comgr_hotswap_tool.so";
+    bool allow_v1_registration =
+        flag().tools_lib_names().find(kHotswapToolLib) != std::string::npos;
     if (os::IsEnvVarSet("HSA_TOOLS_ROCPROFILER_V1_TOOLS")) {
       // assume true if env variable is set
       allow_v1_registration = true;


### PR DESCRIPTION
## Motivation

`Runtime::LoadTools` skips v1 `HSA_TOOLS_LIB` tools once rocprofiler-register (v3) registration succeeds, unless `HSA_TOOLS_ROCPROFILER_V1_TOOLS` is set. rocprofiler-register (v3) provides callback/buffer tracing only; the comgr hotswap tool must intercept and modify HSA calls (it wraps `hsa_code_object_reader_create_from_memory`), which requires the v1 `HSA_TOOLS_LIB` mechanism. As a result the hotswap tool silently fails to load on systems where v3 registration succeeds, forcing an extra env variable (or `LD_PRELOAD`).

This change enables the v1 path **specifically for the comgr hotswap tool** so it loads via `HSA_TOOLS_LIB` alone. It does **not** re-enable v1 for other tools, so the existing v1 de-prioritization is preserved for everything else.

## Technical Details

- **projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp**: in `LoadTools`, set `allow_v1_registration` to true only when `libamd_comgr_hotswap_tool.so` is named in `HSA_TOOLS_LIB` (a first-party AMD tool). The explicit `HSA_TOOLS_ROCPROFILER_V1_TOOLS` override still forces v1 on for any tool, exactly as before. When the hotswap tool is not present in `HSA_TOOLS_LIB`, behavior is unchanged (including the no-tool path).

## JIRA ID

N/A

## Test Plan

- No tool / unrelated tool in `HSA_TOOLS_LIB`: `allow_v1_registration` stays false; load path unchanged.
- `HSA_TOOLS_LIB` naming `libamd_comgr_hotswap_tool.so` with v3 registration succeeding: the hotswap tool loads without `HSA_TOOLS_ROCPROFILER_V1_TOOLS`.
- `HSA_TOOLS_ROCPROFILER_V1_TOOLS` set: still forces v1 on (unchanged).

## Test Result

The comgr hotswap tool loads via `HSA_TOOLS_LIB` alone; no change to behavior for other tools or when no tool is loaded.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
