### PR TITLE
[rocjitsu] Improve CMakeLists to use ROCM_PATH

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -3,6 +3,21 @@
 
 cmake_minimum_required(VERSION 3.22)
 
+if(DEFINED ENV{ROCM_PATH} AND NOT "$ENV{ROCM_PATH}" STREQUAL "")
+    set(_RJ_DEFAULT_ROCM_PATH "$ENV{ROCM_PATH}")
+else()
+    set(_RJ_DEFAULT_ROCM_PATH "/opt/rocm")
+endif()
+set(ROCM_PATH
+    "${_RJ_DEFAULT_ROCM_PATH}"
+    CACHE PATH
+    "Path to the ROCm installation"
+)
+unset(_RJ_DEFAULT_ROCM_PATH)
+if(NOT ROCM_PATH OR NOT IS_DIRECTORY "${ROCM_PATH}")
+    message(FATAL_ERROR "ROCM_PATH must be set to a valid directory")
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(rj_default_compiler)
 
@@ -16,11 +31,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Default install prefix to /opt/rocm, matching other ROCm projects.
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    if(DEFINED ENV{ROCM_PATH})
-        set(CMAKE_INSTALL_PREFIX "$ENV{ROCM_PATH}" CACHE PATH "" FORCE)
-    else()
-        set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "" FORCE)
-    endif()
+    set(CMAKE_INSTALL_PREFIX "${ROCM_PATH}" CACHE PATH "" FORCE)
 endif()
 
 include(CTest)

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -3,20 +3,20 @@
 
 cmake_minimum_required(VERSION 3.22)
 
-if(DEFINED ENV{ROCM_PATH} AND NOT "$ENV{ROCM_PATH}" STREQUAL "")
-    set(_RJ_DEFAULT_ROCM_PATH "$ENV{ROCM_PATH}")
-else()
-    set(_RJ_DEFAULT_ROCM_PATH "/opt/rocm")
+set(_RJ_ROCM_PATH_EXPLICIT OFF)
+if(DEFINED ROCM_PATH AND NOT "${ROCM_PATH}" STREQUAL "")
+    set(_RJ_ROCM_PATH_EXPLICIT ON)
+elseif(DEFINED ENV{ROCM_PATH} AND NOT "$ENV{ROCM_PATH}" STREQUAL "")
+    set(_RJ_ROCM_PATH_EXPLICIT ON)
+    set(ROCM_PATH "$ENV{ROCM_PATH}" CACHE PATH "Path to the ROCm installation")
+elseif(IS_DIRECTORY "/opt/rocm")
+    set(ROCM_PATH "/opt/rocm" CACHE PATH "Path to the ROCm installation")
 endif()
-set(ROCM_PATH
-    "${_RJ_DEFAULT_ROCM_PATH}"
-    CACHE PATH
-    "Path to the ROCm installation"
-)
-unset(_RJ_DEFAULT_ROCM_PATH)
-if(NOT ROCM_PATH OR NOT IS_DIRECTORY "${ROCM_PATH}")
+
+if(_RJ_ROCM_PATH_EXPLICIT AND NOT IS_DIRECTORY "${ROCM_PATH}")
     message(FATAL_ERROR "ROCM_PATH must be set to a valid directory")
 endif()
+unset(_RJ_ROCM_PATH_EXPLICIT)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(rj_default_compiler)
@@ -30,7 +30,7 @@ include(rj_version)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Default install prefix to /opt/rocm, matching other ROCm projects.
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND ROCM_PATH)
     set(CMAKE_INSTALL_PREFIX "${ROCM_PATH}" CACHE PATH "" FORCE)
 endif()
 

--- a/emulation/rocjitsu/cmake/rj_add_device_kernel.cmake
+++ b/emulation/rocjitsu/cmake/rj_add_device_kernel.cmake
@@ -5,7 +5,7 @@
 #
 # The -c flag produces a relocatable object with a .hip_fatbin section
 # that contains the Clang offload bundle with the device code object for
