### PR TITLE
[clr] Reset cached queue-progress state on HW queue swap (ROCM-25836)

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1097,6 +1097,14 @@ bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address para
 void VirtualGPU::SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer) {
   gpu_queue_ = queue;
   cached_read_dispatch_id_ = 0;
+  // The cached queue-progress state belongs to the previously assigned HW queue. When the HW
+  // queue changes (released back to / reacquired from the shared dynamic-queue pool), that state
+  // is stale: the recorded completion signal may have been recycled/destroyed and the write
+  // indices refer to a different queue. Reset to the "empty queue" sentinel so IsQueueIdle() does
+  // not dereference a stale completion-signal handle.
+  last_write_index_ = kInvalidQueueIndex;
+  last_packet_with_signal_index_ = kInvalidQueueIndex;
+  last_completion_signal_.handle = 0;
   metadata_preloader_.SetQueueBase(metadata_ring_buffer,
                                    roc_device_.MetadataVersionHeader());
 }

--- a/projects/hip-tests/catch/config/configs/unit/memory.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/memory.yaml
@@ -351,6 +351,9 @@ memory:
     # Does not play well with ASAN
     disabled: [asan]
     tags: []
+  Unit_hipMemcpy_DynamicQueueChurn_StagedCopies:
+    <<: *level_2
+    tags: [multigpu, transfer]
   Unit_hipHostRegister_ReferenceFromKernelandhipMemset:
     <<: *level_2
     # disabling due to flaky segfault in CI nightly https://github.com/ROCm/TheRock/issues/4111

