### PR TITLE
[DO NOT MERGE] bisect: LKG + 6909 (isolate which commit fails the patch)

### DIFF
--- a/projects/rocprofiler-systems/CHANGELOG.md
+++ b/projects/rocprofiler-systems/CHANGELOG.md
@@ -74,6 +74,9 @@ Full documentation for ROCm Systems Profiler is available at [https://rocm.docs.
 - Fix cmake issue that caused the wrong version of `elfutils` to be linked when
   building for TheRock. The system version of `elfutils` was used, rather than
   the vendored version causing package install failures.
+- Fix documentation and internal config handling that referenced the non-existent
+  `ROCPROFSYS_USE_TRACE`. The Perfetto tracing backend is controlled by
+  `ROCPROFSYS_TRACE`; setting `ROCPROFSYS_USE_TRACE` had no effect.
 
 ## ROCm Systems Profiler 1.6.0 for ROCm 7.13.0
 

--- a/projects/rocprofiler-systems/docs/how-to/profiling-python-scripts.rst
+++ b/projects/rocprofiler-systems/docs/how-to/profiling-python-scripts.rst
@@ -30,7 +30,7 @@ be the same size.
 
 .. note::
 
-   Direct Perfetto output (using ``--trace`` or ``ROCPROFSYS_USE_TRACE=ON``) has limited support for Artificial Intelligence (AI) and Machine Learning (ML) workloads.
+   Direct Perfetto output (using ``--trace`` or ``ROCPROFSYS_TRACE=ON``) has limited support for Artificial Intelligence (AI) and Machine Learning (ML) workloads.
    Data from child threads is not captured. Instead, use ROCPD (``ROCPROFSYS_USE_ROCPD=ON``) as the output type.
    For more information, see the :ref:`rocprof_sys_rocpd_output` section.
 

--- a/projects/rocprofiler-systems/docs/how-to/understanding-rocprof-sys-output.rst
+++ b/projects/rocprofiler-systems/docs/how-to/understanding-rocprof-sys-output.rst
@@ -325,7 +325,7 @@ To generate profiling data in the rocpd format, add ``ROCPROFSYS_USE_ROCPD=ON`` 
 .. code-block:: shell
 
    export ROCPROFSYS_USE_ROCPD=ON
-   export ROCPROFSYS_USE_TRACE=OFF # disabling default Perfetto output
+   export ROCPROFSYS_TRACE=OFF # disabling default Perfetto output
    rocprof-sys-sample -- ./your_application
 
 See :doc:`configuring runtime options <./configuring-runtime-options>` for additional

--- a/projects/rocprofiler-systems/source/lib/core/config.cpp
+++ b/projects/rocprofiler-systems/source/lib/core/config.cpp
@@ -1278,7 +1278,7 @@ configure_mode_settings(const std::shared_ptr<settings>& _config)
 
     if(!_config->get_enabled())
     {
-        _set("ROCPROFSYS_USE_TRACE", false);
+        _set("ROCPROFSYS_TRACE", false);
         _set("ROCPROFSYS_PROFILE", false);
         _set("ROCPROFSYS_USE_CAUSAL", false);
         _set("ROCPROFSYS_USE_AMD_SMI", false);
@@ -1459,7 +1459,7 @@ configure_disabled_settings(const std::shared_ptr<settings>& _config)
     _handle_use_option("ROCPROFSYS_USE_PROCESS_SAMPLING", "process_sampling");
     _handle_use_option("ROCPROFSYS_USE_CAUSAL", "causal");
     _handle_use_option("ROCPROFSYS_USE_KOKKOSP", "kokkos");
-    _handle_use_option("ROCPROFSYS_USE_TRACE", "perfetto");
+    _handle_use_option("ROCPROFSYS_TRACE", "perfetto");
     _handle_use_option("ROCPROFSYS_PROFILE", "timemory");
     _handle_use_option("ROCPROFSYS_USE_OMPT", "ompt");
     _handle_use_option("ROCPROFSYS_USE_RCCLP", "rcclp");

--- a/projects/rocprofiler-systems/tests/pytest/test_config.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_config.py
@@ -86,3 +86,28 @@ class TestConfig(RocprofsysTest):
             pass_regex=[r"Error reading configuration file"],
             use_abort_fail_regex=False,
         )
+
+    @pytest.mark.timeout(120)
+    def test_trace_category_enabled_in_runtime(self, config_target: str):
+        """Perfetto settings must appear in the runtime config print when tracing is on.
+
+        Regression for the phantom ``ROCPROFSYS_USE_TRACE`` key: the perfetto
+        setting category was gated on an unregistered key, so it was always
+        disabled at runtime and every perfetto setting (including
+        ``ROCPROFSYS_TRACE``) was silently dropped from the printed
+        configuration. The canonical switch is ``ROCPROFSYS_TRACE``.
+        """
+        env = {
+            "ROCPROFSYS_TRACE": "ON",
+            "ROCPROFSYS_VERBOSE": "2",
+        }
+
+        result = self.run_test("sampling", target=config_target, env=env)
+
+        self.assert_regex(
+            result,
+            pass_regex=[
+                r"ROCPROFSYS_TRACE\s+=\s+(true|false)",
+                r"ROCPROFSYS_PERFETTO_\w+\s+=",
+            ],
+        )


### PR DESCRIPTION
## DO NOT MERGE — per-commit bisect of the #7420→#7421 window

Base = `exp-lkg-2a108a17` (LKG = #6632 extsem patch + develop pre-#5219, PASSES). Head = LKG + **one** cherry-picked develop commit: #6909 (env-var rename) — expect PASS (benign).

Diff is exactly that one commit (parent-as-base trick → mergeable, CI runs, merge ref = patch + that commit). If only the #5219 branch fails and the other three pass, #5219 is the isolated culprit with the patch present. Bimodal — needs repeats. Delete after.