### PR TITLE
rocjitsu: Rocjitsu DBT Guest Mode 

### DIFF
--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -290,6 +290,7 @@ target_link_libraries(
         rocjitsu_plugin_race_detector
         rocjitsu_vm_risc_v
         rocjitsu_config
+        rocjitsu_dbt_config
         util
         flatbuffers
         Threads::Threads

--- a/emulation/rocjitsu/configs/guest_gfx950_on_gfx1201.json
+++ b/emulation/rocjitsu/configs/guest_gfx950_on_gfx1201.json
@@ -13,7 +13,7 @@
       "unique_id": 5929628898254127105,
       "marketing_name": "AMD Instinct MI350X",
       "drm_render_minor": 191,
-      "simd_count": 1024,
+      "simd_count": 64,
       "max_waves_per_simd": 8,
       "num_shader_engines": 4,
       "num_shader_arrays_per_engine": 2,

--- a/emulation/rocjitsu/configs/guest_gfx950_on_gfx1201.json
+++ b/emulation/rocjitsu/configs/guest_gfx950_on_gfx1201.json
@@ -1,0 +1,40 @@
+{
+  "dbt_guest": {
+    "enabled": true,
+    "guest_isa": "gfx950",
+    "host_isa": "gfx1201",
+    "host_gpu_id": 0,
+    "guest_device": {
+      "gpu_id": 38144,
+      "gfx_target_version": 90500,
+      "vendor_id": 4098,
+      "device_id": 30112,
+      "family_id": 160,
+      "unique_id": 5929628898254127105,
+      "marketing_name": "AMD Instinct MI350X",
+      "drm_render_minor": 191,
+      "simd_count": 1024,
+      "max_waves_per_simd": 8,
+      "num_shader_engines": 4,
+      "num_shader_arrays_per_engine": 2,
+      "num_cu_per_sh": 4,
+      "simd_per_cu": 4,
+      "wave_front_size": 64,
+      "max_slots_scratch_cu": 32,
+      "local_mem_size": 309237645312,
+      "lds_size_kb": 160,
+      "mem_width": 8192,
+      "mem_clk_max": 1600,
+      "l1_size_kb": 32,
+      "l1_line_size": 128,
+      "l1_assoc": 4,
+      "l2_size_kb": 4096,
+      "l2_line_size": 128,
+      "l2_assoc": 16,
+      "num_sdma_engines": 5,
+      "num_sdma_xgmi_engines": 12,
+      "num_cp_queues": 128,
+      "max_engine_clk_fcompute": 2400
+    }
+  }
+}

--- a/emulation/rocjitsu/configs/guest_gfx950_on_gfx942.json
+++ b/emulation/rocjitsu/configs/guest_gfx950_on_gfx942.json
@@ -1,0 +1,40 @@
+{
+  "dbt_guest": {
+    "enabled": true,
+    "guest_isa": "gfx950",
+    "host_isa": "gfx942",
+    "host_gpu_id": 0,
+    "guest_device": {
+      "gpu_id": 38144,
+      "gfx_target_version": 90500,
+      "vendor_id": 4098,
+      "device_id": 30112,
+      "family_id": 160,
+      "unique_id": 5929628898254127105,
+      "marketing_name": "AMD Instinct MI350X",
+      "drm_render_minor": 191,
+      "simd_count": 1024,
+      "max_waves_per_simd": 8,
+      "num_shader_engines": 4,
+      "num_shader_arrays_per_engine": 2,
+      "num_cu_per_sh": 4,
+      "simd_per_cu": 4,
+      "wave_front_size": 64,
+      "max_slots_scratch_cu": 32,
+      "local_mem_size": 309237645312,
+      "lds_size_kb": 160,
+      "mem_width": 8192,
+      "mem_clk_max": 1600,
+      "l1_size_kb": 32,
+      "l1_line_size": 128,
+      "l1_assoc": 4,
+      "l2_size_kb": 4096,
+      "l2_line_size": 128,
+      "l2_assoc": 16,
+      "num_sdma_engines": 5,
+      "num_sdma_xgmi_engines": 12,
+      "num_cp_queues": 128,
+      "max_engine_clk_fcompute": 2400
+    }
+  }
+}

--- a/emulation/rocjitsu/configs/guest_gfx950_on_gfx942.json
+++ b/emulation/rocjitsu/configs/guest_gfx950_on_gfx942.json
@@ -13,7 +13,7 @@
       "unique_id": 5929628898254127105,
       "marketing_name": "AMD Instinct MI350X",
       "drm_render_minor": 191,
-      "simd_count": 1024,
+      "simd_count": 64,
       "max_waves_per_simd": 8,
       "num_shader_engines": 4,
       "num_shader_arrays_per_engine": 2,

--- a/emulation/rocjitsu/docs/plugins.md
+++ b/emulation/rocjitsu/docs/plugins.md
@@ -92,5 +92,5 @@ Multiple plugins can be active simultaneously via `ExecutionPluginGroup`.
 
 1. Implement `ExecutionPlugin` in a new `.cpp`/`.h` pair under `vm/plugins/`.
 2. Add the source to `CMakeLists.txt`.
-3. Register the plugin in `simulated_driver.cpp` (gated by an environment variable).
+3. Register the plugin in `simulated_kfd.cpp` (gated by an environment variable).
 4. Use `sink().write()` for all output — never write to stderr directly.

--- a/emulation/rocjitsu/docs/rocjitsu-cli.md
+++ b/emulation/rocjitsu/docs/rocjitsu-cli.md
@@ -280,7 +280,7 @@ kernel 6.12.59+ and 6.15+.
 | `rpc.h` | Protocol types, send/recv helpers |
 | `transport.h/.cpp` | Abstract transport + Unix socket implementation |
 | `remote_driver.h/.cpp` | Client-side RPC stub |
-| `simulated_driver.h/.cpp` | KFD ioctl dispatch, allocation table, events |
+| `simulated_kfd.h/.cpp` | KFD ioctl dispatch, allocation table, events |
 | `interposer.cpp` | LD_PRELOAD syscall intercepts |
 | `events.h/.cpp` | KFD event subsystem (create, set, wait, destroy) |
 | `tools/rocjitsu/main.cpp` | CLI entry point, RPC dispatch loop (daemon mode) |

--- a/emulation/rocjitsu/docs/rocjitsu_dbt_guest.md
+++ b/emulation/rocjitsu/docs/rocjitsu_dbt_guest.md
@@ -1,0 +1,156 @@
+# rocjitsu DBT Guest Mode
+
+A rocjitsu-only path where an unmodified ROCm process can see a
+guest GPU, but translate kernels and execute on a real host GPU.
+
+The design has three main components with their own responsibilities:
+
+1. **GuestKfd Interposer**: Shows applications a guest GPU device that looks
+   like a real KFD/DRM device.
+2. **HSA Hooks**: Intercepts HSA Runtime calls for the guest GPU and forwards
+   them to the host GPU, translating kernels as needed.
+3. **DBT**: Translates guest GPU kernels to host GPU kernels.
+
+## High Level Flow
+
+User:
+```bash
+rocjitsu --config configs/guest_gfx950_on_gfx942.json -- ./app
+```
+
+Underneath:
+```
+  LD_PRELOAD=librocjitsu.so
+      open/read sysfs topology -> host topology plus synthetic gfx950 node
+      open/ioctl /dev/kfd      -> real KFD for host nodes, GuestKfd for guest discovery/startup
+
+  HSA_TOOLS_LIB=librocjitsu_hooks.so
+      ROCR internally sees     -> selected host agent plus synthetic guest agent
+      hsa_iterate_agents       -> public host slot is replaced by the guest agent
+      hsa_agent_get_info       -> guest still reports gfx950 identity
+      hsa_queue_create         -> guest agent is replaced with host agent
+      hsa_executable_load...   -> guest ELF translated to host ELF, then loaded on host
+      hsa_executable_get...    -> guest symbol lookup is replaced with host symbol lookup
+      AMD extension calls      -> guest agents are replaced with host agents where needed
+```
+
+## Design Principles
+
+1. ROCR must internally discover both the real host GPU and the synthetic guest
+   GPU.
+
+   The selected host must stay available for queues, allocations, and code
+   loading. The synthetic guest must also exist so ROCR can build the guest HSA
+   agent. Public HSA iteration is then shadowed: rocjitsu emits the guest agent
+   in the selected host's ordinal slot and suppresses the guest's own slot. This
+   keeps applications that choose the first GPU on the guest path while leaving
+   the host agent alive for execution.
+
+   If `ROCR_VISIBLE_DEVICES` is set, the launcher expands it so the selected
+   host ordinal and appended guest ordinal both remain visible to ROCR before
+   the HSA hook applies this public shadowing.
+
+2. Guest-facing discovery stays guest-shaped.
+
+   Calls that applications use to decide which kernel image to load, such as
+   agent name and ISA iteration, should report the synthetic guest agent. If we
+   mapped those calls to the host, the application would choose host kernels
+   and skip DBT.
+
+3. Execution-facing calls map guest handles to host handles.
+
+   Queue creation, code-object load, symbol lookup, memory access, and AMD
+   extension operations that take an agent are redirected from the guest agent
+   to the selected host agent.
+
+4. KFD emulation stops at guest discovery.
+
+   `GuestKfd` should not run queues, allocate real guest VRAM, or process AQL
+   packets. It does handle enough startup plumbing for ROCR discovery: process
+   apertures, clock counters, VM acquisition, available-memory queries, memory
+   policy setup, synthetic guest memory handles, and guest-to-host gpu_id
+   rewrites for map/unmap requests. If a guest execution ioctl is reached after
+   the HSA hooks are in place, that is a missed HSA interception and should be
+   visible in logs.
+
+5. Code objects are loaded against the host ROCR agent.
+
+   ROCR validates code-object ISA against the load agent using ELF header
+   fields. The hook translates the ELF to host ISA and calls the original
+   `hsa_executable_load_agent_code_object()` with the host agent, not the guest
+   agent. Symbol queries using the guest agent are later remapped to the host
+   agent so application code still works.
+
+## Architecture
+
+rocjitsu DBT guest mode has two layers:
+
+1. A Linux KMD/driver interposer that makes the process believe a synthetic GPU
+   exists.
+2. An HSA tools hook that forwards synthetic-GPU work to the selected real host
+   GPU and translates guest code objects to host code objects.
+
+These layers solve different problems and should stay separate.
+
+### KMD Driver Interposer
+
+Applications do not always use HSA as their only GPU discovery path. Some
+frameworks and tools inspect `/dev/kfd`, KFD topology sysfs, DRM render nodes,
+or AMDGPU device metadata directly. If rocjitsu only hooks HSA, those clients
+may never believe a guest GPU exists.
+
+The KMD layer therefore appends a synthetic GPU to KFD topology and exposes a
+matching synthetic DRM render node. Its job ends at discovery and startup
+plumbing. It should not execute guest queues or emulate packet dispatch for this
+DBT path.
+
+For host-facing operations, `GuestKfd` forwards to the real `/dev/kfd`. For
+guest-facing startup operations, it either answers from the synthetic metadata
+or rewrites the request to the configured host GPU. Guest doorbell mappings and
+unsupported guest execution ioctls fail visibly.
+
+### HSA Hooks
+
+Applications generally dispatch through HSA. HSA API calls are mostly target
+independent, but AQL packets, queue resources, code-object ISA validation, and
+some extension calls carry target-specific meaning. Patching every packet and
+every target-dependent field after queue creation is too fragile.
+
+Instead, ROCR builds two HSA agents:
+
+- the selected host agent, backed by the real GPU and real KFD execution path;
+- the synthetic guest agent, backed by the KFD overlay and guest metadata.
+
+The HSA hook presents one public replacement agent: the guest agent in the
+selected host's enumeration slot. Execution-facing guest handles are then mapped
+back to the host agent. When a guest code object is loaded, the hook translates
+the code object to the host ISA and calls ROCR's original load API with the host
+agent. Kernel dispatch then uses normal host queues and normal host ROCR
+execution machinery.
+
+The important invariant is:
+
+```text
+public identity:   guest agent, guest ISA, guest name, guest memory pools
+execution identity: host agent, host queues, host memory backing, host code object
+```
+
+## Known Limits and Follow-Ups
+
+- File-backed HSA code-object readers are not translated in the MVP. Add a way
+  to capture stable bytes from `hsa_file_t` if an application needs this path.
+  Today the hook prints a warning when such a reader is created, and guest loads
+  without registered memory bytes fail rather than retrying an incompatible
+  original ELF.
+- `HSA_TOOLS_DISABLE_REGISTER=1` is a workaround. The better design is a
+  rocprofiler-register API-table interposer that applies the same shadowing
+  before rocprofiler validates HSA agents.
+- KFD guest queue execution is intentionally unsupported. If a guest execution
+  ioctl is reached, add or fix an HSA forwarding hook rather than teaching
+  `GuestKfd` to execute packets.
+- `signal_backtrace` is an opt-in best-effort diagnostic. rocjitsu prewarms the
+  unwinder before installing the handler, but fatal-signal stack unwinding can
+  still hang if unwinder or loader state is corrupted.
+- DBT guest mode is local-launch only right now. Daemon and attach modes still
+  belong to the simulation path.
+- IPC and advanced multi-process memory sharing are out of scope for the MVP.

--- a/emulation/rocjitsu/docs/vm-design.md
+++ b/emulation/rocjitsu/docs/vm-design.md
@@ -241,10 +241,10 @@ ROCm application
   └── ROCR / HIP runtime
         └── libhsakmt
               ├── open("/dev/kfd")    ──►  interposer.cpp intercepts
-              ├── ioctl(kfd_fd, …)   ──►  SimulatedDriver::ioctl()
-              ├── mmap(kfd_fd, …)    ──►  SimulatedDriver::mmap()
+              ├── ioctl(kfd_fd, …)   ──►  SimulatedKfd::ioctl()
+              ├── mmap(kfd_fd, …)    ──►  SimulatedKfd::mmap()
               ├── fopen("/sys/…")    ──►  interposer.cpp redirects → Sysfs temp dir
-              └── close(kfd_fd)      ──►  SimulatedDriver::close()
+              └── close(kfd_fd)      ──►  SimulatedKfd::close()
 ```
 
 ### Components
@@ -252,7 +252,7 @@ ROCm application
 | File | Purpose |
 |------|---------|
 | `interposer.cpp` | LD_PRELOAD shim: intercepts `open`, `ioctl`, `mmap`, `munmap`, `fopen`, `close` via syscall |
-| `simulated_driver.h/cpp` | `SimulatedDriver`: handles all KFD ioctls, owns doorbell/event pages |
+| `simulated_kfd.h/cpp` | `SimulatedKfd`: handles all KFD ioctls, owns doorbell/event pages |
 | `sysfs.h/cpp` | `Sysfs`: generates a per-process `/tmp/rocjitsu_topology_*` directory that ROCR reads instead of the real `/sys/devices/virtual/kfd/kfd/topology` |
 
 ### KFD ioctl surface

--- a/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_api_trace_minimal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_api_trace_minimal.h
@@ -125,6 +125,11 @@ struct AmdExtTable {
   void *hsa_amd_external_semaphore_handle_open_fn;
   void *hsa_amd_external_semaphore_handle_close_fn;
 };
+static_assert(offsetof(AmdExtTable, hsa_amd_memory_get_preferred_copy_engine_fn) == 592);
+static_assert(offsetof(AmdExtTable, hsa_amd_memory_async_batch_copy_fn) == 640);
+static_assert(offsetof(AmdExtTable, hsa_amd_agent_preload_fn) == 648);
+static_assert(offsetof(AmdExtTable, hsa_amd_external_semaphore_handle_close_fn) == 680);
+static_assert(sizeof(AmdExtTable) == 688);
 
 /// @brief Minimal mirror of ROCR's `CoreApiTable` through agent code-object load.
 ///

--- a/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_api_trace_minimal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_api_trace_minimal.h
@@ -5,17 +5,20 @@
 /// @brief Minimal ROCR HSA tools API-table ABI mirror used by rocjitsu hooks.
 ///
 /// @details ROCR passes HSA tools a table whose layout is defined by
-/// `hsa_api_trace.h`. The full ROCR trace header pulls in extension headers that
-/// are unnecessary for the DBT-only MVP. This file mirrors only the table
-/// headers and the core API entries through the code-object load functions that
-/// rocjitsu patches. Field order must match ROCR exactly for every mirrored
-/// field; callers must validate `CoreApiTable::version.minor_id` before reading
-/// or writing function pointers near the tail of the table.
+/// `hsa_api_trace.h`. AMD extension handle and function types live in
+/// `hsa_ext_amd_minimal.h`, matching ROCR's `hsa_api_trace.h` /
+/// `hsa_ext_amd.h` split. This file mirrors only the API-table headers and the
+/// core entries through the code-object load functions that rocjitsu patches.
+/// Field order must match ROCR exactly for every mirrored field; callers must
+/// validate `CoreApiTable::version.minor_id` before reading or writing function
+/// pointers near the tail of the table.
 
 #pragma once
 
 #include "hsa/hsa.h"
+#include "hsa/hsa_ext_amd_minimal.h"
 
+#include <cstddef>
 #include <cstdint>
 
 /// @brief Version header present at the start of every ROCR API table.
@@ -28,6 +31,99 @@ struct ApiTableVersion {
   uint32_t minor_id;
   uint32_t step_id;
   uint32_t reserved;
+};
+
+/// @brief Minimal mirror of ROCR's AMD extension API table.
+///
+/// @details Only patched entries are typed. Other fields remain opaque but
+/// preserve their exact positions in the table.
+struct AmdExtTable {
+  ApiTableVersion version;
+  void *hsa_amd_coherency_get_type_fn;
+  void *hsa_amd_coherency_set_type_fn;
+  hsa_amd_profiling_set_profiler_enabled_fn_t hsa_amd_profiling_set_profiler_enabled_fn;
+  void *hsa_amd_profiling_async_copy_enable_fn;
+  hsa_amd_profiling_get_dispatch_time_fn_t hsa_amd_profiling_get_dispatch_time_fn;
+  void *hsa_amd_profiling_get_async_copy_time_fn;
+  hsa_amd_profiling_convert_tick_to_system_domain_fn_t
+      hsa_amd_profiling_convert_tick_to_system_domain_fn;
+  void *hsa_amd_signal_async_handler_fn;
+  void *hsa_amd_async_function_fn;
+  void *hsa_amd_signal_wait_any_fn;
+  void *hsa_amd_queue_cu_set_mask_fn;
+  hsa_amd_memory_pool_get_info_fn_t hsa_amd_memory_pool_get_info_fn;
+  hsa_amd_agent_iterate_memory_pools_fn_t hsa_amd_agent_iterate_memory_pools_fn;
+  hsa_amd_memory_pool_allocate_fn_t hsa_amd_memory_pool_allocate_fn;
+  hsa_amd_memory_pool_free_fn_t hsa_amd_memory_pool_free_fn;
+  hsa_amd_memory_async_copy_fn_t hsa_amd_memory_async_copy_fn;
+  hsa_amd_memory_async_copy_on_engine_fn_t hsa_amd_memory_async_copy_on_engine_fn;
+  hsa_amd_memory_copy_engine_status_fn_t hsa_amd_memory_copy_engine_status_fn;
+  hsa_amd_agent_memory_pool_get_info_fn_t hsa_amd_agent_memory_pool_get_info_fn;
+  hsa_amd_agents_allow_access_fn_t hsa_amd_agents_allow_access_fn;
+  void *hsa_amd_memory_pool_can_migrate_fn;
+  void *hsa_amd_memory_migrate_fn;
+  hsa_amd_memory_lock_fn_t hsa_amd_memory_lock_fn;
+  void *hsa_amd_memory_unlock_fn;
+  hsa_amd_memory_fill_fn_t hsa_amd_memory_fill_fn;
+  void *hsa_amd_interop_map_buffer_fn;
+  void *hsa_amd_interop_unmap_buffer_fn;
+  void *hsa_amd_image_create_fn;
+  hsa_amd_pointer_info_fn_t hsa_amd_pointer_info_fn;
+  void *hsa_amd_pointer_info_set_userdata_fn;
+  void *hsa_amd_ipc_memory_create_fn;
+  void *hsa_amd_ipc_memory_attach_fn;
+  void *hsa_amd_ipc_memory_detach_fn;
+  void *hsa_amd_signal_create_fn;
+  void *hsa_amd_ipc_signal_create_fn;
+  void *hsa_amd_ipc_signal_attach_fn;
+  void *hsa_amd_register_system_event_handler_fn;
+  void *hsa_amd_queue_intercept_create_fn;
+  void *hsa_amd_queue_intercept_register_fn;
+  void *hsa_amd_queue_set_priority_fn;
+  hsa_amd_memory_async_copy_rect_fn_t hsa_amd_memory_async_copy_rect_fn;
+  void *hsa_amd_runtime_queue_create_register_fn;
+  hsa_amd_memory_lock_to_pool_fn_t hsa_amd_memory_lock_to_pool_fn;
+  void *hsa_amd_register_deallocation_callback_fn;
+  void *hsa_amd_deregister_deallocation_callback_fn;
+  void *hsa_amd_signal_value_pointer_fn;
+  void *hsa_amd_svm_attributes_set_fn;
+  void *hsa_amd_svm_attributes_get_fn;
+  hsa_amd_svm_prefetch_async_fn_t hsa_amd_svm_prefetch_async_fn;
+  void *hsa_amd_spm_acquire_fn;
+  void *hsa_amd_spm_release_fn;
+  void *hsa_amd_spm_set_dest_buffer_fn;
+  void *hsa_amd_queue_cu_get_mask_fn;
+  void *hsa_amd_portable_export_dmabuf_fn;
+  void *hsa_amd_portable_close_dmabuf_fn;
+  void *hsa_amd_vmem_address_reserve_fn;
+  void *hsa_amd_vmem_address_free_fn;
+  void *hsa_amd_vmem_handle_create_fn;
+  void *hsa_amd_vmem_handle_release_fn;
+  void *hsa_amd_vmem_map_fn;
+  void *hsa_amd_vmem_unmap_fn;
+  hsa_amd_vmem_set_access_fn_t hsa_amd_vmem_set_access_fn;
+  hsa_amd_vmem_get_access_fn_t hsa_amd_vmem_get_access_fn;
+  void *hsa_amd_vmem_export_shareable_handle_fn;
+  void *hsa_amd_vmem_import_shareable_handle_fn;
+  void *hsa_amd_vmem_retain_alloc_handle_fn;
+  void *hsa_amd_vmem_get_alloc_properties_from_handle_fn;
+  hsa_amd_agent_set_async_scratch_limit_fn_t hsa_amd_agent_set_async_scratch_limit_fn;
+  void *hsa_amd_queue_get_info_fn;
+  void *hsa_amd_vmem_address_reserve_align_fn;
+  void *hsa_amd_enable_logging_fn;
+  void *hsa_amd_signal_wait_all_fn;
+  hsa_amd_memory_get_preferred_copy_engine_fn_t hsa_amd_memory_get_preferred_copy_engine_fn;
+  void *hsa_amd_portable_export_dmabuf_v2_fn;
+  void *hsa_amd_ais_file_write_fn;
+  void *hsa_amd_ais_file_read_fn;
+  void *hsa_amd_counted_queue_acquire_fn;
+  void *hsa_amd_counted_queue_release_fn;
+  hsa_amd_memory_async_batch_copy_fn_t hsa_amd_memory_async_batch_copy_fn;
+  hsa_amd_agent_preload_fn_t hsa_amd_agent_preload_fn;
+  void *hsa_amd_svm_discard_batch_async_fn;
+  void *hsa_amd_signal_get_event_id_fn;
+  void *hsa_amd_external_semaphore_handle_open_fn;
+  void *hsa_amd_external_semaphore_handle_close_fn;
 };
 
 /// @brief Minimal mirror of ROCR's `CoreApiTable` through agent code-object load.
@@ -162,6 +258,10 @@ struct CoreApiTable {
   decltype(hsa_executable_create_alt) *hsa_executable_create_alt_fn;
   decltype(hsa_executable_load_program_code_object) *hsa_executable_load_program_code_object_fn;
   decltype(hsa_executable_load_agent_code_object) *hsa_executable_load_agent_code_object_fn;
+  decltype(hsa_executable_validate_alt) *hsa_executable_validate_alt_fn;
+  decltype(hsa_executable_get_symbol_by_name) *hsa_executable_get_symbol_by_name_fn;
+  decltype(hsa_executable_iterate_agent_symbols) *hsa_executable_iterate_agent_symbols_fn;
+  decltype(hsa_executable_iterate_program_symbols) *hsa_executable_iterate_program_symbols_fn;
 };
 
 /// @brief Top-level ROCR API table passed to HSA tools from `OnLoad()`.
@@ -172,7 +272,7 @@ struct CoreApiTable {
 struct HsaApiTable {
   ApiTableVersion version;
   CoreApiTable *core_;
-  void *amd_ext_;
+  AmdExtTable *amd_ext_;
   void *finalizer_ext_;
   void *image_ext_;
   void *tools_;

--- a/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_ext_amd_minimal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_ext_amd_minimal.h
@@ -1,0 +1,190 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file hsa_ext_amd_minimal.h
+/// @brief Minimal AMD HSA extension ABI mirror used by rocjitsu hooks.
+
+#pragma once
+
+#include "hsa/hsa.h"
+
+#include <cstddef>
+#include <cstdint>
+
+/// @brief Minimal AMD extension memory-pool handle mirror.
+struct hsa_amd_memory_pool_s {
+  uint64_t handle;
+};
+using hsa_amd_memory_pool_t = hsa_amd_memory_pool_s;
+
+using hsa_amd_memory_pool_info_t = uint32_t;
+using hsa_amd_agent_memory_pool_info_t = uint32_t;
+using hsa_amd_sdma_engine_id_t = uint32_t;
+using hsa_amd_pointer_type_t = uint32_t;
+using hsa_amd_copy_direction_t = uint32_t;
+
+/// @brief Minimal profiling dispatch-time result mirror.
+struct hsa_amd_profiling_dispatch_time_t {
+  uint64_t start;
+  uint64_t end;
+};
+
+// Public hsa_ext_amd.h enum values mirrored by name so ABI renumbering is visible.
+inline constexpr uint32_t HSA_AMD_AGENT_INFO_DRIVER_NODE_ID = 0xA004;
+inline constexpr hsa_amd_memory_pool_info_t HSA_AMD_MEMORY_POOL_INFO_SEGMENT = 0;
+inline constexpr hsa_amd_memory_pool_info_t HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS = 1;
+inline constexpr hsa_amd_memory_pool_info_t HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_ALLOWED = 5;
+inline constexpr hsa_amd_memory_pool_info_t HSA_AMD_MEMORY_POOL_INFO_LOCATION = 17;
+
+/// @brief Minimal pitched pointer mirror for hsa_amd_memory_async_copy_rect.
+struct hsa_pitched_ptr_t {
+  void *base;
+  size_t pitch;
+  size_t slice;
+};
+
+/// @brief Minimal AMD virtual-memory access descriptor mirror.
+struct hsa_amd_memory_access_desc_t {
+  hsa_access_permission_t permissions;
+  hsa_agent_t agent_handle;
+};
+
+/// @brief Minimal AMD pointer info mirror used to rewrite app-facing agent fields.
+struct hsa_amd_pointer_info_t {
+  uint32_t size;
+  hsa_amd_pointer_type_t type;
+  void *agentBaseAddress;
+  void *hostBaseAddress;
+  size_t sizeInBytes;
+  void *userData;
+  hsa_agent_t agentOwner;
+  uint32_t global_flags;
+  bool registered;
+  uint32_t alloc_flags;
+};
+static_assert(offsetof(hsa_amd_pointer_info_t, registered) == 52);
+static_assert(offsetof(hsa_amd_pointer_info_t, alloc_flags) == 56);
+static_assert(sizeof(hsa_amd_pointer_info_t) == 64);
+
+/// @brief Operation type values used by hsa_amd_memory_async_batch_copy.
+enum hsa_amd_memory_copy_op_type_t : uint16_t {
+  HSA_AMD_MEMORY_COPY_OP_LINEAR = 0,
+  HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST = 1,
+  HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP = 2,
+  HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC = 3,
+  HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST = 4,
+  HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST = 5,
+};
+
+/// @brief Minimal layout mirror of ROCR's batch-copy operation descriptor.
+///
+/// @details The HSA hook copies these descriptors only to rewrite agent
+/// handles from guest to host before forwarding the call. Field order and
+/// widths must match hsa_ext_amd.h.
+struct hsa_amd_memory_copy_op_t {
+  uint16_t version;
+  uint16_t type;
+  uint16_t num_entries;
+  uint16_t traffic_class;
+  hsa_signal_t completion_signal;
+  union {
+    void *src;
+    void **src_list;
+  };
+  union {
+    hsa_agent_t src_agent;
+    hsa_agent_t *src_agent_list;
+  };
+  union {
+    hsa_agent_t dst_agent;
+    hsa_agent_t *dst_agent_list;
+  };
+  union {
+    void *dst;
+    void **dst_list;
+  };
+  union {
+    struct {
+      size_t size;
+      size_t unused_size;
+    };
+    struct {
+      size_t src_size;
+      size_t dst_size;
+    };
+    struct {
+      size_t *size_list;
+      size_t reserved0;
+    };
+  };
+  struct {
+    uint16_t function;
+    uint16_t scope;
+    uint32_t reserved;
+    void *addr;
+    uint64_t value;
+    uint64_t mask;
+  } wait;
+  struct {
+    uint16_t operation;
+    uint16_t scope;
+    uint32_t reserved;
+    void *addr;
+    uint64_t data;
+  } signal;
+  uint64_t reserved1[1];
+};
+
+using hsa_amd_agent_iterate_memory_pools_fn_t = hsa_status_t(HSA_API *)(
+    hsa_agent_t, hsa_status_t (*)(hsa_amd_memory_pool_t memory_pool, void *data), void *);
+using hsa_amd_memory_pool_get_info_fn_t = hsa_status_t(HSA_API *)(hsa_amd_memory_pool_t,
+                                                                  hsa_amd_memory_pool_info_t,
+                                                                  void *);
+using hsa_amd_agent_memory_pool_get_info_fn_t = hsa_status_t(HSA_API *)(
+    hsa_agent_t, hsa_amd_memory_pool_t, hsa_amd_agent_memory_pool_info_t, void *);
+using hsa_amd_memory_pool_allocate_fn_t = hsa_status_t(HSA_API *)(hsa_amd_memory_pool_t, size_t,
+                                                                  uint32_t, void **);
+using hsa_amd_memory_pool_free_fn_t = hsa_status_t(HSA_API *)(void *);
+using hsa_amd_profiling_set_profiler_enabled_fn_t = hsa_status_t(HSA_API *)(hsa_queue_t *, int);
+using hsa_amd_profiling_get_dispatch_time_fn_t =
+    hsa_status_t(HSA_API *)(hsa_agent_t, hsa_signal_t, hsa_amd_profiling_dispatch_time_t *);
+using hsa_amd_profiling_convert_tick_to_system_domain_fn_t = hsa_status_t(HSA_API *)(hsa_agent_t,
+                                                                                     uint64_t,
+                                                                                     uint64_t *);
+using hsa_amd_agents_allow_access_fn_t = hsa_status_t(HSA_API *)(uint32_t, const hsa_agent_t *,
+                                                                 const uint32_t *, const void *);
+using hsa_amd_memory_async_copy_fn_t = hsa_status_t(HSA_API *)(void *, hsa_agent_t, const void *,
+                                                               hsa_agent_t, size_t, uint32_t,
+                                                               const hsa_signal_t *, hsa_signal_t);
+using hsa_amd_memory_async_copy_on_engine_fn_t =
+    hsa_status_t(HSA_API *)(void *, hsa_agent_t, const void *, hsa_agent_t, size_t, uint32_t,
+                            const hsa_signal_t *, hsa_signal_t, hsa_amd_sdma_engine_id_t, bool);
+using hsa_amd_memory_copy_engine_status_fn_t = hsa_status_t(HSA_API *)(hsa_agent_t, hsa_agent_t,
+                                                                       uint32_t *);
+using hsa_amd_memory_get_preferred_copy_engine_fn_t =
+    hsa_status_t(HSA_API *)(hsa_agent_t, hsa_agent_t, hsa_amd_sdma_engine_id_t *);
+using hsa_amd_memory_lock_fn_t = hsa_status_t(HSA_API *)(void *, size_t, hsa_agent_t *, int,
+                                                         void **);
+using hsa_amd_memory_fill_fn_t = hsa_status_t(HSA_API *)(void *, uint32_t, size_t);
+using hsa_amd_pointer_info_fn_t = hsa_status_t(HSA_API *)(const void *, hsa_amd_pointer_info_t *,
+                                                          void *(*)(size_t), uint32_t *,
+                                                          hsa_agent_t **);
+using hsa_amd_memory_lock_to_pool_fn_t = hsa_status_t(HSA_API *)(void *, size_t, hsa_agent_t *, int,
+                                                                 hsa_amd_memory_pool_t, uint32_t,
+                                                                 void **);
+using hsa_amd_svm_prefetch_async_fn_t = hsa_status_t(HSA_API *)(void *, size_t, hsa_agent_t,
+                                                                uint32_t, const hsa_signal_t *,
+                                                                hsa_signal_t);
+using hsa_amd_vmem_set_access_fn_t = hsa_status_t(HSA_API *)(void *, size_t,
+                                                             const hsa_amd_memory_access_desc_t *,
+                                                             size_t);
+using hsa_amd_vmem_get_access_fn_t = hsa_status_t(HSA_API *)(void *, hsa_access_permission_t *,
+                                                             hsa_agent_t);
+using hsa_amd_memory_async_copy_rect_fn_t = hsa_status_t(HSA_API *)(
+    const hsa_pitched_ptr_t *, const hsa_dim3_t *, const hsa_pitched_ptr_t *, const hsa_dim3_t *,
+    const hsa_dim3_t *, hsa_agent_t, hsa_amd_copy_direction_t, uint32_t, const hsa_signal_t *,
+    hsa_signal_t);
+using hsa_amd_agent_set_async_scratch_limit_fn_t = hsa_status_t(HSA_API *)(hsa_agent_t, size_t);
+using hsa_amd_memory_async_batch_copy_fn_t = hsa_status_t(HSA_API *)(
+    const hsa_amd_memory_copy_op_t *, uint32_t, uint32_t, const hsa_signal_t *);
+using hsa_amd_agent_preload_fn_t = hsa_status_t(HSA_API *)(hsa_agent_t, uint64_t);

--- a/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_ext_amd_minimal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_ext_amd_minimal.h
@@ -134,6 +134,20 @@ struct hsa_amd_memory_copy_op_t {
   } signal;
   uint64_t reserved1[1];
 };
+static_assert(offsetof(hsa_amd_memory_copy_op_t, version) == 0);
+static_assert(offsetof(hsa_amd_memory_copy_op_t, type) == 2);
+static_assert(offsetof(hsa_amd_memory_copy_op_t, num_entries) == 4);
+static_assert(offsetof(hsa_amd_memory_copy_op_t, traffic_class) == 6);
+static_assert(offsetof(hsa_amd_memory_copy_op_t, completion_signal) == 8);
+static_assert(offsetof(hsa_amd_memory_copy_op_t, src) == 16);
+static_assert(offsetof(hsa_amd_memory_copy_op_t, src_agent) == 24);
+static_assert(offsetof(hsa_amd_memory_copy_op_t, dst_agent) == 32);
+static_assert(offsetof(hsa_amd_memory_copy_op_t, dst) == 40);
+static_assert(offsetof(hsa_amd_memory_copy_op_t, size) == 48);
+static_assert(offsetof(hsa_amd_memory_copy_op_t, wait) == 64);
+static_assert(offsetof(hsa_amd_memory_copy_op_t, signal) == 96);
+static_assert(offsetof(hsa_amd_memory_copy_op_t, reserved1) == 120);
+static_assert(sizeof(hsa_amd_memory_copy_op_t) == 128);
 
 using hsa_amd_agent_iterate_memory_pools_fn_t = hsa_status_t(HSA_API *)(
     hsa_agent_t, hsa_status_t (*)(hsa_amd_memory_pool_t memory_pool, void *data), void *);

--- a/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_ext_amd_minimal.h
+++ b/emulation/rocjitsu/lib/rocjitsu/external_headers/hsa_headers/hsa/hsa_ext_amd_minimal.h
@@ -30,7 +30,9 @@ struct hsa_amd_profiling_dispatch_time_t {
 };
 
 // Public hsa_ext_amd.h enum values mirrored by name so ABI renumbering is visible.
+inline constexpr hsa_status_t HSA_STATUS_ERROR_INVALID_MEMORY_POOL = static_cast<hsa_status_t>(40);
 inline constexpr uint32_t HSA_AMD_AGENT_INFO_DRIVER_NODE_ID = 0xA004;
+inline constexpr hsa_amd_agent_memory_pool_info_t HSA_AMD_AGENT_MEMORY_POOL_INFO_ACCESS = 0;
 inline constexpr hsa_amd_memory_pool_info_t HSA_AMD_MEMORY_POOL_INFO_SEGMENT = 0;
 inline constexpr hsa_amd_memory_pool_info_t HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS = 1;
 inline constexpr hsa_amd_memory_pool_info_t HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_ALLOWED = 5;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/CMakeLists.txt
@@ -1,10 +1,12 @@
 # Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-rj_add_object_library(rocjitsu_config
-    config_loader.cpp
-    checkpoint.cpp
-)
+rj_add_object_library(rocjitsu_dbt_config dbt_guest_config.cpp)
+target_link_libraries(rocjitsu_dbt_config PRIVATE flatbuffers)
+target_include_directories(rocjitsu_dbt_config PRIVATE ${GENERATED_DIR})
+add_dependencies(rocjitsu_dbt_config flatbuffers_schemas)
+
+rj_add_object_library(rocjitsu_config config_loader.cpp checkpoint.cpp)
 
 # Config loader depends on FlatBuffers library (for runtime JSON parsing)
 # and on the generated schema headers.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/CMakeLists.txt
@@ -10,6 +10,6 @@ rj_add_object_library(rocjitsu_config config_loader.cpp checkpoint.cpp)
 
 # Config loader depends on FlatBuffers library (for runtime JSON parsing)
 # and on the generated schema headers.
-target_link_libraries(rocjitsu_config PRIVATE flatbuffers)
+target_link_libraries(rocjitsu_config PRIVATE flatbuffers rocjitsu_dbt_config)
 target_include_directories(rocjitsu_config PRIVATE ${GENERATED_DIR})
 add_dependencies(rocjitsu_config flatbuffers_schemas)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_common.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_common.h
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file config_common.h
+/// @brief Shared FlatBuffers config parsing helpers.
+
+#ifndef ROCJITSU_CONFIG_CONFIG_COMMON_H_
+#define ROCJITSU_CONFIG_CONFIG_COMMON_H_
+
+#include "rocjitsu/config/kfd_device_config.h"
+
+#include "flatbuffers/idl.h"
+#include "simulation_config_generated.h"
+
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace rocjitsu {
+namespace config {
+
+inline std::string read_config_file(const std::string &path) {
+  std::ifstream file(path);
+  if (!file.is_open())
+    throw std::runtime_error("Cannot open file: " + path);
+
+  std::ostringstream contents;
+  contents << file.rdbuf();
+  return contents.str();
+}
+
+inline const fb::SimulationConfig *parse_simulation_config_json(const std::string &json,
+                                                                const std::string &schema_text,
+                                                                flatbuffers::Parser &parser) {
+  parser.opts.skip_unexpected_fields_in_json = true;
+  if (!parser.Parse(schema_text.c_str()))
+    throw std::runtime_error("Failed to parse schema: " + std::string(parser.error_));
+  if (!parser.Parse(json.c_str()))
+    throw std::runtime_error("Failed to parse JSON config: " + std::string(parser.error_));
+  return flatbuffers::GetRoot<fb::SimulationConfig>(parser.builder_.GetBufferPointer());
+}
+
+/// @brief Convert a FlatBuffers KFD identity table into the runtime config form.
+///
+/// @details This copies only scalar/string topology values. The resulting
+/// config owns its marketing-name string so it is safe after the FlatBuffers
+/// parser storage goes out of scope.
+inline KfdDeviceConfig kfd_device_from_fb(const fb::KfdDeviceInfo *device) {
+  KfdDeviceConfig config;
+  if (device == nullptr)
+    return config;
+
+  config.present = true;
+  config.gpu_id = device->gpu_id();
+  config.gfx_target_version = device->gfx_target_version();
+  config.vendor_id = device->vendor_id();
+  config.device_id = device->device_id();
+  config.family_id = device->family_id();
+  config.unique_id = device->unique_id();
+  if (device->marketing_name())
+    config.marketing_name = device->marketing_name()->str();
+  config.drm_render_minor = device->drm_render_minor();
+  config.revision_id = device->revision_id();
+  config.pci_revision_id = device->pci_revision_id();
+  config.simd_count = device->simd_count();
+  config.max_waves_per_simd = device->max_waves_per_simd();
+  config.num_shader_engines = device->num_shader_engines();
+  config.num_shader_arrays_per_engine = device->num_shader_arrays_per_engine();
+  config.num_cu_per_sh = device->num_cu_per_sh();
+  config.simd_per_cu = device->simd_per_cu();
+  config.wave_front_size = device->wave_front_size();
+  config.max_slots_scratch_cu = device->max_slots_scratch_cu();
+  config.local_mem_size = device->local_mem_size();
+  config.vram_type = device->vram_type();
+  config.lds_size_kb = device->lds_size_kb();
+  config.mem_width = device->mem_width();
+  config.mem_clk_max = device->mem_clk_max();
+  config.l1_size_kb = device->l1_size_kb();
+  config.l1_line_size = device->l1_line_size();
+  config.l1_assoc = device->l1_assoc();
+  config.l2_size_kb = device->l2_size_kb();
+  config.l2_line_size = device->l2_line_size();
+  config.l2_assoc = device->l2_assoc();
+  config.num_sdma_engines = device->num_sdma_engines();
+  config.num_sdma_xgmi_engines = device->num_sdma_xgmi_engines();
+  config.num_cp_queues = device->num_cp_queues();
+  config.max_engine_clk_fcompute = device->max_engine_clk_fcompute();
+  config.location_id = device->location_id();
+  config.hive_id = device->hive_id();
+  config.domain = device->domain();
+  return config;
+}
+
+} // namespace config
+} // namespace rocjitsu
+
+#endif // ROCJITSU_CONFIG_CONFIG_COMMON_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_common.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_common.h
@@ -99,6 +99,9 @@ inline KfdDeviceConfig kfd_device_from_fb(const fb::KfdDeviceInfo *device) {
   config.location_id = device->location_id();
   config.hive_id = device->hive_id();
   config.domain = device->domain();
+  config.capability = device->capability();
+  config.capability2 = device->capability2();
+  config.debug_prop = device->debug_prop();
   return config;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_common.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_common.h
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace rocjitsu {
 namespace config {
@@ -30,15 +31,24 @@ inline std::string read_config_file(const std::string &path) {
   return contents.str();
 }
 
-inline const fb::SimulationConfig *parse_simulation_config_json(const std::string &json,
-                                                                const std::string &schema_text,
-                                                                flatbuffers::Parser &parser) {
+/// @brief Parse simulation-config JSON and consume the FlatBuffer while parser storage is alive.
+///
+/// @details FlatBuffers returns pointers into `Parser::builder_`. Keeping the
+/// parser local to this helper makes the lifetime explicit: callers must copy
+/// any values they need inside @p callback rather than retaining raw pointers.
+template <typename Callback>
+decltype(auto) with_parsed_simulation_config_json(const std::string &json,
+                                                  const std::string &schema_text,
+                                                  Callback &&callback) {
+  flatbuffers::Parser parser;
   parser.opts.skip_unexpected_fields_in_json = true;
   if (!parser.Parse(schema_text.c_str()))
     throw std::runtime_error("Failed to parse schema: " + std::string(parser.error_));
   if (!parser.Parse(json.c_str()))
     throw std::runtime_error("Failed to parse JSON config: " + std::string(parser.error_));
-  return flatbuffers::GetRoot<fb::SimulationConfig>(parser.builder_.GetBufferPointer());
+  const fb::SimulationConfig *config =
+      flatbuffers::GetRoot<fb::SimulationConfig>(parser.builder_.GetBufferPointer());
+  return std::forward<Callback>(callback)(config);
 }
 
 /// @brief Convert a FlatBuffers KFD identity table into the runtime config form.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -694,6 +694,7 @@ LoadedConfig build_from_fb(const rocjitsu::fb::SimulationConfig *fb_config) {
   if (fb_config->vm() && fb_config->vm()->gpu() && fb_config->vm()->gpu()->device()) {
     result.device = kfd_device_from_fb(fb_config->vm()->gpu()->device());
   }
+
   result.dbt_guest = dbt_guest_from_fb(fb_config->dbt_guest());
 
   if (fb_config->vm() && fb_config->vm()->gpu())

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -780,15 +780,15 @@ const char *arch_to_string(rj_code_arch_t arch) {
 
 LoadedConfig load_config(const std::string &json_path, const std::string &schema_text) {
   std::string json_text = read_config_file(json_path);
-  flatbuffers::Parser parser;
-  auto *fb_config = parse_simulation_config_json(json_text, schema_text, parser);
-  return build_from_fb(fb_config);
+  return with_parsed_simulation_config_json(
+      json_text, schema_text,
+      [](const fb::SimulationConfig *fb_config) { return build_from_fb(fb_config); });
 }
 
 LoadedConfig load_config_from_string(const std::string &json, const std::string &schema_text) {
-  flatbuffers::Parser parser;
-  auto *fb_config = parse_simulation_config_json(json, schema_text, parser);
-  return build_from_fb(fb_config);
+  return with_parsed_simulation_config_json(
+      json, schema_text,
+      [](const fb::SimulationConfig *fb_config) { return build_from_fb(fb_config); });
 }
 
 } // namespace config

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -3,13 +3,10 @@
 
 #include "rocjitsu/config/config_loader.h"
 
+#include "rocjitsu/config/config_common.h"
 #include "rocjitsu/vm/virtual_machine.h"
 
 #include "rocjitsu/vm/amdgpu/command_processor.h"
-
-rocjitsu::SoC *rocjitsu::config::LoadedConfig::soc() {
-  return dynamic_cast<SoC *>(build_result.root.get());
-}
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/hbm_controller.h"
@@ -26,7 +23,6 @@ rocjitsu::SoC *rocjitsu::config::LoadedConfig::soc() {
 
 #include <cassert>
 #include <cctype>
-#include <fstream>
 #include <regex>
 #include <sstream>
 #include <stdexcept>
@@ -38,16 +34,9 @@ rocjitsu::SoC *rocjitsu::config::LoadedConfig::soc() {
 namespace rocjitsu {
 namespace config {
 
-namespace {
+SoC *LoadedConfig::soc() { return dynamic_cast<SoC *>(build_result.root.get()); }
 
-std::string read_file(const std::string &path) {
-  std::ifstream f(path);
-  if (!f.is_open())
-    throw std::runtime_error("Cannot open file: " + path);
-  std::ostringstream ss;
-  ss << f.rdbuf();
-  return ss.str();
-}
+namespace {
 
 simdojo::SimulationEngine::Config
 engine_config_from_fb(const rocjitsu::fb::SimulationConfig *fb_config) {
@@ -64,16 +53,6 @@ simdojo::ExecMode parse_exec_mode(const rocjitsu::fb::SimulationConfig *fb_confi
       return simdojo::ExecMode::CLOCKED;
   }
   return simdojo::ExecMode::FUNCTIONAL;
-}
-
-const rocjitsu::fb::SimulationConfig *
-parse_json(const std::string &json, const std::string &schema_text, flatbuffers::Parser &parser) {
-  parser.opts.skip_unexpected_fields_in_json = true;
-  if (!parser.Parse(schema_text.c_str()))
-    throw std::runtime_error("Failed to parse schema: " + std::string(parser.error_));
-  if (!parser.Parse(json.c_str()))
-    throw std::runtime_error("Failed to parse JSON config: " + std::string(parser.error_));
-  return flatbuffers::GetRoot<rocjitsu::fb::SimulationConfig>(parser.builder_.GetBufferPointer());
 }
 
 uint32_t config_u32(const std::unordered_map<std::string, std::string> &cfg, const std::string &key,
@@ -713,50 +692,9 @@ LoadedConfig build_from_fb(const rocjitsu::fb::SimulationConfig *fb_config) {
 
   // Extract KFD device identity from vm.gpu.device if present.
   if (fb_config->vm() && fb_config->vm()->gpu() && fb_config->vm()->gpu()->device()) {
-    auto *d = fb_config->vm()->gpu()->device();
-    auto &dev = result.device;
-    dev.present = true;
-    dev.gpu_id = d->gpu_id();
-    dev.gfx_target_version = d->gfx_target_version();
-    dev.vendor_id = d->vendor_id();
-    dev.device_id = d->device_id();
-    dev.family_id = d->family_id();
-    dev.unique_id = d->unique_id();
-    if (d->marketing_name())
-      dev.marketing_name = d->marketing_name()->str();
-    dev.drm_render_minor = d->drm_render_minor();
-    dev.revision_id = d->revision_id();
-    dev.pci_revision_id = d->pci_revision_id();
-    dev.simd_count = d->simd_count();
-    dev.max_waves_per_simd = d->max_waves_per_simd();
-    dev.num_shader_engines = d->num_shader_engines();
-    dev.num_shader_arrays_per_engine = d->num_shader_arrays_per_engine();
-    dev.num_cu_per_sh = d->num_cu_per_sh();
-    dev.simd_per_cu = d->simd_per_cu();
-    dev.wave_front_size = d->wave_front_size();
-    dev.max_slots_scratch_cu = d->max_slots_scratch_cu();
-    dev.local_mem_size = d->local_mem_size();
-    dev.vram_type = d->vram_type();
-    dev.lds_size_kb = d->lds_size_kb();
-    dev.mem_width = d->mem_width();
-    dev.mem_clk_max = d->mem_clk_max();
-    dev.l1_size_kb = d->l1_size_kb();
-    dev.l1_line_size = d->l1_line_size();
-    dev.l1_assoc = d->l1_assoc();
-    dev.l2_size_kb = d->l2_size_kb();
-    dev.l2_line_size = d->l2_line_size();
-    dev.l2_assoc = d->l2_assoc();
-    dev.num_sdma_engines = d->num_sdma_engines();
-    dev.num_sdma_xgmi_engines = d->num_sdma_xgmi_engines();
-    dev.num_cp_queues = d->num_cp_queues();
-    dev.max_engine_clk_fcompute = d->max_engine_clk_fcompute();
-    dev.location_id = d->location_id();
-    dev.hive_id = d->hive_id();
-    dev.domain = d->domain();
-    dev.capability = d->capability();
-    dev.capability2 = d->capability2();
-    dev.debug_prop = d->debug_prop();
+    result.device = kfd_device_from_fb(fb_config->vm()->gpu()->device());
   }
+  result.dbt_guest = dbt_guest_from_fb(fb_config->dbt_guest());
 
   if (fb_config->vm() && fb_config->vm()->gpu())
     result.num_gpus = std::max(1u, fb_config->vm()->gpu()->num_gpus());
@@ -840,15 +778,15 @@ const char *arch_to_string(rj_code_arch_t arch) {
 }
 
 LoadedConfig load_config(const std::string &json_path, const std::string &schema_text) {
-  std::string json_text = read_file(json_path);
+  std::string json_text = read_config_file(json_path);
   flatbuffers::Parser parser;
-  auto *fb_config = parse_json(json_text, schema_text, parser);
+  auto *fb_config = parse_simulation_config_json(json_text, schema_text, parser);
   return build_from_fb(fb_config);
 }
 
 LoadedConfig load_config_from_string(const std::string &json, const std::string &schema_text) {
   flatbuffers::Parser parser;
-  auto *fb_config = parse_json(json, schema_text, parser);
+  auto *fb_config = parse_simulation_config_json(json, schema_text, parser);
   return build_from_fb(fb_config);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.h
@@ -7,8 +7,9 @@
 #ifndef ROCJITSU_CONFIG_CONFIG_LOADER_H_
 #define ROCJITSU_CONFIG_CONFIG_LOADER_H_
 
-#include "rocjitsu/vm/amdgpu/gpu_memory.h"
-#include "rocjitsu/vm/soc.h"
+#include "rocjitsu/code/rj_code.h"
+#include "rocjitsu/config/dbt_guest_config.h"
+#include "rocjitsu/config/kfd_device_config.h"
 
 #include "simdojo/sim/simulation.h"
 #include "simdojo/sim/topology.h"
@@ -20,6 +21,12 @@
 #include <vector>
 
 namespace rocjitsu {
+class SoC;
+namespace amdgpu {
+class GpuMemory;
+class Xcd;
+} // namespace amdgpu
+
 namespace config {
 
 /// @brief Result of building a declarative topology.
@@ -49,51 +56,6 @@ struct TopologyBuildResult {
 ///   loaded.wire_links(engine.topology());
 ///   engine.build();
 /// @endcode
-/// @brief KFD device identity extracted from vm.gpu.device in the config.
-/// All values use the same names as Sysfs::GpuInfo fields for easy mapping.
-struct KfdDeviceConfig {
-  uint32_t gpu_id = 0;
-  uint32_t gfx_target_version = 0;
-  uint32_t vendor_id = 0x1002;
-  uint32_t device_id = 0;
-  uint32_t family_id = 0;
-  uint64_t unique_id = 0;
-  std::string marketing_name;
-  uint32_t drm_render_minor = 128;
-  uint32_t revision_id = 0;
-  uint32_t pci_revision_id = 0;
-  uint32_t simd_count = 0;
-  uint32_t max_waves_per_simd = 10;
-  uint32_t num_shader_engines = 0; ///< KFD array_count: total shader arrays.
-  uint32_t num_shader_arrays_per_engine = 1;
-  uint32_t num_cu_per_sh = 0;
-  uint32_t simd_per_cu = 4;
-  uint32_t wave_front_size = 64;
-  uint32_t max_slots_scratch_cu = 32;
-  uint64_t local_mem_size = 0;
-  uint32_t vram_type = 6;
-  uint32_t lds_size_kb = 64;
-  uint32_t mem_width = 4096;
-  uint32_t mem_clk_max = 1200;
-  uint32_t l1_size_kb = 32;
-  uint32_t l1_line_size = 128;
-  uint32_t l1_assoc = 4;
-  uint32_t l2_size_kb = 4096;
-  uint32_t l2_line_size = 128;
-  uint32_t l2_assoc = 16;
-  uint32_t num_sdma_engines = 2;
-  uint32_t num_sdma_xgmi_engines = 0;
-  uint32_t num_cp_queues = 128;
-  uint32_t max_engine_clk_fcompute = 2100;
-  uint32_t location_id = 0x0300;
-  uint64_t hive_id = 0;
-  uint32_t domain = 0;
-  uint32_t capability = 0;
-  uint32_t capability2 = 0;
-  uint64_t debug_prop = 0;
-  bool present = false; ///< True if device section existed in config.
-};
-
 struct LoadedConfig {
   simdojo::SimulationEngine::Config engine_config;
   TopologyBuildResult build_result;
@@ -101,6 +63,7 @@ struct LoadedConfig {
       extra_gpu_builds; ///< Additional GPU SoC trees (for num_gpus > 1).
   simdojo::ExecMode exec_mode = simdojo::ExecMode::FUNCTIONAL;
   KfdDeviceConfig device;               ///< KFD device identity from vm.gpu.device.
+  DbtGuestConfig dbt_guest;             ///< Optional DBT guest-GPU discovery config.
   uint32_t num_gpus = 1;                ///< Number of simulated GPU instances.
   std::vector<KfdDeviceConfig> devices; ///< Per-GPU configs (populated when num_gpus > 1).
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
@@ -37,10 +37,9 @@ DbtGuestConfig dbt_guest_from_fb(const fb::DbtGuestConfig *guest) {
 }
 
 DbtGuestConfig load_dbt_guest_config_from_file(const std::string &path) {
-  flatbuffers::Parser parser;
-  const fb::SimulationConfig *config =
-      parse_simulation_config_json(read_config_file(path), rocjitsu::kEmbeddedSchema, parser);
-  return dbt_guest_from_fb(config->dbt_guest());
+  return with_parsed_simulation_config_json(
+      read_config_file(path), rocjitsu::kEmbeddedSchema,
+      [](const fb::SimulationConfig *config) { return dbt_guest_from_fb(config->dbt_guest()); });
 }
 
 std::optional<DbtGuestConfig> load_dbt_guest_config_from_runtime_config() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
@@ -18,6 +18,27 @@
 
 namespace rocjitsu {
 namespace config {
+namespace {
+
+void validate_guest_device_geometry(const KfdDeviceConfig &device) {
+  if (!device.present || device.simd_count == 0)
+    return;
+
+  const uint64_t expected_simds =
+      static_cast<uint64_t>(device.num_shader_engines) * device.num_cu_per_sh * device.simd_per_cu;
+  if (expected_simds == device.simd_count)
+    return;
+
+  // DBT guest configs are written verbatim into synthetic KFD sysfs. Reject
+  // internally inconsistent CU/SIMD geometry before ROCR observes properties
+  // that disagree with each other during guest-agent discovery.
+  throw std::runtime_error("dbt_guest.guest_device simd_count (" +
+                           std::to_string(device.simd_count) +
+                           ") must equal num_shader_engines * num_cu_per_sh * simd_per_cu (" +
+                           std::to_string(expected_simds) + ")");
+}
+
+} // namespace
 
 DbtGuestConfig dbt_guest_from_fb(const fb::DbtGuestConfig *guest) {
   DbtGuestConfig config;
@@ -33,6 +54,7 @@ DbtGuestConfig dbt_guest_from_fb(const fb::DbtGuestConfig *guest) {
   config.log_level = guest->log_level();
   config.signal_backtrace = guest->signal_backtrace();
   config.guest_device = kfd_device_from_fb(guest->guest_device());
+  validate_guest_device_geometry(config.guest_device);
   return config;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
@@ -18,7 +18,6 @@
 
 namespace rocjitsu {
 namespace config {
-namespace {
 
 DbtGuestConfig dbt_guest_from_fb(const fb::DbtGuestConfig *guest) {
   DbtGuestConfig config;
@@ -36,8 +35,6 @@ DbtGuestConfig dbt_guest_from_fb(const fb::DbtGuestConfig *guest) {
   config.guest_device = kfd_device_from_fb(guest->guest_device());
   return config;
 }
-
-} // namespace
 
 DbtGuestConfig load_dbt_guest_config_from_file(const std::string &path) {
   flatbuffers::Parser parser;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/config/dbt_guest_config.h"
+
+#include "rocjitsu/config/config_common.h"
+#include "rocjitsu/kmd/linux/rpc.h"
+
+#include "embedded_schema.h"
+#include "flatbuffers/idl.h"
+#include "simulation_config_generated.h"
+
+#include <cstdlib>
+#include <fstream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+namespace rocjitsu {
+namespace config {
+namespace {
+
+DbtGuestConfig dbt_guest_from_fb(const fb::DbtGuestConfig *guest) {
+  DbtGuestConfig config;
+  if (guest == nullptr)
+    return config;
+
+  config.enabled = guest->enabled();
+  if (guest->guest_isa())
+    config.guest_isa = guest->guest_isa()->str();
+  if (guest->host_isa())
+    config.host_isa = guest->host_isa()->str();
+  config.host_gpu_id = guest->host_gpu_id();
+  config.log_level = guest->log_level();
+  config.signal_backtrace = guest->signal_backtrace();
+  config.guest_device = kfd_device_from_fb(guest->guest_device());
+  return config;
+}
+
+} // namespace
+
+DbtGuestConfig load_dbt_guest_config_from_file(const std::string &path) {
+  flatbuffers::Parser parser;
+  const fb::SimulationConfig *config =
+      parse_simulation_config_json(read_config_file(path), rocjitsu::kEmbeddedSchema, parser);
+  return dbt_guest_from_fb(config->dbt_guest());
+}
+
+std::optional<DbtGuestConfig> load_dbt_guest_config_from_runtime_config() {
+  std::ifstream file(rocjitsu::rpc_default_config_file_path());
+  if (!file.is_open())
+    return std::nullopt;
+
+  std::string path;
+  std::getline(file, path);
+  if (path.empty())
+    return std::nullopt;
+  return load_dbt_guest_config_from_file(path);
+}
+
+} // namespace config
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.h
@@ -13,6 +13,10 @@
 #include <optional>
 #include <string>
 
+namespace rocjitsu::fb {
+struct DbtGuestConfig;
+} // namespace rocjitsu::fb
+
 namespace rocjitsu::config {
 
 /// @brief DBT guest-GPU discovery configuration.
@@ -30,6 +34,12 @@ struct DbtGuestConfig {
   bool signal_backtrace = false; ///< Install a best-effort HSA-hook crash backtrace handler.
   KfdDeviceConfig guest_device;  ///< Synthetic guest device appended to KFD topology.
 };
+
+/// @brief Convert a generated FlatBuffers DBT guest table into runtime config.
+///
+/// @details Shared by the DBT-only loader and the full simulation config
+/// loader so both paths interpret `dbt_guest` identically.
+DbtGuestConfig dbt_guest_from_fb(const fb::DbtGuestConfig *guest);
 
 /// @brief Load only dbt_guest from a rocjitsu JSON config.
 ///

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/dbt_guest_config.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file dbt_guest_config.h
+/// @brief DBT guest-GPU configuration shared by the launcher, KMD interposer, and HSA hook.
+
+#ifndef ROCJITSU_CONFIG_DBT_GUEST_CONFIG_H_
+#define ROCJITSU_CONFIG_DBT_GUEST_CONFIG_H_
+
+#include "rocjitsu/config/kfd_device_config.h"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace rocjitsu::config {
+
+/// @brief DBT guest-GPU discovery configuration.
+///
+/// @details When enabled, the Linux KFD interposer exposes one synthetic guest
+/// GPU alongside the real host GPUs and the HSA tools hook maps guest-agent
+/// execution calls to the host agent. The KFD layer only owns discovery; DBT and
+/// HSA forwarding happen in the HSA hook.
+struct DbtGuestConfig {
+  bool enabled = false;          ///< True when GuestKfd mode is active.
+  std::string guest_isa;         ///< Guest ISA advertised by the synthetic agent.
+  std::string host_isa;          ///< Host ISA used for actual ROCR execution.
+  uint32_t host_gpu_id = 0;      ///< Host KFD topology gpu_id; 0 matches topology to host_isa.
+  int log_level = 0;             ///< DBT hook logging level loaded from the config file.
+  bool signal_backtrace = false; ///< Install a best-effort HSA-hook crash backtrace handler.
+  KfdDeviceConfig guest_device;  ///< Synthetic guest device appended to KFD topology.
+};
+
+/// @brief Load only dbt_guest from a rocjitsu JSON config.
+///
+/// @details DBT guest mode does not instantiate the simulation VM. This helper
+/// intentionally accepts configs that contain only the top-level `dbt_guest`
+/// table, so guest discovery configs do not need unused `vm` or `topology`
+/// sections.
+/// @throws std::runtime_error on file I/O, parse errors, or invalid config.
+DbtGuestConfig load_dbt_guest_config_from_file(const std::string &path);
+
+/// @brief Load only dbt_guest from the rocjitsu child-process runtime config file.
+///
+/// @details HSA tools run inside ROCR initialization and must not depend on the
+/// full simulation topology builder. This helper parses the same JSON schema as
+/// the main config loader but copies only the DBT guest-GPU block.
+/// @returns DbtGuestConfig when the runtime config path file exists; std::nullopt otherwise.
+/// @throws std::runtime_error on file I/O, parse errors, or invalid config.
+std::optional<DbtGuestConfig> load_dbt_guest_config_from_runtime_config();
+
+} // namespace rocjitsu::config
+
+#endif // ROCJITSU_CONFIG_DBT_GUEST_CONFIG_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/kfd_device_config.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/kfd_device_config.h
@@ -55,6 +55,9 @@ struct KfdDeviceConfig {
   uint32_t location_id = 0x0300;             ///< PCI BDF location id.
   uint64_t hive_id = 0;                      ///< XGMI hive id.
   uint32_t domain = 0;                       ///< PCI domain.
+  uint32_t capability = 0;                   ///< KFD debug capability bits, or 0 to derive.
+  uint32_t capability2 = 0;                  ///< KFD debug capability2 bits, or 0 to derive.
+  uint64_t debug_prop = 0;                   ///< KFD debug_prop bits, or 0 to derive.
   bool present = false;                      ///< True if device section existed in config.
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/kfd_device_config.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/kfd_device_config.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file kfd_device_config.h
+/// @brief KFD device identity shared by VM simulation and DBT guest discovery.
+
+#ifndef ROCJITSU_CONFIG_KFD_DEVICE_CONFIG_H_
+#define ROCJITSU_CONFIG_KFD_DEVICE_CONFIG_H_
+
+#include <cstdint>
+#include <string>
+
+namespace rocjitsu::config {
+
+/// @brief KFD device identity extracted from vm.gpu.device or dbt_guest.guest_device.
+///
+/// @details The KMD interposer copies these values into generated KFD topology
+/// files and synthetic DRM/AMDGPU metadata. VM simulation uses them for the
+/// simulated GPU. DBT guest mode uses them for the guest GPU that applications
+/// see, not the host GPU that executes translated code.
+struct KfdDeviceConfig {
+  uint32_t gpu_id = 0;              ///< KFD gpu_id advertised in topology and ioctls.
+  uint32_t gfx_target_version = 0;  ///< KFD gfx target version, for example 90500 for gfx950.
+  uint32_t vendor_id = 0x1002;      ///< PCI vendor id used by synthetic DRM metadata.
+  uint32_t device_id = 0;           ///< PCI device id used by synthetic DRM metadata.
+  uint32_t family_id = 0;           ///< AMDGPU family id reported for this device.
+  uint64_t unique_id = 0;           ///< Stable synthetic unique id for this node.
+  std::string marketing_name;       ///< User-visible GPU name, for example MI350X.
+  uint32_t drm_render_minor = 128;  ///< Preferred synthetic /dev/dri/renderD minor.
+  uint32_t revision_id = 0;         ///< AMDGPU ASIC revision id.
+  uint32_t pci_revision_id = 0;     ///< PCI config-space revision id.
+  uint32_t simd_count = 0;          ///< Total SIMD units exposed in KFD properties.
+  uint32_t max_waves_per_simd = 10; ///< Maximum waves per SIMD.
+  uint32_t num_shader_engines = 0;  ///< Shader engine count.
+  uint32_t num_shader_arrays_per_engine = 1; ///< Shader arrays per shader engine.
+  uint32_t num_cu_per_sh = 0;                ///< Compute units per shader array.
+  uint32_t simd_per_cu = 4;                  ///< SIMD units per compute unit.
+  uint32_t wave_front_size = 64;             ///< Wavefront width reported to runtimes.
+  uint32_t max_slots_scratch_cu = 32;        ///< Scratch slots per compute unit.
+  uint64_t local_mem_size = 0;               ///< Advertised local memory size.
+  uint32_t vram_type = 6;                    ///< AMDGPU_VRAM_TYPE_* (6 = HBM).
+  uint32_t lds_size_kb = 64;                 ///< LDS size per CU in KiB.
+  uint32_t mem_width = 4096;                 ///< Memory interface width in bits.
+  uint32_t mem_clk_max = 1200;               ///< Maximum memory clock in MHz.
+  uint32_t l1_size_kb = 32;                  ///< L1 cache size in KiB.
+  uint32_t l1_line_size = 128;               ///< L1 cache line size in bytes.
+  uint32_t l1_assoc = 4;                     ///< L1 cache associativity.
+  uint32_t l2_size_kb = 4096;                ///< L2 cache size in KiB.
+  uint32_t l2_line_size = 128;               ///< L2 cache line size in bytes.
+  uint32_t l2_assoc = 16;                    ///< L2 cache associativity.
+  uint32_t num_sdma_engines = 2;             ///< SDMA engine count.
+  uint32_t num_sdma_xgmi_engines = 0;        ///< XGMI SDMA engine count.
+  uint32_t num_cp_queues = 128;              ///< Hardware queue count.
+  uint32_t max_engine_clk_fcompute = 2100;   ///< Maximum compute clock in MHz.
+  uint32_t location_id = 0x0300;             ///< PCI BDF location id.
+  uint64_t hive_id = 0;                      ///< XGMI hive id.
+  uint32_t domain = 0;                       ///< PCI domain.
+  bool present = false;                      ///< True if device section existed in config.
+};
+
+} // namespace rocjitsu::config
+
+#endif // ROCJITSU_CONFIG_KFD_DEVICE_CONFIG_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/kfd_device_config.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/kfd_device_config.h
@@ -31,7 +31,7 @@ struct KfdDeviceConfig {
   uint32_t pci_revision_id = 0;     ///< PCI config-space revision id.
   uint32_t simd_count = 0;          ///< Total SIMD units exposed in KFD properties.
   uint32_t max_waves_per_simd = 10; ///< Maximum waves per SIMD.
-  uint32_t num_shader_engines = 0;  ///< Shader engine count.
+  uint32_t num_shader_engines = 0;  ///< KFD array_count: total shader arrays.
   uint32_t num_shader_arrays_per_engine = 1; ///< Shader arrays per shader engine.
   uint32_t num_cu_per_sh = 0;                ///< Compute units per shader array.
   uint32_t simd_per_cu = 4;                  ///< SIMD units per compute unit.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/CMakeLists.txt
@@ -7,7 +7,7 @@ set_target_properties(rocjitsu_hooks PROPERTIES OUTPUT_NAME rocjitsu_hooks)
 
 target_include_directories(
     rocjitsu_hooks
-    PRIVATE ${ROCJITSU_INCLUDE_DIR} ${ROCJITSU_SRC_DIR}
+    PRIVATE ${ROCJITSU_INCLUDE_DIR} ${ROCJITSU_SRC_DIR} ${GENERATED_DIR}
 )
 
 target_include_directories(rocjitsu_hooks SYSTEM PRIVATE ${HSA_INCLUDE_DIR})
@@ -17,6 +17,7 @@ target_link_libraries(
     PRIVATE
         rocjitsu_analysis
         rocjitsu_code
+        rocjitsu_dbt_config
         rocjitsu_isa
         rocjitsu_isa_cdna1
         rocjitsu_isa_cdna2
@@ -27,8 +28,11 @@ target_link_libraries(
         rocjitsu_isa_rdna3
         rocjitsu_isa_rdna3_5
         rocjitsu_isa_rdna4
+        rocjitsu_isa_gfx1250
         # \NPI new ISA family: link its rocjitsu_isa_<isa> object library here.
+        rocjitsu_vm_amdgpu
         util
+        flatbuffers
         simdojo
         Threads::Threads
 )

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
@@ -106,9 +106,28 @@ constexpr std::array<TargetInfo, 4> kArchAliases = {{
     {"rdna4", ROCJITSU_CODE_ARCH_RDNA4, elf_mach_for_arch(ROCJITSU_CODE_ARCH_RDNA4)},
 }};
 
-#define RJ_AMD_EXT_HAS_FIELD(table, field)                                                         \
-  ((table) != nullptr &&                                                                           \
-   (table)->version.minor_id >= offsetof(AmdExtTable, field) + sizeof((table)->field))
+/// @brief Return the byte offset immediately after an API-table field.
+///
+/// @details ROCR uses `ApiTableVersion::minor_id` as the HSA-tools table size.
+/// Checking the end offset before reading a tail field lets the hook run against
+/// older runtimes whose table stops before recently-added AMD extension entries.
+template <typename Table, typename Field>
+constexpr uint32_t api_table_field_end_offset(size_t field_offset, Field Table::*) {
+  return static_cast<uint32_t>(field_offset + sizeof(Field));
+}
+
+/// @brief Return true when @p table is large enough to contain @p field.
+template <typename Table, typename Field>
+[[nodiscard]] bool api_table_has_field(const Table *table, size_t field_offset,
+                                       Field Table::*field) {
+  return table != nullptr &&
+         table->version.minor_id >= api_table_field_end_offset(field_offset, field);
+}
+
+static_assert(api_table_field_end_offset(offsetof(AmdExtTable, hsa_amd_memory_async_batch_copy_fn),
+                                         &AmdExtTable::hsa_amd_memory_async_batch_copy_fn) == 648);
+static_assert(api_table_field_end_offset(offsetof(AmdExtTable, hsa_amd_agent_preload_fn),
+                                         &AmdExtTable::hsa_amd_agent_preload_fn) == 656);
 
 /// @brief Runtime configuration consumed by the HSA tools hook.
 struct HookConfig {
@@ -859,12 +878,14 @@ void clear_agent_mapper();
   X(amd_memory_fill, amd_ext_, amd_ext_ != nullptr, true, hsa_amd_memory_fill_fn,                  \
     rj_amd_memory_fill, hsa_amd_memory_fill_fn_t)                                                  \
   X(amd_memory_async_batch_copy, amd_ext_,                                                         \
-    amd_ext_ != nullptr && RJ_AMD_EXT_HAS_FIELD(amd_ext_, hsa_amd_memory_async_batch_copy_fn),     \
+    api_table_has_field(amd_ext_, offsetof(AmdExtTable, hsa_amd_memory_async_batch_copy_fn),       \
+                        &AmdExtTable::hsa_amd_memory_async_batch_copy_fn),                         \
     true, hsa_amd_memory_async_batch_copy_fn, rj_amd_memory_async_batch_copy,                      \
     hsa_amd_memory_async_batch_copy_fn_t)                                                          \
   X(amd_agent_preload, amd_ext_,                                                                   \
-    amd_ext_ != nullptr && RJ_AMD_EXT_HAS_FIELD(amd_ext_, hsa_amd_agent_preload_fn), true,         \
-    hsa_amd_agent_preload_fn, rj_amd_agent_preload, hsa_amd_agent_preload_fn_t)
+    api_table_has_field(amd_ext_, offsetof(AmdExtTable, hsa_amd_agent_preload_fn),                 \
+                        &AmdExtTable::hsa_amd_agent_preload_fn),                                   \
+    true, hsa_amd_agent_preload_fn, rj_amd_agent_preload, hsa_amd_agent_preload_fn_t)
 
 /// @brief Process-local HSA API table patch state for the rocjitsu DBT tool.
 ///
@@ -1514,6 +1535,55 @@ void clear_memory_pool_mapper() { MemoryPoolMapper::instance().clear(); }
 /// @brief Clear agent mappings when the HSA layer unloads.
 void clear_agent_mapper() { AgentMapper::instance().clear(); }
 
+/// @brief Map one execution-facing agent from the visible guest handle to the host handle.
+[[nodiscard]] hsa_agent_t mapped_agent(hsa_agent_t agent) {
+  return AgentMapper::instance().map(agent);
+}
+
+/// @brief Map one guest memory pool to the matching host memory pool.
+[[nodiscard]] hsa_amd_memory_pool_t mapped_memory_pool(hsa_amd_memory_pool_t pool) {
+  return MemoryPoolMapper::instance().map(pool);
+}
+
+/// @brief Function-call argument that must be forwarded as a mapped HSA agent.
+struct MappedAgentArg {
+  hsa_agent_t value{};
+};
+
+/// @brief Function-call argument that must be forwarded as a mapped AMD memory pool.
+struct MappedPoolArg {
+  hsa_amd_memory_pool_t value{};
+};
+
+/// @brief Create a typed forwarding marker for agent arguments.
+[[nodiscard]] MappedAgentArg mapped_agent_arg(hsa_agent_t agent) {
+  return MappedAgentArg{mapped_agent(agent)};
+}
+
+/// @brief Create a typed forwarding marker for memory-pool arguments.
+[[nodiscard]] MappedPoolArg mapped_pool_arg(hsa_amd_memory_pool_t pool) {
+  return MappedPoolArg{mapped_memory_pool(pool)};
+}
+
+/// @brief Unwrap a non-mapped forwarding argument without changing its value category.
+template <typename Arg> decltype(auto) forward_amd_arg(Arg &&arg) { return std::forward<Arg>(arg); }
+
+/// @brief Unwrap an explicitly mapped agent marker for AMD-extension forwarding.
+inline hsa_agent_t forward_amd_arg(MappedAgentArg arg) { return arg.value; }
+
+/// @brief Unwrap an explicitly mapped pool marker for AMD-extension forwarding.
+inline hsa_amd_memory_pool_t forward_amd_arg(MappedPoolArg arg) { return arg.value; }
+
+/// @brief Forward an AMD-extension call after call-site arguments have declared mapping policy.
+///
+/// @details This helper is intentionally small: each wrapper still names the API
+/// semantics and any logging/output rewriting, but execution-facing handles are
+/// visibly marked with `mapped_agent_arg` or `mapped_pool_arg` at the call site.
+template <typename Original, typename... Args>
+hsa_status_t forward_amd_call(Original original, Args &&...args) {
+  return original(forward_amd_arg(std::forward<Args>(args))...);
+}
+
 hsa_status_t HSA_API rj_code_object_reader_create_from_memory(
     const void *code_object, size_t size, hsa_code_object_reader_t *code_object_reader) {
   auto *original = layer().create_from_memory();
@@ -1622,6 +1692,45 @@ MappedAccessAgents map_access_agent_array(const hsa_agent_t *agents, uint32_t co
   }
 
   return mapped;
+}
+
+/// @brief Agent fields used by one supported AMD batch-copy operation shape.
+struct BatchCopyAgentShape {
+  bool src_scalar = false;
+  bool dst_scalar = false;
+  bool dst_list = false;
+};
+
+/// @brief Return the current ROCR-owned agent fields for a batch-copy descriptor.
+///
+/// @details `hsa_amd_memory_copy_op_t` stores scalar and list fields in unions.
+/// Current ROCR uses a scalar `src_agent` for every supported operation and uses
+/// `dst_agent_list` for multi-entry/broadcast forms. `src_agent_list` is
+/// documented as reserved, so probing it as a pointer misclassifies ordinary
+/// scalar source-agent handles as caller-owned arrays.
+BatchCopyAgentShape batch_copy_agent_shape(const hsa_amd_memory_copy_op_t &op) {
+  switch (static_cast<hsa_amd_memory_copy_op_type_t>(op.type)) {
+  case HSA_AMD_MEMORY_COPY_OP_LINEAR:
+  case HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP:
+  case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC:
+  case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST:
+  case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST:
+    return BatchCopyAgentShape{
+        .src_scalar = true,
+        .dst_scalar = op.num_entries == 0,
+        .dst_list = op.num_entries > 0,
+    };
+  case HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST:
+    return BatchCopyAgentShape{
+        .src_scalar = true,
+        .dst_scalar = false,
+        .dst_list = true,
+    };
+  }
+
+  // Unknown future operation types have an unknown union contract. Forward them
+  // unchanged so the runtime can reject or handle them without rocjitsu guessing.
+  return {};
 }
 
 /// @brief Remap pointer-info accessible agents to guest handles and remove duplicates.
@@ -1875,7 +1984,7 @@ hsa_status_t HSA_API rj_amd_agent_iterate_memory_pools(
   auto *original = layer().amd_agent_iterate_memory_pools();
   if (!original)
     return HSA_STATUS_ERROR;
-  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  hsa_agent_t mapped = mapped_agent(agent);
   log_message(kLogDebug, "amd_agent_iterate_memory_pools agent=%llu mapped=%llu",
               static_cast<unsigned long long>(agent.handle),
               static_cast<unsigned long long>(mapped.handle));
@@ -1899,11 +2008,11 @@ hsa_status_t HSA_API rj_amd_memory_pool_allocate(hsa_amd_memory_pool_t memory_po
   auto *original = layer().amd_memory_pool_allocate();
   if (!original)
     return HSA_STATUS_ERROR;
-  hsa_amd_memory_pool_t mapped_pool = MemoryPoolMapper::instance().map(memory_pool);
+  hsa_amd_memory_pool_t mapped_pool = mapped_memory_pool(memory_pool);
   log_message(kLogVerbose, "amd_memory_pool_allocate pool=%llu mapped=%llu size=%zu flags=0x%x",
               static_cast<unsigned long long>(memory_pool.handle),
               static_cast<unsigned long long>(mapped_pool.handle), size, flags);
-  hsa_status_t status = original(mapped_pool, size, flags, ptr);
+  hsa_status_t status = forward_amd_call(original, MappedPoolArg{mapped_pool}, size, flags, ptr);
   log_message(kLogVerbose, "amd_memory_pool_allocate status=%d ptr=%p", static_cast<int>(status),
               ptr ? *ptr : nullptr);
   return status;
@@ -1933,8 +2042,8 @@ hsa_status_t HSA_API rj_amd_profiling_get_dispatch_time(hsa_agent_t agent, hsa_s
   auto *original = layer().amd_profiling_get_dispatch_time();
   if (!original)
     return HSA_STATUS_ERROR;
-  hsa_agent_t mapped = AgentMapper::instance().map(agent);
-  hsa_status_t status = original(mapped, signal, time);
+  hsa_agent_t mapped = mapped_agent(agent);
+  hsa_status_t status = forward_amd_call(original, MappedAgentArg{mapped}, signal, time);
   log_message(kLogVerbose,
               "amd_profiling_get_dispatch_time agent=%llu mapped=%llu signal=%llu status=%d "
               "start=%llu end=%llu",
@@ -1952,8 +2061,8 @@ hsa_status_t HSA_API rj_amd_profiling_convert_tick_to_system_domain(hsa_agent_t 
   auto *original = layer().amd_profiling_convert_tick_to_system_domain();
   if (!original)
     return HSA_STATUS_ERROR;
-  hsa_agent_t mapped = AgentMapper::instance().map(agent);
-  hsa_status_t status = original(mapped, agent_tick, system_tick);
+  hsa_agent_t mapped = mapped_agent(agent);
+  hsa_status_t status = forward_amd_call(original, MappedAgentArg{mapped}, agent_tick, system_tick);
   log_message(kLogVerbose,
               "amd_profiling_convert_tick_to_system_domain agent=%llu mapped=%llu status=%d "
               "agent_tick=%llu system_tick=%llu",
@@ -1971,8 +2080,8 @@ hsa_status_t HSA_API rj_amd_agent_memory_pool_get_info(hsa_agent_t agent,
   auto *original = layer().amd_agent_memory_pool_get_info();
   if (!original)
     return HSA_STATUS_ERROR;
-  hsa_agent_t mapped = AgentMapper::instance().map(agent);
-  hsa_amd_memory_pool_t mapped_pool = MemoryPoolMapper::instance().map(memory_pool);
+  hsa_agent_t mapped = mapped_agent(agent);
+  hsa_amd_memory_pool_t mapped_pool = mapped_memory_pool(memory_pool);
   log_message(
       kLogDebug,
       "amd_agent_memory_pool_get_info agent=%llu mapped=%llu pool=%llu mapped=%llu "
@@ -1980,7 +2089,8 @@ hsa_status_t HSA_API rj_amd_agent_memory_pool_get_info(hsa_agent_t agent,
       static_cast<unsigned long long>(agent.handle), static_cast<unsigned long long>(mapped.handle),
       static_cast<unsigned long long>(memory_pool.handle),
       static_cast<unsigned long long>(mapped_pool.handle), static_cast<unsigned>(attribute));
-  return original(mapped, mapped_pool, attribute, value);
+  return forward_amd_call(original, MappedAgentArg{mapped}, MappedPoolArg{mapped_pool}, attribute,
+                          value);
 }
 
 hsa_status_t HSA_API rj_amd_agents_allow_access(uint32_t num_agents, const hsa_agent_t *agents,
@@ -2008,8 +2118,8 @@ hsa_status_t HSA_API rj_amd_memory_async_copy(void *dst, hsa_agent_t dst_agent, 
   auto *original = layer().amd_memory_async_copy();
   if (!original)
     return HSA_STATUS_ERROR;
-  hsa_agent_t mapped_dst = AgentMapper::instance().map(dst_agent);
-  hsa_agent_t mapped_src = AgentMapper::instance().map(src_agent);
+  hsa_agent_t mapped_dst = mapped_agent(dst_agent);
+  hsa_agent_t mapped_src = mapped_agent(src_agent);
   log_message(kLogVerbose,
               "amd_memory_async_copy dst_agent=%llu mapped=%llu src_agent=%llu mapped=%llu "
               "size=%zu",
@@ -2017,8 +2127,9 @@ hsa_status_t HSA_API rj_amd_memory_async_copy(void *dst, hsa_agent_t dst_agent, 
               static_cast<unsigned long long>(mapped_dst.handle),
               static_cast<unsigned long long>(src_agent.handle),
               static_cast<unsigned long long>(mapped_src.handle), size);
-  return original(dst, mapped_dst, src, mapped_src, size, num_dep_signals, dep_signals,
-                  completion_signal);
+  return forward_amd_call(original, dst, MappedAgentArg{mapped_dst}, src,
+                          MappedAgentArg{mapped_src}, size, num_dep_signals, dep_signals,
+                          completion_signal);
 }
 
 hsa_status_t HSA_API rj_amd_memory_async_copy_on_engine(
@@ -2028,8 +2139,8 @@ hsa_status_t HSA_API rj_amd_memory_async_copy_on_engine(
   auto *original = layer().amd_memory_async_copy_on_engine();
   if (!original)
     return HSA_STATUS_ERROR;
-  hsa_agent_t mapped_dst = AgentMapper::instance().map(dst_agent);
-  hsa_agent_t mapped_src = AgentMapper::instance().map(src_agent);
+  hsa_agent_t mapped_dst = mapped_agent(dst_agent);
+  hsa_agent_t mapped_src = mapped_agent(src_agent);
   log_message(kLogVerbose,
               "amd_memory_async_copy_on_engine dst_agent=%llu mapped=%llu src_agent=%llu "
               "mapped=%llu size=%zu engine=%u",
@@ -2038,8 +2149,9 @@ hsa_status_t HSA_API rj_amd_memory_async_copy_on_engine(
               static_cast<unsigned long long>(src_agent.handle),
               static_cast<unsigned long long>(mapped_src.handle), size,
               static_cast<unsigned>(engine_id));
-  return original(dst, mapped_dst, src, mapped_src, size, num_dep_signals, dep_signals,
-                  completion_signal, engine_id, force_copy_on_sdma);
+  return forward_amd_call(original, dst, MappedAgentArg{mapped_dst}, src,
+                          MappedAgentArg{mapped_src}, size, num_dep_signals, dep_signals,
+                          completion_signal, engine_id, force_copy_on_sdma);
 }
 
 hsa_status_t HSA_API rj_amd_memory_async_copy_rect(
@@ -2050,12 +2162,12 @@ hsa_status_t HSA_API rj_amd_memory_async_copy_rect(
   auto *original = layer().amd_memory_async_copy_rect();
   if (!original)
     return HSA_STATUS_ERROR;
-  hsa_agent_t mapped = AgentMapper::instance().map(copy_agent);
+  hsa_agent_t mapped = mapped_agent(copy_agent);
   log_message(kLogVerbose, "amd_memory_async_copy_rect agent=%llu mapped=%llu dir=%u",
               static_cast<unsigned long long>(copy_agent.handle),
               static_cast<unsigned long long>(mapped.handle), static_cast<unsigned>(dir));
-  return original(dst, dst_offset, src, src_offset, range, mapped, dir, num_dep_signals,
-                  dep_signals, completion_signal);
+  return forward_amd_call(original, dst, dst_offset, src, src_offset, range, MappedAgentArg{mapped},
+                          dir, num_dep_signals, dep_signals, completion_signal);
 }
 
 hsa_status_t HSA_API rj_amd_memory_copy_engine_status(hsa_agent_t dst_agent, hsa_agent_t src_agent,
@@ -2063,8 +2175,8 @@ hsa_status_t HSA_API rj_amd_memory_copy_engine_status(hsa_agent_t dst_agent, hsa
   auto *original = layer().amd_memory_copy_engine_status();
   if (!original)
     return HSA_STATUS_ERROR;
-  return original(AgentMapper::instance().map(dst_agent), AgentMapper::instance().map(src_agent),
-                  engine_ids_mask);
+  return forward_amd_call(original, mapped_agent_arg(dst_agent), mapped_agent_arg(src_agent),
+                          engine_ids_mask);
 }
 
 hsa_status_t HSA_API rj_amd_memory_get_preferred_copy_engine(hsa_agent_t dst_agent,
@@ -2073,8 +2185,8 @@ hsa_status_t HSA_API rj_amd_memory_get_preferred_copy_engine(hsa_agent_t dst_age
   auto *original = layer().amd_memory_get_preferred_copy_engine();
   if (!original)
     return HSA_STATUS_ERROR;
-  return original(AgentMapper::instance().map(dst_agent), AgentMapper::instance().map(src_agent),
-                  engine_id);
+  return forward_amd_call(original, mapped_agent_arg(dst_agent), mapped_agent_arg(src_agent),
+                          engine_id);
 }
 
 hsa_status_t HSA_API rj_amd_memory_lock(void *host_ptr, size_t size, hsa_agent_t *agents,
@@ -2095,9 +2207,8 @@ hsa_status_t HSA_API rj_amd_memory_lock_to_pool(void *host_ptr, size_t size, hsa
     return HSA_STATUS_ERROR;
   auto mapped = num_agent > 0 ? map_agent_array(agents, static_cast<size_t>(num_agent))
                               : std::vector<hsa_agent_t>{};
-  hsa_amd_memory_pool_t mapped_pool = MemoryPoolMapper::instance().map(pool);
-  return original(host_ptr, size, mapped.empty() ? agents : mapped.data(), num_agent, mapped_pool,
-                  flags, agent_ptr);
+  return forward_amd_call(original, host_ptr, size, mapped.empty() ? agents : mapped.data(),
+                          num_agent, mapped_pool_arg(pool), flags, agent_ptr);
 }
 
 hsa_status_t HSA_API rj_amd_memory_fill(void *ptr, uint32_t value, size_t count) {
@@ -2138,11 +2249,12 @@ hsa_status_t HSA_API rj_amd_svm_prefetch_async(void *ptr, size_t size, hsa_agent
   auto *original = layer().amd_svm_prefetch_async();
   if (!original)
     return HSA_STATUS_ERROR;
-  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  hsa_agent_t mapped = mapped_agent(agent);
   log_message(kLogVerbose, "amd_svm_prefetch_async ptr=%p size=%zu agent=%llu mapped=%llu", ptr,
               size, static_cast<unsigned long long>(agent.handle),
               static_cast<unsigned long long>(mapped.handle));
-  return original(ptr, size, mapped, num_dep_signals, dep_signals, completion_signal);
+  return forward_amd_call(original, ptr, size, MappedAgentArg{mapped}, num_dep_signals, dep_signals,
+                          completion_signal);
 }
 
 hsa_status_t HSA_API rj_amd_vmem_set_access(void *va, size_t size,
@@ -2155,7 +2267,7 @@ hsa_status_t HSA_API rj_amd_vmem_set_access(void *va, size_t size,
   if (desc && desc_cnt > 0) {
     mapped.assign(desc, desc + desc_cnt);
     for (auto &entry : mapped)
-      entry.agent_handle = AgentMapper::instance().map(entry.agent_handle);
+      entry.agent_handle = mapped_agent(entry.agent_handle);
   }
   log_message(kLogVerbose, "amd_vmem_set_access va=%p size=%zu desc_cnt=%zu", va, size, desc_cnt);
   return original(va, size, mapped.empty() ? desc : mapped.data(), desc_cnt);
@@ -2166,22 +2278,22 @@ hsa_status_t HSA_API rj_amd_vmem_get_access(void *va, hsa_access_permission_t *p
   auto *original = layer().amd_vmem_get_access();
   if (!original)
     return HSA_STATUS_ERROR;
-  hsa_agent_t mapped = AgentMapper::instance().map(agent_handle);
+  hsa_agent_t mapped = mapped_agent(agent_handle);
   log_message(kLogVerbose, "amd_vmem_get_access va=%p agent=%llu mapped=%llu", va,
               static_cast<unsigned long long>(agent_handle.handle),
               static_cast<unsigned long long>(mapped.handle));
-  return original(va, perms, mapped);
+  return forward_amd_call(original, va, perms, MappedAgentArg{mapped});
 }
 
 hsa_status_t HSA_API rj_amd_agent_set_async_scratch_limit(hsa_agent_t agent, size_t threshold) {
   auto *original = layer().amd_agent_set_async_scratch_limit();
   if (!original)
     return HSA_STATUS_ERROR;
-  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  hsa_agent_t mapped = mapped_agent(agent);
   log_message(kLogVerbose, "amd_agent_set_async_scratch_limit agent=%llu mapped=%llu threshold=%zu",
               static_cast<unsigned long long>(agent.handle),
               static_cast<unsigned long long>(mapped.handle), threshold);
-  return original(mapped, threshold);
+  return forward_amd_call(original, MappedAgentArg{mapped}, threshold);
 }
 
 hsa_status_t HSA_API rj_amd_memory_async_batch_copy(const hsa_amd_memory_copy_op_t *copy_ops,
@@ -2194,30 +2306,21 @@ hsa_status_t HSA_API rj_amd_memory_async_batch_copy(const hsa_amd_memory_copy_op
     return original(copy_ops, num_copy_ops, num_dep_signals, dep_signals);
 
   std::vector<hsa_amd_memory_copy_op_t> mapped(copy_ops, copy_ops + num_copy_ops);
-  std::vector<std::vector<hsa_agent_t>> mapped_src_lists;
   std::vector<std::vector<hsa_agent_t>> mapped_dst_lists;
-  mapped_src_lists.reserve(num_copy_ops);
   mapped_dst_lists.reserve(num_copy_ops);
   log_message(kLogVerbose, "amd_memory_async_batch_copy ops=%u deps=%u", num_copy_ops,
               num_dep_signals);
   for (uint32_t i = 0; i < num_copy_ops; ++i) {
     auto &op = mapped[i];
-    if (op.num_entries == 0) {
-      op.src_agent = AgentMapper::instance().map(op.src_agent);
-      op.dst_agent = AgentMapper::instance().map(op.dst_agent);
-      continue;
-    }
-    if (op.src_agent_list != nullptr) {
-      mapped_src_lists.push_back(map_agent_array(op.src_agent_list, op.num_entries));
-      op.src_agent_list = mapped_src_lists.back().data();
-    } else {
-      op.src_agent = AgentMapper::instance().map(op.src_agent);
-    }
-    if (op.dst_agent_list != nullptr) {
+    const BatchCopyAgentShape shape = batch_copy_agent_shape(op);
+
+    if (shape.src_scalar)
+      op.src_agent = mapped_agent(op.src_agent);
+    if (shape.dst_scalar)
+      op.dst_agent = mapped_agent(op.dst_agent);
+    if (shape.dst_list && op.dst_agent_list != nullptr) {
       mapped_dst_lists.push_back(map_agent_array(op.dst_agent_list, op.num_entries));
       op.dst_agent_list = mapped_dst_lists.back().data();
-    } else {
-      op.dst_agent = AgentMapper::instance().map(op.dst_agent);
     }
   }
   return original(mapped.data(), num_copy_ops, num_dep_signals, dep_signals);
@@ -2227,12 +2330,12 @@ hsa_status_t HSA_API rj_amd_agent_preload(hsa_agent_t agent, uint64_t flags) {
   auto *original = layer().amd_agent_preload();
   if (!original)
     return HSA_STATUS_ERROR;
-  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  hsa_agent_t mapped = mapped_agent(agent);
   log_message(kLogVerbose, "amd_agent_preload agent=%llu mapped=%llu flags=0x%llx",
               static_cast<unsigned long long>(agent.handle),
               static_cast<unsigned long long>(mapped.handle),
               static_cast<unsigned long long>(flags));
-  return original(mapped, flags);
+  return forward_amd_call(original, MappedAgentArg{mapped}, flags);
 }
 
 /// @brief Create an HSA reader from translated ELF bytes and keep the storage alive.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
@@ -30,6 +30,7 @@
 #include <array>
 #include <atomic>
 #include <cerrno>
+#include <condition_variable>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
@@ -1292,64 +1293,86 @@ private:
   void ensure_discovered() {
     uint64_t generation = 0;
     {
-      std::lock_guard lock(mutex_);
+      std::unique_lock lock(mutex_);
+      while (discovering_)
+        discovery_cv_.wait(lock);
       if (discovered_)
         return;
-      discovered_ = true;
+      discovering_ = true;
       generation = generation_;
     }
 
     auto config = layer().config();
-    if (!config || !config->guest_target)
-      return;
+    hsa_agent_t discovered_guest{};
+    hsa_agent_t discovered_host{};
+    bool has_mapping = false;
+    bool attempted_agent_search = false;
 
-    auto *iterate_agents = layer().iterate_agents();
-    if (!iterate_agents)
-      return;
+    if (config && config->guest_target) {
+      auto *iterate_agents = layer().iterate_agents();
+      if (iterate_agents) {
+        std::optional<uint32_t> host_node_id;
+        bool can_search = true;
+        if (config->host_gpu_id != 0) {
+          host_node_id = node_id_for_kfd_gpu_id(config->host_gpu_id);
+          if (!host_node_id) {
+            std::fprintf(stderr,
+                         "[rocjitsu-hooks] failed to find topology node for host KFD gpu_id=%u\n",
+                         config->host_gpu_id);
+            can_search = false;
+          }
+        }
 
-    std::optional<uint32_t> host_node_id;
-    if (config->host_gpu_id != 0) {
-      host_node_id = node_id_for_kfd_gpu_id(config->host_gpu_id);
-      if (!host_node_id) {
-        std::fprintf(stderr,
-                     "[rocjitsu-hooks] failed to find topology node for host KFD gpu_id=%u\n",
-                     config->host_gpu_id);
-        return;
+        if (can_search) {
+          AgentSearchData search{this, *config->guest_target, config->target, host_node_id};
+          hsa_status_t status = iterate_agents(agent_callback, &search);
+          attempted_agent_search = true;
+          has_mapping = (status == HSA_STATUS_SUCCESS || status == HSA_STATUS_INFO_BREAK) &&
+                        search.guest_agent.handle != 0 && search.host_agent.handle != 0 &&
+                        search.guest_agent.handle != search.host_agent.handle;
+          discovered_guest = search.guest_agent;
+          discovered_host = search.host_agent;
+        }
       }
     }
 
-    AgentSearchData search{this, *config->guest_target, config->target, host_node_id};
-    hsa_status_t status = iterate_agents(agent_callback, &search);
-    const bool has_mapping = (status == HSA_STATUS_SUCCESS || status == HSA_STATUS_INFO_BREAK) &&
-                             search.guest_agent.handle != 0 && search.host_agent.handle != 0 &&
-                             search.guest_agent.handle != search.host_agent.handle;
+    bool published = false;
     {
       std::lock_guard lock(mutex_);
-      if (generation != generation_)
-        return;
-      guest_ = search.guest_agent;
-      host_ = search.host_agent;
-      has_mapping_ = has_mapping;
+      if (generation == generation_) {
+        guest_ = discovered_guest;
+        host_ = discovered_host;
+        has_mapping_ = has_mapping;
+        discovered_ = true;
+        published = true;
+      }
+      discovering_ = false;
     }
+    discovery_cv_.notify_all();
+    if (!published)
+      return;
+
     if (has_mapping) {
       log_message(kLogInfo, "mapped guest agent=%llu to host agent=%llu",
-                  static_cast<unsigned long long>(search.guest_agent.handle),
-                  static_cast<unsigned long long>(search.host_agent.handle));
+                  static_cast<unsigned long long>(discovered_guest.handle),
+                  static_cast<unsigned long long>(discovered_host.handle));
       if (config->log_level > kLogDisabled) {
-        std::optional<uint32_t> selected_node_id = agent_driver_node_id(search.host_agent);
+        std::optional<uint32_t> selected_node_id = agent_driver_node_id(discovered_host);
         std::fprintf(stderr,
                      "[rocjitsu-hooks] selected host agent=%llu for guest agent=%llu "
                      "host_gpu_id=%u host_node_id=%u\n",
-                     static_cast<unsigned long long>(search.host_agent.handle),
-                     static_cast<unsigned long long>(search.guest_agent.handle),
-                     config->host_gpu_id, selected_node_id.value_or(0));
+                     static_cast<unsigned long long>(discovered_host.handle),
+                     static_cast<unsigned long long>(discovered_guest.handle), config->host_gpu_id,
+                     selected_node_id.value_or(0));
       }
-    } else {
+    } else if (attempted_agent_search) {
       std::fprintf(stderr, "[rocjitsu-hooks] failed to find guest/host HSA agents for DBT\n");
     }
   }
 
   std::mutex mutex_;
+  std::condition_variable discovery_cv_;
+  bool discovering_ = false;
   bool discovered_ = false;
   bool has_mapping_ = false;
   uint64_t generation_ = 0;
@@ -1447,9 +1470,11 @@ private:
 
     hsa_agent_t guest = AgentMapper::instance().guest_agent();
     hsa_agent_t host = AgentMapper::instance().host_for_guest();
+    if (guest.handle == 0 || host.handle == 0)
+      return;
 
     std::unordered_map<uint64_t, uint64_t> discovered;
-    if (iterate_pools != nullptr && get_info != nullptr && guest.handle != 0 && host.handle != 0) {
+    if (iterate_pools != nullptr && get_info != nullptr) {
       PoolList guest_pools;
       PoolList host_pools;
       guest_pools.get_info = get_info;
@@ -1597,6 +1622,33 @@ MappedAccessAgents map_access_agent_array(const hsa_agent_t *agents, uint32_t co
   }
 
   return mapped;
+}
+
+/// @brief Remap pointer-info accessible agents to guest handles and remove duplicates.
+///
+/// @details ROCR owns the returned array and exposes only a mutable pointer plus
+/// count. Shrinking the array in place preserves that ownership while avoiding
+/// the common host+guest pair collapsing into two copies of the visible guest.
+void map_pointer_info_accessible_agents(uint32_t *num_agents_accessible, hsa_agent_t **accessible) {
+  if (num_agents_accessible == nullptr || accessible == nullptr || *accessible == nullptr)
+    return;
+
+  hsa_agent_t *agents = *accessible;
+  uint32_t out_count = 0;
+  for (uint32_t i = 0; i < *num_agents_accessible; ++i) {
+    hsa_agent_t mapped = AgentMapper::instance().guest_for_host(agents[i]);
+    bool duplicate = false;
+    for (uint32_t out_idx = 0; out_idx < out_count; ++out_idx) {
+      if (agents[out_idx].handle == mapped.handle) {
+        duplicate = true;
+        break;
+      }
+    }
+    if (duplicate)
+      continue;
+    agents[out_count++] = mapped;
+  }
+  *num_agents_accessible = out_count;
 }
 
 hsa_status_t HSA_API rj_iterate_agents(hsa_status_t (*callback)(hsa_agent_t agent, void *data),
@@ -2070,10 +2122,7 @@ hsa_status_t HSA_API rj_amd_pointer_info(const void *ptr, hsa_amd_pointer_info_t
     if (info != nullptr &&
         info->size >= offsetof(hsa_amd_pointer_info_t, agentOwner) + sizeof(info->agentOwner))
       info->agentOwner = AgentMapper::instance().guest_for_host(info->agentOwner);
-    if (num_agents_accessible != nullptr && accessible != nullptr && *accessible != nullptr) {
-      for (uint32_t i = 0; i < *num_agents_accessible; ++i)
-        (*accessible)[i] = AgentMapper::instance().guest_for_host((*accessible)[i]);
-    }
+    map_pointer_info_accessible_agents(num_agents_accessible, accessible);
   }
   log_message(kLogVerbose, "amd_pointer_info status=%d owner=%llu accessible=%u",
               static_cast<int>(status),
@@ -2236,13 +2285,6 @@ hsa_status_t HSA_API rj_executable_load_agent_code_object(
               static_cast<unsigned long long>(executable.handle),
               static_cast<unsigned long long>(agent.handle), guest_load ? 1 : 0,
               static_cast<unsigned long long>(code_object_reader.handle));
-  if (config->guest_target && !guest_load) {
-    hsa_status_t status =
-        original_load(executable, agent, code_object_reader, options, loaded_code_object);
-    log_message(kLogVerbose, "load_agent_code_object host/pass-through status=%d",
-                static_cast<int>(status));
-    return status;
-  }
 
   hsa_agent_t load_agent = guest_load ? AgentMapper::instance().host_for_guest() : agent;
   if (guest_load && load_agent.handle == 0)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
@@ -4,14 +4,17 @@
 /// @file rj_hsa_dbt_hooks.cpp
 /// @brief HSA tools load-time DBT hook for translating AMDGPU code objects.
 ///
-/// @details ROCR loads this shared library through `HSA_TOOLS_LIB` during
-/// `hsa_init()`. The hook saves the API table entries that are present at
-/// `OnLoad()` time, installs wrappers for code-object reader creation/destruction
-/// and agent code-object loads, and invokes rocjitsu DBT before ROCR sees a
-/// memory-backed guest code object. The MVP is deliberately strict: when
-/// translation is requested and fails, the hook returns an HSA error instead of
-/// retrying the original reader, because the original ELF may target a different
-/// GPU ISA.
+/// @details DBT guest mode is split across KFD discovery and HSA execution.
+/// GuestKfd appends one synthetic guest GPU to KFD topology so ROCR discovers
+/// the agent requested by the application, while the real host GPU remains
+/// available for execution. ROCR loads this shared library through
+/// `HSA_TOOLS_LIB` during `hsa_init()`. The hook selects the configured host
+/// agent, presents guest-facing agent handles where applications enumerate or
+/// query devices, rewrites execution-facing calls back to the host agent, and
+/// invokes rocjitsu DBT before ROCR sees a memory-backed guest code object.
+/// The MVP is deliberately strict: when translation is requested and fails, the
+/// hook returns an HSA error instead of retrying the original reader, because
+/// the original ELF may target a different GPU ISA.
 
 #include "hsa/hsa_api_trace_minimal.h"
 
@@ -19,24 +22,33 @@
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/dbt/binary_translator.h"
 #include "rocjitsu/code/dbt/translation_diagnostic.h"
+#include "rocjitsu/config/dbt_guest_config.h"
 #include "util/arena_alloc.h"
 #include "util/intrusive_list.h"
 #include "util/log.h"
 
 #include <array>
 #include <atomic>
+#include <cerrno>
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <dirent.h>
+#include <exception>
+#include <execinfo.h>
+#include <fcntl.h>
 #include <memory>
 #include <mutex>
 #include <new>
 #include <optional>
 #include <shared_mutex>
+#include <signal.h>
 #include <span>
 #include <string>
 #include <string_view>
+#include <unistd.h>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -70,7 +82,12 @@ enum HookLogLevel : int {
 };
 
 std::atomic<int> g_log_level{kLogDisabled};
+std::atomic<bool> g_signal_backtrace_enabled{false};
+std::atomic<bool> g_signal_backtrace_installed{false};
+struct sigaction g_previous_sigsegv {};
+struct sigaction g_previous_sigabrt {};
 
+/// @brief Parsed ISA target used by DBT and HSA agent matching.
 struct TargetInfo {
   std::string_view name;
   rj_code_arch_t arch;
@@ -88,12 +105,21 @@ constexpr std::array<TargetInfo, 4> kArchAliases = {{
     {"rdna4", ROCJITSU_CODE_ARCH_RDNA4, elf_mach_for_arch(ROCJITSU_CODE_ARCH_RDNA4)},
 }};
 
+#define RJ_AMD_EXT_HAS_FIELD(table, field)                                                         \
+  ((table) != nullptr &&                                                                           \
+   (table)->version.minor_id >= offsetof(AmdExtTable, field) + sizeof((table)->field))
+
+/// @brief Runtime configuration consumed by the HSA tools hook.
 struct HookConfig {
   TargetInfo target{};
   std::optional<TargetInfo> source_override;
+  std::optional<TargetInfo> guest_target;
+  uint32_t host_gpu_id = 0;
   int log_level = kLogDisabled;
+  bool signal_backtrace = false;
 };
 
+/// @brief Parse a config ISA name or architecture alias into a DBT target.
 [[nodiscard]] std::optional<TargetInfo> parse_target(std::string_view value) {
   for (uint32_t mach : kAcceptedConcreteTargetMachs) {
     std::string_view name = elf_mach_name(mach);
@@ -110,53 +136,140 @@ struct HookConfig {
   return std::nullopt;
 }
 
-[[nodiscard]] int parse_log_level() {
-  const char *value = std::getenv("RJ_DBT_LOG");
-  if (value == nullptr || *value == '\0')
+/// @brief Clamp a user-provided hook log level to the supported range.
+[[nodiscard]] int clamp_log_level(int value) {
+  if (value < kLogDisabled)
     return kLogDisabled;
-
-  char *end = nullptr;
-  const long parsed = std::strtol(value, &end, 10);
-  if (end == value)
-    return kLogDisabled;
-  if (parsed < 0)
-    return kLogDisabled;
-  if (parsed > kLogDebug)
+  if (value > kLogDebug)
     return kLogDebug;
-  return static_cast<int>(parsed);
+  return value;
 }
 
+/// @brief Chain to the signal handler that was installed before rocjitsu.
+void invoke_previous_signal_handler(int signo, siginfo_t *info, void *context) {
+  const struct sigaction &previous = signo == SIGABRT ? g_previous_sigabrt : g_previous_sigsegv;
+  if ((previous.sa_flags & SA_SIGINFO) != 0 && previous.sa_sigaction != nullptr) {
+    previous.sa_sigaction(signo, info, context);
+    return;
+  }
+  if (previous.sa_handler == SIG_IGN)
+    return;
+  if (previous.sa_handler != SIG_DFL && previous.sa_handler != nullptr) {
+    previous.sa_handler(signo);
+    return;
+  }
+  (void)::sigaction(signo, &previous, nullptr);
+  (void)::raise(signo);
+}
+
+void prewarm_signal_backtrace() {
+  void *frames[1];
+  int count = ::backtrace(frames, 1);
+  int fd = ::open("/dev/null", O_WRONLY | O_CLOEXEC);
+  if (fd >= 0) {
+    ::backtrace_symbols_fd(frames, count, fd);
+    ::close(fd);
+  }
+}
+
+/// @brief Print a best-effort stack trace for fatal hook signals.
+///
+/// @details The handler uses prewarmed unwinder paths, but glibc backtrace APIs
+/// are not async-signal-safe. Keep this diagnostic opt-in.
+void signal_backtrace_handler(int signo, siginfo_t *info, void *context) {
+  if (!g_signal_backtrace_enabled.exchange(false, std::memory_order_relaxed)) {
+    invoke_previous_signal_handler(signo, info, context);
+    return;
+  }
+
+  const char header[] = "\n[rocjitsu-hooks] signal backtrace\n";
+  const ssize_t written = ::write(STDERR_FILENO, header, sizeof(header) - 1);
+  (void)written;
+  void *frames[128];
+  int count = ::backtrace(frames, 128);
+  ::backtrace_symbols_fd(frames, count, STDERR_FILENO);
+  invoke_previous_signal_handler(signo, info, context);
+}
+
+/// @brief Install fatal-signal backtrace handling when enabled by config.
+void maybe_install_signal_backtrace(bool enabled) {
+  if (!enabled)
+    return;
+
+  prewarm_signal_backtrace();
+
+  struct sigaction action {};
+  action.sa_sigaction = signal_backtrace_handler;
+  sigemptyset(&action.sa_mask);
+  action.sa_flags = SA_SIGINFO;
+
+  struct sigaction previous_sigsegv {};
+  struct sigaction previous_sigabrt {};
+  if (::sigaction(SIGSEGV, &action, &previous_sigsegv) != 0)
+    return;
+  if (::sigaction(SIGABRT, &action, &previous_sigabrt) != 0) {
+    (void)::sigaction(SIGSEGV, &previous_sigsegv, nullptr);
+    return;
+  }
+
+  g_previous_sigsegv = previous_sigsegv;
+  g_previous_sigabrt = previous_sigabrt;
+  g_signal_backtrace_installed.store(true, std::memory_order_release);
+  g_signal_backtrace_enabled.store(true, std::memory_order_release);
+}
+
+/// @brief Restore fatal-signal handlers installed before rocjitsu.
+void restore_signal_backtrace_handlers() {
+  g_signal_backtrace_enabled.store(false, std::memory_order_release);
+  if (!g_signal_backtrace_installed.exchange(false, std::memory_order_acq_rel))
+    return;
+  (void)::sigaction(SIGSEGV, &g_previous_sigsegv, nullptr);
+  (void)::sigaction(SIGABRT, &g_previous_sigabrt, nullptr);
+}
+
+/// @brief Load and validate DBT hook configuration from the runtime config file.
 [[nodiscard]] std::optional<HookConfig> parse_config() {
-  HookConfig config;
-  config.log_level = parse_log_level();
-
-  const char *target_value = std::getenv("RJ_DBT_TARGET_ISA");
-  if (target_value == nullptr || *target_value == '\0') {
-    std::fprintf(stderr,
-                 "[rocjitsu-hooks] RJ_DBT_TARGET_ISA is required for the DBT HSA tools hook\n");
+  std::optional<rocjitsu::config::DbtGuestConfig> dbt_guest;
+  try {
+    dbt_guest = rocjitsu::config::load_dbt_guest_config_from_runtime_config();
+  } catch (const std::exception &error) {
+    std::fprintf(stderr, "[rocjitsu-hooks] failed to load runtime config: %s\n", error.what());
+    return std::nullopt;
+  }
+  if (!dbt_guest) {
+    std::fprintf(stderr, "[rocjitsu-hooks] runtime config is required for the DBT HSA hook\n");
     return std::nullopt;
   }
 
-  auto target = parse_target(target_value);
+  if (!dbt_guest->enabled) {
+    std::fprintf(stderr, "[rocjitsu-hooks] runtime config does not enable dbt_guest mode\n");
+    return std::nullopt;
+  }
+
+  auto target = parse_target(dbt_guest->host_isa);
   if (!target) {
-    std::fprintf(stderr, "[rocjitsu-hooks] invalid RJ_DBT_TARGET_ISA='%s'\n", target_value);
+    std::fprintf(stderr, "[rocjitsu-hooks] invalid dbt_guest.host_isa='%s'\n",
+                 dbt_guest->host_isa.c_str());
     return std::nullopt;
   }
-  config.target = *target;
-
-  const char *source_value = std::getenv("RJ_DBT_SOURCE_ISA");
-  if (source_value != nullptr && *source_value != '\0') {
-    auto source = parse_target(source_value);
-    if (!source) {
-      std::fprintf(stderr, "[rocjitsu-hooks] invalid RJ_DBT_SOURCE_ISA='%s'\n", source_value);
-      return std::nullopt;
-    }
-    config.source_override = *source;
+  auto guest = parse_target(dbt_guest->guest_isa);
+  if (!guest) {
+    std::fprintf(stderr, "[rocjitsu-hooks] invalid dbt_guest.guest_isa='%s'\n",
+                 dbt_guest->guest_isa.c_str());
+    return std::nullopt;
   }
 
+  HookConfig config;
+  config.target = *target;
+  config.source_override = *guest;
+  config.guest_target = *guest;
+  config.host_gpu_id = dbt_guest->host_gpu_id;
+  config.log_level = clamp_log_level(dbt_guest->log_level);
+  config.signal_backtrace = dbt_guest->signal_backtrace;
   return config;
 }
 
+/// @brief Emit a hook log message through the rocjitsu logger.
 void log_message(int required_level, const char *format, ...) {
   if (g_log_level.load(std::memory_order_relaxed) < required_level)
     return;
@@ -170,6 +283,7 @@ void log_message(int required_level, const char *format, ...) {
   util::Logger::dbt_hooks(message.data());
 }
 
+/// @brief Return a compact architecture-family name for diagnostics.
 [[nodiscard]] const char *arch_name(rj_code_arch_t arch) {
   switch (arch) {
   case ROCJITSU_CODE_ARCH_CDNA3:
@@ -185,6 +299,7 @@ void log_message(int required_level, const char *format, ...) {
   }
 }
 
+/// @brief Return a stable diagnostic severity name.
 [[nodiscard]] const char *diagnostic_severity_name(DiagnosticSeverity severity) {
   switch (severity) {
   case DiagnosticSeverity::Warning:
@@ -195,6 +310,7 @@ void log_message(int required_level, const char *format, ...) {
   return "diagnostic";
 }
 
+/// @brief Return a stable diagnostic kind name.
 [[nodiscard]] const char *diagnostic_kind_name(DiagnosticKind kind) {
   switch (kind) {
   case DiagnosticKind::UnsupportedGuestArch:
@@ -236,6 +352,7 @@ void print_diagnostics(FILE *stream, std::span<const TranslationDiagnostic> diag
   }
 }
 
+/// @brief ISA family and exact ELF machine value detected from a code object.
 struct DetectedElfTarget {
   rj_code_arch_t arch = ROCJITSU_CODE_ARCH_INVALID;
   uint32_t mach = 0;
@@ -349,6 +466,7 @@ public:
   }
 
 private:
+  /// @brief One code-object reader entry tracked by reader handle.
   struct Entry : util::IListNode<Entry> {
     Entry(uint64_t h, const uint8_t *b, size_t s, std::vector<uint8_t> *o)
         : handle(h), bytes(b), size(s), owned(o) {}
@@ -359,6 +477,7 @@ private:
     std::vector<uint8_t> *owned = nullptr;
   };
 
+  /// @brief Destroy one reader entry and release optional owned ELF storage.
   void destroy_entry(Entry *entry) {
     delete entry->owned;
     entry->~Entry();
@@ -370,14 +489,381 @@ private:
   util::IntrusiveList<Entry> entries_;
 };
 
+/// @brief Tracks executable guest-agent loads that must resolve symbols on the host agent.
+class ExecutableAgentRegistry {
+public:
+  /// @brief Return the process-local executable-agent registry.
+  static ExecutableAgentRegistry &instance() {
+    static ExecutableAgentRegistry registry;
+    return registry;
+  }
+
+  /// @brief Remember that @p executable loaded guest code for @p guest on @p host.
+  void record(hsa_executable_t executable, hsa_agent_t guest, hsa_agent_t host) {
+    std::lock_guard lock(mutex_);
+    map_[key(executable, guest)] = host.handle;
+  }
+
+  /// @brief Map a guest executable-agent pair back to the host agent used for loading.
+  hsa_agent_t map_agent(hsa_executable_t executable, hsa_agent_t agent) {
+    std::lock_guard lock(mutex_);
+    auto it = map_.find(key(executable, agent));
+    if (it == map_.end())
+      return agent;
+    return hsa_agent_t{it->second};
+  }
+
+  /// @brief Drop all recorded agent mappings for one executable.
+  void erase_executable(hsa_executable_t executable) {
+    std::lock_guard lock(mutex_);
+    const uint64_t prefix = executable.handle;
+    for (auto it = map_.begin(); it != map_.end();) {
+      if (it->first.first == prefix)
+        it = map_.erase(it);
+      else
+        ++it;
+    }
+  }
+
+  /// @brief Clear all executable-agent mappings during hook unload.
+  void clear() {
+    std::lock_guard lock(mutex_);
+    map_.clear();
+  }
+
+private:
+  using Key = std::pair<uint64_t, uint64_t>;
+
+  /// @brief Hash function for executable/agent handle pairs.
+  struct KeyHash {
+    size_t operator()(Key key) const {
+      size_t h = std::hash<uint64_t>{}(key.first);
+      h ^= std::hash<uint64_t>{}(key.second) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+      return h;
+    }
+  };
+
+  /// @brief Build the map key from an executable and agent handle.
+  static Key key(hsa_executable_t executable, hsa_agent_t agent) {
+    return {executable.handle, agent.handle};
+  }
+
+  std::mutex mutex_;
+  std::unordered_map<Key, uint64_t, KeyHash> map_;
+};
+
+/// @brief Record memory-backed HSA code-object bytes for later DBT translation.
 hsa_status_t HSA_API rj_code_object_reader_create_from_memory(
     const void *code_object, size_t size, hsa_code_object_reader_t *code_object_reader);
+
+/// @brief Warn for file-backed readers, which the MVP cannot translate safely.
 hsa_status_t HSA_API rj_code_object_reader_create_from_file(
     hsa_file_t file, hsa_code_object_reader_t *code_object_reader);
+
+/// @brief Remove tracked reader bytes and forward reader destruction.
 hsa_status_t HSA_API rj_code_object_reader_destroy(hsa_code_object_reader_t code_object_reader);
+
+/// @brief Skip ROCR shutdown in guest mode and uninstall rocjitsu wrappers.
+hsa_status_t HSA_API rj_shut_down();
+
+/// @brief Shadow public HSA agent iteration with the guest replacing the host.
+hsa_status_t HSA_API rj_iterate_agents(hsa_status_t (*callback)(hsa_agent_t agent, void *data),
+                                       void *data);
+
+/// @brief Translate guest code objects and load the translated ELF on the host agent.
 hsa_status_t HSA_API rj_executable_load_agent_code_object(
     hsa_executable_t executable, hsa_agent_t agent, hsa_code_object_reader_t code_object_reader,
     const char *options, hsa_loaded_code_object_t *loaded_code_object);
+
+/// @brief Preserve guest ISA iteration so framework fatbin selection picks guest images.
+hsa_status_t HSA_API rj_agent_iterate_isas(hsa_agent_t agent,
+                                           hsa_status_t (*callback)(hsa_isa_t isa, void *data),
+                                           void *data);
+
+/// @brief Create real host queues when the application asks for a guest queue.
+hsa_status_t HSA_API rj_queue_create(hsa_agent_t agent, uint32_t size, hsa_queue_type32_t type,
+                                     void (*callback)(hsa_status_t, hsa_queue_t *, void *),
+                                     void *data, uint32_t private_segment_size,
+                                     uint32_t group_segment_size, hsa_queue_t **queue);
+
+/// @brief Forward destruction for queues returned by guest queue creation.
+hsa_status_t HSA_API rj_queue_destroy(hsa_queue_t *queue);
+
+/// @brief Return host memory regions for guest region iteration.
+hsa_status_t HSA_API rj_agent_iterate_regions(
+    hsa_agent_t agent, hsa_status_t (*callback)(hsa_region_t region, void *data), void *data);
+
+/// @brief Assign memory access to the host agent when the caller passes the guest.
+hsa_status_t HSA_API rj_memory_assign_agent(void *ptr, hsa_agent_t agent,
+                                            hsa_access_permission_t access);
+
+/// @brief Drop executable-agent mappings before forwarding executable destruction.
+hsa_status_t HSA_API rj_executable_destroy(hsa_executable_t executable);
+
+/// @brief Remap guest symbol queries to the host load agent.
+hsa_status_t HSA_API rj_executable_get_symbol(hsa_executable_t executable, const char *module_name,
+                                              const char *symbol_name, hsa_agent_t agent,
+                                              int32_t call_convention,
+                                              hsa_executable_symbol_t *symbol);
+
+/// @brief Remap by-name guest symbol queries to the host load agent.
+hsa_status_t HSA_API rj_executable_get_symbol_by_name(hsa_executable_t executable,
+                                                      const char *symbol_name,
+                                                      const hsa_agent_t *agent,
+                                                      hsa_executable_symbol_t *symbol);
+
+/// @brief Define executable globals against the host load agent.
+hsa_status_t HSA_API rj_executable_agent_global_variable_define(hsa_executable_t executable,
+                                                                hsa_agent_t agent,
+                                                                const char *variable_name,
+                                                                void *address);
+
+/// @brief Iterate host-agent symbols while reporting the guest agent to callbacks.
+hsa_status_t HSA_API rj_executable_iterate_agent_symbols(
+    hsa_executable_t executable, hsa_agent_t agent,
+    hsa_status_t (*callback)(hsa_executable_t, hsa_agent_t, hsa_executable_symbol_t, void *),
+    void *data);
+
+/// @brief Enumerate guest memory pools for public guest-agent discovery.
+hsa_status_t HSA_API rj_amd_agent_iterate_memory_pools(
+    hsa_agent_t agent, hsa_status_t (*callback)(hsa_amd_memory_pool_t, void *), void *data);
+
+/// @brief Return memory-pool properties without changing guest-facing identity.
+hsa_status_t HSA_API rj_amd_memory_pool_get_info(hsa_amd_memory_pool_t memory_pool,
+                                                 hsa_amd_memory_pool_info_t attribute, void *value);
+
+/// @brief Allocate from a matching host pool when the caller passes a guest pool.
+hsa_status_t HSA_API rj_amd_memory_pool_allocate(hsa_amd_memory_pool_t memory_pool, size_t size,
+                                                 uint32_t flags, void **ptr);
+
+/// @brief Free host-backed memory allocated through mapped pools.
+hsa_status_t HSA_API rj_amd_memory_pool_free(void *ptr);
+
+/// @brief Enable profiling on the mapped host queue.
+hsa_status_t HSA_API rj_amd_profiling_set_profiler_enabled(hsa_queue_t *queue, int enable);
+
+/// @brief Query dispatch timestamps through the mapped host agent.
+hsa_status_t HSA_API rj_amd_profiling_get_dispatch_time(hsa_agent_t agent, hsa_signal_t signal,
+                                                        hsa_amd_profiling_dispatch_time_t *time);
+
+/// @brief Convert agent ticks through the mapped host agent.
+hsa_status_t HSA_API rj_amd_profiling_convert_tick_to_system_domain(hsa_agent_t agent,
+                                                                    uint64_t agent_tick,
+                                                                    uint64_t *system_tick);
+
+/// @brief Query agent/pool relationships through mapped host handles.
+hsa_status_t HSA_API rj_amd_agent_memory_pool_get_info(hsa_agent_t agent,
+                                                       hsa_amd_memory_pool_t memory_pool,
+                                                       hsa_amd_agent_memory_pool_info_t attribute,
+                                                       void *value);
+
+/// @brief Allow memory access for mapped host agents, removing duplicates.
+hsa_status_t HSA_API rj_amd_agents_allow_access(uint32_t num_agents, const hsa_agent_t *agents,
+                                                const uint32_t *flags, const void *ptr);
+
+/// @brief Map source and destination agents for async memory copies.
+hsa_status_t HSA_API rj_amd_memory_async_copy(void *dst, hsa_agent_t dst_agent, const void *src,
+                                              hsa_agent_t src_agent, size_t size,
+                                              uint32_t num_dep_signals,
+                                              const hsa_signal_t *dep_signals,
+                                              hsa_signal_t completion_signal);
+
+/// @brief Map source and destination agents for engine-selected async copies.
+hsa_status_t HSA_API rj_amd_memory_async_copy_on_engine(
+    void *dst, hsa_agent_t dst_agent, const void *src, hsa_agent_t src_agent, size_t size,
+    uint32_t num_dep_signals, const hsa_signal_t *dep_signals, hsa_signal_t completion_signal,
+    hsa_amd_sdma_engine_id_t engine_id, bool force_copy_on_sdma);
+
+/// @brief Map the copy agent for rectangular async copies.
+hsa_status_t HSA_API rj_amd_memory_async_copy_rect(
+    const hsa_pitched_ptr_t *dst, const hsa_dim3_t *dst_offset, const hsa_pitched_ptr_t *src,
+    const hsa_dim3_t *src_offset, const hsa_dim3_t *range, hsa_agent_t copy_agent,
+    hsa_amd_copy_direction_t dir, uint32_t num_dep_signals, const hsa_signal_t *dep_signals,
+    hsa_signal_t completion_signal);
+
+/// @brief Query copy-engine status using mapped host agents.
+hsa_status_t HSA_API rj_amd_memory_copy_engine_status(hsa_agent_t dst_agent, hsa_agent_t src_agent,
+                                                      uint32_t *engine_ids_mask);
+
+/// @brief Query preferred copy engines using mapped host agents.
+hsa_status_t HSA_API rj_amd_memory_get_preferred_copy_engine(hsa_agent_t dst_agent,
+                                                             hsa_agent_t src_agent,
+                                                             hsa_amd_sdma_engine_id_t *engine_id);
+
+/// @brief Map agent arrays before locking host memory for GPU access.
+hsa_status_t HSA_API rj_amd_memory_lock(void *host_ptr, size_t size, hsa_agent_t *agents,
+                                        int num_agent, void **agent_ptr);
+
+/// @brief Forward memory-fill operations while preserving trace visibility.
+hsa_status_t HSA_API rj_amd_memory_fill(void *ptr, uint32_t value, size_t count);
+
+/// @brief Map pointer-info owner and accessible agents from host back to guest.
+hsa_status_t HSA_API rj_amd_pointer_info(const void *ptr, hsa_amd_pointer_info_t *info,
+                                         void *(*alloc)(size_t), uint32_t *num_agents_accessible,
+                                         hsa_agent_t **accessible);
+
+/// @brief Map agent arrays and guest pools before locking host memory to a pool.
+hsa_status_t HSA_API rj_amd_memory_lock_to_pool(void *host_ptr, size_t size, hsa_agent_t *agents,
+                                                int num_agent, hsa_amd_memory_pool_t pool,
+                                                uint32_t flags, void **agent_ptr);
+
+/// @brief Prefetch SVM memory to the host agent when the caller passes the guest.
+hsa_status_t HSA_API rj_amd_svm_prefetch_async(void *ptr, size_t size, hsa_agent_t agent,
+                                               uint32_t num_dep_signals,
+                                               const hsa_signal_t *dep_signals,
+                                               hsa_signal_t completion_signal);
+
+/// @brief Rewrite virtual-memory access descriptors from guest to host.
+hsa_status_t HSA_API rj_amd_vmem_set_access(void *va, size_t size,
+                                            const hsa_amd_memory_access_desc_t *desc,
+                                            size_t desc_cnt);
+
+/// @brief Query virtual-memory access through the host agent.
+hsa_status_t HSA_API rj_amd_vmem_get_access(void *va, hsa_access_permission_t *perms,
+                                            hsa_agent_t agent_handle);
+
+/// @brief Apply async scratch limits to the real host agent.
+hsa_status_t HSA_API rj_amd_agent_set_async_scratch_limit(hsa_agent_t agent, size_t threshold);
+
+/// @brief Map every embedded agent in AMD batch-copy operations.
+hsa_status_t HSA_API rj_amd_memory_async_batch_copy(const hsa_amd_memory_copy_op_t *copy_ops,
+                                                    uint32_t num_copy_ops, uint32_t num_dep_signals,
+                                                    const hsa_signal_t *dep_signals);
+
+/// @brief Preload runtime state on the real host agent.
+hsa_status_t HSA_API rj_amd_agent_preload(hsa_agent_t agent, uint64_t flags);
+
+/// @brief Clear cached guest-to-host memory-pool mappings on HSA unload.
+void clear_memory_pool_mapper();
+
+/// @brief Clear cached guest-to-host agent mapping on HSA unload.
+void clear_agent_mapper();
+
+/// @brief Original HSA table entries saved for internal hook queries but not patched.
+///
+/// @details Each entry is:
+/// `X(name, table_ptr, present, field, type)`.
+/// - `name` is the `RjHsaLayer` getter name and `original_<name>_` member stem.
+/// - `table_ptr` is the API-table member pointer that owns `field`.
+/// - `present` guards table access when a table or versioned field may be absent.
+/// - `field` is the HSA table function-pointer field to save.
+/// - `type` is the exact function-pointer type stored in `original_<name>_`.
+#define RJ_HSA_SAVED_ONLY_ENTRIES(X)                                                               \
+  X(agent_get_info, core_, true, hsa_agent_get_info_fn, decltype(hsa_agent_get_info) *)            \
+  X(isa_get_info_alt, core_, true, hsa_isa_get_info_alt_fn, decltype(hsa_isa_get_info_alt) *)
+
+/// @brief HSA table entries patched by the DBT hook.
+///
+/// @details Each entry is:
+/// `X(name, table_ptr, present, patch_if_original, field, wrapper, type)`.
+/// - `name` is the `RjHsaLayer` getter name and `original_<name>_` member stem.
+/// - `table_ptr` is the API-table member pointer that owns `field`.
+/// - `present` guards table access when a table or versioned field may be absent.
+/// - `patch_if_original` means install only writes `wrapper` when the saved
+///   original function pointer is non-null. Core entries set this false because
+///   they are required after `validate_table()`. AMD extension entries set this
+///   true because ROCR may expose the table field but leave the function absent.
+/// - `field` is the HSA table function-pointer field to save/patch/restore.
+/// - `wrapper` is the rocjitsu replacement function assigned during install.
+/// - `type` is the exact function-pointer type stored in `original_<name>_`.
+#define RJ_HSA_PATCH_ENTRIES(X)                                                                    \
+  X(shut_down, core_, true, false, hsa_shut_down_fn, rj_shut_down, decltype(hsa_shut_down) *)      \
+  X(iterate_agents, core_, true, false, hsa_iterate_agents_fn, rj_iterate_agents,                  \
+    decltype(hsa_iterate_agents) *)                                                                \
+  X(agent_iterate_isas, core_, true, false, hsa_agent_iterate_isas_fn, rj_agent_iterate_isas,      \
+    decltype(hsa_agent_iterate_isas) *)                                                            \
+  X(queue_create, core_, true, false, hsa_queue_create_fn, rj_queue_create,                        \
+    decltype(hsa_queue_create) *)                                                                  \
+  X(queue_destroy, core_, true, false, hsa_queue_destroy_fn, rj_queue_destroy,                     \
+    decltype(hsa_queue_destroy) *)                                                                 \
+  X(agent_iterate_regions, core_, true, false, hsa_agent_iterate_regions_fn,                       \
+    rj_agent_iterate_regions, decltype(hsa_agent_iterate_regions) *)                               \
+  X(memory_assign_agent, core_, true, false, hsa_memory_assign_agent_fn, rj_memory_assign_agent,   \
+    decltype(hsa_memory_assign_agent) *)                                                           \
+  X(executable_destroy, core_, true, false, hsa_executable_destroy_fn, rj_executable_destroy,      \
+    decltype(hsa_executable_destroy) *)                                                            \
+  X(executable_get_symbol, core_, true, false, hsa_executable_get_symbol_fn,                       \
+    rj_executable_get_symbol, decltype(hsa_executable_get_symbol) *)                               \
+  X(executable_get_symbol_by_name, core_, true, false, hsa_executable_get_symbol_by_name_fn,       \
+    rj_executable_get_symbol_by_name, decltype(hsa_executable_get_symbol_by_name) *)               \
+  X(executable_agent_global_variable_define, core_, true, false,                                   \
+    hsa_executable_agent_global_variable_define_fn, rj_executable_agent_global_variable_define,    \
+    decltype(hsa_executable_agent_global_variable_define) *)                                       \
+  X(executable_iterate_agent_symbols, core_, true, false, hsa_executable_iterate_agent_symbols_fn, \
+    rj_executable_iterate_agent_symbols, decltype(hsa_executable_iterate_agent_symbols) *)         \
+  X(create_from_file, core_, true, false, hsa_code_object_reader_create_from_file_fn,              \
+    rj_code_object_reader_create_from_file, decltype(hsa_code_object_reader_create_from_file) *)   \
+  X(create_from_memory, core_, true, false, hsa_code_object_reader_create_from_memory_fn,          \
+    rj_code_object_reader_create_from_memory,                                                      \
+    decltype(hsa_code_object_reader_create_from_memory) *)                                         \
+  X(destroy, core_, true, false, hsa_code_object_reader_destroy_fn, rj_code_object_reader_destroy, \
+    decltype(hsa_code_object_reader_destroy) *)                                                    \
+  X(load_agent_code_object, core_, true, false, hsa_executable_load_agent_code_object_fn,          \
+    rj_executable_load_agent_code_object, decltype(hsa_executable_load_agent_code_object) *)       \
+  X(amd_memory_pool_get_info, amd_ext_, amd_ext_ != nullptr, true,                                 \
+    hsa_amd_memory_pool_get_info_fn, rj_amd_memory_pool_get_info,                                  \
+    hsa_amd_memory_pool_get_info_fn_t)                                                             \
+  X(amd_agent_iterate_memory_pools, amd_ext_, amd_ext_ != nullptr, true,                           \
+    hsa_amd_agent_iterate_memory_pools_fn, rj_amd_agent_iterate_memory_pools,                      \
+    hsa_amd_agent_iterate_memory_pools_fn_t)                                                       \
+  X(amd_memory_pool_allocate, amd_ext_, amd_ext_ != nullptr, true,                                 \
+    hsa_amd_memory_pool_allocate_fn, rj_amd_memory_pool_allocate,                                  \
+    hsa_amd_memory_pool_allocate_fn_t)                                                             \
+  X(amd_memory_pool_free, amd_ext_, amd_ext_ != nullptr, true, hsa_amd_memory_pool_free_fn,        \
+    rj_amd_memory_pool_free, hsa_amd_memory_pool_free_fn_t)                                        \
+  X(amd_profiling_set_profiler_enabled, amd_ext_, amd_ext_ != nullptr, true,                       \
+    hsa_amd_profiling_set_profiler_enabled_fn, rj_amd_profiling_set_profiler_enabled,              \
+    hsa_amd_profiling_set_profiler_enabled_fn_t)                                                   \
+  X(amd_profiling_get_dispatch_time, amd_ext_, amd_ext_ != nullptr, true,                          \
+    hsa_amd_profiling_get_dispatch_time_fn, rj_amd_profiling_get_dispatch_time,                    \
+    hsa_amd_profiling_get_dispatch_time_fn_t)                                                      \
+  X(amd_profiling_convert_tick_to_system_domain, amd_ext_, amd_ext_ != nullptr, true,              \
+    hsa_amd_profiling_convert_tick_to_system_domain_fn,                                            \
+    rj_amd_profiling_convert_tick_to_system_domain,                                                \
+    hsa_amd_profiling_convert_tick_to_system_domain_fn_t)                                          \
+  X(amd_agent_memory_pool_get_info, amd_ext_, amd_ext_ != nullptr, true,                           \
+    hsa_amd_agent_memory_pool_get_info_fn, rj_amd_agent_memory_pool_get_info,                      \
+    hsa_amd_agent_memory_pool_get_info_fn_t)                                                       \
+  X(amd_agents_allow_access, amd_ext_, amd_ext_ != nullptr, true, hsa_amd_agents_allow_access_fn,  \
+    rj_amd_agents_allow_access, hsa_amd_agents_allow_access_fn_t)                                  \
+  X(amd_memory_async_copy, amd_ext_, amd_ext_ != nullptr, true, hsa_amd_memory_async_copy_fn,      \
+    rj_amd_memory_async_copy, hsa_amd_memory_async_copy_fn_t)                                      \
+  X(amd_memory_async_copy_on_engine, amd_ext_, amd_ext_ != nullptr, true,                          \
+    hsa_amd_memory_async_copy_on_engine_fn, rj_amd_memory_async_copy_on_engine,                    \
+    hsa_amd_memory_async_copy_on_engine_fn_t)                                                      \
+  X(amd_memory_async_copy_rect, amd_ext_, amd_ext_ != nullptr, true,                               \
+    hsa_amd_memory_async_copy_rect_fn, rj_amd_memory_async_copy_rect,                              \
+    hsa_amd_memory_async_copy_rect_fn_t)                                                           \
+  X(amd_memory_copy_engine_status, amd_ext_, amd_ext_ != nullptr, true,                            \
+    hsa_amd_memory_copy_engine_status_fn, rj_amd_memory_copy_engine_status,                        \
+    hsa_amd_memory_copy_engine_status_fn_t)                                                        \
+  X(amd_memory_lock, amd_ext_, amd_ext_ != nullptr, true, hsa_amd_memory_lock_fn,                  \
+    rj_amd_memory_lock, hsa_amd_memory_lock_fn_t)                                                  \
+  X(amd_memory_lock_to_pool, amd_ext_, amd_ext_ != nullptr, true, hsa_amd_memory_lock_to_pool_fn,  \
+    rj_amd_memory_lock_to_pool, hsa_amd_memory_lock_to_pool_fn_t)                                  \
+  X(amd_svm_prefetch_async, amd_ext_, amd_ext_ != nullptr, true, hsa_amd_svm_prefetch_async_fn,    \
+    rj_amd_svm_prefetch_async, hsa_amd_svm_prefetch_async_fn_t)                                    \
+  X(amd_pointer_info, amd_ext_, amd_ext_ != nullptr, true, hsa_amd_pointer_info_fn,                \
+    rj_amd_pointer_info, hsa_amd_pointer_info_fn_t)                                                \
+  X(amd_vmem_set_access, amd_ext_, amd_ext_ != nullptr, true, hsa_amd_vmem_set_access_fn,          \
+    rj_amd_vmem_set_access, hsa_amd_vmem_set_access_fn_t)                                          \
+  X(amd_vmem_get_access, amd_ext_, amd_ext_ != nullptr, true, hsa_amd_vmem_get_access_fn,          \
+    rj_amd_vmem_get_access, hsa_amd_vmem_get_access_fn_t)                                          \
+  X(amd_agent_set_async_scratch_limit, amd_ext_, amd_ext_ != nullptr, true,                        \
+    hsa_amd_agent_set_async_scratch_limit_fn, rj_amd_agent_set_async_scratch_limit,                \
+    hsa_amd_agent_set_async_scratch_limit_fn_t)                                                    \
+  X(amd_memory_get_preferred_copy_engine, amd_ext_, amd_ext_ != nullptr, true,                     \
+    hsa_amd_memory_get_preferred_copy_engine_fn, rj_amd_memory_get_preferred_copy_engine,          \
+    hsa_amd_memory_get_preferred_copy_engine_fn_t)                                                 \
+  X(amd_memory_fill, amd_ext_, amd_ext_ != nullptr, true, hsa_amd_memory_fill_fn,                  \
+    rj_amd_memory_fill, hsa_amd_memory_fill_fn_t)                                                  \
+  X(amd_memory_async_batch_copy, amd_ext_,                                                         \
+    amd_ext_ != nullptr && RJ_AMD_EXT_HAS_FIELD(amd_ext_, hsa_amd_memory_async_batch_copy_fn),     \
+    true, hsa_amd_memory_async_batch_copy_fn, rj_amd_memory_async_batch_copy,                      \
+    hsa_amd_memory_async_batch_copy_fn_t)                                                          \
+  X(amd_agent_preload, amd_ext_,                                                                   \
+    amd_ext_ != nullptr && RJ_AMD_EXT_HAS_FIELD(amd_ext_, hsa_amd_agent_preload_fn), true,         \
+    hsa_amd_agent_preload_fn, rj_amd_agent_preload, hsa_amd_agent_preload_fn_t)
 
 /// @brief Process-local HSA API table patch state for the rocjitsu DBT tool.
 ///
@@ -400,24 +886,37 @@ public:
 
     table_ = table;
     core_ = table->core_;
+    amd_ext_ = table->amd_ext_;
     g_log_level.store(config.log_level, std::memory_order_relaxed);
     config_ = std::move(config);
-    original_create_from_file_ = core_->hsa_code_object_reader_create_from_file_fn;
-    original_create_from_memory_ = core_->hsa_code_object_reader_create_from_memory_fn;
-    original_destroy_ = core_->hsa_code_object_reader_destroy_fn;
-    original_load_agent_code_object_ = core_->hsa_executable_load_agent_code_object_fn;
+
+#define RJ_SAVE_SAVED_ONLY(name, table_ptr, present, field, type)                                  \
+  if (present)                                                                                     \
+    original_##name##_ = (table_ptr)->field;
+    RJ_HSA_SAVED_ONLY_ENTRIES(RJ_SAVE_SAVED_ONLY)
+#undef RJ_SAVE_SAVED_ONLY
+
+#define RJ_SAVE_PATCH(name, table_ptr, present, patch_if_original, field, wrapper, type)           \
+  if (present)                                                                                     \
+    original_##name##_ = (table_ptr)->field;
+    RJ_HSA_PATCH_ENTRIES(RJ_SAVE_PATCH)
+#undef RJ_SAVE_PATCH
 
     if (original_create_from_file_ == nullptr || original_create_from_memory_ == nullptr ||
-        original_destroy_ == nullptr || original_load_agent_code_object_ == nullptr) {
+        original_destroy_ == nullptr || original_load_agent_code_object_ == nullptr ||
+        original_iterate_agents_ == nullptr || original_agent_get_info_ == nullptr ||
+        original_agent_iterate_isas_ == nullptr || original_isa_get_info_alt_ == nullptr) {
       std::fprintf(stderr, "[rocjitsu-hooks] HSA core table contains null code-object entries\n");
       clear_unlocked();
       return false;
     }
 
-    core_->hsa_code_object_reader_create_from_file_fn = rj_code_object_reader_create_from_file;
-    core_->hsa_code_object_reader_create_from_memory_fn = rj_code_object_reader_create_from_memory;
-    core_->hsa_code_object_reader_destroy_fn = rj_code_object_reader_destroy;
-    core_->hsa_executable_load_agent_code_object_fn = rj_executable_load_agent_code_object;
+#define RJ_INSTALL_PATCH(name, table_ptr, present, patch_if_original, field, wrapper, type)        \
+  if ((present) && (!(patch_if_original) || original_##name##_ != nullptr))                        \
+    (table_ptr)->field = wrapper;
+    RJ_HSA_PATCH_ENTRIES(RJ_INSTALL_PATCH)
+#undef RJ_INSTALL_PATCH
+
     active_ = true;
 
     log_message(kLogInfo, "installed DBT hook target=%s arch=%s mach=0x%x",
@@ -427,55 +926,63 @@ public:
 
   /// @brief Restore rocjitsu wrappers if still installed and clear owned state.
   void uninstall() {
-    std::lock_guard lock(mutex_);
-    if (active_ && core_ != nullptr) {
-      if (core_->hsa_code_object_reader_create_from_file_fn ==
-          rj_code_object_reader_create_from_file)
-        core_->hsa_code_object_reader_create_from_file_fn = original_create_from_file_;
-      if (core_->hsa_code_object_reader_create_from_memory_fn ==
-          rj_code_object_reader_create_from_memory)
-        core_->hsa_code_object_reader_create_from_memory_fn = original_create_from_memory_;
-      if (core_->hsa_code_object_reader_destroy_fn == rj_code_object_reader_destroy)
-        core_->hsa_code_object_reader_destroy_fn = original_destroy_;
-      if (core_->hsa_executable_load_agent_code_object_fn == rj_executable_load_agent_code_object)
-        core_->hsa_executable_load_agent_code_object_fn = original_load_agent_code_object_;
+    bool had_state = false;
+    {
+      std::lock_guard lock(mutex_);
+      had_state = active_ || core_ != nullptr || amd_ext_ != nullptr;
+      if (active_ && core_ != nullptr) {
+        log_message(kLogVerbose, "uninstall begin");
+#define RJ_RESTORE_PATCH(name, table_ptr, present, patch_if_original, field, wrapper, type)        \
+  if ((present) && (table_ptr)->field == wrapper)                                                  \
+    (table_ptr)->field = original_##name##_;
+        RJ_HSA_PATCH_ENTRIES(RJ_RESTORE_PATCH)
+#undef RJ_RESTORE_PATCH
+      }
+      active_ = false;
     }
 
     CodeObjectReaderRegistry::instance().clear();
+    ExecutableAgentRegistry::instance().clear();
+    clear_agent_mapper();
+    clear_memory_pool_mapper();
+    if (!had_state)
+      return;
+
+    std::lock_guard lock(mutex_);
+    log_message(kLogVerbose, "uninstall end");
     clear_unlocked();
   }
 
+  /// @brief Return the active hook log level, or disabled when uninstalled.
   [[nodiscard]] int log_level() const {
     std::lock_guard lock(mutex_);
     return config_ ? config_->log_level : kLogDisabled;
   }
 
+  /// @brief Return a copy of the active hook configuration.
   [[nodiscard]] std::optional<HookConfig> config() const {
     std::lock_guard lock(mutex_);
     return config_;
   }
 
-  [[nodiscard]] decltype(hsa_code_object_reader_create_from_file) *create_from_file() const {
-    std::lock_guard lock(mutex_);
-    return original_create_from_file_;
+#define RJ_DEFINE_SAVED_ONLY_GETTER(name, table_ptr, present, field, type)                         \
+  [[nodiscard]] type name() const {                                                                \
+    std::lock_guard lock(mutex_);                                                                  \
+    return original_##name##_;                                                                     \
   }
+  RJ_HSA_SAVED_ONLY_ENTRIES(RJ_DEFINE_SAVED_ONLY_GETTER)
+#undef RJ_DEFINE_SAVED_ONLY_GETTER
 
-  [[nodiscard]] decltype(hsa_code_object_reader_create_from_memory) *create_from_memory() const {
-    std::lock_guard lock(mutex_);
-    return original_create_from_memory_;
+#define RJ_DEFINE_PATCH_GETTER(name, table_ptr, present, patch_if_original, field, wrapper, type)  \
+  [[nodiscard]] type name() const {                                                                \
+    std::lock_guard lock(mutex_);                                                                  \
+    return original_##name##_;                                                                     \
   }
-
-  [[nodiscard]] decltype(hsa_code_object_reader_destroy) *destroy() const {
-    std::lock_guard lock(mutex_);
-    return original_destroy_;
-  }
-
-  [[nodiscard]] decltype(hsa_executable_load_agent_code_object) *load_agent_code_object() const {
-    std::lock_guard lock(mutex_);
-    return original_load_agent_code_object_;
-  }
+  RJ_HSA_PATCH_ENTRIES(RJ_DEFINE_PATCH_GETTER)
+#undef RJ_DEFINE_PATCH_GETTER
 
 private:
+  /// @brief Check that ROCR supplied the HSA entry points used by this hook.
   [[nodiscard]] static bool validate_table(HsaApiTable *table) {
     if (table == nullptr || table->core_ == nullptr) {
       std::fprintf(stderr, "[rocjitsu-hooks] invalid HSA API table passed to OnLoad\n");
@@ -483,8 +990,8 @@ private:
     }
 
     constexpr size_t required_size =
-        offsetof(CoreApiTable, hsa_executable_load_agent_code_object_fn) +
-        sizeof(CoreApiTable::hsa_executable_load_agent_code_object_fn);
+        offsetof(CoreApiTable, hsa_executable_iterate_agent_symbols_fn) +
+        sizeof(CoreApiTable::hsa_executable_iterate_agent_symbols_fn);
     if (table->core_->version.minor_id < required_size) {
       std::fprintf(stderr,
                    "[rocjitsu-hooks] HSA core table too small: got %u bytes, need %zu bytes\n",
@@ -494,33 +1001,493 @@ private:
     return true;
   }
 
+  /// @brief Clear saved table pointers and runtime configuration.
   void clear_unlocked() {
     active_ = false;
     g_log_level.store(kLogDisabled, std::memory_order_relaxed);
+    restore_signal_backtrace_handlers();
     table_ = nullptr;
     core_ = nullptr;
+    amd_ext_ = nullptr;
     config_.reset();
-    original_create_from_file_ = nullptr;
-    original_create_from_memory_ = nullptr;
-    original_destroy_ = nullptr;
-    original_load_agent_code_object_ = nullptr;
+
+#define RJ_CLEAR_SAVED_ONLY(name, table_ptr, present, field, type) original_##name##_ = nullptr;
+    RJ_HSA_SAVED_ONLY_ENTRIES(RJ_CLEAR_SAVED_ONLY)
+#undef RJ_CLEAR_SAVED_ONLY
+
+#define RJ_CLEAR_PATCH(name, table_ptr, present, patch_if_original, field, wrapper, type)          \
+  original_##name##_ = nullptr;
+    RJ_HSA_PATCH_ENTRIES(RJ_CLEAR_PATCH)
+#undef RJ_CLEAR_PATCH
   }
 
   mutable std::mutex mutex_;
   HsaApiTable *table_ = nullptr;
   CoreApiTable *core_ = nullptr;
+  AmdExtTable *amd_ext_ = nullptr;
   std::optional<HookConfig> config_;
   bool active_ = false;
-  decltype(hsa_code_object_reader_create_from_file) *original_create_from_file_ = nullptr;
-  decltype(hsa_code_object_reader_create_from_memory) *original_create_from_memory_ = nullptr;
-  decltype(hsa_code_object_reader_destroy) *original_destroy_ = nullptr;
-  decltype(hsa_executable_load_agent_code_object) *original_load_agent_code_object_ = nullptr;
+
+#define RJ_DECLARE_SAVED_ONLY(name, table_ptr, present, field, type)                               \
+  type original_##name##_ = nullptr;
+  RJ_HSA_SAVED_ONLY_ENTRIES(RJ_DECLARE_SAVED_ONLY)
+#undef RJ_DECLARE_SAVED_ONLY
+
+#define RJ_DECLARE_PATCH(name, table_ptr, present, patch_if_original, field, wrapper, type)        \
+  type original_##name##_ = nullptr;
+  RJ_HSA_PATCH_ENTRIES(RJ_DECLARE_PATCH)
+#undef RJ_DECLARE_PATCH
 };
 
+/// @brief Return the singleton hook state used by every wrapper.
 RjHsaLayer &layer() {
   static RjHsaLayer state;
   return state;
 }
+
+/// @brief Parse a uint32_t from a NUL-terminated sysfs text value.
+[[nodiscard]] bool parse_u32_text(const char *text, uint32_t *out) {
+  if (!text || !out)
+    return false;
+  errno = 0;
+  char *end = nullptr;
+  unsigned long parsed = std::strtoul(text, &end, 0);
+  if (errno != 0 || end == text || parsed > UINT32_MAX)
+    return false;
+  while (*end == '\n' || *end == '\r' || *end == ' ' || *end == '\t')
+    ++end;
+  if (*end != '\0')
+    return false;
+  *out = static_cast<uint32_t>(parsed);
+  return true;
+}
+
+/// @brief Read a uint32_t from a sysfs-style file.
+[[nodiscard]] std::optional<uint32_t> read_u32_file(const std::string &path) {
+  FILE *file = std::fopen(path.c_str(), "r");
+  if (!file)
+    return std::nullopt;
+
+  std::array<char, 64> buffer{};
+  char *line = std::fgets(buffer.data(), static_cast<int>(buffer.size()), file);
+  std::fclose(file);
+  if (!line)
+    return std::nullopt;
+
+  uint32_t value = 0;
+  if (!parse_u32_text(buffer.data(), &value))
+    return std::nullopt;
+  return value;
+}
+
+/// @brief Search one KFD topology root for the node id owning @p gpu_id.
+[[nodiscard]] std::optional<uint32_t> node_id_for_kfd_gpu_id_in_root(const char *root,
+                                                                     uint32_t gpu_id) {
+  DIR *dir = opendir(root);
+  if (!dir)
+    return std::nullopt;
+
+  std::optional<uint32_t> result;
+  while (dirent *entry = readdir(dir)) {
+    if (entry->d_name[0] == '.')
+      continue;
+
+    uint32_t node_id = 0;
+    if (!parse_u32_text(entry->d_name, &node_id))
+      continue;
+
+    std::string gpu_id_path = std::string(root) + "/" + entry->d_name + "/gpu_id";
+    std::optional<uint32_t> node_gpu_id = read_u32_file(gpu_id_path);
+    if (node_gpu_id && *node_gpu_id == gpu_id) {
+      result = node_id;
+      break;
+    }
+  }
+  closedir(dir);
+  return result;
+}
+
+/// @brief Translate a configured KFD gpu_id to ROCR's HSA driver node id.
+///
+/// @details The config uses the KFD topology `gpu_id` because it is stable
+/// across ROCR agent handle creation and is the id KFD ioctls use. HSA does
+/// not expose that value directly, so the hook reads the redirected topology
+/// tree and later compares agents by `HSA_AMD_AGENT_INFO_DRIVER_NODE_ID`.
+[[nodiscard]] std::optional<uint32_t> node_id_for_kfd_gpu_id(uint32_t gpu_id) {
+  constexpr std::array<const char *, 2> kTopologyNodeRoots = {
+      "/sys/devices/virtual/kfd/kfd/topology/nodes", "/sys/class/kfd/kfd/topology/nodes"};
+  for (const char *root : kTopologyNodeRoots) {
+    if (std::optional<uint32_t> node_id = node_id_for_kfd_gpu_id_in_root(root, gpu_id))
+      return node_id;
+  }
+  return std::nullopt;
+}
+
+/// @brief Maps the configured guest HSA agent to the selected host execution agent.
+///
+/// @details Discovery is lazy because HSA tools are installed before ROCR has
+/// necessarily enumerated agents. The guest agent remains visible to callers,
+/// but calls that would execute or allocate through it are redirected to host_.
+class AgentMapper {
+public:
+  /// @brief Return the process-wide agent mapper.
+  static AgentMapper &instance() {
+    static AgentMapper mapper;
+    return mapper;
+  }
+
+  /// @brief Replace the guest agent with the selected host agent.
+  hsa_agent_t map(hsa_agent_t agent) {
+    ensure_discovered();
+    std::lock_guard lock(mutex_);
+    if (has_mapping_ && agent.handle == guest_.handle)
+      return host_;
+    return agent;
+  }
+
+  /// @brief Return true when @p agent is the configured guest agent.
+  bool is_guest(hsa_agent_t agent) {
+    ensure_discovered();
+    std::lock_guard lock(mutex_);
+    return has_mapping_ && agent.handle == guest_.handle;
+  }
+
+  /// @brief Return the host agent selected to execute guest work.
+  hsa_agent_t host_for_guest() {
+    ensure_discovered();
+    std::lock_guard lock(mutex_);
+    return has_mapping_ ? host_ : hsa_agent_t{};
+  }
+
+  /// @brief Return the visible guest agent, if a mapping was discovered.
+  hsa_agent_t guest_agent() {
+    ensure_discovered();
+    std::lock_guard lock(mutex_);
+    return has_mapping_ ? guest_ : hsa_agent_t{};
+  }
+
+  /// @brief Replace the selected host agent with the visible guest agent.
+  hsa_agent_t guest_for_host(hsa_agent_t agent) {
+    ensure_discovered();
+    std::lock_guard lock(mutex_);
+    if (has_mapping_ && agent.handle == host_.handle)
+      return guest_;
+    return agent;
+  }
+
+  /// @brief Drop cached agent mapping so unload/reload can rediscover it.
+  void clear() {
+    std::lock_guard lock(mutex_);
+    discovered_ = false;
+    has_mapping_ = false;
+    guest_ = {};
+    host_ = {};
+    ++generation_;
+  }
+
+private:
+  /// @brief Agent discovery callback state.
+  struct AgentSearchData {
+    AgentMapper *self = nullptr;
+    TargetInfo guest{};
+    TargetInfo host{};
+    std::optional<uint32_t> host_node_id;
+    hsa_agent_t guest_agent{};
+    hsa_agent_t host_agent{};
+  };
+
+  /// @brief ISA discovery callback state for matching configured targets.
+  struct IsaSearchData {
+    AgentMapper *self = nullptr;
+    TargetInfo target{};
+    bool found = false;
+  };
+
+  /// @brief Return true when an HSA ISA name names the requested target.
+  static bool target_matches_isa_name(std::string_view isa_name, std::string_view target) {
+    constexpr std::string_view prefix = "amdgcn-amd-amdhsa--";
+    if (isa_name.starts_with(prefix))
+      isa_name.remove_prefix(prefix.size());
+    if (!isa_name.starts_with(target))
+      return false;
+    if (isa_name.size() == target.size())
+      return true;
+    return isa_name[target.size()] == ':' || isa_name[target.size()] == '\0';
+  }
+
+  /// @brief HSA ISA iteration callback used while matching an agent target.
+  static hsa_status_t isa_callback(hsa_isa_t isa, void *data) {
+    auto *search = static_cast<IsaSearchData *>(data);
+    auto *get_info = layer().isa_get_info_alt();
+    if (!get_info)
+      return HSA_STATUS_ERROR;
+
+    uint32_t name_length = 0;
+    if (get_info(isa, HSA_ISA_INFO_NAME_LENGTH, &name_length) != HSA_STATUS_SUCCESS ||
+        name_length == 0)
+      return HSA_STATUS_SUCCESS;
+    std::vector<char> name(name_length + 1, 0);
+    if (get_info(isa, HSA_ISA_INFO_NAME, name.data()) != HSA_STATUS_SUCCESS)
+      return HSA_STATUS_SUCCESS;
+
+    if (target_matches_isa_name(std::string_view(name.data()), search->target.name)) {
+      search->found = true;
+      return HSA_STATUS_INFO_BREAK;
+    }
+    return HSA_STATUS_SUCCESS;
+  }
+
+  /// @brief Return true when @p agent advertises an ISA matching @p target.
+  bool agent_has_target(hsa_agent_t agent, TargetInfo target) {
+    auto *iterate_isas = layer().agent_iterate_isas();
+    if (!iterate_isas)
+      return false;
+    IsaSearchData search{this, target, false};
+    hsa_status_t status = iterate_isas(agent, isa_callback, &search);
+    return search.found || status == HSA_STATUS_INFO_BREAK;
+  }
+
+  /// @brief Read ROCR's KFD topology node id for @p agent.
+  std::optional<uint32_t> agent_driver_node_id(hsa_agent_t agent) {
+    auto *get_info = layer().agent_get_info();
+    if (!get_info)
+      return std::nullopt;
+
+    uint32_t node_id = 0;
+    hsa_status_t status =
+        get_info(agent, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_DRIVER_NODE_ID), &node_id);
+    if (status != HSA_STATUS_SUCCESS)
+      return std::nullopt;
+    return node_id;
+  }
+
+  /// @brief Return true when @p agent belongs to @p expected_node_id.
+  bool agent_has_driver_node(hsa_agent_t agent, uint32_t expected_node_id) {
+    std::optional<uint32_t> node_id = agent_driver_node_id(agent);
+    return node_id && *node_id == expected_node_id;
+  }
+
+  /// @brief Return true when @p agent is the configured host execution agent.
+  bool agent_matches_host(hsa_agent_t agent, const AgentSearchData &search) {
+    if (!agent_has_target(agent, search.host))
+      return false;
+    if (search.host_node_id)
+      return agent_has_driver_node(agent, *search.host_node_id);
+    return true;
+  }
+
+  /// @brief HSA agent iteration callback that records guest and host agents.
+  static hsa_status_t agent_callback(hsa_agent_t agent, void *data) {
+    auto *search = static_cast<AgentSearchData *>(data);
+    if (search->guest_agent.handle == 0 && search->self->agent_has_target(agent, search->guest))
+      search->guest_agent = agent;
+    if (search->host_agent.handle == 0 && search->self->agent_matches_host(agent, *search))
+      search->host_agent = agent;
+    if (search->guest_agent.handle != 0 && search->host_agent.handle != 0)
+      return HSA_STATUS_INFO_BREAK;
+    return HSA_STATUS_SUCCESS;
+  }
+
+  /// @brief Lazily discover the guest-to-host agent mapping.
+  void ensure_discovered() {
+    uint64_t generation = 0;
+    {
+      std::lock_guard lock(mutex_);
+      if (discovered_)
+        return;
+      discovered_ = true;
+      generation = generation_;
+    }
+
+    auto config = layer().config();
+    if (!config || !config->guest_target)
+      return;
+
+    auto *iterate_agents = layer().iterate_agents();
+    if (!iterate_agents)
+      return;
+
+    std::optional<uint32_t> host_node_id;
+    if (config->host_gpu_id != 0) {
+      host_node_id = node_id_for_kfd_gpu_id(config->host_gpu_id);
+      if (!host_node_id) {
+        std::fprintf(stderr,
+                     "[rocjitsu-hooks] failed to find topology node for host KFD gpu_id=%u\n",
+                     config->host_gpu_id);
+        return;
+      }
+    }
+
+    AgentSearchData search{this, *config->guest_target, config->target, host_node_id};
+    hsa_status_t status = iterate_agents(agent_callback, &search);
+    const bool has_mapping = (status == HSA_STATUS_SUCCESS || status == HSA_STATUS_INFO_BREAK) &&
+                             search.guest_agent.handle != 0 && search.host_agent.handle != 0 &&
+                             search.guest_agent.handle != search.host_agent.handle;
+    {
+      std::lock_guard lock(mutex_);
+      if (generation != generation_)
+        return;
+      guest_ = search.guest_agent;
+      host_ = search.host_agent;
+      has_mapping_ = has_mapping;
+    }
+    if (has_mapping) {
+      log_message(kLogInfo, "mapped guest agent=%llu to host agent=%llu",
+                  static_cast<unsigned long long>(search.guest_agent.handle),
+                  static_cast<unsigned long long>(search.host_agent.handle));
+      if (config->log_level > kLogDisabled) {
+        std::optional<uint32_t> selected_node_id = agent_driver_node_id(search.host_agent);
+        std::fprintf(stderr,
+                     "[rocjitsu-hooks] selected host agent=%llu for guest agent=%llu "
+                     "host_gpu_id=%u host_node_id=%u\n",
+                     static_cast<unsigned long long>(search.host_agent.handle),
+                     static_cast<unsigned long long>(search.guest_agent.handle),
+                     config->host_gpu_id, selected_node_id.value_or(0));
+      }
+    } else {
+      std::fprintf(stderr, "[rocjitsu-hooks] failed to find guest/host HSA agents for DBT\n");
+    }
+  }
+
+  std::mutex mutex_;
+  bool discovered_ = false;
+  bool has_mapping_ = false;
+  uint64_t generation_ = 0;
+  hsa_agent_t guest_{};
+  hsa_agent_t host_{};
+};
+
+/// @brief Maps guest memory pools to matching pools on the selected host agent.
+class MemoryPoolMapper {
+public:
+  /// @brief Return the process-wide memory pool mapper.
+  static MemoryPoolMapper &instance() {
+    static MemoryPoolMapper mapper;
+    return mapper;
+  }
+
+  /// @brief Replace a guest pool with the matching host pool, when known.
+  hsa_amd_memory_pool_t map(hsa_amd_memory_pool_t pool) {
+    ensure_discovered();
+    std::lock_guard lock(mutex_);
+    auto it = guest_to_host_.find(pool.handle);
+    if (it == guest_to_host_.end())
+      return pool;
+    return hsa_amd_memory_pool_t{it->second};
+  }
+
+  /// @brief Drop cached pool mappings so unload/reload can rediscover them.
+  void clear() {
+    std::lock_guard lock(mutex_);
+    discovered_ = false;
+    guest_to_host_.clear();
+  }
+
+private:
+  /// @brief Memory pool attributes used to match guest and host pools.
+  struct PoolInfo {
+    hsa_amd_memory_pool_t pool{};
+    uint32_t segment = 0;
+    uint32_t global_flags = 0;
+    bool runtime_alloc_allowed = false;
+    uint32_t location = 0;
+  };
+
+  /// @brief Collected memory pools for one HSA agent.
+  struct PoolList {
+    hsa_amd_memory_pool_get_info_fn_t get_info = nullptr;
+    std::vector<PoolInfo> pools;
+  };
+
+  /// @brief Callback that records a pool and its matching attributes.
+  static hsa_status_t collect_pool(hsa_amd_memory_pool_t pool, void *data) {
+    auto *list = static_cast<PoolList *>(data);
+    if (list == nullptr || list->get_info == nullptr)
+      return HSA_STATUS_ERROR;
+
+    PoolInfo info{};
+    info.pool = pool;
+    if (list->get_info(pool, HSA_AMD_MEMORY_POOL_INFO_SEGMENT, &info.segment) != HSA_STATUS_SUCCESS)
+      return HSA_STATUS_SUCCESS;
+    (void)list->get_info(pool, HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS, &info.global_flags);
+    (void)list->get_info(pool, HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_ALLOWED,
+                         &info.runtime_alloc_allowed);
+    (void)list->get_info(pool, HSA_AMD_MEMORY_POOL_INFO_LOCATION, &info.location);
+    list->pools.push_back(info);
+    return HSA_STATUS_SUCCESS;
+  }
+
+  /// @brief Return true when guest and host pools are interchangeable for forwarding.
+  static bool same_kind(const PoolInfo &guest, const PoolInfo &host) {
+    return guest.segment == host.segment && guest.global_flags == host.global_flags &&
+           guest.runtime_alloc_allowed == host.runtime_alloc_allowed &&
+           guest.location == host.location;
+  }
+
+  /// @brief Find the first host pool matching @p guest.
+  static std::optional<PoolInfo> find_match(const PoolInfo &guest,
+                                            std::span<const PoolInfo> host_pools) {
+    for (const PoolInfo &host : host_pools) {
+      if (same_kind(guest, host))
+        return host;
+    }
+    return std::nullopt;
+  }
+
+  /// @brief Lazily discover guest-to-host memory-pool mappings.
+  void ensure_discovered() {
+    {
+      std::lock_guard lock(mutex_);
+      if (discovered_)
+        return;
+    }
+
+    auto *iterate_pools = layer().amd_agent_iterate_memory_pools();
+    auto *get_info = layer().amd_memory_pool_get_info();
+
+    hsa_agent_t guest = AgentMapper::instance().guest_agent();
+    hsa_agent_t host = AgentMapper::instance().host_for_guest();
+
+    std::unordered_map<uint64_t, uint64_t> discovered;
+    if (iterate_pools != nullptr && get_info != nullptr && guest.handle != 0 && host.handle != 0) {
+      PoolList guest_pools;
+      PoolList host_pools;
+      guest_pools.get_info = get_info;
+      host_pools.get_info = get_info;
+      hsa_status_t guest_status = iterate_pools(guest, collect_pool, &guest_pools);
+      hsa_status_t host_status = iterate_pools(host, collect_pool, &host_pools);
+      if (guest_status == HSA_STATUS_SUCCESS && host_status == HSA_STATUS_SUCCESS) {
+        for (const PoolInfo &guest_pool : guest_pools.pools) {
+          std::optional<PoolInfo> host_pool = find_match(guest_pool, host_pools.pools);
+          if (!host_pool)
+            continue;
+          discovered[guest_pool.pool.handle] = host_pool->pool.handle;
+          log_message(kLogDebug, "mapped guest pool=%llu to host pool=%llu",
+                      static_cast<unsigned long long>(guest_pool.pool.handle),
+                      static_cast<unsigned long long>(host_pool->pool.handle));
+        }
+      }
+    }
+
+    {
+      std::lock_guard lock(mutex_);
+      if (discovered_)
+        return;
+      guest_to_host_ = std::move(discovered);
+      discovered_ = true;
+    }
+  }
+
+  std::mutex mutex_;
+  bool discovered_ = false;
+  std::unordered_map<uint64_t, uint64_t> guest_to_host_;
+};
+
+/// @brief Clear memory-pool mappings when the HSA layer unloads.
+void clear_memory_pool_mapper() { MemoryPoolMapper::instance().clear(); }
+
+/// @brief Clear agent mappings when the HSA layer unloads.
+void clear_agent_mapper() { AgentMapper::instance().clear(); }
 
 hsa_status_t HSA_API rj_code_object_reader_create_from_memory(
     const void *code_object, size_t size, hsa_code_object_reader_t *code_object_reader) {
@@ -564,14 +1531,662 @@ hsa_status_t HSA_API rj_code_object_reader_create_from_file(
 }
 
 hsa_status_t HSA_API rj_code_object_reader_destroy(hsa_code_object_reader_t code_object_reader) {
+  log_message(kLogVerbose, "reader_destroy reader=%llu",
+              static_cast<unsigned long long>(code_object_reader.handle));
   CodeObjectReaderRegistry::instance().remove(code_object_reader);
 
   auto *original = layer().destroy();
   if (original == nullptr)
     return HSA_STATUS_ERROR;
-  return original(code_object_reader);
+  hsa_status_t status = original(code_object_reader);
+  log_message(kLogVerbose, "reader_destroy status=%d", static_cast<int>(status));
+  return status;
 }
 
+/// @brief Map every agent in a caller-owned array into a temporary vector.
+std::vector<hsa_agent_t> map_agent_array(const hsa_agent_t *agents, size_t count) {
+  std::vector<hsa_agent_t> mapped;
+  if (!agents || count == 0)
+    return mapped;
+  mapped.reserve(count);
+  for (size_t i = 0; i < count; ++i)
+    mapped.push_back(AgentMapper::instance().map(agents[i]));
+  return mapped;
+}
+
+/// @brief Forwardable allow-access agent list plus optional per-agent flags.
+struct MappedAccessAgents {
+  std::vector<hsa_agent_t> agents;
+  std::vector<uint32_t> flags;
+  bool changed = false;
+};
+
+/// @brief Map and deduplicate agents passed to hsa_amd_agents_allow_access.
+MappedAccessAgents map_access_agent_array(const hsa_agent_t *agents, uint32_t count,
+                                          const uint32_t *flags) {
+  MappedAccessAgents mapped;
+  if (!agents || count == 0)
+    return mapped;
+
+  mapped.agents.reserve(count);
+  if (flags)
+    mapped.flags.reserve(count);
+
+  for (uint32_t i = 0; i < count; ++i) {
+    hsa_agent_t agent = AgentMapper::instance().map(agents[i]);
+    mapped.changed = mapped.changed || agent.handle != agents[i].handle;
+
+    bool duplicate = false;
+    for (hsa_agent_t existing : mapped.agents) {
+      if (existing.handle == agent.handle) {
+        duplicate = true;
+        break;
+      }
+    }
+    if (duplicate) {
+      // Mapping the visible guest to its host can make an all-agent list contain
+      // the selected host twice. Forwarding unique agents avoids asking ROCR to
+      // install duplicate access records for the same allocation.
+      mapped.changed = true;
+      continue;
+    }
+
+    mapped.agents.push_back(agent);
+    if (flags)
+      mapped.flags.push_back(flags[i]);
+  }
+
+  return mapped;
+}
+
+hsa_status_t HSA_API rj_iterate_agents(hsa_status_t (*callback)(hsa_agent_t agent, void *data),
+                                       void *data) {
+  auto *original = layer().iterate_agents();
+  if (!original)
+    return HSA_STATUS_ERROR;
+
+  hsa_agent_t guest = AgentMapper::instance().guest_agent();
+  hsa_agent_t host = AgentMapper::instance().host_for_guest();
+  if (guest.handle == 0 || host.handle == 0)
+    return original(callback, data);
+
+  struct ShadowIteration {
+    hsa_status_t (*callback)(hsa_agent_t, void *) = nullptr;
+    void *data = nullptr;
+    hsa_agent_t guest{};
+    hsa_agent_t host{};
+  } shadow{callback, data, guest, host};
+
+  auto shadow_callback = [](hsa_agent_t agent, void *opaque) -> hsa_status_t {
+    auto *shadow = static_cast<ShadowIteration *>(opaque);
+    if (agent.handle == shadow->host.handle) {
+      // Public enumeration is the replacement boundary: applications see the
+      // guest agent in the selected host's ordinal slot, while ROCR keeps the
+      // host agent alive for translated execution.
+      return shadow->callback(shadow->guest, shadow->data);
+    }
+    if (agent.handle == shadow->guest.handle) {
+      // The synthetic KFD node may appear before or after the real host in
+      // ROCR enumeration. Always suppress its own slot so public clients see
+      // exactly one guest agent, emitted where the selected host appeared.
+      return HSA_STATUS_SUCCESS;
+    }
+    return shadow->callback(agent, shadow->data);
+  };
+
+  log_message(kLogDebug, "iterate_agents shadow host=%llu guest=%llu",
+              static_cast<unsigned long long>(host.handle),
+              static_cast<unsigned long long>(guest.handle));
+  return original(shadow_callback, &shadow);
+}
+
+hsa_status_t HSA_API rj_agent_iterate_isas(hsa_agent_t agent,
+                                           hsa_status_t (*callback)(hsa_isa_t isa, void *data),
+                                           void *data) {
+  auto *original = layer().agent_iterate_isas();
+  if (!original)
+    return HSA_STATUS_ERROR;
+
+  // HIP/CLR derives the application-visible device ISA from this callback.
+  // Keep the synthetic agent guest-facing so fatbin selection picks gfx950 code
+  // objects; execution-facing hooks translate and map those loads to the host.
+  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  log_message(kLogDebug, "agent_iterate_isas agent=%llu mapped=%llu",
+              static_cast<unsigned long long>(agent.handle),
+              static_cast<unsigned long long>(mapped.handle));
+  return original(agent, callback, data);
+}
+
+hsa_status_t HSA_API rj_queue_create(hsa_agent_t agent, uint32_t size, hsa_queue_type32_t type,
+                                     void (*callback)(hsa_status_t, hsa_queue_t *, void *),
+                                     void *data, uint32_t private_segment_size,
+                                     uint32_t group_segment_size, hsa_queue_t **queue) {
+  auto *original = layer().queue_create();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  log_message(kLogVerbose, "queue_create agent=%llu mapped=%llu size=%u",
+              static_cast<unsigned long long>(agent.handle),
+              static_cast<unsigned long long>(mapped.handle), size);
+  return original(mapped, size, type, callback, data, private_segment_size, group_segment_size,
+                  queue);
+}
+
+hsa_status_t HSA_API rj_queue_destroy(hsa_queue_t *queue) {
+  auto *original = layer().queue_destroy();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  log_message(kLogVerbose, "queue_destroy queue=%p id=%llu", static_cast<void *>(queue),
+              queue ? static_cast<unsigned long long>(queue->id) : 0);
+  hsa_status_t status = original(queue);
+  log_message(kLogVerbose, "queue_destroy status=%d", static_cast<int>(status));
+  return status;
+}
+
+hsa_status_t HSA_API rj_agent_iterate_regions(
+    hsa_agent_t agent, hsa_status_t (*callback)(hsa_region_t region, void *data), void *data) {
+  auto *original = layer().agent_iterate_regions();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  log_message(kLogDebug, "agent_iterate_regions agent=%llu mapped=%llu",
+              static_cast<unsigned long long>(agent.handle),
+              static_cast<unsigned long long>(mapped.handle));
+  return original(mapped, callback, data);
+}
+
+hsa_status_t HSA_API rj_memory_assign_agent(void *ptr, hsa_agent_t agent,
+                                            hsa_access_permission_t access) {
+  auto *original = layer().memory_assign_agent();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  log_message(kLogVerbose, "memory_assign_agent ptr=%p agent=%llu mapped=%llu access=%d", ptr,
+              static_cast<unsigned long long>(agent.handle),
+              static_cast<unsigned long long>(mapped.handle), static_cast<int>(access));
+  return original(ptr, mapped, access);
+}
+
+hsa_status_t HSA_API rj_shut_down() {
+  auto config = layer().config();
+  if (config && config->guest_target) {
+    // Guest mode does not call the real ROCR shutdown. Later language-runtime
+    // teardown can still run HSA cleanup paths, so keep rocjitsu's API-table
+    // mappings installed until process exit.
+    log_message(kLogVerbose, "skipping real hsa_shut_down in guest mode");
+    return HSA_STATUS_SUCCESS;
+  }
+
+  auto *original = layer().shut_down();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  return original();
+}
+
+hsa_status_t HSA_API rj_executable_destroy(hsa_executable_t executable) {
+  log_message(kLogVerbose, "executable_destroy exec=%llu",
+              static_cast<unsigned long long>(executable.handle));
+  ExecutableAgentRegistry::instance().erase_executable(executable);
+  auto *original = layer().executable_destroy();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_status_t status = original(executable);
+  log_message(kLogVerbose, "executable_destroy status=%d", static_cast<int>(status));
+  return status;
+}
+
+hsa_status_t HSA_API rj_executable_get_symbol(hsa_executable_t executable, const char *module_name,
+                                              const char *symbol_name, hsa_agent_t agent,
+                                              int32_t call_convention,
+                                              hsa_executable_symbol_t *symbol) {
+  auto *original = layer().executable_get_symbol();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = ExecutableAgentRegistry::instance().map_agent(executable, agent);
+  mapped = AgentMapper::instance().map(mapped);
+  log_message(kLogVerbose, "get_symbol exec=%llu agent=%llu mapped=%llu symbol=%s",
+              static_cast<unsigned long long>(executable.handle),
+              static_cast<unsigned long long>(agent.handle),
+              static_cast<unsigned long long>(mapped.handle), symbol_name ? symbol_name : "");
+  return original(executable, module_name, symbol_name, mapped, call_convention, symbol);
+}
+
+hsa_status_t HSA_API rj_executable_get_symbol_by_name(hsa_executable_t executable,
+                                                      const char *symbol_name,
+                                                      const hsa_agent_t *agent,
+                                                      hsa_executable_symbol_t *symbol) {
+  auto *original = layer().executable_get_symbol_by_name();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped_agent{};
+  const hsa_agent_t *mapped_ptr = nullptr;
+  if (agent != nullptr) {
+    mapped_agent = ExecutableAgentRegistry::instance().map_agent(executable, *agent);
+    mapped_agent = AgentMapper::instance().map(mapped_agent);
+    mapped_ptr = &mapped_agent;
+  }
+  log_message(kLogVerbose, "get_symbol_by_name exec=%llu agent=%llu mapped=%llu symbol=%s",
+              static_cast<unsigned long long>(executable.handle),
+              static_cast<unsigned long long>(agent ? agent->handle : 0),
+              static_cast<unsigned long long>(mapped_agent.handle), symbol_name ? symbol_name : "");
+  return original(executable, symbol_name, mapped_ptr, symbol);
+}
+
+hsa_status_t HSA_API rj_executable_agent_global_variable_define(hsa_executable_t executable,
+                                                                hsa_agent_t agent,
+                                                                const char *variable_name,
+                                                                void *address) {
+  auto *original = layer().executable_agent_global_variable_define();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = ExecutableAgentRegistry::instance().map_agent(executable, agent);
+  mapped = AgentMapper::instance().map(mapped);
+  log_message(kLogVerbose, "global_variable_define exec=%llu agent=%llu mapped=%llu name=%s",
+              static_cast<unsigned long long>(executable.handle),
+              static_cast<unsigned long long>(agent.handle),
+              static_cast<unsigned long long>(mapped.handle), variable_name ? variable_name : "");
+  return original(executable, mapped, variable_name, address);
+}
+
+/// @brief Callback context for restoring the caller-visible agent in symbol iteration.
+struct IterateAgentSymbolsData {
+  hsa_status_t (*callback)(hsa_executable_t, hsa_agent_t, hsa_executable_symbol_t,
+                           void *) = nullptr;
+  void *data = nullptr;
+  hsa_agent_t guest{};
+};
+
+/// @brief Agent-symbol callback wrapper that reports the original guest agent.
+hsa_status_t HSA_API rj_iterate_agent_symbols_callback(hsa_executable_t executable, hsa_agent_t,
+                                                       hsa_executable_symbol_t symbol, void *data) {
+  auto *wrapped = static_cast<IterateAgentSymbolsData *>(data);
+  return wrapped->callback(executable, wrapped->guest, symbol, wrapped->data);
+}
+
+hsa_status_t HSA_API rj_executable_iterate_agent_symbols(
+    hsa_executable_t executable, hsa_agent_t agent,
+    hsa_status_t (*callback)(hsa_executable_t, hsa_agent_t, hsa_executable_symbol_t, void *),
+    void *data) {
+  auto *original = layer().executable_iterate_agent_symbols();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = ExecutableAgentRegistry::instance().map_agent(executable, agent);
+  mapped = AgentMapper::instance().map(mapped);
+  if (mapped.handle == agent.handle)
+    return original(executable, mapped, callback, data);
+  IterateAgentSymbolsData wrapped{callback, data, agent};
+  return original(executable, mapped, rj_iterate_agent_symbols_callback, &wrapped);
+}
+
+hsa_status_t HSA_API rj_amd_agent_iterate_memory_pools(
+    hsa_agent_t agent, hsa_status_t (*callback)(hsa_amd_memory_pool_t, void *), void *data) {
+  auto *original = layer().amd_agent_iterate_memory_pools();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  log_message(kLogDebug, "amd_agent_iterate_memory_pools agent=%llu mapped=%llu",
+              static_cast<unsigned long long>(agent.handle),
+              static_cast<unsigned long long>(mapped.handle));
+  return original(AgentMapper::instance().is_guest(agent) ? agent : mapped, callback, data);
+}
+
+hsa_status_t HSA_API rj_amd_memory_pool_get_info(hsa_amd_memory_pool_t memory_pool,
+                                                 hsa_amd_memory_pool_info_t attribute,
+                                                 void *value) {
+  auto *original = layer().amd_memory_pool_get_info();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  log_message(kLogDebug, "amd_memory_pool_get_info pool=%llu attr=%u",
+              static_cast<unsigned long long>(memory_pool.handle),
+              static_cast<unsigned>(attribute));
+  return original(memory_pool, attribute, value);
+}
+
+hsa_status_t HSA_API rj_amd_memory_pool_allocate(hsa_amd_memory_pool_t memory_pool, size_t size,
+                                                 uint32_t flags, void **ptr) {
+  auto *original = layer().amd_memory_pool_allocate();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_amd_memory_pool_t mapped_pool = MemoryPoolMapper::instance().map(memory_pool);
+  log_message(kLogVerbose, "amd_memory_pool_allocate pool=%llu mapped=%llu size=%zu flags=0x%x",
+              static_cast<unsigned long long>(memory_pool.handle),
+              static_cast<unsigned long long>(mapped_pool.handle), size, flags);
+  hsa_status_t status = original(mapped_pool, size, flags, ptr);
+  log_message(kLogVerbose, "amd_memory_pool_allocate status=%d ptr=%p", static_cast<int>(status),
+              ptr ? *ptr : nullptr);
+  return status;
+}
+
+hsa_status_t HSA_API rj_amd_memory_pool_free(void *ptr) {
+  auto *original = layer().amd_memory_pool_free();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  log_message(kLogVerbose, "amd_memory_pool_free ptr=%p", ptr);
+  hsa_status_t status = original(ptr);
+  log_message(kLogVerbose, "amd_memory_pool_free status=%d", static_cast<int>(status));
+  return status;
+}
+
+hsa_status_t HSA_API rj_amd_profiling_set_profiler_enabled(hsa_queue_t *queue, int enable) {
+  auto *original = layer().amd_profiling_set_profiler_enabled();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  log_message(kLogVerbose, "amd_profiling_set_profiler_enabled queue=%p enable=%d",
+              static_cast<void *>(queue), enable);
+  return original(queue, enable);
+}
+
+hsa_status_t HSA_API rj_amd_profiling_get_dispatch_time(hsa_agent_t agent, hsa_signal_t signal,
+                                                        hsa_amd_profiling_dispatch_time_t *time) {
+  auto *original = layer().amd_profiling_get_dispatch_time();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  hsa_status_t status = original(mapped, signal, time);
+  log_message(kLogVerbose,
+              "amd_profiling_get_dispatch_time agent=%llu mapped=%llu signal=%llu status=%d "
+              "start=%llu end=%llu",
+              static_cast<unsigned long long>(agent.handle),
+              static_cast<unsigned long long>(mapped.handle),
+              static_cast<unsigned long long>(signal.handle), static_cast<int>(status),
+              static_cast<unsigned long long>(time ? time->start : 0),
+              static_cast<unsigned long long>(time ? time->end : 0));
+  return status;
+}
+
+hsa_status_t HSA_API rj_amd_profiling_convert_tick_to_system_domain(hsa_agent_t agent,
+                                                                    uint64_t agent_tick,
+                                                                    uint64_t *system_tick) {
+  auto *original = layer().amd_profiling_convert_tick_to_system_domain();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  hsa_status_t status = original(mapped, agent_tick, system_tick);
+  log_message(kLogVerbose,
+              "amd_profiling_convert_tick_to_system_domain agent=%llu mapped=%llu status=%d "
+              "agent_tick=%llu system_tick=%llu",
+              static_cast<unsigned long long>(agent.handle),
+              static_cast<unsigned long long>(mapped.handle), static_cast<int>(status),
+              static_cast<unsigned long long>(agent_tick),
+              static_cast<unsigned long long>(system_tick ? *system_tick : 0));
+  return status;
+}
+
+hsa_status_t HSA_API rj_amd_agent_memory_pool_get_info(hsa_agent_t agent,
+                                                       hsa_amd_memory_pool_t memory_pool,
+                                                       hsa_amd_agent_memory_pool_info_t attribute,
+                                                       void *value) {
+  auto *original = layer().amd_agent_memory_pool_get_info();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  hsa_amd_memory_pool_t mapped_pool = MemoryPoolMapper::instance().map(memory_pool);
+  log_message(
+      kLogDebug,
+      "amd_agent_memory_pool_get_info agent=%llu mapped=%llu pool=%llu mapped=%llu "
+      "attr=%u",
+      static_cast<unsigned long long>(agent.handle), static_cast<unsigned long long>(mapped.handle),
+      static_cast<unsigned long long>(memory_pool.handle),
+      static_cast<unsigned long long>(mapped_pool.handle), static_cast<unsigned>(attribute));
+  return original(mapped, mapped_pool, attribute, value);
+}
+
+hsa_status_t HSA_API rj_amd_agents_allow_access(uint32_t num_agents, const hsa_agent_t *agents,
+                                                const uint32_t *flags, const void *ptr) {
+  auto *original = layer().amd_agents_allow_access();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  auto mapped = map_access_agent_array(agents, num_agents, flags);
+  const uint32_t forwarded_count =
+      mapped.changed ? static_cast<uint32_t>(mapped.agents.size()) : num_agents;
+  const hsa_agent_t *forwarded_agents = mapped.changed ? mapped.agents.data() : agents;
+  const uint32_t *forwarded_flags = mapped.changed && flags ? mapped.flags.data() : flags;
+  log_message(kLogVerbose, "amd_agents_allow_access ptr=%p count=%u forwarded=%u mapped=%d", ptr,
+              num_agents, forwarded_count, mapped.changed ? 1 : 0);
+  hsa_status_t status = original(forwarded_count, forwarded_agents, forwarded_flags, ptr);
+  log_message(kLogVerbose, "amd_agents_allow_access status=%d", static_cast<int>(status));
+  return status;
+}
+
+hsa_status_t HSA_API rj_amd_memory_async_copy(void *dst, hsa_agent_t dst_agent, const void *src,
+                                              hsa_agent_t src_agent, size_t size,
+                                              uint32_t num_dep_signals,
+                                              const hsa_signal_t *dep_signals,
+                                              hsa_signal_t completion_signal) {
+  auto *original = layer().amd_memory_async_copy();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped_dst = AgentMapper::instance().map(dst_agent);
+  hsa_agent_t mapped_src = AgentMapper::instance().map(src_agent);
+  log_message(kLogVerbose,
+              "amd_memory_async_copy dst_agent=%llu mapped=%llu src_agent=%llu mapped=%llu "
+              "size=%zu",
+              static_cast<unsigned long long>(dst_agent.handle),
+              static_cast<unsigned long long>(mapped_dst.handle),
+              static_cast<unsigned long long>(src_agent.handle),
+              static_cast<unsigned long long>(mapped_src.handle), size);
+  return original(dst, mapped_dst, src, mapped_src, size, num_dep_signals, dep_signals,
+                  completion_signal);
+}
+
+hsa_status_t HSA_API rj_amd_memory_async_copy_on_engine(
+    void *dst, hsa_agent_t dst_agent, const void *src, hsa_agent_t src_agent, size_t size,
+    uint32_t num_dep_signals, const hsa_signal_t *dep_signals, hsa_signal_t completion_signal,
+    hsa_amd_sdma_engine_id_t engine_id, bool force_copy_on_sdma) {
+  auto *original = layer().amd_memory_async_copy_on_engine();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped_dst = AgentMapper::instance().map(dst_agent);
+  hsa_agent_t mapped_src = AgentMapper::instance().map(src_agent);
+  log_message(kLogVerbose,
+              "amd_memory_async_copy_on_engine dst_agent=%llu mapped=%llu src_agent=%llu "
+              "mapped=%llu size=%zu engine=%u",
+              static_cast<unsigned long long>(dst_agent.handle),
+              static_cast<unsigned long long>(mapped_dst.handle),
+              static_cast<unsigned long long>(src_agent.handle),
+              static_cast<unsigned long long>(mapped_src.handle), size,
+              static_cast<unsigned>(engine_id));
+  return original(dst, mapped_dst, src, mapped_src, size, num_dep_signals, dep_signals,
+                  completion_signal, engine_id, force_copy_on_sdma);
+}
+
+hsa_status_t HSA_API rj_amd_memory_async_copy_rect(
+    const hsa_pitched_ptr_t *dst, const hsa_dim3_t *dst_offset, const hsa_pitched_ptr_t *src,
+    const hsa_dim3_t *src_offset, const hsa_dim3_t *range, hsa_agent_t copy_agent,
+    hsa_amd_copy_direction_t dir, uint32_t num_dep_signals, const hsa_signal_t *dep_signals,
+    hsa_signal_t completion_signal) {
+  auto *original = layer().amd_memory_async_copy_rect();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = AgentMapper::instance().map(copy_agent);
+  log_message(kLogVerbose, "amd_memory_async_copy_rect agent=%llu mapped=%llu dir=%u",
+              static_cast<unsigned long long>(copy_agent.handle),
+              static_cast<unsigned long long>(mapped.handle), static_cast<unsigned>(dir));
+  return original(dst, dst_offset, src, src_offset, range, mapped, dir, num_dep_signals,
+                  dep_signals, completion_signal);
+}
+
+hsa_status_t HSA_API rj_amd_memory_copy_engine_status(hsa_agent_t dst_agent, hsa_agent_t src_agent,
+                                                      uint32_t *engine_ids_mask) {
+  auto *original = layer().amd_memory_copy_engine_status();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  return original(AgentMapper::instance().map(dst_agent), AgentMapper::instance().map(src_agent),
+                  engine_ids_mask);
+}
+
+hsa_status_t HSA_API rj_amd_memory_get_preferred_copy_engine(hsa_agent_t dst_agent,
+                                                             hsa_agent_t src_agent,
+                                                             hsa_amd_sdma_engine_id_t *engine_id) {
+  auto *original = layer().amd_memory_get_preferred_copy_engine();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  return original(AgentMapper::instance().map(dst_agent), AgentMapper::instance().map(src_agent),
+                  engine_id);
+}
+
+hsa_status_t HSA_API rj_amd_memory_lock(void *host_ptr, size_t size, hsa_agent_t *agents,
+                                        int num_agent, void **agent_ptr) {
+  auto *original = layer().amd_memory_lock();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  auto mapped = num_agent > 0 ? map_agent_array(agents, static_cast<size_t>(num_agent))
+                              : std::vector<hsa_agent_t>{};
+  return original(host_ptr, size, mapped.empty() ? agents : mapped.data(), num_agent, agent_ptr);
+}
+
+hsa_status_t HSA_API rj_amd_memory_lock_to_pool(void *host_ptr, size_t size, hsa_agent_t *agents,
+                                                int num_agent, hsa_amd_memory_pool_t pool,
+                                                uint32_t flags, void **agent_ptr) {
+  auto *original = layer().amd_memory_lock_to_pool();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  auto mapped = num_agent > 0 ? map_agent_array(agents, static_cast<size_t>(num_agent))
+                              : std::vector<hsa_agent_t>{};
+  hsa_amd_memory_pool_t mapped_pool = MemoryPoolMapper::instance().map(pool);
+  return original(host_ptr, size, mapped.empty() ? agents : mapped.data(), num_agent, mapped_pool,
+                  flags, agent_ptr);
+}
+
+hsa_status_t HSA_API rj_amd_memory_fill(void *ptr, uint32_t value, size_t count) {
+  auto *original = layer().amd_memory_fill();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  log_message(kLogVerbose, "amd_memory_fill ptr=%p value=0x%x count=%zu", ptr, value, count);
+  hsa_status_t status = original(ptr, value, count);
+  log_message(kLogVerbose, "amd_memory_fill status=%d", static_cast<int>(status));
+  return status;
+}
+
+hsa_status_t HSA_API rj_amd_pointer_info(const void *ptr, hsa_amd_pointer_info_t *info,
+                                         void *(*alloc)(size_t), uint32_t *num_agents_accessible,
+                                         hsa_agent_t **accessible) {
+  auto *original = layer().amd_pointer_info();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  log_message(kLogVerbose, "amd_pointer_info ptr=%p", ptr);
+  hsa_status_t status = original(ptr, info, alloc, num_agents_accessible, accessible);
+  if (status == HSA_STATUS_SUCCESS) {
+    if (info != nullptr &&
+        info->size >= offsetof(hsa_amd_pointer_info_t, agentOwner) + sizeof(info->agentOwner))
+      info->agentOwner = AgentMapper::instance().guest_for_host(info->agentOwner);
+    if (num_agents_accessible != nullptr && accessible != nullptr && *accessible != nullptr) {
+      for (uint32_t i = 0; i < *num_agents_accessible; ++i)
+        (*accessible)[i] = AgentMapper::instance().guest_for_host((*accessible)[i]);
+    }
+  }
+  log_message(kLogVerbose, "amd_pointer_info status=%d owner=%llu accessible=%u",
+              static_cast<int>(status),
+              static_cast<unsigned long long>(info ? info->agentOwner.handle : 0),
+              num_agents_accessible ? *num_agents_accessible : 0);
+  return status;
+}
+
+hsa_status_t HSA_API rj_amd_svm_prefetch_async(void *ptr, size_t size, hsa_agent_t agent,
+                                               uint32_t num_dep_signals,
+                                               const hsa_signal_t *dep_signals,
+                                               hsa_signal_t completion_signal) {
+  auto *original = layer().amd_svm_prefetch_async();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  log_message(kLogVerbose, "amd_svm_prefetch_async ptr=%p size=%zu agent=%llu mapped=%llu", ptr,
+              size, static_cast<unsigned long long>(agent.handle),
+              static_cast<unsigned long long>(mapped.handle));
+  return original(ptr, size, mapped, num_dep_signals, dep_signals, completion_signal);
+}
+
+hsa_status_t HSA_API rj_amd_vmem_set_access(void *va, size_t size,
+                                            const hsa_amd_memory_access_desc_t *desc,
+                                            size_t desc_cnt) {
+  auto *original = layer().amd_vmem_set_access();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  std::vector<hsa_amd_memory_access_desc_t> mapped;
+  if (desc && desc_cnt > 0) {
+    mapped.assign(desc, desc + desc_cnt);
+    for (auto &entry : mapped)
+      entry.agent_handle = AgentMapper::instance().map(entry.agent_handle);
+  }
+  log_message(kLogVerbose, "amd_vmem_set_access va=%p size=%zu desc_cnt=%zu", va, size, desc_cnt);
+  return original(va, size, mapped.empty() ? desc : mapped.data(), desc_cnt);
+}
+
+hsa_status_t HSA_API rj_amd_vmem_get_access(void *va, hsa_access_permission_t *perms,
+                                            hsa_agent_t agent_handle) {
+  auto *original = layer().amd_vmem_get_access();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = AgentMapper::instance().map(agent_handle);
+  log_message(kLogVerbose, "amd_vmem_get_access va=%p agent=%llu mapped=%llu", va,
+              static_cast<unsigned long long>(agent_handle.handle),
+              static_cast<unsigned long long>(mapped.handle));
+  return original(va, perms, mapped);
+}
+
+hsa_status_t HSA_API rj_amd_agent_set_async_scratch_limit(hsa_agent_t agent, size_t threshold) {
+  auto *original = layer().amd_agent_set_async_scratch_limit();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  log_message(kLogVerbose, "amd_agent_set_async_scratch_limit agent=%llu mapped=%llu threshold=%zu",
+              static_cast<unsigned long long>(agent.handle),
+              static_cast<unsigned long long>(mapped.handle), threshold);
+  return original(mapped, threshold);
+}
+
+hsa_status_t HSA_API rj_amd_memory_async_batch_copy(const hsa_amd_memory_copy_op_t *copy_ops,
+                                                    uint32_t num_copy_ops, uint32_t num_dep_signals,
+                                                    const hsa_signal_t *dep_signals) {
+  auto *original = layer().amd_memory_async_batch_copy();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  if (!copy_ops || num_copy_ops == 0)
+    return original(copy_ops, num_copy_ops, num_dep_signals, dep_signals);
+
+  std::vector<hsa_amd_memory_copy_op_t> mapped(copy_ops, copy_ops + num_copy_ops);
+  std::vector<std::vector<hsa_agent_t>> mapped_src_lists;
+  std::vector<std::vector<hsa_agent_t>> mapped_dst_lists;
+  mapped_src_lists.reserve(num_copy_ops);
+  mapped_dst_lists.reserve(num_copy_ops);
+  log_message(kLogVerbose, "amd_memory_async_batch_copy ops=%u deps=%u", num_copy_ops,
+              num_dep_signals);
+  for (uint32_t i = 0; i < num_copy_ops; ++i) {
+    auto &op = mapped[i];
+    if (op.num_entries == 0) {
+      op.src_agent = AgentMapper::instance().map(op.src_agent);
+      op.dst_agent = AgentMapper::instance().map(op.dst_agent);
+      continue;
+    }
+    if (op.src_agent_list != nullptr) {
+      mapped_src_lists.push_back(map_agent_array(op.src_agent_list, op.num_entries));
+      op.src_agent_list = mapped_src_lists.back().data();
+    } else {
+      op.src_agent = AgentMapper::instance().map(op.src_agent);
+    }
+    if (op.dst_agent_list != nullptr) {
+      mapped_dst_lists.push_back(map_agent_array(op.dst_agent_list, op.num_entries));
+      op.dst_agent_list = mapped_dst_lists.back().data();
+    } else {
+      op.dst_agent = AgentMapper::instance().map(op.dst_agent);
+    }
+  }
+  return original(mapped.data(), num_copy_ops, num_dep_signals, dep_signals);
+}
+
+hsa_status_t HSA_API rj_amd_agent_preload(hsa_agent_t agent, uint64_t flags) {
+  auto *original = layer().amd_agent_preload();
+  if (!original)
+    return HSA_STATUS_ERROR;
+  hsa_agent_t mapped = AgentMapper::instance().map(agent);
+  log_message(kLogVerbose, "amd_agent_preload agent=%llu mapped=%llu flags=0x%llx",
+              static_cast<unsigned long long>(agent.handle),
+              static_cast<unsigned long long>(mapped.handle),
+              static_cast<unsigned long long>(flags));
+  return original(mapped, flags);
+}
+
+/// @brief Create an HSA reader from translated ELF bytes and keep the storage alive.
 [[nodiscard]] hsa_status_t create_translated_reader(std::vector<uint8_t> translated,
                                                     hsa_code_object_reader_t *translated_reader) {
   auto *owned = new (std::nothrow) std::vector<uint8_t>(std::move(translated));
@@ -608,14 +2223,6 @@ hsa_status_t HSA_API rj_executable_load_agent_code_object(
   if (original_load == nullptr)
     return HSA_STATUS_ERROR;
 
-  const uint8_t *bytes = nullptr;
-  size_t size = 0;
-  if (!CodeObjectReaderRegistry::instance().lookup(code_object_reader, &bytes, &size)) {
-    log_message(kLogInfo, "no memory bytes registered for reader=%llu; passing through",
-                static_cast<unsigned long long>(code_object_reader.handle));
-    return original_load(executable, agent, code_object_reader, options, loaded_code_object);
-  }
-
   auto config = layer().config();
   if (!config) {
     // `OnUnload()` should not normally race active ROCR callbacks, but returning
@@ -624,9 +2231,38 @@ hsa_status_t HSA_API rj_executable_load_agent_code_object(
     return HSA_STATUS_ERROR;
   }
 
+  const bool guest_load = AgentMapper::instance().is_guest(agent);
+  log_message(kLogVerbose, "load_agent_code_object exec=%llu agent=%llu guest=%d reader=%llu",
+              static_cast<unsigned long long>(executable.handle),
+              static_cast<unsigned long long>(agent.handle), guest_load ? 1 : 0,
+              static_cast<unsigned long long>(code_object_reader.handle));
+  if (config->guest_target && !guest_load) {
+    hsa_status_t status =
+        original_load(executable, agent, code_object_reader, options, loaded_code_object);
+    log_message(kLogVerbose, "load_agent_code_object host/pass-through status=%d",
+                static_cast<int>(status));
+    return status;
+  }
+
+  hsa_agent_t load_agent = guest_load ? AgentMapper::instance().host_for_guest() : agent;
+  if (guest_load && load_agent.handle == 0)
+    return HSA_STATUS_ERROR_INVALID_AGENT;
+
+  const uint8_t *bytes = nullptr;
+  size_t size = 0;
+  if (!CodeObjectReaderRegistry::instance().lookup(code_object_reader, &bytes, &size)) {
+    log_message(kLogInfo, "no memory bytes registered for reader=%llu",
+                static_cast<unsigned long long>(code_object_reader.handle));
+    if (guest_load)
+      return HSA_STATUS_ERROR_INVALID_CODE_OBJECT_READER;
+    return original_load(executable, load_agent, code_object_reader, options, loaded_code_object);
+  }
+
   const DetectedElfTarget detected = detect_target_from_elf(bytes, size);
   DetectedElfTarget source_target = detected;
-  if (config->source_override) {
+  const bool detected_already_target =
+      detected.arch == config->target.arch && detected.mach == config->target.mach;
+  if (config->source_override && !detected_already_target) {
     source_target.arch = config->source_override->arch;
     source_target.mach = config->source_override->mach;
   }
@@ -639,7 +2275,13 @@ hsa_status_t HSA_API rj_executable_load_agent_code_object(
     log_message(kLogInfo,
                 "source target %s arch %s already matches requested target; passing through",
                 elf_mach_name(source_target.mach), arch_name(source_target.arch));
-    return original_load(executable, agent, code_object_reader, options, loaded_code_object);
+    hsa_status_t status =
+        original_load(executable, load_agent, code_object_reader, options, loaded_code_object);
+    log_message(kLogVerbose, "load_agent_code_object already-target status=%d",
+                static_cast<int>(status));
+    if (status == HSA_STATUS_SUCCESS && guest_load)
+      ExecutableAgentRegistry::instance().record(executable, agent, load_agent);
+    return status;
   }
 
   log_message(kLogInfo, "translating reader=%llu %s/%s -> %s/%s mach=0x%x",
@@ -674,7 +2316,9 @@ hsa_status_t HSA_API rj_executable_load_agent_code_object(
     return status;
   }
 
-  status = original_load(executable, agent, translated_reader, options, loaded_code_object);
+  status = original_load(executable, load_agent, translated_reader, options, loaded_code_object);
+  log_message(kLogVerbose, "load_agent_code_object translated load_agent=%llu status=%d",
+              static_cast<unsigned long long>(load_agent.handle), static_cast<int>(status));
   CodeObjectReaderRegistry::instance().remove(translated_reader);
   if (auto *original_destroy = layer().destroy(); original_destroy != nullptr)
     (void)original_destroy(translated_reader);
@@ -682,6 +2326,8 @@ hsa_status_t HSA_API rj_executable_load_agent_code_object(
   if (status != HSA_STATUS_SUCCESS) {
     std::fprintf(stderr, "[rocjitsu-hooks] translated code-object load failed: %d\n",
                  static_cast<int>(status));
+  } else if (guest_load) {
+    ExecutableAgentRegistry::instance().record(executable, agent, load_agent);
   }
   return status;
 }
@@ -697,9 +2343,9 @@ hsa_status_t HSA_API rj_executable_load_agent_code_object(
 /// @brief ROCR HSA tools entry point.
 ///
 /// @details Saves the incoming `CoreApiTable` function pointers and installs
-/// DBT load-time wrappers when `RJ_DBT_TARGET_ISA` is configured. The failed
-/// tool list is not modified; ROCR owns that state and passes it for diagnostics
-/// only.
+/// DBT load-time wrappers when the runtime config enables `dbt_guest`. The
+/// failed tool list is not modified; ROCR owns that state and passes it for
+/// diagnostics only.
 extern "C" RJ_HOOK_EXPORT bool OnLoad(HsaApiTable *table, uint64_t runtime_version,
                                       uint64_t failed_tool_count,
                                       const char *const *failed_tool_names) {
@@ -710,7 +2356,11 @@ extern "C" RJ_HOOK_EXPORT bool OnLoad(HsaApiTable *table, uint64_t runtime_versi
   auto config = parse_config();
   if (!config)
     return false;
-  return layer().install(table, std::move(*config));
+  const bool signal_backtrace = config->signal_backtrace;
+  if (!layer().install(table, std::move(*config)))
+    return false;
+  maybe_install_signal_backtrace(signal_backtrace);
+  return true;
 }
 
 /// @brief ROCR HSA tools unload entry point.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/hooks/rj_hsa_dbt_hooks.cpp
@@ -418,21 +418,34 @@ public:
     return registry;
   }
 
+  /// @brief Stable byte snapshot returned by lookup().
+  ///
+  /// @details Application-created memory readers are non-owning because ROCR's
+  /// public API requires the caller to keep those bytes valid for the reader
+  /// lifetime. Translated readers carry shared ownership so a concurrent destroy
+  /// cannot free rocjitsu-owned ELF storage while a load is in progress.
+  struct ReaderBytes {
+    const uint8_t *bytes = nullptr;
+    size_t size = 0;
+    std::shared_ptr<const std::vector<uint8_t>> owned;
+
+    [[nodiscard]] explicit operator bool() const { return bytes != nullptr; }
+  };
+
   /// @brief Record bytes backing a code-object reader.
   /// @param reader HSA reader handle used as the lookup key.
   /// @param bytes Start of the ELF image.
   /// @param size Size of the ELF image in bytes.
   /// @param owned Optional owned storage for translated ELF bytes.
   [[nodiscard]] bool store(hsa_code_object_reader_t reader, const uint8_t *bytes, size_t size,
-                           std::vector<uint8_t> *owned) {
+                           std::shared_ptr<const std::vector<uint8_t>> owned) {
     std::unique_lock lock(mutex_);
     for (auto it = entries_.begin(); it != entries_.end(); ++it) {
       auto *entry = static_cast<Entry *>(it.node_pointer());
       if (entry->handle == reader.handle) {
-        delete entry->owned;
         entry->bytes = bytes;
         entry->size = size;
-        entry->owned = owned;
+        entry->owned = std::move(owned);
         return true;
       }
     }
@@ -446,18 +459,16 @@ public:
   }
 
   /// @brief Find bytes previously recorded for @p reader.
-  /// @returns true when @p bytes and @p size were populated.
-  bool lookup(hsa_code_object_reader_t reader, const uint8_t **bytes, size_t *size) {
+  /// @returns Snapshot with bytes populated when the reader is known.
+  ReaderBytes lookup(hsa_code_object_reader_t reader) {
     std::shared_lock lock(mutex_);
     for (auto it = entries_.begin(); it != entries_.end(); ++it) {
       auto *entry = static_cast<Entry *>(it.node_pointer());
       if (entry->handle == reader.handle) {
-        *bytes = entry->bytes;
-        *size = entry->size;
-        return true;
+        return ReaderBytes{entry->bytes, entry->size, entry->owned};
       }
     }
-    return false;
+    return {};
   }
 
   /// @brief Remove one reader entry and release owned translated bytes if any.
@@ -488,18 +499,17 @@ public:
 private:
   /// @brief One code-object reader entry tracked by reader handle.
   struct Entry : util::IListNode<Entry> {
-    Entry(uint64_t h, const uint8_t *b, size_t s, std::vector<uint8_t> *o)
-        : handle(h), bytes(b), size(s), owned(o) {}
+    Entry(uint64_t h, const uint8_t *b, size_t s, std::shared_ptr<const std::vector<uint8_t>> o)
+        : handle(h), bytes(b), size(s), owned(std::move(o)) {}
 
     uint64_t handle = 0;
     const uint8_t *bytes = nullptr;
     size_t size = 0;
-    std::vector<uint8_t> *owned = nullptr;
+    std::shared_ptr<const std::vector<uint8_t>> owned;
   };
 
   /// @brief Destroy one reader entry and release optional owned ELF storage.
   void destroy_entry(Entry *entry) {
-    delete entry->owned;
     entry->~Entry();
     entry_pool_.deallocate(entry);
   }
@@ -1495,6 +1505,7 @@ private:
       return;
 
     std::unordered_map<uint64_t, uint64_t> discovered;
+    bool mapped_any_pool = false;
     if (iterate_pools != nullptr && get_info != nullptr) {
       PoolList guest_pools;
       PoolList host_pools;
@@ -1508,11 +1519,19 @@ private:
           if (!host_pool)
             continue;
           discovered[guest_pool.pool.handle] = host_pool->pool.handle;
+          mapped_any_pool = true;
           log_message(kLogDebug, "mapped guest pool=%llu to host pool=%llu",
                       static_cast<unsigned long long>(guest_pool.pool.handle),
                       static_cast<unsigned long long>(host_pool->pool.handle));
         }
       }
+    }
+    if (!mapped_any_pool) {
+      // Pool iteration can fail transiently while the agent mapper is still
+      // converging or ROCR is initializing extension state. Do not publish an
+      // empty cache: the next mapped-pool call should retry discovery instead
+      // of forwarding guest pool handles forever.
+      return;
     }
 
     {
@@ -1593,7 +1612,7 @@ hsa_status_t HSA_API rj_code_object_reader_create_from_memory(
   const hsa_status_t status = original(code_object, size, code_object_reader);
   if (status == HSA_STATUS_SUCCESS && code_object_reader != nullptr && code_object != nullptr) {
     if (!CodeObjectReaderRegistry::instance().store(
-            *code_object_reader, static_cast<const uint8_t *>(code_object), size, nullptr)) {
+            *code_object_reader, static_cast<const uint8_t *>(code_object), size, {})) {
       if (auto *original_destroy = layer().destroy(); original_destroy != nullptr)
         (void)original_destroy(*code_object_reader);
       *code_object_reader = {};
@@ -1649,6 +1668,42 @@ std::vector<hsa_agent_t> map_agent_array(const hsa_agent_t *agents, size_t count
   return mapped;
 }
 
+/// @brief Forwardable mapped agent list with duplicate mapped handles removed.
+struct MappedAgentList {
+  std::vector<hsa_agent_t> agents;
+  bool changed = false;
+};
+
+/// @brief Map a caller-owned agent array and keep only the first mapped handle.
+MappedAgentList map_unique_agent_array(const hsa_agent_t *agents, size_t count) {
+  MappedAgentList mapped;
+  if (!agents || count == 0)
+    return mapped;
+
+  mapped.agents.reserve(count);
+  for (size_t i = 0; i < count; ++i) {
+    hsa_agent_t agent = AgentMapper::instance().map(agents[i]);
+    mapped.changed = mapped.changed || agent.handle != agents[i].handle;
+
+    bool duplicate = false;
+    for (hsa_agent_t existing : mapped.agents) {
+      if (existing.handle == agent.handle) {
+        duplicate = true;
+        break;
+      }
+    }
+    if (duplicate) {
+      // Guest and host handles may both appear in "all agents" arrays. After
+      // mapping the visible guest back to the host, forwarding duplicates can
+      // make ROCR reject access setup; retain the first entry's policy.
+      mapped.changed = true;
+      continue;
+    }
+    mapped.agents.push_back(agent);
+  }
+  return mapped;
+}
+
 /// @brief Forwardable allow-access agent list plus optional per-agent flags.
 struct MappedAccessAgents {
   std::vector<hsa_agent_t> agents;
@@ -1691,6 +1746,43 @@ MappedAccessAgents map_access_agent_array(const hsa_agent_t *agents, uint32_t co
       mapped.flags.push_back(flags[i]);
   }
 
+  return mapped;
+}
+
+/// @brief Forwardable virtual-memory access descriptor list.
+struct MappedAccessDescs {
+  std::vector<hsa_amd_memory_access_desc_t> descs;
+  bool changed = false;
+};
+
+/// @brief Map vmem access descriptors and deduplicate mapped agent handles.
+MappedAccessDescs map_unique_access_descs(const hsa_amd_memory_access_desc_t *desc,
+                                          size_t desc_cnt) {
+  MappedAccessDescs mapped;
+  if (!desc || desc_cnt == 0)
+    return mapped;
+
+  mapped.descs.reserve(desc_cnt);
+  for (size_t i = 0; i < desc_cnt; ++i) {
+    hsa_amd_memory_access_desc_t entry = desc[i];
+    entry.agent_handle = mapped_agent(entry.agent_handle);
+    mapped.changed = mapped.changed || entry.agent_handle.handle != desc[i].agent_handle.handle;
+
+    bool duplicate = false;
+    for (const auto &existing : mapped.descs) {
+      if (existing.agent_handle.handle == entry.agent_handle.handle) {
+        duplicate = true;
+        break;
+      }
+    }
+    if (duplicate) {
+      // Keep the first descriptor for a mapped host agent. Supplying the same
+      // agent twice is invalid on some ROCR paths even if permissions match.
+      mapped.changed = true;
+      continue;
+    }
+    mapped.descs.push_back(entry);
+  }
   return mapped;
 }
 
@@ -1811,10 +1903,8 @@ hsa_status_t HSA_API rj_agent_iterate_isas(hsa_agent_t agent,
   // HIP/CLR derives the application-visible device ISA from this callback.
   // Keep the synthetic agent guest-facing so fatbin selection picks gfx950 code
   // objects; execution-facing hooks translate and map those loads to the host.
-  hsa_agent_t mapped = AgentMapper::instance().map(agent);
-  log_message(kLogDebug, "agent_iterate_isas agent=%llu mapped=%llu",
-              static_cast<unsigned long long>(agent.handle),
-              static_cast<unsigned long long>(mapped.handle));
+  log_message(kLogDebug, "agent_iterate_isas agent=%llu",
+              static_cast<unsigned long long>(agent.handle));
   return original(agent, callback, data);
 }
 
@@ -2080,6 +2170,14 @@ hsa_status_t HSA_API rj_amd_agent_memory_pool_get_info(hsa_agent_t agent,
   auto *original = layer().amd_agent_memory_pool_get_info();
   if (!original)
     return HSA_STATUS_ERROR;
+  if (value == nullptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  if (memory_pool.handle == 0) {
+    // ROCR converts the AMD pool handle back to an internal region before
+    // answering agent/pool access queries. Keep null synthetic handles from
+    // crossing that ABI boundary; they are invalid AMD memory pools.
+    return HSA_STATUS_ERROR_INVALID_MEMORY_POOL;
+  }
   hsa_agent_t mapped = mapped_agent(agent);
   hsa_amd_memory_pool_t mapped_pool = mapped_memory_pool(memory_pool);
   log_message(
@@ -2194,9 +2292,12 @@ hsa_status_t HSA_API rj_amd_memory_lock(void *host_ptr, size_t size, hsa_agent_t
   auto *original = layer().amd_memory_lock();
   if (!original)
     return HSA_STATUS_ERROR;
-  auto mapped = num_agent > 0 ? map_agent_array(agents, static_cast<size_t>(num_agent))
-                              : std::vector<hsa_agent_t>{};
-  return original(host_ptr, size, mapped.empty() ? agents : mapped.data(), num_agent, agent_ptr);
+  MappedAgentList mapped = num_agent > 0
+                               ? map_unique_agent_array(agents, static_cast<size_t>(num_agent))
+                               : MappedAgentList{};
+  hsa_agent_t *forwarded_agents = mapped.changed ? mapped.agents.data() : agents;
+  int forwarded_count = mapped.changed ? static_cast<int>(mapped.agents.size()) : num_agent;
+  return original(host_ptr, size, forwarded_agents, forwarded_count, agent_ptr);
 }
 
 hsa_status_t HSA_API rj_amd_memory_lock_to_pool(void *host_ptr, size_t size, hsa_agent_t *agents,
@@ -2205,10 +2306,13 @@ hsa_status_t HSA_API rj_amd_memory_lock_to_pool(void *host_ptr, size_t size, hsa
   auto *original = layer().amd_memory_lock_to_pool();
   if (!original)
     return HSA_STATUS_ERROR;
-  auto mapped = num_agent > 0 ? map_agent_array(agents, static_cast<size_t>(num_agent))
-                              : std::vector<hsa_agent_t>{};
-  return forward_amd_call(original, host_ptr, size, mapped.empty() ? agents : mapped.data(),
-                          num_agent, mapped_pool_arg(pool), flags, agent_ptr);
+  MappedAgentList mapped = num_agent > 0
+                               ? map_unique_agent_array(agents, static_cast<size_t>(num_agent))
+                               : MappedAgentList{};
+  hsa_agent_t *forwarded_agents = mapped.changed ? mapped.agents.data() : agents;
+  int forwarded_count = mapped.changed ? static_cast<int>(mapped.agents.size()) : num_agent;
+  return forward_amd_call(original, host_ptr, size, forwarded_agents, forwarded_count,
+                          mapped_pool_arg(pool), flags, agent_ptr);
 }
 
 hsa_status_t HSA_API rj_amd_memory_fill(void *ptr, uint32_t value, size_t count) {
@@ -2263,14 +2367,11 @@ hsa_status_t HSA_API rj_amd_vmem_set_access(void *va, size_t size,
   auto *original = layer().amd_vmem_set_access();
   if (!original)
     return HSA_STATUS_ERROR;
-  std::vector<hsa_amd_memory_access_desc_t> mapped;
-  if (desc && desc_cnt > 0) {
-    mapped.assign(desc, desc + desc_cnt);
-    for (auto &entry : mapped)
-      entry.agent_handle = mapped_agent(entry.agent_handle);
-  }
+  MappedAccessDescs mapped = map_unique_access_descs(desc, desc_cnt);
+  const hsa_amd_memory_access_desc_t *forwarded_desc = mapped.changed ? mapped.descs.data() : desc;
+  size_t forwarded_count = mapped.changed ? mapped.descs.size() : desc_cnt;
   log_message(kLogVerbose, "amd_vmem_set_access va=%p size=%zu desc_cnt=%zu", va, size, desc_cnt);
-  return original(va, size, mapped.empty() ? desc : mapped.data(), desc_cnt);
+  return original(va, size, forwarded_desc, forwarded_count);
 }
 
 hsa_status_t HSA_API rj_amd_vmem_get_access(void *va, hsa_access_permission_t *perms,
@@ -2341,28 +2442,25 @@ hsa_status_t HSA_API rj_amd_agent_preload(hsa_agent_t agent, uint64_t flags) {
 /// @brief Create an HSA reader from translated ELF bytes and keep the storage alive.
 [[nodiscard]] hsa_status_t create_translated_reader(std::vector<uint8_t> translated,
                                                     hsa_code_object_reader_t *translated_reader) {
-  auto *owned = new (std::nothrow) std::vector<uint8_t>(std::move(translated));
-  if (owned == nullptr)
+  auto *owned_storage = new (std::nothrow) std::vector<uint8_t>(std::move(translated));
+  if (owned_storage == nullptr)
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+  std::shared_ptr<const std::vector<uint8_t>> owned(owned_storage);
 
   auto *original_create = layer().create_from_memory();
   if (original_create == nullptr) {
-    delete owned;
     return HSA_STATUS_ERROR;
   }
 
   const hsa_status_t status = original_create(owned->data(), owned->size(), translated_reader);
-  if (status != HSA_STATUS_SUCCESS) {
-    delete owned;
+  if (status != HSA_STATUS_SUCCESS)
     return status;
-  }
 
   if (!CodeObjectReaderRegistry::instance().store(*translated_reader, owned->data(), owned->size(),
                                                   owned)) {
     if (auto *original_destroy = layer().destroy(); original_destroy != nullptr)
       (void)original_destroy(*translated_reader);
     *translated_reader = {};
-    delete owned;
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
   }
   return HSA_STATUS_SUCCESS;
@@ -2393,15 +2491,17 @@ hsa_status_t HSA_API rj_executable_load_agent_code_object(
   if (guest_load && load_agent.handle == 0)
     return HSA_STATUS_ERROR_INVALID_AGENT;
 
-  const uint8_t *bytes = nullptr;
-  size_t size = 0;
-  if (!CodeObjectReaderRegistry::instance().lookup(code_object_reader, &bytes, &size)) {
+  CodeObjectReaderRegistry::ReaderBytes reader_bytes =
+      CodeObjectReaderRegistry::instance().lookup(code_object_reader);
+  if (!reader_bytes) {
     log_message(kLogInfo, "no memory bytes registered for reader=%llu",
                 static_cast<unsigned long long>(code_object_reader.handle));
     if (guest_load)
       return HSA_STATUS_ERROR_INVALID_CODE_OBJECT_READER;
     return original_load(executable, load_agent, code_object_reader, options, loaded_code_object);
   }
+  const uint8_t *bytes = reader_bytes.bytes;
+  size_t size = reader_bytes.size;
 
   const DetectedElfTarget detected = detect_target_from_elf(bytes, size);
   DetectedElfTarget source_target = detected;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/CMakeLists.txt
@@ -3,9 +3,13 @@
 
 rj_add_object_library(rocjitsu_kmd
     events.cpp
+    guest_kfd.cpp
+    libc_passthrough.cpp
+    linux_kfd.cpp
     remote_driver.cpp
-    simulated_driver.cpp
+    simulated_kfd.cpp
     sysfs.cpp
     transport.cpp
 )
 target_include_directories(rocjitsu_kmd PRIVATE ${GENERATED_DIR})
+target_link_libraries(rocjitsu_kmd PUBLIC ${CMAKE_DL_LIBS})

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/amdgpu_properties.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/amdgpu_properties.h
@@ -8,8 +8,11 @@
 
 #include "util/bit.h"
 
+#include <charconv>
 #include <cstdint>
+#include <optional>
 #include <string>
+#include <string_view>
 
 namespace rocjitsu::kmd {
 
@@ -79,6 +82,36 @@ inline std::string gfx_target_name(uint32_t gfx_target_version) {
   if (ip.minor < 16 && ip.stepping < 16)
     return "gfx" + std::to_string(ip.major) + kHexDigits[ip.minor] + kHexDigits[ip.stepping];
   return "gfx" + std::to_string(ip.major) + std::to_string(ip.minor) + std::to_string(ip.stepping);
+}
+
+inline std::optional<uint32_t> gfx_target_version_from_name(std::string_view name) {
+  constexpr std::string_view prefix = "gfx";
+  if (!name.starts_with(prefix) || name.size() < prefix.size() + 3)
+    return std::nullopt;
+
+  name.remove_prefix(prefix.size());
+  auto hex_nibble = [](char digit) -> std::optional<uint32_t> {
+    if (digit >= '0' && digit <= '9')
+      return static_cast<uint32_t>(digit - '0');
+    if (digit >= 'a' && digit <= 'f')
+      return static_cast<uint32_t>(digit - 'a' + 10);
+    if (digit >= 'A' && digit <= 'F')
+      return static_cast<uint32_t>(digit - 'A' + 10);
+    return std::nullopt;
+  };
+
+  const std::string_view major_text = name.substr(0, name.size() - 2);
+  uint32_t major = 0;
+  auto [ptr, err] =
+      std::from_chars(major_text.data(), major_text.data() + major_text.size(), major);
+  if (err != std::errc{} || ptr != major_text.data() + major_text.size())
+    return std::nullopt;
+
+  std::optional<uint32_t> minor = hex_nibble(name[name.size() - 2]);
+  std::optional<uint32_t> stepping = hex_nibble(name[name.size() - 1]);
+  if (!minor || !stepping)
+    return std::nullopt;
+  return major * 10000 + *minor * 100 + *stepping;
 }
 
 constexpr uint32_t external_rev_id_for_gfx_target_version(uint32_t gfx_target_version,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.cpp
@@ -5,9 +5,9 @@
 /// @brief KFD event ioctl implementations for the simulated driver.
 ///
 /// @details Implements the EventState methods that model KFD's event
-/// lifecycle and the SimulatedDriver ioctl wrappers that delegate to them.
+/// lifecycle and the SimulatedKfd ioctl wrappers that delegate to them.
 
-#include "rocjitsu/kmd/linux/simulated_driver.h"
+#include "rocjitsu/kmd/linux/simulated_kfd.h"
 #include "util/log.h"
 
 #include <algorithm>
@@ -328,10 +328,10 @@ int EventState::wait_events(void *arg, uint32_t process_id) {
   return 0;
 }
 
-/// @brief SimulatedDriver wrapper for CREATE_EVENT.
+/// @brief SimulatedKfd wrapper for CREATE_EVENT.
 /// @details Resolves the dGPU event page from the allocation table before
 ///          delegating to EventState.
-int SimulatedDriver::create_event_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::create_event_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_create_event_args *>(arg);
   if (args->event_page_offset != 0 && !proc.event_state_.page) {
     uint64_t raw = static_cast<uint64_t>(args->event_page_offset);
@@ -352,21 +352,21 @@ int SimulatedDriver::create_event_ioctl(KfdProcess &proc, void *arg) {
   return proc.event_state_.create_event(arg, gpu_id());
 }
 
-int SimulatedDriver::destroy_event_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::destroy_event_ioctl(KfdProcess &proc, void *arg) {
   return proc.event_state_.destroy_event(arg);
 }
 
-int SimulatedDriver::set_event_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::set_event_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_set_event_args *>(arg);
   util::Logger::cp("SET_EVENT_IOCTL: pid=", proc.process_id(), " event_id=", args->event_id);
   return proc.event_state_.set_event(arg);
 }
 
-int SimulatedDriver::reset_event_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::reset_event_ioctl(KfdProcess &proc, void *arg) {
   return proc.event_state_.reset_event(arg);
 }
 
-int SimulatedDriver::wait_events_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::wait_events_ioctl(KfdProcess &proc, void *arg) {
   return proc.event_state_.wait_events(arg, proc.process_id());
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/events.h
@@ -29,7 +29,7 @@ namespace rocjitsu {
 /// @brief KFD event subsystem state.
 ///
 /// @details Owns all event-related state for the simulated driver: the event
-/// table, event page, and synchronization primitives. The SimulatedDriver
+/// table, event page, and synchronization primitives. The SimulatedKfd
 /// delegates event ioctls to this class and accesses the event page and memfd
 /// for mmap/munmap operations.
 class EventState {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
@@ -6,6 +6,7 @@
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
 #include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
 #include "rocjitsu/kmd/linux/libc_passthrough.h"
+#include "rocjitsu/kmd/linux/rpc.h"
 
 #include "util/log.h"
 
@@ -18,6 +19,7 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <filesystem>
+#include <new>
 #include <optional>
 #include <sstream>
 #include <string_view>
@@ -107,9 +109,19 @@ std::string set_property(std::string text, std::string_view key, uint64_t value)
 }
 
 bool make_temp_dir(const char *prefix, std::string *out) {
-  char tmpl[128];
-  std::snprintf(tmpl, sizeof(tmpl), "/tmp/%s_XXXXXX", prefix);
-  char *dir = mkdtemp(tmpl);
+  std::error_code ec;
+  fs::path base = rpc_default_runtime_dir();
+  fs::create_directories(base, ec);
+  if (ec)
+    return false;
+
+  // Keep generated overlay trees under the rocjitsu runtime directory instead
+  // of raw /tmp. That gives test/daemon callers one directory to clean and
+  // avoids process-private synthetic sysfs trees accumulating at /tmp top-level.
+  std::string tmpl = (base / (std::string(prefix) + "_XXXXXX")).string();
+  std::vector<char> tmpl_buffer(tmpl.begin(), tmpl.end());
+  tmpl_buffer.push_back('\0');
+  char *dir = mkdtemp(tmpl_buffer.data());
   if (!dir)
     return false;
   *out = dir;
@@ -489,11 +501,15 @@ GuestKfd::~GuestKfd() {
 }
 
 void GuestKfd::reset_after_fork() {
+  // After fork() only the calling thread survives. If another parent thread was
+  // in an ioctl or close path, mutex_ may be inherited as permanently locked in
+  // the child. Reinitialize it in-place before touching ordinary members; the
+  // child is single-threaded here and the interposer destroys this copy next.
+  new (&mutex_) std::mutex();
   ready_.store(false, std::memory_order_release);
   int kfd_fd = real_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
   if (kfd_fd >= 0)
     libc_passthrough().close(kfd_fd);
-  std::lock_guard lock(mutex_);
   open_refs_ = 0;
   overlay_->release_after_fork();
   synthetic_handles_.clear();
@@ -548,8 +564,15 @@ int GuestKfd::open() {
     std::lock_guard lock(mutex_);
     int kfd_fd = real_kfd_fd_.load(std::memory_order_acquire);
     if (ready_.load(std::memory_order_acquire) && kfd_fd >= 0) {
+      // Keep the real /dev/kfd fd internal to the driver. Applications receive
+      // ordinary dup fds, so close(fd) releases that fd number immediately while
+      // the hidden real fd keeps host-KFD forwarding alive until the last
+      // app-facing open/dup reference is closed.
+      int app_fd = libc_passthrough().fcntl(kfd_fd, F_DUPFD_CLOEXEC, 0);
+      if (app_fd < 0)
+        return -1;
       ++open_refs_;
-      return kfd_fd;
+      return app_fd;
     }
   }
 }
@@ -562,6 +585,8 @@ void GuestKfd::retain_local_open() {
 
 int GuestKfd::close() {
   int kfd_fd = -1;
+  std::unique_ptr<TopologyOverlay> overlay_to_cleanup;
+  auto fresh_overlay = std::make_unique<TopologyOverlay>();
   {
     std::lock_guard lock(mutex_);
     if (open_refs_ == 0)
@@ -578,8 +603,13 @@ int GuestKfd::close() {
     ready_.store(false, std::memory_order_release);
     synthetic_handles_.clear();
     next_synthetic_handle_ = kSyntheticHandleBase;
-    overlay_->cleanup();
+    // Removing copied sysfs trees can block on filesystem work. Swap the
+    // overlay object while serialized, then perform the actual remove_all after
+    // releasing mutex_ so concurrent ioctl/redirect callers are not stalled.
+    overlay_to_cleanup = std::move(overlay_);
+    overlay_ = std::move(fresh_overlay);
   }
+  overlay_to_cleanup.reset();
   if (kfd_fd >= 0)
     libc_passthrough().close(kfd_fd);
   return 0;
@@ -589,17 +619,16 @@ int GuestKfd::forward_ioctl(unsigned long request, void *arg) {
   int kfd_fd = fd();
   if (kfd_fd < 0) {
     errno = ENODEV;
-    return -ENODEV;
+    return -1;
   }
   int ret = libc_passthrough().ioctl(kfd_fd, request, arg);
   if (ret < 0) {
-    // Driver::ioctl implementations return negative errno values internally,
-    // while the real libc ioctl reports -1 and stores the reason in errno.
-    // Preserve the specific kernel error so GuestKfd callers do not collapse
-    // every forwarded failure into a generic -1.
+    // GuestKfd forwards to the real kernel ABI here. Preserve errno and return
+    // -1 so callers that check for libc ioctl failure semantics behave the same
+    // whether an ioctl was handled locally or forwarded to /dev/kfd.
     const int saved_errno = errno != 0 ? errno : EIO;
     errno = saved_errno;
-    return -saved_errno;
+    return -1;
   }
   return ret;
 }
@@ -869,22 +898,31 @@ std::string GuestKfd::redirect_sysfs_path(const char *path) const {
   if (!path)
     return {};
 
-  if (!ready_.load(std::memory_order_acquire))
-    return {};
+  std::string topology_path;
+  std::string guest_drm_path;
+  {
+    std::lock_guard lock(mutex_);
+    if (!ready_.load(std::memory_order_acquire))
+      return {};
+    // Snapshot mutable overlay strings while serialized with close() teardown.
+    // The returned path must not reference buffers that cleanup() may clear.
+    topology_path = overlay_->topology_path();
+    guest_drm_path = overlay_->guest_drm_path();
+  }
 
-  auto redirected = redirect_sysfs_root_path(path, overlay_->topology_path(), {});
+  auto redirected = redirect_sysfs_root_path(path, topology_path, {});
   if (!redirected.empty())
     return redirected;
-  if (overlay_->guest_drm_path().empty())
+  if (guest_drm_path.empty())
     return {};
 
   std::string_view sv(path);
   uint32_t minor = 0;
   std::string_view suffix;
   if (parse_drm_render_path(sv, &minor, &suffix) && minor == guest_.drm_render_minor)
-    return overlay_->guest_drm_path() + "/renderD" + std::to_string(minor) + std::string(suffix);
+    return guest_drm_path + "/renderD" + std::to_string(minor) + std::string(suffix);
   if (parse_sys_dev_drm_render_path(sv, &minor, &suffix) && minor == guest_.drm_render_minor)
-    return overlay_->guest_drm_path() + "/renderD" + std::to_string(minor) + std::string(suffix);
+    return guest_drm_path + "/renderD" + std::to_string(minor) + std::string(suffix);
 
   constexpr std::string_view kDevDriRenderPrefix = "/dev/dri/renderD";
   if (sv.starts_with(kDevDriRenderPrefix)) {
@@ -896,8 +934,7 @@ std::string GuestKfd::redirect_sysfs_path(const char *path) const {
     if (err == std::errc{} && ptr == number.data() + number.size() &&
         parsed == guest_.drm_render_minor) {
       auto dev_suffix = slash == std::string_view::npos ? std::string_view{} : rest.substr(slash);
-      return overlay_->guest_drm_path() + "/dev_dri/renderD" + std::to_string(parsed) +
-             std::string(dev_suffix);
+      return guest_drm_path + "/dev_dri/renderD" + std::to_string(parsed) + std::string(dev_suffix);
     }
   }
 
@@ -915,6 +952,7 @@ const Sysfs::GpuInfo *GuestKfd::gpu_info_for_render_minor(uint32_t minor) const 
 }
 
 std::string GuestKfd::topology_path() const {
+  std::lock_guard lock(mutex_);
   return ready_.load(std::memory_order_acquire) ? overlay_->topology_path() : std::string{};
 }
 
@@ -931,10 +969,6 @@ bool GuestKfd::request_targets_guest(unsigned long request, void *arg) const {
   switch (canonical_ioctl_request(request)) {
   case AMDKFD_IOC_CREATE_QUEUE:
     return static_cast<kfd_ioctl_create_queue_args *>(arg)->gpu_id == guest_.gpu_id;
-  case AMDKFD_IOC_SET_MEMORY_POLICY:
-    return static_cast<kfd_ioctl_set_memory_policy_args *>(arg)->gpu_id == guest_.gpu_id;
-  case AMDKFD_IOC_ALLOC_MEMORY_OF_GPU:
-    return static_cast<kfd_ioctl_alloc_memory_of_gpu_args *>(arg)->gpu_id == guest_.gpu_id;
   case AMDKFD_IOC_IMPORT_DMABUF:
     return static_cast<kfd_ioctl_import_dmabuf_args *>(arg)->gpu_id == guest_.gpu_id;
   case AMDKFD_IOC_SMI_EVENTS:
@@ -945,16 +979,6 @@ bool GuestKfd::request_targets_guest(unsigned long request, void *arg) const {
     return static_cast<kfd_ioctl_get_tile_config_args *>(arg)->gpu_id == guest_.gpu_id;
   case AMDKFD_IOC_SET_TRAP_HANDLER:
     return static_cast<kfd_ioctl_set_trap_handler_args *>(arg)->gpu_id == guest_.gpu_id;
-  case AMDKFD_IOC_MAP_MEMORY_TO_GPU: {
-    auto *a = static_cast<kfd_ioctl_map_memory_to_gpu_args *>(arg);
-    auto *ids = reinterpret_cast<const uint32_t *>(static_cast<uintptr_t>(a->device_ids_array_ptr));
-    return ids && std::find(ids, ids + a->n_devices, guest_.gpu_id) != ids + a->n_devices;
-  }
-  case AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU: {
-    auto *a = static_cast<kfd_ioctl_unmap_memory_from_gpu_args *>(arg);
-    auto *ids = reinterpret_cast<const uint32_t *>(static_cast<uintptr_t>(a->device_ids_array_ptr));
-    return ids && std::find(ids, ids + a->n_devices, guest_.gpu_id) != ids + a->n_devices;
-  }
   case AMDKFD_IOC_SVM: {
     auto *a = static_cast<kfd_ioctl_svm_args *>(arg);
     for (uint32_t i = 0; i < a->nattr; ++i) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
@@ -23,7 +23,6 @@
 #include <string_view>
 #include <sys/mman.h>
 #include <sys/stat.h>
-#include <sys/syscall.h>
 #include <unistd.h>
 #include <utility>
 #include <vector>
@@ -35,53 +34,47 @@ namespace {
 namespace fs = std::filesystem;
 
 constexpr const char *kRealTopologyPath = "/sys/devices/virtual/kfd/kfd/topology";
-struct LinuxDirent64 {
-  uint64_t d_ino;
-  int64_t d_off;
-  unsigned short d_reclen;
-  unsigned char d_type;
-  char d_name[1];
-};
 
 std::string read_text_file(const fs::path &path) {
-  const std::string raw_path = path.string();
-  int fd = static_cast<int>(syscall(SYS_openat, AT_FDCWD, raw_path.c_str(), O_RDONLY | O_CLOEXEC));
+  const std::string path_str = path.string();
+  auto &real = libc_passthrough();
+  int fd = real.openat(AT_FDCWD, path_str.c_str(), O_RDONLY | O_CLOEXEC);
   if (fd < 0)
     return {};
 
   std::string out;
   std::array<char, 4096> buffer{};
   for (;;) {
-    ssize_t n = static_cast<ssize_t>(syscall(SYS_read, fd, buffer.data(), buffer.size()));
+    ssize_t n = real.read(fd, buffer.data(), buffer.size());
     if (n == 0)
       break;
     if (n < 0) {
-      syscall(SYS_close, fd);
+      real.close(fd);
       return {};
     }
     out.append(buffer.data(), static_cast<size_t>(n));
   }
-  syscall(SYS_close, fd);
+  real.close(fd);
   return out;
 }
 
 void write_text_file(const fs::path &path, const std::string &text) {
-  const std::string raw_path = path.string();
-  int fd = static_cast<int>(syscall(SYS_openat, AT_FDCWD, raw_path.c_str(),
-                                    O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644));
+  const std::string path_str = path.string();
+  auto &real = libc_passthrough();
+  int fd = real.openat(AT_FDCWD, path_str.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
   if (fd < 0)
     return;
 
   const char *cursor = text.data();
   size_t remaining = text.size();
   while (remaining > 0) {
-    ssize_t written = static_cast<ssize_t>(syscall(SYS_write, fd, cursor, remaining));
+    ssize_t written = real.write(fd, cursor, remaining);
     if (written <= 0)
       break;
     cursor += written;
     remaining -= static_cast<size_t>(written);
   }
-  syscall(SYS_close, fd);
+  real.close(fd);
 }
 
 uint32_t read_u32_property(const fs::path &path, std::string_view key, uint32_t fallback) {
@@ -241,47 +234,46 @@ uint32_t choose_render_minor(uint32_t requested) {
                                                                          : kRenderMinorEnd - 1;
 }
 
-bool raw_lstat(const std::string &path, struct stat *st) {
-  return syscall(SYS_newfstatat, AT_FDCWD, path.c_str(), st, AT_SYMLINK_NOFOLLOW) == 0;
+bool passthrough_lstat(const std::string &path, struct stat *st) {
+  return libc_passthrough().lstat(path.c_str(), st) == 0;
 }
 
-bool raw_copy_file(const std::string &src, const std::string &dst) {
-  int in = static_cast<int>(syscall(SYS_openat, AT_FDCWD, src.c_str(), O_RDONLY | O_CLOEXEC));
+bool passthrough_copy_file(const std::string &src, const std::string &dst) {
+  auto &real = libc_passthrough();
+  int in = real.openat(AT_FDCWD, src.c_str(), O_RDONLY | O_CLOEXEC);
   if (in < 0)
     return false;
 
   std::error_code ec;
   fs::create_directories(fs::path(dst).parent_path(), ec);
   if (ec) {
-    syscall(SYS_close, in);
+    real.close(in);
     return false;
   }
 
-  int out = static_cast<int>(
-      syscall(SYS_openat, AT_FDCWD, dst.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644));
+  int out = real.openat(AT_FDCWD, dst.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644);
   if (out < 0) {
-    syscall(SYS_close, in);
+    real.close(in);
     return false;
   }
 
   std::array<char, 4096> buffer{};
   for (;;) {
-    ssize_t n = static_cast<ssize_t>(syscall(SYS_read, in, buffer.data(), buffer.size()));
+    ssize_t n = real.read(in, buffer.data(), buffer.size());
     if (n == 0)
       break;
     if (n < 0) {
-      syscall(SYS_close, out);
-      syscall(SYS_close, in);
+      real.close(out);
+      real.close(in);
       return false;
     }
     char *p = buffer.data();
     ssize_t remaining = n;
     while (remaining > 0) {
-      ssize_t written =
-          static_cast<ssize_t>(syscall(SYS_write, out, p, static_cast<size_t>(remaining)));
+      ssize_t written = real.write(out, p, static_cast<size_t>(remaining));
       if (written <= 0) {
-        syscall(SYS_close, out);
-        syscall(SYS_close, in);
+        real.close(out);
+        real.close(in);
         return false;
       }
       p += written;
@@ -289,77 +281,130 @@ bool raw_copy_file(const std::string &src, const std::string &dst) {
     }
   }
 
-  syscall(SYS_close, out);
-  syscall(SYS_close, in);
+  real.close(out);
+  real.close(in);
   return true;
 }
 
 } // namespace
 
-TopologyOverlay::~TopologyOverlay() { cleanup(); }
+/// @brief Generated topology overlay containing host KFD nodes plus one guest node.
+///
+/// @details The overlay is private to GuestKfd because it is an implementation
+/// detail of guest discovery. It copies the real host topology from sysfs, then
+/// appends a guest GPU node generated from the configured KFD identity. Only KFD
+/// topology paths and the guest DRM render node are redirected to this overlay;
+/// host DRM paths remain real so ROCR can still create a host agent and execute
+/// on it.
+class GuestKfd::TopologyOverlay {
+public:
+  /// @brief Construct an empty overlay.
+  TopologyOverlay() = default;
 
-bool TopologyOverlay::copy_tree(const std::string &src, const std::string &dst) {
+  /// @brief Remove any generated overlay directories owned by this instance.
+  ~TopologyOverlay();
+
+  /// @brief Overlays own temporary filesystem state and cannot be copied.
+  TopologyOverlay(const TopologyOverlay &) = delete;
+
+  /// @brief Overlays own temporary filesystem state and cannot be copied.
+  TopologyOverlay &operator=(const TopologyOverlay &) = delete;
+
+  /// @brief Build the overlay from the current host sysfs topology.
+  /// @param guest Synthetic guest GPU properties to append.
+  /// @returns true when topology and guest DRM paths are ready.
+  bool generate(const Sysfs::GpuInfo &guest);
+
+  /// @brief Remove generated overlay directories.
+  void cleanup();
+
+  /// @brief Drop inherited overlay ownership without removing parent-owned paths.
+  void release_after_fork();
+
+  /// @brief Generated KFD topology root.
+  [[nodiscard]] const std::string &topology_path() const { return topology_dir_; }
+
+  /// @brief Generated DRM root containing the guest render node.
+  [[nodiscard]] const std::string &guest_drm_path() const { return guest_drm_dir_; }
+
+  /// @brief Synthetic topology node ID assigned to the guest GPU.
+  [[nodiscard]] uint32_t guest_node_id() const { return guest_node_id_; }
+
+private:
+  /// @brief Copy a host sysfs subtree into the generated overlay.
+  bool copy_tree(const std::string &src, const std::string &dst);
+
+  /// @brief Generate the appended guest KFD node and guest DRM metadata.
+  bool copy_guest_node(const Sysfs::GpuInfo &guest);
+
+  /// @brief Patch aggregate topology files after appending the guest node.
+  bool patch_topology_files();
+
+  std::string topology_dir_;
+  std::string guest_drm_dir_;
+  Sysfs guest_sysfs_;
+  uint32_t guest_node_id_ = 0;
+};
+
+GuestKfd::TopologyOverlay::~TopologyOverlay() { cleanup(); }
+
+bool GuestKfd::TopologyOverlay::copy_tree(const std::string &src, const std::string &dst) {
   std::error_code ec;
   fs::create_directories(dst, ec);
   if (ec)
     return false;
 
-  int dir = static_cast<int>(
-      syscall(SYS_openat, AT_FDCWD, src.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC));
-  if (dir < 0)
+  auto &real = libc_passthrough();
+  DIR *dir = real.opendir(src.c_str());
+  if (!dir)
     return false;
 
-  std::array<char, 32768> entries{};
+  bool ok = true;
   for (;;) {
-    int nread = static_cast<int>(syscall(SYS_getdents64, dir, entries.data(), entries.size()));
-    if (nread == 0)
+    errno = 0;
+    struct dirent *entry = real.readdir(dir);
+    if (!entry) {
+      ok = errno == 0;
       break;
-    if (nread < 0) {
-      syscall(SYS_close, dir);
-      return false;
     }
 
-    for (int pos = 0; pos < nread;) {
-      auto *entry = reinterpret_cast<LinuxDirent64 *>(entries.data() + pos);
-      std::string name = entry->d_name;
-      pos += entry->d_reclen;
-      if (name == "." || name == "..")
-        continue;
+    std::string name = entry->d_name;
+    if (name == "." || name == "..")
+      continue;
 
-      std::string child_src = src + "/" + name;
-      std::string child_dst = dst + "/" + name;
-      struct stat st {};
-      if (!raw_lstat(child_src, &st))
-        continue;
+    std::string child_src = src + "/" + name;
+    std::string child_dst = dst + "/" + name;
+    struct stat st {};
+    if (!passthrough_lstat(child_src, &st))
+      continue;
 
-      if (S_ISDIR(st.st_mode)) {
-        if (!copy_tree(child_src, child_dst)) {
-          syscall(SYS_close, dir);
-          return false;
-        }
-        continue;
+    if (S_ISDIR(st.st_mode)) {
+      if (!copy_tree(child_src, child_dst)) {
+        ok = false;
+        break;
       }
-      if (S_ISLNK(st.st_mode)) {
-        std::array<char, 4096> link_target{};
-        ssize_t n = static_cast<ssize_t>(syscall(SYS_readlinkat, AT_FDCWD, child_src.c_str(),
-                                                 link_target.data(), link_target.size() - 1));
-        if (n > 0) {
-          link_target[static_cast<size_t>(n)] = '\0';
-          fs::create_directories(fs::path(child_dst).parent_path(), ec);
-          fs::create_symlink(link_target.data(), child_dst, ec);
-          ec.clear();
-        }
-        continue;
-      }
-
-      (void)raw_copy_file(child_src, child_dst);
+      continue;
     }
+    if (S_ISLNK(st.st_mode)) {
+      std::array<char, 4096> link_target{};
+      ssize_t n = real.readlink_fn(child_src.c_str(), link_target.data(), link_target.size() - 1);
+      if (n > 0) {
+        link_target[static_cast<size_t>(n)] = '\0';
+        fs::create_directories(fs::path(child_dst).parent_path(), ec);
+        fs::create_symlink(link_target.data(), child_dst, ec);
+        ec.clear();
+      }
+      continue;
+    }
+
+    (void)passthrough_copy_file(child_src, child_dst);
   }
-  syscall(SYS_close, dir);
-  return true;
+  if (real.closedir(dir) != 0)
+    ok = false;
+  return ok;
 }
 
-bool TopologyOverlay::copy_guest_node(const Sysfs::GpuInfo &guest) {
+bool GuestKfd::TopologyOverlay::copy_guest_node(const Sysfs::GpuInfo &guest) {
   if (guest_sysfs_.generate(guest).empty())
     return false;
   guest_drm_dir_ = guest_sysfs_.drm_path();
@@ -370,7 +415,7 @@ bool TopologyOverlay::copy_guest_node(const Sysfs::GpuInfo &guest) {
                    nodes_dir / std::to_string(guest_node_id_));
 }
 
-bool TopologyOverlay::patch_topology_files() {
+bool GuestKfd::TopologyOverlay::patch_topology_files() {
   fs::path root = topology_dir_;
   fs::path nodes_dir = root / "nodes";
   fs::path cpu_props = nodes_dir / "0" / "properties";
@@ -395,7 +440,7 @@ bool TopologyOverlay::patch_topology_files() {
   return true;
 }
 
-bool TopologyOverlay::generate(const Sysfs::GpuInfo &guest) {
+bool GuestKfd::TopologyOverlay::generate(const Sysfs::GpuInfo &guest) {
   cleanup();
   if (!make_temp_dir("rocjitsu_guest_topology", &topology_dir_))
     return false;
@@ -410,7 +455,7 @@ bool TopologyOverlay::generate(const Sysfs::GpuInfo &guest) {
   return true;
 }
 
-void TopologyOverlay::cleanup() {
+void GuestKfd::TopologyOverlay::cleanup() {
   if (!topology_dir_.empty()) {
     std::error_code ec;
     fs::remove_all(topology_dir_, ec);
@@ -421,14 +466,15 @@ void TopologyOverlay::cleanup() {
   guest_sysfs_.cleanup();
 }
 
-void TopologyOverlay::release_after_fork() {
+void GuestKfd::TopologyOverlay::release_after_fork() {
   topology_dir_.clear();
   guest_drm_dir_.clear();
   guest_node_id_ = 0;
   guest_sysfs_.release_after_fork();
 }
 
-GuestKfd::GuestKfd(config::DbtGuestConfig config) : config_(std::move(config)) {
+GuestKfd::GuestKfd(config::DbtGuestConfig config)
+    : config_(std::move(config)), overlay_(std::make_unique<TopologyOverlay>()) {
   libc_passthrough().resolve();
   guest_ = gpu_info_from_config(config_.guest_device,
                                 std::max(1u, config_.guest_device.num_shader_engines));
@@ -447,7 +493,9 @@ void GuestKfd::reset_after_fork() {
   int kfd_fd = real_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
   if (kfd_fd >= 0)
     libc_passthrough().close(kfd_fd);
-  overlay_.release_after_fork();
+  std::lock_guard lock(mutex_);
+  open_refs_ = 0;
+  overlay_->release_after_fork();
   synthetic_handles_.clear();
   next_synthetic_handle_ = kSyntheticHandleBase;
 }
@@ -483,7 +531,7 @@ bool GuestKfd::ensure_ready() {
     }
     host_gpu_id_ = *host_gpu_id;
   }
-  if (!overlay_.generate(guest_)) {
+  if (!overlay_->generate(guest_)) {
     errno = ENODEV;
     return false;
   }
@@ -491,13 +539,51 @@ bool GuestKfd::ensure_ready() {
   return true;
 }
 
+bool GuestKfd::prepare_for_discovery() { return ensure_ready(); }
+
 int GuestKfd::open() {
-  if (!ensure_ready())
-    return -1;
-  return fd();
+  for (;;) {
+    if (!ensure_ready())
+      return -1;
+    std::lock_guard lock(mutex_);
+    int kfd_fd = real_kfd_fd_.load(std::memory_order_acquire);
+    if (ready_.load(std::memory_order_acquire) && kfd_fd >= 0) {
+      ++open_refs_;
+      return kfd_fd;
+    }
+  }
 }
 
-int GuestKfd::close() { return 0; }
+void GuestKfd::retain_local_open() {
+  std::lock_guard lock(mutex_);
+  if (ready_.load(std::memory_order_acquire) && real_kfd_fd_.load(std::memory_order_acquire) >= 0)
+    ++open_refs_;
+}
+
+int GuestKfd::close() {
+  int kfd_fd = -1;
+  {
+    std::lock_guard lock(mutex_);
+    if (open_refs_ == 0)
+      return 0;
+    --open_refs_;
+    if (open_refs_ != 0)
+      return 0;
+
+    // The app sees a real KFD fd, but the interposer owns close ordering so
+    // dup'd descriptors can keep the process KFD connection alive. Only the
+    // final open reference closes the primary real fd and tears down discovery
+    // state; the close hook separately closes any dup fd that triggered this.
+    kfd_fd = real_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
+    ready_.store(false, std::memory_order_release);
+    synthetic_handles_.clear();
+    next_synthetic_handle_ = kSyntheticHandleBase;
+    overlay_->cleanup();
+  }
+  if (kfd_fd >= 0)
+    libc_passthrough().close(kfd_fd);
+  return 0;
+}
 
 int GuestKfd::forward_ioctl(unsigned long request, void *arg) {
   int kfd_fd = fd();
@@ -773,7 +859,9 @@ void *GuestKfd::mmap(void *addr, size_t length, int prot, int flags, off_t offse
 
 int GuestKfd::munmap(void *, size_t) { return -ENOENT; }
 
-bool GuestKfd::owns_fd(int) const { return false; }
+bool GuestKfd::owns_fd(int fd) const {
+  return fd >= 0 && fd == real_kfd_fd_.load(std::memory_order_acquire);
+}
 
 int GuestKfd::fd() const { return real_kfd_fd_.load(std::memory_order_acquire); }
 
@@ -784,19 +872,19 @@ std::string GuestKfd::redirect_sysfs_path(const char *path) const {
   if (!ready_.load(std::memory_order_acquire))
     return {};
 
-  auto redirected = redirect_sysfs_root_path(path, overlay_.topology_path(), {});
+  auto redirected = redirect_sysfs_root_path(path, overlay_->topology_path(), {});
   if (!redirected.empty())
     return redirected;
-  if (overlay_.guest_drm_path().empty())
+  if (overlay_->guest_drm_path().empty())
     return {};
 
   std::string_view sv(path);
   uint32_t minor = 0;
   std::string_view suffix;
   if (parse_drm_render_path(sv, &minor, &suffix) && minor == guest_.drm_render_minor)
-    return overlay_.guest_drm_path() + "/renderD" + std::to_string(minor) + std::string(suffix);
+    return overlay_->guest_drm_path() + "/renderD" + std::to_string(minor) + std::string(suffix);
   if (parse_sys_dev_drm_render_path(sv, &minor, &suffix) && minor == guest_.drm_render_minor)
-    return overlay_.guest_drm_path() + "/renderD" + std::to_string(minor) + std::string(suffix);
+    return overlay_->guest_drm_path() + "/renderD" + std::to_string(minor) + std::string(suffix);
 
   constexpr std::string_view kDevDriRenderPrefix = "/dev/dri/renderD";
   if (sv.starts_with(kDevDriRenderPrefix)) {
@@ -808,7 +896,7 @@ std::string GuestKfd::redirect_sysfs_path(const char *path) const {
     if (err == std::errc{} && ptr == number.data() + number.size() &&
         parsed == guest_.drm_render_minor) {
       auto dev_suffix = slash == std::string_view::npos ? std::string_view{} : rest.substr(slash);
-      return overlay_.guest_drm_path() + "/dev_dri/renderD" + std::to_string(parsed) +
+      return overlay_->guest_drm_path() + "/dev_dri/renderD" + std::to_string(parsed) +
              std::string(dev_suffix);
     }
   }
@@ -827,7 +915,7 @@ const Sysfs::GpuInfo *GuestKfd::gpu_info_for_render_minor(uint32_t minor) const 
 }
 
 std::string GuestKfd::topology_path() const {
-  return ready_.load(std::memory_order_acquire) ? overlay_.topology_path() : std::string{};
+  return ready_.load(std::memory_order_acquire) ? overlay_->topology_path() : std::string{};
 }
 
 int GuestKfd::reject_guest_execution_ioctl(unsigned long request, void *) const {
@@ -889,7 +977,7 @@ kfd_process_device_apertures GuestKfd::guest_apertures() const {
   uint32_t guest_node_id = 0;
   {
     std::lock_guard lock(mutex_);
-    guest_node_id = overlay_.guest_node_id();
+    guest_node_id = overlay_->guest_node_id();
   }
   const uint64_t ordinal = std::max<uint32_t>(1, guest_node_id);
   const uint64_t aperture_stride = 0x10000000000ULL;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
@@ -1,0 +1,907 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/kmd/linux/guest_kfd.h"
+
+#include "rocjitsu/kmd/linux/amdgpu_properties.h"
+#include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
+#include "rocjitsu/kmd/linux/libc_passthrough.h"
+
+#include "util/log.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cerrno>
+#include <charconv>
+#include <cstdio>
+#include <dirent.h>
+#include <fcntl.h>
+#include <filesystem>
+#include <optional>
+#include <sstream>
+#include <string_view>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+namespace rocjitsu {
+
+namespace {
+
+namespace fs = std::filesystem;
+
+constexpr const char *kRealTopologyPath = "/sys/devices/virtual/kfd/kfd/topology";
+struct LinuxDirent64 {
+  uint64_t d_ino;
+  int64_t d_off;
+  unsigned short d_reclen;
+  unsigned char d_type;
+  char d_name[1];
+};
+
+std::string read_text_file(const fs::path &path) {
+  const std::string raw_path = path.string();
+  int fd = static_cast<int>(syscall(SYS_openat, AT_FDCWD, raw_path.c_str(), O_RDONLY | O_CLOEXEC));
+  if (fd < 0)
+    return {};
+
+  std::string out;
+  std::array<char, 4096> buffer{};
+  for (;;) {
+    ssize_t n = static_cast<ssize_t>(syscall(SYS_read, fd, buffer.data(), buffer.size()));
+    if (n == 0)
+      break;
+    if (n < 0) {
+      syscall(SYS_close, fd);
+      return {};
+    }
+    out.append(buffer.data(), static_cast<size_t>(n));
+  }
+  syscall(SYS_close, fd);
+  return out;
+}
+
+void write_text_file(const fs::path &path, const std::string &text) {
+  const std::string raw_path = path.string();
+  int fd = static_cast<int>(syscall(SYS_openat, AT_FDCWD, raw_path.c_str(),
+                                    O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644));
+  if (fd < 0)
+    return;
+
+  const char *cursor = text.data();
+  size_t remaining = text.size();
+  while (remaining > 0) {
+    ssize_t written = static_cast<ssize_t>(syscall(SYS_write, fd, cursor, remaining));
+    if (written <= 0)
+      break;
+    cursor += written;
+    remaining -= static_cast<size_t>(written);
+  }
+  syscall(SYS_close, fd);
+}
+
+uint32_t read_u32_property(const fs::path &path, std::string_view key, uint32_t fallback) {
+  std::istringstream input(read_text_file(path));
+  std::string name;
+  uint64_t value = 0;
+  while (input >> name >> value) {
+    if (name == key)
+      return static_cast<uint32_t>(value);
+  }
+  return fallback;
+}
+
+std::string set_property(std::string text, std::string_view key, uint64_t value) {
+  std::istringstream input(text);
+  std::ostringstream output;
+  std::string line;
+  bool replaced = false;
+  while (std::getline(input, line)) {
+    if (line.starts_with(key) && line.size() > key.size() && line[key.size()] == ' ') {
+      output << key << " " << value << "\n";
+      replaced = true;
+    } else {
+      output << line << "\n";
+    }
+  }
+  if (!replaced)
+    output << key << " " << value << "\n";
+  return output.str();
+}
+
+bool make_temp_dir(const char *prefix, std::string *out) {
+  char tmpl[128];
+  std::snprintf(tmpl, sizeof(tmpl), "/tmp/%s_XXXXXX", prefix);
+  char *dir = mkdtemp(tmpl);
+  if (!dir)
+    return false;
+  *out = dir;
+  return true;
+}
+
+uint32_t count_numeric_dirs(const fs::path &dir) {
+  uint32_t count = 0;
+  std::error_code ec;
+  for (const auto &entry : fs::directory_iterator(dir, ec)) {
+    if (!entry.is_directory(ec))
+      continue;
+    auto name = entry.path().filename().string();
+    uint32_t ignored = 0;
+    auto [ptr, err] = std::from_chars(name.data(), name.data() + name.size(), ignored);
+    if (err == std::errc{} && ptr == name.data() + name.size())
+      ++count;
+  }
+  return count;
+}
+
+std::optional<uint32_t> read_u32_file(const fs::path &path) {
+  std::istringstream in(read_text_file(path));
+  uint32_t value = 0;
+  if (!(in >> value))
+    return std::nullopt;
+  return value;
+}
+
+void append_unique_gpu_id(std::vector<uint32_t> *ids, uint32_t gpu_id) {
+  if (std::find(ids->begin(), ids->end(), gpu_id) == ids->end())
+    ids->push_back(gpu_id);
+}
+
+uint32_t max_numeric_dir(const fs::path &dir) {
+  uint32_t max_id = 0;
+  std::error_code ec;
+  for (const auto &entry : fs::directory_iterator(dir, ec)) {
+    if (!entry.is_directory(ec))
+      continue;
+    auto name = entry.path().filename().string();
+    uint32_t id = 0;
+    auto [ptr, err] = std::from_chars(name.data(), name.data() + name.size(), id);
+    if (err == std::errc{} && ptr == name.data() + name.size())
+      max_id = std::max(max_id, id);
+  }
+  return max_id;
+}
+
+std::optional<uint32_t> first_real_gpu_id_matching_isa(std::string_view host_isa) {
+  std::optional<uint32_t> target_version = kmd::gfx_target_version_from_name(host_isa);
+  if (!target_version)
+    return std::nullopt;
+
+  fs::path nodes_dir = fs::path(kRealTopologyPath) / "nodes";
+  const uint32_t max_node = max_numeric_dir(nodes_dir);
+  for (uint32_t node_id = 1; node_id <= max_node; ++node_id) {
+    fs::path node_dir = nodes_dir / std::to_string(node_id);
+    const uint32_t gfx_target_version =
+        read_u32_property(node_dir / "properties", "gfx_target_version", 0);
+    if (gfx_target_version != *target_version)
+      continue;
+
+    std::optional<uint32_t> gpu_id = read_u32_file(node_dir / "gpu_id");
+    if (gpu_id && *gpu_id != 0)
+      return gpu_id;
+  }
+  return std::nullopt;
+}
+
+std::string io_link_to_cpu(uint32_t node_from) {
+  std::ostringstream link;
+  link << "type 2\n"
+       << "version_major 0\n"
+       << "version_minor 0\n"
+       << "node_from " << node_from << "\n"
+       << "node_to 0\n"
+       << "weight 20\n"
+       << "min_latency 0\n"
+       << "max_latency 0\n"
+       << "min_bandwidth 0\n"
+       << "max_bandwidth 0\n"
+       << "recommended_transfer_size 0\n"
+       << "num_hops 1\n"
+       << "flags 1\n";
+  return link.str();
+}
+
+std::string io_link_from_cpu(uint32_t node_to) {
+  std::ostringstream link;
+  link << "type 2\n"
+       << "version_major 0\n"
+       << "version_minor 0\n"
+       << "node_from 0\n"
+       << "node_to " << node_to << "\n"
+       << "weight 20\n"
+       << "min_latency 0\n"
+       << "max_latency 0\n"
+       << "min_bandwidth 0\n"
+       << "max_bandwidth 0\n"
+       << "recommended_transfer_size 0\n"
+       << "num_hops 1\n"
+       << "flags 1\n";
+  return link.str();
+}
+
+uint32_t choose_render_minor(uint32_t requested) {
+  constexpr uint32_t kRenderMinorBegin = 128;
+  constexpr uint32_t kRenderMinorEnd = 192;
+  auto available = [](uint32_t minor) {
+    return !fs::exists("/sys/class/drm/renderD" + std::to_string(minor)) &&
+           !fs::exists("/dev/dri/renderD" + std::to_string(minor));
+  };
+
+  if (requested >= kRenderMinorBegin && requested < kRenderMinorEnd && available(requested))
+    return requested;
+  for (uint32_t minor = kRenderMinorBegin; minor < kRenderMinorEnd; ++minor) {
+    if (available(minor))
+      return minor;
+  }
+  return (requested >= kRenderMinorBegin && requested < kRenderMinorEnd) ? requested
+                                                                         : kRenderMinorEnd - 1;
+}
+
+bool raw_lstat(const std::string &path, struct stat *st) {
+  return syscall(SYS_newfstatat, AT_FDCWD, path.c_str(), st, AT_SYMLINK_NOFOLLOW) == 0;
+}
+
+bool raw_copy_file(const std::string &src, const std::string &dst) {
+  int in = static_cast<int>(syscall(SYS_openat, AT_FDCWD, src.c_str(), O_RDONLY | O_CLOEXEC));
+  if (in < 0)
+    return false;
+
+  std::error_code ec;
+  fs::create_directories(fs::path(dst).parent_path(), ec);
+  if (ec) {
+    syscall(SYS_close, in);
+    return false;
+  }
+
+  int out = static_cast<int>(
+      syscall(SYS_openat, AT_FDCWD, dst.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0644));
+  if (out < 0) {
+    syscall(SYS_close, in);
+    return false;
+  }
+
+  std::array<char, 4096> buffer{};
+  for (;;) {
+    ssize_t n = static_cast<ssize_t>(syscall(SYS_read, in, buffer.data(), buffer.size()));
+    if (n == 0)
+      break;
+    if (n < 0) {
+      syscall(SYS_close, out);
+      syscall(SYS_close, in);
+      return false;
+    }
+    char *p = buffer.data();
+    ssize_t remaining = n;
+    while (remaining > 0) {
+      ssize_t written =
+          static_cast<ssize_t>(syscall(SYS_write, out, p, static_cast<size_t>(remaining)));
+      if (written <= 0) {
+        syscall(SYS_close, out);
+        syscall(SYS_close, in);
+        return false;
+      }
+      p += written;
+      remaining -= written;
+    }
+  }
+
+  syscall(SYS_close, out);
+  syscall(SYS_close, in);
+  return true;
+}
+
+} // namespace
+
+TopologyOverlay::~TopologyOverlay() { cleanup(); }
+
+bool TopologyOverlay::copy_tree(const std::string &src, const std::string &dst) {
+  std::error_code ec;
+  fs::create_directories(dst, ec);
+  if (ec)
+    return false;
+
+  int dir = static_cast<int>(
+      syscall(SYS_openat, AT_FDCWD, src.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC));
+  if (dir < 0)
+    return false;
+
+  std::array<char, 32768> entries{};
+  for (;;) {
+    int nread = static_cast<int>(syscall(SYS_getdents64, dir, entries.data(), entries.size()));
+    if (nread == 0)
+      break;
+    if (nread < 0) {
+      syscall(SYS_close, dir);
+      return false;
+    }
+
+    for (int pos = 0; pos < nread;) {
+      auto *entry = reinterpret_cast<LinuxDirent64 *>(entries.data() + pos);
+      std::string name = entry->d_name;
+      pos += entry->d_reclen;
+      if (name == "." || name == "..")
+        continue;
+
+      std::string child_src = src + "/" + name;
+      std::string child_dst = dst + "/" + name;
+      struct stat st {};
+      if (!raw_lstat(child_src, &st))
+        continue;
+
+      if (S_ISDIR(st.st_mode)) {
+        if (!copy_tree(child_src, child_dst)) {
+          syscall(SYS_close, dir);
+          return false;
+        }
+        continue;
+      }
+      if (S_ISLNK(st.st_mode)) {
+        std::array<char, 4096> link_target{};
+        ssize_t n = static_cast<ssize_t>(syscall(SYS_readlinkat, AT_FDCWD, child_src.c_str(),
+                                                 link_target.data(), link_target.size() - 1));
+        if (n > 0) {
+          link_target[static_cast<size_t>(n)] = '\0';
+          fs::create_directories(fs::path(child_dst).parent_path(), ec);
+          fs::create_symlink(link_target.data(), child_dst, ec);
+          ec.clear();
+        }
+        continue;
+      }
+
+      (void)raw_copy_file(child_src, child_dst);
+    }
+  }
+  syscall(SYS_close, dir);
+  return true;
+}
+
+bool TopologyOverlay::copy_guest_node(const Sysfs::GpuInfo &guest) {
+  if (guest_sysfs_.generate(guest).empty())
+    return false;
+  guest_drm_dir_ = guest_sysfs_.drm_path();
+
+  fs::path nodes_dir = fs::path(topology_dir_) / "nodes";
+  guest_node_id_ = max_numeric_dir(nodes_dir) + 1;
+  return copy_tree(fs::path(guest_sysfs_.path()) / "nodes" / "1",
+                   nodes_dir / std::to_string(guest_node_id_));
+}
+
+bool TopologyOverlay::patch_topology_files() {
+  fs::path root = topology_dir_;
+  fs::path nodes_dir = root / "nodes";
+  fs::path cpu_props = nodes_dir / "0" / "properties";
+  fs::path system_props = root / "system_properties";
+  fs::path guest_props = nodes_dir / std::to_string(guest_node_id_) / "properties";
+  fs::path guest_link =
+      nodes_dir / std::to_string(guest_node_id_) / "io_links" / "0" / "properties";
+
+  uint32_t existing_links = read_u32_property(cpu_props, "io_links_count",
+                                              count_numeric_dirs(nodes_dir / "0" / "io_links"));
+  fs::path new_cpu_link = nodes_dir / "0" / "io_links" / std::to_string(existing_links);
+  fs::create_directories(new_cpu_link);
+
+  write_text_file(system_props, set_property(read_text_file(system_props), "num_devices",
+                                             count_numeric_dirs(nodes_dir)));
+  write_text_file(nodes_dir / "0" / "gpu_id", "0\n");
+  write_text_file(cpu_props,
+                  set_property(read_text_file(cpu_props), "io_links_count", existing_links + 1));
+  write_text_file(new_cpu_link / "properties", io_link_from_cpu(guest_node_id_));
+  write_text_file(guest_props, set_property(read_text_file(guest_props), "io_links_count", 1));
+  write_text_file(guest_link, io_link_to_cpu(guest_node_id_));
+  return true;
+}
+
+bool TopologyOverlay::generate(const Sysfs::GpuInfo &guest) {
+  cleanup();
+  if (!make_temp_dir("rocjitsu_guest_topology", &topology_dir_))
+    return false;
+  if (!copy_tree(kRealTopologyPath, topology_dir_)) {
+    cleanup();
+    return false;
+  }
+  if (!copy_guest_node(guest) || !patch_topology_files()) {
+    cleanup();
+    return false;
+  }
+  return true;
+}
+
+void TopologyOverlay::cleanup() {
+  if (!topology_dir_.empty()) {
+    std::error_code ec;
+    fs::remove_all(topology_dir_, ec);
+    topology_dir_.clear();
+  }
+  guest_drm_dir_.clear();
+  guest_node_id_ = 0;
+  guest_sysfs_.cleanup();
+}
+
+void TopologyOverlay::release_after_fork() {
+  topology_dir_.clear();
+  guest_drm_dir_.clear();
+  guest_node_id_ = 0;
+  guest_sysfs_.release_after_fork();
+}
+
+GuestKfd::GuestKfd(config::DbtGuestConfig config) : config_(std::move(config)) {
+  libc_passthrough().resolve();
+  guest_ = gpu_info_from_config(config_.guest_device,
+                                std::max(1u, config_.guest_device.num_shader_engines));
+  guest_.drm_render_minor = choose_render_minor(guest_.drm_render_minor);
+  host_gpu_id_ = config_.host_gpu_id;
+}
+
+GuestKfd::~GuestKfd() {
+  int kfd_fd = real_kfd_fd_.load(std::memory_order_acquire);
+  if (kfd_fd >= 0)
+    libc_passthrough().close(kfd_fd);
+}
+
+void GuestKfd::reset_after_fork() {
+  ready_.store(false, std::memory_order_release);
+  int kfd_fd = real_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
+  if (kfd_fd >= 0)
+    libc_passthrough().close(kfd_fd);
+  overlay_.release_after_fork();
+  synthetic_handles_.clear();
+  next_synthetic_handle_ = kSyntheticHandleBase;
+}
+
+bool GuestKfd::ensure_real_kfd_locked() {
+  if (real_kfd_fd_.load(std::memory_order_acquire) >= 0)
+    return true;
+  int fd = libc_passthrough().openat(AT_FDCWD, "/dev/kfd", O_RDWR | O_CLOEXEC, 0);
+  if (fd < 0)
+    return false;
+  real_kfd_fd_.store(fd, std::memory_order_release);
+  return true;
+}
+
+bool GuestKfd::ensure_ready() {
+  if (ready_.load(std::memory_order_acquire))
+    return true;
+
+  std::lock_guard lock(mutex_);
+  if (ready_.load(std::memory_order_acquire))
+    return true;
+  if (!config_.enabled || !config_.guest_device.present) {
+    errno = EINVAL;
+    return false;
+  }
+  if (!ensure_real_kfd_locked())
+    return false;
+  if (host_gpu_id_ == 0) {
+    std::optional<uint32_t> host_gpu_id = first_real_gpu_id_matching_isa(config_.host_isa);
+    if (!host_gpu_id) {
+      errno = ENODEV;
+      return false;
+    }
+    host_gpu_id_ = *host_gpu_id;
+  }
+  if (!overlay_.generate(guest_)) {
+    errno = ENODEV;
+    return false;
+  }
+  ready_.store(true, std::memory_order_release);
+  return true;
+}
+
+int GuestKfd::open() {
+  if (!ensure_ready())
+    return -1;
+  return fd();
+}
+
+int GuestKfd::close() { return 0; }
+
+int GuestKfd::forward_ioctl(unsigned long request, void *arg) {
+  int kfd_fd = fd();
+  if (kfd_fd < 0) {
+    errno = ENODEV;
+    return -ENODEV;
+  }
+  int ret = libc_passthrough().ioctl(kfd_fd, request, arg);
+  if (ret < 0) {
+    // Driver::ioctl implementations return negative errno values internally,
+    // while the real libc ioctl reports -1 and stores the reason in errno.
+    // Preserve the specific kernel error so GuestKfd callers do not collapse
+    // every forwarded failure into a generic -1.
+    const int saved_errno = errno != 0 ? errno : EIO;
+    errno = saved_errno;
+    return -saved_errno;
+  }
+  return ret;
+}
+
+int GuestKfd::get_process_apertures_ioctl(void *arg) {
+  auto *args = static_cast<kfd_ioctl_get_process_apertures_new_args *>(arg);
+  if (!args) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  kfd_ioctl_get_process_apertures_new_args count_args{};
+  int ret = forward_ioctl(AMDKFD_IOC_GET_PROCESS_APERTURES_NEW, &count_args);
+  if (ret != 0)
+    return ret;
+  const uint32_t host_count = count_args.num_of_nodes;
+
+  if (args->num_of_nodes == 0 || args->kfd_process_device_apertures_ptr == 0) {
+    args->num_of_nodes = count_args.num_of_nodes + 1;
+    return 0;
+  }
+
+  auto *out = reinterpret_cast<kfd_process_device_apertures *>(
+      static_cast<uintptr_t>(args->kfd_process_device_apertures_ptr));
+  const uint32_t requested = args->num_of_nodes;
+  // The caller controls requested capacity, so allocate only enough temporary
+  // space for the host nodes KFD reported. The guest aperture is appended
+  // directly into the caller buffer only when the caller supplied a spare slot.
+  const uint32_t host_capacity = std::min(requested, host_count);
+  std::vector<kfd_process_device_apertures> host(host_capacity);
+  if (!host.empty()) {
+    kfd_ioctl_get_process_apertures_new_args host_args{};
+    host_args.kfd_process_device_apertures_ptr =
+        reinterpret_cast<uint64_t>(reinterpret_cast<uintptr_t>(host.data()));
+    host_args.num_of_nodes = host_capacity;
+    ret = forward_ioctl(AMDKFD_IOC_GET_PROCESS_APERTURES_NEW, &host_args);
+    if (ret != 0)
+      return ret;
+    const uint32_t host_to_copy = std::min(host_capacity, host_args.num_of_nodes);
+    for (uint32_t i = 0; i < host_to_copy; ++i)
+      out[i] = host[i];
+    if (requested > host_to_copy) {
+      out[host_to_copy] = guest_apertures();
+      args->num_of_nodes = host_to_copy + 1;
+    } else {
+      args->num_of_nodes = host_to_copy;
+    }
+    return 0;
+  }
+  if (requested > 0) {
+    out[0] = guest_apertures();
+    args->num_of_nodes = 1;
+  }
+  return 0;
+}
+
+int GuestKfd::get_clock_counters_ioctl(void *arg) {
+  auto *args = static_cast<kfd_ioctl_get_clock_counters_args *>(arg);
+  if (!args) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (args->gpu_id != guest_.gpu_id)
+    return forward_ioctl(AMDKFD_IOC_GET_CLOCK_COUNTERS, arg);
+
+  return LinuxKfd::get_clock_counters_ioctl(arg);
+}
+
+int GuestKfd::acquire_vm_ioctl(void *arg) {
+  auto *args = static_cast<kfd_ioctl_acquire_vm_args *>(arg);
+  if (!args) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (args->gpu_id == guest_.gpu_id)
+    return 0;
+  return forward_ioctl(AMDKFD_IOC_ACQUIRE_VM, arg);
+}
+
+int GuestKfd::get_available_memory_ioctl(void *arg) {
+  auto *args = static_cast<kfd_ioctl_get_available_memory_args *>(arg);
+  if (!args) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (args->gpu_id == guest_.gpu_id) {
+    args->available = guest_.local_mem_size;
+    return 0;
+  }
+  return forward_ioctl(AMDKFD_IOC_AVAILABLE_MEMORY, arg);
+}
+
+int GuestKfd::set_memory_policy_ioctl(void *arg) {
+  auto *args = static_cast<kfd_ioctl_set_memory_policy_args *>(arg);
+  if (!args) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (args->gpu_id == guest_.gpu_id)
+    return 0;
+  return forward_ioctl(AMDKFD_IOC_SET_MEMORY_POLICY, arg);
+}
+
+int GuestKfd::alloc_memory_ioctl(void *arg) {
+  auto *args = static_cast<kfd_ioctl_alloc_memory_of_gpu_args *>(arg);
+  if (!args) {
+    errno = EINVAL;
+    return -1;
+  }
+  if (args->gpu_id != guest_.gpu_id) {
+    int ret = forward_ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, arg);
+    if (ret == 0)
+      assert(args->handle < kSyntheticHandleBase);
+    return ret;
+  }
+
+  std::lock_guard lock(mutex_);
+  args->handle = next_synthetic_handle_++;
+  synthetic_handles_.insert(args->handle);
+  return 0;
+}
+
+int GuestKfd::free_memory_ioctl(void *arg) {
+  auto *args = static_cast<kfd_ioctl_free_memory_of_gpu_args *>(arg);
+  if (!args) {
+    errno = EINVAL;
+    return -1;
+  }
+  {
+    std::lock_guard lock(mutex_);
+    if (synthetic_handles_.erase(args->handle) != 0)
+      return 0;
+  }
+  assert(args->handle < kSyntheticHandleBase);
+  return forward_ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, arg);
+}
+
+template <typename Args>
+int GuestKfd::map_or_unmap_memory_ioctl(Args *args, unsigned long request) {
+  if (!args) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  uint32_t host_gpu_id = 0;
+  {
+    std::lock_guard lock(mutex_);
+    host_gpu_id = host_gpu_id_;
+    if (synthetic_handles_.count(args->handle) != 0) {
+      args->n_success = args->n_devices;
+      return 0;
+    }
+  }
+
+  auto *ids =
+      reinterpret_cast<const uint32_t *>(static_cast<uintptr_t>(args->device_ids_array_ptr));
+  if (!ids) {
+    assert(args->handle < kSyntheticHandleBase);
+    return forward_ioctl(request, args);
+  }
+
+  std::vector<uint32_t> host_ids;
+  host_ids.reserve(args->n_devices);
+  bool has_guest = false;
+  for (uint32_t i = 0; i < args->n_devices; ++i) {
+    if (ids[i] == guest_.gpu_id) {
+      has_guest = true;
+      append_unique_gpu_id(&host_ids, host_gpu_id);
+    } else {
+      append_unique_gpu_id(&host_ids, ids[i]);
+    }
+  }
+  if (!has_guest) {
+    assert(args->handle < kSyntheticHandleBase);
+    return forward_ioctl(request, args);
+  }
+  if (host_ids.empty()) {
+    args->n_success = args->n_devices;
+    return 0;
+  }
+
+  assert(args->handle < kSyntheticHandleBase);
+  auto host_args = *args;
+  host_args.device_ids_array_ptr =
+      reinterpret_cast<uint64_t>(reinterpret_cast<uintptr_t>(host_ids.data()));
+  host_args.n_devices = static_cast<uint32_t>(host_ids.size());
+  host_args.n_success = 0;
+  int ret = forward_ioctl(request, &host_args);
+  if (ret != 0)
+    return ret;
+  args->n_success = args->n_devices;
+  return 0;
+}
+
+int GuestKfd::map_memory_ioctl(void *arg) {
+  return map_or_unmap_memory_ioctl(static_cast<kfd_ioctl_map_memory_to_gpu_args *>(arg),
+                                   AMDKFD_IOC_MAP_MEMORY_TO_GPU);
+}
+
+int GuestKfd::unmap_memory_ioctl(void *arg) {
+  return map_or_unmap_memory_ioctl(static_cast<kfd_ioctl_unmap_memory_from_gpu_args *>(arg),
+                                   AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU);
+}
+
+int GuestKfd::ioctl(unsigned long request, void *arg) {
+  if (!ensure_ready())
+    return -1;
+
+  switch (canonical_ioctl_request(request)) {
+  case AMDKFD_IOC_GET_PROCESS_APERTURES_NEW:
+    return get_process_apertures_ioctl(arg);
+  case AMDKFD_IOC_GET_CLOCK_COUNTERS:
+    return get_clock_counters_ioctl(arg);
+  case AMDKFD_IOC_ACQUIRE_VM:
+    return acquire_vm_ioctl(arg);
+  case AMDKFD_IOC_AVAILABLE_MEMORY:
+    return get_available_memory_ioctl(arg);
+  case AMDKFD_IOC_SET_MEMORY_POLICY:
+    return set_memory_policy_ioctl(arg);
+  case AMDKFD_IOC_ALLOC_MEMORY_OF_GPU:
+    return alloc_memory_ioctl(arg);
+  case AMDKFD_IOC_FREE_MEMORY_OF_GPU:
+    return free_memory_ioctl(arg);
+  case AMDKFD_IOC_MAP_MEMORY_TO_GPU:
+    return map_memory_ioctl(arg);
+  case AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU:
+    return unmap_memory_ioctl(arg);
+  case AMDKFD_IOC_GET_VERSION:
+    return get_version_ioctl(arg);
+  case AMDKFD_IOC_SET_XNACK_MODE:
+  case AMDKFD_IOC_RUNTIME_ENABLE:
+    return forward_ioctl(request, arg);
+  default:
+    if (request_targets_guest(request, arg))
+      return reject_guest_execution_ioctl(request, arg);
+    return forward_ioctl(request, arg);
+  }
+}
+
+void *GuestKfd::mmap(void *addr, size_t length, int prot, int flags, off_t offset) {
+  if (!ensure_ready())
+    return MAP_FAILED;
+  int kfd_fd = fd();
+  if (kfd_fd < 0) {
+    errno = ENODEV;
+    return MAP_FAILED;
+  }
+  uint64_t encoded_gpu =
+      (static_cast<uint64_t>(offset) & ~KFD_MMAP_TYPE_MASK) >> KFD_MMAP_GPU_ID_SHIFT;
+  if ((static_cast<uint64_t>(offset) & KFD_MMAP_TYPE_MASK) == KFD_MMAP_TYPE_DOORBELL &&
+      encoded_gpu == guest_.gpu_id) {
+    errno = ENODEV;
+    return MAP_FAILED;
+  }
+  return libc_passthrough().mmap(addr, length, prot, flags, kfd_fd, offset);
+}
+
+int GuestKfd::munmap(void *, size_t) { return -ENOENT; }
+
+bool GuestKfd::owns_fd(int) const { return false; }
+
+int GuestKfd::fd() const { return real_kfd_fd_.load(std::memory_order_acquire); }
+
+std::string GuestKfd::redirect_sysfs_path(const char *path) const {
+  if (!path)
+    return {};
+
+  if (!ready_.load(std::memory_order_acquire))
+    return {};
+
+  auto redirected = redirect_sysfs_root_path(path, overlay_.topology_path(), {});
+  if (!redirected.empty())
+    return redirected;
+  if (overlay_.guest_drm_path().empty())
+    return {};
+
+  std::string_view sv(path);
+  uint32_t minor = 0;
+  std::string_view suffix;
+  if (parse_drm_render_path(sv, &minor, &suffix) && minor == guest_.drm_render_minor)
+    return overlay_.guest_drm_path() + "/renderD" + std::to_string(minor) + std::string(suffix);
+  if (parse_sys_dev_drm_render_path(sv, &minor, &suffix) && minor == guest_.drm_render_minor)
+    return overlay_.guest_drm_path() + "/renderD" + std::to_string(minor) + std::string(suffix);
+
+  constexpr std::string_view kDevDriRenderPrefix = "/dev/dri/renderD";
+  if (sv.starts_with(kDevDriRenderPrefix)) {
+    auto rest = sv.substr(kDevDriRenderPrefix.size());
+    auto slash = rest.find('/');
+    auto number = slash == std::string_view::npos ? rest : rest.substr(0, slash);
+    uint32_t parsed = 0;
+    auto [ptr, err] = std::from_chars(number.data(), number.data() + number.size(), parsed);
+    if (err == std::errc{} && ptr == number.data() + number.size() &&
+        parsed == guest_.drm_render_minor) {
+      auto dev_suffix = slash == std::string_view::npos ? std::string_view{} : rest.substr(slash);
+      return overlay_.guest_drm_path() + "/dev_dri/renderD" + std::to_string(parsed) +
+             std::string(dev_suffix);
+    }
+  }
+
+  return {};
+}
+
+bool GuestKfd::is_doorbell_range(const void *, size_t) const { return false; }
+
+bool GuestKfd::handles_drm_render_minor(uint32_t minor) const {
+  return ready_.load(std::memory_order_acquire) && minor == guest_.drm_render_minor;
+}
+
+const Sysfs::GpuInfo *GuestKfd::gpu_info_for_render_minor(uint32_t minor) const {
+  return handles_drm_render_minor(minor) ? &guest_ : nullptr;
+}
+
+std::string GuestKfd::topology_path() const {
+  return ready_.load(std::memory_order_acquire) ? overlay_.topology_path() : std::string{};
+}
+
+int GuestKfd::reject_guest_execution_ioctl(unsigned long request, void *) const {
+  util::Logger::debug_print("rocjitsu guest gpu: rejecting ", LinuxKfd::ioctl_name(request),
+                            " for guest gpu_id=", guest_.gpu_id);
+  errno = ENODEV;
+  return -1;
+}
+
+bool GuestKfd::request_targets_guest(unsigned long request, void *arg) const {
+  if (!arg)
+    return false;
+  switch (canonical_ioctl_request(request)) {
+  case AMDKFD_IOC_CREATE_QUEUE:
+    return static_cast<kfd_ioctl_create_queue_args *>(arg)->gpu_id == guest_.gpu_id;
+  case AMDKFD_IOC_SET_MEMORY_POLICY:
+    return static_cast<kfd_ioctl_set_memory_policy_args *>(arg)->gpu_id == guest_.gpu_id;
+  case AMDKFD_IOC_ALLOC_MEMORY_OF_GPU:
+    return static_cast<kfd_ioctl_alloc_memory_of_gpu_args *>(arg)->gpu_id == guest_.gpu_id;
+  case AMDKFD_IOC_IMPORT_DMABUF:
+    return static_cast<kfd_ioctl_import_dmabuf_args *>(arg)->gpu_id == guest_.gpu_id;
+  case AMDKFD_IOC_SMI_EVENTS:
+    return static_cast<kfd_ioctl_smi_events_args *>(arg)->gpuid == guest_.gpu_id;
+  case AMDKFD_IOC_SET_SCRATCH_BACKING_VA:
+    return static_cast<kfd_ioctl_set_scratch_backing_va_args *>(arg)->gpu_id == guest_.gpu_id;
+  case AMDKFD_IOC_GET_TILE_CONFIG:
+    return static_cast<kfd_ioctl_get_tile_config_args *>(arg)->gpu_id == guest_.gpu_id;
+  case AMDKFD_IOC_SET_TRAP_HANDLER:
+    return static_cast<kfd_ioctl_set_trap_handler_args *>(arg)->gpu_id == guest_.gpu_id;
+  case AMDKFD_IOC_MAP_MEMORY_TO_GPU: {
+    auto *a = static_cast<kfd_ioctl_map_memory_to_gpu_args *>(arg);
+    auto *ids = reinterpret_cast<const uint32_t *>(static_cast<uintptr_t>(a->device_ids_array_ptr));
+    return ids && std::find(ids, ids + a->n_devices, guest_.gpu_id) != ids + a->n_devices;
+  }
+  case AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU: {
+    auto *a = static_cast<kfd_ioctl_unmap_memory_from_gpu_args *>(arg);
+    auto *ids = reinterpret_cast<const uint32_t *>(static_cast<uintptr_t>(a->device_ids_array_ptr));
+    return ids && std::find(ids, ids + a->n_devices, guest_.gpu_id) != ids + a->n_devices;
+  }
+  case AMDKFD_IOC_SVM: {
+    auto *a = static_cast<kfd_ioctl_svm_args *>(arg);
+    for (uint32_t i = 0; i < a->nattr; ++i) {
+      auto &attr = a->attrs[i];
+      if ((attr.type == KFD_IOCTL_SVM_ATTR_PREFERRED_LOC ||
+           attr.type == KFD_IOCTL_SVM_ATTR_PREFETCH_LOC || attr.type == KFD_IOCTL_SVM_ATTR_ACCESS ||
+           attr.type == KFD_IOCTL_SVM_ATTR_ACCESS_IN_PLACE ||
+           attr.type == KFD_IOCTL_SVM_ATTR_NO_ACCESS) &&
+          attr.value == guest_.gpu_id)
+        return true;
+    }
+    return false;
+  }
+  default:
+    return false;
+  }
+}
+
+kfd_process_device_apertures GuestKfd::guest_apertures() const {
+  uint32_t guest_node_id = 0;
+  {
+    std::lock_guard lock(mutex_);
+    guest_node_id = overlay_.guest_node_id();
+  }
+  const uint64_t ordinal = std::max<uint32_t>(1, guest_node_id);
+  const uint64_t aperture_stride = 0x10000000000ULL;
+  kfd_process_device_apertures apertures{};
+  apertures.lds_base = 0x1000000000000ULL + ordinal * aperture_stride;
+  apertures.lds_limit = apertures.lds_base + 0xFFFFFFFFULL;
+  apertures.scratch_base = 0x2000000000000ULL + ordinal * aperture_stride;
+  apertures.scratch_limit = apertures.scratch_base + 0xFFFFFFFFULL;
+  apertures.gpuvm_base = 0x1000000000ULL;
+  apertures.gpuvm_limit = 0x3FFFFFFFFFFFULL;
+  apertures.gpu_id = guest_.gpu_id;
+  return apertures;
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.cpp
@@ -35,7 +35,12 @@ namespace {
 
 namespace fs = std::filesystem;
 
-constexpr const char *kRealTopologyPath = "/sys/devices/virtual/kfd/kfd/topology";
+constexpr std::string_view kRealTopologyPaths[] = {
+    "/sys/devices/virtual/kfd/kfd/topology",
+    "/sys/class/kfd/kfd/topology",
+};
+constexpr uint64_t kGuestSyntheticMmapType = 0x1ULL << KFD_MMAP_TYPE_SHIFT;
+constexpr uint64_t kGuestSyntheticMmapPayloadMask = (1ULL << KFD_MMAP_TYPE_SHIFT) - 1;
 
 std::string read_text_file(const fs::path &path) {
   const std::string path_str = path.string();
@@ -176,18 +181,20 @@ std::optional<uint32_t> first_real_gpu_id_matching_isa(std::string_view host_isa
   if (!target_version)
     return std::nullopt;
 
-  fs::path nodes_dir = fs::path(kRealTopologyPath) / "nodes";
-  const uint32_t max_node = max_numeric_dir(nodes_dir);
-  for (uint32_t node_id = 1; node_id <= max_node; ++node_id) {
-    fs::path node_dir = nodes_dir / std::to_string(node_id);
-    const uint32_t gfx_target_version =
-        read_u32_property(node_dir / "properties", "gfx_target_version", 0);
-    if (gfx_target_version != *target_version)
-      continue;
+  for (std::string_view topology_path : kRealTopologyPaths) {
+    fs::path nodes_dir = fs::path(std::string(topology_path)) / "nodes";
+    const uint32_t max_node = max_numeric_dir(nodes_dir);
+    for (uint32_t node_id = 1; node_id <= max_node; ++node_id) {
+      fs::path node_dir = nodes_dir / std::to_string(node_id);
+      const uint32_t gfx_target_version =
+          read_u32_property(node_dir / "properties", "gfx_target_version", 0);
+      if (gfx_target_version != *target_version)
+        continue;
 
-    std::optional<uint32_t> gpu_id = read_u32_file(node_dir / "gpu_id");
-    if (gpu_id && *gpu_id != 0)
-      return gpu_id;
+      std::optional<uint32_t> gpu_id = read_u32_file(node_dir / "gpu_id");
+      if (gpu_id && *gpu_id != 0)
+        return gpu_id;
+    }
   }
   return std::nullopt;
 }
@@ -244,6 +251,14 @@ uint32_t choose_render_minor(uint32_t requested) {
   }
   return (requested >= kRenderMinorBegin && requested < kRenderMinorEnd) ? requested
                                                                          : kRenderMinorEnd - 1;
+}
+
+uint64_t synthetic_mmap_offset_for_handle(uint64_t handle, uint64_t handle_base) {
+  // KFD allocation mmap offsets normally use type 0. Use the otherwise unused
+  // type-1 top-bit pattern for guest-only allocations, and keep a private set
+  // of emitted offsets so GuestKfd::mmap() can reject only offsets it created.
+  const uint64_t ordinal = handle - handle_base + 1;
+  return kGuestSyntheticMmapType | ((ordinal << 12) & kGuestSyntheticMmapPayloadMask);
 }
 
 bool passthrough_lstat(const std::string &path, struct stat *st) {
@@ -346,6 +361,9 @@ private:
   /// @brief Copy a host sysfs subtree into the generated overlay.
   bool copy_tree(const std::string &src, const std::string &dst);
 
+  /// @brief Copy the first available real KFD topology root into the overlay.
+  bool copy_host_topology();
+
   /// @brief Generate the appended guest KFD node and guest DRM metadata.
   bool copy_guest_node(const Sysfs::GpuInfo &guest);
 
@@ -416,6 +434,22 @@ bool GuestKfd::TopologyOverlay::copy_tree(const std::string &src, const std::str
   return ok;
 }
 
+bool GuestKfd::TopologyOverlay::copy_host_topology() {
+  for (std::string_view topology_path : kRealTopologyPaths) {
+    if (copy_tree(std::string(topology_path), topology_dir_))
+      return true;
+
+    // If the first topology root is absent or only partially copyable, reset
+    // the destination before trying the alternate root. This mirrors the
+    // launcher/HSA-hook discovery policy without mixing trees from two roots.
+    std::error_code ec;
+    fs::remove_all(topology_dir_, ec);
+    ec.clear();
+    fs::create_directories(topology_dir_, ec);
+  }
+  return false;
+}
+
 bool GuestKfd::TopologyOverlay::copy_guest_node(const Sysfs::GpuInfo &guest) {
   if (guest_sysfs_.generate(guest).empty())
     return false;
@@ -456,7 +490,7 @@ bool GuestKfd::TopologyOverlay::generate(const Sysfs::GpuInfo &guest) {
   cleanup();
   if (!make_temp_dir("rocjitsu_guest_topology", &topology_dir_))
     return false;
-  if (!copy_tree(kRealTopologyPath, topology_dir_)) {
+  if (!copy_host_topology()) {
     cleanup();
     return false;
   }
@@ -513,6 +547,7 @@ void GuestKfd::reset_after_fork() {
   open_refs_ = 0;
   overlay_->release_after_fork();
   synthetic_handles_.clear();
+  synthetic_mmap_offsets_.clear();
   next_synthetic_handle_ = kSyntheticHandleBase;
 }
 
@@ -602,6 +637,7 @@ int GuestKfd::close() {
     kfd_fd = real_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
     ready_.store(false, std::memory_order_release);
     synthetic_handles_.clear();
+    synthetic_mmap_offsets_.clear();
     next_synthetic_handle_ = kSyntheticHandleBase;
     // Removing copied sysfs trees can block on filesystem work. Swap the
     // overlay object while serialized, then perform the actual remove_all after
@@ -747,7 +783,9 @@ int GuestKfd::alloc_memory_ioctl(void *arg) {
 
   std::lock_guard lock(mutex_);
   args->handle = next_synthetic_handle_++;
+  args->mmap_offset = synthetic_mmap_offset_for_handle(args->handle, kSyntheticHandleBase);
   synthetic_handles_.insert(args->handle);
+  synthetic_mmap_offsets_.insert(args->mmap_offset);
   return 0;
 }
 
@@ -759,8 +797,11 @@ int GuestKfd::free_memory_ioctl(void *arg) {
   }
   {
     std::lock_guard lock(mutex_);
-    if (synthetic_handles_.erase(args->handle) != 0)
+    if (synthetic_handles_.erase(args->handle) != 0) {
+      synthetic_mmap_offsets_.erase(
+          synthetic_mmap_offset_for_handle(args->handle, kSyntheticHandleBase));
       return 0;
+    }
   }
   assert(args->handle < kSyntheticHandleBase);
   return forward_ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, arg);
@@ -878,6 +919,13 @@ void *GuestKfd::mmap(void *addr, size_t length, int prot, int flags, off_t offse
   }
   uint64_t encoded_gpu =
       (static_cast<uint64_t>(offset) & ~KFD_MMAP_TYPE_MASK) >> KFD_MMAP_GPU_ID_SHIFT;
+  {
+    std::lock_guard lock(mutex_);
+    if (synthetic_mmap_offsets_.count(static_cast<uint64_t>(offset)) != 0) {
+      errno = ENODEV;
+      return MAP_FAILED;
+    }
+  }
   if ((static_cast<uint64_t>(offset) & KFD_MMAP_TYPE_MASK) == KFD_MMAP_TYPE_DOORBELL &&
       encoded_gpu == guest_.gpu_id) {
     errno = ENODEV;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file guest_kfd.h
+/// @brief KFD discovery driver that appends one synthetic DBT guest GPU.
+
+#ifndef ROCJITSU_KMD_LINUX_GUEST_KFD_H_
+#define ROCJITSU_KMD_LINUX_GUEST_KFD_H_
+
+#include "rocjitsu/config/config_loader.h"
+#include "rocjitsu/kmd/linux/linux_kfd.h"
+#include "rocjitsu/kmd/linux/sysfs.h"
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "linux/uapi/kfd_ioctl.h"
+RJ_DIAGNOSTIC_POP
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+
+namespace rocjitsu {
+
+/// @brief Generated topology overlay containing host KFD nodes plus one guest node.
+///
+/// @details The overlay copies the real host topology from sysfs, then appends a
+/// guest GPU node generated from the configured KFD identity. Only KFD topology
+/// paths and the guest DRM render node are redirected to this overlay; host DRM
+/// paths remain real so ROCR can still create a host agent and execute on it.
+class TopologyOverlay {
+public:
+  /// @brief Construct an empty overlay.
+  TopologyOverlay() = default;
+
+  /// @brief Remove any generated overlay directories owned by this instance.
+  ~TopologyOverlay();
+
+  /// @brief Overlays own temporary filesystem state and cannot be copied.
+  TopologyOverlay(const TopologyOverlay &) = delete;
+
+  /// @brief Overlays own temporary filesystem state and cannot be copied.
+  TopologyOverlay &operator=(const TopologyOverlay &) = delete;
+
+  /// @brief Build the overlay from the current host sysfs topology.
+  /// @param guest Synthetic guest GPU properties to append.
+  /// @returns true when topology and guest DRM paths are ready.
+  bool generate(const Sysfs::GpuInfo &guest);
+
+  /// @brief Remove generated overlay directories.
+  void cleanup();
+
+  /// @brief Drop inherited overlay ownership without removing parent-owned paths.
+  void release_after_fork();
+
+  /// @brief Generated KFD topology root.
+  [[nodiscard]] const std::string &topology_path() const { return topology_dir_; }
+
+  /// @brief Generated DRM root containing the guest render node.
+  [[nodiscard]] const std::string &guest_drm_path() const { return guest_drm_dir_; }
+
+  /// @brief Synthetic topology node ID assigned to the guest GPU.
+  [[nodiscard]] uint32_t guest_node_id() const { return guest_node_id_; }
+
+private:
+  /// @brief Copy a host sysfs subtree into the generated overlay.
+  bool copy_tree(const std::string &src, const std::string &dst);
+
+  /// @brief Generate the appended guest KFD node and guest DRM metadata.
+  bool copy_guest_node(const Sysfs::GpuInfo &guest);
+
+  /// @brief Patch aggregate topology files after appending the guest node.
+  bool patch_topology_files();
+
+  std::string topology_dir_;
+  std::string guest_drm_dir_;
+  Sysfs guest_sysfs_;
+  uint32_t guest_node_id_ = 0;
+};
+
+/// @brief KFD driver that exposes a guest GPU for DBT while forwarding host GPU work.
+///
+/// @details KFD emulation ends at discovery: this class appends one guest GPU
+/// to KFD topology and process apertures, but does not execute guest queues.
+/// Host-GPU ioctls are forwarded to the real /dev/kfd. If an execution ioctl
+/// still targets the guest GPU, the driver returns an error so the missing HSA
+/// forwarding path is visible.
+class GuestKfd : public LinuxKfd {
+public:
+  /// @brief Construct a guest discovery driver from parsed DBT configuration.
+  explicit GuestKfd(config::DbtGuestConfig config);
+
+  /// @brief Close the real KFD fd and remove generated overlay state.
+  ~GuestKfd() override;
+
+  /// @brief Open the real /dev/kfd fd and lazily prepare guest discovery.
+  int open() override;
+
+  /// @brief Handle close for the /dev/kfd fd represented by this driver.
+  int close() override;
+
+  /// @brief Route guest discovery ioctls locally and host ioctls to real KFD.
+  int ioctl(unsigned long request, void *arg) override;
+
+  /// @brief Map host-backed KFD offsets and reject unsupported guest doorbells.
+  void *mmap(void *addr, size_t length, int prot, int flags, off_t offset) override;
+
+  /// @brief Forward unmaps for mappings created through this driver.
+  int munmap(void *addr, size_t length) override;
+
+  /// @brief Return the real /dev/kfd fd.
+  [[nodiscard]] int fd() const override;
+
+  /// @brief Return true when @p fd is an internal rocjitsu-owned fd.
+  [[nodiscard]] bool owns_fd(int fd) const override;
+
+  /// @brief Redirect KFD topology and guest DRM sysfs paths into the overlay.
+  [[nodiscard]] std::string redirect_sysfs_path(const char *path) const override;
+
+  /// @brief Return true if a mapping range overlaps a protected doorbell.
+  [[nodiscard]] bool is_doorbell_range(const void *addr, size_t length) const override;
+
+  /// @brief Return true when @p minor is the configured guest render node.
+  [[nodiscard]] bool handles_drm_render_minor(uint32_t minor) const override;
+
+  /// @brief Return synthetic AMDGPU metadata for the guest render node.
+  [[nodiscard]] const Sysfs::GpuInfo *gpu_info_for_render_minor(uint32_t minor) const override;
+
+  /// @brief Return the generated KFD topology root.
+  [[nodiscard]] std::string topology_path() const override;
+
+  /// @brief Return an empty DRM root because host DRM paths stay real.
+  [[nodiscard]] std::string drm_path() const override { return {}; }
+
+  /// @brief Detach inherited child-process state before destroying this copy.
+  void reset_after_fork() override;
+
+private:
+  /// @brief Open real KFD, generate topology, and select the host GPU.
+  bool ensure_ready();
+
+  /// @brief Open the process's real /dev/kfd fd while mutex_ is held.
+  bool ensure_real_kfd_locked();
+
+  /// @brief Forward one ioctl to the real /dev/kfd fd.
+  int forward_ioctl(unsigned long request, void *arg);
+
+  /// @brief Return real process apertures plus one synthetic guest aperture.
+  int get_process_apertures_ioctl(void *arg) override;
+
+  /// @brief Return guest clock-counter values or forward host requests.
+  int get_clock_counters_ioctl(void *arg) override;
+
+  /// @brief Succeed guest VM acquisition without creating a guest execution VM.
+  int acquire_vm_ioctl(void *arg) override;
+
+  /// @brief Report the configured guest-visible local memory size.
+  int get_available_memory_ioctl(void *arg) override;
+
+  /// @brief Accept guest startup memory policy setup and forward host policy.
+  int set_memory_policy_ioctl(void *arg) override;
+
+  /// @brief Allocate a synthetic KFD memory handle for guest startup bookkeeping.
+  int alloc_memory_ioctl(void *arg) override;
+
+  /// @brief Release a synthetic KFD memory handle or forward a real handle.
+  int free_memory_ioctl(void *arg) override;
+
+  /// @brief Rewrite guest gpu_id entries to the selected host before mapping.
+  int map_memory_ioctl(void *arg) override;
+
+  /// @brief Mirror map_memory rewrites for unmap requests.
+  int unmap_memory_ioctl(void *arg) override;
+
+  /// @brief Shared guest-to-host device-id rewrite for map/unmap memory ioctls.
+  template <typename Args> int map_or_unmap_memory_ioctl(Args *args, unsigned long request);
+
+  /// @brief Fail unsupported guest execution ioctls visibly.
+  int reject_guest_execution_ioctl(unsigned long request, void *arg) const;
+
+  /// @brief Return true when an ioctl argument names the synthetic guest GPU.
+  bool request_targets_guest(unsigned long request, void *arg) const;
+
+  /// @brief Build the synthetic aperture record appended after real apertures.
+  kfd_process_device_apertures guest_apertures() const;
+
+  config::DbtGuestConfig config_;
+  Sysfs::GpuInfo guest_{};
+  TopologyOverlay overlay_;
+  mutable std::mutex mutex_;
+  std::atomic<int> real_kfd_fd_{-1};
+  uint32_t host_gpu_id_ = 0;
+  static constexpr uint64_t kSyntheticHandleBase = 1ULL << 63;
+  uint64_t next_synthetic_handle_ = kSyntheticHandleBase;
+  std::unordered_set<uint64_t> synthetic_handles_;
+  std::atomic<bool> ready_{false};
+};
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_KMD_LINUX_GUEST_KFD_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
@@ -150,6 +150,7 @@ private:
   static constexpr uint64_t kSyntheticHandleBase = 1ULL << 63;
   uint64_t next_synthetic_handle_ = kSyntheticHandleBase;
   std::unordered_set<uint64_t> synthetic_handles_;
+  std::unordered_set<uint64_t> synthetic_mmap_offsets_;
   std::atomic<bool> ready_{false};
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/guest_kfd.h
@@ -19,67 +19,12 @@ RJ_DIAGNOSTIC_POP
 
 #include <atomic>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_set>
 
 namespace rocjitsu {
-
-/// @brief Generated topology overlay containing host KFD nodes plus one guest node.
-///
-/// @details The overlay copies the real host topology from sysfs, then appends a
-/// guest GPU node generated from the configured KFD identity. Only KFD topology
-/// paths and the guest DRM render node are redirected to this overlay; host DRM
-/// paths remain real so ROCR can still create a host agent and execute on it.
-class TopologyOverlay {
-public:
-  /// @brief Construct an empty overlay.
-  TopologyOverlay() = default;
-
-  /// @brief Remove any generated overlay directories owned by this instance.
-  ~TopologyOverlay();
-
-  /// @brief Overlays own temporary filesystem state and cannot be copied.
-  TopologyOverlay(const TopologyOverlay &) = delete;
-
-  /// @brief Overlays own temporary filesystem state and cannot be copied.
-  TopologyOverlay &operator=(const TopologyOverlay &) = delete;
-
-  /// @brief Build the overlay from the current host sysfs topology.
-  /// @param guest Synthetic guest GPU properties to append.
-  /// @returns true when topology and guest DRM paths are ready.
-  bool generate(const Sysfs::GpuInfo &guest);
-
-  /// @brief Remove generated overlay directories.
-  void cleanup();
-
-  /// @brief Drop inherited overlay ownership without removing parent-owned paths.
-  void release_after_fork();
-
-  /// @brief Generated KFD topology root.
-  [[nodiscard]] const std::string &topology_path() const { return topology_dir_; }
-
-  /// @brief Generated DRM root containing the guest render node.
-  [[nodiscard]] const std::string &guest_drm_path() const { return guest_drm_dir_; }
-
-  /// @brief Synthetic topology node ID assigned to the guest GPU.
-  [[nodiscard]] uint32_t guest_node_id() const { return guest_node_id_; }
-
-private:
-  /// @brief Copy a host sysfs subtree into the generated overlay.
-  bool copy_tree(const std::string &src, const std::string &dst);
-
-  /// @brief Generate the appended guest KFD node and guest DRM metadata.
-  bool copy_guest_node(const Sysfs::GpuInfo &guest);
-
-  /// @brief Patch aggregate topology files after appending the guest node.
-  bool patch_topology_files();
-
-  std::string topology_dir_;
-  std::string guest_drm_dir_;
-  Sysfs guest_sysfs_;
-  uint32_t guest_node_id_ = 0;
-};
 
 /// @brief KFD driver that exposes a guest GPU for DBT while forwarding host GPU work.
 ///
@@ -138,7 +83,15 @@ public:
   /// @brief Detach inherited child-process state before destroying this copy.
   void reset_after_fork() override;
 
+  /// @brief Prepare guest discovery without retaining an application open fd.
+  bool prepare_for_discovery();
+
+  /// @brief Add one open reference for a duplicated KFD fd.
+  void retain_local_open() override;
+
 private:
+  class TopologyOverlay;
+
   /// @brief Open real KFD, generate topology, and select the host GPU.
   bool ensure_ready();
 
@@ -189,9 +142,10 @@ private:
 
   config::DbtGuestConfig config_;
   Sysfs::GpuInfo guest_{};
-  TopologyOverlay overlay_;
+  std::unique_ptr<TopologyOverlay> overlay_;
   mutable std::mutex mutex_;
   std::atomic<int> real_kfd_fd_{-1};
+  uint32_t open_refs_ = 0;
   uint32_t host_gpu_id_ = 0;
   static constexpr uint64_t kSyntheticHandleBase = 1ULL << 63;
   uint64_t next_synthetic_handle_ = kSyntheticHandleBase;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -97,7 +97,7 @@ static int connect_to_daemon() {
   addr.sun_family = AF_UNIX;
   path.copy(addr.sun_path, sizeof(addr.sun_path) - 1);
   if (connect(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0) {
-    syscall(SYS_close, sock);
+    rocjitsu::libc_passthrough().close(sock);
     return -1;
   }
   return sock;
@@ -126,12 +126,13 @@ int kfd_ioctl_ret(int r) {
 std::optional<std::string> child_config_path() {
   auto cfg_file = rocjitsu::rpc_default_config_file_path();
   char cfg_buf[4096]{};
-  int cfg_fd = static_cast<int>(syscall(SYS_openat, AT_FDCWD, cfg_file.c_str(), O_RDONLY, 0));
+  auto &real = rocjitsu::libc_passthrough();
+  int cfg_fd = real.openat(AT_FDCWD, cfg_file.c_str(), O_RDONLY, 0);
   if (cfg_fd < 0)
     return std::nullopt;
 
-  auto n = syscall(SYS_read, cfg_fd, cfg_buf, sizeof(cfg_buf) - 1);
-  syscall(SYS_close, cfg_fd);
+  auto n = real.read(cfg_fd, cfg_buf, sizeof(cfg_buf) - 1);
+  real.close(cfg_fd);
   if (n <= 0)
     return std::nullopt;
 
@@ -463,7 +464,7 @@ public:
         auto dbt_guest = rocjitsu::config::load_dbt_guest_config_from_file(*cfg_path);
         if (dbt_guest.enabled) {
           auto guest_driver = std::make_unique<GuestKfd>(std::move(dbt_guest));
-          if (guest_driver->open() < 0) {
+          if (!guest_driver->prepare_for_discovery()) {
             in_construction = false;
             return nullptr;
           }
@@ -661,7 +662,7 @@ static SyntheticDrmOpenResult open_synthetic_drm_fd(const char *path) {
   if (!local_handles_render && !remote_handles_render)
     return {};
 
-  auto raw_drm_fd = static_cast<int>(syscall(SYS_memfd_create, "rocjitsu_drm", MFD_CLOEXEC));
+  auto raw_drm_fd = InterposerContext::real().memfd_create("rocjitsu_drm", MFD_CLOEXEC);
   if (raw_drm_fd < 0)
     return {true, -1};
 
@@ -689,7 +690,7 @@ RJ_INTERPOSER_EXPORT int open(const char *path, int flags, ...) {
   assert(InterposerContext::real().ready());
   auto *volatile p = path;
   if (!p || InterposerContext::in_construction)
-    return static_cast<int>(syscall(SYS_openat, AT_FDCWD, path, flags, mode));
+    return InterposerContext::real().openat(AT_FDCWD, path, flags, mode);
 
   if (auto drm_fd = open_synthetic_drm_fd(path); drm_fd.handled)
     return drm_fd.fd;
@@ -703,9 +704,12 @@ RJ_INTERPOSER_EXPORT int open(const char *path, int flags, ...) {
       errno = ENODEV;
       return -1;
     }
-    drv->open();
-    InterposerContext::ctx.clear_dups();
-    return InterposerContext::ctx.driver_fd();
+    int kfd_fd = drv->open();
+    if (kfd_fd < 0)
+      return kfd_fd;
+    if (!drv->owns_fd(drv->fd()))
+      InterposerContext::ctx.clear_dups();
+    return kfd_fd;
   }
 
   std::string redirected = InterposerContext::ctx.redirect_sysfs_path(path);
@@ -1189,6 +1193,13 @@ RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, 
 
   if (auto *drv = InterposerContext::ctx.lookup(fd))
     return drv->mmap(addr, length, prot, flags, offset);
+
+  if (InterposerContext::ctx.is_kfd_dup(fd)) {
+    if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()))
+      return remote->mmap(addr, length, prot, flags, offset);
+    if (auto *drv = InterposerContext::ctx.driver())
+      return drv->mmap(addr, length, prot, flags, offset);
+  }
 
   if (InterposerContext::ctx.is_drm(fd)) {
     if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -2,17 +2,27 @@
 // SPDX-License-Identifier: MIT
 
 /// @file interposer.cpp
-/// @brief LD_PRELOAD interposer that redirects KFD syscalls to the simulated driver.
+/// @brief LD_PRELOAD interposer that redirects KFD syscalls to rocjitsu KFD drivers.
 ///
-/// @details Intercepts open, close, ioctl, mmap, munmap, and fopen to route
-/// /dev/kfd operations and sysfs topology reads through SimulatedDriver.
-/// All mutable state is consolidated in InterposerContext.
+/// @details Intercepts open, close, ioctl, mmap, munmap, and filesystem access
+/// to route /dev/kfd operations and sysfs topology reads through one of two
+/// strategies. Normal simulation creates a VM and uses SimulatedKfd to own all
+/// visible GPU discovery and queue execution. DBT guest mode does not create a
+/// VM: GuestKfd forwards host-GPU KFD work to the real /dev/kfd while appending
+/// one synthetic guest GPU for ROCR discovery. The HSA tools hook then maps
+/// guest-agent API calls to the selected host agent and translates guest code
+/// objects before loading them. All mutable state is consolidated in
+/// InterposerContext.
 
 #include "rocjitsu/base/rj_compiler.h"
+#include "rocjitsu/config/dbt_guest_config.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
+#include "rocjitsu/kmd/linux/guest_kfd.h"
+#include "rocjitsu/kmd/linux/libc_passthrough.h"
+#include "rocjitsu/kmd/linux/linux_kfd.h"
 #include "rocjitsu/kmd/linux/remote_driver.h"
 #include "rocjitsu/kmd/linux/rpc.h"
-#include "rocjitsu/kmd/linux/simulated_driver.h"
+#include "rocjitsu/kmd/linux/simulated_kfd.h"
 #include "rocjitsu/kmd/linux/sysfs.h"
 #include "rocjitsu/vm/plugins/execution_plugin_group.h"
 #include "rocjitsu/vm/plugins/plugin_sink.h"
@@ -42,12 +52,16 @@ RJ_DIAGNOSTIC_POP
 #include <csignal>
 #include <cstdarg>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <dirent.h>
 #include <dlfcn.h>
+#include <exception>
 #include <fcntl.h>
 #include <linux/memfd.h>
+#include <memory>
 #include <mutex>
+#include <optional>
 #include <signal.h>
 #include <sstream>
 #include <string>
@@ -63,12 +77,15 @@ RJ_DIAGNOSTIC_POP
 #include <unistd.h>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 extern "C" rocjitsu::ExecutionPlugin *createKernelLoggingPlugin();
 extern "C" rocjitsu::ExecutionPlugin *createRaceDetectorPlugin();
 
+using rocjitsu::GuestKfd;
+using rocjitsu::LinuxKfd;
 using rocjitsu::RemoteDriver;
-using rocjitsu::SimulatedDriver;
+using rocjitsu::SimulatedKfd;
 using rocjitsu::Sysfs;
 
 static int connect_to_daemon() {
@@ -102,6 +119,27 @@ int kfd_ioctl_ret(int r) {
   return r;
 }
 
+/// @brief Return the child-process rocjitsu config path.
+///
+/// @details The launcher writes the config path to the shared runtime file for
+/// both local simulation and DBT guest mode.
+std::optional<std::string> child_config_path() {
+  auto cfg_file = rocjitsu::rpc_default_config_file_path();
+  char cfg_buf[4096]{};
+  int cfg_fd = static_cast<int>(syscall(SYS_openat, AT_FDCWD, cfg_file.c_str(), O_RDONLY, 0));
+  if (cfg_fd < 0)
+    return std::nullopt;
+
+  auto n = syscall(SYS_read, cfg_fd, cfg_buf, sizeof(cfg_buf) - 1);
+  syscall(SYS_close, cfg_fd);
+  if (n <= 0)
+    return std::nullopt;
+
+  while (n > 0 && (cfg_buf[n - 1] == '\n' || cfg_buf[n - 1] == '\r'))
+    cfg_buf[--n] = '\0';
+  return std::string(cfg_buf);
+}
+
 void rj_sigsegv_handler(int, siginfo_t *, void *) {
   signal(SIGSEGV, SIG_DFL);
   raise(SIGSEGV);
@@ -114,76 +152,16 @@ __attribute__((constructor)) void rj_install_signal_handler() {
   sigaction(SIGSEGV, &sa, nullptr);
 }
 
-/// @brief Real libc function pointers resolved via dlsym(RTLD_NEXT).
-/// @details Holds the original libc implementations that our LD_PRELOAD
-/// interposer shadows. Resolved once at constructor time via resolve().
-class LibcPassthrough {
-public:
-  int (*openat)(int, const char *, int, ...) = nullptr;
-  int (*close)(int) = nullptr;
-  int (*ioctl)(int, unsigned long, ...) = nullptr;
-  void *(*mmap)(void *, size_t, int, int, int, off_t) = nullptr;
-  int (*munmap)(void *, size_t) = nullptr;
-  int (*mprotect)(void *, size_t, int) = nullptr;
-  int (*madvise)(void *, size_t, int) = nullptr;
-  int (*dup)(int) = nullptr;
-  int (*dup2)(int, int) = nullptr;
-  int (*dup3)(int, int, int) = nullptr;
-  int (*fcntl)(int, int, ...) = nullptr;
-  FILE *(*fopen)(const char *, const char *) = nullptr;
-  FILE *(*freopen)(const char *, const char *, FILE *) = nullptr;
-  DIR *(*opendir)(const char *) = nullptr;
-  int (*stat)(const char *, struct stat *) = nullptr;
-  int (*lstat)(const char *, struct stat *) = nullptr;
-  int (*access)(const char *, int) = nullptr;
-  int (*fstat_fn)(int, struct stat *) = nullptr;
-  ssize_t (*readlink_fn)(const char *, char *, size_t) = nullptr;
-  pid_t (*fork)() = nullptr;
-
-  bool ready() const { return initialized_; }
-
-  void resolve() {
-    auto *handle = RTLD_NEXT;
-    openat = util::lookup_symbol<decltype(openat)>(handle, "openat");
-    close = util::lookup_symbol<decltype(close)>(handle, "close");
-    ioctl = util::lookup_symbol<decltype(ioctl)>(handle, "ioctl");
-    mmap = util::lookup_symbol<decltype(mmap)>(handle, "mmap");
-    munmap = util::lookup_symbol<decltype(munmap)>(handle, "munmap");
-    mprotect = util::lookup_symbol<decltype(mprotect)>(handle, "mprotect");
-    madvise = util::lookup_symbol<decltype(madvise)>(handle, "madvise");
-    dup = util::lookup_symbol<decltype(dup)>(handle, "dup");
-    dup2 = util::lookup_symbol<decltype(dup2)>(handle, "dup2");
-    dup3 = util::lookup_symbol<decltype(dup3)>(handle, "dup3");
-    fcntl = util::lookup_symbol<decltype(fcntl)>(handle, "fcntl");
-    fopen = util::lookup_symbol<decltype(fopen)>(handle, "fopen");
-    freopen = util::lookup_symbol<decltype(freopen)>(handle, "freopen");
-    opendir = util::lookup_symbol<decltype(opendir)>(handle, "opendir");
-    stat = util::lookup_symbol<decltype(stat)>(handle, "stat");
-    lstat = util::lookup_symbol<decltype(lstat)>(handle, "lstat");
-    access = util::lookup_symbol<decltype(access)>(handle, "access");
-    fstat_fn = util::lookup_symbol<decltype(fstat_fn)>(handle, "fstat");
-    readlink_fn = util::lookup_symbol<decltype(readlink_fn)>(handle, "readlink");
-    fork = util::lookup_symbol<decltype(fork)>(handle, "fork");
-    assert(openat && close && ioctl && mmap && munmap && mprotect && madvise);
-    assert(dup && dup2 && fcntl && fopen && freopen && opendir && fork);
-    assert(stat && lstat && access && fstat_fn && readlink_fn);
-    initialized_ = true;
-  }
-
-private:
-  bool initialized_ = false;
-};
-
 /// @brief All mutable interposer state.
 class InterposerContext {
 public:
-  static inline std::atomic<bool> in_construction{false};
-  static inline LibcPassthrough real{};
+  static inline thread_local bool in_construction = false;
+  static rocjitsu::LibcPassthrough &real() { return rocjitsu::libc_passthrough(); }
   static InterposerContext &ctx;
 
   static void init() {
     new (storage_) InterposerContext();
-    real.resolve();
+    real().resolve();
   }
 
   /// @brief Reset interposer state in a forked child process.
@@ -192,7 +170,11 @@ public:
   /// be locked by threads that no longer exist. We reinitialize everything so
   /// the next open("/dev/kfd") creates a fresh connection.
   void reset_after_fork() {
+    active_driver_.store(nullptr, std::memory_order_release);
     rj_vm_ = nullptr;
+    if (guest_driver_)
+      guest_driver_->reset_after_fork();
+    guest_driver_.reset();
     remote_.store(nullptr, std::memory_order_relaxed);
     remote_kfd_fd_.store(-1, std::memory_order_relaxed);
     remote_open_refs_.store(0, std::memory_order_relaxed);
@@ -206,13 +188,14 @@ public:
     in_construction = false;
   }
 
-  SimulatedDriver *driver() { return rj_vm_ ? rj_vm_->vm->driver() : nullptr; }
+  LinuxKfd *driver() { return active_driver_.load(std::memory_order_acquire); }
   int driver_fd() {
     auto *d = driver();
     return d ? d->fd() : -1;
   }
   bool initialized() const {
-    return rj_vm_ != nullptr || remote_.load(std::memory_order_acquire) != nullptr;
+    return active_driver_.load(std::memory_order_acquire) != nullptr ||
+           remote_.load(std::memory_order_acquire) != nullptr;
   }
 
   std::unique_lock<std::mutex> lock_remote() { return std::unique_lock(remote_mutex_); }
@@ -246,7 +229,7 @@ public:
   /// @brief Add one open reference for a remote (daemon-mode) KFD fd.
   /// @details Each live remote KFD fd (the primary plus every dup) holds one
   /// reference; the RPC connection is torn down only when the last reference is
-  /// dropped. Mirrors SimulatedDriver's local open refcount for the daemon path.
+  /// dropped. Mirrors SimulatedKfd's local open refcount for the daemon path.
   void retain_remote_open() { remote_open_refs_.fetch_add(1, std::memory_order_acq_rel); }
 
   /// @brief Drop one remote open reference, tearing down the connection on the
@@ -266,7 +249,7 @@ public:
     RemoteDriver *active_remote = remote_.load(std::memory_order_acquire);
     if (active_remote && remote_kfd_fd_.load(std::memory_order_acquire) >= 0) {
       // Re-open of an already-connected daemon: each open holds one reference,
-      // mirroring SimulatedDriver::open() retaining the local process.
+      // mirroring SimulatedKfd::open() retaining the local process.
       retain_remote_open();
       return active_remote;
     }
@@ -286,7 +269,7 @@ public:
     return active_remote;
   }
 
-  SimulatedDriver *lookup(int fd) {
+  LinuxKfd *lookup(int fd) {
     auto *d = driver();
     return (d && fd >= 0 && fd == d->fd()) ? d : nullptr;
   }
@@ -299,6 +282,29 @@ public:
   std::string redirect(const char *path) {
     auto *d = driver();
     return d ? d->redirect_sysfs_path(path) : std::string{};
+  }
+
+  std::string redirect_sysfs_path(const char *path) {
+    if (!path)
+      return {};
+
+    std::string_view sv(path);
+    if (!sv.starts_with("/sys/class/drm") && !sv.starts_with("/sys/devices/virtual/kfd") &&
+        !sv.starts_with("/sys/class/kfd"))
+      return {};
+
+    if (!remote_lookup(remote_kfd_fd()) && !initialized())
+      get_or_create();
+
+    const std::string remote_topology = remote_topology_path();
+    if (!remote_topology.empty()) {
+      std::string redirected =
+          LinuxKfd::redirect_sysfs_root_path(path, remote_topology, remote_drm_path());
+      if (!redirected.empty())
+        return redirected;
+    }
+
+    return redirect(path);
   }
 
   bool is_kfd_primary(int fd) {
@@ -324,7 +330,7 @@ public:
       return;
     // Each live KFD fd (primary + every dup) holds one open reference, so the
     // process/connection is torn down only when the last fd closes. Retain on
-    // whichever backend is active (local SimulatedDriver or remote daemon RPC).
+    // whichever backend is active (local SimulatedKfd or remote daemon RPC).
     if (auto *d = driver())
       d->retain_local_open();
     else if (is_remote_mode())
@@ -379,7 +385,7 @@ public:
     delete active_remote;
     int fd = remote_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
     if (fd >= 0)
-      InterposerContext::real.close(fd);
+      InterposerContext::real().close(fd);
     std::lock_guard fd_lock(fd_mutex_);
     kfd_dup_fds_.clear();
   }
@@ -442,31 +448,45 @@ public:
     return fd;
   }
 
-  SimulatedDriver *get_or_create() {
+  LinuxKfd *get_or_create() {
     std::lock_guard lock(init_mutex_);
-    if (!rj_vm_) {
+    if (active_driver_.load(std::memory_order_acquire) == nullptr) {
       in_construction = true;
-      auto cfg_file = rocjitsu::rpc_default_config_file_path();
-      char cfg_buf[4096]{};
-      int cfg_fd = static_cast<int>(syscall(SYS_openat, AT_FDCWD, cfg_file.c_str(), O_RDONLY, 0));
-      if (cfg_fd < 0) {
-        util::Logger::debug_print("rocjitsu: no config file at ", cfg_file);
+      std::optional<std::string> cfg_path = child_config_path();
+      if (!cfg_path) {
+        util::Logger::debug_print("rocjitsu: no child config path");
         in_construction = false;
         return nullptr;
       }
-      auto n = syscall(SYS_read, cfg_fd, cfg_buf, sizeof(cfg_buf) - 1);
-      syscall(SYS_close, cfg_fd);
-      if (n <= 0) {
+
+      try {
+        auto dbt_guest = rocjitsu::config::load_dbt_guest_config_from_file(*cfg_path);
+        if (dbt_guest.enabled) {
+          auto guest_driver = std::make_unique<GuestKfd>(std::move(dbt_guest));
+          if (guest_driver->open() < 0) {
+            in_construction = false;
+            return nullptr;
+          }
+          auto *driver = guest_driver.get();
+          guest_driver_ = std::move(guest_driver);
+          active_driver_.store(driver, std::memory_order_release);
+          in_construction = false;
+          return driver;
+        }
+      } catch (const std::exception &e) {
+        util::Logger::debug_print("rocjitsu: failed to load child config: ", e.what());
         in_construction = false;
         return nullptr;
       }
-      while (n > 0 && (cfg_buf[n - 1] == '\n' || cfg_buf[n - 1] == '\r'))
-        cfg_buf[--n] = '\0';
-      if (rj_vm_create(cfg_buf, RJ_VM_MODE_LOCAL, &rj_vm_) != ROCJITSU_STATUS_SUCCESS) {
+
+      rj_vm_t *created_vm = nullptr;
+      if (rj_vm_create(cfg_path->c_str(), RJ_VM_MODE_LOCAL, &created_vm) !=
+          ROCJITSU_STATUS_SUCCESS) {
         util::Logger::debug_print("rocjitsu: failed to create VM");
         in_construction = false;
         return nullptr;
       }
+      rj_vm_ = created_vm;
 
       // Set up execution plugins based on environment variables.
       if (rj_vm_->soc) {
@@ -507,6 +527,8 @@ public:
         rj_vm_->soc->set_plugin_group(pg);
       }
 
+      LinuxKfd *driver = rj_vm_->vm->driver();
+      active_driver_.store(driver, std::memory_order_release);
       std::thread([vm = rj_vm_]() { rj_vm_run(vm, nullptr); }).detach();
       in_construction = false;
     }
@@ -527,6 +549,8 @@ public:
 
 private:
   rj_vm_t *rj_vm_ = nullptr;
+  std::unique_ptr<GuestKfd> guest_driver_;
+  std::atomic<LinuxKfd *> active_driver_{nullptr};
   /// @brief Active daemon-mode remote driver, or nullptr in local mode.
   /// @details Stored atomically so lock-free readers (`remote()`,
   /// `remote_lookup()`, `initialized()`, the AMDKFD ioctl fallback, the mmap
@@ -539,7 +563,7 @@ private:
   /// @brief Open-reference count for the remote (daemon-mode) KFD connection.
   /// @details The primary remote fd and every dup of it each hold one
   /// reference; the RPC connection is torn down only when the last reference is
-  /// released. Mirrors SimulatedDriver's local open refcount for daemon mode.
+  /// released. Mirrors SimulatedKfd's local open refcount for daemon mode.
   std::atomic<int> remote_open_refs_{0};
 
   std::mutex init_mutex_;
@@ -568,16 +592,47 @@ extern "C" {
 
 static std::string redirect_sysfs_path(const char *path);
 static std::string redirect_sys_dev_char(const char *path);
-static const Sysfs::GpuInfo *interposer_gpu_info();
+static const Sysfs::GpuInfo *interposer_gpu_info(uint32_t render_minor);
 
 struct SyntheticDrmOpenResult {
   bool handled = false;
   int fd = -1;
 };
 
+bool parse_render_minor_suffix(const char *first, const char *last, uint32_t *render_minor) {
+  uint32_t parsed = 0;
+  auto result = std::from_chars(first, last, parsed);
+  if (result.ec != std::errc{} || result.ptr != last)
+    return false;
+  *render_minor = parsed;
+  return true;
+}
+
+bool render_minor_from_drm_node_path(const char *raw_path, const char *drm_base,
+                                     uint32_t *render_minor) {
+  std::string_view path(raw_path);
+  static constexpr std::string_view kRealRenderPrefix = "/dev/dri/renderD";
+  if (path.starts_with(kRealRenderPrefix))
+    return parse_render_minor_suffix(path.data() + kRealRenderPrefix.size(),
+                                     path.data() + path.size(), render_minor);
+
+  if (!drm_base || drm_base[0] == '\0')
+    return false;
+
+  std::string redirected_render_prefix = std::string(drm_base) + "/dev_dri/renderD";
+  if (!path.starts_with(redirected_render_prefix))
+    return false;
+  return parse_render_minor_suffix(path.data() + redirected_render_prefix.size(),
+                                   path.data() + path.size(), render_minor);
+}
+
 static SyntheticDrmOpenResult open_synthetic_drm_fd(const char *path) {
-  static constexpr std::string_view kRenderPrefix = "/dev/dri/renderD";
-  if (!path || !std::string_view(path).starts_with(kRenderPrefix))
+  if (!path)
+    return {};
+
+  std::string_view path_view(path);
+  if (!path_view.starts_with("/dev/dri/renderD") &&
+      path_view.find("/dev_dri/renderD") == std::string_view::npos)
     return {};
 
   if (!InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()) &&
@@ -587,16 +642,24 @@ static SyntheticDrmOpenResult open_synthetic_drm_fd(const char *path) {
   if (InterposerContext::ctx.driver_fd() < 0 && InterposerContext::ctx.remote_kfd_fd() < 0)
     return {};
 
-  uint32_t render_minor = 128;
-  auto minor_str = std::string_view(path).substr(kRenderPrefix.size());
-  if (!minor_str.empty()) {
-    uint32_t parsed_minor = 0;
-    auto *first = minor_str.data();
-    auto *last = first + minor_str.size();
-    if (auto result = std::from_chars(first, last, parsed_minor);
-        result.ec == std::errc{} && result.ptr == last)
-      render_minor = parsed_minor;
-  }
+  std::string drm_base;
+  if (auto *drv = InterposerContext::ctx.driver())
+    drm_base = drv->drm_path();
+  else
+    drm_base = InterposerContext::ctx.remote_drm_path();
+
+  // HIP/libdrm may open the generated dev_dri node after following redirected
+  // sysfs metadata instead of opening the literal /dev/dri/renderD* path.
+  // Treat both path forms as the same synthetic DRM render node.
+  uint32_t render_minor = 0;
+  if (!render_minor_from_drm_node_path(path, drm_base.c_str(), &render_minor))
+    return {};
+
+  auto *drv = InterposerContext::ctx.driver();
+  const bool local_handles_render = drv && drv->handles_drm_render_minor(render_minor);
+  const bool remote_handles_render = InterposerContext::ctx.remote_kfd_fd() >= 0;
+  if (!local_handles_render && !remote_handles_render)
+    return {};
 
   auto raw_drm_fd = static_cast<int>(syscall(SYS_memfd_create, "rocjitsu_drm", MFD_CLOEXEC));
   if (raw_drm_fd < 0)
@@ -604,7 +667,7 @@ static SyntheticDrmOpenResult open_synthetic_drm_fd(const char *path) {
 
   int high_fd = fcntl(raw_drm_fd, F_DUPFD_CLOEXEC, 512);
   int saved_errno = errno;
-  InterposerContext::real.close(raw_drm_fd);
+  InterposerContext::real().close(raw_drm_fd);
   if (high_fd < 0) {
     errno = saved_errno;
     return {true, -1};
@@ -623,7 +686,7 @@ RJ_INTERPOSER_EXPORT int open(const char *path, int flags, ...) {
     va_end(ap);
   }
 
-  assert(InterposerContext::real.ready());
+  assert(InterposerContext::real().ready());
   auto *volatile p = path;
   if (!p || InterposerContext::in_construction)
     return static_cast<int>(syscall(SYS_openat, AT_FDCWD, path, flags, mode));
@@ -645,42 +708,17 @@ RJ_INTERPOSER_EXPORT int open(const char *path, int flags, ...) {
     return InterposerContext::ctx.driver_fd();
   }
 
-  if (std::string_view(path).starts_with("/sys/class/drm") ||
-      std::string_view(path).starts_with("/sys/devices/virtual/kfd") ||
-      std::string_view(path).starts_with("/sys/class/kfd")) {
-    if (!InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()) &&
-        !InterposerContext::ctx.initialized())
-      InterposerContext::ctx.get_or_create();
-  }
-  std::string redirected;
-  auto remote_topo = InterposerContext::ctx.remote_topology_path();
-  if (!remote_topo.empty()) {
-    std::string_view sv(path);
-    constexpr const char *kfd_prefix = "/sys/devices/virtual/kfd/kfd/topology";
-    constexpr const char *kfd_alt = "/sys/class/kfd/kfd/topology";
-    constexpr const char *drm_prefix = "/sys/class/drm";
-    if (sv.starts_with(kfd_prefix))
-      redirected = remote_topo + std::string(sv.substr(std::strlen(kfd_prefix)));
-    else if (sv.starts_with(kfd_alt))
-      redirected = remote_topo + std::string(sv.substr(std::strlen(kfd_alt)));
-    else if (sv.starts_with(drm_prefix)) {
-      auto remote_drm = InterposerContext::ctx.remote_drm_path();
-      if (!remote_drm.empty())
-        redirected = remote_drm + std::string(sv.substr(std::strlen(drm_prefix)));
-    }
-  }
-  if (redirected.empty())
-    redirected = InterposerContext::ctx.redirect(path);
+  std::string redirected = InterposerContext::ctx.redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
   if (!redirected.empty()) {
-    int fd = InterposerContext::real.openat(AT_FDCWD, redirected.c_str(), flags, mode);
+    int fd = InterposerContext::real().openat(AT_FDCWD, redirected.c_str(), flags, mode);
     if (fd >= 0)
       InterposerContext::ctx.track_sysfs(fd, redirected);
     return fd;
   }
 
-  return InterposerContext::real.openat(AT_FDCWD, path, flags, mode);
+  return InterposerContext::real().openat(AT_FDCWD, path, flags, mode);
 }
 
 RJ_INTERPOSER_EXPORT int open64(const char *path, int flags, ...) {
@@ -717,44 +755,19 @@ RJ_INTERPOSER_EXPORT int openat(int dirfd, const char *path, int flags, ...) {
 
   auto *volatile p_at = path;
   if (!p_at)
-    return InterposerContext::real.openat(dirfd, path, flags, mode);
+    return InterposerContext::real().openat(dirfd, path, flags, mode);
   if (InterposerContext::in_construction)
-    return InterposerContext::real.openat(dirfd, path, flags, mode);
+    return InterposerContext::real().openat(dirfd, path, flags, mode);
 
   if (path[0] == '/') {
     if (auto drm_fd = open_synthetic_drm_fd(path); drm_fd.handled)
       return drm_fd.fd;
 
-    if (std::string_view(path).starts_with("/sys/class/drm") ||
-        std::string_view(path).starts_with("/sys/devices/virtual/kfd") ||
-        std::string_view(path).starts_with("/sys/class/kfd")) {
-      if (!InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()) &&
-          !InterposerContext::ctx.initialized())
-        InterposerContext::ctx.get_or_create();
-    }
-    std::string redirected;
-    auto remote_topo_at = InterposerContext::ctx.remote_topology_path();
-    if (!remote_topo_at.empty()) {
-      std::string_view sv(path);
-      constexpr const char *kfd_p = "/sys/devices/virtual/kfd/kfd/topology";
-      constexpr const char *kfd_a = "/sys/class/kfd/kfd/topology";
-      constexpr const char *drm_p = "/sys/class/drm";
-      if (sv.starts_with(kfd_p))
-        redirected = remote_topo_at + std::string(sv.substr(std::strlen(kfd_p)));
-      else if (sv.starts_with(kfd_a))
-        redirected = remote_topo_at + std::string(sv.substr(std::strlen(kfd_a)));
-      else if (sv.starts_with(drm_p)) {
-        auto remote_drm_at = InterposerContext::ctx.remote_drm_path();
-        if (!remote_drm_at.empty())
-          redirected = remote_drm_at + std::string(sv.substr(std::strlen(drm_p)));
-      }
-    }
-    if (redirected.empty())
-      redirected = InterposerContext::ctx.redirect(path);
+    std::string redirected = InterposerContext::ctx.redirect_sysfs_path(path);
     if (redirected.empty())
       redirected = redirect_sys_dev_char(path);
     if (!redirected.empty()) {
-      int fd = InterposerContext::real.openat(AT_FDCWD, redirected.c_str(), flags, mode);
+      int fd = InterposerContext::real().openat(AT_FDCWD, redirected.c_str(), flags, mode);
       if (fd >= 0)
         InterposerContext::ctx.track_sysfs(fd, redirected);
       return fd;
@@ -763,14 +776,14 @@ RJ_INTERPOSER_EXPORT int openat(int dirfd, const char *path, int flags, ...) {
     auto dir_path = InterposerContext::ctx.lookup_sysfs(dirfd);
     if (!dir_path.empty()) {
       std::string full = dir_path + "/" + path;
-      int fd = InterposerContext::real.openat(AT_FDCWD, full.c_str(), flags, mode);
+      int fd = InterposerContext::real().openat(AT_FDCWD, full.c_str(), flags, mode);
       if (fd >= 0)
         InterposerContext::ctx.track_sysfs(fd, full);
       return fd;
     }
   }
 
-  return InterposerContext::real.openat(dirfd, path, flags, mode);
+  return InterposerContext::real().openat(dirfd, path, flags, mode);
 }
 
 RJ_INTERPOSER_EXPORT int openat64(int dirfd, const char *path, int flags, ...) {
@@ -785,7 +798,7 @@ RJ_INTERPOSER_EXPORT int openat64(int dirfd, const char *path, int flags, ...) {
 }
 
 RJ_INTERPOSER_EXPORT int close(int fd) {
-  assert(InterposerContext::real.ready());
+  assert(InterposerContext::real().ready());
   if (InterposerContext::ctx.remote_lookup(fd)) {
     // Closing the primary remote KFD fd drops one open reference; the synthetic
     // fd and RPC connection are torn down only when the last reference is
@@ -796,12 +809,12 @@ RJ_INTERPOSER_EXPORT int close(int fd) {
   }
   InterposerContext::ctx.untrack_sysfs(fd);
   if (InterposerContext::ctx.untrack_drm(fd)) {
-    InterposerContext::real.close(fd);
+    InterposerContext::real().close(fd);
     return 0;
   }
   if (InterposerContext::ctx.is_kfd_dup(fd)) {
     InterposerContext::ctx.untrack_dup(fd);
-    return static_cast<int>(InterposerContext::real.close(fd));
+    return static_cast<int>(InterposerContext::real().close(fd));
   }
   if (auto *drv = InterposerContext::ctx.lookup(fd)) {
     drv->close();
@@ -809,13 +822,13 @@ RJ_INTERPOSER_EXPORT int close(int fd) {
   }
   if (InterposerContext::ctx.owns_fd(fd))
     return 0;
-  return static_cast<int>(InterposerContext::real.close(fd));
+  return static_cast<int>(InterposerContext::real().close(fd));
 }
 
 __attribute__((destructor(101))) void rj_interposer_shutdown() {}
 
 RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
-  assert(InterposerContext::real.ready());
+  assert(InterposerContext::real().ready());
   va_list ap;
   va_start(ap, request);
   void *arg = va_arg(ap, void *);
@@ -878,7 +891,7 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
       //   READ_MMR_REG (gb_addr_cfg is mandatory for all families),
       //   VRAM_GTT, MEMORY. Failures (-1) abort device init.
       auto *info = static_cast<drm_amdgpu_info *>(arg);
-      auto *gpu = interposer_gpu_info();
+      auto *gpu = interposer_gpu_info(InterposerContext::ctx.drm_render_minor(fd));
       if (!gpu) {
         errno = ENODEV;
         return -1;
@@ -987,12 +1000,12 @@ RJ_INTERPOSER_EXPORT int ioctl(int fd, unsigned long request, ...) {
   if (drv)
     return kfd_ioctl_ret(drv->ioctl(request, arg));
 
-  return InterposerContext::real.ioctl(fd, request, arg);
+  return InterposerContext::real().ioctl(fd, request, arg);
 }
 
 RJ_INTERPOSER_EXPORT int dup(int oldfd) {
-  assert(InterposerContext::real.ready());
-  int rc = InterposerContext::real.dup(oldfd);
+  assert(InterposerContext::real().ready());
+  int rc = InterposerContext::real().dup(oldfd);
   if (rc >= 0) {
     if (InterposerContext::ctx.is_kfd_tracked(oldfd))
       InterposerContext::ctx.track_dup(rc);
@@ -1003,12 +1016,12 @@ RJ_INTERPOSER_EXPORT int dup(int oldfd) {
 }
 
 RJ_INTERPOSER_EXPORT int dup2(int oldfd, int newfd) {
-  assert(InterposerContext::real.ready());
+  assert(InterposerContext::real().ready());
   // dup2(fd, fd) is a POSIX no-op that leaves the descriptor live; mutating
   // tracking would drop a still-open ref. Forward without touching tracking.
   if (oldfd == newfd)
-    return InterposerContext::real.dup2(oldfd, newfd);
-  int rc = InterposerContext::real.dup2(oldfd, newfd);
+    return InterposerContext::real().dup2(oldfd, newfd);
+  int rc = InterposerContext::real().dup2(oldfd, newfd);
   if (rc < 0)
     return rc;
   // newfd was atomically closed and replaced; reconcile its tracking only now.
@@ -1023,10 +1036,10 @@ RJ_INTERPOSER_EXPORT int dup2(int oldfd, int newfd) {
 
 #ifdef SYS_dup3
 RJ_INTERPOSER_EXPORT int dup3(int oldfd, int newfd, int flags) {
-  assert(InterposerContext::real.ready());
+  assert(InterposerContext::real().ready());
   // dup3(fd, fd, ...) is required to fail with EINVAL without altering the
   // descriptor; do not mutate tracking before the syscall confirms that.
-  int rc = InterposerContext::real.dup3(oldfd, newfd, flags);
+  int rc = InterposerContext::real().dup3(oldfd, newfd, flags);
   if (rc < 0)
     return rc;
   InterposerContext::ctx.untrack_sysfs(newfd);
@@ -1101,20 +1114,20 @@ namespace {
 // Shared implementation for fcntl / fcntl64. The variadic third argument is
 // extracted by the public entry points (which can't forward a va_list) and
 // passed here already resolved. Both fcntl and fcntl64 share the same kernel
-// ABI, so InterposerContext::real.fcntl services both.
+// ABI, so InterposerContext::real().fcntl services both.
 int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
   FcntlArgKind kind = fcntl_arg_kind(cmd);
   long rc = 0;
   switch (kind) {
   case FcntlArgKind::Int:
-    rc = InterposerContext::real.fcntl(fd, cmd, int_arg);
+    rc = InterposerContext::real().fcntl(fd, cmd, int_arg);
     break;
   case FcntlArgKind::Ptr:
-    rc = InterposerContext::real.fcntl(fd, cmd, ptr_arg);
+    rc = InterposerContext::real().fcntl(fd, cmd, ptr_arg);
     break;
   case FcntlArgKind::None:
   default:
-    rc = InterposerContext::real.fcntl(fd, cmd, 0L);
+    rc = InterposerContext::real().fcntl(fd, cmd, 0L);
     break;
   }
 
@@ -1136,7 +1149,7 @@ int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
 } // namespace
 
 RJ_INTERPOSER_EXPORT int fcntl(int fd, int cmd, ...) {
-  assert(InterposerContext::real.ready());
+  assert(InterposerContext::real().ready());
   va_list ap;
   va_start(ap, cmd);
   FcntlArgKind kind = fcntl_arg_kind(cmd);
@@ -1154,7 +1167,7 @@ RJ_INTERPOSER_EXPORT int fcntl(int fd, int cmd, ...) {
 // interposed separately or libdrm's F_DUPFD_CLOEXEC on the render fd bypasses
 // our dup tracking and subsequent ioctls land on an untracked fd.
 RJ_INTERPOSER_EXPORT int fcntl64(int fd, int cmd, ...) {
-  assert(InterposerContext::real.ready());
+  assert(InterposerContext::real().ready());
   va_list ap;
   va_start(ap, cmd);
   FcntlArgKind kind = fcntl_arg_kind(cmd);
@@ -1170,7 +1183,7 @@ RJ_INTERPOSER_EXPORT int fcntl64(int fd, int cmd, ...) {
 
 RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, int fd,
                                 off_t offset) {
-  assert(InterposerContext::real.ready());
+  assert(InterposerContext::real().ready());
   if (auto *remote = InterposerContext::ctx.remote_lookup(fd))
     return remote->mmap(addr, length, prot, flags, offset);
 
@@ -1192,39 +1205,39 @@ RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, 
       auto total = static_cast<off_t>(length) + memfd_offset;
       [[maybe_unused]] auto ft_rc = ftruncate(memfd_out, total);
       fallocate(memfd_out, 0, memfd_offset, static_cast<off_t>(length));
-      auto *raw = InterposerContext::real.mmap(
+      auto *raw = InterposerContext::real().mmap(
           addr, length, prot, (flags & ~MAP_ANONYMOUS) | MAP_SHARED, memfd_out, memfd_offset);
       if (raw != MAP_FAILED) {
 #ifdef MADV_POPULATE_WRITE
-        InterposerContext::real.madvise(raw, length, MADV_POPULATE_WRITE);
+        InterposerContext::real().madvise(raw, length, MADV_POPULATE_WRITE);
 #endif
         return raw;
       }
     }
   }
-  return InterposerContext::real.mmap(addr, length, prot, flags, fd, offset);
+  return InterposerContext::real().mmap(addr, length, prot, flags, fd, offset);
 }
 
 RJ_INTERPOSER_EXPORT int mprotect(void *addr, size_t length, int prot) {
-  assert(InterposerContext::real.ready());
+  assert(InterposerContext::real().ready());
   auto *drv = InterposerContext::ctx.driver();
   if (drv && drv->is_doorbell_range(addr, length)) {
     errno = EPERM;
     return -1;
   }
-  return InterposerContext::real.mprotect(addr, length, prot);
+  return InterposerContext::real().mprotect(addr, length, prot);
 }
 
 RJ_INTERPOSER_EXPORT int madvise(void *addr, size_t length, int advice) {
-  assert(InterposerContext::real.ready());
+  assert(InterposerContext::real().ready());
   if ((advice == MADV_HUGEPAGE || advice == MADV_DONTFORK) &&
       reinterpret_cast<uintptr_t>(addr) >= 0x1000000000ULL)
     return 0;
-  return InterposerContext::real.madvise(addr, length, advice);
+  return InterposerContext::real().madvise(addr, length, advice);
 }
 
 RJ_INTERPOSER_EXPORT int munmap(void *addr, size_t length) {
-  assert(InterposerContext::real.ready());
+  assert(InterposerContext::real().ready());
   if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd())) {
     int ret = remote->munmap(addr, length);
     if (ret != -ENOENT)
@@ -1236,7 +1249,7 @@ RJ_INTERPOSER_EXPORT int munmap(void *addr, size_t length) {
     if (ret != -ENOENT)
       return ret;
   }
-  return InterposerContext::real.munmap(addr, length);
+  return InterposerContext::real().munmap(addr, length);
 }
 
 } // extern "C"
@@ -1246,7 +1259,7 @@ extern "C" {
 // -- fopen / freopen interposition (sysfs redirect) --
 
 RJ_INTERPOSER_EXPORT FILE *fopen(const char *path, const char *mode) {
-  if (!InterposerContext::real.ready()) {
+  if (!InterposerContext::real().ready()) {
     auto fn = util::lookup_symbol<FILE *(*)(const char *, const char *)>(RTLD_NEXT, "fopen");
     return fn ? fn(path, mode) : nullptr;
   }
@@ -1256,39 +1269,15 @@ RJ_INTERPOSER_EXPORT FILE *fopen(const char *path, const char *mode) {
   const char *actual = path;
   std::string redirected;
   if (!InterposerContext::in_construction) {
-    if (std::string_view(path).starts_with("/sys/class/drm") ||
-        std::string_view(path).starts_with("/sys/devices/virtual/kfd") ||
-        std::string_view(path).starts_with("/sys/class/kfd")) {
-      if (!InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()) &&
-          !InterposerContext::ctx.initialized())
-        InterposerContext::ctx.get_or_create();
-    }
-    auto remote_topo_fp = InterposerContext::ctx.remote_topology_path();
-    if (!remote_topo_fp.empty()) {
-      std::string_view sv(path);
-      constexpr const char *kp = "/sys/devices/virtual/kfd/kfd/topology";
-      constexpr const char *ka = "/sys/class/kfd/kfd/topology";
-      constexpr const char *dp = "/sys/class/drm";
-      if (sv.starts_with(kp))
-        redirected = remote_topo_fp + std::string(sv.substr(std::strlen(kp)));
-      else if (sv.starts_with(ka))
-        redirected = remote_topo_fp + std::string(sv.substr(std::strlen(ka)));
-      else if (sv.starts_with(dp)) {
-        auto remote_drm_fp = InterposerContext::ctx.remote_drm_path();
-        if (!remote_drm_fp.empty())
-          redirected = remote_drm_fp + std::string(sv.substr(std::strlen(dp)));
-      }
-    }
-    if (redirected.empty())
-      redirected = InterposerContext::ctx.redirect(path);
+    redirected = InterposerContext::ctx.redirect_sysfs_path(path);
     if (redirected.empty())
       redirected = redirect_sys_dev_char(path);
     if (!redirected.empty())
       actual = redirected.c_str();
   }
 
-  int fd = InterposerContext::real.openat(AT_FDCWD, actual,
-                                          InterposerContext::fopen_flags_from_mode(mode), 0644);
+  int fd = InterposerContext::real().openat(AT_FDCWD, actual,
+                                            InterposerContext::fopen_flags_from_mode(mode), 0644);
   if (fd < 0)
     return nullptr;
   return fdopen(fd, mode);
@@ -1314,36 +1303,13 @@ RJ_INTERPOSER_EXPORT FILE *freopen64(const char *path, const char *mode, FILE *s
 // -- stat/lstat/access interposition --
 
 static std::string redirect_sysfs_path(const char *path) {
-  if (!path || !InterposerContext::real.ready() || InterposerContext::in_construction)
+  if (!path || !InterposerContext::real().ready() || InterposerContext::in_construction)
     return {};
-  std::string_view sv(path);
-  if (!sv.starts_with("/sys/class/drm") && !sv.starts_with("/sys/devices/virtual/kfd") &&
-      !sv.starts_with("/sys/class/kfd"))
-    return {};
-  if (!InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()) &&
-      !InterposerContext::ctx.initialized())
-    InterposerContext::ctx.get_or_create();
-  auto remote_topo = InterposerContext::ctx.remote_topology_path();
-  if (!remote_topo.empty()) {
-    constexpr const char *kp = "/sys/devices/virtual/kfd/kfd/topology";
-    constexpr const char *ka = "/sys/class/kfd/kfd/topology";
-    constexpr const char *dp = "/sys/class/drm";
-    if (sv.starts_with(kp))
-      return remote_topo + std::string(sv.substr(std::strlen(kp)));
-    if (sv.starts_with(ka))
-      return remote_topo + std::string(sv.substr(std::strlen(ka)));
-    if (sv.starts_with(dp)) {
-      auto remote_drm = InterposerContext::ctx.remote_drm_path();
-      if (!remote_drm.empty())
-        return remote_drm + std::string(sv.substr(std::strlen(dp)));
-    }
-  }
-  auto fallback = InterposerContext::ctx.redirect(path);
-  return fallback;
+  return InterposerContext::ctx.redirect_sysfs_path(path);
 }
 
 static std::string redirect_sys_dev_char(const char *path) {
-  if (!path || !InterposerContext::real.ready() || InterposerContext::in_construction)
+  if (!path || !InterposerContext::real().ready() || InterposerContext::in_construction)
     return {};
   std::string_view sv(path);
   constexpr std::string_view prefix = "/sys/dev/char/";
@@ -1369,10 +1335,14 @@ static std::string redirect_sys_dev_char(const char *path) {
 
   std::string drm_base;
   auto *drv = InterposerContext::ctx.driver();
-  if (drv)
-    drm_base = drv->topology().drm_path();
-  else
+  if (drv) {
+    auto direct = drv->redirect_sysfs_path(path);
+    if (!direct.empty())
+      return direct;
+    drm_base = drv->drm_path();
+  } else {
     drm_base = InterposerContext::ctx.remote_drm_path();
+  }
   if (drm_base.empty())
     return {};
 
@@ -1385,17 +1355,17 @@ static std::string redirect_sys_dev_char(const char *path) {
   return drm_base + "/" + entry + suffix;
 }
 
-static const Sysfs::GpuInfo *interposer_gpu_info() {
+static const Sysfs::GpuInfo *interposer_gpu_info(uint32_t render_minor) {
   auto *drv = InterposerContext::ctx.driver();
   if (drv)
-    return &drv->topology().gpu_info();
+    return drv->gpu_info_for_render_minor(render_minor);
   if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()))
     return remote->gpu_info();
   return nullptr;
 }
 
 static std::string redirect_dev_dri(const char *path) {
-  if (!path || !InterposerContext::real.ready() || InterposerContext::in_construction)
+  if (!path || !InterposerContext::real().ready() || InterposerContext::in_construction)
     return {};
   std::string_view sv(path);
   // Redirect both the /dev/dri directory and individual node files
@@ -1412,10 +1382,14 @@ static std::string redirect_dev_dri(const char *path) {
     return {};
   std::string drm_base;
   auto *drv = InterposerContext::ctx.driver();
-  if (drv)
-    drm_base = drv->topology().drm_path();
-  else
+  if (drv) {
+    auto direct = drv->redirect_sysfs_path(path);
+    if (!direct.empty())
+      return direct;
+    drm_base = drv->drm_path();
+  } else {
     drm_base = InterposerContext::ctx.remote_drm_path();
+  }
   if (drm_base.empty())
     return {};
   if (is_dir)
@@ -1424,7 +1398,7 @@ static std::string redirect_dev_dri(const char *path) {
 }
 
 RJ_INTERPOSER_EXPORT int stat(const char *path, struct stat *buf) {
-  if (!InterposerContext::real.ready()) {
+  if (!InterposerContext::real().ready()) {
     auto fn = util::lookup_symbol<int (*)(const char *, struct stat *)>(RTLD_NEXT, "stat");
     return fn ? fn(path, buf) : -1;
   }
@@ -1434,12 +1408,12 @@ RJ_INTERPOSER_EXPORT int stat(const char *path, struct stat *buf) {
   if (redirected.empty())
     redirected = redirect_dev_dri(path);
   if (!redirected.empty())
-    return InterposerContext::real.stat(redirected.c_str(), buf);
-  return InterposerContext::real.stat(path, buf);
+    return InterposerContext::real().stat(redirected.c_str(), buf);
+  return InterposerContext::real().stat(path, buf);
 }
 
 RJ_INTERPOSER_EXPORT int lstat(const char *path, struct stat *buf) {
-  if (!InterposerContext::real.ready()) {
+  if (!InterposerContext::real().ready()) {
     auto fn = util::lookup_symbol<int (*)(const char *, struct stat *)>(RTLD_NEXT, "lstat");
     return fn ? fn(path, buf) : -1;
   }
@@ -1449,12 +1423,12 @@ RJ_INTERPOSER_EXPORT int lstat(const char *path, struct stat *buf) {
   if (redirected.empty())
     redirected = redirect_dev_dri(path);
   if (!redirected.empty())
-    return InterposerContext::real.lstat(redirected.c_str(), buf);
-  return InterposerContext::real.lstat(path, buf);
+    return InterposerContext::real().lstat(redirected.c_str(), buf);
+  return InterposerContext::real().lstat(path, buf);
 }
 
 RJ_INTERPOSER_EXPORT int access(const char *path, int mode) {
-  if (!InterposerContext::real.ready()) {
+  if (!InterposerContext::real().ready()) {
     auto fn = util::lookup_symbol<int (*)(const char *, int)>(RTLD_NEXT, "access");
     return fn ? fn(path, mode) : -1;
   }
@@ -1464,14 +1438,14 @@ RJ_INTERPOSER_EXPORT int access(const char *path, int mode) {
   if (redirected.empty())
     redirected = redirect_dev_dri(path);
   if (!redirected.empty())
-    return InterposerContext::real.access(redirected.c_str(), mode);
-  return InterposerContext::real.access(path, mode);
+    return InterposerContext::real().access(redirected.c_str(), mode);
+  return InterposerContext::real().access(path, mode);
 }
 
 // -- opendir interposition --
 
 RJ_INTERPOSER_EXPORT DIR *opendir(const char *name) {
-  if (!InterposerContext::real.ready()) {
+  if (!InterposerContext::real().ready()) {
     auto fn = util::lookup_symbol<DIR *(*)(const char *)>(RTLD_NEXT, "opendir");
     return fn ? fn(name) : nullptr;
   }
@@ -1481,50 +1455,25 @@ RJ_INTERPOSER_EXPORT DIR *opendir(const char *name) {
     return nullptr;
   }
   if (!InterposerContext::in_construction) {
-    if (std::string_view(name).starts_with("/sys/class/drm") ||
-        std::string_view(name).starts_with("/sys/devices/virtual/kfd") ||
-        std::string_view(name).starts_with("/sys/class/kfd")) {
-      if (!InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()) &&
-          !InterposerContext::ctx.initialized())
-        InterposerContext::ctx.get_or_create();
-    }
-    std::string redirected;
-    auto remote_topo_od = InterposerContext::ctx.remote_topology_path();
-    if (!remote_topo_od.empty()) {
-      std::string_view sv(name);
-      constexpr const char *kp = "/sys/devices/virtual/kfd/kfd/topology";
-      constexpr const char *ka = "/sys/class/kfd/kfd/topology";
-      constexpr const char *dp = "/sys/class/drm";
-      if (sv.starts_with(kp))
-        redirected = remote_topo_od + std::string(sv.substr(std::strlen(kp)));
-      else if (sv.starts_with(ka))
-        redirected = remote_topo_od + std::string(sv.substr(std::strlen(ka)));
-      else if (sv.starts_with(dp)) {
-        auto remote_drm_od = InterposerContext::ctx.remote_drm_path();
-        if (!remote_drm_od.empty())
-          redirected = remote_drm_od + std::string(sv.substr(std::strlen(dp)));
-      }
-    }
-    if (redirected.empty())
-      redirected = InterposerContext::ctx.redirect(name);
+    std::string redirected = InterposerContext::ctx.redirect_sysfs_path(name);
     if (redirected.empty())
       redirected = redirect_sys_dev_char(name);
     if (redirected.empty())
       redirected = redirect_dev_dri(name);
     if (!redirected.empty())
-      return InterposerContext::real.opendir(redirected.c_str());
+      return InterposerContext::real().opendir(redirected.c_str());
   }
-  return InterposerContext::real.opendir(name);
+  return InterposerContext::real().opendir(name);
 }
 
 // -- fstat interposition (DRM memfd → synthetic st_rdev) --
 
 RJ_INTERPOSER_EXPORT int fstat(int fd, struct stat *buf) {
-  if (!InterposerContext::real.ready()) {
+  if (!InterposerContext::real().ready()) {
     auto fn = util::lookup_symbol<int (*)(int, struct stat *)>(RTLD_NEXT, "fstat");
     return fn ? fn(fd, buf) : -1;
   }
-  int rc = InterposerContext::real.fstat_fn(fd, buf);
+  int rc = InterposerContext::real().fstat_fn(fd, buf);
   if (rc == 0 && InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
     buf->st_rdev = makedev(226, render_minor);
@@ -1539,7 +1488,7 @@ RJ_INTERPOSER_EXPORT int fstat64(int fd, struct stat64 *buf) {
   if (!real_fstat64)
     return -1;
   int rc = real_fstat64(fd, buf);
-  if (rc == 0 && InterposerContext::real.ready() && InterposerContext::ctx.is_drm(fd)) {
+  if (rc == 0 && InterposerContext::real().ready() && InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
     buf->st_rdev = makedev(226, render_minor);
     buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFCHR;
@@ -1553,7 +1502,7 @@ RJ_INTERPOSER_EXPORT int __fxstat(int ver, int fd, struct stat *buf) {
   if (!real_fxstat)
     return -1;
   int rc = real_fxstat(ver, fd, buf);
-  if (rc == 0 && InterposerContext::real.ready() && InterposerContext::ctx.is_drm(fd)) {
+  if (rc == 0 && InterposerContext::real().ready() && InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
     buf->st_rdev = makedev(226, render_minor);
     buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFCHR;
@@ -1567,7 +1516,7 @@ RJ_INTERPOSER_EXPORT int __fxstat64(int ver, int fd, struct stat64 *buf) {
   if (!real_fxstat64)
     return -1;
   int rc = real_fxstat64(ver, fd, buf);
-  if (rc == 0 && InterposerContext::real.ready() && InterposerContext::ctx.is_drm(fd)) {
+  if (rc == 0 && InterposerContext::real().ready() && InterposerContext::ctx.is_drm(fd)) {
     uint32_t render_minor = InterposerContext::ctx.drm_render_minor(fd);
     buf->st_rdev = makedev(226, render_minor);
     buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFCHR;
@@ -1578,7 +1527,7 @@ RJ_INTERPOSER_EXPORT int __fxstat64(int ver, int fd, struct stat64 *buf) {
 // -- readlink interposition (redirect /sys/dev/char/) --
 
 RJ_INTERPOSER_EXPORT ssize_t readlink(const char *path, char *buf, size_t bufsiz) {
-  if (!InterposerContext::real.ready()) {
+  if (!InterposerContext::real().ready()) {
     auto fn = util::lookup_symbol<ssize_t (*)(const char *, char *, size_t)>(RTLD_NEXT, "readlink");
     return fn ? fn(path, buf, bufsiz) : -1;
   }
@@ -1586,7 +1535,7 @@ RJ_INTERPOSER_EXPORT ssize_t readlink(const char *path, char *buf, size_t bufsiz
   if (redirected.empty())
     redirected = redirect_sysfs_path(path);
   const char *actual = redirected.empty() ? path : redirected.c_str();
-  return InterposerContext::real.readlink_fn(actual, buf, bufsiz);
+  return InterposerContext::real().readlink_fn(actual, buf, bufsiz);
 }
 
 // -- stat64/lstat64 interposition (distinct from stat on glibc 2.33+) --
@@ -1676,8 +1625,8 @@ RJ_INTERPOSER_EXPORT int __lxstat64(int ver, const char *path, struct stat64 *bu
 }
 
 RJ_INTERPOSER_EXPORT pid_t fork() {
-  assert(InterposerContext::real.ready());
-  pid_t pid = InterposerContext::real.fork();
+  assert(InterposerContext::real().ready());
+  pid_t pid = InterposerContext::real().fork();
   if (pid == 0)
     InterposerContext::ctx.reset_after_fork();
   return pid;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -30,8 +30,6 @@
 #include "rocjitsu/vm/rj_vm.h"
 #include "rocjitsu/vm/rj_vm_impl.h"
 
-#include "hsa/hsa.h"
-
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "linux/uapi/kfd_ioctl.h"
@@ -89,28 +87,6 @@ using rocjitsu::LinuxKfd;
 using rocjitsu::RemoteDriver;
 using rocjitsu::SimulatedKfd;
 using rocjitsu::Sysfs;
-
-namespace {
-
-constexpr uint32_t kHsaExtensionImages = 1;
-constexpr uint32_t kHsaExtAgentInfoImage1dMaxElements = 0x3000;
-constexpr uint32_t kHsaExtAgentInfoImage1daMaxElements = 0x3001;
-constexpr uint32_t kHsaExtAgentInfoImage1dbMaxElements = 0x3002;
-constexpr uint32_t kHsaExtAgentInfoImage2dMaxElements = 0x3003;
-constexpr uint32_t kHsaExtAgentInfoImage2daMaxElements = 0x3004;
-constexpr uint32_t kHsaExtAgentInfoImage2dDepthMaxElements = 0x3005;
-constexpr uint32_t kHsaExtAgentInfoImage2daDepthMaxElements = 0x3006;
-constexpr uint32_t kHsaExtAgentInfoImage3dMaxElements = 0x3007;
-constexpr uint32_t kHsaExtAgentInfoImageArrayMaxLayers = 0x3008;
-constexpr uint32_t kHsaExtAgentInfoMaxImageReadHandles = 0x3009;
-constexpr uint32_t kHsaExtAgentInfoMaxImageReadOrWriteHandles = 0x300A;
-constexpr uint32_t kHsaExtAgentInfoMaxSamplerHandles = 0x300B;
-constexpr uint32_t kHsaExtAgentInfoImageLinearRowPitchAlignment = 0x300C;
-constexpr uint32_t kHsaExtAgentInfoImageSupport = 0x300D;
-
-using HsaAgentGetInfoFn = hsa_status_t (*)(hsa_agent_t, hsa_agent_info_t, void *);
-
-} // namespace
 
 static int connect_to_daemon() {
   auto path = rocjitsu::rpc_default_socket_path();
@@ -598,49 +574,6 @@ InterposerContext &InterposerContext::ctx =
 
 __attribute__((constructor)) static void init_interposer() { InterposerContext::init(); }
 
-bool rocjitsu_simulation_active_for_hsa() {
-  if (!InterposerContext::real().ready() || InterposerContext::in_construction)
-    return false;
-  if (InterposerContext::ctx.driver())
-    return true;
-  return InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()) != nullptr;
-}
-
-hsa_status_t write_disabled_image_agent_info(hsa_agent_info_t attribute, void *value) {
-  if (value == nullptr)
-    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-
-  const uint32_t attr = static_cast<uint32_t>(attribute);
-  switch (attr) {
-  case kHsaExtAgentInfoImage1dMaxElements:
-  case kHsaExtAgentInfoImage1daMaxElements:
-  case kHsaExtAgentInfoImage1dbMaxElements:
-  case kHsaExtAgentInfoImageArrayMaxLayers:
-  case kHsaExtAgentInfoMaxImageReadHandles:
-  case kHsaExtAgentInfoMaxImageReadOrWriteHandles:
-  case kHsaExtAgentInfoMaxSamplerHandles:
-    *static_cast<uint32_t *>(value) = 0;
-    return HSA_STATUS_SUCCESS;
-  case kHsaExtAgentInfoImage2dMaxElements:
-  case kHsaExtAgentInfoImage2daMaxElements:
-  case kHsaExtAgentInfoImage2dDepthMaxElements:
-  case kHsaExtAgentInfoImage2daDepthMaxElements:
-    std::memset(value, 0, sizeof(uint32_t) * 2);
-    return HSA_STATUS_SUCCESS;
-  case kHsaExtAgentInfoImage3dMaxElements:
-    std::memset(value, 0, sizeof(uint32_t) * 3);
-    return HSA_STATUS_SUCCESS;
-  case kHsaExtAgentInfoImageLinearRowPitchAlignment:
-    *static_cast<size_t *>(value) = 0;
-    return HSA_STATUS_SUCCESS;
-  case kHsaExtAgentInfoImageSupport:
-    *static_cast<bool *>(value) = false;
-    return HSA_STATUS_SUCCESS;
-  default:
-    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-  }
-}
-
 } // namespace
 
 extern "C" {
@@ -648,36 +581,6 @@ extern "C" {
 static std::string redirect_sysfs_path(const char *path);
 static std::string redirect_sys_dev_char(const char *path);
 static const Sysfs::GpuInfo *interposer_gpu_info(uint32_t render_minor);
-
-RJ_INTERPOSER_EXPORT hsa_status_t hsa_agent_get_info(hsa_agent_t agent, hsa_agent_info_t attribute,
-                                                     void *value) {
-  auto real = util::lookup_symbol<HsaAgentGetInfoFn>(RTLD_NEXT, "hsa_agent_get_info");
-  if (!real)
-    return HSA_STATUS_ERROR;
-
-  if (rocjitsu_simulation_active_for_hsa()) {
-    const uint32_t attr = static_cast<uint32_t>(attribute);
-    if (attr >= kHsaExtAgentInfoImage1dMaxElements && attr <= kHsaExtAgentInfoImageSupport) {
-      // The functional simulator does not implement HSA image operations. Newer
-      // HIP probes image limits during device initialization; answering these
-      // probes here prevents ROCR's image-extension helper from dereferencing
-      // synthetic-agent state that is not backed by a real image runtime path.
-      return write_disabled_image_agent_info(attribute, value);
-    }
-
-    if (attribute == HSA_AGENT_INFO_EXTENSIONS) {
-      hsa_status_t status = real(agent, attribute, value);
-      if (status == HSA_STATUS_SUCCESS && value != nullptr) {
-        auto *extensions = static_cast<uint8_t *>(value);
-        extensions[kHsaExtensionImages / 8] &=
-            static_cast<uint8_t>(~(1u << (kHsaExtensionImages % 8)));
-      }
-      return status;
-    }
-  }
-
-  return real(agent, attribute, value);
-}
 
 struct SyntheticDrmOpenResult {
   bool handled = false;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -30,6 +30,8 @@
 #include "rocjitsu/vm/rj_vm.h"
 #include "rocjitsu/vm/rj_vm_impl.h"
 
+#include "hsa/hsa.h"
+
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "linux/uapi/kfd_ioctl.h"
@@ -87,6 +89,28 @@ using rocjitsu::LinuxKfd;
 using rocjitsu::RemoteDriver;
 using rocjitsu::SimulatedKfd;
 using rocjitsu::Sysfs;
+
+namespace {
+
+constexpr uint32_t kHsaExtensionImages = 1;
+constexpr uint32_t kHsaExtAgentInfoImage1dMaxElements = 0x3000;
+constexpr uint32_t kHsaExtAgentInfoImage1daMaxElements = 0x3001;
+constexpr uint32_t kHsaExtAgentInfoImage1dbMaxElements = 0x3002;
+constexpr uint32_t kHsaExtAgentInfoImage2dMaxElements = 0x3003;
+constexpr uint32_t kHsaExtAgentInfoImage2daMaxElements = 0x3004;
+constexpr uint32_t kHsaExtAgentInfoImage2dDepthMaxElements = 0x3005;
+constexpr uint32_t kHsaExtAgentInfoImage2daDepthMaxElements = 0x3006;
+constexpr uint32_t kHsaExtAgentInfoImage3dMaxElements = 0x3007;
+constexpr uint32_t kHsaExtAgentInfoImageArrayMaxLayers = 0x3008;
+constexpr uint32_t kHsaExtAgentInfoMaxImageReadHandles = 0x3009;
+constexpr uint32_t kHsaExtAgentInfoMaxImageReadOrWriteHandles = 0x300A;
+constexpr uint32_t kHsaExtAgentInfoMaxSamplerHandles = 0x300B;
+constexpr uint32_t kHsaExtAgentInfoImageLinearRowPitchAlignment = 0x300C;
+constexpr uint32_t kHsaExtAgentInfoImageSupport = 0x300D;
+
+using HsaAgentGetInfoFn = hsa_status_t (*)(hsa_agent_t, hsa_agent_info_t, void *);
+
+} // namespace
 
 static int connect_to_daemon() {
   auto path = rocjitsu::rpc_default_socket_path();
@@ -184,7 +208,6 @@ public:
     new (&remote_mutex_) std::mutex();
     sysfs_fds_.clear();
     drm_fds_.clear();
-    handle_to_drm_fd_.clear();
     kfd_dup_fds_.clear();
     in_construction = false;
   }
@@ -319,6 +342,16 @@ public:
 
   bool is_kfd_tracked(int fd) { return is_kfd_primary(fd) || is_kfd_dup(fd); }
 
+  void track_open_fd(int fd) {
+    if (fd < 0 || is_kfd_primary(fd))
+      return;
+    std::lock_guard lock(fd_mutex_);
+    // GuestKfd::open() already retained one driver reference before returning
+    // this app-facing dup fd. Track it so ioctl/mmap/close are routed through
+    // the driver without incrementing the reference count a second time.
+    kfd_dup_fds_.insert(fd);
+  }
+
   void track_dup(int fd) {
     if (fd < 0 || is_kfd_primary(fd))
       return;
@@ -426,27 +459,6 @@ public:
   bool untrack_drm(int fd) {
     std::lock_guard lock(fd_mutex_);
     return drm_fds_.erase(fd) != 0;
-  }
-
-  int drm_fd_for_handle(void *handle) {
-    std::lock_guard lock(fd_mutex_);
-    auto it = handle_to_drm_fd_.find(handle);
-    return (it != handle_to_drm_fd_.end()) ? it->second : -1;
-  }
-
-  void track_drm_handle(void *handle, int fd) {
-    std::lock_guard lock(fd_mutex_);
-    handle_to_drm_fd_[handle] = fd;
-  }
-
-  int untrack_drm_handle(void *handle) {
-    std::lock_guard lock(fd_mutex_);
-    auto it = handle_to_drm_fd_.find(handle);
-    if (it == handle_to_drm_fd_.end())
-      return -1;
-    int fd = it->second;
-    handle_to_drm_fd_.erase(it);
-    return fd;
   }
 
   LinuxKfd *get_or_create() {
@@ -572,7 +584,6 @@ private:
   std::mutex remote_mutex_;
   std::unordered_map<int, std::string> sysfs_fds_;
   std::unordered_map<int, uint32_t> drm_fds_;
-  std::unordered_map<void *, int> handle_to_drm_fd_;
   std::unordered_set<int> kfd_dup_fds_;
 
   alignas(16) static uint8_t storage_[];
@@ -587,6 +598,49 @@ InterposerContext &InterposerContext::ctx =
 
 __attribute__((constructor)) static void init_interposer() { InterposerContext::init(); }
 
+bool rocjitsu_simulation_active_for_hsa() {
+  if (!InterposerContext::real().ready() || InterposerContext::in_construction)
+    return false;
+  if (InterposerContext::ctx.driver())
+    return true;
+  return InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()) != nullptr;
+}
+
+hsa_status_t write_disabled_image_agent_info(hsa_agent_info_t attribute, void *value) {
+  if (value == nullptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  const uint32_t attr = static_cast<uint32_t>(attribute);
+  switch (attr) {
+  case kHsaExtAgentInfoImage1dMaxElements:
+  case kHsaExtAgentInfoImage1daMaxElements:
+  case kHsaExtAgentInfoImage1dbMaxElements:
+  case kHsaExtAgentInfoImageArrayMaxLayers:
+  case kHsaExtAgentInfoMaxImageReadHandles:
+  case kHsaExtAgentInfoMaxImageReadOrWriteHandles:
+  case kHsaExtAgentInfoMaxSamplerHandles:
+    *static_cast<uint32_t *>(value) = 0;
+    return HSA_STATUS_SUCCESS;
+  case kHsaExtAgentInfoImage2dMaxElements:
+  case kHsaExtAgentInfoImage2daMaxElements:
+  case kHsaExtAgentInfoImage2dDepthMaxElements:
+  case kHsaExtAgentInfoImage2daDepthMaxElements:
+    std::memset(value, 0, sizeof(uint32_t) * 2);
+    return HSA_STATUS_SUCCESS;
+  case kHsaExtAgentInfoImage3dMaxElements:
+    std::memset(value, 0, sizeof(uint32_t) * 3);
+    return HSA_STATUS_SUCCESS;
+  case kHsaExtAgentInfoImageLinearRowPitchAlignment:
+    *static_cast<size_t *>(value) = 0;
+    return HSA_STATUS_SUCCESS;
+  case kHsaExtAgentInfoImageSupport:
+    *static_cast<bool *>(value) = false;
+    return HSA_STATUS_SUCCESS;
+  default:
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+}
+
 } // namespace
 
 extern "C" {
@@ -594,6 +648,36 @@ extern "C" {
 static std::string redirect_sysfs_path(const char *path);
 static std::string redirect_sys_dev_char(const char *path);
 static const Sysfs::GpuInfo *interposer_gpu_info(uint32_t render_minor);
+
+RJ_INTERPOSER_EXPORT hsa_status_t hsa_agent_get_info(hsa_agent_t agent, hsa_agent_info_t attribute,
+                                                     void *value) {
+  auto real = util::lookup_symbol<HsaAgentGetInfoFn>(RTLD_NEXT, "hsa_agent_get_info");
+  if (!real)
+    return HSA_STATUS_ERROR;
+
+  if (rocjitsu_simulation_active_for_hsa()) {
+    const uint32_t attr = static_cast<uint32_t>(attribute);
+    if (attr >= kHsaExtAgentInfoImage1dMaxElements && attr <= kHsaExtAgentInfoImageSupport) {
+      // The functional simulator does not implement HSA image operations. Newer
+      // HIP probes image limits during device initialization; answering these
+      // probes here prevents ROCR's image-extension helper from dereferencing
+      // synthetic-agent state that is not backed by a real image runtime path.
+      return write_disabled_image_agent_info(attribute, value);
+    }
+
+    if (attribute == HSA_AGENT_INFO_EXTENSIONS) {
+      hsa_status_t status = real(agent, attribute, value);
+      if (status == HSA_STATUS_SUCCESS && value != nullptr) {
+        auto *extensions = static_cast<uint8_t *>(value);
+        extensions[kHsaExtensionImages / 8] &=
+            static_cast<uint8_t>(~(1u << (kHsaExtensionImages % 8)));
+      }
+      return status;
+    }
+  }
+
+  return real(agent, attribute, value);
+}
 
 struct SyntheticDrmOpenResult {
   bool handled = false;
@@ -707,6 +791,8 @@ RJ_INTERPOSER_EXPORT int open(const char *path, int flags, ...) {
     int kfd_fd = drv->open();
     if (kfd_fd < 0)
       return kfd_fd;
+    if (kfd_fd != drv->fd())
+      InterposerContext::ctx.track_open_fd(kfd_fd);
     if (!drv->owns_fd(drv->fd()))
       InterposerContext::ctx.clear_dups();
     return kfd_fd;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -6,7 +6,7 @@
 ///
 /// @details Each process that opens /dev/kfd gets a KfdProcess instance holding
 /// its allocations, queues, events, doorbells, and memory policies. The
-/// SimulatedDriver owns a process table mapping fds to KfdProcess instances,
+/// SimulatedKfd owns a process table mapping fds to KfdProcess instances,
 /// and delegates per-process ioctl operations through here.
 
 #ifndef ROCJITSU_KMD_LINUX_KFD_PROCESS_H_
@@ -30,7 +30,7 @@ namespace rocjitsu {
 ///
 /// @details Mirrors the kernel's kfd_process + kfd_process_device for a
 /// single-GPU simulator. Each daemon client connection or local-mode session
-/// gets one KfdProcess. The SimulatedDriver maintains a process table and
+/// gets one KfdProcess. The SimulatedKfd maintains a process table and
 /// routes ioctls to the correct KfdProcess.
 class KfdProcess {
 public:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file libc_passthrough.cpp
+/// @brief dlsym(RTLD_NEXT) libc pass-through table.
+
+#include "rocjitsu/kmd/linux/libc_passthrough.h"
+
+#include "util/dynamic_loader.h"
+
+#include <cassert>
+#include <dlfcn.h>
+
+namespace rocjitsu {
+
+void LibcPassthrough::resolve() {
+  if (initialized_)
+    return;
+
+  auto *handle = RTLD_NEXT;
+  openat = util::lookup_symbol<decltype(openat)>(handle, "openat");
+  close = util::lookup_symbol<decltype(close)>(handle, "close");
+  ioctl = util::lookup_symbol<decltype(ioctl)>(handle, "ioctl");
+  mmap = util::lookup_symbol<decltype(mmap)>(handle, "mmap");
+  munmap = util::lookup_symbol<decltype(munmap)>(handle, "munmap");
+  mprotect = util::lookup_symbol<decltype(mprotect)>(handle, "mprotect");
+  madvise = util::lookup_symbol<decltype(madvise)>(handle, "madvise");
+  dup = util::lookup_symbol<decltype(dup)>(handle, "dup");
+  dup2 = util::lookup_symbol<decltype(dup2)>(handle, "dup2");
+  dup3 = util::lookup_symbol<decltype(dup3)>(handle, "dup3");
+  fcntl = util::lookup_symbol<decltype(fcntl)>(handle, "fcntl");
+  fopen = util::lookup_symbol<decltype(fopen)>(handle, "fopen");
+  freopen = util::lookup_symbol<decltype(freopen)>(handle, "freopen");
+  opendir = util::lookup_symbol<decltype(opendir)>(handle, "opendir");
+  stat = util::lookup_symbol<decltype(stat)>(handle, "stat");
+  lstat = util::lookup_symbol<decltype(lstat)>(handle, "lstat");
+  access = util::lookup_symbol<decltype(access)>(handle, "access");
+  fstat_fn = util::lookup_symbol<decltype(fstat_fn)>(handle, "fstat");
+  readlink_fn = util::lookup_symbol<decltype(readlink_fn)>(handle, "readlink");
+  fork = util::lookup_symbol<decltype(fork)>(handle, "fork");
+  // Keep ready() false unless every required interposed libc entry point was
+  // resolved. In release builds the asserts disappear, so the boolean must not
+  // claim readiness while any later call would dereference a null function
+  // pointer.
+  initialized_ = openat && close && ioctl && mmap && munmap && mprotect && madvise && dup && dup2 &&
+                 dup3 && fcntl && fopen && freopen && opendir && stat && lstat && access &&
+                 fstat_fn && readlink_fn && fork;
+  assert(initialized_);
+}
+
+LibcPassthrough &libc_passthrough() {
+  static LibcPassthrough real;
+  return real;
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.cpp
@@ -20,11 +20,14 @@ void LibcPassthrough::resolve() {
   auto *handle = RTLD_NEXT;
   openat = util::lookup_symbol<decltype(openat)>(handle, "openat");
   close = util::lookup_symbol<decltype(close)>(handle, "close");
+  read = util::lookup_symbol<decltype(read)>(handle, "read");
+  write = util::lookup_symbol<decltype(write)>(handle, "write");
   ioctl = util::lookup_symbol<decltype(ioctl)>(handle, "ioctl");
   mmap = util::lookup_symbol<decltype(mmap)>(handle, "mmap");
   munmap = util::lookup_symbol<decltype(munmap)>(handle, "munmap");
   mprotect = util::lookup_symbol<decltype(mprotect)>(handle, "mprotect");
   madvise = util::lookup_symbol<decltype(madvise)>(handle, "madvise");
+  memfd_create = util::lookup_symbol<decltype(memfd_create)>(handle, "memfd_create");
   dup = util::lookup_symbol<decltype(dup)>(handle, "dup");
   dup2 = util::lookup_symbol<decltype(dup2)>(handle, "dup2");
   dup3 = util::lookup_symbol<decltype(dup3)>(handle, "dup3");
@@ -32,6 +35,8 @@ void LibcPassthrough::resolve() {
   fopen = util::lookup_symbol<decltype(fopen)>(handle, "fopen");
   freopen = util::lookup_symbol<decltype(freopen)>(handle, "freopen");
   opendir = util::lookup_symbol<decltype(opendir)>(handle, "opendir");
+  readdir = util::lookup_symbol<decltype(readdir)>(handle, "readdir");
+  closedir = util::lookup_symbol<decltype(closedir)>(handle, "closedir");
   stat = util::lookup_symbol<decltype(stat)>(handle, "stat");
   lstat = util::lookup_symbol<decltype(lstat)>(handle, "lstat");
   access = util::lookup_symbol<decltype(access)>(handle, "access");
@@ -42,9 +47,10 @@ void LibcPassthrough::resolve() {
   // resolved. In release builds the asserts disappear, so the boolean must not
   // claim readiness while any later call would dereference a null function
   // pointer.
-  initialized_ = openat && close && ioctl && mmap && munmap && mprotect && madvise && dup && dup2 &&
-                 dup3 && fcntl && fopen && freopen && opendir && stat && lstat && access &&
-                 fstat_fn && readlink_fn && fork;
+  initialized_ = openat && close && read && write && ioctl && mmap && munmap && mprotect &&
+                 madvise && memfd_create && dup && dup2 && dup3 && fcntl && fopen && freopen &&
+                 opendir && readdir && closedir && stat && lstat && access && fstat_fn &&
+                 readlink_fn && fork;
   assert(initialized_);
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.h
@@ -26,11 +26,14 @@ class LibcPassthrough {
 public:
   int (*openat)(int, const char *, int, ...) = nullptr;
   int (*close)(int) = nullptr;
+  ssize_t (*read)(int, void *, size_t) = nullptr;
+  ssize_t (*write)(int, const void *, size_t) = nullptr;
   int (*ioctl)(int, unsigned long, ...) = nullptr;
   void *(*mmap)(void *, size_t, int, int, int, off_t) = nullptr;
   int (*munmap)(void *, size_t) = nullptr;
   int (*mprotect)(void *, size_t, int) = nullptr;
   int (*madvise)(void *, size_t, int) = nullptr;
+  int (*memfd_create)(const char *, unsigned int) = nullptr;
   int (*dup)(int) = nullptr;
   int (*dup2)(int, int) = nullptr;
   int (*dup3)(int, int, int) = nullptr;
@@ -38,6 +41,8 @@ public:
   FILE *(*fopen)(const char *, const char *) = nullptr;
   FILE *(*freopen)(const char *, const char *, FILE *) = nullptr;
   DIR *(*opendir)(const char *) = nullptr;
+  struct dirent *(*readdir)(DIR *) = nullptr;
+  int (*closedir)(DIR *) = nullptr;
   int (*stat)(const char *, struct stat *) = nullptr;
   int (*lstat)(const char *, struct stat *) = nullptr;
   int (*access)(const char *, int) = nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/libc_passthrough.h
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file libc_passthrough.h
+/// @brief Resolved libc entry points used to bypass rocjitsu interposer wrappers.
+
+#ifndef ROCJITSU_KMD_LINUX_LIBC_PASSTHROUGH_H_
+#define ROCJITSU_KMD_LINUX_LIBC_PASSTHROUGH_H_
+
+#include <cstddef>
+#include <cstdio>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace rocjitsu {
+
+/// @brief Real libc function pointers resolved with dlsym(RTLD_NEXT).
+///
+/// @details The LD_PRELOAD interposer shadows these symbols. Code that needs
+/// to intentionally pass through to the host kernel or filesystem should call
+/// these pointers instead of plain libc symbols, which would recurse back into
+/// the wrappers.
+class LibcPassthrough {
+public:
+  int (*openat)(int, const char *, int, ...) = nullptr;
+  int (*close)(int) = nullptr;
+  int (*ioctl)(int, unsigned long, ...) = nullptr;
+  void *(*mmap)(void *, size_t, int, int, int, off_t) = nullptr;
+  int (*munmap)(void *, size_t) = nullptr;
+  int (*mprotect)(void *, size_t, int) = nullptr;
+  int (*madvise)(void *, size_t, int) = nullptr;
+  int (*dup)(int) = nullptr;
+  int (*dup2)(int, int) = nullptr;
+  int (*dup3)(int, int, int) = nullptr;
+  int (*fcntl)(int, int, ...) = nullptr;
+  FILE *(*fopen)(const char *, const char *) = nullptr;
+  FILE *(*freopen)(const char *, const char *, FILE *) = nullptr;
+  DIR *(*opendir)(const char *) = nullptr;
+  int (*stat)(const char *, struct stat *) = nullptr;
+  int (*lstat)(const char *, struct stat *) = nullptr;
+  int (*access)(const char *, int) = nullptr;
+  int (*fstat_fn)(int, struct stat *) = nullptr;
+  ssize_t (*readlink_fn)(const char *, char *, size_t) = nullptr;
+  pid_t (*fork)() = nullptr;
+
+  /// @brief Return true after all required symbols have been resolved.
+  [[nodiscard]] bool ready() const { return initialized_; }
+
+  /// @brief Resolve the real libc functions from the next dynamic object.
+  void resolve();
+
+private:
+  bool initialized_ = false;
+};
+
+/// @brief Return the process-wide libc pass-through table.
+LibcPassthrough &libc_passthrough();
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_KMD_LINUX_LIBC_PASSTHROUGH_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/linux_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/linux_kfd.cpp
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file linux_kfd.cpp
+/// @brief Shared Linux KFD ioctl helpers.
+
+#include "rocjitsu/kmd/linux/linux_kfd.h"
+
+#include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "linux/uapi/kfd_ioctl.h"
+RJ_DIAGNOSTIC_POP
+
+#include <cerrno>
+#include <charconv>
+#include <chrono>
+#include <cstdint>
+#include <string_view>
+
+namespace rocjitsu {
+
+namespace {
+
+constexpr std::string_view kKfdTopologyPrefix = "/sys/devices/virtual/kfd/kfd/topology";
+constexpr std::string_view kKfdTopologyAltPrefix = "/sys/class/kfd/kfd/topology";
+constexpr std::string_view kDrmSysfsPrefix = "/sys/class/drm";
+constexpr std::string_view kDrmRenderPrefix = "/sys/class/drm/renderD";
+constexpr std::string_view kSysDevCharPrefix = "/sys/dev/char/";
+
+} // namespace
+
+std::string LinuxKfd::redirect_sysfs_root_path(const char *path, const std::string &topology_path,
+                                               const std::string &drm_path) {
+  if (!path)
+    return {};
+
+  std::string_view sv(path);
+  if (!topology_path.empty()) {
+    if (sv.starts_with(kKfdTopologyPrefix))
+      return topology_path + std::string(sv.substr(kKfdTopologyPrefix.size()));
+    if (sv.starts_with(kKfdTopologyAltPrefix))
+      return topology_path + std::string(sv.substr(kKfdTopologyAltPrefix.size()));
+  }
+
+  if (!drm_path.empty() && sv.starts_with(kDrmSysfsPrefix))
+    return drm_path + std::string(sv.substr(kDrmSysfsPrefix.size()));
+
+  return {};
+}
+
+bool LinuxKfd::parse_drm_render_path(std::string_view path, uint32_t *minor,
+                                     std::string_view *suffix) {
+  if (!minor || !suffix || !path.starts_with(kDrmRenderPrefix))
+    return false;
+
+  auto rest = path.substr(kDrmRenderPrefix.size());
+  auto slash = rest.find('/');
+  auto number = slash == std::string_view::npos ? rest : rest.substr(0, slash);
+  uint32_t parsed = 0;
+  auto [ptr, err] = std::from_chars(number.data(), number.data() + number.size(), parsed);
+  if (err != std::errc{} || ptr != number.data() + number.size())
+    return false;
+
+  *minor = parsed;
+  *suffix = slash == std::string_view::npos ? std::string_view{} : rest.substr(slash);
+  return true;
+}
+
+bool LinuxKfd::parse_sys_dev_drm_render_path(std::string_view path, uint32_t *minor,
+                                             std::string_view *suffix) {
+  if (!minor || !suffix || !path.starts_with(kSysDevCharPrefix))
+    return false;
+
+  auto rest = path.substr(kSysDevCharPrefix.size());
+  auto colon = rest.find(':');
+  if (colon == std::string_view::npos)
+    return false;
+
+  uint32_t major = 0;
+  auto [major_ptr, major_err] = std::from_chars(rest.data(), rest.data() + colon, major);
+  if (major_err != std::errc{} || major_ptr != rest.data() + colon || major != 226)
+    return false;
+
+  auto after_colon = rest.substr(colon + 1);
+  auto slash = after_colon.find('/');
+  auto number = slash == std::string_view::npos ? after_colon : after_colon.substr(0, slash);
+  uint32_t parsed = 0;
+  auto [ptr, err] = std::from_chars(number.data(), number.data() + number.size(), parsed);
+  if (err != std::errc{} || ptr != number.data() + number.size())
+    return false;
+
+  *minor = parsed;
+  *suffix = slash == std::string_view::npos ? std::string_view{} : after_colon.substr(slash);
+  return true;
+}
+
+const char *LinuxKfd::ioctl_name(unsigned long request) {
+  switch (canonical_ioctl_request(request)) {
+  case AMDKFD_IOC_GET_VERSION:
+    return "GET_VERSION";
+  case AMDKFD_IOC_GET_CLOCK_COUNTERS:
+    return "GET_CLOCK_COUNTERS";
+  case AMDKFD_IOC_GET_PROCESS_APERTURES_NEW:
+    return "GET_APERTURES";
+  case AMDKFD_IOC_ACQUIRE_VM:
+    return "ACQUIRE_VM";
+  case AMDKFD_IOC_ALLOC_MEMORY_OF_GPU:
+    return "ALLOC_MEMORY";
+  case AMDKFD_IOC_FREE_MEMORY_OF_GPU:
+    return "FREE_MEMORY";
+  case AMDKFD_IOC_MAP_MEMORY_TO_GPU:
+    return "MAP_MEMORY";
+  case AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU:
+    return "UNMAP_MEMORY";
+  case AMDKFD_IOC_CREATE_QUEUE:
+    return "CREATE_QUEUE";
+  case AMDKFD_IOC_UPDATE_QUEUE:
+    return "UPDATE_QUEUE";
+  case AMDKFD_IOC_DESTROY_QUEUE:
+    return "DESTROY_QUEUE";
+  case AMDKFD_IOC_CREATE_EVENT:
+    return "CREATE_EVENT";
+  case AMDKFD_IOC_DESTROY_EVENT:
+    return "DESTROY_EVENT";
+  case AMDKFD_IOC_SET_EVENT:
+    return "SET_EVENT";
+  case AMDKFD_IOC_RESET_EVENT:
+    return "RESET_EVENT";
+  case AMDKFD_IOC_WAIT_EVENTS:
+    return "WAIT_EVENTS";
+  case AMDKFD_IOC_RUNTIME_ENABLE:
+    return "RUNTIME_ENABLE";
+  case AMDKFD_IOC_SET_SCRATCH_BACKING_VA:
+    return "SET_SCRATCH_VA";
+  case AMDKFD_IOC_SET_TRAP_HANDLER:
+    return "SET_TRAP_HANDLER";
+  case AMDKFD_IOC_SET_XNACK_MODE:
+    return "SET_XNACK";
+  case AMDKFD_IOC_SET_MEMORY_POLICY:
+    return "SET_MEM_POLICY";
+  case AMDKFD_IOC_AVAILABLE_MEMORY:
+    return "AVAIL_MEMORY";
+  case AMDKFD_IOC_GET_TILE_CONFIG:
+    return "GET_TILE_CONFIG";
+  case AMDKFD_IOC_SVM:
+    return "SVM";
+  default:
+    return "UNKNOWN";
+  }
+}
+
+int LinuxKfd::get_version_ioctl(void *arg) { return fill_get_version_ioctl(arg); }
+
+int LinuxKfd::fill_get_version_ioctl(void *arg) {
+  auto *args = static_cast<kfd_ioctl_get_version_args *>(arg);
+  if (!args) {
+    errno = EINVAL;
+    return -1;
+  }
+  args->major_version = KFD_IOCTL_MAJOR_VERSION;
+  args->minor_version = KFD_IOCTL_MINOR_VERSION;
+  return 0;
+}
+
+int LinuxKfd::get_clock_counters_ioctl(void *arg) { return fill_get_clock_counters_ioctl(arg); }
+
+int LinuxKfd::fill_get_clock_counters_ioctl(void *arg) {
+  auto *args = static_cast<kfd_ioctl_get_clock_counters_args *>(arg);
+  if (!args) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  auto now = std::chrono::steady_clock::now().time_since_epoch();
+  uint64_t ns =
+      static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
+  args->system_clock_freq = 1000000000ULL;
+  args->system_clock_counter = ns;
+  args->cpu_clock_counter = ns;
+  args->gpu_clock_counter = ns;
+  return 0;
+}
+
+int LinuxKfd::get_process_apertures_ioctl(void *) {
+  errno = ENOTSUP;
+  return -1;
+}
+
+int LinuxKfd::acquire_vm_ioctl(void *) {
+  errno = ENOTSUP;
+  return -1;
+}
+
+int LinuxKfd::get_available_memory_ioctl(void *) {
+  errno = ENOTSUP;
+  return -1;
+}
+
+int LinuxKfd::set_memory_policy_ioctl(void *) {
+  errno = ENOTSUP;
+  return -1;
+}
+
+int LinuxKfd::alloc_memory_ioctl(void *) {
+  errno = ENOTSUP;
+  return -1;
+}
+
+int LinuxKfd::free_memory_ioctl(void *) {
+  errno = ENOTSUP;
+  return -1;
+}
+
+int LinuxKfd::map_memory_ioctl(void *) {
+  errno = ENOTSUP;
+  return -1;
+}
+
+int LinuxKfd::unmap_memory_ioctl(void *) {
+  errno = ENOTSUP;
+  return -1;
+}
+
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/linux_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/linux_kfd.h
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file linux_kfd.h
+/// @brief Linux-specific KFD driver interface used by the syscall interposer.
+
+#ifndef ROCJITSU_KMD_LINUX_LINUX_KFD_H_
+#define ROCJITSU_KMD_LINUX_LINUX_KFD_H_
+
+#include "rocjitsu/kmd/linux/sysfs.h"
+#include "rocjitsu/vm/driver.h"
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace rocjitsu {
+
+/// @brief KFD mmap offset encoding fields, matching kfd_priv.h.
+inline constexpr uint64_t KFD_MMAP_TYPE_SHIFT = 62;
+inline constexpr uint64_t KFD_MMAP_TYPE_MASK = 0x3ULL << KFD_MMAP_TYPE_SHIFT;
+inline constexpr uint64_t KFD_MMAP_TYPE_DOORBELL = 0x3ULL << KFD_MMAP_TYPE_SHIFT;
+inline constexpr uint64_t KFD_MMAP_TYPE_EVENTS = 0x2ULL << KFD_MMAP_TYPE_SHIFT;
+inline constexpr uint64_t KFD_MMAP_GPU_ID_SHIFT = 46;
+
+/// @brief Encode a KFD GPU id into the mmap offset GPU-id field.
+inline constexpr uint64_t kfd_mmap_gpu_id(uint32_t gpu_id) {
+  return (static_cast<uint64_t>(gpu_id) << KFD_MMAP_GPU_ID_SHIFT) &
+         ((1ULL << KFD_MMAP_TYPE_SHIFT) - (1ULL << KFD_MMAP_GPU_ID_SHIFT));
+}
+
+/// @brief Linux KFD driver surface required by the LD_PRELOAD shim.
+///
+/// @details The base Driver interface handles /dev/kfd calls. The Linux shim
+/// also needs sysfs redirection, DRM render-node ownership, and fd tracking.
+/// SimulatedKfd and GuestKfd both implement this surface, but with
+/// different ownership rules: simulation owns all visible GPU discovery, while
+/// GuestKfd owns only the appended guest GPU.
+class LinuxKfd : public Driver {
+public:
+  ~LinuxKfd() override = default;
+
+  /// @brief Return the /dev/kfd fd represented by this driver.
+  [[nodiscard]] virtual int fd() const = 0;
+
+  /// @brief Reset inherited child-process state after fork().
+  virtual void reset_after_fork() {}
+
+  /// @brief Retain one duplicate open reference, if this driver tracks them.
+  virtual void retain_local_open() {}
+
+  /// @brief Return true when @p fd is owned internally by the driver.
+  [[nodiscard]] virtual bool owns_fd(int fd) const = 0;
+
+  /// @brief Redirect a sysfs path to a generated topology/DRM path.
+  ///
+  /// @details Returns an empty string when the driver does not own the path.
+  [[nodiscard]] virtual std::string redirect_sysfs_path(const char *path) const = 0;
+
+  /// @brief Return true if a memory range is a KFD doorbell mapping.
+  [[nodiscard]] virtual bool is_doorbell_range(const void *addr, size_t length) const = 0;
+
+  /// @brief Return true if this driver should synthesize /dev/dri/renderD@p minor.
+  [[nodiscard]] virtual bool handles_drm_render_minor(uint32_t minor) const = 0;
+
+  /// @brief Return synthetic GPU properties for a handled DRM render minor.
+  [[nodiscard]] virtual const Sysfs::GpuInfo *gpu_info_for_render_minor(uint32_t minor) const = 0;
+
+  /// @brief Return the generated KFD topology root, if any.
+  [[nodiscard]] virtual std::string topology_path() const = 0;
+
+  /// @brief Return a generated /sys/class/drm root for full DRM redirection.
+  ///
+  /// @details GuestKfd returns an empty string because host DRM entries
+  /// must remain real; it redirects only the synthetic guest render node.
+  [[nodiscard]] virtual std::string drm_path() const = 0;
+
+  /// @brief Redirect standard KFD topology and DRM sysfs roots.
+  ///
+  /// @details Empty root paths are ignored. Returns empty when @p path does not
+  /// name a handled sysfs root.
+  static std::string redirect_sysfs_root_path(const char *path, const std::string &topology_path,
+                                              const std::string &drm_path);
+
+protected:
+  /// @brief Parse /sys/class/drm/renderD<minor> paths.
+  static bool parse_drm_render_path(std::string_view path, uint32_t *minor,
+                                    std::string_view *suffix);
+
+  /// @brief Parse /sys/dev/char/226:<minor> paths for DRM render nodes.
+  static bool parse_sys_dev_drm_render_path(std::string_view path, uint32_t *minor,
+                                            std::string_view *suffix);
+
+  /// @brief Return a stable diagnostic name for a KFD ioctl request.
+  static const char *ioctl_name(unsigned long request);
+
+  /// @brief Handle AMDKFD_IOC_GET_VERSION.
+  virtual int get_version_ioctl(void *arg);
+
+  /// @brief Fill AMDKFD_IOC_GET_VERSION with the KFD ioctl ABI version.
+  static int fill_get_version_ioctl(void *arg);
+
+  /// @brief Handle AMDKFD_IOC_GET_CLOCK_COUNTERS.
+  virtual int get_clock_counters_ioctl(void *arg);
+
+  /// @brief Fill AMDKFD_IOC_GET_CLOCK_COUNTERS with synthetic monotonic counters.
+  static int fill_get_clock_counters_ioctl(void *arg);
+
+  /// @brief Handle AMDKFD_IOC_GET_PROCESS_APERTURES_NEW.
+  virtual int get_process_apertures_ioctl(void *arg);
+
+  /// @brief Handle AMDKFD_IOC_ACQUIRE_VM.
+  virtual int acquire_vm_ioctl(void *arg);
+
+  /// @brief Handle AMDKFD_IOC_AVAILABLE_MEMORY.
+  virtual int get_available_memory_ioctl(void *arg);
+
+  /// @brief Handle AMDKFD_IOC_SET_MEMORY_POLICY.
+  virtual int set_memory_policy_ioctl(void *arg);
+
+  /// @brief Handle AMDKFD_IOC_ALLOC_MEMORY_OF_GPU.
+  virtual int alloc_memory_ioctl(void *arg);
+
+  /// @brief Handle AMDKFD_IOC_FREE_MEMORY_OF_GPU.
+  virtual int free_memory_ioctl(void *arg);
+
+  /// @brief Handle AMDKFD_IOC_MAP_MEMORY_TO_GPU.
+  virtual int map_memory_ioctl(void *arg);
+
+  /// @brief Handle AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU.
+  virtual int unmap_memory_ioctl(void *arg);
+};
+
+} // namespace rocjitsu
+
+#endif // ROCJITSU_KMD_LINUX_LINUX_KFD_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -202,7 +202,7 @@ int RemoteDriver::open() {
 
   // Create a high-numbered synthetic KFD fd to avoid collisions with ROCR's
   // internal fd lifecycle. Use the top of the current rlimit range (same
-  // approach as SimulatedDriver::init_reserved_fd_range).
+  // approach as SimulatedKfd::init_reserved_fd_range).
   struct rlimit rl {};
   getrlimit(RLIMIT_NOFILE, &rl);
   int fd_min = static_cast<int>(rl.rlim_cur) - 64;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-#include "rocjitsu/kmd/linux/simulated_driver.h"
+#include "rocjitsu/kmd/linux/simulated_kfd.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
 #include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
 #include "rocjitsu/vm/amdgpu/command_processor.h"
@@ -17,7 +17,6 @@ RJ_DIAGNOSTIC_POP
 
 #include <algorithm>
 #include <cerrno>
-#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -25,7 +24,6 @@ RJ_DIAGNOSTIC_POP
 #include <format>
 #include <linux/types.h>
 #include <sstream>
-#include <string_view>
 #include <sys/mman.h>
 #include <sys/random.h>
 #include <sys/resource.h>
@@ -40,8 +38,6 @@ RJ_DIAGNOSTIC_POP
 
 namespace rocjitsu {
 
-constexpr const char *const kKfdSysfsPrefix = "/sys/devices/virtual/kfd/kfd/topology";
-
 namespace {
 
 bool vm_trace_enabled() {
@@ -49,8 +45,6 @@ bool vm_trace_enabled() {
   return enabled;
 }
 
-constexpr const char *const kDrmSysfsPrefix = "/sys/class/drm";
-constexpr const char *const kKfdSysfsPrefixAlt = "/sys/class/kfd/kfd/topology";
 constexpr uint32_t kTileConfigCount = 32;
 constexpr uint32_t kMacroTileConfigCount = 16;
 
@@ -76,182 +70,103 @@ void *safe_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t of
 
 } // namespace
 
-std::shared_ptr<KfdProcess> SimulatedDriver::find_process(uint32_t process_id) const {
+std::shared_ptr<KfdProcess> SimulatedKfd::find_process(uint32_t process_id) const {
   std::lock_guard<std::mutex> lk(process_mutex_);
   auto it = processes_.find(process_id);
   return (it != processes_.end()) ? it->second : nullptr;
 }
 
-void SimulatedDriver::map_to_gpu(KfdProcess &proc, uint64_t gpu_va, void *host_ptr, size_t size,
-                                 amdgpu::Mtype mtype) {
+std::shared_ptr<KfdProcess> SimulatedKfd::find_local_process() const {
+  return find_process(local_process_id_);
+}
+
+void SimulatedKfd::map_to_gpu(KfdProcess &proc, uint64_t gpu_va, void *host_ptr, size_t size,
+                              amdgpu::Mtype mtype) {
   util::Logger::cp("MAP pid=", proc.process_id(), " va=0x", std::hex, gpu_va, " size=0x", size,
                    std::dec, " mtype=", static_cast<int>(mtype));
   proc.map_pages(gpu_va, host_ptr, size, mtype);
 }
 
-void SimulatedDriver::unmap_from_gpu(KfdProcess &proc, uint64_t gpu_va, size_t size) {
+void SimulatedKfd::unmap_from_gpu(KfdProcess &proc, uint64_t gpu_va, size_t size) {
   util::Logger::cp("UNMAP pid=", proc.process_id(), " va=0x", std::hex, gpu_va, " size=0x", size,
                    std::dec);
   proc.unmap_pages(gpu_va, size);
 }
 
-std::string SimulatedDriver::redirect_sysfs_path(const char *path) const {
-  std::string_view sv(path);
-  std::string_view kfd_prefix(kKfdSysfsPrefix);
-  if (sv.starts_with(kfd_prefix)) {
-    auto result = topology_path() + std::string(sv.substr(kfd_prefix.size()));
+std::string SimulatedKfd::redirect_sysfs_path(const char *path) const {
+  auto result = redirect_sysfs_root_path(path, topology_path(), topology().drm_path());
+  if (!result.empty()) {
     util::Logger::vm("sysfs redirect: ", path, " -> ", result);
     return result;
   }
-  std::string_view kfd_alt_prefix(kKfdSysfsPrefixAlt);
-  if (sv.starts_with(kfd_alt_prefix))
-    return topology_path() + std::string(sv.substr(kfd_alt_prefix.size()));
-
-  const auto &drm = topology().drm_path();
-  if (!drm.empty()) {
-    std::string_view drm_prefix(kDrmSysfsPrefix);
-    if (sv.starts_with(drm_prefix))
-      return drm + std::string(sv.substr(drm_prefix.size()));
-  }
-
   return {};
 }
 
-void SimulatedDriver::setup_topology(const config::KfdDeviceConfig &dev, uint32_t num_xcc) {
+bool SimulatedKfd::handles_drm_render_minor(uint32_t minor) const {
+  if (topology().drm_path().empty())
+    return false;
+  if (num_gpus() <= 1)
+    return true;
+  return minor >= 128 && minor < 128 + num_gpus();
+}
+
+const Sysfs::GpuInfo *SimulatedKfd::gpu_info_for_render_minor(uint32_t /*minor*/) const {
+  if (topology().drm_path().empty())
+    return nullptr;
+  return &topology().gpu_info();
+}
+
+void SimulatedKfd::setup_topology(const config::KfdDeviceConfig &dev, uint32_t num_xcc) {
   if (!dev.present)
     return;
 
-  Sysfs::GpuInfo gpu{};
-  gpu.gpu_id = dev.gpu_id;
-  gpu.gfx_target_version = dev.gfx_target_version;
-  gpu.vendor_id = dev.vendor_id;
-  gpu.device_id = dev.device_id;
-  gpu.family_id = dev.family_id;
-  gpu.unique_id = dev.unique_id;
-  gpu.marketing_name = dev.marketing_name;
-  gpu.drm_render_minor = dev.drm_render_minor;
-  gpu.revision_id = dev.revision_id;
-  gpu.pci_revision_id = dev.pci_revision_id;
-  gpu.simd_count = dev.simd_count;
-  gpu.max_waves_per_simd = dev.max_waves_per_simd;
-  gpu.num_shader_engines = dev.num_shader_engines;
-  gpu.num_shader_arrays_per_engine = dev.num_shader_arrays_per_engine;
-  gpu.num_cu_per_sh = dev.num_cu_per_sh;
-  gpu.simd_per_cu = dev.simd_per_cu;
-  gpu.wave_front_size = dev.wave_front_size;
-  gpu.max_slots_scratch_cu = dev.max_slots_scratch_cu;
-  gpu.local_mem_size = dev.local_mem_size;
-  gpu.vram_type = dev.vram_type;
-  gpu.lds_size_kb = dev.lds_size_kb;
-  gpu.mem_width = dev.mem_width;
-  gpu.mem_clk_max = dev.mem_clk_max;
-  gpu.l1_size_kb = dev.l1_size_kb;
-  gpu.l1_line_size = dev.l1_line_size;
-  gpu.l1_assoc = dev.l1_assoc;
-  gpu.l2_size_kb = dev.l2_size_kb;
-  gpu.l2_line_size = dev.l2_line_size;
-  gpu.l2_assoc = dev.l2_assoc;
-  gpu.num_sdma_engines = dev.num_sdma_engines;
-  gpu.num_sdma_xgmi_engines = dev.num_sdma_xgmi_engines;
-  gpu.num_cp_queues = dev.num_cp_queues;
-  gpu.max_engine_clk_fcompute = dev.max_engine_clk_fcompute;
-  gpu.location_id = dev.location_id;
-  gpu.hive_id = dev.hive_id;
-  gpu.domain = dev.domain;
-  gpu.capability = dev.capability;
-  gpu.capability2 = dev.capability2;
-  gpu.debug_prop = dev.debug_prop;
-  gpu.num_xcc = num_xcc;
-
-  setup_topology(gpu);
+  setup_topology(gpu_info_from_config(dev, num_xcc));
 }
 
-SimulatedDriver::SimulatedDriver(SoC &soc, bool daemon_mode) : daemon_mode_(daemon_mode) {
+SimulatedKfd::SimulatedKfd(SoC &soc, bool daemon_mode) : daemon_mode_(daemon_mode) {
   gpus_.push_back({&soc, 0, false, {}});
 }
 
-SimulatedDriver::SimulatedDriver(std::vector<SoC *> socs, std::vector<uint32_t> gpu_ids,
-                                 bool daemon_mode)
+SimulatedKfd::SimulatedKfd(std::vector<SoC *> socs, std::vector<uint32_t> gpu_ids, bool daemon_mode)
     : daemon_mode_(daemon_mode) {
   for (size_t i = 0; i < socs.size(); ++i)
     gpus_.push_back({socs[i], i < gpu_ids.size() ? gpu_ids[i] : socs[i]->gpu_id(), false, {}});
 }
 
-SimulatedDriver::GpuDevice *SimulatedDriver::find_gpu(uint32_t gpu_id) {
+SimulatedKfd::GpuDevice *SimulatedKfd::find_gpu(uint32_t gpu_id) {
   for (auto &g : gpus_)
     if (g.gpu_id == gpu_id)
       return &g;
   return nullptr;
 }
 
-const SimulatedDriver::GpuDevice *SimulatedDriver::find_gpu(uint32_t gpu_id) const {
+const SimulatedKfd::GpuDevice *SimulatedKfd::find_gpu(uint32_t gpu_id) const {
   for (auto &g : gpus_)
     if (g.gpu_id == gpu_id)
       return &g;
   return nullptr;
 }
 
-SimulatedDriver::~SimulatedDriver() {
+SimulatedKfd::~SimulatedKfd() {
   while (!processes_.empty())
     close(processes_.begin()->first);
 }
 
-void SimulatedDriver::setup_topology(const Sysfs::GpuInfo &gpu) {
+void SimulatedKfd::setup_topology(const Sysfs::GpuInfo &gpu) {
   if (!gpus_.empty())
     gpus_[0].gpu_id = gpu.gpu_id;
   topology_.generate(gpu);
   topology_.setup_environment();
 }
 
-void SimulatedDriver::setup_topology(const std::vector<config::KfdDeviceConfig> &devs,
-                                     uint32_t num_xcc) {
+void SimulatedKfd::setup_topology(const std::vector<config::KfdDeviceConfig> &devs,
+                                  uint32_t num_xcc) {
   std::vector<Sysfs::GpuInfo> infos;
   infos.reserve(devs.size());
   for (auto &dev : devs) {
     if (!dev.present)
       continue;
-    Sysfs::GpuInfo gpu{};
-    gpu.gpu_id = dev.gpu_id;
-    gpu.gfx_target_version = dev.gfx_target_version;
-    gpu.vendor_id = dev.vendor_id;
-    gpu.device_id = dev.device_id;
-    gpu.family_id = dev.family_id;
-    gpu.unique_id = dev.unique_id;
-    gpu.marketing_name = dev.marketing_name;
-    gpu.drm_render_minor = dev.drm_render_minor;
-    gpu.revision_id = dev.revision_id;
-    gpu.pci_revision_id = dev.pci_revision_id;
-    gpu.simd_count = dev.simd_count;
-    gpu.max_waves_per_simd = dev.max_waves_per_simd;
-    gpu.num_shader_engines = dev.num_shader_engines;
-    gpu.num_shader_arrays_per_engine = dev.num_shader_arrays_per_engine;
-    gpu.num_cu_per_sh = dev.num_cu_per_sh;
-    gpu.simd_per_cu = dev.simd_per_cu;
-    gpu.wave_front_size = dev.wave_front_size;
-    gpu.max_slots_scratch_cu = dev.max_slots_scratch_cu;
-    gpu.local_mem_size = dev.local_mem_size;
-    gpu.vram_type = dev.vram_type;
-    gpu.lds_size_kb = dev.lds_size_kb;
-    gpu.mem_width = dev.mem_width;
-    gpu.mem_clk_max = dev.mem_clk_max;
-    gpu.l1_size_kb = dev.l1_size_kb;
-    gpu.l1_line_size = dev.l1_line_size;
-    gpu.l1_assoc = dev.l1_assoc;
-    gpu.l2_size_kb = dev.l2_size_kb;
-    gpu.l2_line_size = dev.l2_line_size;
-    gpu.l2_assoc = dev.l2_assoc;
-    gpu.num_sdma_engines = dev.num_sdma_engines;
-    gpu.num_sdma_xgmi_engines = dev.num_sdma_xgmi_engines;
-    gpu.num_cp_queues = dev.num_cp_queues;
-    gpu.max_engine_clk_fcompute = dev.max_engine_clk_fcompute;
-    gpu.location_id = dev.location_id;
-    gpu.hive_id = dev.hive_id;
-    gpu.domain = dev.domain;
-    gpu.capability = dev.capability;
-    gpu.capability2 = dev.capability2;
-    gpu.debug_prop = dev.debug_prop;
-    gpu.num_xcc = num_xcc;
-    infos.push_back(gpu);
+    infos.push_back(gpu_info_from_config(dev, num_xcc));
   }
   if (infos.empty())
     return;
@@ -261,7 +176,7 @@ void SimulatedDriver::setup_topology(const std::vector<config::KfdDeviceConfig> 
   topology_.setup_environment();
 }
 
-bool SimulatedDriver::is_doorbell_range(const void *addr, size_t length) const {
+bool SimulatedKfd::is_doorbell_range(const void *addr, size_t length) const {
   auto p = find_process(local_process_id_);
   if (!p)
     return false;
@@ -275,7 +190,7 @@ bool SimulatedDriver::is_doorbell_range(const void *addr, size_t length) const {
   return query_base < end && query_end > base;
 }
 
-int SimulatedDriver::open() {
+int SimulatedKfd::open() {
   static std::once_flag raise_nofile_flag;
   std::call_once(raise_nofile_flag, [] {
     struct rlimit rl {};
@@ -360,7 +275,7 @@ int SimulatedDriver::open() {
   return fd_;
 }
 
-void SimulatedDriver::set_process_client_pid(uint32_t process_id, pid_t client_pid) {
+void SimulatedKfd::set_process_client_pid(uint32_t process_id, pid_t client_pid) {
   std::lock_guard<std::mutex> lk(process_mutex_);
   auto it = processes_.find(process_id);
   if (it != processes_.end()) {
@@ -372,7 +287,7 @@ void SimulatedDriver::set_process_client_pid(uint32_t process_id, pid_t client_p
   }
 }
 
-uint32_t SimulatedDriver::open_process(pid_t client_pid) {
+uint32_t SimulatedKfd::open_process(pid_t client_pid) {
   if (fd_ < 0) {
     fd_ = static_cast<int>(syscall(SYS_memfd_create, "rocjitsu_kfd", 0));
     if (fd_ < 0)
@@ -462,7 +377,7 @@ uint32_t SimulatedDriver::open_process(pid_t client_pid) {
   return pid;
 }
 
-void SimulatedDriver::retain_local_open() {
+void SimulatedKfd::retain_local_open() {
   std::lock_guard<std::mutex> lk(process_mutex_);
   if (local_process_id_ == 0)
     return;
@@ -471,7 +386,7 @@ void SimulatedDriver::retain_local_open() {
     it->second->retain_open();
 }
 
-uint32_t SimulatedDriver::local_open_ref_count() const {
+uint32_t SimulatedKfd::local_open_ref_count() const {
   std::lock_guard<std::mutex> lk(process_mutex_);
   if (local_process_id_ == 0)
     return 0;
@@ -479,9 +394,9 @@ uint32_t SimulatedDriver::local_open_ref_count() const {
   return it != processes_.end() ? it->second->open_ref_count() : 0;
 }
 
-int SimulatedDriver::close() { return close(local_process_id_); }
+int SimulatedKfd::close() { return close(local_process_id_); }
 
-int SimulatedDriver::close(uint32_t process_id) {
+int SimulatedKfd::close(uint32_t process_id) {
   std::shared_ptr<KfdProcess> extracted;
   std::vector<uint32_t> queue_ids;
 
@@ -587,74 +502,19 @@ int SimulatedDriver::close(uint32_t process_id) {
   return 0;
 }
 
-int SimulatedDriver::ioctl(unsigned long request, void *arg) {
+int SimulatedKfd::ioctl(unsigned long request, void *arg) {
   return ioctl(local_process_id_, request, arg);
 }
 
-int SimulatedDriver::ioctl(uint32_t process_id, unsigned long request, void *arg) {
+int SimulatedKfd::ioctl(uint32_t process_id, unsigned long request, void *arg) {
   auto proc = find_process(process_id);
   if (!proc)
     return -ESRCH;
   return dispatch_ioctl(*proc, request, arg);
 }
 
-static const char *ioctl_name(unsigned long req) {
-  switch (canonical_ioctl_request(req)) {
-  case AMDKFD_IOC_GET_VERSION:
-    return "GET_VERSION";
-  case AMDKFD_IOC_GET_CLOCK_COUNTERS:
-    return "GET_CLOCK_COUNTERS";
-  case AMDKFD_IOC_GET_PROCESS_APERTURES_NEW:
-    return "GET_APERTURES";
-  case AMDKFD_IOC_ACQUIRE_VM:
-    return "ACQUIRE_VM";
-  case AMDKFD_IOC_ALLOC_MEMORY_OF_GPU:
-    return "ALLOC_MEMORY";
-  case AMDKFD_IOC_FREE_MEMORY_OF_GPU:
-    return "FREE_MEMORY";
-  case AMDKFD_IOC_MAP_MEMORY_TO_GPU:
-    return "MAP_MEMORY";
-  case AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU:
-    return "UNMAP_MEMORY";
-  case AMDKFD_IOC_CREATE_QUEUE:
-    return "CREATE_QUEUE";
-  case AMDKFD_IOC_UPDATE_QUEUE:
-    return "UPDATE_QUEUE";
-  case AMDKFD_IOC_DESTROY_QUEUE:
-    return "DESTROY_QUEUE";
-  case AMDKFD_IOC_CREATE_EVENT:
-    return "CREATE_EVENT";
-  case AMDKFD_IOC_DESTROY_EVENT:
-    return "DESTROY_EVENT";
-  case AMDKFD_IOC_SET_EVENT:
-    return "SET_EVENT";
-  case AMDKFD_IOC_RESET_EVENT:
-    return "RESET_EVENT";
-  case AMDKFD_IOC_WAIT_EVENTS:
-    return "WAIT_EVENTS";
-  case AMDKFD_IOC_RUNTIME_ENABLE:
-    return "RUNTIME_ENABLE";
-  case AMDKFD_IOC_SET_SCRATCH_BACKING_VA:
-    return "SET_SCRATCH_VA";
-  case AMDKFD_IOC_SET_TRAP_HANDLER:
-    return "SET_TRAP_HANDLER";
-  case AMDKFD_IOC_SET_XNACK_MODE:
-    return "SET_XNACK";
-  case AMDKFD_IOC_SET_MEMORY_POLICY:
-    return "SET_MEM_POLICY";
-  case AMDKFD_IOC_AVAILABLE_MEMORY:
-    return "AVAIL_MEMORY";
-  case AMDKFD_IOC_GET_TILE_CONFIG:
-    return "GET_TILE_CONFIG";
-  case AMDKFD_IOC_SVM:
-    return "SVM";
-  default:
-    return "UNKNOWN";
-  }
-}
-
-int SimulatedDriver::dispatch_ioctl(KfdProcess &proc, unsigned long request, void *arg) {
-  util::Logger::cp("IOCTL pid=", proc.process_id(), " ", ioctl_name(request));
+int SimulatedKfd::dispatch_ioctl(KfdProcess &proc, unsigned long request, void *arg) {
+  util::Logger::cp("IOCTL pid=", proc.process_id(), " ", LinuxKfd::ioctl_name(request));
 
   switch (canonical_ioctl_request(request)) {
   case AMDKFD_IOC_GET_VERSION:
@@ -662,7 +522,7 @@ int SimulatedDriver::dispatch_ioctl(KfdProcess &proc, unsigned long request, voi
   case AMDKFD_IOC_GET_CLOCK_COUNTERS:
     return get_clock_counters_ioctl(arg);
   case AMDKFD_IOC_GET_PROCESS_APERTURES_NEW:
-    return get_apertures_ioctl(arg);
+    return get_process_apertures_ioctl(arg);
   case AMDKFD_IOC_ACQUIRE_VM:
     return acquire_vm_ioctl(arg);
   case AMDKFD_IOC_ALLOC_MEMORY_OF_GPU:
@@ -693,18 +553,8 @@ int SimulatedDriver::dispatch_ioctl(KfdProcess &proc, unsigned long request, voi
     return set_xnack_mode_ioctl(arg);
   case AMDKFD_IOC_SET_MEMORY_POLICY:
     return set_memory_policy_ioctl(proc, arg);
-  case AMDKFD_IOC_AVAILABLE_MEMORY: {
-    auto *args = static_cast<kfd_ioctl_get_available_memory_args *>(arg);
-    uint64_t allocated = 0;
-    {
-      std::lock_guard<std::mutex> lk(proc.alloc_mutex_);
-      for (auto &[handle, alloc] : proc.allocations_)
-        allocated += alloc.size;
-    }
-    constexpr uint64_t kVramBytes = 64ULL << 30;
-    args->available = kVramBytes - std::min(allocated, kVramBytes);
-    return 0;
-  }
+  case AMDKFD_IOC_AVAILABLE_MEMORY:
+    return get_available_memory_ioctl(proc, arg);
   case AMDKFD_IOC_RUNTIME_ENABLE:
     return runtime_enable_ioctl(proc, arg);
   case AMDKFD_IOC_SET_SCRATCH_BACKING_VA: {
@@ -748,12 +598,12 @@ int SimulatedDriver::dispatch_ioctl(KfdProcess &proc, unsigned long request, voi
   }
 }
 
-void *SimulatedDriver::mmap(void *addr, size_t length, int prot, int flags, off_t offset) {
+void *SimulatedKfd::mmap(void *addr, size_t length, int prot, int flags, off_t offset) {
   return mmap(local_process_id_, addr, length, prot, flags, offset);
 }
 
-void *SimulatedDriver::mmap(uint32_t process_id, void *addr, size_t length, int prot, int flags,
-                            off_t offset) {
+void *SimulatedKfd::mmap(uint32_t process_id, void *addr, size_t length, int prot, int flags,
+                         off_t offset) {
   auto p = find_process(process_id);
   if (!p)
     return MAP_FAILED;
@@ -762,10 +612,10 @@ void *SimulatedDriver::mmap(uint32_t process_id, void *addr, size_t length, int 
   return dispatch_mmap(*p, addr, length, prot, flags, offset);
 }
 
-void *SimulatedDriver::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, int prot,
-                                     int flags, off_t offset) {
+void *SimulatedKfd::dispatch_mmap(KfdProcess &proc, void *addr, size_t length, int prot, int flags,
+                                  off_t offset) {
   uint64_t type = static_cast<uint64_t>(offset) & KFD_MMAP_TYPE_MASK;
-  util::Logger::vm("SimulatedDriver::mmap type=0x", std::hex, type, " offset=0x", offset,
+  util::Logger::vm("SimulatedKfd::mmap type=0x", std::hex, type, " offset=0x", offset,
                    " length=", std::dec, length, " addr=", addr);
 
   if (type == KFD_MMAP_TYPE_DOORBELL) {
@@ -974,18 +824,18 @@ void *SimulatedDriver::dispatch_mmap(KfdProcess &proc, void *addr, size_t length
   return host_ptr;
 }
 
-int SimulatedDriver::munmap(void *addr, size_t length) {
+int SimulatedKfd::munmap(void *addr, size_t length) {
   return munmap(local_process_id_, addr, length);
 }
 
-int SimulatedDriver::munmap(uint32_t process_id, void *addr, size_t length) {
+int SimulatedKfd::munmap(uint32_t process_id, void *addr, size_t length) {
   auto p = find_process(process_id);
   if (!p)
     return -ESRCH;
   return dispatch_munmap(*p, addr, length);
 }
 
-int SimulatedDriver::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
+int SimulatedKfd::dispatch_munmap(KfdProcess &proc, void *addr, size_t length) {
   for (auto &gs : proc.gpu_state_) {
     if (gs.doorbell_page == addr) {
       if (!proc.event_state_.is_closing()) {
@@ -1019,26 +869,7 @@ int SimulatedDriver::dispatch_munmap(KfdProcess &proc, void *addr, size_t length
   return -ENOENT;
 }
 
-int SimulatedDriver::get_version_ioctl(void *arg) {
-  auto *args = static_cast<kfd_ioctl_get_version_args *>(arg);
-  args->major_version = KFD_IOCTL_MAJOR_VERSION;
-  args->minor_version = KFD_IOCTL_MINOR_VERSION;
-  return 0;
-}
-
-int SimulatedDriver::get_clock_counters_ioctl(void *arg) {
-  auto *args = static_cast<kfd_ioctl_get_clock_counters_args *>(arg);
-  auto now = std::chrono::steady_clock::now().time_since_epoch();
-  uint64_t ns =
-      static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
-  args->system_clock_freq = 1000000000ULL;
-  args->system_clock_counter = ns;
-  args->cpu_clock_counter = ns;
-  args->gpu_clock_counter = ns;
-  return 0;
-}
-
-int SimulatedDriver::get_apertures_ioctl(void *arg) {
+int SimulatedKfd::get_process_apertures_ioctl(void *arg) {
   auto *args = static_cast<kfd_ioctl_get_process_apertures_new_args *>(arg);
   auto n = static_cast<uint32_t>(gpus_.size());
 
@@ -1064,7 +895,25 @@ int SimulatedDriver::get_apertures_ioctl(void *arg) {
   return 0;
 }
 
-int SimulatedDriver::get_tile_config_ioctl(void *arg) {
+int SimulatedKfd::get_available_memory_ioctl(void *arg) {
+  auto proc = find_local_process();
+  return proc ? get_available_memory_ioctl(*proc, arg) : -ESRCH;
+}
+
+int SimulatedKfd::get_available_memory_ioctl(KfdProcess &proc, void *arg) {
+  auto *args = static_cast<kfd_ioctl_get_available_memory_args *>(arg);
+  uint64_t allocated = 0;
+  {
+    std::lock_guard<std::mutex> lk(proc.alloc_mutex_);
+    for (auto &[handle, alloc] : proc.allocations_)
+      allocated += alloc.size;
+  }
+  constexpr uint64_t kVramBytes = 64ULL << 30;
+  args->available = kVramBytes - std::min(allocated, kVramBytes);
+  return 0;
+}
+
+int SimulatedKfd::get_tile_config_ioctl(void *arg) {
   auto *args = static_cast<kfd_ioctl_get_tile_config_args *>(arg);
   if (daemon_mode_)
     return -ENOTSUP;
@@ -1095,12 +944,37 @@ int SimulatedDriver::get_tile_config_ioctl(void *arg) {
   return 0;
 }
 
-int SimulatedDriver::acquire_vm_ioctl([[maybe_unused]] void *arg) {
+int SimulatedKfd::acquire_vm_ioctl([[maybe_unused]] void *arg) {
   (void)arg;
   return 0;
 }
 
-int SimulatedDriver::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::set_memory_policy_ioctl(void *arg) {
+  auto proc = find_local_process();
+  return proc ? set_memory_policy_ioctl(*proc, arg) : -ESRCH;
+}
+
+int SimulatedKfd::alloc_memory_ioctl(void *arg) {
+  auto proc = find_local_process();
+  return proc ? alloc_memory_ioctl(*proc, arg) : -ESRCH;
+}
+
+int SimulatedKfd::free_memory_ioctl(void *arg) {
+  auto proc = find_local_process();
+  return proc ? free_memory_ioctl(*proc, arg) : -ESRCH;
+}
+
+int SimulatedKfd::map_memory_ioctl(void *arg) {
+  auto proc = find_local_process();
+  return proc ? map_memory_ioctl(*proc, arg) : -ESRCH;
+}
+
+int SimulatedKfd::unmap_memory_ioctl(void *arg) {
+  auto proc = find_local_process();
+  return proc ? unmap_memory_ioctl(*proc, arg) : -ESRCH;
+}
+
+int SimulatedKfd::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_alloc_memory_of_gpu_args *>(arg);
 
   std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
@@ -1175,7 +1049,7 @@ int SimulatedDriver::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-bool SimulatedDriver::allocate_scratch_backing(uint32_t process_id, uint64_t gpu_va, size_t size) {
+bool SimulatedKfd::allocate_scratch_backing(uint32_t process_id, uint64_t gpu_va, size_t size) {
   if (size == 0)
     return false;
 
@@ -1251,7 +1125,7 @@ bool SimulatedDriver::allocate_scratch_backing(uint32_t process_id, uint64_t gpu
   return true;
 }
 
-int SimulatedDriver::free_memory_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::free_memory_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_free_memory_of_gpu_args *>(arg);
 
   std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
@@ -1297,7 +1171,7 @@ int SimulatedDriver::free_memory_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-int SimulatedDriver::map_memory_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::map_memory_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_map_memory_to_gpu_args *>(arg);
 
   std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
@@ -1316,7 +1190,7 @@ int SimulatedDriver::map_memory_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-int SimulatedDriver::unmap_memory_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::unmap_memory_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_unmap_memory_from_gpu_args *>(arg);
   std::lock_guard<std::mutex> lock(proc.alloc_mutex_);
   auto it = proc.allocations_.find(args->handle);
@@ -1333,7 +1207,7 @@ int SimulatedDriver::unmap_memory_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-int SimulatedDriver::create_queue_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::create_queue_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_create_queue_args *>(arg);
   auto *gpu = find_gpu(args->gpu_id);
   if (!gpu || !gpu->soc)
@@ -1409,7 +1283,7 @@ int SimulatedDriver::create_queue_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-int SimulatedDriver::update_queue_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::update_queue_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_update_queue_args *>(arg);
   for (auto &g : gpus_)
     if (g.soc)
@@ -1420,7 +1294,7 @@ int SimulatedDriver::update_queue_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-int SimulatedDriver::destroy_queue_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::destroy_queue_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_destroy_queue_args *>(arg);
   for (auto &g : gpus_)
     if (g.soc)
@@ -1443,7 +1317,7 @@ int SimulatedDriver::destroy_queue_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-int SimulatedDriver::set_memory_policy_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::set_memory_policy_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_set_memory_policy_args *>(arg);
   if (!find_gpu(args->gpu_id))
     return -EINVAL;
@@ -1456,7 +1330,7 @@ int SimulatedDriver::set_memory_policy_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-int SimulatedDriver::import_dmabuf_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::import_dmabuf_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_import_dmabuf_args *>(arg);
   if (!find_gpu(args->gpu_id))
     return -EINVAL;
@@ -1503,7 +1377,7 @@ int SimulatedDriver::import_dmabuf_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-int SimulatedDriver::export_dmabuf_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::export_dmabuf_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_export_dmabuf_args *>(arg);
 
   std::lock_guard<std::mutex> lk(proc.alloc_mutex_);
@@ -1520,7 +1394,7 @@ int SimulatedDriver::export_dmabuf_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-int SimulatedDriver::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_ipc_export_handle_args *>(arg);
 
   uint64_t alloc_size = 0;
@@ -1643,7 +1517,7 @@ int SimulatedDriver::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-int SimulatedDriver::ipc_import_handle_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::ipc_import_handle_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_ipc_import_handle_args *>(arg);
 
   IpcHandleKey key{};
@@ -1728,7 +1602,7 @@ int SimulatedDriver::ipc_import_handle_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-int SimulatedDriver::get_dmabuf_info_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::get_dmabuf_info_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_get_dmabuf_info_args *>(arg);
   uint64_t size = 0;
   uint32_t gpu_id = gpus_.empty() ? 0 : gpus_[0].gpu_id;
@@ -1767,7 +1641,7 @@ int SimulatedDriver::get_dmabuf_info_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-int SimulatedDriver::svm_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::svm_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_svm_args *>(arg);
   auto *attrs = reinterpret_cast<kfd_ioctl_svm_attribute *>(args + 1);
 
@@ -1805,7 +1679,7 @@ int SimulatedDriver::svm_ioctl(KfdProcess &proc, void *arg) {
   return -EINVAL;
 }
 
-int SimulatedDriver::runtime_enable_ioctl(KfdProcess &proc, void *arg) {
+int SimulatedKfd::runtime_enable_ioctl(KfdProcess &proc, void *arg) {
   auto *args = static_cast<kfd_ioctl_runtime_enable_args *>(arg);
 
   std::lock_guard<std::mutex> lock(proc.runtime_mutex_);
@@ -1833,27 +1707,27 @@ int SimulatedDriver::runtime_enable_ioctl(KfdProcess &proc, void *arg) {
   return 0;
 }
 
-int SimulatedDriver::set_xnack_mode_ioctl(void *arg) {
+int SimulatedKfd::set_xnack_mode_ioctl(void *arg) {
   auto *args = static_cast<kfd_ioctl_set_xnack_mode_args *>(arg);
   args->xnack_enabled = 0;
   return 0;
 }
 
-bool SimulatedDriver::owns_fd(int fd) const {
+bool SimulatedKfd::owns_fd(int fd) const {
   if (fd < 0)
     return false;
   std::lock_guard<std::mutex> lock(owned_fds_mutex_);
   return owned_fds_.contains(fd);
 }
 
-void SimulatedDriver::init_reserved_fd_range() {
+void SimulatedKfd::init_reserved_fd_range() {
   struct rlimit rl {};
   getrlimit(RLIMIT_NOFILE, &rl);
   reserved_fd_base_ = static_cast<int>(rl.rlim_cur) - kReservedFdCount;
   next_reserved_fd_ = reserved_fd_base_;
 }
 
-int SimulatedDriver::claim_fd(int real_fd) {
+int SimulatedKfd::claim_fd(int real_fd) {
   if (reserved_fd_base_ == 0)
     init_reserved_fd_range();
   int vfd = next_reserved_fd_++;
@@ -1863,23 +1737,23 @@ int SimulatedDriver::claim_fd(int real_fd) {
   return vfd;
 }
 
-bool SimulatedDriver::owns_reserved_fd(int fd) const {
+bool SimulatedKfd::owns_reserved_fd(int fd) const {
   return reserved_fd_base_ > 0 && fd >= reserved_fd_base_ &&
          fd < reserved_fd_base_ + kReservedFdCount;
 }
 
-int SimulatedDriver::get_mmap_memfd(off_t offset) const {
+int SimulatedKfd::get_mmap_memfd(off_t offset) const {
   return get_mmap_memfd(local_process_id_, offset);
 }
 
-int SimulatedDriver::get_mmap_memfd(uint32_t process_id, off_t offset) const {
+int SimulatedKfd::get_mmap_memfd(uint32_t process_id, off_t offset) const {
   auto p = find_process(process_id);
   if (!p)
     return -1;
   return dispatch_get_mmap_memfd(*p, offset);
 }
 
-int SimulatedDriver::dispatch_get_mmap_memfd(KfdProcess &proc, off_t offset) const {
+int SimulatedKfd::dispatch_get_mmap_memfd(KfdProcess &proc, off_t offset) const {
   uint64_t type = static_cast<uint64_t>(offset) & KFD_MMAP_TYPE_MASK;
 
   if (type == KFD_MMAP_TYPE_EVENTS)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_kfd.h
@@ -1,14 +1,14 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-#ifndef ROCJITSU_KMD_LINUX_SIMULATED_DRIVER_H_
-#define ROCJITSU_KMD_LINUX_SIMULATED_DRIVER_H_
+#ifndef ROCJITSU_KMD_LINUX_SIMULATED_KFD_H_
+#define ROCJITSU_KMD_LINUX_SIMULATED_KFD_H_
 
 #include "rocjitsu/base/rj_compiler.h"
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/kmd/linux/kfd_process.h"
+#include "rocjitsu/kmd/linux/linux_kfd.h"
 #include "rocjitsu/kmd/linux/sysfs.h"
-#include "rocjitsu/vm/driver.h"
 #include "rocjitsu/vm/soc.h"
 
 #include "simdojo/sim/simulation.h"
@@ -25,18 +25,6 @@ RJ_DIAGNOSTIC_POP
 #include <unordered_set>
 
 namespace rocjitsu {
-
-// KFD mmap offset encoding (mirrors kfd_priv.h).
-inline constexpr uint64_t KFD_MMAP_TYPE_SHIFT = 62;
-inline constexpr uint64_t KFD_MMAP_TYPE_MASK = 0x3ULL << KFD_MMAP_TYPE_SHIFT;
-inline constexpr uint64_t KFD_MMAP_TYPE_DOORBELL = 0x3ULL << KFD_MMAP_TYPE_SHIFT;
-inline constexpr uint64_t KFD_MMAP_TYPE_EVENTS = 0x2ULL << KFD_MMAP_TYPE_SHIFT;
-inline constexpr uint64_t KFD_MMAP_GPU_ID_SHIFT = 46;
-
-inline constexpr uint64_t kfd_mmap_gpu_id(uint32_t gpu_id) {
-  return (static_cast<uint64_t>(gpu_id) << KFD_MMAP_GPU_ID_SHIFT) &
-         ((1ULL << KFD_MMAP_TYPE_SHIFT) - (1ULL << KFD_MMAP_GPU_ID_SHIFT));
-}
 
 /// @brief 128-bit IPC share handle key, matching the kernel's random handle.
 struct IpcHandleKey {
@@ -76,13 +64,13 @@ struct IpcObject {
 /// the process created by open(). The daemon uses the process_id-aware
 /// overloads so each client thread identifies itself by connection, not by
 /// shared mutable state.
-class SimulatedDriver : public Driver {
+class SimulatedKfd : public LinuxKfd {
 public:
   [[nodiscard]] bool daemon_mode() const { return daemon_mode_; }
 
-  SimulatedDriver(SoC &soc, bool daemon_mode = false);
-  SimulatedDriver(std::vector<SoC *> socs, std::vector<uint32_t> gpu_ids, bool daemon_mode = false);
-  ~SimulatedDriver() override;
+  SimulatedKfd(SoC &soc, bool daemon_mode = false);
+  SimulatedKfd(std::vector<SoC *> socs, std::vector<uint32_t> gpu_ids, bool daemon_mode = false);
+  ~SimulatedKfd() override;
 
   /// @brief Local-mode interface (interposer). Operates on the local process.
   /// @{
@@ -94,7 +82,7 @@ public:
   /// (dup/dup2/dup3/fcntl F_DUPFD). Each live fd holds one reference so the
   /// process is torn down only when the last fd is closed, not the first.
   /// No-op when there is no local process (e.g. daemon/remote mode).
-  void retain_local_open();
+  void retain_local_open() override;
   int ioctl(unsigned long request, void *arg) override;
   void *mmap(void *addr, size_t length, int prot, int flags, off_t offset) override;
   int munmap(void *addr, size_t length) override;
@@ -123,12 +111,13 @@ public:
   void setup_topology(const Sysfs::GpuInfo &gpu);
   void setup_topology(const config::KfdDeviceConfig &dev, uint32_t num_xcc);
   void setup_topology(const std::vector<config::KfdDeviceConfig> &devs, uint32_t num_xcc);
-  bool is_doorbell_range(const void *addr, size_t length) const;
+  bool is_doorbell_range(const void *addr, size_t length) const override;
   uint32_t gpu_id() const { return gpus_.empty() ? 0 : gpus_[0].gpu_id; }
   uint32_t num_gpus() const { return static_cast<uint32_t>(gpus_.size()); }
   const Sysfs &topology() const { return topology_; }
-  std::string topology_path() const { return topology_.path(); }
-  [[nodiscard]] int fd() const { return fd_; }
+  std::string topology_path() const override { return topology_.path(); }
+  std::string drm_path() const override { return topology_.drm_path(); }
+  [[nodiscard]] int fd() const override { return fd_; }
   [[nodiscard]] uint32_t local_process_id() const { return local_process_id_; }
 
   /// @brief Open-reference count of the local process, or 0 if none is alive.
@@ -136,8 +125,10 @@ public:
   /// plus every dup) holds one reference; the process is destroyed at zero.
   [[nodiscard]] uint32_t local_open_ref_count() const;
 
-  [[nodiscard]] bool owns_fd(int fd) const;
-  std::string redirect_sysfs_path(const char *path) const;
+  [[nodiscard]] bool owns_fd(int fd) const override;
+  std::string redirect_sysfs_path(const char *path) const override;
+  [[nodiscard]] bool handles_drm_render_minor(uint32_t minor) const override;
+  [[nodiscard]] const Sysfs::GpuInfo *gpu_info_for_render_minor(uint32_t minor) const override;
   [[nodiscard]] int claim_fd(int real_fd);
   [[nodiscard]] bool owns_reserved_fd(int fd) const;
 
@@ -152,6 +143,9 @@ public:
 private:
   /// @brief Look up a KfdProcess by ID. Returns nullptr if not found.
   std::shared_ptr<KfdProcess> find_process(uint32_t process_id) const;
+
+  /// @brief Look up the local-mode process.
+  std::shared_ptr<KfdProcess> find_local_process() const;
 
   /// @brief Look up a GpuDevice by gpu_id. Returns nullptr if not found.
   GpuDevice *find_gpu(uint32_t gpu_id);
@@ -175,10 +169,15 @@ private:
   int dispatch_munmap(KfdProcess &proc, void *addr, size_t length);
   int dispatch_get_mmap_memfd(KfdProcess &proc, off_t offset) const;
 
-  int get_version_ioctl(void *arg);
-  int get_clock_counters_ioctl(void *arg);
-  int get_apertures_ioctl(void *arg);
-  int acquire_vm_ioctl(void *arg);
+  int get_process_apertures_ioctl(void *arg) override;
+  int acquire_vm_ioctl(void *arg) override;
+  int get_available_memory_ioctl(void *arg) override;
+  int set_memory_policy_ioctl(void *arg) override;
+  int alloc_memory_ioctl(void *arg) override;
+  int free_memory_ioctl(void *arg) override;
+  int map_memory_ioctl(void *arg) override;
+  int unmap_memory_ioctl(void *arg) override;
+  int get_available_memory_ioctl(KfdProcess &proc, void *arg);
   int alloc_memory_ioctl(KfdProcess &proc, void *arg);
   int free_memory_ioctl(KfdProcess &proc, void *arg);
   int map_memory_ioctl(KfdProcess &proc, void *arg);
@@ -252,4 +251,4 @@ private:
 
 } // namespace rocjitsu
 
-#endif // ROCJITSU_KMD_LINUX_SIMULATED_DRIVER_H_
+#endif // ROCJITSU_KMD_LINUX_SIMULATED_KFD_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
@@ -6,6 +6,7 @@
 #include "rocjitsu/base/rj_compiler.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
 #include "rocjitsu/kmd/linux/kfd_topology.h"
+#include "rocjitsu/kmd/linux/rpc.h"
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "linux/uapi/kfd_sysfs.h"
@@ -18,12 +19,33 @@ RJ_DIAGNOSTIC_POP
 #include <sstream>
 #include <string>
 #include <unistd.h>
+#include <utility>
+#include <vector>
 
 namespace rocjitsu {
 
 namespace fs = std::filesystem;
 
 namespace {
+
+std::string make_runtime_temp_dir(const char *prefix) {
+  std::error_code ec;
+  fs::path base = rpc_default_runtime_dir();
+  fs::create_directories(base, ec);
+  if (ec)
+    return {};
+
+  // Synthetic sysfs/DRM trees are process-owned and removed by Sysfs::cleanup().
+  // Place them under the rocjitsu runtime directory so crashes leave state in a
+  // known per-user location instead of scattering entries directly under /tmp.
+  std::string tmpl = (base / (std::string(prefix) + "_XXXXXX")).string();
+  std::vector<char> tmpl_buffer(tmpl.begin(), tmpl.end());
+  tmpl_buffer.push_back('\0');
+  char *dir = mkdtemp(tmpl_buffer.data());
+  if (!dir)
+    return {};
+  return dir;
+}
 
 /// @brief Debug-related topology bits derived from a GPU's GFXIP version.
 ///
@@ -441,11 +463,10 @@ void Sysfs::write_gpu_node(const std::string &nodes_dir, uint32_t node_idx, cons
 }
 
 void Sysfs::write_drm_tree(const std::vector<GpuInfo> &gpus) {
-  char tmpl[] = "/tmp/rocjitsu_drm_XXXXXX";
-  char *dir = mkdtemp(tmpl);
-  if (!dir)
+  std::string dir = make_runtime_temp_dir("rocjitsu_drm");
+  if (dir.empty())
     return;
-  drm_dir_ = dir;
+  drm_dir_ = std::move(dir);
 
   for (size_t i = 0; i < gpus.size(); ++i) {
     auto &gpu = gpus[i];
@@ -501,12 +522,11 @@ std::string Sysfs::generate(const GpuInfo &gpu) { return generate(std::vector<Gp
 std::string Sysfs::generate(const std::vector<GpuInfo> &gpus) {
   cleanup();
 
-  char tmpl[] = "/tmp/rocjitsu_topology_XXXXXX";
-  char *dir = mkdtemp(tmpl);
-  if (!dir)
+  std::string dir = make_runtime_temp_dir("rocjitsu_topology");
+  if (dir.empty())
     return {};
 
-  topology_dir_ = dir;
+  topology_dir_ = std::move(dir);
   if (!gpus.empty())
     gpu_info_ = gpus[0];
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.cpp
@@ -153,6 +153,11 @@ void Sysfs::cleanup() {
   }
 }
 
+void Sysfs::release_after_fork() {
+  topology_dir_.clear();
+  drm_dir_.clear();
+}
+
 void Sysfs::setup_environment() {}
 
 void Sysfs::write_generation_id() { write_file(topology_dir_ + "/generation_id", "1\n"); }
@@ -520,6 +525,48 @@ std::string Sysfs::generate(const std::vector<GpuInfo> &gpus) {
   write_drm_tree(gpus);
 
   return topology_dir_;
+}
+
+Sysfs::GpuInfo gpu_info_from_config(const config::KfdDeviceConfig &dev, uint32_t num_xcc) {
+  Sysfs::GpuInfo gpu{};
+  gpu.gpu_id = dev.gpu_id;
+  gpu.gfx_target_version = dev.gfx_target_version;
+  gpu.vendor_id = dev.vendor_id;
+  gpu.device_id = dev.device_id;
+  gpu.family_id = dev.family_id;
+  gpu.unique_id = dev.unique_id;
+  gpu.location_id = dev.location_id;
+  gpu.domain = dev.domain;
+  gpu.hive_id = dev.hive_id;
+  gpu.drm_render_minor = dev.drm_render_minor;
+  gpu.marketing_name = dev.marketing_name;
+  gpu.revision_id = dev.revision_id;
+  gpu.pci_revision_id = dev.pci_revision_id;
+  gpu.simd_count = dev.simd_count;
+  gpu.max_waves_per_simd = dev.max_waves_per_simd;
+  gpu.num_shader_engines = dev.num_shader_engines;
+  gpu.num_shader_arrays_per_engine = dev.num_shader_arrays_per_engine;
+  gpu.num_cu_per_sh = dev.num_cu_per_sh;
+  gpu.simd_per_cu = dev.simd_per_cu;
+  gpu.wave_front_size = dev.wave_front_size;
+  gpu.max_slots_scratch_cu = dev.max_slots_scratch_cu;
+  gpu.local_mem_size = dev.local_mem_size;
+  gpu.vram_type = dev.vram_type;
+  gpu.lds_size_kb = dev.lds_size_kb;
+  gpu.mem_width = dev.mem_width;
+  gpu.mem_clk_max = dev.mem_clk_max;
+  gpu.l1_size_kb = dev.l1_size_kb;
+  gpu.l1_line_size = dev.l1_line_size;
+  gpu.l1_assoc = dev.l1_assoc;
+  gpu.l2_size_kb = dev.l2_size_kb;
+  gpu.l2_line_size = dev.l2_line_size;
+  gpu.l2_assoc = dev.l2_assoc;
+  gpu.num_sdma_engines = dev.num_sdma_engines;
+  gpu.num_sdma_xgmi_engines = dev.num_sdma_xgmi_engines;
+  gpu.num_cp_queues = dev.num_cp_queues;
+  gpu.max_engine_clk_fcompute = dev.max_engine_clk_fcompute;
+  gpu.num_xcc = num_xcc;
+  return gpu;
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/sysfs.h
@@ -7,6 +7,8 @@
 #ifndef ROCJITSU_KMD_LINUX_SYSFS_H_
 #define ROCJITSU_KMD_LINUX_SYSFS_H_
 
+#include "rocjitsu/config/kfd_device_config.h"
+
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -114,6 +116,9 @@ public:
   /// @brief Remove the generated directories.
   void cleanup();
 
+  /// @brief Drop ownership of inherited paths without removing them.
+  void release_after_fork();
+
 private:
   std::string topology_dir_;
   std::string drm_dir_;
@@ -128,6 +133,9 @@ private:
                       uint32_t total_gpus);
   void write_drm_tree(const std::vector<GpuInfo> &gpus);
 };
+
+/// @brief Convert a parsed KFD device config into generated sysfs GPU metadata.
+Sysfs::GpuInfo gpu_info_from_config(const config::KfdDeviceConfig &dev, uint32_t num_xcc);
 
 } // namespace rocjitsu
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -48,6 +48,17 @@ struct PlannedWorkgroup {
 
 uint32_t nonzero_or_one(uint32_t v) { return v == 0 ? 1 : v; }
 
+/// @brief Return a monotonic timestamp in the guest HSA system-clock domain.
+///
+/// @details The guest KFD advertises a 1 GHz synthetic system clock backed by
+/// `std::chrono::steady_clock`. Dispatch profiling timestamps stored in
+/// `amd_signal_t` use the same HSA system-clock domain, so HIP event timing can
+/// subtract them directly.
+uint64_t hsa_system_timestamp() {
+  auto now = std::chrono::steady_clock::now().time_since_epoch();
+  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
+}
+
 uint32_t checked_ext_dispatch_grid_size(uint32_t cluster_count, uint32_t cluster_size,
                                         uint32_t workgroup_size, const char *axis) {
   if (cluster_count == 0 || cluster_size == 0 || workgroup_size == 0) {
@@ -938,6 +949,7 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
 
   DispatchEntry dp{};
   dp.dispatch_id = next_dispatch_id_++;
+  dp.profiling_start_timestamp = hsa_system_timestamp();
   dp.queue_id = queue.queue_id;
   dp.process_id = queue.process_id;
   dp.kernel_entry_pc = entry_pc;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -4,6 +4,7 @@
 #include "rocjitsu/vm/amdgpu/command_processor.h"
 #include "rocjitsu/code/kernel_symbol.h"
 #include "rocjitsu/vm/amdgpu/amd_ext_aql_packet.h"
+#include "rocjitsu/vm/amdgpu/hsa_clock.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 
 #include "rocjitsu/base/rj_compiler.h"
@@ -47,17 +48,6 @@ struct PlannedWorkgroup {
 };
 
 uint32_t nonzero_or_one(uint32_t v) { return v == 0 ? 1 : v; }
-
-/// @brief Return a monotonic timestamp in the guest HSA system-clock domain.
-///
-/// @details The guest KFD advertises a 1 GHz synthetic system clock backed by
-/// `std::chrono::steady_clock`. Dispatch profiling timestamps stored in
-/// `amd_signal_t` use the same HSA system-clock domain, so HIP event timing can
-/// subtract them directly.
-uint64_t hsa_system_timestamp() {
-  auto now = std::chrono::steady_clock::now().time_since_epoch();
-  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
-}
 
 uint32_t checked_ext_dispatch_grid_size(uint32_t cluster_count, uint32_t cluster_size,
                                         uint32_t workgroup_size, const char *axis) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
@@ -3,6 +3,8 @@
 
 #include "rocjitsu/vm/amdgpu/completion_tracker.h"
 
+#include "rocjitsu/vm/amdgpu/hsa_clock.h"
+
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
@@ -13,28 +15,11 @@ RJ_DIAGNOSTIC_POP
 
 #include <algorithm>
 #include <atomic>
-#include <chrono>
 #include <cstring>
 #include <format>
 
 namespace rocjitsu {
 namespace amdgpu {
-
-namespace {
-
-/// @brief Return a monotonic timestamp in the guest HSA system-clock domain.
-///
-/// @details `LinuxKfd::fill_get_clock_counters_ioctl` exposes a 1 GHz
-/// nanosecond clock for the synthetic guest GPU. The ROCR `amd_signal_t`
-/// profiling fields are specified in the HSA system-clock domain, so using the
-/// same source here makes `hsa_amd_profiling_get_dispatch_time` and HIP event
-/// elapsed-time math agree with the guest KFD clock.
-uint64_t hsa_system_timestamp() {
-  auto now = std::chrono::steady_clock::now().time_since_epoch();
-  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
-}
-
-} // namespace
 
 void CompletionTracker::notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id,
                                            std::vector<HwQueueState> &queues) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
@@ -11,12 +11,30 @@ RJ_DIAGNOSTIC_POP
 
 #include "util/log.h"
 
+#include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstring>
 #include <format>
 
 namespace rocjitsu {
 namespace amdgpu {
+
+namespace {
+
+/// @brief Return a monotonic timestamp in the guest HSA system-clock domain.
+///
+/// @details `LinuxKfd::fill_get_clock_counters_ioctl` exposes a 1 GHz
+/// nanosecond clock for the synthetic guest GPU. The ROCR `amd_signal_t`
+/// profiling fields are specified in the HSA system-clock domain, so using the
+/// same source here makes `hsa_amd_profiling_get_dispatch_time` and HIP event
+/// elapsed-time math agree with the guest KFD clock.
+uint64_t hsa_system_timestamp() {
+  auto now = std::chrono::steady_clock::now().time_since_epoch();
+  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
+}
+
+} // namespace
 
 void CompletionTracker::notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id,
                                            std::vector<HwQueueState> &queues) {
@@ -158,10 +176,18 @@ void CompletionTracker::fire_signal(const DispatchEntry &entry) {
   constexpr uint32_t SIG_VAL_OFF = 8;
   constexpr uint32_t MAILBOX_PTR_OFF = 16;
   constexpr uint32_t EVENT_ID_OFF = 24;
+  // amd_signal_t::start_ts and ::end_ts. The vendored minimal HSA headers omit
+  // amd_hsa_signal.h, but ROCR's profiling APIs read these fixed ABI fields.
+  constexpr uint32_t START_TS_OFF = 32;
+  constexpr uint32_t END_TS_OFF = 40;
 
   if (memory_) {
     auto *sig_page =
         memory_->resolve_host_ptr(entry.completion_signal + SIG_VAL_OFF, entry.process_id);
+    uint64_t start_ts = entry.profiling_start_timestamp;
+    if (start_ts == 0)
+      start_ts = hsa_system_timestamp();
+    uint64_t end_ts = std::max(hsa_system_timestamp(), start_ts + 1);
 
     util::Logger::cp([&](auto &os) {
       auto *page0 = memory_->resolve_host_ptr(entry.completion_signal, entry.process_id);
@@ -188,6 +214,13 @@ void CompletionTracker::fire_signal(const DispatchEntry &entry) {
     int64_t old = 0;
     uint64_t new_val = 0;
     if (sig_page) {
+      auto *start_ptr = reinterpret_cast<uint64_t *>(
+          sig_page + ((entry.completion_signal + START_TS_OFF) & 0xFFF));
+      auto *end_ptr =
+          reinterpret_cast<uint64_t *>(sig_page + ((entry.completion_signal + END_TS_OFF) & 0xFFF));
+      std::atomic_ref<uint64_t>(*start_ptr).store(start_ts, std::memory_order_relaxed);
+      std::atomic_ref<uint64_t>(*end_ptr).store(end_ts, std::memory_order_release);
+
       auto *sig_ptr = reinterpret_cast<uint64_t *>(
           sig_page + ((entry.completion_signal + SIG_VAL_OFF) & 0xFFF));
       old =
@@ -195,6 +228,8 @@ void CompletionTracker::fire_signal(const DispatchEntry &entry) {
       new_val = static_cast<uint64_t>(old - 1);
       std::atomic_ref<uint64_t>(*sig_ptr).store(new_val, std::memory_order_release);
     } else {
+      memory_->write64(entry.completion_signal + START_TS_OFF, start_ts, entry.process_id);
+      memory_->write64(entry.completion_signal + END_TS_OFF, end_ts, entry.process_id);
       old = static_cast<int64_t>(
           memory_->read64(entry.completion_signal + SIG_VAL_OFF, entry.process_id));
       new_val = static_cast<uint64_t>(old - 1);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -77,6 +77,14 @@ struct DispatchEntry {
   uint32_t completed_wgs = 0;
 
   uint64_t completion_signal = 0;
+  /// @brief HSA-system-clock tick captured when the CP accepted this dispatch.
+  ///
+  /// @details ROCR's `hsa_amd_profiling_get_dispatch_time` reads dispatch
+  /// timestamps from the completion signal after the packet retires. Real CP
+  /// firmware writes those fields only for profiled queues; rocjitsu records the
+  /// timestamp on every kernel dispatch because non-profiled signals ignore the
+  /// fields, and this keeps HIP/MIOpen event timing consistent for guest queues.
+  uint64_t profiling_start_timestamp = 0;
   bool host_signal = false;
   bool barrier_bit = false;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/hsa_clock.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/hsa_clock.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_VM_AMDGPU_HSA_CLOCK_H_
+#define ROCJITSU_VM_AMDGPU_HSA_CLOCK_H_
+
+/// @file hsa_clock.h
+/// @brief Shared synthetic HSA system-clock timestamp helper.
+
+#include <chrono>
+#include <cstdint>
+
+namespace rocjitsu::amdgpu {
+
+/// @brief Return a monotonic timestamp in the guest HSA system-clock domain.
+///
+/// @details `LinuxKfd::fill_get_clock_counters_ioctl` exposes a synthetic
+/// 1 GHz nanosecond clock. Dispatch profiling timestamps stored in
+/// `amd_signal_t` use the same HSA system-clock domain, so HIP event timing can
+/// subtract values written by the command processor and completion tracker
+/// directly.
+inline uint64_t hsa_system_timestamp() {
+  auto now = std::chrono::steady_clock::now().time_since_epoch();
+  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
+}
+
+} // namespace rocjitsu::amdgpu
+
+#endif // ROCJITSU_VM_AMDGPU_HSA_CLOCK_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -266,7 +266,7 @@ rj_status_t rj_vm_device_open(rj_vm_t *vm, rj_client_pid_t client_pid, uint32_t 
   auto *drv = dynamic_cast<SimulatedKfd *>(vm->vm->driver());
   if (!drv)
     return ROCJITSU_STATUS_ERROR;
-  // client_pid == 0 (local mode) maps to SimulatedDriver::open_process()'s
+  // client_pid == 0 (local mode) maps to SimulatedKfd::open_process()'s
   // default; a nonzero client_pid enables daemon-mode process reuse and
   // cross-process memory access. Narrow the fixed-width public type to the
   // platform pid_t at the Linux daemon boundary.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -5,7 +5,7 @@
 
 #include "embedded_schema.h"
 #include "rocjitsu/config/checkpoint.h"
-#include "rocjitsu/kmd/linux/simulated_driver.h"
+#include "rocjitsu/kmd/linux/simulated_kfd.h"
 #include "rocjitsu/vm/rj_vm_impl.h"
 #include "rocjitsu/vm/soc.h"
 
@@ -225,7 +225,7 @@ rj_status_t rj_vm_restore_checkpoint(const char *path, rj_vm_t **vm) {
 
 namespace {
 
-rj_status_t execute_impl(SimulatedDriver *driver, uint32_t process_id, rj_vm_cmd_t *cmd) {
+rj_status_t execute_impl(SimulatedKfd *driver, uint32_t process_id, rj_vm_cmd_t *cmd) {
   auto arg_size = _IOC_SIZE(cmd->cmd);
   reconstruct_embedded_pointers(cmd->cmd, cmd->buf, arg_size, cmd->buf_size);
 
@@ -263,7 +263,7 @@ rj_status_t rj_vm_execute_as(rj_vm_t *vm, uint32_t process_id, rj_vm_cmd_t *cmd)
 rj_status_t rj_vm_device_open(rj_vm_t *vm, rj_client_pid_t client_pid, uint32_t *process_id) {
   if (!vm || !vm->vm || !vm->vm->driver())
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
-  auto *drv = dynamic_cast<SimulatedDriver *>(vm->vm->driver());
+  auto *drv = dynamic_cast<SimulatedKfd *>(vm->vm->driver());
   if (!drv)
     return ROCJITSU_STATUS_ERROR;
   // client_pid == 0 (local mode) maps to SimulatedDriver::open_process()'s

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/virtual_machine.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/virtual_machine.cpp
@@ -3,7 +3,7 @@
 
 #include "rocjitsu/vm/virtual_machine.h"
 
-#include "rocjitsu/kmd/linux/simulated_driver.h"
+#include "rocjitsu/kmd/linux/simulated_kfd.h"
 
 #include <cassert>
 #include <memory>
@@ -25,7 +25,7 @@ VirtualMachine::VirtualMachine(std::unique_ptr<SoC> soc, bool daemon_mode)
   set_weight(0);
   adopt_children(*soc);
   add_child(std::move(soc));
-  driver_ = std::make_unique<SimulatedDriver>(*soc_, daemon_mode);
+  driver_ = std::make_unique<SimulatedKfd>(*soc_, daemon_mode);
 }
 
 VirtualMachine::VirtualMachine(std::vector<std::unique_ptr<SoC>> socs,
@@ -42,7 +42,7 @@ VirtualMachine::VirtualMachine(std::vector<std::unique_ptr<SoC>> socs,
     adopt_children(*socs[i]);
     add_child(std::move(socs[i]));
   }
-  driver_ = std::make_unique<SimulatedDriver>(ptrs, std::move(gpu_ids), daemon_mode);
+  driver_ = std::make_unique<SimulatedKfd>(ptrs, std::move(gpu_ids), daemon_mode);
 }
 
 VirtualMachine::~VirtualMachine() = default;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/virtual_machine.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/virtual_machine.h
@@ -28,7 +28,7 @@ namespace rocjitsu {
 /// Fully event-driven: the VM is a structural container. Its descendants
 /// (command processors) schedule and handle events through the engine.
 /// The Driver injects external work as async events.
-class SimulatedDriver;
+class SimulatedKfd;
 
 class VirtualMachine : public simdojo::CompositeComponent {
 public:
@@ -53,12 +53,12 @@ public:
   const amdgpu::GpuMemory *memory() const { return soc_->memory(); }
   const Config &config() const { return config_; }
 
-  SimulatedDriver *driver() { return driver_.get(); }
+  SimulatedKfd *driver() { return driver_.get(); }
 
 private:
   Config config_;
   SoC *soc_ = nullptr;
-  std::unique_ptr<SimulatedDriver> driver_;
+  std::unique_ptr<SimulatedKfd> driver_;
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/schemas/simulation_config.fbs
+++ b/emulation/rocjitsu/schemas/simulation_config.fbs
@@ -118,6 +118,23 @@ table AmdgpuConfig {
   num_gpus: uint32 = 1;          // Number of simulated GPU instances.
 }
 
+/// DBT guest-GPU discovery mode.
+///
+/// When enabled, the KFD interposer does not start the simulated VM. Instead it
+/// forwards real host-GPU KFD ioctls to /dev/kfd and appends one synthetic guest
+/// GPU to the topology seen by ROCR. HSA hooks then map execution-facing calls
+/// from the guest agent to the host agent and translate guest code objects to
+/// host code objects before loading them.
+table DbtGuestConfig {
+  enabled: bool = false;          // Enables GuestKfd discovery mode.
+  guest_isa: string;              // Guest ISA advertised by the synthetic agent, e.g. "gfx950".
+  host_isa: string;               // Host ISA used for execution and DBT output, e.g. "gfx942".
+  host_gpu_id: uint32 = 0;        // Preferred host KFD topology gpu_id, not HIP ordinal/node id; 0 matches topology to host_isa.
+  log_level: int32 = 0;           // DBT hook logging: 0 off, 1 info, 2 verbose, 3 debug.
+  signal_backtrace: bool = false; // Install a best-effort crash backtrace handler in the HSA hook.
+  guest_device: KfdDeviceInfo;    // Synthetic guest KFD/sysfs identity appended to host topology.
+}
+
 /// A dispatch packet describing a kernel launch.
 table DispatchConfig {
   kernel_entry_pc: uint64;          // Byte address of kernel entry point.
@@ -200,8 +217,9 @@ table SimulationConfig {
   max_ticks: uint64;             // Maximum simulation ticks before halting.
   num_threads: uint32;           // Number of simulation threads (partitions).
   exec_mode: string;             // Execution mode: "functional" (default) or "clocked".
-  vm: VirtualMachineConfig;      // Virtual machine hardware model.
-  topology: TopologyDef;         // Declarative topology.
+  vm: VirtualMachineConfig;      // Virtual machine hardware model. Omit for dbt_guest-only configs.
+  topology: TopologyDef;         // Declarative topology. Omit for dbt_guest-only configs.
+  dbt_guest: DbtGuestConfig;     // Optional guest-GPU DBT interposition mode.
 }
 
 root_type SimulationConfig;

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(RJ_OBJECT_LIBS
     rocjitsu_plugin_race_detector
     rocjitsu_vm_risc_v
     rocjitsu_config
+    rocjitsu_dbt_config
 )
 
 if(RJ_INSTALL_TESTS)
@@ -428,7 +429,6 @@ target_link_libraries(
     PRIVATE
         ${RJ_OBJECT_LIBS}
         rocjitsu_kmd
-        rocjitsu_dbt_config
         util
         flatbuffers
         Threads::Threads

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -182,6 +182,39 @@ function(_rj_path_from_installed_test_bin out install_dir file_name)
     set(${out} "${_path}" PARENT_SCOPE)
 endfunction()
 
+function(rj_test_runtime_dir_env out name)
+    string(REGEX REPLACE "[^A-Za-z0-9_.-]" "_" _runtime_name "${name}")
+    set(${out}
+        "ROCJITSU_RUNTIME_DIR=${CMAKE_CURRENT_BINARY_DIR}/runtime/${_runtime_name}"
+        PARENT_SCOPE
+    )
+endfunction()
+
+function(rj_installed_test_runtime_dir_env out name)
+    string(REGEX REPLACE "[^A-Za-z0-9_.-]" "_" _runtime_name "${name}")
+    set(${out} "ROCJITSU_RUNTIME_DIR=runtime/${_runtime_name}" PARENT_SCOPE)
+endfunction()
+
+function(rj_environment_has_runtime_dir out)
+    set(_has_runtime_dir FALSE)
+    foreach(_entry IN LISTS ARGN)
+        if(_entry MATCHES "^ROCJITSU_RUNTIME_DIR=")
+            set(_has_runtime_dir TRUE)
+        endif()
+    endforeach()
+    set(${out} "${_has_runtime_dir}" PARENT_SCOPE)
+endfunction()
+
+function(rj_set_default_runtime_dir name)
+    get_property(_env TEST "${name}" PROPERTY ENVIRONMENT)
+    rj_environment_has_runtime_dir(_has_runtime_dir ${_env})
+    if(NOT _has_runtime_dir)
+        rj_test_runtime_dir_env(_runtime_dir_env "${name}")
+        list(APPEND _env "${_runtime_dir_env}")
+        set_tests_properties("${name}" PROPERTIES ENVIRONMENT "${_env}")
+    endif()
+endfunction()
+
 # Register a test for both the build tree and, when RJ_INSTALL_TESTS is ON, the
 # installed CTest tree. COMMAND is the normal build-tree command passed to
 # add_test(). INSTALL_COMMAND is optional and should use paths relative to the
@@ -205,6 +238,15 @@ function(rj_add_test)
     endif()
     if(NOT ARG_COMMAND)
         message(FATAL_ERROR "rj_add_test(${ARG_NAME}) requires COMMAND")
+    endif()
+
+    rj_environment_has_runtime_dir(_has_runtime_dir ${ARG_ENVIRONMENT})
+    if(NOT _has_runtime_dir)
+        # Each launcher test writes the active config into its runtime dir for
+        # the preloaded interposer. Use a per-test default so ctest -j runs
+        # cannot overwrite another test's config or daemon socket.
+        rj_test_runtime_dir_env(_runtime_dir_env "${ARG_NAME}")
+        list(APPEND ARG_ENVIRONMENT "${_runtime_dir_env}")
     endif()
 
     add_test(NAME "${ARG_NAME}" COMMAND ${ARG_COMMAND})
@@ -252,6 +294,17 @@ function(rj_add_test)
             "ROCJITSU_CONFIG_DIR=\${RJ_INSTALLED_CONFIG_DIR}"
             "ROCJITSU_KERNEL_DIR=\${RJ_INSTALLED_KERNEL_DIR}"
         )
+        rj_environment_has_runtime_dir(
+            _install_has_runtime_dir
+            ${ARG_INSTALL_ENVIRONMENT}
+        )
+        if(NOT _install_has_runtime_dir)
+            rj_installed_test_runtime_dir_env(
+                _install_runtime_dir_env
+                "${ARG_NAME}"
+            )
+            list(APPEND _install_env "${_install_runtime_dir_env}")
+        endif()
         list(APPEND _install_env ${ARG_INSTALL_ENVIRONMENT})
         list(APPEND _install_args ENVIRONMENT ${_install_env})
         rj_install_ctest("${ARG_NAME}" ${_install_args})
@@ -281,7 +334,7 @@ add_executable(
     vector_add_test.cpp
     gfx1250_sim_test.cpp
     simdojo_sim_test.cpp
-    simulated_driver_test.cpp
+    simulated_kfd_test.cpp
     decode_smoke_test.cpp
     smem_sbase_operand_test.cpp
     shared_infra_test.cpp
@@ -375,6 +428,7 @@ target_link_libraries(
     PRIVATE
         ${RJ_OBJECT_LIBS}
         rocjitsu_kmd
+        rocjitsu_dbt_config
         util
         flatbuffers
         Threads::Threads
@@ -425,7 +479,8 @@ rj_configure_target(scaling_test TEST)
 # --- Interposer tests run through the rocjitsu CLI launcher ---
 # All tests that need the simulated GPU go through:
 #   rocjitsu --config <cfg> -- <test_binary> [args]
-# The CLI handles LD_PRELOAD and config discovery. No RESOURCE_LOCK needed.
+# The CLI handles LD_PRELOAD and config discovery. rj_add_test gives launcher
+# tests isolated runtime directories, so no RESOURCE_LOCK is needed.
 
 set(RJ_CDNA4_KMD_CONFIG "${CMAKE_SOURCE_DIR}/configs/gfx950_cdna4_kmd.json")
 set(RJ_CDNA4_KMD_2GPU_CONFIG
@@ -440,10 +495,170 @@ get_filename_component(
 )
 set(RJ_CLI "$<TARGET_FILE:rocjitsu_bin>")
 
+function(rj_detect_kfd_gfx_target_versions out_var)
+    set(_versions)
+    foreach(
+        _nodes_dir
+        IN
+        ITEMS
+            "/sys/devices/virtual/kfd/kfd/topology/nodes"
+            "/sys/class/kfd/kfd/topology/nodes"
+    )
+        if(NOT IS_DIRECTORY "${_nodes_dir}")
+            continue()
+        endif()
+
+        file(GLOB _node_dirs LIST_DIRECTORIES true "${_nodes_dir}/*")
+        foreach(_node_dir IN LISTS _node_dirs)
+            if(NOT IS_DIRECTORY "${_node_dir}")
+                continue()
+            endif()
+            if(NOT EXISTS "${_node_dir}/properties")
+                continue()
+            endif()
+
+            # DBT guest configs name a concrete host ISA. Read KFD topology at
+            # configure time so hardware-backed tests are not registered on
+            # hosts where /dev/kfd exists but the required ISA is absent.
+            file(READ "${_node_dir}/properties" _properties)
+            if(_properties MATCHES "(^|[\r\n])gfx_target_version[ \t]+([0-9]+)")
+                list(APPEND _versions "${CMAKE_MATCH_2}")
+            endif()
+        endforeach()
+    endforeach()
+    if(_versions)
+        list(REMOVE_DUPLICATES _versions)
+    endif()
+    set(${out_var} "${_versions}" PARENT_SCOPE)
+endfunction()
+
+rj_detect_kfd_gfx_target_versions(RJ_KFD_GFX_TARGET_VERSIONS)
+set(RJ_HAS_KFD_DEVICE FALSE)
+if(EXISTS "/dev/kfd")
+    set(RJ_HAS_KFD_DEVICE TRUE)
+endif()
+set(RJ_HAS_GFX1201_GPU FALSE)
+if("120001" IN_LIST RJ_KFD_GFX_TARGET_VERSIONS)
+    set(RJ_HAS_GFX1201_GPU TRUE)
+else()
+    find_program(
+        ROCM_AGENT_ENUM
+        rocm_agent_enumerator
+        HINTS "${ROCM_PATH}"
+        PATH_SUFFIXES bin
+    )
+    if(ROCM_AGENT_ENUM)
+        execute_process(
+            COMMAND ${ROCM_AGENT_ENUM}
+            OUTPUT_VARIABLE _agents
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+            RESULT_VARIABLE _agent_rc
+        )
+        if(
+            _agent_rc EQUAL 0
+            AND _agents MATCHES "(^|[\r\n; ])gfx1201($|[\r\n; ])"
+        )
+            set(RJ_HAS_GFX1201_GPU TRUE)
+        endif()
+    endif()
+endif()
+
 set(RJ_KMD_PRELOAD_ENV
     "LD_PRELOAD=$<TARGET_FILE:rocjitsu_shared>"
     "RJ_CONFIG=${CMAKE_SOURCE_DIR}/configs/gfx950_cdna4.json"
 )
+
+add_executable(guest_kfd_test guest_kfd_test.cpp)
+target_include_directories(
+    guest_kfd_test
+    PRIVATE ${CMAKE_SOURCE_DIR}/lib/rocjitsu/include ${HSA_INCLUDE_DIR}
+)
+target_link_libraries(guest_kfd_test PRIVATE Threads::Threads GTest::gtest_main)
+rj_configure_target(guest_kfd_test TEST)
+add_dependencies(guest_kfd_test rocjitsu_bin rocjitsu_shared rocjitsu_hooks)
+if(RJ_HAS_GFX1201_GPU)
+    add_test(
+        NAME "GuestKfdMultiprocessTest.ForkedChildrenDoNotRemoveParentOverlay"
+        COMMAND
+            ${RJ_CLI} --config
+            ${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_gfx1201.json --
+            $<TARGET_FILE:guest_kfd_test>
+            --gtest_filter=GuestKfdMultiprocessTest.ForkedChildrenDoNotRemoveParentOverlay
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    add_test(
+        NAME
+            "GuestKfdMultiprocessTest.ForkedChildDropsInheritedGuestDriverBeforeReopen"
+        COMMAND
+            ${RJ_CLI} --config
+            ${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_gfx1201.json --
+            $<TARGET_FILE:guest_kfd_test>
+            --gtest_filter=GuestKfdMultiprocessTest.ForkedChildDropsInheritedGuestDriverBeforeReopen
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    add_test(
+        NAME "GuestKfdConcurrencyTest.ConcurrentOpenIoctlAndSysfsRedirect"
+        COMMAND
+            ${RJ_CLI} --config
+            ${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_gfx1201.json --
+            $<TARGET_FILE:guest_kfd_test>
+            --gtest_filter=GuestKfdConcurrencyTest.ConcurrentOpenIoctlAndSysfsRedirect
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    set_tests_properties(
+        "GuestKfdMultiprocessTest.ForkedChildrenDoNotRemoveParentOverlay"
+        "GuestKfdMultiprocessTest.ForkedChildDropsInheritedGuestDriverBeforeReopen"
+        "GuestKfdConcurrencyTest.ConcurrentOpenIoctlAndSysfsRedirect"
+        PROPERTIES TIMEOUT 60 SKIP_REGULAR_EXPRESSION "\\[  SKIPPED \\]"
+    )
+    foreach(
+        _guest_kfd_test
+        IN
+        ITEMS
+            "GuestKfdMultiprocessTest.ForkedChildrenDoNotRemoveParentOverlay"
+            "GuestKfdMultiprocessTest.ForkedChildDropsInheritedGuestDriverBeforeReopen"
+            "GuestKfdConcurrencyTest.ConcurrentOpenIoctlAndSysfsRedirect"
+    )
+        rj_set_default_runtime_dir("${_guest_kfd_test}")
+    endforeach()
+    message(
+        STATUS
+        "GuestKfd DBT guest tests enabled (gfx1201 host GPU detected)"
+    )
+else()
+    message(
+        STATUS
+        "GuestKfd DBT guest tests built but NOT registered with CTest "
+        "(no gfx1201 KFD host GPU)"
+    )
+endif()
+
+add_executable(hsa_hooks_unit_test dbt/hsa_hooks_unit_test.cpp)
+target_compile_definitions(
+    hsa_hooks_unit_test
+    PRIVATE
+        RJ_HOOK_UNIT_CONFIG_PATH="${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_gfx1201.json"
+)
+target_include_directories(
+    hsa_hooks_unit_test
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/lib/rocjitsu/include
+        ${CMAKE_SOURCE_DIR}/lib/rocjitsu/src
+        ${CMAKE_SOURCE_DIR}/lib/util/include
+        ${GENERATED_DIR}
+)
+target_include_directories(
+    hsa_hooks_unit_test
+    SYSTEM
+    PRIVATE ${HSA_INCLUDE_DIR}
+)
+target_link_libraries(
+    hsa_hooks_unit_test
+    PRIVATE rocjitsu_hooks Threads::Threads GTest::gtest_main
+)
+rj_configure_target(hsa_hooks_unit_test TEST)
+gtest_discover_tests(hsa_hooks_unit_test)
 
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---
 # Spawns rocminfo via the rocjitsu CLI and validates output.
@@ -458,6 +673,11 @@ _rj_path_from_installed_test_bin(
     "${CMAKE_INSTALL_DATADIR}/rocjitsu/configs"
     "${RJ_CDNA4_KMD_CONFIG_NAME}"
 )
+_rj_path_from_installed_test_bin(
+    _rj_installed_dbt_guest_config
+    "${CMAKE_INSTALL_DATADIR}/rocjitsu/configs"
+    "guest_gfx950_on_gfx1201.json"
+)
 
 find_program(
     ROCMINFO_EXECUTABLE
@@ -466,7 +686,7 @@ find_program(
     PATH_SUFFIXES bin
     DOC "Path to the rocminfo executable"
 )
-if(ROCMINFO_EXECUTABLE)
+if(ROCMINFO_EXECUTABLE AND RJ_HAS_KFD_DEVICE)
     add_executable(rocminfo_test rocminfo_test.cpp)
     target_compile_definitions(
         rocminfo_test
@@ -515,7 +735,99 @@ if(ROCMINFO_EXECUTABLE)
             ${_rocminfo_install_environment_arg}
         )
     endforeach()
+
+    add_executable(dbt_guest_rocminfo_test rocminfo_test.cpp)
+    target_compile_definitions(
+        dbt_guest_rocminfo_test
+        PRIVATE
+            ROCMINFO_PATH="${ROCMINFO_EXECUTABLE}"
+            ROCJITSU_BIN="$<TARGET_FILE:rocjitsu_bin>"
+            RJ_CONFIG_PATH="${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_gfx1201.json"
+            RJ_INSTALLED_ROCJITSU_BIN="${_rj_installed_rocjitsu_bin}"
+            RJ_INSTALLED_CONFIG_PATH="${_rj_installed_dbt_guest_config}"
+    )
+    target_link_libraries(dbt_guest_rocminfo_test PRIVATE GTest::gtest_main)
+    add_dependencies(
+        dbt_guest_rocminfo_test
+        rocjitsu_bin
+        rocjitsu_shared
+        rocjitsu_hooks
+    )
+
+    if(RJ_HAS_GFX1201_GPU)
+        add_test(
+            NAME "DbtGuestRocminfoTest.ExitsSuccessfully"
+            COMMAND
+                dbt_guest_rocminfo_test
+                --gtest_filter=RocminfoTest.ExitsSuccessfully
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+        add_test(
+            NAME "DbtGuestRocminfoTest.InterposerActive"
+            COMMAND
+                dbt_guest_rocminfo_test
+                --gtest_filter=RocminfoTest.InterposerActive
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+        add_test(
+            NAME "DbtGuestRocminfoTest.HsaSystemAttributes"
+            COMMAND
+                dbt_guest_rocminfo_test
+                --gtest_filter=RocminfoTest.HsaSystemAttributes
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+        add_test(
+            NAME "DbtGuestRocminfoTest.DetectsGpuAgent"
+            COMMAND
+                dbt_guest_rocminfo_test
+                --gtest_filter=RocminfoTest.DetectsGpuAgent
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+        add_test(
+            NAME "DbtGuestRocminfoTest.ReportsGfx950"
+            COMMAND
+                dbt_guest_rocminfo_test
+                --gtest_filter=RocminfoTest.ReportsGfx950
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+        add_test(
+            NAME "DbtGuestRocminfoTest.ReportsWavefrontSize"
+            COMMAND
+                dbt_guest_rocminfo_test
+                --gtest_filter=RocminfoTest.ReportsWavefrontSize
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        )
+        foreach(
+            _dbt_guest_rocminfo_test
+            IN
+            ITEMS
+                "DbtGuestRocminfoTest.ExitsSuccessfully"
+                "DbtGuestRocminfoTest.InterposerActive"
+                "DbtGuestRocminfoTest.HsaSystemAttributes"
+                "DbtGuestRocminfoTest.DetectsGpuAgent"
+                "DbtGuestRocminfoTest.ReportsGfx950"
+                "DbtGuestRocminfoTest.ReportsWavefrontSize"
+        )
+            rj_set_default_runtime_dir("${_dbt_guest_rocminfo_test}")
+        endforeach()
+        message(
+            STATUS
+            "DBT guest rocminfo tests enabled (gfx1201 host GPU detected)"
+        )
+    else()
+        message(
+            STATUS
+            "DBT guest rocminfo tests built but NOT registered with CTest "
+            "(no gfx1201 KFD host GPU)"
+        )
+    endif()
     message(STATUS "rocminfo test enabled (found ${ROCMINFO_EXECUTABLE})")
+elseif(ROCMINFO_EXECUTABLE)
+    message(
+        STATUS
+        "rocminfo test disabled (/dev/kfd not found; rocminfo exits before "
+        "simulated KFD discovery)"
+    )
 else()
     message(STATUS "rocminfo test disabled (rocminfo not found)")
 endif()
@@ -662,7 +974,12 @@ if(HSA_RUNTIME64)
             hsa_hooks_test
             PRIVATE HAS_HOST_AMDGPU=1 KERNEL_DIR="${KERNEL_OUTPUT_DIR}"
         )
-        add_dependencies(hsa_hooks_test device_kernels rocjitsu_hooks)
+        add_dependencies(
+            hsa_hooks_test
+            device_kernels
+            rocjitsu_bin
+            rocjitsu_hooks
+        )
         rj_configure_target(hsa_hooks_test TEST)
         if(RJ_INSTALL_TESTS)
             rj_install_test_target(hsa_hooks_test)
@@ -683,7 +1000,9 @@ if(HSA_RUNTIME64)
             rj_add_test(
                 NAME "HsaHooksTest.TranslateGfx950Mfma16x16ThroughToolsLib"
                 COMMAND
-                    hsa_hooks_test
+                    $<TARGET_FILE:rocjitsu_bin> --config
+                    ${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_gfx1201.json --
+                    $<TARGET_FILE:hsa_hooks_test>
                     --gtest_filter=HsaHooksTest.TranslateGfx950Mfma16x16ThroughToolsLib
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                 TIMEOUT 60
@@ -888,12 +1207,33 @@ endif()
 
 rj_find_amdcxx(AMDCXX)
 set(RJ_ENABLE_HIP_TESTS ON)
+find_library(HIP_RUNTIME64 amdhip64 PATHS "${ROCM_PATH}" PATH_SUFFIXES lib)
+set(RJ_HIP_RUNTIME_SUPPORTS_GFX950 FALSE)
+if(HIP_RUNTIME64)
+    # These tests expose a synthetic gfx950 GPU to HIP. Recent HIP runtimes
+    # reject agents whose PCI ID/ISA are not in their device table, even when
+    # ROCR can enumerate the agent. Do not register tests that would fail before
+    # exercising rocjitsu.
+    file(STRINGS "${HIP_RUNTIME64}" _rj_hip_gfx950_strings REGEX "gfx950")
+    if(_rj_hip_gfx950_strings)
+        set(RJ_HIP_RUNTIME_SUPPORTS_GFX950 TRUE)
+    endif()
+endif()
 if(NOT AMDCXX)
     set(RJ_ENABLE_HIP_TESTS OFF)
     message(STATUS "HIP tests disabled (amdclang++ not found)")
 elseif(NOT HSA_RUNTIME64)
     set(RJ_ENABLE_HIP_TESTS OFF)
     message(STATUS "HIP tests disabled (libhsa-runtime64 not found)")
+elseif(NOT HIP_RUNTIME64)
+    set(RJ_ENABLE_HIP_TESTS OFF)
+    message(STATUS "HIP tests disabled (libamdhip64 not found)")
+elseif(NOT RJ_HIP_RUNTIME_SUPPORTS_GFX950)
+    set(RJ_ENABLE_HIP_TESTS OFF)
+    message(
+        STATUS
+        "HIP tests disabled (libamdhip64 does not advertise gfx950 support)"
+    )
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND RJ_SANITIZER_LINK_OPTIONS)
     set(RJ_ENABLE_HIP_TESTS OFF)
     message(STATUS "HIP tests disabled (GNU host compiler with sanitizers)")

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -487,10 +487,31 @@ set(RJ_CDNA4_KMD_2GPU_CONFIG
     "${CMAKE_SOURCE_DIR}/configs/gfx950_cdna4_kmd_2gpu.json"
 )
 set(RJ_CDNA3_KMD_CONFIG "${CMAKE_SOURCE_DIR}/configs/gfx942_cdna3_kmd.json")
+set(RJ_HIP_TEST_ARCH
+    "gfx950"
+    CACHE STRING
+    "GPU ISA used to build basic HIP smoke tests"
+)
+set(RJ_HIP_TEST_CONFIG
+    "${RJ_CDNA4_KMD_CONFIG}"
+    CACHE FILEPATH
+    "rocjitsu config used by basic HIP smoke tests"
+)
+set(RJ_HIP_TEST_2GPU_CONFIG
+    "${RJ_CDNA4_KMD_2GPU_CONFIG}"
+    CACHE FILEPATH
+    "rocjitsu config used by basic two-GPU HIP tests"
+)
 get_filename_component(RJ_CDNA4_KMD_CONFIG_NAME "${RJ_CDNA4_KMD_CONFIG}" NAME)
 get_filename_component(
     RJ_CDNA4_KMD_2GPU_CONFIG_NAME
     "${RJ_CDNA4_KMD_2GPU_CONFIG}"
+    NAME
+)
+get_filename_component(RJ_HIP_TEST_CONFIG_NAME "${RJ_HIP_TEST_CONFIG}" NAME)
+get_filename_component(
+    RJ_HIP_TEST_2GPU_CONFIG_NAME
+    "${RJ_HIP_TEST_2GPU_CONFIG}"
     NAME
 )
 set(RJ_CLI "$<TARGET_FILE:rocjitsu_bin>")
@@ -1208,17 +1229,25 @@ endif()
 rj_find_amdcxx(AMDCXX)
 set(RJ_ENABLE_HIP_TESTS ON)
 find_library(HIP_RUNTIME64 amdhip64 PATHS "${ROCM_PATH}" PATH_SUFFIXES lib)
+set(RJ_HIP_RUNTIME_SUPPORTS_TEST_ARCH FALSE)
 set(RJ_HIP_RUNTIME_SUPPORTS_GFX950 FALSE)
-if(HIP_RUNTIME64)
-    # These tests expose a synthetic gfx950 GPU to HIP. Recent HIP runtimes
-    # reject agents whose PCI ID/ISA are not in their device table, even when
-    # ROCR can enumerate the agent. Do not register tests that would fail before
-    # exercising rocjitsu.
-    file(STRINGS "${HIP_RUNTIME64}" _rj_hip_gfx950_strings REGEX "gfx950")
-    if(_rj_hip_gfx950_strings)
-        set(RJ_HIP_RUNTIME_SUPPORTS_GFX950 TRUE)
+set(RJ_HIP_RUNTIME_SUPPORTS_GFX942 FALSE)
+
+function(rj_hip_runtime_supports_arch out_var arch)
+    set(_supports FALSE)
+    if(HIP_RUNTIME64)
+        # Recent HIP runtimes reject agents whose PCI ID/ISA are not in their
+        # device table, even when ROCR can enumerate the agent. Gate CTest
+        # registration by the user-space runtime's advertised architectures so
+        # unsupported targets do not fail before exercising rocjitsu.
+        file(STRINGS "${HIP_RUNTIME64}" _rj_hip_arch_strings REGEX "${arch}")
+        if(_rj_hip_arch_strings)
+            set(_supports TRUE)
+        endif()
     endif()
-endif()
+    set(${out_var} "${_supports}" PARENT_SCOPE)
+endfunction()
+
 if(NOT AMDCXX)
     set(RJ_ENABLE_HIP_TESTS OFF)
     message(STATUS "HIP tests disabled (amdclang++ not found)")
@@ -1228,15 +1257,18 @@ elseif(NOT HSA_RUNTIME64)
 elseif(NOT HIP_RUNTIME64)
     set(RJ_ENABLE_HIP_TESTS OFF)
     message(STATUS "HIP tests disabled (libamdhip64 not found)")
-elseif(NOT RJ_HIP_RUNTIME_SUPPORTS_GFX950)
-    set(RJ_ENABLE_HIP_TESTS OFF)
-    message(
-        STATUS
-        "HIP tests disabled (libamdhip64 does not advertise gfx950 support)"
-    )
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND RJ_SANITIZER_LINK_OPTIONS)
     set(RJ_ENABLE_HIP_TESTS OFF)
     message(STATUS "HIP tests disabled (GNU host compiler with sanitizers)")
+endif()
+
+if(RJ_ENABLE_HIP_TESTS)
+    rj_hip_runtime_supports_arch(
+        RJ_HIP_RUNTIME_SUPPORTS_TEST_ARCH
+        "${RJ_HIP_TEST_ARCH}"
+    )
+    rj_hip_runtime_supports_arch(RJ_HIP_RUNTIME_SUPPORTS_GFX950 "gfx950")
+    rj_hip_runtime_supports_arch(RJ_HIP_RUNTIME_SUPPORTS_GFX942 "gfx942")
 endif()
 
 if(RJ_ENABLE_HIP_TESTS)
@@ -1259,7 +1291,7 @@ if(RJ_ENABLE_HIP_TESTS)
     function(rj_add_hip_test TEST_NAME)
         cmake_parse_arguments(ARG "" "ARCH;SOURCE" "EXTRA_LIBS" ${ARGN})
         if(NOT ARG_ARCH)
-            set(ARG_ARCH gfx950)
+            set(ARG_ARCH ${RJ_HIP_TEST_ARCH})
         endif()
         if(ARG_SOURCE)
             set(HIP_TEST_SRC ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_SOURCE})
@@ -1368,213 +1400,290 @@ if(RJ_ENABLE_HIP_TESTS)
         rj_add_test(${_test_args})
     endfunction()
 
-    rj_add_hip_test(hip_memcpy_test)
-    rj_add_hip_test_case(hip_memcpy_test "HipMemcpyTest.RoundTripFloat")
-    rj_add_hip_test_case(hip_memcpy_test "HipMemcpyTest.RoundTripInt")
-    rj_add_hip_test_case(hip_memcpy_test "HipMemcpyTest.DeviceToDevice")
-    rj_add_hip_test(hip_vector_add_test)
-    rj_add_hip_test_case(hip_vector_add_test "HipVectorAddTest.CorrectResult")
-    rj_add_hip_test(hip_ds_transpose_acc_test)
-
-    # --- RCCL collective test ---
-    find_library(RCCL_LIB rccl PATHS "${ROCM_PATH}" PATH_SUFFIXES lib)
-    if(RCCL_LIB)
-        rj_add_hip_test(hip_rccl_test EXTRA_LIBS ${RCCL_LIB})
-        message(STATUS "RCCL collective test enabled (found ${RCCL_LIB})")
-    else()
-        message(STATUS "RCCL collective test disabled (librccl not found)")
-    endif()
-
-    # --- Daemon RPC tests (gtest-driven) ---
-    # A gtest fixture manages the daemon lifecycle: fork+exec the daemon in
-    # SetUp, run the HIP test binary as a subprocess, tear down in TearDown.
-    _rj_path_from_installed_test_bin(
-        _rj_installed_daemon_config
-        "${CMAKE_INSTALL_DATADIR}/rocjitsu/configs"
-        "${RJ_CDNA4_KMD_CONFIG_NAME}"
-    )
-    _rj_path_from_installed_test_bin(
-        _rj_installed_daemon_config_2gpu
-        "${CMAKE_INSTALL_DATADIR}/rocjitsu/configs"
-        "${RJ_CDNA4_KMD_2GPU_CONFIG_NAME}"
-    )
-    _rj_path_from_installed_test_bin(
-        _rj_installed_preload_lib
-        "${CMAKE_INSTALL_LIBDIR}"
-        "${CMAKE_SHARED_LIBRARY_PREFIX}rocjitsu${CMAKE_SHARED_LIBRARY_SUFFIX}"
-    )
-
-    add_executable(daemon_test daemon_test.cpp)
-    target_compile_definitions(
-        daemon_test
-        PRIVATE
-            RJ_DAEMON_BIN="$<TARGET_FILE:rocjitsu_bin>"
-            RJ_DAEMON_CONFIG="${RJ_CDNA4_KMD_CONFIG}"
-            RJ_DAEMON_CONFIG_2GPU="${RJ_CDNA4_KMD_2GPU_CONFIG}"
-            RJ_PRELOAD_LIB="$<TARGET_FILE:rocjitsu_shared>"
-            RJ_HIP_VECTOR_ADD_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_vector_add_test"
-            RJ_HIP_MEMCPY_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_memcpy_test"
-            RJ_HIP_RCCL_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_rccl_test"
-            RJ_INSTALLED_DAEMON_BIN="${_rj_installed_rocjitsu_bin}"
-            RJ_INSTALLED_DAEMON_CONFIG="${_rj_installed_daemon_config}"
-            RJ_INSTALLED_DAEMON_CONFIG_2GPU="${_rj_installed_daemon_config_2gpu}"
-            RJ_INSTALLED_PRELOAD_LIB="${_rj_installed_preload_lib}"
-            RJ_INSTALLED_HIP_VECTOR_ADD_BIN="hip_vector_add_test"
-            RJ_INSTALLED_HIP_MEMCPY_BIN="hip_memcpy_test"
-            RJ_INSTALLED_HIP_RCCL_BIN="hip_rccl_test"
-    )
-    target_link_libraries(daemon_test PRIVATE GTest::gtest_main)
-    add_dependencies(
-        daemon_test
-        rocjitsu_bin
-        hip_vector_add_test_target
-        hip_memcpy_test_target
-    )
-    if(RCCL_LIB)
-        add_dependencies(daemon_test hip_rccl_test_target)
-    endif()
-    if(RJ_INSTALL_TESTS)
-        rj_install_test_target(daemon_test)
-    endif()
-    set(RJ_DAEMON_TESTS
-        DaemonTest.HipVectorAdd
-        DaemonTest.HipMemcpyRoundTripFloat
-        DaemonTest.HipMemcpyRoundTripInt
-        DaemonTest.HipMemcpyDeviceToDevice
-        DaemonTest.TwoIndependentClients
-    )
-    foreach(TC IN LISTS RJ_DAEMON_TESTS)
-        rj_add_test(
-            NAME ${TC}
-            COMMAND daemon_test --gtest_filter=${TC}
-            TIMEOUT 120
-            LABELS daemon
-            INSTALL_COMMAND
-                "bin/daemon_test"
-                "--gtest_filter=${TC}"
+    if(RJ_HIP_RUNTIME_SUPPORTS_TEST_ARCH)
+        rj_add_hip_test(hip_memcpy_test ARCH ${RJ_HIP_TEST_ARCH})
+        rj_add_hip_test_case(
+            hip_memcpy_test
+            "HipMemcpyTest.RoundTripFloat"
+            CONFIG ${RJ_HIP_TEST_CONFIG}
         )
-    endforeach()
-
-    if(RCCL_LIB)
-        set(RJ_RCCL_TESTS
-            RcclDaemonTest.AllReduce
-            RcclDaemonTest.Broadcast
-            RcclDaemonTest.AllGather
-            RcclDaemonTest.ReduceScatter
-            RcclDaemonTest.SendRecv
+        rj_add_hip_test_case(
+            hip_memcpy_test
+            "HipMemcpyTest.RoundTripInt"
+            CONFIG ${RJ_HIP_TEST_CONFIG}
         )
-        foreach(TC IN LISTS RJ_RCCL_TESTS)
+        rj_add_hip_test_case(
+            hip_memcpy_test
+            "HipMemcpyTest.DeviceToDevice"
+            CONFIG ${RJ_HIP_TEST_CONFIG}
+        )
+        rj_add_hip_test(hip_vector_add_test ARCH ${RJ_HIP_TEST_ARCH})
+        rj_add_hip_test_case(
+            hip_vector_add_test
+            "HipVectorAddTest.CorrectResult"
+            CONFIG ${RJ_HIP_TEST_CONFIG}
+        )
+
+        # --- Daemon RPC tests (gtest-driven) ---
+        # A gtest fixture manages the daemon lifecycle: fork+exec the daemon in
+        # SetUp, run the HIP test binary as a subprocess, tear down in TearDown.
+        _rj_path_from_installed_test_bin(
+            _rj_installed_daemon_config
+            "${CMAKE_INSTALL_DATADIR}/rocjitsu/configs"
+            "${RJ_HIP_TEST_CONFIG_NAME}"
+        )
+        _rj_path_from_installed_test_bin(
+            _rj_installed_daemon_config_2gpu
+            "${CMAKE_INSTALL_DATADIR}/rocjitsu/configs"
+            "${RJ_HIP_TEST_2GPU_CONFIG_NAME}"
+        )
+        _rj_path_from_installed_test_bin(
+            _rj_installed_preload_lib
+            "${CMAKE_INSTALL_LIBDIR}"
+            "${CMAKE_SHARED_LIBRARY_PREFIX}rocjitsu${CMAKE_SHARED_LIBRARY_SUFFIX}"
+        )
+
+        add_executable(daemon_test daemon_test.cpp)
+        target_compile_definitions(
+            daemon_test
+            PRIVATE
+                RJ_DAEMON_BIN="$<TARGET_FILE:rocjitsu_bin>"
+                RJ_DAEMON_CONFIG="${RJ_HIP_TEST_CONFIG}"
+                RJ_DAEMON_CONFIG_2GPU="${RJ_HIP_TEST_2GPU_CONFIG}"
+                RJ_PRELOAD_LIB="$<TARGET_FILE:rocjitsu_shared>"
+                RJ_HIP_VECTOR_ADD_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_vector_add_test"
+                RJ_HIP_MEMCPY_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_memcpy_test"
+                RJ_HIP_RCCL_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_rccl_test"
+                RJ_INSTALLED_DAEMON_BIN="${_rj_installed_rocjitsu_bin}"
+                RJ_INSTALLED_DAEMON_CONFIG="${_rj_installed_daemon_config}"
+                RJ_INSTALLED_DAEMON_CONFIG_2GPU="${_rj_installed_daemon_config_2gpu}"
+                RJ_INSTALLED_PRELOAD_LIB="${_rj_installed_preload_lib}"
+                RJ_INSTALLED_HIP_VECTOR_ADD_BIN="hip_vector_add_test"
+                RJ_INSTALLED_HIP_MEMCPY_BIN="hip_memcpy_test"
+                RJ_INSTALLED_HIP_RCCL_BIN="hip_rccl_test"
+        )
+        target_link_libraries(daemon_test PRIVATE GTest::gtest_main)
+        add_dependencies(
+            daemon_test
+            rocjitsu_bin
+            hip_vector_add_test_target
+            hip_memcpy_test_target
+        )
+        if(RJ_INSTALL_TESTS)
+            rj_install_test_target(daemon_test)
+        endif()
+        set(RJ_DAEMON_TESTS
+            DaemonTest.HipVectorAdd
+            DaemonTest.HipMemcpyRoundTripFloat
+            DaemonTest.HipMemcpyRoundTripInt
+            DaemonTest.HipMemcpyDeviceToDevice
+            DaemonTest.TwoIndependentClients
+        )
+        foreach(TC IN LISTS RJ_DAEMON_TESTS)
             rj_add_test(
                 NAME ${TC}
                 COMMAND daemon_test --gtest_filter=${TC}
-                TIMEOUT 180
-                LABELS daemon rccl
+                TIMEOUT 120
+                LABELS daemon
                 INSTALL_COMMAND
                     "bin/daemon_test"
                     "--gtest_filter=${TC}"
             )
         endforeach()
+
+        # --- RCCL collective test ---
+        find_library(RCCL_LIB rccl PATHS "${ROCM_PATH}" PATH_SUFFIXES lib)
+        if(RCCL_LIB AND RJ_HIP_RUNTIME_SUPPORTS_GFX950)
+            rj_add_hip_test(hip_rccl_test ARCH gfx950 EXTRA_LIBS ${RCCL_LIB})
+            add_dependencies(daemon_test hip_rccl_test_target)
+            set(RJ_RCCL_TESTS
+                RcclDaemonTest.AllReduce
+                RcclDaemonTest.Broadcast
+                RcclDaemonTest.AllGather
+                RcclDaemonTest.ReduceScatter
+                RcclDaemonTest.SendRecv
+            )
+            foreach(TC IN LISTS RJ_RCCL_TESTS)
+                rj_add_test(
+                    NAME ${TC}
+                    COMMAND daemon_test --gtest_filter=${TC}
+                    TIMEOUT 180
+                    LABELS daemon rccl
+                    INSTALL_COMMAND
+                        "bin/daemon_test"
+                        "--gtest_filter=${TC}"
+                )
+            endforeach()
+            message(STATUS "RCCL collective test enabled (found ${RCCL_LIB})")
+        elseif(RCCL_LIB)
+            message(
+                STATUS
+                "RCCL collective test disabled (libamdhip64 does not advertise gfx950 support)"
+            )
+        else()
+            message(STATUS "RCCL collective test disabled (librccl not found)")
+        endif()
+    else()
+        message(
+            STATUS
+            "HIP smoke/daemon tests disabled (libamdhip64 does not advertise ${RJ_HIP_TEST_ARCH} support)"
+        )
+    endif()
+
+    if(RJ_HIP_RUNTIME_SUPPORTS_GFX950)
+        # This test exercises CDNA ACCVGPR/DS transpose instructions directly
+        # in inline assembly, so it must stay on a CDNA target even when the
+        # generic HIP smoke tests are built for a local RDNA host such as
+        # gfx1201.
+        rj_add_hip_test(hip_ds_transpose_acc_test ARCH gfx950)
+
+        rj_add_hip_test(hip_bfe_2d_test ARCH gfx950)
+        rj_add_hip_test_case(hip_bfe_2d_test "BfeRegressionTest.ThreadIdxY")
+
+        # --- Logging plugin end-to-end test ---
+        rj_add_hip_test(
+            hip_logging_test
+            ARCH gfx950
+            SOURCE logging/hip_logging_test.hip
+        )
+        set(LOGGING_SINK_DIR ${CMAKE_CURRENT_BINARY_DIR}/logging_test_output)
+        set(LOGGING_RUNTIME_DIR ${LOGGING_SINK_DIR}/runtime)
+        file(MAKE_DIRECTORY ${LOGGING_SINK_DIR})
+        file(MAKE_DIRECTORY ${LOGGING_RUNTIME_DIR})
+        rj_add_hip_test_case(
+            hip_logging_test "LoggingTest.dispatch_logged"
+            TIMEOUT 30
+            ENVIRONMENT
+                "ROCJITSU_RUNTIME_DIR=${LOGGING_RUNTIME_DIR}"
+                "RJ_LOG=1"
+                "RJ_SINKS=file"
+                "RJ_SINK_DIR=${LOGGING_SINK_DIR}"
+        )
+
+        # --- Profiled plugin group end-to-end test ---
+        rj_add_hip_test(
+            hip_profiled_plugin_test
+            ARCH gfx950
+            SOURCE logging/hip_profiled_plugin_test.hip
+        )
+        set(PROFILED_SINK_DIR ${CMAKE_CURRENT_BINARY_DIR}/profiled_test_output)
+        set(PROFILED_RUNTIME_DIR ${PROFILED_SINK_DIR}/runtime)
+        file(MAKE_DIRECTORY ${PROFILED_SINK_DIR})
+        file(MAKE_DIRECTORY ${PROFILED_RUNTIME_DIR})
+        rj_add_hip_test_case(
+            hip_profiled_plugin_test "ProfiledPluginTest.hook_profile_output"
+            TIMEOUT 30
+            ENVIRONMENT
+                "ROCJITSU_RUNTIME_DIR=${PROFILED_RUNTIME_DIR}"
+                "RJ_USE_PROFILED_EXECUTION_PLUGIN_GROUP=1"
+                "RJ_SINKS=file"
+                "RJ_SINK_DIR=${PROFILED_SINK_DIR}"
+        )
+
+        add_subdirectory(race-detector)
+    else()
+        message(
+            STATUS
+            "CDNA4 HIP tests disabled (libamdhip64 does not advertise gfx950 support)"
+        )
     endif()
 
     # --- rocBLAS GEMM test ---
     find_library(ROCBLAS_LIB rocblas PATHS "${ROCM_PATH}" PATH_SUFFIXES lib)
     if(ROCBLAS_LIB)
-        rj_add_hip_test(hip_gemm_test EXTRA_LIBS ${ROCBLAS_LIB})
-        rj_add_hip_test(hip_gemm_test_cdna3 ARCH gfx942 SOURCE hip_gemm_test.cpp EXTRA_LIBS ${ROCBLAS_LIB})
+        if(RJ_HIP_RUNTIME_SUPPORTS_GFX950)
+            rj_add_hip_test(hip_gemm_test ARCH gfx950 EXTRA_LIBS ${ROCBLAS_LIB})
 
-        foreach(
-            TC
-            IN
-            ITEMS
-                Tiny_2x2x3
-                Square_4x4
-                Square_8x8
-                Square_16x16
-                Square_32x32
-                Square_64x64
-                Rect_16x32x8
-                Rect_1x64x1
-                Rect_64x1x64
-                Rect_7x11x13
-                AlphaBeta
-                BetaZero
-                Large_2048x2048
-        )
-            if(TC STREQUAL "Large_2048x2048")
+            foreach(
+                TC
+                IN
+                ITEMS
+                    Tiny_2x2x3
+                    Square_4x4
+                    Square_8x8
+                    Square_16x16
+                    Square_32x32
+                    Square_64x64
+                    Rect_16x32x8
+                    Rect_1x64x1
+                    Rect_64x1x64
+                    Rect_7x11x13
+                    AlphaBeta
+                    BetaZero
+                    Large_2048x2048
+            )
+                if(TC STREQUAL "Large_2048x2048")
+                    rj_add_hip_test_case(
+                        hip_gemm_test
+                        "RocblasGemmTest.${TC}"
+                        TIMEOUT 300
+                    )
+                else()
+                    rj_add_hip_test_case(hip_gemm_test "RocblasGemmTest.${TC}")
+                endif()
+            endforeach()
+            foreach(I RANGE 0 4)
+                rj_add_hip_test_case(hip_gemm_test "RocblasGemmFuzz.Iter${I}")
+            endforeach()
+            message(
+                STATUS
+                "rocBLAS GEMM gfx950 tests enabled (found ${ROCBLAS_LIB})"
+            )
+        endif()
+
+        if(RJ_HIP_RUNTIME_SUPPORTS_GFX942)
+            rj_add_hip_test(
+                hip_gemm_test_cdna3
+                ARCH gfx942
+                SOURCE hip_gemm_test.cpp
+                EXTRA_LIBS ${ROCBLAS_LIB}
+            )
+
+            foreach(
+                TC
+                IN
+                ITEMS Tiny_2x2x3 Square_16x16 Square_32x32 Rect_7x11x13
+            )
                 rj_add_hip_test_case(
-                    hip_gemm_test
+                    hip_gemm_test_cdna3
                     "RocblasGemmTest.${TC}"
-                    TIMEOUT 300
+                    CONFIG ${RJ_CDNA3_KMD_CONFIG}
+                    NAME "RocblasGemmCdna3.${TC}"
                 )
-            else()
-                rj_add_hip_test_case(hip_gemm_test "RocblasGemmTest.${TC}")
-            endif()
-        endforeach()
-        foreach(I RANGE 0 4)
-            rj_add_hip_test_case(hip_gemm_test "RocblasGemmFuzz.Iter${I}")
-        endforeach()
+            endforeach()
+            foreach(I RANGE 0 2)
+                rj_add_hip_test_case(
+                    hip_gemm_test_cdna3
+                    "RocblasGemmFuzz.Iter${I}"
+                    CONFIG ${RJ_CDNA3_KMD_CONFIG}
+                    NAME "RocblasGemmCdna3.Fuzz_Iter${I}"
+                )
+            endforeach()
+            message(
+                STATUS
+                "rocBLAS GEMM gfx942 tests enabled (found ${ROCBLAS_LIB})"
+            )
+        endif()
 
-        foreach(TC IN ITEMS Tiny_2x2x3 Square_16x16 Square_32x32 Rect_7x11x13)
-            rj_add_hip_test_case(hip_gemm_test_cdna3 "RocblasGemmTest.${TC}"
-                CONFIG ${RJ_CDNA3_KMD_CONFIG} NAME "RocblasGemmCdna3.${TC}"
+        if(
+            NOT RJ_HIP_RUNTIME_SUPPORTS_GFX950
+            AND NOT RJ_HIP_RUNTIME_SUPPORTS_GFX942
+        )
+            message(
+                STATUS
+                "rocBLAS GEMM test disabled (libamdhip64 does not advertise gfx950 or gfx942 support)"
             )
-        endforeach()
-        foreach(I RANGE 0 2)
-            rj_add_hip_test_case(hip_gemm_test_cdna3 "RocblasGemmFuzz.Iter${I}"
-                CONFIG ${RJ_CDNA3_KMD_CONFIG} NAME "RocblasGemmCdna3.Fuzz_Iter${I}"
-            )
-        endforeach()
-        message(STATUS "rocBLAS GEMM test enabled (found ${ROCBLAS_LIB})")
+        endif()
     else()
         message(STATUS "rocBLAS GEMM test disabled (librocblas not found)")
     endif()
-
-    rj_add_hip_test(hip_bfe_2d_test)
-    rj_add_hip_test_case(hip_bfe_2d_test "BfeRegressionTest.ThreadIdxY")
-
-    # --- Logging plugin end-to-end test ---
-    rj_add_hip_test(hip_logging_test SOURCE logging/hip_logging_test.hip)
-    set(LOGGING_SINK_DIR ${CMAKE_CURRENT_BINARY_DIR}/logging_test_output)
-    set(LOGGING_RUNTIME_DIR ${LOGGING_SINK_DIR}/runtime)
-    file(MAKE_DIRECTORY ${LOGGING_SINK_DIR})
-    file(MAKE_DIRECTORY ${LOGGING_RUNTIME_DIR})
-    rj_add_hip_test_case(
-        hip_logging_test "LoggingTest.dispatch_logged"
-        TIMEOUT 30
-        ENVIRONMENT
-            "ROCJITSU_RUNTIME_DIR=${LOGGING_RUNTIME_DIR}"
-            "RJ_LOG=1"
-            "RJ_SINKS=file"
-            "RJ_SINK_DIR=${LOGGING_SINK_DIR}"
-    )
-
-    # --- Profiled plugin group end-to-end test ---
-    rj_add_hip_test(
-        hip_profiled_plugin_test
-        SOURCE logging/hip_profiled_plugin_test.hip
-    )
-    set(PROFILED_SINK_DIR ${CMAKE_CURRENT_BINARY_DIR}/profiled_test_output)
-    set(PROFILED_RUNTIME_DIR ${PROFILED_SINK_DIR}/runtime)
-    file(MAKE_DIRECTORY ${PROFILED_SINK_DIR})
-    file(MAKE_DIRECTORY ${PROFILED_RUNTIME_DIR})
-    rj_add_hip_test_case(
-        hip_profiled_plugin_test "ProfiledPluginTest.hook_profile_output"
-        TIMEOUT 30
-        ENVIRONMENT
-            "ROCJITSU_RUNTIME_DIR=${PROFILED_RUNTIME_DIR}"
-            "RJ_USE_PROFILED_EXECUTION_PLUGIN_GROUP=1"
-            "RJ_SINKS=file"
-            "RJ_SINK_DIR=${PROFILED_SINK_DIR}"
-    )
-
-    add_subdirectory(race-detector)
 
     message(STATUS "HIP tests enabled (found ${AMDCXX})")
 endif()
 
 # --- Narrow conversion HIP CTS tests ---
-# Uses the same HIP compiler path as the other HIP tests.
-if(RJ_ENABLE_HIP_TESTS)
+# Uses the same HIP compiler path as the other CDNA4 HIP tests.
+if(RJ_ENABLE_HIP_TESTS AND RJ_HIP_RUNTIME_SUPPORTS_GFX950)
     set(CVT_NARROW_BIN ${CMAKE_CURRENT_BINARY_DIR}/hip_cvt_narrow_test)
     add_custom_command(
         OUTPUT ${CVT_NARROW_BIN}

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -627,10 +627,20 @@ if(RJ_HAS_GFX1201_GPU)
             --gtest_filter=GuestKfdConcurrencyTest.ConcurrentOpenIoctlAndSysfsRedirect
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
+    add_test(
+        NAME "GuestKfdMemoryTest.GuestAllocationMmapOffsetIsRejected"
+        COMMAND
+            ${RJ_CLI} --config
+            ${CMAKE_SOURCE_DIR}/configs/guest_gfx950_on_gfx1201.json --
+            $<TARGET_FILE:guest_kfd_test>
+            --gtest_filter=GuestKfdMemoryTest.GuestAllocationMmapOffsetIsRejected
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
     set_tests_properties(
         "GuestKfdMultiprocessTest.ForkedChildrenDoNotRemoveParentOverlay"
         "GuestKfdMultiprocessTest.ForkedChildDropsInheritedGuestDriverBeforeReopen"
         "GuestKfdConcurrencyTest.ConcurrentOpenIoctlAndSysfsRedirect"
+        "GuestKfdMemoryTest.GuestAllocationMmapOffsetIsRejected"
         PROPERTIES TIMEOUT 60 SKIP_REGULAR_EXPRESSION "\\[  SKIPPED \\]"
     )
     foreach(
@@ -640,6 +650,7 @@ if(RJ_HAS_GFX1201_GPU)
             "GuestKfdMultiprocessTest.ForkedChildrenDoNotRemoveParentOverlay"
             "GuestKfdMultiprocessTest.ForkedChildDropsInheritedGuestDriverBeforeReopen"
             "GuestKfdConcurrencyTest.ConcurrentOpenIoctlAndSysfsRedirect"
+            "GuestKfdMemoryTest.GuestAllocationMmapOffsetIsRejected"
     )
         rj_set_default_runtime_dir("${_guest_kfd_test}")
     endforeach()
@@ -1027,17 +1038,13 @@ if(HSA_RUNTIME64)
                     --gtest_filter=HsaHooksTest.TranslateGfx950Mfma16x16ThroughToolsLib
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
                 TIMEOUT 60
-                ENVIRONMENT
-                    "HSA_TOOLS_LIB=$<TARGET_FILE:rocjitsu_hooks>"
-                    "RJ_DBT_TARGET_ISA=gfx1201"
-                    "RJ_DBT_LOG=1"
                 INSTALL_COMMAND
+                    "\${RJ_INSTALLED_BINDIR}/rocjitsu"
+                    "--config"
+                    "\${RJ_INSTALLED_CONFIG_DIR}/guest_gfx950_on_gfx1201.json"
+                    "--"
                     "bin/hsa_hooks_test"
                     "--gtest_filter=HsaHooksTest.TranslateGfx950Mfma16x16ThroughToolsLib"
-                INSTALL_ENVIRONMENT
-                    "HSA_TOOLS_LIB=\${RJ_INSTALLED_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}rocjitsu_hooks${CMAKE_SHARED_LIBRARY_SUFFIX}"
-                    "RJ_DBT_TARGET_ISA=gfx1201"
-                    "RJ_DBT_LOG=1"
             )
         endif()
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -1401,7 +1401,7 @@ if(RJ_ENABLE_HIP_TESTS)
     _rj_path_from_installed_test_bin(
         _rj_installed_preload_lib
         "${CMAKE_INSTALL_LIBDIR}"
-        "${CMAKE_SHARED_LIBRARY_PREFIX}rocjitsu_kmd${CMAKE_SHARED_LIBRARY_SUFFIX}"
+        "${CMAKE_SHARED_LIBRARY_PREFIX}rocjitsu${CMAKE_SHARED_LIBRARY_SUFFIX}"
     )
 
     add_executable(daemon_test daemon_test.cpp)

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -561,28 +561,6 @@ endif()
 set(RJ_HAS_GFX1201_GPU FALSE)
 if("120001" IN_LIST RJ_KFD_GFX_TARGET_VERSIONS)
     set(RJ_HAS_GFX1201_GPU TRUE)
-else()
-    find_program(
-        ROCM_AGENT_ENUM
-        rocm_agent_enumerator
-        HINTS "${ROCM_PATH}"
-        PATH_SUFFIXES bin
-    )
-    if(ROCM_AGENT_ENUM)
-        execute_process(
-            COMMAND ${ROCM_AGENT_ENUM}
-            OUTPUT_VARIABLE _agents
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-            ERROR_QUIET
-            RESULT_VARIABLE _agent_rc
-        )
-        if(
-            _agent_rc EQUAL 0
-            AND _agents MATCHES "(^|[\r\n; ])gfx1201($|[\r\n; ])"
-        )
-            set(RJ_HAS_GFX1201_GPU TRUE)
-        endif()
-    endif()
 endif()
 
 set(RJ_KMD_PRELOAD_ENV

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -28,6 +28,7 @@ RJ_DIAGNOSTIC_POP
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -364,6 +365,55 @@ TEST(ConfigLoaderTest, LoadsDbtOnlyConfigWithoutVmOrTopology) {
   EXPECT_EQ(dbt.guest_device.drm_render_minor, 191u);
   EXPECT_EQ(dbt.guest_device.num_shader_arrays_per_engine, 2u);
   EXPECT_EQ(dbt.guest_device.local_mem_size, 309237645312ULL);
+}
+
+TEST(ConfigLoaderTest, LoadsDbtGuestThroughFullConfigLoader) {
+  std::ifstream base(CONFIG_DIR_PATH + "/gfx1201_r9700.json");
+  ASSERT_TRUE(base.is_open());
+  std::string json((std::istreambuf_iterator<char>(base)), std::istreambuf_iterator<char>());
+  const size_t insert_pos = json.find('{');
+  ASSERT_NE(insert_pos, std::string::npos);
+  json.insert(insert_pos + 1, R"(
+    "dbt_guest": {
+      "enabled": true,
+      "guest_isa": "gfx950",
+      "host_isa": "gfx1201",
+      "host_gpu_id": 8716,
+      "log_level": 2,
+      "signal_backtrace": true,
+      "guest_device": {
+        "gpu_id": 38144,
+        "gfx_target_version": 90500,
+        "vendor_id": 4098,
+        "device_id": 30112,
+        "family_id": 160,
+        "unique_id": 5929628898254127105,
+        "marketing_name": "AMD Instinct MI350X",
+        "drm_render_minor": 191,
+        "simd_count": 1024,
+        "num_shader_engines": 4,
+        "num_shader_arrays_per_engine": 2,
+        "num_cu_per_sh": 4,
+        "local_mem_size": 309237645312
+      }
+    },
+  )");
+
+  const std::filesystem::path path =
+      write_temp_config("rocjitsu_full_dbt_guest_config_test.json", json);
+  auto loaded = config::load_config(path.string(), rocjitsu::kEmbeddedSchema);
+  std::filesystem::remove(path);
+
+  EXPECT_TRUE(loaded.dbt_guest.enabled);
+  EXPECT_EQ(loaded.dbt_guest.guest_isa, "gfx950");
+  EXPECT_EQ(loaded.dbt_guest.host_isa, "gfx1201");
+  EXPECT_EQ(loaded.dbt_guest.host_gpu_id, 8716u);
+  EXPECT_EQ(loaded.dbt_guest.log_level, 2);
+  EXPECT_TRUE(loaded.dbt_guest.signal_backtrace);
+  ASSERT_TRUE(loaded.dbt_guest.guest_device.present);
+  EXPECT_EQ(loaded.dbt_guest.guest_device.gpu_id, 38144u);
+  EXPECT_EQ(loaded.dbt_guest.guest_device.gfx_target_version, 90500u);
+  EXPECT_EQ(loaded.dbt_guest.guest_device.marketing_name, "AMD Instinct MI350X");
 }
 
 TEST(ConfigLoaderTest, MissingDbtGuestConfigReturnsDefaults) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -6,6 +6,7 @@
 #include "embedded_schema.h"
 #include "rocjitsu/config/checkpoint.h"
 #include "rocjitsu/config/config_loader.h"
+#include "rocjitsu/config/dbt_guest_config.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna3/isa.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/accvgpr_layout.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
@@ -26,7 +27,10 @@ RJ_DIAGNOSTIC_POP
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 
 namespace {
 
@@ -34,6 +38,13 @@ const std::string CONFIG_DIR_PATH = CONFIG_DIR;
 
 // \NPI new GPU: add a config-load test for its configs/<gpu>.json here.
 using namespace rocjitsu;
+
+std::filesystem::path write_temp_config(std::string_view name, std::string_view json) {
+  std::filesystem::path path = std::filesystem::temp_directory_path() / std::string(name);
+  std::ofstream out(path);
+  out << json;
+  return path;
+}
 
 TEST(ConfigLoaderTest, LoadCdna4Config) {
   std::string json = CONFIG_DIR_PATH + "/gfx950_cdna4.json";
@@ -75,7 +86,10 @@ TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {
                                                         rdna4.device.revision_id),
             0x51u);
   EXPECT_EQ(kmd::gfx_target_name(rdna4.device.gfx_target_version), "gfx1201");
+  EXPECT_EQ(kmd::gfx_target_version_from_name("gfx1201"), rdna4.device.gfx_target_version);
   EXPECT_EQ(kmd::gfx_target_name(90010), "gfx90a");
+  EXPECT_EQ(kmd::gfx_target_version_from_name("gfx90a"), 90010u);
+  EXPECT_FALSE(kmd::gfx_target_version_from_name("cdna4"));
   EXPECT_EQ(kmd::gb_addr_config_for_arch(ROCJITSU_CODE_ARCH_RDNA3_5), 0u);
   EXPECT_EQ(kmd::gb_addr_config_for_gfx_target_version(110500), 0u);
   EXPECT_EQ(kmd::gb_addr_config_for_gfx_target_version(120500), 0u);
@@ -305,6 +319,94 @@ TEST(ConfigLoaderTest, DeviceCapabilityFieldsRoundTripFromJson) {
   EXPECT_EQ(loaded.device.capability, 268468354u);
   EXPECT_EQ(loaded.device.capability2, 3u);
   EXPECT_EQ(loaded.device.debug_prop, 3119u);
+}
+
+TEST(ConfigLoaderTest, LoadsDbtOnlyConfigWithoutVmOrTopology) {
+  const std::filesystem::path path = write_temp_config("rocjitsu_dbt_only_config_test.json", R"({
+      "dbt_guest": {
+        "enabled": true,
+        "guest_isa": "gfx950",
+        "host_isa": "gfx1201",
+        "host_gpu_id": 8716,
+        "log_level": 2,
+        "signal_backtrace": true,
+        "guest_device": {
+          "gpu_id": 38144,
+          "gfx_target_version": 90500,
+          "vendor_id": 4098,
+          "device_id": 30112,
+          "family_id": 160,
+          "unique_id": 5929628898254127105,
+          "marketing_name": "AMD Instinct MI350X",
+          "drm_render_minor": 191,
+          "simd_count": 1024,
+          "num_shader_engines": 4,
+          "num_shader_arrays_per_engine": 2,
+          "num_cu_per_sh": 4,
+          "local_mem_size": 309237645312
+        }
+      }
+    })");
+
+  auto dbt = config::load_dbt_guest_config_from_file(path.string());
+  std::filesystem::remove(path);
+
+  EXPECT_TRUE(dbt.enabled);
+  EXPECT_EQ(dbt.guest_isa, "gfx950");
+  EXPECT_EQ(dbt.host_isa, "gfx1201");
+  EXPECT_EQ(dbt.host_gpu_id, 8716u);
+  EXPECT_EQ(dbt.log_level, 2);
+  EXPECT_TRUE(dbt.signal_backtrace);
+  ASSERT_TRUE(dbt.guest_device.present);
+  EXPECT_EQ(dbt.guest_device.gpu_id, 38144u);
+  EXPECT_EQ(dbt.guest_device.gfx_target_version, 90500u);
+  EXPECT_EQ(dbt.guest_device.marketing_name, "AMD Instinct MI350X");
+  EXPECT_EQ(dbt.guest_device.drm_render_minor, 191u);
+  EXPECT_EQ(dbt.guest_device.num_shader_arrays_per_engine, 2u);
+  EXPECT_EQ(dbt.guest_device.local_mem_size, 309237645312ULL);
+}
+
+TEST(ConfigLoaderTest, MissingDbtGuestConfigReturnsDefaults) {
+  const std::filesystem::path path =
+      write_temp_config("rocjitsu_missing_dbt_guest_config_test.json", "{}");
+
+  auto dbt = config::load_dbt_guest_config_from_file(path.string());
+  std::filesystem::remove(path);
+
+  EXPECT_FALSE(dbt.enabled);
+  EXPECT_TRUE(dbt.guest_isa.empty());
+  EXPECT_TRUE(dbt.host_isa.empty());
+  EXPECT_EQ(dbt.host_gpu_id, 0u);
+  EXPECT_EQ(dbt.log_level, 0);
+  EXPECT_FALSE(dbt.signal_backtrace);
+  EXPECT_FALSE(dbt.guest_device.present);
+}
+
+TEST(ConfigLoaderTest, MissingDbtGuestDeviceLeavesDeviceAbsent) {
+  const std::filesystem::path path =
+      write_temp_config("rocjitsu_missing_dbt_guest_device_config_test.json", R"({
+        "dbt_guest": {
+          "enabled": true,
+          "guest_isa": "gfx950",
+          "host_isa": "gfx1201"
+        }
+      })");
+
+  auto dbt = config::load_dbt_guest_config_from_file(path.string());
+  std::filesystem::remove(path);
+
+  EXPECT_TRUE(dbt.enabled);
+  EXPECT_EQ(dbt.guest_isa, "gfx950");
+  EXPECT_EQ(dbt.host_isa, "gfx1201");
+  EXPECT_FALSE(dbt.guest_device.present);
+}
+
+TEST(ConfigLoaderTest, MalformedDbtGuestConfigThrows) {
+  const std::filesystem::path path =
+      write_temp_config("rocjitsu_malformed_dbt_guest_config_test.json", R"({ "dbt_guest": )");
+
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
+  std::filesystem::remove(path);
 }
 
 TEST(ConfigLoaderTest, Gfx1250ComputeUnitDefaultsCoverTtmpAndHighVgprs) {

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -340,7 +340,7 @@ TEST(ConfigLoaderTest, LoadsDbtOnlyConfigWithoutVmOrTopology) {
           "unique_id": 5929628898254127105,
           "marketing_name": "AMD Instinct MI350X",
           "drm_render_minor": 191,
-          "simd_count": 1024,
+          "simd_count": 64,
           "num_shader_engines": 4,
           "num_shader_arrays_per_engine": 2,
           "num_cu_per_sh": 4,
@@ -363,8 +363,33 @@ TEST(ConfigLoaderTest, LoadsDbtOnlyConfigWithoutVmOrTopology) {
   EXPECT_EQ(dbt.guest_device.gfx_target_version, 90500u);
   EXPECT_EQ(dbt.guest_device.marketing_name, "AMD Instinct MI350X");
   EXPECT_EQ(dbt.guest_device.drm_render_minor, 191u);
+  EXPECT_EQ(dbt.guest_device.simd_count, dbt.guest_device.num_shader_engines *
+                                             dbt.guest_device.num_cu_per_sh *
+                                             dbt.guest_device.simd_per_cu);
   EXPECT_EQ(dbt.guest_device.num_shader_arrays_per_engine, 2u);
   EXPECT_EQ(dbt.guest_device.local_mem_size, 309237645312ULL);
+}
+
+TEST(ConfigLoaderTest, RejectsDbtGuestDeviceWithInconsistentSimdCount) {
+  const std::filesystem::path path =
+      write_temp_config("rocjitsu_bad_dbt_guest_geometry_config_test.json", R"({
+      "dbt_guest": {
+        "enabled": true,
+        "guest_isa": "gfx950",
+        "host_isa": "gfx1201",
+        "guest_device": {
+          "gpu_id": 38144,
+          "gfx_target_version": 90500,
+          "simd_count": 1024,
+          "num_shader_engines": 4,
+          "num_cu_per_sh": 4,
+          "simd_per_cu": 4
+        }
+      }
+    })");
+
+  EXPECT_THROW(config::load_dbt_guest_config_from_file(path.string()), std::runtime_error);
+  std::filesystem::remove(path);
 }
 
 TEST(ConfigLoaderTest, LoadsDbtGuestThroughFullConfigLoader) {
@@ -390,7 +415,7 @@ TEST(ConfigLoaderTest, LoadsDbtGuestThroughFullConfigLoader) {
         "unique_id": 5929628898254127105,
         "marketing_name": "AMD Instinct MI350X",
         "drm_render_minor": 191,
-        "simd_count": 1024,
+        "simd_count": 64,
         "num_shader_engines": 4,
         "num_shader_arrays_per_engine": 2,
         "num_cu_per_sh": 4,

--- a/emulation/rocjitsu/tests/daemon_test.cpp
+++ b/emulation/rocjitsu/tests/daemon_test.cpp
@@ -131,13 +131,15 @@ protected:
     std::string tmpl = base + "/rocjitsu-test-XXXXXX";
     ASSERT_NE(mkdtemp(tmpl.data()), nullptr) << "mkdtemp failed: " << strerror(errno);
     tmp_dir_ = tmpl;
-    sock_path_ = tmp_dir_ + "/rocjitsu/daemon.sock";
+    runtime_dir_ = tmp_dir_ + "/rocjitsu";
+    sock_path_ = runtime_dir_ + "/daemon.sock";
 
     daemon_pid_ = fork();
     ASSERT_GE(daemon_pid_, 0) << "fork failed: " << strerror(errno);
 
     if (daemon_pid_ == 0) {
       setenv("XDG_RUNTIME_DIR", tmp_dir_.c_str(), 1);
+      setenv("ROCJITSU_RUNTIME_DIR", runtime_dir_.c_str(), 1);
       execl(daemon_bin(), daemon_bin(), "--daemon", "--config", daemon_config(), nullptr);
       _exit(127);
     }
@@ -167,7 +169,12 @@ protected:
   }
 
   ProcessResult run_hip_test(const char *binary, const char *gtest_filter) {
-    std::string cmd = "XDG_RUNTIME_DIR=";
+    // CTest sets ROCJITSU_RUNTIME_DIR for isolation and the RPC layer prefers it
+    // over XDG_RUNTIME_DIR. Override both here so the daemon and all client
+    // subprocesses agree on the same socket and config-path directory.
+    std::string cmd = "ROCJITSU_RUNTIME_DIR=";
+    cmd += runtime_dir_;
+    cmd += " XDG_RUNTIME_DIR=";
     cmd += tmp_dir_;
     cmd += " LD_PRELOAD=";
     cmd += preload_lib();
@@ -195,7 +202,9 @@ protected:
 
   ProcessResult run_rccl_rank(int rank, int world_size, const std::string &shared_dir,
                               const char *gtest_filter) {
-    std::string cmd = "XDG_RUNTIME_DIR=";
+    std::string cmd = "ROCJITSU_RUNTIME_DIR=";
+    cmd += runtime_dir_;
+    cmd += " XDG_RUNTIME_DIR=";
     cmd += tmp_dir_;
     cmd += " ";
     cmd += daemon_bin();
@@ -251,6 +260,7 @@ protected:
 
   pid_t daemon_pid_ = -1;
   std::string tmp_dir_;
+  std::string runtime_dir_;
   std::string sock_path_;
 };
 
@@ -305,13 +315,15 @@ protected:
     std::string tmpl = base + "/rocjitsu-rccl-XXXXXX";
     ASSERT_NE(mkdtemp(tmpl.data()), nullptr) << "mkdtemp failed: " << strerror(errno);
     tmp_dir_ = tmpl;
-    sock_path_ = tmp_dir_ + "/rocjitsu/daemon.sock";
+    runtime_dir_ = tmp_dir_ + "/rocjitsu";
+    sock_path_ = runtime_dir_ + "/daemon.sock";
 
     daemon_pid_ = fork();
     ASSERT_GE(daemon_pid_, 0) << "fork failed: " << strerror(errno);
 
     if (daemon_pid_ == 0) {
       setenv("XDG_RUNTIME_DIR", tmp_dir_.c_str(), 1);
+      setenv("ROCJITSU_RUNTIME_DIR", runtime_dir_.c_str(), 1);
       execl(daemon_bin(), daemon_bin(), "--daemon", "--config", daemon_config_2gpu(), nullptr);
       _exit(127);
     }
@@ -343,7 +355,9 @@ protected:
 
   ProcessResult run_rccl_rank(int rank, int world_size, const std::string &shared_dir,
                               const char *gtest_filter) {
-    std::string cmd = "timeout 150 env XDG_RUNTIME_DIR=";
+    std::string cmd = "timeout 150 env ROCJITSU_RUNTIME_DIR=";
+    cmd += runtime_dir_;
+    cmd += " XDG_RUNTIME_DIR=";
     cmd += tmp_dir_;
     cmd += " HIP_VISIBLE_DEVICES=";
     cmd += std::to_string(rank);
@@ -403,6 +417,7 @@ protected:
 
   pid_t daemon_pid_ = -1;
   std::string tmp_dir_;
+  std::string runtime_dir_;
   std::string sock_path_;
 };
 

--- a/emulation/rocjitsu/tests/dbt/hsa_hooks_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hooks_test.cpp
@@ -7,11 +7,13 @@
 /// @details This test intentionally creates an HSA code-object reader from the
 /// original gfx950 ELF bytes. It does not call BinaryTranslator directly. The
 /// expected execution path is:
-///   1. ROCR loads librocjitsu_hooks.so from HSA_TOOLS_LIB during hsa_init().
-///   2. The hook records the gfx950 reader bytes.
-///   3. hsa_executable_load_agent_code_object() is intercepted and translated
-///      to the RJ_DBT_TARGET_ISA selected by the test environment.
-///   4. The translated object is loaded and dispatched on the local GPU.
+///   1. The rocjitsu launcher enables DBT guest mode from the runtime config.
+///   2. ROCR loads librocjitsu_hooks.so from HSA_TOOLS_LIB during hsa_init().
+///   3. The public GPU agent is the synthetic gfx950 guest.
+///   4. The hook records the gfx950 reader bytes.
+///   5. hsa_executable_load_agent_code_object() is intercepted, translated to
+///      the host ISA configured in the runtime config, and loaded on the host agent.
+///   6. The translated object is dispatched through the host queue.
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -147,15 +149,14 @@ TEST(HsaHooksTest, TranslateGfx950Mfma16x16ThroughToolsLib) {
 
   ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
 
-  const char *target_isa = std::getenv("RJ_DBT_TARGET_ISA");
-  ASSERT_NE(target_isa, nullptr) << "HSA hook test requires RJ_DBT_TARGET_ISA";
-  // The hook target and dispatch agent must agree exactly. On multi-GPU hosts,
-  // the first HSA GPU can be a different gfx stepping from the CTest-selected
-  // RJ_DBT_TARGET_ISA, which makes ROCR reject the translated code object.
-  GpuTarget gpu_target = find_gpu_agent_for_isa(target_isa);
+  // The test runs under rocjitsu DBT guest mode, so public HSA iteration should
+  // expose the synthetic gfx950 guest in place of the selected host GPU. The
+  // hook maps execution-facing calls for this agent to the host from the runtime config.
+  constexpr const char *kGuestIsa = "gfx950";
+  GpuTarget gpu_target = find_gpu_agent_for_isa(kGuestIsa);
   hsa_agent_t gpu = gpu_target.agent;
   hsa_agent_t cpu = find_cpu_agent();
-  ASSERT_NE(gpu.handle, 0u) << "No GPU agent matched RJ_DBT_TARGET_ISA=" << target_isa
+  ASSERT_NE(gpu.handle, 0u) << "No public GPU agent matched guest ISA " << kGuestIsa
                             << "; seen GPU ISAs: " << join_seen_isas(gpu_target.seen_gpu_isas);
   ASSERT_NE(cpu.handle, 0u);
 

--- a/emulation/rocjitsu/tests/dbt/hsa_hooks_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hooks_unit_test.cpp
@@ -192,15 +192,34 @@ hsa_status_t HSA_API fake_amd_memory_async_batch_copy(const hsa_amd_memory_copy_
 
   for (uint32_t op_idx = 0; op_idx < num_copy_ops; ++op_idx) {
     const hsa_amd_memory_copy_op_t &op = copy_ops[op_idx];
-    if (op.num_entries == 0) {
-      g_last_batch_src_agents.push_back(op.src_agent.handle);
-      g_last_batch_dst_agents.push_back(op.dst_agent.handle);
+    switch (static_cast<hsa_amd_memory_copy_op_type_t>(op.type)) {
+    case HSA_AMD_MEMORY_COPY_OP_LINEAR:
+    case HSA_AMD_MEMORY_COPY_OP_LINEAR_SWAP:
+    case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRC:
+    case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_DST:
+    case HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST:
+      if (op.num_entries == 0) {
+        g_last_batch_src_agents.push_back(op.src_agent.handle);
+        g_last_batch_dst_agents.push_back(op.dst_agent.handle);
+        continue;
+      }
+      if (op.dst_agent_list == nullptr)
+        return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+      for (uint16_t entry_idx = 0; entry_idx < op.num_entries; ++entry_idx) {
+        g_last_batch_src_agents.push_back(op.src_agent.handle);
+        g_last_batch_dst_agents.push_back(op.dst_agent_list[entry_idx].handle);
+      }
+      continue;
+    case HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST:
+      if (op.num_entries == 0 || op.dst_agent_list == nullptr)
+        return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+      for (uint16_t entry_idx = 0; entry_idx < op.num_entries; ++entry_idx) {
+        g_last_batch_src_agents.push_back(op.src_agent.handle);
+        g_last_batch_dst_agents.push_back(op.dst_agent_list[entry_idx].handle);
+      }
       continue;
     }
-    for (uint16_t entry_idx = 0; entry_idx < op.num_entries; ++entry_idx) {
-      g_last_batch_src_agents.push_back(op.src_agent_list[entry_idx].handle);
-      g_last_batch_dst_agents.push_back(op.dst_agent_list[entry_idx].handle);
-    }
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   }
   return HSA_STATUS_SUCCESS;
 }
@@ -351,6 +370,23 @@ void release_agent_blocker() {
   g_agent_cv.notify_all();
 }
 
+void expect_batch_copy_forwarding(const hsa_amd_memory_copy_op_t &op,
+                                  const std::vector<uint64_t> &expected_src_agents,
+                                  const std::vector<uint64_t> &expected_dst_agents) {
+  reset_pool_blocker(false);
+  reset_agent_blocker(false);
+  g_last_batch_src_agents.clear();
+  g_last_batch_dst_agents.clear();
+  FakeApiTable api;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+  ASSERT_NE(api.amd.hsa_amd_memory_async_batch_copy_fn, fake_amd_memory_async_batch_copy);
+
+  EXPECT_EQ(api.amd.hsa_amd_memory_async_batch_copy_fn(&op, 1, 0, nullptr), HSA_STATUS_SUCCESS);
+  EXPECT_EQ(g_last_batch_src_agents, expected_src_agents);
+  EXPECT_EQ(g_last_batch_dst_agents, expected_dst_agents);
+}
+
 TEST(HsaHooksUnitTest, IterateAgentsDropsGuestOwnSlotWhenGuestAppearsFirst) {
   reset_pool_blocker(false);
   reset_agent_blocker(false);
@@ -392,26 +428,80 @@ TEST(HsaHooksUnitTest, IterateAgentsDropsGuestOwnSlotWhenHostAppearsFirst) {
   EXPECT_EQ(seen, std::vector<uint64_t>{kGuestAgent.handle});
 }
 
-TEST(HsaHooksUnitTest, BatchCopyMapsSourceAndDestinationAgentLists) {
-  reset_pool_blocker(false);
-  reset_agent_blocker(false);
-  g_last_batch_src_agents.clear();
-  g_last_batch_dst_agents.clear();
-  FakeApiTable api;
-  InstalledHook hook(api);
-  ASSERT_TRUE(hook.installed());
-  ASSERT_NE(api.amd.hsa_amd_memory_async_batch_copy_fn, fake_amd_memory_async_batch_copy);
-
-  hsa_agent_t src_agents[] = {kGuestAgent, kHostAgent};
-  hsa_agent_t dst_agents[] = {kGuestAgent, kHostAgent};
+TEST(HsaHooksUnitTest, BatchCopyMapsScalarSourceAndDestinationAgents) {
   hsa_amd_memory_copy_op_t op{};
-  op.num_entries = 2;
-  op.src_agent_list = src_agents;
-  op.dst_agent_list = dst_agents;
+  op.type = HSA_AMD_MEMORY_COPY_OP_LINEAR;
+  op.src_agent = kGuestAgent;
+  op.dst_agent = kGuestAgent;
+  op.size = 64;
 
-  EXPECT_EQ(api.amd.hsa_amd_memory_async_batch_copy_fn(&op, 1, 0, nullptr), HSA_STATUS_SUCCESS);
-  EXPECT_EQ(g_last_batch_src_agents, (std::vector<uint64_t>{kHostAgent.handle, kHostAgent.handle}));
-  EXPECT_EQ(g_last_batch_dst_agents, (std::vector<uint64_t>{kHostAgent.handle, kHostAgent.handle}));
+  expect_batch_copy_forwarding(op, {kHostAgent.handle}, {kHostAgent.handle});
+}
+
+TEST(HsaHooksUnitTest, BatchCopyMapsMultiLinearScalarSourceAndDestinationList) {
+  int src0 = 0;
+  int src1 = 0;
+  int dst0 = 0;
+  int dst1 = 0;
+  void *src_list[] = {&src0, &src1};
+  void *dst_list[] = {&dst0, &dst1};
+  hsa_agent_t dst_agents[] = {kGuestAgent, kHostAgent};
+  size_t sizes[] = {64, 128};
+
+  hsa_amd_memory_copy_op_t op{};
+  op.type = HSA_AMD_MEMORY_COPY_OP_LINEAR;
+  op.num_entries = 2;
+  op.src_list = src_list;
+  op.src_agent = kGuestAgent;
+  op.dst_agent_list = dst_agents;
+  op.dst_list = dst_list;
+  op.size_list = sizes;
+
+  expect_batch_copy_forwarding(op, {kHostAgent.handle, kHostAgent.handle},
+                               {kHostAgent.handle, kHostAgent.handle});
+}
+
+TEST(HsaHooksUnitTest, BatchCopyMapsBroadcastScalarSourceAndDestinationList) {
+  int src = 0;
+  int dst0 = 0;
+  int dst1 = 0;
+  void *dst_list[] = {&dst0, &dst1};
+  hsa_agent_t dst_agents[] = {kGuestAgent, kHostAgent};
+
+  hsa_amd_memory_copy_op_t op{};
+  op.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_BROADCAST;
+  op.num_entries = 2;
+  op.src = &src;
+  op.src_agent = kGuestAgent;
+  op.dst_agent_list = dst_agents;
+  op.dst_list = dst_list;
+  op.size = 64;
+
+  expect_batch_copy_forwarding(op, {kHostAgent.handle, kHostAgent.handle},
+                               {kHostAgent.handle, kHostAgent.handle});
+}
+
+TEST(HsaHooksUnitTest, BatchCopyMapsMultiIndirectScalarSourceAndDestinationList) {
+  int src0 = 0;
+  int src1 = 0;
+  int dst0 = 0;
+  int dst1 = 0;
+  void *src_list[] = {&src0, &src1};
+  void *dst_list[] = {&dst0, &dst1};
+  hsa_agent_t dst_agents[] = {kGuestAgent, kHostAgent};
+  size_t sizes[] = {64, 128};
+
+  hsa_amd_memory_copy_op_t op{};
+  op.type = HSA_AMD_MEMORY_COPY_OP_LINEAR_INDIRECT_SRCDST;
+  op.num_entries = 2;
+  op.src_list = src_list;
+  op.src_agent = kGuestAgent;
+  op.dst_agent_list = dst_agents;
+  op.dst_list = dst_list;
+  op.size_list = sizes;
+
+  expect_batch_copy_forwarding(op, {kHostAgent.handle, kHostAgent.handle},
+                               {kHostAgent.handle, kHostAgent.handle});
 }
 
 TEST(HsaHooksUnitTest, PointerInfoReportsGuestIdentityOnce) {

--- a/emulation/rocjitsu/tests/dbt/hsa_hooks_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hooks_unit_test.cpp
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstdlib>
@@ -38,9 +39,15 @@ std::condition_variable g_pool_cv;
 bool g_block_guest_pool_iteration = false;
 bool g_guest_pool_iteration_entered = false;
 bool g_release_guest_pool_iteration = false;
+std::mutex g_agent_mutex;
+std::condition_variable g_agent_cv;
+bool g_block_agent_iteration = false;
+bool g_agent_iteration_entered = false;
+bool g_release_agent_iteration = false;
 int g_fake_shutdown_calls = 0;
 hsa_amd_memory_pool_t g_last_allocate_pool{};
 int g_fake_allocation_storage = 0;
+hsa_agent_t g_pointer_info_accessible[2] = {};
 std::vector<uint64_t> g_last_batch_src_agents;
 std::vector<uint64_t> g_last_batch_dst_agents;
 
@@ -56,6 +63,15 @@ hsa_status_t HSA_API fake_iterate_agents(hsa_status_t (*callback)(hsa_agent_t, v
                                          void *data) {
   if (callback == nullptr)
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  {
+    std::unique_lock lock(g_agent_mutex);
+    if (g_block_agent_iteration) {
+      g_agent_iteration_entered = true;
+      g_agent_cv.notify_all();
+      g_agent_cv.wait(lock, [] { return g_release_agent_iteration; });
+    }
+  }
 
   hsa_status_t status = callback(kGuestAgent, data);
   if (status != HSA_STATUS_SUCCESS)
@@ -189,6 +205,22 @@ hsa_status_t HSA_API fake_amd_memory_async_batch_copy(const hsa_amd_memory_copy_
   return HSA_STATUS_SUCCESS;
 }
 
+hsa_status_t HSA_API fake_amd_pointer_info(const void *, hsa_amd_pointer_info_t *info,
+                                           void *(*)(size_t), uint32_t *num_agents_accessible,
+                                           hsa_agent_t **accessible) {
+  if (info != nullptr) {
+    info->size = sizeof(hsa_amd_pointer_info_t);
+    info->agentOwner = kHostAgent;
+  }
+  if (num_agents_accessible != nullptr && accessible != nullptr) {
+    g_pointer_info_accessible[0] = kHostAgent;
+    g_pointer_info_accessible[1] = kGuestAgent;
+    *num_agents_accessible = 2;
+    *accessible = g_pointer_info_accessible;
+  }
+  return HSA_STATUS_SUCCESS;
+}
+
 hsa_status_t HSA_API fake_amd_agent_iterate_memory_pools(
     hsa_agent_t agent, hsa_status_t (*callback)(hsa_amd_memory_pool_t, void *), void *data) {
   if (callback == nullptr)
@@ -259,6 +291,7 @@ struct FakeApiTable {
     amd.hsa_amd_memory_pool_get_info_fn = fake_amd_memory_pool_get_info;
     amd.hsa_amd_memory_pool_allocate_fn = fake_amd_memory_pool_allocate;
     amd.hsa_amd_memory_async_batch_copy_fn = fake_amd_memory_async_batch_copy;
+    amd.hsa_amd_pointer_info_fn = fake_amd_pointer_info;
   }
 };
 
@@ -303,8 +336,24 @@ void release_pool_blocker() {
   g_pool_cv.notify_all();
 }
 
+void reset_agent_blocker(bool enabled) {
+  std::lock_guard lock(g_agent_mutex);
+  g_block_agent_iteration = enabled;
+  g_agent_iteration_entered = false;
+  g_release_agent_iteration = false;
+}
+
+void release_agent_blocker() {
+  {
+    std::lock_guard lock(g_agent_mutex);
+    g_release_agent_iteration = true;
+  }
+  g_agent_cv.notify_all();
+}
+
 TEST(HsaHooksUnitTest, IterateAgentsDropsGuestOwnSlotWhenGuestAppearsFirst) {
   reset_pool_blocker(false);
+  reset_agent_blocker(false);
   FakeApiTable api;
   InstalledHook hook(api);
   ASSERT_TRUE(hook.installed());
@@ -324,6 +373,7 @@ TEST(HsaHooksUnitTest, IterateAgentsDropsGuestOwnSlotWhenGuestAppearsFirst) {
 
 TEST(HsaHooksUnitTest, IterateAgentsDropsGuestOwnSlotWhenHostAppearsFirst) {
   reset_pool_blocker(false);
+  reset_agent_blocker(false);
   FakeApiTable api;
   api.core.hsa_iterate_agents_fn = fake_iterate_agents_host_first;
   InstalledHook hook(api);
@@ -344,6 +394,7 @@ TEST(HsaHooksUnitTest, IterateAgentsDropsGuestOwnSlotWhenHostAppearsFirst) {
 
 TEST(HsaHooksUnitTest, BatchCopyMapsSourceAndDestinationAgentLists) {
   reset_pool_blocker(false);
+  reset_agent_blocker(false);
   g_last_batch_src_agents.clear();
   g_last_batch_dst_agents.clear();
   FakeApiTable api;
@@ -363,8 +414,86 @@ TEST(HsaHooksUnitTest, BatchCopyMapsSourceAndDestinationAgentLists) {
   EXPECT_EQ(g_last_batch_dst_agents, (std::vector<uint64_t>{kHostAgent.handle, kHostAgent.handle}));
 }
 
+TEST(HsaHooksUnitTest, PointerInfoReportsGuestIdentityOnce) {
+  reset_pool_blocker(false);
+  reset_agent_blocker(false);
+  FakeApiTable api;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+  ASSERT_NE(api.amd.hsa_amd_pointer_info_fn, fake_amd_pointer_info);
+
+  hsa_amd_pointer_info_t info{};
+  uint32_t accessible_count = 0;
+  hsa_agent_t *accessible = nullptr;
+  hsa_status_t status = api.amd.hsa_amd_pointer_info_fn(&g_fake_allocation_storage, &info, nullptr,
+                                                        &accessible_count, &accessible);
+
+  EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+  EXPECT_EQ(info.agentOwner.handle, kGuestAgent.handle);
+  ASSERT_NE(accessible, nullptr);
+  ASSERT_EQ(accessible_count, 1u);
+  EXPECT_EQ(accessible[0].handle, kGuestAgent.handle);
+}
+
+TEST(HsaHooksUnitTest, PoolAllocateWaitsForAgentDiscoveryPublication) {
+  reset_pool_blocker(false);
+  reset_agent_blocker(true);
+  g_last_allocate_pool = {};
+  FakeApiTable api;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+  ASSERT_NE(api.core.hsa_iterate_agents_fn, fake_iterate_agents);
+  ASSERT_NE(api.amd.hsa_amd_memory_pool_allocate_fn, fake_amd_memory_pool_allocate);
+
+  std::vector<uint64_t> seen;
+  hsa_status_t iterate_status = HSA_STATUS_ERROR;
+  std::thread iterate_thread([&] {
+    iterate_status = api.core.hsa_iterate_agents_fn(
+        [](hsa_agent_t agent, void *data) -> hsa_status_t {
+          static_cast<std::vector<uint64_t> *>(data)->push_back(agent.handle);
+          return HSA_STATUS_SUCCESS;
+        },
+        &seen);
+  });
+
+  bool mapper_entered_agent_iteration = false;
+  {
+    std::unique_lock lock(g_agent_mutex);
+    mapper_entered_agent_iteration = g_agent_cv.wait_for(lock, std::chrono::seconds(1),
+                                                         [] { return g_agent_iteration_entered; });
+  }
+  if (!mapper_entered_agent_iteration) {
+    release_agent_blocker();
+    iterate_thread.join();
+    ADD_FAILURE() << "agent mapper did not enter discovery iteration";
+    return;
+  }
+
+  std::atomic_bool allocate_done = false;
+  hsa_status_t allocate_status = HSA_STATUS_ERROR;
+  std::thread allocate_thread([&] {
+    void *ptr = nullptr;
+    allocate_status = api.amd.hsa_amd_memory_pool_allocate_fn(kGuestPool, 4096, 0, &ptr);
+    allocate_done.store(true);
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  EXPECT_FALSE(allocate_done.load());
+
+  release_agent_blocker();
+  iterate_thread.join();
+  allocate_thread.join();
+
+  EXPECT_EQ(iterate_status, HSA_STATUS_SUCCESS);
+  EXPECT_EQ(seen, std::vector<uint64_t>{kGuestAgent.handle});
+  EXPECT_EQ(allocate_status, HSA_STATUS_SUCCESS);
+  EXPECT_EQ(g_last_allocate_pool.handle, kHostPool.handle);
+  reset_agent_blocker(false);
+}
+
 TEST(HsaHooksUnitTest, UninstallDoesNotWaitForPoolMapperDiscoveryLock) {
   reset_pool_blocker(true);
+  reset_agent_blocker(false);
   g_last_allocate_pool = {};
   FakeApiTable api;
   InstalledHook hook(api);
@@ -417,6 +546,7 @@ TEST(HsaHooksUnitTest, UninstallDoesNotWaitForPoolMapperDiscoveryLock) {
 
 TEST(HsaHooksUnitTest, GuestShutdownKeepsHookInstalledForProcessLifetime) {
   reset_pool_blocker(false);
+  reset_agent_blocker(false);
   g_fake_shutdown_calls = 0;
   FakeApiTable api;
   InstalledHook hook(api);

--- a/emulation/rocjitsu/tests/dbt/hsa_hooks_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hooks_unit_test.cpp
@@ -39,6 +39,7 @@ std::condition_variable g_pool_cv;
 bool g_block_guest_pool_iteration = false;
 bool g_guest_pool_iteration_entered = false;
 bool g_release_guest_pool_iteration = false;
+bool g_fail_guest_pool_iteration_once = false;
 std::mutex g_agent_mutex;
 std::condition_variable g_agent_cv;
 bool g_block_agent_iteration = false;
@@ -46,10 +47,17 @@ bool g_agent_iteration_entered = false;
 bool g_release_agent_iteration = false;
 int g_fake_shutdown_calls = 0;
 hsa_amd_memory_pool_t g_last_allocate_pool{};
+hsa_agent_t g_last_agent_memory_pool_agent{};
+hsa_amd_memory_pool_t g_last_agent_memory_pool{};
+int g_agent_memory_pool_get_info_calls = 0;
 int g_fake_allocation_storage = 0;
 hsa_agent_t g_pointer_info_accessible[2] = {};
 std::vector<uint64_t> g_last_batch_src_agents;
 std::vector<uint64_t> g_last_batch_dst_agents;
+std::vector<uint64_t> g_last_memory_lock_agents;
+std::vector<uint64_t> g_last_memory_lock_to_pool_agents;
+std::vector<uint64_t> g_last_vmem_access_agents;
+hsa_amd_memory_pool_t g_last_memory_lock_to_pool_pool{};
 
 const char *isa_name(hsa_isa_t isa) {
   if (isa.handle == kGuestIsa.handle)
@@ -224,6 +232,39 @@ hsa_status_t HSA_API fake_amd_memory_async_batch_copy(const hsa_amd_memory_copy_
   return HSA_STATUS_SUCCESS;
 }
 
+hsa_status_t HSA_API fake_amd_memory_lock(void *, size_t, hsa_agent_t *agents, int num_agent,
+                                          void **) {
+  g_last_memory_lock_agents.clear();
+  if (agents == nullptr && num_agent != 0)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  for (int i = 0; i < num_agent; ++i)
+    g_last_memory_lock_agents.push_back(agents[i].handle);
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t HSA_API fake_amd_memory_lock_to_pool(void *, size_t, hsa_agent_t *agents,
+                                                  int num_agent, hsa_amd_memory_pool_t pool,
+                                                  uint32_t, void **) {
+  g_last_memory_lock_to_pool_pool = pool;
+  g_last_memory_lock_to_pool_agents.clear();
+  if (agents == nullptr && num_agent != 0)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  for (int i = 0; i < num_agent; ++i)
+    g_last_memory_lock_to_pool_agents.push_back(agents[i].handle);
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t HSA_API fake_amd_vmem_set_access(void *, size_t,
+                                              const hsa_amd_memory_access_desc_t *desc,
+                                              size_t desc_cnt) {
+  g_last_vmem_access_agents.clear();
+  if (desc == nullptr && desc_cnt != 0)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  for (size_t i = 0; i < desc_cnt; ++i)
+    g_last_vmem_access_agents.push_back(desc[i].agent_handle.handle);
+  return HSA_STATUS_SUCCESS;
+}
+
 hsa_status_t HSA_API fake_amd_pointer_info(const void *, hsa_amd_pointer_info_t *info,
                                            void *(*)(size_t), uint32_t *num_agents_accessible,
                                            hsa_agent_t **accessible) {
@@ -246,6 +287,10 @@ hsa_status_t HSA_API fake_amd_agent_iterate_memory_pools(
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
   if (agent.handle == kGuestAgent.handle) {
+    if (g_fail_guest_pool_iteration_once) {
+      g_fail_guest_pool_iteration_once = false;
+      return HSA_STATUS_ERROR;
+    }
     std::unique_lock lock(g_pool_mutex);
     if (g_block_guest_pool_iteration) {
       g_guest_pool_iteration_entered = true;
@@ -285,6 +330,25 @@ hsa_status_t HSA_API fake_amd_memory_pool_get_info(hsa_amd_memory_pool_t,
   return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 }
 
+hsa_status_t HSA_API fake_amd_agent_memory_pool_get_info(hsa_agent_t agent,
+                                                         hsa_amd_memory_pool_t memory_pool,
+                                                         hsa_amd_agent_memory_pool_info_t attribute,
+                                                         void *value) {
+  ++g_agent_memory_pool_get_info_calls;
+  g_last_agent_memory_pool_agent = agent;
+  g_last_agent_memory_pool = memory_pool;
+
+  if (value == nullptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  if (memory_pool.handle == 0)
+    return HSA_STATUS_SUCCESS;
+  if (attribute == HSA_AMD_AGENT_MEMORY_POOL_INFO_ACCESS) {
+    *static_cast<uint32_t *>(value) = 0;
+    return HSA_STATUS_SUCCESS;
+  }
+  return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+}
+
 struct FakeApiTable {
   CoreApiTable core{};
   AmdExtTable amd{};
@@ -308,9 +372,13 @@ struct FakeApiTable {
     core.hsa_executable_load_agent_code_object_fn = fake_executable_load_agent_code_object;
     amd.hsa_amd_agent_iterate_memory_pools_fn = fake_amd_agent_iterate_memory_pools;
     amd.hsa_amd_memory_pool_get_info_fn = fake_amd_memory_pool_get_info;
+    amd.hsa_amd_agent_memory_pool_get_info_fn = fake_amd_agent_memory_pool_get_info;
     amd.hsa_amd_memory_pool_allocate_fn = fake_amd_memory_pool_allocate;
     amd.hsa_amd_memory_async_batch_copy_fn = fake_amd_memory_async_batch_copy;
+    amd.hsa_amd_memory_lock_fn = fake_amd_memory_lock;
+    amd.hsa_amd_memory_lock_to_pool_fn = fake_amd_memory_lock_to_pool;
     amd.hsa_amd_pointer_info_fn = fake_amd_pointer_info;
+    amd.hsa_amd_vmem_set_access_fn = fake_amd_vmem_set_access;
   }
 };
 
@@ -345,6 +413,7 @@ void reset_pool_blocker(bool enabled) {
   g_block_guest_pool_iteration = enabled;
   g_guest_pool_iteration_entered = false;
   g_release_guest_pool_iteration = false;
+  g_fail_guest_pool_iteration_once = false;
 }
 
 void release_pool_blocker() {
@@ -523,6 +592,100 @@ TEST(HsaHooksUnitTest, PointerInfoReportsGuestIdentityOnce) {
   ASSERT_NE(accessible, nullptr);
   ASSERT_EQ(accessible_count, 1u);
   EXPECT_EQ(accessible[0].handle, kGuestAgent.handle);
+}
+
+TEST(HsaHooksUnitTest, AgentMemoryPoolGetInfoRejectsNullPoolBeforeForwarding) {
+  reset_pool_blocker(false);
+  reset_agent_blocker(false);
+  g_agent_memory_pool_get_info_calls = 0;
+  g_last_agent_memory_pool_agent = {};
+  g_last_agent_memory_pool = {};
+  FakeApiTable api;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+  ASSERT_NE(api.amd.hsa_amd_agent_memory_pool_get_info_fn, fake_amd_agent_memory_pool_get_info);
+
+  uint32_t access = 0;
+  hsa_status_t status = api.amd.hsa_amd_agent_memory_pool_get_info_fn(
+      kGuestAgent, hsa_amd_memory_pool_t{}, HSA_AMD_AGENT_MEMORY_POOL_INFO_ACCESS, &access);
+
+  EXPECT_EQ(status, HSA_STATUS_ERROR_INVALID_MEMORY_POOL);
+  EXPECT_EQ(g_agent_memory_pool_get_info_calls, 0);
+}
+
+TEST(HsaHooksUnitTest, PoolMapperRetriesAfterTransientPoolIterationFailure) {
+  reset_pool_blocker(false);
+  reset_agent_blocker(false);
+  g_last_allocate_pool = {};
+  FakeApiTable api;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+  ASSERT_NE(api.amd.hsa_amd_memory_pool_allocate_fn, fake_amd_memory_pool_allocate);
+
+  g_fail_guest_pool_iteration_once = true;
+  void *ptr = nullptr;
+  EXPECT_EQ(api.amd.hsa_amd_memory_pool_allocate_fn(kGuestPool, 4096, 0, &ptr), HSA_STATUS_SUCCESS);
+  EXPECT_EQ(g_last_allocate_pool.handle, kGuestPool.handle);
+
+  ptr = nullptr;
+  EXPECT_EQ(api.amd.hsa_amd_memory_pool_allocate_fn(kGuestPool, 4096, 0, &ptr), HSA_STATUS_SUCCESS);
+  EXPECT_EQ(g_last_allocate_pool.handle, kHostPool.handle);
+}
+
+TEST(HsaHooksUnitTest, MemoryLockDeduplicatesAgentsAfterGuestMapping) {
+  reset_pool_blocker(false);
+  reset_agent_blocker(false);
+  g_last_memory_lock_agents.clear();
+  FakeApiTable api;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+  ASSERT_NE(api.amd.hsa_amd_memory_lock_fn, fake_amd_memory_lock);
+
+  hsa_agent_t agents[] = {kGuestAgent, kHostAgent};
+  int storage = 0;
+  void *agent_ptr = nullptr;
+  EXPECT_EQ(api.amd.hsa_amd_memory_lock_fn(&storage, sizeof(storage), agents, 2, &agent_ptr),
+            HSA_STATUS_SUCCESS);
+  EXPECT_EQ(g_last_memory_lock_agents, std::vector<uint64_t>{kHostAgent.handle});
+}
+
+TEST(HsaHooksUnitTest, MemoryLockToPoolMapsPoolAndDeduplicatesAgents) {
+  reset_pool_blocker(false);
+  reset_agent_blocker(false);
+  g_last_memory_lock_to_pool_agents.clear();
+  g_last_memory_lock_to_pool_pool = {};
+  FakeApiTable api;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+  ASSERT_NE(api.amd.hsa_amd_memory_lock_to_pool_fn, fake_amd_memory_lock_to_pool);
+
+  hsa_agent_t agents[] = {kGuestAgent, kHostAgent};
+  int storage = 0;
+  void *agent_ptr = nullptr;
+  EXPECT_EQ(api.amd.hsa_amd_memory_lock_to_pool_fn(&storage, sizeof(storage), agents, 2, kGuestPool,
+                                                   0, &agent_ptr),
+            HSA_STATUS_SUCCESS);
+  EXPECT_EQ(g_last_memory_lock_to_pool_pool.handle, kHostPool.handle);
+  EXPECT_EQ(g_last_memory_lock_to_pool_agents, std::vector<uint64_t>{kHostAgent.handle});
+}
+
+TEST(HsaHooksUnitTest, VmemSetAccessDeduplicatesDescriptorsAfterGuestMapping) {
+  reset_pool_blocker(false);
+  reset_agent_blocker(false);
+  g_last_vmem_access_agents.clear();
+  FakeApiTable api;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+  ASSERT_NE(api.amd.hsa_amd_vmem_set_access_fn, fake_amd_vmem_set_access);
+
+  hsa_amd_memory_access_desc_t desc[] = {
+      {.permissions = HSA_ACCESS_PERMISSION_RW, .agent_handle = kGuestAgent},
+      {.permissions = HSA_ACCESS_PERMISSION_RW, .agent_handle = kHostAgent},
+  };
+  int storage = 0;
+  EXPECT_EQ(api.amd.hsa_amd_vmem_set_access_fn(&storage, sizeof(storage), desc, 2),
+            HSA_STATUS_SUCCESS);
+  EXPECT_EQ(g_last_vmem_access_agents, std::vector<uint64_t>{kHostAgent.handle});
 }
 
 TEST(HsaHooksUnitTest, PoolAllocateWaitsForAgentDiscoveryPublication) {

--- a/emulation/rocjitsu/tests/dbt/hsa_hooks_unit_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hooks_unit_test.cpp
@@ -1,0 +1,434 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+#include "hsa/hsa_api_trace_minimal.h"
+#include "rocjitsu/kmd/linux/rpc.h"
+
+extern "C" bool OnLoad(HsaApiTable *table, uint64_t runtime_version, uint64_t failed_tool_count,
+                       const char *const *failed_tool_names);
+extern "C" void OnUnload();
+
+namespace {
+
+constexpr hsa_agent_t kGuestAgent{1};
+constexpr hsa_agent_t kHostAgent{2};
+constexpr hsa_isa_t kGuestIsa{950};
+constexpr hsa_isa_t kHostIsa{1201};
+constexpr hsa_amd_memory_pool_t kGuestPool{10};
+constexpr hsa_amd_memory_pool_t kHostPool{20};
+constexpr uint32_t kGuestNodeId = 100;
+constexpr uint32_t kHostNodeId = 200;
+
+std::mutex g_pool_mutex;
+std::condition_variable g_pool_cv;
+bool g_block_guest_pool_iteration = false;
+bool g_guest_pool_iteration_entered = false;
+bool g_release_guest_pool_iteration = false;
+int g_fake_shutdown_calls = 0;
+hsa_amd_memory_pool_t g_last_allocate_pool{};
+int g_fake_allocation_storage = 0;
+std::vector<uint64_t> g_last_batch_src_agents;
+std::vector<uint64_t> g_last_batch_dst_agents;
+
+const char *isa_name(hsa_isa_t isa) {
+  if (isa.handle == kGuestIsa.handle)
+    return "amdgcn-amd-amdhsa--gfx950";
+  if (isa.handle == kHostIsa.handle)
+    return "amdgcn-amd-amdhsa--gfx1201";
+  return "";
+}
+
+hsa_status_t HSA_API fake_iterate_agents(hsa_status_t (*callback)(hsa_agent_t, void *),
+                                         void *data) {
+  if (callback == nullptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  hsa_status_t status = callback(kGuestAgent, data);
+  if (status != HSA_STATUS_SUCCESS)
+    return status;
+  return callback(kHostAgent, data);
+}
+
+hsa_status_t HSA_API fake_iterate_agents_host_first(hsa_status_t (*callback)(hsa_agent_t, void *),
+                                                    void *data) {
+  if (callback == nullptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  hsa_status_t status = callback(kHostAgent, data);
+  if (status != HSA_STATUS_SUCCESS)
+    return status;
+  return callback(kGuestAgent, data);
+}
+
+hsa_status_t HSA_API fake_shut_down() {
+  ++g_fake_shutdown_calls;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t HSA_API fake_agent_get_info(hsa_agent_t agent, hsa_agent_info_t attribute,
+                                         void *value) {
+  if (value == nullptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  if (attribute == HSA_AGENT_INFO_DEVICE) {
+    *static_cast<hsa_device_type_t *>(value) = HSA_DEVICE_TYPE_GPU;
+    return HSA_STATUS_SUCCESS;
+  }
+  if (attribute == HSA_AGENT_INFO_ISA) {
+    *static_cast<hsa_isa_t *>(value) = agent.handle == kGuestAgent.handle ? kGuestIsa : kHostIsa;
+    return HSA_STATUS_SUCCESS;
+  }
+  if (attribute == static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_DRIVER_NODE_ID)) {
+    *static_cast<uint32_t *>(value) =
+        agent.handle == kGuestAgent.handle ? kGuestNodeId : kHostNodeId;
+    return HSA_STATUS_SUCCESS;
+  }
+  return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+}
+
+hsa_status_t HSA_API fake_agent_iterate_isas(hsa_agent_t agent,
+                                             hsa_status_t (*callback)(hsa_isa_t, void *),
+                                             void *data) {
+  if (callback == nullptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  if (agent.handle == kGuestAgent.handle)
+    return callback(kGuestIsa, data);
+  if (agent.handle == kHostAgent.handle)
+    return callback(kHostIsa, data);
+  return HSA_STATUS_ERROR_INVALID_AGENT;
+}
+
+hsa_status_t HSA_API fake_isa_get_info_alt(hsa_isa_t isa, hsa_isa_info_t attribute, void *value) {
+  if (value == nullptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  const char *name = isa_name(isa);
+  if (name[0] == '\0')
+    return HSA_STATUS_ERROR_INVALID_ISA;
+
+  if (attribute == HSA_ISA_INFO_NAME_LENGTH) {
+    *static_cast<uint32_t *>(value) = static_cast<uint32_t>(std::strlen(name));
+    return HSA_STATUS_SUCCESS;
+  }
+  if (attribute == HSA_ISA_INFO_NAME) {
+    std::strcpy(static_cast<char *>(value), name);
+    return HSA_STATUS_SUCCESS;
+  }
+  return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+}
+
+hsa_status_t HSA_API
+fake_code_object_reader_create_from_file(hsa_file_t, hsa_code_object_reader_t *code_object_reader) {
+  if (code_object_reader == nullptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  code_object_reader->handle = 1;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t HSA_API fake_code_object_reader_create_from_memory(
+    const void *, size_t, hsa_code_object_reader_t *code_object_reader) {
+  if (code_object_reader == nullptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  code_object_reader->handle = 2;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t HSA_API fake_code_object_reader_destroy(hsa_code_object_reader_t) {
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t HSA_API fake_executable_load_agent_code_object(hsa_executable_t, hsa_agent_t,
+                                                            hsa_code_object_reader_t, const char *,
+                                                            hsa_loaded_code_object_t *) {
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t HSA_API fake_amd_memory_pool_allocate(hsa_amd_memory_pool_t memory_pool, size_t,
+                                                   uint32_t, void **ptr) {
+  g_last_allocate_pool = memory_pool;
+  if (ptr != nullptr)
+    *ptr = &g_fake_allocation_storage;
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t HSA_API fake_amd_memory_async_batch_copy(const hsa_amd_memory_copy_op_t *copy_ops,
+                                                      uint32_t num_copy_ops, uint32_t,
+                                                      const hsa_signal_t *) {
+  g_last_batch_src_agents.clear();
+  g_last_batch_dst_agents.clear();
+  if (copy_ops == nullptr && num_copy_ops != 0)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  for (uint32_t op_idx = 0; op_idx < num_copy_ops; ++op_idx) {
+    const hsa_amd_memory_copy_op_t &op = copy_ops[op_idx];
+    if (op.num_entries == 0) {
+      g_last_batch_src_agents.push_back(op.src_agent.handle);
+      g_last_batch_dst_agents.push_back(op.dst_agent.handle);
+      continue;
+    }
+    for (uint16_t entry_idx = 0; entry_idx < op.num_entries; ++entry_idx) {
+      g_last_batch_src_agents.push_back(op.src_agent_list[entry_idx].handle);
+      g_last_batch_dst_agents.push_back(op.dst_agent_list[entry_idx].handle);
+    }
+  }
+  return HSA_STATUS_SUCCESS;
+}
+
+hsa_status_t HSA_API fake_amd_agent_iterate_memory_pools(
+    hsa_agent_t agent, hsa_status_t (*callback)(hsa_amd_memory_pool_t, void *), void *data) {
+  if (callback == nullptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  if (agent.handle == kGuestAgent.handle) {
+    std::unique_lock lock(g_pool_mutex);
+    if (g_block_guest_pool_iteration) {
+      g_guest_pool_iteration_entered = true;
+      g_pool_cv.notify_all();
+      g_pool_cv.wait(lock, [] { return g_release_guest_pool_iteration; });
+    }
+    lock.unlock();
+    return callback(kGuestPool, data);
+  }
+  if (agent.handle == kHostAgent.handle)
+    return callback(kHostPool, data);
+  return HSA_STATUS_ERROR_INVALID_AGENT;
+}
+
+hsa_status_t HSA_API fake_amd_memory_pool_get_info(hsa_amd_memory_pool_t,
+                                                   hsa_amd_memory_pool_info_t attribute,
+                                                   void *value) {
+  if (value == nullptr)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  if (attribute == HSA_AMD_MEMORY_POOL_INFO_SEGMENT) {
+    *static_cast<uint32_t *>(value) = 0;
+    return HSA_STATUS_SUCCESS;
+  }
+  if (attribute == HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS) {
+    *static_cast<uint32_t *>(value) = 0;
+    return HSA_STATUS_SUCCESS;
+  }
+  if (attribute == HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_ALLOWED) {
+    *static_cast<bool *>(value) = true;
+    return HSA_STATUS_SUCCESS;
+  }
+  if (attribute == HSA_AMD_MEMORY_POOL_INFO_LOCATION) {
+    *static_cast<uint32_t *>(value) = 0;
+    return HSA_STATUS_SUCCESS;
+  }
+  return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+}
+
+struct FakeApiTable {
+  CoreApiTable core{};
+  AmdExtTable amd{};
+  HsaApiTable table{};
+
+  FakeApiTable() {
+    core.version.minor_id = sizeof(CoreApiTable);
+    amd.version.minor_id = sizeof(AmdExtTable);
+    table.version.minor_id = sizeof(HsaApiTable);
+    table.core_ = &core;
+    table.amd_ext_ = &amd;
+
+    core.hsa_shut_down_fn = fake_shut_down;
+    core.hsa_iterate_agents_fn = fake_iterate_agents;
+    core.hsa_agent_get_info_fn = fake_agent_get_info;
+    core.hsa_agent_iterate_isas_fn = fake_agent_iterate_isas;
+    core.hsa_isa_get_info_alt_fn = fake_isa_get_info_alt;
+    core.hsa_code_object_reader_create_from_file_fn = fake_code_object_reader_create_from_file;
+    core.hsa_code_object_reader_create_from_memory_fn = fake_code_object_reader_create_from_memory;
+    core.hsa_code_object_reader_destroy_fn = fake_code_object_reader_destroy;
+    core.hsa_executable_load_agent_code_object_fn = fake_executable_load_agent_code_object;
+    amd.hsa_amd_agent_iterate_memory_pools_fn = fake_amd_agent_iterate_memory_pools;
+    amd.hsa_amd_memory_pool_get_info_fn = fake_amd_memory_pool_get_info;
+    amd.hsa_amd_memory_pool_allocate_fn = fake_amd_memory_pool_allocate;
+    amd.hsa_amd_memory_async_batch_copy_fn = fake_amd_memory_async_batch_copy;
+  }
+};
+
+void write_runtime_config_path() {
+  std::filesystem::path runtime_dir =
+      std::filesystem::temp_directory_path() /
+      ("rocjitsu-hsa-hooks-unit-" + std::to_string(static_cast<long long>(::getpid())));
+  std::filesystem::create_directories(runtime_dir);
+  setenv("ROCJITSU_RUNTIME_DIR", runtime_dir.c_str(), 1);
+
+  std::ofstream config_path(rocjitsu::rpc_default_config_file_path());
+  config_path << RJ_HOOK_UNIT_CONFIG_PATH << '\n';
+}
+
+class InstalledHook {
+public:
+  explicit InstalledHook(FakeApiTable &api) {
+    OnUnload();
+    write_runtime_config_path();
+    installed_ = OnLoad(&api.table, 0, 0, nullptr);
+  }
+  ~InstalledHook() { OnUnload(); }
+
+  [[nodiscard]] bool installed() const { return installed_; }
+
+private:
+  bool installed_ = false;
+};
+
+void reset_pool_blocker(bool enabled) {
+  std::lock_guard lock(g_pool_mutex);
+  g_block_guest_pool_iteration = enabled;
+  g_guest_pool_iteration_entered = false;
+  g_release_guest_pool_iteration = false;
+}
+
+void release_pool_blocker() {
+  {
+    std::lock_guard lock(g_pool_mutex);
+    g_release_guest_pool_iteration = true;
+  }
+  g_pool_cv.notify_all();
+}
+
+TEST(HsaHooksUnitTest, IterateAgentsDropsGuestOwnSlotWhenGuestAppearsFirst) {
+  reset_pool_blocker(false);
+  FakeApiTable api;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+  ASSERT_NE(api.core.hsa_iterate_agents_fn, fake_iterate_agents);
+
+  std::vector<uint64_t> seen;
+  hsa_status_t status = api.core.hsa_iterate_agents_fn(
+      [](hsa_agent_t agent, void *data) -> hsa_status_t {
+        static_cast<std::vector<uint64_t> *>(data)->push_back(agent.handle);
+        return HSA_STATUS_SUCCESS;
+      },
+      &seen);
+
+  EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+  EXPECT_EQ(seen, std::vector<uint64_t>{kGuestAgent.handle});
+}
+
+TEST(HsaHooksUnitTest, IterateAgentsDropsGuestOwnSlotWhenHostAppearsFirst) {
+  reset_pool_blocker(false);
+  FakeApiTable api;
+  api.core.hsa_iterate_agents_fn = fake_iterate_agents_host_first;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+  ASSERT_NE(api.core.hsa_iterate_agents_fn, fake_iterate_agents_host_first);
+
+  std::vector<uint64_t> seen;
+  hsa_status_t status = api.core.hsa_iterate_agents_fn(
+      [](hsa_agent_t agent, void *data) -> hsa_status_t {
+        static_cast<std::vector<uint64_t> *>(data)->push_back(agent.handle);
+        return HSA_STATUS_SUCCESS;
+      },
+      &seen);
+
+  EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+  EXPECT_EQ(seen, std::vector<uint64_t>{kGuestAgent.handle});
+}
+
+TEST(HsaHooksUnitTest, BatchCopyMapsSourceAndDestinationAgentLists) {
+  reset_pool_blocker(false);
+  g_last_batch_src_agents.clear();
+  g_last_batch_dst_agents.clear();
+  FakeApiTable api;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+  ASSERT_NE(api.amd.hsa_amd_memory_async_batch_copy_fn, fake_amd_memory_async_batch_copy);
+
+  hsa_agent_t src_agents[] = {kGuestAgent, kHostAgent};
+  hsa_agent_t dst_agents[] = {kGuestAgent, kHostAgent};
+  hsa_amd_memory_copy_op_t op{};
+  op.num_entries = 2;
+  op.src_agent_list = src_agents;
+  op.dst_agent_list = dst_agents;
+
+  EXPECT_EQ(api.amd.hsa_amd_memory_async_batch_copy_fn(&op, 1, 0, nullptr), HSA_STATUS_SUCCESS);
+  EXPECT_EQ(g_last_batch_src_agents, (std::vector<uint64_t>{kHostAgent.handle, kHostAgent.handle}));
+  EXPECT_EQ(g_last_batch_dst_agents, (std::vector<uint64_t>{kHostAgent.handle, kHostAgent.handle}));
+}
+
+TEST(HsaHooksUnitTest, UninstallDoesNotWaitForPoolMapperDiscoveryLock) {
+  reset_pool_blocker(true);
+  g_last_allocate_pool = {};
+  FakeApiTable api;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+  ASSERT_NE(api.amd.hsa_amd_memory_pool_allocate_fn, fake_amd_memory_pool_allocate);
+
+  hsa_status_t allocate_status = HSA_STATUS_ERROR;
+  std::thread mapper_thread([&] {
+    void *ptr = nullptr;
+    allocate_status = api.amd.hsa_amd_memory_pool_allocate_fn(kGuestPool, 4096, 0, &ptr);
+  });
+
+  bool mapper_entered_pool_iteration = false;
+  {
+    std::unique_lock lock(g_pool_mutex);
+    mapper_entered_pool_iteration = g_pool_cv.wait_for(
+        lock, std::chrono::seconds(1), [] { return g_guest_pool_iteration_entered; });
+  }
+  if (!mapper_entered_pool_iteration) {
+    release_pool_blocker();
+    mapper_thread.join();
+    ADD_FAILURE() << "mapper thread did not enter guest pool discovery";
+    return;
+  }
+
+  bool uninstall_done = false;
+  std::thread uninstall_thread([&] {
+    OnUnload();
+    std::lock_guard lock(g_pool_mutex);
+    uninstall_done = true;
+    g_pool_cv.notify_all();
+  });
+
+  bool completed_without_pool_release = false;
+  {
+    std::unique_lock lock(g_pool_mutex);
+    completed_without_pool_release =
+        g_pool_cv.wait_for(lock, std::chrono::seconds(1), [&] { return uninstall_done; });
+  }
+
+  release_pool_blocker();
+  uninstall_thread.join();
+  mapper_thread.join();
+
+  EXPECT_TRUE(completed_without_pool_release);
+  EXPECT_EQ(allocate_status, HSA_STATUS_SUCCESS);
+  EXPECT_EQ(g_last_allocate_pool.handle, kHostPool.handle);
+  reset_pool_blocker(false);
+}
+
+TEST(HsaHooksUnitTest, GuestShutdownKeepsHookInstalledForProcessLifetime) {
+  reset_pool_blocker(false);
+  g_fake_shutdown_calls = 0;
+  FakeApiTable api;
+  InstalledHook hook(api);
+  ASSERT_TRUE(hook.installed());
+  auto *patched_shutdown = api.core.hsa_shut_down_fn;
+  ASSERT_NE(patched_shutdown, fake_shut_down);
+
+  EXPECT_EQ(patched_shutdown(), HSA_STATUS_SUCCESS);
+
+  EXPECT_EQ(g_fake_shutdown_calls, 0);
+  EXPECT_EQ(api.core.hsa_shut_down_fn, patched_shutdown);
+  EXPECT_NE(api.core.hsa_shut_down_fn, fake_shut_down);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/guest_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/guest_kfd_test.cpp
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "linux/uapi/kfd_ioctl.h"
+RJ_DIAGNOSTIC_POP
+
+#include <atomic>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <dirent.h>
+#include <fcntl.h>
+#include <string>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+namespace {
+
+constexpr const char *kKfdPath = "/dev/kfd";
+constexpr const char *kTopologyNodesPaths[] = {
+    "/sys/devices/virtual/kfd/kfd/topology/nodes",
+    "/sys/class/kfd/kfd/topology/nodes",
+};
+constexpr uint32_t kGuestGpuId = 38144;
+constexpr int kChildCount = 4;
+constexpr int kStressThreadCount = 8;
+constexpr int kStressIterations = 25;
+
+bool read_gpu_id(const std::string &path, uint32_t *gpu_id) {
+  FILE *file = fopen(path.c_str(), "r");
+  if (!file)
+    return false;
+
+  unsigned parsed = 0;
+  const int scanned = fscanf(file, "%u", &parsed);
+  fclose(file);
+  if (scanned != 1)
+    return false;
+
+  *gpu_id = static_cast<uint32_t>(parsed);
+  return true;
+}
+
+std::string topology_nodes_path() {
+  for (const char *path : kTopologyNodesPaths) {
+    if (access(path, R_OK | X_OK) == 0)
+      return path;
+  }
+  return {};
+}
+
+bool guest_gpu_is_visible() {
+  std::string nodes_path = topology_nodes_path();
+  if (nodes_path.empty())
+    return false;
+
+  DIR *dir = opendir(nodes_path.c_str());
+  if (!dir)
+    return false;
+
+  bool found = false;
+  while (auto *entry = readdir(dir)) {
+    if (std::strcmp(entry->d_name, ".") == 0 || std::strcmp(entry->d_name, "..") == 0)
+      continue;
+
+    uint32_t gpu_id = 0;
+    std::string gpu_id_path = nodes_path + "/" + entry->d_name + "/gpu_id";
+    if (read_gpu_id(gpu_id_path, &gpu_id) && gpu_id == kGuestGpuId) {
+      found = true;
+      break;
+    }
+  }
+
+  closedir(dir);
+  return found;
+}
+
+bool read_process_aperture_count(int fd, uint32_t *count) {
+  kfd_ioctl_get_process_apertures_new_args args{};
+  if (ioctl(fd, AMDKFD_IOC_GET_PROCESS_APERTURES_NEW, &args) != 0)
+    return false;
+
+  *count = args.num_of_nodes;
+  return true;
+}
+
+int child_process() {
+  int fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
+  if (fd < 0)
+    return 2;
+
+  const bool visible = guest_gpu_is_visible();
+  close(fd);
+  return visible ? 0 : 3;
+}
+
+int child_reset_process(int inherited_fd, uint32_t expected_reopened_count) {
+  uint32_t inherited_count = 0;
+  if (read_process_aperture_count(inherited_fd, &inherited_count))
+    return 7;
+
+  int fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
+  if (fd < 0)
+    return 2;
+
+  uint32_t reopened_count = 0;
+  const bool count_ok = read_process_aperture_count(fd, &reopened_count);
+  const bool visible_after_reopen = guest_gpu_is_visible();
+  close(fd);
+
+  if (!count_ok)
+    return 5;
+  if (reopened_count < expected_reopened_count)
+    return 6;
+  return visible_after_reopen ? 0 : 3;
+}
+
+TEST(GuestKfdMultiprocessTest, ForkedChildrenDoNotRemoveParentOverlay) {
+  if (access(kKfdPath, R_OK | W_OK) != 0)
+    GTEST_SKIP() << kKfdPath << " is not available: " << std::strerror(errno);
+
+  int parent_fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
+  ASSERT_GE(parent_fd, 0);
+  if (!guest_gpu_is_visible()) {
+    close(parent_fd);
+    GTEST_SKIP() << "guest GPU overlay is not visible";
+  }
+
+  std::vector<pid_t> children;
+  children.reserve(kChildCount);
+  for (int i = 0; i < kChildCount; ++i) {
+    pid_t pid = fork();
+    ASSERT_GE(pid, 0) << "fork failed: " << std::strerror(errno);
+
+    if (pid == 0)
+      _exit(child_process());
+
+    children.push_back(pid);
+  }
+
+  for (pid_t pid : children) {
+    int status = 0;
+    ASSERT_EQ(waitpid(pid, &status, 0), pid);
+    ASSERT_TRUE(WIFEXITED(status)) << "child " << pid << " did not exit normally";
+    EXPECT_EQ(WEXITSTATUS(status), 0) << "child " << pid << " failed";
+  }
+
+  EXPECT_TRUE(guest_gpu_is_visible()) << "parent guest topology disappeared after forked children";
+  close(parent_fd);
+}
+
+TEST(GuestKfdMultiprocessTest, ForkedChildDropsInheritedGuestDriverBeforeReopen) {
+  if (access(kKfdPath, R_OK | W_OK) != 0)
+    GTEST_SKIP() << kKfdPath << " is not available: " << std::strerror(errno);
+
+  int parent_fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
+  ASSERT_GE(parent_fd, 0);
+  if (!guest_gpu_is_visible()) {
+    close(parent_fd);
+    GTEST_SKIP() << "guest GPU overlay is not visible";
+  }
+
+  uint32_t parent_count_before = 0;
+  ASSERT_TRUE(read_process_aperture_count(parent_fd, &parent_count_before));
+
+  pid_t pid = fork();
+  ASSERT_GE(pid, 0) << "fork failed: " << std::strerror(errno);
+  if (pid == 0)
+    _exit(child_reset_process(parent_fd, parent_count_before));
+
+  int status = 0;
+  ASSERT_EQ(waitpid(pid, &status, 0), pid);
+  ASSERT_TRUE(WIFEXITED(status)) << "child " << pid << " did not exit normally";
+  EXPECT_EQ(WEXITSTATUS(status), 0) << "child " << pid << " did not reset and reopen cleanly";
+
+  uint32_t parent_count_after = 0;
+  EXPECT_TRUE(read_process_aperture_count(parent_fd, &parent_count_after));
+  EXPECT_EQ(parent_count_after, parent_count_before);
+  EXPECT_TRUE(guest_gpu_is_visible()) << "parent guest topology disappeared after child reset";
+  close(parent_fd);
+}
+
+TEST(GuestKfdConcurrencyTest, ConcurrentOpenIoctlAndSysfsRedirect) {
+  if (access(kKfdPath, R_OK | W_OK) != 0)
+    GTEST_SKIP() << kKfdPath << " is not available: " << std::strerror(errno);
+
+  int probe_fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
+  ASSERT_GE(probe_fd, 0);
+  if (!guest_gpu_is_visible()) {
+    close(probe_fd);
+    GTEST_SKIP() << "guest GPU overlay is not visible";
+  }
+  close(probe_fd);
+
+  std::atomic<int> open_failures{0};
+  std::atomic<int> ioctl_failures{0};
+  std::atomic<int> sysfs_failures{0};
+  std::vector<std::thread> threads;
+  threads.reserve(kStressThreadCount);
+  for (int thread_idx = 0; thread_idx < kStressThreadCount; ++thread_idx) {
+    threads.emplace_back([&]() {
+      for (int iter = 0; iter < kStressIterations; ++iter) {
+        int fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
+        if (fd < 0) {
+          open_failures.fetch_add(1, std::memory_order_relaxed);
+          continue;
+        }
+
+        kfd_ioctl_get_version_args version{};
+        if (ioctl(fd, AMDKFD_IOC_GET_VERSION, &version) != 0)
+          ioctl_failures.fetch_add(1, std::memory_order_relaxed);
+        if (!guest_gpu_is_visible())
+          sysfs_failures.fetch_add(1, std::memory_order_relaxed);
+        close(fd);
+      }
+    });
+  }
+
+  for (auto &thread : threads)
+    thread.join();
+  EXPECT_EQ(open_failures.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(ioctl_failures.load(std::memory_order_relaxed), 0);
+  EXPECT_EQ(sysfs_failures.load(std::memory_order_relaxed), 0);
+}
+
+} // namespace

--- a/emulation/rocjitsu/tests/guest_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/guest_kfd_test.cpp
@@ -18,6 +18,7 @@ RJ_DIAGNOSTIC_POP
 #include <fcntl.h>
 #include <string>
 #include <sys/ioctl.h>
+#include <sys/mman.h>
 #include <sys/wait.h>
 #include <thread>
 #include <unistd.h>
@@ -34,6 +35,8 @@ constexpr uint32_t kGuestGpuId = 38144;
 constexpr int kChildCount = 4;
 constexpr int kStressThreadCount = 8;
 constexpr int kStressIterations = 25;
+constexpr uint64_t kAllocVa = 0x1000000000ULL;
+constexpr uint64_t kAllocSize = 4096;
 
 bool read_gpu_id(const std::string &path, uint32_t *gpu_id) {
   FILE *file = fopen(path.c_str(), "r");
@@ -132,7 +135,7 @@ TEST(GuestKfdMultiprocessTest, ForkedChildrenDoNotRemoveParentOverlay) {
   ASSERT_GE(parent_fd, 0);
   if (!guest_gpu_is_visible()) {
     close(parent_fd);
-    GTEST_SKIP() << "guest GPU overlay is not visible";
+    FAIL() << "guest GPU overlay is not visible";
   }
 
   std::vector<pid_t> children;
@@ -166,7 +169,7 @@ TEST(GuestKfdMultiprocessTest, ForkedChildDropsInheritedGuestDriverBeforeReopen)
   ASSERT_GE(parent_fd, 0);
   if (!guest_gpu_is_visible()) {
     close(parent_fd);
-    GTEST_SKIP() << "guest GPU overlay is not visible";
+    FAIL() << "guest GPU overlay is not visible";
   }
 
   uint32_t parent_count_before = 0;
@@ -197,7 +200,7 @@ TEST(GuestKfdConcurrencyTest, ConcurrentOpenIoctlAndSysfsRedirect) {
   ASSERT_GE(probe_fd, 0);
   if (!guest_gpu_is_visible()) {
     close(probe_fd);
-    GTEST_SKIP() << "guest GPU overlay is not visible";
+    FAIL() << "guest GPU overlay is not visible";
   }
   close(probe_fd);
 
@@ -230,6 +233,42 @@ TEST(GuestKfdConcurrencyTest, ConcurrentOpenIoctlAndSysfsRedirect) {
   EXPECT_EQ(open_failures.load(std::memory_order_relaxed), 0);
   EXPECT_EQ(ioctl_failures.load(std::memory_order_relaxed), 0);
   EXPECT_EQ(sysfs_failures.load(std::memory_order_relaxed), 0);
+}
+
+TEST(GuestKfdMemoryTest, GuestAllocationMmapOffsetIsRejected) {
+  if (access(kKfdPath, R_OK | W_OK) != 0)
+    GTEST_SKIP() << kKfdPath << " is not available: " << std::strerror(errno);
+
+  int fd = open(kKfdPath, O_RDWR | O_CLOEXEC);
+  ASSERT_GE(fd, 0);
+  if (!guest_gpu_is_visible()) {
+    close(fd);
+    FAIL() << "guest GPU overlay is not visible";
+  }
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc{};
+  alloc.va_addr = kAllocVa;
+  alloc.size = kAllocSize;
+  alloc.gpu_id = kGuestGpuId;
+  alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_VRAM | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+  ASSERT_EQ(ioctl(fd, AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc), 0) << std::strerror(errno);
+  EXPECT_NE(alloc.handle, 0u);
+  EXPECT_NE(alloc.mmap_offset, 0u);
+
+  errno = 0;
+  void *mapped = mmap(nullptr, kAllocSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd,
+                      static_cast<off_t>(alloc.mmap_offset));
+  if (mapped != MAP_FAILED) {
+    munmap(mapped, kAllocSize);
+    ADD_FAILURE() << "guest synthetic allocation mmap unexpectedly succeeded";
+  } else {
+    EXPECT_EQ(errno, ENODEV);
+  }
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc.handle;
+  EXPECT_EQ(ioctl(fd, AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0) << std::strerror(errno);
+  close(fd);
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -3,7 +3,7 @@
 
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/kmd/linux/kfd_ioctl_utils.h"
-#include "rocjitsu/kmd/linux/simulated_driver.h"
+#include "rocjitsu/kmd/linux/simulated_kfd.h"
 #include "rocjitsu/vm/virtual_machine.h"
 
 #include "embedded_schema.h"
@@ -100,7 +100,7 @@ protected:
   rocjitsu::config::LoadedConfig loaded_;
   std::unique_ptr<simdojo::SimulationEngine> engine_;
   rocjitsu::SoC *soc_ = nullptr;
-  rocjitsu::SimulatedDriver *driver_ = nullptr;
+  rocjitsu::SimulatedKfd *driver_ = nullptr;
 };
 
 TEST_F(KfdIoctlTest, SetMemoryPolicy) {
@@ -193,7 +193,7 @@ TEST_F(KfdIoctlTest, GetTileConfigRejectsUnknownGpuId) {
 
 TEST_F(KfdIoctlTest, GetTileConfigReturnsUnsupportedInDaemonMode) {
   ASSERT_NE(soc_, nullptr);
-  rocjitsu::SimulatedDriver daemon_driver(*soc_, true);
+  rocjitsu::SimulatedKfd daemon_driver(*soc_, true);
   uint32_t process_id = daemon_driver.open_process();
   ASSERT_NE(process_id, 0u);
 

--- a/emulation/rocjitsu/tests/race-detector/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/race-detector/CMakeLists.txt
@@ -8,6 +8,9 @@
 # causes OOM kills at moderate parallelism (~15+ concurrent tests). The
 # race detector only needs a few CUs to exercise cross-wave and
 # cross-workgroup synchronization checking.
+# The gfx950 race detector cases include CDNA-specific inline assembly
+# sequences for LDS and waitcnt coverage. Keep that binary on gfx950 even when
+# generic HIP smoke tests are overridden for local validation on another ISA.
 rj_add_hip_test(hip_race_tests_gfx950 ARCH gfx950 SOURCE hip_race_gfx950_test.hip)
 rj_add_hip_test(hip_race_tests_gfx1151 ARCH gfx1151 SOURCE hip_race_gfx1151_test.hip)
 set(RJ_RACE_GFX950_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/race_test_config.json)

--- a/emulation/rocjitsu/tests/simulated_kfd_test.cpp
+++ b/emulation/rocjitsu/tests/simulated_kfd_test.cpp
@@ -1,11 +1,11 @@
 // Copyright (c) 2026 Advanced Micro Devices, Inc.
 // SPDX-License-Identifier: MIT
 
-/// @file simulated_driver_test.cpp
-/// @brief Tests for SimulatedDriver creation, open/close, and topology generation.
+/// @file simulated_kfd_test.cpp
+/// @brief Tests for SimulatedKfd creation, open/close, and topology generation.
 
 #include "rocjitsu/config/config_loader.h"
-#include "rocjitsu/kmd/linux/simulated_driver.h"
+#include "rocjitsu/kmd/linux/simulated_kfd.h"
 #include "rocjitsu/vm/virtual_machine.h"
 
 #include "embedded_schema.h"
@@ -24,7 +24,7 @@ struct TestVM {
   rocjitsu::config::LoadedConfig loaded;
   std::unique_ptr<simdojo::SimulationEngine> engine;
 
-  rocjitsu::SimulatedDriver *driver() {
+  rocjitsu::SimulatedKfd *driver() {
     auto *vm = dynamic_cast<rocjitsu::VirtualMachine *>(engine->topology().root());
     return vm ? vm->driver() : nullptr;
   }
@@ -53,17 +53,17 @@ TestVM create_test_vm() {
   return t;
 }
 
-class SimulatedDriverTest : public ::testing::Test {
+class SimulatedKfdTest : public ::testing::Test {
 protected:
   void SetUp() override { setenv("RJ_CONFIG", CONFIG_PATH.c_str(), 1); }
 };
 
-TEST_F(SimulatedDriverTest, CreateDefault) {
+TEST_F(SimulatedKfdTest, CreateDefault) {
   auto t = create_test_vm();
   ASSERT_NE(t.driver(), nullptr);
 }
 
-TEST_F(SimulatedDriverTest, OpenAndClose) {
+TEST_F(SimulatedKfdTest, OpenAndClose) {
   auto t = create_test_vm();
   ASSERT_NE(t.driver(), nullptr);
 
@@ -74,7 +74,7 @@ TEST_F(SimulatedDriverTest, OpenAndClose) {
   EXPECT_EQ(ret, 0);
 }
 
-TEST_F(SimulatedDriverTest, TopologyDirectoryExists) {
+TEST_F(SimulatedKfdTest, TopologyDirectoryExists) {
   auto t = create_test_vm();
   ASSERT_NE(t.driver(), nullptr);
 

--- a/emulation/rocjitsu/tools/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/tools/rocjitsu/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(
         rocjitsu_vm_amdgpu
         rocjitsu_vm_risc_v
         rocjitsu_config
+        rocjitsu_dbt_config
         util
         flatbuffers
         Threads::Threads

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -460,6 +460,39 @@ std::vector<KfdGpuOrdinal> real_kfd_gpu_ordinals() {
   return gpus;
 }
 
+/// @brief Reject implicit host selection when more than one GPU has the host ISA.
+///
+/// @details The launcher, GuestKfd, and HSA tools hook discover the host through
+/// separate views of KFD and ROCR. Selecting the first ISA match independently
+/// is only well-defined when that match is unique. On a multi-GPU host, require
+/// the config to name the shared KFD gpu_id so every layer routes to the same
+/// physical GPU.
+bool has_unambiguous_host_gpu(const rocjitsu::config::DbtGuestConfig &dbt_guest) {
+  if (dbt_guest.host_gpu_id != 0)
+    return true;
+
+  std::optional<uint32_t> target_version =
+      rocjitsu::kmd::gfx_target_version_from_name(dbt_guest.host_isa);
+  if (!target_version)
+    return true;
+
+  std::vector<uint32_t> matching_gpu_ids;
+  for (const KfdGpuOrdinal &gpu : real_kfd_gpu_ordinals()) {
+    if (gpu.gfx_target_version == *target_version)
+      matching_gpu_ids.push_back(gpu.gpu_id);
+  }
+  if (matching_gpu_ids.size() <= 1)
+    return true;
+
+  std::cerr << std::format(
+      "rocjitsu: dbt_guest.host_isa '{}' matches {} host GPUs; set host_gpu_id to one of:",
+      dbt_guest.host_isa, matching_gpu_ids.size());
+  for (uint32_t gpu_id : matching_gpu_ids)
+    std::cerr << ' ' << gpu_id;
+  std::cerr << '\n';
+  return false;
+}
+
 bool append_unique(std::vector<std::string> *tokens, std::string token) {
   if (token.empty())
     return false;
@@ -646,6 +679,8 @@ int main(int argc, char *argv[]) {
       std::cerr << "rocjitsu: dbt_guest requires guest_isa and host_isa\n";
       return 1;
     }
+    if (!has_unambiguous_host_gpu(dbt_guest_config))
+      return 1;
     hooks_path = find_hooks_lib();
     if (hooks_path.empty()) {
       std::cerr << "rocjitsu: could not find librocjitsu_hooks.so\n";

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -321,18 +321,23 @@ std::string canonical_existing_path(const std::filesystem::path &candidate) {
   return ec ? std::string{} : canonical.string();
 }
 
-std::string find_interposer_lib() {
+std::string find_runtime_lib(std::string_view lib_name) {
   auto self = current_executable_path();
   if (!self)
     return {};
   auto bin_dir = self->parent_path();
-  // Installed layout: <prefix>/bin/rocjitsu → <prefix>/lib/librocjitsu.so
-  //                   or <prefix>/bin/rocjitsu → <prefix>/lib64/librocjitsu.so
-  // Build layout: build/tools/rocjitsu/rocjitsu → build/librocjitsu.so
-  for (auto &candidate : {
-           bin_dir / ".." / "lib" / "librocjitsu.so",
-           bin_dir / ".." / "lib64" / "librocjitsu.so",
-           bin_dir / ".." / ".." / "librocjitsu.so",
+  const std::filesystem::path library_name{std::string(lib_name)};
+
+  // Installed layouts use <prefix>/lib or <prefix>/lib64. CMake build trees may
+  // place shared libraries either at the build root or under target directories,
+  // so use the same ordered probe list for both the interposer and HSA hooks.
+  for (const auto &candidate : {
+           bin_dir / ".." / "lib" / library_name,
+           bin_dir / ".." / "lib64" / library_name,
+           bin_dir / ".." / ".." / library_name,
+           bin_dir / ".." / ".." / "lib" / "rocjitsu" / "src" / "rocjitsu" / "hooks" / library_name,
+           bin_dir / ".." / ".." / "lib64" / "rocjitsu" / "src" / "rocjitsu" / "hooks" /
+               library_name,
        }) {
     if (std::string path = canonical_existing_path(candidate); !path.empty())
       return path;
@@ -340,24 +345,9 @@ std::string find_interposer_lib() {
   return {};
 }
 
-std::string find_hooks_lib() {
-  auto self = current_executable_path();
-  if (!self)
-    return {};
-  auto bin_dir = self->parent_path();
-  for (auto &candidate : {
-           bin_dir / ".." / "lib" / "librocjitsu_hooks.so",
-           bin_dir / ".." / "lib64" / "librocjitsu_hooks.so",
-           bin_dir / ".." / ".." / "lib" / "rocjitsu" / "src" / "rocjitsu" / "hooks" /
-               "librocjitsu_hooks.so",
-           bin_dir / ".." / ".." / "lib64" / "rocjitsu" / "src" / "rocjitsu" / "hooks" /
-               "librocjitsu_hooks.so",
-       }) {
-    if (std::string path = canonical_existing_path(candidate); !path.empty())
-      return path;
-  }
-  return {};
-}
+std::string find_interposer_lib() { return find_runtime_lib("librocjitsu.so"); }
+
+std::string find_hooks_lib() { return find_runtime_lib("librocjitsu_hooks.so"); }
 
 void prepend_env_path(const char *name, const std::string &value) {
   if (const char *old_value = std::getenv(name); old_value && *old_value) {

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -11,16 +11,27 @@
 
 #include "rocjitsu/vm/rj_vm.h"
 
+#include "rocjitsu/config/config_loader.h"
+#include "rocjitsu/config/dbt_guest_config.h"
 #include "rocjitsu/kmd/linux/rpc.h"
 #include "rocjitsu/version.h"
 
+#include "embedded_schema.h"
+
+#include <algorithm>
+#include <cctype>
 #include <cerrno>
+#include <charconv>
 #include <csignal>
+#include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <filesystem>
 #include <format>
 #include <fstream>
 #include <iostream>
+#include <mutex>
+#include <optional>
 #include <stop_token>
 #include <string_view>
 #include <sys/mman.h>
@@ -30,11 +41,14 @@
 #include <sys/wait.h>
 #include <thread>
 #include <unistd.h>
+#include <utility>
 #include <vector>
 
 using namespace rocjitsu;
 
-static pid_t peer_pid_for_socket(int fd) {
+namespace {
+
+pid_t peer_pid_for_socket(int fd) {
   struct ucred cred {};
   socklen_t len = sizeof(cred);
   if (getsockopt(fd, SOL_SOCKET, SO_PEERCRED, &cred, &len) == 0 && cred.pid > 0)
@@ -42,7 +56,7 @@ static pid_t peer_pid_for_socket(int fd) {
   return 0;
 }
 
-static void handle_client(int client_fd, rj_vm_t *vm, pid_t client_pid, std::stop_token stop) {
+void handle_client(int client_fd, rj_vm_t *vm, pid_t client_pid, std::stop_token stop) {
   uint32_t process_id = 0;
   bool connected = true;
 
@@ -207,9 +221,9 @@ static void handle_client(int client_fd, rj_vm_t *vm, pid_t client_pid, std::sto
   ::close(client_fd);
 }
 
-static volatile sig_atomic_t g_listen_fd = -1;
+volatile sig_atomic_t g_listen_fd = -1;
 
-static int run_daemon_server(const char *config_path) {
+int run_daemon_server(const char *config_path) {
   rj_vm_t *vm = nullptr;
   if (rj_vm_create(config_path, RJ_VM_MODE_DAEMON, &vm) != ROCJITSU_STATUS_SUCCESS) {
     std::cerr << std::format("rocjitsu: failed to create VM from {}\n", config_path);
@@ -282,13 +296,35 @@ static int run_daemon_server(const char *config_path) {
   return 0;
 }
 
-static std::string find_interposer_lib() {
-  char self[4096];
-  auto n = readlink("/proc/self/exe", self, sizeof(self) - 1);
-  if (n <= 0)
+std::optional<std::filesystem::path> current_executable_path() {
+  std::vector<char> buffer(256);
+  for (;;) {
+    ssize_t n = readlink("/proc/self/exe", buffer.data(), buffer.size());
+    if (n < 0)
+      return std::nullopt;
+    if (static_cast<size_t>(n) < buffer.size())
+      return std::filesystem::path(std::string(buffer.data(), static_cast<size_t>(n)));
+    buffer.resize(buffer.size() * 2);
+  }
+}
+
+std::string canonical_existing_path(const std::filesystem::path &candidate) {
+  std::error_code ec;
+  if (!std::filesystem::exists(candidate, ec) || ec)
     return {};
-  self[n] = '\0';
-  auto bin_dir = std::filesystem::path(self).parent_path();
+
+  // The launcher should keep probing candidate layouts when a path disappears
+  // or cannot be canonicalized, rather than letting a filesystem exception
+  // terminate the process before exec.
+  std::filesystem::path canonical = std::filesystem::canonical(candidate, ec);
+  return ec ? std::string{} : canonical.string();
+}
+
+std::string find_interposer_lib() {
+  auto self = current_executable_path();
+  if (!self)
+    return {};
+  auto bin_dir = self->parent_path();
   // Installed layout: <prefix>/bin/rocjitsu → <prefix>/lib/librocjitsu.so
   //                   or <prefix>/bin/rocjitsu → <prefix>/lib64/librocjitsu.so
   // Build layout: build/tools/rocjitsu/rocjitsu → build/librocjitsu.so
@@ -297,13 +333,41 @@ static std::string find_interposer_lib() {
            bin_dir / ".." / "lib64" / "librocjitsu.so",
            bin_dir / ".." / ".." / "librocjitsu.so",
        }) {
-    if (std::filesystem::exists(candidate))
-      return std::filesystem::canonical(candidate).string();
+    if (std::string path = canonical_existing_path(candidate); !path.empty())
+      return path;
   }
   return {};
 }
 
-static bool write_config_file(const std::string &config_path) {
+std::string find_hooks_lib() {
+  auto self = current_executable_path();
+  if (!self)
+    return {};
+  auto bin_dir = self->parent_path();
+  for (auto &candidate : {
+           bin_dir / ".." / "lib" / "librocjitsu_hooks.so",
+           bin_dir / ".." / "lib64" / "librocjitsu_hooks.so",
+           bin_dir / ".." / ".." / "lib" / "rocjitsu" / "src" / "rocjitsu" / "hooks" /
+               "librocjitsu_hooks.so",
+           bin_dir / ".." / ".." / "lib64" / "rocjitsu" / "src" / "rocjitsu" / "hooks" /
+               "librocjitsu_hooks.so",
+       }) {
+    if (std::string path = canonical_existing_path(candidate); !path.empty())
+      return path;
+  }
+  return {};
+}
+
+void prepend_env_path(const char *name, const std::string &value) {
+  if (const char *old_value = std::getenv(name); old_value && *old_value) {
+    std::string combined = value + ":" + old_value;
+    setenv(name, combined.c_str(), 1);
+    return;
+  }
+  setenv(name, value.c_str(), 1);
+}
+
+bool write_config_file(const std::string &config_path) {
   auto cfg_file = rpc_default_config_file_path();
   std::filesystem::create_directories(std::filesystem::path(cfg_file).parent_path());
   std::ofstream ofs(cfg_file);
@@ -313,14 +377,148 @@ static bool write_config_file(const std::string &config_path) {
   return ofs.good();
 }
 
-static void cleanup_runtime_files() {
+void cleanup_runtime_files() {
   auto cfg_file = rpc_default_config_file_path();
   unlink(cfg_file.c_str());
   auto sock_file = rpc_default_socket_path();
   unlink(sock_file.c_str());
 }
 
-static void print_usage() {
+struct KfdGpuOrdinal {
+  uint32_t ordinal = 0;
+  uint32_t node_id = 0;
+  uint32_t gpu_id = 0;
+};
+
+std::optional<uint32_t> parse_u32(std::string_view text) {
+  uint32_t value = 0;
+  auto *begin = text.data();
+  auto *end = text.data() + text.size();
+  auto [ptr, err] = std::from_chars(begin, end, value);
+  if (err != std::errc{} || ptr != end)
+    return std::nullopt;
+  return value;
+}
+
+std::string_view trim(std::string_view text) {
+  while (!text.empty() && std::isspace(static_cast<unsigned char>(text.front())))
+    text.remove_prefix(1);
+  while (!text.empty() && std::isspace(static_cast<unsigned char>(text.back())))
+    text.remove_suffix(1);
+  return text;
+}
+
+std::optional<uint32_t> read_u32_file(const std::filesystem::path &path) {
+  std::ifstream in(path);
+  uint32_t value = 0;
+  if (!(in >> value))
+    return std::nullopt;
+  return value;
+}
+
+std::vector<KfdGpuOrdinal> real_kfd_gpu_ordinals() {
+  std::filesystem::path nodes_dir = "/sys/devices/virtual/kfd/kfd/topology/nodes";
+  if (!std::filesystem::exists(nodes_dir))
+    nodes_dir = "/sys/class/kfd/kfd/topology/nodes";
+
+  std::vector<std::pair<uint32_t, uint32_t>> nodes;
+  std::error_code ec;
+  for (const auto &entry : std::filesystem::directory_iterator(nodes_dir, ec)) {
+    if (!entry.is_directory(ec))
+      continue;
+
+    std::string name = entry.path().filename().string();
+    auto node_id = parse_u32(name);
+    if (!node_id)
+      continue;
+
+    auto gpu_id = read_u32_file(entry.path() / "gpu_id");
+    if (gpu_id && *gpu_id != 0)
+      nodes.emplace_back(*node_id, *gpu_id);
+  }
+
+  std::sort(nodes.begin(), nodes.end(),
+            [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+
+  std::vector<KfdGpuOrdinal> gpus;
+  gpus.reserve(nodes.size());
+  for (uint32_t ordinal = 0; ordinal < nodes.size(); ++ordinal)
+    gpus.push_back({ordinal, nodes[ordinal].first, nodes[ordinal].second});
+  return gpus;
+}
+
+bool append_unique(std::vector<std::string> *tokens, std::string token) {
+  if (token.empty())
+    return false;
+  if (std::find(tokens->begin(), tokens->end(), token) != tokens->end())
+    return false;
+  tokens->push_back(std::move(token));
+  return true;
+}
+
+std::string join_comma(const std::vector<std::string> &tokens) {
+  std::string result;
+  for (size_t i = 0; i < tokens.size(); ++i) {
+    if (i != 0)
+      result += ',';
+    result += tokens[i];
+  }
+  return result;
+}
+
+void maybe_expand_rocr_visible_devices(const rocjitsu::config::DbtGuestConfig &dbt_guest) {
+  const char *visible = std::getenv("ROCR_VISIBLE_DEVICES");
+  if (visible == nullptr || *visible == '\0')
+    return;
+
+  std::vector<KfdGpuOrdinal> gpus = real_kfd_gpu_ordinals();
+  if (gpus.empty())
+    return;
+
+  uint32_t host_ordinal = 0;
+  if (dbt_guest.host_gpu_id != 0) {
+    auto match = std::find_if(gpus.begin(), gpus.end(), [&](const KfdGpuOrdinal &gpu) {
+      return gpu.gpu_id == dbt_guest.host_gpu_id;
+    });
+    if (match == gpus.end())
+      return;
+    host_ordinal = match->ordinal;
+  }
+
+  const uint32_t guest_ordinal = static_cast<uint32_t>(gpus.size());
+  std::vector<std::string> expanded;
+  std::string_view rest = visible;
+  bool changed = false;
+
+  while (true) {
+    size_t comma = rest.find(',');
+    std::string_view raw = comma == std::string_view::npos ? rest : rest.substr(0, comma);
+    std::string_view token = trim(raw);
+    if (!token.empty()) {
+      std::optional<uint32_t> ordinal = parse_u32(token);
+      if (ordinal && (*ordinal == host_ordinal || *ordinal == guest_ordinal)) {
+        // ROCR filters topology before HSA tools callbacks. Include both the
+        // hidden host and appended guest internally so our HSA iteration hook
+        // can present one public replacement agent.
+        changed = append_unique(&expanded, std::to_string(host_ordinal)) || changed;
+        changed = append_unique(&expanded, std::to_string(guest_ordinal)) || changed;
+      } else {
+        changed = append_unique(&expanded, std::string(token)) || changed;
+      }
+    }
+
+    if (comma == std::string_view::npos)
+      break;
+    rest.remove_prefix(comma + 1);
+  }
+
+  std::string rewritten = join_comma(expanded);
+  if (!rewritten.empty() && rewritten != visible) {
+    setenv("ROCR_VISIBLE_DEVICES", rewritten.c_str(), 1);
+  }
+}
+
+void print_usage() {
   std::cerr
       << "Usage: rocjitsu --config <config.json> [--daemon|--attach] -- <app> [args...]\n"
          "\n"
@@ -335,6 +533,8 @@ static void print_usage() {
          "  --version, -v     Print version and exit\n"
          "  --help, -h        Print this help and exit\n";
 }
+
+} // namespace
 
 int main(int argc, char *argv[]) {
   std::signal(SIGPIPE, SIG_IGN);
@@ -381,6 +581,21 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
+  rocjitsu::config::DbtGuestConfig dbt_guest_config;
+  try {
+    dbt_guest_config = rocjitsu::config::load_dbt_guest_config_from_file(abs_config);
+    if (!dbt_guest_config.enabled)
+      (void)rocjitsu::config::load_config(abs_config, rocjitsu::kEmbeddedSchema);
+  } catch (const std::exception &e) {
+    std::cerr << std::format("rocjitsu: failed to parse config: {}\n", e.what());
+    return 1;
+  }
+  const bool dbt_guest_mode = dbt_guest_config.enabled;
+  if (dbt_guest_mode && (daemon_mode || attach_mode)) {
+    std::cerr << "rocjitsu: dbt_guest mode currently supports local launch only\n";
+    return 1;
+  }
+
   bool has_app = (separator_idx >= 0 && separator_idx + 1 < argc);
 
   if (daemon_mode && !has_app)
@@ -398,6 +613,19 @@ int main(int argc, char *argv[]) {
   if (lib_path.empty()) {
     std::cerr << "rocjitsu: could not find librocjitsu.so\n";
     return 1;
+  }
+
+  std::string hooks_path;
+  if (dbt_guest_mode) {
+    if (dbt_guest_config.guest_isa.empty() || dbt_guest_config.host_isa.empty()) {
+      std::cerr << "rocjitsu: dbt_guest requires guest_isa and host_isa\n";
+      return 1;
+    }
+    hooks_path = find_hooks_lib();
+    if (hooks_path.empty()) {
+      std::cerr << "rocjitsu: could not find librocjitsu_hooks.so\n";
+      return 1;
+    }
   }
 
   if (attach_mode) {
@@ -437,7 +665,15 @@ int main(int argc, char *argv[]) {
     }
   }
 
-  setenv("LD_PRELOAD", lib_path.c_str(), 1);
+  prepend_env_path("LD_PRELOAD", lib_path);
+  if (dbt_guest_mode) {
+    maybe_expand_rocr_visible_devices(dbt_guest_config);
+    // The HSA hook still uses the legacy tools callback path. Disable only the
+    // rocprofiler-register table-delivery path so it cannot validate an
+    // unshadowed table before rocjitsu installs guest-agent wrappers.
+    setenv("HSA_TOOLS_DISABLE_REGISTER", "1", 1);
+    setenv("HSA_TOOLS_LIB", hooks_path.c_str(), 1);
+  }
   execvp(app_argv[0], app_argv);
 
   std::cerr << std::format("rocjitsu: execvp failed: {}\n", strerror(errno));

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -13,6 +13,7 @@
 
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/config/dbt_guest_config.h"
+#include "rocjitsu/kmd/linux/amdgpu_properties.h"
 #include "rocjitsu/kmd/linux/rpc.h"
 #include "rocjitsu/version.h"
 
@@ -388,6 +389,7 @@ struct KfdGpuOrdinal {
   uint32_t ordinal = 0;
   uint32_t node_id = 0;
   uint32_t gpu_id = 0;
+  uint32_t gfx_target_version = 0;
 };
 
 std::optional<uint32_t> parse_u32(std::string_view text) {
@@ -416,12 +418,29 @@ std::optional<uint32_t> read_u32_file(const std::filesystem::path &path) {
   return value;
 }
 
+std::optional<uint32_t> read_u32_property(const std::filesystem::path &path, std::string_view key) {
+  std::ifstream in(path);
+  std::string name;
+  uint64_t value = 0;
+  while (in >> name >> value) {
+    if (name == key)
+      return static_cast<uint32_t>(value);
+  }
+  return std::nullopt;
+}
+
 std::vector<KfdGpuOrdinal> real_kfd_gpu_ordinals() {
   std::filesystem::path nodes_dir = "/sys/devices/virtual/kfd/kfd/topology/nodes";
   if (!std::filesystem::exists(nodes_dir))
     nodes_dir = "/sys/class/kfd/kfd/topology/nodes";
 
-  std::vector<std::pair<uint32_t, uint32_t>> nodes;
+  struct KfdNodeInfo {
+    uint32_t node_id = 0;
+    uint32_t gpu_id = 0;
+    uint32_t gfx_target_version = 0;
+  };
+
+  std::vector<KfdNodeInfo> nodes;
   std::error_code ec;
   for (const auto &entry : std::filesystem::directory_iterator(nodes_dir, ec)) {
     if (!entry.is_directory(ec))
@@ -433,17 +452,21 @@ std::vector<KfdGpuOrdinal> real_kfd_gpu_ordinals() {
       continue;
 
     auto gpu_id = read_u32_file(entry.path() / "gpu_id");
-    if (gpu_id && *gpu_id != 0)
-      nodes.emplace_back(*node_id, *gpu_id);
+    if (gpu_id && *gpu_id != 0) {
+      uint32_t gfx_target_version =
+          read_u32_property(entry.path() / "properties", "gfx_target_version").value_or(0);
+      nodes.push_back({*node_id, *gpu_id, gfx_target_version});
+    }
   }
 
   std::sort(nodes.begin(), nodes.end(),
-            [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+            [](const auto &lhs, const auto &rhs) { return lhs.node_id < rhs.node_id; });
 
   std::vector<KfdGpuOrdinal> gpus;
   gpus.reserve(nodes.size());
   for (uint32_t ordinal = 0; ordinal < nodes.size(); ++ordinal)
-    gpus.push_back({ordinal, nodes[ordinal].first, nodes[ordinal].second});
+    gpus.push_back({ordinal, nodes[ordinal].node_id, nodes[ordinal].gpu_id,
+                    nodes[ordinal].gfx_target_version});
   return gpus;
 }
 
@@ -479,6 +502,18 @@ void maybe_expand_rocr_visible_devices(const rocjitsu::config::DbtGuestConfig &d
   if (dbt_guest.host_gpu_id != 0) {
     auto match = std::find_if(gpus.begin(), gpus.end(), [&](const KfdGpuOrdinal &gpu) {
       return gpu.gpu_id == dbt_guest.host_gpu_id;
+    });
+    if (match == gpus.end())
+      return;
+    host_ordinal = match->ordinal;
+  } else {
+    std::optional<uint32_t> target_version =
+        rocjitsu::kmd::gfx_target_version_from_name(dbt_guest.host_isa);
+    if (!target_version)
+      return;
+
+    auto match = std::find_if(gpus.begin(), gpus.end(), [&](const KfdGpuOrdinal &gpu) {
+      return gpu.gfx_target_version == *target_version;
     });
     if (match == gpus.end())
       return;


### PR DESCRIPTION
A rocjitsu tool path where an unmodified ROCm process can see a
guest GPU, but translate kernels and execute on a real host GPU.

The design has three main components with their own responsibilities:

1. **GuestKfd Interposer**: Shows applications a guest GPU device that looks
   like a real KFD/DRM device.
2. **HSA Hooks**: Intercepts HSA Runtime calls for the guest GPU and forwards
   them to the host GPU, translating kernels as needed.
3. **DBT**: Translates guest GPU kernels to host GPU kernels.

## High Level Flow

User:
```bash
rocjitsu --config configs/guest_gfx950_on_gfx942.json -- ./app
```

Underneath:
```
  LD_PRELOAD=librocjitsu_kmd.so
      open/read sysfs topology -> host topology plus synthetic gfx950 node
      open/ioctl /dev/kfd      -> real KFD for host nodes, GuestKfd for guest discovery/startup

  HSA_TOOLS_LIB=librocjitsu_hooks.so
      ROCR internally sees     -> selected host agent plus synthetic guest agent
      hsa_iterate_agents       -> public host slot is replaced by the guest agent
      hsa_agent_get_info       -> guest still reports gfx950 identity
      hsa_queue_create         -> guest agent is replaced with host agent
      hsa_executable_load...   -> guest ELF translated to host ELF, then loaded on host
      hsa_executable_get...    -> guest symbol lookup is replaced with host symbol lookup
      AMD extension calls      -> guest agents are replaced with host agents where needed
```

More design docs can be found in docs/rocjitsu_dbt_guest.md

Original Design Document: https://gist.github.com/Groverkss/0f13e40c2d1f0d0a2ec31f7850317269 (may have drifted a bit after review, but the principles are same) 