-# the specified GPU target. AMDCLANG, ROCM_PATH, and KERNEL_OUTPUT_DIR
+# the specified GPU target. AMDCXX, ROCM_PATH, and KERNEL_OUTPUT_DIR
 # must be set before including this module.
 #
 # Usage: rj_add_device_kernel(<name> <offload_arch>)
@@ -18,7 +18,7 @@ function(rj_add_device_kernel name offload_arch)
     add_custom_command(
         OUTPUT ${out}
         COMMAND
-            ${AMDCLANG} -x hip --offload-arch=${offload_arch}
+            ${AMDCXX} -x hip --offload-arch=${offload_arch}
             --rocm-path=${ROCM_PATH} -fPIC -c -O2 -o ${out} ${src}
         DEPENDS ${src}
         COMMENT "Compiling device kernel: ${name} (${offload_arch})"

--- a/emulation/rocjitsu/cmake/rj_default_compiler.cmake
+++ b/emulation/rocjitsu/cmake/rj_default_compiler.cmake
@@ -1,67 +1,14 @@
 # Copyright (c) 2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-# Default to the ROCm LLVM clang/clang++ if available and the user hasn't
-# specified a compiler via -DCMAKE_CXX_COMPILER or the CC/CXX env vars.
-#
-# The ROCm install provides two compiler entry points:
-#   /opt/rocm/bin/amdclang++        → amdllvm wrapper binary
-#   /opt/rocm/lib/llvm/bin/clang++  → direct symlink to clang-NN
-#
-# CMake's clang-scan-deps (C++20 module dependency scanning) is incompatible
-# with the amdllvm wrapper — it cannot resolve resource headers through it.
-# This module resolves amdclang++ to the sibling clang++ in the same LLVM
-# directory so that both the compiler and the scanner work correctly.
-#
-# Usage: include(rj_default_compiler) before project().
-
-# Resolve amdclang/amdclang++ to their LLVM directory siblings.
-# Given /opt/rocm/bin/amdclang++ (symlink to ../lib/llvm/bin/amdllvm),
-# find /opt/rocm/lib/llvm/bin/clang++ in the same directory.
-function(_rj_resolve_rocm_compiler LANG COMPILER_VAR)
-    if(NOT DEFINED ${COMPILER_VAR})
-        return()
-    endif()
-    get_filename_component(_name "${${COMPILER_VAR}}" NAME)
-    if(NOT _name MATCHES "^amd")
-        return() # Not an amdclang variant; nothing to resolve.
-    endif()
-    # If the user passed just a name (e.g. "amdclang++"), resolve via PATH first.
-    set(_compiler "${${COMPILER_VAR}}")
-    if(NOT IS_ABSOLUTE "${_compiler}")
-        find_program(_resolved "${_compiler}")
-        if(_resolved)
-            set(_compiler "${_resolved}")
-        endif()
-        unset(_resolved CACHE)
-    endif()
-    # Follow the symlink to find the real directory containing clang/clang++.
-    get_filename_component(_real "${_compiler}" REALPATH)
-    get_filename_component(_dir "${_real}" DIRECTORY)
-    if(LANG STREQUAL "C")
-        set(_target "clang")
-    else()
-        set(_target "clang++")
-    endif()
-    if(EXISTS "${_dir}/${_target}")
-        set(${COMPILER_VAR}
-            "${_dir}/${_target}"
-            CACHE FILEPATH
-            "${LANG} compiler"
-            FORCE
-        )
-        message(STATUS "rocjitsu: resolved ${_name} → ${_dir}/${_target}")
-    endif()
-endfunction()
-
 # Auto-detect ROCm LLVM compiler if user hasn't specified one.
+# Usage: include(rj_default_compiler) before project().
 if(NOT DEFINED CMAKE_C_COMPILER AND NOT DEFINED ENV{CC})
     find_program(
         _RJ_CC
-        NAMES amdclang clang
-        PATHS /opt/rocm/bin /opt/rocm/lib/llvm/bin
-        ENV ROCM_PATH
-        PATH_SUFFIXES bin lib/llvm/bin
+        NAMES amdclang
+        PATHS ${ROCM_PATH}
+        PATH_SUFFIXES lib/llvm/bin bin
         NO_DEFAULT_PATH
     )
     if(_RJ_CC)
@@ -74,10 +21,9 @@ endif()
 if(NOT DEFINED CMAKE_CXX_COMPILER AND NOT DEFINED ENV{CXX})
     find_program(
         _RJ_CXX
-        NAMES amdclang++ clang++
-        PATHS /opt/rocm/bin /opt/rocm/lib/llvm/bin
-        ENV ROCM_PATH
-        PATH_SUFFIXES bin lib/llvm/bin
+        NAMES amdclang++
+        PATHS ${ROCM_PATH}
+        PATH_SUFFIXES lib/llvm/bin bin
         NO_DEFAULT_PATH
     )
     if(_RJ_CXX)
@@ -86,7 +32,3 @@ if(NOT DEFINED CMAKE_CXX_COMPILER AND NOT DEFINED ENV{CXX})
     endif()
     unset(_RJ_CXX CACHE)
 endif()
-
-# If the user explicitly passed amdclang/amdclang++, resolve to clang/clang++.
-_rj_resolve_rocm_compiler(C CMAKE_C_COMPILER)
-_rj_resolve_rocm_compiler(CXX CMAKE_CXX_COMPILER)

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -184,9 +184,7 @@ set(RJ_KMD_PRELOAD_ENV
 find_program(
     ROCMINFO_EXECUTABLE
     NAMES rocminfo
-    HINTS ${CMAKE_SOURCE_DIR}/.venv
-    ENV ROCM_PATH
-    /opt/rocm
+    HINTS "${ROCM_PATH}"
     PATH_SUFFIXES bin
     DOC "Path to the rocminfo executable"
 )
@@ -248,13 +246,7 @@ endif()
 
 # --- HSA init test (requires ROCm HSA runtime + CLI launcher) ---
 
-find_library(
-    HSA_RUNTIME64
-    hsa-runtime64
-    PATHS /opt/rocm/lib
-    ENV ROCM_PATH
-    PATH_SUFFIXES lib
-)
+find_library(HSA_RUNTIME64 hsa-runtime64 PATHS "${ROCM_PATH}" PATH_SUFFIXES lib)
 if(HSA_RUNTIME64)
     get_filename_component(RJ_HSA_LIBRARY_DIR "${HSA_RUNTIME64}" DIRECTORY)
     get_filename_component(RJ_HSA_ROCM_ROOT "${RJ_HSA_LIBRARY_DIR}" DIRECTORY)
@@ -296,10 +288,7 @@ if(HSA_RUNTIME64)
         find_program(
             ROCM_AGENT_ENUM
             rocm_agent_enumerator
-            HINTS
-            ENV ROCM_PATH
-            ${RJ_HSA_ROCM_ROOT}
-            /opt/rocm
+            HINTS "${ROCM_PATH}"
             PATH_SUFFIXES bin
         )
         set(HAS_DBT_VECTOR_ADD_GPU FALSE)
@@ -546,13 +535,7 @@ endif()
 
 # --- HIP tests (requires hipcc + CLI launcher) ---
 
-find_program(
-    HIPCC_EXECUTABLE
-    hipcc
-    PATHS /opt/rocm/bin
-    ENV ROCM_PATH
-    PATH_SUFFIXES bin
-)
+find_program(HIPCC_EXECUTABLE hipcc PATHS "${ROCM_PATH}" PATH_SUFFIXES bin)
 if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
     set(GTEST_INC ${googletest_SOURCE_DIR}/googletest/include)
     set(GTEST_LIB_DIR ${CMAKE_BINARY_DIR}/lib)
@@ -627,13 +610,7 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
     rj_add_hip_test(hip_ds_transpose_acc_test)
 
     # --- RCCL collective test ---
-    find_library(
-        RCCL_LIB
-        rccl
-        PATHS /opt/rocm/lib
-        ENV ROCM_PATH
-        PATH_SUFFIXES lib
-    )
+    find_library(RCCL_LIB rccl PATHS "${ROCM_PATH}" PATH_SUFFIXES lib)
     if(RCCL_LIB)
         rj_add_hip_test(hip_rccl_test EXTRA_LIBS ${RCCL_LIB})
         message(STATUS "RCCL collective test enabled (found ${RCCL_LIB})")
@@ -697,13 +674,7 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
     endif()
 
     # --- rocBLAS GEMM test ---
-    find_library(
-        ROCBLAS_LIB
-        rocblas
-        PATHS /opt/rocm/lib
-        ENV ROCM_PATH
-        PATH_SUFFIXES lib
-    )
+    find_library(ROCBLAS_LIB rocblas PATHS "${ROCM_PATH}" PATH_SUFFIXES lib)
     if(ROCBLAS_LIB)
         rj_add_hip_test(hip_gemm_test EXTRA_LIBS ${ROCBLAS_LIB})
         rj_add_hip_test(hip_gemm_test_cdna3 ARCH gfx942 SOURCE hip_gemm_test.cpp EXTRA_LIBS ${ROCBLAS_LIB})

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -16,16 +16,15 @@
 # from that wrapper gives /usr, which mixes headers and device libraries from
 # different installs.
 find_program(
-    AMDCLANG
+    AMDCXX
     amdclang++
-    HINTS
-    ENV ROCM_PATH
-    /opt/rocm
-    PATH_SUFFIXES bin
+    PATHS ${ROCM_PATH}
+    PATH_SUFFIXES lib/llvm/bin bin
     DOC "Path to the ROCm amdclang++ compiler"
+    NO_DEFAULT_PATH
 )
 
-if(NOT AMDCLANG)
+if(NOT AMDCXX)
     message(
         STATUS
         "amdclang++ not found - device kernel tests will be disabled"
@@ -41,14 +40,10 @@ if(DEFINED SKIP_DEVICE_KERNELS AND SKIP_DEVICE_KERNELS)
     return()
 endif()
 
-message(STATUS "Found amdclang++: ${AMDCLANG}")
+message(STATUS "Using device compiler: ${AMDCXX}")
 
 set(KERNEL_OUTPUT_DIR ${CMAKE_BINARY_DIR}/kernels)
 file(MAKE_DIRECTORY ${KERNEL_OUTPUT_DIR})
-
-# Locate the ROCm installation root for --rocm-path.
-get_filename_component(ROCM_PATH "${AMDCLANG}" DIRECTORY)
-get_filename_component(ROCM_PATH "${ROCM_PATH}" DIRECTORY)
 
 include(rj_add_device_kernel)
 
@@ -68,7 +63,7 @@ function(rj_add_triton_asm_fixture name target)
     add_custom_command(
         OUTPUT ${asm_obj}
         COMMAND
-            ${AMDCLANG} -x assembler -target amdgcn-amd-amdhsa -mcpu=${target}
+            ${AMDCXX} -x assembler -target amdgcn-amd-amdhsa -mcpu=${target}
             --rocm-path=${ROCM_PATH} -c -o ${asm_obj}
             ${CMAKE_CURRENT_SOURCE_DIR}/${name}.s
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${name}.s
@@ -77,7 +72,7 @@ function(rj_add_triton_asm_fixture name target)
     add_custom_command(
         OUTPUT ${hsaco}
         COMMAND
-            ${AMDCLANG} -target amdgcn-amd-amdhsa -mcpu=${target}
+            ${AMDCXX} -target amdgcn-amd-amdhsa -mcpu=${target}
             --rocm-path=${ROCM_PATH} -nostdlib -shared -o ${hsaco} ${asm_obj}
         DEPENDS ${asm_obj}
         COMMENT "Linking Triton fixture: ${name} (${target})"


### PR DESCRIPTION
## Motivation

ROCM_PATH differs between global installs via the package manager and pip install nightly. This makes it cumbersome to use one or the other.

## Technical Details

In the global install the `rocm-sdk path --bin` is configured well and works, but in the nightly installed, the `rocm-sdk path --bin` amdclang and amdclang++ do not behave well. Both however have `roc-sdk path --root`/lib/llvm/bin which contains amdclang and amdclang++.

## Test Plan

Build with pip install nightly and the rocm from the package manager.

## Test Result

Both build succeeds.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
