### PR TITLE
fix(rocprof-sys): atomically guard SDK configure

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -94,6 +94,8 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 - Fix documentation and internal config handling that referenced the non-existent
   `ROCPROFSYS_USE_TRACE`. The Perfetto tracing backend is controlled by
   `ROCPROFSYS_TRACE`; setting `ROCPROFSYS_USE_TRACE` had no effect.
+- Fixed a pre-main `rocprof-sys-run` `SIGSEGV` in `rocprofiler_configure()` when
+  profiling OpenMPI GPU-aware MPI workloads.
 
 ### Known issues
 

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/rocprofiler-sdk.cpp
@@ -3068,9 +3068,8 @@ extern "C"
     {
         // only activate once
         {
-            static bool _first = true;
-            if(!_first) return nullptr;
-            _first = false;
+            static std::atomic<bool> _first{ true };
+            if(!_first.exchange(false)) return nullptr;
         }
 
         if(!rocprofsys::get_env(rocprofsys::env_vars::INIT_TOOLING, true)) return nullptr;


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Fix a pre-`main()` `rocprof-sys` segfault seen with OpenMPI GPU-aware MPI in the `MPI_Ghost_Exchange_Ver2_Rocprof-Sys` test. The crash occurs in the OMPT/OpenMP offload initialization path through `rocprofiler_configure()`.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
`rocprofiler_configure()` used a non-atomic function-local `static bool` as a one-time guard. Concurrent static-init paths could race past this guard and double-enter the configure body.

This PR replaces the plain bool guard with an atomic exchange.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
ROCM-25465

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Built rocprofiler-systems develop with this fix on AAC6 and ran the GhostExchange repro on a 4-GPU MI300A node.
Commands tested:
mpirun -n 4 ./GhostExchange
mpirun -n 4 rocprof-sys-run -- ./GhostExchange.inst

## Test Result

<!-- Briefly summarize test outcomes. -->
Both runs passed without any segfault in aac6. The rocprof-sys-run run completed without SIGSEGV and generated four Perfetto traces.
<img width="1182" height="331" alt="image" src="https://github.com/user-attachments/assets/e202b60f-5fca-4ac5-a88e-1bf5c89db039" />

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
