### PR TITLE
[AMD SMI] Explain hops and weights

### DIFF
--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -568,6 +568,8 @@ Command Modifiers:
 
 #### Interpreting hops and weight
 
+The following descriptions apply to AMD Instinct GPUs up to and including MI355X.
+
 **Hops (`-o, --hops`)** — The hops table reports an *abstracted topology step count*, not
 the number of physical xGMI links between devices. The possible values are:
 

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -566,6 +566,32 @@ Command Modifiers:
                                 DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
+#### Interpreting hops and weight
+
+**Hops (`-o, --hops`)** — The hops table reports an *abstracted topology step count*, not
+the number of physical xGMI links between devices. The possible values are:
+
+| Hops | Meaning |
+|------|---------|
+| 1 | Endpoints reachable over xGMI (GPU-to-GPU or GPU-to-CPU), regardless of the number of physical xGMI links on the route. |
+| 2 | Endpoints connected over PCIe within the same CPU NUMA node. |
+| 3 | Endpoints on different CPU NUMA nodes; the route crosses both. |
+| 4 | Fallback when the inter-CPU io_link weight cannot be read. |
+
+Two GPUs on the same xGMI fabric always report `1`, even when data physically crosses
+multiple xGMI links. To determine the literal number of physical xGMI links between two
+devices, read the value from the `amdgpu` driver:
+
+```bash
+cat /sys/class/drm/card*/device/xgmi_num_hops
+```
+
+**Weight (`-w, --weight`)** — The weight table reports a qualitative cost metric derived
+from the KFD io_link `weight` property (lower = closer/faster), analogous to the NUMA
+distances reported by `numactl`. Each physical xGMI hop contributes 15 to the weight
+(for example, a single-hop xGMI connection has weight 15); each PCIe segment contributes
+a fixed 20, and multi-segment PCIe routes are summed across all segments.
+
 (cmd-set)=
 ### amd-smi set
 

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -573,9 +573,9 @@ the number of physical xGMI links between devices. The possible values are:
 
 | Hops | Meaning |
 |------|---------|
-| 1 | Endpoints reachable over xGMI (GPU-to-GPU or GPU-to-CPU), regardless of the number of physical xGMI links on the route. |
-| 2 | Endpoints connected over PCIe within the same CPU NUMA node. |
-| 3 | Endpoints on different CPU NUMA nodes; the route crosses both. |
+| 1 | The two GPUs are reachable over xGMI, regardless of the number of physical xGMI links on the route. |
+| 2 | The two GPUs communicate over PCIe within the same CPU NUMA node. |
+| 3 | The two GPUs communicate over PCIe across different CPU NUMA nodes. |
 | 4 | Fallback when the inter-CPU io_link weight cannot be read. |
 
 Two GPUs on the same xGMI fabric always report `1`, even when data physically crosses

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -589,8 +589,10 @@ cat /sys/class/drm/card*/device/xgmi_num_hops
 **Weight (`-w, --weight`)** — The weight table reports a qualitative cost metric derived
 from the KFD io_link `weight` property (lower = closer/faster), analogous to the NUMA
 distances reported by `numactl`. Each physical xGMI hop contributes 15 to the weight
