### PR TITLE
[clr] Add STREAM_CAPTURE support for hipDrvLaunchKernelEx with cluste…

### DIFF
--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -75,7 +75,8 @@ hipError_t ihipGraphAddKernelNode(hip::GraphNode** pGraphNode, hip::Graph* graph
                                   bool capture = true, int coopKernel = 0, int devId = 0,
                                   int globalWorkSizeX_remainder = 0,
                                   int globalWorkSizeY_remainder = 0,
-                                  int globalWorkSizeZ_remainder = 0) {
+                                  int globalWorkSizeZ_remainder = 0,
+                                  dim3 clusterDim = {1, 1, 1}) {
   if (!hip::Graph::isGraphValid(graph)) {
     return hipErrorInvalidValue;
   }
@@ -90,7 +91,8 @@ hipError_t ihipGraphAddKernelNode(hip::GraphNode** pGraphNode, hip::Graph* graph
                                      pNodeParams->gridDim.z, pNodeParams->blockDim.x,
                                      pNodeParams->blockDim.y, pNodeParams->blockDim.z,
                                      pNodeParams->sharedMemBytes, *device, globalWorkSizeX_remainder,
-                                     globalWorkSizeY_remainder, globalWorkSizeZ_remainder, 1, 1, 1);
+                                     globalWorkSizeY_remainder, globalWorkSizeZ_remainder,
+                                     clusterDim.x, clusterDim.y, clusterDim.z);
   if (!launch_params.IsValidConfig()) {
     return hipErrorInvalidConfiguration;
   }
@@ -114,7 +116,7 @@ hipError_t ihipGraphAddKernelNode(hip::GraphNode** pGraphNode, hip::Graph* graph
 
   *pGraphNode =
       new hip::GraphKernelNode(pNodeParams, pNodeEvents, coopKernel, globalWorkSizeX_remainder,
-                               globalWorkSizeY_remainder, globalWorkSizeZ_remainder);
+                               globalWorkSizeY_remainder, globalWorkSizeZ_remainder, clusterDim);
   status = ihipGraphAddNode(*pGraphNode, graph, pDependencies, numDependencies, capture, devId);
   return status;
 }
