### PR TITLE
[rocr] Gate AQLPROFILE extension query on library availability

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -321,7 +321,7 @@ hsa_status_t hsa_system_major_extension_supported(uint16_t extension, uint16_t v
 
   if ((extension == HSA_EXTENSION_AMD_AQLPROFILE) && (version_major == 1)) {
     *version_minor = 0;
-    *result = true;
+    *result = core::Runtime::runtime_singleton_->AqlProfileAvailable();
     return HSA_STATUS_SUCCESS;
   }
 


### PR DESCRIPTION
hsa_system_major_extension_supported() was returning true unconditionally for HSA_EXTENSION_AMD_AQLPROFILE, causing it to disagree with HSA_SYSTEM_INFO_EXTENSIONS and HSA_AGENT_INFO_EXTENSIONS, which both gate the AQLPROFILE bit on whether libhsa-amd-aqlprofile64.so was successfully loaded.

Gate the result on AqlProfileAvailable() to make all three query paths consistent.

Resolves: ROCM-24829