### PR TITLE
[clr] Use builtins for fp4/fp6 header

### DIFF
--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
@@ -41,10 +41,20 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t __hip_cvt_bfloat16raw_to_fp4(
     uint32_t ui32;
     __hip_fp4_storage_t fp4[4];
   } u{0};
-#if __gfx950__
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_bf16))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_bf16(
         u.ui32, internal::hipbf162_to_bf16x2(__hip_bfloat162{x, 0}), 1.0f /* scale */, 0);
+  return u.fp4[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  union {
+    __hip_bfloat16_raw bhalf_raw;
+    __bf16 bf16;
+  } bhalf{x};
+  __amd_bf16x8_storage_t bf16x8{bhalf.bf16, bhalf.bf16, bhalf.bf16, bhalf.bf16,
+                                bhalf.bf16, bhalf.bf16, bhalf.bf16, bhalf.bf16};
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk8_fp4_bf16))
+    u.ui32 = __builtin_amdgcn_cvt_scalef32_pk8_fp4_bf16(bf16x8, 1.0f);
   return u.fp4[0];
 #else
   u.ui32 = fcbx::from_float<__amd_bf16_storage_t, fcbx::Encoding::E2M1, true>(
@@ -60,10 +70,17 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t __hip_cvt_bfloat16raw2_to_fp4x2
     uint32_t ui32;
     __hip_fp4x2_storage_t fp4x2[4];
   } u{0};
-#if __gfx950__
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_bf16))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_bf16(u.ui32, internal::hipbf162_to_bf16x2(x),
                                                        1.0f /* scale */, 0);
+  return u.fp4x2[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  auto bf16x2 = internal::hipbf162_to_bf16x2(x);
+  __amd_bf16x8_storage_t bf16x8{bf16x2[0], bf16x2[1], bf16x2[0], bf16x2[1],
+                                bf16x2[0], bf16x2[1], bf16x2[0], bf16x2[1]};
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk8_fp4_bf16))
+    u.ui32 = __builtin_amdgcn_cvt_scalef32_pk8_fp4_bf16(bf16x8, 1.0f);
   return u.fp4x2[0];
 #else
   auto bf16x2 = internal::hipbf162_to_bf16x2(x);
@@ -83,9 +100,15 @@ __hip_cvt_double_to_fp4(const double x, const __hip_fp4_interpretation_t /* fp4_
     uint32_t ui32;
     __hip_fp4_storage_t fp4[4];
   } u{0};
-#if __gfx950__
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_f32))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(u.ui32, float(x), 0.0f, 1.0f /* scale */, 0);
+  return u.fp4[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  __amd_floatx8_storage_t fp32x8{float(x), float(x), float(x), float(x),
+                                 float(x), float(x), float(x), float(x)};
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk8_fp4_f32))
+    u.ui32 = __builtin_amdgcn_cvt_scalef32_pk8_fp4_f32(fp32x8, 1.0f);
   return u.fp4[0];
 #else
   u.ui32 = fcbx::from_float<float, fcbx::Encoding::E2M1, true>(float(x), 0 /* scale */);
@@ -100,10 +123,16 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t __hip_cvt_double2_to_fp4x2(
     uint32_t ui32;
     __hip_fp4x2_storage_t fp4x2[4];
   } u{0};
-#if __gfx950__
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_f32))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(u.ui32, float(x.x), float(x.y),
                                                       1.0f /* scale */, 0);
+  return u.fp4x2[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  __amd_floatx8_storage_t fp32x8{float(x.x), float(x.y), float(x.x), float(x.y),
+                                 float(x.x), float(x.y), float(x.x), float(x.y)};
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk8_fp4_f32))
+    u.ui32 = __builtin_amdgcn_cvt_scalef32_pk8_fp4_f32(fp32x8, 1.0f);
   return u.fp4x2[0];
 #else
   u.ui32 |= fcbx::from_float<float, fcbx::Encoding::E2M1, true>(float(x.y), 0 /*scale*/);
@@ -120,9 +149,14 @@ __hip_cvt_float_to_fp4(const float x, const __hip_fp4_interpretation_t /* fp4_in
     uint32_t ui32;
     __hip_fp4_storage_t fp4[4];
   } u{0};
-#if __gfx950__
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_f32))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(u.ui32, x, 0.0f, 1.0f /* scale */, 0);
+  return u.fp4[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  __amd_floatx8_storage_t fp32x8{x, x, x, x, x, x, x, x};
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk8_fp4_f32))
+    u.ui32 = __builtin_amdgcn_cvt_scalef32_pk8_fp4_f32(fp32x8, 1.0f);
   return u.fp4[0];
 #else
   u.ui32 = fcbx::from_float<float, fcbx::Encoding::E2M1, true>(x, 0 /*scale*/);
@@ -137,9 +171,14 @@ __hip_cvt_float2_to_fp4x2(const float2 x, const __hip_fp4_interpretation_t /* fp
     uint32_t ui32;
     __hip_fp4x2_storage_t fp4x2[4];
   } u{0};
-#if __gfx950__
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_f32))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_f32(u.ui32, x.x, x.y, 1.0f /* scale */, 0);
+  return u.fp4x2[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  __amd_floatx8_storage_t fp32x8{x.x, x.y, x.x, x.y, x.x, x.y, x.x, x.y};
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk8_fp4_f32))
+    u.ui32 = __builtin_amdgcn_cvt_scalef32_pk8_fp4_f32(fp32x8, 1.0f);
   return u.fp4x2[0];
 #else
   u.ui32 |= fcbx::from_float<float, fcbx::Encoding::E2M1, true>(x.y, 0 /*scale*/);
@@ -152,11 +191,26 @@ __hip_cvt_float2_to_fp4x2(const float2 x, const __hip_fp4_interpretation_t /* fp
 __FP4_HOST_DEVICE_STATIC__ __half_raw __hip_cvt_fp4_to_halfraw(
     const __hip_fp4_storage_t x, const __hip_fp4_interpretation_t /* fp4_interpretation */) {
   __half2_raw ret;
-#if __gfx950__
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
   ret.data =
       __amd_fp16x2_storage_t{__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_f16_fp4)
                                  ? __builtin_amdgcn_cvt_scalef32_pk_f16_fp4(x, 0, 0)
                                  : __amd_fp16x2_storage_t{}};
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  static_assert(sizeof(__amd_fp16x2_storage_t[4]) == sizeof(__amd_fp16x8_storage_t));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
+  union {
+    __amd_fp16x8_storage_t fp16x8;
+    __amd_fp16x2_storage_t fp16x2[4];
+  } uhalf;
+  union {
+    unsigned int ui32;
+    __amd_fp4x2_storage_t fp4x2[4];
+  } u{0};
+  u.fp4x2[0] = x | (x << 4);
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk8_f16_fp4))
+    uhalf.fp16x8 = __builtin_amdgcn_cvt_scale_pk8_f16_fp4(u.ui32, 0x7F7Fu, 0);
+  ret.data = uhalf.fp16x2[0];
 #else
   using namespace fcbx;
   ret.data =