-(for example, a single-hop xGMI connection has weight 15); each PCIe segment contributes
-a fixed 20, and multi-segment PCIe routes are summed across all segments.
+(for example, a single-hop xGMI connection has weight 15). PCIe routes are summed across
+segments (GPU→CPU + CPU→CPU + CPU→GPU); each GPU-to-CPU segment is typically 20, while
+the CPU-to-CPU segment uses the actual io_link weight, or a fallback of 10 if that weight
+cannot be read.
 
 (cmd-set)=
 ### amd-smi set

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6636,9 +6636,10 @@ amdsmi_status_t amdsmi_topo_get_numa_node_number(amdsmi_processor_handle process
  *  - Each physical xGMI hop contributes 15, so an xGMI route traversing
  *    @em N physical links has a weight of @em 15*N. A single-hop xGMI
  *    connection has a weight of 15.
- *  - Each PCIe segment contributes a fixed cost of 20.
- *  - Multi-segment PCIe routes are summed over all segments
- *    (GPU→CPU + CPU→CPU + CPU→GPU).
+ *  - PCIe segments are summed over all segments (GPU→CPU + CPU→CPU + CPU→GPU).
+ *    Each GPU-to-CPU segment typically contributes 20. The CPU-to-CPU segment
+ *    uses the actual io_link weight when available; if that weight cannot be
+ *    read, a fallback value of 10 is used for that segment.
  *
  *  @param[in] processor_handle_src the source processor handle
  *

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6709,7 +6709,7 @@ amdsmi_status_t amdsmi_get_minmax_bandwidth_between_processors(
  *  Two GPUs on the same xGMI fabric always report a hop count of 1, even when
  *  the data physically crosses several xGMI links. To obtain the literal number
  *  of physical xGMI links between two devices, read the value exposed by the
- *  @c amdgpu driver at @c /sys/class/drm/card*/device/xgmi_num_hops instead.
+ *  @c amdgpu driver at @c `/sys/class/drm/card{0,1,…}/device/xgmi_num_hops` instead.
  *
  *  @param[in] processor_handle_src the source processor handle
  *

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6628,6 +6628,18 @@ amdsmi_status_t amdsmi_topo_get_numa_node_number(amdsmi_processor_handle process
  *  weight for the connection between the device @p processor_handle_src
  *  and @p processor_handle_dst to the memory pointed to by @p weight.
  *
+ *  The weight is a qualitative cost metric derived from the KFD io_link
+ *  @c weight property (lower values indicate closer or faster connections),
+ *  similar in spirit to the NUMA distances reported by @c numactl. The value
+ *  is computed as follows:
+ *
+ *  - Each physical xGMI hop contributes 15, so an xGMI route traversing
+ *    @em N physical links has a weight of @em 15*N. A single-hop xGMI
+ *    connection has a weight of 15.
+ *  - Each PCIe segment contributes a fixed cost of 20.
+ *  - Multi-segment PCIe routes are summed over all segments
+ *    (GPU→CPU + CPU→CPU + CPU→GPU).
+ *
  *  @param[in] processor_handle_src the source processor handle
  *
  *  @param[in] processor_handle_dst the destination processor handle
@@ -6684,12 +6696,27 @@ amdsmi_status_t amdsmi_get_minmax_bandwidth_between_processors(
  *  between the device @p processor_handle_src and @p processor_handle_dst to the memory
  *  pointed to by @p hops and @p type.
  *
+ *  @note The value written to @p hops is an <b>abstracted topology step count</b>,
+ *  not the number of physical xGMI links traversed. The possible values are:
+ *
+ *  | Value | Meaning |
+ *  |-------|---------|
+ *  | 1 | Endpoints are reachable over xGMI (GPU-to-GPU or GPU-to-CPU), regardless of how many physical xGMI links the route traverses. |
+ *  | 2 | Endpoints communicate over PCIe within the same CPU NUMA node (GPU-to-GPU or GPU-to-CPU). |
+ *  | 3 | Endpoints are on different CPU NUMA nodes; the route crosses both. |
+ *  | 4 | Fallback value used when the inter-CPU io_link weight cannot be read. |
+ *
+ *  Two GPUs on the same xGMI fabric always report a hop count of 1, even when
+ *  the data physically crosses several xGMI links. To obtain the literal number
+ *  of physical xGMI links between two devices, read the value exposed by the
+ *  @c amdgpu driver at @c /sys/class/drm/card*/device/xgmi_num_hops instead.
+ *
  *  @param[in] processor_handle_src the source processor handle
  *
  *  @param[in] processor_handle_dst the destination processor handle
  *
  *  @param[in,out] hops A pointer to an uint64_t to which the
- *  hops for the connection should be written.
+ *  abstracted hop count for the connection should be written.
  *
  *  @param[in,out] type A pointer to an ::amdsmi_link_type_t to which the
  *  type for the connection should be written.

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6701,9 +6701,9 @@ amdsmi_status_t amdsmi_get_minmax_bandwidth_between_processors(
  *
  *  | Value | Meaning |
  *  |-------|---------|
- *  | 1 | Endpoints are reachable over xGMI (GPU-to-GPU or GPU-to-CPU), regardless of how many physical xGMI links the route traverses. |
- *  | 2 | Endpoints communicate over PCIe within the same CPU NUMA node (GPU-to-GPU or GPU-to-CPU). |
- *  | 3 | Endpoints are on different CPU NUMA nodes; the route crosses both. |
+ *  | 1 | The two GPUs are reachable over xGMI, regardless of how many physical xGMI links the route traverses. |
+ *  | 2 | The two GPUs communicate over PCIe within the same CPU NUMA node. |
+ *  | 3 | The two GPUs communicate over PCIe across different CPU NUMA nodes. |
  *  | 4 | Fallback value used when the inter-CPU io_link weight cannot be read. |
  *
  *  Two GPUs on the same xGMI fabric always report a hop count of 1, even when

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6682,6 +6682,7 @@ amdsmi_status_t amdsmi_get_minmax_bandwidth_between_processors(
     amdsmi_processor_handle processor_handle_src, amdsmi_processor_handle processor_handle_dst,
     uint64_t* min_bandwidth, uint64_t* max_bandwidth);
 
+// clang-format off
 /**
  *  @brief Retrieve the hops and the connection type between 2 GPUs
  *
@@ -6723,6 +6724,7 @@ amdsmi_status_t amdsmi_get_minmax_bandwidth_between_processors(
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
+// clang-format on
 amdsmi_status_t amdsmi_topo_get_link_type(amdsmi_processor_handle processor_handle_src,
                                           amdsmi_processor_handle processor_handle_dst,
                                           uint64_t* hops, amdsmi_link_type_t* type);

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -3837,6 +3837,18 @@ def amdsmi_topo_get_numa_node_number(processor_handle: processor_handle_t):
 def amdsmi_topo_get_link_weight(
     processor_handle_src: processor_handle_t, processor_handle_dst: processor_handle_t
 ):
+    """Return the qualitative link weight between two processors.
+
+    The weight is a cost metric derived from the KFD io_link weight property
+    (lower = closer/faster), analogous to numactl NUMA distances:
+
+    - xGMI: 15 per physical hop (e.g. a single-hop xGMI link has weight 15).
+    - PCIe: 20 per segment; multi-segment routes are summed
+      (GPU→CPU + CPU→CPU + CPU→GPU).
+
+    Returns:
+        int: The link weight.
+    """
     if not isinstance(processor_handle_src, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle_src, amdsmi_wrapper.amdsmi_processor_handle)
 
@@ -3907,6 +3919,24 @@ def amdsmi_get_link_metrics(processor_handle: processor_handle_t):
 def amdsmi_topo_get_link_type(
     processor_handle_src: processor_handle_t, processor_handle_dst: processor_handle_t
 ):
+    """Return the abstracted hop count and link type between two processors.
+
+    The hop count is an abstracted topology step count, not the number of
+    physical xGMI links traversed:
+
+    - 1: Reachable over xGMI (GPU-to-GPU or GPU-to-CPU), regardless of the
+         number of physical xGMI links on the route.
+    - 2: Connected over PCIe within the same CPU NUMA node.
+    - 3: Connected over PCIe across different CPU NUMA nodes.
+    - 4: Fallback when the inter-CPU io_link weight cannot be read.
+
+    Two GPUs on the same xGMI fabric always report 1 even when data physically
+    crosses multiple xGMI links. For the literal physical xGMI hop count, read
+    ``/sys/class/drm/card*/device/xgmi_num_hops`` from the amdgpu driver.
+
+    Returns:
+        dict: ``{"hops": int, "type": amdsmi_link_type_t}``
+    """
     if not isinstance(processor_handle_src, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle_src, amdsmi_wrapper.amdsmi_processor_handle)
 

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -3843,8 +3843,10 @@ def amdsmi_topo_get_link_weight(
     (lower = closer/faster), analogous to numactl NUMA distances:
 
     - xGMI: 15 per physical hop (e.g. a single-hop xGMI link has weight 15).
-    - PCIe: 20 per segment; multi-segment routes are summed
-      (GPU→CPU + CPU→CPU + CPU→GPU).
+    - PCIe: segments are summed (GPU→CPU + CPU→CPU + CPU→GPU). Each
+      GPU-to-CPU segment is typically 20. The CPU-to-CPU segment uses the
+      actual io_link weight when available; if that weight cannot be read, a
+      fallback of 10 is used for that segment.
 
     Both handles must be GPU processor handles.
 

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -3837,7 +3837,7 @@ def amdsmi_topo_get_numa_node_number(processor_handle: processor_handle_t):
 def amdsmi_topo_get_link_weight(
     processor_handle_src: processor_handle_t, processor_handle_dst: processor_handle_t
 ):
-    """Return the qualitative link weight between two processors.
+    """Return the qualitative link weight between two GPUs.
 
     The weight is a cost metric derived from the KFD io_link weight property
     (lower = closer/faster), analogous to numactl NUMA distances:
@@ -3845,6 +3845,8 @@ def amdsmi_topo_get_link_weight(
     - xGMI: 15 per physical hop (e.g. a single-hop xGMI link has weight 15).
     - PCIe: 20 per segment; multi-segment routes are summed
       (GPU→CPU + CPU→CPU + CPU→GPU).
+
+    Both handles must be GPU processor handles.
 
     Returns:
         int: The link weight.
@@ -3919,15 +3921,15 @@ def amdsmi_get_link_metrics(processor_handle: processor_handle_t):
 def amdsmi_topo_get_link_type(
     processor_handle_src: processor_handle_t, processor_handle_dst: processor_handle_t
 ):
-    """Return the abstracted hop count and link type between two processors.
+    """Return the abstracted hop count and link type between two GPUs.
 
-    The hop count is an abstracted topology step count, not the number of
-    physical xGMI links traversed:
+    Both handles must be GPU processor handles. The hop count is an abstracted
+    topology step count, not the number of physical xGMI links traversed:
 
-    - 1: Reachable over xGMI (GPU-to-GPU or GPU-to-CPU), regardless of the
-         number of physical xGMI links on the route.
-    - 2: Connected over PCIe within the same CPU NUMA node.
-    - 3: Connected over PCIe across different CPU NUMA nodes.
+    - 1: The two GPUs are reachable over xGMI, regardless of the number of
+         physical xGMI links on the route.
+    - 2: The two GPUs communicate over PCIe within the same CPU NUMA node.
+    - 3: The two GPUs communicate over PCIe across different CPU NUMA nodes.
     - 4: Fallback when the inter-CPU io_link weight cannot be read.
 
     Two GPUs on the same xGMI fabric always report 1 even when data physically
@@ -3935,7 +3937,8 @@ def amdsmi_topo_get_link_type(
     ``/sys/class/drm/card*/device/xgmi_num_hops`` from the amdgpu driver.
 
     Returns:
-        dict: ``{"hops": int, "type": amdsmi_link_type_t}``
+        dict: ``{"hops": int, "type": int}`` where ``type`` is a value of
+        :class:`amdsmi_link_type_t`.
     """
     if not isinstance(processor_handle_src, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle_src, amdsmi_wrapper.amdsmi_processor_handle)


### PR DESCRIPTION
## Motivation

The current documentation on how to interpret the output of `amd-smi` with regard to XGMI hops and weights is vague und not really helpful. This PR attempts to improve that part of our documentation.

## Technical Details

Explains the actual meaning of hops and weights by grabbing the necessary information from the public AMDGPU amd AMD SMI source code.

## JIRA ID

ROCM-24267, AIROCDOC-3993

## Test Plan

n/a

## Test Result

n/a

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
