### PR TITLE
[rccl] Fix ncclCommGrow channel-count divergence

### DIFF
--- a/projects/rccl/src/graph/connect.cc
+++ b/projects/rccl/src/graph/connect.cc
@@ -12,12 +12,32 @@
 #include "trees.h"
 #include "rings.h"
 #include "topo.h"
+#include "bootstrap.h"
 
 #include <stdio.h>      // For NULL and
 #include <stdlib.h>     // For malloc(), calloc(), and free()
 #include <stdint.h>     // For uint8_t and other fixed-width types
 #include <string.h>     // For memset()
 #include <limits.h>     // For INT_MAX
+
+// Allgather *value across the comm and reduce it to the global minimum. Leak-safe
+// on the allgather error path. See declaration in graph.h for why grow needs this.
+ncclResult_t ncclTopoReconcileGrowChannels(struct ncclComm* comm, int* value) {
+#if defined(TOPO_EXPL)
+  // topo_expl does not link the bootstrap layer and never grows comms.
+  (void)comm; (void)value;
+  return ncclSuccess;
+#else
+  int* perRank = NULL;
+  NCCLCHECK(ncclCalloc(&perRank, comm->nRanks));
+  perRank[comm->rank] = *value;
+  ncclResult_t ret = bootstrapAllGather(comm->bootstrap, perRank, sizeof(int));
+  if (ret == ncclSuccess)
+    for (int r = 0; r < comm->nRanks; r++) *value = std::min(*value, perRank[r]);
+  free(perRank);
+  return ret;
+#endif
+}
 
 
 /******************************************************************/
@@ -1290,6 +1310,11 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
   } else {
     nChannels = comm->nChannels = std::min(std::min(ncclMaxNchannels() * channelMultiplier, nChannels), comm->config.maxCTAs);
     nChannels = comm->nChannels = copyChannels(comm, nChannels, std::max(minNchannels, std::max(nc, comm->config.minCTAs)), ringPrev, ringNext);
+  }
+
+  if (comm->isGrow) {
+    NCCLCHECKGOTO(ncclTopoReconcileGrowChannels(comm, &comm->nChannels), ret, fail);
+    nChannels = comm->nChannels;
   }
 
   comm->collChannels = comm->nChannels;

--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -1213,6 +1213,13 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
   // invariant required by ncclP2pChannelToPart.
   comm->p2pnChannelsPerPeer = std::min(comm->p2pnChannelsPerPeer, comm->p2pnChannels);
 
+  // Same grow reconciliation as ncclTopoPostset, for p2p channels (the grow path
+  // skips the tpP2pNChannels clamp, so arch-specific p2p caps can diverge).
+  if (comm->isGrow) {
+    NCCLCHECK(ncclTopoReconcileGrowChannels(comm, &comm->p2pnChannels));
+    comm->p2pnChannelsPerPeer = std::min(comm->p2pnChannelsPerPeer, comm->p2pnChannels);
+  }
+
   // Init channels that weren't used so far
   for (int c=comm->nChannels; c<std::max(comm->nChannels, comm->p2pnChannels); c++) NCCLCHECK(initChannel(comm, c));
 

--- a/projects/rccl/src/include/graph.h
+++ b/projects/rccl/src/include/graph.h
@@ -19,6 +19,12 @@
 
 ncclResult_t ncclTopoCudaPath(int cudaDev, char** path);
 
+// Reduce a per-rank channel count to the global minimum across comm. Used on the
+// grow path, which keeps a fresh sharedRes (owner==comm) and so skips the
+// tpNChannels/tpP2pNChannels clamp; the arch-specific caps can otherwise leave
+// ranks with different counts and break the ncclConnect exchange.
+ncclResult_t ncclTopoReconcileGrowChannels(struct ncclComm* comm, int* value);
+
 struct ncclTopoSystem;
 // Build the topology
 ncclResult_t ncclTopoGetSystem(struct ncclComm* comm, struct ncclTopoSystem** system, const char* dumpXmlFile=NULL);

--- a/projects/rccl/test/GinNcclTimeoutMPITests.cpp
+++ b/projects/rccl/test/GinNcclTimeoutMPITests.cpp
@@ -337,12 +337,23 @@ TEST_F(LsaBarrierTimeoutMPITest, AbsentPeerProducesTimeout)
     SCOPE_EXIT((void)ncclDevCommDestroy(comm, &devComm));
     int rank = -1, nRanks = -1;
     ncclCommUserRank(comm, &rank); ncclCommCount(comm, &nRanks);
