### PR TITLE
[rocshmem] QP refactor to support GIN

### DIFF
--- a/projects/rocshmem/src/backend_bc.cpp
+++ b/projects/rocshmem/src/backend_bc.cpp
@@ -265,11 +265,15 @@ void Backend::reset_stats() {
 }
 
 int Backend::buffer_register(void *addr, size_t length) {
+  LOG_TRACE("Backend::buffer_register addr=%p length=%zu", addr, length);
+
   if (addr == nullptr) {
+    LOG_TRACE("Backend::buffer_register FAIL: addr is null");
     return ROCSHMEM_ERROR;
   }
 
   if (length == 0) {
+    LOG_TRACE("Backend::buffer_register FAIL: length is 0");
     return ROCSHMEM_ERROR;
   }
 
@@ -277,6 +281,7 @@ int Backend::buffer_register(void *addr, size_t length) {
 
   // Check for overflow when computing end address
   if (start > UINTPTR_MAX - length) {
+    LOG_TRACE("Backend::buffer_register FAIL: overflow start=0x%lx length=%zu", start, length);
     return ROCSHMEM_ERROR;
   }
 
@@ -287,6 +292,9 @@ int Backend::buffer_register(void *addr, size_t length) {
 
   // Check entry at or after our start for overlap
   if (it != user_buffer_regions.end() && it->first < end) {
+    LOG_TRACE("Backend::buffer_register FAIL: overlap with existing region "
+              "[0x%lx, +%zu], new [0x%lx, +%zu]",
+              it->first, it->second, start, length);
     return ROCSHMEM_ERROR;
   }
 
@@ -295,11 +303,16 @@ int Backend::buffer_register(void *addr, size_t length) {
     auto prev = std::prev(it);
     uintptr_t prev_end = prev->first + prev->second;
     if (prev_end > start) {
+      LOG_TRACE("Backend::buffer_register FAIL: overlap with preceding region "
+                "[0x%lx, +%zu] (ends at 0x%lx), new start=0x%lx",
+                prev->first, prev->second, prev_end, start);
       return ROCSHMEM_ERROR;
     }
   }
 
   user_buffer_regions[start] = length;
+  LOG_TRACE("Backend::buffer_register OK: registered [0x%lx, +%zu] (total regions: %zu)",
+            start, length, user_buffer_regions.size());
   return ROCSHMEM_SUCCESS;
 }
 

--- a/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
+++ b/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
@@ -310,12 +310,12 @@ __device__ void QueuePair::bnxt_post_wqe_rma(int32_t length,
   }
 }
 
-__device__ void QueuePair::bnxt_post_wqe_rma_single(int32_t size,
+__device__ void QueuePair::bnxt_post_wqe_rma_single(int32_t length,
     uintptr_t laddr, uint32_t lkey, uintptr_t raddr, uint32_t rkey,
     uint8_t opcode, bool ring_db) {
   lock(&bnxt_sq.lock);
 
-  bnxt_write_rma_wqe(size, raddr, rkey, laddr, lkey, opcode);
+  bnxt_write_rma_wqe(length, raddr, rkey, laddr, lkey, opcode);
 
   if (ring_db) {
     bnxt_ring_doorbell(bnxt_sq.tail);

--- a/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
+++ b/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
@@ -236,7 +236,7 @@ __device__ void QueuePair::bnxt_write_rma_wqe(int32_t length, uintptr_t raddr,
   uint32_t hdr_flags;
   uint32_t inline_msg;
 
-  inline_msg = length <= inline_threshold &&
+  inline_msg = static_cast<int32_t>(length) <= static_cast<int32_t>(inline_threshold) &&
                opcode == gda_op_rdma_write;
 
   bnxt_poll_cq_until(GDA_BNXT_WQE_SLOT_COUNT);
@@ -311,13 +311,10 @@ __device__ void QueuePair::bnxt_post_wqe_rma(int32_t length,
 }
 
 __device__ void QueuePair::bnxt_post_wqe_rma_single(int32_t size,
-    uintptr_t laddr, uintptr_t raddr, uint8_t opcode, bool ring_db) {
-  uint32_t lkey = (static_cast<uint32_t>(size) <= inline_threshold && opcode == gda_op_rdma_write)
-      ? 0 : get_lkey(laddr);
-
+    uintptr_t laddr, uint32_t lkey, uintptr_t raddr, uint32_t rkey,
+    uint8_t opcode, bool ring_db) {
   lock(&bnxt_sq.lock);
 
-  /* Write WQE to SQ */
   bnxt_write_rma_wqe(size, raddr, rkey, laddr, lkey, opcode);
 
   if (ring_db) {
@@ -424,13 +421,13 @@ __device__ uint64_t QueuePair::bnxt_post_wqe_amo(uintptr_t raddr, uint32_t rkey,
 }
 
 __device__ uint64_t QueuePair::bnxt_post_wqe_amo_single(uintptr_t raddr,
-    uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching) {
+    uint32_t rkey, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+    bool fetching, bool fence) {
   uint32_t atomic_idx = 0;
 
   lock(&bnxt_sq.lock);
 
-  /* Write WQE to SQ */
-  atomic_idx = bnxt_write_amo_wqe(raddr, rkey, opcode, atomic_data, atomic_cmp, fetching, false);
+  atomic_idx = bnxt_write_amo_wqe(raddr, rkey, opcode, atomic_data, atomic_cmp, fetching, fence);
 
   bnxt_ring_doorbell(bnxt_sq.tail);
 

--- a/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
+++ b/projects/rocshmem/src/gda/bnxt/queue_pair_bnxt.cpp
@@ -223,7 +223,8 @@ __device__ void QueuePair::bnxt_quiet_single() {
   bnxt_poll_cq_until(bnxt_sq.depth);
 }
 
-__device__ void QueuePair::bnxt_write_rma_wqe(uintptr_t raddr, uintptr_t laddr, int32_t length, uint8_t opcode) {
+__device__ void QueuePair::bnxt_write_rma_wqe(int32_t length, uintptr_t raddr,
+    uint32_t rkey, uintptr_t laddr, uint32_t lkey, uint8_t opcode) {
   struct bnxt_re_bsqe hdr;
   struct bnxt_re_rdma rdma;
   struct bnxt_re_sge sge;
@@ -235,7 +236,7 @@ __device__ void QueuePair::bnxt_write_rma_wqe(uintptr_t raddr, uintptr_t laddr, 
   uint32_t hdr_flags;
   uint32_t inline_msg;
 
-  inline_msg = static_cast<int32_t>(length) <= static_cast<int32_t>(inline_threshold) &&
+  inline_msg = length <= inline_threshold &&
                opcode == gda_op_rdma_write;
 
   bnxt_poll_cq_until(GDA_BNXT_WQE_SLOT_COUNT);
@@ -267,7 +268,7 @@ __device__ void QueuePair::bnxt_write_rma_wqe(uintptr_t raddr, uintptr_t laddr, 
   if (!inline_msg) {
     /* Populate SG Segment */
     sge.pa     = laddr;
-    sge.lkey   = get_lkey(laddr);
+    sge.lkey   = lkey;
     sge.length = length;
   }
 
@@ -289,18 +290,18 @@ __device__ void QueuePair::bnxt_write_rma_wqe(uintptr_t raddr, uintptr_t laddr, 
 }
 
 __device__ void QueuePair::bnxt_post_wqe_rma(int32_t length,
-    uintptr_t laddr, uintptr_t raddr, uint8_t opcode, ActiveWFInfo &wf_info) {
+    uintptr_t raddr, uint32_t rkey, uintptr_t laddr, uint32_t lkey,
+    uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db) {
   if (wf_info.is_pe_group_first) {
     lock(&bnxt_sq.lock);
   }
 
   for (int i = 0; i < wf_info.num_pe_group_lanes; i++) {
     if (i == wf_info.pe_group_logical_lane_id) {
-      /* Write WQE to SQ */
-      bnxt_write_rma_wqe(raddr, laddr, length, opcode);
-
-      /* Ring Doorbell */
-      bnxt_ring_doorbell(bnxt_sq.tail);
+      bnxt_write_rma_wqe(length, raddr, rkey, laddr, lkey, opcode);
+      if (ring_db) {
+        bnxt_ring_doorbell(bnxt_sq.tail);
+      }
     }
   }
 
@@ -309,13 +310,15 @@ __device__ void QueuePair::bnxt_post_wqe_rma(int32_t length,
   }
 }
 
-__device__ void QueuePair::bnxt_post_wqe_rma_single(int32_t length,
+__device__ void QueuePair::bnxt_post_wqe_rma_single(int32_t size,
     uintptr_t laddr, uintptr_t raddr, uint8_t opcode, bool ring_db) {
+  uint32_t lkey = (static_cast<uint32_t>(size) <= inline_threshold && opcode == gda_op_rdma_write)
+      ? 0 : get_lkey(laddr);
 
   lock(&bnxt_sq.lock);
 
   /* Write WQE to SQ */
-  bnxt_write_rma_wqe(raddr, laddr, length, opcode);
+  bnxt_write_rma_wqe(size, raddr, rkey, laddr, lkey, opcode);
 
   if (ring_db) {
     bnxt_ring_doorbell(bnxt_sq.tail);
@@ -324,8 +327,9 @@ __device__ void QueuePair::bnxt_post_wqe_rma_single(int32_t length,
   unlock(&bnxt_sq.lock);
 }
 
-__device__ uint32_t QueuePair::bnxt_write_amo_wqe(uintptr_t raddr,
-    uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching) {
+__device__ uint32_t QueuePair::bnxt_write_amo_wqe(uintptr_t raddr, uint32_t rkey,
+    uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+    bool fetching, bool fence) {
   struct bnxt_re_bsqe hdr;
   struct bnxt_re_atomic amo;
   struct bnxt_re_sge sge;
@@ -349,6 +353,9 @@ __device__ uint32_t QueuePair::bnxt_write_amo_wqe(uintptr_t raddr,
   wqe_size  = BNXT_RE_HDR_WS_MASK & GDA_BNXT_WQE_SLOT_COUNT;
   hdr_flags = ((uint32_t) BNXT_RE_HDR_FLAGS_MASK)
             & ((uint32_t) BNXT_RE_WR_FLAGS_SIGNALED);
+  if (fence) {
+    hdr_flags |= ((uint32_t) BNXT_RE_WR_FLAGS_UC_FENCE);
+  }
   wqe_type  = BNXT_RE_HDR_WT_MASK & opcode;
 
   hdr.rsv_ws_fl_wt  = (wqe_size  << BNXT_RE_HDR_WS_SHIFT)
@@ -386,18 +393,18 @@ __device__ uint32_t QueuePair::bnxt_write_amo_wqe(uintptr_t raddr,
   return atomic_idx;
 }
 
-__device__ uint64_t QueuePair::bnxt_post_wqe_amo(uintptr_t raddr,
-    uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching,
-    ActiveWFInfo &wf_info) {
+__device__ uint64_t QueuePair::bnxt_post_wqe_amo(uintptr_t raddr, uint32_t rkey,
+    uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+    ActiveWFInfo &wf_info, bool fetching, bool fence) {
   uint32_t atomic_idx = 0;
 
-    if (wf_info.is_pe_group_first) {
+  if (wf_info.is_pe_group_first) {
     lock(&bnxt_sq.lock);
   }
 
   for (int i = 0; i < wf_info.num_pe_group_lanes; i++) {
     if (i == wf_info.pe_group_logical_lane_id) {
-      atomic_idx = bnxt_write_amo_wqe(raddr, opcode, atomic_data, atomic_cmp, fetching);
+      atomic_idx = bnxt_write_amo_wqe(raddr, rkey, opcode, atomic_data, atomic_cmp, fetching, fence);
 
       /* Ring Doorbell */
       bnxt_ring_doorbell(bnxt_sq.tail);
@@ -423,7 +430,7 @@ __device__ uint64_t QueuePair::bnxt_post_wqe_amo_single(uintptr_t raddr,
   lock(&bnxt_sq.lock);
 
   /* Write WQE to SQ */
-  atomic_idx = bnxt_write_amo_wqe(raddr, opcode, atomic_data, atomic_cmp, fetching);
+  atomic_idx = bnxt_write_amo_wqe(raddr, rkey, opcode, atomic_data, atomic_cmp, fetching, false);
 
   bnxt_ring_doorbell(bnxt_sq.tail);
 

--- a/projects/rocshmem/src/gda/context_gda_device.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device.cpp
@@ -88,7 +88,7 @@ __device__ void GDAContext::putmem(void *dest, const void *source, size_t nelems
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
-  qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
+  qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
   qps[qp_index].quiet(wf_info);
 }
 
@@ -104,7 +104,7 @@ __device__ void GDAContext::getmem(void *dest, const void *source, size_t nelems
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
   uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
-  qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
+  qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, wf_info);
   qps[qp_index].quiet(wf_info);
 }
 
@@ -119,7 +119,7 @@ __device__ void GDAContext::putmem_nbi(void *dest, const void *source,
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
-  qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
+  qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
 }
 
 __device__ void GDAContext::getmem_nbi(void *dest, const void *source,
@@ -134,7 +134,7 @@ __device__ void GDAContext::getmem_nbi(void *dest, const void *source,
   ActiveWFInfo wf_info(pe);
   int qp_index = get_qp_index(pe, wf_info);
   uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
-  qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
+  qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, wf_info);
 }
 
 __device__ void GDAContext::fence() {
@@ -238,7 +238,7 @@ __device__ void GDAContext::putmem_wg(void *dest, const void *source,
     uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
     ActiveWFInfo wf_info(pe, ThreadScope::wg);
     int qp_index = get_qp_index(pe, wf_info);
-    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
+    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
     qps[qp_index].quiet(wf_info);
   }
 }
@@ -256,7 +256,7 @@ __device__ void GDAContext::getmem_wg(void *dest, const void *source,
     uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
     ActiveWFInfo wf_info(pe, ThreadScope::wg);
     int qp_index = get_qp_index(pe, wf_info);
-    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
+    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, wf_info);
     qps[qp_index].quiet(wf_info);
   }
 }
@@ -273,7 +273,7 @@ __device__ void GDAContext::putmem_nbi_wg(void *dest, const void *source,
     uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
     ActiveWFInfo wf_info(pe, ThreadScope::wg);
     int qp_index = get_qp_index(pe, wf_info);
-    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
+    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
   }
 }
 
@@ -290,7 +290,7 @@ __device__ void GDAContext::getmem_nbi_wg(void *dest, const void *source,
     uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
     ActiveWFInfo wf_info(pe, ThreadScope::wg);
     int qp_index = get_qp_index(pe, wf_info);
-    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
+    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, wf_info);
   }
 }
 
@@ -306,7 +306,7 @@ __device__ void GDAContext::putmem_wave(void *dest, const void *source,
     ActiveWFInfo wf_info(pe, ThreadScope::wave);
     int qp_index = get_qp_index(pe, wf_info);
     uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
-    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
+    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
     qps[qp_index].quiet(wf_info);
   }
 }
@@ -324,7 +324,7 @@ __device__ void GDAContext::getmem_wave(void *dest, const void *source,
     ActiveWFInfo wf_info(pe, ThreadScope::wave);
     int qp_index = get_qp_index(pe, wf_info);
     uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
-    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
+    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, wf_info);
     qps[qp_index].quiet(wf_info);
   }
 }
@@ -341,7 +341,7 @@ __device__ void GDAContext::putmem_nbi_wave(void *dest, const void *source,
     ActiveWFInfo wf_info(pe, ThreadScope::wave);
     int qp_index = get_qp_index(pe, wf_info);
     uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
-    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
+    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
   }
 }
 
@@ -358,7 +358,7 @@ __device__ void GDAContext::getmem_nbi_wave(void *dest, const void *source,
     ActiveWFInfo wf_info(pe, ThreadScope::wave);
     int qp_index = get_qp_index(pe, wf_info);
     uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
-    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
+    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, wf_info);
   }
 }
 
@@ -496,7 +496,7 @@ __device__ void GDAContext::internal_putmem(void *dest, const void *source, size
     return;
   }
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
-  qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
+  qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
   qps[qp_index].quiet(wf_info);
 }
 
@@ -510,7 +510,7 @@ __device__ void GDAContext::internal_getmem(void *dest, const void *source, size
     return;
   }
   uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
-  qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
+  qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, wf_info);
   qps[qp_index].quiet(wf_info);
 }
 
@@ -524,7 +524,7 @@ __device__ void GDAContext::internal_putmem_wg(void *dest, const void *source,
   }
   if (is_thread_zero_in_block()) {
     uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
-    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
+    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
     qps[qp_index].quiet(wf_info);
   }
 }
@@ -540,7 +540,7 @@ __device__ void GDAContext::internal_getmem_wg(void *dest, const void *source,
   }
   if (is_wave_zero_in_block()) {
     uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
-    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
+    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, wf_info);
     qps[qp_index].quiet(wf_info);
   }
 }
@@ -555,7 +555,7 @@ __device__ void GDAContext::internal_putmem_wave(void *dest, const void *source,
   }
   if (is_thread_zero_in_wave()) {
     uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
-    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
+    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
     qps[qp_index].quiet(wf_info);
   }
 }
@@ -571,7 +571,7 @@ __device__ void GDAContext::internal_getmem_wave(void *dest, const void *source,
   }
   if (is_thread_zero_in_wave()) {
     uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
-    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
+    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, wf_info);
     qps[qp_index].quiet(wf_info);
   }
 }
@@ -585,7 +585,7 @@ __device__ void GDAContext::internal_putmem_nbi(void *dest, const void *source, 
     return;
   }
   uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
-  qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
+  qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
 }
 
 __device__ void GDAContext::internal_getmem_nbi(void *dest, const void *source, size_t nelems,
@@ -598,7 +598,7 @@ __device__ void GDAContext::internal_getmem_nbi(void *dest, const void *source, 
     return;
   }
   uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
-  qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
+  qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, wf_info);
 }
 
 __device__ void GDAContext::internal_putmem_nbi_wg(void *dest, const void *source,
@@ -611,7 +611,7 @@ __device__ void GDAContext::internal_putmem_nbi_wg(void *dest, const void *sourc
   }
   if (is_wave_zero_in_block()) {
     uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
-    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
+    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
   }
 }
 
@@ -626,7 +626,7 @@ __device__ void GDAContext::internal_getmem_nbi_wg(void *dest, const void *sourc
   }
   if (is_wave_zero_in_block()) {
     uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
-    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
+    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, wf_info);
   }
 }
 
