### PR TITLE
[rocSHMEM] Utilizing non-default streams in the tests and add missing synchronizations to fix random validation errors

### DIFF
--- a/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
@@ -151,11 +151,10 @@ DefaultCTXPrimitiveTester::DefaultCTXPrimitiveTester(TesterArguments args)
   const int max_sustainable_wgs =
       max_co_resident_wgs_per_cu * deviceProps.multiProcessorCount;
   if (args.num_wgs > static_cast<unsigned>(max_sustainable_wgs)) {
-    std::cout << "Warning: Requested work-groups (" << args.num_wgs
+    std::cerr << "Error: Requested work-groups (" << args.num_wgs
               << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
-              << "). Capping to " << max_sustainable_wgs
-              << " to avoid grid_barrier deadlock." << std::endl;
-    args.num_wgs = max_sustainable_wgs;
+              << "). Reduce -w to avoid grid_barrier deadlock." << std::endl;
+    exit(0);
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
@@ -174,7 +174,8 @@ DefaultCTXPrimitiveTester::DefaultCTXPrimitiveTester(TesterArguments args)
       break;
   }
 
-  CHECK_HIP(hipMemset(source, 'a', buff_size));
+  CHECK_HIP(hipMemsetAsync(source, 'a', buff_size, stream));
+  CHECK_HIP(hipStreamSynchronize(stream));
 }
 
 DefaultCTXPrimitiveTester::~DefaultCTXPrimitiveTester() {
@@ -206,6 +207,7 @@ void DefaultCTXPrimitiveTester::resetBuffers(size_t size) {
   size_t buff_size = size * batch_size * args.wg_size * args.num_wgs;
   CHECK_HIP(hipMemsetAsync(dest, '1', buff_size, stream));
   CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
+  CHECK_HIP(hipStreamSynchronize(stream));
 }
 
 void DefaultCTXPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,

--- a/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/default_ctx_primitive_tester.cpp
@@ -154,7 +154,7 @@ DefaultCTXPrimitiveTester::DefaultCTXPrimitiveTester(TesterArguments args)
     std::cerr << "Error: Requested work-groups (" << args.num_wgs
               << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
               << "). Reduce -w to avoid grid_barrier deadlock." << std::endl;
-    exit(0);
+    exit(-1);
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/flood_amo_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/flood_amo_tester.cpp
@@ -194,7 +194,7 @@ FloodAmoTester::FloodAmoTester(TesterArguments args) : Tester(args) {
     std::cerr << "Error: Requested work-groups (" << args.num_wgs
               << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
               << "). Reduce -w to avoid grid_barrier deadlock." << std::endl;
-    exit(0);
+    exit(-1);
   }
 }
 

--- a/projects/rocshmem/tests/functional_tests/flood_amo_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/flood_amo_tester.cpp
@@ -186,9 +186,7 @@ FloodAmoTester::FloodAmoTester(TesterArguments args) : Tester(args) {
       args.wg_size,
       0));
   // Get the number of compute units
-  hipDeviceProp_t device_prop;
-  CHECK_HIP(hipGetDeviceProperties(&device_prop, 0));
-  const int num_cus = device_prop.multiProcessorCount;
+  const int num_cus = deviceProps.multiProcessorCount;
   const int max_sustainable_wgs = max_co_resident_wgs_per_cu * num_cus;
 
   // Print warning if num_wgs exceeds max co-resident work-groups
