### PR TITLE
[hipFile] Fix remaining ASAN issues in unit tests.

### DIFF
--- a/projects/hipfile/test/amd_detail/async.cpp
+++ b/projects/hipfile/test/amd_detail/async.cpp
@@ -26,7 +26,9 @@
 
 #include <array>
 #include <cerrno>
+#include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <hip/hip_runtime_api.h>
@@ -36,9 +38,12 @@
 #include <string>
 #include <system_error>
 #include <sys/types.h>
+#include <thread>
 #include <tuple>
 #include <utility>
 #include <variant>
+
+using namespace std::chrono_literals;
 
 // Put tests inside the macros to suppress the global constructor
 // warnings
@@ -488,12 +493,6 @@ TEST_P(FallbackAsyncIO, mismatchingGpuIdsThrows)
 
 TEST_P(FallbackAsyncIO, attemptToQueueCleanupOnStreamSubmissionFailure)
 {
-    /* This test will log some errors about async operations being outstanding and being unable to free
-     * memory. The outstanding operations occur because async_io_cleanup is not run. Some memory is unable to
-     * be freed, due to being alloced with malloc, and attempted to be freed with hipHostFree.  This happens
-     * because we mock the allocation of the pinned memory, but the mocks are destructed before the
-     * AsyncOpFallback destructor runs, so we can't mock the deallocation of the pinned memory.
-     */
     EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(1024 * 1024));
     EXPECT_CALL(*mbuffer, getGpuId).Times(AnyNumber()).WillRepeatedly(Return(0));
     EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<hipStream_t>(0xBADBADBB)));
@@ -511,8 +510,8 @@ TEST_P(FallbackAsyncIO, attemptToQueueCleanupOnStreamSubmissionFailure)
         .WillOnce(Return(reinterpret_cast<void *>(0xDEBBBBBB)));
     EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(op_data), _))
         .WillOnce(Return(reinterpret_cast<void *>(0xDE000000)));
-    // EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
-    // EXPECT_CALL(mhip, hipHostFree(Eq(op_data.get())));
+    EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer))).WillOnce([](void *ptr) { free(ptr); });
+    EXPECT_CALL(mhip, hipHostFree(Eq(op_data))).WillOnce([](void *ptr) { free(ptr); });
     EXPECT_CALL(mhip, hipDeviceGetAttribute).WillOnce(Return(1024));
     EXPECT_CALL(*mstream, getLock);
     EXPECT_CALL(*mstream, getHipStream).Times(AnyNumber());
@@ -522,6 +521,10 @@ TEST_P(FallbackAsyncIO, attemptToQueueCleanupOnStreamSubmissionFailure)
     EXPECT_THROW(Fallback().async_io(io_type, mfile, mbuffer, &size, &file_offset, &buffer_offset,
                                      &bytes_written, mstream),
                  Hip::RuntimeError);
