### PR TITLE
Remove ROCPROFSYS_TRACE_LEGACY=ON for OpenMP HPC tests

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/test_hpc.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_hpc.py
@@ -147,7 +147,6 @@ class TestJacobi(RocprofsysTest):
     def test_roctx(self, mode, hpc_openmp_environment):
         env = hpc_openmp_environment.copy()
         env["ROCPROFSYS_ROCM_DOMAINS"] = "hip_api,kernel_dispatch,roctx,memory_copy"
-        env["ROCPROFSYS_TRACE_LEGACY"] = "ON"
         env["ROCPROFSYS_COUT_OUTPUT"] = "OFF"
 
         result = self.run_test(
@@ -237,7 +236,6 @@ class TestMatrixExponential(RocprofsysTest):
         env = hpc_hip_environment.copy()
         env["ROCPROFSYS_ROCM_DOMAINS"] = "hip_api,kernel_dispatch,roctx,memory_copy"
         env["ROCPROFSYS_USE_OMPT"] = "ON"
-        env["ROCPROFSYS_TRACE_LEGACY"] = "ON"
 
         result = self.run_test(
             mode, target="matrix-exponential-streams-sync-hip", env=env


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Remove the use of `ROCPROFSYS_TRACE_LEGACY` for HPC OpenMP tests. The default is to use trace cache.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

 - Remove `ROCPROFSYS_TRACE_LEGACY=ON`
 - We keep it for the `usm` test, as it does not use OpenMP.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-346

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Locall
Workflows

## Test Result

<!-- Briefly summarize test outcomes. -->

Local - Pass
Workflow: See... the workflows...

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
