### PR TITLE
feat(hipfile): Gate fastpath-only tests only to systems that support the AIS fastpath

### DIFF
--- a/projects/hipfile/CMakeLists.txt
+++ b/projects/hipfile/CMakeLists.txt
@@ -311,6 +311,9 @@ if(NOT AIS_CAPABLE_DIR)
     set(AIS_CAPABLE_DIR "/tmp" CACHE STRING "Directory to use for e2e tests.")
 endif()
 
+option(HIPFILE_ALLOW_SKIP_FASTPATH_TESTS
+  "Skip (instead of fail) fastpath-only tests when fastpath is unavailable" OFF)
+
 #-----------------------------------------------------------------------------
 # Configure hipFile
 #-----------------------------------------------------------------------------

--- a/projects/hipfile/test/CMakeLists.txt
+++ b/projects/hipfile/test/CMakeLists.txt
@@ -36,6 +36,7 @@ if(AIS_BUILD_NVIDIA_DETAIL)
     list(APPEND TEST_SYSINCLS ${HIPFILE_NVIDIA_SOURCE_PATH})
 else()
     list(APPEND SYSTEM_TEST_SOURCE_FILES system/amd/io.cpp)
+    list(APPEND SHARED_SOURCE_FILES common/ais-capability.cpp)
     list(APPEND TEST_SYSINCLS ${HIPFILE_AMD_SOURCE_PATH})
 endif()
 

--- a/projects/hipfile/test/CMakeLists.txt
+++ b/projects/hipfile/test/CMakeLists.txt
@@ -79,10 +79,16 @@ target_link_libraries(hipfile_system_tests PRIVATE GTest::gtest)
 target_compile_options(hipfile_system_tests PRIVATE -pthread)
 target_link_options(hipfile_system_tests PRIVATE -pthread)
 
+set(_allow_skip_arg "")
+if(HIPFILE_ALLOW_SKIP_FASTPATH_TESTS)
+    set(_allow_skip_arg --allow-skip-fastpath)
+endif()
+
 ais_gtest_discover_tests(
     hipfile_system_tests
-    EXTRA_ARGS --ais-capable-dir ${AIS_CAPABLE_DIR}
-    PROPERTIES "LABELS;system;LABELS;hipfile"
+    EXTRA_ARGS --ais-capable-dir ${AIS_CAPABLE_DIR} ${_allow_skip_arg}
+    # Keep this marker synchronized with the GTEST_SKIP message in system/amd/io.cpp.
+    PROPERTIES "LABELS;system;LABELS;hipfile;SKIP_REGULAR_EXPRESSION;fastpath not available"
     TEST_LIST hipfile_system_tests
 )
 

