### PR TITLE
ci(rocprofiler-sdk): remove `ROCPROFILER_INTERNAL_RCCL_API_TRACE`

### DIFF
--- a/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
+++ b/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
@@ -248,7 +248,6 @@ jobs:
             -- \
             -DROCPROFILER_DEP_ROCMCORE=ON \
             -DROCPROFILER_BUILD_DOCS=OFF \
-            -DROCPROFILER_INTERNAL_RCCL_API_TRACE=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.system.build-type }} \
             -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }};${{ env.ROCM_PATH }}/llvm' \
             -DPython3_EXECUTABLE=$(which python3) \

--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -257,7 +257,6 @@ jobs:
           --coverage all
           --run-attempt ${{ github.run_attempt }}
           --
-          -DROCPROFILER_INTERNAL_RCCL_API_TRACE=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.system.build-type }}
           -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }};${{ env.ROCM_PATH }}/llvm'
           -DPython3_EXECUTABLE=$(which python3)
@@ -280,7 +279,6 @@ jobs:
           --coverage tests
           --run-attempt ${{ github.run_attempt }}
           --
-          -DROCPROFILER_INTERNAL_RCCL_API_TRACE=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.system.build-type }}
           -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }};${{ env.ROCM_PATH }}/llvm'
           -DPython3_EXECUTABLE=$(which python3)
@@ -303,7 +301,6 @@ jobs:
           --coverage samples
           --run-attempt ${{ github.run_attempt }}
           --
-          -DROCPROFILER_INTERNAL_RCCL_API_TRACE=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.system.build-type }}
           -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }};${{ env.ROCM_PATH }}/llvm'
           -DPython3_EXECUTABLE=$(which python3)

--- a/.github/workflows/rocprofiler-sdk-codeql.yml
+++ b/.github/workflows/rocprofiler-sdk-codeql.yml
@@ -40,7 +40,7 @@ env:
   PATH: "/usr/bin:$PATH"
   SUBMODULE_PATHS: "projects/rocprofiler-sdk projects/clr projects/hip"
   EXCLUDED_PATHS: "external /tmp/build/external"
-  GLOBAL_CMAKE_OPTIONS: "-DROCPROFILER_INTERNAL_RCCL_API_TRACE=ON"
+  GLOBAL_CMAKE_OPTIONS: ""
   ENABLE_ROCR_BUILD: "false"
   ENABLE_HIP_CLR_BUILD: "false"
   ENABLE_ROCPROFILER_REGISTER_BUILD: "false"

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -251,7 +251,6 @@ jobs:
             ${{ matrix.system.ci-flags }} -- \
             -DROCPROFILER_DEP_ROCMCORE=ON \
             -DROCPROFILER_BUILD_DOCS=OFF \
-            -DROCPROFILER_INTERNAL_RCCL_API_TRACE=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.system.build-type }} \
             -DCMAKE_INSTALL_PREFIX=/opt/rocprofiler-sdk \
             -DCPACK_GENERATOR='DEB;RPM;TGZ' \
@@ -465,7 +464,6 @@ jobs:
             -- \
             -DROCPROFILER_DEP_ROCMCORE=ON \
             -DROCPROFILER_BUILD_DOCS=OFF \
-            -DROCPROFILER_INTERNAL_RCCL_API_TRACE=ON \
             -DCMAKE_BUILD_TYPE=${{ matrix.system.build-type }} \
             -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }};${{ env.ROCM_PATH }}/llvm' \
             -DPython3_EXECUTABLE=$(which python3) \
@@ -604,7 +602,6 @@ jobs:
           --memcheck ${{ matrix.system.sanitizer }} \
           --run-attempt ${{ github.run_attempt }} \
           -- \
-          -DROCPROFILER_INTERNAL_RCCL_API_TRACE=ON \
           -DCMAKE_BUILD_TYPE=${{ matrix.system.build-type }} \
           -DCMAKE_INSTALL_PREFIX="${{ env.ROCM_PATH }}" \
           -DCMAKE_PREFIX_PATH='${{ env.ROCM_PATH }};${{ env.ROCM_PATH }}/llvm' \


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Re-enable building with upstream RCCL headers. 

Originally was a part of PR #7138, but the PR fixes the cudaStream_t in the header, so for CI stability, this change was dropped from that PR. After containers pick up the fixed header, this PR can be merged. 

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
