### PR TITLE
[rocJPEG/rocDecode] Error on GPU UUID mismatch instead of silently using wrong render node

### DIFF
--- a/projects/rocdecode/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/projects/rocdecode/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -721,23 +721,26 @@ rocDecStatus VaContext::GetVaContext(int device_id, uint32_t *va_ctx_id) {
         ComputePartition current_compute_partition = (gpu_uuids_to_compute_partition_map_.find(gpu_uuid) != gpu_uuids_to_compute_partition_map_.end()) ? gpu_uuids_to_compute_partition_map_[gpu_uuid] : kSpx;
         GetDrmNodeOffset(va_contexts_[va_ctx_idx].hip_dev_prop.name, va_contexts_[va_ctx_idx].device_id, visible_devices, current_compute_partition, offset);
 
-        std::string drm_node = "/dev/dri/renderD";
-        int render_node_id = (gpu_uuids_to_render_nodes_map_.find(gpu_uuid) != gpu_uuids_to_render_nodes_map_.end()) ? gpu_uuids_to_render_nodes_map_[gpu_uuid] : 128;
-        drm_node += std::to_string(render_node_id + offset);
+        std::ostringstream oss;
+        for (const auto& entry : gpu_uuids_to_render_nodes_map_) {
+            oss << "\n  " << entry.first << ": " << entry.second;
+        }
+        std::string render_nodes_map_str = oss.str();
 
         if (g_rocdec_logger.GetLogLevel() >= kRocDecLogInfo) {
-            std::ostringstream oss;
-            oss << '{';
-            bool first = true;
-            for (const auto& entry : gpu_uuids_to_render_nodes_map_) {
-                if (!first) oss << ", ";
-                oss << entry.first << ": " << entry.second;
-                first = false;
-            }
-            oss << '}';
-            InfoLog(g_rocdec_logger, "gpu_uuids_to_render_nodes_map_: " + oss.str());
+            InfoLog(g_rocdec_logger, "gpu_uuids_to_render_nodes_map_:" + render_nodes_map_str);
             InfoLog(g_rocdec_logger, "Selected GPU UUID: " + gpu_uuid);
         }
+
+        std::string drm_node = "/dev/dri/renderD";
+        auto it = gpu_uuids_to_render_nodes_map_.find(gpu_uuid);
+        if (it == gpu_uuids_to_render_nodes_map_.end()) {
+            ErrorLog(g_rocdec_logger, "GPU UUID: " + gpu_uuid + " received from HIP does not match any GPU UUID retrieved from sysfs. "
+                                      "This likely indicates a DKMS setup issue. Available render nodes map:" + render_nodes_map_str);
+            FunctionExitLog(g_rocdec_logger);
+            return ROCDEC_DEVICE_INVALID;
+        }
+        drm_node += std::to_string(it->second + offset);
 
         rocdec_status = InitVAAPI(va_ctx_idx, drm_node);
         if (rocdec_status != ROCDEC_SUCCESS) {

--- a/projects/rocdecode/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/projects/rocdecode/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -736,7 +736,7 @@ rocDecStatus VaContext::GetVaContext(int device_id, uint32_t *va_ctx_id) {
         auto it = gpu_uuids_to_render_nodes_map_.find(gpu_uuid);
         if (it == gpu_uuids_to_render_nodes_map_.end()) {
             ErrorLog(g_rocdec_logger, "GPU UUID: " + gpu_uuid + " received from HIP does not match any GPU UUID retrieved from sysfs. "
-                                      "This likely indicates a DKMS setup issue. Available render nodes map:" + render_nodes_map_str);
+                                      "This likely indicates a setup issue. Available render nodes map:" + render_nodes_map_str);
             FunctionExitLog(g_rocdec_logger);
             return ROCDEC_DEVICE_INVALID;
         }

--- a/projects/rocdecode/src/rocdecode/vaapi/vaapi_videodecoder.cpp
+++ b/projects/rocdecode/src/rocdecode/vaapi/vaapi_videodecoder.cpp
@@ -736,7 +736,8 @@ rocDecStatus VaContext::GetVaContext(int device_id, uint32_t *va_ctx_id) {
         auto it = gpu_uuids_to_render_nodes_map_.find(gpu_uuid);
         if (it == gpu_uuids_to_render_nodes_map_.end()) {
             ErrorLog(g_rocdec_logger, "GPU UUID: " + gpu_uuid + " received from HIP does not match any GPU UUID retrieved from sysfs. "
-                                      "This likely indicates a setup issue. Available render nodes map:" + render_nodes_map_str);
+                                      "This likely indicates a setup issue. Available render nodes map: " + render_nodes_map_str);
+            va_contexts_.pop_back();
             FunctionExitLog(g_rocdec_logger);
             return ROCDEC_DEVICE_INVALID;
         }

--- a/projects/rocjpeg/src/rocjpeg_vaapi_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_vaapi_decoder.cpp
@@ -399,23 +399,25 @@ RocJpegStatus RocJpegVappiDecoder::InitializeDecoder(std::string device_name, in
     ComputePartition current_compute_partition = (gpu_uuids_to_compute_partition_map_.find(gpu_uuid) != gpu_uuids_to_compute_partition_map_.end()) ? gpu_uuids_to_compute_partition_map_[gpu_uuid] : kSpx;
     GetDrmNodeOffset(device_name, device_id_, visible_devices, current_compute_partition, offset);
 
-    std::string drm_node = "/dev/dri/renderD";
-    int render_node_id = (gpu_uuids_to_render_nodes_map_.find(gpu_uuid) != gpu_uuids_to_render_nodes_map_.end()) ? gpu_uuids_to_render_nodes_map_[gpu_uuid] : 128;
-    drm_node += std::to_string(render_node_id + offset);
+    std::ostringstream oss;
+    for (const auto& entry : gpu_uuids_to_render_nodes_map_) {
+        oss << "\n  " << entry.first << ": " << entry.second;
+    }
+    std::string render_nodes_map_str = oss.str();
 
     if (g_rocjpeg_logger.GetLogLevel() >= kRocJpegLogInfo) {
-        std::ostringstream oss;
-        oss << '{';
-        bool first = true;
-        for (const auto& entry : gpu_uuids_to_render_nodes_map_) {
-            if (!first) oss << ", ";
-            oss << entry.first << ": " << entry.second;
-            first = false;
-        }
-        oss << '}';
-        InfoLog(g_rocjpeg_logger, "gpu_uuids_to_render_nodes_map_: " + oss.str());
+        InfoLog(g_rocjpeg_logger, "gpu_uuids_to_render_nodes_map_:" + render_nodes_map_str);
         InfoLog(g_rocjpeg_logger, "Selected GPU UUID: " + gpu_uuid);
     }
+
+    std::string drm_node = "/dev/dri/renderD";
+    auto it = gpu_uuids_to_render_nodes_map_.find(gpu_uuid);
+    if (it == gpu_uuids_to_render_nodes_map_.end()) {
+        ErrorLog(g_rocjpeg_logger, "GPU UUID: " + gpu_uuid + " received from HIP does not match any GPU UUID retrieved from sysfs. "
+                                  "This likely indicates a DKMS setup issue. Available render nodes map:" + render_nodes_map_str);
+        return ROCJPEG_STATUS_INVALID_PARAMETER;
+    }
+    drm_node += std::to_string(it->second + offset);
 
     CHECK_ROCJPEG(InitVAAPI(drm_node));
     CHECK_ROCJPEG(CreateDecoderConfig());

--- a/projects/rocjpeg/src/rocjpeg_vaapi_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_vaapi_decoder.cpp
@@ -414,7 +414,7 @@ RocJpegStatus RocJpegVappiDecoder::InitializeDecoder(std::string device_name, in
     auto it = gpu_uuids_to_render_nodes_map_.find(gpu_uuid);
     if (it == gpu_uuids_to_render_nodes_map_.end()) {
         ErrorLog(g_rocjpeg_logger, "GPU UUID: " + gpu_uuid + " received from HIP does not match any GPU UUID retrieved from sysfs. "
-                                  "This likely indicates a DKMS setup issue. Available render nodes map:" + render_nodes_map_str);
+                                  "This likely indicates a setup issue. Available render nodes map:" + render_nodes_map_str);
         return ROCJPEG_STATUS_INVALID_PARAMETER;
     }
     drm_node += std::to_string(it->second + offset);

--- a/projects/rocjpeg/src/rocjpeg_vaapi_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_vaapi_decoder.cpp
@@ -414,7 +414,7 @@ RocJpegStatus RocJpegVappiDecoder::InitializeDecoder(std::string device_name, in
     auto it = gpu_uuids_to_render_nodes_map_.find(gpu_uuid);
     if (it == gpu_uuids_to_render_nodes_map_.end()) {
         ErrorLog(g_rocjpeg_logger, "GPU UUID: " + gpu_uuid + " received from HIP does not match any GPU UUID retrieved from sysfs. "
-                                  "This likely indicates a setup issue. Available render nodes map:" + render_nodes_map_str);
+                                  "This likely indicates a setup issue. Available render nodes map: " + render_nodes_map_str);
         return ROCJPEG_STATUS_INVALID_PARAMETER;
     }
     drm_node += std::to_string(it->second + offset);


### PR DESCRIPTION
## Motivation

When the GPU UUID returned by HIP was not found in the render nodes map (built from sysfs), both rocDecode and rocJPEG silently fell back to render node 128. This caused silent mis-initialization — the decoder would attempt to open the wrong DRM node, leading to confusing downstream failures with no actionable diagnostics.

## Technical Details

- Replace the silent fallback to render node 128 with an explicit error return (ROCJPEG_STATUS_INVALID_PARAMETER / ROCDEC_DEVICE_INVALID) when the HIP GPU UUID is not found in the sysfs render nodes map.

- Emit a descriptive error message indicating the UUID mismatch and that it likely points to a setup issue.

- Refactor the render nodes map serialization to build the string once and reuse it in both the info log (conditional on log level) and the error log (unconditional), eliminating duplicated code.

- Improve log formatting: each UUID→render node mapping is now printed on its own line, and the map is logged before the lookup, so it is always visible when a mismatch occurs.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
