### PR TITLE
[rocprofiler-sdk] Enable tests and samples for gfx1250

### DIFF
--- a/projects/rocprofiler-sdk/samples/openmp_target/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/samples/openmp_target/CMakeLists.txt
@@ -40,7 +40,8 @@ set(DEFAULT_GPU_TARGETS
     "gfx1101"
     "gfx1102"
     "gfx1151"
-    "gfx1152")
+    "gfx1152"
+    "gfx1250")
 
 set(OPENMP_GPU_TARGETS
     "${DEFAULT_GPU_TARGETS}"

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/counters/tests/core.cpp
@@ -800,6 +800,7 @@ rocprofiler-sdk:
           - gfx12
           - gfx1200
           - gfx1201
+          - gfx1250
           expression: reduce(GRBM_GUI_ACTIVE,max)*CU_NUM
     )";
     ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
@@ -856,6 +857,7 @@ rocprofiler-sdk:
           - gfx12
           - gfx1200
           - gfx1201
+          - gfx1250
           block: GRBM
           event: 2
     - name: TEST_YAML_LOAD
@@ -885,6 +887,7 @@ rocprofiler-sdk:
           - gfx12
           - gfx1200
           - gfx1201
+          - gfx1250
           expression: reduce(GRBM_GUI_ACTIVE,max)
     )";
     ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);

--- a/projects/rocprofiler-sdk/source/scripts/run-ci.py
+++ b/projects/rocprofiler-sdk/source/scripts/run-ci.py
@@ -50,7 +50,7 @@ _DEFAULT_INSTALL_PREFIX = (
 )
 _DEFAULT_GPU_TARGETS = os.environ.get(
     "GPU_TARGETS",
-    "gfx900 gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1102",
+    "gfx900 gfx906 gfx908 gfx90a gfx942 gfx950 gfx1030 gfx1100 gfx1101 gfx1102 gfx1250",
 ).split()
 
 

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
@@ -552,6 +552,7 @@ rocprofiler-sdk:
             - gfx12
             - gfx1200
             - gfx1201
+            - gfx1250
             - gfx9
             - gfx900
             - gfx906

--- a/projects/rocprofiler-sdk/tests/bin/openmp/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/bin/openmp/CMakeLists.txt
@@ -33,7 +33,8 @@ set(DEFAULT_GPU_TARGETS
     "gfx1101"
     "gfx1102"
     "gfx1151"
-    "gfx1152")
+    "gfx1152"
+    "gfx1250")
 
 set(OPENMP_GPU_TARGETS
     "${DEFAULT_GPU_TARGETS}"

--- a/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
@@ -25,7 +25,8 @@ set(DEFAULT_GPU_TARGETS
     "gfx1101"
     "gfx1102"
     "gfx1151"
-    "gfx1152")
+    "gfx1152"
+    "gfx1250")
 
 set(GPU_TARGETS
     "${DEFAULT_GPU_TARGETS}"

--- a/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/extra_counters.yaml
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/counter-collection/extra_counters/extra_counters.yaml
@@ -28,4 +28,5 @@ rocprofiler-sdk:
           - gfx12
           - gfx1200
           - gfx1201
+          - gfx1250
           expression: reduce(GRBM_GUI_ACTIVE,max)*CU_NUM


### PR DESCRIPTION
## Motivation

Enable rocprofiler-sdk unit tests, integration tests, and samples for gfx1250.

## Technical Details

**Build-target lists**:
- `tests/common/CMakeLists.txt` — add `gfx1250` to `DEFAULT_GPU_TARGETS`.
- `tests/bin/openmp/CMakeLists.txt` — add `gfx1250` to `DEFAULT_GPU_TARGETS`.
- `samples/openmp_target/CMakeLists.txt` — add `gfx1250` to `DEFAULT_GPU_TARGETS`.

**CI harness:**
- `source/scripts/run-ci.py` — add `gfx1250` to the `_DEFAULT_GPU_TARGETS` default list.

**Counter-definition test fixtures**:
- `source/lib/rocprofiler-sdk/counters/tests/core.cpp` — add `gfx1250` in the three `check_load_counter_def_*` YAML blocks.
- `tests/rocprofv3/counter-collection/extra_counters/extra_counters.yaml` — add `gfx1250`

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