@@ -169,11 +223,26 @@ __FP4_HOST_DEVICE_STATIC__ __half_raw __hip_cvt_fp4_to_halfraw(
 __FP4_HOST_DEVICE_STATIC__ __half2_raw __hip_cvt_fp4x2_to_halfraw2(
     const __hip_fp4x2_storage_t x, const __hip_fp4_interpretation_t /* fp4_interpretation */) {
   __half2_raw ret;
-#if __gfx950__
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
   ret.data =
       __amd_fp16x2_storage_t{__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_f16_fp4)
                                  ? __builtin_amdgcn_cvt_scalef32_pk_f16_fp4(x, 0, 0)
                                  : __amd_fp16x2_storage_t{}};
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  static_assert(sizeof(__amd_fp16x2_storage_t[4]) == sizeof(__amd_fp16x8_storage_t));
+  static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
+  union {
+    __amd_fp16x8_storage_t fp16x8;
+    __amd_fp16x2_storage_t fp16x2[4];
+  } uhalf;
+  union {
+    unsigned int ui32;
+    __amd_fp4x2_storage_t fp4x2[4];
+  } u{0};
+  u.fp4x2[0] = x;
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk8_f16_fp4))
+    uhalf.fp16x8 = __builtin_amdgcn_cvt_scale_pk8_f16_fp4(u.ui32, 0x7F7Fu, 0);
+  ret.data = uhalf.fp16x2[0];
 #else
   using namespace fcbx;
   ret.data =
@@ -190,11 +259,17 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4_storage_t __hip_cvt_halfraw_to_fp4(
     uint32_t ui32;
     __hip_fp4_storage_t fp4[4];
   } u{0};
-#if __gfx950__
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_f16))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_f16(
         u.ui32, internal::half2_to_f16x2(__half2{x, 0}), 1.0f /* scale */, 0);
   return u.fp4[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  auto val = internal::half2_to_f16x2(__half2{x, x});
+  __amd_fp16x8_storage_t fp16x8{val[0], val[1], val[0], val[1], val[0], val[1], val[0], val[1]};
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk8_fp4_f16))
+    u.ui32 = __builtin_amdgcn_cvt_scalef32_pk8_fp4_f16(fp16x8, 1.0f);
+  return u.fp4[0] >> 4;
 #else
   u.ui32 = fcbx::from_float<__amd_fp16_storage_t, fcbx::Encoding::E2M1, true>(
       internal::half_to_f16(x), 0 /* scale */);
@@ -209,10 +284,16 @@ __FP4_HOST_DEVICE_STATIC__ __hip_fp4x2_storage_t __hip_cvt_halfraw2_to_fp4x2(
     uint32_t ui32;
     __hip_fp4x2_storage_t fp4x2[4];
   } u{0};
-#if __gfx950__
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
   if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_fp4_f16))
     u.ui32 = __builtin_amdgcn_cvt_scalef32_pk_fp4_f16(u.ui32, internal::half2_to_f16x2(x),
                                                       1.0f /* scale */, 0);
+  return u.fp4x2[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  auto val = internal::half2_to_f16x2(x);
+  __amd_fp16x8_storage_t fp16x8{val[0], val[1], val[0], val[1], val[0], val[1], val[0], val[1]};
+  if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk8_fp4_f16))
+    u.ui32 = __builtin_amdgcn_cvt_scalef32_pk8_fp4_f16(fp16x8, 1.0f);
   return u.fp4x2[0];
 #else
   auto fp16x2 = internal::half2_to_f16x2(x);
@@ -284,6 +365,21 @@ struct __hip_fp4_e2m1 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_bf16_fp4))
       u.bf16x2 = __builtin_amdgcn_cvt_scalef32_pk_bf16_fp4(__x, 1.0f /* scale */, 0);
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    static_assert(sizeof(__amd_bf16x2_storage_t[4]) == sizeof(__amd_bf16x8_storage_t));
+    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
+    union {
+      __amd_bf16x8_storage_t bf16x8;
+      __amd_bf16x2_storage_t bf16x2[4];
+    } bhalf;
+    union {
+      unsigned int ui32;
+      __amd_fp4x2_storage_t fp4x2[4];
+    } u_in{0};
+    u_in.fp4x2[0] = __x | __x << 4;
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk8_bf16_fp4))
+      bhalf.bf16x8 = __builtin_amdgcn_cvt_scale_pk8_bf16_fp4(u_in.ui32, 0x7F7Fu, 0);
+    u.bf16x2[0] = bhalf.bf16x8[0];
 #else
     using namespace fcbx;
     u.bf16x2 =
@@ -298,6 +394,15 @@ struct __hip_fp4_e2m1 {
     auto ret = __builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_f32_fp4)
                    ? __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(__x, 1.0f /* scale */, 0)
                    : __amd_floatx2_storage_t{};
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    union {
+      unsigned int ui32;
+      __amd_fp4x2_storage_t fp4x2[4];
+    } u{0};
+    u.fp4x2[0] = __x | __x << 4;
+    __amd_floatx8_storage_t ret{};
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk8_f32_fp4))
+      ret = __builtin_amdgcn_cvt_scale_pk8_f32_fp4(u.ui32, 0x7F7Fu, 0);
 #else
     using namespace fcbx;
     __amd_floatx2_storage_t ret{to_float<float, Encoding::E2M1, true>(__x & 0xFu, 0),
@@ -345,6 +450,22 @@ struct __hip_fp4x2_e2m1 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_bf16_fp4))
       u.bf16x2 = __builtin_amdgcn_cvt_scalef32_pk_bf16_fp4(__x, 1.0f /* scale */, 0);
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    static_assert(sizeof(__amd_bf16x2_storage_t[4]) == sizeof(__amd_bf16x8_storage_t));
+    static_assert(sizeof(__amd_fp4x2_storage_t[4]) == sizeof(unsigned int));
+    union {
+      __amd_bf16x8_storage_t bf16x8;
+      __amd_bf16x2_storage_t bf16x2[4];
+    } bhalf;
+    union {
+      unsigned int ui32;
+      __amd_fp4x2_storage_t fp4x2[4];
+    } u_in{0};
+    u_in.fp4x2[0] = __x;
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk8_bf16_fp4))
+      bhalf.bf16x8 = __builtin_amdgcn_cvt_scale_pk8_bf16_fp4(u_in.ui32, 0x7F7Fu, 0);
+    u.bf16x2[0] = bhalf.bf16x8[0];
+    u.bf16x2[1] = bhalf.bf16x8[1];
 #else
     using namespace fcbx;
     u.bf16x2 =
