### PR TITLE
rocprofiler-sdk: Fix RPM CI dependency installs to use ROCm lib directory

### DIFF
--- a/.github/actions/rocprofiler-sdk-util/action.yml
+++ b/.github/actions/rocprofiler-sdk-util/action.yml
@@ -110,6 +110,7 @@ runs:
           -DCMAKE_CXX_COMPILER=${{ inputs.rocm-path }}/llvm/bin/clang++ \
           -DCMAKE_PREFIX_PATH='${{ inputs.rocm-path }};${{ inputs.rocm-path }}/llvm' \
           -DCMAKE_INSTALL_PREFIX=${{ inputs.rocm-path }} \
+          -DCMAKE_INSTALL_LIBDIR=lib \
           .
         cmake --build build --target all --parallel ${{ inputs.build-jobs }}
         cmake --build build --target install
@@ -130,6 +131,7 @@ runs:
           -DHIP_PLATFORM=amd \
           -DCMAKE_PREFIX_PATH='${{ inputs.rocm-path }};${{ inputs.rocm-path }}/llvm' \
           -DCMAKE_INSTALL_PREFIX=${{ inputs.rocm-path }} \
+          -DCMAKE_INSTALL_LIBDIR=lib \
           -DHIP_LLVM_ROOT=${{ inputs.rocm-path }}/llvm \
           -DHIP_CATCH_TEST=0 \
           -DCLR_BUILD_HIP=ON \
@@ -151,6 +153,7 @@ runs:
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DCMAKE_PREFIX_PATH=${{ inputs.rocm-path }} \
           -DCMAKE_INSTALL_PREFIX=${{ inputs.rocm-path }} \
+          -DCMAKE_INSTALL_LIBDIR=lib \
           -DCMAKE_C_COMPILER_LAUNCHER=${{ inputs.compiler-launcher }} \
           -DCMAKE_CXX_COMPILER_LAUNCHER=${{ inputs.compiler-launcher }} \
           .
@@ -168,6 +171,7 @@ runs:
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DCMAKE_PREFIX_PATH=${{ inputs.rocm-path }} \
           -DCMAKE_INSTALL_PREFIX=${{ inputs.rocm-path }} \
+          -DCMAKE_INSTALL_LIBDIR=lib \
           -DCMAKE_C_COMPILER_LAUNCHER=${{ inputs.compiler-launcher }} \
           -DCMAKE_CXX_COMPILER_LAUNCHER=${{ inputs.compiler-launcher }} \
           .
@@ -182,6 +186,7 @@ runs:
         echo "Building & Installing ROCDecode..."
         cmake -B build-rocdecode \
           -DCMAKE_INSTALL_PREFIX=${{ inputs.rocm-path }} \
+          -DCMAKE_INSTALL_LIBDIR=lib \
           -DCMAKE_PREFIX_PATH=${{ inputs.rocm-path }} \
           -DCMAKE_CXX_COMPILER=${{ inputs.rocm-path }}/lib/llvm/bin/amdclang++ \
           -DCMAKE_C_COMPILER_LAUNCHER=${{ inputs.compiler-launcher }} \
@@ -198,6 +203,7 @@ runs:
         echo "Building & Installing ROCJPEG..."
         cmake -B build-rocjpeg \
           -DCMAKE_INSTALL_PREFIX=${{ inputs.rocm-path }} \
+          -DCMAKE_INSTALL_LIBDIR=lib \
           -DCMAKE_PREFIX_PATH=${{ inputs.rocm-path }} \
           -DCMAKE_CXX_COMPILER=${{ inputs.rocm-path }}/lib/llvm/bin/amdclang++ \
           -DCMAKE_C_COMPILER_LAUNCHER=${{ inputs.compiler-launcher }} \
@@ -219,6 +225,7 @@ runs:
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DCMAKE_PREFIX_PATH=${{ inputs.rocm-path }} \
           -DCMAKE_INSTALL_PREFIX=${{ inputs.rocm-path }} \
+          -DCMAKE_INSTALL_LIBDIR=lib \
           -DCMAKE_C_COMPILER_LAUNCHER=${{ inputs.compiler-launcher }} \
           -DCMAKE_CXX_COMPILER_LAUNCHER=${{ inputs.compiler-launcher }} \
           .


### PR DESCRIPTION
## Motivation

This PR updates the shared rocprofiler-sdk-util composite GitHub Action to force CMake installs of several ROCm dependency components to use the ROCm lib/ directory (instead of potentially defaulting to lib64/ on RPM-based systems), improving CI dependency installation consistency.
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
