### PR TITLE
[rocprofiler-compute] add rebase pr skill

### DIFF
--- a/projects/rocprofiler-compute/.ai/skills/rocprof-compute-rebase-pr.md
+++ b/projects/rocprofiler-compute/.ai/skills/rocprof-compute-rebase-pr.md
@@ -30,9 +30,9 @@ Cherry-pick the user's commits onto the latest `origin/rocprofiler-compute-devel
    - Present the list and ask the user to confirm which commits are theirs. Do NOT assume — other contributors' commits may be mixed in.
    - Collect the confirmed hashes in the same order shown (oldest-to-newest) for step 6.
 
-5. **Reset the branch to the upstream base.**
+5. **Create a safety backup, then reset the branch to the upstream base.**
+   - Run: `git branch <branch-name>-backup`
    - Run: `git reset --hard origin/rocprofiler-compute-develop`
-
 6. **Cherry-pick the confirmed commits (oldest first).**
    - Run: `git cherry-pick <hash1> <hash2> ... <hashN>` (all in one command).
    - If a commit is already in `rocprofiler-compute-develop`, the cherry-pick will report "empty commit" — run `git cherry-pick --skip` to continue.

--- a/projects/rocprofiler-compute/.ai/skills/rocprof-compute-rebase-pr.md
+++ b/projects/rocprofiler-compute/.ai/skills/rocprof-compute-rebase-pr.md
@@ -1,14 +1,12 @@
----
-description: Rebase a PR branch onto origin/rocprofiler-compute-develop for a clean linear history.
----
-
 # Rebase PR onto origin/rocprofiler-compute-develop
+
+Follow **[`AGENTS.md`](../../AGENTS.md)** and the full redirect chain it references.
 
 ## Goal
 
 Cherry-pick the user's commits onto the latest `origin/rocprofiler-compute-develop` so the PR has a clean, linear history. Only the user's own commits should appear in the PR — no merge commits, no commits from other contributors.
 
-> **Note:** We call this "rebasing" but the procedure is actually reset + cherry-pick. A true `git rebase` is impractical when the base branch has dozens or hundreds of new commits.
+> **Note:** We call this "rebasing" but the procedure is actually reset + cherry-pick. A true `git rebase` is impractical when the branch history contains merge commits that cause cascading conflicts.
 
 ## Steps
 
@@ -18,6 +16,7 @@ Cherry-pick the user's commits onto the latest `origin/rocprofiler-compute-devel
 
 2. **Ensure the PR base branch is `rocprofiler-compute-develop`.**
    - Run: `gh pr view --json number,baseRefName` (uses the current branch).
+   - If the command fails (no open PR), tell the user to create a PR first or proceed without this check if they confirm.
    - If `baseRefName` is NOT `rocprofiler-compute-develop`, tell the user:
      > The PR base is currently `<baseRefName>`. Please change it to `rocprofiler-compute-develop` on GitHub:
      > PR page → Edit (next to title) → base dropdown → select `rocprofiler-compute-develop` → Save.
@@ -46,6 +45,3 @@ Cherry-pick the user's commits onto the latest `origin/rocprofiler-compute-devel
 8. **Force-push.**
    - Run: `git push --force-with-lease origin <branch-name>`
    - Tell the user: the PR on GitHub may take some time to sync — the file-changed count and diff may not immediately reflect the rebase.
-
-9. **Final check.**
-   - Run: `git log --oneline origin/rocprofiler-compute-develop..HEAD` one more time to confirm.

--- a/projects/rocprofiler-compute/.ai/skills/rocprof-compute-rebase-pr.md
+++ b/projects/rocprofiler-compute/.ai/skills/rocprof-compute-rebase-pr.md
@@ -26,9 +26,9 @@ Cherry-pick the user's commits onto the latest `origin/rocprofiler-compute-devel
    - Run: `git fetch origin`
 
 4. **Identify the user's commits.**
-   - Run: `git log --oneline origin/rocprofiler-compute-develop..<branch-name> --no-merges`
+   - Run: `git log --reverse --oneline origin/rocprofiler-compute-develop..<branch-name> --no-merges`
    - Present the list and ask the user to confirm which commits are theirs. Do NOT assume — other contributors' commits may be mixed in.
