### PR TITLE
feat(rocshmem): new host p2p sync ops for the non-mpi ipc path

### DIFF
--- a/projects/rocshmem/CHANGELOG.md
+++ b/projects/rocshmem/CHANGELOG.md
@@ -12,7 +12,7 @@
    * `rocshmem_team_split_2D`
 * Added tile-granular RMA operations for the IPC backend
 * Added host-initiated RMA operations in the IPC backend for the non-MPI
-   bootstrapping path
+   bootstrapping path: put, get, fence, quiet, arithmetic AMOs, and P2P sync ops
 * Added team creation using non-contiguous parent teams in the IPC backend
 * Added Python bindings of memory-management APIs
 * Added Python bindings coverage for team APIs

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -160,6 +160,9 @@ declare -A TEST_NUMBERS=(
   ["host_wait_until_all_vector"]="143"
   ["host_wait_until_any_vector"]="144"
   ["host_wait_until_some_vector"]="145"
+  ["host_wait_until_all_status"]="146"
+  ["host_wait_until_any_status"]="147"
+  ["host_wait_until_some_status"]="148"
 )
 
 # Detect which runtime to use
@@ -781,6 +784,9 @@ TestHostRma() { #AIROCSHMEM-419
   ExecTest  "host_wait_until_all_vector" 2        1      1
   ExecTest  "host_wait_until_any_vector" 2        1      1
   ExecTest  "host_wait_until_some_vector" 2       1      1
+  ExecTest  "host_wait_until_all_status" 2        1      1
+  ExecTest  "host_wait_until_any_status" 2        1      1
+  ExecTest  "host_wait_until_some_status" 2       1      1
   # Concurrency tests — configurable PE count (IPC_HOST_NPES, default 4)
   ExecTest  "host_amo_all_pes"    $npes    1      1
   ExecTest  "host_amo_self"       $npes    1      1

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -152,6 +152,14 @@ declare -A TEST_NUMBERS=(
   ["tile_allgather"]="135"
   ["tile_allgather_wave"]="136"
   ["tile_allgather_wg"]="137"
+  ["host_wait_until"]="138"
+  ["host_test"]="139"
+  ["host_wait_until_all"]="140"
+  ["host_wait_until_any"]="141"
+  ["host_wait_until_some"]="142"
+  ["host_wait_until_all_vector"]="143"
+  ["host_wait_until_any_vector"]="144"
+  ["host_wait_until_some_vector"]="145"
 )
 
 # Detect which runtime to use
@@ -765,6 +773,14 @@ TestHostRma() { #AIROCSHMEM-419
   ExecTest  "host_int_amo_fadd"   2        1      1
   ExecTest  "host_int_amo_fcswap" 2        1      1
   ROCSHMEM_MAX_NUM_HOST_CONTEXTS=2 ExecTest "host_amo_add" 2 1 1
+  ExecTest  "host_wait_until"            2        1      1
+  ExecTest  "host_test"                  2        1      1
+  ExecTest  "host_wait_until_all"        2        1      1
+  ExecTest  "host_wait_until_any"        2        1      1
+  ExecTest  "host_wait_until_some"       2        1      1
+  ExecTest  "host_wait_until_all_vector" 2        1      1
+  ExecTest  "host_wait_until_any_vector" 2        1      1
+  ExecTest  "host_wait_until_some_vector" 2       1      1
   # Concurrency tests — configurable PE count (IPC_HOST_NPES, default 4)
   ExecTest  "host_amo_all_pes"    $npes    1      1
   ExecTest  "host_amo_self"       $npes    1      1

--- a/projects/rocshmem/src/host/host.hpp
+++ b/projects/rocshmem/src/host/host.hpp
@@ -293,6 +293,8 @@ class HostInterface {
   template <typename T>
   __host__ int test(T *ivars, int cmp, T val, WindowInfo* window_info);
 
+  __host__ void hdp_flush() { hdp_policy_->hdp_flush(); }
+
 #if defined USE_HDP_FLUSH
   __host__ void create_hdp_window();
 #endif // USE_HDP_FLUSH

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_host.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_host.hpp
@@ -136,7 +136,29 @@ __host__ int IPCHostContext::reduce_on_stream(rocshmem_team_t team, T *dest,
 }
 
 template <typename T>
+__host__ int IPCHostContext::test(T *ivars, int cmp, T val) {
+  if (is_ipc_non_mpi()) {
+    host_interface->hdp_flush();
+    T loaded = *static_cast<volatile T*>(ivars);
+    switch (cmp) {
+      case ROCSHMEM_CMP_EQ: return loaded == val ? 1 : 0;
+      case ROCSHMEM_CMP_NE: return loaded != val ? 1 : 0;
+      case ROCSHMEM_CMP_GT: return loaded >  val ? 1 : 0;
+      case ROCSHMEM_CMP_GE: return loaded >= val ? 1 : 0;
+      case ROCSHMEM_CMP_LT: return loaded <  val ? 1 : 0;
+      case ROCSHMEM_CMP_LE: return loaded <= val ? 1 : 0;
+      default: return 0;
+    }
+  }
+  return host_interface->test<T>(ivars, cmp, val, context_window_info);
+}
+
+template <typename T>
 __host__ void IPCHostContext::wait_until(T *ivars, int cmp, T val) {
+  if (is_ipc_non_mpi()) {
+    while (!test<T>(ivars, cmp, val)) {}
+    return;
+  }
   host_interface->wait_until<T>(ivars, cmp, val, context_window_info);
 }
 
@@ -144,6 +166,16 @@ template <typename T>
 __host__ void IPCHostContext::wait_until_all(T *ivars, size_t nelems,
                                              const int* status,
                                              int cmp, T val) {
+  if (is_ipc_non_mpi()) {
+    if (!nelems) return;
+    size_t pos{status_entry(nelems, status)};
+    if (pos == nelems) return;
+    for (size_t i{pos}; i < nelems; i++) {
+      if (nullptr != status && status[i]) continue;
+      while (!test<T>(ivars + i, cmp, val)) {}
+    }
+    return;
+  }
   host_interface->wait_until_all<T>(ivars, nelems, status, cmp, val, context_window_info);
 }
 
@@ -151,6 +183,17 @@ template <typename T>
 __host__ size_t IPCHostContext::wait_until_any(T *ivars, size_t nelems,
                                                const int* status,
                                                int cmp, T val) {
+  if (is_ipc_non_mpi()) {
+    if (!nelems) return SIZE_MAX;
+    size_t pos{status_entry(nelems, status)};
+    if (pos == nelems) return SIZE_MAX;
+    while (true) {
+      for (size_t i{pos}; i < nelems; i++) {
+        if (nullptr != status && status[i]) continue;
+        if (test<T>(ivars + i, cmp, val)) return i;
+      }
+    }
+  }
   return host_interface->wait_until_any<T>(ivars, nelems, status, cmp, val, context_window_info);
 }
 
@@ -159,6 +202,24 @@ __host__ size_t IPCHostContext::wait_until_some(T *ivars, size_t nelems,
                                                 size_t* indices,
                                                 const int* status,
                                                 int cmp, T val) {
+  if (is_ipc_non_mpi()) {
+    if (!nelems) return 0;
+    size_t pos{status_entry(nelems, status)};
+    if (pos == nelems) return 0;
+    bool done{false};
+    size_t ncompleted{0};
+    while (!done) {
+      for (size_t i{pos}; i < nelems; i++) {
+        if (nullptr != status && status[i]) continue;
+        if (test<T>(ivars + i, cmp, val)) {
+          done = true;
+          indices[ncompleted] = i;
+          ncompleted++;
+        }
+      }
+    }
+    return ncompleted;
+  }
   return host_interface->wait_until_some<T>(ivars, nelems, indices, status, cmp, val, context_window_info);
 }
 
@@ -166,6 +227,16 @@ template <typename T>
 __host__ void IPCHostContext::wait_until_all_vector(T *ivars, size_t nelems,
                                                     const int* status,
                                                     int cmp, T* vals) {
+  if (is_ipc_non_mpi()) {
+    if (!nelems) return;
+    size_t pos{status_entry(nelems, status)};
+    if (pos == nelems) return;
+    for (size_t i{pos}; i < nelems; i++) {
+      if (nullptr != status && status[i]) continue;
+      while (!test<T>(ivars + i, cmp, vals[i])) {}
+    }
+    return;
+  }
   host_interface->wait_until_all_vector<T>(ivars, nelems, status, cmp, vals, context_window_info);
 }
 
@@ -173,6 +244,17 @@ template <typename T>
 __host__ size_t IPCHostContext::wait_until_any_vector(T *ivars, size_t nelems,
                                                       const int* status,
                                                       int cmp, T* vals) {
+  if (is_ipc_non_mpi()) {
+    if (!nelems) return SIZE_MAX;
+    size_t pos{status_entry(nelems, status)};
+    if (pos == nelems) return SIZE_MAX;
+    while (true) {
+      for (size_t i{pos}; i < nelems; i++) {
+        if (nullptr != status && status[i]) continue;
+        if (test<T>(ivars + i, cmp, vals[i])) return i;
+      }
+    }
+  }
   return host_interface->wait_until_any_vector<T>(ivars, nelems, status, cmp, vals, context_window_info);
 }
 
@@ -181,12 +263,25 @@ __host__ size_t IPCHostContext::wait_until_some_vector(T *ivars, size_t nelems,
                                                        size_t* indices,
                                                        const int* status,
                                                        int cmp, T* vals) {
+  if (is_ipc_non_mpi()) {
+    if (!nelems) return 0;
+    size_t pos{status_entry(nelems, status)};
+    if (pos == nelems) return 0;
+    bool done{false};
+    size_t ncompleted{0};
+    while (!done) {
+      for (size_t i{pos}; i < nelems; i++) {
+        if (nullptr != status && status[i]) continue;
+        if (test<T>(ivars + i, cmp, vals[i])) {
+          done = true;
+          indices[ncompleted] = i;
+          ncompleted++;
+        }
+      }
+    }
+    return ncompleted;
+  }
   return host_interface->wait_until_some_vector<T>(ivars, nelems, indices, status, cmp, vals, context_window_info);
-}
-
-template <typename T>
-__host__ int IPCHostContext::test(T *ivars, int cmp, T val) {
-  return host_interface->test<T>(ivars, cmp, val, context_window_info);
 }
 
 }  // namespace rocshmem

--- a/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
+++ b/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
@@ -153,6 +153,17 @@ set(TEST_tile_broadcast_wg 134)
 set(TEST_tile_allgather 135)
 set(TEST_tile_allgather_wave 136)
 set(TEST_tile_allgather_wg 137)
+set(TEST_host_wait_until 138)
+set(TEST_host_test 139)
+set(TEST_host_wait_until_all 140)
+set(TEST_host_wait_until_any 141)
+set(TEST_host_wait_until_some 142)
+set(TEST_host_wait_until_all_vector 143)
+set(TEST_host_wait_until_any_vector 144)
+set(TEST_host_wait_until_some_vector 145)
+set(TEST_host_wait_until_all_status 146)
+set(TEST_host_wait_until_any_status 147)
+set(TEST_host_wait_until_some_status 148)
 
 # MPI should already be found by the parent CMakeLists.txt
 # Use standard CMake MPI variables set by find_package(MPI)
@@ -1310,6 +1321,32 @@ function(add_host_tests)
         add_rocshmem_functional_test(NAME host_amo_all_pes RANKS 4 WORKGROUPS 1 THREADS 1
             ENV_VARS "ROCSHMEM_TEST_UUID=1")
         add_rocshmem_functional_test(NAME host_amo_self    RANKS 4 WORKGROUPS 1 THREADS 1
+            ENV_VARS "ROCSHMEM_TEST_UUID=1")
+    end_test_group()
+
+    # P2P sync tests: wait_until / test variants (AIROCSHMEM-419)
+    begin_test_group(CATEGORY "HOST;P2P" TIER comprehensive BACKENDS "ipc" GPUS "all")
+        add_rocshmem_functional_test(NAME host_wait_until            RANKS 2 WORKGROUPS 1 THREADS 1
+            ENV_VARS "ROCSHMEM_TEST_UUID=1")
+        add_rocshmem_functional_test(NAME host_test                  RANKS 2 WORKGROUPS 1 THREADS 1
+            ENV_VARS "ROCSHMEM_TEST_UUID=1")
+        add_rocshmem_functional_test(NAME host_wait_until_all        RANKS 2 WORKGROUPS 1 THREADS 1
+            ENV_VARS "ROCSHMEM_TEST_UUID=1")
+        add_rocshmem_functional_test(NAME host_wait_until_any        RANKS 2 WORKGROUPS 1 THREADS 1
+            ENV_VARS "ROCSHMEM_TEST_UUID=1")
+        add_rocshmem_functional_test(NAME host_wait_until_some       RANKS 2 WORKGROUPS 1 THREADS 1
+            ENV_VARS "ROCSHMEM_TEST_UUID=1")
+        add_rocshmem_functional_test(NAME host_wait_until_all_vector RANKS 2 WORKGROUPS 1 THREADS 1
+            ENV_VARS "ROCSHMEM_TEST_UUID=1")
+        add_rocshmem_functional_test(NAME host_wait_until_any_vector RANKS 2 WORKGROUPS 1 THREADS 1
+            ENV_VARS "ROCSHMEM_TEST_UUID=1")
+        add_rocshmem_functional_test(NAME host_wait_until_some_vector RANKS 2 WORKGROUPS 1 THREADS 1
+            ENV_VARS "ROCSHMEM_TEST_UUID=1")
+        add_rocshmem_functional_test(NAME host_wait_until_all_status RANKS 2 WORKGROUPS 1 THREADS 1
+            ENV_VARS "ROCSHMEM_TEST_UUID=1")
+        add_rocshmem_functional_test(NAME host_wait_until_any_status RANKS 2 WORKGROUPS 1 THREADS 1
+            ENV_VARS "ROCSHMEM_TEST_UUID=1")
+        add_rocshmem_functional_test(NAME host_wait_until_some_status RANKS 2 WORKGROUPS 1 THREADS 1
             ENV_VARS "ROCSHMEM_TEST_UUID=1")
     end_test_group()
 endfunction()

--- a/projects/rocshmem/tests/functional_tests/host_rma_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/host_rma_tester.cpp
@@ -303,6 +303,79 @@ void HostRmaTester::launchKernel([[maybe_unused]] dim3 gridSize,
       break;
     }
 
+    // status={0,1,0,1}: PE 0 writes indices 0,2; PE 1 waits on those two (skips 1,3).
+    // Also exercises wait_until_all_vector with per-element vals and same status mask.
+    case HostWaitUntilAllStatusTestType: {
+      const int status[WAIT_NELEMS] = {0, 1, 0, 1};
+      long vals_arr[WAIT_NELEMS];
+      for (size_t i = 0; i < WAIT_NELEMS; i++) vals_arr[i] = static_cast<long>(i + 1);
+      if (my_pe == 0) {
+        rocshmem_long_atomic_add(wait_buf + 0, vals_arr[0], peer);
+        rocshmem_long_atomic_add(wait_buf + 2, vals_arr[2], peer);
+        rocshmem_quiet();
+      } else {
+        rocshmem_long_wait_until_all(wait_buf, WAIT_NELEMS, status,
+                                     ROCSHMEM_CMP_NE, 0L);
+        rocshmem_long_wait_until_all_vector(wait_buf, WAIT_NELEMS, status,
+                                            ROCSHMEM_CMP_EQ, vals_arr);
+      }
+      break;
+    }
+
+    // status={1,0,0,0}: PE 0 writes index 1; PE 1 waits for any (skips index 0).
+    // Also exercises wait_until_any_vector with same status mask.
+    case HostWaitUntilAnyStatusTestType: {
+      const int status[WAIT_NELEMS] = {1, 0, 0, 0};
+      long vals_arr[WAIT_NELEMS];
+      for (size_t i = 0; i < WAIT_NELEMS; i++) vals_arr[i] = static_cast<long>(i + 1);
+      if (my_pe == 0) {
+        rocshmem_long_atomic_add(wait_buf + 1, vals_arr[1], peer);
+        rocshmem_quiet();
+      } else {
+        p2p_result_idx = rocshmem_long_wait_until_any(wait_buf, WAIT_NELEMS,
+                                                       status, ROCSHMEM_CMP_NE, 0L);
+        size_t vec_idx = rocshmem_long_wait_until_any_vector(wait_buf, WAIT_NELEMS,
+                                                              status, ROCSHMEM_CMP_EQ,
+                                                              vals_arr);
+        if (p2p_result_idx != vec_idx) {
+          std::cerr << "[PE " << my_pe << "] WaitUntilAnyStatus: scalar idx="
+                    << p2p_result_idx << " vector idx=" << vec_idx << " mismatch\n";
+          rocshmem_global_exit(1);
+        }
+      }
+      break;
+    }
+
+    // status={1,0,0,1}: PE 0 writes index 2; PE 1 waits for some (skips 0 and 3).
+    // Also exercises wait_until_some_vector with same status mask.
+    case HostWaitUntilSomeStatusTestType: {
+      const int status[WAIT_NELEMS] = {1, 0, 0, 1};
+      long vals_arr[WAIT_NELEMS];
+      for (size_t i = 0; i < WAIT_NELEMS; i++) vals_arr[i] = static_cast<long>(i + 1);
+      size_t indices[WAIT_NELEMS];
+      size_t vec_indices[WAIT_NELEMS];
+      if (my_pe == 0) {
+        rocshmem_long_atomic_add(wait_buf + 2, vals_arr[2], peer);
+        rocshmem_quiet();
+      } else {
+        p2p_result_ncompleted = rocshmem_long_wait_until_some(wait_buf, WAIT_NELEMS,
+                                                               indices, status,
+                                                               ROCSHMEM_CMP_NE, 0L);
+        p2p_result_idx = (p2p_result_ncompleted > 0) ? indices[0] : SIZE_MAX;
+        size_t vec_ncompleted = rocshmem_long_wait_until_some_vector(wait_buf, WAIT_NELEMS,
+                                                                      vec_indices, status,
+                                                                      ROCSHMEM_CMP_EQ,
+                                                                      vals_arr);
+        if (vec_ncompleted == 0 || vec_indices[0] != p2p_result_idx) {
+          std::cerr << "[PE " << my_pe << "] WaitUntilSomeStatus: scalar idx="
+                    << p2p_result_idx << " vector idx="
+                    << (vec_ncompleted > 0 ? vec_indices[0] : SIZE_MAX) << " mismatch\n";
+          rocshmem_global_exit(1);
+        }
+      }
+      break;
+    }
+
     default:
       break;
   }
@@ -510,6 +583,52 @@ void HostRmaTester::verifyResults(size_t size) {
             wait_buf[p2p_result_idx] != vals_arr[p2p_result_idx]) {
           std::cerr << "[PE " << my_pe << "] WaitUntilSomeVector: ncompleted="
                     << p2p_result_ncompleted << " idx=" << p2p_result_idx << "\n";
+          rocshmem_global_exit(1);
+        }
+      }
+      break;
+
+    // status={0,1,0,1}: only indices 0 and 2 were written and waited on.
+    case HostWaitUntilAllStatusTestType:
+      if (my_pe == 1) {
+        for (size_t i : {0u, 2u}) {
+          long expected = static_cast<long>(i + 1);
+          if (wait_buf[i] != expected) {
+            std::cerr << "[PE " << my_pe << "] WaitUntilAllStatus: wait_buf[" << i
+                      << "] expected " << expected << " got " << wait_buf[i] << "\n";
+            rocshmem_global_exit(1);
+          }
+        }
+      }
+      break;
+
+    // status={1,0,0,0}: PE 0 wrote index 1; returned idx must be 1.
+    case HostWaitUntilAnyStatusTestType:
+      if (my_pe == 1) {
+        if (p2p_result_idx != 1) {
+          std::cerr << "[PE " << my_pe << "] WaitUntilAnyStatus: expected idx=1 got "
+                    << p2p_result_idx << "\n";
+          rocshmem_global_exit(1);
+        }
+        if (wait_buf[1] != 2L) {
+          std::cerr << "[PE " << my_pe << "] WaitUntilAnyStatus: wait_buf[1] expected 2 got "
+                    << wait_buf[1] << "\n";
+          rocshmem_global_exit(1);
+        }
+      }
+      break;
+
+    // status={1,0,0,1}: PE 0 wrote index 2; returned idx must be 2.
+    case HostWaitUntilSomeStatusTestType:
+      if (my_pe == 1) {
+        if (p2p_result_ncompleted == 0 || p2p_result_idx != 2) {
+          std::cerr << "[PE " << my_pe << "] WaitUntilSomeStatus: expected idx=2 got "
+                    << p2p_result_idx << " ncompleted=" << p2p_result_ncompleted << "\n";
+          rocshmem_global_exit(1);
+        }
+        if (wait_buf[2] != 3L) {
+          std::cerr << "[PE " << my_pe << "] WaitUntilSomeStatus: wait_buf[2] expected 3 got "
+                    << wait_buf[2] << "\n";
           rocshmem_global_exit(1);
         }
       }

