### PR TITLE
[rocprofv3] Document GPU performance level requirement for Navi3x/Nav…

### DIFF
--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
@@ -32,10 +32,8 @@ Setting GPU performance level for PMC profiling
 ---------------------------------------------
 
 On RDNA3 (Navi3x) and RDNA4 (Navi4x) GPUs, the ``AUTO`` performance mode disables GPU profiling
-in hardware: the perfmon clock is gated off
-(``RLC_CGTT_MGCG_OVERRIDE.PERFMON_CLOCK_STATE = 0``), which prevents performance counters from
-functioning. Setting the performance level to ``stable_std`` (or any non-``AUTO`` mode that sets
-``PERFMON_CLOCK_STATE = 1``) turns the perfmon clock back on and enables PMC profiling.
+in hardware: the perfmon clock is gated off, which prevents performance counters from functioning.
+Setting the performance level to ``STABLE_STD`` turns the perfmon clock back on and enables PMC profiling.
 
 This is a hardware feature enablement requirement. Without it, PMC profiling on these GPUs
 produces no meaningful counter data.

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
@@ -31,12 +31,12 @@ Before tracing or profiling your HIP application using ``rocprofv3``, build it u
 Setting GPU performance level for PMC profiling
 ---------------------------------------------
 
-On RDNA3 (Navi3x) and RDNA4 (Navi4x) GPUs, the ``AUTO`` performance mode disables GPU profiling
-in hardware: the perfmon clock is gated off, which prevents performance counters from functioning.
-Setting the performance level to ``STABLE_STD`` turns the perfmon clock back on and enables PMC profiling.
+On RDNA3 (Navi3x) and RDNA4 (Navi4x) GPUs, the ``AUTO`` performance mode disables PMC profiling in some GPU hardware blocks:
+the perfmon clock is gated off, which prevents performance counters from functioning. Setting the performance level to
+``STABLE_STD`` turns the perfmon clock back on and enables PMC profiling on all GPU hardware blocks.
 
-This is a hardware feature enablement requirement. Without it, PMC profiling on these GPUs
-produces no meaningful counter data.
+This is a hardware feature enablement requirement. Without it, PMC profiling on these GPUs produces no meaningful counter
+data in some GPU hardware blocks.
 
 There are two ways to configure the GPU performance level:
 
@@ -66,40 +66,42 @@ To restore the default behavior after PMC profiling:
 
 Alternatively, use the ``amd-smi`` tool installed with ROCm to query and set the performance level.
 
+Replace ``<N>`` with the card index:
+
 To check the current performance level:
 
 .. code-block:: shell
 
-   $ sudo /opt/rocm/bin/amd-smi metric --perf-level
-   GPU: 0
+   $ sudo /opt/rocm/bin/amd-smi metric --gpu <N> --perf-level
+   GPU: <N>
        PERF_LEVEL: AMDSMI_DEV_PERF_LEVEL_AUTO
 
 To set the performance level to ``STABLE_STD`` (the ``amd-smi`` name for ``profile_standard``):
 
 .. code-block:: shell
 
-   $ sudo /opt/rocm/bin/amd-smi set --perf-level STABLE_STD
-   GPU: 0
+   $ sudo /opt/rocm/bin/amd-smi set --gpu <N> --perf-level STABLE_STD
+   GPU: <N>
        PERFLEVEL: Successfully set performance level STABLE_STD
 
 To verify the change:
 
 .. code-block:: shell
 
-   $ sudo /opt/rocm/bin/amd-smi metric --perf-level
-   GPU: 0
+   $ sudo /opt/rocm/bin/amd-smi metric --gpu <N> --perf-level
+   GPU: <N>
        PERF_LEVEL: AMDSMI_DEV_PERF_LEVEL_STABLE_STD
 
 To restore the default performance level after PMC profiling:
 
 .. code-block:: shell
 
-   $ sudo /opt/rocm/bin/amd-smi set --perf-level AUTO
-   GPU: 0
+   $ sudo /opt/rocm/bin/amd-smi set --gpu <N> --perf-level AUTO
+   GPU: <N>
        PERFLEVEL: Successfully set performance level AUTO
 
-   $ sudo /opt/rocm/bin/amd-smi metric --perf-level
-   GPU: 0
+   $ sudo /opt/rocm/bin/amd-smi metric --gpu <N> --perf-level
+   GPU: <N>
        PERF_LEVEL: AMDSMI_DEV_PERF_LEVEL_AUTO
 
 .. _application-tracing:

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
@@ -66,7 +66,20 @@ To restore the default behavior after PMC profiling:
 
 Alternatively, use the ``amd-smi`` tool installed with ROCm to query and set the performance level.
 
