### PR TITLE
[hipfile] Add stats counter for unaligned IOs

### DIFF
--- a/projects/hipfile/docs/stats_collection.rst
+++ b/projects/hipfile/docs/stats_collection.rst
@@ -51,6 +51,7 @@ Stats Collected
 * Basic: Bandwidth for reads/writes on the fastpath/fallback backends.
 * Basic: Latency for reads/writes on the fastpath/fallback backends.
 * Basic: I/O error counts for reads/writes on the fastpath/fallback backends.
+* Basic: Number of unaligned I/O operations for reads/writes on the fastpath/fallback backends.
 * Basic: Histograms of above stats broken into buckets based on the size of the I/O.
 
 Output
@@ -72,21 +73,25 @@ Example output shape:
     Average Fastpath Read Bandwidth (GiB/s): 0.776272
     Average Fastpath Read Latency (us): 1258.02
     Total Fastpath Read Errors: 0
+    Total Fastpath Read Unaligned: 0
 
     Total Fastpath Write Size (B): 67108864
     Average Fastpath Write Bandwidth (GiB/s): 0.358882
     Average Fastpath Write Latency (us): 2721.12
     Total Fastpath Write Errors: 0
+    Total Fastpath Write Unaligned: 0
 
     Total Fallback Read Size (B): 0
     Average Fallback Read Bandwidth (GiB/s): 0
     Average Fallback Read Latency (us): 0
     Total Fallback Read Errors: 0
+    Total Fallback Read Unaligned: 0
 
     Total Fallback Write Size (B): 0
     Average Fallback Write Bandwidth (GiB/s): 0
     Average Fallback Write Latency (us): 0
     Total Fallback Write Errors: 0
+    Total Fallback Write Unaligned: 0
 
     GPU 0:
     IO Size Histogram
@@ -122,6 +127,10 @@ Example output shape:
     0-4                                              0                                 0                                 0                                 0
     ...
     65536-...                                        0                                 0                                 0                                 0
+    Fastpath Read Unaligned Count: 0
+    Fastpath Write Unaligned Count: 0
+    Fallback Read Unaligned Count: 0
+    Fallback Write Unaligned Count: 0
 
 Scope and Limitations
 ---------------------

--- a/projects/hipfile/src/amd_detail/backend/fallback.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fallback.cpp
@@ -72,10 +72,11 @@ ssize_t
 Fallback::_io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
                    hoff_t file_offset, hoff_t buffer_offset, size_t chunk_size)
 {
-    StatsIoTracker ioTracker{type, StatsBackend::Fallback};
     if (!Context<Configuration>::get()->fallback()) {
         throw BackendDisabled();
     }
+
+    StatsIoTracker ioTracker{type, StatsBackend::Fallback, file, buffer, size, file_offset, buffer_offset};
 
     size = min(size, hipFile::getMaxRwCount());
 

--- a/projects/hipfile/src/amd_detail/stats.cpp
+++ b/projects/hipfile/src/amd_detail/stats.cpp
@@ -370,7 +370,7 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
     static constexpr StatsBackend backends[]{StatsBackend::Fastpath, StatsBackend::Fallback};
     for (const auto &backend : backends) {
         for (const auto &ioType : ioTypes) {
-            uint64_t totalBytes{}, totalCount{}, totalTimeUs{}, totalErrors{};
+            uint64_t totalBytes{}, totalCount{}, totalTimeUs{}, totalErrors{}, totalUnaligned{};
             for (size_t i{}; i < StatsV1::MaxGpus; ++i) {
                 if (const auto *perGpuStats{stats->getPerGpuStats(i, backend)}) {
                     if (const auto [sizeHist, countHist, timeHist, errorCountHist] =
@@ -381,6 +381,7 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
                         totalCount += countHist->accumulate();
                         totalTimeUs += timeHist->accumulate();
                         totalErrors += errorCountHist->accumulate();
+                        totalUnaligned += perGpuStats->unalignedCount[static_cast<size_t>(ioType)].load();
                     }
                 }
             }
@@ -391,7 +392,9 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
             stream << "Average " << reportUtil::toString(backend) << ' ' << reportUtil::toString(ioType)
                    << " Latency (us): " << reportUtil::latencyUs(totalTimeUs, totalCount) << '\n';
             stream << "Total " << reportUtil::toString(backend) << ' ' << reportUtil::toString(ioType)
-                   << " Errors: " << totalErrors << "\n\n";
+                   << " Errors: " << totalErrors << '\n';
+            stream << "Total " << reportUtil::toString(backend) << ' ' << reportUtil::toString(ioType)
+                   << " Unaligned: " << totalUnaligned << "\n\n";
         }
     }
     for (size_t gpuId{}; gpuId < StatsV1::MaxGpus; ++gpuId) {
@@ -451,6 +454,15 @@ StatsClient::generateReportV1(std::ostream &stream, const StatsV1 *stats)
         generateReportHistogramV1(stream, stats, gpuId, "Bandwidth", "Bandwidth (GiB/s)", bandwidth);
         generateReportHistogramV1(stream, stats, gpuId, "Latency", "Latency (us)", latency);
         generateReportHistogramV1(stream, stats, gpuId, "Errors", "Error Count", errorCount);
+        for (const auto &backend : backends) {
+            for (const auto &ioType : ioTypes) {
+                auto unalignedCount{stats->getPerGpuStats(gpuId, backend)
+                                        ->unalignedCount[static_cast<size_t>(ioType)]
+                                        .load()};
+                stream << reportUtil::toString(backend) << ' ' << reportUtil::toString(ioType)
+                       << " Unaligned Count: " << unalignedCount << '\n';
+            }
+        }
     }
 }
 

