### PR TITLE
[rocprofiler] Fix find_library(NUMA): use NAMES numa

### DIFF
--- a/projects/rocprofiler/CMakeLists.txt
+++ b/projects/rocprofiler/CMakeLists.txt
@@ -147,7 +147,7 @@ Please install it for your OS distribution. e.g: for Ubuntu: \"sudo apt-get inst
 ")
 endif()
 
-find_library(NUMA NAME numa REQUIRED)
+find_library(NUMA NAMES numa REQUIRED)
 link_libraries(${NUMA})
 
 get_property(


### PR DESCRIPTION
## Summary

- Bugfix: `find_library(NUMA NAME numa REQUIRED)` used the wrong keyword; CMake treated `NAME` as a library name to search for instead of the `NAMES` keyword, so discovery for `libnuma` was broken.
- Change to `find_library(NUMA NAMES numa REQUIRED)` so only `numa` is resolved.

## Test plan

- [ ] Reconfigure `projects/rocprofiler` with CMake against a layout where `libnuma` is present (e.g. TheRock `lib/rocm_sysdeps/lib`).
- [ ] Confirm `NUMA` resolves to the expected shared library and link succeeds.

## JIRA ID

(none)
