### PR TITLE
[CLR] Reduce atomic overhead's for hipKernelLaunch

### DIFF
--- a/projects/clr/rocclr/platform/command.cpp
+++ b/projects/clr/rocclr/platform/command.cpp
@@ -30,7 +30,7 @@ Event::Event(HostQueue& queue, bool profilingEnabled)
       device_(&queue.device()),
       profilingInfo_(profilingEnabled) {
   event_entry_scope_.store(Device::kCacheStateInvalid, std::memory_order_relaxed);
-  notified_.clear();
+  notified_.clear(std::memory_order_relaxed);
 }
 
 // ================================================================================================
@@ -41,7 +41,7 @@ Event::Event()
       notify_event_(nullptr),
       device_(nullptr) {
   event_entry_scope_.store(Device::kCacheStateInvalid, std::memory_order_relaxed);
-  notified_.clear();
+  notified_.clear(std::memory_order_relaxed);
 }
 
 // ================================================================================================

--- a/projects/clr/rocclr/thread/monitor.hpp
+++ b/projects/clr/rocclr/thread/monitor.hpp
@@ -21,8 +21,9 @@ namespace amd {
 class Monitor {
  public:
   explicit Monitor() {
-    waits_.store(0);                               // 0 waiting thread initially
-    notifyState_.store(notifyState::notNotified);  // initially not notified
+    waits_.store(0, std::memory_order_relaxed);  // 0 waiting thread initially
+    notifyState_.store(notifyState::notNotified,
+                       std::memory_order_relaxed);  // initially not notified
   }
 
   //! Try to acquire the lock, return true if successful, false if failed.


### PR DESCRIPTION
## Motivation

Reduce hipKernelLaunch overheads in a multi-threaded environment

## Technical Details

Relaxes atomic stores/clears on construction - Not needed as object hasn't been created yet, causing a hot spot on Event and Monitor construction


| Scenario | WITH patch top functions | WITHOUT patch top functions |
|---|---|---|
| multi-theaded multi-gpu submission| submitKernelInternal (46.7%), mutex_unlock (3.6%), malloc_consolidate (4.1%), _int_free (8.0%) | submitKernelInternal (43.8%), _int_malloc (7.6%), retain (5.3%), mutex_unlock (3.7%), **Event::Event (3.2%)** |

## JIRA ID

ROCM-26064

## Test Plan

This is a performance re-write no test changes are needed

## Test Result

Tested locally and benchmarked locally

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
