### PR TITLE
[AMD-SMI] Format frequency_levels for all static --clock

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -51,6 +51,10 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - Added the new types to `amdsmi_link_types` as part of support for NICs
 
 ### Changed
+
+- **Fixed `amd-smi static --clock` csv and human_readable formatting to output frequency 
+levels as strings instead of dictionary objects**.  
+
 - **Deprecated `amdsmi_get_gpu_vram_vendor()` in favor of `amdsmi_get_gpu_vram_info()`**.  
   - `amdsmi_get_gpu_vram_vendor` is slated for removal in a future ROCm release. It now emits a `DeprecationWarning` from the Python interface and functions as a wrapper of `amdsmi_get_gpu_vram_info()`.
 

--- a/projects/amdsmi/amdsmi_cli/subcommands/static.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/static.py
@@ -1270,9 +1270,14 @@ class StaticCommands:
                                             AMDSMIHelpers.SI_Unit.MICRO,
                                         )
                                     )
-                                    freq_dict["frequency_levels"].update(
-                                        {f"Level {level}": {"value": freq, "unit": "MHz"}}
-                                    )
+                                    if self.logger.is_json_format():
+                                        freq_dict["frequency_levels"].update(
+                                            {f"Level {level}": {"value": freq, "unit": "MHz"}}
+                                        )
+                                    else:
+                                        freq_dict["frequency_levels"].update(
+                                            {f"Level {level}": f"{freq} MHz"}
+                                        )
                                 else:
                                     freq_dict["frequency_levels"].update({f"Level {level}": "N/A"})
                         else:


### PR DESCRIPTION

## Motivation

CSV and human-readable output formats for `amd-smi static --clock` was incorrect.

## Technical Details

Clock frequency levels were always formatted as {"value": freq, "unit": "MHz"} dict objects, breaking CSV and human-readable output which expect simple strings. Corrected these to display as below:

- JSON output: {"value": "500", "unit": "MHz"}
- CSV/human-readable: "500 MHz"


## JIRA ID

N/A

## Test Plan

amd-smi static -g 0 --clock

## Test Result

<img width="457" height="637" alt="image" src="https://github.com/user-attachments/assets/deeab278-4253-4d6a-9e17-7905e5aa7a9f" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
