### PR TITLE
rocr/trap_handler: Fix trap-on-end handling in the gfx12 trap handler

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
@@ -342,7 +342,7 @@
   //                                                 -> WAVE_APERTURE_VIOLATION
   // - EXCP_FLAG_PRIV.ILLEGAL_INST                   -> WAVE_ILLEGAL_INSTRUCTION
   // - EXCP_FLAG_PRIV.WAVE_START                     -> WAVE_TRAP
-  // - EXCP_FLAG_PRIV.WAVE_END && TRAP_CTRL.WAVE_END -> WAVE_TRAP
+  // - EXCP_FLAG_PRIV.WAVE_END                       -> WAVE_TRAP
   // - TRAP_CTRL.TRAP_AFTER_INST                     -> WAVE_TRAP
   // - EXCP_FLAG_PRIV.ADDR_WATCH && TRAP_CTL.WATCH   -> WAVE_TRAP
   // - (EXCP_FLAG_USER[ALU] & TRAP_CTRL[ALU]) != 0   -> WAVE_MATH_ERROR
@@ -374,8 +374,6 @@
 
 .not_wave_start:
   s_bitcmp1_b32     ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_WAVE_END_SHIFT
-  s_cbranch_scc0    .not_wave_end
-  s_bitcmp1_b32     ttmp13, SQ_WAVE_TRAP_CTRL_WAVE_END_SHIFT
   s_cbranch_scc0    .not_wave_end
   s_or_b32          ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
@@ -369,7 +369,7 @@
 
 .not_illegal_instruction:
   s_bitcmp1_b32     ttmp2, SQ_WAVE_EXCP_FLAG_PRIV_WAVE_START_SHIFT
-  s_cbranch_scc0    .not_wave_end
+  s_cbranch_scc0    .not_wave_start
   s_or_b32          ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
 
 .not_wave_start:


### PR DESCRIPTION
## Motivation

During manual review, it appeared that the gfx12 trap handler had minor issues when it comes to handling trap on wave end. This feature is not used at all, so those bugs are not an active issue, but they should be fixed anyway.

## Technical Details

2 issues exist:

- The logic for detecting if a wave_end exception was raised is currently
   wrong in the trap handler.  When taking this trap, HW clears the
   trap_ctrl bit controling this exception, which is different from other
   maskable exceptions.  As a consequence, the trap handler should not
   check that this exception was requested, but should only look at the
   excp_flag_priv bit, not trap_ctrl.  This patch fixes this.

-  The current gfx12 trap handler has an error login when looking for
   WAVE_START / WAVE_END traps.  If the trap handler detect that the
   wave_start exception was not raised, it skips past after the part to
   check wave_end, effectively skipping wave end.

## Test Plan

Regression tested against ROCgdb's testsuite.  The trap on wave end is never actively used, no test specific to it.

## Test Result

Pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

JIRA ID: AIROCGDB-123
