### PR TITLE
[hipFile] Add system tests for zero-sized IO operations using the sync APIs

### DIFF
--- a/projects/hipfile/src/amd_detail/backend/fastpath.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fastpath.cpp
@@ -57,8 +57,6 @@ using namespace std;
  *        header so hipGetProcAddress() is used to lookup each function's function
  *        pointer
  *      - returns
- *          - hipSuccess if size is zero
- *              - This check should be removed
  *          - hipErrorInvalidDevice if unable to lookup current device
  *          - hipErrorUnknown if rocr runtime does not return success
  *  - ROCR Runtime (userspace)
@@ -75,8 +73,6 @@ using namespace std;
  *      - hsa_amd_ais_file_read(...), hsa_amd_ais_file_write(...)
  *      - status and size_coppied untouched
  *      - returns
- *          - HSA_STATUS_ERROR_INVALID_ARGUMENT if size is zero
- *              - This check should be be removed
  *          - HSA_STATUS_ERROR_INVALID_ARGUMENT if devicePtr is NULL
  *              - This check should be be removed
  *          - HSA_STATUS_ERROR if hsaKmtAisReadWriteFile(...) does not return success

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -182,6 +182,11 @@ try {
     int                      score{-1};
     std::shared_ptr<Backend> backend{};
 
+    if (file_offset < 0 || buffer_offset < 0) {
+        errno = EINVAL;
+        return -1;
+    }
+
     for (const auto &_backend : backends) {
         auto _score = _backend->score(file, buffer, size, file_offset, buffer_offset);
         if (score < _score) {

--- a/projects/hipfile/test/common/test-common.h
+++ b/projects/hipfile/test/common/test-common.h
@@ -99,3 +99,13 @@ struct Tmpfile {
         close(fd);
     }
 };
+
+/// @brief Round value to the next multiple of align. Align _must_ be a power of 2.
+/// @param value The value to round up.
+/// @param align Value will be rounded up to a multiple of align
+/// @return Value rounded up to a multiple of align.
+static inline size_t
+align_up(size_t value, size_t align)
+{
+    return (value + align - 1) & ~(align - 1);
+}

--- a/projects/hipfile/test/system/amd/io.cpp
+++ b/projects/hipfile/test/system/amd/io.cpp
@@ -159,6 +159,55 @@ TEST_P(HipFileIo, writeAtNegativeBufferOffsetReturnsEINVAL)
     ASSERT_EQ(EINVAL, errno);
 }
 
+// Zero-sized IO tests require >= ROCm 7.14
+#if HIP_VERSION_MAJOR > 7 || (HIP_VERSION_MAJOR == 7 && HIP_VERSION_MINOR >= 14)
+TEST_P(HipFileIo, zeroSizedReadAtAlignedFileOffsetReturnsZero)
+{
+    for (hoff_t offset = 0; offset < static_cast<hoff_t>(tmpfile_size); offset += tmpfile_dio_offset_align) {
+        ASSERT_EQ(0, pread(tmpfile.fd, host_buffer.data(), 0, offset));
+        ASSERT_EQ(0, hipFileRead(tmpfile_handle, unregistered_device_buffer, 0, offset, 0));
+    }
+}
+
+TEST_P(HipFileIo, zeroSizedWriteAtAlignedFileOffsetReturnsZero)
+{
+    for (hoff_t offset = 0; offset < static_cast<hoff_t>(tmpfile_size); offset += tmpfile_dio_offset_align) {
+        ASSERT_EQ(0, pwrite(tmpfile.fd, host_buffer.data(), 0, offset));
+        ASSERT_EQ(0, hipFileWrite(tmpfile_handle, unregistered_device_buffer, 0, offset, 0));
+    }
+}
+
+TEST_P(HipFileIo, zeroSizedReadAtAlignedOffsetBeyondEndOfFileReturnsZero)
+{
+    size_t aligned_eof{align_up(tmpfile_size, tmpfile_dio_offset_align)};
+    for (size_t i = 0; i < 10; i++) {
+        hoff_t offset{static_cast<hoff_t>(aligned_eof * i)};
+        ASSERT_EQ(0, pread(tmpfile.fd, host_buffer.data(), 0, offset));
+        ASSERT_EQ(0, hipFileRead(tmpfile_handle, unregistered_device_buffer, 0, offset, 0));
+
+        // ensure the file size has not increased
+        struct stat st {};
+        ASSERT_EQ(0, fstat(tmpfile.fd, &st));
+        ASSERT_EQ(tmpfile_size, static_cast<size_t>(st.st_size));
+    }
+}
+
+TEST_P(HipFileIo, zeroSizedWriteAtAlignedOffsetBeyondEndOfFileReturnsZero)
+{
+    size_t aligned_eof{align_up(tmpfile_size, tmpfile_dio_offset_align)};
+    for (size_t i = 0; i < 10; i++) {
+        hoff_t offset{static_cast<hoff_t>(aligned_eof * i)};
+        ASSERT_EQ(0, pwrite(tmpfile.fd, host_buffer.data(), 0, static_cast<off_t>(offset)));
+        ASSERT_EQ(0, hipFileWrite(tmpfile_handle, unregistered_device_buffer, 0, offset, 0));
+
+        // ensure the file size has not increased
+        struct stat st {};
+        ASSERT_EQ(0, fstat(tmpfile.fd, &st));
+        ASSERT_EQ(tmpfile_size, static_cast<size_t>(st.st_size));
+    }
+}
+#endif
+
 INSTANTIATE_TEST_SUITE_P(, HipFileIo, testing::ValuesIn(io_test_params),
                          [](const testing::TestParamInfo<HipFileIo::ParamType> &param_info) {
                              return param_info.param.name;

--- a/projects/hipfile/test/system/amd/io.cpp
+++ b/projects/hipfile/test/system/amd/io.cpp
@@ -13,11 +13,14 @@
 
 #include <array>
 #include <cstdlib>
+#include <fcntl.h>
 #include <gtest/gtest.h>
 #include <hip/hip_runtime_api.h>
+#include <linux/stat.h>
 #include <string>
 #include <thread>
 #include <unistd.h>
+#include <vector>
 
 extern SystemTestOptions test_env;
 
@@ -42,16 +45,26 @@ HIPFILE_WARN_NO_EXIT_DTOR_ON
 
 struct HipFileIo : public testing::TestWithParam<IoTestParam> {
 
-    Tmpfile         tmpfile;
-    size_t          tmpfile_size;
-    hipFileHandle_t tmpfile_handle;
-    void           *unregistered_device_buffer;
-    size_t          unregistered_device_buffer_size;
+    Tmpfile              tmpfile;
+    size_t               tmpfile_size;
+    uint32_t             tmpfile_dio_offset_align;
+    hipFileHandle_t      tmpfile_handle;
+    void                *unregistered_device_buffer;
+    size_t               unregistered_device_buffer_size;
+    std::vector<uint8_t> host_buffer;
 
     HipFileIo()
-        : tmpfile{test_env.ais_capable_dir}, tmpfile_size{1024 * 1024}, tmpfile_handle{nullptr},
-          unregistered_device_buffer{nullptr}, unregistered_device_buffer_size{1024 * 1024}
+        : tmpfile{test_env.ais_capable_dir}, tmpfile_size{1024 * 1024}, tmpfile_dio_offset_align{4096},
+          tmpfile_handle{nullptr}, unregistered_device_buffer{nullptr},
+          unregistered_device_buffer_size{1024 * 1024}, host_buffer(1024)
     {
+#if defined(STATX_DIOALIGN)
+        struct statx stx {};
+        if (0 == statx(tmpfile.fd, "", AT_EMPTY_PATH, STATX_DIOALIGN, &stx) &&
+            stx.stx_mask & STATX_DIOALIGN) {
+            tmpfile_dio_offset_align = stx.stx_dio_offset_align;
+        }
+#endif
     }
 
     void SetUp() override
@@ -108,6 +121,42 @@ TEST_P(HipFileIo, ReadToUnregisteredBufferAtOffsetReturnsErrorIfOverflow)
 
     ASSERT_EQ(-hipFileInvalidValue,
               hipFileRead(tmpfile_handle, unregistered_device_buffer, io_size, 0, io_buffer_offset));
+}
+
+TEST_P(HipFileIo, readAtNegativeFileOffsetReturnsEINVAL)
+{
+    errno = 0;
+    ASSERT_EQ(-1, pread(tmpfile.fd, host_buffer.data(), 512, -1));
+    ASSERT_EQ(EINVAL, errno);
+
+    errno = 0;
+    ASSERT_EQ(-1, hipFileRead(tmpfile_handle, unregistered_device_buffer, 512, -1, 0));
+    ASSERT_EQ(EINVAL, errno);
+}
+
+TEST_P(HipFileIo, writeAtNegativeFileOffsetReturnsEINVAL)
+{
+    errno = 0;
+    ASSERT_EQ(-1, pwrite(tmpfile.fd, host_buffer.data(), 512, -1));
+    ASSERT_EQ(EINVAL, errno);
+
+    errno = 0;
+    ASSERT_EQ(-1, hipFileWrite(tmpfile_handle, unregistered_device_buffer, 512, -1, 0));
+    ASSERT_EQ(EINVAL, errno);
+}
+
+TEST_P(HipFileIo, readAtNegativeBufferOffsetReturnsEINVAL)
+{
+    errno = 0;
+    ASSERT_EQ(-1, hipFileRead(tmpfile_handle, unregistered_device_buffer, 512, 0, -1));
+    ASSERT_EQ(EINVAL, errno);
+}
+
+TEST_P(HipFileIo, writeAtNegativeBufferOffsetReturnsEINVAL)
+{
+    errno = 0;
+    ASSERT_EQ(-1, hipFileWrite(tmpfile_handle, unregistered_device_buffer, 512, 0, -1));
+    ASSERT_EQ(EINVAL, errno);
 }
 
 INSTANTIATE_TEST_SUITE_P(, HipFileIo, testing::ValuesIn(io_test_params),


### PR DESCRIPTION
## Motivation

`hipFileRead`/`hipfileWrite` should support zero-sized IO operations. Ensures that zero-sized IO works end-to-end.

## Technical Details

Support for zero sized IO required changes to the HIP Runtime, ROCr Runtime, and amdgpu. The changes to the these layers are available in >= ROCm 7.14.

Related changes:
* https://github.com/ROCm/rocm-systems/pull/6639
* https://github.com/ROCm/rocm-systems/pull/6744

## JIRA ID

Resolves AIHIPFILE-110
ROCM-1353

## Test Plan

This change adds system tests that run when the ROCm version >= 7.14.