### PR TITLE
[rocprofiler-systems] Align code coverage report with HTML report

### DIFF
--- a/projects/rocprofiler-systems/scripts/generate-coverage.py
+++ b/projects/rocprofiler-systems/scripts/generate-coverage.py
@@ -117,9 +117,26 @@ def compute_file_coverage(data: dict) -> list[dict]:
         if not lines:
             continue
 
-        covered = sum(1 for l in lines if l.get("count", 0) > 0)
-        total = len(lines)
+        line_counts: dict[int, int] = {}
+        for line in lines:
+            ln = line.get("line_number", 0)
+            count = line.get("count", 0)
+            if ln not in line_counts or count > line_counts[ln]:
+                line_counts[ln] = count
+
+        covered = sum(1 for c in line_counts.values() if c > 0)
+        total = len(line_counts)
         pct = (covered / total * 100) if total > 0 else 0.0
+
+        func_by_line: dict[int, bool] = {}
+        for func in file_data.get("functions", []):
+            lineno = func.get("lineno", 0)
+            ran = func.get("execution_count", 0) > 0
+            func_by_line[lineno] = func_by_line.get(lineno, False) or ran
+
+        func_covered = sum(1 for v in func_by_line.values() if v)
+        func_total = len(func_by_line)
+        func_pct = (func_covered / func_total * 100) if func_total > 0 else 0.0
 
         files.append(
             {
@@ -127,6 +144,9 @@ def compute_file_coverage(data: dict) -> list[dict]:
                 "covered_lines": covered,
                 "total_lines": total,
                 "coverage_pct": pct,
+                "covered_functions": func_covered,
+                "total_functions": func_total,
+                "function_pct": func_pct,
             }
         )
 
@@ -137,11 +157,19 @@ def compute_totals(file_coverages: list[dict]) -> dict:
     total_covered = sum(f["covered_lines"] for f in file_coverages)
     total_lines = sum(f["total_lines"] for f in file_coverages)
     pct = (total_covered / total_lines * 100) if total_lines > 0 else 0.0
+
+    total_func_covered = sum(f.get("covered_functions", 0) for f in file_coverages)
+    total_funcs = sum(f.get("total_functions", 0) for f in file_coverages)
+    func_pct = (total_func_covered / total_funcs * 100) if total_funcs > 0 else 0.0
+
     return {
         "covered_lines": total_covered,
         "total_lines": total_lines,
         "coverage_pct": pct,
         "file_count": len(file_coverages),
+        "covered_functions": total_func_covered,
+        "total_functions": total_funcs,
+        "function_pct": func_pct,
     }
 
 
@@ -174,10 +202,14 @@ def generate_markdown(
         emoji = "📈" if delta >= 0 else "📉"
         delta_str = f" ({emoji} {sign}{delta:.2f}% vs base)"
 
-    lines.append(f"**Overall**: {coverage_bar(totals['coverage_pct'])}{delta_str}")
     lines.append(
-        f"**Lines**: {totals['covered_lines']:,} / {totals['total_lines']:,} "
+        f"**Lines**: {coverage_bar(totals['coverage_pct'])}{delta_str} "
+        f"— {totals['covered_lines']:,}/{totals['total_lines']:,} "
         f"across {totals['file_count']} files"
+    )
+    lines.append(
+        f"**Functions**: {coverage_bar(totals['function_pct'])} "
+        f"— {totals['covered_functions']:,}/{totals['total_functions']:,}"
     )
     lines.append("")
 
@@ -194,14 +226,18 @@ def generate_markdown(
             lines.append(f"<details>")
             lines.append(f"<summary>{group_label} ({len(group_files)} files)</summary>")
             lines.append("")
-            lines.append("| Coverage | Lines | File |")
-            lines.append("|----------|-------|------|")
+            lines.append("| Lines | Functions | File |")
+            lines.append("|-------|-----------|------|")
             for f in group_files:
                 rel = os.path.relpath(f["filename"], source_dir)
-                pct = f["coverage_pct"]
+                func_str = (
+                    f"{f['covered_functions']}/{f['total_functions']}"
+                    if f.get("total_functions", 0) > 0
+                    else "—"
+                )
                 lines.append(
-                    f"| {pct:5.1f}% | "
-                    f"{f['covered_lines']}/{f['total_lines']} | "
+                    f"| {f['coverage_pct']:5.1f}% {f['covered_lines']}/{f['total_lines']} | "
+                    f"{func_str} | "
                     f"`{rel}` |"
                 )
             lines.append("")
@@ -324,6 +360,9 @@ def main():
         "coverage_pct": round(totals["coverage_pct"], 2),
         "covered_lines": totals["covered_lines"],
         "total_lines": totals["total_lines"],
+        "function_pct": round(totals["function_pct"], 2),
+        "covered_functions": totals["covered_functions"],
+        "total_functions": totals["total_functions"],
         "file_count": totals["file_count"],
     }
     if baseline_totals:


### PR DESCRIPTION
## Motivation

The `generate-coverage.py` script produces Markdown and JSON summary reports from gcovr's JSON output. When a codebase uses C++ templates, gcovr emits multiple JSON entries for the same source line — one per instantiation. The previous line-counting logic iterated the raw entry list, so a line with two template instantiations (e.g. `provider<amdsmi_backend>` and `provider<mock_backend>`) was counted twice: once as uncovered and once as covered, inflating the total line count and suppressing the effective coverage percentage. The result was a Markdown report that disagreed with gcovr's own HTML output for the same run.

## Technical Details

**Line deduplication (`compute_file_coverage`)**: Lines are now deduplicated by line number before counting. For each source line the maximum execution count across all instantiations is kept, so a line is marked covered when any instantiation ran it — exactly the semantics gcovr uses in its HTML report.

**Function coverage**: The commit adds per-file and aggregate function coverage (`covered_functions`, `total_functions`, `function_pct`) derived from the `functions` array in gcovr's JSON. Template instantiations at the same source line are collapsed: a function is marked covered when any instantiation's `execution_count` is non-zero.

**Markdown report layout**: The summary header is updated to show a compact "Lines" row (coverage bar + covered/total + file count) and a new "Functions" row. The per-file detail table drops the now-redundant separate "Coverage" column in favour of a combined "Lines" column (`pct% covered/total`) and a new "Functions" column (`covered/total`).

The summary JSON written to disk gains three new fields (`function_pct`, `covered_functions`, `total_functions`) for downstream consumers.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-567
## Test Plan

- [x] Run `generate-coverage.py` on a build that exercises template-heavy code and confirm the Markdown line coverage percentage matches the gcovr HTML report.
- [x] Verify that files with zero functions produce a `—` placeholder instead of `0/0` in the Functions column.
- [x] Check that the summary JSON contains the three new function coverage fields (`function_pct`, `covered_functions`, `total_functions`).

## Test Result

<!-- Briefly summarize test outcomes. -->
Tests pass.
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.