### PR TITLE
[clr] do not allow clr to read out of bounds in some cases

### DIFF
--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -436,8 +436,14 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
   // It better be elf if its neither compressed nor uncompressed
   if (!is_compressed && !is_uncompressed) {
     if (IsCodeObjectElf(image_)) {
-      // Load the binary directly
-      auto elf_size = amd::Elf::getElfSize(image_);
+      auto elf_size = amd::Elf::getElfSize(image_, image_size_);
+      // If we got 0, validation has failed.
+      if (elf_size == 0) {
+        LogPrintfError(
+            "Invalid ELF code object: failed size/bounds validation, image_size is: %zu",
+            image_size_);
+        return hipErrorInvalidImage;
+      }
       for (auto* device : devices) {
         if (hipSuccess != AddDevProgram(device, image_, elf_size, fdesc))
           return hipErrorInvalidImage;

--- a/projects/clr/hipamd/src/hip_fatbin.cpp
+++ b/projects/clr/hipamd/src/hip_fatbin.cpp
@@ -407,8 +407,11 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
     if (fdesc != amd::Os::FDescInit()) amd::Os::CloseFileHandle(fdesc);
   });
 
+  // Readable bytes from image_ to the end of its mapping; used to bound the ELF
+  // parse on the in-memory path (e.g. hipModuleLoadData) where no length is given.
+  size_t image_region_bound = 0;
   if (image_ != nullptr) {
-    if (!amd::Os::FindFileNameFromAddress(image_, &fname_, &foffset_)) {
+    if (!amd::Os::FindFileNameFromAddress(image_, &fname_, &foffset_, &image_region_bound)) {
       fname_ = std::string("");
       foffset_ = 0;
     }
@@ -436,12 +439,18 @@ hipError_t FatBinaryInfo::ExtractFatBinaryUsingCOMGR(const std::vector<hip::Devi
   // It better be elf if its neither compressed nor uncompressed
   if (!is_compressed && !is_uncompressed) {
     if (IsCodeObjectElf(image_)) {
-      auto elf_size = amd::Elf::getElfSize(image_, image_size_);
+      // Use the exact file size when known, else the mapping bound derived above.
+      size_t buf_size = image_size_ != 0 ? image_size_ : image_region_bound;
+      if (buf_size == 0) {
+        LogError("Cannot determine bounds of in-memory code object");
+        return hipErrorInvalidImage;
+      }
+      auto elf_size = amd::Elf::getElfSize(image_, buf_size);
       // If we got 0, validation has failed.
       if (elf_size == 0) {
         LogPrintfError(
             "Invalid ELF code object: failed size/bounds validation, image_size is: %zu",
-            image_size_);
+            buf_size);
         return hipErrorInvalidImage;
       }
       for (auto* device : devices) {

--- a/projects/clr/rocclr/elf/elf.cpp
+++ b/projects/clr/rocclr/elf/elf.cpp
@@ -801,47 +801,73 @@ bool Elf::dumpImage(std::istream& is, char** buff, size_t* len) const {
 }
 
 uint64_t Elf::getElfSize(const void* emi, const size_t buf_size) {
-  if (emi == nullptr || (buf_size != 0 && buf_size <= EI_CLASS)) {
+  // Fail closed: never parse without a known upper bound on the buffer.
+  if (emi == nullptr || buf_size <= EI_CLASS) {
     return 0;
   }
   const unsigned char eclass = static_cast<const unsigned char*>(emi)[EI_CLASS];
-  if (buf_size != 0 && (eclass == ELFCLASS64 && buf_size < sizeof(Elf64_Ehdr))) {
+  // Only 64-bit AMDGPU code objects are supported.
+  if (eclass != ELFCLASS64 || buf_size < sizeof(Elf64_Ehdr)) {
     return 0;
   }
 
-  uint64_t total_size = 0;
-  if (eclass == ELFCLASS64) {
-    auto ehdr = static_cast<const Elf64_Ehdr*>(emi);
-    if (buf_size != 0) {
-      if (ehdr->e_shoff >= buf_size) {
-        return 0;
-      }
-      if (static_cast<uint64_t>(ehdr->e_shnum) * sizeof(Elf64_Shdr) > buf_size - ehdr->e_shoff) {
-        return 0;
-      }
-    }
-    auto shdr = reinterpret_cast<const Elf64_Shdr*>(static_cast<const char*>(emi) + ehdr->e_shoff);
-
-    auto max_offset = ehdr->e_shoff;
-    total_size = max_offset + ehdr->e_shentsize *
-                                  static_cast<uint64_t>(ehdr->e_shnum);  // deliberately promote it
-
-    for (decltype(ehdr->e_shnum) i = 0; i < ehdr->e_shnum; ++i) {
-      auto cur_offset = shdr[i].sh_offset;
-      if (max_offset < cur_offset) {
-        max_offset = cur_offset;
-        total_size = max_offset;
-        if (SHT_NOBITS != shdr[i].sh_type) {
+  // end = off + sz, returns false on overflow.
+  auto checked_end = [](uint64_t off, uint64_t sz, uint64_t& end) -> bool {
 #if __has_builtin(__builtin_add_overflow)
-          if (__builtin_add_overflow(total_size, shdr[i].sh_size, &total_size)) return 0;
+    return !__builtin_add_overflow(off, sz, &end);
 #else
-          total_size += shdr[i].sh_size;
+    if (off > ~uint64_t(0) - sz) return false;
+    end = off + sz;
+    return true;
 #endif
-        }
-      }
+  };
+
+  auto ehdr = static_cast<const Elf64_Ehdr*>(emi);
+  uint64_t total_size = sizeof(Elf64_Ehdr);
+
+  // Validate and bound the section-header table before any dereference.
+  if (ehdr->e_shnum != 0) {
+    if (ehdr->e_shentsize != sizeof(Elf64_Shdr) || ehdr->e_shoff >= buf_size) {
+      return 0;
+    }
+    uint64_t shtab = static_cast<uint64_t>(ehdr->e_shnum) * sizeof(Elf64_Shdr);
+    if (shtab > buf_size - ehdr->e_shoff) {
+      return 0;
+    }
+    if (ehdr->e_shoff + shtab > total_size) total_size = ehdr->e_shoff + shtab;
+
+    auto shdr = reinterpret_cast<const Elf64_Shdr*>(static_cast<const char*>(emi) + ehdr->e_shoff);
+    for (uint64_t i = 0; i < ehdr->e_shnum; ++i) {
+      if (SHT_NOBITS == shdr[i].sh_type) continue;
+      uint64_t end;
+      if (!checked_end(shdr[i].sh_offset, shdr[i].sh_size, end)) return 0;
+      if (end > buf_size) return 0;
+      if (end > total_size) total_size = end;
     }
   }
-  return (buf_size != 0 && total_size > buf_size) ? 0 : total_size;
+
+  // Validate and bound the program-header table before any dereference.
+  if (ehdr->e_phnum != 0) {
+    if (ehdr->e_phentsize != sizeof(Elf64_Phdr) || ehdr->e_phoff >= buf_size) {
+      return 0;
+    }
+    uint64_t phtab = static_cast<uint64_t>(ehdr->e_phnum) * sizeof(Elf64_Phdr);
+    if (phtab > buf_size - ehdr->e_phoff) {
+      return 0;
+    }
+    if (ehdr->e_phoff + phtab > total_size) total_size = ehdr->e_phoff + phtab;
+
+    auto phdr = reinterpret_cast<const Elf64_Phdr*>(static_cast<const char*>(emi) + ehdr->e_phoff);
+    for (uint64_t i = 0; i < ehdr->e_phnum; ++i) {
+      if (PT_NULL == phdr[i].p_type) continue;
+      uint64_t end;
+      if (!checked_end(phdr[i].p_offset, phdr[i].p_filesz, end)) return 0;
+      if (end > buf_size) return 0;
+      if (end > total_size) total_size = end;
+    }
+  }
+
+  return (total_size > buf_size) ? 0 : total_size;
 }
 
 bool Elf::isElfMagic(const char* p) {

--- a/projects/clr/rocclr/elf/elf.cpp
+++ b/projects/clr/rocclr/elf/elf.cpp
@@ -800,32 +800,31 @@ bool Elf::dumpImage(std::istream& is, char** buff, size_t* len) const {
   return true;
 }
 
-uint64_t Elf::getElfSize(const void* emi) {
+uint64_t Elf::getElfSize(const void* emi, const size_t buf_size) {
+  if (emi == nullptr || (buf_size != 0 && buf_size <= EI_CLASS)) {
+    return 0;
+  }
   const unsigned char eclass = static_cast<const unsigned char*>(emi)[EI_CLASS];
+  if (buf_size != 0 && (eclass == ELFCLASS64 && buf_size < sizeof(Elf64_Ehdr))) {
+    return 0;
+  }
+
   uint64_t total_size = 0;
-  if (eclass == ELFCLASS32) {
-    auto ehdr = static_cast<const Elf32_Ehdr*>(emi);
-    auto shdr = reinterpret_cast<const Elf32_Shdr*>(static_cast<const char*>(emi) + ehdr->e_shoff);
-
-    auto max_offset = ehdr->e_shoff;
-    total_size = max_offset + ehdr->e_shentsize * ehdr->e_shnum;
-
-    for (decltype(ehdr->e_shnum) i = 0; i < ehdr->e_shnum; ++i) {
-      auto cur_offset = shdr[i].sh_offset;
-      if (max_offset < cur_offset) {
-        max_offset = cur_offset;
-        total_size = max_offset;
-        if (SHT_NOBITS != shdr[i].sh_type) {
-          total_size += shdr[i].sh_size;
-        }
+  if (eclass == ELFCLASS64) {
+    auto ehdr = static_cast<const Elf64_Ehdr*>(emi);
+    if (buf_size != 0) {
+      if (ehdr->e_shoff >= buf_size) {
+        return 0;
+      }
+      if (static_cast<uint64_t>(ehdr->e_shnum) * sizeof(Elf64_Shdr) > buf_size - ehdr->e_shoff) {
+        return 0;
       }
     }
-  } else if (eclass == ELFCLASS64) {
-    auto ehdr = static_cast<const Elf64_Ehdr*>(emi);
     auto shdr = reinterpret_cast<const Elf64_Shdr*>(static_cast<const char*>(emi) + ehdr->e_shoff);
 
     auto max_offset = ehdr->e_shoff;
-    total_size = max_offset + ehdr->e_shentsize * ehdr->e_shnum;
+    total_size = max_offset + ehdr->e_shentsize *
+                                  static_cast<uint64_t>(ehdr->e_shnum);  // deliberately promote it
 
     for (decltype(ehdr->e_shnum) i = 0; i < ehdr->e_shnum; ++i) {
       auto cur_offset = shdr[i].sh_offset;
@@ -833,12 +832,16 @@ uint64_t Elf::getElfSize(const void* emi) {
         max_offset = cur_offset;
         total_size = max_offset;
         if (SHT_NOBITS != shdr[i].sh_type) {
+#if __has_builtin(__builtin_add_overflow)
+          if (__builtin_add_overflow(total_size, shdr[i].sh_size, &total_size)) return 0;
+#else
           total_size += shdr[i].sh_size;
+#endif
         }
       }
     }
   }
-  return total_size;
+  return (buf_size != 0 && total_size > buf_size) ? 0 : total_size;
 }
 
 bool Elf::isElfMagic(const char* p) {

--- a/projects/clr/rocclr/elf/elf.hpp
+++ b/projects/clr/rocclr/elf/elf.hpp
@@ -300,7 +300,7 @@ class Elf {
   bool getSegment(const unsigned int index, segment*& seg) const;
 
   /* Return size of elf file */
-  static uint64_t getElfSize(const void* emi);
+  static uint64_t getElfSize(const void* emi, const size_t size);
 
   /* is it ELF */
   static bool isElfMagic(const char* p);

--- a/projects/clr/rocclr/os/os.hpp
+++ b/projects/clr/rocclr/os/os.hpp
@@ -55,8 +55,11 @@ class Os : AllStatic {
   static bool GetFileHandle(const char* fname, FileDesc* fd_ptr, size_t* sz_ptr);
 
   // Returns the file name & file offset of mapped memory if the file is mapped.
+  // If region_bound_ptr is non-null and 'image' lies in a readable mapping, it is
+  // set to the number of readable bytes from 'image' to the end of that mapping
+  // (populated for anonymous mappings too, even when no file name is resolved).
   static bool FindFileNameFromAddress(const void* image, std::string* fname_ptr,
-                                      size_t* foffset_ptr);
+                                      size_t* foffset_ptr, size_t* region_bound_ptr = nullptr);
 
   // Given a valid file descriptor returns mmaped memory for size and offset
   static bool MemoryMapFileDesc(FileDesc fdesc, size_t fsize, size_t foffset,

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -852,7 +852,7 @@ bool Os::GetFileHandle(const char* fname, FileDesc* fd_ptr, size_t* sz_ptr) {
 }
 
 bool amd::Os::FindFileNameFromAddress(const void* image, std::string* fname_ptr,
-                                      size_t* foffset_ptr) {
+                                      size_t* foffset_ptr, size_t* region_bound_ptr) {
   // Get the list of mapped file list
   bool ret_value = false;
   std::ifstream proc_maps;
@@ -881,6 +881,11 @@ bool amd::Os::FindFileNameFromAddress(const void* image, std::string* fname_ptr,
       uint64_t inode;
       tokens >> permissions >> std::hex >> offset >> std::dec >> device >> inode;
       std::getline(tokens >> std::ws, uri_file_path);
+
+      // Readable bytes from image to the end of this mapping (anonymous or not).
+      if (region_bound_ptr != nullptr && !permissions.empty() && permissions[0] == 'r') {
+        *region_bound_ptr = static_cast<size_t>(high_address - address);
+      }
 
       if (inode == 0 || uri_file_path.empty()) {
         return ret_value;

--- a/projects/clr/rocclr/os/os_win32.cpp
+++ b/projects/clr/rocclr/os/os_win32.cpp
@@ -665,7 +665,20 @@ bool Os::MemoryMapFileTruncated(const char* fname, const void** mmap_ptr, size_t
   return true;
 }
 
-bool Os::FindFileNameFromAddress(const void* image, std::string* fname_ptr, size_t* foffset_ptr) {
+bool Os::FindFileNameFromAddress(const void* image, std::string* fname_ptr, size_t* foffset_ptr,
+                                 size_t* region_bound_ptr) {
+  // Readable bytes from image to the end of its committed region (anonymous or not).
+  if (region_bound_ptr != nullptr && image != nullptr) {
+    MEMORY_BASIC_INFORMATION mbi;
+    const DWORD readable = PAGE_READONLY | PAGE_READWRITE | PAGE_EXECUTE_READ |
+                           PAGE_EXECUTE_READWRITE | PAGE_WRITECOPY | PAGE_EXECUTE_WRITECOPY;
+    if (VirtualQuery(image, &mbi, sizeof(mbi)) != 0 && mbi.State == MEM_COMMIT &&
+        (mbi.Protect & readable) != 0) {
+      uintptr_t region_end = reinterpret_cast<uintptr_t>(mbi.BaseAddress) + mbi.RegionSize;
+      *region_bound_ptr = static_cast<size_t>(region_end - reinterpret_cast<uintptr_t>(image));
+    }
+  }
+
   HMODULE hm = NULL;
   if (!GetModuleHandleExA(
           GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,

--- a/projects/hip-tests/catch/CMakeLists.txt
+++ b/projects/hip-tests/catch/CMakeLists.txt
@@ -32,6 +32,7 @@ option(RTC_TESTING "Run tests using HIP RTC to compile the kernels" OFF)
 option(ENABLE_SPIRV "Build hip-tests for SPIRV" OFF)
 option(ENABLE_YAML_TAGS "Enable YAML tags for test cases" ON)
 option(STANDALONE_TESTS "Generate standalone executable per source file" OFF)
+option(ENABLE_OOB_TESTS "Build OOB tests, deliberately wrong inputs" ON)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
@@ -123,7 +124,9 @@ if(NOT DEFINED THEROCK_SANITIZER)
 endif()
 
 set(ASAN_CONFIG_DEF)
+set(HIP_TESTS_ASAN_ENABLED OFF)
 if(ENABLE_ADDRESS_SANITIZER OR THEROCK_SANITIZER STREQUAL "ASAN" OR THEROCK_SANITIZER STREQUAL "HOST_ASAN")
+  set(HIP_TESTS_ASAN_ENABLED ON)
   message(STATUS "Building catch tests with Address Sanitizer options")
   # If user is building hip-tests standalone (without TheRock) and wants to turn on sanitizer
   # We append the flags manually, otherwise we use TheRock's CXX flags which already should have

--- a/projects/hip-tests/catch/config/configs/unit/oob.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/oob.yaml
@@ -4,3 +4,11 @@ oob:
     <<: *level_4
     disabled: [windows, amd_windows, nvidia_linux, nvidia_windows]
     tags: [oob]
+  OOB_hip_module_load_data_over:
+    <<: *level_4
+    disabled: [windows, amd_windows, nvidia_linux, nvidia_windows]
+    tags: [oob]
+  OOB_hiprtc_roundtrip_loads:
+    <<: *level_4
+    disabled: [windows, amd_windows, nvidia_linux, nvidia_windows]
+    tags: [oob]

--- a/projects/hip-tests/catch/config/configs/unit/oob.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/oob.yaml
@@ -1,0 +1,6 @@
+---
+oob:
+  OOB_hip_module_load_over:
+    <<: *level_4
+    disabled: [windows, amd_windows, nvidia_linux, nvidia_windows]
+    tags: [oob]

--- a/projects/hip-tests/catch/unit/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/CMakeLists.txt
@@ -60,3 +60,7 @@ add_subdirectory(assertion)
 add_subdirectory(library)
 add_subdirectory(sanityTests)
 add_subdirectory(executionContext)
+
+if(ENABLE_OOB_TESTS AND HIP_PLATFORM STREQUAL "amd" AND NOT HIP_ASAN_ENABLED)
+  add_subdirectory(oob)
+endif()

--- a/projects/hip-tests/catch/unit/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/CMakeLists.txt
@@ -61,6 +61,6 @@ add_subdirectory(library)
 add_subdirectory(sanityTests)
 add_subdirectory(executionContext)
 
-if(ENABLE_OOB_TESTS AND HIP_PLATFORM STREQUAL "amd" AND NOT HIP_ASAN_ENABLED)
+if(ENABLE_OOB_TESTS AND HIP_PLATFORM STREQUAL "amd" AND NOT HIP_ASAN_ENABLED AND UNIX)
   add_subdirectory(oob)
 endif()

--- a/projects/hip-tests/catch/unit/oob/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/oob/CMakeLists.txt
@@ -1,0 +1,34 @@
+set(TEST_SRC
+    oob_module.cc)
+
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/oob_kernel.co
+                COMMAND ${CMAKE_HIP_COMPILER} ${HIP_DEVICE_BUILD_FLAGS_NO_ARCH} ${OFFLOAD_ARCH_LIST} --cuda-device-only
+                -x hip ${CMAKE_CURRENT_SOURCE_DIR}/kernel.cc
+                -I${HIP_INCLUDE_DIR} ${HIP_PATH_OPT}
+                -o oob_kernel.co
+                DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/kernel.cc)
+
+set(ELF_FIXTURES
+    ${CMAKE_CURRENT_BINARY_DIR}/elf_valid.co
+    ${CMAKE_CURRENT_BINARY_DIR}/elf_huge_shnum.co
+    ${CMAKE_CURRENT_BINARY_DIR}/elf_bad_shoff.co
+    ${CMAKE_CURRENT_BINARY_DIR}/elf_table_spill.co
+    ${CMAKE_CURRENT_BINARY_DIR}/elf_sh_overflow.co)
+
+add_custom_command(
+    OUTPUT  ${ELF_FIXTURES}
+    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/gen_evil_elfs.py
+            ${CMAKE_CURRENT_BINARY_DIR}/oob_kernel.co
+            ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/oob_kernel.co
+            ${CMAKE_CURRENT_SOURCE_DIR}/gen_evil_elfs.py)
+set_property(GLOBAL APPEND PROPERTY G_INSTALL_CUSTOM_TARGETS ${ELF_FIXTURES})
+
+add_custom_target(gen_oob_kernel DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/oob_kernel.co)
+add_custom_target(gen_elf_fixtures DEPENDS ${ELF_FIXTURES})
+
+hip_add_exe_to_target(NAME oob_module
+                      TEST_SRC ${TEST_SRC}
+                      TEST_TARGET_NAME build_tests)
+add_dependencies(oob_module gen_oob_kernel gen_elf_fixtures)
+target_compile_definitions(oob_module PRIVATE OOB_FIXTURES_DIR="${CMAKE_CURRENT_BINARY_DIR}")

--- a/projects/hip-tests/catch/unit/oob/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/oob/CMakeLists.txt
@@ -31,5 +31,6 @@ add_custom_target(gen_elf_fixtures DEPENDS ${ELF_FIXTURES})
 
 hip_add_exe_to_target(NAME oob_module
                       TEST_SRC ${TEST_SRC}
-                      TEST_TARGET_NAME build_tests)
+                      TEST_TARGET_NAME build_tests
+                      LINKER_LIBS hiprtc::hiprtc)
 add_dependencies(oob_module gen_oob_kernel gen_elf_fixtures)

--- a/projects/hip-tests/catch/unit/oob/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/oob/CMakeLists.txt
@@ -22,7 +22,9 @@ add_custom_command(
             ${CMAKE_CURRENT_BINARY_DIR}
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/oob_kernel.co
             ${CMAKE_CURRENT_SOURCE_DIR}/gen_evil_elfs.py)
-set_property(GLOBAL APPEND PROPERTY G_INSTALL_CUSTOM_TARGETS ${ELF_FIXTURES})
+set_property(GLOBAL APPEND PROPERTY G_INSTALL_CUSTOM_TARGETS
+    ${CMAKE_CURRENT_BINARY_DIR}/oob_kernel.co
+    ${ELF_FIXTURES})
 
 add_custom_target(gen_oob_kernel DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/oob_kernel.co)
 add_custom_target(gen_elf_fixtures DEPENDS ${ELF_FIXTURES})
@@ -31,4 +33,3 @@ hip_add_exe_to_target(NAME oob_module
                       TEST_SRC ${TEST_SRC}
                       TEST_TARGET_NAME build_tests)
 add_dependencies(oob_module gen_oob_kernel gen_elf_fixtures)
-target_compile_definitions(oob_module PRIVATE OOB_FIXTURES_DIR="${CMAKE_CURRENT_BINARY_DIR}")

--- a/projects/hip-tests/catch/unit/oob/gen_evil_elfs.py
+++ b/projects/hip-tests/catch/unit/oob/gen_evil_elfs.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""gen_evil_elfs.py <bundle_or_elf.co> <outdir>
+
+Accepts a clang offload bundle OR a raw ELF. Extracts the first AMDGPU ELF
+entry (so arch is always whatever was just compiled), then writes malformed
+copies that exercise the getElfSize rejection paths.
+"""
+
+
+"""
+This script corrupts the Elf64_Ehdr of a module.
+It generates 5 outputs
+elf_valid.co - exactly the same as input
+elf_huge_shnum.co - corrupt the e_shnum, we read past the buffer
+elf_bad_shoff.co - corrupt the e_shoff, section table start is past end of file
+elf_table_spill.co - corrupts e_shnum and e_shoff, table starts inbounds but end past file
+elf_sh_overflow.co - corrupts sh_offset + sh_size, total size is too big
+"""
+import struct, sys, os
+
+def extract_elf(data):
+    if data[:4] == b'\x7fELF':
+        return data
+    assert data[:24] == b'__CLANG_OFFLOAD_BUNDLE__', "unrecognised format"
+    off = 24
+    num, = struct.unpack_from('<Q', data, off); off += 8
+    for _ in range(num):
+        o, s, idl = struct.unpack_from('<QQQ', data, off); off += 24
+        bid = data[off:off+idl].decode(); off += idl
+        if s > 0 and data[o:o+4] == b'\x7fELF':
+            return data[o:o+s]
+    raise ValueError("no ELF entry in bundle")
+
+def u16(b, o): return struct.unpack_from('<H', b, o)[0]
+def u64(b, o): return struct.unpack_from('<Q', b, o)[0]
+def w16(b, o, v): struct.pack_into('<H', b, o, v)
+def w64(b, o, v): struct.pack_into('<Q', b, o, v)
+
+elf   = extract_elf(open(sys.argv[1], 'rb').read())
+out   = sys.argv[2]
+os.makedirs(out, exist_ok=True)
+
+assert elf[4] == 2, "ELFCLASS64 only"
+shoff     = u64(elf, 40)
+shentsize = u16(elf, 58)
+shnum     = u16(elf, 60)
+size      = len(elf)
+
+def emit(name, b):
+    p = os.path.join(out, name)
+    open(p, 'wb').write(bytes(b))
+    print(f"  {p}")
+
+emit('elf_valid.co',       elf)
+
+b = bytearray(elf); w16(b, 60, 0xFFFF)
+emit('elf_huge_shnum.co',  b)
+
+b = bytearray(elf); w64(b, 40, 1 << 40)
+emit('elf_bad_shoff.co',   b)
+
+b = bytearray(elf); w64(b, 40, size - 10); w16(b, 60, 1)
+emit('elf_table_spill.co', b)
+
+b = bytearray(elf)
+s5 = shoff + 5 * shentsize
+struct.pack_into('<I', b, s5 + 4, 1)          # sh_type = SHT_PROGBITS
+w64(b, s5 + 24, 0xFFFFFFFFFFFFFFFF)           # sh_offset -> overflow on +sh_size
+w64(b, s5 + 32, 0x10)
+emit('elf_sh_overflow.co', b)

--- a/projects/hip-tests/catch/unit/oob/kernel.cc
+++ b/projects/hip-tests/catch/unit/oob/kernel.cc
@@ -1,0 +1,7 @@
+#include <hip/hip_runtime.h>
+
+extern "C" __global__ void hello_kernel() {
+    int tid = threadIdx.x + blockIdx.x * blockDim.x;
+    printf("Hello from thread %d (block %d, lane %d)\n",
+           tid, blockIdx.x, threadIdx.x);
+}

--- a/projects/hip-tests/catch/unit/oob/oob_module.cc
+++ b/projects/hip-tests/catch/unit/oob/oob_module.cc
@@ -1,8 +1,8 @@
 #include <hip_test_common.hh>
 #include <string_view>
 
-#define DECL_MODULE_PATH(input_name)                                                               \
-  constexpr std::string_view input_name = OOB_FIXTURES_DIR "/" #input_name ".co"
+// Fixtures are installed flat alongside the test binary; load by basename (cwd-relative).
+#define DECL_MODULE_PATH(input_name) constexpr std::string_view input_name = #input_name ".co"
 
 HIP_TEST_CASE(OOB_hip_module_load_over) {
   DECL_MODULE_PATH(oob_kernel);

--- a/projects/hip-tests/catch/unit/oob/oob_module.cc
+++ b/projects/hip-tests/catch/unit/oob/oob_module.cc
@@ -1,0 +1,39 @@
+#include <hip_test_common.hh>
+#include <string_view>
+
+#define DECL_MODULE_PATH(input_name)                                                               \
+  constexpr std::string_view input_name = OOB_FIXTURES_DIR "/" #input_name ".co"
+
+HIP_TEST_CASE(OOB_hip_module_load_over) {
+  DECL_MODULE_PATH(oob_kernel);
+  DECL_MODULE_PATH(elf_huge_shnum);
+  DECL_MODULE_PATH(elf_bad_shoff);
+  DECL_MODULE_PATH(elf_table_spill);
+  DECL_MODULE_PATH(elf_sh_overflow);
+
+  SECTION("valid - sanity") {
+    hipModule_t module{};
+    HIP_CHECK(hipModuleLoad(&module, oob_kernel.data()));
+    HIP_CHECK(hipModuleUnload(module));
+  }
+
+  SECTION("huge shnum") {
+    hipModule_t module{};
+    HIP_CHECK_ERROR(hipModuleLoad(&module, elf_huge_shnum.data()), hipErrorInvalidImage);
+  }
+
+  SECTION("bad shoff") {
+    hipModule_t module{};
+    HIP_CHECK_ERROR(hipModuleLoad(&module, elf_bad_shoff.data()), hipErrorInvalidImage);
+  }
+
+  SECTION("table spill") {
+    hipModule_t module{};
+    HIP_CHECK_ERROR(hipModuleLoad(&module, elf_table_spill.data()), hipErrorInvalidImage);
+  }
+
+  SECTION("sh overflow") {
+    hipModule_t module{};
+    HIP_CHECK_ERROR(hipModuleLoad(&module, elf_sh_overflow.data()), hipErrorInvalidImage);
+  }
+}

--- a/projects/hip-tests/catch/unit/oob/oob_module.cc
+++ b/projects/hip-tests/catch/unit/oob/oob_module.cc
@@ -1,9 +1,25 @@
 #include <hip_test_common.hh>
+#include <hip/hiprtc.h>
+#include <fstream>
+#include <string>
 #include <string_view>
+#include <vector>
 
 // Fixtures are installed flat alongside the test binary; load by basename (cwd-relative).
 #define DECL_MODULE_PATH(input_name) constexpr std::string_view input_name = #input_name ".co"
 
+static std::vector<char> ReadFile(std::string_view path) {
+  std::ifstream f(std::string(path), std::ios::binary | std::ios::ate);
+  REQUIRE(f.good());
+  auto size = f.tellg();
+  f.seekg(0);
+  std::vector<char> buf(static_cast<size_t>(size));
+  f.read(buf.data(), size);
+  REQUIRE(f.good());
+  return buf;
+}
+
+// File-backed path: hipModuleLoad(fname) - image_size_ is the exact file size.
 HIP_TEST_CASE(OOB_hip_module_load_over) {
   DECL_MODULE_PATH(oob_kernel);
   DECL_MODULE_PATH(elf_huge_shnum);
@@ -36,4 +52,57 @@ HIP_TEST_CASE(OOB_hip_module_load_over) {
     hipModule_t module{};
     HIP_CHECK_ERROR(hipModuleLoad(&module, elf_sh_overflow.data()), hipErrorInvalidImage);
   }
+}
+
+// In-memory path: hipModuleLoadData(image) - no length, bound is derived from the
+// mapping that contains the (anonymous heap) buffer. These cases reject regardless
+// of the arena size: bad_shoff points 1TB out, sh_overflow overflows on any bound.
+HIP_TEST_CASE(OOB_hip_module_load_data_over) {
+  DECL_MODULE_PATH(elf_valid);
+  DECL_MODULE_PATH(elf_bad_shoff);
+  DECL_MODULE_PATH(elf_sh_overflow);
+
+  SECTION("valid in-memory - sanity") {
+    auto buf = ReadFile(elf_valid);
+    hipModule_t module{};
+    HIP_CHECK(hipModuleLoadData(&module, buf.data()));
+    HIP_CHECK(hipModuleUnload(module));
+  }
+
+  SECTION("bad shoff in-memory") {
+    auto buf = ReadFile(elf_bad_shoff);
+    hipModule_t module{};
+    HIP_CHECK_ERROR(hipModuleLoadData(&module, buf.data()), hipErrorInvalidImage);
+  }
+
+  SECTION("sh overflow in-memory") {
+    auto buf = ReadFile(elf_sh_overflow);
+    hipModule_t module{};
+    HIP_CHECK_ERROR(hipModuleLoadData(&module, buf.data()), hipErrorInvalidImage);
+  }
+}
+
+// Runtime-compiled code objects live in an anonymous heap buffer and must still
+// load through hipModuleLoadData after the bounds hardening.
+HIP_TEST_CASE(OOB_hiprtc_roundtrip_loads) {
+  static constexpr char kSource[] = "extern \"C\" __global__ void nop() {}\n";
+
+  hipDeviceProp_t props;
+  HIP_CHECK(hipGetDeviceProperties(&props, 0));
+  std::string arch = std::string("--offload-arch=") + props.gcnArchName;
+  const char* options[] = {arch.c_str()};
+
+  hiprtcProgram prog;
+  HIPRTC_CHECK(hiprtcCreateProgram(&prog, kSource, "nop.cu", 0, nullptr, nullptr));
+  HIPRTC_CHECK(hiprtcCompileProgram(prog, 1, options));
+
+  size_t code_size = 0;
+  HIPRTC_CHECK(hiprtcGetCodeSize(prog, &code_size));
+  std::vector<char> code(code_size);
+  HIPRTC_CHECK(hiprtcGetCode(prog, code.data()));
+  HIPRTC_CHECK(hiprtcDestroyProgram(&prog));
+
+  hipModule_t module{};
+  HIP_CHECK(hipModuleLoadData(&module, code.data()));
+  HIP_CHECK(hipModuleUnload(module));
 }

--- a/projects/hip-tests/catch/unit/oob/oob_module.cc
+++ b/projects/hip-tests/catch/unit/oob/oob_module.cc
@@ -55,19 +55,12 @@ HIP_TEST_CASE(OOB_hip_module_load_over) {
 }
 
 // In-memory path: hipModuleLoadData(image) - no length, bound is derived from the
-// mapping that contains the (anonymous heap) buffer. These cases reject regardless
-// of the arena size: bad_shoff points 1TB out, sh_overflow overflows on any bound.
+// mapping that contains the (anonymous heap) buffer. These cases reject in
+// getElfSize before any device/arch check, so they are arch-independent. The valid
+// in-memory load is covered by OOB_hiprtc_roundtrip_loads, which is arch-correct.
 HIP_TEST_CASE(OOB_hip_module_load_data_over) {
-  DECL_MODULE_PATH(elf_valid);
   DECL_MODULE_PATH(elf_bad_shoff);
   DECL_MODULE_PATH(elf_sh_overflow);
-
-  SECTION("valid in-memory - sanity") {
-    auto buf = ReadFile(elf_valid);
-    hipModule_t module{};
-    HIP_CHECK(hipModuleLoadData(&module, buf.data()));
-    HIP_CHECK(hipModuleUnload(module));
-  }
 
   SECTION("bad shoff in-memory") {
     auto buf = ReadFile(elf_bad_shoff);


### PR DESCRIPTION
## Motivation

Add checks so that we do not get seg faults when reading modules.

## Technical Details

Some elf can have incorrect sizes, we basically adjust for it.

## JIRA ID

JIRA ID : ROCM-26177

## Test Plan

Tested locally with incorrect elf.

## Test Result

The error is no longer seen.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Co-authored-by: Claude <noreply@anthropic.com>