### PR TITLE
[rccl-tests] Implement sparse alltoallv size matrix

### DIFF
--- a/projects/rccl-tests/src/alltoallv.cu
+++ b/projects/rccl-tests/src/alltoallv.cu
@@ -8,7 +8,108 @@
 #include "cuda_runtime.h"
 #include "common.h"
 
+#include <vector>
+#include <random>
+#include <cmath>
+#include <cstdlib>
+
 #define USE_RCCL_GATHER_SCATTER
+
+// Build a deterministic sparse "send-size" matrix M[i][j] (sender i -> receiver j),
+// identical on every rank, where every row and every column sums to exactly `total`.
+//
+// Method (Birkhoff--von Neumann): a doubly-stochastic matrix is a weighted sum of
+// permutation matrices. Each random permutation contributes its weight to exactly one
+// cell per row and per column, so all row/column sums equal the sum of the weights.
+// Using integer weights that sum to `total` makes every row/column sum exactly `total`,
+// which keeps the send/recv buffers exactly filled.
+//
+// Two tuning knobs (overridable via environment, but defaulted so all ranks agree):
+//   RCCL_TESTS_A2AV_SPARSITY   fraction of (i,j) pairs forced to zero  [default 0.5]
+//   RCCL_TESTS_A2AV_SIZESPREAD max/min ratio knob for nonzero weights  [default 3.0]
+//   RCCL_TESTS_A2AV_SEED       shared RNG seed                         [default 2602]
+//   RCCL_TESTS_A2AV_VERBOSE    if set, rank 0 prints the size matrix once
+static void AlltoAllvGenSizeMatrix(int nranks, int rank, size_t total, std::vector<size_t>& M) {
+  M.assign((size_t)nranks * nranks, 0);
+  if (nranks <= 0 || total == 0) return;
+  if (nranks == 1) { M[0] = total; return; }
+
+  double sparsity = 0.5;
+  double sizeSpread = 3.0;
+  unsigned long seed = 2602;
+  const char* s;
+  if ((s = getenv("RCCL_TESTS_A2AV_SPARSITY")))   sparsity   = atof(s);
+  if ((s = getenv("RCCL_TESTS_A2AV_SIZESPREAD"))) sizeSpread = atof(s);
+  if ((s = getenv("RCCL_TESTS_A2AV_SEED")))       seed       = strtoul(s, NULL, 0);
+
+  if (sparsity < 0.0)  sparsity = 0.0;
+  if (sparsity > 0.95) sparsity = 0.95;
+  if (sizeSpread < 1.0) sizeSpread = 1.0;
+
+  // Number of permutation terms controls density. With k independent random
+  // permutations, the expected fraction of zero cells is (1 - 1/N)^k, so
+  // k ~= ln(sparsity) / ln(1 - 1/N) hits the requested sparsity.
+  int k;
+  if (sparsity > 0.0) {
+    k = (int)std::lround(std::log(sparsity) / std::log(1.0 - 1.0 / nranks));
+  } else {
+    k = 4 * nranks; // effectively dense
+  }
+  if (k < 1) k = 1;
+
+  std::mt19937_64 rng(seed);
+
+  // Raw weights spread geometrically so max/min ~= sizeSpread.
+  std::vector<double> raw(k);
+  double rawSum = 0.0;
+  std::uniform_real_distribution<double> uni(0.0, 1.0);
+  for (int t = 0; t < k; t++) {
+    raw[t] = std::pow(sizeSpread, uni(rng)); // in [1, sizeSpread]
+    rawSum += raw[t];
+  }
+
+  // Integer weights summing exactly to `total`.
+  std::vector<size_t> w(k, 0);
+  size_t assigned = 0;
+  for (int t = 0; t < k; t++) {
+    w[t] = (size_t)std::floor(raw[t] / rawSum * (double)total);
+    assigned += w[t];
+  }
+  for (size_t rem = total - assigned, t = 0; rem > 0; rem--, t = (t + 1) % k) w[t] += 1;
+
+  // Accumulate weighted random permutation matrices.
+  std::vector<int> perm(nranks);
+  for (int i = 0; i < nranks; i++) perm[i] = i;
+  for (int t = 0; t < k; t++) {
+    for (int i = nranks - 1; i > 0; i--) { // Fisher-Yates
+      std::uniform_int_distribution<int> d(0, i);
+      std::swap(perm[i], perm[d(rng)]);
+    }
+    for (int i = 0; i < nranks; i++) M[(size_t)i * nranks + perm[i]] += w[t];
+  }
+
+  if (rank == 0 && getenv("RCCL_TESTS_A2AV_VERBOSE")) {
+    static bool printed = false;
+    if (!printed) {
+      printed = true;
+      size_t nz = 0, mn = (size_t)-1, mx = 0;
+      for (size_t e = 0; e < M.size(); e++) {
+        if (M[e]) { nz++; if (M[e] < mn) mn = M[e]; if (M[e] > mx) mx = M[e]; }
+      }
+      if (mn == (size_t)-1) mn = 0;
+      printf("AlltoAllv size matrix (rows=sender, cols=receiver):\n");
+      printf("config:    total=%zu  requestedSparsity=%.1f%%  sizeSpread=%.2f  N=%d  seed=%lu\n",
+             total, 100.0 * sparsity, sizeSpread, nranks, seed);
+      printf("realized:  sparsity=%.1f%%  sizeSpreadRatio(max/min)=%.2f  nonzero[min..max]=[%zu..%zu]  terms=%d\n",
+             100.0 * (1.0 - (double)nz / M.size()),
+             mn ? (double)mx / (double)mn : 0.0, mn, mx, k);
+      for (int i = 0; i < nranks; i++) {
+        for (int j = 0; j < nranks; j++) printf("%10zu", M[(size_t)i * nranks + j]);
+        printf("\n");
+      }
+    }
+  }
+}
 
 void AlltoAllvGetCollByteCount(size_t *sendcount, size_t *recvcount, size_t *paramcount, size_t *sendInplaceOffset, size_t *recvInplaceOffset, size_t count, size_t eltSize, int nranks) {
   if (count < nranks*nranks/2) {
@@ -49,22 +150,17 @@ testResult_t AlltoAllvInitData(struct threadArgs* args, ncclDataType_t type, ncc
     free(dataHost);
 #endif
 
+    // Shared sparse size matrix: M[j][r] = bytes sender j sends to receiver r.
+    // `expected` for this rank is column `rank`, concatenated in sender order.
+    std::vector<size_t> M;
+    AlltoAllvGenSizeMatrix(nranks, rank, sendcount, M);
+
     size_t rdisp = 0;
-    size_t data_count = sendcount*2/nranks;
-    size_t chunksize = data_count/nranks;
     for (int j=0; j<nranks; j++) {
-      size_t scount = 0, rcount = ((j+rank)%nranks)*chunksize;
-      if ((j+rank)%nranks == 0)
-        rcount += (sendcount-chunksize*(nranks-1)*nranks/2);
+      size_t rcount = M[(size_t)j*nranks + rank];
+      // Displacement of this chunk inside sender j's send buffer (prefix sum of row j).
       size_t sdisp = 0;
-      for (int k=0; k<nranks; k++) {
-        scount = ((k+j)%nranks)*chunksize;
-        if ((k+j)%nranks == 0)
-          scount += (sendcount-chunksize*(nranks-1)*nranks/2);
-        if (k == rank)
-          break;
-        sdisp += scount;
-      }
+      for (int d=0; d<rank; d++) sdisp += M[(size_t)j*nranks + d];
       TESTCHECK(InitData(((char*)args->expected[i])+rdisp*wordSize(type), rcount, sdisp, type, ncclSum, 33*rep+j, 1, 0));
       rdisp += rcount;
     }
@@ -105,16 +201,21 @@ testResult_t AlltoAllvRunColl(void* sendbuff, size_t sendoffset, void* recvbuff,
     return testNcclError;
   }
 
-  size_t disp = 0;
-  size_t chunksize = count*2/nranks;
+  // Shared sparse size matrix: row `rank` = what we send, column `rank` = what we recv.
+  std::vector<size_t> M;
+  AlltoAllvGenSizeMatrix(nranks, rank, count*nranks, M);
+
+  size_t sdisp = 0, rdisp = 0;
   for (int i = 0; i < nranks; i++) {
-      size_t scount = ((i+rank)%nranks)*chunksize;
-      if ((i+rank)%nranks == 0)
-          scount += (count*nranks-chunksize*(nranks-1)*nranks/2);
-      sendcounts[i+rank*nranks] = recvcounts[i+rank*nranks] = scount;
-      sdispls[i+rank*nranks] = rdispls[i+rank*nranks] = disp;
-      disp += scount;
-      //printf("%d->%d: sendcounts/recvcounts %lx sdispls/rdispls %lx\n", rank, i, sendcounts[i+rank*nranks]*wordSize(type), sdispls[i+rank*nranks]*wordSize(type));
+      size_t scount = M[(size_t)rank*nranks + i]; // rank -> i
+      size_t rcount = M[(size_t)i*nranks + rank]; // i -> rank
+      sendcounts[i+rank*nranks] = scount;
+      recvcounts[i+rank*nranks] = rcount;
+      sdispls[i+rank*nranks] = sdisp;
+      rdispls[i+rank*nranks] = rdisp;
+      sdisp += scount;
+      rdisp += rcount;
+      //printf("%d->%d: send %zu @ %zu, recv %zu @ %zu\n", rank, i, scount, sdispls[i+rank*nranks], rcount, rdispls[i+rank*nranks]);
   }
 
 #if NCCL_MAJOR < 2 || NCCL_MINOR < 7


### PR DESCRIPTION
## Motivation

Make alltoallv send size sparse to match real world workloads better

## Technical Details

Implementation idea contributed by Gilbert Lee.

Replace the symmetric dense send-size scheme in alltoallv with a deterministic doubly-stochastic sparse matrix (Birkhoff-von Neumann: weighted sum of random permutation matrices). Every row and column sums to total so send/recv buffers stay exactly filled and verification holds.

Adds tuning knobs via env vars: RCCL_TESTS_A2AV_SPARSITY, RCCL_TESTS_A2AV_SIZESPREAD, RCCL_TESTS_A2AV_SEED, and RCCL_TESTS_A2AV_VERBOSE (rank 0 prints the size matrix once).

## JIRA ID

AICOMRCCL-890

## Test Plan

Verify alltoallv size matrix

## Test Result

Pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