-   - Collect the confirmed hashes in oldest-to-newest order for step 6.
+   - Collect the confirmed hashes in the same order shown (oldest-to-newest) for step 6.
 
 5. **Reset the branch to the upstream base.**
    - Run: `git reset --hard origin/rocprofiler-compute-develop`

--- a/projects/rocprofiler-compute/.claude/commands/rebase-pr.md
+++ b/projects/rocprofiler-compute/.claude/commands/rebase-pr.md
@@ -1,0 +1,51 @@
+---
+description: Rebase a PR branch onto origin/rocprofiler-compute-develop for a clean linear history.
+---
+
+# Rebase PR onto origin/rocprofiler-compute-develop
+
+## Goal
+
+Cherry-pick the user's commits onto the latest `origin/rocprofiler-compute-develop` so the PR has a clean, linear history. Only the user's own commits should appear in the PR — no merge commits, no commits from other contributors.
+
+> **Note:** We call this "rebasing" but the procedure is actually reset + cherry-pick. A true `git rebase` is impractical when the base branch has dozens or hundreds of new commits.
+
+## Steps
+
+1. **Detect the current branch.**
+   - Run: `git rev-parse --abbrev-ref HEAD`
+   - If the branch is `rocprofiler-compute-develop` or `develop`, stop — the user must checkout their PR branch first.
+
+2. **Ensure the PR base branch is `rocprofiler-compute-develop`.**
+   - Run: `gh pr view --json number,baseRefName` (uses the current branch).
+   - If `baseRefName` is NOT `rocprofiler-compute-develop`, tell the user:
+     > The PR base is currently `<baseRefName>`. Please change it to `rocprofiler-compute-develop` on GitHub:
+     > PR page → Edit (next to title) → base dropdown → select `rocprofiler-compute-develop` → Save.
+   - Wait for confirmation before continuing.
+
+3. **Fetch the latest upstream.**
+   - Run: `git fetch origin`
+
+4. **Identify the user's commits.**
+   - Run: `git log --oneline origin/rocprofiler-compute-develop..<branch-name> --no-merges`
+   - Present the list and ask the user to confirm which commits are theirs. Do NOT assume — other contributors' commits may be mixed in.
+   - Collect the confirmed hashes in oldest-to-newest order for step 6.
+
+5. **Reset the branch to the upstream base.**
+   - Run: `git reset --hard origin/rocprofiler-compute-develop`
+
+6. **Cherry-pick the confirmed commits (oldest first).**
+   - Run: `git cherry-pick <hash1> <hash2> ... <hashN>` (all in one command).
+   - If a commit is already in `rocprofiler-compute-develop`, the cherry-pick will report "empty commit" — run `git cherry-pick --skip` to continue.
+   - If there is a conflict, help the user resolve it, stage the file(s), then run `git cherry-pick --continue` to proceed to the next commit.
+
+7. **Verify the result.**
+   - Run: `git log --oneline origin/rocprofiler-compute-develop..HEAD`
+   - Confirm only the user's commits appear and there are no merge commits.
+
+8. **Force-push.**
+   - Run: `git push --force-with-lease origin <branch-name>`
+   - Tell the user: the PR on GitHub may take some time to sync — the file-changed count and diff may not immediately reflect the rebase.
+
+9. **Final check.**
+   - Run: `git log --oneline origin/rocprofiler-compute-develop..HEAD` one more time to confirm.

--- a/projects/rocprofiler-compute/.claude/commands/rocprof-compute-rebase-pr.md
+++ b/projects/rocprofiler-compute/.claude/commands/rocprof-compute-rebase-pr.md
@@ -1,0 +1,5 @@
+---
+description: Rebase a PR branch onto origin/rocprofiler-compute-develop for a clean linear history.
+---
+
+Follow **[`.ai/skills/rocprof-compute-rebase-pr.md`](../../.ai/skills/rocprof-compute-rebase-pr.md)**.

