### PR TITLE
[DO NOT MERGE] bisect v1-abi: no_bubbles code-vs-flake

### DIFF
--- a/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
+++ b/projects/rocr-runtime/libhsakmt/include/hsakmt/hsakmt.h
@@ -601,6 +601,37 @@ hsaKmtDestroyExternalSemaphore(
     );
 
 /**
+  Enqueues a GPU-side signal of an imported external semaphore on
+  QueueId, ordered behind prior submissions. Handle must come from
+  hsaKmtImportExternalSemaphore on the same node as QueueId's device;
+  cross-adapter use returns HSAKMT_STATUS_INVALID_NODE_UNIT.
+*/
+
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtQueueSignalExternalSemaphore(
+    HSA_QUEUEID                   QueueId,   //IN
+    HSA_EXTERNAL_SEMAPHORE_HANDLE Handle,    //IN
+    HSAuint64                     Value      //IN
+    );
+
+/**
+  Posts a GPU-side wait on an imported external semaphore. The wait
+  blocks any subsequent submissions on QueueId until the syncobj
+  reaches Value. The semaphore must have been imported via
+  hsaKmtImportExternalSemaphore on the same node as QueueId's device;
+  cross-adapter use returns HSAKMT_STATUS_INVALID_NODE_UNIT.
+*/
+
+HSAKMT_STATUS
+HSAKMTAPI
+hsaKmtQueueWaitExternalSemaphore(
+    HSA_QUEUEID                   QueueId,   //IN
+    HSA_EXTERNAL_SEMAPHORE_HANDLE Handle,    //IN
+    HSAuint64                     Value      //IN
+    );
+
+/**
  * Export a dmabuf handle and offset for a given memory address
  *
  * Validates that @MemoryAddress belongs to a valid allocation and that the

--- a/projects/rocr-runtime/libhsakmt/src/dxg/extsem.cpp
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/extsem.cpp
@@ -6,6 +6,7 @@
 
 #include "hsakmt/hsakmt.h"
 #include "impl/wddm/device.h"
+#include "impl/wddm/queue.h"
 #include "librocdxg.h"
 
 using namespace wsl::thunk;
@@ -65,6 +66,68 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtDestroyExternalSemaphore(
   // Propagate WDDM destroy failure so the HSA layer can fail close()
   // and callers don't silently leak the imported sync object.
   if (!device->DestroySyncobj(syncobj))
+    return HSAKMT_STATUS_ERROR;
+  return HSAKMT_STATUS_SUCCESS;
+}
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtQueueSignalExternalSemaphore(
+    HSA_QUEUEID QueueId,
+    HSA_EXTERNAL_SEMAPHORE_HANDLE Handle,
+    HSAuint64 Value) {
+  CHECK_DXG_OPEN();
+  if (QueueId == 0) return HSAKMT_STATUS_INVALID_HANDLE;
+
+  D3DKMT_HANDLE syncobj = 0;
+  HSAuint32 node_id = 0;
+  DecodeExtSemHandle(Handle.handle, &syncobj, &node_id);
+  if (syncobj == 0) return HSAKMT_STATUS_INVALID_HANDLE;
+
+  WDDMDevice *device = get_wddmdev(node_id);
+  if (device == nullptr) return HSAKMT_STATUS_INVALID_NODE_UNIT;
+
+  // HSA_QUEUEID is a (WDDMQueue *); reverse-cast matches dxg/queues.cpp.
+  auto *queue = reinterpret_cast<WDDMQueue *>(QueueId);
+
+  // The syncobj belongs to the semaphore's node; issuing on a queue from a
+  // different adapter mixes mismatched handles. Require the nodes to match.
+  if (queue->device == nullptr ||
+      queue->device->NodeId() != static_cast<int>(node_id))
+    return HSAKMT_STATUS_INVALID_NODE_UNIT;
+
+  // GpuSignal takes the value by pointer; keep it in an addressable local.
+  uint64_t fence_value = Value;
+  if (!device->GpuSignal(queue->context, &syncobj, &fence_value, 1))
+    return HSAKMT_STATUS_ERROR;
+  return HSAKMT_STATUS_SUCCESS;
+}
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtQueueWaitExternalSemaphore(
+    HSA_QUEUEID QueueId,
+    HSA_EXTERNAL_SEMAPHORE_HANDLE Handle,
+    HSAuint64 Value) {
+  CHECK_DXG_OPEN();
+  if (QueueId == 0) return HSAKMT_STATUS_INVALID_HANDLE;
+
+  D3DKMT_HANDLE syncobj = 0;
+  HSAuint32 node_id = 0;
+  DecodeExtSemHandle(Handle.handle, &syncobj, &node_id);
+  if (syncobj == 0) return HSAKMT_STATUS_INVALID_HANDLE;
+
+  WDDMDevice *device = get_wddmdev(node_id);
+  if (device == nullptr) return HSAKMT_STATUS_INVALID_NODE_UNIT;
+
+  auto *queue = reinterpret_cast<WDDMQueue *>(QueueId);
+
+  // Same cross-adapter guard as the signal path.
+  if (queue->device == nullptr ||
+      queue->device->NodeId() != static_cast<int>(node_id))
+    return HSAKMT_STATUS_INVALID_NODE_UNIT;
+
+  // GpuWait takes the WDDMQueue * directly (pulling .context out
+  // internally), unlike GpuSignal which takes the bare D3DKMT_HANDLE.
+  // Keep fence_value alive for the ioctl.
+  uint64_t fence_value = Value;
+  if (!device->GpuWait(queue, &syncobj, &fence_value, 1))
     return HSAKMT_STATUS_ERROR;
   return HSAKMT_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/libhsakmt/src/dxg/librocdxg.ver
+++ b/projects/rocr-runtime/libhsakmt/src/dxg/librocdxg.ver
@@ -33,6 +33,8 @@ hsaKmtRegisterMemory;
 hsaKmtRegisterMemoryToNodes;
 hsaKmtImportExternalSemaphore;
 hsaKmtDestroyExternalSemaphore;
+hsaKmtQueueSignalExternalSemaphore;
+hsaKmtQueueWaitExternalSemaphore;
 hsaKmtRegisterMemoryWithFlags;
 hsaKmtRegisterGraphicsHandleToNodes;
 hsaKmtRegisterGraphicsHandleToNodesExt;

--- a/projects/rocr-runtime/libhsakmt/src/extsem.c
+++ b/projects/rocr-runtime/libhsakmt/src/extsem.c
@@ -19,3 +19,17 @@ HSAKMT_STATUS HSAKMTAPI hsaKmtDestroyExternalSemaphore(
   (void)Handle;
   return HSAKMT_STATUS_NOT_SUPPORTED;
 }
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtQueueSignalExternalSemaphore(
+    HSA_QUEUEID QueueId, HSA_EXTERNAL_SEMAPHORE_HANDLE Handle,
+    HSAuint64 Value) {
+  (void)QueueId; (void)Handle; (void)Value;
+  return HSAKMT_STATUS_NOT_SUPPORTED;
+}
+
+HSAKMT_STATUS HSAKMTAPI hsaKmtQueueWaitExternalSemaphore(
+    HSA_QUEUEID QueueId, HSA_EXTERNAL_SEMAPHORE_HANDLE Handle,
+    HSAuint64 Value) {
+  (void)QueueId; (void)Handle; (void)Value;
+  return HSAKMT_STATUS_NOT_SUPPORTED;
+}

--- a/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
+++ b/projects/rocr-runtime/libhsakmt/src/libhsakmt.ver
@@ -31,6 +31,8 @@ hsaKmtRegisterMemory;
 hsaKmtRegisterMemoryToNodes;
 hsaKmtImportExternalSemaphore;
 hsaKmtDestroyExternalSemaphore;
+hsaKmtQueueSignalExternalSemaphore;
+hsaKmtQueueWaitExternalSemaphore;
 hsaKmtRegisterMemoryWithFlags;
 hsaKmtRegisterGraphicsHandleToNodes;
 hsaKmtShareMemory;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/common/hsa_table_interface.cpp
@@ -1408,6 +1408,22 @@ hsa_status_t HSA_API hsa_amd_external_semaphore_handle_close(
   return amdExtTable->hsa_amd_external_semaphore_handle_close_fn(sem);
 }
 
+// Mirrors Amd Extension Apis
+hsa_status_t HSA_API hsa_amd_queue_signal_external_semaphore(
+    hsa_queue_t *queue,
+    hsa_amd_external_semaphore_t sem,
+    uint64_t value) {
+  return amdExtTable->hsa_amd_queue_signal_external_semaphore_fn(queue, sem, value);
+}
+
+// Mirrors Amd Extension Apis
+hsa_status_t HSA_API hsa_amd_queue_wait_external_semaphore(
+    hsa_queue_t *queue,
+    hsa_amd_external_semaphore_t sem,
+    uint64_t value) {
+  return amdExtTable->hsa_amd_queue_wait_external_semaphore_fn(queue, sem, value);
+}
+
 // Tools only table interfaces.
 namespace rocr {
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -736,8 +736,15 @@ hsa_status_t KfdDriver::ImportExternalSemaphore(uint32_t node_id, void* nt_handl
       static_cast<HSA_EXTERNAL_SEMAPHORE_HANDLE_TYPE>(type);
 
   HSA_EXTERNAL_SEMAPHORE_HANDLE kmt_handle = {};
+  // Require both thunks up front: importing without destroy would leak the
+  // handle. Missing either -> NOT_SUPPORTED, not a null call.
+  auto* thunk_loader = core::Runtime::runtime_singleton_->thunkLoader();
+  const bool loaded =
+      thunk_loader->HSAKMT_PFN(hsaKmtImportExternalSemaphore) != nullptr &&
+      thunk_loader->HSAKMT_PFN(hsaKmtDestroyExternalSemaphore) != nullptr;
   HSAKMT_STATUS s =
-      HSAKMT_CALL(hsaKmtImportExternalSemaphore(node_id, nt_handle, kmt_type, &kmt_handle));
+      loaded ? HSAKMT_CALL(hsaKmtImportExternalSemaphore(node_id, nt_handle, kmt_type, &kmt_handle))
+             : HSAKMT_STATUS_NOT_SUPPORTED;
 
   // libhsakmt distinguishes invalid input (null handle, unknown type)
   // from "no node for this agent" and from generic KMD failures.
@@ -747,8 +754,9 @@ hsa_status_t KfdDriver::ImportExternalSemaphore(uint32_t node_id, void* nt_handl
     case HSAKMT_STATUS_SUCCESS:
       break;
     case HSAKMT_STATUS_INVALID_PARAMETER:  // e.g. null nt_handle
-    case HSAKMT_STATUS_NOT_SUPPORTED:      // unsupported handle type (incl. Linux stub)
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    case HSAKMT_STATUS_NOT_SUPPORTED:      // missing thunk / unsupported type / Linux stub
+      return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
     case HSAKMT_STATUS_INVALID_NODE_UNIT:  // no WDDM device for node
       return HSA_STATUS_ERROR_INVALID_AGENT;
     default:
@@ -761,10 +769,56 @@ hsa_status_t KfdDriver::ImportExternalSemaphore(uint32_t node_id, void* nt_handl
 
 hsa_status_t KfdDriver::DestroyExternalSemaphore(hsa_amd_external_semaphore_t sem) const {
   HSA_EXTERNAL_SEMAPHORE_HANDLE kmt_handle = {sem.handle};
+  // No export -> not this driver's handle. INVALID_AGENT (base-class
+  // contract) lets handle_close keep polling other drivers.
+  if (core::Runtime::runtime_singleton_->thunkLoader()->HSAKMT_PFN(hsaKmtDestroyExternalSemaphore) == nullptr)
+    return HSA_STATUS_ERROR_INVALID_AGENT;
   if (HSAKMT_CALL(hsaKmtDestroyExternalSemaphore(kmt_handle)) != HSAKMT_STATUS_SUCCESS)
     return HSA_STATUS_ERROR;
   return HSA_STATUS_SUCCESS;
 }
+
+namespace {
+// Preserve the libhsakmt distinctions a caller can act on (bad handle vs.
+// wrong node vs. generic failure) instead of folding everything into ERROR.
+hsa_status_t MapQueueExtSemStatus(HSAKMT_STATUS s) {
+  switch (s) {
+    case HSAKMT_STATUS_SUCCESS:
+      return HSA_STATUS_SUCCESS;
+    case HSAKMT_STATUS_INVALID_HANDLE:
+      return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    case HSAKMT_STATUS_INVALID_NODE_UNIT:
+      return HSA_STATUS_ERROR_INVALID_AGENT;
+    case HSAKMT_STATUS_NOT_SUPPORTED:  // missing thunk / platform stub
+      return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
+    default:
+      return HSA_STATUS_ERROR;
+  }
+}
+}  // namespace
+
+hsa_status_t KfdDriver::SignalExternalSemaphore(uint64_t queue_id,
+                                                hsa_amd_external_semaphore_t sem,
+                                                uint64_t value) const {
+  HSA_EXTERNAL_SEMAPHORE_HANDLE kmt_handle = {sem.handle};
+  // Optional thunk: missing export maps to NOT_SUPPORTED, not a null call.
+  if (core::Runtime::runtime_singleton_->thunkLoader()->HSAKMT_PFN(hsaKmtQueueSignalExternalSemaphore) == nullptr)
+    return MapQueueExtSemStatus(HSAKMT_STATUS_NOT_SUPPORTED);
+  return MapQueueExtSemStatus(
+      HSAKMT_CALL(hsaKmtQueueSignalExternalSemaphore(queue_id, kmt_handle, value)));
+}
+
+hsa_status_t KfdDriver::WaitExternalSemaphore(uint64_t queue_id,
+                                              hsa_amd_external_semaphore_t sem,
+                                              uint64_t value) const {
+  HSA_EXTERNAL_SEMAPHORE_HANDLE kmt_handle = {sem.handle};
+  // Optional thunk: missing export maps to NOT_SUPPORTED, not a null call.
+  if (core::Runtime::runtime_singleton_->thunkLoader()->HSAKMT_PFN(hsaKmtQueueWaitExternalSemaphore) == nullptr)
+    return MapQueueExtSemStatus(HSAKMT_STATUS_NOT_SUPPORTED);
+  return MapQueueExtSemStatus(
+      HSAKMT_CALL(hsaKmtQueueWaitExternalSemaphore(queue_id, kmt_handle, value)));
+}
+
 bool KfdDriver::BindXnackMode() {
   // Get users' preference for Xnack mode of ROCm platform.
   HSAint32 mode = core::Runtime::runtime_singleton_->flag().xnack();

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -150,6 +150,11 @@ public:
                                        hsa_amd_external_semaphore_t* out_sem) const override;
   hsa_status_t DestroyExternalSemaphore(hsa_amd_external_semaphore_t sem) const override;
 
+  hsa_status_t SignalExternalSemaphore(uint64_t queue_id, hsa_amd_external_semaphore_t sem,
+                                       uint64_t value) const override;
+  hsa_status_t WaitExternalSemaphore(uint64_t queue_id, hsa_amd_external_semaphore_t sem,
+                                     uint64_t value) const override;
+
   hsa_status_t IsModelEnabled(bool* enable) const override;
 
   hsa_status_t GetQueueSaveAreaInfo(HSA_QUEUEID queue_id, void** address, size_t* size) const override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -351,6 +351,32 @@ public:
     return HSA_STATUS_ERROR_INVALID_AGENT;
   }
 
+  /// @brief Submits a GPU-side signal of an imported external semaphore on
+  /// the given KMD queue.
+  /// @param[in] queue_id KMD queue id (HSA_QUEUEID) the signal is appended to.
+  /// @param[in] sem Semaphore from @ref ImportExternalSemaphore.
+  /// @param[in] value Payload for timeline semaphores (ignored for binary).
+  /// @retval HSA_STATUS_ERROR_NOT_SUPPORTED if the driver does not support
+  /// external semaphores.
+  virtual hsa_status_t SignalExternalSemaphore(uint64_t queue_id,
+                                               hsa_amd_external_semaphore_t sem,
+                                               uint64_t value) const {
+    return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
+  }
+
+  /// @brief Submits a GPU-side wait on an imported external semaphore on the
+  /// given KMD queue.
+  /// @param[in] queue_id KMD queue id (HSA_QUEUEID) the wait is appended to.
+  /// @param[in] sem Semaphore from @ref ImportExternalSemaphore.
+  /// @param[in] value Payload for timeline semaphores (ignored for binary).
+  /// @retval HSA_STATUS_ERROR_NOT_SUPPORTED if the driver does not support
+  /// external semaphores.
+  virtual hsa_status_t WaitExternalSemaphore(uint64_t queue_id,
+                                             hsa_amd_external_semaphore_t sem,
+                                             uint64_t value) const {
+    return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
+  }
+
   /// @brief Sets trap handler and trap buffer to be used for all queues associated
   /// with the specified NodeId within this process context
   /// @param[in] node_id Node ID of the agent

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hsa_ext_amd_impl.h
@@ -430,6 +430,18 @@ hsa_status_t hsa_amd_external_semaphore_handle_open(
 hsa_status_t hsa_amd_external_semaphore_handle_close(
     hsa_amd_external_semaphore_t sem);
 
+// Mirrors Amd Extension Apis
+hsa_status_t hsa_amd_queue_signal_external_semaphore(
+    hsa_queue_t *queue,
+    hsa_amd_external_semaphore_t sem,
+    uint64_t value);
+
+// Mirrors Amd Extension Apis
+hsa_status_t hsa_amd_queue_wait_external_semaphore(
+    hsa_queue_t *queue,
+    hsa_amd_external_semaphore_t sem,
+    uint64_t value);
+
 }  // namespace amd
 }  // namespace rocr
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/thunk_loader.h
@@ -360,6 +360,12 @@ class ThunkLoader {
                                       HSA_EXTERNAL_SEMAPHORE_HANDLE_TYPE Type, \
                                       HSA_EXTERNAL_SEMAPHORE_HANDLE* OutHandle);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtDestroyExternalSemaphore))(HSA_EXTERNAL_SEMAPHORE_HANDLE Handle);
+    typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtQueueSignalExternalSemaphore))(HSA_QUEUEID QueueId, \
+                                      HSA_EXTERNAL_SEMAPHORE_HANDLE Handle, \
+                                      HSAuint64 Value);
+    typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtQueueWaitExternalSemaphore))(HSA_QUEUEID QueueId, \
+                                      HSA_EXTERNAL_SEMAPHORE_HANDLE Handle, \
+                                      HSAuint64 Value);
     typedef HSAKMT_STATUS (HSAKMT_DEF(hsaKmtHandleExport))(const HsaHandleExportDesc* desc, \
                                       HsaMemoryExportResult* res, \
                                       HsaHandleExportFlags* flags);
@@ -538,6 +544,8 @@ class ThunkLoader {
     HSAKMT_DEF(hsaKmtHandleImport)* HSAKMT_PFN(hsaKmtHandleImport);
     HSAKMT_DEF(hsaKmtImportExternalSemaphore)* HSAKMT_PFN(hsaKmtImportExternalSemaphore);
     HSAKMT_DEF(hsaKmtDestroyExternalSemaphore)* HSAKMT_PFN(hsaKmtDestroyExternalSemaphore);
+    HSAKMT_DEF(hsaKmtQueueSignalExternalSemaphore)* HSAKMT_PFN(hsaKmtQueueSignalExternalSemaphore);
+    HSAKMT_DEF(hsaKmtQueueWaitExternalSemaphore)* HSAKMT_PFN(hsaKmtQueueWaitExternalSemaphore);
     HSAKMT_DEF(hsaKmtHandleExport)* HSAKMT_PFN(hsaKmtHandleExport);
     HSAKMT_DEF(hsaKmtMemoryVaMap)* HSAKMT_PFN(hsaKmtMemoryVaMap);
     HSAKMT_DEF(hsaKmtMemoryVaUnmap)* HSAKMT_PFN(hsaKmtMemoryVaUnmap);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
@@ -87,7 +87,7 @@ void HsaApiTable::Init() {
   // they can add preprocessor macros on the new functions
 
   constexpr size_t expected_core_api_table_size = 1016;
-  constexpr size_t expected_amd_ext_table_size = 704;
+  constexpr size_t expected_amd_ext_table_size = 720;
   constexpr size_t expected_image_ext_table_size = 128;
   constexpr size_t expected_finalizer_ext_table_size = 64;
   constexpr size_t expected_tools_table_size = 64;
@@ -489,6 +489,8 @@ void HsaApiTable::UpdateAmdExts() {
   amd_ext_api.hsa_amd_external_semaphore_handle_close_fn = AMD::hsa_amd_external_semaphore_handle_close;
   amd_ext_api.hsa_amd_vmem_export_fabric_handle_fn = AMD::hsa_amd_vmem_export_fabric_handle;
   amd_ext_api.hsa_amd_vmem_import_fabric_handle_fn = AMD::hsa_amd_vmem_import_fabric_handle;
+  amd_ext_api.hsa_amd_queue_signal_external_semaphore_fn = AMD::hsa_amd_queue_signal_external_semaphore;
+  amd_ext_api.hsa_amd_queue_wait_external_semaphore_fn   = AMD::hsa_amd_queue_wait_external_semaphore;
 }
 
 void HsaApiTable::UpdateTools() {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -52,6 +52,7 @@
 
 #include "core/inc/agent.h"
 #include "core/inc/amd_aie_agent.h"
+#include "core/inc/amd_aql_queue.h"
 #include "core/inc/amd_cpu_agent.h"
 #include "core/inc/amd_gpu_agent.h"
 #include "core/inc/amd_memory_region.h"
@@ -1966,14 +1967,12 @@ hsa_status_t hsa_amd_external_semaphore_handle_open(
       core_agent->device_type() != core::Agent::kAmdGpuDevice)
     return HSA_STATUS_ERROR_INVALID_AGENT;
 
-  // The descriptor union has separate active members per handle type
-  // (win32_handle for OPAQUE_WIN32 / OPAQUE_WIN32_KMT, fd for OPAQUE_FD).
-  // Only the Win32 NT-handle path is wired through the driver today, so
-  // reject other types up front: reading an inactive union member is
-  // undefined behaviour in C++.
+  // Only the Win32 NT-handle path is wired today. Reject other types up
+  // front: NOT_SUPPORTED (vs malformed-handle INVALID_ARGUMENT), and reading
+  // the wrong union member would be UB anyway.
   if (desc->type != HSA_AMD_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32 &&
       desc->type != HSA_AMD_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT) {
-    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+    return static_cast<hsa_status_t>(HSA_STATUS_ERROR_NOT_SUPPORTED);
   }
 
   return core_agent->driver().ImportExternalSemaphore(
@@ -2016,6 +2015,66 @@ hsa_status_t hsa_amd_vmem_import_fabric_handle(hsa_fabric_handle_t fabric_handle
   CATCH;
 }
 
+
+// Tool layers wrap the queue in a core::InterceptQueue, which is not an
+// AqlQueue, so a direct static_cast is UB. Peel off any (nestable) wrapper
+// layers and confirm the concrete type via IsType() (dynamic_cast is
+// unavailable; RTTI is off). Returns nullptr if the queue is not, or does
+// not wrap, an AqlQueue.
+static AMD::AqlQueue *UnwrapAqlQueue(core::Queue *core_queue) {
+  while (core_queue != nullptr && core::InterceptQueue::IsType(core_queue)) {
+    core_queue = static_cast<core::InterceptQueue *>(core_queue)->wrapped.get();
+  }
+  if (core_queue == nullptr || !AMD::AqlQueue::IsType(core_queue))
+    return nullptr;
+  return static_cast<AMD::AqlQueue *>(core_queue);
+}
+
+hsa_status_t hsa_amd_queue_signal_external_semaphore(
+    hsa_queue_t *queue,
+    hsa_amd_external_semaphore_t sem,
+    uint64_t value) {
+  TRY;
+  IS_OPEN();
+  if (queue == nullptr) return HSA_STATUS_ERROR_INVALID_QUEUE;
+  if (sem.handle == 0)  return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  core::Queue *core_queue = core::Queue::Convert(queue);
+  IS_VALID(core_queue);
+
+  // Only AMD AQL queues carry a KMD queue id; unwrap tool layers first.
+  AMD::AqlQueue *aql = UnwrapAqlQueue(core_queue);
+  if (aql == nullptr) return HSA_STATUS_ERROR_INVALID_QUEUE;
+
+  core::Agent *core_agent = aql->GetAgent();
+  IS_VALID(core_agent);
+
+  return core_agent->driver().SignalExternalSemaphore(aql->aql_queue_id(), sem, value);
+  CATCH;
+}
+
+hsa_status_t hsa_amd_queue_wait_external_semaphore(
+    hsa_queue_t *queue,
+    hsa_amd_external_semaphore_t sem,
+    uint64_t value) {
+  TRY;
+  IS_OPEN();
+  if (queue == nullptr) return HSA_STATUS_ERROR_INVALID_QUEUE;
+  if (sem.handle == 0)  return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  core::Queue *core_queue = core::Queue::Convert(queue);
+  IS_VALID(core_queue);
+
+  // Same unwrap as the signal path.
+  AMD::AqlQueue *aql = UnwrapAqlQueue(core_queue);
+  if (aql == nullptr) return HSA_STATUS_ERROR_INVALID_QUEUE;
+
+  core::Agent *core_agent = aql->GetAgent();
+  IS_VALID(core_agent);
+
+  return core_agent->driver().WaitExternalSemaphore(aql->aql_queue_id(), sem, value);
+  CATCH;
+}
 
 }   //  namespace amd
 }   //  namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/thunk_loader.cpp
@@ -407,11 +407,13 @@ namespace core {
       HSAKMT_PFN(hsaKmtHandleImport) = (HSAKMT_DEF(hsaKmtHandleImport)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtHandleImport");
       if (HSAKMT_PFN(hsaKmtHandleImport) == nullptr) goto LOAD_ERROR;
 
+      // Optional: a missing export leaves the pfn null (KfdDriver guards
+      // each call) instead of failing the whole table load.
       HSAKMT_PFN(hsaKmtImportExternalSemaphore) = (HSAKMT_DEF(hsaKmtImportExternalSemaphore)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtImportExternalSemaphore");
-      if (HSAKMT_PFN(hsaKmtImportExternalSemaphore) == nullptr) goto LOAD_ERROR;
-
       HSAKMT_PFN(hsaKmtDestroyExternalSemaphore) = (HSAKMT_DEF(hsaKmtDestroyExternalSemaphore)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtDestroyExternalSemaphore");
-      if (HSAKMT_PFN(hsaKmtDestroyExternalSemaphore) == nullptr) goto LOAD_ERROR;
+      HSAKMT_PFN(hsaKmtQueueSignalExternalSemaphore) = (HSAKMT_DEF(hsaKmtQueueSignalExternalSemaphore)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtQueueSignalExternalSemaphore");
+      HSAKMT_PFN(hsaKmtQueueWaitExternalSemaphore) = (HSAKMT_DEF(hsaKmtQueueWaitExternalSemaphore)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtQueueWaitExternalSemaphore");
+
       HSAKMT_PFN(hsaKmtHandleExport) = (HSAKMT_DEF(hsaKmtHandleExport)*)rocr::os::GetExportAddress(thunk_handle, "hsaKmtHandleExport");
       if (HSAKMT_PFN(hsaKmtHandleExport) == nullptr) goto LOAD_ERROR;
 
@@ -574,6 +576,8 @@ LOAD_ERROR:
       HSAKMT_PFN(hsaKmtHandleImport) = (HSAKMT_DEF(hsaKmtHandleImport)*)(&hsaKmtHandleImport);
       HSAKMT_PFN(hsaKmtImportExternalSemaphore) = (HSAKMT_DEF(hsaKmtImportExternalSemaphore)*)(&hsaKmtImportExternalSemaphore);
       HSAKMT_PFN(hsaKmtDestroyExternalSemaphore) = (HSAKMT_DEF(hsaKmtDestroyExternalSemaphore)*)(&hsaKmtDestroyExternalSemaphore);
+      HSAKMT_PFN(hsaKmtQueueSignalExternalSemaphore) = (HSAKMT_DEF(hsaKmtQueueSignalExternalSemaphore)*)(&hsaKmtQueueSignalExternalSemaphore);
+      HSAKMT_PFN(hsaKmtQueueWaitExternalSemaphore) = (HSAKMT_DEF(hsaKmtQueueWaitExternalSemaphore)*)(&hsaKmtQueueWaitExternalSemaphore);
       HSAKMT_PFN(hsaKmtHandleExport) = (HSAKMT_DEF(hsaKmtHandleExport)*)(&hsaKmtHandleExport);
       HSAKMT_PFN(hsaKmtMemoryVaMap) = (HSAKMT_DEF(hsaKmtMemoryVaMap)*)(&hsaKmtMemoryVaMap);
       HSAKMT_PFN(hsaKmtMemoryVaUnmap) = (HSAKMT_DEF(hsaKmtMemoryVaUnmap)*)(&hsaKmtMemoryVaUnmap);

--- a/projects/rocr-runtime/runtime/hsa-runtime/hsacore.dll.def
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hsacore.dll.def
@@ -186,6 +186,8 @@ EXPORTS
   hsa_amd_ipc_memory_detach
   hsa_amd_external_semaphore_handle_open
   hsa_amd_external_semaphore_handle_close
+  hsa_amd_queue_signal_external_semaphore
+  hsa_amd_queue_wait_external_semaphore
   hsa_amd_ipc_signal_create
   hsa_amd_ipc_signal_attach
   hsa_amd_register_system_event_handler

--- a/projects/rocr-runtime/runtime/hsa-runtime/hsacore.so.def
+++ b/projects/rocr-runtime/runtime/hsa-runtime/hsacore.so.def
@@ -223,6 +223,8 @@ global:
 	hsa_amd_ipc_memory_detach;
 	hsa_amd_external_semaphore_handle_open;
 	hsa_amd_external_semaphore_handle_close;
+	hsa_amd_queue_signal_external_semaphore;
+	hsa_amd_queue_wait_external_semaphore;
 	hsa_amd_ipc_signal_create;
 	hsa_amd_ipc_signal_attach;
 	hsa_amd_register_system_event_handler;

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace.h
@@ -283,6 +283,8 @@ struct AmdExtTable {
   decltype(hsa_amd_external_semaphore_handle_close)* hsa_amd_external_semaphore_handle_close_fn;
   decltype(hsa_amd_vmem_export_fabric_handle)* hsa_amd_vmem_export_fabric_handle_fn;
   decltype(hsa_amd_vmem_import_fabric_handle)* hsa_amd_vmem_import_fabric_handle_fn;
+  decltype(hsa_amd_queue_signal_external_semaphore)* hsa_amd_queue_signal_external_semaphore_fn;
+  decltype(hsa_amd_queue_wait_external_semaphore)*   hsa_amd_queue_wait_external_semaphore_fn;
 };
 
 // Table to export HSA Core Runtime Apis

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace_version.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_api_trace_version.h
@@ -58,7 +58,7 @@
 // Step Ids of the Api tables exported by Hsa Core Runtime
 #define HSA_API_TABLE_STEP_VERSION                  0x01
 #define HSA_CORE_API_TABLE_STEP_VERSION             0x00
-#define HSA_AMD_EXT_API_TABLE_STEP_VERSION          0x0F
+#define HSA_AMD_EXT_API_TABLE_STEP_VERSION          0x10
 #define HSA_FINALIZER_API_TABLE_STEP_VERSION        0x00
 #define HSA_IMAGE_API_TABLE_STEP_VERSION            0x01
 // Rocprofiler just checks HSA_MAGE_EXT_API_TABLE_STEP_VERSION

--- a/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/inc/hsa_ext_amd.h
@@ -77,9 +77,10 @@
  * - 1.23 - hsa_amd_agent_info_t: HSA_AMD_AGENT_INFO_MAX_DATA_PREFETCH_REGIONS
  * - 1.24 - hsa_amd_external_semaphore_handle_open/hsa_amd_external_semaphore_handle_close
  * - 1.25 - hsa_amd_vmem_export_fabric_handle, hsa_amd_vmem_import_fabric_handle
+ * - 1.26 - hsa_amd_queue_signal_external_semaphore, hsa_amd_queue_wait_external_semaphore
  */
 #define HSA_AMD_INTERFACE_VERSION_MAJOR 1
