### PR TITLE
Drain callback thread before destroying queue

### DIFF
--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1349,6 +1349,8 @@ class VirtualDevice : public amd::ReferenceCountedObject {
   virtual void ReleaseSdmaEngines() {}  //!< Release SDMA engine assignments (ROCm specific)
   virtual void ReleaseAllHwQueues() {}
   virtual void ReleaseHwQueue() {}
+  //! Wait for backend async handlers that still hold this virtual device.
+  virtual void DrainAsyncHandlers() {}
   //!< Request a system-scope release fence on the next AQL packet (ROCm specific)
   virtual void addSystemScope() {}
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -250,34 +250,20 @@ Device::~Device() {
 void NullDevice::tearDown() {}
 
 void Device::WaitForHsaAsyncHandlersIdle() {
-  constexpr int kDrainTimeoutMs = 5000;
-  const std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
-  const std::chrono::steady_clock::duration fast_timeout =
-      std::chrono::milliseconds(kDrainTimeoutMs);
-
-  auto sumQueuedHandlers = [this]() -> uint64_t {
-    uint64_t sum = 0;
+  std::vector<VirtualGPU*> snapshot;
+  {
     std::scoped_lock lock(vgpusAccess_);
     for (VirtualGPU* vgpu : vgpus_) {
       if (vgpu != nullptr) {
-        sum += vgpu->QueuedAsyncHandlers().load(std::memory_order_acquire);
+        vgpu->retain();
+        snapshot.push_back(vgpu);
       }
     }
-    return sum;
-  };
+  }
 
-  while (sumQueuedHandlers() != 0) {
-    if (std::chrono::steady_clock::now() - start_time > fast_timeout) {
-      const uint64_t remaining = sumQueuedHandlers();
-      if (remaining != 0) {
-        LogPrintfError(
-            "WaitForHsaAsyncHandlersIdle: %d ms elapsed, VirtualGPU queued_async total=%llu; "
-            "proceeding with device destruction.",
-            kDrainTimeoutMs, static_cast<unsigned long long>(remaining));
-      }
-      return;
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  for (VirtualGPU* vgpu : snapshot) {
+    vgpu->DrainAsyncHandlers();
+    vgpu->release();
   }
 }
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -650,7 +650,7 @@ class Device : public NullDevice {
   //! Returns true if PM4 emulation is enabled
   bool IsPm4Emulation() const { return pm4_emulation_; }
 
-  //! Waits until all VirtualGPU QueuedAsyncHandlers are zero (30s timeout).
+  //! Waits until all VirtualGPU async handlers have drained.
   void WaitForHsaAsyncHandlersIdle() override;
 
  private:

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -402,7 +402,9 @@ bool HsaAmdSignalHandler(hsa_signal_value_t value, void* arg) {
   }
 
   // Return false, so the callback will not be called again for this signal
-  gpu->QueuedAsyncHandlers()--;
+  if (gpu->QueuedAsyncHandlers().fetch_sub(1, std::memory_order_acq_rel) == 1) {
+    gpu->NotifyAsyncHandlersIdle();
+  }
   gpu->release();
   return false;
 }
@@ -705,7 +707,9 @@ hsa_signal_t VirtualGPU::HwQueueTracker::ActiveSignal(hsa_signal_value_t init_va
       hsa_status_t result = Hsa::signal_async_handler(
           prof_signal->signal_, HSA_SIGNAL_CONDITION_LT, init_value, &HsaAmdSignalHandler, ts);
       if (HSA_STATUS_SUCCESS != result) {
-        gpu_.QueuedAsyncHandlers()--;
+        if (gpu_.QueuedAsyncHandlers().fetch_sub(1, std::memory_order_acq_rel) == 1) {
+          gpu_.NotifyAsyncHandlersIdle();
+        }
         ts->gpu()->release();
         LogError("hsa_amd_signal_async_handler() failed to set the handler!");
       } else {
@@ -2032,6 +2036,20 @@ VirtualGPU::~VirtualGPU() {
     amd::disableHostcalls(hostcallBuffer_);
     roc_device_.hostFree(hostcallBuffer_, hostcallBufferSize_);
   }
+}
+
+// ================================================================================================
+void VirtualGPU::DrainAsyncHandlers() {
+  amd::ScopedLock lock(async_handlers_lock_);
+  while (QueuedAsyncHandlers().load(std::memory_order_acquire) != 0) {
+    async_handlers_lock_.wait();
+  }
+}
+
+// ================================================================================================
+void VirtualGPU::NotifyAsyncHandlersIdle() const {
+  amd::ScopedLock lock(async_handlers_lock_);
+  async_handlers_lock_.notifyAll();
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -15,6 +15,7 @@
 #include "rocsched.hpp"
 #include "device/device.hpp"
 #include "os/os.hpp"
+#include "thread/monitor.hpp"
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
@@ -503,6 +504,8 @@ class VirtualGPU : public device::VirtualDevice {
   virtual void ReleaseSdmaEngines() final;  //!< Release SDMA engine assignments
   virtual void ReleaseAllHwQueues() final;
   virtual void ReleaseHwQueue() final;
+  void DrainAsyncHandlers() final;
+  void NotifyAsyncHandlersIdle() const;
 
   /**
    * @brief Waits on an outstanding kernel without regard to how
@@ -845,6 +848,8 @@ class VirtualGPU : public device::VirtualDevice {
 
   //! SDMA engine affinity tracking for this VirtualGPU/stream
   uint32_t assigned_sdma_engine_ = 0;           //!< Assigned SDMA engine mask for all operations
+
+  mutable amd::Monitor async_handlers_lock_;
 
   void* hostcallBuffer_;        //!< Hostcall buffer
   size_t hostcallBufferSize_ = 0; //!< Byte size of hostcallBuffer_, for hostFree

--- a/projects/clr/rocclr/platform/commandqueue.cpp
+++ b/projects/clr/rocclr/platform/commandqueue.cpp
@@ -80,6 +80,9 @@ bool HostQueue::terminate() {
         lastCommand->release();
       }
     }
+    if (vdev() != nullptr) {
+      vdev()->DrainAsyncHandlers();
+    }
     thread_.Release();
     thread_.acceptingCommands_ = false;
   } else {

--- a/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxRecordEvent.cc
+++ b/projects/hip-tests/catch/unit/executionContext/hipExecutionCtxRecordEvent.cc
@@ -34,7 +34,7 @@ HIP_TEST_CASE(Unit_hipExecutionCtxRecordWaitEvent_Sanity) {
 
   HIP_CHECK(hipGreenCtxCreate(&green_ctx, desc, 0, 0));
   REQUIRE(green_ctx != nullptr);
-  
+
   hipStream_t stream = nullptr;
   HIP_CHECK(hipExecutionCtxStreamCreate(&stream, green_ctx, hipStreamNonBlocking, 0x0));
   REQUIRE(stream != nullptr);


### PR DESCRIPTION
## Motivation

 - Test Unit_hipExecutionCtxRecordWaitEvent_Sanity hangs.

## Technical Details

How hang happens:
- The issue is that the callback thread ends up holding the last reference to VirtualGPU, so it starts destroying AqlQueue on the callback thread.
- Destroying an AQL queue on the callback thread causes a hang because AQL queue teardown depends on the callback thread to deliver or process certain events, which creates a deadlock.
- Callback thread holds the last reference because stream destroy releases VirtualGPU reference before callback is fired.
- This is not an issue with normal contexts, because they do not destroy AQL queues directly, they return them to a pool.

Code changes:
- Drain callback thread before destroying a Stream.

## JIRA ID

ROCM-25931

## Test Plan

 - This change fixes the existing test Unit_hipExecutionCtxRecordWaitEvent_Sanity.

## Test Result

 - Unit_hipExecutionCtxRecordWaitEvent_Sanity passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