--- a/projects/rocprofiler-compute/.cursor/commands/rocprof-compute-rebase-pr.md
+++ b/projects/rocprofiler-compute/.cursor/commands/rocprof-compute-rebase-pr.md
@@ -1,5 +1,5 @@
 ---
-agent: Rebase a PR branch onto origin/rocprofiler-compute-develop for a clean linear history.
+description: Rebase a PR branch onto origin/rocprofiler-compute-develop for a clean linear history.
 ---
 
 Follow [`.ai/skills/rocprof-compute-rebase-pr.md`](../../.ai/skills/rocprof-compute-rebase-pr.md).

--- a/projects/rocprofiler-compute/.github/prompts/rocprof-compute-code-review.prompt.md
+++ b/projects/rocprofiler-compute/.github/prompts/rocprof-compute-code-review.prompt.md
@@ -1,5 +1,6 @@
 ---
-agent: Review the current PR branch against project guidelines.
+agent: 'agent'
+description: Review the current PR branch against project guidelines.
 ---
 
 Follow [`.ai/skills/rocprof-compute-code-review.md`](../../.ai/skills/rocprof-compute-code-review.md).

--- a/projects/rocprofiler-compute/.github/prompts/rocprof-compute-code-review.prompt.md
+++ b/projects/rocprofiler-compute/.github/prompts/rocprof-compute-code-review.prompt.md
@@ -1,6 +1,5 @@
 ---
-mode: agent
-description: Review the current PR branch against project guidelines.
+agent: Review the current PR branch against project guidelines.
 ---
 
 Follow [`.ai/skills/rocprof-compute-code-review.md`](../../.ai/skills/rocprof-compute-code-review.md).

--- a/projects/rocprofiler-compute/.github/prompts/rocprof-compute-rebase-pr.prompt.md
+++ b/projects/rocprofiler-compute/.github/prompts/rocprof-compute-rebase-pr.prompt.md
@@ -1,0 +1,6 @@
+---
+agent: Rebase a PR branch onto origin/rocprofiler-compute-develop for a clean linear history.
+description: Rebase a PR branch onto origin/rocprofiler-compute-develop for a clean linear history.
+---
+
+Follow [`.ai/skills/rocprof-compute-rebase-pr.md`](../../.ai/skills/rocprof-compute-rebase-pr.md).

--- a/projects/rocprofiler-compute/.github/prompts/rocprof-compute-rebase-pr.prompt.md
+++ b/projects/rocprofiler-compute/.github/prompts/rocprof-compute-rebase-pr.prompt.md
@@ -1,5 +1,6 @@
 ---
-agent: Rebase a PR branch onto origin/rocprofiler-compute-develop for a clean linear history.
+agent: 'agent'
+description: Rebase a PR branch onto origin/rocprofiler-compute-develop for a clean linear history.
 ---
 
 Follow [`.ai/skills/rocprof-compute-rebase-pr.md`](../../.ai/skills/rocprof-compute-rebase-pr.md).


### PR DESCRIPTION
## Motivation

At sprint end, `rocprofiler-compute-develop` merges into `develop`, causing GitHub to retarget open PRs to `develop`. These PRs need rebasing back to `rocprofiler-compute-develop`, but standard git rebase fails on merge-heavy histories. This skill automates a reset + cherry-pick workflow to produce clean linear history.

## Technical Details

### What the skill does

1. Validates branch and PR base
2. Asks user to confirm which commits are theirs
3. Resets to `origin/rocprofiler-compute-develop` and cherry-picks confirmed commits
4. Force-pushes with `--force-with-lease`

### Files changed

- .ai/skills/rocprof-compute-rebase-pr.md — Core skill definition
- .claude/commands/rocprof-compute-rebase-pr.md — Claude Code shim
- .github/prompts/rocprof-compute-rebase-pr.prompt.md — GitHub Copilot shim
- .cursor/commands/rocprof-compute-rebase-pr.md — Cursor shim
- .github/prompts/rocprof-compute-code-review.prompt.md — Fix deprecated mode: agent

## JIRA ID

N/A

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