--- a/projects/hipfile/src/amd_detail/stats.cpp
+++ b/projects/hipfile/src/amd_detail/stats.cpp
@@ -460,11 +460,12 @@ StatsIoTracker::complete(uint64_t bytes) const noexcept
     auto endTime{std::chrono::steady_clock::now()};
     auto duration{std::chrono::duration_cast<std::chrono::microseconds>(endTime - m_startTime)};
     Context<StatsCollection>::get()->addIo(m_ioType, m_backend, bytes,
-                                           static_cast<uint64_t>(duration.count()));
+                                           static_cast<uint64_t>(duration.count()), m_aligned);
 }
 
 void
-StatsCollection::addIo(IoType ioType, StatsBackend backend, uint64_t bytes, uint64_t timeUs) const noexcept
+StatsCollection::addIo(IoType ioType, StatsBackend backend, uint64_t bytes, uint64_t timeUs,
+                       bool aligned) const noexcept
 {
     Stats *stats{Context<IStatsServer>::get()->getStats()};
     if (stats == nullptr || stats->getLevel() < StatsLevel::Basic) {
@@ -491,6 +492,9 @@ StatsCollection::addIo(IoType ioType, StatsBackend backend, uint64_t bytes, uint
     countHist->buckets[bucket].fetch_add(1, std::memory_order_relaxed);
     timeHist->buckets[bucket].fetch_add(timeUs, std::memory_order_relaxed);
     perGpuStats->inUse.store(1, std::memory_order_relaxed);
+    if (!aligned) {
+        perGpuStats->unalignedCount[static_cast<size_t>(ioType)].fetch_add(1, std::memory_order_relaxed);
+    }
 }
 
 void

--- a/projects/hipfile/src/amd_detail/stats.h
+++ b/projects/hipfile/src/amd_detail/stats.h
@@ -4,6 +4,8 @@
  */
 #pragma once
 
+#include "buffer.h"
+#include "file.h"
 #include "file-descriptor.h"
 #include "io.h"
 
@@ -69,12 +71,13 @@ struct StatsHistogram {
 };
 
 struct PerGpuStatsV1 {
-    static constexpr uint64_t     version{1};
-    std::atomic_uint64_t          inUse{};
-    std::array<StatsHistogram, 2> ioSizeBytes{};
-    std::array<StatsHistogram, 2> ioCount{};
-    std::array<StatsHistogram, 2> ioTimeUs{};
-    std::array<StatsHistogram, 2> errorCount{};
+    static constexpr uint64_t           version{1};
+    std::atomic_uint64_t                inUse{};
+    std::array<StatsHistogram, 2>       ioSizeBytes{};
+    std::array<StatsHistogram, 2>       ioCount{};
+    std::array<StatsHistogram, 2>       ioTimeUs{};
+    std::array<StatsHistogram, 2>       errorCount{};
+    std::array<std::atomic_uint64_t, 2> unalignedCount{};
 
     using Histograms = std::tuple<StatsHistogram *, StatsHistogram *, StatsHistogram *, StatsHistogram *>;
     using ConstHistograms = std::tuple<const StatsHistogram *, const StatsHistogram *, const StatsHistogram *,
@@ -283,8 +286,22 @@ private:
 class StatsIoTracker {
 public:
     StatsIoTracker(IoType ioType, StatsBackend backend) noexcept
-        : m_ioType(ioType), m_backend(backend), m_startTime{std::chrono::steady_clock::now()}
+        : m_ioType(ioType), m_backend(backend), m_startTime{std::chrono::steady_clock::now()}, m_aligned{true}
     {
+    }
+
+    StatsIoTracker(IoType ioType, StatsBackend backend, const std::shared_ptr<IFile> &file,
+                   const std::shared_ptr<IBuffer> &buffer, size_t size, hoff_t file_offset,
+                   hoff_t buffer_offset) noexcept
+        : StatsIoTracker(ioType, backend)
+    {
+        const uint32_t dio_offset_align{file->dioOffsetAlign()};
+        m_aligned &= dio_offset_align && !(file_offset & (dio_offset_align - 1));
+        m_aligned &= dio_offset_align && !(size & (dio_offset_align - 1));
+
+        const uint32_t dio_mem_align{file->dioMemAlign()};
+        const auto     mem_addr{reinterpret_cast<intptr_t>(buffer->getBuffer()) + buffer_offset};
+        m_aligned &= dio_mem_align && !(mem_addr & (dio_mem_align - 1));
     }
     void complete(uint64_t bytes) const noexcept;
 
@@ -292,12 +309,14 @@ private:
     IoType                                m_ioType;
     StatsBackend                          m_backend;
     std::chrono::steady_clock::time_point m_startTime;
+    bool                                  m_aligned;
 };
 
 class StatsCollection {
 public:
     virtual ~StatsCollection() = default;
-    virtual void addIo(IoType ioType, StatsBackend backend, uint64_t bytes, uint64_t timeUs) const noexcept;
+    virtual void addIo(IoType ioType, StatsBackend backend, uint64_t bytes, uint64_t timeUs,
+                       bool aligned) const noexcept;
     virtual void error(IoType ioType, StatsBackend backend, uint64_t bytes) const noexcept;
     virtual void fileRegistration() const noexcept;
     virtual void bufferRegistration() const noexcept;

--- a/projects/hipfile/test/amd_detail/fastpath.cpp
+++ b/projects/hipfile/test/amd_detail/fastpath.cpp
@@ -742,11 +742,7 @@ TEST_P(FastpathIoParam, IoWithFallbackThrowsAFallbackIneligibleException)
     auto m_fallback = std::make_shared<StrictMock<MBackend>>();
     backend->register_fallback_backend(m_fallback);
 
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(true));
-    EXPECT_CALL(mhip, hipInit).WillRepeatedly(Return());
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR)));
-    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    expect_io();
     EXPECT_CALL(mstats, error).Times(1);
 
     switch (GetParam()) {
@@ -772,11 +768,7 @@ TEST_P(FastpathIoParam, IoWithFallbackThrowsHipRuntimeException)
     auto m_fallback = std::make_shared<StrictMock<MBackend>>();
     backend->register_fallback_backend(m_fallback);
 
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(true));
-    EXPECT_CALL(mhip, hipInit).WillOnce(Return());
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR)));
-    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    expect_io();
     EXPECT_CALL(mstats, error).Times(1);
 
     switch (GetParam()) {
@@ -801,11 +793,7 @@ TEST_P(FastpathIoParam, IoThrowsAFallbackEligibleENODEV)
     auto m_fallback = std::make_shared<StrictMock<MBackend>>();
     backend->register_fallback_backend(m_fallback);
 
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(true));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR)));
-    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
-    EXPECT_CALL(mhip, hipInit).WillOnce(Return());
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    expect_io();
     EXPECT_CALL(mstats, error).Times(1);
 
     switch (GetParam()) {
@@ -833,11 +821,7 @@ TEST_P(FastpathIoParam, IoThrowsAFallbackEligibleEREMOTEIO)
     auto m_fallback = std::make_shared<StrictMock<MBackend>>();
     backend->register_fallback_backend(m_fallback);
 
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(true));
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR)));
-    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
-    EXPECT_CALL(mhip, hipInit).WillOnce(Return());
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    expect_io();
     EXPECT_CALL(mstats, error).Times(1);
 
     switch (GetParam()) {
@@ -871,11 +855,7 @@ TEST_P(FastpathIoParam, FallbackRejectsIoRequest)
     auto m_fallback = std::make_shared<StrictMock<MBackend>>();
     backend->register_fallback_backend(m_fallback);
 
-    EXPECT_CALL(mcfg, fastpath()).WillOnce(Return(true));
-    EXPECT_CALL(mhip, hipInit).WillRepeatedly(Return());
-    EXPECT_CALL(*mbuffer, getBuffer).WillOnce(Return(reinterpret_cast<void *>(DEFAULT_BUFFER_ADDR)));
-    EXPECT_CALL(*mbuffer, getLength).WillOnce(Return(DEFAULT_BUFFER_LENGTH));
-    EXPECT_CALL(*mfile, unbufferedFd).WillOnce(Return(DEFAULT_UNBUFFERED_FD));
+    expect_io();
     EXPECT_CALL(*m_fallback, score).WillOnce(Return(SCORE_REJECT));
     EXPECT_CALL(mstats, error).Times(1);
 

--- a/projects/hipfile/test/amd_detail/mstats.h
+++ b/projects/hipfile/test/amd_detail/mstats.h
@@ -28,7 +28,8 @@ public:
     MStatsCollection() : co{this}
     {
     }
-    MOCK_METHOD(void, addIo, (IoType ioType, StatsBackend backend, uint64_t bytes, uint64_t timeUs),
+    MOCK_METHOD(void, addIo,
+                (IoType ioType, StatsBackend backend, uint64_t bytes, uint64_t timeUs, bool aligned),
                 (const, noexcept, override));
     MOCK_METHOD(void, error, (IoType ioType, StatsBackend backend, uint64_t bytes),
                 (const, noexcept, override));

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -32,27 +32,45 @@ TEST_F(HipFileStats, StatsCollectionAddIo)
     EXPECT_CALL(mstats, getStats).WillRepeatedly(testing::Return(&stats));
     EXPECT_CALL(mhip, hipGetDevice).WillRepeatedly(testing::Return(0));
     stats.setLevel(StatsLevel::Basic);
-    Context<StatsCollection>::get()->addIo(IoType::Read, StatsBackend::Fastpath, 10, 0);
+    Context<StatsCollection>::get()->addIo(IoType::Read, StatsBackend::Fastpath, 10, 0, true);
     ASSERT_EQ(10, stats.getPerGpuStats(0, StatsBackend::Fastpath)
                       ->ioSizeBytes[static_cast<size_t>(IoType::Read)]
                       .buckets[0]
                       .load());
-    Context<StatsCollection>::get()->addIo(IoType::Write, StatsBackend::Fallback, 10, 0);
+    Context<StatsCollection>::get()->addIo(IoType::Write, StatsBackend::Fallback, 10, 0, true);
     ASSERT_EQ(10, stats.getPerGpuStats(0, StatsBackend::Fallback)
                       ->ioSizeBytes[static_cast<size_t>(IoType::Write)]
                       .buckets[0]
                       .load());
-    Context<StatsCollection>::get()->addIo(IoType::Read, StatsBackend::Fastpath, 10, 0);
+    Context<StatsCollection>::get()->addIo(IoType::Read, StatsBackend::Fastpath, 10, 0, true);
     ASSERT_EQ(20, stats.getPerGpuStats(0, StatsBackend::Fastpath)
                       ->ioSizeBytes[static_cast<size_t>(IoType::Read)]
                       .buckets[0]
                       .load());
     stats.setLevel(StatsLevel::Disabled);
-    Context<StatsCollection>::get()->addIo(IoType::Write, StatsBackend::Fallback, 10, 0);
+    Context<StatsCollection>::get()->addIo(IoType::Write, StatsBackend::Fallback, 10, 0, true);
     ASSERT_EQ(10, stats.getPerGpuStats(0, StatsBackend::Fallback)
                       ->ioSizeBytes[static_cast<size_t>(IoType::Write)]
                       .buckets[0]
                       .load());
+}
+
+TEST_F(HipFileStats, StatsCollectionAddIoUnaligned)
+{
+    Stats                    stats{};
+    StrictMock<MStatsServer> mstats{};
+    StrictMock<MHip>         mhip{};
+    EXPECT_CALL(mstats, getStats).WillRepeatedly(testing::Return(&stats));
+    EXPECT_CALL(mhip, hipGetDevice).WillRepeatedly(testing::Return(0));
+    stats.setLevel(StatsLevel::Basic);
+    Context<StatsCollection>::get()->addIo(IoType::Read, StatsBackend::Fastpath, 10, 0, false);
+    ASSERT_EQ(1, stats.getPerGpuStats(0, StatsBackend::Fastpath)
+                     ->unalignedCount[static_cast<size_t>(IoType::Read)]
+                     .load());
+    Context<StatsCollection>::get()->addIo(IoType::Read, StatsBackend::Fastpath, 10, 0, true);
+    ASSERT_EQ(1, stats.getPerGpuStats(0, StatsBackend::Fastpath)
+                     ->unalignedCount[static_cast<size_t>(IoType::Read)]
+                     .load());
 }
 
 TEST_F(HipFileStats, StatsCollectionError)

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -208,10 +208,15 @@ TEST_F(HipFileStats, GenerateReportV1)
         .buckets[0] = 3;
     stats.getPerGpuStats(0, StatsBackend::Fallback)
         ->errorCount[static_cast<size_t>(IoType::Write)]
-        .buckets[0]                = 4;
+        .buckets[0] = 4;
+
     stats.getBufferRegistrations() = 10;
     stats.getFileRegistrations()   = 20;
     stats.getFastpathRejections()  = 30;
+
+    stats.getPerGpuStats(0, StatsBackend::Fallback)->unalignedCount[static_cast<size_t>(IoType::Read)]  = 40;
+    stats.getPerGpuStats(0, StatsBackend::Fallback)->unalignedCount[static_cast<size_t>(IoType::Write)] = 50;
+
     StatsClient::generateReportV1(os, &stats);
     std::string str{os.str()};
     ASSERT_GT(std::string::npos, str.find("Total Fastpath Read Size (B): 2"));
@@ -225,6 +230,8 @@ TEST_F(HipFileStats, GenerateReportV1)
     ASSERT_GT(std::string::npos, str.find("Buffer Registrations: 10"));
     ASSERT_GT(std::string::npos, str.find("File Handle Registrations: 20"));
     ASSERT_GT(std::string::npos, str.find("Fastpath Rejections: 30"));
+    ASSERT_GT(std::string::npos, str.find("Total Fallback Read Unaligned: 40"));
+    ASSERT_GT(std::string::npos, str.find("Total Fallback Write Unaligned: 50"));
 }
 
 TEST_F(HipFileStats, GenerateReportV1TwoGpus)


### PR DESCRIPTION
## Motivation

We want to track unaligned IOs in ais-stats.

## Technical Details

I copied the file offset and buffer alignment checks from Fastpath::score() into StatsIoTracker so it can pass an alignment value into StatsCollection.

## JIRA ID

AIHIPFILE-99

## Test Plan

Run unit tests. Copy a small file with aiscp.

## Test Result

All unit tests pass. aiscp output expected values.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