--- a/projects/hipfile/test/common/ais-capability.cpp
+++ b/projects/hipfile/test/common/ais-capability.cpp
@@ -1,0 +1,218 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "ais-capability.h"
+
+#include "hip.h"
+#include "hipfile.h"
+
+#include <charconv>
+#include <cerrno>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <string>
+
+namespace hipFile::test {
+
+namespace {
+
+    // BIT6 of the KFD topology node "capability" field signals that amdgpu has
+    // initialized AIS on that node, implying the kernel supports P2PDMA.
+    constexpr uint64_t KFD_AIS_CAPABILITY_BIT = 0x40;
+
+}
+
+void
+AisCapability::detectKernelAis()
+{
+    const std::string topology_nodes = "/sys/class/kfd/kfd/topology/nodes";
+
+    bool any_gpu = false;
+
+    std::error_code ec;
+    auto            node = std::filesystem::directory_iterator{topology_nodes, ec};
+    const auto      end  = std::filesystem::directory_iterator{};
+    for (; !ec && node != end; node.increment(ec)) {
+        const auto    properties_path = node->path() / "properties";
+        std::ifstream in{properties_path};
+        if (!in.is_open()) {
+            continue;
+        }
+
+        uint64_t    capability = 0;
+        uint32_t    simd_count = 0;
+        std::string line;
+        while (std::getline(in, line)) {
+            std::istringstream fields{line};
+            std::string        key;
+            std::string        value_text;
+            if (!(fields >> key >> value_text) || (key != "capability" && key != "simd_count")) {
+                continue;
+            }
+
+            uint64_t value = 0;
+            auto [last, parse_error] =
+                std::from_chars(value_text.data(), value_text.data() + value_text.size(), value);
+            if (parse_error != std::errc{} || last != value_text.data() + value_text.size()) {
+                continue;
+            }
+
+            if (key == "capability") {
+                capability = value;
+            }
+            else if (value <= std::numeric_limits<uint32_t>::max()) {
+                simd_count = static_cast<uint32_t>(value);
+            }
+        }
+
+        if (simd_count == 0) {
+            continue; // Not a GPU, disregard
+        }
+        any_gpu = true;
+        if ((capability & KFD_AIS_CAPABILITY_BIT) == 0) {
+            kernel_ais = false;
+            return;
+        }
+    }
+
+    kernel_ais = any_gpu;
+}
+
+void
+AisCapability::detectHipRuntime()
+{
+    hip_runtime = hipFile::getHipAmdFileReadPtr() != nullptr && hipFile::getHipAmdFileWritePtr() != nullptr;
+}
+
+void
+AisCapability::detectAmdgpu()
+{
+    std::ifstream kallsyms{"/proc/kallsyms"};
+    if (!kallsyms.is_open()) {
+        std::cerr << "Unable to open /proc/kallsyms\n";
+        amdgpu = false;
+        return;
+    }
+
+    std::string line;
+    while (std::getline(kallsyms, line)) {
+        if (line.find("kfd_ais_rw_file") != std::string::npos) {
+            amdgpu = true;
+            return;
+        }
+    }
+    amdgpu = false;
+}
+
+void
+AisCapability::detectIoProbe(hipFileHandle_t handle, void *device_buffer)
+{
+#if HIP_VERSION_MAJOR > 7 || (HIP_VERSION_MAJOR == 7 && HIP_VERSION_MINOR >= 14)
+    errno          = 0;
+    ssize_t ret    = hipFileRead(handle, device_buffer, /*size=*/0, /*file_offset=*/0, /*buffer_offset=*/0);
+    io_probe_ret   = ret;
+    io_probe_errno = errno;
+    io_probe       = classifyIoProbe(ret, errno);
+#else
+    // Avoid unused argument compiler warning.
+    static_cast<void>(handle);
+    static_cast<void>(device_buffer);
+    io_probe = IoProbeResult::NotRun;
+#endif
+}
+
+AisCapability::IoProbeResult
+AisCapability::classifyIoProbe(ssize_t ret, int err)
+{
+    if (ret == 0) {
+        return IoProbeResult::Ok;
+    }
+    if (ret == -1 && err == ENODEV) {
+        return IoProbeResult::NoDevice;
+    }
+    if (ret == -static_cast<ssize_t>(hipFileInternalError)) {
+        return IoProbeResult::InternalError;
+    }
+    return IoProbeResult::OtherError;
+}
+
+const char *
+AisCapability::ioProbeReason(IoProbeResult result)
+{
+    switch (result) {
+        case IoProbeResult::NotRun:
+            return "not run (zero-sized I/O probe unavailable)";
+        case IoProbeResult::Ok:
+            return "ok";
+        case IoProbeResult::NoDevice:
+            return "ENODEV: storage not on a P2PDMA-capable NVMe device (e.g. lvm/md "
+                   "volume), AIS not initialized on the device, or pcie_p2pdma_distance < 0";
+        case IoProbeResult::InternalError:
+            return "fastpath rejected the request (unsupported filesystem, misaligned I/O, "
+                   "or non-device buffer)";
+        case IoProbeResult::OtherError:
+            return "unexpected error (zero-sized I/O may be unsupported)";
+        default:
+            return "unknown";
+    }
+}
+
+AisCapability::GateDecision
+AisCapability::populate(hipFileHandle_t handle, void *device_buffer)
+{
+    static const AisCapability static_capability = [] {
+        AisCapability capability{false};
+        capability.detectKernelAis();
+        capability.detectHipRuntime();
+        capability.detectAmdgpu();
+        return capability;
+    }();
+
+    kernel_ais  = static_capability.kernel_ais;
+    hip_runtime = static_capability.hip_runtime;
+    amdgpu      = static_capability.amdgpu;
+    detectIoProbe(handle, device_buffer);
+
+    if (fastpathAvailable()) {
+        return GateDecision::Run;
+    }
+    return allow_skip ? GateDecision::Skip : GateDecision::Fail;
+}
+
+std::string
+AisCapability::report() const
+{
+    auto pass_fail = [](bool ok) { return ok ? "Pass" : "Fail"; };
+
+    std::ostringstream os;
+    os << "Fastpath Validation:\n";
+    os << "  HIP Runtime Check:  " << pass_fail(hip_runtime) << "\n";
+    os << "  amdgpu Check:       " << pass_fail(amdgpu) << "\n";
+    os << "  AIS init check:     " << pass_fail(kernel_ais) << "\n";
+
+    const char *io_status =
+        io_probe == IoProbeResult::Ok ? "Pass" : (io_probe == IoProbeResult::NotRun ? "Skipped" : "Fail");
+    os << "  Test I/O check:     " << io_status;
+    if (io_probe != IoProbeResult::Ok && io_probe != IoProbeResult::NotRun) {
+        os << " (" << ioProbeReason(io_probe) << "; ret=" << io_probe_ret << ", errno=" << io_probe_errno
+           << ")";
+    }
+
+    return os.str();
+}
+
+std::string
+AisCapability::skipHint() const
+{
+    return "To skip these tests instead of failing, configure the build with "
+           "-DHIPFILE_ALLOW_SKIP_FASTPATH_TESTS=ON "
+           "(passes --allow-skip-fastpath to the system test binary).";
+}
+
+}