@@ -359,6 +480,17 @@ struct __hip_fp4x2_e2m1 {
     auto fp32x2 = __builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_f32_fp4)
                       ? __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(__x, 1.0f /* scale */, 0)
                       : __amd_floatx2_storage_t{};
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    union {
+      unsigned int ui32;
+      __amd_fp4x2_storage_t fp4x2[4];
+    } u{0};
+    u.fp4x2[0] = __x;
+
+    // Even though its x8, we call it x2 so that we have a common return line
+    __amd_floatx8_storage_t fp32x2{};
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk8_f32_fp4))
+      fp32x2 = __builtin_amdgcn_cvt_scale_pk8_f32_fp4(u.ui32, 0x7F7Fu, 0);
 #else
     using namespace fcbx;
     auto fp32x2 = __amd_floatx2_storage_t{to_float<float, Encoding::E2M1, true>(__x & 0xFu, 0),
@@ -372,6 +504,16 @@ struct __hip_fp4x2_e2m1 {
     auto fp32x2 = __builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_f32_fp4)
                       ? __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(__x, 1.0f /* scale */, 0)
                       : __amd_floatx2_storage_t{};
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    union {
+      unsigned int ui32;
+      __amd_fp4x2_storage_t fp4x2[4];
+    } u{0};
+    u.fp4x2[0] = __x;
+    // Although it's x8 but we still call it x2 since we will use it in common code.
+    __amd_floatx8_storage_t fp32x2{};
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk8_f32_fp4))
+      fp32x2 = __builtin_amdgcn_cvt_scale_pk8_f32_fp4(u.ui32, 0x7F7Fu, 0);
 #else
     using namespace fcbx;
     auto fp32x2 = __amd_floatx2_storage_t{to_float<float, Encoding::E2M1, true>(__x & 0xFu, 0),
@@ -416,6 +558,17 @@ struct __hip_fp4x4_e2m1 {
     auto fp32x2_2 = __builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_f32_fp4)
                         ? __builtin_amdgcn_cvt_scalef32_pk_f32_fp4(__x >> 8, 1.0f /* scale */, 0)
                         : __amd_floatx2_storage_t{};
+    return float4{fp32x2_1[0], fp32x2_1[1], fp32x2_2[0], fp32x2_2[1]};
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    union {
+      unsigned int ui32;
+      __hip_fp4x4_storage_t fp4x4[2];
+    } u{0};
+    u.fp4x4[0] = __x;
+    __amd_floatx8_storage_t fp32x8{};
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk8_f32_fp4))
+      fp32x8 = __builtin_amdgcn_cvt_scale_pk8_f32_fp4(u.ui32, 0x7F7Fu, 0);
+    return float4{fp32x8[0], fp32x8[1], fp32x8[2], fp32x8[3]};
 #else
     using namespace fcbx;
     auto fp32x2_1 =
@@ -424,8 +577,8 @@ struct __hip_fp4x4_e2m1 {
     auto fp32x2_2 =
         __amd_floatx2_storage_t{to_float<float, Encoding::E2M1, true>((__x >> 8) & 0xFu, 0),
                                 to_float<float, Encoding::E2M1, true>(__x >> 12, 0)};
-#endif
     return float4{fp32x2_1[0], fp32x2_1[1], fp32x2_2[0], fp32x2_2[1]};
+#endif
   }
 
   __FP4_HOST_DEVICE__ operator double4() const {

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
@@ -371,7 +371,7 @@ struct __hip_fp4_e2m1 {
     union {
       __amd_bf16x8_storage_t bf16x8;
       __amd_bf16x2_storage_t bf16x2[4];
-    } bhalf;
+    } bhalf{};
     union {
       unsigned int ui32;
       __amd_fp4x2_storage_t fp4x2[4];
@@ -456,7 +456,7 @@ struct __hip_fp4x2_e2m1 {
     union {
       __amd_bf16x8_storage_t bf16x8;
       __amd_bf16x2_storage_t bf16x2[4];
-    } bhalf;
+    } bhalf{};
     union {
       unsigned int ui32;
       __amd_fp4x2_storage_t fp4x2[4];
@@ -487,7 +487,7 @@ struct __hip_fp4x2_e2m1 {
     } u{0};
     u.fp4x2[0] = __x;
 
-    // Even though its x8, we call it x2 so that we have a common return line
+    // Even though it's x8, we call it x2 so that we have a common return line
     __amd_floatx8_storage_t fp32x2{};
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk8_f32_fp4))
       fp32x2 = __builtin_amdgcn_cvt_scale_pk8_f32_fp4(u.ui32, 0x7F7Fu, 0);

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp4.h
@@ -202,7 +202,7 @@ __FP4_HOST_DEVICE_STATIC__ __half_raw __hip_cvt_fp4_to_halfraw(
   union {
     __amd_fp16x8_storage_t fp16x8;
     __amd_fp16x2_storage_t fp16x2[4];
-  } uhalf;
+  } uhalf{};
   union {
     unsigned int ui32;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -234,7 +234,7 @@ __FP4_HOST_DEVICE_STATIC__ __half2_raw __hip_cvt_fp4x2_to_halfraw2(
   union {
     __amd_fp16x8_storage_t fp16x8;
     __amd_fp16x2_storage_t fp16x2[4];
-  } uhalf;
+  } uhalf{};
   union {
     unsigned int ui32;
     __amd_fp4x2_storage_t fp4x2[4];
@@ -361,7 +361,7 @@ struct __hip_fp4_e2m1 {
     union {
       __hip_bfloat16_raw bf16_raw[2];
       __amd_bf16x2_storage_t bf16x2;
-    } u;
+    } u{};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_bf16_fp4))
       u.bf16x2 = __builtin_amdgcn_cvt_scalef32_pk_bf16_fp4(__x, 1.0f /* scale */, 0);
@@ -446,7 +446,7 @@ struct __hip_fp4x2_e2m1 {
     union {
       __hip_bfloat162_raw bf162_raw;
       __amd_bf16x2_storage_t bf16x2;
-    } u;
+    } u{};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk_bf16_fp4))
       u.bf16x2 = __builtin_amdgcn_cvt_scalef32_pk_bf16_fp4(__x, 1.0f /* scale */, 0);

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp6.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp6.h
@@ -42,8 +42,8 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6_storage_t __hip_cvt_bfloat16raw_to_fp6(
     uint32_t ui32;
     __hip_fp6_storage_t fp6[4];
   } u{0};
-#if __gfx950__
-  __amd_bf16x32_storage_t in;
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
+  __amd_bf16x32_storage_t in{};
   __amd_fp6x32_storage_t out{};
   in[0] = internal::hipbf16_to_bf16(x);
   if (fp6_interpretation == __HIP_E2M3) {
@@ -52,6 +52,19 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6_storage_t __hip_cvt_bfloat16raw_to_fp6(
   } else if (fp6_interpretation == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf6_bf16))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf6_bf16(in, 1.0f /* scale */);
+  }
+  u.ui32 = out[0];
+  return u.fp6[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  __amd_bf16x16_storage_t in{};
+  __amd_fp6x16_storage_t out{};
+  in[0] = internal::hipbf16_to_bf16(x);
+  if (fp6_interpretation == __HIP_E2M3) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_fp6_bf16))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_fp6_bf16(in, 1.0f /* scale */);
+  } else if (fp6_interpretation == __HIP_E3M2) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_bf6_bf16))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_bf6_bf16(in, 1.0f /* scale */);
   }
   u.ui32 = out[0];
   return u.fp6[0];
