### PR TITLE
[rocprofiler-compute] Fix PC sampling panel dropped in mixed analyze runs

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -32,7 +32,8 @@ from utils.utils_analysis import (
 from utils.utils_common import (
     canonical_config_arch,
     get_uuid,
-    is_only_pc_sampling,
+    is_counters_collected,
+    is_pc_sampling_collected,
     load_panel_configs,
     validate_roofline_csv,
 )
@@ -89,10 +90,71 @@ class OmniAnalyze_Base:
     def get_profiling_config(self) -> dict[str, Any]:
         return self._profiling_config
 
-    def pc_sampling_only(self) -> bool:
-        """True when profiling collected only PC sampling (block 21)."""
+    def pc_sampling_collected(self) -> bool:
+        """True when PC sampling (block 21) was among the collected blocks.
+
+        Stays True for mixed runs that also collect counters, so the PC
+        sampling panel is populated whenever its data was gathered.
+        """
         config = getattr(self, "_profiling_config", {})
-        return is_only_pc_sampling(config.get("filter_blocks", []))
+        return is_pc_sampling_collected(config.get("filter_blocks", []))
+
+    def counters_collected(self) -> bool:
+        """True when any hardware-counter block was collected."""
+        config = getattr(self, "_profiling_config", {})
+        return is_counters_collected(config.get("filter_blocks", []))
+
+    def pc_sampling_only(self) -> bool:
+        """True when PC sampling was collected and no counters were."""
+        return self.pc_sampling_collected() and not self.counters_collected()
+
+    def load_pc_sampling_tool_data(
+        self, workload_path: str
+    ) -> Optional[dict[str, Any]]:
+        """Parse ``ps_file_results.json`` when PC sampling was collected.
+
+        Returns ``None`` when PC sampling was not part of this run, so callers
+        on the counter path stay cheap while mixed runs still get their data.
+        """
+        if not self.pc_sampling_collected():
+            return None
+        return file_io.load_pc_sampling_results(str(workload_path))
+
+    def build_pc_sampling_only_workload(
+        self,
+        workload: schema.Workload,
+        dir_path: str,
+        args: argparse.Namespace,
+        tool_data: Optional[dict[str, Any]],
+        filter_nodes: Optional[list[str]] = None,
+    ) -> None:
+        """Populate a workload that has no hardware counters.
+
+        The dispatch scaffolding is derived from the PC sampling kernel trace
+        (there is no ``pmc_perf`` data), the non-metric tables are loaded, and
+        the metric cells are set to ``N/A`` since ``eval_metric`` is skipped.
+        """
+        workload.raw_pmc = file_io.process_pc_sampling_kernel_trace(tool_data)
+        workload.raw_pmc = workload.raw_pmc.rename(
+            columns={"Dispatch_Id": "Dispatch_ID"}
+        )
+        kernel_top_df, dispatch_info_df = file_io.create_df_kernel_top_stats(
+            df_in=workload.raw_pmc,
+            raw_data_dir=str(dir_path),
+            filter_gpu_ids=workload.filter_gpu_ids,
+            filter_dispatch_ids=workload.filter_dispatch_ids,
+            filter_nodes=(
+                filter_nodes if filter_nodes is not None else workload.filter_nodes
+            ),
+            time_unit=args.time_unit,
+            kernel_verbose=args.kernel_verbose,
+        )
+        workload.dfs[parser.PMC_KERNEL_TOP_TABLE_ID] = kernel_top_df
+        workload.dfs[parser.PMC_DISPATCH_INFO_TABLE_ID] = dispatch_info_df
+        parser.load_non_mertrics_table(
+            workload, dir_path, args, pc_sampling_tool_data=tool_data
+        )
+        parser.nullify_unevaluated_metric_values(workload)
 
     def set_soc(self, omni_socs: dict[str, OmniSoC_Base]) -> None:
         self.__socs = omni_socs

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -30,10 +30,10 @@ from utils.utils_analysis import (
     merge_counters_spatial_multiplex,
 )
 from utils.utils_common import (
+    PC_SAMPLING_BLOCK_IDS,
     canonical_config_arch,
     get_uuid,
-    is_counters_collected,
-    is_pc_sampling_collected,
+    is_only_pc_sampling,
     load_panel_configs,
     validate_roofline_csv,
 )
@@ -91,31 +91,21 @@ class OmniAnalyze_Base:
         return self._profiling_config
 
     def pc_sampling_collected(self) -> bool:
-        """True when PC sampling (block 21) was among the collected blocks.
-
-        Stays True for mixed runs that also collect counters, so the PC
-        sampling panel is populated whenever its data was gathered.
-        """
+        """True when PC sampling is among the collected blocks."""
         config = getattr(self, "_profiling_config", {})
-        return is_pc_sampling_collected(config.get("filter_blocks", []))
-
-    def counters_collected(self) -> bool:
-        """True when any hardware-counter block was collected."""
-        config = getattr(self, "_profiling_config", {})
-        return is_counters_collected(config.get("filter_blocks", []))
+        return any(
+            block in PC_SAMPLING_BLOCK_IDS for block in config.get("filter_blocks", [])
+        )
 
     def pc_sampling_only(self) -> bool:
-        """True when PC sampling was collected and no counters were."""
-        return self.pc_sampling_collected() and not self.counters_collected()
+        """True when every collected block is PC sampling."""
+        config = getattr(self, "_profiling_config", {})
+        return is_only_pc_sampling(config.get("filter_blocks", []))
 
     def load_pc_sampling_tool_data(
         self, workload_path: str
     ) -> Optional[dict[str, Any]]:
-        """Parse ``ps_file_results.json`` when PC sampling was collected.
-
-        Returns ``None`` when PC sampling was not part of this run, so callers
-        on the counter path stay cheap while mixed runs still get their data.
-        """
+        """Return parsed PC sampling tool data, or None when not collected."""
         if not self.pc_sampling_collected():
             return None
         return file_io.load_pc_sampling_results(str(workload_path))
@@ -128,12 +118,7 @@ class OmniAnalyze_Base:
         tool_data: Optional[dict[str, Any]],
         filter_nodes: Optional[list[str]] = None,
     ) -> None:
