### PR TITLE
[clr] Export hipMemDiscardBatchAsync family on Windows

### DIFF
--- a/projects/clr/hipamd/src/amdhip.def.in
+++ b/projects/clr/hipamd/src/amdhip.def.in
@@ -512,6 +512,10 @@ hipGetDriverEntryPoint
 hipGetDriverEntryPoint_spt
 hipMemPrefetchAsync_v2
 hipMemPrefetchBatchAsync
+hipMemDiscardBatchAsync
+hipDrvMemDiscardBatchAsync
+hipMemDiscardAndPrefetchBatchAsync
+hipDrvMemDiscardAndPrefetchBatchAsync
 hipMemAdvise_v2
 hipStreamGetId
 hipLibraryLoadData

--- a/projects/clr/hipamd/src/hip_hmm.cpp
+++ b/projects/clr/hipamd/src/hip_hmm.cpp
@@ -159,6 +159,16 @@ hipError_t ihipMemDiscardBatchAsync(void** dev_ptrs, size_t* sizes, size_t count
     return hipErrorInvalidValue;
   }
 
+  // Validate each operation's arguments before checking device capability, so
+  // that invalid arguments are reported as hipErrorInvalidValue regardless of
+  // whether the device supports the discard feature. Otherwise a bad argument
+  // would be masked by hipErrorNotSupported on platforms without HMM.
+  for (size_t op_idx = 0; op_idx < count; op_idx++) {
+    if (dev_ptrs[op_idx] == nullptr || sizes[op_idx] == 0) {
+      return hipErrorInvalidValue;
+    }
+  }
+
   // Check that all devices support HMM (required for discard)
   if (!AllDevicesSupportHmm()) {
     return hipErrorNotSupported;
@@ -182,14 +192,11 @@ hipError_t ihipMemDiscardBatchAsync(void** dev_ptrs, size_t* sizes, size_t count
     std::vector<amd::Memory*> mem_objs =
         getMemoryObjectBatch(hip::getCurrentDevice(), dev_ptrs, count, offsets);
 
-    // Validate and prepare each operation
+    // Prepare each operation. Null pointers and zero sizes were already
+    // rejected above, before the device-capability check.
     for (size_t op_idx = 0; op_idx < count; op_idx++) {
       void* dev_ptr = dev_ptrs[op_idx];
       size_t size = sizes[op_idx];
-
-      if (size == 0 || dev_ptr == nullptr) {
-        return hipErrorInvalidValue;
-      }
 
       amd::Memory* mem_obj = mem_objs[op_idx];
       size_t offset = offsets[op_idx];

--- a/projects/hip-tests/catch/unit/memory/hipMemDiscardBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemDiscardBatchAsync.cc
@@ -44,6 +44,11 @@ static bool HmmSupported(int device = 0) {
  *  - HIP_VERSION >= 7.2
  */
 HIP_TEST_CASE(Unit_hipMemDiscardBatchAsync_NegativeTests) {
+  if (!HmmSupported()) {
+    HIP_SKIP_TEST("HMM/managed memory not supported");
+    return;
+  }
+
   constexpr size_t kAllocSize = 4096;
   hipStream_t stream;
   HIP_CHECK(hipStreamCreate(&stream));


### PR DESCRIPTION
## Motivation
PR #5772 added the hipMemDiscardBatchAsync / hipDrvMemDiscardBatchAsync / hipMemDiscardAndPrefetchBatchAsync / hipDrvMemDiscardAndPrefetchBatchAsync APIs and registered them in the Linux export map (hip_hcc.map.in) but not in the Windows DLL export list (amdhip.def.in). As a result the symbols are compiled into amdhip64 but not exported, so on Windows hip-tests fails to link hipMemDiscardBatchAsync.cc with:

  lld-link: error: undefined symbol: hipMemDiscardBatchAsync
  lld-link: error: undefined symbol: hipDrvMemDiscardBatchAsync
  lld-link: error: undefined symbol: hipMemDiscardAndPrefetchBatchAsync
  lld-link: error: undefined symbol: hipDrvMemDiscardAndPrefetchBatchAsync

This breaks the Windows build for every PR built against develop after #5772 merged. Add the four symbols to amdhip.def.in to match the Linux export map and restore the Windows build.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
The PR should fix the windows build. No additional tests are needed for this fix.
 
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
