### PR TITLE
Update CODEOWNERS to allow rocjitsu reviewers to review mirage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,7 +62,7 @@
 
 # Emulation
 /emulation/                                                           @atgutier
-/emulation/mirage/                                                    @atgutier @amd-arosa
+/emulation/mirage/                                                    @amd-arosa @ROCm/rocjitsu-core-team
 /emulation/rocjitsu/                                                  @atgutier @ROCm/rocjitsu-core-team
 
 # Profilers


### PR DESCRIPTION
## Motivation

to make it so @atgutier doesn't have to review all my prs.

## Technical Details

made change to the github codeowner file

## JIRA ID

n/a

## Test Plan

it not catching fire

## Test Result

didn't catch fire

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
