### PR TITLE
[RCCL] Add unit test pinning NCCL_PXN_C2C default off

### DIFF
--- a/projects/rccl/CHANGELOG.md
+++ b/projects/rccl/CHANGELOG.md
@@ -39,6 +39,7 @@ Full documentation for RCCL is available at [https://rccl.readthedocs.io](https:
 * Changed GPU Direct RDMA mode selection logic to prefer peermem over DMAbuf by default. `NCCL_DMABUF_ENABLE` now defaults to 1 (previously 0). When both peermem and DMAbuf are available, RCCL will use peermem. If peermem is unavailable, RCCL will automatically fall back to DMAbuf (if available and enabled). Setting `RCCL_FORCE_ENABLE_DMABUF=1` forces DMAbuf usage exclusively, skipping peermem even if available, and disables GPU Direct RDMA if DMAbuf is unavailable.
 * CTS offload is now controlled per-connection rather than globally, allowing P2P connections to fall back to standard RDMA writes while non-P2P traffic continues to use CTS.
 * The bootstrap AllGather now uses the bidirectional ring (N/2 steps) by default on the socket OOB path. `NCCL_BOOTSTRAP_BIDIR_ALLGATHER` now defaults to `1`; set it to `0` to fall back to the unidirectional ring. The net OOB path (`NCCL_OOB_NET_ENABLE`) and its bidirectional variant (`NCCL_BOOTSTRAP_BIDIR_NET`) remain off by default.
+* `NCCL_PXN_C2C` is kept default-off (`0`); upstream NCCL defaults it to `1` since 2.28. The C2C PXN routing path is NVIDIA-specific and is not currently applicable on AMD hardware.
 
 ### Removed
 * Removed MSCCL and MSCCL++ custom collective integration; legacy ``mscclLoadAlgo``, ``mscclRunAlgo``, and ``mscclUnloadAlgo`` APIs remain as no-ops for link compatibility.

--- a/projects/rccl/docs/api-reference/env-variables.rst
+++ b/projects/rccl/docs/api-reference/env-variables.rst
@@ -152,6 +152,13 @@ in the following table.
       - | Integer value (default: ``-1``)
         | See InfiniBand ``show_gids`` command for valid values
 
+    * - | ``NCCL_PXN_C2C``
+        | Allows PXN routing through a C2C link to reach a NIC attached to a
+          peer GPU. The C2C path is NVIDIA-specific and is not currently
+          applicable on AMD hardware.
+      - | ``0``: Disabled (default).
+        | ``1``: Enabled.
+
     * - | ``NCCL_SOCKET_IFNAME``
         | Specifies which IP interfaces to use for communication.
       - | Interface prefix string or list

--- a/projects/rccl/test/ParamTests.cpp
+++ b/projects/rccl/test/ParamTests.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <rccl/rccl.h>
 #include "common/ProcessIsolatedTestRunner.hpp"
+#include "graph/topo.h"
 
 namespace RcclUnitTesting {
 TEST(ParamTests, initEnv_ParseValidConfFile) {
@@ -52,6 +53,19 @@ TEST(ParamTests, ncclLoadParam_InvalidParam) {
           unsetenv("TEST_INVALID_PARAM");
 
           ASSERT_EQ(cache, defaultVal); // Cache should be set to default value
+      }
+  );
+}
+
+TEST(ParamTests, ncclPxnC2cParam_DefaultOff) {
+  RUN_ISOLATED_TEST(
+      "ncclPxnC2cParam_DefaultOff",
+      []()
+      {
+          initEnv();
+          // No-op on xGMI; default must stay off.
+          unsetenv("NCCL_PXN_C2C");
+          ASSERT_EQ(ncclParamPxnC2c(), 0);
       }
   );
 }


### PR DESCRIPTION
## Motivation

`NCCL_PXN_C2C` selects PXN routing over a C2C link (NVIDIA hardware only); it is a no-op on xGMI. Upstream NCCL defaults it to `1` since 2.28, while RCCL keeps it `0`. This guards against an upstream merge silently flipping the default.

## Technical Details

Adds `ParamTests.ncclPxnC2cParam_DefaultOff` to `rccl-UnitTestsFixturesDebug`. Reads the compiled-in default via `topo.h`'s `ncclParamPxnC2c()` and asserts it is `0` when the env var is unset.

## JIRA ID

Resolves AICOMRCCL-1168.

## Test Plan

Debug build (`./install.sh -l --debug -t`); run `rccl-UnitTestsFixturesDebug --gtest_filter=ParamTests.*`.

## Test Result

ParamTests (3 tests) PASS, including `ncclPxnC2cParam_DefaultOff`

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
