### PR TITLE
fix (hip-tests): Fix unsafe Catch2 macros in multithreaded graph tests for ASAN

### DIFF
--- a/projects/hip-tests/catch/unit/graph/hipGraphAsyncUserObj.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphAsyncUserObj.cc
@@ -41,8 +41,8 @@ template <typename T> __global__ void KernelFn(T* Ad, int clockrate, int WaitMs)
 void threadFunc_dltMemory() {
   std::unique_lock lk(m);
   cv.wait(lk, [] { return setVar; });
-  REQUIRE(globalPtr != nullptr);
-  HIP_CHECK(hipHostFree(globalPtr));
+  REQUIRE_THREAD(globalPtr != nullptr);
+  HIP_CHECK_THREAD(hipHostFree(globalPtr));
   setVar = false;
 }
 static int kernelDelayMs() { return isQuickLevel() ? 500 : 5000; }
@@ -117,6 +117,7 @@ HIP_TEST_CASE(Unit_hipGraphUserObj_Int_float_Objects) {
     hipUserObjectCreate_int_float_Objects(hostArr, devArr, destroyPinnedObj);
     HIP_CHECK(hipFree(devArr));
     t1.join();
+    HIP_CHECK_THREAD_FINALIZE();
   }
   SECTION("Called with float Obj") {
     std::thread t1(threadFunc_dltMemory);
@@ -130,6 +131,7 @@ HIP_TEST_CASE(Unit_hipGraphUserObj_Int_float_Objects) {
     hipUserObjectCreate_int_float_Objects(hostArr, devArr, destroyPinnedObj);
     HIP_CHECK(hipFree(devArr));
     t1.join();
+    HIP_CHECK_THREAD_FINALIZE();
   }
 }
 void destroyHostRegObj(void* ptr) {
@@ -251,6 +253,7 @@ HIP_TEST_CASE(Unit_hipGraphUserObj_Struct_Class_Ojects) {
     REQUIRE(structObj_d != nullptr);
     hipUserObjectCreate_Struct_Class_Objects<BoxStruct>(structObj_h, structObj_d);
     t1.join();
+    HIP_CHECK_THREAD_FINALIZE();
   }
   SECTION("Called with Class Object") {
     std::thread t1(threadFunc_dltMemory);
@@ -263,6 +266,7 @@ HIP_TEST_CASE(Unit_hipGraphUserObj_Struct_Class_Ojects) {
     REQUIRE(classObj_d != nullptr);
     hipUserObjectCreate_Struct_Class_Objects<BoxClass>(classObj_h, classObj_d);
     t1.join();
+    HIP_CHECK_THREAD_FINALIZE();
   }
 }
 /**
@@ -324,6 +328,7 @@ HIP_TEST_CASE(Unit_hipGraphUserObj_ClonedGraph) {
   REQUIRE(*hostArr == 9999);
   HIP_CHECK(hipUserObjectRelease(Uobj, 1));
   t1.join();
+  HIP_CHECK_THREAD_FINALIZE();
   HIP_CHECK(hipStreamDestroy(stream));
   HIP_CHECK(hipFree(devArr));
 }
@@ -400,6 +405,7 @@ HIP_TEST_CASE(Unit_hipGraphUserObj_ManualGraph) {
   REQUIRE(*hostArr == 9999);
   HIP_CHECK(hipUserObjectRelease(Uobj, 1));
   t1.join();
+  HIP_CHECK_THREAD_FINALIZE();
   HIP_CHECK(hipStreamDestroy(stream));
   HIP_CHECK(hipFree(devArr));
 }

--- a/projects/hip-tests/catch/unit/graph/hipGraphClone.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphClone.cc
@@ -264,21 +264,18 @@ HIP_TEST_CASE(Unit_hipGraphClone_MultiThreaded) {
   auto lambdaFunc = [&]() {
     hipGraph_t clonedgraph;
     hipGraphExec_t graphExec;
-    HIP_CHECK(hipGraphClone(&clonedgraph, graph));
+    HIP_CHECK_THREAD(hipGraphClone(&clonedgraph, graph));
     // Instantiate and launch the cloned graph
-    HIP_CHECK(hipGraphInstantiate(&graphExec, clonedgraph, nullptr, nullptr, 0));
-    HIP_CHECK(hipGraphLaunch(graphExec, 0));
-    HIP_CHECK(hipStreamSynchronize(0));
+    HIP_CHECK_THREAD(hipGraphInstantiate(&graphExec, clonedgraph, nullptr, nullptr, 0));
+    HIP_CHECK_THREAD(hipGraphLaunch(graphExec, 0));
+    HIP_CHECK_THREAD(hipStreamSynchronize(0));
 
     for (size_t i = 0; i < N; i++) {
-      if (A_h[i] != B_h[i]) {
-        INFO("Validation failed A_h[i] " << A_h[i] << " B_h[i] " << B_h[i]);
-        REQUIRE(false);
-      }
+      REQUIRE_THREAD(A_h[i] == B_h[i]);
     }
 
-    HIP_CHECK(hipGraphExecDestroy(graphExec));
-    HIP_CHECK(hipGraphDestroy(clonedgraph));
+    HIP_CHECK_THREAD(hipGraphExecDestroy(graphExec));
+    HIP_CHECK_THREAD(hipGraphDestroy(clonedgraph));
   };
   for (int i = 0; i < NUM_THREADS; i++) {
     std::thread t(lambdaFunc);
@@ -287,6 +284,7 @@ HIP_TEST_CASE(Unit_hipGraphClone_MultiThreaded) {
   for (auto& t : threads) {
     t.join();
   }
+  HIP_CHECK_THREAD_FINALIZE();
   HipTest::freeArrays<int>(A_d, nullptr, nullptr, A_h, B_h, nullptr, false);
   HIP_CHECK(hipGraphDestroy(graph));
 }

--- a/projects/hip-tests/catch/unit/graph/hipGraphCloneComplx.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphCloneComplx.cc
@@ -1574,7 +1574,7 @@ static void hipGraphClone_address_change_in_thread(hipGraph_t* graph, hipGraphNo
                                                    hipGraphNode_t* memcpyH2D_B,
                                                    hipGraphNode_t* memcpyD2H_C,
                                                    hipGraphNode_t* kVecAdd, int dev) {
-  HIP_CHECK(hipSetDevice(dev));
+  HIP_CHECK_THREAD(hipSetDevice(dev));
 
   constexpr size_t Nbytes = N * sizeof(int);
   constexpr auto blocksPerCU = 6;  // to hide latency
@@ -1590,16 +1590,16 @@ static void hipGraphClone_address_change_in_thread(hipGraph_t* graph, hipGraphNo
   HipTest::initArrays(&D_d, &E_d, &F_d, &D_h, &E_h, &F_h, N, false);
   unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, N);
 
-  HIP_CHECK(hipStreamCreate(&stream));
-  HIP_CHECK(hipGraphClone(&graph_C, *graph));
-  HIP_CHECK(hipGraphNodeFindInClone(&memcpyH2D_AC, *memcpyH2D_A, graph_C));
-  HIP_CHECK(hipGraphNodeFindInClone(&memcpyH2D_BC, *memcpyH2D_B, graph_C));
-  HIP_CHECK(hipGraphNodeFindInClone(&memcpyD2H_CC, *memcpyD2H_C, graph_C));
-  HIP_CHECK(hipGraphNodeFindInClone(&kVecAddC, *kVecAdd, graph_C));
+  HIP_CHECK_THREAD(hipStreamCreate(&stream));
+  HIP_CHECK_THREAD(hipGraphClone(&graph_C, *graph));
+  HIP_CHECK_THREAD(hipGraphNodeFindInClone(&memcpyH2D_AC, *memcpyH2D_A, graph_C));
+  HIP_CHECK_THREAD(hipGraphNodeFindInClone(&memcpyH2D_BC, *memcpyH2D_B, graph_C));
+  HIP_CHECK_THREAD(hipGraphNodeFindInClone(&memcpyD2H_CC, *memcpyD2H_C, graph_C));
+  HIP_CHECK_THREAD(hipGraphNodeFindInClone(&kVecAddC, *kVecAdd, graph_C));
 
-  HIP_CHECK(hipGraphMemcpyNodeSetParams1D(memcpyH2D_AC, D_d, D_h, Nbytes, hipMemcpyHostToDevice));
-  HIP_CHECK(hipGraphMemcpyNodeSetParams1D(memcpyH2D_BC, E_d, E_h, Nbytes, hipMemcpyHostToDevice));
-  HIP_CHECK(hipGraphMemcpyNodeSetParams1D(memcpyD2H_CC, F_h, F_d, Nbytes, hipMemcpyDeviceToHost));
+  HIP_CHECK_THREAD(hipGraphMemcpyNodeSetParams1D(memcpyH2D_AC, D_d, D_h, Nbytes, hipMemcpyHostToDevice));
+  HIP_CHECK_THREAD(hipGraphMemcpyNodeSetParams1D(memcpyH2D_BC, E_d, E_h, Nbytes, hipMemcpyHostToDevice));
+  HIP_CHECK_THREAD(hipGraphMemcpyNodeSetParams1D(memcpyD2H_CC, F_h, F_d, Nbytes, hipMemcpyDeviceToHost));
 
   void* kernelArgs1[] = {&D_d, &E_d, &F_d, reinterpret_cast<void*>(&NElem)};
   kNodeParams1.func = reinterpret_cast<void*>(HipTest::vectorSUB<int>);
@@ -1608,20 +1608,20 @@ static void hipGraphClone_address_change_in_thread(hipGraph_t* graph, hipGraphNo
   kNodeParams1.sharedMemBytes = 0;
   kNodeParams1.kernelParams = reinterpret_cast<void**>(kernelArgs1);
   kNodeParams1.extra = nullptr;
-  HIP_CHECK(hipGraphKernelNodeSetParams(kVecAddC, &kNodeParams1));
+  HIP_CHECK_THREAD(hipGraphKernelNodeSetParams(kVecAddC, &kNodeParams1));
 
   // Instantiate and launch the graph
-  HIP_CHECK(hipGraphInstantiate(&graphExecC, graph_C, NULL, NULL, 0));
-  HIP_CHECK(hipGraphLaunch(graphExecC, stream));
-  HIP_CHECK(hipStreamSynchronize(stream));
+  HIP_CHECK_THREAD(hipGraphInstantiate(&graphExecC, graph_C, NULL, NULL, 0));
+  HIP_CHECK_THREAD(hipGraphLaunch(graphExecC, stream));
+  HIP_CHECK_THREAD(hipStreamSynchronize(stream));
 
   // Verify graph execution result
   HipTest::checkVectorSUB<int>(D_h, E_h, F_h, N);
 
   HipTest::freeArrays(D_d, E_d, F_d, D_h, E_h, F_h, false);
-  HIP_CHECK(hipGraphExecDestroy(graphExecC));
-  HIP_CHECK(hipGraphDestroy(graph_C));
-  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK_THREAD(hipGraphExecDestroy(graphExecC));
+  HIP_CHECK_THREAD(hipGraphDestroy(graph_C));
+  HIP_CHECK_THREAD(hipStreamDestroy(stream));
 }
 
 /* Scenarios - 22
@@ -1691,6 +1691,8 @@ HIP_TEST_CASE(Unit_hipGraphClone_address_change_in_thread) {
   for (auto& t : threads) {
     t.join();
   }
+
+  HIP_CHECK_THREAD_FINALIZE();
 
   HipTest::freeArrays(A_d, B_d, C_d, A_h, B_h, C_h, false);
   HIP_CHECK(hipGraphExecDestroy(graphExec));

--- a/projects/hip-tests/catch/unit/graph/hipGraphNodeGetType.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphNodeGetType.cc
@@ -271,16 +271,11 @@ static void ChkNodeType(hipGraph_t graph, const std::map<hipGraphNodeType, int>*
     HIP_CHECK_OPT_THREAD(threadSafe, hipGraphNodeGetType(nodes[i], &nodeType));
     cntNode[nodeType] += 1;
   }
-  std::map<hipGraphNodeType, int>::iterator iter;
-  std::map<hipGraphNodeType, int>::const_iterator iter1 = nodeTypeToQuery->begin();
-  for (iter = cntNode.begin(); iter != cntNode.end(); iter++) {
-    REQUIRE_OPT_THREAD(threadSafe, iter->first == iter1->first);
-    REQUIRE_OPT_THREAD(threadSafe, iter->second == iter1->second);
-    if (iter1 == nodeTypeToQuery->end())
-      break;
-    else
-      iter1++;
-  }
+  // Compare the counted node types directly against the expected map. std::map
+  // equality checks both the size and every key/value pair, which avoids walking
+  // two iterators in lock-step and the resulting end() dereference when the maps
+  // differ in size.
+  REQUIRE_OPT_THREAD(threadSafe, cntNode == *nodeTypeToQuery);
   free(nodes);
 }
 // Thread Function

--- a/projects/hip-tests/catch/unit/graph/hipGraphNodeGetType.cc
+++ b/projects/hip-tests/catch/unit/graph/hipGraphNodeGetType.cc
@@ -257,24 +257,25 @@ HIP_TEST_CASE(Unit_hipGraphNodeGetType_NodeType) {
 }
 
 // Function to verify node Type
-static void ChkNodeType(hipGraph_t graph, const std::map<hipGraphNodeType, int>* nodeTypeToQuery) {
+static void ChkNodeType(hipGraph_t graph, const std::map<hipGraphNodeType, int>* nodeTypeToQuery,
+                        bool threadSafe = false) {
   size_t numNodes{};
   hipGraphNodeType nodeType;
-  HIP_CHECK(hipGraphGetNodes(graph, nullptr, &numNodes));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipGraphGetNodes(graph, nullptr, &numNodes));
   int numBytes = sizeof(hipGraphNode_t) * numNodes;
   hipGraphNode_t* nodes = reinterpret_cast<hipGraphNode_t*>(malloc(numBytes));
-  REQUIRE(nodes != nullptr);
-  HIP_CHECK(hipGraphGetNodes(graph, nodes, &numNodes));
+  REQUIRE_OPT_THREAD(threadSafe, nodes != nullptr);
+  HIP_CHECK_OPT_THREAD(threadSafe, hipGraphGetNodes(graph, nodes, &numNodes));
   std::map<hipGraphNodeType, int> cntNode;
   for (size_t i = 0; i < numNodes; i++) {
-    HIP_CHECK(hipGraphNodeGetType(nodes[i], &nodeType));
+    HIP_CHECK_OPT_THREAD(threadSafe, hipGraphNodeGetType(nodes[i], &nodeType));
     cntNode[nodeType] += 1;
   }
   std::map<hipGraphNodeType, int>::iterator iter;
   std::map<hipGraphNodeType, int>::const_iterator iter1 = nodeTypeToQuery->begin();
   for (iter = cntNode.begin(); iter != cntNode.end(); iter++) {
-    REQUIRE(iter->first == iter1->first);
-    REQUIRE(iter->second == iter1->second);
+    REQUIRE_OPT_THREAD(threadSafe, iter->first == iter1->first);
+    REQUIRE_OPT_THREAD(threadSafe, iter->second == iter1->second);
     if (iter1 == nodeTypeToQuery->end())
       break;
     else
@@ -284,7 +285,7 @@ static void ChkNodeType(hipGraph_t graph, const std::map<hipGraphNodeType, int>*
 }
 // Thread Function
 static void thread_func(hipGraph_t graph, std::map<hipGraphNodeType, int>* numNode) {
-  ChkNodeType(graph, numNode);
+  ChkNodeType(graph, numNode, true);
 }
 /*
  * 1.Create a graph with different types of nodes. Clone the graph. Verify the types
@@ -396,6 +397,7 @@ HIP_TEST_CASE(Unit_hipGraphNodeGetType_NodeTypeOfClonedGraph_NodeTypeInThread) {
   SECTION("Node Type In The Thread") {
     std::thread t(thread_func, graph, &numNode);
     t.join();
+    HIP_CHECK_THREAD_FINALIZE();
   }
 
   HIP_CHECK(hipStreamDestroy(stream1));
@@ -520,7 +522,8 @@ HIP_TEST_CASE(Unit_hipGraphNodeGetType_NodeTypeOfChildGraph) {
 }
 enum graphType { Parent, Child };
 // Function to verify node Type
-static void ChkNodeTypeWithDependency(hipGraph_t graph, enum graphType Type) {
+static void ChkNodeTypeWithDependency(hipGraph_t graph, enum graphType Type,
+                                      bool threadSafe = false) {
   size_t numNodes{};
   hipGraphNodeType nodeType;
   hipGraphNodeType Arr[] = {hipGraphNodeTypeHost,   hipGraphNodeTypeMemcpy,
@@ -531,18 +534,18 @@ static void ChkNodeTypeWithDependency(hipGraph_t graph, enum graphType Type) {
   hipGraphNodeType childArr[] = {hipGraphNodeTypeMemset, hipGraphNodeTypeWaitEvent,
                                  hipGraphNodeTypeEmpty, hipGraphNodeTypeEventRecord};
 
-  HIP_CHECK(hipGraphGetNodes(graph, nullptr, &numNodes));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipGraphGetNodes(graph, nullptr, &numNodes));
   int numBytes = sizeof(hipGraphNode_t) * numNodes;
   hipGraphNode_t* nodes = reinterpret_cast<hipGraphNode_t*>(malloc(numBytes));
-  REQUIRE(nodes != nullptr);
+  REQUIRE_OPT_THREAD(threadSafe, nodes != nullptr);
 
-  HIP_CHECK(hipGraphGetNodes(graph, nodes, &numNodes));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipGraphGetNodes(graph, nodes, &numNodes));
   for (size_t i = 0; i < numNodes; i++) {
-    HIP_CHECK(hipGraphNodeGetType(nodes[i], &nodeType));
+    HIP_CHECK_OPT_THREAD(threadSafe, hipGraphNodeGetType(nodes[i], &nodeType));
     if (Type == Parent) {
-      REQUIRE(nodeType == Arr[i]);
+      REQUIRE_OPT_THREAD(threadSafe, nodeType == Arr[i]);
     } else if (Type == Child) {
-      REQUIRE(nodeType == childArr[i]);
+      REQUIRE_OPT_THREAD(threadSafe, nodeType == childArr[i]);
     }
   }
   free(nodes);
@@ -550,7 +553,7 @@ static void ChkNodeTypeWithDependency(hipGraph_t graph, enum graphType Type) {
 
 // Thread Function
 static void thread_func1(hipGraph_t graph, enum graphType type) {
-  ChkNodeTypeWithDependency(graph, type);
+  ChkNodeTypeWithDependency(graph, type, true);
 }
 /*
  * 1.Create a graph with different types of nodes along with dependencies between
@@ -639,6 +642,7 @@ HIP_TEST_CASE(Unit_hipGraphNodeGetType_ClonedGraph_InThread_WithDependencies) {
   SECTION("Node Type In The Thread") {
     std::thread t(thread_func1, graph, Parent);
     t.join();
+    HIP_CHECK_THREAD_FINALIZE();
   }
   HIP_CHECK(hipStreamDestroy(stream1));
   HIP_CHECK(hipEventDestroy(event1));

--- a/projects/hip-tests/catch/unit/graph/hipLaunchHostFuncWithGraph.cc
+++ b/projects/hip-tests/catch/unit/graph/hipLaunchHostFuncWithGraph.cc
@@ -110,9 +110,9 @@ HIP_TEST_CASE(Unit_hipLaunchHostFunc_Positive_Functional) {
   HIP_CHECK(hipGraphDestroy(graph));
 }
 
-static void thread_func_pos(hipStream_t* stream, hipHostFn_t fn, float** data){
-
-    HIP_CHECK_THREAD(hipLaunchHostFunc(*stream, fn, static_cast<void*>(data)))}
+static void thread_func_pos(hipStream_t* stream, hipHostFn_t fn, float** data) {
+  HIP_CHECK_THREAD(hipLaunchHostFunc(*stream, fn, static_cast<void*>(data)));
+}
 
 /**
  * Test Description

--- a/projects/hip-tests/catch/unit/graph/hipLaunchHostFuncWithGraph.cc
+++ b/projects/hip-tests/catch/unit/graph/hipLaunchHostFuncWithGraph.cc
@@ -112,7 +112,7 @@ HIP_TEST_CASE(Unit_hipLaunchHostFunc_Positive_Functional) {
 
 static void thread_func_pos(hipStream_t* stream, hipHostFn_t fn, float** data){
 
-    HIP_CHECK(hipLaunchHostFunc(*stream, fn, static_cast<void*>(data)))}
+    HIP_CHECK_THREAD(hipLaunchHostFunc(*stream, fn, static_cast<void*>(data)))}
 
 /**
  * Test Description
@@ -145,6 +145,7 @@ HIP_TEST_CASE(Unit_hipLaunchHostFunc_Positive_Thread) {
   float* data[2] = {A_h.host_ptr(), B_h.host_ptr()};
   std::thread t(thread_func_pos, &stream, fn, data);
   t.join();
+  HIP_CHECK_THREAD_FINALIZE();
 
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
   // Validate end capture is successful

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture.cc
@@ -372,10 +372,10 @@ static void colligatedStrmCaptureFunc(const hipStream_t& stream1, const hipStrea
 static void threadStrmCaptureFunc(hipStream_t stream, int* A_h, int* A_d, int* B_h, int* B_d,
                                   hipGraph_t* graph, size_t N, hipStreamCaptureMode mode) {
   // Capture stream
-  HIP_CHECK(hipStreamBeginCapture(stream, mode));
-  captureSequenceLinear(A_h, A_d, B_h, B_d, N, stream);
-  captureSequenceCompute(A_d, B_h, B_d, N, stream);
-  HIP_CHECK(hipStreamEndCapture(stream, graph));
+  HIP_CHECK_THREAD(hipStreamBeginCapture(stream, mode));
+  captureSequenceLinear(A_h, A_d, B_h, B_d, N, stream, true);
+  captureSequenceCompute(A_d, B_h, B_d, N, stream, true);
+  HIP_CHECK_THREAD(hipStreamEndCapture(stream, graph));
 }
 
 /* Local Function for multithreaded tests
@@ -408,6 +408,7 @@ static void multithreadedTest(hipStreamCaptureMode mode) {
                  D_d.ptr(), &graph2, N, mode);
   t1.join();
   t2.join();
+  HIP_CHECK_THREAD_FINALIZE();
 
   // Create Executable Graphs
   HIP_CHECK(hipGraphInstantiate(&graphExec1, graph1, nullptr, nullptr, 0));
@@ -1508,8 +1509,8 @@ HIP_TEST_CASE(Unit_hipStreamBeginCapture_StreamSync_OngoingCapture) {
 // Local function executed as thread
 static void strmSyncThread(int* Ah, int* Ad, int* Bh, int* Bd, int BLOCKSIZE, hipError_t* error) {
   StreamsGuard stream(1);
-  HIP_CHECK(hipMemcpyAsync(Ad, Ah, BLOCKSIZE * sizeof(int), hipMemcpyDefault, stream[0]));
-  HIP_CHECK(hipMemcpyAsync(Bd, Bh, BLOCKSIZE * sizeof(int), hipMemcpyDefault, stream[0]));
+  HIP_CHECK_THREAD(hipMemcpyAsync(Ad, Ah, BLOCKSIZE * sizeof(int), hipMemcpyDefault, stream[0]));
+  HIP_CHECK_THREAD(hipMemcpyAsync(Bd, Bh, BLOCKSIZE * sizeof(int), hipMemcpyDefault, stream[0]));
   *error = hipStreamSynchronize(stream[0]);
 }
 
@@ -1521,6 +1522,7 @@ static void captureStrmThread(hipGraph_t* graph, int* Ah, int* Ad, int* Bh, int*
   HIP_CHECK(hipStreamBeginCapture(stream[0], flag));
   std::thread t1(strmSyncThread, Ah, Ad, Bh, Bd, BLOCKSIZE, error);
   t1.join();
+  HIP_CHECK_THREAD_FINALIZE();
   myadd<<<GRIDSIZE, BLOCKSIZE, 0, stream[0]>>>(Ad, Bd);
   if (flag == hipStreamCaptureModeGlobal) {
     HIP_CHECK_ERROR(hipStreamEndCapture(stream[0], graph),

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCaptureToGraph.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCaptureToGraph.cc
@@ -26,11 +26,17 @@ constexpr int threadsPerBlock = 256;
 constexpr int blocks =
     (N % threadsPerBlock == 0) ? (N / threadsPerBlock) : ((N / threadsPerBlock) + 1);
 
-static bool CaptureStreamAndLaunchGraph(int* A_d, int* B_d, int* C_d, int* A_h, int* B_h, int* C_h,
+// Captures a stream into a graph, launches it and validates the result. Returns
+// the boolean outcome through resultOut. When threadSafe is true the optionally
+// thread-safe check macros are used so the same function can run from a worker
+// thread (call HIP_CHECK_THREAD_FINALIZE() on the main thread after joining);
+// when false it behaves like a normal single-threaded helper.
+static void CaptureStreamAndLaunchGraph(int* A_d, int* B_d, int* C_d, int* A_h, int* B_h, int* C_h,
                                         hipStreamCaptureMode mode, hipStream_t& stream1,
-                                        hipStream_t& stream2, hipGraph_t& graph,
+                                        hipStream_t& stream2, hipGraph_t& graph, bool* resultOut,
                                         bool verifyStreamSync = false,
-                                        std::function<bool()> verifyFunc1 = nullptr) {
+                                        std::function<bool()> verifyFunc1 = nullptr,
+                                        bool threadSafe = false) {
   auto verifyFunc = [&]() {
     // Validate the computation
     for (size_t i = 0; i < N; i++) {
@@ -45,25 +51,26 @@ static bool CaptureStreamAndLaunchGraph(int* A_d, int* B_d, int* C_d, int* A_h, 
   hipGraphExec_t graphExec{nullptr};
   size_t Nbytes = N * sizeof(int);
   hipEvent_t e;
-  HIP_CHECK(hipEventCreate(&e));
-  HIP_CHECK(hipStreamBeginCaptureToGraph(stream1, graph, nullptr, nullptr, 0, mode));
-  HIP_CHECK(hipEventRecord(e, stream1));
-  HIP_CHECK(hipStreamWaitEvent(stream2, e, 0));
-  HIP_CHECK(hipMemsetAsync(C_d, 0, Nbytes, stream1));
-  HIP_CHECK(hipMemcpyAsync(A_d, A_h, Nbytes, hipMemcpyHostToDevice, stream1));
-  HIP_CHECK(hipMemcpyAsync(B_d, B_h, Nbytes, hipMemcpyHostToDevice, stream2));
-  HIP_CHECK(hipEventRecord(e, stream2));
-  HIP_CHECK(hipStreamWaitEvent(stream1, e, 0));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipEventCreate(&e));
+  HIP_CHECK_OPT_THREAD(threadSafe,
+                       hipStreamBeginCaptureToGraph(stream1, graph, nullptr, nullptr, 0, mode));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipEventRecord(e, stream1));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipStreamWaitEvent(stream2, e, 0));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipMemsetAsync(C_d, 0, Nbytes, stream1));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipMemcpyAsync(A_d, A_h, Nbytes, hipMemcpyHostToDevice, stream1));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipMemcpyAsync(B_d, B_h, Nbytes, hipMemcpyHostToDevice, stream2));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipEventRecord(e, stream2));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipStreamWaitEvent(stream1, e, 0));
   HipTest::vectorSUB<<<dim3(blocks), dim3(threadsPerBlock), 0, stream1>>>(A_d, B_d, C_d, N);
-  HIP_CHECK(hipMemcpyAsync(C_h, C_d, Nbytes, hipMemcpyDeviceToHost, stream1));
-  HIP_CHECK(hipStreamEndCapture(stream1, &graph));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipMemcpyAsync(C_h, C_d, Nbytes, hipMemcpyDeviceToHost, stream1));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipStreamEndCapture(stream1, &graph));
 
-  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
-  REQUIRE(graphExec != nullptr);
+  HIP_CHECK_OPT_THREAD(threadSafe, hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+  REQUIRE_OPT_THREAD(threadSafe, graphExec != nullptr);
 
   // Replay the recorded sequence multiple times
-  HIP_CHECK(hipGraphLaunch(graphExec, stream1));
-  HIP_CHECK(hipStreamSynchronize(stream1));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipGraphLaunch(graphExec, stream1));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipStreamSynchronize(stream1));
   bool res = true;
   if (verifyStreamSync) {
     // Verify if hipStreamSynchronize() works as expected
@@ -71,73 +78,14 @@ static bool CaptureStreamAndLaunchGraph(int* A_d, int* B_d, int* C_d, int* A_h, 
     res = res && verifyFunc();
   }
 
-  HIP_CHECK(hipGraphExecDestroy(graphExec));
-  HIP_CHECK(hipEventDestroy(e));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipGraphExecDestroy(graphExec));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipEventDestroy(e));
 
   if (!verifyStreamSync) {
     // After hipGraphExecDestroy(), all internal streams are
     // surely synced!
     res = verifyFunc1 ? verifyFunc1() : true;
     res = res && verifyFunc();
-  }
-  return res;
-}
-
-// Thread-safe variant of CaptureStreamAndLaunchGraph executed from worker threads.
-// Uses the *_THREAD check macros (which defer failures and early-return on error,
-// hence void) and writes its boolean result through resultOut. Call
-// HIP_CHECK_THREAD_FINALIZE() on the main thread after the worker joins.
-static void CaptureStreamAndLaunchGraphThread(int* A_d, int* B_d, int* C_d, int* A_h, int* B_h,
-                                              int* C_h, hipStreamCaptureMode mode,
-                                              hipStream_t& stream1, hipStream_t& stream2,
-                                              hipGraph_t& graph, bool verifyStreamSync,
-                                              bool* resultOut) {
-  auto verifyFunc = [&]() {
-    // Validate the computation
-    for (size_t i = 0; i < N; i++) {
-      if (C_h[i] != (A_h[i] - B_h[i])) {
-        fprintf(stderr, "Error at %zu: C=%d, A=%d, B=%d\n", i, C_h[i], A_h[i], B_h[i]);
-        return false;
-      }
-    }
-    return true;
-  };
-
-  hipGraphExec_t graphExec{nullptr};
-  size_t Nbytes = N * sizeof(int);
-  hipEvent_t e;
-  HIP_CHECK_THREAD(hipEventCreate(&e));
-  HIP_CHECK_THREAD(hipStreamBeginCaptureToGraph(stream1, graph, nullptr, nullptr, 0, mode));
-  HIP_CHECK_THREAD(hipEventRecord(e, stream1));
-  HIP_CHECK_THREAD(hipStreamWaitEvent(stream2, e, 0));
-  HIP_CHECK_THREAD(hipMemsetAsync(C_d, 0, Nbytes, stream1));
-  HIP_CHECK_THREAD(hipMemcpyAsync(A_d, A_h, Nbytes, hipMemcpyHostToDevice, stream1));
-  HIP_CHECK_THREAD(hipMemcpyAsync(B_d, B_h, Nbytes, hipMemcpyHostToDevice, stream2));
-  HIP_CHECK_THREAD(hipEventRecord(e, stream2));
-  HIP_CHECK_THREAD(hipStreamWaitEvent(stream1, e, 0));
-  HipTest::vectorSUB<<<dim3(blocks), dim3(threadsPerBlock), 0, stream1>>>(A_d, B_d, C_d, N);
-  HIP_CHECK_THREAD(hipMemcpyAsync(C_h, C_d, Nbytes, hipMemcpyDeviceToHost, stream1));
-  HIP_CHECK_THREAD(hipStreamEndCapture(stream1, &graph));
-
-  HIP_CHECK_THREAD(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
-  REQUIRE_THREAD(graphExec != nullptr);
-
-  // Replay the recorded sequence multiple times
-  HIP_CHECK_THREAD(hipGraphLaunch(graphExec, stream1));
-  HIP_CHECK_THREAD(hipStreamSynchronize(stream1));
-  bool res = true;
-  if (verifyStreamSync) {
-    // Verify if hipStreamSynchronize() works as expected
-    res = verifyFunc();
-  }
-
-  HIP_CHECK_THREAD(hipGraphExecDestroy(graphExec));
-  HIP_CHECK_THREAD(hipEventDestroy(e));
-
-  if (!verifyStreamSync) {
-    // After hipGraphExecDestroy(), all internal streams are
-    // surely synced!
-    res = verifyFunc();
   }
   *resultOut = res;
 }
@@ -160,7 +108,7 @@ HIP_TEST_CASE(Unit_hipStreamBeginCaptureToGraph_BasicFunctional) {
   std::vector<int> A_h(N), B_h(N), C_h(N);
   size_t Nbytes = N * sizeof(int);
   hipStream_t stream1, stream2;
-  bool ret;
+  bool ret = false;
   hipGraph_t graph{nullptr};
 
   // Fill with data
@@ -180,25 +128,25 @@ HIP_TEST_CASE(Unit_hipStreamBeginCaptureToGraph_BasicFunctional) {
   SECTION("Capture stream and launch graph when mode is global") {
     SECTION("Verify after hipGraphExecDestroy()") { verifyStreamSync = false; }
     SECTION("Verify after hipStreamSynchronize()") { verifyStreamSync = true; }
-    ret = CaptureStreamAndLaunchGraph(A_d, B_d, C_d, A_h.data(), B_h.data(), C_h.data(),
-                                      hipStreamCaptureModeGlobal, stream1, stream2, graph,
-                                      verifyStreamSync);
+    CaptureStreamAndLaunchGraph(A_d, B_d, C_d, A_h.data(), B_h.data(), C_h.data(),
+                                hipStreamCaptureModeGlobal, stream1, stream2, graph, &ret,
+                                verifyStreamSync);
   }
 
   SECTION("Capture stream and launch graph when mode is local") {
     SECTION("Verify after hipGraphExecDestroy()") { verifyStreamSync = false; }
     SECTION("Verify after hipStreamSynchronize()") { verifyStreamSync = true; }
-    ret = CaptureStreamAndLaunchGraph(A_d, B_d, C_d, A_h.data(), B_h.data(), C_h.data(),
-                                      hipStreamCaptureModeThreadLocal, stream1, stream2, graph,
-                                      verifyStreamSync);
+    CaptureStreamAndLaunchGraph(A_d, B_d, C_d, A_h.data(), B_h.data(), C_h.data(),
+                                hipStreamCaptureModeThreadLocal, stream1, stream2, graph, &ret,
+                                verifyStreamSync);
   }
 
   SECTION("Capture stream and launch graph when mode is relaxed") {
     SECTION("Verify after hipGraphExecDestroy()") { verifyStreamSync = false; }
     SECTION("Verify after hipStreamSynchronize()") { verifyStreamSync = true; }
-    ret = CaptureStreamAndLaunchGraph(A_d, B_d, C_d, A_h.data(), B_h.data(), C_h.data(),
-                                      hipStreamCaptureModeRelaxed, stream1, stream2, graph,
-                                      verifyStreamSync);
+    CaptureStreamAndLaunchGraph(A_d, B_d, C_d, A_h.data(), B_h.data(), C_h.data(),
+                                hipStreamCaptureModeRelaxed, stream1, stream2, graph, &ret,
+                                verifyStreamSync);
   }
 
   HIP_CHECK(hipStreamDestroy(stream1));
@@ -229,7 +177,7 @@ HIP_TEST_CASE(Unit_hipStreamBeginCaptureToGraph_CaptureIndepGraph) {
   std::vector<int> A2_h(N), B2_h(N), C2_h(N);
   size_t Nbytes = N * sizeof(int);
   hipStream_t stream1, stream2;
-  bool ret;
+  bool ret = false;
   hipGraph_t graph{nullptr};
   hipGraphNode_t memcpyNode1, memcpyNode2, memcpyNode3, kernelNode;
 
@@ -290,9 +238,9 @@ HIP_TEST_CASE(Unit_hipStreamBeginCaptureToGraph_CaptureIndepGraph) {
   // Capture an independent graph from stream
   SECTION("Verify after hipGraphExecDestroy()") { verifyStreamSync = false; }
   SECTION("Verify after hipStreamSynchronize()") { verifyStreamSync = true; }
-  ret = CaptureStreamAndLaunchGraph(A1_d, B1_d, C1_d, A1_h.data(), B1_h.data(), C1_h.data(),
-                                    hipStreamCaptureModeGlobal, stream1, stream2, graph,
-                                    verifyStreamSync, verifyFunc);
+  CaptureStreamAndLaunchGraph(A1_d, B1_d, C1_d, A1_h.data(), B1_h.data(), C1_h.data(),
+                              hipStreamCaptureModeGlobal, stream1, stream2, graph, &ret,
+                              verifyStreamSync, verifyFunc);
   REQUIRE(ret == true);
 
   HIP_CHECK(hipStreamDestroy(stream1));
@@ -1100,7 +1048,7 @@ HIP_TEST_CASE(Unit_hipStreamBeginCaptureToGraph_MultipleFlags) {
   std::vector<int> A_h(N), B_h(N), C_h(N);
   size_t Nbytes = N * sizeof(int);
   hipStream_t stream1, stream2;
-  bool ret;
+  bool ret = false;
   hipGraph_t graph{nullptr};
 
   // Fill with data
@@ -1130,9 +1078,9 @@ HIP_TEST_CASE(Unit_hipStreamBeginCaptureToGraph_MultipleFlags) {
   bool verifyStreamSync = false;
   SECTION("Verify after hipGraphExecDestroy()") { verifyStreamSync = false; }
   SECTION("Verify after hipStreamSynchronize()") { verifyStreamSync = true; }
-  ret = CaptureStreamAndLaunchGraph(A_d, B_d, C_d, A_h.data(), B_h.data(), C_h.data(),
-                                    hipStreamCaptureModeGlobal, stream1, stream2, graph,
-                                    verifyStreamSync);
+  CaptureStreamAndLaunchGraph(A_d, B_d, C_d, A_h.data(), B_h.data(), C_h.data(),
+                              hipStreamCaptureModeGlobal, stream1, stream2, graph, &ret,
+                              verifyStreamSync);
   REQUIRE(ret == true);
 
   HIP_CHECK(hipStreamDestroy(stream1));
@@ -1242,8 +1190,8 @@ void threadCaptureExec(int* A_d, int* B_d, int* C_d, int* A_h, int* B_h, int* C_
                        hipStream_t* stream1, hipStream_t* stream2, hipGraph_t* graph,
                        bool verifyStreamSync) {
   bool ret = false;
-  CaptureStreamAndLaunchGraphThread(A_d, B_d, C_d, A_h, B_h, C_h, hipStreamCaptureModeRelaxed,
-                                    *stream1, *stream2, *graph, verifyStreamSync, &ret);
+  CaptureStreamAndLaunchGraph(A_d, B_d, C_d, A_h, B_h, C_h, hipStreamCaptureModeRelaxed, *stream1,
+                              *stream2, *graph, &ret, verifyStreamSync, nullptr, true);
   int val = 0;
   if (ret) {
     val = 1;

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCaptureToGraph.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCaptureToGraph.cc
@@ -83,6 +83,65 @@ static bool CaptureStreamAndLaunchGraph(int* A_d, int* B_d, int* C_d, int* A_h, 
   return res;
 }
 
+// Thread-safe variant of CaptureStreamAndLaunchGraph executed from worker threads.
+// Uses the *_THREAD check macros (which defer failures and early-return on error,
+// hence void) and writes its boolean result through resultOut. Call
+// HIP_CHECK_THREAD_FINALIZE() on the main thread after the worker joins.
+static void CaptureStreamAndLaunchGraphThread(int* A_d, int* B_d, int* C_d, int* A_h, int* B_h,
+                                              int* C_h, hipStreamCaptureMode mode,
+                                              hipStream_t& stream1, hipStream_t& stream2,
+                                              hipGraph_t& graph, bool verifyStreamSync,
+                                              bool* resultOut) {
+  auto verifyFunc = [&]() {
+    // Validate the computation
+    for (size_t i = 0; i < N; i++) {
+      if (C_h[i] != (A_h[i] - B_h[i])) {
+        fprintf(stderr, "Error at %zu: C=%d, A=%d, B=%d\n", i, C_h[i], A_h[i], B_h[i]);
+        return false;
+      }
+    }
+    return true;
+  };
+
+  hipGraphExec_t graphExec{nullptr};
+  size_t Nbytes = N * sizeof(int);
+  hipEvent_t e;
+  HIP_CHECK_THREAD(hipEventCreate(&e));
+  HIP_CHECK_THREAD(hipStreamBeginCaptureToGraph(stream1, graph, nullptr, nullptr, 0, mode));
+  HIP_CHECK_THREAD(hipEventRecord(e, stream1));
+  HIP_CHECK_THREAD(hipStreamWaitEvent(stream2, e, 0));
+  HIP_CHECK_THREAD(hipMemsetAsync(C_d, 0, Nbytes, stream1));
+  HIP_CHECK_THREAD(hipMemcpyAsync(A_d, A_h, Nbytes, hipMemcpyHostToDevice, stream1));
+  HIP_CHECK_THREAD(hipMemcpyAsync(B_d, B_h, Nbytes, hipMemcpyHostToDevice, stream2));
+  HIP_CHECK_THREAD(hipEventRecord(e, stream2));
+  HIP_CHECK_THREAD(hipStreamWaitEvent(stream1, e, 0));
+  HipTest::vectorSUB<<<dim3(blocks), dim3(threadsPerBlock), 0, stream1>>>(A_d, B_d, C_d, N);
+  HIP_CHECK_THREAD(hipMemcpyAsync(C_h, C_d, Nbytes, hipMemcpyDeviceToHost, stream1));
+  HIP_CHECK_THREAD(hipStreamEndCapture(stream1, &graph));
+
+  HIP_CHECK_THREAD(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+  REQUIRE_THREAD(graphExec != nullptr);
+
+  // Replay the recorded sequence multiple times
+  HIP_CHECK_THREAD(hipGraphLaunch(graphExec, stream1));
+  HIP_CHECK_THREAD(hipStreamSynchronize(stream1));
+  bool res = true;
+  if (verifyStreamSync) {
+    // Verify if hipStreamSynchronize() works as expected
+    res = verifyFunc();
+  }
+
+  HIP_CHECK_THREAD(hipGraphExecDestroy(graphExec));
+  HIP_CHECK_THREAD(hipEventDestroy(e));
+
+  if (!verifyStreamSync) {
+    // After hipGraphExecDestroy(), all internal streams are
+    // surely synced!
+    res = verifyFunc();
+  }
+  *resultOut = res;
+}
+
 /**
  * Test Description
  * ------------------------
@@ -1099,25 +1158,25 @@ static void threadCaptureEnd(hipStream_t* streamCapt, hipGraph_t* graph, int* A_
                              int* C_d, int* C_h, size_t N) {
   size_t Nbytes = N * sizeof(int);
   HipTest::vectorSUB<<<dim3(blocks), dim3(threadsPerBlock), 0, *streamCapt>>>(A_d, B_d, C_d, N);
-  HIP_CHECK(hipMemcpyAsync(C_h, C_d, Nbytes, hipMemcpyDeviceToHost, *streamCapt));
-  HIP_CHECK(hipStreamEndCapture(*streamCapt, graph));
+  HIP_CHECK_THREAD(hipMemcpyAsync(C_h, C_d, Nbytes, hipMemcpyDeviceToHost, *streamCapt));
+  HIP_CHECK_THREAD(hipStreamEndCapture(*streamCapt, graph));
 }
 
 static void threadCaptureStart(hipStream_t* streamCapt, hipStream_t* streamFork, hipGraph_t* graph,
                                int* A_d, int* B_d, int* C_d, int* A_h, int* B_h, size_t N) {
   size_t Nbytes = N * sizeof(int);
   hipEvent_t e;
-  HIP_CHECK(hipEventCreate(&e));
-  HIP_CHECK(hipStreamBeginCaptureToGraph(*streamCapt, *graph, nullptr, nullptr, 0,
-                                         hipStreamCaptureModeRelaxed));
-  HIP_CHECK(hipEventRecord(e, *streamCapt));
-  HIP_CHECK(hipStreamWaitEvent(*streamFork, e, 0));
-  HIP_CHECK(hipMemsetAsync(C_d, 0, Nbytes, *streamCapt));
-  HIP_CHECK(hipMemcpyAsync(A_d, A_h, Nbytes, hipMemcpyHostToDevice, *streamCapt));
-  HIP_CHECK(hipMemcpyAsync(B_d, B_h, Nbytes, hipMemcpyHostToDevice, *streamFork));
-  HIP_CHECK(hipEventRecord(e, *streamFork));
-  HIP_CHECK(hipStreamWaitEvent(*streamCapt, e, 0));
-  HIP_CHECK(hipEventDestroy(e));
+  HIP_CHECK_THREAD(hipEventCreate(&e));
+  HIP_CHECK_THREAD(hipStreamBeginCaptureToGraph(*streamCapt, *graph, nullptr, nullptr, 0,
+                                                hipStreamCaptureModeRelaxed));
+  HIP_CHECK_THREAD(hipEventRecord(e, *streamCapt));
+  HIP_CHECK_THREAD(hipStreamWaitEvent(*streamFork, e, 0));
+  HIP_CHECK_THREAD(hipMemsetAsync(C_d, 0, Nbytes, *streamCapt));
+  HIP_CHECK_THREAD(hipMemcpyAsync(A_d, A_h, Nbytes, hipMemcpyHostToDevice, *streamCapt));
+  HIP_CHECK_THREAD(hipMemcpyAsync(B_d, B_h, Nbytes, hipMemcpyHostToDevice, *streamFork));
+  HIP_CHECK_THREAD(hipEventRecord(e, *streamFork));
+  HIP_CHECK_THREAD(hipStreamWaitEvent(*streamCapt, e, 0));
+  HIP_CHECK_THREAD(hipEventDestroy(e));
 }
 
 HIP_TEST_CASE(Unit_hipStreamBeginCaptureToGraph_CapturePartialInThreads) {
@@ -1143,8 +1202,10 @@ HIP_TEST_CASE(Unit_hipStreamBeginCaptureToGraph_CapturePartialInThreads) {
   std::thread startCaptureThread(threadCaptureStart, &stream1, &stream2, &graph, A_d, B_d, C_d,
                                  A_h.data(), B_h.data(), N);
   startCaptureThread.join();
+  HIP_CHECK_THREAD_FINALIZE();
   std::thread endCaptureThread(threadCaptureEnd, &stream1, &graph, A_d, B_d, C_d, C_h.data(), N);
   endCaptureThread.join();
+  HIP_CHECK_THREAD_FINALIZE();
   // Instantiate and execute the graph
   hipGraphExec_t graphExec{nullptr};
   HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
@@ -1181,8 +1242,8 @@ void threadCaptureExec(int* A_d, int* B_d, int* C_d, int* A_h, int* B_h, int* C_
                        hipStream_t* stream1, hipStream_t* stream2, hipGraph_t* graph,
                        bool verifyStreamSync) {
   bool ret = false;
-  ret = CaptureStreamAndLaunchGraph(A_d, B_d, C_d, A_h, B_h, C_h, hipStreamCaptureModeRelaxed,
-                                    *stream1, *stream2, *graph, verifyStreamSync);
+  CaptureStreamAndLaunchGraphThread(A_d, B_d, C_d, A_h, B_h, C_h, hipStreamCaptureModeRelaxed,
+                                    *stream1, *stream2, *graph, verifyStreamSync, &ret);
   int val = 0;
   if (ret) {
     val = 1;
@@ -1235,6 +1296,7 @@ HIP_TEST_CASE(Unit_hipStreamBeginCaptureToGraph_IndepGraphsThreads) {
                       &stream3, &stream4, &graph2, verifyStreamSync);
   thread1.join();
   thread2.join();
+  HIP_CHECK_THREAD_FINALIZE();
 
   REQUIRE(retValG.load() == 1);
   HIP_CHECK(hipStreamDestroy(stream1));

--- a/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamBeginCapture_old.cc
@@ -472,12 +472,14 @@ static void threadStrmCaptureFunc(hipStream_t stream, int* inputVec_d, int* outp
   constexpr auto threadsPerBlock = 256;
   unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, size);
   // Capture stream
-  HIP_CHECK(hipStreamBeginCapture(stream, mode));
-  HIP_CHECK(hipMemcpyAsync(inputVec_d, inputVec_h, sizeof(int) * size, hipMemcpyDefault, stream));
+  HIP_CHECK_THREAD(hipStreamBeginCapture(stream, mode));
+  HIP_CHECK_THREAD(hipMemcpyAsync(inputVec_d, inputVec_h, sizeof(int) * size, hipMemcpyDefault,
+                                  stream));
   HipTest::vector_square<int>
       <<<blocks, threadsPerBlock, 0, stream>>>(inputVec_d, outputVec_d, size);
-  HIP_CHECK(hipMemcpyAsync(outputVec_h, outputVec_d, sizeof(int) * size, hipMemcpyDefault, stream));
-  HIP_CHECK(hipStreamEndCapture(stream, graph));
+  HIP_CHECK_THREAD(hipMemcpyAsync(outputVec_h, outputVec_d, sizeof(int) * size, hipMemcpyDefault,
+                                  stream));
+  HIP_CHECK_THREAD(hipStreamEndCapture(stream, graph));
 }
 /* Local Function for multithreaded tests
  */
@@ -502,6 +504,7 @@ static void multithreadedTest(hipStreamCaptureMode mode) {
                  outputVec_h2, &graph2, size, mode);
   t1.join();
   t2.join();
+  HIP_CHECK_THREAD_FINALIZE();
   // Create Executable Graphs
   HIP_CHECK(hipGraphInstantiate(&graphExec1, graph1, nullptr, nullptr, 0));
   HIP_CHECK(hipGraphInstantiate(&graphExec2, graph2, nullptr, nullptr, 0));

--- a/projects/hip-tests/catch/unit/graph/hipStreamEndCapture.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamEndCapture.cc
@@ -89,7 +89,7 @@ HIP_TEST_CASE(Unit_hipStreamEndCapture_Positive_GraphDestroy) {
 }
 
 static void thread_func_neg(hipStream_t stream, hipGraph_t graph) {
-  HIP_ASSERT(hipErrorStreamCaptureWrongThread == hipStreamEndCapture(stream, &graph));
+  REQUIRE_THREAD(hipErrorStreamCaptureWrongThread == hipStreamEndCapture(stream, &graph));
 }
 
 /**
@@ -124,6 +124,7 @@ HIP_TEST_CASE(Unit_hipStreamEndCapture_Negative_Thread) {
 
   std::thread t(thread_func_neg, stream, graph);
   t.join();
+  HIP_CHECK_THREAD_FINALIZE();
 
 #if HT_AMD
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
@@ -133,7 +134,7 @@ HIP_TEST_CASE(Unit_hipStreamEndCapture_Negative_Thread) {
 }
 
 static void thread_func_pos(hipStream_t stream, hipGraph_t* graph) {
-  HIP_CHECK(hipStreamEndCapture(stream, graph));
+  HIP_CHECK_THREAD(hipStreamEndCapture(stream, graph));
 }
 
 /**
@@ -169,6 +170,7 @@ HIP_TEST_CASE(Unit_hipStreamEndCapture_Positive_Thread) {
 
   std::thread t(thread_func_pos, stream, &graph);
   t.join();
+  HIP_CHECK_THREAD_FINALIZE();
   // Validate end capture is successful
   REQUIRE(graph != nullptr);
 

--- a/projects/hip-tests/catch/unit/graph/hipStreamEndCapture_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamEndCapture_old.cc
@@ -117,7 +117,7 @@ HIP_TEST_CASE(Unit_hipStreamEndCapture_Negative) {
 }
 
 static void thread_func(hipStream_t stream, hipGraph_t graph) {
-  HIP_ASSERT(hipErrorStreamCaptureWrongThread == hipStreamEndCapture(stream, &graph));
+  REQUIRE_THREAD(hipErrorStreamCaptureWrongThread == hipStreamEndCapture(stream, &graph));
 }
 static void StreamEndCaptureThreadNegative(float* A_d, float* A_h, float* C_d, float* C_h,
                                            hipStreamCaptureMode mode) {
@@ -140,6 +140,7 @@ static void StreamEndCaptureThreadNegative(float* A_d, float* A_h, float* C_d, f
 
   std::thread t(thread_func, stream, graph);
   t.join();
+  HIP_CHECK_THREAD_FINALIZE();
 
 #if HT_AMD
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
@@ -182,8 +183,8 @@ HIP_TEST_CASE(Unit_hipStreamEndCapture_Thread_Negative) {
 // Thread function
 static void thread_func1(hipStream_t stream, hipGraph_t* graph, size_t Nbytes, float* A_d,
                          float* B_h) {
-  HIP_CHECK(hipMemcpyAsync(B_h, A_d, Nbytes, hipMemcpyDeviceToHost, stream));
-  HIP_CHECK(hipStreamEndCapture(stream, graph));
+  HIP_CHECK_THREAD(hipMemcpyAsync(B_h, A_d, Nbytes, hipMemcpyDeviceToHost, stream));
+  HIP_CHECK_THREAD(hipStreamEndCapture(stream, graph));
 }
 /*
  * Start stream capture on stream1 using mode hipStreamCaptureModeRelaxed.
@@ -233,6 +234,7 @@ HIP_TEST_CASE(Unit_hipStreamEndCapture_mode_hipStreamCaptureModeRelaxed) {
   // Thread Launch
   std::thread t(thread_func1, stream, &graph, Nbytes, A_d, B_h);
   t.join();
+  HIP_CHECK_THREAD_FINALIZE();
 
   // Launch the graph
   hipGraphExec_t graphExec;
@@ -310,9 +312,9 @@ HIP_TEST_CASE(Unit_hipStreamEndCapture_chkError_on_wrongStream) {
 }
 static void thread_func4(hipStream_t stream1, hipStream_t stream2, hipEvent_t event, size_t Nbytes,
                          int* B_d, int* B_h) {
-  HIP_CHECK(hipMemcpyAsync(B_d, B_h, Nbytes, hipMemcpyHostToDevice, stream2));
-  HIP_CHECK(hipEventRecord(event, stream2));
-  HIP_CHECK(hipStreamWaitEvent(stream1, event, 0));
+  HIP_CHECK_THREAD(hipMemcpyAsync(B_d, B_h, Nbytes, hipMemcpyHostToDevice, stream2));
+  HIP_CHECK_THREAD(hipEventRecord(event, stream2));
+  HIP_CHECK_THREAD(hipStreamWaitEvent(stream1, event, 0));
 }
 /*
  * Create 2 streams s1 and s2. Begin stream capture in s1 and spawn a captured
@@ -377,6 +379,7 @@ HIP_TEST_CASE(Unit_hipStreamEndCapture_streamMerge_in_thread) {
   // Thread Launch
   std::thread t(thread_func4, stream1, stream2, event, Nbytes, B_d, B_h);
   t.join();
+  HIP_CHECK_THREAD_FINALIZE();
   // Launch kernal
   hipLaunchKernelGGL(HipTest::vectorADD, dim3(blocks), dim3(threadsPerBlock), 0, stream1, A_d, B_d,
                      C_d, N);

--- a/projects/hip-tests/catch/unit/graph/hipStreamGetCaptureInfo_old.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamGetCaptureInfo_old.cc
@@ -184,15 +184,15 @@ static void thread_func(hipStream_t stream, unsigned long long capSequenceID1,  
   hipStreamCaptureStatus captureStatus{hipStreamCaptureStatusNone};
   unsigned long long capSequenceID3, capSequenceID4;  // NOLINT
   SECTION("hipStreamGetCaptureInfo CaptureStatus in Thread") {
-    HIP_CHECK(hipStreamGetCaptureInfo(stream, &captureStatus, &capSequenceID3));
-    REQUIRE(capSequenceID1 == capSequenceID3);
-    REQUIRE(captureStatus == hipStreamCaptureStatusActive);
+    HIP_CHECK_THREAD(hipStreamGetCaptureInfo(stream, &captureStatus, &capSequenceID3));
+    REQUIRE_THREAD(capSequenceID1 == capSequenceID3);
+    REQUIRE_THREAD(captureStatus == hipStreamCaptureStatusActive);
   }
   SECTION("hipStreamGetCaptureInfo_v2 CaptureStatus in Thread") {
-    HIP_CHECK(hipStreamGetCaptureInfo_v2(stream, &captureStatus, &capSequenceID4, nullptr, nullptr,
-                                         nullptr));
-    REQUIRE(capSequenceID2 == capSequenceID4);
-    REQUIRE(captureStatus == hipStreamCaptureStatusActive);
+    HIP_CHECK_THREAD(hipStreamGetCaptureInfo_v2(stream, &captureStatus, &capSequenceID4, nullptr,
+                                                nullptr, nullptr));
+    REQUIRE_THREAD(capSequenceID2 == capSequenceID4);
+    REQUIRE_THREAD(captureStatus == hipStreamCaptureStatusActive);
   }
 }
 /*
@@ -219,6 +219,7 @@ HIP_TEST_CASE(Unit_hipStreamGetCaptureInfo_CaptureStatus_InThread) {
   // Thread launch
   std::thread t(thread_func, stream, capSequenceID1, capSequenceID2);
   t.join();
+  HIP_CHECK_THREAD_FINALIZE();
 
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
   REQUIRE(graph != nullptr);

--- a/projects/hip-tests/catch/unit/graph/hipStreamIsCapturing.cc
+++ b/projects/hip-tests/catch/unit/graph/hipStreamIsCapturing.cc
@@ -146,8 +146,8 @@ HIP_TEST_CASE(Unit_hipStreamIsCapturing_Positive_Functional) {
 
 static void thread_func(hipStream_t stream) {
   hipStreamCaptureStatus cStatus;
-  HIP_CHECK(hipStreamIsCapturing(stream, &cStatus));
-  REQUIRE(hipStreamCaptureStatusActive == cStatus);
+  HIP_CHECK_THREAD(hipStreamIsCapturing(stream, &cStatus));
+  REQUIRE_THREAD(hipStreamCaptureStatusActive == cStatus);
 }
 
 /**
@@ -182,6 +182,7 @@ HIP_TEST_CASE(Unit_hipStreamIsCapturing_Positive_Thread) {
 
   std::thread t(thread_func, stream);
   t.join();
+  HIP_CHECK_THREAD_FINALIZE();
 
   HIP_CHECK(hipStreamEndCapture(stream, &graph));
   HIP_CHECK(hipGraphDestroy(graph));

--- a/projects/hip-tests/catch/unit/graph/hipThreadExchangeStreamCaptureMode.cc
+++ b/projects/hip-tests/catch/unit/graph/hipThreadExchangeStreamCaptureMode.cc
@@ -22,7 +22,8 @@
 
 /* Local Function for swaping stream capture mode of a thread
  */
-static void hipGraphLaunchWithMode(hipStream_t stream, hipStreamCaptureMode mode) {
+static void hipGraphLaunchWithMode(hipStream_t stream, hipStreamCaptureMode mode,
+                                   bool threadSafe = false) {
   constexpr size_t N = 1024;
   size_t Nbytes = N * sizeof(float);
   constexpr float fill_value = 5.0f;
@@ -36,40 +37,40 @@ static void hipGraphLaunchWithMode(hipStream_t stream, hipStreamCaptureMode mode
   LinearAllocGuard<float> B_d(LinearAllocs::hipMalloc, Nbytes);
   float* C_d;
 
-  HIP_CHECK(hipThreadExchangeStreamCaptureMode(&mode));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipThreadExchangeStreamCaptureMode(&mode));
 
-  HIP_CHECK(hipStreamBeginCapture(stream, mode));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipStreamBeginCapture(stream, mode));
 
-  captureSequenceLinear(A_h.host_ptr(), A_d.ptr(), B_h.host_ptr(), B_d.ptr(), N, stream);
-  captureSequenceCompute(A_d.ptr(), B_h.host_ptr(), B_d.ptr(), N, stream);
+  captureSequenceLinear(A_h.host_ptr(), A_d.ptr(), B_h.host_ptr(), B_d.ptr(), N, stream, threadSafe);
+  captureSequenceCompute(A_d.ptr(), B_h.host_ptr(), B_d.ptr(), N, stream, threadSafe);
 
   if (mode == hipStreamCaptureModeRelaxed) {
-    HIP_CHECK(hipMalloc(&C_d, Nbytes));
+    HIP_CHECK_OPT_THREAD(threadSafe, hipMalloc(&C_d, Nbytes));
   }
 
-  HIP_CHECK(hipStreamEndCapture(stream, &graph));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipStreamEndCapture(stream, &graph));
 
   // Validate end capture is successful
-  REQUIRE(graph != nullptr);
+  REQUIRE_OPT_THREAD(threadSafe, graph != nullptr);
 
-  HIP_CHECK(hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipGraphInstantiate(&graphExec, graph, nullptr, nullptr, 0));
 
   std::fill_n(A_h.host_ptr(), N, fill_value);
-  HIP_CHECK(hipGraphLaunch(graphExec, stream));
-  HIP_CHECK(hipStreamSynchronize(stream));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipGraphLaunch(graphExec, stream));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipStreamSynchronize(stream));
 
   // Validate the computation
   ArrayFindIfNot(B_h.host_ptr(), fill_value * fill_value, N);
   if (mode == hipStreamCaptureModeRelaxed) {
-    HIP_CHECK(hipFree(C_d));
+    HIP_CHECK_OPT_THREAD(threadSafe, hipFree(C_d));
   }
 
