### PR TITLE
[RCCL] Detect undefined symbols post librccl.so linking

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -77,6 +77,7 @@ option(BUILD_BFD                               "Enable custom backtrace (if bfd.
 option(BUILD_LOCAL_GPU_TARGET_ONLY             "Build only for GPUs detected on this machine"  OFF)
 option(BUILD_SHARED_LIBS                       "Build as shared library"                       ON)
 option(BUILD_TESTS                             "Build unit test programs"                      OFF)
+option(CHECK_UNDEFINED_SYMBOLS                 "Fail build if librccl has unresolved symbols"  ON)
 option(BUILD_EXT_EXAMPLES                      "Build ext-{net,tuner,profiler} example plugins" OFF)
 option(DUMP_ASM                                "Disassemble and dump"                          OFF)
 option(ENABLE_CODE_COVERAGE                    "Enable code coverage"                          OFF)

--- a/projects/rccl/cmake/scripts/check_undefined_symbols.cmake
+++ b/projects/rccl/cmake/scripts/check_undefined_symbols.cmake
@@ -117,8 +117,10 @@ if(libatomic_path AND EXISTS "${libatomic_path}")
         endif()
       endif()
     endforeach()
-    # Step 3: record the libatomic failure with the offending symbols.
-    string(APPEND failures "libatomic dependency (misaligned/oversized atomic):${atomic_report}\n")
+    # Step 3: only fail if librccl itself references libatomic symbols (ldd lists transitive deps too).
+    if(NOT atomic_report STREQUAL "")
+      string(APPEND failures "libatomic dependency (misaligned/oversized atomic):${atomic_report}\n")
+    endif()
   endif()
 endif()
 

--- a/projects/rccl/cmake/scripts/check_undefined_symbols.cmake
+++ b/projects/rccl/cmake/scripts/check_undefined_symbols.cmake
@@ -46,13 +46,12 @@ foreach(line ${ldd_lines})
   endif()
 endforeach()
 
-# A missing dependency (=> not found) means ldd could not fully resolve the
-# graph, so the absence of "undefined symbol" lines would be unreliable. Warn
-# loudly but don't fail the build on what is really an environment issue.
+# Missing dependencies (=> not found) make resolution unreliable, so skip (don't pass/fail) the check.
 if(missing_deps)
   list(REMOVE_DUPLICATES missing_deps)
   string(REPLACE ";" "\n  " missing_deps_pretty "${missing_deps}")
-  message(WARNING "Undefined-symbol check incomplete - unresolved dependencies:\n  ${missing_deps_pretty}")
+  message(WARNING "Undefined-symbol check skipped - unresolved dependencies:\n  ${missing_deps_pretty}")
+  return()
 endif()
 
 # Accumulate all failures so every problem is reported in a single error.
@@ -85,11 +84,11 @@ endif()
 # Step 1: detect whether librccl pulled in a libatomic dependency.
 set(libatomic_path "")
 foreach(line ${ldd_lines})
-  if(line MATCHES "libatomic\\.so[^ ]* => ([^ \t]+)")
+  if(line MATCHES "libatomic\\.so[^ ]* => (/[^ \t]+)")
     set(libatomic_path "${CMAKE_MATCH_1}")
   endif()
 endforeach()
-if(libatomic_path)
+if(libatomic_path AND EXISTS "${libatomic_path}")
   # Step 2: nm is required to name the symbols; without it, warn and skip (do not fail).
   find_program(NM_EXECUTABLE nm)
   if(NOT NM_EXECUTABLE)

--- a/projects/rccl/cmake/scripts/check_undefined_symbols.cmake
+++ b/projects/rccl/cmake/scripts/check_undefined_symbols.cmake
@@ -1,0 +1,135 @@
+# ===================================================================================
+# Post-build sanity check: verify librccl.so has no unresolved (undefined) symbols.
+#
+# This reproduces, at build time, the failure mode that otherwise only shows up at
+# runtime when the library is dlopen()'d (e.g. ctypes.CDLL() from a Python test)
+# and aborts with an "undefined symbol" error.
+#
+# Invoked via:  cmake -DRCCL_LIB=<path-to-librccl.so> -P check_undefined_symbols.cmake
+# ===================================================================================
+
+if(NOT DEFINED RCCL_LIB)
+  message(FATAL_ERROR "check_undefined_symbols.cmake requires -DRCCL_LIB=<path>")
+endif()
+
+if(NOT EXISTS "${RCCL_LIB}")
+  message(FATAL_ERROR "Undefined-symbol check: library not found: ${RCCL_LIB}")
+endif()
+
+find_program(LDD_EXECUTABLE ldd)
+if(NOT LDD_EXECUTABLE)
+  message(WARNING "Undefined-symbol check skipped: 'ldd' not found in PATH.")
+  return()
+endif()
+
+# `ldd -r` performs full (data + function) relocation resolution against the
+# library's dependency graph and prints a line per unresolved symbol of the form:
+#     undefined symbol: <name>    (<path>)
+# It exits 0 even when symbols are missing, so we parse the output instead of
+# relying on the return code.
+execute_process(
+  COMMAND ${LDD_EXECUTABLE} -r "${RCCL_LIB}"
+  OUTPUT_VARIABLE ldd_stdout
+  ERROR_VARIABLE  ldd_stderr
+)
+
+set(ldd_output "${ldd_stdout}\n${ldd_stderr}")
+string(REPLACE "\n" ";" ldd_lines "${ldd_output}")
+
+set(undefined_symbols "")
+set(missing_deps "")
+foreach(line ${ldd_lines})
+  if(line MATCHES "undefined symbol: ([^ \t]+)")
+    list(APPEND undefined_symbols "${CMAKE_MATCH_1}")
+  elseif(line MATCHES "=> not found")
+    list(APPEND missing_deps "${line}")
+  endif()
+endforeach()
+
+# A missing dependency (=> not found) means ldd could not fully resolve the
+# graph, so the absence of "undefined symbol" lines would be unreliable. Warn
+# loudly but don't fail the build on what is really an environment issue.
+if(missing_deps)
+  list(REMOVE_DUPLICATES missing_deps)
+  string(REPLACE ";" "\n  " missing_deps_pretty "${missing_deps}")
+  message(WARNING "Undefined-symbol check incomplete - unresolved dependencies:\n  ${missing_deps_pretty}")
+endif()
+
+# Accumulate all failures so every problem is reported in a single error.
+set(failures "")
+
+if(undefined_symbols)
+  list(REMOVE_DUPLICATES undefined_symbols)
+
+  # Demangle for readability when c++filt is available.
+  find_program(CXXFILT_EXECUTABLE c++filt)
+  set(report "")
+  foreach(sym ${undefined_symbols})
+    set(pretty "${sym}")
+    if(CXXFILT_EXECUTABLE)
+      execute_process(
+        COMMAND ${CXXFILT_EXECUTABLE} "${sym}"
+        OUTPUT_VARIABLE demangled
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+      if(demangled AND NOT demangled STREQUAL sym)
+        set(pretty "${sym}  [${demangled}]")
+      endif()
+    endif()
+    string(APPEND report "\n  - ${pretty}")
+  endforeach()
+
+  string(APPEND failures "Unresolved symbols:${report}\n")
+endif()
+
+# RCCL atomics must stay inline/lock-free; a libatomic dependency signals a misaligned/oversized atomic (see -Watomic-alignment).
+# Step 1: detect whether librccl pulled in a libatomic dependency.
+set(libatomic_path "")
+foreach(line ${ldd_lines})
+  if(line MATCHES "libatomic\\.so[^ ]* => ([^ \t]+)")
+    set(libatomic_path "${CMAKE_MATCH_1}")
+  endif()
+endforeach()
+if(libatomic_path)
+  # Step 2: nm is required to name the symbols; without it, warn and skip (do not fail).
+  find_program(NM_EXECUTABLE nm)
+  if(NOT NM_EXECUTABLE)
+    message(WARNING "libatomic check skipped: 'nm' not found.")
+  else()
+    # Step 2a: list the symbols libatomic defines and the symbols librccl leaves undefined.
+    execute_process(COMMAND ${NM_EXECUTABLE} -D --defined-only "${libatomic_path}" OUTPUT_VARIABLE atomic_defined)
+    execute_process(COMMAND ${NM_EXECUTABLE} -D --undefined-only "${RCCL_LIB}" OUTPUT_VARIABLE rccl_undefined)
+    # Step 2b: collect libatomic's exported symbol names (strip version suffix after '@').
+    string(REPLACE "\n" ";" atomic_defined_lines "${atomic_defined}")
+    set(atomic_names "")
+    foreach(l ${atomic_defined_lines})
+      if(l MATCHES " [A-Za-z] ([^ \t@]+)")
+        list(APPEND atomic_names "${CMAKE_MATCH_1}")
+      endif()
+    endforeach()
+    # Step 2c: report each librccl undefined symbol that libatomic provides.
+    set(atomic_report "")
+    string(REPLACE "\n" ";" rccl_undefined_lines "${rccl_undefined}")
+    foreach(l ${rccl_undefined_lines})
+      if(l MATCHES " [UwvV] ([^ \t@]+)")
+        set(sym "${CMAKE_MATCH_1}")
+        list(FIND atomic_names "${sym}" idx)
+        if(NOT idx EQUAL -1)
+          string(APPEND atomic_report "\n  - ${sym}")
+        endif()
+      endif()
+    endforeach()
+    # Step 3: record the libatomic failure with the offending symbols.
+    string(APPEND failures "libatomic dependency (misaligned/oversized atomic):${atomic_report}\n")
+  endif()
+endif()
+
+# Report all accumulated failures once, or pass.
+if(NOT failures STREQUAL "")
+  get_filename_component(lib_name "${RCCL_LIB}" NAME)
+  message(FATAL_ERROR
+    "Undefined-symbol check failed for ${lib_name}\n"
+    "${failures}"
+    "Bypass: -DCHECK_UNDEFINED_SYMBOLS=OFF (install.sh: --no-undef-check)")
+endif()
+
+message(STATUS "Undefined-symbol check passed")

--- a/projects/rccl/install.sh
+++ b/projects/rccl/install.sh
@@ -17,6 +17,7 @@ build_release=true
 debug_fast=false
 build_static=false
 build_tests=false
+check_undefined_symbols=true
 build_verbose=false
 clean_build=true
 dump_asm=false
@@ -73,6 +74,7 @@ function display_help()
     echo "    -l|--local_gpu_only        Only compile for local GPU architecture"
     echo "       --log-trace             Build with log trace enabled (i.e. NCCL_DEBUG=TRACE)"
     echo "       --no_clean              Don't delete files if they already exist"
+    echo "       --no-undef-check        Skip the post-build check for undefined symbols in librccl"
     echo "       --no-device-linker      Disable device linker, use standard -fgpu-rdc"
     echo "       --openmp-test-enable    Enable OpenMP in rccl unit tests"
     echo "    -p|--package_build         Build RCCL package"
@@ -114,7 +116,7 @@ function display_help()
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ "$?" -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,amdgpu_targets:,cmake-options:,debug,debug-fast,dependencies,device-linker,disable-roctx,disable-sym-kernels,disable-warp-speed,dump-asm,enable-code-coverage,enable_backtrace,enable-mpi-tests,fast,force-reduce-pipeline,generate-sym-kernels,help,install,jobs:,kernel-resource-use,local_gpu_only,log-trace,no_clean,no-device-linker,openmp-test-enable,package_build,prefix:,quiet-warnings,rm-legacy-include-dir,rocshmem,roctx-enable,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,amdgpu_targets:,cmake-options:,debug,debug-fast,dependencies,device-linker,disable-roctx,disable-sym-kernels,disable-warp-speed,dump-asm,enable-code-coverage,enable_backtrace,enable-mpi-tests,fast,force-reduce-pipeline,generate-sym-kernels,help,install,jobs:,kernel-resource-use,local_gpu_only,log-trace,no_clean,no-device-linker,no-undef-check,openmp-test-enable,package_build,prefix:,quiet-warnings,rm-legacy-include-dir,rocshmem,roctx-enable,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -153,6 +155,7 @@ while true; do
          --log-trace)                log_trace=true;                                                                                   shift ;;
          --no_clean)                 clean_build=false;                                                                                shift ;;
          --no-device-linker)         device_linker=false;                                                                              shift ;;
