### PR TITLE
[RCCL] Fix build failure for ROCm 7.0.2

### DIFF
--- a/projects/rccl/src/device/symmetric/primitives.cuh
+++ b/projects/rccl/src/device/symmetric/primitives.cuh
@@ -22,7 +22,13 @@ struct tmaSmemStruct {
 #if defined(__HIP_PLATFORM_AMD__) && !defined(NCCL_SYMK_HAVE_ISSHARED)
 #define NCCL_SYMK_HAVE_ISSHARED 1
 static __device__ __forceinline__ bool __isShared(const void* p) {
+#ifdef __HIP_DEVICE_COMPILE__
   return __builtin_amdgcn_is_shared((void*)p);
+#else
+  // __builtin_amdgcn_is_shared is a device-only intrinsic; host pass only needs a stub for the __builtin_assume hint.
+  (void)p;
+  return true;
+#endif
 }
 #endif
 

--- a/projects/rccl/src/device/symmetric/primitives.cuh
+++ b/projects/rccl/src/device/symmetric/primitives.cuh
@@ -22,7 +22,7 @@ struct tmaSmemStruct {
 #if defined(__HIP_PLATFORM_AMD__) && !defined(NCCL_SYMK_HAVE_ISSHARED)
 #define NCCL_SYMK_HAVE_ISSHARED 1
 static __device__ __forceinline__ bool __isShared(const void* p) {
-#ifdef __HIP_DEVICE_COMPILE__
+#if defined(__HIP_DEVICE_COMPILE__) && __HIP_DEVICE_COMPILE__
   return __builtin_amdgcn_is_shared((void*)p);
 #else
   // __builtin_amdgcn_is_shared is a device-only intrinsic; host pass only needs a stub for the __builtin_assume hint.


### PR DESCRIPTION
## Motivation

Fix RCCL build failure on ROCm 7.0.2 (clang 20) where the host compilation pass rejects `__builtin_amdgcn_is_shared` in `__isShared()`

## Technical Details

Guard the device-only `__builtin_amdgcn_is_shared` intrinsic behind `__HIP_DEVICE_COMPILE__` with a host stub

## JIRA ID

AICOMRCCL-1319

## Test Plan

Test build on ROCm 7.0.2

## Test Result

Build passeed:
```
[ 78%] Linking CXX shared library ../librccl.so
Elapsed time (seconds): 0.648499
[100%] Built target rccl
[100%] Building CXX object src/CMakeFiles/rcclras.dir/__/hipify/src/ras/client.cc.o
[100%] Linking CXX executable rcclras
[100%] Built target rcclras
```
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