@@ -360,6 +362,41 @@ hipError_t capturehipModuleLaunchKernel(hipStream_t& stream, hipFunction_t& f, u
   hipError_t status = ihipGraphAddKernelNode(
       &pGraphNode, s->GetCaptureGraph(), s->GetLastCapturedNodes().data(),
       s->GetLastCapturedNodes().size(), &nodeParams, nullptr, true, 0, s->DeviceId());
+  if (status != hipSuccess) {
+    return status;
+  }
+  s->SetLastCapturedNode(pGraphNode);
+  return hipSuccess;
+}
+
+hipError_t capturehipDrvLaunchKernelEx(hipStream_t& stream, const HIP_LAUNCH_CONFIG*& config,
+                                       hipFunction_t& f, void**& kernelParams, void**& extra,
+                                       dim3 clusterDim) {
+  ClPrint(amd::LOG_INFO, amd::LOG_ALWAYS,
+          "[hipGraph] DrvLaunchKernelEx capture on stream : %p"
+          " grid=[%u,%u,%u] block=[%u,%u,%u] cluster=[%u,%u,%u] sharedMem=%u",
+          stream,
+          config->gridDimX, config->gridDimY, config->gridDimZ,
+          config->blockDimX, config->blockDimY, config->blockDimZ,
+          clusterDim.x, clusterDim.y, clusterDim.z,
+          config->sharedMemBytes);
+  if (!hip::isValid(stream)) {
+    return hipErrorContextIsDestroyed;
+  }
+  hip::Stream* s = reinterpret_cast<hip::Stream*>(stream);
+  hipKernelNodeParams nodeParams;
+  nodeParams.func = f;
+  nodeParams.blockDim = {config->blockDimX, config->blockDimY, config->blockDimZ};
+  nodeParams.gridDim = {config->gridDimX, config->gridDimY, config->gridDimZ};
+  nodeParams.sharedMemBytes = config->sharedMemBytes;
+  nodeParams.kernelParams = kernelParams;
+  nodeParams.extra = extra;
+
+  hip::GraphNode* pGraphNode;
+  hipError_t status = ihipGraphAddKernelNode(
+      &pGraphNode, s->GetCaptureGraph(), s->GetLastCapturedNodes().data(),
+      s->GetLastCapturedNodes().size(), &nodeParams, nullptr, true, 0, s->DeviceId(),
+      0, 0, 0, clusterDim);
   if (status != hipSuccess) {
     return status;
   }

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -386,34 +386,14 @@ hipError_t capturehipDrvLaunchKernelEx(hipStream_t& stream, const HIP_LAUNCH_CON
 
   hip::Stream* s = reinterpret_cast<hip::Stream*>(stream);
   dim3 clusterDim = {1, 1, 1};
-
-  auto addKernelNode = [&](int coopKernel, void** nodeExtra, dim3 clusterDim) -> hipError_t {
-    hipKernelNodeParams nodeParams;
-    nodeParams.func = f;
-    nodeParams.blockDim = {config->blockDimX, config->blockDimY, config->blockDimZ};
-    nodeParams.extra = nodeExtra;
-    nodeParams.gridDim = {config->gridDimX, config->gridDimY, config->gridDimZ};
-    nodeParams.kernelParams = kernelParams;
-    nodeParams.sharedMemBytes = config->sharedMemBytes;
-
-    hip::GraphNode* pGraphNode;
-    hipError_t status = ihipGraphAddKernelNode(
-        &pGraphNode, s->GetCaptureGraph(), s->GetLastCapturedNodes().data(),
-        s->GetLastCapturedNodes().size(), &nodeParams, nullptr, true, coopKernel, s->DeviceId(),
-        0, 0, 0, clusterDim);
-    if (status != hipSuccess) {
-      return status;
-    }
-    s->SetLastCapturedNode(pGraphNode);
-    return hipSuccess;
-  };
+  int coopKernel = 0;
 
   for (size_t attr_idx = 0; attr_idx < config->numAttrs; ++attr_idx) {
     const hipLaunchAttribute& attr = config->attrs[attr_idx];
     switch (attr.id) {
       case hipLaunchAttributeCooperative:
         if (attr.value.cooperative != 0) {
-          return addKernelNode(amd::NDRangeKernelCommand::CooperativeGroups, nullptr, {1, 1, 1});
+          coopKernel = amd::NDRangeKernelCommand::CooperativeGroups;
         }
         break;
       case hipLaunchAttributeClusterDimension:
@@ -436,7 +416,24 @@ hipError_t capturehipDrvLaunchKernelEx(hipStream_t& stream, const HIP_LAUNCH_CON
     }
   }
 
-  return addKernelNode(0, extra, clusterDim);
+  hipKernelNodeParams nodeParams;
+  nodeParams.func = f;
+  nodeParams.blockDim = {config->blockDimX, config->blockDimY, config->blockDimZ};
+  nodeParams.gridDim = {config->gridDimX, config->gridDimY, config->gridDimZ};
+  nodeParams.sharedMemBytes = config->sharedMemBytes;
+  nodeParams.kernelParams = kernelParams;
+  nodeParams.extra = coopKernel ? nullptr : extra;
+
+  hip::GraphNode* pGraphNode;
+  hipError_t status = ihipGraphAddKernelNode(
+      &pGraphNode, s->GetCaptureGraph(), s->GetLastCapturedNodes().data(),
+      s->GetLastCapturedNodes().size(), &nodeParams, nullptr, true, coopKernel, s->DeviceId(),
+      0, 0, 0, clusterDim);
+  if (status != hipSuccess) {
+    return status;
+  }
+  s->SetLastCapturedNode(pGraphNode);
+  return hipSuccess;
 }
 
 hipError_t capturehipModuleLaunchCooperativeKernel(hipStream_t& stream, hipFunction_t& f,

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -372,8 +372,8 @@ hipError_t capturehipModuleLaunchKernel(hipStream_t& stream, hipFunction_t& f, u
 hipError_t capturehipDrvLaunchKernelEx(hipStream_t& stream, const HIP_LAUNCH_CONFIG*& config,
                                        hipFunction_t& f, void**& kernelParams, void**& extra,
                                        dim3 clusterDim) {
-  ClPrint(amd::LOG_INFO, amd::LOG_ALWAYS,
-          "[hipGraph] DrvLaunchKernelEx capture on stream : %p"
+  ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_API,
+          "[hipGraph] capturehipDrvLaunchKernelEx on stream : %p"
           " grid=[%u,%u,%u] block=[%u,%u,%u] cluster=[%u,%u,%u] sharedMem=%u",
           stream,
           config->gridDimX, config->gridDimY, config->gridDimZ,

--- a/projects/clr/hipamd/src/hip_graph.cpp
+++ b/projects/clr/hipamd/src/hip_graph.cpp
@@ -72,7 +72,7 @@ hipError_t ihipGraphAddKernelNode(hip::GraphNode** pGraphNode, hip::Graph* graph
                                   hip::GraphNode* const* pDependencies, size_t numDependencies,
                                   const hipKernelNodeParams* pNodeParams,
                                   const ihipExtKernelEvents* pNodeEvents = nullptr,
-                                  bool capture = true, int coopKernel = 0, int devId = 0,
+                                  bool capture = true, int coopKernel = 0, int devId = -1,
                                   int globalWorkSizeX_remainder = 0,
                                   int globalWorkSizeY_remainder = 0,
                                   int globalWorkSizeZ_remainder = 0,
@@ -81,12 +81,13 @@ hipError_t ihipGraphAddKernelNode(hip::GraphNode** pGraphNode, hip::Graph* graph
     return hipErrorInvalidValue;
   }
 
-  hipFunction_t func = hip::GraphKernelNode::getFunc(*pNodeParams, ihipGetDevice());
+  int deviceId = (devId >= 0) ? devId : ihipGetDevice();
+  hipFunction_t func = hip::GraphKernelNode::getFunc(*pNodeParams, deviceId);
   if (!func) {
     return hipErrorInvalidDeviceFunction;
   }
 
-  const amd::Device* device = g_devices[ihipGetDevice()]->devices()[0];
+  const amd::Device* device = g_devices[deviceId]->devices()[0];
   amd::HIPLaunchParams launch_params(pNodeParams->gridDim.x, pNodeParams->gridDim.y,
                                      pNodeParams->gridDim.z, pNodeParams->blockDim.x,
                                      pNodeParams->blockDim.y, pNodeParams->blockDim.z,
@@ -97,7 +98,7 @@ hipError_t ihipGraphAddKernelNode(hip::GraphNode** pGraphNode, hip::Graph* graph
     return hipErrorInvalidConfiguration;
   }
   hipError_t status = ihipLaunchKernel_validate(func, launch_params, pNodeParams->kernelParams,
-                                                pNodeParams->extra, ihipGetDevice(), 0);
+                                                pNodeParams->extra, deviceId, coopKernel);
   if (hipSuccess != status) {
     return status;
   }
@@ -117,7 +118,7 @@ hipError_t ihipGraphAddKernelNode(hip::GraphNode** pGraphNode, hip::Graph* graph
   *pGraphNode =
       new hip::GraphKernelNode(pNodeParams, pNodeEvents, coopKernel, globalWorkSizeX_remainder,
                                globalWorkSizeY_remainder, globalWorkSizeZ_remainder, clusterDim);
-  status = ihipGraphAddNode(*pGraphNode, graph, pDependencies, numDependencies, capture, devId);
+  status = ihipGraphAddNode(*pGraphNode, graph, pDependencies, numDependencies, capture, deviceId);
   return status;
 }
 
@@ -370,38 +371,72 @@ hipError_t capturehipModuleLaunchKernel(hipStream_t& stream, hipFunction_t& f, u
 }
 
 hipError_t capturehipDrvLaunchKernelEx(hipStream_t& stream, const HIP_LAUNCH_CONFIG*& config,
-                                       hipFunction_t& f, void**& kernelParams, void**& extra,
-                                       dim3 clusterDim) {
+                                       hipFunction_t& f, void**& kernelParams, void**& extra) {
   ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_API,
-          "[hipGraph] capturehipDrvLaunchKernelEx on stream : %p"
-          " grid=[%u,%u,%u] block=[%u,%u,%u] cluster=[%u,%u,%u] sharedMem=%u",
-          stream,
-          config->gridDimX, config->gridDimY, config->gridDimZ,
-          config->blockDimX, config->blockDimY, config->blockDimZ,
-          clusterDim.x, clusterDim.y, clusterDim.z,
-          config->sharedMemBytes);
+          "[hipGraph] Current capture node DrvLaunchKernelEx on stream : %p", stream);
   if (!hip::isValid(stream)) {
     return hipErrorContextIsDestroyed;
   }
-  hip::Stream* s = reinterpret_cast<hip::Stream*>(stream);
-  hipKernelNodeParams nodeParams;
-  nodeParams.func = f;
-  nodeParams.blockDim = {config->blockDimX, config->blockDimY, config->blockDimZ};
-  nodeParams.gridDim = {config->gridDimX, config->gridDimY, config->gridDimZ};
-  nodeParams.sharedMemBytes = config->sharedMemBytes;
-  nodeParams.kernelParams = kernelParams;
-  nodeParams.extra = extra;
-
-  hip::GraphNode* pGraphNode;
-  hipError_t status = ihipGraphAddKernelNode(
-      &pGraphNode, s->GetCaptureGraph(), s->GetLastCapturedNodes().data(),
-      s->GetLastCapturedNodes().size(), &nodeParams, nullptr, true, 0, s->DeviceId(),
-      0, 0, 0, clusterDim);
-  if (status != hipSuccess) {
-    return status;
+  if (f == nullptr) {
+    return hipErrorInvalidResourceHandle;
   }
-  s->SetLastCapturedNode(pGraphNode);
-  return hipSuccess;
+  if (config == nullptr) {
+    return hipErrorInvalidValue;
+  }
+
+  hip::Stream* s = reinterpret_cast<hip::Stream*>(stream);
+  dim3 clusterDim = {1, 1, 1};
+
+  auto addKernelNode = [&](int coopKernel, void** nodeExtra, dim3 clusterDim) -> hipError_t {
+    hipKernelNodeParams nodeParams;
+    nodeParams.func = f;
+    nodeParams.blockDim = {config->blockDimX, config->blockDimY, config->blockDimZ};
+    nodeParams.extra = nodeExtra;
+    nodeParams.gridDim = {config->gridDimX, config->gridDimY, config->gridDimZ};
+    nodeParams.kernelParams = kernelParams;
+    nodeParams.sharedMemBytes = config->sharedMemBytes;
+
+    hip::GraphNode* pGraphNode;
+    hipError_t status = ihipGraphAddKernelNode(
+        &pGraphNode, s->GetCaptureGraph(), s->GetLastCapturedNodes().data(),
+        s->GetLastCapturedNodes().size(), &nodeParams, nullptr, true, coopKernel, s->DeviceId(),
+        0, 0, 0, clusterDim);
+    if (status != hipSuccess) {
+      return status;
+    }
+    s->SetLastCapturedNode(pGraphNode);
+    return hipSuccess;
+  };
+
+  for (size_t attr_idx = 0; attr_idx < config->numAttrs; ++attr_idx) {
+    const hipLaunchAttribute& attr = config->attrs[attr_idx];
+    switch (attr.id) {
+      case hipLaunchAttributeCooperative:
+        if (attr.value.cooperative != 0) {
+          return addKernelNode(amd::NDRangeKernelCommand::CooperativeGroups, nullptr, {1, 1, 1});
+        }
+        break;
+      case hipLaunchAttributeClusterDimension:
+        clusterDim.x = attr.value.clusterDim.x;
+        clusterDim.y = attr.value.clusterDim.y;
+        clusterDim.z = attr.value.clusterDim.z;
+        if (clusterDim.x == 0 || clusterDim.y == 0 || clusterDim.z == 0) {
+          return hipErrorInvalidConfiguration;
+        }
+        break;
+      case hipLaunchAttributeExtDynDataPrefetch:
+        if (attr.value.dynDataPrefetch == nullptr) {
+          return hipErrorInvalidValue;
+        }
+        s->SetCaptureStatus(hipStreamCaptureStatusInvalidated);
+        return hipErrorStreamCaptureUnsupported;
+      default:
+        LogPrintfError("Attribute %u not supported", attr.id);
+        return hipErrorInvalidValue;
+    }
+  }
+
+  return addKernelNode(0, extra, clusterDim);
 }
 
 hipError_t capturehipModuleLaunchCooperativeKernel(hipStream_t& stream, hipFunction_t& f,
@@ -1805,7 +1840,8 @@ hipError_t hipGraphKernelNodeSetAttribute(hipGraphNode_t hNode, hipKernelNodeAtt
     HIP_RETURN(hipErrorInvalidValue);
   }
   if (attr != hipKernelNodeAttributeAccessPolicyWindow &&
-      attr != hipKernelNodeAttributeCooperative && attr != hipLaunchAttributePriority) {
+      attr != hipKernelNodeAttributeCooperative && attr != hipLaunchAttributePriority &&
+      attr != hipLaunchAttributeClusterDimension) {
     HIP_RETURN(hipErrorInvalidValue);
   }
 
@@ -1823,7 +1859,8 @@ hipError_t hipGraphKernelNodeGetAttribute(hipGraphNode_t hNode, hipKernelNodeAtt
     HIP_RETURN(hipErrorInvalidValue);
   }
   if (attr != hipKernelNodeAttributeAccessPolicyWindow &&
-      attr != hipKernelNodeAttributeCooperative && attr != hipLaunchAttributePriority) {
+      attr != hipKernelNodeAttributeCooperative && attr != hipLaunchAttributePriority &&
+      attr != hipLaunchAttributeClusterDimension) {
     HIP_RETURN(hipErrorInvalidValue);
   }
 

--- a/projects/clr/hipamd/src/hip_graph_capture.hpp
+++ b/projects/clr/hipamd/src/hip_graph_capture.hpp
@@ -28,6 +28,10 @@ hipError_t capturehipModuleLaunchKernel(hipStream_t& stream, hipFunction_t& f, u
                                         uint32_t& sharedMemBytes, void**& kernelParams,
                                         void**& extra);
 
+hipError_t capturehipDrvLaunchKernelEx(hipStream_t& stream, const HIP_LAUNCH_CONFIG*& config,
+                                       hipFunction_t& f, void**& kernelParams, void**& extra,
+                                       dim3 clusterDim = {1, 1, 1});
+
 hipError_t capturehipModuleLaunchCooperativeKernel(hipStream_t& stream, hipFunction_t& f,
                                                    uint32_t& gridDimX, uint32_t& gridDimY,
                                                    uint32_t& gridDimZ, uint32_t& blockDimX,

--- a/projects/clr/hipamd/src/hip_graph_capture.hpp
+++ b/projects/clr/hipamd/src/hip_graph_capture.hpp
@@ -29,8 +29,7 @@ hipError_t capturehipModuleLaunchKernel(hipStream_t& stream, hipFunction_t& f, u
                                         void**& extra);
 
 hipError_t capturehipDrvLaunchKernelEx(hipStream_t& stream, const HIP_LAUNCH_CONFIG*& config,
-                                       hipFunction_t& f, void**& kernelParams, void**& extra,
-                                       dim3 clusterDim = {1, 1, 1});
+                                       hipFunction_t& f, void**& kernelParams, void**& extra);
 
 hipError_t capturehipModuleLaunchCooperativeKernel(hipStream_t& stream, hipFunction_t& f,
                                                    uint32_t& gridDimX, uint32_t& gridDimY,

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1723,6 +1723,24 @@ class GraphKernelNode : public GraphNode {
         return hipErrorInvalidValue;
       }
       kernelAttr_.priority = params->priority;
+    } else if (attr == hipLaunchAttributeClusterDimension) {
+      dim3 clusterDim = {params->clusterDim.x, params->clusterDim.y, params->clusterDim.z};
+      if (clusterDim.x == 0 || clusterDim.y == 0 || clusterDim.z == 0) {
+        return hipErrorInvalidConfiguration;
+      }
+      const amd::Device* device = g_devices[dev_id_]->devices()[0];
+      amd::HIPLaunchParams launch_params(kernelParams_.gridDim.x, kernelParams_.gridDim.y,
+                                         kernelParams_.gridDim.z, kernelParams_.blockDim.x,
+                                         kernelParams_.blockDim.y, kernelParams_.blockDim.z,
+                                         kernelParams_.sharedMemBytes, *device,
+                                         globalWorkSizeX_remainder_, globalWorkSizeY_remainder_,
+                                         globalWorkSizeZ_remainder_, clusterDim.x, clusterDim.y,
+                                         clusterDim.z);
+      if (!launch_params.IsValidConfig()) {
+        return hipErrorInvalidConfiguration;
+      }
+      clusterDim_ = clusterDim;
+      return hipSuccess;
     }
 
     kernelAttrInUse_ = attr;
@@ -1730,7 +1748,10 @@ class GraphKernelNode : public GraphNode {
   }
   hipError_t GetAttrParams(hipKernelNodeAttrID attr, hipKernelNodeAttrValue* params) {
     // Get kernel attr params
-    if (kernelAttrInUse_ != 0 && kernelAttrInUse_ != attr) return hipErrorInvalidValue;
+    if (attr != hipLaunchAttributeClusterDimension &&
+        kernelAttrInUse_ != 0 && kernelAttrInUse_ != attr) {
+      return hipErrorInvalidValue;
+    }
     if (attr == hipKernelNodeAttributeAccessPolicyWindow) {
       params->accessPolicyWindow.base_ptr = kernelAttr_.accessPolicyWindow.base_ptr;
       params->accessPolicyWindow.hitProp = kernelAttr_.accessPolicyWindow.hitProp;
@@ -1741,15 +1762,20 @@ class GraphKernelNode : public GraphNode {
       params->cooperative = kernelAttr_.cooperative;
     } else if (attr == hipLaunchAttributePriority) {
       params->priority = kernelAttr_.priority;
+    } else if (attr == hipLaunchAttributeClusterDimension) {
+      params->clusterDim.x = clusterDim_.x;
+      params->clusterDim.y = clusterDim_.y;
+      params->clusterDim.z = clusterDim_.z;
     }
     return hipSuccess;
   }
   hipError_t CopyAttr(const GraphKernelNode* srcNode) {
-    if (kernelAttrInUse_ == 0 && srcNode->kernelAttrInUse_ == 0) {
-      return hipSuccess;
-    }
     if (kernelAttrInUse_ != 0 && srcNode->kernelAttrInUse_ != kernelAttrInUse_) {
       return hipErrorInvalidContext;
+    }
+    clusterDim_ = srcNode->clusterDim_;
+    if (kernelAttrInUse_ == 0 && srcNode->kernelAttrInUse_ == 0) {
+      return hipSuccess;
     }
     kernelAttrInUse_ = srcNode->kernelAttrInUse_;
     switch (srcNode->kernelAttrInUse_) {
@@ -1776,7 +1802,13 @@ class GraphKernelNode : public GraphNode {
   hipError_t SetParams(GraphNode* node) override {
     dev_id_ = ihipGetDevice();
     const GraphKernelNode* kernelNode = static_cast<GraphKernelNode const*>(node);
-    return SetParams(&kernelNode->kernelParams_);
+    dim3 oldClusterDim = clusterDim_;
+    clusterDim_ = kernelNode->clusterDim_;
+    hipError_t status = SetParams(&kernelNode->kernelParams_);
+    if (status != hipSuccess) {
+      clusterDim_ = oldClusterDim;
+    }
+    return status;
   }
 
   hipError_t validateKernelParams(const hipKernelNodeParams* pNodeParams,
@@ -1795,7 +1827,7 @@ class GraphKernelNode : public GraphNode {
     }
 
     hipError_t status = ihipLaunchKernel_validate(func, launch_params, pNodeParams->kernelParams,
-                                                  pNodeParams->extra, devId, 0);
+                                                  pNodeParams->extra, devId, coopKernel_);
     if (status != hipSuccess) {
       return status;
     }

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -1324,6 +1324,7 @@ class GraphKernelNode : public GraphNode {
   int globalWorkSizeX_remainder_;
   int globalWorkSizeY_remainder_;
   int globalWorkSizeZ_remainder_;
+  dim3 clusterDim_;                    //!< Cluster dimensions for cluster launch
   hipFunction_t resolvedFunc_ = nullptr;  //!< Cached resolved function to avoid redundant lookups
 
  protected:
@@ -1335,6 +1336,7 @@ class GraphKernelNode : public GraphNode {
     globalWorkSizeX_remainder_ = rhs.globalWorkSizeX_remainder_;
     globalWorkSizeY_remainder_ = rhs.globalWorkSizeY_remainder_;
     globalWorkSizeZ_remainder_ = rhs.globalWorkSizeZ_remainder_;
+    clusterDim_ = rhs.clusterDim_;
     hipError_t status = copyParams(&rhs.kernelParams_);
     if (status != hipSuccess) {
       ClPrint(amd::LOG_ERROR, amd::LOG_CODE, "[hipGraph] Failed to allocate memory to copy params");
@@ -1544,7 +1546,8 @@ class GraphKernelNode : public GraphNode {
                   int coopKernel = 0,
                   int globalWorkSizeX_remainder = 0,
                   int globalWorkSizeY_remainder = 0,
-                  int globalWorkSizeZ_remainder = 0)
+                  int globalWorkSizeZ_remainder = 0,
+                  dim3 clusterDim = {1, 1, 1})
       : GraphNode(hipGraphNodeTypeKernel, "bold", "octagon", "KERNEL") {
     kernelEvents_ = {0};
     if (pEvents != nullptr) {
@@ -1560,6 +1563,7 @@ class GraphKernelNode : public GraphNode {
     globalWorkSizeX_remainder_ = globalWorkSizeX_remainder;
     globalWorkSizeY_remainder_ = globalWorkSizeY_remainder;
     globalWorkSizeZ_remainder_ = globalWorkSizeZ_remainder;
+    clusterDim_ = clusterDim;
   }
 
   ~GraphKernelNode() { freeParams(); }
@@ -1631,7 +1635,8 @@ class GraphKernelNode : public GraphNode {
                                        kernelParams_.gridDim.z, kernelParams_.blockDim.x,
                                        kernelParams_.blockDim.y, kernelParams_.blockDim.z,
                                        kernelParams_.sharedMemBytes, *device, globalWorkSizeX_remainder_,
-                                       globalWorkSizeY_remainder_, globalWorkSizeZ_remainder_, 1, 1, 1);
+                                       globalWorkSizeY_remainder_, globalWorkSizeZ_remainder_,
+                                       clusterDim_.x, clusterDim_.y, clusterDim_.z);
 
     if (!launch_params.IsValidConfig()) {
       return hipErrorInvalidConfiguration;
@@ -1782,7 +1787,8 @@ class GraphKernelNode : public GraphNode {
                                        pNodeParams->gridDim.z, pNodeParams->blockDim.x,
                                        pNodeParams->blockDim.y, pNodeParams->blockDim.z,
                                        pNodeParams->sharedMemBytes, *device, globalWorkSizeX_remainder_,
-                                       globalWorkSizeY_remainder_, globalWorkSizeZ_remainder_, 1, 1, 1);
+                                       globalWorkSizeY_remainder_, globalWorkSizeZ_remainder_,
+                                       clusterDim_.x, clusterDim_.y, clusterDim_.z);
 
     if (!launch_params.IsValidConfig()) {
       HIP_RETURN(hipErrorInvalidConfiguration);

--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -1391,6 +1391,8 @@ hipError_t hipDrvLaunchKernelEx(const HIP_LAUNCH_CONFIG* config, hipFunction_t f
   }
   CHECK_STREAM_DETACHED_API(hStream);
 
+  STREAM_CAPTURE(hipDrvLaunchKernelEx, hStream, config, f, kernelParams, extra);
+
   int drvDeviceId = hip::Stream::DeviceId(hStream);
   const amd::Device* drvDevice = g_devices[drvDeviceId]->devices()[0];
   amd::HIPLaunchParams launch_params(config->gridDimX, config->gridDimY, config->gridDimZ,
@@ -1402,7 +1404,6 @@ hipError_t hipDrvLaunchKernelEx(const HIP_LAUNCH_CONFIG* config, hipFunction_t f
   }
 
   if (config->numAttrs == 0) {
-    STREAM_CAPTURE(hipDrvLaunchKernelEx, hStream, config, f, kernelParams, extra);
     HIP_RETURN(ihipModuleLaunchKernel(f, launch_params, hStream, kernelParams, nullptr,
                                       nullptr, nullptr, 0));
   }
@@ -1415,7 +1416,6 @@ hipError_t hipDrvLaunchKernelEx(const HIP_LAUNCH_CONFIG* config, hipFunction_t f
     switch (attr.id) {
       case hipLaunchAttributeCooperative: {
         if (attr.value.cooperative != 0) {
-          STREAM_CAPTURE(hipDrvLaunchKernelEx, hStream, config, f, kernelParams, extra);
           HIP_RETURN(ihipModuleLaunchKernel(f, launch_params, hStream, kernelParams,
                                             nullptr, nullptr, nullptr, 0,
                                             amd::NDRangeKernelCommand::CooperativeGroups));
@@ -1449,8 +1449,6 @@ hipError_t hipDrvLaunchKernelEx(const HIP_LAUNCH_CONFIG* config, hipFunction_t f
   if (clusterDim.x == 0 || clusterDim.y == 0 || clusterDim.z == 0) {
     HIP_RETURN(hipErrorInvalidConfiguration);
   }
-
-  STREAM_CAPTURE(hipDrvLaunchKernelEx, hStream, config, f, kernelParams, extra, clusterDim);
 
   amd::HIPLaunchParams launch_params_cluster(config->gridDimX, config->gridDimY, config->gridDimZ,
                                           config->blockDimX, config->blockDimY, config->blockDimZ,

--- a/projects/clr/hipamd/src/hip_module.cpp
+++ b/projects/clr/hipamd/src/hip_module.cpp
@@ -1402,6 +1402,7 @@ hipError_t hipDrvLaunchKernelEx(const HIP_LAUNCH_CONFIG* config, hipFunction_t f
   }
 
   if (config->numAttrs == 0) {
+    STREAM_CAPTURE(hipDrvLaunchKernelEx, hStream, config, f, kernelParams, extra);
     HIP_RETURN(ihipModuleLaunchKernel(f, launch_params, hStream, kernelParams, nullptr,
                                       nullptr, nullptr, 0));
   }
@@ -1414,6 +1415,7 @@ hipError_t hipDrvLaunchKernelEx(const HIP_LAUNCH_CONFIG* config, hipFunction_t f
     switch (attr.id) {
       case hipLaunchAttributeCooperative: {
         if (attr.value.cooperative != 0) {
+          STREAM_CAPTURE(hipDrvLaunchKernelEx, hStream, config, f, kernelParams, extra);
           HIP_RETURN(ihipModuleLaunchKernel(f, launch_params, hStream, kernelParams,
                                             nullptr, nullptr, nullptr, 0,
                                             amd::NDRangeKernelCommand::CooperativeGroups));
@@ -1447,6 +1449,8 @@ hipError_t hipDrvLaunchKernelEx(const HIP_LAUNCH_CONFIG* config, hipFunction_t f
   if (clusterDim.x == 0 || clusterDim.y == 0 || clusterDim.z == 0) {
     HIP_RETURN(hipErrorInvalidConfiguration);
   }
+
+  STREAM_CAPTURE(hipDrvLaunchKernelEx, hStream, config, f, kernelParams, extra, clusterDim);
 
   amd::HIPLaunchParams launch_params_cluster(config->gridDimX, config->gridDimY, config->gridDimZ,
                                           config->blockDimX, config->blockDimY, config->blockDimZ,

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1569,7 +1569,6 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
             slot->reserved2 = timestamp_->command().profilingInfo().correlation_id_;
           }
         }
-        const bool isExtKernelDispatch = dev().settings().ext_dispatch_packet_;
         if ((IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2) ||
              IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) &&
             kernelNames != nullptr && i < kernelNames->size() &&
@@ -1577,7 +1576,7 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
           ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2, "Graph ShaderName : %s, device id : %u",
                   (*kernelNames)[i] != nullptr ? (*kernelNames)[i]->c_str() : "<null>",
                   dev().index());
-          if (isExtKernelDispatch) {
+          if (pktType == HSA_PACKET_TYPE_VENDOR_SPECIFIC) {
             logAqlDispatchPacketExtended(gpu_queue_, hdr,
                 reinterpret_cast<hsa_amd_ext_kernel_dispatch_packet_t*>(slot),
                 Hsa::queue_load_read_index_scacquire(gpu_queue_), slotIdx, " Graph");

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1569,11 +1569,19 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
             slot->reserved2 = timestamp_->command().profilingInfo().correlation_id_;
           }
         }
+        const bool isExtKernelDispatch = dev().settings().ext_dispatch_packet_;
         if ((IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2) ||
              IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) &&
-            kernelNames != nullptr && i < kernelNames->size() && isKernelDispatch) {
+            kernelNames != nullptr && i < kernelNames->size() &&
+            (isKernelDispatch || isExtKernelDispatch)) {
           ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2, "Graph ShaderName : %s, device id : %u",
-                  (*kernelNames)[i]->c_str(), dev().index());
+                  (*kernelNames)[i] != nullptr ? (*kernelNames)[i]->c_str() : "<null>",
+                  dev().index());
+          if (isExtKernelDispatch) {
+            logAqlDispatchPacketExtended(gpu_queue_, hdr,
+                reinterpret_cast<hsa_amd_ext_kernel_dispatch_packet_t*>(slot),
+                Hsa::queue_load_read_index_scacquire(gpu_queue_), slotIdx, " Graph");
+          } else {
           ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL,
                   "SWq=0x%zx, HWq=0x%zx, id=%d, Dispatch Header = "
                   "0x%x (type=%d, barrier=%d, acquire=%d, release=%d), "
@@ -1595,6 +1603,7 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
                   slot->kernel_object, slot->kernarg_address,
                   slot->completion_signal, slot->reserved2,
                   Hsa::queue_load_read_index_scacquire(gpu_queue_), slotIdx);
+          }
         } else if ((IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2) ||
                     IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) &&
                    (pktType == HSA_PACKET_TYPE_BARRIER_AND ||

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1572,7 +1572,7 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
         if ((IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2) ||
              IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) &&
             kernelNames != nullptr && i < kernelNames->size() &&
-            (isKernelDispatch || isExtKernelDispatch)) {
+            (pktType == HSA_PACKET_TYPE_KERNEL_DISPATCH || pktType == HSA_PACKET_TYPE_VENDOR_SPECIFIC)) {
           ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2, "Graph ShaderName : %s, device id : %u",
                   (*kernelNames)[i] != nullptr ? (*kernelNames)[i]->c_str() : "<null>",
                   dev().index());

--- a/projects/hip-tests/catch/config/configs/unit/module.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/module.yaml
@@ -130,6 +130,9 @@ module:
   Unit_hipDrvLaunchKernelEx_With_MaxBlockDims:
     <<: *level_2
     tags: [launch]
+  Unit_hipDrvLaunchKernelEx_StreamCapture_ClusterDim:
+    <<: *level_2
+    tags: [launch]
   Unit_hipExtLaunchMultiKernelMultiDevice_Functional:
     <<: *level_2
     tags: [launch]

--- a/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
+++ b/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
@@ -439,8 +439,8 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_MaxBlockDims) {
  * Test Description
  * ------------------------
  *  - Verifies that hipDrvLaunchKernelEx with hipLaunchAttributeClusterDimension
- *  - is correctly captured during stream capture and replays with the correct
- *  - cluster dimensions in the AQL ext dispatch packet.
+ *  - is correctly captured during stream capture and that the replayed kernel
+ *  - produces the expected output (captures >=1 graph node and writes correct values).
  *  - Only runs on gfx1250/gfx1251 where cluster launches are supported.
  * Test source
  * ------------------------
@@ -502,7 +502,7 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_StreamCapture_ClusterDim) {
     cfg.gridDimX = GRID; cfg.gridDimY = 1; cfg.gridDimZ = 1;
     cfg.blockDimX = BLOCK; cfg.blockDimY = 1; cfg.blockDimZ = 1;
     cfg.hStream = stream;
-    hipLaunchAttribute attr;
+    hipLaunchAttribute attr{};
     attr.id = hipLaunchAttributeClusterDimension;
     attr.value.clusterDim = {CLUSTER, 1, 1};
     cfg.attrs = &attr;
@@ -522,7 +522,7 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_StreamCapture_ClusterDim) {
     cfg.gridDimX = GRID; cfg.gridDimY = 1; cfg.gridDimZ = 1;
     cfg.blockDimX = BLOCK; cfg.blockDimY = 1; cfg.blockDimZ = 1;
     cfg.hStream = stream;
-    hipLaunchAttribute attr;
+    hipLaunchAttribute attr{};
     attr.id = hipLaunchAttributeClusterDimension;
     attr.value.clusterDim = {CLUSTER, 1, 1};
     cfg.attrs = &attr;

--- a/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
+++ b/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
@@ -439,9 +439,12 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_MaxBlockDims) {
  * Test Description
  * ------------------------
  *  - Verifies that hipDrvLaunchKernelEx with hipLaunchAttributeClusterDimension
- *  - is correctly captured during stream capture and that the replayed kernel
- *  - produces the expected output (captures >=1 graph node and writes correct values).
- *  - Only runs on gfx1250/gfx1251 where cluster launches are supported.
+ *  - is correctly captured during stream capture:
+ *  - 1) Captured graph node count >= 1.
+ *  - 2) hipGraphKernelNodeGetAttribute returns the captured cluster dims.
+ *  - 3) hipGraphKernelNodeSetAttribute updates cluster dims on the graph node.
+ *  - 4) Graph replay produces the expected kernel output.
+ *  - Only runs on devices with cluster launch support (gfx1250/gfx1251).
  * Test source
  * ------------------------
  *  - unit/module/hipDrvLaunchKernelEx.cc
@@ -454,12 +457,10 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_StreamCapture_ClusterDim) {
   hipDeviceProp_t prop{};
   HIP_CHECK(hipGetDeviceProperties(&prop, 0));
 
-  // Cluster launches require hardware support (gfx1250/gfx1251)
   if (!prop.clusterLaunch) {
     HIP_SKIP_TEST("Test requires a device with cluster launch support");
   }
 
-  // Compile a simple fill kernel via hiprtc
   static const char* fill_src = R"(
     extern "C" __global__ void fill(int* out, int val, int n) {
       int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -487,7 +488,7 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_StreamCapture_ClusterDim) {
 
   constexpr int N_ELEM  = 1024;
   constexpr int BLOCK   = 64;
-  constexpr int GRID    = N_ELEM / BLOCK;  // 16
+  constexpr int GRID    = N_ELEM / BLOCK;  // 16 blocks
   constexpr int CLUSTER = 4;              // 4 blocks per cluster
 
   int* d_out = nullptr;
@@ -496,7 +497,7 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_StreamCapture_ClusterDim) {
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));
 
-  // Warmup before capture
+  // Warmup run before capture to ensure JIT compilation is done
   {
     HIP_LAUNCH_CONFIG cfg{};
     cfg.gridDimX = GRID; cfg.gridDimY = 1; cfg.gridDimZ = 1;
@@ -515,7 +516,7 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_StreamCapture_ClusterDim) {
 
   HIP_CHECK(hipMemset(d_out, 0, N_ELEM * sizeof(int)));
 
-  // Stream capture
+  // Capture a cluster-dim kernel launch into a graph
   HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
   {
     HIP_LAUNCH_CONFIG cfg{};
@@ -535,12 +536,53 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_StreamCapture_ClusterDim) {
   hipGraph_t graph;
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
 
-  // Verify at least one node was captured
+  // 1) Verify at least one kernel node was captured
   size_t num_nodes = 0;
   HIP_CHECK(hipGraphGetNodes(graph, nullptr, &num_nodes));
   REQUIRE(num_nodes >= 1);
 
-  // Instantiate and replay
+  std::vector<hipGraphNode_t> nodes(num_nodes);
+  HIP_CHECK(hipGraphGetNodes(graph, nodes.data(), &num_nodes));
+
+  // Find the kernel node
+  hipGraphNode_t kernel_node = nullptr;
+  for (auto node : nodes) {
+    hipGraphNodeType type;
+    HIP_CHECK(hipGraphNodeGetType(node, &type));
+    if (type == hipGraphNodeTypeKernel) {
+      kernel_node = node;
+      break;
+    }
+  }
+  REQUIRE(kernel_node != nullptr);
+
+  // 2) Verify hipGraphKernelNodeGetAttribute returns the captured cluster dims
+  hipKernelNodeAttrValue got_attr{};
+  HIP_CHECK(hipGraphKernelNodeGetAttribute(kernel_node, hipLaunchAttributeClusterDimension,
+                                           &got_attr));
+  REQUIRE(got_attr.clusterDim.x == CLUSTER);
+  REQUIRE(got_attr.clusterDim.y == 1);
+  REQUIRE(got_attr.clusterDim.z == 1);
+
+  // 3) Update cluster dims via hipGraphKernelNodeSetAttribute and read back
+  hipKernelNodeAttrValue set_attr{};
+  set_attr.clusterDim = {2, 1, 1};
+  HIP_CHECK(hipGraphKernelNodeSetAttribute(kernel_node, hipLaunchAttributeClusterDimension,
+                                           &set_attr));
+
+  hipKernelNodeAttrValue verify_attr{};
+  HIP_CHECK(hipGraphKernelNodeGetAttribute(kernel_node, hipLaunchAttributeClusterDimension,
+                                           &verify_attr));
+  REQUIRE(verify_attr.clusterDim.x == 2);
+  REQUIRE(verify_attr.clusterDim.y == 1);
+  REQUIRE(verify_attr.clusterDim.z == 1);
+
+  // Restore original cluster dim for replay
+  set_attr.clusterDim = {CLUSTER, 1, 1};
+  HIP_CHECK(hipGraphKernelNodeSetAttribute(kernel_node, hipLaunchAttributeClusterDimension,
+                                           &set_attr));
+
+  // 4) Instantiate and replay; verify correct kernel output
   hipGraphExec_t exec;
   HIP_CHECK(hipGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
   HIP_CHECK(hipGraphLaunch(exec, stream));

--- a/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
+++ b/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
@@ -435,6 +435,7 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_MaxBlockDims) {
   HIP_CHECK(hipModuleUnload(module));
   CTX_DESTROY();
 }
+#if !defined(_WIN32)
 /**
  * Test Description
  * ------------------------
@@ -600,6 +601,7 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_StreamCapture_ClusterDim) {
   HIP_CHECK(hipFree(d_out));
   HIP_CHECK(hipModuleUnload(mod));
 }
+#endif  // !defined(_WIN32)
 
 /**
  * End doxygen group ModuleTest.

--- a/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
+++ b/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
@@ -469,17 +469,17 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_StreamCapture_ClusterDim) {
   )";
 
   hiprtcProgram prog;
-  HIP_CHECK(hiprtcCreateProgram(&prog, fill_src, "fill.cu", 0, nullptr, nullptr));
+  HIPRTC_CHECK(hiprtcCreateProgram(&prog, fill_src, "fill.cu", 0, nullptr, nullptr));
   char arch_flag[64];
   snprintf(arch_flag, sizeof(arch_flag), "--offload-arch=%s", prop.gcnArchName);
   const char* opts[] = {arch_flag};
   REQUIRE(hiprtcCompileProgram(prog, 1, opts) == HIPRTC_SUCCESS);
 
   size_t code_size;
-  HIP_CHECK(hiprtcGetCodeSize(prog, &code_size));
+  HIPRTC_CHECK(hiprtcGetCodeSize(prog, &code_size));
   std::vector<char> code(code_size);
-  HIP_CHECK(hiprtcGetCode(prog, code.data()));
-  hiprtcDestroyProgram(&prog);
+  HIPRTC_CHECK(hiprtcGetCode(prog, code.data()));
+  HIPRTC_CHECK(hiprtcDestroyProgram(&prog));
 
   hipModule_t mod;
   hipFunction_t fn;

--- a/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
+++ b/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
@@ -436,6 +436,130 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_MaxBlockDims) {
   CTX_DESTROY();
 }
 /**
+ * Test Description
+ * ------------------------
+ *  - Verifies that hipDrvLaunchKernelEx with hipLaunchAttributeClusterDimension
+ *  - is correctly captured during stream capture and replays with the correct
+ *  - cluster dimensions in the AQL ext dispatch packet.
+ *  - Only runs on gfx1250/gfx1251 where cluster launches are supported.
+ * Test source
+ * ------------------------
+ *  - unit/module/hipDrvLaunchKernelEx.cc
+ * Test requirements
+ * ------------------------
+ *  - HIP_VERSION >= 6.5
+ *  - AMD GPU with cluster launch support (gfx1250/gfx1251)
+ */
+HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_StreamCapture_ClusterDim) {
+  hipDeviceProp_t prop{};
+  HIP_CHECK(hipGetDeviceProperties(&prop, 0));
+
+  // Cluster launches require hardware support (gfx1250/gfx1251)
+  if (!prop.clusterLaunch) {
+    HIP_SKIP_TEST("Test requires a device with cluster launch support");
+  }
+
+  // Compile a simple fill kernel via hiprtc
+  static const char* fill_src = R"(
+    extern "C" __global__ void fill(int* out, int val, int n) {
+      int i = blockIdx.x * blockDim.x + threadIdx.x;
+      if (i < n) out[i] = val;
+    }
+  )";
+
+  hiprtcProgram prog;
+  HIP_CHECK(hiprtcCreateProgram(&prog, fill_src, "fill.cu", 0, nullptr, nullptr));
+  char arch_flag[64];
+  snprintf(arch_flag, sizeof(arch_flag), "--offload-arch=%s", prop.gcnArchName);
+  const char* opts[] = {arch_flag};
+  REQUIRE(hiprtcCompileProgram(prog, 1, opts) == HIPRTC_SUCCESS);
+
+  size_t code_size;
+  HIP_CHECK(hiprtcGetCodeSize(prog, &code_size));
+  std::vector<char> code(code_size);
+  HIP_CHECK(hiprtcGetCode(prog, code.data()));
+  hiprtcDestroyProgram(&prog);
+
+  hipModule_t mod;
+  hipFunction_t fn;
+  HIP_CHECK(hipModuleLoadData(&mod, code.data()));
+  HIP_CHECK(hipModuleGetFunction(&fn, mod, "fill"));
+
+  constexpr int N_ELEM  = 1024;
+  constexpr int BLOCK   = 64;
+  constexpr int GRID    = N_ELEM / BLOCK;  // 16
+  constexpr int CLUSTER = 4;              // 4 blocks per cluster
+
+  int* d_out = nullptr;
+  HIP_CHECK(hipMalloc(&d_out, N_ELEM * sizeof(int)));
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  // Warmup before capture
+  {
+    HIP_LAUNCH_CONFIG cfg{};
+    cfg.gridDimX = GRID; cfg.gridDimY = 1; cfg.gridDimZ = 1;
+    cfg.blockDimX = BLOCK; cfg.blockDimY = 1; cfg.blockDimZ = 1;
+    cfg.hStream = stream;
+    hipLaunchAttribute attr;
+    attr.id = hipLaunchAttributeClusterDimension;
+    attr.value.clusterDim = {CLUSTER, 1, 1};
+    cfg.attrs = &attr;
+    cfg.numAttrs = 1;
+    int val = 0, n = N_ELEM;
+    void* kargs[] = {&d_out, &val, &n};
+    HIP_CHECK(hipDrvLaunchKernelEx(&cfg, fn, kargs, nullptr));
+    HIP_CHECK(hipStreamSynchronize(stream));
+  }
+
+  HIP_CHECK(hipMemset(d_out, 0, N_ELEM * sizeof(int)));
+
+  // Stream capture
+  HIP_CHECK(hipStreamBeginCapture(stream, hipStreamCaptureModeGlobal));
+  {
+    HIP_LAUNCH_CONFIG cfg{};
+    cfg.gridDimX = GRID; cfg.gridDimY = 1; cfg.gridDimZ = 1;
+    cfg.blockDimX = BLOCK; cfg.blockDimY = 1; cfg.blockDimZ = 1;
+    cfg.hStream = stream;
+    hipLaunchAttribute attr;
+    attr.id = hipLaunchAttributeClusterDimension;
+    attr.value.clusterDim = {CLUSTER, 1, 1};
+    cfg.attrs = &attr;
+    cfg.numAttrs = 1;
+    int val = 42, n = N_ELEM;
+    void* kargs[] = {&d_out, &val, &n};
+    HIP_CHECK(hipDrvLaunchKernelEx(&cfg, fn, kargs, nullptr));
+  }
+
+  hipGraph_t graph;
+  HIP_CHECK(hipStreamEndCapture(stream, &graph));
+
+  // Verify at least one node was captured
+  size_t num_nodes = 0;
+  HIP_CHECK(hipGraphGetNodes(graph, nullptr, &num_nodes));
+  REQUIRE(num_nodes >= 1);
+
+  // Instantiate and replay
+  hipGraphExec_t exec;
+  HIP_CHECK(hipGraphInstantiate(&exec, graph, nullptr, nullptr, 0));
+  HIP_CHECK(hipGraphLaunch(exec, stream));
+  HIP_CHECK(hipStreamSynchronize(stream));
+
+  std::vector<int> h_out(N_ELEM);
+  HIP_CHECK(hipMemcpy(h_out.data(), d_out, N_ELEM * sizeof(int), hipMemcpyDeviceToHost));
+  for (int i = 0; i < N_ELEM; i++) {
+    REQUIRE(h_out[i] == 42);
+  }
+
+  HIP_CHECK(hipGraphExecDestroy(exec));
+  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipFree(d_out));
+  HIP_CHECK(hipModuleUnload(mod));
+}
+
+/**
  * End doxygen group ModuleTest.
  * @}
  */


### PR DESCRIPTION
…r dimensions

hipDrvLaunchKernelEx was not captured during stream capture, resulting in an empty graph when kernels with hipLaunchAttributeClusterDimension were recorded. This adds full capture support including cluster dimension propagation through the graph node to the AQL packet at replay time.

Changes:
- hip_module.cpp: Add STREAM_CAPTURE at all three dispatch paths in hipDrvLaunchKernelEx (no-attrs, cooperative, and cluster-dim paths), passing parsed clusterDim to the capture function
- hip_graph_capture.hpp: Declare capturehipDrvLaunchKernelEx with default clusterDim={1,1,1}
- hip_graph.cpp: Implement capturehipDrvLaunchKernelEx with capture log; extend ihipGraphAddKernelNode with optional dim3 clusterDim parameter
- hip_graph_internal.hpp: Add clusterDim_ field to GraphKernelNode; propagate through constructor, copy constructor, CreateCommand and validateKernelParams so HIPLaunchParams carries the cluster dims into NDRangeContainer at graph replay time (AQL ext dispatch packet)
- rocvirtual.cpp: Fix dispatchAqlPacketBatchFlat graph batch log to call logAqlDispatchPacketExtended for ext kernel dispatch packets (cluster launches) instead of skipping them entirely
- hipDrvLaunchKernelEx.cc: Add stream capture test with cluster dims, gated on gfx1250/gfx1251

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
AIRUNTIME-2341
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
