### PR TITLE
[hip-tests] Use HIP_TEST_CASE for hipMemPrefetchBatchAsync tests so Y…

### DIFF
--- a/projects/hip-tests/catch/unit/graph/hipGraphAllocNodeMemReuse.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAllocNodeMemReuse.cc
@@ -157,7 +157,7 @@ void printDeviceMem(const char* label) {
  * ------------------------
  *  - HIP_VERSION >= 7.14
  */
-TEST_CASE("Unit_hipGraphAllocNodeMemReuse_SameStream_SameSizes") {
+HIP_TEST_CASE(Unit_hipGraphAllocNodeMemReuse_SameStream_SameSizes) {
   const int device = 0;
   HIP_CHECK(hipSetDevice(device));
 
@@ -215,7 +215,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_SameStream_SameSizes") {
  * ------------------------
  *  - HIP_VERSION >= 7.14
  */
-TEST_CASE("Unit_hipGraphAllocNodeMemReuse_SameStream_DifferentSizes_NoReuse") {
+HIP_TEST_CASE(Unit_hipGraphAllocNodeMemReuse_SameStream_DifferentSizes_NoReuse) {
   const int device = 0;
   HIP_CHECK(hipSetDevice(device));
 
@@ -277,7 +277,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_SameStream_DifferentSizes_NoReuse") {
  * ------------------------
  *  - HIP_VERSION >= 7.14
  */
-TEST_CASE("Unit_hipGraphAllocNodeMemReuse_RepeatedLaunches") {
+HIP_TEST_CASE(Unit_hipGraphAllocNodeMemReuse_RepeatedLaunches) {
   const int device = 0;
   HIP_CHECK(hipSetDevice(device));
 
@@ -326,7 +326,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_RepeatedLaunches") {
  * ------------------------
  *  - HIP_VERSION >= 7.14
  */
-TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MemoryTrim") {
+HIP_TEST_CASE(Unit_hipGraphAllocNodeMemReuse_MemoryTrim) {
   const int device = 0;
   HIP_CHECK(hipSetDevice(device));
 
@@ -373,7 +373,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MemoryTrim") {
  * ------------------------
  *  - HIP_VERSION >= 7.14
  */
-TEST_CASE("Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_SameSize") {
+HIP_TEST_CASE(Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_SameSize) {
   const int device = 0;
   HIP_CHECK(hipSetDevice(device));
 
@@ -463,7 +463,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_SameSize") {
  * ------------------------
  *  - HIP_VERSION >= 7.14
  */
-TEST_CASE("Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_DifferentSizes") {
+HIP_TEST_CASE(Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_DifferentSizes) {
   const int device = 0;
   HIP_CHECK(hipSetDevice(device));
 
@@ -564,7 +564,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_ExplicitAllocFreeNodes_DifferentSizes"
  * ------------------------
  *  - HIP_VERSION >= 7.14
  */
-TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MallocWithoutFree_NoReuse") {
+HIP_TEST_CASE(Unit_hipGraphAllocNodeMemReuse_MallocWithoutFree_NoReuse) {
   const int device = 0;
   HIP_CHECK(hipSetDevice(device));
 
@@ -681,7 +681,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MallocWithoutFree_NoReuse") {
  * ------------------------
  *  - HIP_VERSION >= 7.14
  */
-TEST_CASE("Unit_hipGraphAllocNodeMemReuse_DifferentStreams_Reuse") {
+HIP_TEST_CASE(Unit_hipGraphAllocNodeMemReuse_DifferentStreams_Reuse) {
   const int device = 0;
   HIP_CHECK(hipSetDevice(device));
 
@@ -742,7 +742,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_DifferentStreams_Reuse") {
  * ------------------------
  *  - HIP_VERSION >= 7.14
  */
-TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MemSteal_Remap") {
+HIP_TEST_CASE(Unit_hipGraphAllocNodeMemReuse_MemSteal_Remap) {
   const int device = 0;
   HIP_CHECK(hipSetDevice(device));
 
@@ -836,7 +836,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_MemSteal_Remap") {
  * ------------------------
  *  - HIP_VERSION >= 7.14
  */
-TEST_CASE("Unit_hipGraphAllocNodeMemReuse_AutoFreeOnLaunch") {
+HIP_TEST_CASE(Unit_hipGraphAllocNodeMemReuse_AutoFreeOnLaunch) {
   const int device = 0;
   HIP_CHECK(hipSetDevice(device));
 
@@ -952,7 +952,7 @@ TEST_CASE("Unit_hipGraphAllocNodeMemReuse_AutoFreeOnLaunch") {
  * ------------------------
  *  - HIP_VERSION >= 7.14
  */
-TEST_CASE("Unit_hipGraphAllocNodeMemReuse_CaptureEscapedUseAfterDestroy") {
+HIP_TEST_CASE(Unit_hipGraphAllocNodeMemReuse_CaptureEscapedUseAfterDestroy) {
   const int device = 0;
   HIP_CHECK(hipSetDevice(device));
 

--- a/projects/hip-tests/catch/unit/graph/hipSimpleGraphWithKernel.cc
+++ b/projects/hip-tests/catch/unit/graph/hipSimpleGraphWithKernel.cc
@@ -151,7 +151,7 @@ TEST_CASE("Unit_hipGraph_SimpleGraphWithKernel_kernel_arg_prefetch") {
     HIP_SKIP_TEST("Kernel arg prefetch is not supported on the device. Skipped.");
   }
 #else
-TEST_CASE("Unit_hipGraph_SimpleGraphWithKernel") {
+HIP_TEST_CASE(Unit_hipGraph_SimpleGraphWithKernel) {
 #endif  // KERNEL_ARG_PREFETCH
   // Sections run test with and without graph.
   SECTION("Run Test Without Graph") { hipTestWithoutGraph(); }

--- a/projects/hip-tests/catch/unit/kernel/hipLaunchParmFunctor.cc
+++ b/projects/hip-tests/catch/unit/kernel/hipLaunchParmFunctor.cc
@@ -414,7 +414,7 @@ TEST_CASE("Unit_hipLaunchParmFunctor_kernel_arg_prefetch") {
     HIP_SKIP_TEST("Kernel arg prefetch is not supported on the device. Skipped.");
   }
 #else
-TEST_CASE("Unit_hipLaunchParmFunctor") {
+HIP_TEST_CASE(Unit_hipLaunchParmFunctor) {
 #endif  // KERNEL_ARG_PREFETCH
   HipFunctorTests FunctorTests;
 

--- a/projects/hip-tests/catch/unit/memory/hipHostUnregister.cc
+++ b/projects/hip-tests/catch/unit/memory/hipHostUnregister.cc
@@ -26,7 +26,7 @@ inline void hipHostRegisterSupported() {
 }
 
 
-TEST_CASE("Unit_hipHostUnregister_MemoryNotAccessibleAfterUnregister") {
+HIP_TEST_CASE(Unit_hipHostUnregister_MemoryNotAccessibleAfterUnregister) {
   hipHostRegisterSupported();
 
   // try all combinations of flags

--- a/projects/hip-tests/catch/unit/memory/hipMalloc.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMalloc.cc
@@ -48,7 +48,7 @@ HIP_TEST_CASE(Unit_hipMalloc_Positive_Alignment) {
   HIP_CHECK(hipFree(ptr2));
 }
 
-TEST_CASE("Unit_hipMalloc_Negative_Parameters") {
+HIP_TEST_CASE(Unit_hipMalloc_Negative_Parameters) {
   SECTION("ptr == nullptr") {
     HIP_CHECK_ERROR(hipMalloc(nullptr, 4096), hipErrorInvalidValue);
   }

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchBatchAsync.cc
@@ -78,7 +78,7 @@ static void VerifyDataOnDevice(int* data, hipStream_t stream) {
  *  - Allocates managed memory, writes data, prefetches to device, verifies data
  *  - Validates that prefetch actually occurred using hipMemRangeGetAttribute
  */
-TEST_CASE("Unit_hipMemPrefetchBatchAsync_SingleOperationSingleLocation") {
+HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_SingleOperationSingleLocation) {
   REQUIRE_MANAGED_ACCESS_DEVICE(device);
 
   LinearAllocGuard<int> managed_memory(LinearAllocs::hipMallocManaged, kTestBufferBytes);
@@ -223,7 +223,7 @@ HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_LocationDistribution) {
  *  - Prefetch Device->Host->Device and verify data integrity throughout
  *  - Tests round-trip data preservation and accessibility
  */
-TEST_CASE("Unit_hipMemPrefetchBatchAsync_RoundTripDataIntegrity") {
+HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_RoundTripDataIntegrity) {
   REQUIRE_MANAGED_ACCESS_DEVICE(device);
 
   LinearAllocGuard<int> managed_memory(LinearAllocs::hipMallocManaged, kTestBufferBytes);

--- a/projects/hip-tests/catch/unit/memory/hipMemPrefetchBatchAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemPrefetchBatchAsync.cc
@@ -286,7 +286,7 @@ HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_RoundTripDataIntegrity) {
  *  - Test NULL dptrs, sizes, prefetchLocs, prefetchLocIdxs arrays and freed memory pointers
  *  - Verify API returns appropriate error for invalid NULL parameters and invalid pointers
  */
-TEST_CASE("Unit_hipMemPrefetchBatchAsync_Negative_NullAndInvalidPointers") {
+HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_Negative_NullAndInvalidPointers) {
   REQUIRE_MANAGED_ACCESS_DEVICE(device);
 
   LinearAllocGuard<int> managed_memory(LinearAllocs::hipMallocManaged, kTestBufferBytes);
@@ -351,7 +351,7 @@ TEST_CASE("Unit_hipMemPrefetchBatchAsync_Negative_NullAndInvalidPointers") {
  *  - Test various invalid prefetchLocIdxs array constraints
  *  - Verify API validates: first element must be 0, strict ordering, bounds checking
  */
-TEST_CASE("Unit_hipMemPrefetchBatchAsync_Negative_IndexArrayConstraints") {
+HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_Negative_IndexArrayConstraints) {
   REQUIRE_MANAGED_ACCESS_DEVICE(device);
 
   constexpr size_t num_operations = 3;
@@ -429,7 +429,7 @@ TEST_CASE("Unit_hipMemPrefetchBatchAsync_Negative_IndexArrayConstraints") {
  *  - Test invalid parameters: count, sizes, flags, stream
  *  - Verify API validates all parameter constraints
  */
-TEST_CASE("Unit_hipMemPrefetchBatchAsync_Negative_ParameterValidation") {
+HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_Negative_ParameterValidation) {
   constexpr int device = 0;
   HIP_CHECK(hipSetDevice(device));
 
@@ -530,7 +530,7 @@ TEST_CASE("Unit_hipMemPrefetchBatchAsync_Negative_ParameterValidation") {
  *    - Non-managed memory requires hipDeviceAttributePageableMemoryAccess
  *    - Managed memory requires hipDeviceAttributeConcurrentManagedAccess
  */
-TEST_CASE("Unit_hipMemPrefetchBatchAsync_Negative_DeviceCapabilities") {
+HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_Negative_DeviceCapabilities) {
   int device = 0;
   HIP_CHECK(hipSetDevice(device));
 
@@ -569,7 +569,7 @@ TEST_CASE("Unit_hipMemPrefetchBatchAsync_Negative_DeviceCapabilities") {
  *  - Prefetch to different devices in same batch
  *  - Skip if single GPU system
  */
-TEST_CASE("Unit_hipMemPrefetchBatchAsync_MultiDevice") {
+HIP_TEST_CASE(Unit_hipMemPrefetchBatchAsync_MultiDevice) {
   int device_count = 0;
   HIP_CHECK(hipGetDeviceCount(&device_count));
 

--- a/projects/hip-tests/catch/unit/rtc/rtc_coop.cc
+++ b/projects/hip-tests/catch/unit/rtc/rtc_coop.cc
@@ -210,7 +210,7 @@ void runAndCompileTest(const std::tuple<Types...> types) {
   HIPRTC_CHECK(hiprtcDestroyProgram(&prog));
 }
 
-TEST_CASE("Unit_Rtc_CoopReduce")
+HIP_TEST_CASE(Unit_Rtc_CoopReduce)
 {
   const std::tuple<int, unsigned int, long long, unsigned long long, float, half, double> allTypes;
   const std::tuple<int, unsigned int, long long, unsigned long long> integralTypes;


### PR DESCRIPTION
## Motivation

Unit_hipMemPrefetchBatchAsync_SingleOperationSingleLocation and Unit_hipMemPrefetchBatchAsync_RoundTripDataIntegrity were declared with raw TEST_CASE("name"), which provides no tags argument and bypasses the generated hip_test_config.hh. As a result their YAML config (including the AIRUNTIME-2337 disabled: entry) was silently ignored and the tests kept running/failing in CI despite being marked disabled.

HIP_TEST_CASE(name) expands to TEST_CASE(#name, GET_TAGS(name)), pulling the generated tags (e.g. the hidden [.] tag for disabled tests) so catch_discover_tests correctly excludes them. Convert these two cases to the macro form.

## Technical Details

Change TEST_CASE to HIP_TEST_CASE macro

## JIRA ID

Not applicable

## Test Plan

CI should pass

## Test Result

CI passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