--- a/projects/hip-tests/catch/unit/memory/CMakeLists.txt
+++ b/projects/hip-tests/catch/unit/memory/CMakeLists.txt
@@ -41,6 +41,7 @@ set(TEST_SRC
     hipMemcpyHtoA_old.cc
     hipMemcpyAllApiNegative.cc
     hipMemcpy_MultiThread.cc
+    hipMemcpyDynamicQueueChurn.cc
     hipHostRegister.cc
     hipHostUnregister.cc
     hipHostGetFlags.cc

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDynamicQueueChurn.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDynamicQueueChurn.cc
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <hip_test_common.hh>
+
+#include <atomic>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+namespace {
+
+struct Transfer {
+  int src_gpu;
+  int dma_gpu;
+  bool dst_is_gpu;
+  int dst_index;
+};
+
+constexpr Transfer kTransfers[] = {
+    {0, 0, false, 0}, {1, 1, false, 0}, {2, 2, false, 0}, {3, 3, false, 0},
+    {4, 4, false, 1}, {5, 5, false, 1}, {6, 6, false, 1}, {7, 7, false, 1},
+    {0, 0, false, 1}, {1, 1, false, 1}, {2, 2, false, 1}, {3, 3, false, 1},
+    {4, 4, false, 0}, {5, 5, false, 0}, {6, 6, false, 0}, {7, 7, false, 0},
+    {0, 0, true, 0}, {0, 0, true, 1}, {0, 0, true, 2}, {0, 0, true, 3},
+    {0, 0, true, 4}, {0, 0, true, 5}, {0, 0, true, 6}, {0, 0, true, 7},
+    {1, 1, true, 1}, {1, 1, true, 2}, {1, 1, true, 3}, {1, 1, true, 4},
+    {1, 1, true, 5}, {1, 1, true, 6}, {1, 1, true, 7},
+    {2, 2, true, 3}, {2, 2, true, 4}, {2, 2, true, 5}, {2, 2, true, 6},
+    {2, 2, true, 7},
+    {3, 3, true, 3}, {3, 3, true, 4}, {3, 3, true, 5}, {3, 3, true, 6},
+    {3, 3, true, 7},
+    {4, 4, true, 4}, {4, 4, true, 5}, {4, 4, true, 6}, {4, 4, true, 7},
+    {5, 5, true, 5}, {5, 5, true, 6}, {5, 5, true, 7},
+    {6, 6, true, 6}, {6, 6, true, 7},
+    {7, 7, true, 7},
+};
+
+}  // namespace
+
+HIP_TEST_CASE(Unit_hipMemcpy_DynamicQueueChurn_StagedCopies) {
+  int device_count = 0;
+  HIP_CHECK(hipGetDeviceCount(&device_count));
+  if (device_count < 8) {
+    HIP_SKIP_TEST("Requires at least 8 GPUs");
+  }
+
+  constexpr size_t kSize = 1ULL * 1024ULL * 1024ULL * 1024ULL;
+  void* device_buffers[8] = {};
+  void* host_buffers[2] = {};
+
+  for (int dev = 0; dev < 8; ++dev) {
+    HIP_CHECK(hipSetDevice(dev));
+    for (int peer = 0; peer < 8; ++peer) {
+      if (peer != dev) {
+        hipDeviceEnablePeerAccess(peer, 0);
+      }
+    }
+    HIP_CHECK(hipMalloc(&device_buffers[dev], kSize));
+    HIP_CHECK(hipMemset(device_buffers[dev], 0, kSize));
+  }
+
+  HIP_CHECK(hipSetDevice(0));
+  HIP_CHECK(hipHostMalloc(&host_buffers[0], kSize));
+  HIP_CHECK(hipHostMalloc(&host_buffers[1], kSize));
+  std::memset(host_buffers[0], 0, kSize);
+  std::memset(host_buffers[1], 0, kSize);
+  HIP_CHECK(hipDeviceSynchronize());
+
+  std::vector<hipStream_t> streams(std::size(kTransfers));
+  for (size_t i = 0; i < std::size(kTransfers); ++i) {
+    HIP_CHECK(hipSetDevice(kTransfers[i].dma_gpu));
+    HIP_CHECK(hipStreamCreate(&streams[i]));
+  }
+
+  std::atomic<bool> failed{false};
+  std::vector<std::thread> threads;
+  threads.reserve(std::size(kTransfers));
+
+  for (size_t i = 0; i < std::size(kTransfers); ++i) {
+    threads.emplace_back([&, i]() {
+      const Transfer& transfer = kTransfers[i];
+      if (hipSetDevice(transfer.dma_gpu) != hipSuccess) {
+        failed.store(true, std::memory_order_relaxed);
+        return;
+      }
+      void* dst = transfer.dst_is_gpu ? device_buffers[transfer.dst_index]
+                                      : host_buffers[transfer.dst_index];
+      void* src = device_buffers[transfer.src_gpu];
+      if (hipMemcpyAsync(dst, src, kSize, hipMemcpyDefault, streams[i]) != hipSuccess) {
+        failed.store(true, std::memory_order_relaxed);
+        return;
+      }
+      if (hipStreamSynchronize(streams[i]) != hipSuccess) {
+        failed.store(true, std::memory_order_relaxed);
+      }
+    });
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  REQUIRE_FALSE(failed.load(std::memory_order_relaxed));
+  HIP_CHECK(hipDeviceSynchronize());
+
+  for (size_t i = 0; i < std::size(kTransfers); ++i) {
+    HIP_CHECK(hipSetDevice(kTransfers[i].dma_gpu));
+    HIP_CHECK(hipStreamDestroy(streams[i]));
+  }
+
+  HIP_CHECK(hipHostFree(host_buffers[0]));
+  HIP_CHECK(hipHostFree(host_buffers[1]));
+  for (int dev = 0; dev < 8; ++dev) {
+    HIP_CHECK(hipSetDevice(dev));
+    HIP_CHECK(hipFree(device_buffers[dev]));
+  }
+  HIP_CHECK(hipDeviceSynchronize());
+}

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDynamicQueueChurn.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDynamicQueueChurn.cc
@@ -69,6 +69,7 @@ HIP_TEST_CASE(Unit_hipMemcpy_DynamicQueueChurn_StagedCopies) {
     }
     HIP_CHECK(hipMalloc(&device_buffers[dev], kSize));
     HIP_CHECK(hipMemset(device_buffers[dev], 0, kSize));
+    HIP_CHECK(hipDeviceSynchronize());
   }
 
   HIP_CHECK(hipSetDevice(0));