@@ -207,6 +205,7 @@ FloodAmoTester::~FloodAmoTester() {
 void FloodAmoTester::resetBuffers([[maybe_unused]] size_t size) {
   CHECK_HIP(hipMemsetAsync(d_buf, 0, sizeof(uint64_t) * args.num_wgs, stream));
   CHECK_HIP(hipMemsetAsync(grid_psync, 0, 4 * sizeof(int), stream));
+  CHECK_HIP(hipStreamSynchronize(stream));
 }
 
 void FloodAmoTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,

--- a/projects/rocshmem/tests/functional_tests/flood_amo_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/flood_amo_tester.cpp
@@ -191,9 +191,10 @@ FloodAmoTester::FloodAmoTester(TesterArguments args) : Tester(args) {
 
   // Print warning if num_wgs exceeds max co-resident work-groups
   if (static_cast<unsigned int>(args.num_wgs) > static_cast<unsigned int>(max_sustainable_wgs)) {
-    std::cout << "Warning: Number of work-groups (" << args.num_wgs
-              << ") exceeds max sustainable work-groups ("
-              << max_sustainable_wgs << ")." << std::endl;
+    std::cerr << "Error: Requested work-groups (" << args.num_wgs
+              << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
+              << "). Reduce -w to avoid grid_barrier deadlock." << std::endl;
+    exit(0);
   }
 }
 

--- a/projects/rocshmem/tests/functional_tests/primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/primitive_tester.cpp
@@ -154,7 +154,7 @@ PrimitiveTester::PrimitiveTester(TesterArguments args) : Tester(args) {
     std::cerr << "Error: Requested work-groups (" << args.num_wgs
               << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
               << "). Reduce -w to avoid grid_barrier deadlock." << std::endl;
-    exit(0);
+    exit(-1);
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/primitive_tester.cpp
@@ -151,11 +151,10 @@ PrimitiveTester::PrimitiveTester(TesterArguments args) : Tester(args) {
   const int max_sustainable_wgs =
       max_co_resident_wgs_per_cu * deviceProps.multiProcessorCount;
   if (args.num_wgs > static_cast<unsigned>(max_sustainable_wgs)) {
-    std::cout << "Warning: Requested work-groups (" << args.num_wgs
+    std::cerr << "Error: Requested work-groups (" << args.num_wgs
               << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
-              << "). Capping to " << max_sustainable_wgs
-              << " to avoid grid_barrier deadlock." << std::endl;
-    args.num_wgs = max_sustainable_wgs;
+              << "). Reduce -w to avoid grid_barrier deadlock." << std::endl;
+    exit(0);
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/primitive_tester.cpp
@@ -174,7 +174,8 @@ PrimitiveTester::PrimitiveTester(TesterArguments args) : Tester(args) {
       break;
   }
 
-  CHECK_HIP(hipMemset(source, 'a', buff_size));
+  CHECK_HIP(hipMemsetAsync(source, 'a', buff_size, stream));
+  CHECK_HIP(hipStreamSynchronize(stream));
 }
 
 PrimitiveTester::~PrimitiveTester() {
@@ -206,6 +207,7 @@ void PrimitiveTester::resetBuffers(size_t size) {
   size_t buff_size = size * batch_size * args.wg_size * args.num_wgs;
   CHECK_HIP(hipMemsetAsync(dest, '1', buff_size, stream));
   CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
+  CHECK_HIP(hipStreamSynchronize(stream));
 }
 
 void PrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize, int loop,

--- a/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.cpp
@@ -146,11 +146,10 @@ TeamCtxPrimitiveTester::TeamCtxPrimitiveTester(TesterArguments args)
   const int max_sustainable_wgs =
       max_co_resident_wgs_per_cu * deviceProps.multiProcessorCount;
   if (args.num_wgs > static_cast<unsigned>(max_sustainable_wgs)) {
-    std::cout << "Warning: Requested work-groups (" << args.num_wgs
+    std::cerr << "Error: Requested work-groups (" << args.num_wgs
               << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
-              << "). Capping to " << max_sustainable_wgs
-              << " to avoid grid_barrier deadlock." << std::endl;
-    args.num_wgs = max_sustainable_wgs;
+              << "). Reduce -w to avoid grid_barrier deadlock." << std::endl;
+    exit(0);
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.cpp
@@ -149,7 +149,7 @@ TeamCtxPrimitiveTester::TeamCtxPrimitiveTester(TesterArguments args)
     std::cerr << "Error: Requested work-groups (" << args.num_wgs
               << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
               << "). Reduce -w to avoid grid_barrier deadlock." << std::endl;
-    exit(0);
+    exit(-1);
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/team_ctx_primitive_tester.cpp
@@ -168,7 +168,8 @@ TeamCtxPrimitiveTester::TeamCtxPrimitiveTester(TesterArguments args)
   }
 
 
-  CHECK_HIP(hipMemset(source, 'a', buff_size));
+  CHECK_HIP(hipMemsetAsync(source, 'a', buff_size, stream));
+  CHECK_HIP(hipStreamSynchronize(stream));
 }
 
 TeamCtxPrimitiveTester::~TeamCtxPrimitiveTester() {
@@ -198,6 +199,7 @@ void TeamCtxPrimitiveTester::resetBuffers(size_t size) {
   size_t buff_size = size * batch_size * args.wg_size * args.num_wgs;
   CHECK_HIP(hipMemsetAsync(dest, '1', buff_size, stream));
   CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
+  CHECK_HIP(hipStreamSynchronize(stream));
 }
 
 void TeamCtxPrimitiveTester::preLaunchKernel() {

--- a/projects/rocshmem/tests/functional_tests/wavefront_primitives.cpp
+++ b/projects/rocshmem/tests/functional_tests/wavefront_primitives.cpp
@@ -119,7 +119,7 @@ WaveFrontPrimitiveTester::WaveFrontPrimitiveTester(TesterArguments args)
     std::cerr << "Error: Requested work-groups (" << args.num_wgs
               << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
               << "). Reduce -w to avoid grid_barrier deadlock." << std::endl;
-    exit(0);
+    exit(-1);
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/wavefront_primitives.cpp
+++ b/projects/rocshmem/tests/functional_tests/wavefront_primitives.cpp
@@ -137,7 +137,8 @@ WaveFrontPrimitiveTester::WaveFrontPrimitiveTester(TesterArguments args)
       break;
   }
 
-  CHECK_HIP(hipMemset(source, 'a', buff_size));
+  CHECK_HIP(hipMemsetAsync(source, 'a', buff_size, stream));
+  CHECK_HIP(hipStreamSynchronize(stream));
 }
 
 WaveFrontPrimitiveTester::~WaveFrontPrimitiveTester() {
@@ -167,6 +168,7 @@ void WaveFrontPrimitiveTester::resetBuffers(size_t size) {
   size_t buff_size = size * batch_size * args.num_wgs * num_warps;
   CHECK_HIP(hipMemsetAsync(dest, '1', buff_size, stream));
   CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
+  CHECK_HIP(hipStreamSynchronize(stream));
 }
 
 void WaveFrontPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,

--- a/projects/rocshmem/tests/functional_tests/wavefront_primitives.cpp
+++ b/projects/rocshmem/tests/functional_tests/wavefront_primitives.cpp
@@ -116,11 +116,10 @@ WaveFrontPrimitiveTester::WaveFrontPrimitiveTester(TesterArguments args)
   const int max_sustainable_wgs =
       max_co_resident_wgs_per_cu * deviceProps.multiProcessorCount;
   if (args.num_wgs > static_cast<unsigned>(max_sustainable_wgs)) {
-    std::cout << "Warning: Requested work-groups (" << args.num_wgs
+    std::cerr << "Error: Requested work-groups (" << args.num_wgs
               << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
-              << "). Capping to " << max_sustainable_wgs
-              << " to avoid grid_barrier deadlock." << std::endl;
-    args.num_wgs = max_sustainable_wgs;
+              << "). Reduce -w to avoid grid_barrier deadlock." << std::endl;
+    exit(0);
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp
+++ b/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp
@@ -115,7 +115,7 @@ WorkGroupPrimitiveTester::WorkGroupPrimitiveTester(TesterArguments args)
     std::cerr << "Error: Requested work-groups (" << args.num_wgs
               << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
               << "). Reduce -w to avoid grid_barrier deadlock." << std::endl;
-    exit(0);
+    exit(-1);
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp
+++ b/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp
@@ -112,11 +112,10 @@ WorkGroupPrimitiveTester::WorkGroupPrimitiveTester(TesterArguments args)
   const int max_sustainable_wgs =
       max_co_resident_wgs_per_cu * deviceProps.multiProcessorCount;
   if (args.num_wgs > static_cast<unsigned>(max_sustainable_wgs)) {
-    std::cout << "Warning: Requested work-groups (" << args.num_wgs
+    std::cerr << "Error: Requested work-groups (" << args.num_wgs
               << ") exceeds max co-resident work-groups (" << max_sustainable_wgs
-              << "). Capping to " << max_sustainable_wgs
-              << " to avoid grid_barrier deadlock." << std::endl;
-    args.num_wgs = max_sustainable_wgs;
+              << "). Reduce -w to avoid grid_barrier deadlock." << std::endl;
+    exit(0);
   }
 
   switch (_type) {

--- a/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp
+++ b/projects/rocshmem/tests/functional_tests/workgroup_primitives.cpp
@@ -133,7 +133,8 @@ WorkGroupPrimitiveTester::WorkGroupPrimitiveTester(TesterArguments args)
       break;
   }
 
-  CHECK_HIP(hipMemset(source, 'a', buff_size));
+  CHECK_HIP(hipMemsetAsync(source, 'a', buff_size, stream));
+  CHECK_HIP(hipStreamSynchronize(stream));
 }
 
 WorkGroupPrimitiveTester::~WorkGroupPrimitiveTester() {
@@ -163,6 +164,7 @@ void WorkGroupPrimitiveTester::resetBuffers(size_t size) {
   size_t buff_size = size * batch_size * args.num_wgs;
   CHECK_HIP(hipMemsetAsync(dest, '1', buff_size, stream));
   CHECK_HIP(hipMemsetAsync(grid_psync, 0, sizeof(int), stream));
+  CHECK_HIP(hipStreamSynchronize(stream));
 }
 
 void WorkGroupPrimitiveTester::launchKernel(dim3 gridSize, dim3 blockSize,


### PR DESCRIPTION
## Motivation

I have been seeing random validation errors on gfx1201 with ROCm 7.13 in IPC tests. 

```
mpirun -np 2 --mca pml ucx --mca osc ucx --timeout 300 --map-by numa -x UCX_ROCM_IPC_SIGPOOL_MAX_ELEMS=16384 -x ROCSHMEM_DEBUG_LEVEL=trace ./build/tests/functional_tests/rocshmem_functional_tests -a 2 -w 1 -z 1 -s 1048576
I-001h rocSHMEM TcpBootstrap : Using eth1:10.7.34.125<0>        netInit@src/bootstrap/bootstrap.cpp:464
I0000h rocSHMEM TcpBootstrap : Using eth1:10.7.34.125<0>        netInit@src/bootstrap/bootstrap.cpp:464
I0001h rocSHMEM TcpBootstrap : Using eth1:10.7.34.125<0>        netInit@src/bootstrap/bootstrap.cpp:464
I0001h rocSHMEM rank 1 nranks 2 - connecting to 10.7.34.125<52351>      initialize@src/bootstrap/bootstrap.cpp:297
I0000h rocSHMEM rank 0 nranks 2 - connecting to 10.7.34.125<52351>      initialize@src/bootstrap/bootstrap.cpp:297
I0000h rocSHMEM Received connect from rank 1 total 1/2  bootstrapRoot@src/bootstrap/bootstrap.cpp:414
I0000h rocSHMEM Received connect from rank 0 total 2/2  bootstrapRoot@src/bootstrap/bootstrap.cpp:414
################################################################################
#                                rocSHMEM Info                                 #
################################################################################
# Version                     : 3.4.0                                          #
# Vendor String               : rocSHMEM_v3.4.0_IPC                            #
# Git Hash                    : bc273de5745af14574382e7d2211f8e94deff04d       #
# Build Type                  : Release                                        #
# Install Prefix              : /root/rocshmem                                 #
# Compiled Arch(s)            : gfx90a                                         #
#                             : gfx1100                                        #
#                             : gfx1201                                        #
#                             : gfx942                                         #
#                             : gfx950                                         #
#                             : gfx1250                                        #
# System Arch                 : gfx1201                                        #
# System Arch is supported    : Yes                                            #
# ROCm                        : 7.13.0                                         #
# External MPI                : Open MPI 5.0.10                                #
#------------------------------------------------------------------------------#
#                              Build Configuration                             #
#------------------------------------------------------------------------------#
# PROFILE                     : OFF                                            #
# BUILD_DEBUG_TRACE_HOST      : OFF                                            #
# BUILD_DEBUG_TRACE_DEVICE    : OFF                                            #
# BUILD_DEBUG_DEVICE          : OFF                                            #
# USE_RO                      : OFF                                            #
# USE_IPC                     : ON                                             #
# USE_GDA                     : OFF                                            #
# USE_SDMA                    : OFF                                            #
# USE_THREADS                 : OFF                                            #
# USE_SHARED_CTX              : OFF                                            #
# USE_WF_COAL                 : OFF                                            #
# USE_HEAP_DEVICE_FINEGRAIN   : ON                                             #
# USE_HEAP_DEVICE_UNCACHED    : OFF                                            #
# USE_HEAP_DEVICE_COARSEGRAIN : OFF                                            #
# USE_HEAP_DEVICE_VMM_POSIX   : OFF                                            #
# USE_HEAP_DEVICE_VMM_FABRIC  : OFF                                            #
# HAVE_AMDSMI_GPU_FABRIC_INFO : OFF                                            #
# USE_FUNC_CALL               : OFF                                            #
# USE_SINGLE_NODE             : ON                                             #
# USE_HDP_FLUSH               : OFF                                            #
# USE_HDP_FLUSH_HOST_SIDE     : OFF                                            #
# GDA_IONIC                   : OFF                                            #
# GDA_BNXT                    : OFF                                            #
# GDA_MLX5                    : OFF                                            #
# HAVE_EXTERNAL_MPI           : ON                                             #
# HAVE_DEVICE_MALLOC_UNCACHED : ON                                             #
################################################################################
################################################################################
#                   rocSHMEM Environment Variables                             #
################################################################################
# ROCSHMEM_DEBUG_LEVEL=TRACE
# ROCSHMEM_BACKEND=ipc
################################################################################
### Creating Test:      Blocking Puts   B=ipc PE=2 W=1 Z=1 ###
Data validation error at buffer 0 slot 0 idx 0
 Got 49, Expected 97
```

## Technical Details

After hours of struggling, I realized IPC backend was not causing this failure. In more detail, the functional tests used to utilize the default stream for data transfer and stream `stream` for kernel submissions. Moving all of the operations on the `stream` and properly synchronize them fixes the recent validation issues.

The second fix is regarding handling high number of WGs when it's higher than the limit that the device can handle (all of the workgroups be resident for the grid-wide sync)

## JIRA ID

AIROCSHMEM-435

## Test Result

Functional tests and unit tests pass on gfx950, and gfx1201
