### PR TITLE
rocr: Fix coredump for gfx1201

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
@@ -242,9 +242,8 @@ class PackageBuilder {
   std::stringstream st_;
 };
 
-// Track memory regions that should be included in lightweight coredumps (Scratch + CWSR)
+// Track memory regions that should be included in lightweight coredumps
 class MemoryRegionFilter {
-public:
   struct AddressRange {
     uint64_t start;
     uint64_t end;
@@ -269,27 +268,21 @@ public:
     return false;
   }
 
-  // Helper to check if address range overlaps with any scratch or CWSR memory ranges
+public:
+  // Check if address range overlaps with any region required for the
+  // coredump.
   bool should_include(const uint64_t& addr, const uint64_t& size) {
-    return address_in_map(scratch_ranges, addr, size) ||
-           address_in_map(code_object_ranges, addr, size);
+    return address_in_map(ranges, addr, size);
   }
 
-  void add_scratch_range(uint64_t start, size_t size) {
+  void add_range(uint64_t start, size_t size) {
     if (size > 0) {
-      scratch_ranges.emplace(start, AddressRange{start, start + size});
-    }
-  }
-
-  void add_code_object_range(uint64_t start, size_t size) {
-    if (size > 0) {
-      code_object_ranges.emplace(start, AddressRange{start, start + size});
+      ranges.emplace(start, AddressRange{start, start + size});
     }
   }
 
 private:
-  std::map<uint64_t, AddressRange> scratch_ranges;
-  std::map<uint64_t, AddressRange> code_object_ranges;
+  std::map<uint64_t, AddressRange> ranges;
 }; 
 
 // Build list of memory regions to be included in the lightweight coredump
@@ -308,7 +301,7 @@ static hsa_status_t build_lightweight_coredump_ranges(MemoryRegionFilter& filter
 
     if (scratch_base && scratch_size > 0) {
       // Filter will hold all of the reserved address range, even if unused 
-      filter.add_scratch_range(reinterpret_cast<uint64_t>(scratch_base), scratch_size);
+      filter.add_range(reinterpret_cast<uint64_t>(scratch_base), scratch_size);
       debug_print("Added scratch range: 0x%lx - 0x%lx (size: %zu)\n",
                   reinterpret_cast<uint64_t>(scratch_base),
                   reinterpret_cast<uint64_t>(scratch_base) + scratch_size,
@@ -319,7 +312,7 @@ static hsa_status_t build_lightweight_coredump_ranges(MemoryRegionFilter& filter
   // Add code object allocations from allocation_map_
   core::Runtime::runtime_singleton_->IterateCodeObjectAllocations(
     [&filter](uint64_t start, size_t size) {
-      filter.add_code_object_range(start, size);
+      filter.add_range(start, size);
       debug_print("Added code object range: 0x%lx - 0x%lx (size: %zu)\n",
                     start, start + size, size);
   });
@@ -580,7 +573,7 @@ struct LoadSegmentBuilder : public SegmentBuilder {
 
       // For lightweight dumps, keep only scratch allocations
       if (lightweight_dump && !filter.should_include(start, size)) {
-        debug_print("Skipping load 0x%lx size: %ld (Not Scratch or Code Object)\n", start, size);
+        debug_print("Skipping load 0x%lx size: %ld\n", start, size);
         continue;
       }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
@@ -307,6 +307,40 @@ static hsa_status_t build_lightweight_coredump_ranges(MemoryRegionFilter& filter
                   reinterpret_cast<uint64_t>(scratch_base) + scratch_size,
                   scratch_size);
     }
+
+    for (core::Queue* q : gpu_agent->GetAqlQueues()) {
+      AMD::AqlQueue* aql_queue = static_cast<AMD::AqlQueue*>(q);
+
+      // We need to capture the queue amd_queue_t for the debugger.
+      debug_print("Added aql_queue_t range: %#p - %#p (size: %zu)\n",
+                  &aql_queue->amd_queue_, &aql_queue->amd_queue_ + 1,
+                  sizeof(aql_queue->amd_queue_));
+      filter.add_range(reinterpret_cast<uint64_t>(&aql_queue->amd_queue_),
+                       sizeof(aql_queue->amd_queue_));
+
+      // Same goes for the ring buffer.
+      debug_print("Added ring buffer range: %#p - %#p (size: %zu)\n",
+                  aql_queue->amd_queue_.hsa_queue.base_address,
+                  static_cast<void*>(aql_queue->amd_queue_.hsa_queue.base_address)
+                    + aql_queue->amd_queue_.hsa_queue.size * sizeof(hsa_kernel_dispatch_packet_t),
+                  aql_queue->amd_queue_.hsa_queue.size * sizeof(hsa_kernel_dispatch_packet_t));
+      filter.add_range(reinterpret_cast<uint64_t>(aql_queue->amd_queue_.hsa_queue.base_address),
+                       aql_queue->amd_queue_.hsa_queue.size * sizeof(hsa_kernel_dispatch_packet_t));
+
+      HsaQueueInfo queue_info;
+      HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtGetQueueInfo(aql_queue->aql_queue_id(), &queue_info));
+      if (status != HSAKMT_STATUS_SUCCESS) {
+        fprintf(stderr, "hsaKmtGetQueueInfo failed during core dump creation\n");
+        return HSA_STATUS_ERROR;
+      }
+
+      debug_print("Added CWSR area range: %#p - %#p (size: %zu)\n",
+                  queue_info.SaveAreaHeader,
+                  static_cast<void*>(queue_info.SaveAreaHeader) + queue_info.SaveAreaSizeInBytes,
+                  queue_info.SaveAreaSizeInBytes);
+      filter.add_range(reinterpret_cast<uint64_t>(queue_info.SaveAreaHeader),
+                       queue_info.SaveAreaSizeInBytes);
+    }
   }
 
   // Add code object allocations from allocation_map_


### PR DESCRIPTION
## Motivation

It seems that the lightweight coredump feature is not behaving properly on gfx1201.  The gdb.rocm/runtime-core.exp testcase fails on that architecture.  This is due to missing data in the core dump, making it unusable to the debugger.

## Technical Details

The first issue the debugger fails on is when trying to find the queue's
read/write pointer values (stored in the amd_queue_t).  It seems that on
gfx1201, the amd_queue_t resides in device memory, and because it is not
explicitly listed as "must keep" is absent from the core dump when
enabling lightweight core dumps.  Other architectures seem to hold this
data in system memory, so it is eventually available since is is saved
by the kernel.

In this patch I make sure that any data the debugger will need is kept
when opening the core dump.  When listing the address ranges that we
must include in the core dump, it is safe to include data that might
actually reside in system memory.  The core dumping machinery will list
all the device mappings, and filter out any range not intersecting with
ranges to keep.  If such range are on system memory, they will never
intersect with any device mappings, and this is fine.

## Test Plan

Test using ROCgdb's testsuite.

## Test Results

This fixes failures in gdb.rocm/runtime-core.exp

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