@@ -72,8 +85,8 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t __hip_cvt_bfloat16raw2_to_fp6x2
     uint32_t ui32;
     __hip_fp6x2_storage_t fp6x2[2];
   } u{0};
-#if __gfx950__
-  __amd_bf16x32_storage_t in;
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
+  __amd_bf16x32_storage_t in{};
   in[0] = internal::hipbf16_to_bf16(x.x);
   in[1] = internal::hipbf16_to_bf16(x.y);
   __amd_fp6x32_storage_t out{};
@@ -83,6 +96,20 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t __hip_cvt_bfloat16raw2_to_fp6x2
   } else if (fp6_interpretation == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf6_bf16))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf6_bf16(in, 1.0f /* scale */);
+  }
+  u.ui32 = out[0];
+  return u.fp6x2[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  __amd_bf16x16_storage_t in{};
+  in[0] = internal::hipbf16_to_bf16(x.x);
+  in[1] = internal::hipbf16_to_bf16(x.y);
+  __amd_fp6x16_storage_t out{};
+  if (fp6_interpretation == __HIP_E2M3) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_fp6_bf16))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_fp6_bf16(in, 1.0f /* scale */);
+  } else if (fp6_interpretation == __HIP_E3M2) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_bf6_bf16))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_bf6_bf16(in, 1.0f /* scale */);
   }
   u.ui32 = out[0];
   return u.fp6x2[0];
@@ -108,9 +135,9 @@ __hip_cvt_double_to_fp6(const double x, const __hip_fp6_interpretation_t fp6_int
     uint32_t ui32;
     __hip_fp6_storage_t fp6[4];
   } u{0};
-#if __gfx950__
-  __amd_floatx16_storage_t in1;
-  __amd_floatx16_storage_t in2;
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
+  __amd_floatx16_storage_t in1{};
+  __amd_floatx16_storage_t in2{};
   __amd_fp6x32_storage_t out{};
   in1[0] = float(x);
   in2[0] = 0.0f;
@@ -120,6 +147,19 @@ __hip_cvt_double_to_fp6(const double x, const __hip_fp6_interpretation_t fp6_int
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32))
       out = __builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32(in1, in2, 1.0f /* scale */);
+  }
+  u.ui32 = out[0];
+  return u.fp6[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  __amd_floatx16_storage_t in{};
+  __amd_fp6x16_storage_t out{};
+  in[0] = float(x);
+  if (fp6_interpretation_t == __HIP_E2M3) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_fp6_f32))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_fp6_f32(in, 1.0f /* scale */);
+  } else if (fp6_interpretation_t == __HIP_E3M2) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_bf6_f32))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_bf6_f32(in, 1.0f /* scale */);
   }
   u.ui32 = out[0];
   return u.fp6[0];
@@ -139,9 +179,9 @@ __hip_cvt_double2_to_fp6x2(const double2 x, const __hip_fp6_interpretation_t fp6
     uint32_t ui32;
     __hip_fp6x2_storage_t fp6x2[2];
   } u{0};
-#if __gfx950__
-  __amd_floatx16_storage_t in1;
-  __amd_floatx16_storage_t in2;
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
+  __amd_floatx16_storage_t in1{};
+  __amd_floatx16_storage_t in2{};
   __amd_fp6x32_storage_t out{};
   in1[0] = float(x.x);
   in2[0] = float(x.y);
@@ -151,6 +191,21 @@ __hip_cvt_double2_to_fp6x2(const double2 x, const __hip_fp6_interpretation_t fp6
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32))
       out = __builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32(in1, in2, 1.0f /* scale */);
+  }
+  u.ui32 = out[0] & 0x3Fu;
+  u.ui32 |= ((out[0] & 0xFC0u) << 2);
+  return u.fp6x2[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  __amd_floatx16_storage_t in{};
+  __amd_fp6x16_storage_t out{};
+  in[0] = float(x.x);
+  in[1] = float(x.y);
+  if (fp6_interpretation_t == __HIP_E2M3) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_fp6_f32))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_fp6_f32(in, 1.0f /* scale */);
+  } else if (fp6_interpretation_t == __HIP_E3M2) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_bf6_f32))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_bf6_f32(in, 1.0f /* scale */);
   }
   u.ui32 = out[0] & 0x3Fu;
   u.ui32 |= ((out[0] & 0xFC0u) << 2);
@@ -175,9 +230,9 @@ __hip_cvt_float_to_fp6(const float x, const __hip_fp6_interpretation_t fp6_inter
     uint32_t ui32;
     __hip_fp6_storage_t fp6[4];
   } u{0};
-#if __gfx950__
-  __amd_floatx16_storage_t in1;
-  __amd_floatx16_storage_t in2;
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
+  __amd_floatx16_storage_t in1{};
+  __amd_floatx16_storage_t in2{};
   __amd_fp6x32_storage_t out{};
   in1[0] = x;
   in2[0] = 0.0f;
@@ -187,6 +242,19 @@ __hip_cvt_float_to_fp6(const float x, const __hip_fp6_interpretation_t fp6_inter
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32))
       out = __builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32(in1, in2, 1.0f /* scale */);
+  }
+  u.ui32 = out[0];
+  return u.fp6[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  __amd_floatx16_storage_t in{};
+  __amd_fp6x16_storage_t out{};
+  in[0] = float(x);
+  if (fp6_interpretation_t == __HIP_E2M3) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_fp6_f32))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_fp6_f32(in, 1.0f /* scale */);
+  } else if (fp6_interpretation_t == __HIP_E3M2) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_bf6_f32))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_bf6_f32(in, 1.0f /* scale */);
   }
   u.ui32 = out[0];
   return u.fp6[0];
@@ -205,9 +273,9 @@ __hip_cvt_float2_to_fp6x2(const float2 x, const __hip_fp6_interpretation_t fp6_i
     uint32_t ui32;
     __hip_fp6x2_storage_t fp6x2[2];
   } u{0};
-#if __gfx950__
-  __amd_floatx16_storage_t in1;
-  __amd_floatx16_storage_t in2;
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
+  __amd_floatx16_storage_t in1{};
+  __amd_floatx16_storage_t in2{};
   __amd_fp6x32_storage_t out{};
   in1[0] = x.x;
   in2[0] = x.y;
@@ -217,6 +285,21 @@ __hip_cvt_float2_to_fp6x2(const float2 x, const __hip_fp6_interpretation_t fp6_i
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32))
       out = __builtin_amdgcn_cvt_scalef32_2xpk16_bf6_f32(in1, in2, 1.0f /* scale */);