--- a/projects/hipfile/test/common/ais-capability.h
+++ b/projects/hipfile/test/common/ais-capability.h
@@ -1,0 +1,75 @@
+/* Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include "hipfile.h"
+
+#include <string>
+#include <sys/types.h>
+
+namespace hipFile::test {
+
+// Check AIS capability for tests that attempt to force fast path.
+// Reimplements logic from hipfile/tools/ais-check/ais-check.
+class AisCapability {
+public:
+    // allow_skip_on_unavailable: if true, an unavailable fastpath yields Skip
+    // instead of Fail.
+    explicit AisCapability(bool allow_skip_on_unavailable) : allow_skip{allow_skip_on_unavailable}
+    {
+    }
+
+    // Described if fastpath tests should fail with a warning message, skip, or run.
+    enum class GateDecision {
+        Run,
+        Skip,
+        Fail,
+    };
+
+    // Try 0 size I/O on ROCm >= 7.14.
+    GateDecision populate(hipFileHandle_t handle, void *device_buffer);
+
+    std::string report() const;
+    std::string skipHint() const;
+
+private:
+    enum class IoProbeResult {
+        NotRun,        // zero-sized I/O probe unavailable (ROCm < 7.14)
+        Ok,            // zero-sized read returned 0
+        NoDevice,      // -1/ENODEV: one of buffer not on NVMe device (e.g. lvm volume or md device), AIS not
+                       // initialized on device, or p2pdma not ready
+        InternalError, // -hipFileInternalError: usually a fastpath score() rejection
+        OtherError,    // any other result
+    };
+
+    void detectKernelAis();
+    void detectHipRuntime();
+    void detectAmdgpu();
+    void detectIoProbe(hipFileHandle_t handle, void *device_buffer);
+
+    static IoProbeResult classifyIoProbe(ssize_t ret, int err);
+    static const char   *ioProbeReason(IoProbeResult result);
+
+    bool fastpathAvailable() const
+    {
+        const bool static_ok = kernel_ais && hip_runtime && amdgpu;
+        if (io_probe == IoProbeResult::NotRun) {
+            return static_ok;
+        }
+        return static_ok && io_probe == IoProbeResult::Ok;
+    }
+
+    bool allow_skip = false;
+
+    bool          kernel_ais     = false; // AIS-init bit set on all GPU nodes in KFD topology
+    bool          hip_runtime    = false; // hipAmdFileRead + hipAmdFileWrite resolvable
+    bool          amdgpu         = false; // kfd_ais_rw_file present in /proc/kallsyms
+    IoProbeResult io_probe       = IoProbeResult::NotRun;
+    ssize_t       io_probe_ret   = 0;
+    int           io_probe_errno = 0;
+};
+
+}

--- a/projects/hipfile/test/common/test-options.h
+++ b/projects/hipfile/test/common/test-options.h
@@ -31,6 +31,7 @@ parseCli(args::ArgumentParser &parser, int argc, char **argv)
 struct SystemTestOptions {
     std::string ais_capable_dir;
     uint32_t    sleep_seconds;
+    bool        allow_skip_fastpath{false};
     void        parseTestOptions(int argc, char **argv)
     {
         args::ArgumentParser            parser{"System test options"};
@@ -42,11 +43,16 @@ struct SystemTestOptions {
         args::ValueFlag<uint32_t>       sleep_on_exit_arg(parser, "seconds", "Sleep before returning to main",
                                                           args::Matcher{"sleep-on-exit"}, 0U,
                                                           args::Options::Single);
+        args::Flag                      allow_skip_fastpath_arg(
+            parser, "allow-skip-fastpath",
+            "Skip fastpath-only tests instead of failing when fastpath is unavailable",
+            args::Matcher{"allow-skip-fastpath"});
 
         parseCli(parser, argc, argv);
 
-        ais_capable_dir = args::get(ais_capable_dir_arg);
-        sleep_seconds   = args::get(sleep_on_exit_arg);
+        ais_capable_dir     = args::get(ais_capable_dir_arg);
+        sleep_seconds       = args::get(sleep_on_exit_arg);
+        allow_skip_fastpath = args::get(allow_skip_fastpath_arg);
     }
 };
 

--- a/projects/hipfile/test/system/amd/io.cpp
+++ b/projects/hipfile/test/system/amd/io.cpp
@@ -8,6 +8,7 @@
 #include "hipfile-warnings.h"
 #include "hipfile.h"
 
+#include "ais-capability.h"
 #include "test-common.h"
 #include "test-options.h"
 
@@ -22,6 +23,30 @@
 extern SystemTestOptions test_env;
 
 using namespace hipFile;
+
+namespace {
+
+// Gate fastpath-only tests on AIS capability.
+void
+enforceFastpathGate(hipFileHandle_t handle, void *device_buffer)
+{
+    hipFile::test::AisCapability ais_capability{test_env.allow_skip_fastpath};
+
+    const auto decision = ais_capability.populate(handle, device_buffer);
+
+    if (decision == hipFile::test::AisCapability::GateDecision::Run) {
+        return;
+    }
+
+    if (decision == hipFile::test::AisCapability::GateDecision::Skip) {
+        // Keep this marker synchronized with test/CMakeLists.txt SKIP_REGULAR_EXPRESSION.
+        GTEST_SKIP() << "fastpath not available in this environment\n" << ais_capability.report();
+    }
+
+    FAIL() << "Fastpath Validation Failed!\n" << ais_capability.report() << "\n" << ais_capability.skipHint();
+}
+
+}
 
 HIPFILE_WARN_NO_GLOBAL_CTOR_OFF
 
@@ -83,6 +108,10 @@ struct HipFileIo : public testing::TestWithParam<IoTestParam> {
         ASSERT_EQ(HIPFILE_SUCCESS, hipFileHandleRegister(&tmpfile_handle, &descr));
 
         ASSERT_EQ(hipSuccess, hipMalloc(&unregistered_device_buffer, unregistered_device_buffer_size));
+
+        if (GetParam().backend == IoTestBackend::Fastpath) {
+            enforceFastpathGate(tmpfile_handle, unregistered_device_buffer);
+        }
     }
 
     void TearDown() override
@@ -144,6 +173,8 @@ struct HipFileIoHipInit : public testing::Test {
         ASSERT_EQ(hipSuccess, hipMalloc(&registered_device_buffer, registered_device_buffer_size));
         ASSERT_EQ(HIPFILE_SUCCESS,
                   hipFileBufRegister(registered_device_buffer, registered_device_buffer_size, 0));
+
+        enforceFastpathGate(tmpfile_handle, registered_device_buffer);
     }
 
     void TearDown() override

--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -663,6 +663,7 @@ def capable_volumes():
     return rows, any(r["capable"] is True for r in rows)
 
 
+# Reimplemented in hipfile/test/common/ais-capability.h.
 def main():
     """
     Parse command-line arguments, check AIS support in kernel/libraries and


### PR DESCRIPTION
## Motivation

We don't want test failures on systems that don't support the fastpath if the user is aware of this limitation.

## Technical Details

Some of our tests previously forced the use of the fastpath, and manifested as test failures. These tests can instead be skipped when we detect the system does not support the fastpath.

We duplicate the logic in the `ais-check` tool to provide a C++ helper that can be used from the tests. The helper also does 0-sized I/O to gate fastpath availability, and attempts to report a reason why it may not fail. 0-sized I/O require ROCm >= 7.14, so we use preprocessor macros to gate these tests to systems that have the latest version of ROCm available.

Note, all of the output that indicates to the user that they can use a specific flag to skip the tests instead of fail, or reports why the tests got skipped, are only output when -V is used with `ctest`.

## JIRA ID

AIHIPFILE-202

## Test Plan

Test on a system that does not support the fastpath. Verify that the following tests are reported as skipped when the CMake option `HIPFILE_ALLOW_SKIP_FASTPATH_TESTS` is enabled when building:
```
77 - HipFileIoHipInit.spawnedThreadReadRunsWithoutSegfault (Skipped)
78 - HipFileIoHipInit.spawnedThreadWriteRunsWithoutSegfault (Skipped)
216 - HipFileIo.ReadToUnregisteredBufferAtOffset/Fastpath  # GetParam() = 40-byte object <00-00 00-00 00-00 00-00 E8-3B 44-2D 00-00 00-00 08-00 00-00 00-00 00-00 46-61 73-74 70-61 74-68 00-00 00-00 00-00 00-00> (Skipped)
218 - HipFileIo.ReadToUnregisteredBufferAtOffsetReturnsErrorIfOverflow/Fastpath  # GetParam() = 40-byte object <00-00 00-00 00-00 00-00 E8-3B 44-2D 00-00 00-00 08-00 00-00 00-00 00-00 46-61 73-74 70-61 74-68 00-00 00-00 00-00 00-00> (Skipped)

```

Verify that `ctest . -V` shows the skip message `SKIP: fastpath not available in this environment` for the above tests.

Verify that when not built with the CMake option `HIPFILE_ALLOW_SKIP_FASTPATH_TESTS`, these tests output a message to indicate the option is available for users that are aware the fastpath is not available.

## Test Result

Tests no longer fail, and report to be skipped as expected. Verbose output prints the expected SKIP message for only those four tests. Verbose output prints the skip hint when the tests fail (when the program is built without the `HIPFILE_ALLOW_SKIP_FASTPATH_TESTS` option).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