+    // Call to allow destruction of the op and bounce buffer
+    async_io_cleanup(op_data);
+    // Sleep to allow cleanup thread to destruct op
+    std::this_thread::sleep_for(500ms);
 }
 
 INSTANTIATE_TEST_SUITE_P(FallbackAsyncIOSuite, FallbackAsyncIO,

--- a/projects/hipfile/test/amd_detail/async.cpp
+++ b/projects/hipfile/test/amd_detail/async.cpp
@@ -27,6 +27,7 @@
 #include <array>
 #include <cerrno>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <gmock/gmock.h>
@@ -62,14 +63,10 @@ using ::testing::Throw;
 using ::testing::Values;
 using ::testing::WithParamInterface;
 
-// Wrap a `new T[n]` allocation in a shared_ptr<void> with a deleter that
-// uses delete[], avoiding the alloc-dealloc-mismatch with shared_ptr<void>'s
-// default deleter.
-template <typename T>
 static std::shared_ptr<void>
-make_shared_array(std::size_t n)
+make_shared_void(std::size_t num_bytes)
 {
-    return std::shared_ptr<void>(new T[n], [](void *p) { delete[] static_cast<T *>(p); });
+    return std::static_pointer_cast<void>(std::make_shared<std::byte[]>(num_bytes));
 }
 
 struct HipFileAsyncOp : public Test {
@@ -160,8 +157,8 @@ TEST_F(HipFileAsyncOp, AsyncOpFallback_new_uses_pinned_host_memory)
     hoff_t  file_offset       = 0;
     hoff_t  buffer_offset     = 0;
     ssize_t bytes_transferred = 0;
-    auto    op_data           = make_shared_array<uint8_t>(sizeof(AsyncOpFallback));
-    auto    bounce_buffer     = make_shared_array<uint8_t>(size);
+    auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
+    auto    bounce_buffer     = make_shared_void(size);
     EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
     EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
     EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
@@ -176,8 +173,8 @@ TEST_F(HipFileAsyncOp, AsyncOpFallbackLimitsMaxIoSize)
     hoff_t  file_offset       = 0;
     hoff_t  buffer_offset     = 0;
     ssize_t bytes_transferred = 0;
-    auto    op_data           = make_shared_array<uint8_t>(sizeof(AsyncOpFallback));
-    auto    bounce_buffer     = make_shared_array<uint8_t>(1_KiB);
+    auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
+    auto    bounce_buffer     = make_shared_void(1_KiB);
     EXPECT_CALL(mhip, hipHostMalloc(hipFile::getMaxRwCount(), _)).WillOnce(Return(bounce_buffer.get()));
     EXPECT_CALL(mhip, hipHostMalloc(sizeof(AsyncOpFallback), _)).WillOnce(Return(op_data.get()));
     EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
@@ -194,7 +191,7 @@ TEST_F(HipFileAsyncOp, AsyncOpFallback_new_failure_throws_bad_alloc)
     hoff_t  file_offset       = 0;
     hoff_t  buffer_offset     = 0;
     ssize_t bytes_transferred = 0;
-    auto    op_data           = make_shared_array<uint8_t>(sizeof(AsyncOpFallback));
+    auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
     EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Throw(Hip::RuntimeError(hipErrorOutOfMemory)));
     EXPECT_THROW(std::shared_ptr<AsyncOpFallback>(new AsyncOpFallback{IoType::Read, file, buffer, stream,
                                                                       &size, &file_offset, &buffer_offset,
@@ -208,7 +205,7 @@ TEST_F(HipFileAsyncOp, AsyncOpFallback_bounce_alloc_failure_throws)
     hoff_t  file_offset       = 0;
     hoff_t  buffer_offset     = 0;
     ssize_t bytes_transferred = 0;
-    auto    op_data           = make_shared_array<uint8_t>(sizeof(AsyncOpFallback));
+    auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
     EXPECT_CALL(mhip, hipHostMalloc)
         .WillOnce(Return(op_data.get()))
         .WillOnce(Throw(Hip::RuntimeError(hipErrorOutOfMemory)));
@@ -225,8 +222,8 @@ TEST_F(HipFileAsyncOp, AsyncOpFallback_bounce_buffer_deleter_failure_calls_syslo
     hoff_t  file_offset       = 0;
     hoff_t  buffer_offset     = 0;
     ssize_t bytes_transferred = 0;
-    auto    op_data           = make_shared_array<uint8_t>(sizeof(AsyncOpFallback));
-    auto    bounce_buffer     = make_shared_array<uint8_t>(size);
+    auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
+    auto    bounce_buffer     = make_shared_void(size);
     EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
     EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
     EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())))
@@ -243,8 +240,8 @@ TEST_F(HipFileAsyncOp, AsyncOpFallback_delete_failure_calls_syslog)
     hoff_t  file_offset       = 0;
     hoff_t  buffer_offset     = 0;
     ssize_t bytes_transferred = 0;
-    auto    op_data           = make_shared_array<uint8_t>(sizeof(AsyncOpFallback));
-    auto    bounce_buffer     = make_shared_array<uint8_t>(size);
+    auto    op_data           = make_shared_void(sizeof(AsyncOpFallback));
+    auto    bounce_buffer     = make_shared_void(size);
     EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data.get())).WillOnce(Return(bounce_buffer.get()));
     EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer.get()), _));
     EXPECT_CALL(mhip, hipHostFree(Eq(bounce_buffer.get())));
