### PR TITLE
fix(amdsmi): Fix status string for TIMEOUT & MORE_DATA

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -218,6 +218,7 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 - **Fixed `amdsmi_status_code_to_string()` returning `AMDSMI_STATUS_UNKNOWN_ERROR` for valid status codes**.  
   - Added the missing `case` entries for `AMDSMI_STATUS_TIMEOUT` and `AMDSMI_STATUS_MORE_DATA`, which previously fell through to the unknown-error description.
+  - Calling with a null `status_string` now returns `AMDSMI_STATUS_INVAL` instead of dereferencing the null pointer.
 
 - **Fixed a crash in `amdsmi_get_gpu_vram_vendor()` and made `amdsmi_get_gpu_vram_info()` resilient to DRM failures**.  
   - `amdsmi_get_gpu_vram_vendor()` now validates the output buffer and only writes it on success, fixing a null-pointer dereference on the not-supported path.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -216,6 +216,8 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Corrected invalid AMD SMI status-code names in exception messages and documentation**.  
   - Some `AmdSmiLibraryException` messages and API documentation entries were misspelled; they now use the correct `AMDSMI_STATUS_*` names.
 
+- **Fixed `amdsmi_status_code_to_string()` returning `AMDSMI_STATUS_UNKNOWN_ERROR` for valid status codes**.  
+
 - **Fixed a crash in `amdsmi_get_gpu_vram_vendor()` and made `amdsmi_get_gpu_vram_info()` resilient to DRM failures**.  
   - `amdsmi_get_gpu_vram_vendor()` now validates the output buffer and only writes it on success, fixing a null-pointer dereference on the not-supported path.
   - `amdsmi_get_gpu_vram_info()` now reads the VRAM vendor from sysfs first and treats the DRM ioctl (VRAM type/bit width/bandwidth) as best effort, so the vendor is still returned when the DRM path is unavailable.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -217,6 +217,7 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - Some `AmdSmiLibraryException` messages and API documentation entries were misspelled; they now use the correct `AMDSMI_STATUS_*` names.
 
 - **Fixed `amdsmi_status_code_to_string()` returning `AMDSMI_STATUS_UNKNOWN_ERROR` for valid status codes**.  
