### PR TITLE
[rocprofiler-systems] [AI-NIC] Add runtime diagnostics and end-to-end test

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/base/collector.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/base/collector.hpp
@@ -176,8 +176,8 @@ struct collector
         {
             const auto   _device_id   = entry.device->get_index();
             const auto&  _device_name = entry.device->get_name();
-            const size_t _count =
-                m_sample_counts.count(_device_id) ? m_sample_counts.at(_device_id) : 0;
+            const auto   _it          = m_sample_counts.find(_device_id);
+            const size_t _count   = _it == m_sample_counts.end() ? 0 : _it->second;
             if(_count == 0)
             {
                 LOG_WARNING("No samples were collected for {} device '{}'",

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/base/collector.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/base/collector.hpp
@@ -177,7 +177,7 @@ struct collector
             const auto   _device_id   = entry.device->get_index();
             const auto&  _device_name = entry.device->get_name();
             const auto   _it          = m_sample_counts.find(_device_id);
-            const size_t _count   = _it == m_sample_counts.end() ? 0 : _it->second;
+            const size_t _count       = _it == m_sample_counts.end() ? 0 : _it->second;
             if(_count == 0)
             {
                 LOG_WARNING("No samples were collected for {} device '{}'",

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/base/collector.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/base/collector.hpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <stdexcept>
 #include <vector>
@@ -146,6 +147,7 @@ struct collector
                     {
                         PerfettoApi::store_sample(_device_id, _metrics, _timestamp);
                     }
+                    m_sample_counts[_device_id]++;
                     return false;  // Keep device
                 } catch(const std::runtime_error& e)
                 {
@@ -169,6 +171,23 @@ struct collector
         {
             Traits::template post_process_perfetto<PerfettoApi>(m_device_entries,
                                                                 m_enabled_metrics);
+        }
+        for(const auto& entry : m_device_entries)
+        {
+            const auto   _device_id   = entry.device->get_index();
+            const auto&  _device_name = entry.device->get_name();
+            const size_t _count =
+                m_sample_counts.count(_device_id) ? m_sample_counts.at(_device_id) : 0;
+            if(_count == 0)
+            {
+                LOG_WARNING("No samples were collected for {} device '{}'",
+                            Traits::device_name, _device_name);
+            }
+            else
+            {
+                LOG_DEBUG("Collected {} samples for {} device '{}'", _count,
+                          Traits::device_name, _device_name);
+            }
         }
     }
 
@@ -250,6 +269,7 @@ private:
     device_entries_t m_device_entries;  ///< Devices with cached supported metrics
     std::shared_ptr<device_provider> m_device_provider;  ///< Device provider instance
     enabled_metrics_t                m_enabled_metrics;  ///< Enabled metrics
+    std::map<size_t, size_t>         m_sample_counts;    ///< Per-device sample counts
 };
 
 }  // namespace rocprofsys::pmc::collectors::base

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
@@ -138,9 +138,7 @@ struct nic_traits
             bool should_include = false;
             switch(filter.mode)
             {
-                case device_selection_mode::ALL:
-                    should_include = true;
-                    break;
+                case device_selection_mode::ALL: should_include = true; break;
                 case device_selection_mode::SPECIFIC:
                     should_include = filter.names.count(device->get_name()) > 0;
                     break;
@@ -150,8 +148,9 @@ struct nic_traits
             {
                 if(!device->is_supported())
                 {
-                    LOG_WARNING("NIC device [{}] ({}) has no supported RDMA metrics, skipping",
-                                device->get_index(), device->get_name());
+                    LOG_WARNING(
+                        "NIC device [{}] ({}) has no supported RDMA metrics, skipping",
+                        device->get_index(), device->get_name());
                     continue;
                 }
                 LOG_INFO("NIC device [{}] ({}) enabled for AI NIC PMC sampling",

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
@@ -139,6 +139,8 @@ struct nic_traits
             switch(filter.mode)
             {
                 case device_selection_mode::ALL: should_include = true; break;
+                // Unreachable (early return above), kept for switch exhaustiveness
+                case device_selection_mode::NONE: should_include = false; break;
                 case device_selection_mode::SPECIFIC:
                     should_include = filter.names.count(device->get_name()) > 0;
                     break;

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
@@ -135,18 +135,12 @@ struct nic_traits
 
         for(auto& device : devices)
         {
-            if(!device->is_supported())
-            {
-                LOG_DEBUG("NIC device [{}] ({}) has no supported RDMA metrics, skipping",
-                          device->get_index(), device->get_name());
-                continue;
-            }
-
             bool should_include = false;
             switch(filter.mode)
             {
-                case device_selection_mode::ALL: should_include = true; break;
-                case device_selection_mode::NONE: should_include = false; break;
+                case device_selection_mode::ALL:
+                    should_include = true;
+                    break;
                 case device_selection_mode::SPECIFIC:
                     should_include = filter.names.count(device->get_name()) > 0;
                     break;
@@ -154,6 +148,12 @@ struct nic_traits
 
             if(should_include)
             {
+                if(!device->is_supported())
+                {
+                    LOG_WARNING("NIC device [{}] ({}) has no supported RDMA metrics, skipping",
+                                device->get_index(), device->get_name());
+                    continue;
+                }
                 LOG_INFO("NIC device [{}] ({}) enabled for AI NIC PMC sampling",
                          device->get_index(), device->get_name());
                 auto supported = device->get_supported_metrics();

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
@@ -150,9 +150,20 @@ struct nic_traits
             {
                 if(!device->is_supported())
                 {
-                    LOG_WARNING(
-                        "NIC device [{}] ({}) has no supported RDMA metrics, skipping",
-                        device->get_index(), device->get_name());
+                    // Warn only when the user explicitly requested this device; under
+                    // ALL an unsupported (e.g. non-RDMA) NIC is expected, not an error.
+                    if(filter.mode == device_selection_mode::SPECIFIC)
+                    {
+                        LOG_WARNING("Requested NIC device [{}] ({}) has no supported "
+                                    "RDMA metrics, skipping",
+                                    device->get_index(), device->get_name());
+                    }
+                    else
+                    {
+                        LOG_DEBUG("NIC device [{}] ({}) has no supported RDMA metrics, "
+                                  "skipping",
+                                  device->get_index(), device->get_name());
+                    }
                     continue;
                 }
                 LOG_INFO("NIC device [{}] ({}) enabled for AI NIC PMC sampling",

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
@@ -12,7 +12,10 @@
 
 #include <cstdint>
 #include <memory>
+#include <set>
 #include <vector>
+
+#include <spdlog/fmt/fmt.h>
 
 namespace rocprofsys::pmc::collectors::nic
 {
@@ -123,9 +126,20 @@ struct nic_traits
 
         auto devices = provider->template get_nic_devices<device_t, backend_t>();
 
+        LOG_DEBUG("Discovered {} AI NIC device(s) via AMD SMI", devices.size());
+
+        std::set<std::string> available_names;
+        for(const auto& device : devices)
+            available_names.insert(device->get_name());
+
         for(auto& device : devices)
         {
-            if(!device->is_supported()) continue;
+            if(!device->is_supported())
+            {
+                LOG_DEBUG("NIC device [{}] ({}) has no supported RDMA metrics, skipping",
+                          device->get_index(), device->get_name());
+                continue;
+            }
 
             bool should_include = false;
             switch(filter.mode)
@@ -139,14 +153,43 @@ struct nic_traits
 
             if(should_include)
             {
+                LOG_INFO("NIC device [{}] ({}) enabled for AI NIC PMC sampling",
+                         device->get_index(), device->get_name());
                 auto supported = device->get_supported_metrics();
                 entries.push_back(device_entry{ std::move(device), supported });
             }
+            else
+            {
+                LOG_DEBUG(
+                    "NIC device [{}] ({}) excluded by ROCPROFSYS_SAMPLING_AINICS filter",
+                    device->get_index(), device->get_name());
+            }
         }
 
+        warn_invalid_names(filter, available_names);
         register_nic_agents(entries);
 
         return entries;
+    }
+
+    static void warn_invalid_names(const nic_device_filter&     filter,
+                                   const std::set<std::string>& available_names)
+    {
+        if(filter.mode != device_selection_mode::SPECIFIC) return;
+        if(available_names.empty())
+        {
+            LOG_WARNING("No AI NIC devices were discovered.");
+            return;
+        }
+        for(const auto& requested : filter.names)
+        {
+            if(available_names.find(requested) == available_names.end())
+            {
+                LOG_WARNING("Requested AI NIC device '{}' not found. "
+                            "Available device(s): [{}]",
+                            requested, fmt::join(available_names, ", "));
+            }
+        }
     }
 
     static void register_nic_agents(const std::vector<device_entry>& entries)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/nic_traits.hpp
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include <spdlog/fmt/fmt.h>
+#include <spdlog/fmt/ranges.h>
 
 namespace rocprofsys::pmc::collectors::nic
 {

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -290,6 +290,7 @@ def pytest_configure(config: pytest.Config) -> None:
         "no_docker",
         "shmem",
         "nic",
+        "ainic",
     ]
 
     # Informational markers, only used for test labeling
@@ -569,6 +570,10 @@ def pytest_collection_modifyitems(config, items) -> None:
             _msg = nic_unavailable_reason(rocprof_config)
             if _msg is not None:
                 item.add_marker(pytest.mark.skip(reason=_msg))
+        if "ainic" in item.keywords:
+            _msg = ainic_unavailable_reason(rocprof_config)
+            if _msg is not None:
+                item.add_marker(pytest.mark.skip(reason=_msg))
         if "kfd" in item.keywords or "unified_memory" in item.keywords:
             _msg = kfd_unavailable_reason(rocprof_config)
             if _msg is not None:
@@ -797,6 +802,16 @@ def nic_unavailable_reason(rocprof_config: RocprofsysConfig) -> Optional[str]:
     if caps.papi_nic_events is not None and caps.perf_event_paranoid <= 2:
         return None
     return "Requires PAPI network events and perf_event_paranoid <= 2 to be available"
+
+
+def ainic_unavailable_reason(rocprof_config: RocprofsysConfig) -> Optional[str]:
+    """Check if AI NIC tracking is available.
+
+    Requires ``amd-smi static`` to report at least one NETDEV entry.
+    """
+    if not rocprof_config.capabilities.ai_nic_devices:
+        return "No AI NIC devices found (amd-smi static reports no NETDEV entries)"
+    return None
 
 
 def kfd_unavailable_reason(rocprof_config: RocprofsysConfig) -> Optional[str]:
@@ -1356,13 +1371,14 @@ def _generate_rocprofsys_config_header() -> list[str]:
         _row("Ptrace scope:", cap.ptrace_scope),
         _row("Is inside docker:", rocprof_config.capabilities.is_inside_docker),
         _row("PAPI available:", cap.papi_availability),
+        _row("AI NIC devices:", cap.ai_nic_devices),
         _row("Default NIC:", cap.default_nic),
         *(
             lambda evts: (
-                [_subrow("PAPI NIC events:", evts[0])]
-                + [_subrow("", e) for e in evts[1:]]
+                [_row("PAPI NIC events:", evts[0])]
+                + [_row("", e) for e in evts[1:]]
                 if evts
-                else [_subrow("PAPI NIC events:", "None")]
+                else [_row("PAPI NIC events:", "None")]
             )
         )(cap.papi_nic_events.split() if cap.papi_nic_events else []),
         "-" * 70,

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -1375,8 +1375,7 @@ def _generate_rocprofsys_config_header() -> list[str]:
         _row("Default NIC:", cap.default_nic),
         *(
             lambda evts: (
-                [_row("PAPI NIC events:", evts[0])]
-                + [_row("", e) for e in evts[1:]]
+                [_row("PAPI NIC events:", evts[0])] + [_row("", e) for e in evts[1:]]
                 if evts
                 else [_row("PAPI NIC events:", "None")]
             )

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -108,6 +108,42 @@ class SystemCapabilities:
             return None
 
     @cached_property
+    def ai_nic_devices(self) -> list[str]:
+        """Get the unique AI NIC device names reported by AMD SMI.
+
+        Runs ``amd-smi static`` and extracts every distinct NETDEV value.
+        Returns an empty list when AMD SMI is unavailable or reports no NICs.
+
+        Example output line from ``amd-smi static``:
+        ``NETDEV: enp137s0np0``
+        """
+        amd_smi = shutil.which("amd-smi")
+        if not amd_smi:
+            return []
+        try:
+            result = subprocess.run(
+                [amd_smi, "static"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if result.returncode != 0:
+                return []
+            seen: set[str] = set()
+            devices: list[str] = []
+            for line in result.stdout.splitlines():
+                if "netdev" in line.lower():
+                    colon_idx = line.find(":")
+                    if colon_idx != -1:
+                        name = line[colon_idx + 1 :].strip()
+                        if name and name not in seen:
+                            seen.add(name)
+                            devices.append(name)
+            return devices
+        except (subprocess.SubprocessError, OSError, subprocess.TimeoutExpired):
+            return []
+
+    @cached_property
     def papi_nic_events(self) -> Optional[str]:
         """Get the list of all events that we want PAPI to record.
 

--- a/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
@@ -103,6 +103,7 @@ class TestAINIC(RocprofsysTest):
         ainic_download_url_1,
         ainic_download_url_2,
         ainic_rocpd_rules,
+        test_output_dir,
     ):
         target = shutil.which("wget")
         if not target:

--- a/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
@@ -1,0 +1,140 @@
+# Copyright (c) Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""
+AI NIC tests using AMD SMI RDMA metrics (amdsmi_get_nic_rdma_dev_info).
+
+These tests verify that rocprofiler-systems correctly collects all AI NIC
+RDMA counters per device and writes them to both the Perfetto (.proto) trace
+and the ROCpd (.db) database.
+
+AI NIC devices are discovered at runtime via ``amd-smi static | grep -i netdev``.
+The test is skipped automatically when no AI NIC devices are present on the system.
+"""
+
+from __future__ import annotations
+
+import os
+import pytest
+import shutil
+from pathlib import Path
+from conftest import RocprofsysTest
+
+pytestmark = [pytest.mark.ainic, pytest.mark.network]
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+# Substrings used to match the 10 Perfetto counter track names via LIKE.
+# Full name format: "NIC [<device_id>] <METRIC> (S)"
+AINIC_PERFETTO_COUNTER_NAMES = [
+    "RX RDMA Bytes",
+    "TX RDMA Bytes",
+    "RX RDMA Packets",
+    "TX RDMA Packets",
+    "RX CNP Packets",
+    "TX CNP Packets",
+    "TX ACK TIMEOUT",
+    "RESP TX PKT SEQ ERR",
+    "REQ RX PKT SEQ ERR",
+    "REQ RX IMPL NAK SEQ ERR",
+]
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def ainic_perf_env() -> dict[str, str]:
+    """Environment variables for AI NIC performance tests."""
+    env = {
+        "ROCPROFSYS_USE_PID": "OFF",
+        "ROCPROFSYS_LOG_LEVEL": "trace",
+        "ROCPROFSYS_USE_PROCESS_SAMPLING": "ON",
+        "ROCPROFSYS_SAMPLING_FREQ": "50",
+        "ROCPROFSYS_SAMPLING_CPUS": "none",
+        "ROCPROFSYS_USE_AMD_SMI": "ON",
+        "ROCPROFSYS_USE_AINIC": "ON",
+        "ROCPROFSYS_SAMPLING_AINICS": "all",
+        "ROCPROFSYS_SAMPLING_DELAY": "0.05",
+    }
+    sysfs_root = os.environ.get("SMI_NIC_SYSFS_ROOT", "")
+    if sysfs_root:
+        env["SMI_NIC_SYSFS_ROOT"] = sysfs_root
+    return env
+
+
+@pytest.fixture
+def ainic_download_url_1() -> str:
+    """Download URL for the first file to download."""
+    return "https://github.com/ROCm/rocprofiler-systems/releases/download/rocm-6.4.1/rocprofiler-systems-1.0.1-ubuntu-22.04-ROCm-60400-PAPI-OMPT-Python3.sh"
+
+
+@pytest.fixture
+def ainic_download_url_2() -> str:
+    """Download URL for the second file to download."""
+    return "https://github.com/ROCm/rocprofiler-systems/releases/download/rocm-6.4.3/rocprofiler-systems-1.0.2-rhel-9.4-PAPI-OMPT-Python3.sh"
+
+
+@pytest.fixture
+def ainic_rocpd_rules(validation_rules_dir) -> list[Path]:
+    """Validation rules for AI NIC RDMA track presence in ROCpd database."""
+    rules_dir = validation_rules_dir / "ainic"
+    return [rules_dir / "ainic-rdma-rules.json"]
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+class TestAINIC(RocprofsysTest):
+    """Tests for AI NIC performance using AMD SMI Phase 2 RDMA metrics."""
+
+    PERFETTO_PASS_REGEX = [r"perfetto-trace\.proto validated"]
+    PERFETTO_FAIL_REGEX = [r"Failure validating.*perfetto-trace\.proto"]
+
+    @pytest.mark.rocpd("ainic_perf_env")
+    def test_performance_tracks(
+        self,
+        ainic_perf_env,
+        ainic_download_url_1,
+        ainic_download_url_2,
+        ainic_rocpd_rules,
+    ):
+        target = shutil.which("wget")
+        if not target:
+            pytest.skip("wget not found")
+
+        download_cmd = [
+            "--no-check-certificate",
+            ainic_download_url_1,
+            ainic_download_url_2,
+            "-O",
+            str(test_output_dir / "rocprofiler-systems.test.bin"),
+        ]
+        result = self.run_test(
+            "sampling",
+            target,
+            run_args=download_cmd,
+            env=ainic_perf_env,
+        )
+
+        self.assert_regex(result)
+
+        # Validate Perfetto .proto: all 10 AI NIC counter track substrings must match
+        self.assert_perfetto(
+            result,
+            counter_names=AINIC_PERFETTO_COUNTER_NAMES,
+            pass_regex=self.PERFETTO_PASS_REGEX,
+            fail_regex=self.PERFETTO_FAIL_REGEX,
+        )
+
+        # Validate ROCpd .db: all 10 AI NIC track names must be present
+        self.assert_rocpd(
+            result,
+            subtest_name="ROCpd AI NIC track validation",
+            rules_files=ainic_rocpd_rules,
+        )

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/ainic/ainic-rdma-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/ainic/ainic-rdma-rules.json
@@ -3,7 +3,9 @@
         {
             "name_prefix": "rocpd_string_",
             "min_rows": 1,
-            "required_columns": ["string"],
+            "required_columns": [
+                "string"
+            ],
             "validation_queries": [
                 {
                     "description": "Check for ainic_rx_rdma_ucast_bytes track name",
@@ -74,6 +76,87 @@
                     "comparison": "greater_than",
                     "expected_result": 0,
                     "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_req_rx_impl_nak_seq_err'"
+                }
+            ]
+        },
+        {
+            "name_prefix": "rocpd_info_pmc_",
+            "min_rows": 10,
+            "required_columns": [
+                "name",
+                "units",
+                "value_type"
+            ],
+            "validation_queries": [
+                {
+                    "description": "Check PMC description row for nic_rx_ucast_pkts",
+                    "error_message": "No info_pmc row for PMC name 'nic_rx_ucast_pkts' \u2014 add_pmc_info() was not called for this counter",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE name = 'nic_rx_ucast_pkts'"
+                },
+                {
+                    "description": "Check PMC description row for nic_tx_ucast_pkts",
+                    "error_message": "No info_pmc row for PMC name 'nic_tx_ucast_pkts' \u2014 add_pmc_info() was not called for this counter",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE name = 'nic_tx_ucast_pkts'"
+                },
+                {
+                    "description": "Check PMC description row for nic_rx_cnp_pkts",
+                    "error_message": "No info_pmc row for PMC name 'nic_rx_cnp_pkts' \u2014 add_pmc_info() was not called for this counter",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE name = 'nic_rx_cnp_pkts'"
+                },
+                {
+                    "description": "Check PMC description row for nic_tx_cnp_pkts",
+                    "error_message": "No info_pmc row for PMC name 'nic_tx_cnp_pkts' \u2014 add_pmc_info() was not called for this counter",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE name = 'nic_tx_cnp_pkts'"
+                },
+                {
+                    "description": "Check PMC description row for nic_rx_ucast_bytes",
+                    "error_message": "No info_pmc row for PMC name 'nic_rx_ucast_bytes' \u2014 add_pmc_info() was not called for this counter",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE name = 'nic_rx_ucast_bytes'"
+                },
+                {
+                    "description": "Check PMC description row for nic_tx_ucast_bytes",
+                    "error_message": "No info_pmc row for PMC name 'nic_tx_ucast_bytes' \u2014 add_pmc_info() was not called for this counter",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE name = 'nic_tx_ucast_bytes'"
+                },
+                {
+                    "description": "Check PMC description row for nic_tx_rdma_ack_timeout",
+                    "error_message": "No info_pmc row for PMC name 'nic_tx_rdma_ack_timeout' \u2014 add_pmc_info() was not called for this counter",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE name = 'nic_tx_rdma_ack_timeout'"
+                },
+                {
+                    "description": "Check PMC description row for nic_resp_tx_pkt_seq_err",
+                    "error_message": "No info_pmc row for PMC name 'nic_resp_tx_pkt_seq_err' \u2014 add_pmc_info() was not called for this counter",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE name = 'nic_resp_tx_pkt_seq_err'"
+                },
+                {
+                    "description": "Check PMC description row for nic_req_rx_pkt_seq_err",
+                    "error_message": "No info_pmc row for PMC name 'nic_req_rx_pkt_seq_err' \u2014 add_pmc_info() was not called for this counter",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE name = 'nic_req_rx_pkt_seq_err'"
+                },
+                {
+                    "description": "Check PMC description row for nic_req_rx_impl_nak_seq_err",
+                    "error_message": "No info_pmc row for PMC name 'nic_req_rx_impl_nak_seq_err' \u2014 add_pmc_info() was not called for this counter",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE name = 'nic_req_rx_impl_nak_seq_err'"
                 }
             ]
         }

--- a/projects/rocprofiler-systems/tests/rocpd-validation-rules/ainic/ainic-rdma-rules.json
+++ b/projects/rocprofiler-systems/tests/rocpd-validation-rules/ainic/ainic-rdma-rules.json
@@ -1,0 +1,81 @@
+{
+    "required_tables": [
+        {
+            "name_prefix": "rocpd_string_",
+            "min_rows": 1,
+            "required_columns": ["string"],
+            "validation_queries": [
+                {
+                    "description": "Check for ainic_rx_rdma_ucast_bytes track name",
+                    "error_message": "Did not find ainic_rx_rdma_ucast_bytes in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_rx_rdma_ucast_bytes'"
+                },
+                {
+                    "description": "Check for ainic_tx_rdma_ucast_bytes track name",
+                    "error_message": "Did not find ainic_tx_rdma_ucast_bytes in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_tx_rdma_ucast_bytes'"
+                },
+                {
+                    "description": "Check for ainic_rx_rdma_ucast_pkts track name",
+                    "error_message": "Did not find ainic_rx_rdma_ucast_pkts in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_rx_rdma_ucast_pkts'"
+                },
+                {
+                    "description": "Check for ainic_tx_rdma_ucast_pkts track name",
+                    "error_message": "Did not find ainic_tx_rdma_ucast_pkts in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_tx_rdma_ucast_pkts'"
+                },
+                {
+                    "description": "Check for ainic_rx_rdma_cnp_pkts track name",
+                    "error_message": "Did not find ainic_rx_rdma_cnp_pkts in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_rx_rdma_cnp_pkts'"
+                },
+                {
+                    "description": "Check for ainic_tx_rdma_cnp_pkts track name",
+                    "error_message": "Did not find ainic_tx_rdma_cnp_pkts in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_tx_rdma_cnp_pkts'"
+                },
+                {
+                    "description": "Check for ainic_tx_rdma_ack_timeout track name",
+                    "error_message": "Did not find ainic_tx_rdma_ack_timeout in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_tx_rdma_ack_timeout'"
+                },
+                {
+                    "description": "Check for ainic_resp_tx_pkt_seq_err track name",
+                    "error_message": "Did not find ainic_resp_tx_pkt_seq_err in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_resp_tx_pkt_seq_err'"
+                },
+                {
+                    "description": "Check for ainic_req_rx_pkt_seq_err track name",
+                    "error_message": "Did not find ainic_req_rx_pkt_seq_err in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_req_rx_pkt_seq_err'"
+                },
+                {
+                    "description": "Check for ainic_req_rx_impl_nak_seq_err track name",
+                    "error_message": "Did not find ainic_req_rx_impl_nak_seq_err in ROCpd string table",
+                    "comparison": "greater_than",
+                    "expected_result": 0,
+                    "query": "SELECT COUNT(*) as count FROM {table_name} WHERE string = 'ainic_req_rx_impl_nak_seq_err'"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Motivation

After fixing the missing tracks (see `users/ajanicijamd/ai-nic-phase2-add-missing-tracks`),
there was no test coverage to verify that all 10 AI NIC RDMA counters actually appear in the
output, and no observability into why a device might produce zero samples. This PR addresses both gaps.

The test also catches the class of regression fixed by the companion PR: an `initialize_pmc_metadata()` implementation that omits `add_pmc_info()` calls would pass the track-name check while silently producing zero rows in `rocpd_pmc_event`. The new `rocpd_info_pmc_` validation rule makes that failure visible.

## Technical Details

This PR improves observability and test coverage for the AI NIC sampling pipeline.
### Runtime diagnostics — `nic_traits.hpp`
Added structured logging throughout the device enumeration path:
* `LOG_DEBUG`: total number of AI NIC devices discovered via AMD SMI
* `LOG_DEBUG`: each device skipped because it has no supported RDMA metrics
  * Upgraded to `LOG_WARNING` if the device was explicitly selected in `SPECIFIC` mode.
* `LOG_DEBUG`: each device excluded by the `ROCPROFSYS_SAMPLING_AINICS` filter
* `LOG_INFO`: each device successfully enabled for PMC sampling
* `LOG_WARNING`: when a specifically-requested device name is not found, with the
  list of available device names (`SPECIFIC` mode only)

### Runtime diagnostics — `base/collector.hpp`

Added per-device sample count tracking that applies generically to all collector
types (NIC, GPU, CPU):
* Increments a per-device counter on every successful `store_sample()` call
* After `post_process()`, logs `LOG_WARNING` for any enrolled device that
  accumulated zero samples, and `LOG_DEBUG` with the exact count otherwise

### Test infrastructure

* `capabilities.py`: added `ai_nic_devices` cached property that runs
  `amd-smi static` and extracts all distinct `NETDEV` values
* `conftest.py`: registered the `ainic` pytest marker and added
  `ainic_unavailable_reason()`, which skips the test automatically when
  no AI NIC devices are found on the system
* `ainic-rdma-rules.json`: ROCpd validation rules for all 10 RDMA counter
  names in both `rocpd_string_*` (track registration) **and** `rocpd_info_pmc_*`
  (PMC description registration). The `rocpd_info_pmc_` rules are the ones
  that catch a missing `add_pmc_info()` call while `rocpd_string_*` alone would
  still pass.

### End-to-end test — `test_ainic_perf.py`

New `TestAINIC` test class that profiles `wget` downloading two files and verifies:
* All 10 AI NIC RDMA counter track names appear in the Perfetto trace
* All 10 AI NIC RDMA track names are present in the ROCpd string table,
  validated via `assert_rocpd()` and `ainic-rdma-rules.json`
* All 10 NIC PMC names are present in the `rocpd_info_pmc_*` table,
  confirming that `add_pmc_info()` was called for every counter

Fixed a `NameError` in `test_performance_tracks()` caused by a missing
`test_output_dir` fixture parameter; without it the test failed before
even launching the profiler.

The test supports simulation mode via `SMI_NIC_SYSFS_ROOT` and skips
automatically on systems without AI NIC hardware.

### Compile fix — `nic_traits.hpp`

Added missing `#include <spdlog/fmt/ranges.h>` required by `fmt::join` in
`warn_invalid_names()` (header was absent in the ROCm 7.0 CI container).

## JIRA ID

AIPROFSYST-416

## Test Plan

* Run `pytest -m ainic` on a system with AI NIC hardware (or with `SMI_NIC_SYSFS_ROOT` set)
* Verify the test passes and all 10 counters are reported in both Perfetto and ROCpd output
* Verify the `rocpd_info_pmc_` rules pass, confirming PMC descriptions are registered
* On a system without AI NIC hardware, verify the test is skipped automatically

## Test Result

Tests passing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