+  }
+  u.ui32 = out[0] & 0x3Fu;
+  u.ui32 |= ((out[0] & 0xFC0u) << 2);
+  return u.fp6x2[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  __amd_floatx16_storage_t in{};
+  __amd_fp6x16_storage_t out{};
+  in[0] = float(x.x);
+  in[1] = float(x.y);
+  if (fp6_interpretation_t == __HIP_E2M3) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_fp6_f32))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_fp6_f32(in, 1.0f /* scale */);
+  } else if (fp6_interpretation_t == __HIP_E3M2) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_bf6_f32))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_bf6_f32(in, 1.0f /* scale */);
   }
   u.ui32 = out[0] & 0x3Fu;
   u.ui32 |= ((out[0] & 0xFC0u) << 2);
@@ -237,9 +320,9 @@ __hip_cvt_float2_to_fp6x2(const float2 x, const __hip_fp6_interpretation_t fp6_i
 __FP6_HOST_DEVICE_STATIC__ __half_raw __hip_cvt_fp6_to_halfraw(
     const __hip_fp6_storage_t x, const __hip_fp6_interpretation_t fp6_interpretation_t) {
   __half_raw ret;
-#if __gfx950__
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
   __amd_fp16x32_storage_t out{};
-  __amd_fp6x32_storage_t in;
+  __amd_fp6x32_storage_t in{};
   in[0] = (uint32_t)x;
   if (fp6_interpretation_t == __HIP_E2M3) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f16_fp6))
@@ -247,6 +330,18 @@ __FP6_HOST_DEVICE_STATIC__ __half_raw __hip_cvt_fp6_to_halfraw(
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f16_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f16_bf6(in, 1.0f);
+  }
+  ret.data = out[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  __amd_fp16x16_storage_t out{};
+  __amd_fp6x16_storage_t in{};
+  in[0] = (uint32_t)x;
+  if (fp6_interpretation_t == __HIP_E2M3) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f16_fp6))
+      out = __builtin_amdgcn_cvt_scale_pk16_f16_fp6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
+  } else if (fp6_interpretation_t == __HIP_E3M2) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f16_bf6))
+      out = __builtin_amdgcn_cvt_scale_pk16_f16_bf6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
   }
   ret.data = out[0];
 #else
@@ -262,9 +357,9 @@ __FP6_HOST_DEVICE_STATIC__ __half_raw __hip_cvt_fp6_to_halfraw(
 __FP6_HOST_DEVICE_STATIC__ __half2_raw __hip_cvt_fp6x2_to_halfraw2(
     const __hip_fp6x2_storage_t x, const __hip_fp6_interpretation_t fp6_interpretation_t) {
   __half2_raw ret;
-#if __gfx950__
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
   __amd_fp16x32_storage_t out{};
-  __amd_fp6x32_storage_t in;
+  __amd_fp6x32_storage_t in{};
   in[0] = x & 0x3Fu;            // first 6 bits
   in[0] |= (x & 0x3F00u) >> 2;  // next 6 bits
   if (fp6_interpretation_t == __HIP_E2M3) {
@@ -273,6 +368,19 @@ __FP6_HOST_DEVICE_STATIC__ __half2_raw __hip_cvt_fp6x2_to_halfraw2(
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f16_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f16_bf6(in, 1.0f);
+  }
+  ret.data = {out[0], out[1]};
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  __amd_fp16x16_storage_t out{};
+  __amd_fp6x16_storage_t in{};
+  in[0] = x & 0x3Fu;            // first 6 bits
+  in[0] |= (x & 0x3F00u) >> 2;  // next 6 bits
+  if (fp6_interpretation_t == __HIP_E2M3) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f16_fp6))
+      out = __builtin_amdgcn_cvt_scale_pk16_f16_fp6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
+  } else if (fp6_interpretation_t == __HIP_E3M2) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f16_bf6))
+      out = __builtin_amdgcn_cvt_scale_pk16_f16_bf6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
   }
   ret.data = {out[0], out[1]};
 #else
@@ -296,7 +404,7 @@ __hip_cvt_halfraw_to_fp6(const __half_raw x, const __hip_fp6_interpretation_t fp
     uint32_t ui32;
     __hip_fp6_storage_t fp6[4];
   } u{0};
-#if __gfx950__
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
   __amd_fp16x32_storage_t in;
   __amd_fp6x32_storage_t out{};
   in[0] = x.data;
@@ -306,6 +414,19 @@ __hip_cvt_halfraw_to_fp6(const __half_raw x, const __hip_fp6_interpretation_t fp
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf6_f16))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf6_f16(in, 1.0f);
+  }
+  u.ui32 = out[0];
+  return u.fp6[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  __amd_fp16x16_storage_t in{};
+  __amd_fp6x16_storage_t out{};
+  in[0] = x.data;
+  if (fp6_interpretation_t == __HIP_E2M3) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_fp6_f16))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_fp6_f16(in, 1.0f);
+  } else if (fp6_interpretation_t == __HIP_E3M2) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_bf6_f16))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_bf6_f16(in, 1.0f);
   }
   u.ui32 = out[0];
   return u.fp6[0];
@@ -327,7 +448,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t __hip_cvt_halfraw2_to_fp6x2(
     uint32_t ui32;
     __hip_fp6x2_storage_t fp6x2[2];
   } u{0};
-#if __gfx950__
+#if HIP_ENABLE_GFX950_OCP_BUILTINS
   __amd_fp16x32_storage_t in;
   __amd_fp6x32_storage_t out{};
   in[0] = x.data[0];
@@ -338,6 +459,21 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t __hip_cvt_halfraw2_to_fp6x2(
   } else if (fp6_interpretation_t == __HIP_E3M2) {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf6_f16))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf6_f16(in, 1.0f);
+  }
+  u.ui32 = out[0] & 0x3Fu;
+  u.ui32 |= ((out[0] & 0xFC0u) << 2);
+  return u.fp6x2[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+  __amd_fp16x16_storage_t in{};
+  __amd_fp6x16_storage_t out{};
+  in[0] = x.data[0];
+  in[1] = x.data[1];
+  if (fp6_interpretation_t == __HIP_E2M3) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_fp6_f16))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_fp6_f16(in, 1.0f);
+  } else if (fp6_interpretation_t == __HIP_E3M2) {
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk16_bf6_f16))
+      out = __builtin_amdgcn_cvt_scalef32_pk16_bf6_f16(in, 1.0f);
   }
   u.ui32 = out[0] & 0x3Fu;
   u.ui32 |= ((out[0] & 0xFC0u) << 2);
@@ -406,6 +542,13 @@ struct __hip_fp6_e2m3 {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf16_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf16_fp6(in, 1.0f /* scale */);
     u.bf16 = out[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    __amd_fp6x16_storage_t in{};
+    __amd_bf16x16_storage_t out{};
+    in[0] = (uint32_t)__x;
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_bf16_fp6))
+      out = __builtin_amdgcn_cvt_scale_pk16_bf16_fp6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
+    u.bf16 = out[0];
 #else
     using namespace fcbx;
     u.bf16 = to_float<__amd_bf16_storage_t, Encoding::E2M3, true>(__x, 0);
