### PR TITLE
kfdtest: add NoAccessUnmapTest for SVM no-access unmap

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.cpp
@@ -1692,6 +1692,119 @@ void KFDSVMRangeTest::HMMProfilingEvent(int gpuNode) {
 
 }
 
+/*
+ * No-access unmap test: setting KFD_IOCTL_SVM_ATTR_NO_ACCESS on a mapped range
+ * must silently unmap it from the GPU (UNMAP_FROM_GPU) and must NOT trigger a
+ * queue eviction (QUEUE_EVICTION). Guards against the jemalloc eviction storm
+ * regressing.
+ */
+struct NoAccessEventParams {
+    int nodeid;
+    pthread_barrier_t *barrier;
+    volatile int *stop;
+    int queue_eviction;
+    int unmap_from_gpu;
+};
+
+unsigned int CountSMIEventThread(void *p) {
+    struct NoAccessEventParams *a = (struct NoAccessEventParams *)p;
+    char msg[HSA_SMI_EVENT_MSG_SIZE];
+    struct pollfd fds = {0};
+    HSAuint64 events;
+    int fd;
+
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtOpenSMI, g_baseTest->m_hsakmt_current_ctx,
+                                   a->nodeid, &fd), a->nodeid);
+    events = HSA_SMI_EVENT_MASK_FROM_INDEX(HSA_SMI_EVENT_INDEX_MAX) - 1;
+    EXPECT_EQ_GPU(write(fd, &events, sizeof(events)), sizeof(events), a->nodeid);
+
+    pthread_barrier_wait(a->barrier);
+
+    fds.fd = fd;
+    fds.events = POLLIN;
+    while (!*a->stop) {
+        if (poll(&fds, 1, 200) <= 0)
+            continue;
+        memset(msg, 0, sizeof(msg));
+        if (read(fd, msg, HSA_SMI_EVENT_MSG_SIZE) <= 0)
+            continue;
+        int event_id = 0;
+        sscanf(msg, "%x", &event_id);
+        if (event_id == HSA_SMI_EVENT_QUEUE_EVICTION)
+            a->queue_eviction++;
+        else if (event_id == HSA_SMI_EVENT_UNMAP_FROM_GPU)
+            a->unmap_from_gpu++;
+    }
+    close(fd);
+    return 0;
+}
+
+void KFDSVMRangeTest::NoAccessUnmapTest(int gpuNode) {
+    if (!SVMAPISupported_GPU(gpuNode)) {
+        LOG() << "Skipping test: SVM not supported on gpuNode." << gpuNode << std::endl;
+        return;
+    }
+    if (Get_Version()->KernelInterfaceMinorVersion < 10)
+        return;
+
+    const HsaNodeProperties *pNodeProperties =
+        Get_NodeInfo()->GetNodeProperties(gpuNode);
+    if (pNodeProperties->Integrated || Get_NodeInfo()->IsAppAPU(gpuNode)) {
+        LOG() << "Skipping test on APU." << std::endl;
+        return;
+    }
+
+    int BufSize = PAGE_SIZE;
+    HsaSVMRange sysBuffer(BufSize, gpuNode);
+    HSAuint32 *pBuf = sysBuffer.As<HSAuint32 *>();
+
+    /* Force the range to actually be mapped to the GPU before revoking. */
+    SDMAQueue sdmaQueue;
+    ASSERT_SUCCESS_GPU(sdmaQueue.Create(gpuNode), gpuNode);
+    sdmaQueue.PlaceAndSubmitPacket(SDMAWriteDataPacket(sdmaQueue.GetFamilyId(),
+                                   pBuf, 0x12345678));
+    sdmaQueue.Wait4PacketConsumption();
+    EXPECT_TRUE_GPU(WaitOnValue(pBuf, 0x12345678), gpuNode);
+    EXPECT_SUCCESS_GPU(sdmaQueue.Destroy(), gpuNode);
+
+    pthread_barrier_t barrier;
+    ASSERT_SUCCESS(pthread_barrier_init(&barrier, NULL, 2));
+    volatile int stop = 0;
+    struct NoAccessEventParams pArgs = {gpuNode, &barrier, &stop, 0, 0};
+    uint64_t threadId;
+    ASSERT_EQ(true, StartThread(&CountSMIEventThread, &pArgs, threadId));
+    pthread_barrier_wait(&barrier);
+
+    /* Revoke GPU access: must silently unmap, never evict queues. */
+    HSA_SVM_ATTRIBUTE attr;
+    attr.type = HSA_SVM_ATTR_NO_ACCESS;
+    attr.value = (HSAuint32)gpuNode;
+    EXPECT_SUCCESS_GPU(HSAKMT_CALL(hsaKmtSVMSetAttr, m_hsakmt_current_ctx,
+                                   pBuf, BufSize, 1, &attr), gpuNode);
+
+    /* Drop pages the way an allocator would; range already unmapped => no evict. */
+    madvise(pBuf, BufSize, MADV_DONTNEED);
+
+    usleep(200000);
+    stop = 1;
+    WaitForThread(threadId);
+
+    EXPECT_EQ_GPU(pArgs.queue_eviction, 0, gpuNode);
+    EXPECT_GE_GPU(pArgs.unmap_from_gpu, 1, gpuNode);
+
+    ASSERT_SUCCESS(pthread_barrier_destroy(&barrier));
+}
+
+TEST_P(KFDSVMRangeTest, NoAccessUnmapTest) {
+    TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
+    TEST_START(TESTPROFILE_RUNALL);
+    ASSERT_SUCCESS(KFDTestLaunch([this](int gpuNode) {
+        this->NoAccessUnmapTest(gpuNode);
+    }));
+    TEST_END;
+}
+
+
 TEST_P(KFDSVMRangeTest, HMMProfilingEvent) {
     TEST_REQUIRE_ENV_CAPABILITIES(ENVCAPS_64BITLINUX);
     TEST_START(TESTPROFILE_RUNALL);

--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.hpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDSVMRangeTest.hpp
@@ -51,6 +51,7 @@ class KFDSVMRangeTest : public KFDBaseComponentTest,
     void MultiThreadMigrationTest(int gpuNode);
     void MigrateFileBackedRangeTest(int gpuNode);
     void HMMProfilingEvent(int gpuNode);
+    void NoAccessUnmapTest(int gpuNode);
     void VramOvercommitTest(int gpuNode);
     void PrefaultPartialRangeTest(int gpuNode);
 


### PR DESCRIPTION
Add a regression test for the KFD SVM NO_ACCESS behavior: applying KFD_IOCTL_SVM_ATTR_NO_ACCESS to a range that is mapped to a GPU must silently unmap it (KFD_SMI_EVENT_UNMAP_FROM_GPU) and must NOT trigger a queue eviction (KFD_SMI_EVENT_QUEUE_EVICTION).

The test maps an SVM range to the GPU via an SDMA write, subscribes to the KFD SMI event stream on a helper thread, sets NO_ACCESS for the GPU, and then issues madvise(MADV_DONTNEED) to mimic an allocator returning the pages. It asserts that at least one UNMAP_FROM_GPU event is seen and zero QUEUE_EVICTION events occur.

On a kernel without the no-access unmap support the same sequence produces a QUEUE_EVICTION and no UNMAP_FROM_GPU, so the test fails, making it an effective guard against regressing the unmap-not-evict behavior.

## Motivation

Applying `KFD_IOCTL_SVM_ATTR_NO_ACCESS` to an SVM range that is mapped to a GPU must silently unmap the range from the GPU (emitting `KFD_SMI_EVENT_UNMAP_FROM_GPU`) and must not trigger a queue eviction (`KFD_SMI_EVENT_QUEUE_EVICTION`). This unmap-not-evict behavior is what prevents the queue-eviction storm under allocator page-decay workloads (e.g. an allocator calling `madvise(MADV_DONTNEED)` on ranges that were auto-registered for GPU access). There was no kfdtest coverage exercising this path, so a regression in it would go undetected. This PR adds a focused regression test that guards the behavior.

## Technical Details

Adds `KFDSVMRangeTest.NoAccessUnmapTest`:

- Allocates an SVM range and maps it to the GPU via an SDMA write (so the range is actually mapped before access is revoked).
- Subscribes to the KFD SMI event stream on a helper thread, reusing the existing `hsaKmtOpenSMI` pattern already used by `HMMProfilingEvent`.
- Sets `KFD_IOCTL_SVM_ATTR_NO_ACCESS` for the GPU.
- Issues `madvise(MADV_DONTNEED)` to mimic an allocator returning the pages.
- Asserts at least one `UNMAP_FROM_GPU` event and zero `QUEUE_EVICTION` events.

Files changed: `tests/kfdtest/src/KFDSVMRangeTest.cpp`,
`tests/kfdtest/src/KFDSVMRangeTest.hpp`.

## JIRA ID

N/A

## Test Plan

On a discrete GPU with SVM/HMM support:

```
kfdtest --gtest_filter="*NoAccessUnmapTest*"
```

Run against both (a) a kernel that has the SVM no-access unmap support and (b) a kernel without it, to confirm the test passes only when the behavior is present.

## Test Result

- Kernel with no-access unmap support: PASS — `UNMAP_FROM_GPU` observed, zero `QUEUE_EVICTION`.
- Kernel without it: FAIL — `QUEUE_EVICTION` observed and no `UNMAP_FROM_GPU`, confirming the test is an effective guard against regressing the unmap-not-evict behavior.

Validated on an MI355X system (8 GPUs), per-GPU test instances.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.