--- a/projects/rocshmem/tests/functional_tests/host_rma_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/host_rma_tester.cpp
@@ -38,6 +38,7 @@ HostRmaTester::HostRmaTester(TesterArguments args) : Tester(args) {
   dest_buf    = reinterpret_cast<char *>(alloc_test_buffer(max_msg_size));
   amo_buf     = reinterpret_cast<long *>(alloc_test_buffer(sizeof(long)));
   amo_int_buf = reinterpret_cast<int  *>(alloc_test_buffer(sizeof(int)));
+  wait_buf    = reinterpret_cast<long *>(alloc_test_buffer(WAIT_NELEMS * sizeof(long)));
 }
 
 HostRmaTester::~HostRmaTester() {
@@ -45,6 +46,7 @@ HostRmaTester::~HostRmaTester() {
   free_test_buffer(dest_buf);
   free_test_buffer(amo_buf);
   free_test_buffer(amo_int_buf);
+  free_test_buffer(wait_buf);
 }
 
 void HostRmaTester::resetBuffers(size_t size) {
@@ -53,6 +55,10 @@ void HostRmaTester::resetBuffers(size_t size) {
   memset(dest_buf, 0, size);
   *amo_buf     = 0L;
   *amo_int_buf = 0;
+  for (size_t i = 0; i < WAIT_NELEMS; i++)
+    wait_buf[i] = 0L;
+  p2p_result_idx = SIZE_MAX;
+  p2p_result_ncompleted = 0;
 }
 
 void HostRmaTester::launchKernel([[maybe_unused]] dim3 gridSize,
@@ -190,6 +196,113 @@ void HostRmaTester::launchKernel([[maybe_unused]] dim3 gridSize,
       }
       break;
 
+    // P2P Sync: PE 0 writes sentinel via atomic_add + quiet; PE 1 blocks in wait_until.
+    // atomic_add works on both MPI and non-MPI IPC paths (rocshmem_long_p aborts on non-MPI).
+    case HostWaitUntilTestType:
+      if (my_pe == 0) {
+        rocshmem_long_atomic_add(amo_buf, 42L, peer);
+        rocshmem_quiet();
+      } else {
+        rocshmem_long_wait_until(amo_buf, ROCSHMEM_CMP_EQ, 42L);
+      }
+      break;
+
+    // P2P Sync: PE 0 writes; PE 1 polls with rocshmem_test until non-zero.
+    case HostTestTestType:
+      if (my_pe == 0) {
+        rocshmem_long_atomic_add(amo_buf, 42L, peer);
+        rocshmem_quiet();
+      } else {
+        while (!rocshmem_long_test(amo_buf, ROCSHMEM_CMP_EQ, 42L)) {}
+      }
+      break;
+
+    // P2P Sync: PE 0 writes WAIT_NELEMS values; PE 1 blocks in wait_until_all.
+    case HostWaitUntilAllTestType:
+      if (my_pe == 0) {
+        for (size_t i = 0; i < WAIT_NELEMS; i++)
+          rocshmem_long_atomic_add(wait_buf + i, static_cast<long>(i + 1), peer);
+        rocshmem_quiet();
+      } else {
+        rocshmem_long_wait_until_all(wait_buf, WAIT_NELEMS, nullptr,
+                                     ROCSHMEM_CMP_NE, 0L);
+      }
+      break;
+
+    // P2P Sync: PE 0 writes index 2; PE 1 blocks in wait_until_any.
+    case HostWaitUntilAnyTestType:
+      if (my_pe == 0) {
+        rocshmem_long_atomic_add(wait_buf + 2, 42L, peer);
+        rocshmem_quiet();
+      } else {
+        p2p_result_idx = rocshmem_long_wait_until_any(wait_buf, WAIT_NELEMS,
+                                                       nullptr, ROCSHMEM_CMP_EQ, 42L);
+      }
+      break;
+
+    // P2P Sync: PE 0 writes index 1; PE 1 blocks in wait_until_some.
+    case HostWaitUntilSomeTestType: {
+      size_t indices[WAIT_NELEMS];
+      if (my_pe == 0) {
+        rocshmem_long_atomic_add(wait_buf + 1, 42L, peer);
+        rocshmem_quiet();
+      } else {
+        p2p_result_ncompleted = rocshmem_long_wait_until_some(wait_buf, WAIT_NELEMS,
+                                                               indices, nullptr,
+                                                               ROCSHMEM_CMP_EQ, 42L);
+        p2p_result_idx = (p2p_result_ncompleted > 0) ? indices[0] : SIZE_MAX;
+      }
+      break;
+    }
+
+    // P2P Sync: PE 0 writes per-element values; PE 1 blocks in wait_until_all_vector.
+    case HostWaitUntilAllVectorTestType: {
+      long vals_arr[WAIT_NELEMS];
+      for (size_t i = 0; i < WAIT_NELEMS; i++) vals_arr[i] = static_cast<long>(i + 1);
+      if (my_pe == 0) {
+        for (size_t i = 0; i < WAIT_NELEMS; i++)
+          rocshmem_long_atomic_add(wait_buf + i, vals_arr[i], peer);
+        rocshmem_quiet();
+      } else {
+        rocshmem_long_wait_until_all_vector(wait_buf, WAIT_NELEMS, nullptr,
+                                             ROCSHMEM_CMP_EQ, vals_arr);
+      }
+      break;
+    }
+
+    // P2P Sync: PE 0 writes index 2 (val=3); PE 1 blocks in wait_until_any_vector.
+    case HostWaitUntilAnyVectorTestType: {
+      long vals_arr[WAIT_NELEMS];
+      for (size_t i = 0; i < WAIT_NELEMS; i++) vals_arr[i] = static_cast<long>(i + 1);
+      if (my_pe == 0) {
+        rocshmem_long_atomic_add(wait_buf + 2, vals_arr[2], peer);
+        rocshmem_quiet();
+      } else {
+        p2p_result_idx = rocshmem_long_wait_until_any_vector(wait_buf, WAIT_NELEMS,
+                                                              nullptr, ROCSHMEM_CMP_EQ,
+                                                              vals_arr);
+      }
+      break;
+    }
+
+    // P2P Sync: PE 0 writes index 1 (val=2); PE 1 blocks in wait_until_some_vector.
+    case HostWaitUntilSomeVectorTestType: {
+      long vals_arr[WAIT_NELEMS];
+      for (size_t i = 0; i < WAIT_NELEMS; i++) vals_arr[i] = static_cast<long>(i + 1);
+      size_t indices[WAIT_NELEMS];
+      if (my_pe == 0) {
+        rocshmem_long_atomic_add(wait_buf + 1, vals_arr[1], peer);
+        rocshmem_quiet();
+      } else {
+        p2p_result_ncompleted = rocshmem_long_wait_until_some_vector(wait_buf, WAIT_NELEMS,
+                                                                      indices, nullptr,
+                                                                      ROCSHMEM_CMP_EQ,
+                                                                      vals_arr);
+        p2p_result_idx = (p2p_result_ncompleted > 0) ? indices[0] : SIZE_MAX;
+      }
+      break;
+    }
+
     default:
       break;
   }
@@ -315,6 +428,90 @@ void HostRmaTester::verifyResults(size_t size) {
         std::cerr << "[PE " << my_pe << "] AmoAdd(int): expected 1 got "
                   << *amo_int_buf << "\n";
         rocshmem_global_exit(1);
+      }
+      break;
+
+    case HostWaitUntilTestType:
+    case HostTestTestType:
+      // PE 1 unblocked from wait_until/test in launchKernel; verify the value arrived.
+      if (my_pe == 1 && *amo_buf != 42L) {
+        std::cerr << "[PE " << my_pe << "] WaitUntil/Test: expected 42 got "
+                  << *amo_buf << "\n";
+        rocshmem_global_exit(1);
+      }
+      break;
+
+    case HostWaitUntilAllTestType:
+      // PE 1 unblocked from wait_until_all; verify all elements arrived.
+      if (my_pe == 1) {
+        for (size_t i = 0; i < WAIT_NELEMS; i++) {
+          long expected = static_cast<long>(i + 1);
+          if (wait_buf[i] != expected) {
+            std::cerr << "[PE " << my_pe << "] WaitUntilAll: wait_buf[" << i
+                      << "] expected " << expected << " got " << wait_buf[i] << "\n";
+            rocshmem_global_exit(1);
+          }
+        }
+      }
+      break;
+
+    case HostWaitUntilAnyTestType:
+      if (my_pe == 1) {
+        if (p2p_result_idx >= WAIT_NELEMS || wait_buf[p2p_result_idx] != 42L) {
+          std::cerr << "[PE " << my_pe << "] WaitUntilAny: bad idx="
+                    << p2p_result_idx << "\n";
+          rocshmem_global_exit(1);
+        }
+      }
+      break;
+
+    case HostWaitUntilSomeTestType:
+      if (my_pe == 1) {
+        if (p2p_result_ncompleted == 0 || p2p_result_idx >= WAIT_NELEMS ||
+            wait_buf[p2p_result_idx] != 42L) {
+          std::cerr << "[PE " << my_pe << "] WaitUntilSome: ncompleted="
+                    << p2p_result_ncompleted << " idx=" << p2p_result_idx << "\n";
+          rocshmem_global_exit(1);
+        }
+      }
+      break;
+
+    case HostWaitUntilAllVectorTestType:
+      if (my_pe == 1) {
+        for (size_t i = 0; i < WAIT_NELEMS; i++) {
+          long expected = static_cast<long>(i + 1);
+          if (wait_buf[i] != expected) {
+            std::cerr << "[PE " << my_pe << "] WaitUntilAllVector: wait_buf[" << i
+                      << "] expected " << expected << " got " << wait_buf[i] << "\n";
+            rocshmem_global_exit(1);
+          }
+        }
+      }
+      break;
+
+    case HostWaitUntilAnyVectorTestType:
+      if (my_pe == 1) {
+        long vals_arr[WAIT_NELEMS];
+        for (size_t i = 0; i < WAIT_NELEMS; i++) vals_arr[i] = static_cast<long>(i + 1);
+        if (p2p_result_idx >= WAIT_NELEMS ||
+            wait_buf[p2p_result_idx] != vals_arr[p2p_result_idx]) {
+          std::cerr << "[PE " << my_pe << "] WaitUntilAnyVector: bad idx="
+                    << p2p_result_idx << "\n";
+          rocshmem_global_exit(1);
+        }
+      }
+      break;
+
+    case HostWaitUntilSomeVectorTestType:
+      if (my_pe == 1) {
+        long vals_arr[WAIT_NELEMS];
+        for (size_t i = 0; i < WAIT_NELEMS; i++) vals_arr[i] = static_cast<long>(i + 1);
+        if (p2p_result_ncompleted == 0 || p2p_result_idx >= WAIT_NELEMS ||
+            wait_buf[p2p_result_idx] != vals_arr[p2p_result_idx]) {
+          std::cerr << "[PE " << my_pe << "] WaitUntilSomeVector: ncompleted="
+                    << p2p_result_ncompleted << " idx=" << p2p_result_idx << "\n";
+          rocshmem_global_exit(1);
+        }
       }
       break;
 

--- a/projects/rocshmem/tests/functional_tests/host_rma_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/host_rma_tester.hpp
@@ -62,6 +62,14 @@ class HostRmaTester : public Tester {
 
   /* Symmetric int counter/flag for int AMO tests (exercises 32-bit kernel path) */
   int *amo_int_buf{nullptr};
+
+  /* Symmetric array of longs for wait_until_all/any/some/vector tests */
+  static constexpr size_t WAIT_NELEMS = 4;
+  long *wait_buf{nullptr};
+
+  /* Local storage for results from _any / _some variants (non-symmetric) */
+  size_t p2p_result_idx{SIZE_MAX};
+  size_t p2p_result_ncompleted{0};
 };
 
 #endif  // _HOST_RMA_TESTER_HPP_

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -432,6 +432,21 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
       if (BackendType::IPC_BACKEND == backend_type)
         testers.push_back(new HostRmaTester(args));
       break;
+    case HostWaitUntilAllStatusTestType:
+      test_name = "Host_Wait_Until_All_Status";
+      if (BackendType::IPC_BACKEND == backend_type)
+        testers.push_back(new HostRmaTester(args));
+      break;
+    case HostWaitUntilAnyStatusTestType:
+      test_name = "Host_Wait_Until_Any_Status";
+      if (BackendType::IPC_BACKEND == backend_type)
+        testers.push_back(new HostRmaTester(args));
+      break;
+    case HostWaitUntilSomeStatusTestType:
+      test_name = "Host_Wait_Until_Some_Status";
+      if (BackendType::IPC_BACKEND == backend_type)
+        testers.push_back(new HostRmaTester(args));
+      break;
     case PutmemSignalOnStreamTestType:
       test_name = "Putmem_Signal_On_Stream";
       testers.push_back(new PutmemSignalOnStreamTester(args));
@@ -1026,6 +1041,9 @@ bool Tester::peLaunchesKernel() {
     case HostWaitUntilAllVectorTestType:
     case HostWaitUntilAnyVectorTestType:
     case HostWaitUntilSomeVectorTestType:
+    case HostWaitUntilAllStatusTestType:
+    case HostWaitUntilAnyStatusTestType:
+    case HostWaitUntilSomeStatusTestType:
       is_launcher = true;
       break;
     default:

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -392,6 +392,46 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
       if (BackendType::IPC_BACKEND == backend_type)
         testers.push_back(new HostRmaTester(args));
       break;
+    case HostWaitUntilTestType:
+      test_name = "Host_Wait_Until";
+      if (BackendType::IPC_BACKEND == backend_type)
+        testers.push_back(new HostRmaTester(args));
+      break;
+    case HostTestTestType:
+      test_name = "Host_Test";
+      if (BackendType::IPC_BACKEND == backend_type)
+        testers.push_back(new HostRmaTester(args));
+      break;
+    case HostWaitUntilAllTestType:
+      test_name = "Host_Wait_Until_All";
+      if (BackendType::IPC_BACKEND == backend_type)
+        testers.push_back(new HostRmaTester(args));
+      break;
+    case HostWaitUntilAnyTestType:
+      test_name = "Host_Wait_Until_Any";
+      if (BackendType::IPC_BACKEND == backend_type)
+        testers.push_back(new HostRmaTester(args));
+      break;
+    case HostWaitUntilSomeTestType:
+      test_name = "Host_Wait_Until_Some";
+      if (BackendType::IPC_BACKEND == backend_type)
+        testers.push_back(new HostRmaTester(args));
+      break;
+    case HostWaitUntilAllVectorTestType:
+      test_name = "Host_Wait_Until_All_Vector";
+      if (BackendType::IPC_BACKEND == backend_type)
+        testers.push_back(new HostRmaTester(args));
+      break;
+    case HostWaitUntilAnyVectorTestType:
+      test_name = "Host_Wait_Until_Any_Vector";
+      if (BackendType::IPC_BACKEND == backend_type)
+        testers.push_back(new HostRmaTester(args));
+      break;
+    case HostWaitUntilSomeVectorTestType:
+      test_name = "Host_Wait_Until_Some_Vector";
+      if (BackendType::IPC_BACKEND == backend_type)
+        testers.push_back(new HostRmaTester(args));
+      break;
     case PutmemSignalOnStreamTestType:
       test_name = "Putmem_Signal_On_Stream";
       testers.push_back(new PutmemSignalOnStreamTester(args));
@@ -978,6 +1018,14 @@ bool Tester::peLaunchesKernel() {
     case HostIntAmoFCswapTestType:
     case HostAmoAllPesTestType:
     case HostAmoSelfTestType:
+    case HostWaitUntilTestType:
+    case HostTestTestType:
+    case HostWaitUntilAllTestType:
+    case HostWaitUntilAnyTestType:
+    case HostWaitUntilSomeTestType:
+    case HostWaitUntilAllVectorTestType:
+    case HostWaitUntilAnyVectorTestType:
+    case HostWaitUntilSomeVectorTestType:
       is_launcher = true;
       break;
     default:

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -187,7 +187,10 @@
   X(HostWaitUntilSome,         142)  \
   X(HostWaitUntilAllVector,    143)  \
   X(HostWaitUntilAnyVector,    144)  \
-  X(HostWaitUntilSomeVector,   145)
+  X(HostWaitUntilSomeVector,   145)  \
+  X(HostWaitUntilAllStatus,    146)  \
+  X(HostWaitUntilAnyStatus,    147)  \
+  X(HostWaitUntilSomeStatus,   148)
 #define _ROCSHMEM_ENUM_ENTRY(name, val) name##TestType = val,
 enum TestType {
   ROCSHMEM_FOREACH_TEST_TYPE(_ROCSHMEM_ENUM_ENTRY)

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -179,7 +179,15 @@
   X(TileBroadcastWG,           134)  \
   X(TileAllgather,             135)  \
   X(TileAllgatherWave,         136)  \
-  X(TileAllgatherWG,           137)
+  X(TileAllgatherWG,           137)  \
+  X(HostWaitUntil,             138)  \
+  X(HostTest,                  139)  \
+  X(HostWaitUntilAll,          140)  \
+  X(HostWaitUntilAny,          141)  \
+  X(HostWaitUntilSome,         142)  \
+  X(HostWaitUntilAllVector,    143)  \
+  X(HostWaitUntilAnyVector,    144)  \
+  X(HostWaitUntilSomeVector,   145)
 #define _ROCSHMEM_ENUM_ENTRY(name, val) name##TestType = val,
 enum TestType {
   ROCSHMEM_FOREACH_TEST_TYPE(_ROCSHMEM_ENUM_ENTRY)

--- a/projects/rocshmem/tests/test_categories.yaml
+++ b/projects/rocshmem/tests/test_categories.yaml
@@ -198,6 +198,10 @@ test_categories:
       - "host_amo_all_pes_.*"
       - "host_amo_self_.*"
 
+      # Host P2P sync tests (non-MPI IPC TcpBootstrap path, IPC-only)
+      - "host_wait_until_.*"
+      - "host_test_.*"
+
       # Tile collective tests (IPC-only)
       - "tile_broadcast_.*"
       - "tile_allgather_.*"


### PR DESCRIPTION
## Motivation

A follow-up of PR #6793 (merged) and on top of #7269 (open)
- Add is_ipc_non_mpi() branches for all 8 P2P sync host methods - test, wait_until, and the _all/_any/_some/_vector variants

## Technical Details

## JIRA ID
AIROCSHMEM-419

## Test Plan

Added relevant tests to the host_rma_tester

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