@@ -419,6 +562,13 @@ struct __hip_fp6_e2m3 {
     in[0] = (uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_fp6(in, 1.0f /* scale */);
+    auto ret = out[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    __amd_fp6x16_storage_t in{};
+    __amd_floatx16_storage_t out{};
+    in[0] = (uint32_t)__x;
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f32_fp6))
+      out = __builtin_amdgcn_cvt_scale_pk16_f32_fp6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     auto ret = out[0];
 #else
     using namespace fcbx;
@@ -477,6 +627,13 @@ struct __hip_fp6_e3m2 {
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf16_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf16_bf6(in, 1.0f /* scale */);
     u.bf16 = out[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    __amd_fp6x16_storage_t in{};
+    __amd_bf16x16_storage_t out{};
+    in[0] = (uint32_t)__x;
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_bf16_bf6))
+      out = __builtin_amdgcn_cvt_scale_pk16_bf16_bf6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
+    u.bf16 = out[0];
 #else
     using namespace fcbx;
     u.bf16 = to_float<__amd_bf16_storage_t, Encoding::E3M2, true>(__x, 0);
@@ -490,6 +647,13 @@ struct __hip_fp6_e3m2 {
     in[0] = (uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_bf6(in, 1.0f /* scale */);
+    auto ret = out[0];
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    __amd_fp6x16_storage_t in;
+    __amd_floatx16_storage_t out;
+    in[0] = (uint32_t)__x;
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f32_bf6))
+      out = __builtin_amdgcn_cvt_scale_pk16_f32_bf6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     auto ret = out[0];
 #else
     using namespace fcbx;
@@ -527,10 +691,18 @@ struct __hip_fp6x2_e2m3 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     __amd_fp6x32_storage_t in;
     __amd_bf16x32_storage_t out{};
-    in[0] = __x & 0x3Fu;          // first 6 bits
+    in[0] = __x & 0x3Fu;            // first 6 bits
     in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf16_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf16_fp6(in, 1.0f /* scale */);
+    u.bf16x2 = {out[0], out[1]};
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    __amd_fp6x16_storage_t in;
+    __amd_bf16x16_storage_t out;
+    in[0] = __x & 0x3Fu;            // first 6 bits
+    in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_bf16_fp6))
+      out = __builtin_amdgcn_cvt_scale_pk16_bf16_fp6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     u.bf16x2 = {out[0], out[1]};
 #else
     using namespace fcbx;
@@ -544,10 +716,18 @@ struct __hip_fp6x2_e2m3 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     __amd_fp6x32_storage_t in;
     __amd_floatx32_storage_t out{};
-    in[0] = __x & 0x3Fu;          // first 6 bits
+    in[0] = __x & 0x3Fu;            // first 6 bits
     in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_fp6(in, 1.0f /* scale */);
+    __amd_floatx2_storage_t fp32x2 = {out[0], out[1]};
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    __amd_fp6x16_storage_t in;
+    __amd_floatx16_storage_t out;
+    in[0] = __x & 0x3Fu;            // first 6 bits
+    in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f32_fp6))
+      out = __builtin_amdgcn_cvt_scale_pk16_f32_fp6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     __amd_floatx2_storage_t fp32x2 = {out[0], out[1]};
 #else
     using namespace fcbx;
@@ -589,10 +769,18 @@ struct __hip_fp6x2_e3m2 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     __amd_fp6x32_storage_t in;
     __amd_bf16x32_storage_t out{};
-    in[0] = __x & 0x3Fu;          // first 6 bits
+    in[0] = __x & 0x3Fu;            // first 6 bits
     in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf16_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf16_bf6(in, 1.0f /* scale */);
+    u.bf16x2 = {out[0], out[1]};
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    __amd_fp6x16_storage_t in;
+    __amd_bf16x16_storage_t out;
+    in[0] = __x & 0x3Fu;            // first 6 bits
+    in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_bf16_bf6))
+      out = __builtin_amdgcn_cvt_scale_pk16_bf16_bf6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     u.bf16x2 = {out[0], out[1]};
 #else
     using namespace fcbx;
@@ -606,10 +794,18 @@ struct __hip_fp6x2_e3m2 {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
     __amd_fp6x32_storage_t in;
     __amd_floatx32_storage_t out{};
-    in[0] = __x & 0x3Fu;          // first 6 bits
+    in[0] = __x & 0x3Fu;            // first 6 bits
     in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_bf6(in, 1.0f /* scale */);
+    __amd_floatx2_storage_t fp32x2 = {out[0], out[1]};
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    __amd_fp6x16_storage_t in;
+    __amd_floatx16_storage_t out;
+    in[0] = __x & 0x3Fu;            // first 6 bits
+    in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f32_bf6))
+      out = __builtin_amdgcn_cvt_scale_pk16_f32_bf6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     __amd_floatx2_storage_t fp32x2 = {out[0], out[1]};
 #else
     using namespace fcbx;
@@ -654,6 +850,17 @@ struct __hip_fp6x4_e2m3 {
     in[0] |= ((__x >> 24) & 0x3Fu) << 18;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_fp6(in, 1.0f /* scale */);
+    __amd_floatx2_storage_t fp32x2_1 = {out[0], out[1]};
+    __amd_floatx2_storage_t fp32x2_2 = {out[2], out[3]};
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    __amd_fp6x16_storage_t in;
+    __amd_floatx16_storage_t out;
+    in[0] = __x & 0x3Fu;                 // first 6 bits
+    in[0] |= ((__x >> 8) & 0x3Fu) << 6;  // second 6 bits
+    in[0] |= ((__x >> 16) & 0x3Fu) << 12;
+    in[0] |= ((__x >> 24) & 0x3Fu) << 18;
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f32_fp6))
+      out = __builtin_amdgcn_cvt_scale_pk16_f32_fp6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     __amd_floatx2_storage_t fp32x2_1 = {out[0], out[1]};
     __amd_floatx2_storage_t fp32x2_2 = {out[2], out[3]};
 #else