-  HIP_CHECK(hipGraphExecDestroy(graphExec));
-  HIP_CHECK(hipGraphDestroy(graph));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipGraphExecDestroy(graphExec));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipGraphDestroy(graph));
 }
 
 void threadFuncCaptureMode(hipStream_t stream, hipStreamCaptureMode mode) {
-  hipGraphLaunchWithMode(stream, mode);
+  hipGraphLaunchWithMode(stream, mode, true);
 }
 
 /**
@@ -97,6 +98,7 @@ HIP_TEST_CASE(Unit_hipThreadExchangeStreamCaptureMode_Positive_Functional) {
   hipGraphLaunchWithMode(stream, captureModeMain);
   std::thread t(threadFuncCaptureMode, stream, captureModeThread);
   t.join();
+  HIP_CHECK_THREAD_FINALIZE();
 }
 
 /**

--- a/projects/hip-tests/catch/unit/graph/stream_capture_common.hh
+++ b/projects/hip-tests/catch/unit/graph/stream_capture_common.hh
@@ -16,24 +16,32 @@ inline constexpr size_t kLaunchIters = 10;
 }  // anonymous namespace
 
 template <typename T> void captureSequenceSimple(T* hostMem1, T* devMem1, T* hostMem2, size_t N,
-                                                 hipStream_t captureStream) {
+                                                 hipStream_t captureStream,
+                                                 bool threadSafe = false) {
   size_t Nbytes = N * sizeof(T);
 
-  HIP_CHECK(hipMemsetAsync(devMem1, 0, Nbytes, captureStream));
-  HIP_CHECK(hipMemcpyAsync(devMem1, hostMem1, Nbytes, hipMemcpyHostToDevice, captureStream));
-  HIP_CHECK(hipMemcpyAsync(hostMem2, devMem1, Nbytes, hipMemcpyDeviceToHost, captureStream));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipMemsetAsync(devMem1, 0, Nbytes, captureStream));
+  HIP_CHECK_OPT_THREAD(threadSafe,
+                       hipMemcpyAsync(devMem1, hostMem1, Nbytes, hipMemcpyHostToDevice,
+                                      captureStream));
+  HIP_CHECK_OPT_THREAD(threadSafe,
+                       hipMemcpyAsync(hostMem2, devMem1, Nbytes, hipMemcpyDeviceToHost,
+                                      captureStream));
 }
 
 template <typename T> void captureSequenceLinear(T* hostMem1, T* devMem1, T* hostMem2, T* devMem2,
-                                                 size_t N, hipStream_t captureStream) {
+                                                 size_t N, hipStream_t captureStream,
+                                                 bool threadSafe = false) {
   {
     (void)(hostMem2);
   }  // unused hostMem2
   size_t Nbytes = N * sizeof(T);
 
-  HIP_CHECK(hipMemcpyAsync(devMem1, hostMem1, Nbytes, hipMemcpyHostToDevice, captureStream));
+  HIP_CHECK_OPT_THREAD(threadSafe,
+                       hipMemcpyAsync(devMem1, hostMem1, Nbytes, hipMemcpyHostToDevice,
+                                      captureStream));
 
-  HIP_CHECK(hipMemsetAsync(devMem2, 0, Nbytes, captureStream));
+  HIP_CHECK_OPT_THREAD(threadSafe, hipMemsetAsync(devMem2, 0, Nbytes, captureStream));
 }
 
 template <typename T> void captureSequenceBranched(T* hostMem1, T* devMem1, T* hostMem2, T* devMem2,
@@ -58,7 +66,8 @@ template <typename T> void captureSequenceBranched(T* hostMem1, T* devMem1, T* h
 }
 
 template <typename T>
-void captureSequenceCompute(T* devMem1, T* hostMem2, T* devMem2, size_t N, hipStream_t stream) {
+void captureSequenceCompute(T* devMem1, T* hostMem2, T* devMem2, size_t N, hipStream_t stream,
+                            bool threadSafe = false) {
   size_t Nbytes = N * sizeof(T);
   constexpr unsigned threadsPerBlock = 256;
   const unsigned blocks =
@@ -67,5 +76,6 @@ void captureSequenceCompute(T* devMem1, T* hostMem2, T* devMem2, size_t N, hipSt
   hipLaunchKernelGGL(HipTest::vector_square, dim3(blocks), dim3(threadsPerBlock), 0, stream,
                      devMem1, devMem2, N);
 
-  HIP_CHECK(hipMemcpyAsync(hostMem2, devMem2, Nbytes, hipMemcpyDeviceToHost, stream));
+  HIP_CHECK_OPT_THREAD(threadSafe,
+                       hipMemcpyAsync(hostMem2, devMem2, Nbytes, hipMemcpyDeviceToHost, stream));
 }


### PR DESCRIPTION
## Motivation

Catch2 assertion macros (REQUIRE/CHECK) and HIP_CHECK (which ends in REQUIRE) are not thread-safe; invoking them from worker threads corrupts Catch2 internal state and surfaces as failures/crashes under ASAN.

## Technical Details

Convert the multithreaded tests in the graph folder to use the thread-safe variants:
- HIP_CHECK -> HIP_CHECK_THREAD and REQUIRE/CHECK/HIP_ASSERT -> REQUIRE_THREAD in code paths executed by worker threads.
- Shared helpers called from both single- and multi-threaded contexts (ChkNodeType, ChkNodeTypeWithDependency, hipGraphLaunchWithMode and the captureSequence* helpers in stream_capture_common.hh) take a runtime threadSafe flag and use HIP_CHECK_OPT_THREAD / REQUIRE_OPT_THREAD.
- Bool-returning shared helpers that cannot host HIP_CHECK_THREAD's bare return get a dedicated thread-safe void variant (e.g. CaptureStreamAndLaunchGraphThread).
- Add HIP_CHECK_THREAD_FINALIZE() after joining worker threads to propagate deferred failures back to Catch2.

Also add HIP_CHECK_OPT_THREAD / REQUIRE_OPT_THREAD to hip_test_common.hh.


## JIRA ID

JIRA ID : AIRUNTIME-2352

## Test Plan

Tests should pass under ASAN

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
