### PR TITLE
hiprtc: Block system headers in HIPRTC

### DIFF
--- a/projects/clr/hipamd/src/hiprtc/hiprtc.cpp
+++ b/projects/clr/hipamd/src/hiprtc/hiprtc.cpp
@@ -121,6 +121,11 @@ hiprtcResult hiprtcCompileProgram(hiprtcProgram prog, int numOptions, const char
   // Do not include the default hiprtc header if the app passes --hiprtc-no-builtin-header option.
   // This is to avoid conflicts with std type traits defined in hiprtc header. Once the actual fix
   // to move type traits to __hip_internal namespace is made in 7.0, this option can be removed.
+
+  // Always block system C/C++ headers to match NVRTC behavior (AIRUNTIME-2028)
+  compile_options.push_back("-nostdinc");
+  compile_options.push_back("-nostdinc++");
+
   if (!no_builtin_header) {
     compile_options.push_back("-D__HIPCC_RTC__");
     compile_options.push_back("-nogpuinc");

--- a/projects/clr/hipamd/src/hiprtc/hiprtc.cpp
+++ b/projects/clr/hipamd/src/hiprtc/hiprtc.cpp
@@ -105,7 +105,7 @@ hiprtcResult hiprtcCompileProgram(hiprtcProgram prog, int numOptions, const char
   bool no_builtin_header = false;
   std::vector<std::string> opt, compile_options;
   opt.reserve(numOptions);
-  compile_options.reserve(numOptions + 4);
+  compile_options.reserve(numOptions + 6);
   for (int i = 0; i < numOptions; i++) {
     if (std::string(options[i]) == std::string("-fgpu-rdc")) {
       fgpu_rdc = true;
@@ -117,15 +117,13 @@ hiprtcResult hiprtcCompileProgram(hiprtcProgram prog, int numOptions, const char
       no_builtin_header = true;
     }
   }
-
-  // Do not include the default hiprtc header if the app passes --hiprtc-no-builtin-header option.
-  // This is to avoid conflicts with std type traits defined in hiprtc header. Once the actual fix
-  // to move type traits to __hip_internal namespace is made in 7.0, this option can be removed.
-
   // Always block system C/C++ headers to match NVRTC behavior (AIRUNTIME-2028)
   compile_options.push_back("-nostdinc");
   compile_options.push_back("-nostdinc++");
 
+  // Do not include the default hiprtc header if the app passes --hiprtc-no-builtin-header option.
+  // This is to avoid conflicts with std type traits defined in hiprtc header. Once the actual fix
+  // to move type traits to __hip_internal namespace is made in 7.0, this option can be removed.
   if (!no_builtin_header) {
     compile_options.push_back("-D__HIPCC_RTC__");
     compile_options.push_back("-nogpuinc");


### PR DESCRIPTION
## Motivation
Add -nostdinc and -nostdinc++ to match NVRTC behavior

## Technical Details
Add -nostdinc and -nostdinc++ to match NVRTC behavior. including them creates redefinition errors when including libhipcxx headers.

## JIRA ID
AIRUNTIME-2028

## Test Plan
hip and hiprtc tests build and execute fine

## Test Result
hip and hiprtc tests build and execute fine

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