@@ -703,6 +910,17 @@ struct __hip_fp6x4_e3m2 {
     in[0] |= ((__x >> 24) & 0x3Fu) << 18;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_bf6(in, 1.0f /* scale */);
+    __amd_floatx2_storage_t fp32x2_1 = {out[0], out[1]};
+    __amd_floatx2_storage_t fp32x2_2 = {out[2], out[3]};
+#elif HIP_ENABLE_GFX1250_OCP_BUILTINS
+    __amd_fp6x16_storage_t in;
+    __amd_floatx16_storage_t out;
+    in[0] = __x & 0x3Fu;                 // first 6 bits
+    in[0] |= ((__x >> 8) & 0x3Fu) << 6;  // second 6 bits
+    in[0] |= ((__x >> 16) & 0x3Fu) << 12;
+    in[0] |= ((__x >> 24) & 0x3Fu) << 18;
+    if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f32_bf6))
+      out = __builtin_amdgcn_cvt_scale_pk16_f32_bf6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     __amd_floatx2_storage_t fp32x2_1 = {out[0], out[1]};
     __amd_floatx2_storage_t fp32x2_2 = {out[2], out[3]};
 #else

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp6.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_fp6.h
@@ -319,7 +319,7 @@ __hip_cvt_float2_to_fp6x2(const float2 x, const __hip_fp6_interpretation_t fp6_i
 }
 __FP6_HOST_DEVICE_STATIC__ __half_raw __hip_cvt_fp6_to_halfraw(
     const __hip_fp6_storage_t x, const __hip_fp6_interpretation_t fp6_interpretation_t) {
-  __half_raw ret;
+  __half_raw ret{};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
   __amd_fp16x32_storage_t out{};
   __amd_fp6x32_storage_t in{};
@@ -356,7 +356,7 @@ __FP6_HOST_DEVICE_STATIC__ __half_raw __hip_cvt_fp6_to_halfraw(
 }
 __FP6_HOST_DEVICE_STATIC__ __half2_raw __hip_cvt_fp6x2_to_halfraw2(
     const __hip_fp6x2_storage_t x, const __hip_fp6_interpretation_t fp6_interpretation_t) {
-  __half2_raw ret;
+  __half2_raw ret{};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
   __amd_fp16x32_storage_t out{};
   __amd_fp6x32_storage_t in{};
@@ -405,7 +405,7 @@ __hip_cvt_halfraw_to_fp6(const __half_raw x, const __hip_fp6_interpretation_t fp
     __hip_fp6_storage_t fp6[4];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  __amd_fp16x32_storage_t in;
+  __amd_fp16x32_storage_t in{};
   __amd_fp6x32_storage_t out{};
   in[0] = x.data;
   if (fp6_interpretation_t == __HIP_E2M3) {
@@ -449,7 +449,7 @@ __FP6_HOST_DEVICE_STATIC__ __hip_fp6x2_storage_t __hip_cvt_halfraw2_to_fp6x2(
     __hip_fp6x2_storage_t fp6x2[2];
   } u{0};
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-  __amd_fp16x32_storage_t in;
+  __amd_fp16x32_storage_t in{};
   __amd_fp6x32_storage_t out{};
   in[0] = x.data[0];
   in[1] = x.data[1];
@@ -536,7 +536,7 @@ struct __hip_fp6_e2m3 {
       __amd_bf16_storage_t bf16;
     } u;
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-    __amd_fp6x32_storage_t in;
+    __amd_fp6x32_storage_t in{};
     __amd_bf16x32_storage_t out{};
     in[0] = (uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf16_fp6))
@@ -557,7 +557,7 @@ struct __hip_fp6_e2m3 {
   }
   __FP6_HOST_DEVICE__ operator float() const {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-    __amd_fp6x32_storage_t in;
+    __amd_fp6x32_storage_t in{};
     __amd_floatx32_storage_t out{};
     in[0] = (uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_fp6))
@@ -621,7 +621,7 @@ struct __hip_fp6_e3m2 {
       __amd_bf16_storage_t bf16;
     } u;
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-    __amd_fp6x32_storage_t in;
+    __amd_fp6x32_storage_t in{};
     __amd_bf16x32_storage_t out{};
     in[0] = (uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf16_bf6))
@@ -642,15 +642,15 @@ struct __hip_fp6_e3m2 {
   }
   __FP6_HOST_DEVICE__ operator float() const {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-    __amd_fp6x32_storage_t in;
+    __amd_fp6x32_storage_t in{};
     __amd_floatx32_storage_t out{};
     in[0] = (uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_bf6(in, 1.0f /* scale */);
     auto ret = out[0];
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
-    __amd_fp6x16_storage_t in;
-    __amd_floatx16_storage_t out;
+    __amd_fp6x16_storage_t in{};
+    __amd_floatx16_storage_t out{};
     in[0] = (uint32_t)__x;
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f32_bf6))
       out = __builtin_amdgcn_cvt_scale_pk16_f32_bf6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
@@ -689,18 +689,18 @@ struct __hip_fp6x2_e2m3 {
       __amd_bf16x2_storage_t bf16x2;
     } u;
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-    __amd_fp6x32_storage_t in;
+    __amd_fp6x32_storage_t in{};
     __amd_bf16x32_storage_t out{};
     in[0] = __x & 0x3Fu;            // first 6 bits
-    in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
+    in[0] |= (__x & 0x3F00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf16_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf16_fp6(in, 1.0f /* scale */);
     u.bf16x2 = {out[0], out[1]};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
-    __amd_fp6x16_storage_t in;
-    __amd_bf16x16_storage_t out;
+    __amd_fp6x16_storage_t in{};
+    __amd_bf16x16_storage_t out{};
     in[0] = __x & 0x3Fu;            // first 6 bits
-    in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
+    in[0] |= (__x & 0x3F00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_bf16_fp6))
       out = __builtin_amdgcn_cvt_scale_pk16_bf16_fp6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     u.bf16x2 = {out[0], out[1]};
@@ -714,18 +714,18 @@ struct __hip_fp6x2_e2m3 {
   }
   __FP6_HOST_DEVICE__ operator float2() const {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-    __amd_fp6x32_storage_t in;
+    __amd_fp6x32_storage_t in{};
     __amd_floatx32_storage_t out{};
     in[0] = __x & 0x3Fu;            // first 6 bits
-    in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
+    in[0] |= (__x & 0x3F00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_fp6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_fp6(in, 1.0f /* scale */);
     __amd_floatx2_storage_t fp32x2 = {out[0], out[1]};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
-    __amd_fp6x16_storage_t in;
-    __amd_floatx16_storage_t out;
+    __amd_fp6x16_storage_t in{};
+    __amd_floatx16_storage_t out{};
     in[0] = __x & 0x3Fu;            // first 6 bits
-    in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
+    in[0] |= (__x & 0x3F00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f32_fp6))
       out = __builtin_amdgcn_cvt_scale_pk16_f32_fp6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     __amd_floatx2_storage_t fp32x2 = {out[0], out[1]};
@@ -767,18 +767,18 @@ struct __hip_fp6x2_e3m2 {
       __amd_bf16x2_storage_t bf16x2;
     } u;
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-    __amd_fp6x32_storage_t in;
+    __amd_fp6x32_storage_t in{};
     __amd_bf16x32_storage_t out{};
     in[0] = __x & 0x3Fu;            // first 6 bits
-    in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
+    in[0] |= (__x & 0x3F00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_bf16_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_bf16_bf6(in, 1.0f /* scale */);
     u.bf16x2 = {out[0], out[1]};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
-    __amd_fp6x16_storage_t in;
-    __amd_bf16x16_storage_t out;
+    __amd_fp6x16_storage_t in{};
+    __amd_bf16x16_storage_t out{};
     in[0] = __x & 0x3Fu;            // first 6 bits
-    in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
+    in[0] |= (__x & 0x3F00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_bf16_bf6))
       out = __builtin_amdgcn_cvt_scale_pk16_bf16_bf6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     u.bf16x2 = {out[0], out[1]};
@@ -792,18 +792,18 @@ struct __hip_fp6x2_e3m2 {
   }
   __FP6_HOST_DEVICE__ operator float2() const {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-    __amd_fp6x32_storage_t in;
+    __amd_fp6x32_storage_t in{};
     __amd_floatx32_storage_t out{};
     in[0] = __x & 0x3Fu;            // first 6 bits
-    in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
+    in[0] |= (__x & 0x3F00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scalef32_pk32_f32_bf6))
       out = __builtin_amdgcn_cvt_scalef32_pk32_f32_bf6(in, 1.0f /* scale */);
     __amd_floatx2_storage_t fp32x2 = {out[0], out[1]};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
-    __amd_fp6x16_storage_t in;
-    __amd_floatx16_storage_t out;
+    __amd_fp6x16_storage_t in{};
+    __amd_floatx16_storage_t out{};
     in[0] = __x & 0x3Fu;            // first 6 bits
-    in[0] |= (__x & 0xFC00u) >> 2;  // next 6 bits
+    in[0] |= (__x & 0x3F00u) >> 2;  // next 6 bits
     if (__builtin_amdgcn_is_invocable(__builtin_amdgcn_cvt_scale_pk16_f32_bf6))
       out = __builtin_amdgcn_cvt_scale_pk16_f32_bf6(in, 0x7F7Fu /* scale e8m0 = 1.0 */, 0);
     __amd_floatx2_storage_t fp32x2 = {out[0], out[1]};
@@ -842,7 +842,7 @@ struct __hip_fp6x4_e2m3 {
 #if !defined(__HIP_NO_FP6_CONVERSION_OPERATORS__)
   __FP6_HOST_DEVICE__ operator float4() const {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-    __amd_fp6x32_storage_t in;
+    __amd_fp6x32_storage_t in{};
     __amd_floatx32_storage_t out{};
     in[0] = __x & 0x3Fu;                 // first 6 bits
     in[0] |= ((__x >> 8) & 0x3Fu) << 6;  // second 6 bits
@@ -853,8 +853,8 @@ struct __hip_fp6x4_e2m3 {
     __amd_floatx2_storage_t fp32x2_1 = {out[0], out[1]};
     __amd_floatx2_storage_t fp32x2_2 = {out[2], out[3]};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
-    __amd_fp6x16_storage_t in;
-    __amd_floatx16_storage_t out;
+    __amd_fp6x16_storage_t in{};
+    __amd_floatx16_storage_t out{};
     in[0] = __x & 0x3Fu;                 // first 6 bits
     in[0] |= ((__x >> 8) & 0x3Fu) << 6;  // second 6 bits
     in[0] |= ((__x >> 16) & 0x3Fu) << 12;
@@ -885,11 +885,11 @@ struct __hip_fp6x4_e3m2 {
   __hip_fp6x4_storage_t __x;
   __FP6_HOST_DEVICE__ inline __hip_fp6x4_e3m2() = default;
 #if !defined(__HIP_NO_FP6_CONVERSIONS__)
-  __FP6_HOST_DEVICE__ inline explicit __hip_fp6x4_e3m2(const __half2 high, const __half2 low)
+  __FP6_HOST_DEVICE__ inline explicit __hip_fp6x4_e3m2(const __half2 low, const __half2 high)
       : __x(__hip_cvt_halfraw2_to_fp6x2(high, __HIP_E3M2, hipRoundNearest) << 16 |
             __hip_cvt_halfraw2_to_fp6x2(low, __HIP_E3M2, hipRoundNearest)) {}
-  __FP6_HOST_DEVICE__ inline explicit __hip_fp6x4_e3m2(const __hip_bfloat162 high,
-                                                       const __hip_bfloat162 low)
+  __FP6_HOST_DEVICE__ inline explicit __hip_fp6x4_e3m2(const __hip_bfloat162 low,
+                                                       const __hip_bfloat162 high)
       : __x(__hip_cvt_bfloat16raw2_to_fp6x2(high, __HIP_E3M2, hipRoundNearest) << 16 |
             __hip_cvt_bfloat16raw2_to_fp6x2(low, __HIP_E3M2, hipRoundNearest)) {}
   __FP6_HOST_DEVICE__ inline explicit __hip_fp6x4_e3m2(const double4 f)
@@ -902,7 +902,7 @@ struct __hip_fp6x4_e3m2 {
 #if !defined(__HIP_NO_FP6_CONVERSION_OPERATORS__)
   __FP6_HOST_DEVICE__ operator float4() const {
 #if HIP_ENABLE_GFX950_OCP_BUILTINS
-    __amd_fp6x32_storage_t in;
+    __amd_fp6x32_storage_t in{};
     __amd_floatx32_storage_t out{};
     in[0] = __x & 0x3Fu;                 // first 6 bits
     in[0] |= ((__x >> 8) & 0x3Fu) << 6;  // second 6 bits
@@ -913,8 +913,8 @@ struct __hip_fp6x4_e3m2 {
     __amd_floatx2_storage_t fp32x2_1 = {out[0], out[1]};
     __amd_floatx2_storage_t fp32x2_2 = {out[2], out[3]};
 #elif HIP_ENABLE_GFX1250_OCP_BUILTINS
-    __amd_fp6x16_storage_t in;
-    __amd_floatx16_storage_t out;
+    __amd_fp6x16_storage_t in{};
+    __amd_floatx16_storage_t out{};
     in[0] = __x & 0x3Fu;                 // first 6 bits
     in[0] |= ((__x >> 8) & 0x3Fu) << 6;  // second 6 bits
     in[0] |= ((__x >> 16) & 0x3Fu) << 12;

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_mx_common.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_mx_common.h
@@ -15,7 +15,7 @@
 #else
 #define HIP_ENABLE_GFX1250_OCP_BUILTINS 0
 #endif
-#if !defined(__gfx950__)
+#if !defined(__gfx950__) && !defined(__gfx1250__)
 #define HIP_ENABLE_HOST_OCP_CONVERSIONS 1
 #else
 #define HIP_ENABLE_HOST_OCP_CONVERSIONS 0

--- a/projects/clr/hipamd/include/hip/amd_detail/amd_hip_mx_common.h
+++ b/projects/clr/hipamd/include/hip/amd_detail/amd_hip_mx_common.h
@@ -10,6 +10,11 @@
 #else
 #define HIP_ENABLE_GFX950_OCP_BUILTINS 0
 #endif
+#if defined(__gfx1250__)
+#define HIP_ENABLE_GFX1250_OCP_BUILTINS 1
+#else
+#define HIP_ENABLE_GFX1250_OCP_BUILTINS 0
+#endif
 #if !defined(__gfx950__)
 #define HIP_ENABLE_HOST_OCP_CONVERSIONS 1
 #else


### PR DESCRIPTION
## Motivation

Use builtins for fp4/fp6

## Technical Details

instead of relying on host implementation, we use the builtins.

## JIRA ID

NA

## Test Plan

There are tests present for fp4/fp6. They should pass with the new change.

## Test Result

This passes locally.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
