### PR TITLE
[RCCL] Gate Direct AllGather/ReduceScatter per-op INFO logs

### DIFF
--- a/projects/rccl/src/collectives.cc
+++ b/projects/rccl/src/collectives.cc
@@ -259,7 +259,7 @@ ncclResult_t ncclAllGather_impl(const void* sendbuff, void* recvbuff, size_t sen
     case RCCL_AG_HIERARCHICAL:
     return ncclHierarchicalAllGather_Impl(sendbuff, recvbuff, sendcount, datatype, comm, stream);
     case RCCL_AG_DIRECT:
-    INFO(NCCL_INIT, "RCCL DIRECT ALLGATHER count = %zu, msgSize = %zu, comm = %p, stream = %p, rank = %d, sendbuff = %p, recvbuff = %p",
+    INFO(NCCL_TUNING, "RCCL DIRECT ALLGATHER count = %zu, msgSize = %zu, comm = %p, stream = %p, rank = %d, sendbuff = %p, recvbuff = %p",
       sendcount, msgSize, comm, stream, rank, sendbuff, recvbuff);
     // Use direct allgather (only when not in a group; in-group use Ring so
     // ncclGroupSimulateEnd gets estimatedTime).
@@ -587,7 +587,7 @@ ncclResult_t ncclReduceScatter_impl(const void* sendbuff, void* recvbuff, size_t
   }
 
   if (!symEligible && rcclUseReduceScatterDirect(comm, msgSize)) {
-    INFO(NCCL_INIT, "RCCL DIRECT REDUCE-SCATTER recvcount=%zu msgSize=%zu rank=%d nRanks=%d nNodes=%d comm=%p stream=%p sendbuff=%p recvbuff=%p",
+    INFO(NCCL_TUNING, "RCCL DIRECT REDUCE-SCATTER recvcount=%zu msgSize=%zu rank=%d nRanks=%d nNodes=%d comm=%p stream=%p sendbuff=%p recvbuff=%p",
       recvcount, msgSize, comm->rank, nRanks, comm->nNodes, comm, stream, sendbuff, recvbuff);
 
     // Temporary Buffer to store data from each rank


### PR DESCRIPTION
## Motivation

The per-operation `RCCL DIRECT ALLGATHER` / `RCCL DIRECT REDUCE-SCATTER` diagnostics
were logged under `NCCL_INIT`, which is in the default debug mask (`INIT|BOOTSTRAP|ENV`)
and therefore emitted at the default `NCCL_DEBUG=INFO` level. On the critical path this
interleaves mid-`printf` with the rccl-tests perf table, corrupting benchmark rows
(e.g. the 4 MiB AllGather row on 16/32 ranks) and breaking automated regression parsing.

## Technical Details

Moved both per-op tuning logs in `src/collectives.cc` from `NCCL_INIT` to the dedicated
`NCCL_TUNING` subsystem (not in the default mask). They are now opt-in via
`NCCL_DEBUG_SUBSYS=TUNING` and no longer appear at the default `NCCL_DEBUG=INFO` level.

## JIRA ID

Resolves AICOMRCCL-1280

## Test Plan

`all_gather_perf`, 16 ranks across 2 nodes (MI350X / gfx950), which selects the Direct
algo for msgSize <= 4 MiB:
