### PR TITLE
hip-tests: Disable execution ctx test due to timeout in CI

### DIFF
--- a/projects/hip-tests/catch/config/configs/unit/executionctx.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/executionctx.yaml
@@ -15,6 +15,7 @@ executionctx:
     disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_hipExecutionCtxRecordWaitEvent_Sanity:
     <<: *level_2
+    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_hipExecutionCtxRecordEventFunctional:
     <<: *level_2
   Unit_hipExecutionCtxRecordWait_Blocking:


### PR DESCRIPTION
## Motivation

- Disable Unit_hipExecutionCtxRecordWaitEvent_Sanity test due to timeout in CI

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
