### PR TITLE
[rocjitsu] Fix gfx1250 TDM barrier completion

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/tensor_dma.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/tensor_dma.h
@@ -5,6 +5,7 @@
 #define ROCJITSU_ISA_ARCH_AMDGPU_SHARED_TENSOR_DMA_H_
 
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/lds_barrier_cell.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "util/except.h"
 
@@ -20,9 +21,6 @@ namespace tensor_dma_detail {
 
 constexpr int kSgprNull = 124;
 constexpr uint32_t kGlobalHighBitsMask = (1u << 25) - 1u;
-constexpr uint64_t kDsBarrierPendingMask = (1ull << 29) - 1ull;
-constexpr uint32_t kDsBarrierPhaseShift = 29;
-constexpr uint32_t kDsBarrierInitCountShift = 32;
 
 template <size_t N>
 uint64_t read_bits(const std::array<uint32_t, N> &words, uint32_t bit_offset, uint32_t bit_count) {
@@ -113,8 +111,8 @@ inline TensorDmaDescriptor parse_descriptor(std::array<uint32_t, 4> d0, std::arr
 
   // Descriptor bit layout follows LLVM MLIR's gfx1250 TDM lowering in
   // mlir/lib/Conversion/AMDGPUToROCDL/AMDGPUToROCDL.cpp.
-  desc.gather = (d0[0] & (1u << 30)) != 0;
-  desc.gather_indices_32bit = (d0[0] & (1u << 31)) != 0;
+  desc.gather_indices_32bit = (d0[0] & (1u << 30)) != 0;
+  desc.gather = (d0[0] & (1u << 31)) != 0;
   desc.lds_base = d0[1];
   desc.global_base =
       static_cast<uint64_t>(d0[2]) | (static_cast<uint64_t>(d0[3] & kGlobalHighBitsMask) << 32);
@@ -310,24 +308,28 @@ inline void copy_tensor(const TensorDmaDescriptor &desc, Wavefront &wf, bool sto
 }
 
 inline void arrive_atomic_barrier(const TensorDmaDescriptor &desc, Wavefront &wf) {
-  // Layout follows LLVM MLIR's ds_barrier_state lowering:
-  // [63:32] init count, [31:29] phase, [28:0] pending count.
   const uint32_t addr = wf.lds_base() + desc.atomic_barrier_addr;
   const uint64_t state = wf.cu().lds().read64(addr);
-  const uint64_t init_count = state >> kDsBarrierInitCountShift;
-  uint64_t phase = (state >> kDsBarrierPhaseShift) & 0x7ull;
-  uint64_t pending = state & kDsBarrierPendingMask;
+  wf.cu().lds().write64(addr, lds_barrier_cell::update_arrive(state));
+}
 
-  if (pending == 0) {
-    phase = (phase + 7) & 0x7ull;
-    pending = init_count;
-  } else {
-    --pending;
+class ScopedWaitCounter {
+public:
+  ScopedWaitCounter(Wavefront &wf, WaitCounterType type) : wf_(wf), type_(type) {
+    wf_.wait_counters().increment(type_);
   }
 
-  wf.cu().lds().write64(addr, (init_count << kDsBarrierInitCountShift) |
-                                  (phase << kDsBarrierPhaseShift) | pending);
-}
+  ScopedWaitCounter(const ScopedWaitCounter &) = delete;
+  ScopedWaitCounter &operator=(const ScopedWaitCounter &) = delete;
+  ScopedWaitCounter(ScopedWaitCounter &&) = delete;
+  ScopedWaitCounter &operator=(ScopedWaitCounter &&) = delete;
+
+  ~ScopedWaitCounter() { wf_.release_wait_counter(type_); }
+
+private:
+  Wavefront &wf_;
+  WaitCounterType type_;
+};
 
 template <typename Inst>
 TensorDmaDescriptor read_descriptor(const Inst &inst, const Wavefront &wf) {
@@ -340,6 +342,7 @@ TensorDmaDescriptor read_descriptor(const Inst &inst, const Wavefront &wf) {
 } // namespace tensor_dma_detail
 
 template <typename Inst> void execute_tensor_load_to_lds(const Inst &inst, Wavefront &wf) {
+  tensor_dma_detail::ScopedWaitCounter counter(wf, WaitCounterType::TENSORCNT);
   const auto desc = tensor_dma_detail::read_descriptor(inst, wf);
   tensor_dma_detail::copy_tensor(desc, wf, false);
   if (desc.atomic_barrier)
@@ -347,6 +350,7 @@ template <typename Inst> void execute_tensor_load_to_lds(const Inst &inst, Wavef
 }
 
 template <typename Inst> void execute_tensor_store_from_lds(const Inst &inst, Wavefront &wf) {
+  tensor_dma_detail::ScopedWaitCounter counter(wf, WaitCounterType::TENSORCNT);
   const auto desc = tensor_dma_detail::read_descriptor(inst, wf);
   tensor_dma_detail::copy_tensor(desc, wf, true);
   if (desc.atomic_barrier)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/tensor_dma.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/tensor_dma.h
@@ -310,7 +310,7 @@ inline void copy_tensor(const TensorDmaDescriptor &desc, Wavefront &wf, bool sto
 inline void arrive_atomic_barrier(const TensorDmaDescriptor &desc, Wavefront &wf) {
   const uint32_t addr = wf.lds_base() + desc.atomic_barrier_addr;
   const uint64_t state = wf.cu().lds().read64(addr);
-  wf.cu().lds().write64(addr, lds_barrier_cell::update_arrive(state));
+  wf.cu().lds().write64(addr, lds_barrier_cell_update_arrive(state));
 }
 
 class ScopedWaitCounter {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/lds_barrier_cell.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/lds_barrier_cell.h
@@ -9,30 +9,42 @@
 namespace rocjitsu {
 namespace amdgpu {
 
-namespace lds_barrier_cell {
+/// Raw LDS barrier cell used by the gfx1250 DS barrier-arrive instructions.
+///
+/// The AMDGCN ISA raw async-barrier object uses [15:0] pending, [31:16]
+/// phase, and [47:32] init count. This is intentionally distinct from MLIR's
+/// ds_barrier_state helper; kernels that poll the raw cell directly test bit
+/// 16 for phase parity.
+constexpr uint64_t kLdsBarrierCellPendingMask = 0xffffull;
+constexpr uint64_t kLdsBarrierCellPhaseMask = 0xffffull;
+constexpr uint64_t kLdsBarrierCellInitCountMask = 0xffffull;
+constexpr uint32_t kLdsBarrierCellPhaseShift = 16;
+constexpr uint32_t kLdsBarrierCellInitCountShift = 32;
+constexpr uint64_t kLdsBarrierCellReservedMask = 0xffff000000000000ull;
 
-// Raw LDS barrier cell used by the gfx1250 DS barrier-arrive instructions.
-// The AMDGCN ISA raw async-barrier object uses [15:0] pending, [31:16]
-// phase, and [47:32] init count. This is intentionally distinct from MLIR's
-// ds_barrier_state helper; kernels that poll the raw cell directly test bit
-// 16 for phase parity.
-constexpr uint64_t kPendingMask = 0xffffull;
-constexpr uint64_t kPhaseMask = 0xffffull;
-constexpr uint64_t kInitCountMask = 0xffffull;
-constexpr uint32_t kPhaseShift = 16;
-constexpr uint32_t kInitCountShift = 32;
-constexpr uint64_t kReservedMask = 0xffff000000000000ull;
+/// Return the remaining arrivals before the current phase completes.
+inline uint64_t lds_barrier_cell_pending_count(uint64_t state) {
+  return state & kLdsBarrierCellPendingMask;
+}
 
-inline uint64_t pending_count(uint64_t state) { return state & kPendingMask; }
+/// Return the raw 16-bit phase counter.
+inline uint64_t lds_barrier_cell_phase(uint64_t state) {
+  return (state >> kLdsBarrierCellPhaseShift) & kLdsBarrierCellPhaseMask;
+}
 
-inline uint64_t phase(uint64_t state) { return (state >> kPhaseShift) & kPhaseMask; }
+/// Return the encoded initial pending count for each phase.
+inline uint64_t lds_barrier_cell_init_count(uint64_t state) {
+  return (state >> kLdsBarrierCellInitCountShift) & kLdsBarrierCellInitCountMask;
+}
 
-inline uint64_t init_count(uint64_t state) { return (state >> kInitCountShift) & kInitCountMask; }
-
-inline uint64_t update_arrive(uint64_t state, uint64_t decrement = 1) {
-  uint64_t pending = pending_count(state);
-  uint64_t phase_value = phase(state);
-  const uint64_t initial_count = init_count(state);
+/// Apply one or more barrier-arrive operations to a raw barrier cell.
+///
+/// A zero decrement is a no-op. A decrement larger than the remaining pending
+/// count may complete multiple phases.
+inline uint64_t lds_barrier_cell_update_arrive(uint64_t state, uint64_t decrement = 1) {
+  uint64_t pending = lds_barrier_cell_pending_count(state);
+  uint64_t phase_value = lds_barrier_cell_phase(state);
+  const uint64_t initial_count = lds_barrier_cell_init_count(state);
 
   if (decrement == 0) {
     // Explicitly arriving zero waves is a no-op; it must not flip phase on an
@@ -44,28 +56,34 @@ inline uint64_t update_arrive(uint64_t state, uint64_t decrement = 1) {
     pending -= decrement;
   } else {
     decrement -= pending + 1;
-    phase_value = (phase_value - 1) & kPhaseMask;
+    phase_value = (phase_value - 1) & kLdsBarrierCellPhaseMask;
 
     const uint64_t phase_period = initial_count + 1;
     const uint64_t full_periods = decrement / phase_period;
-    phase_value = (phase_value - full_periods) & kPhaseMask;
+    phase_value = (phase_value - full_periods) & kLdsBarrierCellPhaseMask;
 
     const uint64_t remainder = decrement % phase_period;
     pending = initial_count - remainder;
   }
 
-  return (state & kReservedMask) | (initial_count << kInitCountShift) |
-         (phase_value << kPhaseShift) | pending;
+  return (state & kLdsBarrierCellReservedMask) | (initial_count << kLdsBarrierCellInitCountShift) |
+         (phase_value << kLdsBarrierCellPhaseShift) | pending;
 }
 
-inline uint64_t init_state(uint32_t arrivals_per_phase) {
+/// Initialize a raw barrier cell for the requested arrivals per phase.
+///
+/// The encoding stores `arrivals_per_phase - 1`, so requests for zero or one
+/// arrival both encode as zero pending arrivals in the initial phase.
+inline uint64_t lds_barrier_cell_init_state(uint32_t arrivals_per_phase) {
   const uint64_t count = arrivals_per_phase == 0 ? 0 : arrivals_per_phase - 1;
-  return ((count & kInitCountMask) << kInitCountShift) | (count & kPendingMask);
+  return ((count & kLdsBarrierCellInitCountMask) << kLdsBarrierCellInitCountShift) |
+         (count & kLdsBarrierCellPendingMask);
 }
 
-inline bool phase_parity(uint64_t state) { return (phase(state) & 1ull) != 0; }
-
-} // namespace lds_barrier_cell
+/// Return the low bit of the raw phase counter used by polling kernels.
+inline bool lds_barrier_cell_phase_parity(uint64_t state) {
+  return (lds_barrier_cell_phase(state) & 1ull) != 0;
+}
 
 } // namespace amdgpu
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/lds_barrier_cell.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/lds_barrier_cell.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_VM_AMDGPU_LDS_BARRIER_CELL_H_
+#define ROCJITSU_VM_AMDGPU_LDS_BARRIER_CELL_H_
+
+#include <cstdint>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+namespace lds_barrier_cell {
+
+// Raw LDS barrier cell used by the gfx1250 DS barrier-arrive instructions.
+// The AMDGCN ISA raw async-barrier object uses [15:0] pending, [31:16]
+// phase, and [47:32] init count. This is intentionally distinct from MLIR's
+// ds_barrier_state helper; kernels that poll the raw cell directly test bit
+// 16 for phase parity.
+constexpr uint64_t kPendingMask = 0xffffull;
+constexpr uint64_t kPhaseMask = 0xffffull;
+constexpr uint64_t kInitCountMask = 0xffffull;
+constexpr uint32_t kPhaseShift = 16;
+constexpr uint32_t kInitCountShift = 32;
+constexpr uint64_t kReservedMask = 0xffff000000000000ull;
+
+inline uint64_t pending_count(uint64_t state) { return state & kPendingMask; }
+
+inline uint64_t phase(uint64_t state) { return (state >> kPhaseShift) & kPhaseMask; }
+
+inline uint64_t init_count(uint64_t state) { return (state >> kInitCountShift) & kInitCountMask; }
+
+inline uint64_t update_arrive(uint64_t state, uint64_t decrement = 1) {
+  uint64_t pending = pending_count(state);
+  uint64_t phase_value = phase(state);
+  const uint64_t initial_count = init_count(state);
+
+  if (decrement == 0) {
+    // Explicitly arriving zero waves is a no-op; it must not flip phase on an
+    // already-drained cell.
+    return state;
+  }
+
+  if (decrement <= pending) {
+    pending -= decrement;
+  } else {
+    decrement -= pending + 1;
+    phase_value = (phase_value - 1) & kPhaseMask;
+
+    const uint64_t phase_period = initial_count + 1;
+    const uint64_t full_periods = decrement / phase_period;
+    phase_value = (phase_value - full_periods) & kPhaseMask;
+
+    const uint64_t remainder = decrement % phase_period;
+    pending = initial_count - remainder;
+  }
+
+  return (state & kReservedMask) | (initial_count << kInitCountShift) |
+         (phase_value << kPhaseShift) | pending;
+}
+
+inline uint64_t init_state(uint32_t arrivals_per_phase) {
+  const uint64_t count = arrivals_per_phase == 0 ? 0 : arrivals_per_phase - 1;
+  return ((count & kInitCountMask) << kInitCountShift) | (count & kPendingMask);
+}
+
+inline bool phase_parity(uint64_t state) { return (phase(state) & 1ull) != 0; }
+
+} // namespace lds_barrier_cell
+
+} // namespace amdgpu
+} // namespace rocjitsu
+
+#endif // ROCJITSU_VM_AMDGPU_LDS_BARRIER_CELL_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/vm/amdgpu/l1_vector_cache.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
 #include "rocjitsu/vm/amdgpu/lds.h"
+#include "rocjitsu/vm/amdgpu/lds_barrier_cell.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 #include "util/log.h"
 
@@ -230,29 +231,6 @@ template <typename T> T apply_int_atomic(AtomicOp op, T old_val, T src_val, T cm
   }
 }
 
-uint64_t update_ds_barrier_arrive(uint64_t state, uint64_t decrement, bool has_decrement) {
-  constexpr uint64_t kPendingMask = (1ull << 29) - 1ull;
-  constexpr uint32_t kPhaseShift = 29;
-  constexpr uint32_t kInitCountShift = 32;
-
-  const uint64_t init_count = state >> kInitCountShift;
-  uint64_t phase = (state >> kPhaseShift) & 0x7ull;
-  uint64_t pending = state & kPendingMask;
-
-  if (pending == 0) {
-    phase = (phase + 7) & 0x7ull;
-    pending = init_count;
-  }
-
-  if (has_decrement) {
-    pending = decrement >= pending ? 0 : pending - decrement;
-  } else if (pending > 0) {
-    --pending;
-  }
-
-  return (init_count << kInitCountShift) | (phase << kPhaseShift) | pending;
-}
-
 /// @brief Apply a floating-point atomic RMW operation.
 template <typename F> F apply_fp_atomic(AtomicOp op, F old_val, F src_val) {
   switch (op) {
@@ -410,7 +388,7 @@ void execute_lds_atomic_rmw(VectorMemState &d, Lds *lds) {
         const bool has_decrement = d.store_data.size() >= lane * src_stride + 8;
         if (has_decrement)
           std::memcpy(&decrement, &d.store_data[lane * src_stride], 8);
-        new_val = update_ds_barrier_arrive(old_val, decrement, has_decrement);
+        new_val = lds_barrier_cell::update_arrive(old_val, has_decrement ? decrement : 1);
       } else if (is_fp) {
         double old_f = std::bit_cast<double>(old_val);
         double src_f;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -388,7 +388,7 @@ void execute_lds_atomic_rmw(VectorMemState &d, Lds *lds) {
         const bool has_decrement = d.store_data.size() >= lane * src_stride + 8;
         if (has_decrement)
           std::memcpy(&decrement, &d.store_data[lane * src_stride], 8);
-        new_val = lds_barrier_cell::update_arrive(old_val, has_decrement ? decrement : 1);
+        new_val = lds_barrier_cell_update_arrive(old_val, has_decrement ? decrement : 1);
       } else if (is_fp) {
         double old_f = std::bit_cast<double>(old_val);
         double src_f;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.h
@@ -70,11 +70,7 @@ public:
     wf.wait_counters().increment(issue_counter);
     initiate_access(*inst, wf);
     complete_access(*inst, wf);
-    wf.wait_counters().decrement(issue_counter);
-    if (wf.state() == WfState::WAITCNT && wf.wait_satisfied())
-      wf.set_state(WfState::RUNNING);
-    if (wf.state() == WfState::ENDING && wf.wait_counters().empty())
-      wf.halt();
+    wf.release_wait_counter(issue_counter);
     delete inst;
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.cpp
@@ -14,5 +14,13 @@ void Wavefront::halt() {
   cu_.release_wf(dispatch_id_, wg_id_);
 }
 
+void Wavefront::release_wait_counter(WaitCounterType type) {
+  wait_counters_.decrement(type);
+  if (state_ == WfState::WAITCNT && wait_satisfied())
+    state_ = WfState::RUNNING;
+  if (state_ == WfState::ENDING && wait_counters_.empty())
+    halt();
+}
+
 } // namespace amdgpu
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
@@ -243,6 +243,9 @@ public:
   /// @returns Const reference to the wait counters.
   const WaitCounters &wait_counters() const { return wait_counters_; }
 
+  /// @brief Retire one outstanding wait-counter operation and wake the wave if ready.
+  void release_wait_counter(WaitCounterType type);
+
   /// @brief Set the s_waitcnt target thresholds and stall if not yet satisfied.
   ///
   /// @details Used by GFX9 (CDNA1-4), GFX10 (RDNA1/2), and GFX11 (RDNA3/3.5)

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -414,6 +414,25 @@ uint32_t read_global_u32(amdgpu::GpuMemory &memory, uint64_t addr) {
   return value;
 }
 
+std::unique_ptr<Instruction> decode_gfx1250(const std::array<uint32_t, 3> &words,
+                                            std::string_view expected_mnemonic) {
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  if (!decoder) {
+    ADD_FAILURE() << "Decoder::create() returned nullptr for gfx1250";
+    return nullptr;
+  }
+
+  std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+  if (!inst) {
+    ADD_FAILURE() << "decode() returned nullptr for gfx1250 instruction";
+    return nullptr;
+  }
+
+  EXPECT_EQ(inst->mnemonic(), expected_mnemonic);
+  EXPECT_EQ(inst->size(), static_cast<int>(words.size() * sizeof(words[0])));
+  return inst;
+}
+
 template <typename T> void append_bytes(std::vector<uint8_t> &bytes, const T &value) {
   auto *src = reinterpret_cast<const uint8_t *>(&value);
   bytes.insert(bytes.end(), src, src + sizeof(T));
@@ -1072,6 +1091,148 @@ TEST(Gfx1250ExecutionTest, TensorDmaD2CopiesGlobalAndLds) {
   for (uint32_t i = 0; i < kElements; ++i) {
     const uint32_t actual = read_global_u32(*sim.memory, kStoreGlobal + i * 4);
     EXPECT_EQ(actual, 0x22000000u + i * 0x303u);
+  }
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaDecodeExecuteCoversLoadStoreD2D4Forms) {
+  constexpr uint32_t kNullSgpr = 124;
+  constexpr std::array<uint32_t, 3> kLoadD2 = {0xd0710001u, 0x7c000000u, 0x7c7c0c00u};
+  constexpr std::array<uint32_t, 3> kStoreD2 = {0xd0714001u, 0x7c000000u, 0x7c7c0c08u};
+  constexpr std::array<uint32_t, 3> kLoadD4 = {0xd0710001u, 0x7c000000u, 0x18140c00u};
+  constexpr std::array<uint32_t, 3> kStoreD4 = {0xd0714001u, 0x7c000000u, 0x18140c08u};
+
+  {
+    Gfx1250Sim sim;
+    auto *cu = sim.cu();
+    auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+    ASSERT_NE(wf, nullptr);
+    wf->set_lds_base(cu->allocate_lds(256));
+
+    constexpr uint32_t kElements = 4;
+    constexpr uint64_t kLoadGlobal = 0x1a0000;
+    constexpr uint64_t kStoreGlobal = 0x1b0000;
+
+    write_tensor_dma_d0(*cu, *wf, 0, kLoadGlobal);
+    write_tensor_dma_d0(*cu, *wf, 8, kStoreGlobal);
+    write_wave_sgpr(*cu, *wf, 12, 2u << 16);        // i32 elements.
+    write_wave_sgpr(*cu, *wf, 13, kElements << 16); // Tensor dim0.
+    write_wave_sgpr(*cu, *wf, 14, 0);
+    write_wave_sgpr(*cu, *wf, 15, kElements << 16); // Tile dim0.
+    write_wave_sgpr(*cu, *wf, 16, 0);
+    write_wave_sgpr(*cu, *wf, 17, 0);
+    write_wave_sgpr(*cu, *wf, 18, 0);
+    write_wave_sgpr(*cu, *wf, 19, 0);
+
+    for (uint32_t i = 0; i < kElements; ++i)
+      write_global_u32(*sim.memory, kLoadGlobal + i * 4, 0x71000000u + i);
+
+    auto load = decode_gfx1250(kLoadD2, "tensor_load_to_lds");
+    ASSERT_NE(load, nullptr);
+    ASSERT_EQ(load->num_src_operands(), 4);
+    EXPECT_EQ(load->src_operand(2)->encoding_value(), static_cast<int>(kNullSgpr));
+    EXPECT_EQ(load->src_operand(3)->encoding_value(), static_cast<int>(kNullSgpr));
+    load->execute(*load, wf);
+
+    for (uint32_t i = 0; i < kElements; ++i)
+      EXPECT_EQ(cu->lds().read32(wf->lds_base() + i * 4), 0x71000000u + i);
+
+    for (uint32_t i = 0; i < kElements; ++i)
+      cu->lds().write32(wf->lds_base() + i * 4, 0x72000000u + i);
+
+    auto store = decode_gfx1250(kStoreD2, "tensor_store_from_lds");
+    ASSERT_NE(store, nullptr);
+    ASSERT_EQ(store->num_src_operands(), 4);
+    EXPECT_EQ(store->src_operand(2)->encoding_value(), static_cast<int>(kNullSgpr));
+    EXPECT_EQ(store->src_operand(3)->encoding_value(), static_cast<int>(kNullSgpr));
+    store->execute(*store, wf);
+
+    for (uint32_t i = 0; i < kElements; ++i)
+      EXPECT_EQ(read_global_u32(*sim.memory, kStoreGlobal + i * 4), 0x72000000u + i);
+  }
+
+  {
+    Gfx1250Sim sim;
+    auto *cu = sim.cu();
+    auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+    ASSERT_NE(wf, nullptr);
+    wf->set_lds_base(cu->allocate_lds(256));
+
+    constexpr uint32_t kCols = 2;
+    constexpr uint32_t kRows = 2;
+    constexpr uint32_t kTileRows = 3;
+    constexpr uint32_t kDepth = 2;
+    constexpr uint32_t kPlaneStride = kTileRows * kCols;
+    constexpr uint64_t kLoadGlobal = 0x1c0000;
+    constexpr uint64_t kStoreGlobal = 0x1d0000;
+    constexpr uint32_t kSentinel = 0x7e7e7e7eu;
+
+    write_tensor_dma_d0(*cu, *wf, 0, kLoadGlobal);
+    write_tensor_dma_d0(*cu, *wf, 8, kStoreGlobal);
+    write_wave_sgpr(*cu, *wf, 12, 2u << 16);    // i32 elements.
+    write_wave_sgpr(*cu, *wf, 13, kCols << 16); // Tensor dim0.
+    write_wave_sgpr(*cu, *wf, 14, kRows << 16); // Tensor dim1.
+    write_wave_sgpr(*cu, *wf, 15, kCols << 16); // Tile dim0.
+    write_wave_sgpr(*cu, *wf, 16, kTileRows | (kDepth << 16));
+    write_wave_sgpr(*cu, *wf, 17, kCols); // Tensor dim0 stride.
+    write_wave_sgpr(*cu, *wf, 18, kPlaneStride << 16);
+    write_wave_sgpr(*cu, *wf, 19, 0);
+    write_wave_sgpr(*cu, *wf, 20, kDepth); // Tensor dim2, from D2.
+    write_wave_sgpr(*cu, *wf, 21, 0);
+    write_wave_sgpr(*cu, *wf, 22, 0);
+    write_wave_sgpr(*cu, *wf, 23, 0);
+    write_wave_sgpr(*cu, *wf, 24, 0);
+    write_wave_sgpr(*cu, *wf, 25, 0);
+    write_wave_sgpr(*cu, *wf, 26, 0);
+    write_wave_sgpr(*cu, *wf, 27, 0);
+
+    for (uint32_t z = 0; z < kDepth; ++z) {
+      for (uint32_t y = 0; y < kTileRows; ++y) {
+        for (uint32_t x = 0; x < kCols; ++x) {
+          const uint64_t offset = static_cast<uint64_t>(z * kPlaneStride + y * kCols + x) * 4;
+          const uint32_t value = 0x73000000u + z * 0x100u + y * 0x10u + x;
+          write_global_u32(*sim.memory, kLoadGlobal + offset, value);
+          write_global_u32(*sim.memory, kStoreGlobal + offset, kSentinel);
+        }
+      }
+    }
+
+    auto load = decode_gfx1250(kLoadD4, "tensor_load_to_lds");
+    ASSERT_NE(load, nullptr);
+    ASSERT_EQ(load->num_src_operands(), 4);
+    EXPECT_EQ(load->src_operand(2)->encoding_value(), 20);
+    EXPECT_EQ(load->src_operand(3)->encoding_value(), 24);
+    load->execute(*load, wf);
+
+    for (uint32_t z = 0; z < kDepth; ++z) {
+      for (uint32_t y = 0; y < kTileRows; ++y) {
+        for (uint32_t x = 0; x < kCols; ++x) {
+          const uint32_t lds_index = z * kTileRows * kCols + y * kCols + x;
+          const uint32_t expected = (y < kRows) ? (0x73000000u + z * 0x100u + y * 0x10u + x) : 0u;
+          EXPECT_EQ(cu->lds().read32(wf->lds_base() + lds_index * 4), expected);
+        }
+      }
+    }
+
+    for (uint32_t i = 0; i < kDepth * kTileRows * kCols; ++i)
+      cu->lds().write32(wf->lds_base() + i * 4, 0x74000000u + i);
+
+    auto store = decode_gfx1250(kStoreD4, "tensor_store_from_lds");
+    ASSERT_NE(store, nullptr);
+    ASSERT_EQ(store->num_src_operands(), 4);
+    EXPECT_EQ(store->src_operand(2)->encoding_value(), 20);
+    EXPECT_EQ(store->src_operand(3)->encoding_value(), 24);
+    store->execute(*store, wf);
+
+    for (uint32_t z = 0; z < kDepth; ++z) {
+      for (uint32_t y = 0; y < kTileRows; ++y) {
+        for (uint32_t x = 0; x < kCols; ++x) {
+          const uint64_t offset = static_cast<uint64_t>(z * kPlaneStride + y * kCols + x) * 4;
+          const uint32_t lds_index = z * kTileRows * kCols + y * kCols + x;
+          const uint32_t expected = (y < kRows) ? (0x74000000u + lds_index) : kSentinel;
+          EXPECT_EQ(read_global_u32(*sim.memory, kStoreGlobal + offset), expected);
+        }
+      }
+    }
   }
 }
 

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -1407,7 +1407,7 @@ TEST(Gfx1250ExecutionTest, TensorDmaAtomicBarrierArrivesAfterCopy) {
   EXPECT_EQ(cu->lds().read32(wf->lds_base() + 1 * 4), 0x55000001u);
   const uint64_t state = cu->lds().read64(wf->lds_base() + kBarrierLdsAddr);
   EXPECT_EQ(state, 0xffffull << 16);
-  EXPECT_TRUE(amdgpu::lds_barrier_cell::phase_parity(state));
+  EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(state));
 }
 
 TEST(Gfx1250ExecutionTest, ReleaseWaitCounterWakesWaitcntWhenTargetIsSatisfied) {
@@ -1452,7 +1452,7 @@ TEST(Gfx1250ExecutionTest, DsAtomicAsyncBarrierArriveFlipsRawBarrierPhase) {
 
   constexpr uint32_t kBarrierLdsAddr = 64;
   cu->write_vgpr(wf->vgpr_alloc().base + 0, 0, kBarrierLdsAddr);
-  cu->lds().write64(wf->lds_base() + kBarrierLdsAddr, amdgpu::lds_barrier_cell::init_state(1));
+  cu->lds().write64(wf->lds_base() + kBarrierLdsAddr, amdgpu::lds_barrier_cell_init_state(1));
 
   const std::array<uint32_t, 2> words = {0xd9580000u, 0x00000000u};
   auto *arrive_inst = new gfx1250::DsAtomicAsyncBarrierArriveB64Vds(words.data());
@@ -1462,7 +1462,7 @@ TEST(Gfx1250ExecutionTest, DsAtomicAsyncBarrierArriveFlipsRawBarrierPhase) {
 
   const uint64_t state = cu->lds().read64(wf->lds_base() + kBarrierLdsAddr);
   EXPECT_EQ(state, 0xffffull << 16);
-  EXPECT_TRUE(amdgpu::lds_barrier_cell::phase_parity(state));
+  EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(state));
   EXPECT_TRUE(wf->wait_counters().empty());
 }
 
@@ -1476,7 +1476,7 @@ TEST(Gfx1250ExecutionTest, LocalMemPipelineUsesInjectedBarrierDecrementPayload) 
 
   constexpr uint32_t kBarrierLdsAddr = 64;
   cu->write_vgpr(wf->vgpr_alloc().base + 0, 0, kBarrierLdsAddr);
-  cu->lds().write64(wf->lds_base() + kBarrierLdsAddr, amdgpu::lds_barrier_cell::init_state(2));
+  cu->lds().write64(wf->lds_base() + kBarrierLdsAddr, amdgpu::lds_barrier_cell_init_state(2));
 
   const std::array<uint32_t, 2> words = {0xd9580000u, 0x00000000u};
   auto *arrive_inst = new gfx1250::DsAtomicAsyncBarrierArriveB64Vds(words.data());
@@ -1491,51 +1491,53 @@ TEST(Gfx1250ExecutionTest, LocalMemPipelineUsesInjectedBarrierDecrementPayload) 
   local_pipeline.issue(arrive_inst, *wf);
 
   const uint64_t expected =
-      amdgpu::lds_barrier_cell::update_arrive(amdgpu::lds_barrier_cell::init_state(2), decrement);
+      amdgpu::lds_barrier_cell_update_arrive(amdgpu::lds_barrier_cell_init_state(2), decrement);
   EXPECT_EQ(cu->lds().read64(wf->lds_base() + kBarrierLdsAddr), expected);
   EXPECT_EQ(expected, (1ull << 32) | (0xffffull << 16) | 1ull);
   EXPECT_TRUE(wf->wait_counters().empty());
 }
 
 TEST(Gfx1250ExecutionTest, LdsBarrierCellHandlesSingleAndBatchedArrivals) {
-  using namespace amdgpu::lds_barrier_cell;
-
-  uint64_t state = init_state(2);
+  uint64_t state = amdgpu::lds_barrier_cell_init_state(2);
   EXPECT_EQ(state, (1ull << 32) | 1ull);
 
-  state = update_arrive(state);
+  state = amdgpu::lds_barrier_cell_update_arrive(state);
   EXPECT_EQ(state, 1ull << 32);
-  EXPECT_FALSE(phase_parity(state));
+  EXPECT_FALSE(amdgpu::lds_barrier_cell_phase_parity(state));
 
-  state = update_arrive(state);
+  state = amdgpu::lds_barrier_cell_update_arrive(state);
   EXPECT_EQ(state, (1ull << 32) | (0xffffull << 16) | 1ull);
-  EXPECT_TRUE(phase_parity(state));
+  EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(state));
 
-  const uint64_t drained = update_arrive(init_state(2));
-  ASSERT_EQ(pending_count(drained), 0ull);
-  EXPECT_EQ(update_arrive(drained, 0), drained);
-  EXPECT_EQ(update_arrive(init_state(3), 0), init_state(3));
+  const uint64_t drained =
+      amdgpu::lds_barrier_cell_update_arrive(amdgpu::lds_barrier_cell_init_state(2));
+  ASSERT_EQ(amdgpu::lds_barrier_cell_pending_count(drained), 0ull);
+  EXPECT_EQ(amdgpu::lds_barrier_cell_update_arrive(drained, 0), drained);
+  EXPECT_EQ(amdgpu::lds_barrier_cell_update_arrive(amdgpu::lds_barrier_cell_init_state(3), 0),
+            amdgpu::lds_barrier_cell_init_state(3));
 
-  uint64_t iterated = init_state(2);
+  uint64_t iterated = amdgpu::lds_barrier_cell_init_state(2);
   for (int i = 0; i < 5; ++i)
-    iterated = update_arrive(iterated);
-  const uint64_t batched = update_arrive(init_state(2), 5);
+    iterated = amdgpu::lds_barrier_cell_update_arrive(iterated);
+  const uint64_t batched =
+      amdgpu::lds_barrier_cell_update_arrive(amdgpu::lds_barrier_cell_init_state(2), 5);
   EXPECT_EQ(batched, iterated);
   EXPECT_EQ(batched, (1ull << 32) | (0xfffeull << 16));
 
   for (uint32_t arrivals_per_phase : {0u, 1u}) {
-    state = init_state(arrivals_per_phase);
-    EXPECT_EQ(pending_count(state), 0ull);
-    state = update_arrive(state);
-    EXPECT_EQ(pending_count(state), 0ull);
-    EXPECT_EQ(phase(state), kPhaseMask);
-    EXPECT_TRUE(phase_parity(state));
+    state = amdgpu::lds_barrier_cell_init_state(arrivals_per_phase);
+    EXPECT_EQ(amdgpu::lds_barrier_cell_pending_count(state), 0ull);
+    state = amdgpu::lds_barrier_cell_update_arrive(state);
+    EXPECT_EQ(amdgpu::lds_barrier_cell_pending_count(state), 0ull);
+    EXPECT_EQ(amdgpu::lds_barrier_cell_phase(state), amdgpu::kLdsBarrierCellPhaseMask);
+    EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(state));
   }
 
   const uint64_t reserved = 0xabcdull << 48;
-  const uint64_t reserved_state = update_arrive(reserved | init_state(2));
-  EXPECT_EQ(reserved_state & kReservedMask, reserved);
-  EXPECT_EQ(init_count(reserved_state), 1ull);
+  const uint64_t reserved_state =
+      amdgpu::lds_barrier_cell_update_arrive(reserved | amdgpu::lds_barrier_cell_init_state(2));
+  EXPECT_EQ(reserved_state & amdgpu::kLdsBarrierCellReservedMask, reserved);
+  EXPECT_EQ(amdgpu::lds_barrier_cell_init_count(reserved_state), 1ull);
 }
 
 TEST(Gfx1250ExecutionTest, TensorDmaDenseDescriptorCopiesDenseRows) {

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -9,6 +9,7 @@
 #include "rocjitsu/code/executable.h"
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/operand.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/vds.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/vimage.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/vop2.h"
@@ -17,6 +18,9 @@
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/lds_barrier_cell.h"
+#include "rocjitsu/vm/amdgpu/mem_state.h"
+#include "rocjitsu/vm/amdgpu/memory_pipeline.h"
 #include "rocjitsu/vm/amdgpu/vgpr_msb.h"
 #include "rocjitsu/vm/soc.h"
 #include "util/except.h"
@@ -1236,9 +1240,141 @@ TEST(Gfx1250ExecutionTest, TensorDmaAtomicBarrierArrivesAfterCopy) {
   gfx1250::TensorLoadToLdsVimage load_inst(load_words.data());
   load_inst.execute_impl(*wf);
 
+  EXPECT_TRUE(wf->wait_counters().empty());
+  EXPECT_EQ(wf->state(), amdgpu::WfState::RUNNING);
   EXPECT_EQ(cu->lds().read32(wf->lds_base() + 0 * 4), 0x55000000u);
   EXPECT_EQ(cu->lds().read32(wf->lds_base() + 1 * 4), 0x55000001u);
-  EXPECT_EQ(cu->lds().read64(wf->lds_base() + kBarrierLdsAddr), 7ull << 29);
+  const uint64_t state = cu->lds().read64(wf->lds_base() + kBarrierLdsAddr);
+  EXPECT_EQ(state, 0xffffull << 16);
+  EXPECT_TRUE(amdgpu::lds_barrier_cell::phase_parity(state));
+}
+
+TEST(Gfx1250ExecutionTest, ReleaseWaitCounterWakesWaitcntWhenTargetIsSatisfied) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+
+  wf->wait_counters().increment(amdgpu::WaitCounterType::TENSORCNT);
+  wf->set_wait_target_tensorcnt(0);
+  ASSERT_EQ(wf->state(), amdgpu::WfState::WAITCNT);
+
+  wf->release_wait_counter(amdgpu::WaitCounterType::TENSORCNT);
+
+  EXPECT_TRUE(wf->wait_counters().empty());
+  EXPECT_EQ(wf->state(), amdgpu::WfState::RUNNING);
+}
+
+TEST(Gfx1250ExecutionTest, ReleaseWaitCounterHaltsEndingWaveWhenLastCounterRetires) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+
+  wf->wait_counters().increment(amdgpu::WaitCounterType::TENSORCNT);
+  wf->end();
+  ASSERT_EQ(wf->state(), amdgpu::WfState::ENDING);
+
+  wf->release_wait_counter(amdgpu::WaitCounterType::TENSORCNT);
+
+  EXPECT_TRUE(wf->wait_counters().empty());
+  EXPECT_TRUE(wf->is_halted());
+}
+
+TEST(Gfx1250ExecutionTest, DsAtomicAsyncBarrierArriveFlipsRawBarrierPhase) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint32_t kBarrierLdsAddr = 64;
+  cu->write_vgpr(wf->vgpr_alloc().base + 0, 0, kBarrierLdsAddr);
+  cu->lds().write64(wf->lds_base() + kBarrierLdsAddr, amdgpu::lds_barrier_cell::init_state(1));
+
+  const std::array<uint32_t, 2> words = {0xd9580000u, 0x00000000u};
+  auto *arrive_inst = new gfx1250::DsAtomicAsyncBarrierArriveB64Vds(words.data());
+  arrive_inst->execute_impl(*wf);
+  amdgpu::LocalMemPipeline local_pipeline(&cu->lds());
+  local_pipeline.issue(arrive_inst, *wf);
+
+  const uint64_t state = cu->lds().read64(wf->lds_base() + kBarrierLdsAddr);
+  EXPECT_EQ(state, 0xffffull << 16);
+  EXPECT_TRUE(amdgpu::lds_barrier_cell::phase_parity(state));
+  EXPECT_TRUE(wf->wait_counters().empty());
+}
+
+TEST(Gfx1250ExecutionTest, LocalMemPipelineUsesInjectedBarrierDecrementPayload) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(1);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint32_t kBarrierLdsAddr = 64;
+  cu->write_vgpr(wf->vgpr_alloc().base + 0, 0, kBarrierLdsAddr);
+  cu->lds().write64(wf->lds_base() + kBarrierLdsAddr, amdgpu::lds_barrier_cell::init_state(2));
+
+  const std::array<uint32_t, 2> words = {0xd9580000u, 0x00000000u};
+  auto *arrive_inst = new gfx1250::DsAtomicAsyncBarrierArriveB64Vds(words.data());
+  arrive_inst->execute_impl(*wf);
+
+  auto *state = arrive_inst->data_as<amdgpu::VectorMemState>();
+  const uint64_t decrement = 2;
+  state->store_data.resize(static_cast<size_t>(wf->wf_size()) * sizeof(decrement));
+  std::memcpy(state->store_data.data(), &decrement, sizeof(decrement));
+
+  amdgpu::LocalMemPipeline local_pipeline(&cu->lds());
+  local_pipeline.issue(arrive_inst, *wf);
+
+  const uint64_t expected =
+      amdgpu::lds_barrier_cell::update_arrive(amdgpu::lds_barrier_cell::init_state(2), decrement);
+  EXPECT_EQ(cu->lds().read64(wf->lds_base() + kBarrierLdsAddr), expected);
+  EXPECT_EQ(expected, (1ull << 32) | (0xffffull << 16) | 1ull);
+  EXPECT_TRUE(wf->wait_counters().empty());
+}
+
+TEST(Gfx1250ExecutionTest, LdsBarrierCellHandlesSingleAndBatchedArrivals) {
+  using namespace amdgpu::lds_barrier_cell;
+
+  uint64_t state = init_state(2);
+  EXPECT_EQ(state, (1ull << 32) | 1ull);
+
+  state = update_arrive(state);
+  EXPECT_EQ(state, 1ull << 32);
+  EXPECT_FALSE(phase_parity(state));
+
+  state = update_arrive(state);
+  EXPECT_EQ(state, (1ull << 32) | (0xffffull << 16) | 1ull);
+  EXPECT_TRUE(phase_parity(state));
+
+  const uint64_t drained = update_arrive(init_state(2));
+  ASSERT_EQ(pending_count(drained), 0ull);
+  EXPECT_EQ(update_arrive(drained, 0), drained);
+  EXPECT_EQ(update_arrive(init_state(3), 0), init_state(3));
+
+  uint64_t iterated = init_state(2);
+  for (int i = 0; i < 5; ++i)
+    iterated = update_arrive(iterated);
+  const uint64_t batched = update_arrive(init_state(2), 5);
+  EXPECT_EQ(batched, iterated);
+  EXPECT_EQ(batched, (1ull << 32) | (0xfffeull << 16));
+
+  for (uint32_t arrivals_per_phase : {0u, 1u}) {
+    state = init_state(arrivals_per_phase);
+    EXPECT_EQ(pending_count(state), 0ull);
+    state = update_arrive(state);
+    EXPECT_EQ(pending_count(state), 0ull);
+    EXPECT_EQ(phase(state), kPhaseMask);
+    EXPECT_TRUE(phase_parity(state));
+  }
+
+  const uint64_t reserved = 0xabcdull << 48;
+  const uint64_t reserved_state = update_arrive(reserved | init_state(2));
+  EXPECT_EQ(reserved_state & kReservedMask, reserved);
+  EXPECT_EQ(init_count(reserved_state), 1ull);
 }
 
 TEST(Gfx1250ExecutionTest, TensorDmaDenseDescriptorCopiesDenseRows) {
@@ -1386,7 +1522,7 @@ TEST(Gfx1250ExecutionTest, TensorDmaGatherSupportsI16Indices) {
   constexpr uint32_t kSentinel = 0xCDAECDAEu;
 
   write_tensor_dma_d0(*cu, *wf, 0, kGlobal);
-  write_wave_sgpr(*cu, *wf, 0, 1u | (1u << 30));
+  write_wave_sgpr(*cu, *wf, 0, 1u | (1u << 31));
   write_wave_sgpr(*cu, *wf, 12, 2u << 16);    // i32 elements.
   write_wave_sgpr(*cu, *wf, 13, kCols << 16); // Tensor dim0.
   write_wave_sgpr(*cu, *wf, 14, kRows << 16); // Tensor dim1.


### PR DESCRIPTION
## Motivation

We were updating gfx1250 TDM/DS async barrier cells using the wrong layout. It was treating the LDS barrier object like MLIR's `ds_barrier_state`, but gfx1250 kernels poll the raw async-barrier cell layout: pending count in bits `[15:0]`, phase in `[31:16]`, and init count in `[47:32]`. As a result, TDM copies could complete without making the phase transition visible to kernels waiting on the raw barrier state, leading to hangs/timeouts in HipKittens-style kernels.

## Technical Details

- Add a shared `lds_barrier_cell` helper for raw barrier-cell state transitions.
- Use that helper for both TDM atomic-barrier arrival and `ds_atomic_async_barrier_arrive`.
- Retire `TENSORCNT` around synchronous TDM execution so `s_wait_tensorcnt` and ending-wave handling observe completion.
- Add gfx1250 unit coverage for TDM barrier arrival, raw barrier phase transitions, batched arrivals, and wait-counter release behavior.

## JIRA ID

N/A

## Test Plan

Tested across unit tests and hip kitten kernels. No isa regeneration required.

## Test Result

All good.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
