### PR TITLE
[rocprofiler-compute] Fix stale pmc perf bypassing kernel filtering

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_base.py
@@ -73,6 +73,16 @@ def test_df_column_equality(df: pd.DataFrame) -> bool:
     return df.eq(df.iloc[:, 0], axis=0).all(1).all()
 
 
+def _pmc_perf_is_current(pmc_perf: Path, results_files: list[Path]) -> bool:
+    """Return True if pmc_perf.csv can be reused (no newer results_*.csv)."""
+    if not pmc_perf.exists():
+        return False
+    if not results_files:
+        return True
+    newest_results_mtime = max(file.stat().st_mtime for file in results_files)
+    return pmc_perf.stat().st_mtime >= newest_results_mtime
+
+
 class OmniAnalyze_Base:
     def __init__(
         self, args: argparse.Namespace, supported_archs: dict[str, str]
@@ -700,7 +710,7 @@ class OmniAnalyze_Base:
             pmc_perf = directory / "pmc_perf.csv"
             results_files = list(directory.glob("results_*.csv"))
 
-            if pmc_perf.exists():
+            if _pmc_perf_is_current(pmc_perf, results_files):
                 console_debug(f"Using existing {pmc_perf}")
             elif results_files:
                 console_log(f"Joining results_*.csv for {directory}...")

--- a/projects/rocprofiler-compute/tests/test_analyze_commands.py
+++ b/projects/rocprofiler-compute/tests/test_analyze_commands.py
@@ -2185,3 +2185,30 @@ def test_join_prof_renames_sq_accum_prev_hires_to_bucket_target(tmp_path):
     assert "SQ_ACCUM_PREV_HIRES" not in merged.columns
     assert set(merged["SQ_LEVEL_WAVES_ACCUM"].tolist()) == {100, 200}
     assert "SQ_WAVES" in merged.columns
+
+
+def test_pmc_perf_is_current_detects_stale_join(tmp_path):
+    """pmc_perf.csv must be treated as stale when a results_*.csv is newer.
+    """
+    from rocprof_compute_analyze.analysis_base import _pmc_perf_is_current
+
+    pmc_perf = tmp_path / "pmc_perf.csv"
+    results_file = tmp_path / "results_pmc_perf_0.csv"
+
+    # No pmc_perf.csv so we must rejoin.
+    assert _pmc_perf_is_current(pmc_perf, [results_file]) is False
+
+    # pmc_perf.csv exists and no results, reuse (deprecated direct path).
+    pmc_perf.write_text("a,b\n1,2\n")
+    assert _pmc_perf_is_current(pmc_perf, []) is True
+
+    # pmc_perf.csv newer than results, reuse.
+    results_file.write_text("a,b\n3,4\n")
+    os.utime(results_file, (1000, 1000))
+    os.utime(pmc_perf, (2000, 2000))
+    assert _pmc_perf_is_current(pmc_perf, [results_file]) is True
+
+    # results newer than pmc_perf.csv, stale, must rejoin.
+    os.utime(pmc_perf, (1000, 1000))
+    os.utime(results_file, (2000, 2000))
+    assert _pmc_perf_is_current(pmc_perf, [results_file]) is False


### PR DESCRIPTION
## Motivation

Roofline charts silently ignored kernel filtering after a re-profile into an already analyzed workload dir. 
For example, `profile` -> `analyze` -> `profile --roof-only -k <kernel>` -> `analyze` produced a roofline containing *all* kernels instead of the selected one with no error or warning. 
This made `--roof-only -k` effectively unusable in the normal workflow where the full run is analyzed first

## Technical Details

Root cause is that `join_workload_csvs()` in `src/rocprof_compute_analyze/analysis_base.py` reused any existing `pmc_perf.csv` unconditionally. A reprofile rewrites the per-pass `results_*.csv` just fine, but the stale `pmc_perf.csv` (left behind by the earlier `analyze`) was reused so the kernel-top table kept every kernel and `calc_ai_analyze()` fell back to plotting all of them unfiltered.

Fix is to only reuse `pmc_perf.csv` when it is at least as new as every `results_*.csv`, otherwise rejoin them. I added a small helper for this, everything in the rest of the analyze pipeline is preserved

## JIRA ID

AIPROFCOMP-253

## Test Plan

- Added unit test in `tests/test_analyze_commands.py` covering the following cases: 
   - missing `pmc_perf.csv`, 
   - no `results_*.csv`, 
   - `pmc_perf.csv` newer or same "age" than `results_*.csv` (basically just regular profile into analyze timeline), and 
   - `results_*.csv` newer than `pmc_perf.csv` (stale pmc perf).
- Ran the full `tests/test_analyze_commands.py` suite and `ruff check`
- Tested the origional repro on MI350 (`tests/occupancy`, filtering on `vgprbound`):
  - `profile → analyze → profile --roof-only -k vgprbound → analyze`
  - `profile --roof-only → analyze → profile --roof-only -k vgprbound → analyze`
  - Also ran regular re-analyze with no new profiling.

## Test Result

- All tests in `test_analyze_commands.py` pass (including the new test) pass, ruff clean.
- Both previously failing scenarios now rejoin and report 1 kernel (`vgprbound`) instead of 4 which is expected
- Control case still reports `Using existing pmc_perf.csv` with no needless rejoin

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.