--- a/projects/hip-tests/catch/unit/memory/hipMemcpyDynamicQueueChurn.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemcpyDynamicQueueChurn.cc
@@ -48,7 +48,8 @@ HIP_TEST_CASE(Unit_hipMemcpy_DynamicQueueChurn_StagedCopies) {
     HIP_SKIP_TEST("Requires at least 8 GPUs");
   }
 
-  constexpr size_t kSize = 1ULL * 1024ULL * 1024ULL * 1024ULL;
+  const size_t kSize = isQuickLevel() ? 128ULL * 1024ULL * 1024ULL
+                                      : 1ULL * 1024ULL * 1024ULL * 1024ULL;
   void* device_buffers[8] = {};
   void* host_buffers[2] = {};
 
@@ -56,7 +57,14 @@ HIP_TEST_CASE(Unit_hipMemcpy_DynamicQueueChurn_StagedCopies) {
     HIP_CHECK(hipSetDevice(dev));
     for (int peer = 0; peer < 8; ++peer) {
       if (peer != dev) {
-        hipDeviceEnablePeerAccess(peer, 0);
+        int can_access_peer = 0;
+        HIP_CHECK(hipDeviceCanAccessPeer(&can_access_peer, dev, peer));
+        if (can_access_peer != 0) {
+          hipError_t peer_access = hipDeviceEnablePeerAccess(peer, 0);
+          if (peer_access != hipSuccess && peer_access != hipErrorPeerAccessAlreadyEnabled) {
+            HIP_CHECK(peer_access);
+          }
+        }
       }
     }
     HIP_CHECK(hipMalloc(&device_buffers[dev], kSize));
@@ -103,7 +111,7 @@ HIP_TEST_CASE(Unit_hipMemcpy_DynamicQueueChurn_StagedCopies) {
   for (auto& thread : threads) {
     thread.join();
   }
-  REQUIRE_FALSE(failed.load(std::memory_order_relaxed));
+  const bool transfer_failed = failed.load(std::memory_order_relaxed);
   HIP_CHECK(hipDeviceSynchronize());
 
   for (size_t i = 0; i < std::size(kTransfers); ++i) {
@@ -118,4 +126,5 @@ HIP_TEST_CASE(Unit_hipMemcpy_DynamicQueueChurn_StagedCopies) {
     HIP_CHECK(hipFree(device_buffers[dev]));
   }
   HIP_CHECK(hipDeviceSynchronize());
+  REQUIRE_FALSE(transfer_failed);
 }


### PR DESCRIPTION
## Motivation

VirtualGPU::IsQueueIdle() reads last_completion_signal_ via hsa_signal_load_relaxed to decide whether the current HW queue is idle. Under dynamic queue pool, a VGPU can release its HW queue back to the shared pool and later reacquire a different one via SetGpuQueue(). The three cached fields (last_write_index_, last_packet_with_signal_index_, last_completion_signal_) were never cleared on queue swap, so IsQueueIdle() could dereference a completion-signal handle that had already been recycled or destroyed, causing a SIGSEGV inside hsa_signal_load_relaxed.

The issue appears to come up after   https://github.com/ROCm/rocm-systems/pull/5244 but it is a pre-exisitng issue. That change makes it more likely to happen.

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

The fix is  to reset all three fields to their "empty queue" sentinels inside SetGpuQueue()

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
Resolves ROCM-25836
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
The issue shows up under stress conditions and could only be reproduced with the transferBench job so far. 
Attempts to capture the failure in a unit test did not succeed. This would need to be tracked separately.


<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
 - Ran the TransferBench SDMA reproducer from ROCM-25836 repeatedly — no segfaults observed after the fix (previously crashed consistently). 
- Ran the full hip-tests suite locally on MI300X - no regressions introduced by the fix. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