-#define HSA_AMD_INTERFACE_VERSION_MINOR 25
+#define HSA_AMD_INTERFACE_VERSION_MINOR 26
 
 #ifdef __cplusplus
 extern "C" {
@@ -3210,12 +3211,8 @@ typedef enum {
  * @brief Imported external semaphore. Opaque; created by
  * hsa_amd_external_semaphore_handle_open and released by
  * hsa_amd_external_semaphore_handle_close. Internally encodes the
- * libhsakmt HSA_EXTERNAL_SEMAPHORE_HANDLE.
- *
- * @note This release adds the import / close half only. The HSA queue
- * signal/wait APIs that consume hsa_amd_external_semaphore_t will land
- * in a separate change; until then the imported handle is only useful
- * as a lifecycle owner.
+ * libhsakmt HSA_EXTERNAL_SEMAPHORE_HANDLE. Consumed by
+ * hsa_amd_queue_signal_external_semaphore / _wait_external_semaphore.
  */
 typedef struct hsa_amd_external_semaphore_s {
   uint64_t handle;
@@ -3237,11 +3234,6 @@ typedef struct {
  * agent's KMD node. The returned semaphore must be released with
  * hsa_amd_external_semaphore_handle_close.
  *
- * @note This release adds the import / close path only. There is no
- * HSA queue signal/wait API in this header that consumes
- * hsa_amd_external_semaphore_t yet; the submission half will land in
- * a separate change.
- *
  * @param[in] agent A GPU agent whose node owns the imported syncobj.
  * @param[in] desc Descriptor naming the OS handle and its type.
  * @param[out] out_sem On success, the imported semaphore.
@@ -3249,8 +3241,10 @@ typedef struct {
  * @retval HSA_STATUS_SUCCESS Imported.
  * @retval HSA_STATUS_ERROR_INVALID_AGENT Agent is not a GPU, or its
  *   KMD node has no associated WDDM device.
- * @retval HSA_STATUS_ERROR_INVALID_ARGUMENT desc/out_sem null,
- *   the OS handle is null, or the handle type is unsupported.
+ * @retval HSA_STATUS_ERROR_INVALID_ARGUMENT desc/out_sem null, or the
+ *   OS handle is null.
+ * @retval HSA_STATUS_ERROR_NOT_SUPPORTED The handle type is unsupported,
+ *   or libhsakmt lacks the import/destroy thunks (incl. Linux/KFD stub).
  * @retval HSA_STATUS_ERROR Underlying KMD import failed.
  */
 hsa_status_t HSA_API hsa_amd_external_semaphore_handle_open(
@@ -3259,13 +3253,80 @@ hsa_status_t HSA_API hsa_amd_external_semaphore_handle_open(
     hsa_amd_external_semaphore_t *out_sem);
 
 /**
- * @brief Releases an imported external semaphore. Until the HSA queue
- * signal/wait API for hsa_amd_external_semaphore_t is added, callers
- * are expected to keep the handle alive only for as long as the
- * higher-level (HIP / rocclr) wrapper that owns the same syncobj.
+ * @brief Releases an imported external semaphore. Keep the handle alive
+ * as long as any queued signal/wait that references it may still be
+ * in flight, and as long as the higher-level (HIP / rocclr) wrapper that
+ * owns the same syncobj.
  */
 hsa_status_t HSA_API hsa_amd_external_semaphore_handle_close(
     hsa_amd_external_semaphore_t sem);
+
+/**
+ * @brief Submits a GPU-side signal of an imported external semaphore
+ * onto @p queue, queued behind prior packets on the AQL ring. Windows
+ * routes to D3DKMTSignalSynchronizationObjectFromGpu via libhsakmt;
+ * Linux / KFD is currently a stub (HSA_STATUS_ERROR_NOT_SUPPORTED).
+ *
+ * @param queue Must be an AMD GPU AQL queue. A null, non-GPU, or
+ *   non-AQL queue returns HSA_STATUS_ERROR_INVALID_QUEUE; a valid AQL
+ *   queue whose node differs from the one that imported @p sem returns
+ *   HSA_STATUS_ERROR_INVALID_AGENT.
+ * @param sem   Handle from hsa_amd_external_semaphore_handle_open.
+ * @param value Fence value written to the syncobj (passed verbatim).
+ *
+ * @retval HSA_STATUS_SUCCESS                Signal queued.
+ * @retval HSA_STATUS_ERROR_INVALID_QUEUE    Null/invalid/non-GPU queue.
+ * @retval HSA_STATUS_ERROR_INVALID_ARGUMENT sem.handle is malformed.
+ * @retval HSA_STATUS_ERROR_INVALID_AGENT    Queue's node has no WDDM
+ *   device, or its node differs from the one that imported @p sem.
+ * @retval HSA_STATUS_ERROR_NOT_SUPPORTED    libhsakmt lacks the thunk
+ *   (incl. Linux/KFD stub).
+ * @retval HSA_STATUS_ERROR                  KMD signal ioctl failed.
+ */
+hsa_status_t HSA_API hsa_amd_queue_signal_external_semaphore(
+    hsa_queue_t                  *queue,
+    hsa_amd_external_semaphore_t  sem,
+    uint64_t                      value);
+
+/**
+ * @brief Submits a GPU-side wait on an imported external semaphore
+ * onto @p queue. The wait blocks any subsequent packets on the AQL
+ * ring until the imported syncobj reaches @p value. Ordering against
+ * prior submissions is the caller's responsibility (rocclr's
+ * host-queue worker submits commands sequentially, so the wait is
+ * appended in program order ahead of subsequent submitKernel /
+ * submitCopyMemory calls).
+ *
+ * Wired to KMD via libhsakmt's hsaKmtQueueWaitExternalSemaphore,
+ * which on Windows resolves to D3DKMTWaitForSynchronizationObjectFromGpu
+ * against the queue's WDDM context. Linux / KFD route is currently a
+ * stub returning HSA_STATUS_ERROR_NOT_SUPPORTED.
+ *
+ * @param queue Must be an AMD GPU AQL queue. Null, HostQueue, and AIE
+ *   queues return HSA_STATUS_ERROR_INVALID_QUEUE; a valid AQL queue
+ *   whose node differs from the one that imported @p sem returns
+ *   HSA_STATUS_ERROR_INVALID_AGENT.
+ * @param sem   Handle returned by hsa_amd_external_semaphore_handle_open.
+ * @param value Fence value to wait for. Vulkan binary semaphores
+ *   conventionally use 0 / 1 but the value is passed through verbatim
+ *   so timeline-style callers can pick their own.
+ *
+ * @retval HSA_STATUS_SUCCESS                Wait queued successfully.
+ * @retval HSA_STATUS_ERROR_INVALID_QUEUE    queue is null, invalid, or
+ *   not an AMD GPU AQL queue.
+ * @retval HSA_STATUS_ERROR_INVALID_ARGUMENT sem.handle is malformed.
+ * @retval HSA_STATUS_ERROR_INVALID_AGENT    The queue's KMD node has
+ *   no associated WDDM device, or it differs from the one that
+ *   imported @p sem.
+ * @retval HSA_STATUS_ERROR_NOT_SUPPORTED    libhsakmt lacks the thunk
+ *   (incl. Linux/KFD stub).
+ * @retval HSA_STATUS_ERROR                  Underlying KMD wait
+ *   ioctl failed.
+ */
+hsa_status_t HSA_API hsa_amd_queue_wait_external_semaphore(
+    hsa_queue_t                  *queue,
+    hsa_amd_external_semaphore_t  sem,
+    uint64_t                      value);
 
 /** @} */
 


### PR DESCRIPTION
## DO NOT MERGE — CI bisect experiment

V1 = extsem plumbing + ABI/table wiring only (no profiler, no rocclr). Bisect of #6632 over #7239.

All variants share base `7f7642c2` (= #6632 and #7395 base). Goal: locate where (if anywhere) the `no_bubbles` / `transpose-sampling` failure appears across the #7239→#6632 stack. Note: outcome is bimodal-flaky by runner, so a single run is indicative only. Will be deleted after results.