-    const bool isAbsent = (rank == nRanks - 1);
+    // The single-absent-peer timeout only starves reliably with a 2-rank LSA team;
+    // at N>2 the all-to-all inbox + rolling-epoch wait can complete, so skip instead.
+    // Decide collectively (max LSA size across the job) so every rank skips or runs
+    // together — a per-rank skip would deadlock the MPI_Barrier below.
+    ncclTeam_t lsaTeam = ncclTeamLsa(comm);
+    int maxLsaNRanks = lsaTeam.nRanks;
+    MPI_Allreduce(MPI_IN_PLACE, &maxLsaNRanks, 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+    if (maxLsaNRanks != 2) {
+        GTEST_SKIP() << "LSA absent-peer timeout requires a 2-rank LSA team; got "
+                     << maxLsaNRanks << ". Run with 2 ranks sharing one LSA domain.";
+    }
+    const bool isAbsent = (lsaTeam.rank == lsaTeam.nRanks - 1);
     int hResult = static_cast<int>(ncclSuccess);
     if (!isAbsent) {
         hResult = runLsaBarrier(devComm, stream, kShortTimeoutCycles);
         EXPECT_EQ(static_cast<int>(ncclTimeout), hResult)
-            << "Rank " << rank << " expected ncclTimeout, got "
+            << "LSA rank " << lsaTeam.rank << " expected ncclTimeout, got "
             << ncclGetErrorString(static_cast<ncclResult_t>(hResult));
     }
     MPI_Barrier(MPI_COMM_WORLD);
@@ -356,12 +367,19 @@ TEST_F(LsaBarrierTimeoutMPITest, ZeroBudgetAbsentPeerTimesOut)
     SCOPE_EXIT((void)ncclDevCommDestroy(comm, &devComm));
     int rank = -1, nRanks = -1;
     ncclCommUserRank(comm, &rank); ncclCommCount(comm, &nRanks);
-    const bool isAbsent = (rank == nRanks - 1);
+    ncclTeam_t lsaTeam = ncclTeamLsa(comm);
+    // The single-absent-peer timeout only starves reliably with a 2-rank LSA team;
+    // at N>2 the all-to-all inbox + rolling-epoch wait can complete, so skip instead.
+    if (lsaTeam.nRanks != 2) {
+        GTEST_SKIP() << "LSA absent-peer timeout requires a 2-rank LSA team; got "
+                     << lsaTeam.nRanks << ". Run with 2 ranks sharing one LSA domain.";
+    }
+    const bool isAbsent = (lsaTeam.rank == lsaTeam.nRanks - 1);
     int hResult = static_cast<int>(ncclSuccess);
     if (!isAbsent) {
         hResult = runLsaBarrier(devComm, stream, /*timeoutCycles=*/0ULL);
         EXPECT_EQ(static_cast<int>(ncclTimeout), hResult)
-            << "Rank " << rank << " expected immediate ncclTimeout, got "
+            << "LSA rank " << lsaTeam.rank << " expected immediate ncclTimeout, got "
             << ncclGetErrorString(static_cast<ncclResult_t>(hResult));
     }
     MPI_Barrier(MPI_COMM_WORLD);
@@ -394,7 +412,14 @@ TEST_F(LsaBarrierTimeoutMPITest, RecoversAfterTimeout)
     SCOPE_EXIT((void)ncclDevCommDestroy(comm, &devComm));
     int rank = -1, nRanks = -1;
     ncclCommUserRank(comm, &rank); ncclCommCount(comm, &nRanks);
-    const bool isAbsent = (rank == nRanks - 1);
+    ncclTeam_t lsaTeam = ncclTeamLsa(comm);
+    // The single-absent-peer timeout only starves reliably with a 2-rank LSA team;
+    // at N>2 the all-to-all inbox + rolling-epoch wait can complete, so skip instead.
+    if (lsaTeam.nRanks != 2) {
+        GTEST_SKIP() << "LSA absent-peer timeout requires a 2-rank LSA team; got "
+                     << lsaTeam.nRanks << ". Run with 2 ranks sharing one LSA domain.";
+    }
+    const bool isAbsent = (lsaTeam.rank == lsaTeam.nRanks - 1);
     if (!isAbsent) {
         EXPECT_EQ(static_cast<int>(ncclTimeout),
                   runLsaBarrier(devComm, stream, kShortTimeoutCycles));
@@ -415,7 +440,14 @@ TEST_F(LsaBarrierTimeoutMPITest, BackToBackTimeouts)
     SCOPE_EXIT((void)ncclDevCommDestroy(comm, &devComm));
     int rank = -1, nRanks = -1;
     ncclCommUserRank(comm, &rank); ncclCommCount(comm, &nRanks);
-    const bool isAbsent = (rank == nRanks - 1);
+    ncclTeam_t lsaTeam = ncclTeamLsa(comm);
+    // The single-absent-peer timeout only starves reliably with a 2-rank LSA team;
+    // at N>2 the all-to-all inbox + rolling-epoch wait can complete, so skip instead.
+    if (lsaTeam.nRanks != 2) {
+        GTEST_SKIP() << "LSA absent-peer timeout requires a 2-rank LSA team; got "
+                     << lsaTeam.nRanks << ". Run with 2 ranks sharing one LSA domain.";
+    }
+    const bool isAbsent = (lsaTeam.rank == lsaTeam.nRanks - 1);
     constexpr int kRounds = 4;
     int timeouts = 0;
     for (int i = 0; i < kRounds; ++i) {

--- a/projects/rccl/test/GrowMPITests.cpp
+++ b/projects/rccl/test/GrowMPITests.cpp
@@ -1168,4 +1168,48 @@ TEST_F(GrowMPITest, Grow_NewRankNRanksEqualExisting)
     }
 }
 
+// Grow from a 1-rank parent straight to the full world, then run a SendRecv ring
+// (p2p channels) and an AllReduce (ring channels). The 1->world jump forces the
+// largest topology-class change, under which ranks must still agree on the
+// channel count; a mismatch surfaces as a bootstrap "Message truncated" / hang
+// during the grow or its first collective. Strongest on a multi-node allocation,
+// where the single->multi-node arch-cap flip makes the counts diverge.
+TEST_F(GrowMPITest, Grow_ChannelReconciliation_OneToWorld_SendRecv)
+{
+    if (MPIEnvironment::world_size < 3) {
+        GTEST_SKIP() << "Channel-reconciliation grow needs >=3 ranks to force a "
+                        "topology-class change (1 -> world)";
+    }
+    const int wr        = MPIEnvironment::world_rank;
+    const int worldSize = MPIEnvironment::world_size;
+
+    // 1-rank parent on rank 0 only; everyone else joins as new ranks.
+    ASSERT_MPI_EQ(ncclSuccess, buildComm(1, &initialComm_));
+
+    ncclUniqueId growId{};
+    if (wr == 0) {
+        ASSERT_EQ(ncclSuccess, ncclCommGetUniqueId(initialComm_, &growId));
+    }
+    MPI_Bcast(&growId, sizeof(growId), MPI_BYTE, 0, MPI_COMM_WORLD);
+
+    // rank 0 is the lone existing rank; ranks 1..world-1 all join at once.
+    if (wr == 0) {
+        ASSERT_EQ(ncclSuccess,
+                  ncclCommGrow(initialComm_, worldSize, &growId, -1, &grownComm_, nullptr));
+    } else {
+        ASSERT_EQ(ncclSuccess,
+                  ncclCommGrow(nullptr, worldSize, &growId, wr, &grownComm_, nullptr));
+    }
+    ASSERT_MPI_NE(grownComm_, nullptr);
+
+    int grownCount = -1;
+    ASSERT_MPI_EQ(ncclSuccess, ncclCommCount(grownComm_, &grownCount));
+    ASSERT_MPI_EQ(grownCount, worldSize);
+
+    // SendRecv ring exercises the p2p channels (the path that truncates when
+    // p2pnChannels disagrees across ranks). AllReduce too, to cover ring channels.
+    ASSERT_MPI_TRUE(runSendRecvRing(grownComm_, worldSize));
+    ASSERT_MPI_TRUE(runAllReduceAndVerify(grownComm_, worldSize));
+}
+
 #endif // MPI_TESTS_ENABLED


### PR DESCRIPTION
## Motivation
`ncclCommGrow` fails with a bootstrap "Message truncated" / `ncclInternalError` (or hangs in the first p2p collective) when a grow changes the topology class on gfx950/MI350. Grow allocates each new comm with a fresh `sharedRes` (`owner==comm`), so it skips the `owner!=comm` clamp that reconciles the channel count to the parent's `tpNChannels`/`tpP2pNChannels`. RCCL's arch-specific channel caps (single/multi-node, p2p 16/32) then evaluate differently across ranks, leaving them with mismatched `nChannels`/`p2pnChannels`; `ncclTransportP2pSetup` exchanges `sizeof(ncclConnect)*channelCount` per rank, so the divergence breaks the connect. Upstream NCCL has no such caps and never re-diverges after the graph allgather.

## Technical Details
- `ncclTopoPostset` (connect.cc): for `comm->isGrow`, allgather each rank's `nChannels` and reduce to the global minimum.
- `ncclTopoComputeP2pChannels` (paths.cc): same reconciliation for `p2pnChannels` (and dependent `p2pnChannelsPerPeer`).
- Tests: add `GrowMPITests.Grow_ChannelReconciliation_OneToWorld_SendRecv` (grows 1->world, drives SendRecv+AllReduce; fails without the fix, passes with it); scope the `LsaBarrierTimeoutMPITest` absent-peer cases to a 2-rank LSA team and skip otherwise.

## JIRA ID
-

## Test Plan
Ruby cluster (gfx950/MI350X, ROCm 7.13), single-node (8 ranks) and 2-node (4x4): run Revoke, Grow, and GinNcclTimeout MPI suites.

## Test Result
- Grow: 28/28 (single + 2-node), incl. the new regression test
- Revoke: 18/18 (2-node)
- GinNcclTimeout: 11/11 (2-node); LSA absent-peer skip where LSA team != 2