### PR TITLE
[AMD-SMI] Add worktree isolation to PR review prompt

### DIFF
--- a/projects/amdsmi/.github/prompts/amdsmi-review-pr.prompt.md
+++ b/projects/amdsmi/.github/prompts/amdsmi-review-pr.prompt.md
@@ -27,13 +27,43 @@ Use the PR number directly — `gh` resolves the repo from the local git remote:
 gh pr view <PR_NUMBER> --json number,title,author,body,files,additions,deletions,state,baseRefName,headRefName,comments,reviews
 ```
 
-### 2. Fetch the Diff
+Extract the `headRefName` (the PR branch name) — it is needed for the worktree step.
+
+### 2. Set Up Worktree
+
+Use the `amdsmi-using-git-worktrees` skill to check out the PR branch in an isolated worktree so the main checkout is not disturbed.
+
+```bash
+PR_NUM=<PR_NUMBER>
+BRANCH=<headRefName from step 1>
+
+MAIN_CHECKOUT=$(git rev-parse --show-toplevel)
+WORKTREE_PARENT=$(dirname "$MAIN_CHECKOUT")
+WORKTREE="${WORKTREE_PARENT}/rocm-systems-pr${PR_NUM}"
+
+# Reuse existing worktree if already present
+if [[ -d "$WORKTREE" ]]; then
+  cd "${WORKTREE}/projects/amdsmi"
+  git checkout "$BRANCH" 2>/dev/null && git pull origin "$BRANCH" --ff-only 2>/dev/null
+else
+  cd "$MAIN_CHECKOUT"
+  git fetch origin "${BRANCH}:${BRANCH}" 2>/dev/null || git fetch origin "pull/${PR_NUM}/head:${BRANCH}"
+  git worktree add "${WORKTREE}" "${BRANCH}"
+  cd "${WORKTREE}/projects/amdsmi"
+fi
+```
+
+If `git worktree add` fails (e.g. permissions), fall back to in-place work and note the fallback.
+
+All subsequent steps (diff, build, file reads by subagents) operate from within this worktree.
+
+### 3. Fetch the Diff
 
 ```bash
 gh pr diff <PR_NUMBER>
 ```
 
-### 3. Gather CI Evidence
+### 4. Gather CI Evidence
 
 Check for linked CI runs and fetch step-level data:
 
@@ -68,6 +98,7 @@ Invoke the **AMD-SMI Review Agent** with:
 - The review type(s) from `$ARGUMENTS` (or "comprehensive" if none)
 - CI evidence (test results, step timings, baseline comparison)
 - Unresolved comments
+- The worktree path so subagents read files from the correct checkout
 - If `inherit` was specified, tell the agent to have subagents inherit the orchestrator's model (ignore their frontmatter `model` field)
 
 The agent will dispatch to the appropriate subagent(s) and produce a formatted review.
@@ -79,6 +110,7 @@ By default, comprehensive reviews include a rebuttal round (Round 2) with the sk
 - Summarize the overall assessment
 - List any blocking issues found
 - If saving requested, use: `reviews/pr_{NUMBER}[_{TYPE}].md`
+- The worktree at `rocm-systems-pr<PR_NUMBER>` persists for post-review investigation; cleanup follows the `amdsmi-restructure-commits` skill
 
 ## Examples
 


### PR DESCRIPTION
## Description

Add a worktree setup step to `amdsmi-review-pr.prompt.md` so each PR review runs in an isolated `rocm-systems-pr<PR#>` worktree, following the `amdsmi-using-git-worktrees` skill convention.

### Changes
- Insert step 2 ("Set Up Worktree") that creates/reuses a sibling worktree for the PR branch
- Renumber subsequent steps (Fetch Diff becomes step 3, CI Evidence becomes step 4, etc.)
- Pass worktree path to subagents so file reads target the correct checkout
- Note worktree persistence for post-review investigation
- Graceful fallback to in-place work if worktree creation fails

## JIRA ID

N/A (internal tooling improvement)