### PR TITLE
[hipfile] Link Threads::Threads to GTest targets to fix lld build

### DIFF
--- a/projects/hipfile/CMakeLists.txt
+++ b/projects/hipfile/CMakeLists.txt
@@ -293,6 +293,7 @@ endif()
 
 # Add the testing directories
 if(BUILD_TESTING)
+    include(AISUseGTest)
     add_subdirectory(test)
 endif()
 if(BUILD_TESTING AND AIS_BUILD_AMD_DETAIL)

--- a/projects/hipfile/cmake/AISUseGTest.cmake
+++ b/projects/hipfile/cmake/AISUseGTest.cmake
@@ -2,8 +2,19 @@
 #
 # SPDX-License-Identifier: MIT
 
+# This module sets up GoogleTest and applies settings to its targets, so it must
+# run exactly once.
+include_guard(GLOBAL)
+
 include(AISSanitizers)
 include(FetchContent)
+
+# GoogleTest's ThreadLocal<T> implementation uses POSIX thread-key APIs
+# (pthread_key_create, pthread_setspecific, etc.). These must be linked
+# explicitly: lld (used by the sanitizer toolchain) errors on the undefined
+# symbols in libgtest.a / libgmock.a, whereas GNU ld resolves them
+# transitively and masks the missing dependency.
+find_package(Threads REQUIRED)
 
 # Decide whether to check for a system GoogleTest install first. When building
 # with the sanitizers, we HAVE to build GoogleTest from source.
@@ -46,6 +57,32 @@ if(AIS_USE_SANITIZERS OR AIS_USE_THREAD_SANITIZER)
     ais_add_sanitizers(GTest::gtest)
     ais_add_sanitizers(GTest::gmock)
 endif()
+
+# Propagate pthread linkage to anything that links a GTest target, so the
+# individual test CMakeLists files don't each have to add Threads::Threads.
+# Fetched GoogleTest exposes GTest::gtest/GTest::gmock as ALIAS targets, which
+# cannot be modified directly, so resolve to the underlying target first. We
+# use set_property(... APPEND ...) rather than target_link_libraries() so this
+# works uniformly for the IMPORTED targets that a system find_package(GTest)
+# produces as well as the normal targets from a fetched build. A system GTest
+# install may provide gtest without gmock, so only touch targets that exist.
+#
+# A from-source GoogleTest already links Threads::Threads on its targets, so
+# check before appending to avoid a duplicate entry in the link interface.
+foreach(gtest_target GTest::gtest GTest::gmock)
+    if(NOT TARGET ${gtest_target})
+        continue()
+    endif()
+    get_target_property(aliased ${gtest_target} ALIASED_TARGET)
+    if(aliased)
+        set(gtest_target ${aliased})
+    endif()
+    get_target_property(existing_libs ${gtest_target} INTERFACE_LINK_LIBRARIES)
+    if(NOT existing_libs MATCHES "Threads::Threads")
+        set_property(TARGET ${gtest_target} APPEND PROPERTY
+            INTERFACE_LINK_LIBRARIES Threads::Threads)
+    endif()
+endforeach()
 
 include(GoogleTest)
 

--- a/projects/hipfile/test/CMakeLists.txt
+++ b/projects/hipfile/test/CMakeLists.txt
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 include(AISAddExecutable)
-include(AISUseGTest)
 
 set(SHARED_SOURCE_FILES
     common/magic-word.cpp

--- a/projects/hipfile/test/amd_detail/CMakeLists.txt
+++ b/projects/hipfile/test/amd_detail/CMakeLists.txt
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 include(AISAddExecutable)
-include(AISUseGTest)
 find_package(Threads REQUIRED)
 
 set(SHARED_SOURCE_FILES


### PR DESCRIPTION
## Motivation

The hipfile test executables (hipfile_tests, hipfile_system_tests, and internal_tests) fail to link under the ASAN toolchain with undefined symbol errors -- pthread_key_create, pthread_setspecific, pthread_getspecific, pthread_key_delete -- referenced from libgtest.a / libgmock.a.

GoogleTest's ThreadLocal<T> uses POSIX thread-key APIs, but the test targets never declared a dependency on pthread. The dependency was implicit: ld.lld (used by the sanitizer toolchain) is strict about resolving undefined symbols pulled in from static archives and errors out, whereas GNU ld resolves them transitively and masks the missing dependency. Systems where pthread is a separate library rather than folded into libc (glibc < 2.34) would be affected the same way.

Introduced by https://github.com/ROCm/TheRock/pull/5217

Fixes https://github.com/ROCm/TheRock/issues/5898

## Technical Details

The fix is centralized in the cmake directory, consistent with the project convention of keeping the test/src CMakeLists files minimal:

- find_package(Threads REQUIRED) in AISUseGTest.cmake, and attach
  Threads::Threads to the INTERFACE_LINK_LIBRARIES of GTest::gtest and
  GTest::gmock so every executable that links a GTest target
  transitively picks up pthread.
- Resolve ALIAS targets to their underlying target first, since a
  fetched GoogleTest exposes GTest::gtest / GTest::gmock as aliases
  (which cannot be modified directly).
- Use set_property(... APPEND ...) rather than target_link_libraries()
  so the change applies uniformly to the IMPORTED targets from a system
  find_package(GTest) and the normal targets from a fetched build.
- Guard with if(TARGET ...) so a gtest-only system install (no gmock)
  does not error during configure.
- Skip the append when Threads::Threads is already present, since a
  from-source GoogleTest already links it on its own targets.

AISUseGTest.cmake performs side-effecting setup (finds/builds GoogleTest and applies settings to its targets), but was included separately from test/ and test/amd_detail/, which are sibling scopes. This re-ran the module and re-applied its target settings, duplicating the sanitizer compile/link options on the GTest targets under ASAN/TSAN.

Hoist the include to the top-level CMakeLists.txt (before the test subdirectories) so the GTest targets are created once in an ancestor scope and inherited by both test directories, and remove the per-directory includes. Add include_guard(GLOBAL) to AISUseGTest.cmake to enforce single execution defensively.

## JIRA ID

AIHIPFILE-154

## Test Plan

- [x] Clean configure + build of hipfile_tests, hipfile_system_tests,
      and internal_tests (system-GTest / imported-target path).
- [x] Fresh ASAN configure: GTest targets carry exactly one copy of the
      sanitizer flags and one Threads::Threads entry.
- [x] internal_tests (in the sibling test/amd_detail) builds, confirming
      it sees the GTest targets created in the top-level scope.
- [ ] Confirm the link succeeds on the ASAN/lld CI configuration (could
      not be reproduced locally -- this machine runs glibc 2.39 where
      pthread is folded into libc, so -lpthread is a no-op here).

## Test Result

Passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