+  - Added the missing `case` entries for `AMDSMI_STATUS_TIMEOUT` and `AMDSMI_STATUS_MORE_DATA`, which previously fell through to the unknown-error description.
 
 - **Fixed a crash in `amdsmi_get_gpu_vram_vendor()` and made `amdsmi_get_gpu_vram_info()` resilient to DRM failures**.  
   - `amdsmi_get_gpu_vram_vendor()` now validates the output buffer and only writes it on success, fixing a null-pointer dereference on the not-supported path.

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6222,11 +6222,12 @@ amdsmi_status_t amdsmi_get_gpu_ecc_status(amdsmi_processor_handle processor_hand
  *
  *  @param[in] status The error status for which a description is desired
  *
- *  @param[in,out] status_string A pointer to a const char * which will be made
- *  to point to a description of the provided error code. Must not be null.
+ *  @param[out] status_string A pointer to a const char * which will be made
+ *  to point to a description of the provided error code.
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success,
- *  ::AMDSMI_STATUS_INVAL if @p status_string is null, non-zero on other failures
+ *  ::AMDSMI_STATUS_INVAL if @p status_string is null,
+ *  ::AMDSMI_STATUS_UNKNOWN_ERROR if @p status is not a recognized status code
  */
 amdsmi_status_t amdsmi_status_code_to_string(amdsmi_status_t status, const char** status_string);
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -6223,9 +6223,10 @@ amdsmi_status_t amdsmi_get_gpu_ecc_status(amdsmi_processor_handle processor_hand
  *  @param[in] status The error status for which a description is desired
  *
  *  @param[in,out] status_string A pointer to a const char * which will be made
- *  to point to a description of the provided error code
+ *  to point to a description of the provided error code. Must not be null.
  *
- *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
+ *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success,
+ *  ::AMDSMI_STATUS_INVAL if @p status_string is null, non-zero on other failures
  */
 amdsmi_status_t amdsmi_status_code_to_string(amdsmi_status_t status, const char** status_string);
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -389,7 +389,7 @@ typedef enum {
   AMDSMI_STATUS_NO_SLOT = 33,            //!< No more free slot
   AMDSMI_STATUS_DRIVER_NOT_LOADED = 34,  //!< Processor driver not loaded
   // Data and size errors
-  AMDSMI_STATUS_MORE_DATA = 39,  //!< There is more data than the buffer size the user passed
+  AMDSMI_STATUS_MORE_DATA = 39,  //!< More data is available than fits in the caller-supplied buffer
   AMDSMI_STATUS_NO_DATA = 40,    //!< No data was found for a given input
   AMDSMI_STATUS_INSUFFICIENT_SIZE = 41,  //!< Not enough resources were available for the operation
   AMDSMI_STATUS_UNEXPECTED_SIZE = 42,    //!< An unexpected amount of data was read

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_common.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_common.h
@@ -41,8 +41,11 @@ extern "C" {
 }
 namespace amd::smi {
 
-// Define a map of rsmi status codes to amdsmi status codes
-const std::map<rsmi_status_t, amdsmi_status_t> rsmi_status_map = {
+// Define a map of rsmi status codes to amdsmi status codes. Declared inline
+// (C++17) so it has external linkage and is a single entity across translation
+// units, which is required for the inline rsmi_to_amdsmi_status() below to
+// legally reference it.
+inline const std::map<rsmi_status_t, amdsmi_status_t> rsmi_status_map = {
     {RSMI_STATUS_SUCCESS, AMDSMI_STATUS_SUCCESS},
     {RSMI_STATUS_INVALID_ARGS, AMDSMI_STATUS_INVAL},
     {RSMI_STATUS_NOT_SUPPORTED, AMDSMI_STATUS_NOT_SUPPORTED},
@@ -78,7 +81,19 @@ const std::map<unsigned, amdsmi_vram_type_t> vram_type_map = {
     {12, AMDSMI_VRAM_TYPE_LPDDR5}, {13, AMDSMI_VRAM_TYPE_HBM3E},
 };
 
-amdsmi_status_t rsmi_to_amdsmi_status(rsmi_status_t status);
+inline amdsmi_status_t rsmi_to_amdsmi_status(rsmi_status_t status) {
+  amdsmi_status_t amdsmi_status = AMDSMI_STATUS_MAP_ERROR;
+
+  // Look for it in the map
+  // If found: use the mapped value
+  // If not found: return the map error established above
+  auto search = rsmi_status_map.find(status);
+  if (search != rsmi_status_map.end()) {
+    amdsmi_status = search->second;
+  }
+
+  return amdsmi_status;
+}
 
 amdsmi_vram_type_t vram_type_value(unsigned type);
 

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_common.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_common.h
@@ -41,10 +41,7 @@ extern "C" {
 }
 namespace amd::smi {
 
-// Define a map of rsmi status codes to amdsmi status codes. Declared inline
-// (C++17) so it has external linkage and is a single entity across translation
-// units, which is required for the inline rsmi_to_amdsmi_status() below to
-// legally reference it.
+// Define a map of rsmi status codes to amdsmi status codes
 inline const std::map<rsmi_status_t, amdsmi_status_t> rsmi_status_map = {
     {RSMI_STATUS_SUCCESS, AMDSMI_STATUS_SUCCESS},
     {RSMI_STATUS_INVALID_ARGS, AMDSMI_STATUS_INVAL},

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_common.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_common.h
@@ -79,11 +79,9 @@ const std::map<unsigned, amdsmi_vram_type_t> vram_type_map = {
 };
 
 inline amdsmi_status_t rsmi_to_amdsmi_status(rsmi_status_t status) {
+  // Unmapped rsmi codes fall back to AMDSMI_STATUS_MAP_ERROR.
   amdsmi_status_t amdsmi_status = AMDSMI_STATUS_MAP_ERROR;
 
-  // Look for it in the map
-  // If found: use the mapped value
-  // If not found: return the map error established above
   auto search = rsmi_status_map.find(status);
   if (search != rsmi_status_map.end()) {
     amdsmi_status = search->second;

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_common.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_common.h
@@ -79,7 +79,6 @@ const std::map<unsigned, amdsmi_vram_type_t> vram_type_map = {
 };
 
 inline amdsmi_status_t rsmi_to_amdsmi_status(rsmi_status_t status) {
-  // Unmapped rsmi codes fall back to AMDSMI_STATUS_MAP_ERROR.
   amdsmi_status_t amdsmi_status = AMDSMI_STATUS_MAP_ERROR;
 
   auto search = rsmi_status_map.find(status);

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_common.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_common.h
@@ -70,7 +70,7 @@ inline const std::map<rsmi_status_t, amdsmi_status_t> rsmi_status_map = {
     {RSMI_STATUS_UNKNOWN_ERROR, AMDSMI_STATUS_UNKNOWN_ERROR},
 };
 
-const std::map<unsigned, amdsmi_vram_type_t> vram_type_map = {
+inline const std::map<unsigned, amdsmi_vram_type_t> vram_type_map = {
     {0, AMDSMI_VRAM_TYPE_UNKNOWN}, {1, AMDSMI_VRAM_TYPE_GDDR1},  {2, AMDSMI_VRAM_TYPE_DDR2},
     {3, AMDSMI_VRAM_TYPE_GDDR3},   {4, AMDSMI_VRAM_TYPE_GDDR4},  {5, AMDSMI_VRAM_TYPE_GDDR5},
     {6, AMDSMI_VRAM_TYPE_HBM},     {7, AMDSMI_VRAM_TYPE_DDR3},   {8, AMDSMI_VRAM_TYPE_DDR4},
@@ -93,7 +93,7 @@ amdsmi_vram_type_t vram_type_value(unsigned type);
 
 #ifdef ENABLE_ESMI_LIB
 // Define a map of esmi status codes to amdsmi status codes
-const std::map<esmi_status_t, amdsmi_status_t> esmi_status_map = {
+inline const std::map<esmi_status_t, amdsmi_status_t> esmi_status_map = {
     {ESMI_SUCCESS, AMDSMI_STATUS_SUCCESS},
     {ESMI_INITIALIZED, AMDSMI_STATUS_SUCCESS},
     {ESMI_INVALID_INPUT, AMDSMI_STATUS_INVAL},
@@ -122,7 +122,7 @@ amdsmi_status_t esmi_to_amdsmi_status(esmi_status_t status);
 #endif
 
 // Define a map of smi nic status codes to amdsmi status codes
-const std::map<smi_nic_status_t, amdsmi_status_t> ainic_status_map = {
+inline const std::map<smi_nic_status_t, amdsmi_status_t> ainic_status_map = {
     {SMI_NIC_STATUS_SUCCESS, AMDSMI_STATUS_SUCCESS},
     {SMI_NIC_STATUS_ERROR, AMDSMI_STATUS_API_FAILED},
     {SMI_NIC_STATUS_WRONG_PARAM, AMDSMI_STATUS_INVAL},

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -340,6 +340,9 @@ amdsmi_status_t amdsmi_status_code_to_string(amdsmi_status_t status, const char*
     case AMDSMI_STATUS_API_FAILED:
       *status_string = "AMDSMI_STATUS_API_FAILED: API call failed.";
       break;
+    case AMDSMI_STATUS_TIMEOUT:
+      *status_string = "AMDSMI_STATUS_TIMEOUT: Timeout in API call.";
+      break;
     case AMDSMI_STATUS_RETRY:
       *status_string = "AMDSMI_STATUS_RETRY: Retry operation.";
       break;
@@ -403,6 +406,11 @@ amdsmi_status_t amdsmi_status_code_to_string(amdsmi_status_t status, const char*
       break;
     case AMDSMI_STATUS_DRIVER_NOT_LOADED:
       *status_string = "AMDSMI_STATUS_DRIVER_NOT_LOADED: Processor driver not loaded.";
+      break;
+    case AMDSMI_STATUS_MORE_DATA:
+      *status_string =
+          "AMDSMI_STATUS_MORE_DATA: There is more data than the buffer"
+          " size the user passed.";
       break;
     case AMDSMI_STATUS_NO_DATA:
       *status_string = "AMDSMI_STATUS_NO_DATA: No data was found for a given input.";

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -413,8 +413,8 @@ amdsmi_status_t amdsmi_status_code_to_string(amdsmi_status_t status, const char*
       break;
     case AMDSMI_STATUS_MORE_DATA:
       *status_string =
-          "AMDSMI_STATUS_MORE_DATA: There is more data than the buffer"
-          " size the user passed.";
+          "AMDSMI_STATUS_MORE_DATA: More data is available than fits in the"
+          " caller-supplied buffer.";
       break;
     case AMDSMI_STATUS_NO_DATA:
       *status_string = "AMDSMI_STATUS_NO_DATA: No data was found for a given input.";

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -315,6 +315,10 @@ amdsmi_status_t amdsmi_shut_down() {
 }
 
 amdsmi_status_t amdsmi_status_code_to_string(amdsmi_status_t status, const char** status_string) {
+  if (status_string == nullptr) {
+    return AMDSMI_STATUS_INVAL;
+  }
+
   switch (status) {
     case AMDSMI_STATUS_SUCCESS:
       *status_string = "AMDSMI_STATUS_SUCCESS: Call succeeded.";

--- a/projects/amdsmi/src/amd_smi/amd_smi_common.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_common.cc
@@ -45,20 +45,6 @@ bool amdsmi_library_init_ref_release() {
   return (g_amdsmi_init_ref_count == 0);
 }
 
-amdsmi_status_t rsmi_to_amdsmi_status(rsmi_status_t status) {
-  amdsmi_status_t amdsmi_status = AMDSMI_STATUS_MAP_ERROR;
-
-  // Look for it in the map
-  // If found: use the mapped value
-  // If not found: return the map error established above
-  auto search = amd::smi::rsmi_status_map.find(status);
-  if (search != amd::smi::rsmi_status_map.end()) {
-    amdsmi_status = search->second;
-  }
-
-  return amdsmi_status;
-}
-
 amdsmi_vram_type_t vram_type_value(unsigned type) {
   amdsmi_vram_type_t value = AMDSMI_VRAM_TYPE_UNKNOWN;
 

--- a/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
@@ -37,14 +37,10 @@
 namespace {
 
 // ---------------------------------------------------------------------------
-// Compile-time enum reflection (stopgap until C++26 static reflection / P2996).
-// C++17 cannot enumerate enum members, so this uses the magic_enum trick:
-// instantiate a template on a value and parse its name from __PRETTY_FUNCTION__.
-// Real enumerators render as names, whereas unused values render as numbers or casts.
-//
-// Normal status codes are discovered by scanning a low numeric range. The two
-// high-value codes, AMDSMI_STATUS_MAP_ERROR and AMDSMI_STATUS_UNKNOWN_ERROR, are
-// appended explicitly because their values are near UINT_MAX.
+// Compile-time enum reflection: stopgap until C++26 static reflection (P2996).
+// C++17 cannot enumerate enum members, so this parses enumerator names out of
+// __PRETTY_FUNCTION__. AMDSMI_STATUS_MAP_ERROR and AMDSMI_STATUS_UNKNOWN_ERROR
+// sit near UINT_MAX, outside the scan range, so they are appended explicitly.
 // ---------------------------------------------------------------------------
 
 // Reflection needs enumerator names in __PRETTY_FUNCTION__. Clang does this at any version,
@@ -63,7 +59,7 @@ namespace enum_reflect {
 constexpr bool kAvailable = AMDSMI_ENUM_REFLECTION_AVAILABLE;
 
 // Compiler name and version, included in failure/skip diagnostics.
-inline const char* CompilerId() {
+inline const char* compiler_id() {
 #if defined(__clang__)
   return "clang " __clang_version__;
 #elif defined(__GNUC__)
@@ -76,7 +72,7 @@ inline const char* CompilerId() {
 #if AMDSMI_ENUM_REFLECTION_AVAILABLE
 
 template <amdsmi_status_t V>
-constexpr const char* Signature() {
+constexpr const char* signature() {
   // Return type is a plain `const char*` so the signature has no stray "= "
   // from typedef expansion to confuse the parse below.
   return __PRETTY_FUNCTION__;
@@ -84,8 +80,8 @@ constexpr const char* Signature() {
 
 // Enumerator name for V, e.g. "AMDSMI_STATUS_TIMEOUT".
 template <amdsmi_status_t V>
-constexpr std::string_view EnumName() {
-  std::string_view s = Signature<V>();
+constexpr std::string_view enum_name() {
+  std::string_view s = signature<V>();
   const auto start = s.find("V = ") + 4;  // anchor on the value parameter
   const auto end = s.find_first_of(";]", start);
   return s.substr(start, end - start);
@@ -94,19 +90,19 @@ constexpr std::string_view EnumName() {
 // Real enumerators start like C identifiers. Unused values start with '(' on
 // GCC or a digit on Clang, so this rejects both renderings.
 template <amdsmi_status_t V>
-constexpr bool IsEnumerator() {
-  const auto name = EnumName<V>();
+constexpr bool is_enumerator() {
+  const auto name = enum_name<V>();
   if (name.empty()) return false;
   const char c = name.front();
   return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_';
 }
 
 template <uint32_t... Is>
-void Collect(std::vector<std::pair<amdsmi_status_t, std::string>>& out,
+void collect(std::vector<std::pair<amdsmi_status_t, std::string>>& out,
              std::integer_sequence<uint32_t, Is...>) {
-  ((IsEnumerator<static_cast<amdsmi_status_t>(Is)>()
+  ((is_enumerator<static_cast<amdsmi_status_t>(Is)>()
         ? out.push_back({static_cast<amdsmi_status_t>(Is),
-                         std::string(EnumName<static_cast<amdsmi_status_t>(Is)>())})
+                         std::string(enum_name<static_cast<amdsmi_status_t>(Is)>())})
         : void()),
    ...);
 }
@@ -116,30 +112,30 @@ void Collect(std::vector<std::pair<amdsmi_status_t, std::string>>& out,
 constexpr uint32_t kScanLimit = 256;
 
 // {value, "AMDSMI_STATUS_..."} for every amdsmi_status_t enumerator.
-std::vector<std::pair<amdsmi_status_t, std::string>> AllStatusCodes() {
+std::vector<std::pair<amdsmi_status_t, std::string>> all_status_codes() {
   std::vector<std::pair<amdsmi_status_t, std::string>> out;
-  Collect(out, std::make_integer_sequence<uint32_t, kScanLimit>{});
+  collect(out, std::make_integer_sequence<uint32_t, kScanLimit>{});
   // Append the two high-value codes the scan cannot reach.
-  out.push_back({AMDSMI_STATUS_MAP_ERROR, std::string(EnumName<AMDSMI_STATUS_MAP_ERROR>())});
+  out.push_back({AMDSMI_STATUS_MAP_ERROR, std::string(enum_name<AMDSMI_STATUS_MAP_ERROR>())});
   out.push_back(
-      {AMDSMI_STATUS_UNKNOWN_ERROR, std::string(EnumName<AMDSMI_STATUS_UNKNOWN_ERROR>())});
+      {AMDSMI_STATUS_UNKNOWN_ERROR, std::string(enum_name<AMDSMI_STATUS_UNKNOWN_ERROR>())});
   return out;
 }
 
 // Include a raw signature in failures so compiler-format changes are visible.
-inline const char* SampleSignature() { return Signature<AMDSMI_STATUS_TIMEOUT>(); }
+inline const char* sample_signature() { return signature<AMDSMI_STATUS_TIMEOUT>(); }
 
 #else  // !AMDSMI_ENUM_REFLECTION_AVAILABLE
 
 // Unsupported compiler: no codes discovered; the positive test skips itself.
-std::vector<std::pair<amdsmi_status_t, std::string>> AllStatusCodes() { return {}; }
-inline const char* SampleSignature() { return "<enum reflection unavailable>"; }
+std::vector<std::pair<amdsmi_status_t, std::string>> all_status_codes() { return {}; }
+inline const char* sample_signature() { return "<enum reflection unavailable>"; }
 
 #endif  // AMDSMI_ENUM_REFLECTION_AVAILABLE
 
 }  // namespace enum_reflect
 
-bool StartsWith(const std::string& s, const std::string& prefix) {
+bool starts_with(const std::string& s, const std::string& prefix) {
   return s.size() >= prefix.size() && s.compare(0, prefix.size(), prefix) == 0;
 }
 
@@ -150,13 +146,13 @@ bool StartsWith(const std::string& s, const std::string& prefix) {
 // runs in CI without a GPU.
 TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
   if (!enum_reflect::kAvailable) {
-    GTEST_SKIP() << "enum reflection unavailable on this compiler (" << enum_reflect::CompilerId()
+    GTEST_SKIP() << "enum reflection unavailable on this compiler (" << enum_reflect::compiler_id()
                  << "). This test needs Clang or GCC >= 9 "
                  << "(older GCC renders enum template args as numeric casts). "
                  << "The matching Python test covers this case elsewhere.";
   }
 
-  const auto all_status_codes = enum_reflect::AllStatusCodes();
+  const auto all_status_codes = enum_reflect::all_status_codes();
 
   // Guard against an empty or incomplete reflection result: if these known
   // codes aren't discovered, the __PRETTY_FUNCTION__ parser or kScanLimit broke.
@@ -165,8 +161,8 @@ TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
   ASSERT_GE(all_status_codes.size(), 40u)
       << "enum reflection discovered only " << all_status_codes.size()
       << " status codes; the __PRETTY_FUNCTION__ parser or kScanLimit is broken. "
-      << "Compiler: " << enum_reflect::CompilerId() << "; sample signature: \""
-      << enum_reflect::SampleSignature() << "\".";
+      << "Compiler: " << enum_reflect::compiler_id() << "; sample signature: \""
+      << enum_reflect::sample_signature() << "\".";
 
   auto contains = [&](amdsmi_status_t code) {
     for (const auto& [value, name] : all_status_codes) {
@@ -179,8 +175,8 @@ TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
     ASSERT_TRUE(contains(code))
         << "enum reflection did not discover known status code " << code
         << "; the __PRETTY_FUNCTION__ parser in enum_reflect likely broke due to "
-        << "a compiler change (or kScanLimit is too low). Compiler: " << enum_reflect::CompilerId()
-        << "; sample signature: \"" << enum_reflect::SampleSignature()
+        << "a compiler change (or kScanLimit is too low). Compiler: " << enum_reflect::compiler_id()
+        << "; sample signature: \"" << enum_reflect::sample_signature()
         << "\". This is a test-harness "
         << "problem, not an amdsmi library bug.";
   }
@@ -195,7 +191,7 @@ TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
     ASSERT_NE(status_string, nullptr) << name;
 
     const std::string description(status_string);
-    EXPECT_TRUE(StartsWith(description, name))
+    EXPECT_TRUE(starts_with(description, name))
         << name << " (" << code << ") resolved to \"" << description
         << "\". Expected the description to start with its own enum name. A "
         << "missing case falls through to the UNKNOWN_ERROR default.";
@@ -224,7 +220,7 @@ TEST(AmdSmiStatusStringTest, KnownStatusCodesResolveToTheirOwnName) {
         << "amdsmi_status_code_to_string(). Must return AMDSMI_STATUS_SUCCESS "
         << "for a valid status code.";
     ASSERT_NE(status_string, nullptr) << name;
-    EXPECT_TRUE(StartsWith(status_string, name))
+    EXPECT_TRUE(starts_with(status_string, name))
         << name << " (" << code << ") resolved to \"" << status_string
         << "\". Expected the description to start with its own enum name.";
   }
@@ -243,7 +239,8 @@ TEST(AmdSmiStatusStringTest, UnmappedLowerLevelStatusYieldsMapError) {
   // Sanity: known mappings must NOT produce MAP_ERROR.
   EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(RSMI_STATUS_SUCCESS), AMDSMI_STATUS_SUCCESS);
   EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(RSMI_STATUS_INVALID_ARGS), AMDSMI_STATUS_INVAL);
-  EXPECT_NE(amd::smi::rsmi_to_amdsmi_status(RSMI_STATUS_NOT_SUPPORTED), AMDSMI_STATUS_MAP_ERROR);
+  EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(RSMI_STATUS_NOT_SUPPORTED),
+            AMDSMI_STATUS_NOT_SUPPORTED);
 }
 
 // A value that is not a defined status code (an enum gap) must hit the default
@@ -256,6 +253,10 @@ TEST(AmdSmiStatusStringTest, UndefinedStatusCodeYieldsUnknownError) {
   EXPECT_EQ(amdsmi_status_code_to_string(undefined_code, &status_string),
             AMDSMI_STATUS_UNKNOWN_ERROR);
   ASSERT_NE(status_string, nullptr);
+  // The default branch must actually write a description, not leave the pointer
+  // stale or empty.
+  EXPECT_STRNE(status_string, "")
+      << "an undefined status code returned UNKNOWN_ERROR but left an empty description.";
 }
 
 // A null output pointer must be rejected, not dereferenced.

--- a/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
@@ -200,18 +200,13 @@ TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
 
   const auto all_status_codes = enum_reflect::AllStatusCodes();
 
-  // Guard against a vacuous pass: reflection must have discovered the full set,
-  // including the codes whose missing cases prompted this test and the
-  // out-of-range sentinels. A failure here almost certainly means the compiler
-  // changed its __PRETTY_FUNCTION__ rendering and enum_reflect::EnumName() needs
-  // updating -- the amdsmi library itself is probably fine.
-  ASSERT_GE(all_status_codes.size(), 40u)
-      << "enum reflection found too few codes (" << all_status_codes.size()
-      << "); the __PRETTY_FUNCTION__ parser in enum_reflect likely broke due to a "
-      << "compiler change (or kScanLimit is too low). Compiler: " << enum_reflect::CompilerId()
-      << "; sample signature: \"" << enum_reflect::SampleSignature()
-      << "\". This is a test-harness problem, "
-      << "not an amdsmi library bug.";
+  // Guard against a vacuous pass without pinning a magic count (which would need
+  // bumping every time a status code is added). Reflection must have discovered
+  // the specific normal codes whose missing cases prompted this test, plus the
+  // two out-of-range sentinels. TIMEOUT (8) and MORE_DATA (39) are ordinary
+  // scanned codes: if the __PRETTY_FUNCTION__ parser broke (e.g. a compiler
+  // change) the scan finds no enumerators and they drop out, failing the check
+  // below -- a test-harness problem, not an amdsmi library bug.
   auto contains = [&](amdsmi_status_t code) {
     for (const auto& [value, name] : all_status_codes) {
       if (value == code) return true;
@@ -221,10 +216,12 @@ TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
   for (amdsmi_status_t code : {AMDSMI_STATUS_TIMEOUT, AMDSMI_STATUS_MORE_DATA,
                                AMDSMI_STATUS_MAP_ERROR, AMDSMI_STATUS_UNKNOWN_ERROR}) {
     ASSERT_TRUE(contains(code))
-        << "enum reflection did not discover a known status code (" << code
-        << "); the __PRETTY_FUNCTION__ parser in enum_reflect likely broke due "
-        << "to a compiler change. This is a test-harness problem, not an amdsmi "
-        << "library bug.";
+        << "enum reflection did not discover known status code " << code
+        << "; the __PRETTY_FUNCTION__ parser in enum_reflect likely broke due to "
+        << "a compiler change (or kScanLimit is too low). Compiler: " << enum_reflect::CompilerId()
+        << "; sample signature: \"" << enum_reflect::SampleSignature()
+        << "\". This is a test-harness "
+        << "problem, not an amdsmi library bug.";
   }
 
   for (const auto& [code, name] : all_status_codes) {

--- a/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
@@ -192,8 +192,8 @@ bool StartsWith(const std::string& s, const std::string& prefix) {
 // "unknown error" string, which fails both assertions below.
 TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
   if (!enum_reflect::kAvailable) {
-    GTEST_SKIP() << "enum reflection unavailable on this compiler ("
-                 << enum_reflect::CompilerId() << "); it needs Clang or GCC >= 9 "
+    GTEST_SKIP() << "enum reflection unavailable on this compiler (" << enum_reflect::CompilerId()
+                 << "); it needs Clang or GCC >= 9 "
                  << "(older GCC renders enum template args as numeric casts). "
                  << "The matching Python test covers this case elsewhere.";
   }
@@ -208,9 +208,9 @@ TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
   ASSERT_GE(all_status_codes.size(), 40u)
       << "enum reflection found too few codes (" << all_status_codes.size()
       << "); the __PRETTY_FUNCTION__ parser in enum_reflect likely broke due to a "
-      << "compiler change (or kScanLimit is too low). Compiler: "
-      << enum_reflect::CompilerId() << "; sample signature: \""
-      << enum_reflect::SampleSignature() << "\". This is a test-harness problem, "
+      << "compiler change (or kScanLimit is too low). Compiler: " << enum_reflect::CompilerId()
+      << "; sample signature: \"" << enum_reflect::SampleSignature()
+      << "\". This is a test-harness problem, "
       << "not an amdsmi library bug.";
   auto contains = [&](amdsmi_status_t code) {
     for (const auto& [value, name] : all_status_codes) {

--- a/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+// Driver-free unit test for amdsmi status-code handling. It needs no GPU and
+// performs no amdsmi_init(), so it can move into a dedicated unit-test target
+// during the test refactor.
+//
+// Two complementary checks:
+//   1. Positive (mirror of the Python test_status_code_to_string): every
+//      amdsmi_status_t enumerator must resolve, via amdsmi_status_code_to_string(),
+//      to a description that begins with its own enum name. A missing `case`
+//      makes the code fall through to the UNKNOWN_ERROR default, which this
+//      catches.
+//   2. Negative: simulate a lower-level (rocm_smi) status that the amdsmi layer
+//      has no mapping for and confirm rsmi_to_amdsmi_status() surfaces
+//      AMDSMI_STATUS_MAP_ERROR rather than silently mistranslating it. This is
+//      the case the Python test cannot reach, because it can only feed codes
+//      that already exist in the amdsmi layer.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "amd_smi/amdsmi.h"
+#include "rocm_smi/rocm_smi.h"
+
+// rsmi_to_amdsmi_status() is compiled into libamd_smi and declared in
+// amd_smi/impl/amd_smi_common.h. Forward-declare it here to avoid pulling in the
+// heavy esmi/nic includes that header transitively requires.
+namespace amd::smi {
+amdsmi_status_t rsmi_to_amdsmi_status(rsmi_status_t status);
+}  // namespace amd::smi
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Compile-time enum reflection (stopgap until C++26 static reflection / P2996).
+//
+// C++17 erases enums to plain integers: there is no built-in way to list an
+// enum's members or recover their names, which is why the matching Python test
+// can loop `for status in amdsmi.AmdSmiStatus` but C++ cannot. We recover the
+// names the same way the magic_enum library does: instantiate a template on the
+// value and read the enumerator name the compiler bakes into __PRETTY_FUNCTION__
+// (or __FUNCSIG__ on MSVC). For a real enumerator GCC/Clang render
+// `... V = AMDSMI_STATUS_TIMEOUT]`; for an unused slot GCC renders a cast,
+// `... V = (amdsmi_status_t)28]`, and Clang renders a bare integer,
+// `... V = 28]`. A real enumerator name is therefore the one that starts like a
+// C identifier, which lets us auto-discover every member in a bounded range.
+//
+// amdsmi_status_t is sparse and ends in two ~4-billion sentinels
+// (AMDSMI_STATUS_MAP_ERROR = 0xFFFFFFFE, AMDSMI_STATUS_UNKNOWN_ERROR =
+// 0xFFFFFFFF). A value scan cannot practically reach those, so the normal codes
+// are discovered by scanning the low range and the two stable sentinels are
+// seeded explicitly (their names still come from reflection, not hand-typing).
+// Adding a normal status code in range needs no change here.
+// ---------------------------------------------------------------------------
+
+// The reflection trick relies on __PRETTY_FUNCTION__ AND on the compiler
+// rendering enumerator *names* (not numeric casts) for enum template arguments.
+// Clang does this at any version; GCC only started doing so in GCC 9. On GCC 8
+// and earlier every value renders as "(amdsmi_status_t)N", so reflection finds
+// no enumerators. On GCC < 9 or any other compiler the helper is unavailable and
+// the positive test GTEST_SKIPs rather than failing the build; the driverless
+// negative test below needs no reflection and always runs.
+#if defined(__clang__)
+#define AMDSMI_ENUM_REFLECTION_AVAILABLE 1
+#elif defined(__GNUC__) && (__GNUC__ >= 9)
+#define AMDSMI_ENUM_REFLECTION_AVAILABLE 1
+#else
+#define AMDSMI_ENUM_REFLECTION_AVAILABLE 0
+#endif
+
+namespace enum_reflect {
+
+constexpr bool kAvailable = AMDSMI_ENUM_REFLECTION_AVAILABLE;
+
+// Human-readable compiler identification for diagnostics, so a failure or skip
+// on an unexpected toolchain names the compiler and version in its output.
+inline const char* CompilerId() {
+#if defined(__clang__)
+  return "clang " __clang_version__;
+#elif defined(__GNUC__)
+  return "gcc " __VERSION__;
+#else
+  return "unknown compiler";
+#endif
+}
+
+#if AMDSMI_ENUM_REFLECTION_AVAILABLE
+
+template <amdsmi_status_t V>
+constexpr const char* Signature() {
+  // Return type is `const char*` (not a library typedef) so the signature
+  // carries no extra "= " clause from typedef expansion to confuse parsing.
+  return __PRETTY_FUNCTION__;
+}
+
+// Enumerator name for V, e.g. "AMDSMI_STATUS_TIMEOUT". For an integer with no
+// corresponding enumerator the compilers differ: GCC renders a cast,
+// "(amdsmi_status_t)28", while Clang renders a bare integer, "28".
+template <amdsmi_status_t V>
+constexpr std::string_view EnumName() {
+  std::string_view s = Signature<V>();
+  const auto start = s.find("V = ") + 4;  // anchor on the value parameter
+  const auto end = s.find_first_of(";]", start);
+  return s.substr(start, end - start);
+}
+
+// True when V names a real enumerator rather than an unused slot. A real
+// enumerator name is a C identifier (starts with a letter or '_'); an unused
+// slot starts with '(' on GCC ("(amdsmi_status_t)28") or a digit on Clang
+// ("28"). Requiring an identifier-start character rejects both, so this works
+// on either compiler.
+template <amdsmi_status_t V>
+constexpr bool IsEnumerator() {
+  const auto name = EnumName<V>();
+  if (name.empty()) return false;
+  const char c = name.front();
+  return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_';
+}
+
+template <uint32_t... Is>
+void Collect(std::vector<std::pair<amdsmi_status_t, std::string>>& out,
+             std::integer_sequence<uint32_t, Is...>) {
+  ((IsEnumerator<static_cast<amdsmi_status_t>(Is)>()
+        ? out.push_back({static_cast<amdsmi_status_t>(Is),
+                         std::string(EnumName<static_cast<amdsmi_status_t>(Is)>())})
+        : void()),
+   ...);
+}
+
+// The highest normal enumerator is well under 100; scan past it for headroom.
+constexpr uint32_t kScanLimit = 128;
+
+// {value, "AMDSMI_STATUS_..."} for every amdsmi_status_t enumerator.
+std::vector<std::pair<amdsmi_status_t, std::string>> AllStatusCodes() {
+  std::vector<std::pair<amdsmi_status_t, std::string>> out;
+  Collect(out, std::make_integer_sequence<uint32_t, kScanLimit>{});
+  // Sentinels live at 0xFFFFFFFE/0xFFFFFFFF, far outside any practical scan.
+  out.push_back({AMDSMI_STATUS_MAP_ERROR, std::string(EnumName<AMDSMI_STATUS_MAP_ERROR>())});
+  out.push_back(
+      {AMDSMI_STATUS_UNKNOWN_ERROR, std::string(EnumName<AMDSMI_STATUS_UNKNOWN_ERROR>())});
+  return out;
+}
+
+// A sample raw __PRETTY_FUNCTION__ rendering, surfaced in failure diagnostics so
+// a compiler change to the signature format is immediately visible in the log.
+inline const char* SampleSignature() { return Signature<AMDSMI_STATUS_TIMEOUT>(); }
+
+#else  // !AMDSMI_ENUM_REFLECTION_AVAILABLE
+
+// Unsupported compiler: no codes discovered; the positive test skips itself.
+std::vector<std::pair<amdsmi_status_t, std::string>> AllStatusCodes() { return {}; }
+inline const char* SampleSignature() { return "<enum reflection unavailable>"; }
+
+#endif  // AMDSMI_ENUM_REFLECTION_AVAILABLE
+
+}  // namespace enum_reflect
+
+bool StartsWith(const std::string& s, const std::string& prefix) {
+  return s.size() >= prefix.size() && s.compare(0, prefix.size(), prefix) == 0;
+}
+
+}  // namespace
+
+// Positive: every status code resolves to a description starting with its own
+// enum name. A missing `case` (e.g. AMDSMI_STATUS_TIMEOUT / MORE_DATA) makes
+// amdsmi_status_code_to_string() return AMDSMI_STATUS_UNKNOWN_ERROR with the
+// "unknown error" string, which fails both assertions below.
+TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
+  if (!enum_reflect::kAvailable) {
+    GTEST_SKIP() << "enum reflection unavailable on this compiler ("
+                 << enum_reflect::CompilerId() << "); it needs Clang or GCC >= 9 "
+                 << "(older GCC renders enum template args as numeric casts). "
+                 << "The matching Python test covers this case elsewhere.";
+  }
+
+  const auto all_status_codes = enum_reflect::AllStatusCodes();
+
+  // Guard against a vacuous pass: reflection must have discovered the full set,
+  // including the codes whose missing cases prompted this test and the
+  // out-of-range sentinels. A failure here almost certainly means the compiler
+  // changed its __PRETTY_FUNCTION__ rendering and enum_reflect::EnumName() needs
+  // updating -- the amdsmi library itself is probably fine.
+  ASSERT_GE(all_status_codes.size(), 40u)
+      << "enum reflection found too few codes (" << all_status_codes.size()
+      << "); the __PRETTY_FUNCTION__ parser in enum_reflect likely broke due to a "
+      << "compiler change (or kScanLimit is too low). Compiler: "
+      << enum_reflect::CompilerId() << "; sample signature: \""
+      << enum_reflect::SampleSignature() << "\". This is a test-harness problem, "
+      << "not an amdsmi library bug.";
+  auto contains = [&](amdsmi_status_t code) {
+    for (const auto& [value, name] : all_status_codes) {
+      if (value == code) return true;
+    }
+    return false;
+  };
+  for (amdsmi_status_t code : {AMDSMI_STATUS_TIMEOUT, AMDSMI_STATUS_MORE_DATA,
+                               AMDSMI_STATUS_MAP_ERROR, AMDSMI_STATUS_UNKNOWN_ERROR}) {
+    ASSERT_TRUE(contains(code))
+        << "enum reflection did not discover a known status code (" << code
+        << "); the __PRETTY_FUNCTION__ parser in enum_reflect likely broke due "
+        << "to a compiler change. This is a test-harness problem, not an amdsmi "
+        << "library bug.";
+  }
+
+  for (const auto& [code, name] : all_status_codes) {
+    const char* status_string = nullptr;
+    amdsmi_status_t ret = amdsmi_status_code_to_string(code, &status_string);
+
+    EXPECT_EQ(ret, AMDSMI_STATUS_SUCCESS)
+        << name << " (" << code << ") did not resolve; a case is missing from "
+        << "amdsmi_status_code_to_string().";
+    ASSERT_NE(status_string, nullptr) << name;
+
+    const std::string description(status_string);
+    EXPECT_TRUE(StartsWith(description, name))
+        << name << " (" << code << ") resolved to \"" << description
+        << "\"; expected the description to start with its own enum name. A "
+        << "missing case falls through to the UNKNOWN_ERROR default.";
+  }
+}
+
+// Simpler alternative to the reflection-based test above. It does not aim for
+// exhaustive coverage; it just spot-checks the codes that actually regressed
+// (AMDSMI_STATUS_TIMEOUT, AMDSMI_STATUS_MORE_DATA) plus a couple of controls.
+// No enum reflection, no scan, no compiler dependency -- it reads top to bottom
+// and pins the exact bug this change fixes. The trade-off is that a future
+// missing case for some *other* code would slip past it (the reflection test
+// and the Python test cover that breadth).
+TEST(AmdSmiStatusStringTest, KnownStatusCodesResolveToTheirOwnName) {
+  const std::vector<std::pair<amdsmi_status_t, const char*>> spot_checks = {
+      // The two codes whose missing cases prompted this fix.
+      {AMDSMI_STATUS_TIMEOUT, "AMDSMI_STATUS_TIMEOUT"},
+      {AMDSMI_STATUS_MORE_DATA, "AMDSMI_STATUS_MORE_DATA"},
+      // Controls that were already handled, including both sentinels.
+      {AMDSMI_STATUS_SUCCESS, "AMDSMI_STATUS_SUCCESS"},
+      {AMDSMI_STATUS_INVAL, "AMDSMI_STATUS_INVAL"},
+      {AMDSMI_STATUS_MAP_ERROR, "AMDSMI_STATUS_MAP_ERROR"},
+      {AMDSMI_STATUS_UNKNOWN_ERROR, "AMDSMI_STATUS_UNKNOWN_ERROR"},
+  };
+
+  for (const auto& [code, name] : spot_checks) {
+    const char* status_string = nullptr;
+    amdsmi_status_t ret = amdsmi_status_code_to_string(code, &status_string);
+
+    EXPECT_EQ(ret, AMDSMI_STATUS_SUCCESS)
+        << name << " (" << code << ") did not resolve; a case is missing from "
+        << "amdsmi_status_code_to_string().";
+    ASSERT_NE(status_string, nullptr) << name;
+    EXPECT_TRUE(StartsWith(status_string, name))
+        << name << " (" << code << ") resolved to \"" << status_string
+        << "\"; expected the description to start with its own enum name.";
+  }
+}
+
+// Negative: a lower-level (rocm_smi) status that amdsmi has no mapping for must
+// surface AMDSMI_STATUS_MAP_ERROR. This guards against rocm_smi adding a new
+// status that silently goes untranslated through rsmi_to_amdsmi_status().
+TEST(AmdSmiStatusStringTest, UnmappedLowerLevelStatusYieldsMapError) {
+  // A value that is intentionally not present in amd::smi::rsmi_status_map.
+  const auto unmapped_rsmi_status = static_cast<rsmi_status_t>(0x0BADF00D);
+  EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(unmapped_rsmi_status), AMDSMI_STATUS_MAP_ERROR)
+      << "An unmapped rocm_smi status must translate to AMDSMI_STATUS_MAP_ERROR; "
+      << "a new rsmi status is missing from amd::smi::rsmi_status_map.";
+
+  // Sanity: known mappings must NOT produce MAP_ERROR.
+  EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(RSMI_STATUS_SUCCESS), AMDSMI_STATUS_SUCCESS);
+  EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(RSMI_STATUS_INVALID_ARGS), AMDSMI_STATUS_INVAL);
+  EXPECT_NE(amd::smi::rsmi_to_amdsmi_status(RSMI_STATUS_NOT_SUPPORTED), AMDSMI_STATUS_MAP_ERROR);
+}

--- a/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
@@ -43,7 +43,7 @@ namespace {
 // Real enumerators render as names, whereas unused values render as numbers or casts.
 //
 // Normal status codes are discovered by scanning a low numeric range. The two
-// high sentinels, AMDSMI_STATUS_MAP_ERROR and AMDSMI_STATUS_UNKNOWN_ERROR, are
+// high-value codes, AMDSMI_STATUS_MAP_ERROR and AMDSMI_STATUS_UNKNOWN_ERROR, are
 // appended explicitly because their values are near UINT_MAX.
 // ---------------------------------------------------------------------------
 
@@ -111,14 +111,15 @@ void Collect(std::vector<std::pair<amdsmi_status_t, std::string>>& out,
    ...);
 }
 
-// Scan beyond the current normal status-code range for future additions.
-constexpr uint32_t kScanLimit = 128;
+// Scan the full range status codes can occupy (normal codes stay well below
+// this; the two high-value codes near UINT_MAX are appended separately).
+constexpr uint32_t kScanLimit = 256;
 
 // {value, "AMDSMI_STATUS_..."} for every amdsmi_status_t enumerator.
 std::vector<std::pair<amdsmi_status_t, std::string>> AllStatusCodes() {
   std::vector<std::pair<amdsmi_status_t, std::string>> out;
   Collect(out, std::make_integer_sequence<uint32_t, kScanLimit>{});
-  // Append the two high-value sentinels the scan cannot reach.
+  // Append the two high-value codes the scan cannot reach.
   out.push_back({AMDSMI_STATUS_MAP_ERROR, std::string(EnumName<AMDSMI_STATUS_MAP_ERROR>())});
   out.push_back(
       {AMDSMI_STATUS_UNKNOWN_ERROR, std::string(EnumName<AMDSMI_STATUS_UNKNOWN_ERROR>())});
@@ -144,8 +145,9 @@ bool StartsWith(const std::string& s, const std::string& prefix) {
 
 }  // namespace
 
-// Every status code should resolve to a string that starts with its enum name.
-// Missing cases fall through to AMDSMI_STATUS_UNKNOWN_ERROR and fail below.
+// The Python unit test (test_status_code_to_string) covers the same ground, but
+// it needs an initialized library and drivers; this C++ test is driver-free and
+// runs in CI without a GPU.
 TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
   if (!enum_reflect::kAvailable) {
     GTEST_SKIP() << "enum reflection unavailable on this compiler (" << enum_reflect::CompilerId()
@@ -156,12 +158,16 @@ TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
 
   const auto all_status_codes = enum_reflect::AllStatusCodes();
 
-  // Keep this from passing with an empty or incomplete reflection result. We
-  // check a small set of required codes instead of asserting the full enum
-  // count, so adding a new status code does not require updating this test.
-  // The required set covers the regression cases (TIMEOUT, MORE_DATA) and both
-  // sentinels. If any are absent, the reflection parser or scan limit is broken;
-  // the failure is in the test harness, not the amdsmi status-string code.
+  // Guard against an empty or incomplete reflection result: if these known
+  // codes aren't discovered, the __PRETTY_FUNCTION__ parser or kScanLimit broke.
+  // The floor is a loose lower bound (well below the current enumerator count)
+  // to catch a broken parser without needing an update for every new code.
+  ASSERT_GE(all_status_codes.size(), 40u)
+      << "enum reflection discovered only " << all_status_codes.size()
+      << " status codes; the __PRETTY_FUNCTION__ parser or kScanLimit is broken. "
+      << "Compiler: " << enum_reflect::CompilerId() << "; sample signature: \""
+      << enum_reflect::SampleSignature() << "\".";
+
   auto contains = [&](amdsmi_status_t code) {
     for (const auto& [value, name] : all_status_codes) {
       if (value == code) return true;
@@ -202,7 +208,7 @@ TEST(AmdSmiStatusStringTest, KnownStatusCodesResolveToTheirOwnName) {
       // The two codes whose missing cases prompted this fix.
       {AMDSMI_STATUS_TIMEOUT, "AMDSMI_STATUS_TIMEOUT"},
       {AMDSMI_STATUS_MORE_DATA, "AMDSMI_STATUS_MORE_DATA"},
-      // Controls that were already handled, including both sentinels.
+      // Controls that were already handled, including both catch-all codes.
       {AMDSMI_STATUS_SUCCESS, "AMDSMI_STATUS_SUCCESS"},
       {AMDSMI_STATUS_INVAL, "AMDSMI_STATUS_INVAL"},
       {AMDSMI_STATUS_MAP_ERROR, "AMDSMI_STATUS_MAP_ERROR"},
@@ -238,4 +244,21 @@ TEST(AmdSmiStatusStringTest, UnmappedLowerLevelStatusYieldsMapError) {
   EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(RSMI_STATUS_SUCCESS), AMDSMI_STATUS_SUCCESS);
   EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(RSMI_STATUS_INVALID_ARGS), AMDSMI_STATUS_INVAL);
   EXPECT_NE(amd::smi::rsmi_to_amdsmi_status(RSMI_STATUS_NOT_SUPPORTED), AMDSMI_STATUS_MAP_ERROR);
+}
+
+// A value that is not a defined status code (an enum gap) must hit the default
+// path and report AMDSMI_STATUS_UNKNOWN_ERROR rather than a stale string.
+TEST(AmdSmiStatusStringTest, UndefinedStatusCodeYieldsUnknownError) {
+  const char* status_string = nullptr;
+  // 100 sits in an enum gap (above the highest normal code, below the two
+  // high-value error codes).
+  const auto undefined_code = static_cast<amdsmi_status_t>(100);
+  EXPECT_EQ(amdsmi_status_code_to_string(undefined_code, &status_string),
+            AMDSMI_STATUS_UNKNOWN_ERROR);
+  ASSERT_NE(status_string, nullptr);
+}
+
+// A null output pointer must be rejected, not dereferenced.
+TEST(AmdSmiStatusStringTest, NullOutputPointerYieldsInval) {
+  EXPECT_EQ(amdsmi_status_code_to_string(AMDSMI_STATUS_SUCCESS, nullptr), AMDSMI_STATUS_INVAL);
 }

--- a/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
@@ -22,15 +22,6 @@
 
 // Driver-free unit test for amdsmi status-code handling: no GPU, no
 // amdsmi_init().
-//
-// Two checks:
-//   1. Positive: every amdsmi_status_t enumerator resolves, via
-//      amdsmi_status_code_to_string(), to a description starting with its own
-//      enum name. A missing `case` falls through to the UNKNOWN_ERROR default,
-//      which this catches. (Mirrors the Python test_status_code_to_string.)
-//   2. Negative: a lower-level rocm_smi status with no amdsmi mapping must
-//      surface AMDSMI_STATUS_MAP_ERROR via rsmi_to_amdsmi_status(). The Python
-//      test cannot reach this, since it only feeds existing amdsmi codes.
 
 #include <gtest/gtest.h>
 
@@ -47,27 +38,18 @@ namespace {
 
 // ---------------------------------------------------------------------------
 // Compile-time enum reflection (stopgap until C++26 static reflection / P2996).
+// C++17 cannot enumerate enum members, so this uses the magic_enum trick:
+// instantiate a template on a value and parse its name from __PRETTY_FUNCTION__.
+// Real enumerators render as names, whereas unused values render as numbers or casts.
 //
-// C++17 cannot enumerate an enum's members or recover their names, so unlike
-// the Python test we cannot just loop over amdsmi.AmdSmiStatus. We use the
-// magic_enum trick: instantiate a template on a value and read the enumerator
-// name the compiler bakes into __PRETTY_FUNCTION__. A real enumerator renders
-// as `V = AMDSMI_STATUS_TIMEOUT`; an unused value renders as a cast on GCC
-// (`V = (amdsmi_status_t)28`) or a bare integer on Clang (`V = 28`). A name
-// that starts like a C identifier is therefore a real enumerator, which lets
-// us auto-discover every member by scanning a bounded range of values.
-//
-// The two sentinels sit at the top of the value range: AMDSMI_STATUS_MAP_ERROR
-// (UINT_MAX - 1) and AMDSMI_STATUS_UNKNOWN_ERROR (UINT_MAX). A scan cannot
-// reach those, so the low range is scanned for normal codes and the two
-// sentinels are seeded explicitly (names still come from reflection). Adding a
-// normal status code in range needs no change here.
+// Normal status codes are discovered by scanning a low numeric range. The two
+// high sentinels, AMDSMI_STATUS_MAP_ERROR and AMDSMI_STATUS_UNKNOWN_ERROR, are
+// appended explicitly because their values are near UINT_MAX.
 // ---------------------------------------------------------------------------
 
-// Reflection needs the compiler to render enumerator *names* (not numeric
-// casts) in __PRETTY_FUNCTION__. Clang does this at any version; GCC only since
-// GCC 9. On older GCC the positive test GTEST_SKIPs instead of failing the
-// build; the negative test needs no reflection and always runs.
+// Reflection needs enumerator names in __PRETTY_FUNCTION__. Clang does this at any version,
+// whereas GCC does it starting in GCC 9. When an older GCC is detected,
+// the test automatically skips the reflection-based test.
 #if defined(__clang__)
 #define AMDSMI_ENUM_REFLECTION_AVAILABLE 1
 #elif defined(__GNUC__) && (__GNUC__ >= 9)
@@ -100,9 +82,7 @@ constexpr const char* Signature() {
   return __PRETTY_FUNCTION__;
 }
 
-// Enumerator name for V, e.g. "AMDSMI_STATUS_TIMEOUT". For an integer with no
-// corresponding enumerator the compilers differ: GCC renders a cast,
-// "(amdsmi_status_t)28", while Clang renders a bare integer, "28".
+// Enumerator name for V, e.g. "AMDSMI_STATUS_TIMEOUT".
 template <amdsmi_status_t V>
 constexpr std::string_view EnumName() {
   std::string_view s = Signature<V>();
@@ -111,9 +91,8 @@ constexpr std::string_view EnumName() {
   return s.substr(start, end - start);
 }
 
-// True when V names a real enumerator. A real name starts like a C identifier
-// (letter or '_'); an unused value starts with '(' on GCC or a digit on Clang,
-// so requiring an identifier-start character rejects both.
+// Real enumerators start like C identifiers. Unused values start with '(' on
+// GCC or a digit on Clang, so this rejects both renderings.
 template <amdsmi_status_t V>
 constexpr bool IsEnumerator() {
   const auto name = EnumName<V>();
@@ -132,22 +111,21 @@ void Collect(std::vector<std::pair<amdsmi_status_t, std::string>>& out,
    ...);
 }
 
-// The highest normal enumerator is well under 100; scan past it for headroom.
+// Scan beyond the current normal status-code range for future additions.
 constexpr uint32_t kScanLimit = 128;
 
 // {value, "AMDSMI_STATUS_..."} for every amdsmi_status_t enumerator.
 std::vector<std::pair<amdsmi_status_t, std::string>> AllStatusCodes() {
   std::vector<std::pair<amdsmi_status_t, std::string>> out;
   Collect(out, std::make_integer_sequence<uint32_t, kScanLimit>{});
-  // Append the two sentinels the scan can't reach (see note above).
+  // Append the two high-value sentinels the scan cannot reach.
   out.push_back({AMDSMI_STATUS_MAP_ERROR, std::string(EnumName<AMDSMI_STATUS_MAP_ERROR>())});
   out.push_back(
       {AMDSMI_STATUS_UNKNOWN_ERROR, std::string(EnumName<AMDSMI_STATUS_UNKNOWN_ERROR>())});
   return out;
 }
 
-// A sample raw __PRETTY_FUNCTION__ rendering, surfaced in failure diagnostics so
-// a compiler change to the signature format is immediately visible in the log.
+// Include a raw signature in failures so compiler-format changes are visible.
 inline const char* SampleSignature() { return Signature<AMDSMI_STATUS_TIMEOUT>(); }
 
 #else  // !AMDSMI_ENUM_REFLECTION_AVAILABLE
@@ -166,25 +144,24 @@ bool StartsWith(const std::string& s, const std::string& prefix) {
 
 }  // namespace
 
-// Positive: every status code resolves to a description starting with its own
-// enum name. A missing `case` (e.g. AMDSMI_STATUS_TIMEOUT / MORE_DATA) makes
-// amdsmi_status_code_to_string() return AMDSMI_STATUS_UNKNOWN_ERROR with the
-// "unknown error" string, which fails both assertions below.
+// Every status code should resolve to a string that starts with its enum name.
+// Missing cases fall through to AMDSMI_STATUS_UNKNOWN_ERROR and fail below.
 TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
   if (!enum_reflect::kAvailable) {
     GTEST_SKIP() << "enum reflection unavailable on this compiler (" << enum_reflect::CompilerId()
-                 << "); it needs Clang or GCC >= 9 "
+                 << "). This test needs Clang or GCC >= 9 "
                  << "(older GCC renders enum template args as numeric casts). "
                  << "The matching Python test covers this case elsewhere.";
   }
 
   const auto all_status_codes = enum_reflect::AllStatusCodes();
 
-  // Guard against a vacuous pass without pinning a magic count (which would need
-  // bumping for every new status code). Reflection must have found the codes
-  // whose missing cases prompted this test (TIMEOUT, MORE_DATA) plus the two
-  // sentinels; if the __PRETTY_FUNCTION__ parser broke they would drop out and
-  // fail the check below -- a test-harness problem, not an amdsmi library bug.
+  // Keep this from passing with an empty or incomplete reflection result. We
+  // check a small set of required codes instead of asserting the full enum
+  // count, so adding a new status code does not require updating this test.
+  // The required set covers the regression cases (TIMEOUT, MORE_DATA) and both
+  // sentinels. If any are absent, the reflection parser or scan limit is broken;
+  // the failure is in the test harness, not the amdsmi status-string code.
   auto contains = [&](amdsmi_status_t code) {
     for (const auto& [value, name] : all_status_codes) {
       if (value == code) return true;
@@ -207,22 +184,19 @@ TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
     amdsmi_status_t ret = amdsmi_status_code_to_string(code, &status_string);
 
     EXPECT_EQ(ret, AMDSMI_STATUS_SUCCESS)
-        << name << " (" << code << ") did not resolve; a case is missing from "
+        << name << " (" << code << ") did not resolve, this status is missing from "
         << "amdsmi_status_code_to_string().";
     ASSERT_NE(status_string, nullptr) << name;
 
     const std::string description(status_string);
     EXPECT_TRUE(StartsWith(description, name))
         << name << " (" << code << ") resolved to \"" << description
-        << "\"; expected the description to start with its own enum name. A "
+        << "\". Expected the description to start with its own enum name. A "
         << "missing case falls through to the UNKNOWN_ERROR default.";
   }
 }
 
-// Simpler companion to the reflection test above: no reflection, no scan, no
-// compiler dependency. It spot-checks the codes that regressed (TIMEOUT,
-// MORE_DATA) plus a few controls. It will not catch a missing case for some
-// other code -- the reflection test and the Python test cover that breadth.
+// Reflection-free spot check for the regressed codes + a few other common returns.
 TEST(AmdSmiStatusStringTest, KnownStatusCodesResolveToTheirOwnName) {
   const std::vector<std::pair<amdsmi_status_t, const char*>> spot_checks = {
       // The two codes whose missing cases prompted this fix.
@@ -240,12 +214,13 @@ TEST(AmdSmiStatusStringTest, KnownStatusCodesResolveToTheirOwnName) {
     amdsmi_status_t ret = amdsmi_status_code_to_string(code, &status_string);
 
     EXPECT_EQ(ret, AMDSMI_STATUS_SUCCESS)
-        << name << " (" << code << ") did not resolve; a case is missing from "
-        << "amdsmi_status_code_to_string().";
+        << name << " (" << code << ") did not resolve, this case is missing from "
+        << "amdsmi_status_code_to_string(). Must return AMDSMI_STATUS_SUCCESS "
+        << "for a valid status code.";
     ASSERT_NE(status_string, nullptr) << name;
     EXPECT_TRUE(StartsWith(status_string, name))
         << name << " (" << code << ") resolved to \"" << status_string
-        << "\"; expected the description to start with its own enum name.";
+        << "\". Expected the description to start with its own enum name.";
   }
 }
 

--- a/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
@@ -20,21 +20,17 @@
  * THE SOFTWARE.
  */
 
-// Driver-free unit test for amdsmi status-code handling. It needs no GPU and
-// performs no amdsmi_init(), so it can move into a dedicated unit-test target
-// during the test refactor.
+// Driver-free unit test for amdsmi status-code handling: no GPU, no
+// amdsmi_init().
 //
-// Two complementary checks:
-//   1. Positive (mirror of the Python test_status_code_to_string): every
-//      amdsmi_status_t enumerator must resolve, via amdsmi_status_code_to_string(),
-//      to a description that begins with its own enum name. A missing `case`
-//      makes the code fall through to the UNKNOWN_ERROR default, which this
-//      catches.
-//   2. Negative: simulate a lower-level (rocm_smi) status that the amdsmi layer
-//      has no mapping for and confirm rsmi_to_amdsmi_status() surfaces
-//      AMDSMI_STATUS_MAP_ERROR rather than silently mistranslating it. This is
-//      the case the Python test cannot reach, because it can only feed codes
-//      that already exist in the amdsmi layer.
+// Two checks:
+//   1. Positive: every amdsmi_status_t enumerator resolves, via
+//      amdsmi_status_code_to_string(), to a description starting with its own
+//      enum name. A missing `case` falls through to the UNKNOWN_ERROR default,
+//      which this catches. (Mirrors the Python test_status_code_to_string.)
+//   2. Negative: a lower-level rocm_smi status with no amdsmi mapping must
+//      surface AMDSMI_STATUS_MAP_ERROR via rsmi_to_amdsmi_status(). The Python
+//      test cannot reach this, since it only feeds existing amdsmi codes.
 
 #include <gtest/gtest.h>
 
@@ -52,32 +48,26 @@ namespace {
 // ---------------------------------------------------------------------------
 // Compile-time enum reflection (stopgap until C++26 static reflection / P2996).
 //
-// C++17 erases enums to plain integers: there is no built-in way to list an
-// enum's members or recover their names, which is why the matching Python test
-// can loop `for status in amdsmi.AmdSmiStatus` but C++ cannot. We recover the
-// names the same way the magic_enum library does: instantiate a template on the
-// value and read the enumerator name the compiler bakes into __PRETTY_FUNCTION__
-// (or __FUNCSIG__ on MSVC). For a real enumerator GCC/Clang render
-// `... V = AMDSMI_STATUS_TIMEOUT]`; for an unused slot GCC renders a cast,
-// `... V = (amdsmi_status_t)28]`, and Clang renders a bare integer,
-// `... V = 28]`. A real enumerator name is therefore the one that starts like a
-// C identifier, which lets us auto-discover every member in a bounded range.
+// C++17 cannot enumerate an enum's members or recover their names, so unlike
+// the Python test we cannot just loop over amdsmi.AmdSmiStatus. We use the
+// magic_enum trick: instantiate a template on a value and read the enumerator
+// name the compiler bakes into __PRETTY_FUNCTION__. A real enumerator renders
+// as `V = AMDSMI_STATUS_TIMEOUT`; an unused value renders as a cast on GCC
+// (`V = (amdsmi_status_t)28`) or a bare integer on Clang (`V = 28`). A name
+// that starts like a C identifier is therefore a real enumerator, which lets
+// us auto-discover every member by scanning a bounded range of values.
 //
-// amdsmi_status_t is sparse and ends in two ~4-billion sentinels
-// (AMDSMI_STATUS_MAP_ERROR = 0xFFFFFFFE, AMDSMI_STATUS_UNKNOWN_ERROR =
-// 0xFFFFFFFF). A value scan cannot practically reach those, so the normal codes
-// are discovered by scanning the low range and the two stable sentinels are
-// seeded explicitly (their names still come from reflection, not hand-typing).
-// Adding a normal status code in range needs no change here.
+// The two sentinels sit at the top of the value range: AMDSMI_STATUS_MAP_ERROR
+// (UINT_MAX - 1) and AMDSMI_STATUS_UNKNOWN_ERROR (UINT_MAX). A scan cannot
+// reach those, so the low range is scanned for normal codes and the two
+// sentinels are seeded explicitly (names still come from reflection). Adding a
+// normal status code in range needs no change here.
 // ---------------------------------------------------------------------------
 
-// The reflection trick relies on __PRETTY_FUNCTION__ AND on the compiler
-// rendering enumerator *names* (not numeric casts) for enum template arguments.
-// Clang does this at any version; GCC only started doing so in GCC 9. On GCC 8
-// and earlier every value renders as "(amdsmi_status_t)N", so reflection finds
-// no enumerators. On GCC < 9 or any other compiler the helper is unavailable and
-// the positive test GTEST_SKIPs rather than failing the build; the driverless
-// negative test below needs no reflection and always runs.
+// Reflection needs the compiler to render enumerator *names* (not numeric
+// casts) in __PRETTY_FUNCTION__. Clang does this at any version; GCC only since
+// GCC 9. On older GCC the positive test GTEST_SKIPs instead of failing the
+// build; the negative test needs no reflection and always runs.
 #if defined(__clang__)
 #define AMDSMI_ENUM_REFLECTION_AVAILABLE 1
 #elif defined(__GNUC__) && (__GNUC__ >= 9)
@@ -90,8 +80,7 @@ namespace enum_reflect {
 
 constexpr bool kAvailable = AMDSMI_ENUM_REFLECTION_AVAILABLE;
 
-// Human-readable compiler identification for diagnostics, so a failure or skip
-// on an unexpected toolchain names the compiler and version in its output.
+// Compiler name and version, included in failure/skip diagnostics.
 inline const char* CompilerId() {
 #if defined(__clang__)
   return "clang " __clang_version__;
@@ -106,8 +95,8 @@ inline const char* CompilerId() {
 
 template <amdsmi_status_t V>
 constexpr const char* Signature() {
-  // Return type is `const char*` (not a library typedef) so the signature
-  // carries no extra "= " clause from typedef expansion to confuse parsing.
+  // Return type is a plain `const char*` so the signature has no stray "= "
+  // from typedef expansion to confuse the parse below.
   return __PRETTY_FUNCTION__;
 }
 
@@ -122,11 +111,9 @@ constexpr std::string_view EnumName() {
   return s.substr(start, end - start);
 }
 
-// True when V names a real enumerator rather than an unused slot. A real
-// enumerator name is a C identifier (starts with a letter or '_'); an unused
-// slot starts with '(' on GCC ("(amdsmi_status_t)28") or a digit on Clang
-// ("28"). Requiring an identifier-start character rejects both, so this works
-// on either compiler.
+// True when V names a real enumerator. A real name starts like a C identifier
+// (letter or '_'); an unused value starts with '(' on GCC or a digit on Clang,
+// so requiring an identifier-start character rejects both.
 template <amdsmi_status_t V>
 constexpr bool IsEnumerator() {
   const auto name = EnumName<V>();
@@ -152,7 +139,7 @@ constexpr uint32_t kScanLimit = 128;
 std::vector<std::pair<amdsmi_status_t, std::string>> AllStatusCodes() {
   std::vector<std::pair<amdsmi_status_t, std::string>> out;
   Collect(out, std::make_integer_sequence<uint32_t, kScanLimit>{});
-  // Sentinels live at 0xFFFFFFFE/0xFFFFFFFF, far outside any practical scan.
+  // Append the two sentinels the scan can't reach (see note above).
   out.push_back({AMDSMI_STATUS_MAP_ERROR, std::string(EnumName<AMDSMI_STATUS_MAP_ERROR>())});
   out.push_back(
       {AMDSMI_STATUS_UNKNOWN_ERROR, std::string(EnumName<AMDSMI_STATUS_UNKNOWN_ERROR>())});
@@ -194,12 +181,10 @@ TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
   const auto all_status_codes = enum_reflect::AllStatusCodes();
 
   // Guard against a vacuous pass without pinning a magic count (which would need
-  // bumping every time a status code is added). Reflection must have discovered
-  // the specific normal codes whose missing cases prompted this test, plus the
-  // two out-of-range sentinels. TIMEOUT (8) and MORE_DATA (39) are ordinary
-  // scanned codes: if the __PRETTY_FUNCTION__ parser broke (e.g. a compiler
-  // change) the scan finds no enumerators and they drop out, failing the check
-  // below -- a test-harness problem, not an amdsmi library bug.
+  // bumping for every new status code). Reflection must have found the codes
+  // whose missing cases prompted this test (TIMEOUT, MORE_DATA) plus the two
+  // sentinels; if the __PRETTY_FUNCTION__ parser broke they would drop out and
+  // fail the check below -- a test-harness problem, not an amdsmi library bug.
   auto contains = [&](amdsmi_status_t code) {
     for (const auto& [value, name] : all_status_codes) {
       if (value == code) return true;
@@ -234,13 +219,10 @@ TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
   }
 }
 
-// Simpler alternative to the reflection-based test above. It does not aim for
-// exhaustive coverage; it just spot-checks the codes that actually regressed
-// (AMDSMI_STATUS_TIMEOUT, AMDSMI_STATUS_MORE_DATA) plus a couple of controls.
-// No enum reflection, no scan, no compiler dependency -- it reads top to bottom
-// and pins the exact bug this change fixes. The trade-off is that a future
-// missing case for some *other* code would slip past it (the reflection test
-// and the Python test cover that breadth).
+// Simpler companion to the reflection test above: no reflection, no scan, no
+// compiler dependency. It spot-checks the codes that regressed (TIMEOUT,
+// MORE_DATA) plus a few controls. It will not catch a missing case for some
+// other code -- the reflection test and the Python test cover that breadth.
 TEST(AmdSmiStatusStringTest, KnownStatusCodesResolveToTheirOwnName) {
   const std::vector<std::pair<amdsmi_status_t, const char*>> spot_checks = {
       // The two codes whose missing cases prompted this fix.

--- a/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/status_string_test.cc
@@ -45,14 +45,7 @@
 #include <vector>
 
 #include "amd_smi/amdsmi.h"
-#include "rocm_smi/rocm_smi.h"
-
-// rsmi_to_amdsmi_status() is compiled into libamd_smi and declared in
-// amd_smi/impl/amd_smi_common.h. Forward-declare it here to avoid pulling in the
-// heavy esmi/nic includes that header transitively requires.
-namespace amd::smi {
-amdsmi_status_t rsmi_to_amdsmi_status(rsmi_status_t status);
-}  // namespace amd::smi
+#include "amd_smi/impl/amd_smi_common.h"
 
 namespace {
 

--- a/projects/amdsmi/tests/amd_smi_test/unit/system/status_string_test.cc
+++ b/projects/amdsmi/tests/amd_smi_test/unit/system/status_string_test.cc
@@ -144,7 +144,7 @@ bool starts_with(const std::string& s, const std::string& prefix) {
 // The Python unit test (test_status_code_to_string) covers the same ground, but
 // it needs an initialized library and drivers; this C++ test is driver-free and
 // runs in CI without a GPU.
-TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
+TEST(SystemUnit, StatusStringEveryCodeResolvesToItsOwnName) {
   if (!enum_reflect::kAvailable) {
     GTEST_SKIP() << "enum reflection unavailable on this compiler (" << enum_reflect::compiler_id()
                  << "). This test needs Clang or GCC >= 9 "
@@ -199,7 +199,7 @@ TEST(AmdSmiStatusStringTest, EveryStatusCodeResolvesToItsOwnName) {
 }
 
 // Reflection-free spot check for the regressed codes + a few other common returns.
-TEST(AmdSmiStatusStringTest, KnownStatusCodesResolveToTheirOwnName) {
+TEST(SystemUnit, StatusStringKnownCodesResolveToTheirOwnName) {
   const std::vector<std::pair<amdsmi_status_t, const char*>> spot_checks = {
       // The two codes whose missing cases prompted this fix.
       {AMDSMI_STATUS_TIMEOUT, "AMDSMI_STATUS_TIMEOUT"},
@@ -229,14 +229,17 @@ TEST(AmdSmiStatusStringTest, KnownStatusCodesResolveToTheirOwnName) {
 // Negative: a lower-level (rocm_smi) status that amdsmi has no mapping for must
 // surface AMDSMI_STATUS_MAP_ERROR. This guards against rocm_smi adding a new
 // status that silently goes untranslated through rsmi_to_amdsmi_status().
-TEST(AmdSmiStatusStringTest, UnmappedLowerLevelStatusYieldsMapError) {
+TEST(SystemUnit, RsmiStatusMappingUnmappedYieldsMapError) {
   // A value that is intentionally not present in amd::smi::rsmi_status_map.
   const auto unmapped_rsmi_status = static_cast<rsmi_status_t>(0x0BADF00D);
   EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(unmapped_rsmi_status), AMDSMI_STATUS_MAP_ERROR)
       << "An unmapped rocm_smi status must translate to AMDSMI_STATUS_MAP_ERROR; "
       << "a new rsmi status is missing from amd::smi::rsmi_status_map.";
+}
 
-  // Sanity: known mappings must NOT produce MAP_ERROR.
+// Known rocm_smi statuses must translate to their mapped amdsmi code, never to
+// the MAP_ERROR fallback.
+TEST(SystemUnit, RsmiStatusMappingKnownCodesMapToAmdsmi) {
   EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(RSMI_STATUS_SUCCESS), AMDSMI_STATUS_SUCCESS);
   EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(RSMI_STATUS_INVALID_ARGS), AMDSMI_STATUS_INVAL);
   EXPECT_EQ(amd::smi::rsmi_to_amdsmi_status(RSMI_STATUS_NOT_SUPPORTED),
@@ -245,7 +248,7 @@ TEST(AmdSmiStatusStringTest, UnmappedLowerLevelStatusYieldsMapError) {
 
 // A value that is not a defined status code (an enum gap) must hit the default
 // path and report AMDSMI_STATUS_UNKNOWN_ERROR rather than a stale string.
-TEST(AmdSmiStatusStringTest, UndefinedStatusCodeYieldsUnknownError) {
+TEST(SystemUnit, StatusStringUndefinedCodeYieldsUnknownError) {
   const char* status_string = nullptr;
   // 100 sits in an enum gap (above the highest normal code, below the two
   // high-value error codes).
@@ -260,6 +263,6 @@ TEST(AmdSmiStatusStringTest, UndefinedStatusCodeYieldsUnknownError) {
 }
 
 // A null output pointer must be rejected, not dereferenced.
-TEST(AmdSmiStatusStringTest, NullOutputPointerYieldsInval) {
+TEST(SystemUnit, StatusStringNullOutputPointerYieldsInval) {
   EXPECT_EQ(amdsmi_status_code_to_string(AMDSMI_STATUS_SUCCESS, nullptr), AMDSMI_STATUS_INVAL);
 }

--- a/projects/amdsmi/tests/python/functional/gpu/test_system.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_system.py
@@ -91,9 +91,8 @@ class TestGpuSystem(unittest.TestCase):
     def test_status_code_to_string(self):
         self.common.print_func_name("")
 
-        # Every status code must resolve to a description starting with its own
-        # enum name. Skip the two catch-all error codes: a real code resolving to
-        # one of them is a library bug this test is meant to catch.
+        # Skip the two catch-all codes; a real code resolving to either is a
+        # library bug this test is meant to catch:
         #   * AMDSMI_STATUS_UNKNOWN_ERROR -> a `case` is missing from
         #     amdsmi_status_code_to_string() (e.g. TIMEOUT / MORE_DATA).
         #   * AMDSMI_STATUS_MAP_ERROR -> a lower-level rsmi/esmi/nic status has

--- a/projects/amdsmi/tests/python/functional/gpu/test_system.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_system.py
@@ -91,20 +91,45 @@ class TestGpuSystem(unittest.TestCase):
     def test_status_code_to_string(self):
         self.common.print_func_name("")
 
-        if self.common.TODO_SKIP_FAIL:
-            msg = "\tSkipping test_status_code_to_string as it fails (Unhashable type)."
-            self.common.print(msg)
-            self.skipTest(msg)
+        # Every status code must resolve to a description starting with its own
+        # enum name. Skip the two catch-all error codes: a real code resolving to
+        # one of them is a library bug this test is meant to catch.
+        #   * AMDSMI_STATUS_UNKNOWN_ERROR -> a `case` is missing from
+        #     amdsmi_status_code_to_string() (e.g. TIMEOUT / MORE_DATA).
+        #   * AMDSMI_STATUS_MAP_ERROR -> a lower-level rsmi/esmi/nic status has
+        #     no amdsmi mapping.
+        fallback_descs = ("AMDSMI_STATUS_UNKNOWN_ERROR", "AMDSMI_STATUS_MAP_ERROR")
+        for status in amdsmi.AmdSmiStatus:
+            error_name = f"AMDSMI_STATUS_{status.name}"
+            if error_name in fallback_descs:
+                continue
+            msg = f"\t### amdsmi_status_code_to_string({error_name}={status.value}):"
 
-        for error_num, _ in self.common.error_map.items():
-            msg = f"\t### amdsmi_status_code_to_string(error_num={error_num}):"
+            ret = None
+            library_error = None
             try:
-                ret = amdsmi.amdsmi_status_code_to_string(ctypes.c_uint32(int(error_num, 0)))
-                self.common.print(msg, ret)
+                ret = amdsmi.amdsmi_status_code_to_string(ctypes.c_uint32(status.value))
             except amdsmi.AmdSmiLibraryException as e:
-                if self.common.check_ret(msg, e, self.common.PASS):
-                    self.raise_exception = e
+                library_error = e
+
+            if library_error is not None:
+                self.fail(
+                    f"{msg} Missing status code string - please update amdsmi_status_code_to_string() "
+                    f"\n(Returned: "
+                    f"'{library_error.get_error_info(detailed=False)}')."
+                )
+
+            self.common.print(msg, ret)
+
+            # string_cast may return bytes; normalize for comparison.
+            ret_str = ret.decode("utf-8") if isinstance(ret, bytes) else str(ret)
+
+            # Every code's description must begin with its own enum name.
+            # e.g. Some code fallbacks provide an RSMI_STATUS_* string,
+            # but that is not a valid AMDSMI_STATUS_* string.
+            self.assertTrue(
+                ret_str.startswith(error_name),
+                f"{msg} expected description to start with '{error_name}', got '{ret_str}'.",
+            )
             self.common.print("")
-        if self.raise_exception:
-            raise self.raise_exception
         return

--- a/projects/amdsmi/tests/python/functional/gpu/test_system.py
+++ b/projects/amdsmi/tests/python/functional/gpu/test_system.py
@@ -91,17 +91,10 @@ class TestGpuSystem(unittest.TestCase):
     def test_status_code_to_string(self):
         self.common.print_func_name("")
 
-        # Skip the two catch-all codes; a real code resolving to either is a
-        # library bug this test is meant to catch:
-        #   * AMDSMI_STATUS_UNKNOWN_ERROR -> a `case` is missing from
-        #     amdsmi_status_code_to_string() (e.g. TIMEOUT / MORE_DATA).
-        #   * AMDSMI_STATUS_MAP_ERROR -> a lower-level rsmi/esmi/nic status has
-        #     no amdsmi mapping.
-        fallback_descs = ("AMDSMI_STATUS_UNKNOWN_ERROR", "AMDSMI_STATUS_MAP_ERROR")
+        # Every code, including the two catch-all codes, must resolve to a
+        # description that begins with its own enum name.
         for status in amdsmi.AmdSmiStatus:
             error_name = f"AMDSMI_STATUS_{status.name}"
-            if error_name in fallback_descs:
-                continue
             msg = f"\t### amdsmi_status_code_to_string({error_name}={status.value}):"
 
             ret = None


### PR DESCRIPTION
## Summary
JIRA ID : AILITOOLS-279

`amdsmi_status_code_to_string()` was missing `case` entries for `AMDSMI_STATUS_TIMEOUT` and `AMDSMI_STATUS_MORE_DATA`, so both fell through to the `default` branch and returned `AMDSMI_STATUS_UNKNOWN_ERROR` with the `"An unknown error occurred"` description instead of their real descriptions.

Both are codes callers can legitimately receive:
- `AMDSMI_STATUS_TIMEOUT` — returned by the fabric-telemetry path (`amdsmi_get_fabric_telemetry()`).
- `AMDSMI_STATUS_MORE_DATA` — returned by `amdsmi_get_gpu_cper_entries()` as a normal buffer-paging signal.

## Changes

- **src/amd_smi/amd_smi.cc** — Added the two missing `case` entries so every member of `amdsmi_status_t` maps to a correct description.
- **tests/python_unittest/unit_tests.py** — Reworked `test_status_code_to_string` to iterate every `AmdSmiStatus` member and assert each resolves to a description starting with its own enum name, with no fall-through to the `UNKNOWN_ERROR` / `MAP_ERROR` sentinels.
- **tests/amd_smi_test/functional/status_string_test.cc** (new) — Driver-free GTest covering the positive path (every status code resolves to its own name) and the negative path (an unmapped lower-level rsmi status surfaces `AMDSMI_STATUS_MAP_ERROR`).
- **CHANGELOG.md** — Added a Resolved Issues entry.

## Testing

- Built `amd-smi-lib` locally.
- New GTest and the updated Python unit test pass.
