### PR TITLE
fix(hip): enable Doxygen include search so cooperative groups classes render

### DIFF
--- a/projects/hip/.readthedocs.yaml
+++ b/projects/hip/.readthedocs.yaml
@@ -19,6 +19,9 @@ build:
    os: ubuntu-22.04
    tools:
       python: "mambaforge-22.9" # needed until ubuntu ships doxygen >= 1.9.8
+   jobs:
+     post_checkout:
+       - git sparse-checkout add projects/clr/hipamd/include
    apt_packages:
      - "gfortran" # For pre-processing fortran sources
      - "graphviz" # For dot graphs in doxygen


### PR DESCRIPTION
## Motivation
The cooperative groups reference page renders blank sections for all six
`cooperative_groups::` classes and both construct/API function groups,
with Doxygen warnings: `Cannot find class "cooperative_groups::thread_group"`.

## Technical Details
`SEARCH_INCLUDES` was set to `NO`, so Doxygen did not follow `#include`
directives when parsing `amd_hip_cooperative_groups.h`. The class
definitions live in `clr/hipamd/include/hip/amd_detail/amd_hip_cooperative_groups.h`,
which is already listed in `INPUT`, but without include resolution Doxygen
could not parse the namespace and class bodies.

Set `SEARCH_INCLUDES = YES` and add `INCLUDE_PATH` pointing at
`../../../clr/hipamd/include` and `../../include` to give Doxygen the
roots it needs to resolve the include chain.

Same fix should be cherry-picked to `docs/7.13.0` and `docs/7.2.4`.

## Test Plan
- [ ] Run `doxygen Doxyfile` locally and confirm `cooperative_groups::` classes appear in XML output with no "Cannot find class" warnings.

## Test Result
Verified locally: Doxygen now generates XML for all six classes
(`thread_group`, `thread_block`, `grid_group`, `multi_grid_group`,
`thread_block_tile`, `coalesced_group`) and both function groups.

## Submission Checklist
- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.