-        """Populate a workload that has no hardware counters.
-
-        The dispatch scaffolding is derived from the PC sampling kernel trace
-        (there is no ``pmc_perf`` data), the non-metric tables are loaded, and
-        the metric cells are set to ``N/A`` since ``eval_metric`` is skipped.
-        """
+        """Build dispatch scaffolding and tables for a run without counters."""
         workload.raw_pmc = file_io.process_pc_sampling_kernel_trace(tool_data)
         workload.raw_pmc = workload.raw_pmc.rename(
             columns={"Dispatch_Id": "Dispatch_ID"}

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -60,40 +60,20 @@ class cli_analysis(OmniAnalyze_Base):
         for path_info in args.path:
             workload = self._runs[path_info[0]]
 
-            # PC sampling only -- skip counter collection data loading
-            if self.pc_sampling_only():
+            pc_sampling_data = self.load_pc_sampling_tool_data(path_info[0])
+
+            # No counters collected -- derive scaffolding from the PC sampling
+            # kernel trace and skip metrics calculation.
+            if not self.counters_collected():
                 console_log(
                     "analysis",
                     "Only PC sampling and kernel tracing data"
                     " available, metrics calculation will be"
                     " skipped",
                 )
-
-                pc_sampling_data = file_io.load_pc_sampling_results(path_info[0])
-
-                workload.raw_pmc = file_io.process_pc_sampling_kernel_trace(
-                    pc_sampling_data
+                self.build_pc_sampling_only_workload(
+                    workload, path_info[0], args, pc_sampling_data
                 )
-                workload.raw_pmc = workload.raw_pmc.rename(
-                    columns={"Dispatch_Id": "Dispatch_ID"}
-                )
-
-                kernel_top_df, dispatch_info_df = file_io.create_df_kernel_top_stats(
-                    df_in=workload.raw_pmc,
-                    raw_data_dir=path_info[0],
-                    filter_gpu_ids=workload.filter_gpu_ids,
-                    filter_dispatch_ids=workload.filter_dispatch_ids,
-                    filter_nodes=workload.filter_nodes,
-                    time_unit=args.time_unit,
-                    kernel_verbose=args.kernel_verbose,
-                )
-                workload.dfs[parser.PMC_KERNEL_TOP_TABLE_ID] = kernel_top_df
-                workload.dfs[parser.PMC_DISPATCH_INFO_TABLE_ID] = dispatch_info_df
-
-                parser.load_non_mertrics_table(
-                    workload, path_info[0], args, pc_sampling_tool_data=pc_sampling_data
-                )
-                parser.nullify_unevaluated_metric_values(workload)
                 continue
 
             # create 'mega dataframe'
@@ -157,6 +137,7 @@ class cli_analysis(OmniAnalyze_Base):
                 is_gui=False,
                 args=args,
                 dfs_expressions=self._arch_configs[gpu_arch].dfs_expressions,
+                pc_sampling_tool_data=pc_sampling_data,
             )
 
     @demarcate

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_cli.py
@@ -64,7 +64,7 @@ class cli_analysis(OmniAnalyze_Base):
 
             # No counters collected -- derive scaffolding from the PC sampling
             # kernel trace and skip metrics calculation.
-            if not self.counters_collected():
+            if self.pc_sampling_only():
                 console_log(
                     "analysis",
                     "Only PC sampling and kernel tracing data"

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -75,7 +75,7 @@ class db_analysis(OmniAnalyze_Base):
         self._roofline_ceilings_per_workload = self.calc_roofline_ceilings()
         pc_sampling_tool_data = (
             {path: load_pc_sampling_results(path) for path in self._runs}
-            if self.pc_sampling_only()
+            if self.pc_sampling_collected()
             else {}
         )
         self._pc_sampling_data_per_workload = self.calc_pc_sampling_data(

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_webui.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_webui.py
@@ -120,34 +120,15 @@ class webui_analysis(OmniAnalyze_Base):
 
             run_workload = base_data[base_run]
 
-            if self.pc_sampling_only():
-                pc_sampling_data = file_io.load_pc_sampling_results(str(self.dest_dir))
-                run_workload.raw_pmc = file_io.process_pc_sampling_kernel_trace(
-                    pc_sampling_data
-                )
-                run_workload.raw_pmc = run_workload.raw_pmc.rename(
-                    columns={"Dispatch_Id": "Dispatch_ID"}
-                )
+            pc_sampling_data = self.load_pc_sampling_tool_data(str(self.dest_dir))
 
-                kernel_top_df, dispatch_info_df = file_io.create_df_kernel_top_stats(
-                    df_in=run_workload.raw_pmc,
-                    raw_data_dir=str(self.dest_dir),
-                    filter_gpu_ids=run_workload.filter_gpu_ids,
-                    filter_dispatch_ids=run_workload.filter_dispatch_ids,
-                    filter_nodes=self._runs[self.dest_dir].filter_nodes,
-                    time_unit=args.time_unit,
-                    kernel_verbose=args.kernel_verbose,
-                )
-                run_workload.dfs[parser.PMC_KERNEL_TOP_TABLE_ID] = kernel_top_df
-                run_workload.dfs[parser.PMC_DISPATCH_INFO_TABLE_ID] = dispatch_info_df
-                parser.load_non_mertrics_table(
+            if not self.counters_collected():
+                self.build_pc_sampling_only_workload(
                     run_workload,
                     self.dest_dir,
                     args,
-                    pc_sampling_tool_data=pc_sampling_data,
-                )
-                parser.nullify_unevaluated_metric_values(
-                    run_workload,
+                    pc_sampling_data,
+                    filter_nodes=self._runs[self.dest_dir].filter_nodes,
                 )
             else:
                 # Generate original raw df
@@ -243,6 +224,7 @@ class webui_analysis(OmniAnalyze_Base):
                     is_gui=True,
                     args=args,
                     dfs_expressions=self._arch_configs[gpu_arch].dfs_expressions,
+                    pc_sampling_tool_data=pc_sampling_data,
                 )
 
             # ~~~~~~~~~~~~~~~~~~~~~~~
@@ -424,33 +406,15 @@ class webui_analysis(OmniAnalyze_Base):
 
         workload = self._runs[self.dest_dir]
 
-        if self.pc_sampling_only():
+        pc_sampling_data = self.load_pc_sampling_tool_data(str(self.dest_dir))
+
+        if not self.counters_collected():
             console_log(
                 "analysis",
                 "PC sampling only -- skipping counter collection data loading",
             )
-            pc_sampling_data = file_io.load_pc_sampling_results(str(self.dest_dir))
-            workload.raw_pmc = file_io.process_pc_sampling_kernel_trace(
-                pc_sampling_data
-            )
-            workload.raw_pmc = workload.raw_pmc.rename(
-                columns={"Dispatch_Id": "Dispatch_ID"}
-            )
-
-            kernel_top_df, dispatch_info_df = file_io.create_df_kernel_top_stats(
-                df_in=workload.raw_pmc,
-                raw_data_dir=self.dest_dir,
-                filter_gpu_ids=workload.filter_gpu_ids,
-                filter_dispatch_ids=workload.filter_dispatch_ids,
-                filter_nodes=workload.filter_nodes,
-                time_unit=args.time_unit,
-                kernel_verbose=args.kernel_verbose,
-            )
-            workload.dfs[parser.PMC_KERNEL_TOP_TABLE_ID] = kernel_top_df
-            workload.dfs[parser.PMC_DISPATCH_INFO_TABLE_ID] = dispatch_info_df
-
-            parser.load_non_mertrics_table(
-                workload, self.dest_dir, args, pc_sampling_tool_data=pc_sampling_data
+            self.build_pc_sampling_only_workload(
+                workload, self.dest_dir, args, pc_sampling_data
             )
             self.arch = workload.sys_info.iloc[0]["gpu_arch"]
             return
@@ -486,7 +450,9 @@ class webui_analysis(OmniAnalyze_Base):
         workload.dfs[parser.PMC_KERNEL_TOP_TABLE_ID] = kernel_top_df
         workload.dfs[parser.PMC_DISPATCH_INFO_TABLE_ID] = dispatch_info_df
         # Load remaining non-metric tables (sysinfo, etc.)
-        parser.load_non_mertrics_table(workload, self.dest_dir, args)
+        parser.load_non_mertrics_table(
+            workload, self.dest_dir, args, pc_sampling_tool_data=pc_sampling_data
+        )
         # set architecture
         self.arch = workload.sys_info.iloc[0]["gpu_arch"]
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_webui.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_webui.py
@@ -122,7 +122,7 @@ class webui_analysis(OmniAnalyze_Base):
 
             pc_sampling_data = self.load_pc_sampling_tool_data(str(self.dest_dir))
 
-            if not self.counters_collected():
+            if self.pc_sampling_only():
                 self.build_pc_sampling_only_workload(
                     run_workload,
                     self.dest_dir,
@@ -408,7 +408,7 @@ class webui_analysis(OmniAnalyze_Base):
 
         pc_sampling_data = self.load_pc_sampling_tool_data(str(self.dest_dir))
 
-        if not self.counters_collected():
+        if self.pc_sampling_only():
             console_log(
                 "analysis",
                 "PC sampling only -- skipping counter collection data loading",

--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/analysis_tui.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/analysis_tui.py
@@ -45,7 +45,7 @@ class tui_analysis(OmniAnalyze_Base):
 
         # No counters collected -- derive scaffolding from the PC sampling
         # kernel trace and skip metrics calculation.
-        if not self.counters_collected():
+        if self.pc_sampling_only():
             console_log(
                 "analysis",
                 "Only PC sampling and kernel tracing data"

--- a/projects/rocprofiler-compute/src/rocprof_compute_tui/analysis_tui.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_tui/analysis_tui.py
@@ -41,41 +41,20 @@ class tui_analysis(OmniAnalyze_Base):
         # Initialize per-kernel dataframes
         self.raw_dfs: dict[str, Any] = {}
 
-        if self.pc_sampling_only():
+        pc_sampling_data = self.load_pc_sampling_tool_data(self.path)
+
+        # No counters collected -- derive scaffolding from the PC sampling
+        # kernel trace and skip metrics calculation.
+        if not self.counters_collected():
             console_log(
                 "analysis",
                 "Only PC sampling and kernel tracing data"
                 " available, metrics calculation will be"
                 " skipped",
             )
-            pc_sampling_data = file_io.load_pc_sampling_results(self.path)
-
-            workload.raw_pmc = file_io.process_pc_sampling_kernel_trace(
-                pc_sampling_data
+            self.build_pc_sampling_only_workload(
+                workload, self.path, self.args, pc_sampling_data
             )
-            workload.raw_pmc = workload.raw_pmc.rename(
-                columns={"Dispatch_Id": "Dispatch_ID"}
-            )
-
-            kernel_top_df, dispatch_info_df = file_io.create_df_kernel_top_stats(
-                df_in=workload.raw_pmc,
-                raw_data_dir=self.path,
-                filter_gpu_ids=workload.filter_gpu_ids,
-                filter_dispatch_ids=workload.filter_dispatch_ids,
-                filter_nodes=workload.filter_nodes,
-                time_unit=self.args.time_unit,
-                kernel_verbose=self.args.kernel_verbose,
-            )
-            workload.dfs[parser.PMC_KERNEL_TOP_TABLE_ID] = kernel_top_df
-            workload.dfs[parser.PMC_DISPATCH_INFO_TABLE_ID] = dispatch_info_df
-
-            parser.load_non_mertrics_table(
-                workload=workload,
-                dir_path=self.path,
-                args=self.args,
-                pc_sampling_tool_data=pc_sampling_data,
-            )
-            parser.nullify_unevaluated_metric_values(workload)
             return
 
         # Join results_*.csv source files into pmc_perf.csv if needed (Phase 2)
@@ -109,6 +88,7 @@ class tui_analysis(OmniAnalyze_Base):
             workload=workload,
             dir_path=self.path,
             args=self.args,
+            pc_sampling_tool_data=pc_sampling_data,
         )
 
         # Group raw PMC data by kernel name

--- a/projects/rocprofiler-compute/src/utils/file_io.py
+++ b/projects/rocprofiler-compute/src/utils/file_io.py
@@ -239,7 +239,8 @@ def load_pc_sampling_results(workload_path: str) -> Optional[dict[str, Any]]:
         with json_path.open(encoding="utf-8") as json_file:
             return json.load(json_file)["rocprofiler-sdk-tool"][0]
     except (json.JSONDecodeError, KeyError, IndexError) as error:
-        console_error(f"PC sampling: failed to parse {json_path}: {error}")
+        console_warning(f"PC sampling: failed to parse {json_path}: {error}")
+        return None
 
 
 def process_pc_sampling_kernel_trace(

--- a/projects/rocprofiler-compute/src/utils/file_io.py
+++ b/projects/rocprofiler-compute/src/utils/file_io.py
@@ -227,7 +227,8 @@ def build_agent_to_gpu_map_from_json(
 def load_pc_sampling_results(workload_path: str) -> Optional[dict[str, Any]]:
     """
     Parse ``ps_file_results.json`` and return its ``rocprofiler-sdk-tool[0]``
-    record, or ``None`` if the file is absent.
+    record. Returns ``None`` if the file is absent or fails to parse (a
+    warning is logged in the latter case).
 
     The json can be multiple GB: parse once here and pass the dict to every
     PC sampling consumer instead of re-reading the file.

--- a/projects/rocprofiler-compute/src/utils/parser.py
+++ b/projects/rocprofiler-compute/src/utils/parser.py
@@ -414,16 +414,22 @@ def load_pc_sampling_data_per_kernel(
     :param sorting_type: "offset" or "count".
     :param kernel_name: Kernel to filter to, or None for all kernels.
     """
+    kernel_context = f"kernel '{kernel_name}'" if kernel_name else "all kernels"
     pc_samples = tool_data["buffer_records"][
         "pc_sample_host_trap" if method == "host_trap" else "pc_sample_stochastic"
     ]
     if not pc_samples:
-        console_error("PC sampling: can not find pc sample.")
+        console_warning(f"PC sampling: no pc samples found for {kernel_context}.")
+        return pd.DataFrame()
 
     instructions = tool_data["strings"]["pc_sample_instructions"]
     comments = tool_data["strings"]["pc_sample_comments"]
     if not instructions or not comments:
-        console_error("PC sampling: instruction or comment string table is empty.")
+        console_warning(
+            "PC sampling: instruction or comment string table is empty for "
+            f"{kernel_context}."
+        )
+        return pd.DataFrame()
 
     records_df = load_pc_sample_records(tool_data)
     aggregated_df = aggregate_pc_sample_records(
@@ -642,6 +648,7 @@ def load_table_data(
     args: argparse.Namespace,
     dfs_expressions: dict[int, list[str]],
     skip_kernel_top: bool = False,
+    pc_sampling_tool_data: Optional[dict[str, Any]] = None,
 ) -> None:
     """
     - Load data for all "raw_csv_table"
@@ -649,7 +656,7 @@ def load_table_data(
     - Calculate mertric value for all "metric_table"
     """
     if not skip_kernel_top:
-        load_non_mertrics_table(workload, dir_path, args)
+        load_non_mertrics_table(workload, dir_path, args, pc_sampling_tool_data)
 
     eval_metric(
         workload.dfs,

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -630,23 +630,6 @@ def is_only_pc_sampling(filter_blocks: list[str]) -> bool:
     )
 
 
-def is_pc_sampling_collected(filter_blocks: list[str]) -> bool:
-    """Return True if any requested block is PC sampling (block 21 or the
-    ``pc_sampling`` alias).
-
-    Unlike :func:`is_only_pc_sampling`, this stays True for mixed runs that
-    also collect hardware counters, so the PC sampling panel is populated
-    whenever PC sampling data was gathered.
-    """
-    return any(block in PC_SAMPLING_BLOCK_IDS for block in filter_blocks)
-
-
-def is_counters_collected(filter_blocks: list[str]) -> bool:
-    """Return True if any requested block is a hardware-counter block (i.e.
-    anything other than PC sampling)."""
-    return any(block not in PC_SAMPLING_BLOCK_IDS for block in filter_blocks)
-
-
 def format_time(seconds: float) -> str:
     hours = int(seconds // 3600)
     minutes = int((seconds % 3600) // 60)

--- a/projects/rocprofiler-compute/src/utils/utils_common.py
+++ b/projects/rocprofiler-compute/src/utils/utils_common.py
@@ -630,6 +630,23 @@ def is_only_pc_sampling(filter_blocks: list[str]) -> bool:
     )
 
 
+def is_pc_sampling_collected(filter_blocks: list[str]) -> bool:
+    """Return True if any requested block is PC sampling (block 21 or the
+    ``pc_sampling`` alias).
+
+    Unlike :func:`is_only_pc_sampling`, this stays True for mixed runs that
+    also collect hardware counters, so the PC sampling panel is populated
+    whenever PC sampling data was gathered.
+    """
+    return any(block in PC_SAMPLING_BLOCK_IDS for block in filter_blocks)
+
+
+def is_counters_collected(filter_blocks: list[str]) -> bool:
+    """Return True if any requested block is a hardware-counter block (i.e.
+    anything other than PC sampling)."""
+    return any(block not in PC_SAMPLING_BLOCK_IDS for block in filter_blocks)
+
+
 def format_time(seconds: float) -> str:
     hours = int(seconds // 3600)
     minutes = int((seconds % 3600) // 60)

--- a/projects/rocprofiler-compute/tests/test_pc_sampling.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling.py
@@ -302,9 +302,8 @@ def test_pc_sampling_with_sol_block(
     monkeypatch,
 ):
     """
-    Test that PC sampling works with --block 21 and --block 2
-    (PC sampling with counter collection), and that analyze renders both the
-    counter panels and a populated PC sampling panel for the mixed run.
+    PC sampling with counter collection (--block 21 2): profiling produces the
+    expected artifacts and analyze renders both counter and PC sampling panels.
     """
     common.require_pc_sampling_gpu()
     monkeypatch.setenv("ROCPROF", "rocprofiler-sdk")
@@ -340,10 +339,7 @@ def test_pc_sampling_with_sol_block(
     assert common.check_file_pattern("- '21'", f"{workload_dir}/profiling_config.yaml")
     assert common.check_file_pattern("- '2'", f"{workload_dir}/profiling_config.yaml")
 
-    # Analyze the mixed run: a single kernel is required to render the detailed
-    # PC sampling table (21.x). Both the counter SoL panel and the PC sampling
-    # panel must appear, and the PC sampling table must contain instruction rows
-    # (an empty table would still print the header, so assert on row content).
+    # Analyze with a single kernel so the detailed PC sampling table renders.
     code = binary_handler_analyze_rocprof_compute(
         [
             "analyze",
@@ -358,8 +354,7 @@ def test_pc_sampling_with_sol_block(
     captured = capsys.readouterr()
     assert "2.1 System Speed-of-Light" in captured.out
     assert "21. PC Sampling" in captured.out
-    # The detailed PC sampling table only renders the "instruction" column when
-    # it has rows; an empty table (the mixed-run regression) would not.
+    # The "instruction" column header only renders when the table has rows.
     assert "instruction" in captured.out
 
     common.clean_output_dir(config["cleanup"], workload_dir)

--- a/projects/rocprofiler-compute/tests/test_pc_sampling.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling.py
@@ -296,11 +296,15 @@ def test_pc_sampling_profile_then_analyze(
 
 
 def test_pc_sampling_with_sol_block(
-    binary_handler_profile_rocprof_compute, monkeypatch
+    binary_handler_profile_rocprof_compute,
+    binary_handler_analyze_rocprof_compute,
+    capsys,
+    monkeypatch,
 ):
     """
     Test that PC sampling works with --block 21 and --block 2
-    (PC sampling with counter collection)
+    (PC sampling with counter collection), and that analyze renders both the
+    counter panels and a populated PC sampling panel for the mixed run.
     """
     common.require_pc_sampling_gpu()
     monkeypatch.setenv("ROCPROF", "rocprofiler-sdk")
@@ -335,5 +339,27 @@ def test_pc_sampling_with_sol_block(
 
     assert common.check_file_pattern("- '21'", f"{workload_dir}/profiling_config.yaml")
     assert common.check_file_pattern("- '2'", f"{workload_dir}/profiling_config.yaml")
+
+    # Analyze the mixed run: a single kernel is required to render the detailed
+    # PC sampling table (21.x). Both the counter SoL panel and the PC sampling
+    # panel must appear, and the PC sampling table must contain instruction rows
+    # (an empty table would still print the header, so assert on row content).
+    code = binary_handler_analyze_rocprof_compute(
+        [
+            "analyze",
+            "--path",
+            workload_dir,
+            "--kernel",
+            "0",
+        ],
+    )
+    assert code == 0
+
+    captured = capsys.readouterr()
+    assert "2.1 System Speed-of-Light" in captured.out
+    assert "21. PC Sampling" in captured.out
+    # The detailed PC sampling table only renders the "instruction" column when
+    # it has rows; an empty table (the mixed-run regression) would not.
+    assert "instruction" in captured.out
 
     common.clean_output_dir(config["cleanup"], workload_dir)

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
@@ -1,6 +1,7 @@
 # Copyright (c) Advanced Micro Devices, Inc.
 # SPDX-License-Identifier:  MIT
 
+import argparse
 import json
 import sqlite3
 from pathlib import Path
@@ -19,8 +20,10 @@ from utils.file_io import (
 )
 from utils.parser import (
     PMC_KERNEL_TOP_TABLE_ID,
+    load_non_mertrics_table,
     load_pc_sampling_data,
     load_pc_sampling_data_per_kernel,
+    load_table_data,
     nullify_unevaluated_metric_values,
 )
 from utils.pc_sampling_analysis import (
@@ -30,7 +33,11 @@ from utils.pc_sampling_analysis import (
     load_aggregated_pc_sampling,
     load_pc_sample_records,
 )
-from utils.utils_common import is_only_pc_sampling
+from utils.utils_common import (
+    is_counters_collected,
+    is_only_pc_sampling,
+    is_pc_sampling_collected,
+)
 
 PC_SAMPLING_WORKLOAD = "tests/workloads/vcopy_pc_sampling_only/MI300A_A1"
 
@@ -173,6 +180,38 @@ def write_results_json(path: Path, **kwargs) -> Path:
 def test_is_only_pc_sampling(filter_blocks: list[str], expected: bool) -> None:
     """True only when every requested block is PC sampling (21 / pc_sampling)."""
     assert is_only_pc_sampling(filter_blocks) is expected
+
+
+@pytest.mark.parametrize(
+    "filter_blocks, expected",
+    [
+        ([], False),
+        (["21"], True),
+        (["pc_sampling"], True),
+        (["21", "pc_sampling"], True),
+        (["21", "2"], True),
+        (["2"], False),
+    ],
+)
+def test_is_pc_sampling_collected(filter_blocks: list[str], expected: bool) -> None:
+    """True when ANY requested block is PC sampling, incl. mixed runs."""
+    assert is_pc_sampling_collected(filter_blocks) is expected
+
+
+@pytest.mark.parametrize(
+    "filter_blocks, expected",
+    [
+        ([], False),
+        (["21"], False),
+        (["pc_sampling"], False),
+        (["21", "pc_sampling"], False),
+        (["21", "2"], True),
+        (["2"], True),
+    ],
+)
+def test_is_counters_collected(filter_blocks: list[str], expected: bool) -> None:
+    """True when ANY requested block is a hardware-counter block."""
+    assert is_counters_collected(filter_blocks) is expected
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -659,19 +698,22 @@ def test_load_per_kernel_out_of_range_index_guards(
         pytest.param(["v_mov", "v_add"], None, id="empty_comments"),
     ],
 )
-def test_load_per_kernel_empty_string_table_exits(
+def test_load_per_kernel_empty_string_table_warns_and_skips(
     instructions: list | None,
     comments: list | None,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """An empty instruction/comment table is treated as missing and exits."""
+    """An empty instruction/comment table warns (with kernel name) and returns
+    an empty frame instead of aborting the whole analysis."""
     tool_data = make_per_kernel_guard_data(instructions, comments)
-    with pytest.raises(SystemExit):
-        load_pc_sampling_data_per_kernel(
-            method="host_trap",
-            tool_data=tool_data,
-            kernel_name="vecCopy",
-            sorting_type="offset",
-        )
+    df = load_pc_sampling_data_per_kernel(
+        method="host_trap",
+        tool_data=tool_data,
+        kernel_name="vecCopy",
+        sorting_type="offset",
+    )
+    assert df.empty
+    assert "vecCopy" in caplog.text
 
 
 def assert_none_kind(column: pd.Series, kind: str) -> None:
@@ -754,22 +796,25 @@ def test_load_per_kernel_kernel_not_found() -> None:
     assert df.empty
 
 
-def test_load_per_kernel_no_pc_sample_key() -> None:
+def test_load_per_kernel_no_pc_sample_key_warns_and_skips(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """
-    When the tool data has no populated pc_sample array,
-    the per-kernel loader calls console_error which exits.
+    When the tool data has no populated pc_sample array, the per-kernel loader
+    warns (with kernel name) and returns an empty frame instead of exiting.
     """
     tool_data = make_tool_data(
         kernel_symbols=[make_kernel_symbol(100, 5, "vecCopy")],
         kernel_dispatch=[make_dispatch(0, 100)],
     )
-    with pytest.raises(SystemExit):
-        load_pc_sampling_data_per_kernel(
-            method="host_trap",
-            tool_data=tool_data,
-            kernel_name="vecCopy",
-            sorting_type="offset",
-        )
+    df = load_pc_sampling_data_per_kernel(
+        method="host_trap",
+        tool_data=tool_data,
+        kernel_name="vecCopy",
+        sorting_type="offset",
+    )
+    assert df.empty
+    assert "vecCopy" in caplog.text
 
 
 def test_load_per_kernel_invalid_sorting_type() -> None:
@@ -1157,6 +1202,100 @@ def make_db_analysis(workload_path: str) -> db_analysis:
     return instance
 
 
+def _make_from_pc_sampling_workload() -> schema.Workload:
+    """A workload holding a single ``from_pc_sampling`` table to be loaded."""
+    workload = schema.Workload()
+    workload.dfs = {2101: pd.DataFrame({"from_pc_sampling": ["ps_file"]})}
+    return workload
+
+
+def _mixed_tool_data_kwargs() -> dict:
+    return {
+        "stochastic": [make_record(5, 0x10, 0, dispatch_id=0, wave_issued=True)],
+        "instructions": ["v_mov"],
+        "comments": ["/s/a.cpp:1"],
+        "kernel_symbols": [make_kernel_symbol(100, 5, "vecCopy")],
+        "kernel_dispatch": [make_dispatch(0, 100)],
+    }
+
+
+def _mixed_tool_data() -> dict:
+    return make_tool_data(**_mixed_tool_data_kwargs())
+
+
+def test_load_pc_sampling_tool_data_gate(tmp_path: Path) -> None:
+    """The shared load gate keys on collection, not on PC-sampling-only mode.
+
+    This guards the mixed-run regression: counters + PC sampling must still
+    load the tool data so the block-21 panel is populated.
+    """
+    write_results_json(tmp_path / "ps_file_results.json", **_mixed_tool_data_kwargs())
+    instance = make_db_analysis(str(tmp_path))
+
+    instance._profiling_config = {"filter_blocks": ["21", "2"]}  # mixed
+    assert instance.pc_sampling_collected() is True
+    assert instance.counters_collected() is True
+    assert instance.pc_sampling_only() is False
+    assert instance.load_pc_sampling_tool_data(str(tmp_path)) is not None
+
+    instance._profiling_config = {"filter_blocks": ["21"]}  # pc sampling only
+    assert instance.pc_sampling_only() is True
+    assert instance.load_pc_sampling_tool_data(str(tmp_path)) is not None
+
+    instance._profiling_config = {"filter_blocks": ["2"]}  # counters only
+    assert instance.pc_sampling_collected() is False
+    assert instance.load_pc_sampling_tool_data(str(tmp_path)) is None
+
+
+def test_load_table_data_forwards_pc_sampling_tool_data() -> None:
+    """load_table_data forwards tool data to load_non_mertrics_table.
+
+    Directly guards the line whose omission dropped the PC sampling table on
+    the counter path in mixed runs.
+    """
+    sentinel = {"sentinel": True}
+    args = argparse.Namespace(debug=False)
+    workload = schema.Workload()
+    workload.sys_info = pd.DataFrame([{"gpu_arch": "gfx942"}])
+    with (
+        patch("utils.parser.load_non_mertrics_table") as mock_load_non_metrics,
+        patch("utils.parser.eval_metric"),
+        patch("utils.parser.apply_filters"),
+    ):
+        load_table_data(
+            workload=workload,
+            dir_path="dir",
+            is_gui=False,
+            args=args,
+            dfs_expressions={},
+            pc_sampling_tool_data=sentinel,
+        )
+    mock_load_non_metrics.assert_called_once()
+    assert mock_load_non_metrics.call_args.args[3] is sentinel
+
+
+def test_load_non_mertrics_table_populates_pc_sampling_from_tool_data(
+    tmp_path: Path,
+) -> None:
+    """A ``from_pc_sampling`` table is populated when tool data is provided."""
+    args = argparse.Namespace(pc_sampling_sorting_type="count")
+    workload = _make_from_pc_sampling_workload()
+    load_non_mertrics_table(
+        workload, str(tmp_path), args, pc_sampling_tool_data=_mixed_tool_data()
+    )
+    assert not workload.dfs[2101].empty
+
+
+def test_load_non_mertrics_table_pc_sampling_empty_without_tool_data(
+    tmp_path: Path,
+) -> None:
+    """Without tool data the ``from_pc_sampling`` table stays empty (no crash)."""
+    args = argparse.Namespace(pc_sampling_sorting_type="count")
+    workload = _make_from_pc_sampling_workload()
+    load_non_mertrics_table(workload, str(tmp_path), args)
+    assert workload.dfs[2101].empty
+
+
 def test_calc_pc_sampling_data_missing_file(
     tmp_path: Path,
 ) -> None:
@@ -1414,7 +1553,7 @@ def test_pc_sampling_analyze_db_output(
     binary_handler_analyze_rocprof_compute,
     monkeypatch,
 ) -> None:
-    """Analyze in db mode produces a populated pcsampling table."""
+    """Analyze in db mode produces a populated pc sampling table."""
     workload_dir = Path(common.setup_workload_dir(PC_SAMPLING_WORKLOAD)).resolve()
     db_name = "pc_sampling_db_test"
     db_path = workload_dir / f"{db_name}.db"

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
@@ -33,11 +33,7 @@ from utils.pc_sampling_analysis import (
     load_aggregated_pc_sampling,
     load_pc_sample_records,
 )
-from utils.utils_common import (
-    is_counters_collected,
-    is_only_pc_sampling,
-    is_pc_sampling_collected,
-)
+from utils.utils_common import is_only_pc_sampling
 
 PC_SAMPLING_WORKLOAD = "tests/workloads/vcopy_pc_sampling_only/MI300A_A1"
 
@@ -161,6 +157,17 @@ def write_results_json(path: Path, **kwargs) -> Path:
     return path
 
 
+def sample_tool_data_kwargs() -> dict:
+    """Minimal populated tool-data kwargs with one kernel and one sample."""
+    return {
+        "stochastic": [make_record(5, 0x10, 0, dispatch_id=0, wave_issued=True)],
+        "instructions": ["v_mov"],
+        "comments": ["/s/a.cpp:1"],
+        "kernel_symbols": [make_kernel_symbol(100, 5, "vecCopy")],
+        "kernel_dispatch": [make_dispatch(0, 100)],
+    }
+
+
 # ═══════════════════════════════════════════════════════════════
 # is_only_pc_sampling
 # ═══════════════════════════════════════════════════════════════
@@ -193,25 +200,13 @@ def test_is_only_pc_sampling(filter_blocks: list[str], expected: bool) -> None:
         (["2"], False),
     ],
 )
-def test_is_pc_sampling_collected(filter_blocks: list[str], expected: bool) -> None:
-    """True when ANY requested block is PC sampling, incl. mixed runs."""
-    assert is_pc_sampling_collected(filter_blocks) is expected
-
-
-@pytest.mark.parametrize(
-    "filter_blocks, expected",
-    [
-        ([], False),
-        (["21"], False),
-        (["pc_sampling"], False),
-        (["21", "pc_sampling"], False),
-        (["21", "2"], True),
-        (["2"], True),
-    ],
-)
-def test_is_counters_collected(filter_blocks: list[str], expected: bool) -> None:
-    """True when ANY requested block is a hardware-counter block."""
-    assert is_counters_collected(filter_blocks) is expected
+def test_pc_sampling_collected(
+    filter_blocks: list[str], expected: bool, tmp_path: Path
+) -> None:
+    """True when any collected block is PC sampling, including mixed runs."""
+    instance = make_db_analysis(str(tmp_path))
+    instance._profiling_config = {"filter_blocks": filter_blocks}
+    assert instance.pc_sampling_collected() is expected
 
 
 # ═══════════════════════════════════════════════════════════════
@@ -703,8 +698,7 @@ def test_load_per_kernel_empty_string_table_warns_and_skips(
     comments: list | None,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """An empty instruction/comment table warns (with kernel name) and returns
-    an empty frame instead of aborting the whole analysis."""
+    """Empty instruction/comment table warns with the kernel name, no exit."""
     tool_data = make_per_kernel_guard_data(instructions, comments)
     df = load_pc_sampling_data_per_kernel(
         method="host_trap",
@@ -799,10 +793,7 @@ def test_load_per_kernel_kernel_not_found() -> None:
 def test_load_per_kernel_no_pc_sample_key_warns_and_skips(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """
-    When the tool data has no populated pc_sample array, the per-kernel loader
-    warns (with kernel name) and returns an empty frame instead of exiting.
-    """
+    """Missing pc_sample array warns with the kernel name, no exit."""
     tool_data = make_tool_data(
         kernel_symbols=[make_kernel_symbol(100, 5, "vecCopy")],
         kernel_dispatch=[make_dispatch(0, 100)],
@@ -1202,39 +1193,13 @@ def make_db_analysis(workload_path: str) -> db_analysis:
     return instance
 
 
-def _make_from_pc_sampling_workload() -> schema.Workload:
-    """A workload holding a single ``from_pc_sampling`` table to be loaded."""
-    workload = schema.Workload()
-    workload.dfs = {2101: pd.DataFrame({"from_pc_sampling": ["ps_file"]})}
-    return workload
-
-
-def _mixed_tool_data_kwargs() -> dict:
-    return {
-        "stochastic": [make_record(5, 0x10, 0, dispatch_id=0, wave_issued=True)],
-        "instructions": ["v_mov"],
-        "comments": ["/s/a.cpp:1"],
-        "kernel_symbols": [make_kernel_symbol(100, 5, "vecCopy")],
-        "kernel_dispatch": [make_dispatch(0, 100)],
-    }
-
-
-def _mixed_tool_data() -> dict:
-    return make_tool_data(**_mixed_tool_data_kwargs())
-
-
 def test_load_pc_sampling_tool_data_gate(tmp_path: Path) -> None:
-    """The shared load gate keys on collection, not on PC-sampling-only mode.
-
-    This guards the mixed-run regression: counters + PC sampling must still
-    load the tool data so the block-21 panel is populated.
-    """
-    write_results_json(tmp_path / "ps_file_results.json", **_mixed_tool_data_kwargs())
+    """Tool data loads whenever PC sampling was collected, else returns None."""
+    write_results_json(tmp_path / "ps_file_results.json", **sample_tool_data_kwargs())
     instance = make_db_analysis(str(tmp_path))
 
     instance._profiling_config = {"filter_blocks": ["21", "2"]}  # mixed
     assert instance.pc_sampling_collected() is True
-    assert instance.counters_collected() is True
     assert instance.pc_sampling_only() is False
     assert instance.load_pc_sampling_tool_data(str(tmp_path)) is not None
 
@@ -1248,11 +1213,7 @@ def test_load_pc_sampling_tool_data_gate(tmp_path: Path) -> None:
 
 
 def test_load_table_data_forwards_pc_sampling_tool_data() -> None:
-    """load_table_data forwards tool data to load_non_mertrics_table.
-
-    Directly guards the line whose omission dropped the PC sampling table on
-    the counter path in mixed runs.
-    """
+    """load_table_data forwards tool data to load_non_mertrics_table."""
     sentinel = {"sentinel": True}
     args = argparse.Namespace(debug=False)
     workload = schema.Workload()
@@ -1279,9 +1240,11 @@ def test_load_non_mertrics_table_populates_pc_sampling_from_tool_data(
 ) -> None:
     """A ``from_pc_sampling`` table is populated when tool data is provided."""
     args = argparse.Namespace(pc_sampling_sorting_type="count")
-    workload = _make_from_pc_sampling_workload()
+    workload = schema.Workload()
+    workload.dfs = {2101: pd.DataFrame({"from_pc_sampling": ["ps_file"]})}
+    tool_data = make_tool_data(**sample_tool_data_kwargs())
     load_non_mertrics_table(
-        workload, str(tmp_path), args, pc_sampling_tool_data=_mixed_tool_data()
+        workload, str(tmp_path), args, pc_sampling_tool_data=tool_data
     )
     assert not workload.dfs[2101].empty
 
@@ -1291,7 +1254,8 @@ def test_load_non_mertrics_table_pc_sampling_empty_without_tool_data(
 ) -> None:
     """Without tool data the ``from_pc_sampling`` table stays empty (no crash)."""
     args = argparse.Namespace(pc_sampling_sorting_type="count")
-    workload = _make_from_pc_sampling_workload()
+    workload = schema.Workload()
+    workload.dfs = {2101: pd.DataFrame({"from_pc_sampling": ["ps_file"]})}
     load_non_mertrics_table(workload, str(tmp_path), args)
     assert workload.dfs[2101].empty
 

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
@@ -696,18 +696,19 @@ def test_load_per_kernel_out_of_range_index_guards(
 def test_load_per_kernel_empty_string_table_warns_and_skips(
     instructions: list | None,
     comments: list | None,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Empty instruction/comment table warns with the kernel name, no exit."""
     tool_data = make_per_kernel_guard_data(instructions, comments)
-    df = load_pc_sampling_data_per_kernel(
-        method="host_trap",
-        tool_data=tool_data,
-        kernel_name="vecCopy",
-        sorting_type="offset",
-    )
+    with patch("utils.parser.console_warning") as console_warning_mock:
+        df = load_pc_sampling_data_per_kernel(
+            method="host_trap",
+            tool_data=tool_data,
+            kernel_name="vecCopy",
+            sorting_type="offset",
+        )
     assert df.empty
-    assert "vecCopy" in caplog.text
+    console_warning_mock.assert_called_once()
+    assert "vecCopy" in console_warning_mock.call_args.args[0]
 
 
 def assert_none_kind(column: pd.Series, kind: str) -> None:
@@ -790,22 +791,22 @@ def test_load_per_kernel_kernel_not_found() -> None:
     assert df.empty
 
 
-def test_load_per_kernel_no_pc_sample_key_warns_and_skips(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_load_per_kernel_no_pc_sample_key_warns_and_skips() -> None:
     """Missing pc_sample array warns with the kernel name, no exit."""
     tool_data = make_tool_data(
         kernel_symbols=[make_kernel_symbol(100, 5, "vecCopy")],
         kernel_dispatch=[make_dispatch(0, 100)],
     )
-    df = load_pc_sampling_data_per_kernel(
-        method="host_trap",
-        tool_data=tool_data,
-        kernel_name="vecCopy",
-        sorting_type="offset",
-    )
+    with patch("utils.parser.console_warning") as console_warning_mock:
+        df = load_pc_sampling_data_per_kernel(
+            method="host_trap",
+            tool_data=tool_data,
+            kernel_name="vecCopy",
+            sorting_type="offset",
+        )
     assert df.empty
-    assert "vecCopy" in caplog.text
+    console_warning_mock.assert_called_once()
+    assert "vecCopy" in console_warning_mock.call_args.args[0]
 
 
 def test_load_per_kernel_invalid_sorting_type() -> None:


### PR DESCRIPTION
## Motivation

Bugfix: PC sampling analysis (block 21) is dropped when PC sampling is collected alongside hardware counters (e.g. `-b 2 --pc-sampling`). The PC sampling tool data was only loaded in PC-sampling-only mode, so mixed runs rendered an empty block 21 panel across all four analyze backends (cli, db, webui, tui).

## Technical Details

- Add `pc_sampling_collected()` (any block 21) in `analysis_base`, and load PC sampling tool data whenever it is true; `pc_sampling_only()` still selects the no-counter scaffolding path.
- Thread `pc_sampling_tool_data` through `parser.load_table_data` so the counter path populates the PC sampling table.
- Route cli/tui/webui through a shared `analysis_base` helper; widen the db gate to `pc_sampling_collected()`.
- Warn and skip instead of aborting analysis when PC sampling data is missing or malformed; include the kernel name for context.

## JIRA ID

AIPROFCOMP-605

## Test Plan

- New unit tests: predicate check, `load_table_data` forwarding, `load_non_mertrics_table` population, and the shared load gate for mixed / pc-only / counters-only configs.
- Extended GPU test `test_pc_sampling_with_sol_block` to run analyze on a `-b 21 2` workload and assert both the counter SoL panel and a populated PC sampling table render.
- Manually verified on a mixed `rocflop` workload (`-b 2 --pc-sampling`): block 21 now renders with instruction rows alongside the counter panels.

## Test Result

Unit tests pass locally (`test_pc_sampling_analysis.py`, `test_analyze_commands.py` with `-n 4`). The GPU integration test is left to CI.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.