@@ -256,7 +253,7 @@ TEST_F(HipFileAsyncOp, AsyncOpFallback_delete_failure_calls_syslog)
 }
 
 struct HipFileAsyncOpFallbackMethods : public HipFileAsyncOp {
-    HipFileAsyncOpFallbackMethods() : bounce_buffer{make_shared_array<uint8_t>(size)}
+    HipFileAsyncOpFallbackMethods() : bounce_buffer{make_shared_void(size)}
     {
         //  make_shared uses placement new, which will not use hipHostMalloc/hipHostFree for
         //  AsyncOpFallback
@@ -539,8 +536,8 @@ struct AsyncIoOp : public ::testing::Test {
     }
     void SetUp() override
     {
-        op_data       = make_shared_array<uint8_t>(sizeof(AsyncOpFallback));
-        bounce_buffer = make_shared_array<uint8_t>(size);
+        op_data       = make_shared_void(sizeof(AsyncOpFallback));
+        bounce_buffer = make_shared_void(size);
         EXPECT_CALL(mhip, hipHostMalloc)
             .WillOnce(Return(op_data.get()))
             .WillOnce(Return(bounce_buffer.get()));

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -18,6 +18,7 @@
 #include <cstdio>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <utility>
@@ -135,7 +136,7 @@ TEST_F(HipFileBatch, CreateOperationBadFileOffsetIsNegative)
 
 TEST_F(HipFileBatch, CreateOperationBadOpcode)
 {
-    io_params->opcode = invalidEnum<hipFileOpcode_t>(-1);
+    io_params->opcode = invalidEnum<hipFileOpcode_t>(maxEnum<hipFileOpcode_t>());
 
     EXPECT_THROW(BatchOperation(std::move(io_params), default_mock_buffer, default_mock_file),
                  std::invalid_argument);
@@ -143,7 +144,7 @@ TEST_F(HipFileBatch, CreateOperationBadOpcode)
 
 TEST_F(HipFileBatch, CreateOperationBadMode)
 {
-    io_params->mode = invalidEnum<hipFileBatchMode_t>(-1);
+    io_params->mode = invalidEnum<hipFileBatchMode_t>(maxEnum<hipFileBatchMode_t>());
 
     EXPECT_THROW(BatchOperation(std::move(io_params), default_mock_buffer, default_mock_file),
                  std::invalid_argument);
@@ -336,14 +337,14 @@ TEST_F(HipFileBatchContext, SubmitSingleBadParamFileOffsetNegative)
 TEST_F(HipFileBatchContext, SubmitSingleBadParamOpcodeInvalid)
 {
     hipFileIOParams_t bad_io_params = io_params;
-    bad_io_params.opcode            = invalidEnum<hipFileOpcode_t>(-1);
+    bad_io_params.opcode            = invalidEnum<hipFileOpcode_t>(maxEnum<hipFileOpcode_t>());
     ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
 }
 
 TEST_F(HipFileBatchContext, SubmitSingleBadParamModeInvalid)
 {
     hipFileIOParams_t bad_io_params = io_params;
-    bad_io_params.mode              = invalidEnum<hipFileBatchMode_t>(-1);
+    bad_io_params.mode              = invalidEnum<hipFileBatchMode_t>(maxEnum<hipFileBatchMode_t>());
     ASSERT_THROW(_context->submit_operations(&bad_io_params, 1), std::invalid_argument);
 }
 

--- a/projects/hipfile/test/common/invalid-enum.h
+++ b/projects/hipfile/test/common/invalid-enum.h
@@ -3,11 +3,26 @@
  * SPDX-License-Identifier: MIT
  */
 
-// Create an invalid enum value without causing compiler errors. This works for
-// enums that use int as the underlying type
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <utility>
+
+template <typename Enum> using promoted_enum_t = decltype(+std::declval<Enum>());
+
 template <typename Enum>
 constexpr Enum
-invalidEnum(int value)
+invalidEnum(std::underlying_type_t<Enum> value)
 {
     return static_cast<Enum>(value); // NOLINT(clang-analyzer-optin.core.EnumCastOutOfRange)
+}
+
+// Return the max enum value representable by the result of integral promotion and the underlying type
+template <typename Enum>
+constexpr auto
+maxEnum()
+{
+    return std::min<std::uintmax_t>(std::numeric_limits<std::underlying_type_t<Enum>>::max(),
+                                    std::numeric_limits<promoted_enum_t<Enum>>::max());
 }

--- a/projects/hipfile/test/nvidia_detail/cufile-api-compat.cpp
+++ b/projects/hipfile/test/nvidia_detail/cufile-api-compat.cpp
@@ -28,7 +28,8 @@ HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
 
 TEST(ToHipFile, hipFileOpError_t)
 {
-    ASSERT_THROW(toHipFileOpError(invalidEnum<CUfileOpError>(CU_FILE_SUCCESS - 1)), std::invalid_argument);
+    ASSERT_THROW(toHipFileOpError(invalidEnum<CUfileOpError>(maxEnum<CUfileOpError>())),
+                 std::invalid_argument);
     ASSERT_THROW(toHipFileOpError(invalidEnum<CUfileOpError>(CU_FILE_SUCCESS + 1)), std::invalid_argument);
 
     ASSERT_THROW(toHipFileOpError(invalidEnum<CUfileOpError>(CUFILEOP_BASE_ERR)), std::invalid_argument);
@@ -82,9 +83,9 @@ TEST(ToHipFile, hipFileOpError_t)
 
 TEST(ToHipFile, hipFileError_t)
 {
-    ASSERT_THROW(
-        (void)toHipFileError(CUfileError_t{invalidEnum<CUfileOpError>(CU_FILE_SUCCESS - 1), CUDA_SUCCESS}),
-        std::invalid_argument);
+    ASSERT_THROW((void)toHipFileError(
+                     CUfileError_t{invalidEnum<CUfileOpError>(maxEnum<CUfileOpError>()), CUDA_SUCCESS}),
+                 std::invalid_argument);
 
     ASSERT_EQ(toHipFileError(CUfileError_t{CU_FILE_SUCCESS, CUDA_SUCCESS}), HIPFILE_SUCCESS);
     ASSERT_EQ(toHipFileError(CUfileError_t{CU_FILE_CUDA_DRIVER_ERROR, CUDA_ERROR_INVALID_VALUE}),
@@ -164,7 +165,7 @@ TEST(ToHipFile, hipFileIOEvents_t)
 TEST(ToCufile, CUFileSizeTConfigParameter_t)
 {
     ASSERT_THROW(toCUFileSizeTConfigParameter(
-                     invalidEnum<hipFileSizeTConfigParameter_t>(hipFileParamProfileStats - 1)),
+                     invalidEnum<hipFileSizeTConfigParameter_t>(maxEnum<hipFileSizeTConfigParameter_t>())),
                  std::invalid_argument);
 
 #define h2c(H, C) ASSERT_EQ(toCUFileSizeTConfigParameter((H)), (C))
@@ -191,7 +192,7 @@ TEST(ToCufile, CUFileSizeTConfigParameter_t)
 TEST(ToCufile, CUFileBoolConfigParameter_t)
 {
     ASSERT_THROW(toCUFileBoolConfigParameter(
-                     invalidEnum<hipFileBoolConfigParameter_t>(hipFileParamPropertiesUsePollMode - 1)),
+                     invalidEnum<hipFileBoolConfigParameter_t>(maxEnum<hipFileBoolConfigParameter_t>())),
                  std::invalid_argument);
 
 #define h2c(H, C) ASSERT_EQ(toCUFileBoolConfigParameter((H)), (C))
@@ -217,7 +218,7 @@ TEST(ToCufile, CUFileBoolConfigParameter_t)
 TEST(ToCufile, CUFileStringConfigParameter_t)
 {
     ASSERT_THROW(toCUFileStringConfigParameter(
-                     invalidEnum<hipFileStringConfigParameter_t>(hipFileParamLoggingLevel - 1)),
+                     invalidEnum<hipFileStringConfigParameter_t>(maxEnum<hipFileStringConfigParameter_t>())),
                  std::invalid_argument);
 
 #define h2c(H, C) ASSERT_EQ(toCUFileStringConfigParameter((H)), (C))
@@ -308,7 +309,8 @@ TEST(ToCufile, CUfileBatchMode_t)
 
 TEST(ToCufile, CUfileOpcode_t)
 {
-    ASSERT_THROW(toCUfileOpcode(invalidEnum<hipFileOpcode_t>(hipFileBatchRead - 1)), std::invalid_argument);
+    ASSERT_THROW(toCUfileOpcode(invalidEnum<hipFileOpcode_t>(maxEnum<hipFileOpcode_t>())),
+                 std::invalid_argument);
 
 #define h2c(H, C) ASSERT_EQ(toCUfileOpcode((H)), (C))
     h2c(hipFileBatchRead, CUFILE_READ);


### PR DESCRIPTION
## Motivation

Fix remaining ASAN issues in unit tests.

## Technical Details

- Fix invalid enum tests by using the min(max(underlying_type),max(promoted_type))
- Fix cleanup in async test
- Idiomatic change to async void shared_ptr helper

## JIRA ID

AIHIPFILE-154

## Test Plan

Run unit tests with sanitizers enabled.

## Test Result

Unit tests run cleanly without sanitizer issues.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
