### PR TITLE
[rocjitsu] Use mirage instead of rocjitsu for testing corpus

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -139,6 +139,7 @@ SKIPPABLE_PATH_PATTERNS = [
     ".github/label*.yml",
     ".github/workflows/labeler.yml",
     ".github/workflows/amdsmi-manylinux-build.yml",
+    ".github/workflows/rocjitsu-corpus-tests.yml",
 ]
 
 

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -1,0 +1,145 @@
+# Pytest corpus checks for emulation/rocjitsu/.
+#
+# Fast smoke tests for rocjitsu. This is likely going to be added to TheRock
+# tests, but it is currently a stopgap solution. It allows developers to
+# quickly check that their changes to rocjitsu didn't break gfx1250 emulation.
+name: "rocjitsu-test-corpus"
+
+on:
+  pull_request:
+    paths:
+      - "emulation/rocjitsu/**"
+      - ".github/workflows/rocjitsu-*.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "emulation/rocjitsu/**"
+      - ".github/workflows/rocjitsu-*.yml"
+  workflow_dispatch:
+    inputs:
+      corpus_repository:
+        description: "Repository containing the rocjitsu pytest corpus"
+        default: "ROCm/rocjitsu-test-corpus"
+        required: true
+      corpus_ref:
+        description: "Branch, tag, or SHA to check out from the corpus repository"
+        # Last updated on 2026/06/16.
+        default: "dc70e0519b3587543e3892149207b7658f04b56b"
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ROCJITSU_SOURCE_DIR: ${{ github.workspace }}/rocm-systems/emulation/rocjitsu
+  ROCJITSU_BUILD_DIR: ${{ github.workspace }}/build
+  ROCJITSU_CORPUS_DIR: ${{ github.workspace }}/rocjitsu-test-corpus
+  ROCJITSU_CORPUS_CONFIG: ${{ github.workspace }}/rocm-systems/emulation/rocjitsu/tests/corpus/iree_gfx1250_hip.json
+
+jobs:
+  pytest:
+    runs-on: azure-linux-scale-rocm
+    container:
+      image: ubuntu:24.04
+      env:
+        DEBIAN_FRONTEND: noninteractive
+    continue-on-error: true
+
+    steps:
+      - name: Install base dependencies
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            cmake \
+            git \
+            libdrm-dev \
+            ninja-build
+
+      - name: Checkout rocm-systems
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          path: rocm-systems
+          sparse-checkout: |
+            emulation/rocjitsu
+            .github
+
+      - name: Checkout rocjitsu corpus
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: ${{ github.event.inputs.corpus_repository || 'ROCm/rocjitsu-test-corpus' }}
+          # Last updated on 2026/06/16.
+          ref: dc70e0519b3587543e3892149207b7658f04b56b
+          path: rocjitsu-test-corpus
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install ROCm SDK
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --pre \
+            --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+            "rocm[devel]"
+
+          ROCM_ROOT="$(rocm-sdk path --root)"
+          ROCM_LIB="$(rocm-sdk path --root)"/lib
+          LLVM_BIN="${ROCM_LIB}/llvm/bin"
+          LLVM_LIB="${ROCM_LIB}/llvm/lib"
+          ROCM_SYSDEPS="${ROCM_LIB}/rocm_sysdeps"
+
+          test -x "${LLVM_BIN}/amdclang"
+          test -x "${LLVM_BIN}/amdclang++"
+          test -d "${LLVM_LIB}"
+
+          {
+            echo "ROCM_PATH=${ROCM_ROOT}"
+            echo "CC=${LLVM_BIN}/amdclang"
+            echo "CXX=${LLVM_BIN}/amdclang++"
+            echo "LD_LIBRARY_PATH=${ROCM_LIB}:${LD_LIBRARY_PATH:-}"
+          } >> "${GITHUB_ENV}"
+
+          if [ -d "${ROCM_SYSDEPS}/include" ]; then
+            {
+              echo "CFLAGS=-I${ROCM_SYSDEPS}/include"
+              echo "CXXFLAGS=-I${ROCM_SYSDEPS}/include -Wno-error=unknown-warning-option -Wno-error=nested-anon-types"
+            } >> "${GITHUB_ENV}"
+          else
+            echo "CXXFLAGS=-Wno-error=unknown-warning-option -Wno-error=nested-anon-types" >> "${GITHUB_ENV}"
+          fi
+
+          echo "${LLVM_BIN}" >> "${GITHUB_PATH}"
+
+      - name: Build rocjitsu
+        working-directory: ${{ env.ROCJITSU_SOURCE_DIR }}
+        run: |
+          cmake -B "${ROCJITSU_BUILD_DIR}" -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER="${CC}" \
+            -DCMAKE_CXX_COMPILER="${CXX}" \
+            -DCMAKE_C_FLAGS="${CFLAGS:-}" \
+            -DCMAKE_CXX_FLAGS="${CXXFLAGS:-}" \
+            -DAMDCLANG="${CXX}"
+          cmake --build "${ROCJITSU_BUILD_DIR}"
+          echo "${ROCJITSU_BUILD_DIR}/tools/rocjitsu" >> "${GITHUB_PATH}"
+
+      - name: Install corpus test dependencies
+        working-directory: ${{ env.ROCJITSU_CORPUS_DIR }}
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run corpus tests
+        working-directory: ${{ env.ROCJITSU_CORPUS_DIR }}
+        env:
+          ROCJITSU_ROOT: ${{ env.ROCJITSU_SOURCE_DIR }}
+          ROCJITSU_BUILD: ${{ env.ROCJITSU_BUILD_DIR }}
+        run: rocjitsu --config "${ROCJITSU_SOURCE_DIR}/configs/amdgpu_gfx1250.json" -- pytest --config-files="${ROCJITSU_CORPUS_CONFIG}" --timeout 15

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -9,12 +9,14 @@ on:
   pull_request:
     paths:
       - "emulation/rocjitsu/**"
+      - "emulation/mirage/**"
       - ".github/workflows/rocjitsu-*.yml"
   push:
     branches:
       - main
     paths:
       - "emulation/rocjitsu/**"
+      - "emulation/mirage/**"
       - ".github/workflows/rocjitsu-*.yml"
   workflow_dispatch:
     inputs:
@@ -38,8 +40,10 @@ permissions:
 env:
   ROCJITSU_SOURCE_DIR: ${{ github.workspace }}/rocm-systems/emulation/rocjitsu
   ROCJITSU_BUILD_DIR: ${{ github.workspace }}/build
+  ROCJITSU_KMD_LIB: ${{ github.workspace }}/build/lib/rocjitsu/src/rocjitsu/kmd/linux/librocjitsu_kmd.so
   ROCJITSU_CORPUS_DIR: ${{ github.workspace }}/rocjitsu-test-corpus
   ROCJITSU_CORPUS_CONFIG: ${{ github.workspace }}/rocm-systems/emulation/rocjitsu/tests/corpus/iree_gfx1250_hip.json
+  MIRAGE_SOURCE_DIR: ${{ github.workspace }}/rocm-systems/emulation/mirage
 
 jobs:
   pytest:
@@ -58,8 +62,11 @@ jobs:
             build-essential \
             ca-certificates \
             cmake \
+            curl \
             git \
             libdrm-dev \
+            pkg-config \
+            libssl-dev \
             ninja-build
 
       - name: Checkout rocm-systems
@@ -68,6 +75,7 @@ jobs:
           path: rocm-systems
           sparse-checkout: |
             emulation/rocjitsu
+            emulation/mirage
             .github
 
       - name: Checkout rocjitsu corpus
@@ -92,18 +100,10 @@ jobs:
 
           ROCM_ROOT="$(rocm-sdk path --root)"
           ROCM_LIB="$(rocm-sdk path --root)"/lib
-          LLVM_BIN="${ROCM_LIB}/llvm/bin"
-          LLVM_LIB="${ROCM_LIB}/llvm/lib"
           ROCM_SYSDEPS="${ROCM_LIB}/rocm_sysdeps"
-
-          test -x "${LLVM_BIN}/amdclang"
-          test -x "${LLVM_BIN}/amdclang++"
-          test -d "${LLVM_LIB}"
 
           {
             echo "ROCM_PATH=${ROCM_ROOT}"
-            echo "CC=${LLVM_BIN}/amdclang"
-            echo "CXX=${LLVM_BIN}/amdclang++"
             echo "LD_LIBRARY_PATH=${ROCM_LIB}:${LD_LIBRARY_PATH:-}"
           } >> "${GITHUB_ENV}"
 
@@ -116,20 +116,31 @@ jobs:
             echo "CXXFLAGS=-Wno-error=unknown-warning-option -Wno-error=nested-anon-types" >> "${GITHUB_ENV}"
           fi
 
-          echo "${LLVM_BIN}" >> "${GITHUB_PATH}"
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+          echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
 
-      - name: Build rocjitsu
+      - name: Build rocjitsu dependency
         working-directory: ${{ env.ROCJITSU_SOURCE_DIR }}
         run: |
           cmake -B "${ROCJITSU_BUILD_DIR}" -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER="${CC}" \
-            -DCMAKE_CXX_COMPILER="${CXX}" \
             -DCMAKE_C_FLAGS="${CFLAGS:-}" \
-            -DCMAKE_CXX_FLAGS="${CXXFLAGS:-}" \
-            -DAMDCLANG="${CXX}"
+            -DCMAKE_CXX_FLAGS="${CXXFLAGS:-}"
           cmake --build "${ROCJITSU_BUILD_DIR}"
-          echo "${ROCJITSU_BUILD_DIR}/tools/rocjitsu" >> "${GITHUB_PATH}"
+          test -f "${ROCJITSU_KMD_LIB}"
+
+      - name: Build mirage
+        working-directory: ${{ env.MIRAGE_SOURCE_DIR }}
+        env:
+          MIRAGE_DASHBOARD_SKIP_NPM_CI: "1"
+          ROCJITSU_ROOT: ${{ env.ROCJITSU_SOURCE_DIR }}
+          ROCJITSU_KMD_LIB: ${{ env.ROCJITSU_KMD_LIB }}
+        run: |
+          cargo build
+          ./target/debug/mirage state builtins
+          echo "${MIRAGE_SOURCE_DIR}/target/debug" >> "${GITHUB_PATH}"
 
       - name: Install corpus test dependencies
         working-directory: ${{ env.ROCJITSU_CORPUS_DIR }}
@@ -141,5 +152,5 @@ jobs:
         working-directory: ${{ env.ROCJITSU_CORPUS_DIR }}
         env:
           ROCJITSU_ROOT: ${{ env.ROCJITSU_SOURCE_DIR }}
-          ROCJITSU_BUILD: ${{ env.ROCJITSU_BUILD_DIR }}
-        run: rocjitsu --config "${ROCJITSU_SOURCE_DIR}/configs/amdgpu_gfx1250.json" -- pytest --config-files="${ROCJITSU_CORPUS_CONFIG}" --timeout 15
+          ROCJITSU_KMD_LIB: ${{ env.ROCJITSU_KMD_LIB }}
+        run: mirage run --profile MI450 --env LD_LIBRARY_PATH=$LD_LIBRARY_PATH -- pytest --config-files="${ROCJITSU_CORPUS_CONFIG}" --timeout 15

--- a/emulation/rocjitsu/tests/corpus/iree_gfx1250_hip.json
+++ b/emulation/rocjitsu/tests/corpus/iree_gfx1250_hip.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "../schemas/target_config.schema.json",
+  "config_name": "iree_gfx1250_hip",
+  "iree_compile_flags": [
+    "--iree-hal-target-backends=rocm",
+    "--iree-rocm-target=gfx1250"
+  ],
+  "iree_run_module_flags": [
+    "--device=hip"
+  ],
+  "skip_compile_tests": [],
+  "skip_run_tests": [
+    "static_pack_vnni_lhs_large",
+    "static_pack_vnni_lhs_large_with_pad",
+    "static_pack_vnni_rhs_large",
+    "static_pack_vnni_rhs_large_with_pad",
+    "softmax_dynamic_10x256x256xf32",
+    "softmax_static_10x256x256xf32",
+    "dynamic_unpack_extract_slice_large",
+    "dynamic_unpack_extract_slice_transpose_inner_and_outer_dims_large",
+    "dynamic_unpack_extract_slice_transpose_outer_dims_large",
+    "dynamic_unpack_large",
+    "dynamic_unpack_simple",
+    "dynamic_unpack_transpose_inner_dims_large",
+    "static_unpack_extract_slice_large",
+    "e2e_matmul_gfx1250_dt_f16",
+    "e2e_matmul_gfx1250_dt_f8E4M3FN",
+    "e2e_matmul_gfx1250_dt_i8",
+    "dynamic_unpack_extract_slice_transpose_inner_dims_large",
+    "dynamic_unpack_simple_extract_slice",
+    "dynamic_unpack_transpose_inner_and_outer_dims_large",
+    "dynamic_unpack_transpose_outer_dims_large",
+    "static_unpack_extract_slice_transpose_inner_and_outer_dims_large",
+    "static_unpack_extract_slice_transpose_inner_dims_large",
+    "static_unpack_extract_slice_transpose_outer_dims_large",
+    "static_unpack_large",
+    "static_unpack_simple",
+    "static_unpack_simple_extract_slice"
+  ],
+  "expected_compile_failures": [],
+  "expected_run_failures": [
+  ]
+}


### PR DESCRIPTION
## Motivation

Switch to mirage instead of rocjitsu. Do not merge yet. This PR depends on https://github.com/ROCm/rocm-systems/pull/7175 and https://github.com/ROCm/rocm-systems/pull/7352

## Technical Details

Build mirage

## JIRA ID

None applicable

## Test Plan

Test in CI

## Test Result

CI should pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
