### PR TITLE
Multi-arch CI : Limit failing occupancy tests to arch it supports.

### DIFF
--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -677,7 +677,9 @@ hipError_t ihipGetDeviceProperties(hipDeviceProp_tR0600* props, int device) {
   // access policy
   deviceProps.accessPolicyMaxWindowSize = 0;
   // cluster launch
-  deviceProps.clusterLaunch = info.clusterMaxSize_ > 0;
+  // A cluster of size 1 is a regular single-block launch (legal on all GPUs); clusterLaunch
+  // advertises multi-block cluster support, which only devices reporting a max size > 1 have.
+  deviceProps.clusterLaunch = info.clusterMaxSize_ > 1;
   // Mapping HIP array
   deviceProps.deferredMappingHipArraySupported = 0;
   // RDMA options

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1755,6 +1755,13 @@ bool Device::populateOCLDeviceConstants() {
   if (HSA_STATUS_SUCCESS != hsaStatus && HSA_STATUS_ERROR_INVALID_ARGUMENT != hsaStatus)
     LogError("HSA_AMD_AGENT_INFO_CLUSTER_MAX_SIZE query failed");
 
+  // A cluster of size 1 is a regular single-block launch, not multi-block cluster support.
+  // Devices without multi-block cluster support (e.g. pre-gfx12.5) report a max size of 1, so
+  // normalize it to 0 to mean "no cluster support" consistently across all consumers.
+  if (info_.clusterMaxSize_ <= 1) {
+    info_.clusterMaxSize_ = 0;
+  }
+
   info_.gpuDirectRdmaWithHipVmmSupported_ =
       info_.virtualMemoryManagement_ && info_.dmabufSupported_;
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1755,13 +1755,6 @@ bool Device::populateOCLDeviceConstants() {
   if (HSA_STATUS_SUCCESS != hsaStatus && HSA_STATUS_ERROR_INVALID_ARGUMENT != hsaStatus)
     LogError("HSA_AMD_AGENT_INFO_CLUSTER_MAX_SIZE query failed");
 
-  // A cluster of size 1 is a regular single-block launch, not multi-block cluster support.
-  // Devices without multi-block cluster support (e.g. pre-gfx12.5) report a max size of 1, so
-  // normalize it to 0 to mean "no cluster support" consistently across all consumers.
-  if (info_.clusterMaxSize_ <= 1) {
-    info_.clusterMaxSize_ = 0;
-  }
-
   info_.gpuDirectRdmaWithHipVmmSupported_ =
       info_.virtualMemoryManagement_ && info_.dmabufSupported_;
 

--- a/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxActiveClusters.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxActiveClusters.cc
@@ -48,8 +48,7 @@ TEST_CASE("Unit_hipOccupancyMaxActiveClusters_Positive_RangeValidation") {
   HIP_CHECK(hipGetDeviceProperties(&props, 0));
 
   if (!props.clusterLaunch) {
-    SUCCEED("cluster launches are not supported on this device");
-    return;
+    HIP_SKIP_TEST("cluster launches are not supported on this device");
   }
 
   auto& clusterDim = attribute[0].val.clusterDim;

--- a/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxPotentialClusterSize.cc
+++ b/projects/hip-tests/catch/unit/occupancy/hipOccupancyMaxPotentialClusterSize.cc
@@ -40,21 +40,20 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialClusterSize_Positive_RangeValidation") {
   int clusterSize;
   hipDeviceProp_t props;
   hipLaunchConfig_t config = {};
-  hipError_t hip_error;
 
   config.blockDim = {1024};
   HIP_CHECK(hipGetDeviceProperties(&props, 0));
-  hip_error =
-      hipOccupancyMaxPotentialClusterSize(&clusterSize, reinterpret_cast<const void*>(f1), &config);
 
-  if (props.clusterLaunch) {
-    INFO("Max potential cluster size is: " << clusterSize);
-    // at the time of this writing a SPI could be drive up to 15 CUs. The number of CUs per SE
-    // varies per silicon, but any AMD silicon should have at least 8
-    REQUIRE((clusterSize > 8 && clusterSize <= 16));
-  } else {
-    REQUIRE(hip_error == hipErrorInvalidClusterSize);
+  if (!props.clusterLaunch) {
+    HIP_SKIP_TEST("cluster launches are not supported on this device");
   }
+
+  HIP_CHECK(
+      hipOccupancyMaxPotentialClusterSize(&clusterSize, reinterpret_cast<const void*>(f1), &config));
+  INFO("Max potential cluster size is: " << clusterSize);
+  // at the time of this writing a SPI could be drive up to 15 CUs. The number of CUs per SE
+  // varies per silicon, but any AMD silicon should have at least 8
+  REQUIRE((clusterSize > 8 && clusterSize <= 16));
 }
 
 // TODO gehernan enable this test (requires distributed shared memory)
@@ -66,6 +65,13 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialClusterSize_Verify_Launch") {
   hipError_t hip_error;
   hipLaunchConfig_t config = {};
   int clusterSize;
+  hipDeviceProp_t props;
+
+  HIP_CHECK(hipGetDeviceProperties(&props, 0));
+
+  if (!props.clusterLaunch) {
+    HIP_SKIP_TEST("cluster launches are not supported on this device");
+  }
 
   SECTION("launch with maximum size no shmem") {
     hipLaunchConfig_t f1config = {};


### PR DESCRIPTION
## Motivation

This tests are develop to run on gfx1250. On multi-arch CI, TU gets compiled if gfx1250 is included in arch list however runtime needs to limit to arch with cluster support.

Multiarch CI https://github.com/ROCm/TheRock/actions/runs/27729666118/job/82064867736?pr=5946 has failures due to this.

## Technical Details

This tests are develop to run on gfx1250. On multi-arch CI, TU gets compiled if gfx1250 is included in arch list however runtime needs to limit to arch with cluster support.

## JIRA ID

Multi arch CI issue.

## Test Plan

Ran on gfx942 with multiarchs

## Test Result

Skipped on gfx942 with multiarchs bins

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
