### PR TITLE
ci: bump TheRock ref to 300c0928

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: c90e6caf0700096d2f19b4f1ddcd43d6b9b584fa # 2026-06-15
+          ref: 300c0928ffba5ceb555db6ef59f4948210fe5b78 # 2026-06-17
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: c90e6caf0700096d2f19b4f1ddcd43d6b9b584fa # 2026-06-15
+          ref: 300c0928ffba5ceb555db6ef59f4948210fe5b78 # 2026-06-17
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: c90e6caf0700096d2f19b4f1ddcd43d6b9b584fa # 2026-06-15
+          ref: 300c0928ffba5ceb555db6ef59f4948210fe5b78 # 2026-06-17
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: c90e6caf0700096d2f19b4f1ddcd43d6b9b584fa # 2026-06-15
+          ref: 300c0928ffba5ceb555db6ef59f4948210fe5b78 # 2026-06-17
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: c90e6caf0700096d2f19b4f1ddcd43d6b9b584fa # 2026-06-15
+          ref: 300c0928ffba5ceb555db6ef59f4948210fe5b78 # 2026-06-17
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: c90e6caf0700096d2f19b4f1ddcd43d6b9b584fa # 2026-06-15
+          ref: 300c0928ffba5ceb555db6ef59f4948210fe5b78 # 2026-06-17
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0


### PR DESCRIPTION
## Summary

Updates the pinned TheRock commit hash across all top-level `therock-ci*` and `therock-test*` workflows. This picks up the change to route **100% of Linux builds to AWS runners** (previously 50/50 Azure/AWS).

| | Hash |
|---|---|
| **Before** | `c90e6caf0700096d2f19b4f1ddcd43d6b9b584fa` |
| **After** | `300c0928ffba5ceb555db6ef59f4948210fe5b78` |

## Files updated
- `.github/workflows/therock-ci-linux.yml`
- `.github/workflows/therock-ci.yml`
- `.github/workflows/therock-ci-windows.yml`
- `.github/workflows/therock-ci-nightly.yml`
- `.github/workflows/therock-test-component.yml`
- `.github/workflows/therock-test-packages.yml`

## Test plan
- [ ] CI passes against the new TheRock ref