+         --no-undef-check)           check_undefined_symbols=false;                                                                    shift ;;
          --openmp-test-enable)       openmp_test_enabled=true;                                                                         shift ;;
     -p | --package_build)            build_package=true;                                                                               shift ;;
          --prefix)                   install_library=true; install_prefix=${2};                                                        shift 2 ;;
@@ -406,6 +409,11 @@ fi
 # Suppress Warnings
 if [[ "${quiet_warnings}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DQUIET_WARNINGS=ON"
+fi
+
+# Skip post-build undefined-symbol check on librccl
+if [[ "${check_undefined_symbols}" == false ]]; then
+    cmake_common_options="${cmake_common_options} -DCHECK_UNDEFINED_SYMBOLS=OFF"
 fi
 
 

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -1107,6 +1107,17 @@ set_property(TARGET rccl PROPERTY RULE_LAUNCH_LINK "${CMAKE_COMMAND} -E time")
 ## Setup librccl.so version
 rocm_set_soversion(rccl "1.0")
 
+## Post-build sanity check: fail the build if librccl.so has unresolved (undefined) symbols that would only surface at dlopen()/ctypes.CDLL() time.
+if(NCCL_OS_LINUX AND BUILD_SHARED_LIBS AND CHECK_UNDEFINED_SYMBOLS)
+  add_custom_command(TARGET rccl POST_BUILD
+    COMMENT "Checking librccl for undefined symbols"
+    COMMAND ${CMAKE_COMMAND}
+            -DRCCL_LIB=$<TARGET_FILE:rccl>
+            -P ${PROJECT_SOURCE_DIR}/cmake/scripts/check_undefined_symbols.cmake
+    VERBATIM
+  )
+endif()
+
 if(NOT BUILD_SHARED_LIBS)
   # To create a static lib with `-fgpu-rdc`, you need `--emit-static-lib` and `--hip-link`.
   # You also need to invoke amdclang++ again to trigger GPU code generation.


### PR DESCRIPTION
## Motivation

With rapid development we keep hitting PyTorch build/load failures from undefined symbols in `librccl.so`; this catches them at build time so we can detect and fix them early

## Technical Details

- Runs as a post-build step after librccl.so is linked (skippable with `--no-undef-check`). If we don't want this to run by default, we can change it to an opt-in option and add it to the CI
- Uses `ldd -r` to resolve the library against its dependencies - the same thing `dlopen()/ctypes.CDLL()` does at runtime.
- Fails the build and lists any unresolved symbols
- Flags a `libatomic` dependency (a misaligned/oversized atomic regression) and names the offending symbols via nm.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Manually inject undef symbols to verify 

## Test Result

Example result:

<img width="955" height="379" alt="image" src="https://github.com/user-attachments/assets/45e75345-dbb9-4dcc-b953-2a9782a24ceb" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