-Replace ``<N>`` with the card index:
+One advantage of using ``amd-smi`` is that it can be used to query and set the performance level on multiple
+GPUs in a single command. For example, to set the performance level to ``STABLE_STD`` on all GPUs in the
+system, use:
+
+.. code-block:: shell
+
+   $ sudo /opt/rocm/bin/amd-smi set --perf-level STABLE_STD
+   GPU: 0
+       PERFLEVEL: Successfully set performance level STABLE_STD
+   GPU: 1
+       PERFLEVEL: Successfully set performance level STABLE_STD
+
+The following examples show how to query and set the performance level for a specific GPU. Replace ``<N>``
+with the card index:
 
 To check the current performance level:
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3.rst
@@ -26,6 +26,84 @@ Before tracing or profiling your HIP application using ``rocprofv3``, build it u
    cmake -B <build-directory> <source-directory> -DCMAKE_PREFIX_PATH=/opt/rocm
    cmake --build <build-directory> --target all --parallel <N>
 
+.. _gpu-performance-level:
+
+Setting GPU performance level for PMC profiling
+---------------------------------------------
+
+On RDNA3 (Navi3x) and RDNA4 (Navi4x) GPUs, the ``AUTO`` performance mode disables GPU profiling
+in hardware: the perfmon clock is gated off
+(``RLC_CGTT_MGCG_OVERRIDE.PERFMON_CLOCK_STATE = 0``), which prevents performance counters from
+functioning. Setting the performance level to ``stable_std`` (or any non-``AUTO`` mode that sets
+``PERFMON_CLOCK_STATE = 1``) turns the perfmon clock back on and enables PMC profiling.
+
+This is a hardware feature enablement requirement. Without it, PMC profiling on these GPUs
+produces no meaningful counter data.
+
+There are two ways to configure the GPU performance level:
+
+**Option 1: Using the** ``power_dpm_force_performance_level`` **sysfs entry**
+
+Set the performance level to ``profile_standard`` via the sysfs interface. Replace ``<N>`` with
+the card index (for example, ``0`` for ``card0``):
+
+.. code-block:: bash
+
+   sudo chmod 777 /sys/class/drm/card<N>/device/power_dpm_force_performance_level
+   sudo sh -c 'echo profile_standard > /sys/class/drm/card<N>/device/power_dpm_force_performance_level'
+
+To verify the setting:
+
+.. code-block:: bash
+
+   cat /sys/class/drm/card<N>/device/power_dpm_force_performance_level
+
+To restore the default behavior after PMC profiling:
+
+.. code-block:: bash
+
+   sudo sh -c 'echo auto > /sys/class/drm/card<N>/device/power_dpm_force_performance_level'
+
+**Option 2: Using** ``amd-smi``
+
+Alternatively, use the ``amd-smi`` tool installed with ROCm to query and set the performance level.
+
+To check the current performance level:
+
+.. code-block:: shell
+
+   $ sudo /opt/rocm/bin/amd-smi metric --perf-level
+   GPU: 0
+       PERF_LEVEL: AMDSMI_DEV_PERF_LEVEL_AUTO
+
+To set the performance level to ``STABLE_STD`` (the ``amd-smi`` name for ``profile_standard``):
+
+.. code-block:: shell
+
+   $ sudo /opt/rocm/bin/amd-smi set --perf-level STABLE_STD
+   GPU: 0
+       PERFLEVEL: Successfully set performance level STABLE_STD
+
+To verify the change:
+
+.. code-block:: shell
+
+   $ sudo /opt/rocm/bin/amd-smi metric --perf-level
+   GPU: 0
+       PERF_LEVEL: AMDSMI_DEV_PERF_LEVEL_STABLE_STD
+
+To restore the default performance level after PMC profiling:
+
+.. code-block:: shell
+
+   $ sudo /opt/rocm/bin/amd-smi set --perf-level AUTO
+   GPU: 0
+       PERFLEVEL: Successfully set performance level AUTO
+
+   $ sudo /opt/rocm/bin/amd-smi metric --perf-level
+   GPU: 0
+       PERF_LEVEL: AMDSMI_DEV_PERF_LEVEL_AUTO
+
 .. _application-tracing:
 
 Application tracing


### PR DESCRIPTION
…i4x profiling

Add a new section explaining that on RDNA3 (Navi3x) and RDNA4 (Navi4x) GPUs, AUTO performance mode gates off the perfmon clock in hardware (RLC_CGTT_MGCG_OVERRIDE.PERFMON_CLOCK_STATE = 0), which disables GPU profiling entirely. Setting performance level to stable_std (or similar non-AUTO modes) turns the perfmon clock back on, enabling PMC profiling.

This is a hardware feature enablement requirement, not a clock-stability or result-reproducibility concern. The section documents two ways to set the performance level: via the power_dpm_force_performance_level sysfs entry and via amd-smi.