@@ -640,7 +640,7 @@ __device__ void GDAContext::internal_putmem_nbi_wave(void *dest, const void *sou
   }
   if (is_thread_zero_in_wave()) {
     uint64_t L_offset = reinterpret_cast<char*>(dest) - base_heap[constmem.my_pe];
-    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, pe, wf_info);
+    qps[qp_index].put_nbi(base_heap[pe] + L_offset, source, nelems, wf_info);
   }
 }
 
@@ -655,7 +655,7 @@ __device__ void GDAContext::internal_getmem_nbi_wave(void *dest, const void *sou
   }
   if (is_thread_zero_in_wave()) {
     uint64_t L_offset = const_cast<char *>(src_typed) - base_heap[constmem.my_pe];
-    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, pe, wf_info);
+    qps[qp_index].get_nbi(dest, base_heap[pe] + L_offset, nelems, wf_info);
   }
 }
 

--- a/projects/rocshmem/src/gda/ibv_wrapper.cpp
+++ b/projects/rocshmem/src/gda/ibv_wrapper.cpp
@@ -265,10 +265,19 @@ struct ibv_mr* IBVWrapper::reg_mr(struct ibv_pd* pd, void* addr, size_t length, 
   }
 }
 
+struct ibv_mr* IBVWrapper::reg_mr_iova2(struct ibv_pd *pd, void *addr, size_t length, uint64_t iova, int access) {
+  return ibv.reg_mr_iova2(pd, addr, length, iova, access);
+}
+
+struct ibv_mr* IBVWrapper::reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access) {
+  return ibv.reg_dmabuf_mr(pd, offset, length, iova, fd, access);
+}
+
 int IBVWrapper::dereg_mr(struct ibv_mr *mr) {
-  if (is_dmabuf_supported()) {
-    int fd = dmabuf_fd_map.erase((uintptr_t) mr);
-    close(fd);
+  auto it = dmabuf_fd_map.find((uintptr_t) mr);
+  if (it != dmabuf_fd_map.end()) {
+    close(it->second);
+    dmabuf_fd_map.erase(it);
   }
   return ibv.dereg_mr(mr);
 }

--- a/projects/rocshmem/src/gda/ibv_wrapper.hpp
+++ b/projects/rocshmem/src/gda/ibv_wrapper.hpp
@@ -65,6 +65,8 @@ class IBVWrapper {
     int dealloc_pd(struct ibv_pd *pd);
 
     struct ibv_mr* reg_mr(struct ibv_pd *pd, void *addr, size_t length, int access, HIPAllocator *allocator = nullptr);
+    struct ibv_mr* reg_mr_iova2(struct ibv_pd *pd, void *addr, size_t length, uint64_t iova, int access);
+    struct ibv_mr* reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length, uint64_t iova, int fd, int access);
     int dereg_mr(struct ibv_mr *mr);
 
     struct ibv_cq_ex* create_cq_ex(struct ibv_context *context,

--- a/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
+++ b/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
@@ -350,7 +350,7 @@ __device__ void QueuePair::ionic_post_wqe_rma(int32_t length,
   }
 }
 
-__device__ void QueuePair::ionic_post_wqe_rma_single(int32_t size,
+__device__ void QueuePair::ionic_post_wqe_rma_single(int32_t length,
     uintptr_t laddr, uint32_t lkey, uintptr_t raddr,
     uint32_t rkey, uint8_t opcode, bool ring_db) {
   uint32_t num_wqes = 1;
@@ -366,33 +366,33 @@ __device__ void QueuePair::ionic_post_wqe_rma_single(int32_t size,
   wqe_flags |= byteswap<uint16_t>(IONIC_V1_FLAG_SIG);
 
   // TODO why is this needed?
-  if (size && !laddr && opcode == IONIC_V2_OP_RDMA_WRITE) {
-    size = 1;
+  if (length && !laddr && opcode == IONIC_V2_OP_RDMA_WRITE) {
+    length = 1;
   }
 
   wqe->base.wqe_idx = my_sq_pos;
   wqe->base.op = opcode;
-  wqe->base.num_sge_key = size ? 1 : 0;
+  wqe->base.num_sge_key = length ? 1 : 0;
   wqe->base.imm_data_key = byteswap<uint32_t>(0);
 
   wqe->common.rdma.remote_va_high = byteswap<uint32_t>(raddr >> 32);
   wqe->common.rdma.remote_va_low = byteswap<uint32_t>(raddr);
   wqe->common.rdma.remote_rkey = byteswap<uint32_t>(rkey);
-  wqe->common.length = byteswap<uint32_t>(size);
+  wqe->common.length = byteswap<uint32_t>(length);
 
-  if (size) {
-    if (opcode == IONIC_V2_OP_RDMA_WRITE && static_cast<int32_t>(size) <= static_cast<int32_t>(inline_threshold)) {
+  if (length) {
+    if (opcode == IONIC_V2_OP_RDMA_WRITE && static_cast<int32_t>(length) <= static_cast<int32_t>(inline_threshold)) {
       wqe_flags |= byteswap<uint16_t>(IONIC_V1_FLAG_INL);
       wqe->base.num_sge_key = 0;
       if (!laddr) {
         // TODO why is this needed?
         wqe->common.pld.data[0] = 1;
       } else {
-        memcpy(wqe->common.pld.data, reinterpret_cast<const void*>(laddr), size);
+        memcpy(wqe->common.pld.data, reinterpret_cast<const void*>(laddr), length);
       }
     } else {
       wqe->common.pld.sgl[0].va = byteswap<uint64_t>(laddr);
-      wqe->common.pld.sgl[0].len = byteswap<uint32_t>(size);
+      wqe->common.pld.sgl[0].len = byteswap<uint32_t>(length);
       wqe->common.pld.sgl[0].lkey = byteswap<uint32_t>(lkey);
     }
   }

--- a/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
+++ b/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
@@ -288,8 +288,9 @@ __device__ void QueuePair::ionic_quiet_single() {
   ionic_quiet_internal_ccqe_single(sq_prod);
 }
 
-__device__ void QueuePair::ionic_post_wqe_rma(int32_t size, uintptr_t laddr,
-    uintptr_t raddr, uint8_t opcode, ActiveWFInfo &wf_info) {
+__device__ void QueuePair::ionic_post_wqe_rma(int32_t length,
+    uintptr_t raddr, uint32_t rkey, uintptr_t laddr, uint32_t lkey,
+    uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db) {
   uint32_t num_wqes = 1;
   if (wf_info.scope == ThreadScope::thread) {
     num_wqes = wf_info.num_pe_group_lanes;
@@ -310,41 +311,43 @@ __device__ void QueuePair::ionic_post_wqe_rma(int32_t size, uintptr_t laddr,
   }
 
   // TODO why is this needed?
-  if (size && !laddr && opcode == IONIC_V2_OP_RDMA_WRITE) {
-    size = 1;
+  if (length && !laddr && opcode == IONIC_V2_OP_RDMA_WRITE) {
+    length = 1;
   }
 
   wqe->base.wqe_idx = my_sq_pos;
   wqe->base.op = opcode;
-  wqe->base.num_sge_key = size ? 1 : 0;
+  wqe->base.num_sge_key = length ? 1 : 0;
   wqe->base.imm_data_key = byteswap<uint32_t>(0);
 
   wqe->common.rdma.remote_va_high = byteswap<uint32_t>(raddr >> 32);
   wqe->common.rdma.remote_va_low = byteswap<uint32_t>(raddr);
   wqe->common.rdma.remote_rkey = byteswap<uint32_t>(rkey);
-  wqe->common.length = byteswap<uint32_t>(size);
+  wqe->common.length = byteswap<uint32_t>(length);
 
-  if (size) {
-    if (opcode == IONIC_V2_OP_RDMA_WRITE && static_cast<int32_t>(size) <= static_cast<int32_t>(inline_threshold)) {
+  if (length) {
+    if (opcode == IONIC_V2_OP_RDMA_WRITE && length <= inline_threshold) {
       wqe_flags |= byteswap<uint16_t>(IONIC_V1_FLAG_INL);
       wqe->base.num_sge_key = 0;
       if (!laddr) {
         // TODO why is this needed?
         wqe->common.pld.data[0] = 1;
       } else {
-        memcpy(wqe->common.pld.data, reinterpret_cast<const void*>(laddr), size);
+        memcpy(wqe->common.pld.data, reinterpret_cast<const void*>(laddr), length);
       }
     } else {
       wqe->common.pld.sgl[0].va = byteswap<uint64_t>(laddr);
-      wqe->common.pld.sgl[0].len = byteswap<uint32_t>(size);
-      wqe->common.pld.sgl[0].lkey = byteswap<uint32_t>(get_lkey(laddr));
+      wqe->common.pld.sgl[0].len = byteswap<uint32_t>(length);
+      wqe->common.pld.sgl[0].lkey = byteswap<uint32_t>(lkey);
     }
   }
 
   __hip_atomic_store(&wqe->base.flags, wqe_flags, __ATOMIC_RELEASE,
     __HIP_MEMORY_SCOPE_AGENT);
 
-  commit_sq(wf_info, my_sq_prod, my_sq_pos, num_wqes);
+  if (ring_db) {
+    commit_sq(wf_info, my_sq_prod, my_sq_pos, num_wqes);
+  }
 }
 
 __device__ void QueuePair::ionic_post_wqe_rma_single(int32_t size,
@@ -389,7 +392,7 @@ __device__ void QueuePair::ionic_post_wqe_rma_single(int32_t size,
     } else {
       wqe->common.pld.sgl[0].va = byteswap<uint64_t>(laddr);
       wqe->common.pld.sgl[0].len = byteswap<uint32_t>(size);
-      wqe->common.pld.sgl[0].lkey = byteswap<uint32_t>(get_lkey(laddr));
+      wqe->common.pld.sgl[0].lkey = byteswap<uint32_t>(laddr ? get_lkey(laddr) : 0);
     }
   }
 
@@ -398,9 +401,9 @@ __device__ void QueuePair::ionic_post_wqe_rma_single(int32_t size,
   commit_sq_single(my_sq_prod, my_sq_pos, num_wqes);
 }
 
-__device__ uint64_t QueuePair::ionic_post_wqe_amo([[maybe_unused]] int32_t size, uintptr_t raddr,
+__device__ uint64_t QueuePair::ionic_post_wqe_amo(uintptr_t raddr, uint32_t rkey,
     uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
-    bool fetching, ActiveWFInfo &wf_info) {
+    ActiveWFInfo &wf_info, bool fetching, bool fence) {
   uint32_t num_wqes = wf_info.num_pe_group_lanes;
   uint32_t my_sq_prod = reserve_sq(wf_info, num_wqes);
   uint32_t my_sq_pos = my_sq_prod + wf_info.pe_group_logical_lane_id;
@@ -427,6 +430,9 @@ __device__ uint64_t QueuePair::ionic_post_wqe_amo([[maybe_unused]] int32_t size,
 
   if (wf_info.is_pe_group_last) {
     wqe_flags |= byteswap<uint16_t>(IONIC_V1_FLAG_SIG);
+  }
+  if (fence) {
+    wqe_flags |= byteswap<uint16_t>(IONIC_V1_FLAG_FENCE);
   }
 
   wqe->base.wqe_idx = my_sq_pos;
@@ -470,8 +476,8 @@ __device__ uint64_t QueuePair::ionic_post_wqe_amo([[maybe_unused]] int32_t size,
   return ret;
 }
 
-__device__ uint64_t QueuePair::ionic_post_wqe_amo_single([[maybe_unused]] int32_t size,
-    uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+__device__ uint64_t QueuePair::ionic_post_wqe_amo_single(uintptr_t raddr,
+    uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
     bool fetching) {
   uint32_t num_wqes = 1;
   uint32_t my_sq_prod = reserve_sq_single(num_wqes);

--- a/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
+++ b/projects/rocshmem/src/gda/ionic/queue_pair_ionic.cpp
@@ -326,7 +326,7 @@ __device__ void QueuePair::ionic_post_wqe_rma(int32_t length,
   wqe->common.length = byteswap<uint32_t>(length);
 
   if (length) {
-    if (opcode == IONIC_V2_OP_RDMA_WRITE && length <= inline_threshold) {
+    if (opcode == IONIC_V2_OP_RDMA_WRITE && static_cast<int32_t>(length) <= static_cast<int32_t>(inline_threshold)) {
       wqe_flags |= byteswap<uint16_t>(IONIC_V1_FLAG_INL);
       wqe->base.num_sge_key = 0;
       if (!laddr) {
@@ -351,7 +351,8 @@ __device__ void QueuePair::ionic_post_wqe_rma(int32_t length,
 }
 
 __device__ void QueuePair::ionic_post_wqe_rma_single(int32_t size,
-    uintptr_t laddr, uintptr_t raddr, uint8_t opcode) {
+    uintptr_t laddr, uint32_t lkey, uintptr_t raddr,
+    uint32_t rkey, uint8_t opcode, bool ring_db) {
   uint32_t num_wqes = 1;
   uint32_t my_sq_prod = reserve_sq_single(num_wqes);
   uint32_t my_sq_pos = my_sq_prod;
@@ -392,13 +393,15 @@ __device__ void QueuePair::ionic_post_wqe_rma_single(int32_t size,
     } else {
       wqe->common.pld.sgl[0].va = byteswap<uint64_t>(laddr);
       wqe->common.pld.sgl[0].len = byteswap<uint32_t>(size);
-      wqe->common.pld.sgl[0].lkey = byteswap<uint32_t>(laddr ? get_lkey(laddr) : 0);
+      wqe->common.pld.sgl[0].lkey = byteswap<uint32_t>(lkey);
     }
   }
 
   __hip_atomic_store(&wqe->base.flags, wqe_flags, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_AGENT);
 
-  commit_sq_single(my_sq_prod, my_sq_pos, num_wqes);
+  if (ring_db) {
+    commit_sq_single(my_sq_prod, my_sq_pos, num_wqes);
+  }
 }
 
 __device__ uint64_t QueuePair::ionic_post_wqe_amo(uintptr_t raddr, uint32_t rkey,
@@ -477,8 +480,8 @@ __device__ uint64_t QueuePair::ionic_post_wqe_amo(uintptr_t raddr, uint32_t rkey
 }
 
 __device__ uint64_t QueuePair::ionic_post_wqe_amo_single(uintptr_t raddr,
-    uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
-    bool fetching) {
+    uint32_t rkey, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+    bool fetching, bool fence) {
   uint32_t num_wqes = 1;
   uint32_t my_sq_prod = reserve_sq_single(num_wqes);
   uint32_t my_sq_pos = my_sq_prod;
@@ -500,6 +503,9 @@ __device__ uint64_t QueuePair::ionic_post_wqe_amo_single(uintptr_t raddr,
   }
 
   wqe_flags |= byteswap<uint16_t>(IONIC_V1_FLAG_SIG);
+  if (fence) {
+    wqe_flags |= byteswap<uint16_t>(IONIC_V1_FLAG_FENCE);
+  }
 
   wqe->base.wqe_idx = my_sq_pos;
   wqe->base.op = opcode;

--- a/projects/rocshmem/src/gda/mlx5/backend_gda_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/backend_gda_mlx5.cpp
@@ -114,8 +114,8 @@ void GDABackend::mlx5_initialize_gpu_qp(QueuePair* gpu_qp, int conn_num) {
   int pe = conn_num % num_pes;
   int nic_idx = nic_idx_for_qp(conn_num);
   NicDevice &nic = nic_for_qp(conn_num);
-  gpu_qp->rkey = htobe32(heap_rkey[pe * num_nics_ + nic_idx]);
-  gpu_qp->lkey = htobe32(nic.heap_mr->lkey);
+  gpu_qp->rkey = heap_rkey[pe * num_nics_ + nic_idx];
+  gpu_qp->lkey = nic.heap_mr->lkey;
   gpu_qp->qp_num = qp.qpn;
   gpu_qp->inline_threshold = inline_threshold;
 

--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -258,8 +258,9 @@ __device__ void QueuePair::mlx5_quiet_single() {
 }
 
 // can be called with all active lanes using any number of different QPs, don't assume anything
-__device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t laddr, uintptr_t raddr,
-                                             uint8_t opcode, ActiveWFInfo &wf_info) {
+__device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t raddr,
+    uint32_t rkey, uintptr_t laddr, uint32_t lkey,
+    uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db) {
   if (wf_info.is_pe_group_last) {
     // get SQ lock
     acquire_lock(&mlx5_sq.lock);
@@ -276,8 +277,7 @@ __device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t laddr, ui
 
   // construct the WQE on the stack
   gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
-                   raddr, rkey, laddr,
-                   send_inline ? 0 : get_lkey(laddr),
+                   raddr, byteswap<uint32_t>(rkey), laddr, byteswap<uint32_t>(lkey),
                    static_cast<uint32_t>(length), send_inline};
 
   // copy to SQ
@@ -287,7 +287,9 @@ __device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t laddr, ui
     // increment post counter
     mlx5_sq.post += wf_info.num_pe_group_lanes;
     // we are the last thread in the wavefront, so we have the last WQE posted
-    mlx5_ring_doorbell(mlx5_sq.post, wqe);
+    if (ring_db) {
+      mlx5_ring_doorbell(mlx5_sq.post, wqe);
+    }
     // release SQ lock
     release_lock(&mlx5_sq.lock);
   }
@@ -296,6 +298,9 @@ __device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t laddr, ui
 // precondition: called with all active lanes using different QPs
 __device__ void QueuePair::mlx5_post_wqe_rma_single(int32_t length, uintptr_t laddr, uintptr_t raddr,
                                                     uint8_t opcode, bool ring_db) {
+  bool send_inline = gda_mlx5_wqe_rma::can_inline(opcode, length, inline_threshold);
+  uint32_t lkey_val = send_inline ? 0 : byteswap<uint32_t>(get_lkey(laddr));
+
   // get SQ lock
   acquire_lock(&mlx5_sq.lock);
   // poll until we have enough space for at least one WQE
@@ -305,12 +310,10 @@ __device__ void QueuePair::mlx5_post_wqe_rma_single(int32_t length, uintptr_t la
   uint16_t wqe_idx = mlx5_wqe_idx(mlx5_sq, 0);
   uint16_t sq_idx = mlx5_sq_idx(mlx5_sq, wqe_idx);
 
-  // can we inline the data into the WQE?
-  bool send_inline = gda_mlx5_wqe_rma::can_inline(opcode, length, inline_threshold);
-
   // construct the WQE on the stack
   gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
-                   raddr, rkey, laddr, get_lkey(laddr), static_cast<uint32_t>(length), send_inline};
+                   raddr, byteswap<uint32_t>(rkey), laddr, lkey_val,
+                   static_cast<uint32_t>(length), send_inline};
 
   // copy to SQ
   mlx5_sq.buf[sq_idx] = wqe;
@@ -330,10 +333,9 @@ __device__ void QueuePair::mlx5_post_wqe_rma_single(int32_t length, uintptr_t la
 /* can be called with all active lanes using any number of different QPs, don't assume anything
  * assumes that `fetching' is constant across all lanes using the same QP
  * TODO: make `fetching' a template parameter */
-__device__ uint64_t QueuePair::mlx5_post_wqe_amo([[maybe_unused]] int32_t length,
-                                                 uintptr_t raddr, uint8_t opcode,
-                                                 int64_t atomic_data, int64_t atomic_cmp,
-                                                 bool fetching, ActiveWFInfo &wf_info) {
+__device__ uint64_t QueuePair::mlx5_post_wqe_amo(uintptr_t raddr, uint32_t rkey,
+    uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+    ActiveWFInfo &wf_info, bool fetching, bool fence) {
   if (wf_info.is_pe_group_last) {
     // get SQ lock
     acquire_lock(&mlx5_sq.lock);
@@ -353,9 +355,12 @@ __device__ uint64_t QueuePair::mlx5_post_wqe_amo([[maybe_unused]] int32_t length
   uint16_t wqe_idx = mlx5_wqe_idx(mlx5_sq, wf_info.pe_group_logical_lane_id);
   uint16_t sq_idx = mlx5_sq_idx(mlx5_sq, wqe_idx);
 
+  uint8_t fm_ce_se = MLX5_WQE_CTRL_CQ_UPDATE;
+  if (fence) fm_ce_se |= MLX5_WQE_CTRL_FENCE;
+
   // construct the WQE on the stack
-  gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
-                   raddr, rkey,
+  gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, fm_ce_se,
+                   raddr, byteswap<uint32_t>(rkey),
                    static_cast<uint64_t>(atomic_data), static_cast<uint64_t>(atomic_cmp),
                    reinterpret_cast<uintptr_t>(atomic_laddr), atomic_lkey};
 
@@ -382,8 +387,7 @@ __device__ uint64_t QueuePair::mlx5_post_wqe_amo([[maybe_unused]] int32_t length
 }
 
 // precondition: called with all active lanes using different QPs
-__device__ uint64_t QueuePair::mlx5_post_wqe_amo_single([[maybe_unused]] int32_t length,
-                                                        uintptr_t raddr, uint8_t opcode,
+__device__ uint64_t QueuePair::mlx5_post_wqe_amo_single(uintptr_t raddr, uint8_t opcode,
                                                         int64_t atomic_data, int64_t atomic_cmp,
                                                         bool fetching) {
   // get SQ lock

--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -296,10 +296,11 @@ __device__ void QueuePair::mlx5_post_wqe_rma(int32_t length, uintptr_t raddr,
 }
 
 // precondition: called with all active lanes using different QPs
-__device__ void QueuePair::mlx5_post_wqe_rma_single(int32_t length, uintptr_t laddr, uintptr_t raddr,
-                                                    uint8_t opcode, bool ring_db) {
+__device__ void QueuePair::mlx5_post_wqe_rma_single(int32_t length, uintptr_t laddr,
+                                                    uint32_t lkey, uintptr_t raddr,
+                                                    uint32_t rkey, uint8_t opcode,
+                                                    bool ring_db) {
   bool send_inline = gda_mlx5_wqe_rma::can_inline(opcode, length, inline_threshold);
-  uint32_t lkey_val = send_inline ? 0 : byteswap<uint32_t>(get_lkey(laddr));
 
   // get SQ lock
   acquire_lock(&mlx5_sq.lock);
@@ -312,7 +313,7 @@ __device__ void QueuePair::mlx5_post_wqe_rma_single(int32_t length, uintptr_t la
 
   // construct the WQE on the stack
   gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
-                   raddr, byteswap<uint32_t>(rkey), laddr, lkey_val,
+                   raddr, byteswap<uint32_t>(rkey), laddr, byteswap<uint32_t>(lkey),
                    static_cast<uint32_t>(length), send_inline};
 
   // copy to SQ
@@ -387,9 +388,10 @@ __device__ uint64_t QueuePair::mlx5_post_wqe_amo(uintptr_t raddr, uint32_t rkey,
 }
 
 // precondition: called with all active lanes using different QPs
-__device__ uint64_t QueuePair::mlx5_post_wqe_amo_single(uintptr_t raddr, uint8_t opcode,
+__device__ uint64_t QueuePair::mlx5_post_wqe_amo_single(uintptr_t raddr,
+                                                        uint32_t rkey, uint8_t opcode,
                                                         int64_t atomic_data, int64_t atomic_cmp,
-                                                        bool fetching) {
+                                                        bool fetching, bool fence) {
   // get SQ lock
   acquire_lock(&mlx5_sq.lock);
   // poll until we have enough space for at least one WQE
@@ -407,8 +409,11 @@ __device__ uint64_t QueuePair::mlx5_post_wqe_amo_single(uintptr_t raddr, uint8_t
   uint16_t wqe_idx = mlx5_wqe_idx(mlx5_sq, 0);
   uint16_t sq_idx = mlx5_sq_idx(mlx5_sq, wqe_idx);
 
+  uint8_t fm_ce_se = MLX5_WQE_CTRL_CQ_UPDATE;
+  if (fence) fm_ce_se |= MLX5_WQE_CTRL_FENCE;
+
   // construct the WQE on the stack
-  gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, MLX5_WQE_CTRL_CQ_UPDATE,
+  gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, fm_ce_se,
                    raddr, rkey,
                    static_cast<uint64_t>(atomic_data), static_cast<uint64_t>(atomic_cmp),
                    reinterpret_cast<uintptr_t>(atomic_laddr), atomic_lkey};

--- a/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
+++ b/projects/rocshmem/src/gda/mlx5/queue_pair_mlx5.cpp
@@ -363,7 +363,7 @@ __device__ uint64_t QueuePair::mlx5_post_wqe_amo(uintptr_t raddr, uint32_t rkey,
   gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, fm_ce_se,
                    raddr, byteswap<uint32_t>(rkey),
                    static_cast<uint64_t>(atomic_data), static_cast<uint64_t>(atomic_cmp),
-                   reinterpret_cast<uintptr_t>(atomic_laddr), atomic_lkey};
+                   reinterpret_cast<uintptr_t>(atomic_laddr), byteswap<uint32_t>(atomic_lkey)};
 
   // copy to SQ
   mlx5_sq.buf[sq_idx] = wqe;
@@ -414,9 +414,9 @@ __device__ uint64_t QueuePair::mlx5_post_wqe_amo_single(uintptr_t raddr,
 
   // construct the WQE on the stack
   gda_mlx5_wqe wqe{wqe_idx, opcode, qp_num, fm_ce_se,
-                   raddr, rkey,
+                   raddr, byteswap<uint32_t>(rkey),
                    static_cast<uint64_t>(atomic_data), static_cast<uint64_t>(atomic_cmp),
-                   reinterpret_cast<uintptr_t>(atomic_laddr), atomic_lkey};
+                   reinterpret_cast<uintptr_t>(atomic_laddr), byteswap<uint32_t>(atomic_lkey)};
 
   // copy to SQ
   mlx5_sq.buf[sq_idx] = wqe;

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -66,7 +66,9 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider) {
 
   int deviceId;
   CHECK_HIP(hipGetDevice(&deviceId));
-  int wf_size = get_wf_size(deviceId);
+  hipDeviceProp_t prop;
+  CHECK_HIP(hipGetDeviceProperties(&prop, deviceId));
+  int wf_size = prop.warpSize;
   for(uint32_t i{0}; i < FETCHING_ATOMIC_CNT; i+=wf_size) {
     fetching_atomic_freelist->push_back(fetching_atomic + i);
   }
@@ -141,22 +143,24 @@ __device__ uint64_t QueuePair::get_same_qp_lane_mask() {
 /******************************************************************************
  ************************ PROVIDER-SPECIFIC HELPERS ***************************
  *****************************************************************************/
-__device__ void QueuePair::post_wqe_rma([[maybe_unused]] int pe, int32_t size, uintptr_t laddr,
-    uintptr_t raddr, uint8_t opcode, ActiveWFInfo &wf_info) {
+__device__ void QueuePair::post_wqe_rma(
+    int32_t length, uintptr_t raddr, uint32_t rkey,
+    uintptr_t laddr, uint32_t lkey,
+    uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db) {
   switch (constmem.gda_provider) {
 #if defined(GDA_IONIC)
   case GDAProvider::IONIC:
-    ionic_post_wqe_rma(size, laddr, raddr, opcode, wf_info);
+    ionic_post_wqe_rma(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
     return;
 #endif
 #if defined(GDA_BNXT)
   case GDAProvider::BNXT:
-    bnxt_post_wqe_rma(size, laddr, raddr, opcode, wf_info);
+    bnxt_post_wqe_rma(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
     return;
 #endif
 #if defined(GDA_MLX5)
   case GDAProvider::MLX5:
-    mlx5_post_wqe_rma(size, laddr, raddr, opcode, wf_info);
+    mlx5_post_wqe_rma(length, raddr, rkey, laddr, lkey, opcode, wf_info, ring_db);
     return;
 #endif
   default:
@@ -189,37 +193,12 @@ __device__ void QueuePair::post_wqe_rma_single([[maybe_unused]] int32_t size, ui
   }
 }
 
-__device__ uint64_t QueuePair::post_wqe_amo([[maybe_unused]] int32_t size, uintptr_t raddr,
-    uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
-    bool fetching, ActiveWFInfo &wf_info) {
-  switch (constmem.gda_provider) {
-#if defined(GDA_IONIC)
-  case GDAProvider::IONIC:
-    return ionic_post_wqe_amo(size, raddr, opcode, atomic_data, atomic_cmp,
-           fetching, wf_info);
-#endif
-#if defined(GDA_BNXT)
-  case GDAProvider::BNXT:
-    return bnxt_post_wqe_amo(raddr, opcode, atomic_data, atomic_cmp, fetching,
-           wf_info);
-#endif
-#if defined(GDA_MLX5)
-  case GDAProvider::MLX5:
-    return mlx5_post_wqe_amo(size, raddr, opcode, atomic_data, atomic_cmp,
-           fetching, wf_info);
-#endif
-  default:
-    assert(false /* invalid nic provider */);
-    __builtin_unreachable();
-  }
-}
-
 __device__ uint64_t QueuePair::post_wqe_amo_single(uintptr_t raddr,
     uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching) {
   switch (constmem.gda_provider) {
 #if defined(GDA_IONIC)
   case GDAProvider::IONIC:
-    return ionic_post_wqe_amo_single(8 /*size_bytes (only 8-byte atomics implemented)*/, raddr, opcode, atomic_data, atomic_cmp, fetching);
+    return ionic_post_wqe_amo_single(raddr, opcode, atomic_data, atomic_cmp, fetching);
 #endif
 #if defined(GDA_BNXT)
   case GDAProvider::BNXT:
@@ -228,7 +207,32 @@ __device__ uint64_t QueuePair::post_wqe_amo_single(uintptr_t raddr,
 #endif
 #if defined(GDA_MLX5)
   case GDAProvider::MLX5:
-    return mlx5_post_wqe_amo_single(8 /* 8-byte atomics */, raddr, opcode, atomic_data, atomic_cmp, fetching);
+    return mlx5_post_wqe_amo_single(raddr, opcode, atomic_data, atomic_cmp, fetching);
+#endif
+  default:
+    assert(false /* invalid nic provider */);
+    __builtin_unreachable();
+  }
+}
+
+__device__ uint64_t QueuePair::post_wqe_amo(uintptr_t raddr, uint32_t rkey,
+    uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+    ActiveWFInfo &wf_info, bool fetching, bool fence) {
+  switch (constmem.gda_provider) {
+#if defined(GDA_IONIC)
+  case GDAProvider::IONIC:
+    return ionic_post_wqe_amo(raddr, rkey, opcode, atomic_data, atomic_cmp,
+           wf_info, fetching, fence);
+#endif
+#if defined(GDA_BNXT)
+  case GDAProvider::BNXT:
+    return bnxt_post_wqe_amo(raddr, rkey, opcode, atomic_data, atomic_cmp,
+           wf_info, fetching, fence);
+#endif
+#if defined(GDA_MLX5)
+  case GDAProvider::MLX5:
+    return mlx5_post_wqe_amo(raddr, rkey, opcode, atomic_data, atomic_cmp,
+           wf_info, fetching, fence);
 #endif
   default:
     assert(false /* invalid nic provider */);
@@ -288,64 +292,83 @@ __device__ void QueuePair::quiet_single() {
  ****************************** SHMEM INTERFACE *******************************
  *****************************************************************************/
 __device__ void QueuePair::put_nbi(void *dest, const void *source,
-    size_t nelems, int pe, ActiveWFInfo &wf_info) {
-  uintptr_t src = reinterpret_cast<uintptr_t>(source);
-  uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  post_wqe_rma(pe, nelems, src, dst, gda_op_rdma_write, wf_info);
+    size_t length, ActiveWFInfo &wf_info) {
+  uint32_t dst_rkey = rkey;
+  uint32_t src_lkey = (length <= inline_threshold)
+      ? 0 : get_lkey(reinterpret_cast<uintptr_t>(source));
+  put_nbi(dest, dst_rkey, source, src_lkey, length, wf_info);
+}
+
+__device__ void QueuePair::put_nbi(void *raddr, uint32_t rkey,
+    const void *laddr, uint32_t lkey,
+    size_t length, ActiveWFInfo &wf_info, bool ring_db) {
+  uintptr_t l = reinterpret_cast<uintptr_t>(laddr);
+  uintptr_t r = reinterpret_cast<uintptr_t>(raddr);
+  post_wqe_rma(static_cast<int32_t>(length), r, rkey, l, lkey,
+               gda_op_rdma_write, wf_info, ring_db);
 }
 
 // Used in all to all
 __device__ void QueuePair::put_nbi_single(void *dest, const void *source,
-    size_t nelems, bool ring_db) {
+    size_t length, bool ring_db) {
   uintptr_t src = reinterpret_cast<uintptr_t>(source);
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  post_wqe_rma_single(nelems, src, dst, gda_op_rdma_write, ring_db);
+  post_wqe_rma_single(length, src, dst, gda_op_rdma_write, ring_db);
 }
 
-__device__ void QueuePair::get_nbi_single(void *dest, const void *source, size_t nelems, bool ring_db) {
+__device__ void QueuePair::get_nbi_single(void *dest, const void *source, size_t length, bool ring_db) {
   uintptr_t src = reinterpret_cast<uintptr_t>(source);
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  post_wqe_rma_single(nelems, dst, src, gda_op_rdma_read, ring_db);
+  post_wqe_rma_single(length, dst, src, gda_op_rdma_read, ring_db);
 }
 
 __device__ void QueuePair::get_nbi(void *dest, const void *source,
-    size_t nelems, int pe, ActiveWFInfo &wf_info) {
+    size_t length, ActiveWFInfo &wf_info) {
+  uint32_t src_rkey = rkey;
+  uint32_t dst_lkey = get_lkey(reinterpret_cast<uintptr_t>(dest));
   uintptr_t src = reinterpret_cast<uintptr_t>(source);
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  post_wqe_rma(pe, nelems, dst, src, gda_op_rdma_read, wf_info);
+  post_wqe_rma(static_cast<int32_t>(length), src, src_rkey, dst, dst_lkey,
+               gda_op_rdma_read, wf_info, true);
 }
 
 __device__ int64_t QueuePair::atomic_cas(void *dest, int64_t atomic_data,
     int64_t atomic_cmp, ActiveWFInfo &wf_info) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  return post_wqe_amo(sizeof(int64_t), dst, gda_op_atomic_cs, atomic_data,
-                      atomic_cmp, true, wf_info);
+  return post_wqe_amo(dst, rkey, gda_op_atomic_cs, atomic_data,
+                      atomic_cmp, wf_info, true);
 }
 
 __device__ int64_t QueuePair::atomic_cas_nofetch(void *dest,
     int64_t atomic_data, int64_t atomic_cmp, ActiveWFInfo &wf_info) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  return post_wqe_amo(sizeof(int64_t), dst, gda_op_atomic_cs, atomic_data,
-                      atomic_cmp, false, wf_info);
+  return post_wqe_amo(dst, rkey, gda_op_atomic_cs, atomic_data,
+                      atomic_cmp, wf_info);
 }
 
 __device__ int64_t QueuePair::atomic_fetch(void *dest, int64_t atomic_data,
     int64_t atomic_cmp, ActiveWFInfo &wf_info) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  return post_wqe_amo(sizeof(int64_t), dst, gda_op_atomic_fa, atomic_data,
-                      atomic_cmp, true, wf_info);
+  return post_wqe_amo(dst, rkey, gda_op_atomic_fa, atomic_data,
+                      atomic_cmp, wf_info, true);
 }
 
 __device__ void QueuePair::atomic_nofetch(void *dest, int64_t atomic_data,
     int64_t atomic_cmp, ActiveWFInfo &wf_info) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  post_wqe_amo(sizeof(int64_t), dst, gda_op_atomic_fa, atomic_data,
-               atomic_cmp, false, wf_info);
+  post_wqe_amo(dst, rkey, gda_op_atomic_fa, atomic_data,
+               atomic_cmp, wf_info);
 }
 
 __device__ void QueuePair::atomic_nofetch_single(void *dest, int64_t value) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
   post_wqe_amo_single(dst, gda_op_atomic_fa, value, 0, false);
+}
+
+__device__ void QueuePair::atomic_add(void *raddr, uint32_t rkey,
+    int64_t value, ActiveWFInfo &wf_info, bool fence) {
+  uintptr_t r = reinterpret_cast<uintptr_t>(raddr);
+  post_wqe_amo(r, rkey, gda_op_atomic_fa, value, 0, wf_info, false, fence);
 }
 
 int QueuePair::buffer_register(uintptr_t addr, size_t length) {

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -169,45 +169,24 @@ __device__ void QueuePair::post_wqe_rma(
   }
 }
 
-__device__ void QueuePair::post_wqe_rma_single([[maybe_unused]] int32_t size, uintptr_t laddr,
-    uintptr_t raddr, uint8_t opcode, [[maybe_unused]] bool ring_db) {
+__device__ void QueuePair::post_wqe_rma_single(int32_t size,
+    uintptr_t laddr, uint32_t lkey, uintptr_t raddr, uint32_t rkey,
+    uint8_t opcode, bool ring_db) {
   switch (constmem.gda_provider) {
 #if defined(GDA_IONIC)
   case GDAProvider::IONIC:
-    ionic_post_wqe_rma_single(size, laddr, raddr, opcode);
+    ionic_post_wqe_rma_single(size, laddr, lkey, raddr, rkey, opcode, ring_db);
     return;
 #endif
 #if defined(GDA_BNXT)
   case GDAProvider::BNXT:
-    bnxt_post_wqe_rma_single(size, laddr, raddr, opcode, ring_db);
+    bnxt_post_wqe_rma_single(size, laddr, lkey, raddr, rkey, opcode, ring_db);
     return;
 #endif
 #if defined(GDA_MLX5)
   case GDAProvider::MLX5:
-    mlx5_post_wqe_rma_single(size, laddr, raddr, opcode, ring_db);
+    mlx5_post_wqe_rma_single(size, laddr, lkey, raddr, rkey, opcode, ring_db);
     return;
-#endif
-  default:
-    assert(false /* invalid nic provider */);
-    __builtin_unreachable();
-  }
-}
-
-__device__ uint64_t QueuePair::post_wqe_amo_single(uintptr_t raddr,
-    uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching) {
-  switch (constmem.gda_provider) {
-#if defined(GDA_IONIC)
-  case GDAProvider::IONIC:
-    return ionic_post_wqe_amo_single(raddr, opcode, atomic_data, atomic_cmp, fetching);
-#endif
-#if defined(GDA_BNXT)
-  case GDAProvider::BNXT:
-    return bnxt_post_wqe_amo_single(raddr, opcode, atomic_data, atomic_cmp,
-           fetching);
-#endif
-#if defined(GDA_MLX5)
-  case GDAProvider::MLX5:
-    return mlx5_post_wqe_amo_single(raddr, opcode, atomic_data, atomic_cmp, fetching);
 #endif
   default:
     assert(false /* invalid nic provider */);
@@ -233,6 +212,29 @@ __device__ uint64_t QueuePair::post_wqe_amo(uintptr_t raddr, uint32_t rkey,
   case GDAProvider::MLX5:
     return mlx5_post_wqe_amo(raddr, rkey, opcode, atomic_data, atomic_cmp,
            wf_info, fetching, fence);
+#endif
+  default:
+    assert(false /* invalid nic provider */);
+    __builtin_unreachable();
+  }
+}
+
+__device__ uint64_t QueuePair::post_wqe_amo_single(uintptr_t raddr,
+    uint32_t rkey, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+    bool fetching, bool fence) {
+  switch (constmem.gda_provider) {
+#if defined(GDA_IONIC)
+  case GDAProvider::IONIC:
+    return ionic_post_wqe_amo_single(raddr, rkey, opcode, atomic_data, atomic_cmp, fetching, fence);
+#endif
+#if defined(GDA_BNXT)
+  case GDAProvider::BNXT:
+    return bnxt_post_wqe_amo_single(raddr, rkey, opcode, atomic_data, atomic_cmp,
+           fetching, fence);
+#endif
+#if defined(GDA_MLX5)
+  case GDAProvider::MLX5:
+    return mlx5_post_wqe_amo_single(raddr, rkey, opcode, atomic_data, atomic_cmp, fetching, fence);
 #endif
   default:
     assert(false /* invalid nic provider */);
@@ -313,14 +315,29 @@ __device__ void QueuePair::put_nbi_single(void *dest, const void *source,
     size_t length, bool ring_db) {
   uintptr_t src = reinterpret_cast<uintptr_t>(source);
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  post_wqe_rma_single(length, src, dst, gda_op_rdma_write, ring_db);
+  uint32_t src_lkey = (length <= inline_threshold)
+      ? 0 : get_lkey(src);
+  post_wqe_rma_single(length, src, src_lkey, dst, rkey,
+                       gda_op_rdma_write, ring_db);
+}
+
+__device__ void QueuePair::put_nbi_single(void *raddr, uint32_t rkey,
+    const void *laddr, uint32_t lkey,
+    size_t length, bool ring_db) {
+  uintptr_t l = reinterpret_cast<uintptr_t>(laddr);
+  uintptr_t r = reinterpret_cast<uintptr_t>(raddr);
+  post_wqe_rma_single(length, l, lkey, r, rkey,
+                       gda_op_rdma_write, ring_db);
 }
 
 __device__ void QueuePair::get_nbi_single(void *dest, const void *source, size_t length, bool ring_db) {
   uintptr_t src = reinterpret_cast<uintptr_t>(source);
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  post_wqe_rma_single(length, dst, src, gda_op_rdma_read, ring_db);
+  uint32_t dst_lkey = get_lkey(dst);
+  post_wqe_rma_single(length, dst, dst_lkey, src, rkey,
+                       gda_op_rdma_read, ring_db);
 }
+
 
 __device__ void QueuePair::get_nbi(void *dest, const void *source,
     size_t length, ActiveWFInfo &wf_info) {
@@ -362,7 +379,13 @@ __device__ void QueuePair::atomic_nofetch(void *dest, int64_t atomic_data,
 
 __device__ void QueuePair::atomic_nofetch_single(void *dest, int64_t value) {
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  post_wqe_amo_single(dst, gda_op_atomic_fa, value, 0, false);
+  post_wqe_amo_single(dst, rkey, gda_op_atomic_fa, value, 0);
+}
+
+__device__ void QueuePair::atomic_add_single(void *raddr, uint32_t rkey,
+    int64_t value, bool fence) {
+  uintptr_t r = reinterpret_cast<uintptr_t>(raddr);
+  post_wqe_amo_single(r, rkey, gda_op_atomic_fa, value, 0, false, fence);
 }
 
 __device__ void QueuePair::atomic_add(void *raddr, uint32_t rkey,

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -64,11 +64,14 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider) {
     fetching_atomic_lkey = mr_fetching_atomic->lkey;
   }
 
-  int deviceId;
-  CHECK_HIP(hipGetDevice(&deviceId));
-  hipDeviceProp_t prop;
-  CHECK_HIP(hipGetDeviceProperties(&prop, deviceId));
-  int wf_size = prop.warpSize;
+  static int wf_size = 0;
+  if (wf_size == 0) {
+    int deviceId;
+    CHECK_HIP(hipGetDevice(&deviceId));
+    hipDeviceProp_t prop;
+    CHECK_HIP(hipGetDeviceProperties(&prop, deviceId));
+    wf_size = prop.warpSize;
+  }
   for(uint32_t i{0}; i < FETCHING_ATOMIC_CNT; i+=wf_size) {
     fetching_atomic_freelist->push_back(fetching_atomic + i);
   }

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -169,23 +169,23 @@ __device__ void QueuePair::post_wqe_rma(
   }
 }
 
-__device__ void QueuePair::post_wqe_rma_single(int32_t size,
+__device__ void QueuePair::post_wqe_rma_single(int32_t length,
     uintptr_t laddr, uint32_t lkey, uintptr_t raddr, uint32_t rkey,
     uint8_t opcode, bool ring_db) {
   switch (constmem.gda_provider) {
 #if defined(GDA_IONIC)
   case GDAProvider::IONIC:
-    ionic_post_wqe_rma_single(size, laddr, lkey, raddr, rkey, opcode, ring_db);
+    ionic_post_wqe_rma_single(length, laddr, lkey, raddr, rkey, opcode, ring_db);
     return;
 #endif
 #if defined(GDA_BNXT)
   case GDAProvider::BNXT:
-    bnxt_post_wqe_rma_single(size, laddr, lkey, raddr, rkey, opcode, ring_db);
+    bnxt_post_wqe_rma_single(length, laddr, lkey, raddr, rkey, opcode, ring_db);
     return;
 #endif
 #if defined(GDA_MLX5)
   case GDAProvider::MLX5:
-    mlx5_post_wqe_rma_single(size, laddr, lkey, raddr, rkey, opcode, ring_db);
+    mlx5_post_wqe_rma_single(length, laddr, lkey, raddr, rkey, opcode, ring_db);
     return;
 #endif
   default:
@@ -296,7 +296,7 @@ __device__ void QueuePair::quiet_single() {
 __device__ void QueuePair::put_nbi(void *dest, const void *source,
     size_t length, ActiveWFInfo &wf_info) {
   uint32_t dst_rkey = rkey;
-  uint32_t src_lkey = (length <= inline_threshold)
+  uint32_t src_lkey = (static_cast<int32_t>(length) <= static_cast<int32_t>(inline_threshold))
       ? 0 : get_lkey(reinterpret_cast<uintptr_t>(source));
   put_nbi(dest, dst_rkey, source, src_lkey, length, wf_info);
 }
@@ -315,7 +315,7 @@ __device__ void QueuePair::put_nbi_single(void *dest, const void *source,
     size_t length, bool ring_db) {
   uintptr_t src = reinterpret_cast<uintptr_t>(source);
   uintptr_t dst = reinterpret_cast<uintptr_t>(dest);
-  uint32_t src_lkey = (length <= inline_threshold)
+  uint32_t src_lkey = (static_cast<int32_t>(length) <= static_cast<int32_t>(inline_threshold))
       ? 0 : get_lkey(src);
   post_wqe_rma_single(length, src, src_lkey, dst, rkey,
                        gda_op_rdma_write, ring_db);

--- a/projects/rocshmem/src/gda/queue_pair.cpp
+++ b/projects/rocshmem/src/gda/queue_pair.cpp
@@ -56,13 +56,8 @@ QueuePair::QueuePair(struct ibv_pd* pd, int gda_provider) {
   mr_fetching_atomic = ibv.reg_mr(pd, fetching_atomic, 8 * FETCHING_ATOMIC_CNT, access, &allocator);
   CHECK_NNULL(mr_fetching_atomic, "ibv_reg_mr");
 
-  if (gda_provider == GDAProvider::MLX5) {
-    nonfetching_atomic_lkey = htobe32(mr_nonfetching_atomic->lkey);
-    fetching_atomic_lkey = htobe32(mr_fetching_atomic->lkey);
-  } else {
-    nonfetching_atomic_lkey = mr_nonfetching_atomic->lkey;
-    fetching_atomic_lkey = mr_fetching_atomic->lkey;
-  }
+  nonfetching_atomic_lkey = mr_nonfetching_atomic->lkey;
+  fetching_atomic_lkey = mr_fetching_atomic->lkey;
 
   static int wf_size = 0;
   if (wf_size == 0) {
@@ -426,11 +421,7 @@ int QueuePair::buffer_register(uintptr_t addr, size_t length) {
       user_buf_info[i].addr   = addr;
       user_buf_info[i].length = length;
 
-      if (gda_provider_ == GDAProvider::MLX5) {
-        user_buf_info[i].lkey = htobe32(mr->lkey);
-      } else {
-        user_buf_info[i].lkey = mr->lkey;
-      }
+      user_buf_info[i].lkey = mr->lkey;
 
       break;
     }

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -353,14 +353,14 @@ class QueuePair {
       uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
 
   __device__ __attribute__((noinline)) void
-  post_wqe_rma_single(int32_t size, uintptr_t laddr, uint32_t lkey,
+  post_wqe_rma_single(int32_t length, uintptr_t laddr, uint32_t lkey,
       uintptr_t raddr, uint32_t rkey, uint8_t opcode, bool ring_db);
 
 #if defined(GDA_MLX5)
   __device__ uint64_t mlx5_post_wqe_amo_single(uintptr_t raddr, uint32_t rkey,
       uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
       bool fetch = false, bool fence = false);
-  __device__ void mlx5_post_wqe_rma_single(int32_t size, uintptr_t laddr,
+  __device__ void mlx5_post_wqe_rma_single(int32_t length, uintptr_t laddr,
       uint32_t lkey, uintptr_t raddr, uint32_t rkey,
       uint8_t opcode, bool ring_db);
   __device__ void mlx5_post_wqe_rma(int32_t length, uintptr_t raddr,
@@ -380,7 +380,7 @@ class QueuePair {
   __device__ uint64_t bnxt_post_wqe_amo_single(uintptr_t raddr, uint32_t rkey,
       uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
       bool fetching = false, bool fence = false);
-  __device__ void bnxt_post_wqe_rma_single(int32_t size, uintptr_t laddr,
+  __device__ void bnxt_post_wqe_rma_single(int32_t length, uintptr_t laddr,
       uint32_t lkey, uintptr_t raddr, uint32_t rkey,
       uint8_t opcode, bool ring_db);
   __device__ void bnxt_post_wqe_rma(int32_t length, uintptr_t raddr,
@@ -393,7 +393,7 @@ class QueuePair {
   __device__ uint64_t ionic_post_wqe_amo_single(uintptr_t raddr, uint32_t rkey,
       uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
       bool fetch = false, bool fence = false);
-  __device__ void ionic_post_wqe_rma_single(int32_t size,
+  __device__ void ionic_post_wqe_rma_single(int32_t length,
       uintptr_t laddr, uint32_t lkey, uintptr_t raddr,
       uint32_t rkey, uint8_t opcode, bool ring_db);
   __device__ void ionic_post_wqe_rma(int32_t length, uintptr_t raddr,

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -177,6 +177,10 @@ class QueuePair {
   __device__ void put_nbi_single(void *dest, const void *source, size_t length,
       bool ring_db);
 
+  __device__ void put_nbi_single(void *raddr, uint32_t rkey,
+      const void *laddr, uint32_t lkey,
+      size_t length, bool ring_db = true);
+
   /**
    * @brief Create and enqueue a non-blocking put with explicit rkey/lkey.
    *
@@ -248,6 +252,9 @@ class QueuePair {
       ActiveWFInfo &wf_info);
 
   __device__ void atomic_nofetch_single(void *dest, int64_t value);
+
+  __device__ void atomic_add_single(void *raddr, uint32_t rkey,
+      int64_t value, bool fence = false);
 
   /**
    * @brief Non-fetching atomic add with explicit remote key.
@@ -325,7 +332,8 @@ class QueuePair {
 #endif
 
   __device__ __attribute__((noinline)) uint64_t post_wqe_amo_single(uintptr_t raddr,
-      uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching);
+      uint32_t rkey, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+      bool fetching = false, bool fence = false);
 
   /**
    * @brief Build and post an RMA work queue entry with explicit keys.
@@ -345,15 +353,16 @@ class QueuePair {
       uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
 
   __device__ __attribute__((noinline)) void
-  post_wqe_rma_single(int32_t size, uintptr_t laddr, uintptr_t raddr,
-      uint8_t opcode, bool ring_db);
+  post_wqe_rma_single(int32_t size, uintptr_t laddr, uint32_t lkey,
+      uintptr_t raddr, uint32_t rkey, uint8_t opcode, bool ring_db);
 
 #if defined(GDA_MLX5)
-  __device__ uint64_t mlx5_post_wqe_amo_single(uintptr_t raddr,
+  __device__ uint64_t mlx5_post_wqe_amo_single(uintptr_t raddr, uint32_t rkey,
       uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
-      bool fetch);
+      bool fetch = false, bool fence = false);
   __device__ void mlx5_post_wqe_rma_single(int32_t size, uintptr_t laddr,
-      uintptr_t raddr, uint8_t opcode, bool ring_db);
+      uint32_t lkey, uintptr_t raddr, uint32_t rkey,
+      uint8_t opcode, bool ring_db);
   __device__ void mlx5_post_wqe_rma(int32_t length, uintptr_t raddr,
       uint32_t rkey, uintptr_t laddr, uint32_t lkey,
       uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
@@ -368,10 +377,12 @@ class QueuePair {
       uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
       bool fetching, bool fence);
 
-  __device__ uint64_t bnxt_post_wqe_amo_single(uintptr_t raddr, uint8_t opcode,
-      int64_t atomic_data, int64_t atomic_cmp, bool fetching);
+  __device__ uint64_t bnxt_post_wqe_amo_single(uintptr_t raddr, uint32_t rkey,
+      uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+      bool fetching = false, bool fence = false);
   __device__ void bnxt_post_wqe_rma_single(int32_t size, uintptr_t laddr,
-      uintptr_t raddr, uint8_t opcode, bool ring_db);
+      uint32_t lkey, uintptr_t raddr, uint32_t rkey,
+      uint8_t opcode, bool ring_db);
   __device__ void bnxt_post_wqe_rma(int32_t length, uintptr_t raddr,
       uint32_t rkey, uintptr_t laddr, uint32_t lkey,
       uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
@@ -379,11 +390,12 @@ class QueuePair {
   __device__ void bnxt_quiet_single();
 #endif
 #if defined(GDA_IONIC)
-  __device__ uint64_t ionic_post_wqe_amo_single(uintptr_t raddr,
+  __device__ uint64_t ionic_post_wqe_amo_single(uintptr_t raddr, uint32_t rkey,
       uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
-      bool fetch);
+      bool fetch = false, bool fence = false);
   __device__ void ionic_post_wqe_rma_single(int32_t size,
-      uintptr_t laddr, uintptr_t raddr, uint8_t opcode);
+      uintptr_t laddr, uint32_t lkey, uintptr_t raddr,
+      uint32_t rkey, uint8_t opcode, bool ring_db);
   __device__ void ionic_post_wqe_rma(int32_t length, uintptr_t raddr,
       uint32_t rkey, uintptr_t laddr, uint32_t lkey,
       uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -50,8 +50,6 @@
 
 #include <map>
 
-struct rocshmem_gin_qp_set;
-
 namespace rocshmem {
 
 class GDABackend;
@@ -151,7 +149,6 @@ class ActiveWFInfo {
 class QueuePair {
  public:
   friend GDABackend;
-  friend struct ::rocshmem_gin_qp_set;
 
   /**
    * @brief Constructor.
@@ -419,6 +416,8 @@ class QueuePair {
   __device__ void ionic_ring_doorbell_single(uint32_t pos);
 #endif
 
+  // TODO: make private once gin_qp_factory uses a proper init API
+ public:
   /* GDAProvider::BNXT START */
   uint64_t *bnxt_dbr;
   struct bnxt_device_cq bnxt_cq;

--- a/projects/rocshmem/src/gda/queue_pair.hpp
+++ b/projects/rocshmem/src/gda/queue_pair.hpp
@@ -50,6 +50,8 @@
 
 #include <map>
 
+struct rocshmem_gin_qp_set;
+
 namespace rocshmem {
 
 class GDABackend;
@@ -149,6 +151,7 @@ class ActiveWFInfo {
 class QueuePair {
  public:
   friend GDABackend;
+  friend struct ::rocshmem_gin_qp_set;
 
   /**
    * @brief Constructor.
@@ -165,29 +168,45 @@ class QueuePair {
    *
    * @param[in] dest Destination address for data transmission.
    * @param[in] source Source address for data transmission.
-   * @param[in] nelems Size in bytes of data transmission.
-   * @param[in] pe Destination processing element of data transmission.
+   * @param[in] length Size in bytes of data transmission.
    * @param[in] wf_info Wavefront information.
    */
-  __device__ void put_nbi(void *dest, const void *source, size_t nelems,
-      int pe, ActiveWFInfo &wf_info);
+  __device__ void put_nbi(void *dest, const void *source, size_t length,
+      ActiveWFInfo &wf_info);
 
-  __device__ void put_nbi_single(void *dest, const void *source, size_t nelems,
+  __device__ void put_nbi_single(void *dest, const void *source, size_t length,
       bool ring_db);
+
+  /**
+   * @brief Create and enqueue a non-blocking put with explicit rkey/lkey.
+   *
+   * Used when each buffer registration has its own keys, distinct from
+   * the QP's default heap keys.
+   *
+   * @param[in] length Size in bytes of data transmission.
+   * @param[in] raddr Remote destination address.
+   * @param[in] rkey Remote key for the destination buffer.
+   * @param[in] laddr Local source address.
+   * @param[in] lkey Local key for the source buffer.
+   * @param[in] wf_info Wavefront information.
+   * @param[in] ring_db Ring doorbell after posting (default true).
+   */
+  __device__ void put_nbi(void *raddr, uint32_t rkey,
+      const void *laddr, uint32_t lkey,
+      size_t length, ActiveWFInfo &wf_info, bool ring_db = true);
 
   /**
    * @brief Create and enqueue a non-blocking get work queue entry (wqe).
    *
    * @param[in] dest Destination address for data transmission.
    * @param[in] source Source address for data transmission.
-   * @param[in] nelems Size in bytes of data transmission.
-   * @param[in] pe Destination processing element of data transmission.
+   * @param[in] length Size in bytes of data transmission.
    * @param[in] wf_info Wavefront information.
    */
-  __device__ void get_nbi(void *dest, const void *source, size_t nelems,
-      int pe, ActiveWFInfo &wf_info);
+  __device__ void get_nbi(void *dest, const void *source, size_t length,
+      ActiveWFInfo &wf_info);
 
-  __device__ void get_nbi_single(void *dest, const void *source, size_t nelems,
+  __device__ void get_nbi_single(void *dest, const void *source, size_t length,
       bool ring_db);
 
   /**
@@ -231,6 +250,20 @@ class QueuePair {
   __device__ void atomic_nofetch_single(void *dest, int64_t value);
 
   /**
+   * @brief Non-fetching atomic add with explicit remote key.
+   *
+   * Used when the signal buffer has its own rkey distinct from
+   * the QP's default heap key.
+   *
+   * @param[in] raddr Remote destination address.
+   * @param[in] rkey  Remote key for the destination buffer.
+   * @param[in] value Atomic add value.
+   * @param[in] wf_info Wavefront information.
+   */
+  __device__ void atomic_add(void *raddr, uint32_t rkey,
+      int64_t value, ActiveWFInfo &wf_info, bool fence = false);
+
+  /**
    * @brief Create and enqueue an atomic cas work queue entry (wqe).
    *
    * @param[in] dest Destination address for data transmission.
@@ -261,86 +294,99 @@ class QueuePair {
   /**
    * @brief Helper method to build work requests for the send queue.
    *
-   * @param[in] size Size in bytes of data transmission.
    * @param[in] raddr Remote address.
+   * @param[in] rkey Remote key.
    * @param[in] opcode Operation to be performed.
    * @param[in] atomic_data An atomic data value to be used.
-   * @param[in] atomic_cmp An atomic comparison operation to be performed.
-   * @param[in] fetch True if the operation returns a value.
+   * @param[in] atomic_cmp An atomic comparison value.
    * @param[in] wf_info Wavefront information.
+   * @param[in] fetching True if the operation returns a value.
+   * @param[in] fence True to set fence flag on the WQE.
    */
   __device__ __attribute__((noinline)) uint64_t
-  post_wqe_amo(int32_t size, uintptr_t raddr, uint8_t opcode,
-      int64_t atomic_data, int64_t atomic_cmp, bool fetch,
-      ActiveWFInfo &wf_info);
+  post_wqe_amo(uintptr_t raddr, uint32_t rkey, uint8_t opcode,
+      int64_t atomic_data, int64_t atomic_cmp,
+      ActiveWFInfo &wf_info, bool fetching = false, bool fence = false);
+
+#if defined(GDA_IONIC)
+  __device__ uint64_t ionic_post_wqe_amo(uintptr_t raddr, uint32_t rkey,
+      uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+      ActiveWFInfo &wf_info, bool fetching = false, bool fence = false);
+#endif
+#if defined(GDA_BNXT)
+  __device__ uint64_t bnxt_post_wqe_amo(uintptr_t raddr, uint32_t rkey,
+      uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+      ActiveWFInfo &wf_info, bool fetching = false, bool fence = false);
+#endif
+#if defined(GDA_MLX5)
+  __device__ uint64_t mlx5_post_wqe_amo(uintptr_t raddr, uint32_t rkey,
+      uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+      ActiveWFInfo &wf_info, bool fetching = false, bool fence = false);
+#endif
 
   __device__ __attribute__((noinline)) uint64_t post_wqe_amo_single(uintptr_t raddr,
       uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetching);
 
   /**
-   * @brief Helper method to build work requests for the send queue.
+   * @brief Build and post an RMA work queue entry with explicit keys.
    *
-   * @param[in] pe Destination processing element of data transmission.
    * @param[in] size Size in bytes of data transmission.
-   * @param[in] laddr Local address.
    * @param[in] raddr Remote address.
+   * @param[in] rkey Remote key.
+   * @param[in] laddr Local address.
+   * @param[in] lkey Local key.
    * @param[in] opcode Operation to be performed.
    * @param[in] wf_info Wavefront information.
+   * @param[in] ring_db Ring doorbell after posting.
    */
   __device__ __attribute__((noinline)) void
-  post_wqe_rma(int pe, int32_t size, uintptr_t laddr, uintptr_t raddr,
-      uint8_t opcode, ActiveWFInfo &wf_info);
+  post_wqe_rma(int32_t length, uintptr_t raddr, uint32_t rkey,
+      uintptr_t laddr, uint32_t lkey,
+      uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
 
   __device__ __attribute__((noinline)) void
   post_wqe_rma_single(int32_t size, uintptr_t laddr, uintptr_t raddr,
       uint8_t opcode, bool ring_db);
 
 #if defined(GDA_MLX5)
-  __device__ uint64_t mlx5_post_wqe_amo(int32_t size, uintptr_t raddr,
-      uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetch,
-      ActiveWFInfo &wf_info);
-  __device__ uint64_t mlx5_post_wqe_amo_single(int32_t size, uintptr_t raddr,
+  __device__ uint64_t mlx5_post_wqe_amo_single(uintptr_t raddr,
       uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
       bool fetch);
-  __device__ void mlx5_post_wqe_rma(int32_t size, uintptr_t laddr,
-      uintptr_t raddr, uint8_t opcode, ActiveWFInfo &wf_info);
   __device__ void mlx5_post_wqe_rma_single(int32_t size, uintptr_t laddr,
       uintptr_t raddr, uint8_t opcode, bool ring_db);
+  __device__ void mlx5_post_wqe_rma(int32_t length, uintptr_t raddr,
+      uint32_t rkey, uintptr_t laddr, uint32_t lkey,
+      uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
   __device__ void mlx5_quiet();
   __device__ void mlx5_quiet_single();
 #endif
 #if defined(GDA_BNXT)
 
-  __device__ void bnxt_write_rma_wqe(uintptr_t raddr, uintptr_t laddr,
-      int32_t length, uint8_t opcode);
-  __device__ uint32_t bnxt_write_amo_wqe(uintptr_t raddr, uint8_t opcode,
-      int64_t atomic_data, int64_t atomic_cmp, bool fetching);
+  __device__ void bnxt_write_rma_wqe(int32_t length, uintptr_t raddr,
+      uint32_t rkey, uintptr_t laddr, uint32_t lkey, uint8_t opcode);
+  __device__ uint32_t bnxt_write_amo_wqe(uintptr_t raddr, uint32_t rkey,
+      uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+      bool fetching, bool fence);
 
   __device__ uint64_t bnxt_post_wqe_amo_single(uintptr_t raddr, uint8_t opcode,
       int64_t atomic_data, int64_t atomic_cmp, bool fetching);
-  __device__ uint64_t bnxt_post_wqe_amo(uintptr_t raddr, uint8_t opcode,
-      int64_t atomic_data, int64_t atomic_cmp, bool fetching,
-      ActiveWFInfo &wf_info);
-
-  __device__ void bnxt_post_wqe_rma(int32_t size, uintptr_t laddr,
-      uintptr_t raddr, uint8_t opcode, ActiveWFInfo &wf_info);
-
   __device__ void bnxt_post_wqe_rma_single(int32_t size, uintptr_t laddr,
       uintptr_t raddr, uint8_t opcode, bool ring_db);
+  __device__ void bnxt_post_wqe_rma(int32_t length, uintptr_t raddr,
+      uint32_t rkey, uintptr_t laddr, uint32_t lkey,
+      uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
   __device__ void bnxt_quiet();
   __device__ void bnxt_quiet_single();
 #endif
 #if defined(GDA_IONIC)
-  __device__ uint64_t ionic_post_wqe_amo(int32_t size, uintptr_t raddr,
-      uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp, bool fetch,
-      ActiveWFInfo &wf_info);
-  __device__ uint64_t ionic_post_wqe_amo_single(int32_t size,
-      uintptr_t raddr, uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
+  __device__ uint64_t ionic_post_wqe_amo_single(uintptr_t raddr,
+      uint8_t opcode, int64_t atomic_data, int64_t atomic_cmp,
       bool fetch);
-  __device__ void ionic_post_wqe_rma(int32_t size, uintptr_t laddr,
-      uintptr_t raddr, uint8_t opcode, ActiveWFInfo &wf_info);
   __device__ void ionic_post_wqe_rma_single(int32_t size,
       uintptr_t laddr, uintptr_t raddr, uint8_t opcode);
+  __device__ void ionic_post_wqe_rma(int32_t length, uintptr_t raddr,
+      uint32_t rkey, uintptr_t laddr, uint32_t lkey,
+      uint8_t opcode, ActiveWFInfo &wf_info, bool ring_db);
   __device__ void ionic_quiet(ActiveWFInfo &wf_info);
   __device__ void ionic_quiet_single();
 #endif


### PR DESCRIPTION
## Motivation

Rework the QP class to be a generic GDA provider
Despecialize the code so that it is not tied to the shmem API. 
* Explicit lkey/rkey
* optional ring_db
* optional fence-flag on signals
* No context/backend dependency

## Technical Details

The computation of lkey/rkey and identification of heap/loffset computation is up-leveled to the context class.

## JIRA ID

https://amd-hub.atlassian.net/browse/AICOMRCCL-1040


## Test Plan

* [x] functional tests on bnxt/ionic/mlx5
* [ ] CI

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
