### PR TITLE
[rocjitsu] Add gfx1250 cluster load multicast

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -3972,13 +3972,23 @@ class CodeGenerator:
         L.append('  auto &cu = wf.cu();')
         L.append('  const auto &lds = cu.lds();')
         L.append('  uint64_t exec = wf.exec();')
+        L.append(
+            '  // VGLOBAL async-from-LDS applies ioffset to both destination and LDS source.'
+        )
+        L.append(
+            '  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);'
+        )
         L.append(f"  uint32_t lds_addr_base = {self._vgpr_base_expr('vsrc')};")
         L.append(f'  d->store_data.resize(wf.wf_size() * {stride});')
         L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
         L.append('    if (!(exec & (1ULL << lane))) continue;')
         L.append(
-            '    uint32_t lds_addr = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);'
+            '    uint32_t lds_addr = static_cast<uint32_t>(static_cast<int64_t>(wf.lds_base()) +'
         )
+        L.append(
+            '                                           static_cast<int64_t>(cu.read_vgpr(lds_addr_base, lane)) +'
+        )
+        L.append('                                           lds_offset);')
         L.append(f'    lds.read(lds_addr, &d->store_data[lane * {stride}], {stride});')
         L.append('  }')
         L.append('  set_data(std::move(d));')

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -3852,6 +3852,8 @@ class CodeGenerator:
             L.append(f'  d->transpose = {sem.transpose_kind};')
         L.append(f'  d->mtype = {self._mtype_expr()};')
         L.append(f'  d->non_temporal = {nt};')
+        if sem.name.startswith('CLUSTER_LOAD_'):
+            L.append('  d->request_force_l1_bypass = true;')
         L.append('  flat_calculate_addresses(inst_, wf, *d);')
         L.append('  set_data(std::move(d));')
         return '\n'.join(L)
@@ -3927,27 +3929,20 @@ class CodeGenerator:
             L.append(
                 '  d->cluster_mcast_mask = wf.m0() & amdgpu::kClusterMulticastMask;'
             )
+            L.append('  d->request_force_l1_bypass = true;')
         L.append(f'  d->mtype = {self._mtype_expr()};')
         L.append(f'  d->non_temporal = {nt};')
         L.append('  flat_calculate_addresses(inst_, wf, *d);')
         L.append('  auto &cu = wf.cu();')
         L.append('  uint64_t exec = wf.exec();')
         L.append(
-            '  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.'
-        )
-        L.append(
-            '  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);'
+            '  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.'
         )
         L.append(f"  uint32_t lds_addr_base = {self._vgpr_base_expr('vdst')};")
         L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
         L.append('    if (!(exec & (1ULL << lane))) continue;')
         L.append('    uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);')
-        L.append(
-            '    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(static_cast<int64_t>(wf.lds_base()) +'
-        )
-        L.append(
-            '                                            static_cast<int64_t>(lane_lds_addr) + lds_offset);'
-        )
+        L.append('    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;')
         L.append('  }')
         L.append('  set_data(std::move(d));')
         return '\n'.join(L)
@@ -3973,22 +3968,15 @@ class CodeGenerator:
         L.append('  const auto &lds = cu.lds();')
         L.append('  uint64_t exec = wf.exec();')
         L.append(
-            '  // VGLOBAL async-from-LDS applies ioffset to both destination and LDS source.'
-        )
-        L.append(
-            '  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);'
+            '  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.'
         )
         L.append(f"  uint32_t lds_addr_base = {self._vgpr_base_expr('vsrc')};")
         L.append(f'  d->store_data.resize(wf.wf_size() * {stride});')
         L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
         L.append('    if (!(exec & (1ULL << lane))) continue;')
         L.append(
-            '    uint32_t lds_addr = static_cast<uint32_t>(static_cast<int64_t>(wf.lds_base()) +'
+            '    uint32_t lds_addr = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);'
         )
-        L.append(
-            '                                           static_cast<int64_t>(cu.read_vgpr(lds_addr_base, lane)) +'
-        )
-        L.append('                                           lds_offset);')
         L.append(f'    lds.read(lds_addr, &d->store_data[lane * {stride}], {stride});')
         L.append('  }')
         L.append('  set_data(std::move(d));')

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -3921,16 +3921,32 @@ class CodeGenerator:
         self._append_wait_counter_type(L, 'global_load_async_to_lds')
         L.append('  d->lds_dst = true;')
         L.append('  d->lds_per_lane_addr = true;')
+        L.append('  d->lds_base = wf.lds_base();')
+        if sem.name.startswith('CLUSTER_LOAD_ASYNC_TO_LDS_'):
+            L.append('  d->cluster_multicast = true;')
+            L.append(
+                '  d->cluster_mcast_mask = wf.m0() & amdgpu::kClusterMulticastMask;'
+            )
         L.append(f'  d->mtype = {self._mtype_expr()};')
         L.append(f'  d->non_temporal = {nt};')
         L.append('  flat_calculate_addresses(inst_, wf, *d);')
         L.append('  auto &cu = wf.cu();')
         L.append('  uint64_t exec = wf.exec();')
+        L.append(
+            '  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.'
+        )
+        L.append(
+            '  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);'
+        )
         L.append(f"  uint32_t lds_addr_base = {self._vgpr_base_expr('vdst')};")
         L.append('  for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {')
         L.append('    if (!(exec & (1ULL << lane))) continue;')
+        L.append('    uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);')
         L.append(
-            '    d->per_lane_lds_addr[lane] = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);'
+            '    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(static_cast<int64_t>(wf.lds_base()) +'
+        )
+        L.append(
+            '                                            static_cast<int64_t>(lane_lds_addr) + lds_offset);'
         )
         L.append('  }')
         L.append('  set_data(std::move(d));')

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_generator_profile_gates.py
@@ -1176,6 +1176,52 @@ def test_gfx1250_flat_u64_atomic_payload_width_uses_two_dwords():
     assert 'data_base + 1' in body
 
 
+def test_gfx1250_cluster_load_generators_force_request_l1_bypass():
+    codegen = object.__new__(CodeGenerator)
+    codegen.isa_spec = SimpleNamespace(
+        arch_name='gfx1250',
+        profile=Gfx1250Profile(),
+    )
+
+    cluster = SimpleNamespace(
+        name='CLUSTER_LOAD_B32',
+        elem_size=4,
+        num_elems=1,
+        sign_extend=False,
+        d16_hi=False,
+        d16_lo=False,
+    )
+    ordinary = SimpleNamespace(
+        name='GLOBAL_LOAD_B32',
+        elem_size=4,
+        num_elems=1,
+        sign_extend=False,
+        d16_hi=False,
+        d16_lo=False,
+    )
+    cluster_body = codegen._gen_flat_load([], [], cluster)
+    ordinary_body = codegen._gen_flat_load([], [], ordinary)
+
+    assert 'd->request_force_l1_bypass = true;' in cluster_body
+    assert 'd->request_force_l1_bypass = true;' not in ordinary_body
+
+    cluster_async = SimpleNamespace(
+        name='CLUSTER_LOAD_ASYNC_TO_LDS_B32',
+        elem_size=4,
+        num_elems=1,
+    )
+    global_async = SimpleNamespace(
+        name='GLOBAL_LOAD_ASYNC_TO_LDS_B32',
+        elem_size=4,
+        num_elems=1,
+    )
+    cluster_async_body = codegen._gen_global_load_async_to_lds([], [], cluster_async)
+    global_async_body = codegen._gen_global_load_async_to_lds([], [], global_async)
+
+    assert 'd->request_force_l1_bypass = true;' in cluster_async_body
+    assert 'd->request_force_l1_bypass = true;' not in global_async_body
+
+
 def test_gfx1250_buffer_cmpswap_payload_width_is_independent_of_element_width():
     codegen = object.__new__(CodeGenerator)
     codegen.isa_spec = SimpleNamespace(

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vglobal.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vglobal.cpp
@@ -2899,8 +2899,7 @@ void GlobalLoadAsyncToLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
-  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
+  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -2908,8 +2907,7 @@ void GlobalLoadAsyncToLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
-        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
+    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
   }
   set_data(std::move(d));
 }
@@ -2944,8 +2942,7 @@ void GlobalLoadAsyncToLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
-  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
+  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -2953,8 +2950,7 @@ void GlobalLoadAsyncToLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
-        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
+    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
   }
   set_data(std::move(d));
 }
@@ -2989,8 +2985,7 @@ void GlobalLoadAsyncToLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
-  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
+  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -2998,8 +2993,7 @@ void GlobalLoadAsyncToLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
-        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
+    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
   }
   set_data(std::move(d));
 }
@@ -3034,8 +3028,7 @@ void GlobalLoadAsyncToLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
-  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
+  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -3043,8 +3036,7 @@ void GlobalLoadAsyncToLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
-        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
+    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
   }
   set_data(std::move(d));
 }
@@ -3077,8 +3069,7 @@ void GlobalStoreAsyncFromLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   auto &cu = wf.cu();
   const auto &lds = cu.lds();
   uint64_t exec = wf.exec();
-  // VGLOBAL async-from-LDS applies ioffset to both destination and LDS source.
-  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
+  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vsrc.opr_type_, vsrc.encoding_value_, vsrc.vgpr_msb_role());
@@ -3086,9 +3077,7 @@ void GlobalStoreAsyncFromLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t lds_addr =
-        static_cast<uint32_t>(static_cast<int64_t>(wf.lds_base()) +
-                              static_cast<int64_t>(cu.read_vgpr(lds_addr_base, lane)) + lds_offset);
+    uint32_t lds_addr = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
     lds.read(lds_addr, &d->store_data[lane * 1], 1);
   }
   set_data(std::move(d));
@@ -3122,8 +3111,7 @@ void GlobalStoreAsyncFromLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   auto &cu = wf.cu();
   const auto &lds = cu.lds();
   uint64_t exec = wf.exec();
-  // VGLOBAL async-from-LDS applies ioffset to both destination and LDS source.
-  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
+  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vsrc.opr_type_, vsrc.encoding_value_, vsrc.vgpr_msb_role());
@@ -3131,9 +3119,7 @@ void GlobalStoreAsyncFromLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t lds_addr =
-        static_cast<uint32_t>(static_cast<int64_t>(wf.lds_base()) +
-                              static_cast<int64_t>(cu.read_vgpr(lds_addr_base, lane)) + lds_offset);
+    uint32_t lds_addr = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
     lds.read(lds_addr, &d->store_data[lane * 4], 4);
   }
   set_data(std::move(d));
@@ -3167,8 +3153,7 @@ void GlobalStoreAsyncFromLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   auto &cu = wf.cu();
   const auto &lds = cu.lds();
   uint64_t exec = wf.exec();
-  // VGLOBAL async-from-LDS applies ioffset to both destination and LDS source.
-  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
+  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vsrc.opr_type_, vsrc.encoding_value_, vsrc.vgpr_msb_role());
@@ -3176,9 +3161,7 @@ void GlobalStoreAsyncFromLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t lds_addr =
-        static_cast<uint32_t>(static_cast<int64_t>(wf.lds_base()) +
-                              static_cast<int64_t>(cu.read_vgpr(lds_addr_base, lane)) + lds_offset);
+    uint32_t lds_addr = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
     lds.read(lds_addr, &d->store_data[lane * 8], 8);
   }
   set_data(std::move(d));
@@ -3212,8 +3195,7 @@ void GlobalStoreAsyncFromLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   auto &cu = wf.cu();
   const auto &lds = cu.lds();
   uint64_t exec = wf.exec();
-  // VGLOBAL async-from-LDS applies ioffset to both destination and LDS source.
-  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
+  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vsrc.opr_type_, vsrc.encoding_value_, vsrc.vgpr_msb_role());
@@ -3221,9 +3203,7 @@ void GlobalStoreAsyncFromLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t lds_addr =
-        static_cast<uint32_t>(static_cast<int64_t>(wf.lds_base()) +
-                              static_cast<int64_t>(cu.read_vgpr(lds_addr_base, lane)) + lds_offset);
+    uint32_t lds_addr = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
     lds.read(lds_addr, &d->store_data[lane * 16], 16);
   }
   set_data(std::move(d));
@@ -3256,6 +3236,7 @@ void ClusterLoadB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LOADCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
+  d->request_force_l1_bypass = true;
   flat_calculate_addresses(inst_, wf, *d);
   set_data(std::move(d));
 }
@@ -3287,6 +3268,7 @@ void ClusterLoadB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LOADCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
+  d->request_force_l1_bypass = true;
   flat_calculate_addresses(inst_, wf, *d);
   set_data(std::move(d));
 }
@@ -3318,6 +3300,7 @@ void ClusterLoadB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::LOADCNT;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
+  d->request_force_l1_bypass = true;
   flat_calculate_addresses(inst_, wf, *d);
   set_data(std::move(d));
 }
@@ -3349,13 +3332,13 @@ void ClusterLoadAsyncToLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->lds_base = wf.lds_base();
   d->cluster_multicast = true;
   d->cluster_mcast_mask = wf.m0() & amdgpu::kClusterMulticastMask;
+  d->request_force_l1_bypass = true;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
-  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
+  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -3363,8 +3346,7 @@ void ClusterLoadAsyncToLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
-        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
+    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
   }
   set_data(std::move(d));
 }
@@ -3396,13 +3378,13 @@ void ClusterLoadAsyncToLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->lds_base = wf.lds_base();
   d->cluster_multicast = true;
   d->cluster_mcast_mask = wf.m0() & amdgpu::kClusterMulticastMask;
+  d->request_force_l1_bypass = true;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
-  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
+  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -3410,8 +3392,7 @@ void ClusterLoadAsyncToLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
-        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
+    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
   }
   set_data(std::move(d));
 }
@@ -3443,13 +3424,13 @@ void ClusterLoadAsyncToLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->lds_base = wf.lds_base();
   d->cluster_multicast = true;
   d->cluster_mcast_mask = wf.m0() & amdgpu::kClusterMulticastMask;
+  d->request_force_l1_bypass = true;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
-  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
+  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -3457,8 +3438,7 @@ void ClusterLoadAsyncToLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
-        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
+    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
   }
   set_data(std::move(d));
 }
@@ -3490,13 +3470,13 @@ void ClusterLoadAsyncToLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->lds_base = wf.lds_base();
   d->cluster_multicast = true;
   d->cluster_mcast_mask = wf.m0() & amdgpu::kClusterMulticastMask;
+  d->request_force_l1_bypass = true;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
-  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
-  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
+  // flat_calculate_addresses applies ioffset to the global side; the LDS operand is independent.
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
@@ -3504,8 +3484,7 @@ void ClusterLoadAsyncToLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
-    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
-        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
+    d->per_lane_lds_addr[lane] = wf.lds_base() + lane_lds_addr;
   }
   set_data(std::move(d));
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vglobal.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vglobal.cpp
@@ -3077,6 +3077,8 @@ void GlobalStoreAsyncFromLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   auto &cu = wf.cu();
   const auto &lds = cu.lds();
   uint64_t exec = wf.exec();
+  // VGLOBAL async-from-LDS applies ioffset to both destination and LDS source.
+  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vsrc.opr_type_, vsrc.encoding_value_, vsrc.vgpr_msb_role());
@@ -3084,7 +3086,9 @@ void GlobalStoreAsyncFromLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t lds_addr = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
+    uint32_t lds_addr =
+        static_cast<uint32_t>(static_cast<int64_t>(wf.lds_base()) +
+                              static_cast<int64_t>(cu.read_vgpr(lds_addr_base, lane)) + lds_offset);
     lds.read(lds_addr, &d->store_data[lane * 1], 1);
   }
   set_data(std::move(d));
@@ -3118,6 +3122,8 @@ void GlobalStoreAsyncFromLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   auto &cu = wf.cu();
   const auto &lds = cu.lds();
   uint64_t exec = wf.exec();
+  // VGLOBAL async-from-LDS applies ioffset to both destination and LDS source.
+  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vsrc.opr_type_, vsrc.encoding_value_, vsrc.vgpr_msb_role());
@@ -3125,7 +3131,9 @@ void GlobalStoreAsyncFromLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t lds_addr = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
+    uint32_t lds_addr =
+        static_cast<uint32_t>(static_cast<int64_t>(wf.lds_base()) +
+                              static_cast<int64_t>(cu.read_vgpr(lds_addr_base, lane)) + lds_offset);
     lds.read(lds_addr, &d->store_data[lane * 4], 4);
   }
   set_data(std::move(d));
@@ -3159,6 +3167,8 @@ void GlobalStoreAsyncFromLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   auto &cu = wf.cu();
   const auto &lds = cu.lds();
   uint64_t exec = wf.exec();
+  // VGLOBAL async-from-LDS applies ioffset to both destination and LDS source.
+  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vsrc.opr_type_, vsrc.encoding_value_, vsrc.vgpr_msb_role());
@@ -3166,7 +3176,9 @@ void GlobalStoreAsyncFromLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t lds_addr = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
+    uint32_t lds_addr =
+        static_cast<uint32_t>(static_cast<int64_t>(wf.lds_base()) +
+                              static_cast<int64_t>(cu.read_vgpr(lds_addr_base, lane)) + lds_offset);
     lds.read(lds_addr, &d->store_data[lane * 8], 8);
   }
   set_data(std::move(d));
@@ -3200,6 +3212,8 @@ void GlobalStoreAsyncFromLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   auto &cu = wf.cu();
   const auto &lds = cu.lds();
   uint64_t exec = wf.exec();
+  // VGLOBAL async-from-LDS applies ioffset to both destination and LDS source.
+  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vsrc.opr_type_, vsrc.encoding_value_, vsrc.vgpr_msb_role());
@@ -3207,7 +3221,9 @@ void GlobalStoreAsyncFromLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint32_t lds_addr = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
+    uint32_t lds_addr =
+        static_cast<uint32_t>(static_cast<int64_t>(wf.lds_base()) +
+                              static_cast<int64_t>(cu.read_vgpr(lds_addr_base, lane)) + lds_offset);
     lds.read(lds_addr, &d->store_data[lane * 16], 16);
   }
   set_data(std::move(d));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vglobal.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vglobal.cpp
@@ -2893,18 +2893,23 @@ void GlobalLoadAsyncToLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::ASYNCCNT;
   d->lds_dst = true;
   d->lds_per_lane_addr = true;
+  d->lds_base = wf.lds_base();
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
+  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
+  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    d->per_lane_lds_addr[lane] = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
+    uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
+    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
+        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
   }
   set_data(std::move(d));
 }
@@ -2933,18 +2938,23 @@ void GlobalLoadAsyncToLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::ASYNCCNT;
   d->lds_dst = true;
   d->lds_per_lane_addr = true;
+  d->lds_base = wf.lds_base();
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
+  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
+  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    d->per_lane_lds_addr[lane] = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
+    uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
+    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
+        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
   }
   set_data(std::move(d));
 }
@@ -2973,18 +2983,23 @@ void GlobalLoadAsyncToLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::ASYNCCNT;
   d->lds_dst = true;
   d->lds_per_lane_addr = true;
+  d->lds_base = wf.lds_base();
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
+  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
+  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    d->per_lane_lds_addr[lane] = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
+    uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
+    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
+        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
   }
   set_data(std::move(d));
 }
@@ -3013,18 +3028,23 @@ void GlobalLoadAsyncToLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::ASYNCCNT;
   d->lds_dst = true;
   d->lds_per_lane_addr = true;
+  d->lds_base = wf.lds_base();
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
+  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
+  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    d->per_lane_lds_addr[lane] = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
+    uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
+    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
+        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
   }
   set_data(std::move(d));
 }
@@ -3310,18 +3330,25 @@ void ClusterLoadAsyncToLdsB8Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::ASYNCCNT;
   d->lds_dst = true;
   d->lds_per_lane_addr = true;
+  d->lds_base = wf.lds_base();
+  d->cluster_multicast = true;
+  d->cluster_mcast_mask = wf.m0() & amdgpu::kClusterMulticastMask;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
+  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
+  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    d->per_lane_lds_addr[lane] = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
+    uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
+    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
+        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
   }
   set_data(std::move(d));
 }
@@ -3350,18 +3377,25 @@ void ClusterLoadAsyncToLdsB32Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::ASYNCCNT;
   d->lds_dst = true;
   d->lds_per_lane_addr = true;
+  d->lds_base = wf.lds_base();
+  d->cluster_multicast = true;
+  d->cluster_mcast_mask = wf.m0() & amdgpu::kClusterMulticastMask;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
+  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
+  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    d->per_lane_lds_addr[lane] = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
+    uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
+    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
+        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
   }
   set_data(std::move(d));
 }
@@ -3390,18 +3424,25 @@ void ClusterLoadAsyncToLdsB64Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::ASYNCCNT;
   d->lds_dst = true;
   d->lds_per_lane_addr = true;
+  d->lds_base = wf.lds_base();
+  d->cluster_multicast = true;
+  d->cluster_mcast_mask = wf.m0() & amdgpu::kClusterMulticastMask;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
+  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
+  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    d->per_lane_lds_addr[lane] = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
+    uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
+    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
+        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
   }
   set_data(std::move(d));
 }
@@ -3430,18 +3471,25 @@ void ClusterLoadAsyncToLdsB128Vglobal::execute_impl(amdgpu::Wavefront &wf) {
   d->wait_counter_type = amdgpu::WaitCounterType::ASYNCCNT;
   d->lds_dst = true;
   d->lds_per_lane_addr = true;
+  d->lds_base = wf.lds_base();
+  d->cluster_multicast = true;
+  d->cluster_mcast_mask = wf.m0() & amdgpu::kClusterMulticastMask;
   d->mtype = amdgpu::mtype_from_flags_gfx12(inst_.scope, inst_.th);
   d->non_temporal = 0;
   flat_calculate_addresses(inst_, wf, *d);
   auto &cu = wf.cu();
   uint64_t exec = wf.exec();
+  // VGLOBAL async-to-LDS applies ioffset to both source and LDS destination.
+  int64_t lds_offset = static_cast<int64_t>(static_cast<int32_t>(inst_.ioffset << 8) >> 8);
   uint32_t lds_addr_base =
       wf.vgpr_alloc().base +
       *Isa::resolved_vgpr_offset(wf, vdst.opr_type_, vdst.encoding_value_, vdst.vgpr_msb_role());
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    d->per_lane_lds_addr[lane] = wf.lds_base() + cu.read_vgpr(lds_addr_base, lane);
+    uint32_t lane_lds_addr = cu.read_vgpr(lds_addr_base, lane);
+    d->per_lane_lds_addr[lane] = static_cast<uint32_t>(
+        static_cast<int64_t>(wf.lds_base()) + static_cast<int64_t>(lane_lds_addr) + lds_offset);
   }
   set_data(std::move(d));
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 rj_add_object_library(rocjitsu_vm_amdgpu
     wavefront.cpp
+    cluster_lds_multicast.cpp
     compute_unit.cpp
     memory_pipeline.cpp
     command_processor.cpp

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/amd_ext_aql_packet.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/amd_ext_aql_packet.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_VM_AMDGPU_AMD_EXT_AQL_PACKET_H_
+#define ROCJITSU_VM_AMDGPU_AMD_EXT_AQL_PACKET_H_
+
+#ifndef HSA_LARGE_MODEL
+#define HSA_LARGE_MODEL 1
+#endif
+
+#include "rocjitsu/base/rj_compiler.h"
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "hsa/hsa.h"
+RJ_DIAGNOSTIC_POP
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace rocjitsu::amdgpu {
+
+constexpr uint8_t kHsaAmdPacketTypeExtKernelDispatch = 3;
+
+struct AmdExtKernelDispatchPacket {
+  uint16_t header;
+  uint8_t amd_format;
+  uint8_t setup;
+  uint16_t workgroup_size_x;
+  uint16_t workgroup_size_y;
+  uint16_t workgroup_size_z;
+  uint16_t reserved0;
+  uint32_t cluster_count_x;
+  uint16_t cluster_count_y;
+  uint16_t cluster_count_z;
+  uint8_t cluster_size_x;
+  uint8_t cluster_size_y;
+  uint8_t cluster_size_z;
+  uint8_t perf_hint;
+  uint32_t private_segment_size;
+  uint32_t group_segment_size;
+  uint64_t kernel_object;
+  void *kernarg_address;
+  hsa_signal_t dep_signal;
+  hsa_signal_t completion_signal;
+};
+
+static_assert(std::is_trivially_copyable_v<AmdExtKernelDispatchPacket>);
+static_assert(sizeof(AmdExtKernelDispatchPacket) == 64);
+static_assert(offsetof(AmdExtKernelDispatchPacket, cluster_count_x) == 12);
+static_assert(offsetof(AmdExtKernelDispatchPacket, cluster_size_x) == 20);
+static_assert(offsetof(AmdExtKernelDispatchPacket, private_segment_size) == 24);
+static_assert(offsetof(AmdExtKernelDispatchPacket, group_segment_size) == 28);
+static_assert(offsetof(AmdExtKernelDispatchPacket, kernel_object) == 32);
+static_assert(offsetof(AmdExtKernelDispatchPacket, kernarg_address) == 40);
+static_assert(offsetof(AmdExtKernelDispatchPacket, dep_signal) == 48);
+static_assert(offsetof(AmdExtKernelDispatchPacket, completion_signal) == 56);
+
+} // namespace rocjitsu::amdgpu
+
+#endif // ROCJITSU_VM_AMDGPU_AMD_EXT_AQL_PACKET_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/amd_ext_aql_packet.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/amd_ext_aql_packet.h
@@ -20,8 +20,14 @@ RJ_DIAGNOSTIC_POP
 
 namespace rocjitsu::amdgpu {
 
+/// AMD vendor-specific packet format selector for extended kernel dispatch.
 constexpr uint8_t kHsaAmdPacketTypeExtKernelDispatch = 3;
 
+/// @brief AMD vendor-specific extended kernel dispatch packet layout.
+///
+/// @details This mirrors the 64-byte wire packet consumed from an AQL ring for
+/// clustered dispatch. Keep the field order and size stable; tests and runtime
+/// queue code copy this type directly into packet slots.
 struct AmdExtKernelDispatchPacket {
   uint16_t header;
   uint8_t amd_format;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.cpp
@@ -8,6 +8,7 @@
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <format>
@@ -16,6 +17,37 @@
 
 namespace rocjitsu {
 namespace amdgpu {
+
+namespace {
+
+void write_cluster_lds_target(const ClusterLdsMulticastTransaction &txn,
+                              const ClusterLdsTarget &target) {
+  if (!target.cu)
+    return;
+
+  auto &lds = target.cu->lds();
+  for (uint32_t lane = 0; lane < txn.wf_size; ++lane) {
+    if ((txn.lane_mask & (1ULL << lane)) == 0)
+      continue;
+    uint32_t data_offset = lane * txn.bytes_per_lane;
+    if (data_offset + txn.bytes_per_lane > txn.payload.size()) {
+      throw std::runtime_error(std::format(
+          "cluster LDS multicast payload too small: lane={} offset={} bytes={} payload={}", lane,
+          data_offset, txn.bytes_per_lane, txn.payload.size()));
+    }
+    uint32_t lds_addr = cluster_lds_lane_addr(txn, lane, target.lds_base);
+    if (uint64_t(lds_addr) + txn.bytes_per_lane > lds.size_bytes()) {
+      throw std::runtime_error(std::format(
+          "cluster LDS multicast target address out of range: lane={} target_wg={} addr={:#x} "
+          "bytes={} lds_size={}",
+          lane, target.wg_id, lds_addr, txn.bytes_per_lane, lds.size_bytes()));
+    }
+    for (uint32_t b = 0; b < txn.bytes_per_lane; ++b)
+      lds.write8(lds_addr + b, txn.payload[data_offset + b]);
+  }
+}
+
+} // namespace
 
 uint32_t remap_cluster_lds_addr(uint32_t source_lds_base, uint32_t target_lds_base,
                                 uint32_t source_lds_addr) {
@@ -51,39 +83,30 @@ make_cluster_lds_multicast_transaction(VectorMemState &state, const Wavefront &w
   txn.wf_size = state.wf_size;
   txn.lane_mask = state.lane_mask;
   txn.per_lane_addr = state.lds_per_lane_addr;
+  txn.per_lane_global_addr = state.per_lane_addr;
   txn.per_lane_lds_addr = state.per_lane_lds_addr;
   txn.payload = std::move(state.response_data);
   txn.targets = std::move(targets);
   return txn;
 }
 
+bool cluster_lds_source_rank_selected(const ClusterLdsMulticastTransaction &txn) {
+  return txn.mcast_mask == 0 ||
+         (txn.mcast_mask & cluster_multicast_rank_mask(txn.source_cluster_rank)) != 0;
+}
+
 ClusterLdsMulticastResult
 ImmediateClusterLdsMulticastEngine::submit(ClusterLdsMulticastTransaction txn,
                                            ClusterLdsMulticastCompletion /*complete*/) {
-  for (const auto &target : txn.targets) {
-    if (!target.cu)
-      continue;
-    auto &lds = target.cu->lds();
-    for (uint32_t lane = 0; lane < txn.wf_size; ++lane) {
-      if ((txn.lane_mask & (1ULL << lane)) == 0)
-        continue;
-      uint32_t data_offset = lane * txn.bytes_per_lane;
-      if (data_offset + txn.bytes_per_lane > txn.payload.size()) {
-        throw std::runtime_error(std::format(
-            "cluster LDS multicast payload too small: lane={} offset={} bytes={} payload={}", lane,
-            data_offset, txn.bytes_per_lane, txn.payload.size()));
-      }
-      uint32_t lds_addr = cluster_lds_lane_addr(txn, lane, target.lds_base);
-      if (uint64_t(lds_addr) + txn.bytes_per_lane > lds.size_bytes()) {
-        throw std::runtime_error(std::format(
-            "cluster LDS multicast target address out of range: lane={} target_wg={} addr={:#x} "
-            "bytes={} lds_size={}",
-            lane, target.wg_id, lds_addr, txn.bytes_per_lane, lds.size_bytes()));
-      }
-      for (uint32_t b = 0; b < txn.bytes_per_lane; ++b)
-        lds.write8(lds_addr + b, txn.payload[data_offset + b]);
-    }
-  }
+  if (!cluster_lds_source_rank_selected(txn))
+    return ClusterLdsMulticastResult::Complete;
+
+  auto target_it = std::find_if(txn.targets.begin(), txn.targets.end(), [&](const auto &target) {
+    return target.wg_id == txn.source_wg_id && target.cluster_rank == txn.source_cluster_rank;
+  });
+
+  if (target_it != txn.targets.end())
+    write_cluster_lds_target(txn, *target_it);
   return ClusterLdsMulticastResult::Complete;
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#include "rocjitsu/vm/amdgpu/cluster_lds_multicast.h"
+
+#include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/lds.h"
+#include "rocjitsu/vm/amdgpu/mem_state.h"
+#include "rocjitsu/vm/amdgpu/wavefront.h"
+
+#include <format>
+#include <stdexcept>
+#include <utility>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+uint32_t remap_cluster_lds_addr(uint32_t source_lds_base, uint32_t target_lds_base,
+                                uint32_t source_lds_addr) {
+  if (source_lds_addr < source_lds_base) {
+    throw std::runtime_error(std::format("cluster LDS source address {:#x} precedes base {:#x}",
+                                         source_lds_addr, source_lds_base));
+  }
+  return target_lds_base + (source_lds_addr - source_lds_base);
+}
+
+uint32_t cluster_lds_lane_addr(const ClusterLdsMulticastTransaction &txn, uint32_t lane,
+                               uint32_t target_lds_base) {
+  uint32_t source_lds_addr = txn.source_lds_base + lane * txn.bytes_per_lane;
+  if (txn.per_lane_addr)
+    source_lds_addr = txn.per_lane_lds_addr[lane];
+  return remap_cluster_lds_addr(txn.source_lds_base, target_lds_base, source_lds_addr);
+}
+
+ClusterLdsMulticastTransaction
+make_cluster_lds_multicast_transaction(const VectorMemState &state, const Wavefront &wf,
+                                       std::vector<ClusterLdsTarget> targets) {
+  ClusterLdsMulticastTransaction txn{};
+  txn.dispatch_id = wf.dispatch_id();
+  txn.source_wg_id = wf.wg_id();
+  txn.source_cluster_rank = wf.cluster_rank();
+  txn.source_lds_base = state.lds_base;
+  txn.mcast_mask = state.cluster_mcast_mask;
+  txn.wait_counter_type = state.wait_counter_type;
+  txn.bytes_per_lane = state.num_elems * state.elem_size;
+  txn.wf_size = state.wf_size;
+  txn.lane_mask = state.lane_mask;
+  txn.per_lane_addr = state.lds_per_lane_addr;
+  txn.per_lane_lds_addr = state.per_lane_lds_addr;
+  txn.payload = state.response_data;
+  txn.targets = std::move(targets);
+  return txn;
+}
+
+ClusterLdsMulticastResult
+ImmediateClusterLdsMulticastEngine::submit(ClusterLdsMulticastTransaction txn,
+                                           ClusterLdsMulticastCompletion /*complete*/) {
+  for (const auto &target : txn.targets) {
+    if (!target.cu)
+      continue;
+    auto &lds = target.cu->lds();
+    for (uint32_t lane = 0; lane < txn.wf_size; ++lane) {
+      if ((txn.lane_mask & (1ULL << lane)) == 0)
+        continue;
+      uint32_t data_offset = lane * txn.bytes_per_lane;
+      if (data_offset + txn.bytes_per_lane > txn.payload.size()) {
+        throw std::runtime_error(std::format(
+            "cluster LDS multicast payload too small: lane={} offset={} bytes={} payload={}", lane,
+            data_offset, txn.bytes_per_lane, txn.payload.size()));
+      }
+      uint32_t lds_addr = cluster_lds_lane_addr(txn, lane, target.lds_base);
+      for (uint32_t b = 0; b < txn.bytes_per_lane; ++b)
+        lds.write8(lds_addr + b, txn.payload[data_offset + b]);
+    }
+  }
+  return ClusterLdsMulticastResult::Complete;
+}
+
+} // namespace amdgpu
+} // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.cpp
@@ -8,6 +8,8 @@
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 
+#include <cassert>
+#include <cstdint>
 #include <format>
 #include <stdexcept>
 #include <utility>
@@ -33,8 +35,11 @@ uint32_t cluster_lds_lane_addr(const ClusterLdsMulticastTransaction &txn, uint32
 }
 
 ClusterLdsMulticastTransaction
-make_cluster_lds_multicast_transaction(const VectorMemState &state, const Wavefront &wf,
+make_cluster_lds_multicast_transaction(VectorMemState &state, const Wavefront &wf,
                                        std::vector<ClusterLdsTarget> targets) {
+  assert(state.cluster_multicast && "cluster LDS multicast transaction requires cluster_multicast");
+  assert(state.lds_base == wf.lds_base() &&
+         "cluster LDS multicast source base must be the source WG allocation base");
   ClusterLdsMulticastTransaction txn{};
   txn.dispatch_id = wf.dispatch_id();
   txn.source_wg_id = wf.wg_id();
@@ -47,7 +52,7 @@ make_cluster_lds_multicast_transaction(const VectorMemState &state, const Wavefr
   txn.lane_mask = state.lane_mask;
   txn.per_lane_addr = state.lds_per_lane_addr;
   txn.per_lane_lds_addr = state.per_lane_lds_addr;
-  txn.payload = state.response_data;
+  txn.payload = std::move(state.response_data);
   txn.targets = std::move(targets);
   return txn;
 }
@@ -69,6 +74,12 @@ ImmediateClusterLdsMulticastEngine::submit(ClusterLdsMulticastTransaction txn,
             data_offset, txn.bytes_per_lane, txn.payload.size()));
       }
       uint32_t lds_addr = cluster_lds_lane_addr(txn, lane, target.lds_base);
+      if (uint64_t(lds_addr) + txn.bytes_per_lane > lds.size_bytes()) {
+        throw std::runtime_error(std::format(
+            "cluster LDS multicast target address out of range: lane={} target_wg={} addr={:#x} "
+            "bytes={} lds_size={}",
+            lane, target.wg_id, lds_addr, txn.bytes_per_lane, lds.size_bytes()));
+      }
       for (uint32_t b = 0; b < txn.bytes_per_lane; ++b)
         lds.write8(lds_addr + b, txn.payload[data_offset + b]);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.h
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_VM_AMDGPU_CLUSTER_LDS_MULTICAST_H_
+#define ROCJITSU_VM_AMDGPU_CLUSTER_LDS_MULTICAST_H_
+
+#include "rocjitsu/vm/amdgpu/wait_counters.h"
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+class ComputeUnitCore;
+struct VectorMemState;
+class Wavefront;
+
+struct ClusterLdsTarget {
+  ComputeUnitCore *cu = nullptr;
+  uint32_t wg_id = 0;
+  uint32_t lds_base = 0;
+  /// Informational placement rank for diagnostics and future rank-sensitive
+  /// cluster operations; current multicast writes need only CU and LDS base.
+  uint32_t cluster_rank = 0;
+};
+
+/// @brief Fully described LDS multicast writeback produced by an async cluster load.
+///
+/// @details The immediate functional backend consumes this synchronously today.
+/// A future timing backend can instead retain the transaction, model delivery
+/// latency/contention, and complete ASYNCCNT only after all target LDS writes
+/// have been delivered. The transaction is the boundary where a future fabric
+/// model can preserve source/target rank, LDS windows, payload, and lane mask
+/// before scheduling per-target delivery events.
+struct ClusterLdsMulticastTransaction {
+  uint32_t dispatch_id = 0;
+  uint32_t source_wg_id = 0;
+  uint32_t source_cluster_rank = 0;
+  uint32_t source_lds_base = 0;
+  uint32_t mcast_mask = 0;
+  WaitCounterType wait_counter_type = WaitCounterType::ASYNCCNT;
+  uint32_t bytes_per_lane = 0;
+  uint32_t wf_size = 0;
+  uint64_t lane_mask = 0;
+  bool per_lane_addr = false;
+  std::array<uint32_t, 64> per_lane_lds_addr = {};
+  std::vector<uint8_t> payload;
+  std::vector<ClusterLdsTarget> targets;
+};
+
+enum class ClusterLdsMulticastResult {
+  Complete,
+  Deferred,
+};
+
+using ClusterLdsMulticastCompletion = std::function<void()>;
+
+/// @brief Remap a source WG LDS address into an equivalent target WG LDS window.
+uint32_t remap_cluster_lds_addr(uint32_t source_lds_base, uint32_t target_lds_base,
+                                uint32_t source_lds_addr);
+
+/// @brief Return the target LDS address for a lane in one multicast target.
+uint32_t cluster_lds_lane_addr(const ClusterLdsMulticastTransaction &txn, uint32_t lane,
+                               uint32_t target_lds_base);
+
+ClusterLdsMulticastTransaction
+make_cluster_lds_multicast_transaction(const VectorMemState &state, const Wavefront &wf,
+                                       std::vector<ClusterLdsTarget> targets);
+
+/// @brief Execution boundary for cluster-load async-to-LDS fan-out.
+class ClusterLdsMulticastEngine {
+public:
+  virtual ~ClusterLdsMulticastEngine() = default;
+
+  /// @brief Submit one owned multicast transaction.
+  ///
+  /// @details Backends returning Complete must perform all writes before return
+  /// and must not invoke complete. Backends returning Deferred take ownership of
+  /// txn and must invoke complete exactly once after all writes are visible.
+  virtual ClusterLdsMulticastResult submit(ClusterLdsMulticastTransaction txn,
+                                           ClusterLdsMulticastCompletion complete) = 0;
+};
+
+/// @brief Functional backend: immediately writes the multicast payload to target LDS.
+class ImmediateClusterLdsMulticastEngine final : public ClusterLdsMulticastEngine {
+public:
+  ClusterLdsMulticastResult submit(ClusterLdsMulticastTransaction txn,
+                                   ClusterLdsMulticastCompletion complete) override;
+};
+
+} // namespace amdgpu
+} // namespace rocjitsu
+
+#endif // ROCJITSU_VM_AMDGPU_CLUSTER_LDS_MULTICAST_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.h
@@ -51,7 +51,7 @@ struct ClusterLdsMulticastTransaction {
   std::vector<ClusterLdsTarget> targets;
 };
 
-enum class ClusterLdsMulticastResult {
+enum class [[nodiscard]] ClusterLdsMulticastResult {
   Complete,
   Deferred,
 };
@@ -67,7 +67,7 @@ uint32_t cluster_lds_lane_addr(const ClusterLdsMulticastTransaction &txn, uint32
                                uint32_t target_lds_base);
 
 ClusterLdsMulticastTransaction
-make_cluster_lds_multicast_transaction(const VectorMemState &state, const Wavefront &wf,
+make_cluster_lds_multicast_transaction(VectorMemState &state, const Wavefront &wf,
                                        std::vector<ClusterLdsTarget> targets);
 
 /// @brief Execution boundary for cluster-load async-to-LDS fan-out.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/cluster_lds_multicast.h
@@ -27,14 +27,14 @@ struct ClusterLdsTarget {
   uint32_t cluster_rank = 0;
 };
 
-/// @brief Fully described LDS multicast writeback produced by an async cluster load.
+/// @brief Fully described LDS writeback request produced by an async cluster load.
 ///
-/// @details The immediate functional backend consumes this synchronously today.
-/// A future timing backend can instead retain the transaction, model delivery
-/// latency/contention, and complete ASYNCCNT only after all target LDS writes
-/// have been delivered. The transaction is the boundary where a future fabric
-/// model can preserve source/target rank, LDS windows, payload, and lane mask
-/// before scheduling per-target delivery events.
+/// @details Each transaction represents one workgroup's participation in a
+/// cluster async-to-LDS operation. The mask still records the selected cluster
+/// ranks, but functional writeback uses the issuing workgroup's own LDS
+/// destination metadata; peers only receive data when they issue their own
+/// matching transaction. A future timing backend can retain these transactions
+/// and use per-lane global addresses to model request coalescing.
 struct ClusterLdsMulticastTransaction {
   uint32_t dispatch_id = 0;
   uint32_t source_wg_id = 0;
@@ -46,6 +46,9 @@ struct ClusterLdsMulticastTransaction {
   uint32_t wf_size = 0;
   uint64_t lane_mask = 0;
   bool per_lane_addr = false;
+  /// Captured for future timing/coalescing backends; the immediate backend only
+  /// needs the participant-owned LDS destination.
+  std::array<uint64_t, 64> per_lane_global_addr = {};
   std::array<uint32_t, 64> per_lane_lds_addr = {};
   std::vector<uint8_t> payload;
   std::vector<ClusterLdsTarget> targets;
@@ -62,29 +65,41 @@ using ClusterLdsMulticastCompletion = std::function<void()>;
 uint32_t remap_cluster_lds_addr(uint32_t source_lds_base, uint32_t target_lds_base,
                                 uint32_t source_lds_addr);
 
-/// @brief Return the target LDS address for a lane in one multicast target.
+/// @brief Return the lane LDS address remapped into one target LDS window.
+///
+/// @details Immediate functional writeback only uses this with the issuing
+/// participant's own target, where the remap is identity. Deferred/timing
+/// backends can reuse it when modeling peer-visible multicast responses.
 uint32_t cluster_lds_lane_addr(const ClusterLdsMulticastTransaction &txn, uint32_t lane,
                                uint32_t target_lds_base);
+
+/// @brief Return true when the transaction mask selects the issuing workgroup.
+bool cluster_lds_source_rank_selected(const ClusterLdsMulticastTransaction &txn);
 
 ClusterLdsMulticastTransaction
 make_cluster_lds_multicast_transaction(VectorMemState &state, const Wavefront &wf,
                                        std::vector<ClusterLdsTarget> targets);
 
-/// @brief Execution boundary for cluster-load async-to-LDS fan-out.
+/// @brief Execution boundary for one participant's cluster async-to-LDS writeback.
 class ClusterLdsMulticastEngine {
 public:
   virtual ~ClusterLdsMulticastEngine() = default;
 
-  /// @brief Submit one owned multicast transaction.
+  /// @brief Submit one owned participant transaction.
   ///
   /// @details Backends returning Complete must perform all writes before return
   /// and must not invoke complete. Backends returning Deferred take ownership of
-  /// txn and must invoke complete exactly once after all writes are visible.
+  /// txn and must invoke complete exactly once after all participant writes are
+  /// visible.
   virtual ClusterLdsMulticastResult submit(ClusterLdsMulticastTransaction txn,
                                            ClusterLdsMulticastCompletion complete) = 0;
 };
 
-/// @brief Functional backend: immediately writes the multicast payload to target LDS.
+/// @brief Functional backend: immediately writes the issuing participant's own LDS payload.
+///
+/// @details This deliberately does not fan out one requester payload into peer
+/// LDS windows. Peers selected by M0 are eligible participants, but each peer's
+/// LDS destination is taken from that peer's own issued transaction.
 class ImmediateClusterLdsMulticastEngine final : public ClusterLdsMulticastEngine {
 public:
   ClusterLdsMulticastResult submit(ClusterLdsMulticastTransaction txn,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -660,10 +660,13 @@ CommandProcessor::cluster_lds_targets(uint32_t dispatch_id, uint32_t wg_id, uint
     return targets;
 
   const auto &src = src_it->second;
-  if (src.cluster_size <= 1 || mcast_mask == 0) {
+  const uint32_t self_mask = cluster_multicast_rank_mask(src.cluster_rank);
+  if (mcast_mask == 0 || (src.cluster_size <= 1 && (mcast_mask & self_mask) != 0)) {
     targets.push_back({src.cu, wg_id, src.lds_base, src.cluster_rank});
     return targets;
   }
+  if (src.cluster_size <= 1)
+    return targets;
 
   for (uint32_t rank = 0; rank < src.cluster_size && rank < kClusterMulticastMaskBits; ++rank) {
     if ((mcast_mask & (1u << rank)) == 0)
@@ -679,7 +682,7 @@ CommandProcessor::cluster_lds_targets(uint32_t dispatch_id, uint32_t wg_id, uint
     targets.push_back({peer.cu, peer_wg_id, peer.lds_base, peer.cluster_rank});
   }
 
-  if (targets.empty())
+  if (targets.empty() && (mcast_mask & self_mask) != 0)
     targets.push_back({src.cu, wg_id, src.lds_base, src.cluster_rank});
   return targets;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -661,6 +661,7 @@ CommandProcessor::cluster_lds_targets(uint32_t dispatch_id, uint32_t wg_id, uint
 
   const auto &src = src_it->second;
   const uint32_t self_mask = cluster_multicast_rank_mask(src.cluster_rank);
+  // Defensive for direct helper callers; the issue path handles mask 0 locally.
   if (mcast_mask == 0 || (src.cluster_size <= 1 && (mcast_mask & self_mask) != 0)) {
     targets.push_back({src.cu, wg_id, src.lds_base, src.cluster_rank});
     return targets;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -3,6 +3,8 @@
 
 #include "rocjitsu/vm/amdgpu/command_processor.h"
 #include "rocjitsu/code/kernel_symbol.h"
+#include "rocjitsu/vm/amdgpu/amd_ext_aql_packet.h"
+#include "rocjitsu/vm/amdgpu/mem_state.h"
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -33,40 +35,112 @@ namespace amdgpu {
 
 namespace {
 
-constexpr uint8_t HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH = 3;
+// The supported cluster size must fit the M0 multicast mask captured at issue time.
+constexpr uint32_t kMaxClusterWorkgroups = kClusterMulticastMaskBits;
+static_assert(kMaxClusterWorkgroups <= kClusterMulticastMaskBits);
 
-struct AmdExtKernelDispatchPacket {
-  uint16_t header;
-  uint8_t amd_format;
-  uint8_t setup;
-  uint16_t workgroup_size_x;
-  uint16_t workgroup_size_y;
-  uint16_t workgroup_size_z;
-  uint16_t reserved0;
-  uint32_t cluster_count_x;
-  uint16_t cluster_count_y;
-  uint16_t cluster_count_z;
-  uint8_t cluster_size_x;
-  uint8_t cluster_size_y;
-  uint8_t cluster_size_z;
-  uint8_t perf_hint;
-  uint32_t private_segment_size;
-  uint32_t group_segment_size;
-  uint64_t kernel_object;
-  void *kernarg_address;
-  hsa_signal_t dep_signal;
-  hsa_signal_t completion_signal;
+struct PlannedWorkgroup {
+  uint32_t local_wg_id = 0;
+  uint32_t global_wg_id = 0;
+  ComputeUnitCore *cu = nullptr;
 };
 
-static_assert(sizeof(AmdExtKernelDispatchPacket) == 64);
-
 uint32_t nonzero_or_one(uint32_t v) { return v == 0 ? 1 : v; }
+
+uint32_t checked_ext_dispatch_grid_size(uint32_t cluster_count, uint32_t cluster_size,
+                                        uint32_t workgroup_size, const char *axis) {
+  if (cluster_count == 0 || cluster_size == 0 || workgroup_size == 0) {
+    throw std::runtime_error(
+        std::format("AMD extended dispatch {} fields must be nonzero: cluster_count={} "
+                    "cluster_size={} workgroup_size={}",
+                    axis, cluster_count, cluster_size, workgroup_size));
+  }
+  uint64_t grid_size =
+      static_cast<uint64_t>(cluster_count) * cluster_size * static_cast<uint64_t>(workgroup_size);
+  if (grid_size > std::numeric_limits<uint32_t>::max()) {
+    throw std::runtime_error(std::format(
+        "AMD extended dispatch grid_size_{} overflows 32 bits: cluster_count={} cluster_size={} "
+        "workgroup_size={}",
+        axis, cluster_count, cluster_size, workgroup_size));
+  }
+  return static_cast<uint32_t>(grid_size);
+}
+
+void validate_cluster_shape(const DispatchEntry &dp) {
+  if (!dp.has_workgroup_clusters())
+    return;
+  auto cluster_size =
+      static_cast<uint64_t>(dp.cluster_size_x) * dp.cluster_size_y * dp.cluster_size_z;
+  if (cluster_size == 0 || cluster_size > kMaxClusterWorkgroups) {
+    throw std::runtime_error(
+        std::format("unsupported workgroup cluster size {}x{}x{} ({} workgroups)",
+                    dp.cluster_size_x, dp.cluster_size_y, dp.cluster_size_z, cluster_size));
+  }
+  if (!dp.cluster_grid_is_complete()) {
+    throw std::runtime_error(std::format(
+        "workgroup cluster shape {}x{}x{} count {}x{}x{} does not cover grid {}x{}x{} exactly",
+        dp.cluster_size_x, dp.cluster_size_y, dp.cluster_size_z, dp.cluster_count_x,
+        dp.cluster_count_y, dp.cluster_count_z, dp.grid_wgs_x, dp.grid_wgs_y, dp.grid_wgs_z));
+  }
+}
 
 uint32_t read_memory_u32(GpuMemory *memory, uint64_t addr) {
   uint32_t value = 0;
   for (uint32_t i = 0; i < sizeof(value); ++i)
     value |= static_cast<uint32_t>(memory->read8(addr + i)) << (i * 8);
   return value;
+}
+
+uint32_t aligned_lds_bytes_per_workgroup(const DispatchEntry &entry) {
+  // Match ComputeUnitCore::allocate_lds()/can_accept_workgroup() granularity for all dispatches.
+  return util::align_up(entry.group_segment_fixed_size, 256u);
+}
+
+bool any_active_wavefronts(const std::vector<ComputeUnitCore *> &cus) {
+  return std::any_of(cus.begin(), cus.end(), [](const auto *cu) { return cu->has_active_wfs(); });
+}
+
+bool plan_cluster_workgroups(const DispatchEntry &entry, uint32_t cluster_base_local_wg_id,
+                             size_t next_cu, const std::vector<ComputeUnitCore *> &cus,
+                             std::vector<PlannedWorkgroup> &plan, size_t &planned_next_cu) {
+  plan.clear();
+  uint32_t cluster_size = entry.cluster_size();
+  const uint32_t lds_bytes_per_wg = aligned_lds_bytes_per_workgroup(entry);
+  constexpr auto kU32Max = std::numeric_limits<uint32_t>::max();
+  std::vector<uint32_t> planned_per_cu(cus.size(), 0);
+  size_t last_cu_idx = next_cu;
+
+  for (uint32_t rank = 0; rank < cluster_size; ++rank) {
+    bool assigned = false;
+    uint32_t local_wg_id = entry.cluster_peer_local_wg_id(cluster_base_local_wg_id, rank);
+    for (size_t attempt = 0; attempt < cus.size(); ++attempt) {
+      size_t cu_idx = (next_cu + rank + attempt) % cus.size();
+      auto *cu = cus[cu_idx];
+      cu->retire_halted_wfs();
+
+      uint32_t reserved_wgs = planned_per_cu[cu_idx] + 1;
+      uint64_t reserved_wfs = static_cast<uint64_t>(entry.wfs_per_workgroup) * reserved_wgs;
+      uint64_t reserved_lds = static_cast<uint64_t>(lds_bytes_per_wg) * reserved_wgs;
+      if (reserved_wfs > kU32Max || reserved_lds > kU32Max)
+        continue;
+      if (!cu->can_accept_workgroup(static_cast<uint32_t>(reserved_wfs),
+                                    static_cast<uint32_t>(reserved_lds)))
+        continue;
+
+      plan.push_back({local_wg_id, local_wg_id + entry.workgroup_id_offset, cu});
+      ++planned_per_cu[cu_idx];
+      last_cu_idx = cu_idx;
+      assigned = true;
+      break;
+    }
+    if (!assigned) {
+      plan.clear();
+      return false;
+    }
+  }
+
+  planned_next_cu = (last_cu_idx + 1) % cus.size();
+  return true;
 }
 
 bool sgpr_count_is_descriptor_encoded(rj_code_arch_t arch, uint32_t sgpr_gran) {
@@ -291,6 +365,8 @@ void CommandProcessor::startup() {
       [this](simdojo::Tick ts, simdojo::Message *) { handle_doorbell(ts); });
   completion_ = std::make_unique<CompletionTracker>(memory_, cus_);
   completion_->set_plugin_group(plugin_group_);
+  completion_->set_dispatch_retired_callback(
+      [this](const DispatchEntry &entry) { erase_cluster_workgroups(entry.dispatch_id); });
   if (interrupt_cb_)
     completion_->set_interrupt_callback(interrupt_cb_);
 }
@@ -515,6 +591,99 @@ bool CommandProcessor::barrier_satisfied(const HwQueueState &qs, size_t idx) con
   return true;
 }
 
+void CommandProcessor::register_cluster_workgroup(const DispatchEntry &entry, uint32_t local_wg_id,
+                                                  uint32_t global_wg_id, ComputeUnitCore *cu,
+                                                  uint32_t lds_base) {
+  if (!entry.has_workgroup_clusters())
+    return;
+  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+  uint32_t cluster_base_wg_id =
+      entry.cluster_base_local_wg_id(local_wg_id) + entry.workgroup_id_offset;
+  uint64_t cluster_key = wg_key(entry.dispatch_id, cluster_base_wg_id);
+  cu->pin_lds_until_cluster_retired(cluster_key);
+  ClusterWorkgroupPlacement placement{};
+  placement.cu = cu;
+  placement.lds_base = lds_base;
+  placement.cluster_key = cluster_key;
+  placement.cluster_rank = entry.cluster_rank_for_local_wg(local_wg_id);
+  placement.cluster_size = entry.cluster_size();
+  placement.peer_wg_ids.reserve(placement.cluster_size);
+  for (uint32_t rank = 0; rank < placement.cluster_size; ++rank) {
+    uint32_t peer_local_wg_id = entry.cluster_peer_local_wg_id(local_wg_id, rank);
+    placement.peer_wg_ids.push_back(peer_local_wg_id + entry.workgroup_id_offset);
+  }
+  cluster_wg_placements_[wg_key(entry.dispatch_id, global_wg_id)] = std::move(placement);
+}
+
+void CommandProcessor::mark_cluster_workgroup_complete(uint32_t dispatch_id, uint32_t wg_id) {
+  auto it = cluster_wg_placements_.find(wg_key(dispatch_id, wg_id));
+  if (it == cluster_wg_placements_.end())
+    return;
+
+  it->second.completed = true;
+  uint64_t cluster_key = it->second.cluster_key;
+  auto peer_wg_ids = it->second.peer_wg_ids;
+  for (uint32_t peer_wg_id : peer_wg_ids) {
+    auto peer_it = cluster_wg_placements_.find(wg_key(dispatch_id, peer_wg_id));
+    if (peer_it == cluster_wg_placements_.end() || !peer_it->second.completed)
+      return;
+  }
+
+  for (uint32_t peer_wg_id : peer_wg_ids) {
+    auto peer_it = cluster_wg_placements_.find(wg_key(dispatch_id, peer_wg_id));
+    if (peer_it != cluster_wg_placements_.end() && peer_it->second.cu)
+      peer_it->second.cu->unpin_lds_for_cluster(cluster_key);
+  }
+  for (uint32_t peer_wg_id : peer_wg_ids)
+    cluster_wg_placements_.erase(wg_key(dispatch_id, peer_wg_id));
+}
+
+void CommandProcessor::erase_cluster_workgroups(uint32_t dispatch_id) {
+  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+  for (auto it = cluster_wg_placements_.begin(); it != cluster_wg_placements_.end();) {
+    if ((it->first >> 32) == dispatch_id) {
+      if (it->second.cu)
+        it->second.cu->unpin_lds_for_cluster(it->second.cluster_key);
+      it = cluster_wg_placements_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+std::vector<ClusterLdsTarget>
+CommandProcessor::cluster_lds_targets(uint32_t dispatch_id, uint32_t wg_id, uint32_t mcast_mask) {
+  std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+  std::vector<ClusterLdsTarget> targets;
+  auto src_it = cluster_wg_placements_.find(wg_key(dispatch_id, wg_id));
+  if (src_it == cluster_wg_placements_.end())
+    return targets;
+
+  const auto &src = src_it->second;
+  if (src.cluster_size <= 1 || mcast_mask == 0) {
+    targets.push_back({src.cu, wg_id, src.lds_base, src.cluster_rank});
+    return targets;
+  }
+
+  for (uint32_t rank = 0; rank < src.cluster_size && rank < kClusterMulticastMaskBits; ++rank) {
+    if ((mcast_mask & (1u << rank)) == 0)
+      continue;
+    uint32_t peer_wg_id = src.peer_wg_ids[rank];
+    auto peer_it = cluster_wg_placements_.find(wg_key(dispatch_id, peer_wg_id));
+    if (peer_it == cluster_wg_placements_.end()) {
+      throw std::runtime_error(std::format(
+          "cluster multicast target is not resident: dispatch={} source_wg={} peer_wg={} rank={}",
+          dispatch_id, wg_id, peer_wg_id, rank));
+    }
+    const auto &peer = peer_it->second;
+    targets.push_back({peer.cu, peer_wg_id, peer.lds_base, peer.cluster_rank});
+  }
+
+  if (targets.empty())
+    targets.push_back({src.cu, wg_id, src.lds_base, src.cluster_rank});
+  return targets;
+}
+
 uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
   assert(!cus_.empty() && "command processor has no compute units");
 
@@ -523,8 +692,65 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
   // LDS is per-CU and s_barrier synchronises within a CU). Query each CU for
   // capacity before dispatching to guarantee all-or-nothing placement.
   uint32_t dispatched = 0;
+  auto dispatch_to_cu = [&](uint32_t local_wg_id, uint32_t global_wg_id, ComputeUnitCore *cu) {
+    uint32_t lds_base = cu->allocate_lds(entry.group_segment_fixed_size);
+    cu->begin_workgroup(entry.dispatch_id, global_wg_id, entry.wfs_per_workgroup);
+    register_cluster_workgroup(entry, local_wg_id, global_wg_id, cu, lds_base);
+
+    std::vector<Wavefront *> wg_wavefronts;
+    wg_wavefronts.reserve(entry.wfs_per_workgroup);
+    for (uint32_t w = 0; w < entry.wfs_per_workgroup; ++w) {
+      Wavefront *wf = cu->dispatch_wf(global_wg_id, entry.kernel_entry_pc, entry.sgprs_per_wf,
+                                      entry.vgprs_per_wf);
+      assert(wf && "dispatch_wf failed after can_accept_workgroup returned true");
+      wf->set_lds_base(lds_base);
+      wf->set_dispatch_id(entry.dispatch_id);
+      wf->set_process_id(entry.process_id);
+      wf->set_exec(initial_exec_mask_for_wave(entry, w, cu->wf_size()));
+      wf->set_cluster_info(entry.cluster_rank_for_local_wg(local_wg_id), entry.cluster_size());
+      init_wavefront_regs(cu, wf, entry, global_wg_id, w);
+      wg_wavefronts.push_back(wf);
+    }
+    plugin_group_->onAmdgpuWorkgroupDispatched(entry.dispatch_id, global_wg_id,
+                                               cu->vgpr_allocation_block_size(), entry.sgprs_per_wf,
+                                               std::span<Wavefront *>(wg_wavefronts));
+    for (auto *wf : wg_wavefronts)
+      plugin_group_->onAmdgpuWavefrontDispatched(*wf);
+
+    ++entry.dispatched_wgs;
+    ++dispatched;
+  };
+
   while (entry.dispatched_wgs < entry.total_wgs) {
-    uint32_t global_wg_id = entry.dispatched_wgs + entry.workgroup_id_offset;
+    uint32_t local_wg_id = entry.dispatched_wgs;
+    uint32_t global_wg_id = local_wg_id + entry.workgroup_id_offset;
+
+    if (entry.has_workgroup_clusters()) {
+      // The SPI interface chooses one WG at a time and cannot reserve all peers
+      // in a cluster atomically. Plan clusters directly across the CP-visible CU
+      // list until SPI grows an all-or-nothing cluster placement API.
+      uint32_t cluster_size = entry.cluster_size();
+      assert(entry.dispatched_wgs % cluster_size == 0 &&
+             "clustered dispatch advances by whole clusters");
+      assert(entry.total_wgs - entry.dispatched_wgs >= cluster_size &&
+             "validate_cluster_shape guarantees a complete trailing cluster");
+      uint32_t cluster_ordinal = entry.dispatched_wgs / cluster_size;
+      local_wg_id = entry.cluster_base_local_wg_id_for_ordinal(cluster_ordinal);
+      std::vector<PlannedWorkgroup> plan;
+      size_t planned_next_cu = next_cu_;
+      if (!plan_cluster_workgroups(entry, local_wg_id, next_cu_, cus_, plan, planned_next_cu)) {
+        if (!any_active_wavefronts(cus_)) {
+          throw std::runtime_error(
+              std::format("workgroup cluster {}x{}x{} cannot fit in available CU resources",
+                          entry.cluster_size_x, entry.cluster_size_y, entry.cluster_size_z));
+        }
+        break;
+      }
+      next_cu_ = planned_next_cu;
+      for (const auto &wg : plan)
+        dispatch_to_cu(wg.local_wg_id, wg.global_wg_id, wg.cu);
+      continue;
+    }
 
     // SPI selects the CU based on resource availability.
     ComputeUnitCore *cu = nullptr;
@@ -550,30 +776,7 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
     if (!cu)
       break;
 
-    uint32_t lds_base = cu->allocate_lds(entry.group_segment_fixed_size);
-    cu->begin_workgroup(entry.dispatch_id, global_wg_id, entry.wfs_per_workgroup);
-
-    std::vector<Wavefront *> wg_wavefronts;
-    wg_wavefronts.reserve(entry.wfs_per_workgroup);
-    for (uint32_t w = 0; w < entry.wfs_per_workgroup; ++w) {
-      Wavefront *wf = cu->dispatch_wf(global_wg_id, entry.kernel_entry_pc, entry.sgprs_per_wf,
-                                      entry.vgprs_per_wf);
-      assert(wf && "dispatch_wf failed after can_accept_workgroup returned true");
-      wf->set_lds_base(lds_base);
-      wf->set_dispatch_id(entry.dispatch_id);
-      wf->set_process_id(entry.process_id);
-      wf->set_exec(initial_exec_mask_for_wave(entry, w, cu->wf_size()));
-      init_wavefront_regs(cu, wf, entry, global_wg_id, w);
-      wg_wavefronts.push_back(wf);
-    }
-    plugin_group_->onAmdgpuWorkgroupDispatched(entry.dispatch_id, global_wg_id,
-                                               cu->vgpr_allocation_block_size(), entry.sgprs_per_wf,
-                                               std::span<Wavefront *>(wg_wavefronts));
-    for (auto *wf : wg_wavefronts)
-      plugin_group_->onAmdgpuWavefrontDispatched(*wf);
-
-    ++entry.dispatched_wgs;
-    ++dispatched;
+    dispatch_to_cu(local_wg_id, global_wg_id, cu);
   }
   return dispatched;
 }
@@ -586,6 +789,7 @@ void CommandProcessor::notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id) 
   util::Logger::cp(
       [&](auto &os) { os << std::format("WG_COMPLETE d={} wg={}", dispatch_id, wg_id); });
   std::lock_guard<std::recursive_mutex> lock(hw_queue_mutex_);
+  mark_cluster_workgroup_complete(dispatch_id, wg_id);
   if (completion_)
     completion_->notify_wg_complete(dispatch_id, wg_id, new_queue_states_);
 }
@@ -692,8 +896,8 @@ static const uint8_t *find_elf_base(const uint8_t *ptr, const uint8_t *limit) {
 }
 
 void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pkt,
-                                          const HwQueue &queue, uint64_t pkt_addr,
-                                          HwQueueState &qs) {
+                                          const HwQueue &queue, uint64_t pkt_addr, HwQueueState &qs,
+                                          ClusterDispatchShape cluster_shape) {
   bool host_accessible = queue.host_accessible;
   using namespace rocr::llvm::amdhsa;
   kernel_descriptor_t kd =
@@ -758,6 +962,19 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   dp.grid_wgs_x = (num_dims <= 1) ? total_wgs : grid_wgs_x;
   dp.grid_wgs_y = (num_dims >= 2) ? grid_wgs_y : 1;
   dp.grid_wgs_z = (num_dims >= 3) ? grid_wgs_z : 1;
+  dp.cluster_size_x = nonzero_or_one(cluster_shape.size_x);
+  dp.cluster_size_y = nonzero_or_one(cluster_shape.size_y);
+  dp.cluster_size_z = nonzero_or_one(cluster_shape.size_z);
+  dp.cluster_count_x = cluster_shape.count_x == 0
+                           ? (dp.grid_wgs_x + dp.cluster_size_x - 1) / dp.cluster_size_x
+                           : cluster_shape.count_x;
+  dp.cluster_count_y = cluster_shape.count_y == 0
+                           ? (dp.grid_wgs_y + dp.cluster_size_y - 1) / dp.cluster_size_y
+                           : cluster_shape.count_y;
+  dp.cluster_count_z = cluster_shape.count_z == 0
+                           ? (dp.grid_wgs_z + dp.cluster_size_z - 1) / dp.cluster_size_z
+                           : cluster_shape.count_z;
+  validate_cluster_shape(dp);
   dp.enable_wg_id_x =
       AMDHSA_BITS_GET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_X);
   dp.enable_wg_id_y =
@@ -990,11 +1207,11 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
     } else if (pkt_type == HSA_PACKET_TYPE_VENDOR_SPECIFIC) {
       AmdExtKernelDispatchPacket ext{};
       std::memcpy(&ext, &pkt, sizeof(ext));
-      if (ext.amd_format == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH) {
+      if (ext.amd_format == kHsaAmdPacketTypeExtKernelDispatch) {
         if (ext.dep_signal.handle != 0) {
           constexpr uint32_t SIG_VAL_OFF = 8;
-          auto *val = reinterpret_cast<int64_t *>(ext.dep_signal.handle + SIG_VAL_OFF);
-          int64_t v = std::atomic_ref<int64_t>(*val).load(std::memory_order_acquire);
+          auto v = static_cast<int64_t>(
+              read_gpu_u64(ext.dep_signal.handle + SIG_VAL_OFF, queue.process_id));
           if (v != 0) {
             process_limit = read_idx;
             engine()->schedule_event_now(&doorbell_event_);
@@ -1002,27 +1219,35 @@ void CommandProcessor::fetch_from_queue(HwQueue &queue, HwQueueState &qs) {
           }
         }
 
+        uint32_t grid_size_x = checked_ext_dispatch_grid_size(
+            ext.cluster_count_x, ext.cluster_size_x, ext.workgroup_size_x, "x");
+        uint32_t grid_size_y = checked_ext_dispatch_grid_size(
+            ext.cluster_count_y, ext.cluster_size_y, ext.workgroup_size_y, "y");
+        uint32_t grid_size_z = checked_ext_dispatch_grid_size(
+            ext.cluster_count_z, ext.cluster_size_z, ext.workgroup_size_z, "z");
+
         hsa_kernel_dispatch_packet_t dispatch{};
         dispatch.header = ext.header;
         dispatch.setup = ext.setup;
         dispatch.workgroup_size_x = ext.workgroup_size_x;
         dispatch.workgroup_size_y = ext.workgroup_size_y;
         dispatch.workgroup_size_z = ext.workgroup_size_z;
-        dispatch.grid_size_x = nonzero_or_one(ext.cluster_count_x) *
-                               nonzero_or_one(ext.cluster_size_x) *
-                               nonzero_or_one(ext.workgroup_size_x);
-        dispatch.grid_size_y = nonzero_or_one(ext.cluster_count_y) *
-                               nonzero_or_one(ext.cluster_size_y) *
-                               nonzero_or_one(ext.workgroup_size_y);
-        dispatch.grid_size_z = nonzero_or_one(ext.cluster_count_z) *
-                               nonzero_or_one(ext.cluster_size_z) *
-                               nonzero_or_one(ext.workgroup_size_z);
+        dispatch.grid_size_x = grid_size_x;
+        dispatch.grid_size_y = grid_size_y;
+        dispatch.grid_size_z = grid_size_z;
         dispatch.private_segment_size = ext.private_segment_size;
         dispatch.group_segment_size = ext.group_segment_size;
         dispatch.kernel_object = ext.kernel_object;
         dispatch.kernarg_address = ext.kernarg_address;
         dispatch.completion_signal = ext.completion_signal;
-        process_aql_packet(dispatch, queue, pkt_addr, qs);
+        ClusterDispatchShape cluster_shape{};
+        cluster_shape.count_x = ext.cluster_count_x;
+        cluster_shape.count_y = ext.cluster_count_y;
+        cluster_shape.count_z = ext.cluster_count_z;
+        cluster_shape.size_x = ext.cluster_size_x;
+        cluster_shape.size_y = ext.cluster_size_y;
+        cluster_shape.size_z = ext.cluster_size_z;
+        process_aql_packet(dispatch, queue, pkt_addr, qs, cluster_shape);
       } else {
         constexpr uint32_t SIG_OFF = 56;
         uint64_t sig = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -20,6 +20,7 @@
 /// href="https://rocm.docs.amd.com/projects/rocprofiler-compute/en/latest/conceptual/command-processor.html">ROCm
 /// CP documentation</a>
 
+#include "rocjitsu/vm/amdgpu/cluster_lds_multicast.h"
 #include "rocjitsu/vm/amdgpu/completion_tracker.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/dispatch_entry.h"
@@ -35,11 +36,14 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "rocjitsu/base/rj_compiler.h"
+#ifndef HSA_LARGE_MODEL
 #define HSA_LARGE_MODEL 1
+#endif
 RJ_DIAGNOSTIC_PUSH
 RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "hsa/AMDHSAKernelDescriptor.h"
@@ -155,6 +159,10 @@ public:
   const std::vector<simdojo::Port *> &dispatch_ports() const { return dispatch_ports_; }
   const std::vector<ComputeUnitCore *> &compute_units() const { return cus_; }
 
+  /// @brief Return LDS targets selected by a cluster multicast mask.
+  std::vector<ClusterLdsTarget> cluster_lds_targets(uint32_t dispatch_id, uint32_t wg_id,
+                                                    uint32_t mcast_mask);
+
 private:
   /// @brief Initialize a wavefront's registers per the AMDHSA ABI.
   void init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf, const DispatchEntry &entry,
@@ -173,12 +181,18 @@ private:
 
   /// @brief Parse an AQL dispatch packet, read its kernel descriptor, and create a DispatchEntry.
   void process_aql_packet(const hsa_kernel_dispatch_packet_t &pkt, const HwQueue &queue,
-                          uint64_t pkt_addr, HwQueueState &qs);
+                          uint64_t pkt_addr, HwQueueState &qs,
+                          ClusterDispatchShape cluster_shape = {});
 
   rocr::llvm::amdhsa::kernel_descriptor_t
   read_kernel_descriptor(uint64_t kernel_object, uint32_t vmid, bool host_accessible = false);
   /// @brief Dispatch workgroups from entry to CUs. Returns number dispatched.
   uint32_t dispatch_workgroups(DispatchEntry &entry);
+
+  void register_cluster_workgroup(const DispatchEntry &entry, uint32_t local_wg_id,
+                                  uint32_t global_wg_id, ComputeUnitCore *cu, uint32_t lds_base);
+  void mark_cluster_workgroup_complete(uint32_t dispatch_id, uint32_t wg_id);
+  void erase_cluster_workgroups(uint32_t dispatch_id);
 
   /// @brief Asynchronous Compute Engine (ACE): dispatch workgroups from all
   /// active queues to SPIs and run CUs to completion.
@@ -236,6 +250,17 @@ private:
   uint32_t next_dispatch_id_ = 1;
   size_t total_dispatched_ = 0;
 
+  struct ClusterWorkgroupPlacement {
+    ComputeUnitCore *cu = nullptr;
+    uint32_t lds_base = 0;
+    uint64_t cluster_key = 0;
+    uint32_t cluster_rank = 0;
+    uint32_t cluster_size = 1;
+    bool completed = false;
+    std::vector<uint32_t> peer_wg_ids;
+  };
+  std::unordered_map<uint64_t, ClusterWorkgroupPlacement> cluster_wg_placements_;
+
   simdojo::Event doorbell_event_{this, simdojo::EventType::TIMER_CALLBACK};
   std::recursive_mutex hw_queue_mutex_;
 
@@ -263,6 +288,10 @@ private:
 
   void doorbell_poll_loop(std::stop_token stop);
   std::jthread doorbell_thread_;
+
+  static uint64_t wg_key(uint32_t dispatch_id, uint32_t wg_id) {
+    return (uint64_t(dispatch_id) << 32) | wg_id;
+  }
 };
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -27,6 +27,7 @@
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
 #include "rocjitsu/vm/amdgpu/spi.h"
+#include "rocjitsu/vm/amdgpu/workgroup_key.h"
 
 #include "simdojo/sim/component.h"
 
@@ -288,10 +289,6 @@ private:
 
   void doorbell_poll_loop(std::stop_token stop);
   std::jthread doorbell_thread_;
-
-  static uint64_t wg_key(uint32_t dispatch_id, uint32_t wg_id) {
-    return (uint64_t(dispatch_id) << 32) | wg_id;
-  }
 };
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.cpp
@@ -53,6 +53,8 @@ void CompletionTracker::drain_completions(std::vector<HwQueueState> &queues) {
       if (entry.completion_signal != 0) {
         fire_signal(entry);
       }
+      if (dispatch_retired_cb_)
+        dispatch_retired_cb_(entry);
 
       if (qs.next_dispatch_idx > 0)
         --qs.next_dispatch_idx;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/completion_tracker.h
@@ -25,6 +25,7 @@ namespace amdgpu {
 class CompletionTracker {
 public:
   using InterruptCallback = std::function<void(uint32_t process_id, uint32_t event_id)>;
+  using DispatchRetiredCallback = std::function<void(const DispatchEntry &entry)>;
 
   CompletionTracker(GpuMemory *mem, std::vector<ComputeUnitCore *> &cus)
       : memory_(mem), cus_(cus) {}
@@ -34,6 +35,9 @@ public:
   }
 
   void set_interrupt_callback(InterruptCallback cb) { interrupt_cb_ = std::move(cb); }
+  void set_dispatch_retired_callback(DispatchRetiredCallback cb) {
+    dispatch_retired_cb_ = std::move(cb);
+  }
 
   /// @brief Notify that a workgroup has completed all its wavefronts.
   void notify_wg_complete(uint32_t dispatch_id, uint32_t wg_id, std::vector<HwQueueState> &queues);
@@ -56,6 +60,7 @@ private:
   GpuMemory *memory_;
   std::vector<ComputeUnitCore *> &cus_;
   InterruptCallback interrupt_cb_;
+  DispatchRetiredCallback dispatch_retired_cb_;
   std::shared_ptr<ExecutionPluginGroup> plugin_group_ = ExecutionPluginGroup::empty_group();
 };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -165,6 +165,7 @@ size_t ComputeUnitCore::num_wfs() const {
 }
 
 void ComputeUnitCore::reset_all_wf() {
+  lds_pinned_clusters_.clear();
   for (auto &w : wfs_) {
     if (w->sgpr_alloc().count > 0) {
       sgpr_file_.free(w->sgpr_alloc().base);
@@ -194,7 +195,7 @@ void ComputeUnitCore::retire_halted_wfs() {
       w->reset();
     }
   }
-  if (!has_active_wfs()) {
+  if (!has_active_wfs() && !lds_allocation_pinned()) {
     reset_lds_alloc();
   }
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -238,7 +238,7 @@ public:
     return base;
   }
 
-  /// @brief Reset LDS allocation (called when all WFs retire).
+  /// @brief Reset LDS allocation when no resident waves or pinned clusters remain.
   void reset_lds_alloc() { next_lds_alloc_ = 0; }
 
   /// @brief Hold LDS allocation state while a workgroup cluster is resident.
@@ -250,7 +250,11 @@ public:
   void pin_lds_until_cluster_retired(uint64_t cluster_key) {
     lds_pinned_clusters_.insert(cluster_key);
   }
+
+  /// @brief Release the LDS allocation pin for a retired workgroup cluster.
   void unpin_lds_for_cluster(uint64_t cluster_key) { lds_pinned_clusters_.erase(cluster_key); }
+
+  /// @brief Return true while any cluster can still receive multicast LDS writes.
   bool lds_allocation_pinned() const { return !lds_pinned_clusters_.empty(); }
 
   /// @brief Flush all per-CU caches and the shared L2 to backing store.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -11,6 +11,7 @@
 #include "rocjitsu/isa/arch/amdgpu/shared/accvgpr_layout.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/cluster_lds_multicast.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/l1_scalar_cache.h"
 #include "rocjitsu/vm/amdgpu/l1_vector_cache.h"
@@ -38,6 +39,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -148,6 +150,23 @@ public:
   /// @brief Set the command processor for WG completion notification.
   void set_command_processor(CommandProcessor *cp) { cp_ = cp; }
 
+  /// @brief Return the command processor that owns this CU's dispatch stream.
+  CommandProcessor *command_processor() { return cp_; }
+
+  /// @brief Override the cluster LDS multicast backend.
+  ///
+  /// @details Passing nullptr restores the immediate functional backend. Timed
+  /// models can install a shared fabric object here without changing the ISA
+  /// execution path that produces multicast transactions.
+  void set_cluster_lds_multicast_engine(ClusterLdsMulticastEngine *engine) {
+    cluster_lds_multicast_engine_ = engine ? engine : &default_cluster_lds_multicast_engine_;
+  }
+
+  /// @brief Return the active cluster LDS multicast backend.
+  ClusterLdsMulticastEngine &cluster_lds_multicast_engine() {
+    return *cluster_lds_multicast_engine_;
+  }
+
   /// @brief Register a new workgroup with its expected WF count.
   /// @details Called by the DispatchController when assigning a WG to this CU.
   /// Initializes the refcount so retire_halted_wfs() can detect WG completion.
@@ -220,6 +239,18 @@ public:
 
   /// @brief Reset LDS allocation (called when all WFs retire).
   void reset_lds_alloc() { next_lds_alloc_ = 0; }
+
+  /// @brief Hold LDS allocation state while a workgroup cluster is resident.
+  ///
+  /// @details Cluster multicast can target peer workgroups after the source WG
+  /// halts. Keep the per-CU LDS allocator pinned until the whole peer cluster
+  /// completes so a later WG cannot reuse LDS while peer multicast writes are
+  /// still possible, but larger dispatches can reclaim LDS between clusters.
+  void pin_lds_until_cluster_retired(uint64_t cluster_key) {
+    lds_pinned_clusters_.insert(cluster_key);
+  }
+  void unpin_lds_for_cluster(uint64_t cluster_key) { lds_pinned_clusters_.erase(cluster_key); }
+  bool lds_allocation_pinned() const { return !lds_pinned_clusters_.empty(); }
 
   /// @brief Flush all per-CU caches and the shared L2 to backing store.
   ///
@@ -474,7 +505,10 @@ protected:
   L1ScalarCache l1_scalar_;
   L1VectorCache l1_vector_;
   Lds lds_;
+  ImmediateClusterLdsMulticastEngine default_cluster_lds_multicast_engine_;
+  ClusterLdsMulticastEngine *cluster_lds_multicast_engine_ = &default_cluster_lds_multicast_engine_;
   uint32_t next_lds_alloc_ = 0; ///< Next free LDS offset for per-WG allocation.
+  std::unordered_set<uint64_t> lds_pinned_clusters_;
   ScalarMemPipeline scalar_mem_pipeline_;
   GlobalMemPipeline global_mem_pipeline_;
   LocalMemPipeline local_mem_pipeline_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -21,6 +21,7 @@
 #include "rocjitsu/vm/amdgpu/mtype.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 #include "rocjitsu/vm/amdgpu/wf_scheduler.h"
+#include "rocjitsu/vm/amdgpu/workgroup_key.h"
 #include "rocjitsu/vm/plugins/execution_plugin_group.h"
 #include "simdojo/components/register_file.h"
 #include "simdojo/components/vector_reg.h"
@@ -515,9 +516,6 @@ protected:
   std::function<void()> on_idle_; ///< Callback invoked when CU becomes idle.
   CommandProcessor *cp_ = nullptr;
 
-  static uint64_t wg_key(uint32_t dispatch_id, uint32_t wg_id) {
-    return (uint64_t(dispatch_id) << 32) | wg_id;
-  }
   std::unordered_map<uint64_t, uint32_t> active_wgs_;
 
   uint64_t shared_aperture_base_ = 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -14,9 +14,25 @@
 
 #include <cstdint>
 #include <deque>
+#include <stdexcept>
 
 namespace rocjitsu {
 namespace amdgpu {
+
+struct WorkgroupCoord {
+  uint32_t x = 0;
+  uint32_t y = 0;
+  uint32_t z = 0;
+};
+
+struct ClusterDispatchShape {
+  uint32_t count_x = 0;
+  uint32_t count_y = 0;
+  uint32_t count_z = 0;
+  uint32_t size_x = 1;
+  uint32_t size_y = 1;
+  uint32_t size_z = 1;
+};
 
 /// @brief Per-dispatch tracking entry created by the AQL Packet Processor.
 struct DispatchEntry {
@@ -39,6 +55,12 @@ struct DispatchEntry {
   uint32_t grid_wgs_x = 0;
   uint32_t grid_wgs_y = 1;
   uint32_t grid_wgs_z = 1;
+  uint32_t cluster_count_x = 0;
+  uint32_t cluster_count_y = 0;
+  uint32_t cluster_count_z = 0;
+  uint32_t cluster_size_x = 1;
+  uint32_t cluster_size_y = 1;
+  uint32_t cluster_size_z = 1;
   bool enable_wg_id_x = true;
   bool enable_wg_id_y = false;
   bool enable_wg_id_z = false;
@@ -61,6 +83,75 @@ struct DispatchEntry {
   bool fully_dispatched() const { return dispatched_wgs >= total_wgs; }
   bool fully_completed() const { return completed_wgs >= total_wgs; }
   bool is_non_kernel() const { return total_wgs == 0; }
+
+  uint32_t cluster_size() const { return cluster_size_x * cluster_size_y * cluster_size_z; }
+  bool has_workgroup_clusters() const { return cluster_size() > 1; }
+  bool cluster_grid_is_complete() const {
+    return static_cast<uint64_t>(cluster_count_x) * cluster_size_x == grid_wgs_x &&
+           static_cast<uint64_t>(cluster_count_y) * cluster_size_y == grid_wgs_y &&
+           static_cast<uint64_t>(cluster_count_z) * cluster_size_z == grid_wgs_z;
+  }
+
+  WorkgroupCoord local_wg_coord(uint32_t local_wg_id) const {
+    uint32_t gx = grid_wgs_x == 0 ? 1 : grid_wgs_x;
+    uint32_t gy = grid_wgs_y == 0 ? 1 : grid_wgs_y;
+    return {local_wg_id % gx, (local_wg_id / gx) % gy, local_wg_id / (gx * gy)};
+  }
+
+  uint32_t flatten_local_wg_coord(WorkgroupCoord coord) const {
+    uint32_t gx = grid_wgs_x == 0 ? 1 : grid_wgs_x;
+    uint32_t gy = grid_wgs_y == 0 ? 1 : grid_wgs_y;
+    return coord.x + gx * (coord.y + gy * coord.z);
+  }
+
+  uint32_t cluster_rank_for_local_wg(uint32_t local_wg_id) const {
+    WorkgroupCoord coord = local_wg_coord(local_wg_id);
+    uint32_t sx = cluster_size_x == 0 ? 1 : cluster_size_x;
+    uint32_t sy = cluster_size_y == 0 ? 1 : cluster_size_y;
+    uint32_t sz = cluster_size_z == 0 ? 1 : cluster_size_z;
+    uint32_t local_x = coord.x % sx;
+    uint32_t local_y = coord.y % sy;
+    uint32_t local_z = coord.z % sz;
+    return local_x + sx * (local_y + sy * local_z);
+  }
+
+  uint32_t cluster_base_local_wg_id(uint32_t local_wg_id) const {
+    WorkgroupCoord coord = local_wg_coord(local_wg_id);
+    uint32_t sx = cluster_size_x == 0 ? 1 : cluster_size_x;
+    uint32_t sy = cluster_size_y == 0 ? 1 : cluster_size_y;
+    uint32_t sz = cluster_size_z == 0 ? 1 : cluster_size_z;
+    coord.x -= coord.x % sx;
+    coord.y -= coord.y % sy;
+    coord.z -= coord.z % sz;
+    return flatten_local_wg_coord(coord);
+  }
+
+  uint32_t cluster_base_local_wg_id_for_ordinal(uint32_t cluster_ordinal) const {
+    uint32_t cx = cluster_count_x == 0 ? 1 : cluster_count_x;
+    uint32_t cy = cluster_count_y == 0 ? 1 : cluster_count_y;
+    WorkgroupCoord cluster_coord{};
+    cluster_coord.x = cluster_ordinal % cx;
+    cluster_coord.y = (cluster_ordinal / cx) % cy;
+    cluster_coord.z = cluster_ordinal / (cx * cy);
+    WorkgroupCoord base{};
+    base.x = cluster_coord.x * cluster_size_x;
+    base.y = cluster_coord.y * cluster_size_y;
+    base.z = cluster_coord.z * cluster_size_z;
+    return flatten_local_wg_coord(base);
+  }
+
+  uint32_t cluster_peer_local_wg_id(uint32_t local_wg_id, uint32_t rank) const {
+    if (!cluster_grid_is_complete())
+      throw std::logic_error("cluster peer math requires full clusters in every grid dimension");
+    WorkgroupCoord base = local_wg_coord(cluster_base_local_wg_id(local_wg_id));
+    uint32_t sx = cluster_size_x == 0 ? 1 : cluster_size_x;
+    uint32_t sy = cluster_size_y == 0 ? 1 : cluster_size_y;
+    WorkgroupCoord peer{};
+    peer.x = base.x + rank % sx;
+    peer.y = base.y + (rank / sx) % sy;
+    peer.z = base.z + rank / (sx * sy);
+    return flatten_local_wg_coord(peer);
+  }
 };
 
 inline uint32_t dispatch_workgroup_size(const DispatchEntry &entry) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -12,9 +12,9 @@
 /// independently. Completion signals fire when all WGs of a dispatch finish,
 /// in per-queue submission order.
 
+#include <cassert>
 #include <cstdint>
 #include <deque>
-#include <stdexcept>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -141,8 +141,8 @@ struct DispatchEntry {
   }
 
   uint32_t cluster_peer_local_wg_id(uint32_t local_wg_id, uint32_t rank) const {
-    if (!cluster_grid_is_complete())
-      throw std::logic_error("cluster peer math requires full clusters in every grid dimension");
+    assert(cluster_grid_is_complete() &&
+           "cluster peer math requires full clusters in every grid dimension");
     WorkgroupCoord base = local_wg_coord(cluster_base_local_wg_id(local_wg_id));
     uint32_t sx = cluster_size_x == 0 ? 1 : cluster_size_x;
     uint32_t sy = cluster_size_y == 0 ? 1 : cluster_size_y;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
@@ -36,7 +36,7 @@ void L1VectorCache::ensure_line(uint64_t addr, uint32_t vmid) {
 // management before dispatch N+1 begins execution, so no blanket invalidation
 // at dispatch boundaries is needed.
 void L1VectorCache::read_bytes(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype,
-                               bool non_temporal, uint32_t vmid) {
+                               bool non_temporal, bool request_l1_bypass, uint32_t vmid) {
   Mtype inst_mtype = mtype;
   Mtype effective = mtype;
   if (memory_)
@@ -65,7 +65,7 @@ void L1VectorCache::read_bytes(uint64_t addr, uint8_t *dst, uint32_t size, Mtype
     if (memory_)
       chunk_mtype = effective_mtype(inst_mtype, memory_->pte_mtype(ea, vmid));
 
-    if (chunk_mtype == Mtype::UC || non_temporal) {
+    if (chunk_mtype == Mtype::UC || non_temporal || request_l1_bypass) {
       l2_->read(ea, dst + copied, chunk, chunk_mtype, vmid);
       copied += chunk;
       continue;
@@ -145,7 +145,7 @@ void L1VectorCache::write_bytes(uint64_t addr, const uint8_t *src, uint32_t size
 
 void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size,
                          uint32_t num_elems, uint8_t *dst, Mtype mtype, bool non_temporal,
-                         uint32_t vmid) {
+                         bool request_l1_bypass, uint32_t vmid) {
   uint32_t stride = num_elems * elem_size;
   uint64_t remaining = lane_mask;
   while (remaining) {
@@ -154,7 +154,8 @@ void L1VectorCache::load(const uint64_t *addrs, uint64_t lane_mask, uint32_t ele
     uint64_t base = addrs[lane];
     for (uint32_t e = 0; e < num_elems; ++e) {
       uint64_t ea = base + e * elem_size;
-      read_bytes(ea, dst + lane * stride + e * elem_size, elem_size, mtype, non_temporal, vmid);
+      read_bytes(ea, dst + lane * stride + e * elem_size, elem_size, mtype, non_temporal,
+                 request_l1_bypass, vmid);
     }
   }
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.h
@@ -36,7 +36,8 @@ public:
   void set_l2(L2Cache *l2) { l2_ = l2; }
   void set_memory(GpuMemory *mem) { memory_ = mem; }
   void load(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size, uint32_t num_elems,
-            uint8_t *dst, Mtype mtype, bool non_temporal, uint32_t vmid = 0);
+            uint8_t *dst, Mtype mtype, bool non_temporal, bool request_l1_bypass,
+            uint32_t vmid = 0);
 
   void store(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size, uint32_t num_elems,
              const uint8_t *src, Mtype mtype, bool non_temporal, uint32_t vmid = 0);
@@ -51,7 +52,7 @@ public:
 
 private:
   void read_bytes(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype, bool non_temporal,
-                  uint32_t vmid);
+                  bool request_l1_bypass, uint32_t vmid);
   void write_bytes(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtype, bool non_temporal,
                    uint32_t vmid);
   void ensure_line(uint64_t addr, uint32_t vmid);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
@@ -24,8 +24,15 @@
 namespace rocjitsu {
 namespace amdgpu {
 
+/// gfx1250 cluster async-to-LDS uses the low M0 bits as a destination
+/// workgroup-rank mask. Dispatch validation keeps cluster size within this
+/// architectural mask width.
 constexpr uint32_t kClusterMulticastMaskBits = 16;
 constexpr uint32_t kClusterMulticastMask = (1u << kClusterMulticastMaskBits) - 1u;
+
+constexpr uint32_t cluster_multicast_rank_mask(uint32_t cluster_rank) {
+  return cluster_rank < kClusterMulticastMaskBits ? (1u << cluster_rank) : 0u;
+}
 
 /// @brief Pipeline routing tags for AMDGPU memory instructions.
 enum MemPipelineTag : uint8_t {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
@@ -24,6 +24,9 @@
 namespace rocjitsu {
 namespace amdgpu {
 
+constexpr uint32_t kClusterMulticastMaskBits = 16;
+constexpr uint32_t kClusterMulticastMask = (1u << kClusterMulticastMaskBits) - 1u;
+
 /// @brief Pipeline routing tags for AMDGPU memory instructions.
 enum MemPipelineTag : uint8_t {
   SCALAR_MEM = 1,
@@ -96,13 +99,19 @@ struct VectorMemState : DynamicInstState {
   bool d16_lo = false;                 ///< D16 load: write to lower 16 bits, preserve upper 16.
   AtomicOp atomic_op = AtomicOp::NONE; ///< Atomic RMW operation (NONE for regular loads/stores).
   bool lds_dst = false;                ///< Buffer load with LDS bit: write to LDS, not VGPRs.
-  uint32_t lds_base = 0;               ///< M0 value for LDS-destination buffer loads.
-  bool lds_per_lane_addr = false;      ///< Use per_lane_lds_addr for LDS destination addresses.
+  /// Reference LDS address for LDS-destination loads. For ordinary LDS-dst
+  /// paths this may include the lane-0 destination offset. For cluster
+  /// multicast it must be the source WG allocation base; per-lane destination
+  /// offsets are carried in per_lane_lds_addr.
+  uint32_t lds_base = 0;
+  bool lds_per_lane_addr = false; ///< Use per_lane_lds_addr for LDS destination addresses.
   std::array<uint32_t, 64> per_lane_lds_addr = {};
-  uint64_t issue_pc = 0; ///< PC at which the instruction was issued (debug).
-  uint32_t wg_id = 0;    ///< Workgroup ID (for trace output).
-  uint32_t wf_id = 0;    ///< Wavefront ID within WG (for trace output).
-  std::string cu_path;   ///< CU full path (for trace output).
+  bool cluster_multicast = false;  ///< Cluster async-to-LDS load: multicast LDS writes by M0 mask.
+  uint32_t cluster_mcast_mask = 0; ///< Cluster workgroup destination mask captured at issue time.
+  uint64_t issue_pc = 0;           ///< PC at which the instruction was issued (debug).
+  uint32_t wg_id = 0;              ///< Workgroup ID (for trace output).
+  uint32_t wf_id = 0;              ///< Wavefront ID within WG (for trace output).
+  std::string cu_path;             ///< CU full path (for trace output).
   std::vector<uint8_t> response_data;
   std::vector<uint8_t> store_data;
   uint8_t transpose = 0; ///< Transpose-load kind (0=none, see ds_transpose.h).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
@@ -108,8 +108,9 @@ struct VectorMemState : DynamicInstState {
   bool lds_dst = false;                ///< Buffer load with LDS bit: write to LDS, not VGPRs.
   /// Reference LDS address for LDS-destination loads. For ordinary LDS-dst
   /// paths this may include the lane-0 destination offset. For cluster
-  /// multicast it must be the source WG allocation base; per-lane destination
-  /// offsets are carried in per_lane_lds_addr.
+  /// multicast this must be exactly Wavefront::lds_base(), the source WG
+  /// allocation base; per-lane destination offsets are carried in
+  /// per_lane_lds_addr.
   uint32_t lds_base = 0;
   bool lds_per_lane_addr = false; ///< Use per_lane_lds_addr for LDS destination addresses.
   std::array<uint32_t, 64> per_lane_lds_addr = {};

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/mem_state.h
@@ -101,6 +101,10 @@ struct VectorMemState : DynamicInstState {
   Mtype mtype = Mtype::RW;
   WaitCounterType wait_counter_type = WaitCounterType::VMCNT;
   bool non_temporal = false;
+  // Keep this outside Mtype: cluster loads force only the request-side vector
+  // L1 lookup to miss, while mtype must still preserve the instruction/PTE
+  // cacheability and response policy used by the downstream memory path.
+  bool request_force_l1_bypass = false;
   bool sign_extend = false;
   bool d16_hi = false;                 ///< D16_HI load: write to upper 16 bits, preserve lower 16.
   bool d16_lo = false;                 ///< D16 load: write to lower 16 bits, preserve upper 16.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -19,6 +19,8 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <format>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 
@@ -55,11 +57,32 @@ std::vector<ClusterLdsTarget> resolve_lds_write_targets(VectorMemState &d, Wavef
   return targets;
 }
 
+void write_lds_dst_load_direct(const VectorMemState &d, ComputeUnitCore &cu,
+                               uint32_t per_lane_bytes) {
+  for (uint32_t lane = 0; lane < d.wf_size; ++lane) {
+    if ((d.lane_mask & (1ULL << lane)) == 0)
+      continue;
+    uint32_t data_offset = lane * per_lane_bytes;
+    if (data_offset + per_lane_bytes > d.response_data.size()) {
+      throw std::runtime_error(std::format(
+          "LDS-destination load payload too small: lane={} offset={} bytes={} payload={}", lane,
+          data_offset, per_lane_bytes, d.response_data.size()));
+    }
+    uint32_t lds_addr =
+        d.lds_per_lane_addr ? d.per_lane_lds_addr[lane] : d.lds_base + lane * per_lane_bytes;
+    cu.lds().write(lds_addr, &d.response_data[data_offset], per_lane_bytes);
+  }
+}
+
 MemoryAccessCompletion complete_lds_dst_load(VectorMemState &d, Wavefront &wf, ComputeUnitCore &cu,
                                              MemoryAccessDeferredCompletion complete) {
   uint32_t per_lane_bytes = d.num_elems * d.elem_size;
-  auto targets = resolve_lds_write_targets(d, wf, cu);
-  size_t target_count = targets.size();
+  std::vector<ClusterLdsTarget> targets;
+  size_t target_count = 1;
+  if (d.cluster_multicast) {
+    targets = resolve_lds_write_targets(d, wf, cu);
+    target_count = targets.size();
+  }
 
   // Per-lane LDS-dst buffer load trace.
   util::Logger::vm([&](auto &os) {
@@ -80,6 +103,11 @@ MemoryAccessCompletion complete_lds_dst_load(VectorMemState &d, Wavefront &wf, C
       os << std::format(" L{}:@{:#x}->lds[{:#x}]={:#x}", ln, d.per_lane_addr[ln], lds_addr, v);
     }
   });
+
+  if (!d.cluster_multicast) {
+    write_lds_dst_load_direct(d, cu, per_lane_bytes);
+    return MemoryAccessCompletion::Complete;
+  }
 
   auto txn = make_cluster_lds_multicast_transaction(d, wf, std::move(targets));
   auto result = cu.cluster_lds_multicast_engine().submit(std::move(txn), std::move(complete));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -3,6 +3,8 @@
 
 #include "rocjitsu/vm/amdgpu/memory_pipeline.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/ds_transpose.h"
+#include "rocjitsu/vm/amdgpu/cluster_lds_multicast.h"
+#include "rocjitsu/vm/amdgpu/command_processor.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/l1_scalar_cache.h"
 #include "rocjitsu/vm/amdgpu/l1_vector_cache.h"
@@ -17,6 +19,8 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <utility>
+#include <vector>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -35,49 +39,61 @@ uint32_t extend_scalar_load(const uint8_t *bytes, uint32_t elem_size, bool sign_
   return value;
 }
 
-/// Shared complete_access logic for vector/LDS loads (write VGPRs from
-/// response data). Used by both GlobalMemPipeline and LocalMemPipeline.
-///
-/// For atomics with elem_size=8 and num_elems=1, the 8-byte old value
-/// occupies two consecutive VGPRs (low dword in vdst, high in vdst+1).
-void vector_complete(VectorMemState &d, ComputeUnitCore &cu) {
+std::vector<ClusterLdsTarget> resolve_lds_write_targets(VectorMemState &d, Wavefront &wf,
+                                                        ComputeUnitCore &cu) {
+  std::vector<ClusterLdsTarget> targets;
+  if (d.cluster_multicast && d.cluster_mcast_mask != 0) {
+    if (auto *cp = cu.command_processor())
+      targets = cp->cluster_lds_targets(wf.dispatch_id(), wf.wg_id(), d.cluster_mcast_mask);
+  }
+  if (targets.empty())
+    targets.push_back({&cu, wf.wg_id(), d.lds_base, wf.cluster_rank()});
+  return targets;
+}
+
+MemoryAccessCompletion complete_lds_dst_load(VectorMemState &d, Wavefront &wf, ComputeUnitCore &cu,
+                                             MemoryAccessDeferredCompletion complete) {
+  uint32_t per_lane_bytes = d.num_elems * d.elem_size;
+  auto targets = resolve_lds_write_targets(d, wf, cu);
+  size_t target_count = targets.size();
+
+  // Per-lane LDS-dst buffer load trace.
+  util::Logger::vm([&](auto &os) {
+    static thread_local uint64_t lds_dst_trace = 0;
+    if (++lds_dst_trace > 80)
+      return;
+    os << std::format("{} wg[{}] wf[{}] BUF->LDS: lds_base={:#x} plb={} mcast={:#x} targets={}",
+                      d.cu_path, d.wg_id, d.wf_id, d.lds_base, per_lane_bytes, d.cluster_mcast_mask,
+                      target_count);
+    for (uint32_t ln = 0; ln < d.wf_size; ++ln) {
+      if (!(d.lane_mask & (1ULL << ln)))
+        continue;
+      uint32_t v = 0;
+      if (per_lane_bytes >= 4)
+        std::memcpy(&v, &d.response_data[ln * per_lane_bytes], 4);
+      uint32_t lds_addr =
+          d.lds_per_lane_addr ? d.per_lane_lds_addr[ln] : d.lds_base + ln * per_lane_bytes;
+      os << std::format(" L{}:@{:#x}->lds[{:#x}]={:#x}", ln, d.per_lane_addr[ln], lds_addr, v);
+    }
+  });
+
+  auto txn = make_cluster_lds_multicast_transaction(d, wf, std::move(targets));
+  auto result = cu.cluster_lds_multicast_engine().submit(std::move(txn), std::move(complete));
+
+  return result == ClusterLdsMulticastResult::Deferred ? MemoryAccessCompletion::Deferred
+                                                       : MemoryAccessCompletion::Complete;
+}
+
+MemoryAccessCompletion vector_complete(VectorMemState &d, Wavefront &wf,
+                                       MemoryAccessDeferredCompletion complete) {
+  ComputeUnitCore &cu = wf.cu();
   if (!d.is_load)
-    return;
+    return MemoryAccessCompletion::Complete;
 
   // Buffer load with LDS bit: scatter loaded data into LDS instead of VGPRs.
   // Each lane writes num_elems * elem_size bytes to LDS at lds_base + lane_offset.
-  if (d.lds_dst) {
-    auto &lds = cu.lds();
-    uint32_t per_lane_bytes = d.num_elems * d.elem_size;
-    for (uint32_t lane = 0; lane < d.wf_size; ++lane) {
-      if (!(d.lane_mask & (1ULL << lane)))
-        continue;
-      uint32_t lds_addr =
-          d.lds_per_lane_addr ? d.per_lane_lds_addr[lane] : d.lds_base + lane * per_lane_bytes;
-      uint32_t data_offset = lane * per_lane_bytes;
-      for (uint32_t b = 0; b < per_lane_bytes; ++b)
-        lds.write8(lds_addr + b, d.response_data[data_offset + b]);
-    }
-    // Per-lane LDS-dst buffer load trace.
-    util::Logger::vm([&](auto &os) {
-      static thread_local uint64_t lds_dst_trace = 0;
-      if (++lds_dst_trace > 80)
-        return;
-      os << std::format("{} wg[{}] wf[{}] BUF->LDS: lds_base={:#x} plb={}", d.cu_path, d.wg_id,
-                        d.wf_id, d.lds_base, per_lane_bytes);
-      for (uint32_t ln = 0; ln < d.wf_size; ++ln) {
-        if (!(d.lane_mask & (1ULL << ln)))
-          continue;
-        uint32_t v = 0;
-        if (per_lane_bytes >= 4)
-          std::memcpy(&v, &d.response_data[ln * per_lane_bytes], 4);
-        uint32_t lds_addr =
-            d.lds_per_lane_addr ? d.per_lane_lds_addr[ln] : d.lds_base + ln * per_lane_bytes;
-        os << std::format(" L{}:@{:#x}->lds[{:#x}]={:#x}", ln, d.per_lane_addr[ln], lds_addr, v);
-      }
-    });
-    return;
-  }
+  if (d.lds_dst)
+    return complete_lds_dst_load(d, wf, cu, std::move(complete));
 
   // Atomics: response layout is [lane * elem_size], regular loads are
   // [lane * (num_elems * elem_size) + elem * elem_size].
@@ -148,6 +164,7 @@ void vector_complete(VectorMemState &d, ComputeUnitCore &cu) {
       cu.write_vgpr(d.dst_reg_base + i, lane, val);
     }
   }
+  return MemoryAccessCompletion::Complete;
 }
 
 } // namespace
@@ -167,10 +184,12 @@ void ScalarMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
   }
 }
 
-void ScalarMemPipeline::complete_access(Instruction &inst, Wavefront &wf) {
+MemoryAccessCompletion
+ScalarMemPipeline::complete_access(Instruction &inst, Wavefront &wf,
+                                   MemoryAccessDeferredCompletion /*complete*/) {
   auto &d = *inst.data_as<ScalarMemState>();
   if (!d.is_load)
-    return;
+    return MemoryAccessCompletion::Complete;
   auto &cu = wf.cu();
   for (uint32_t i = 0; i < d.num_dwords; ++i) {
     cu.write_sgpr(d.dst_reg_base + i, d.response_data[i]);
@@ -188,6 +207,7 @@ void ScalarMemPipeline::complete_access(Instruction &inst, Wavefront &wf) {
       }
     }
   });
+  return MemoryAccessCompletion::Complete;
 }
 
 namespace {
@@ -444,11 +464,12 @@ void GlobalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
   }
 }
 
-void GlobalMemPipeline::complete_access(Instruction &inst, Wavefront &wf) {
+MemoryAccessCompletion GlobalMemPipeline::complete_access(Instruction &inst, Wavefront &wf,
+                                                          MemoryAccessDeferredCompletion complete) {
   auto &d = *inst.data_as<VectorMemState>();
   if (d.transpose != 0)
     transpose_response(d);
-  vector_complete(d, wf.cu());
+  return vector_complete(d, wf, std::move(complete));
 }
 
 void LocalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
@@ -543,11 +564,12 @@ void LocalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
   }
 }
 
-void LocalMemPipeline::complete_access(Instruction &inst, Wavefront &wf) {
+MemoryAccessCompletion LocalMemPipeline::complete_access(Instruction &inst, Wavefront &wf,
+                                                         MemoryAccessDeferredCompletion complete) {
   auto &d = *inst.data_as<VectorMemState>();
   if (d.transpose != 0)
     transpose_response(d);
-  vector_complete(d, wf.cu());
+  MemoryAccessCompletion completion = vector_complete(d, wf, std::move(complete));
 
   // DS dual-access (ds_read2/ds_write2): write the second access results.
   if (d.ds2_active && d.is_load) {
@@ -580,6 +602,7 @@ void LocalMemPipeline::complete_access(Instruction &inst, Wavefront &wf) {
       }
     });
   }
+  return completion;
 }
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -490,7 +490,7 @@ void GlobalMemPipeline::initiate_access(Instruction &inst, Wavefront &wf) {
   if (d.is_load) {
     d.response_data.resize(d.wf_size * d.num_elems * d.elem_size);
     l1_->load(d.per_lane_addr.data(), d.lane_mask, d.elem_size, d.num_elems, d.response_data.data(),
-              d.mtype, d.non_temporal, wf.process_id());
+              d.mtype, d.non_temporal, d.request_force_l1_bypass, wf.process_id());
   } else {
     l1_->store(d.per_lane_addr.data(), d.lane_mask, d.elem_size, d.num_elems, d.store_data.data(),
                d.mtype, d.non_temporal, wf.process_id());

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -46,7 +46,11 @@ std::vector<ClusterLdsTarget> resolve_lds_write_targets(VectorMemState &d, Wavef
     if (auto *cp = cu.command_processor())
       targets = cp->cluster_lds_targets(wf.dispatch_id(), wf.wg_id(), d.cluster_mcast_mask);
   }
-  if (targets.empty())
+
+  const bool writes_self =
+      !d.cluster_multicast || d.cluster_mcast_mask == 0 ||
+      (d.cluster_mcast_mask & cluster_multicast_rank_mask(wf.cluster_rank())) != 0;
+  if (targets.empty() && writes_self)
     targets.push_back({&cu, wf.wg_id(), d.lds_base, wf.cluster_rank()});
   return targets;
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -79,7 +79,8 @@ MemoryAccessCompletion complete_lds_dst_load(VectorMemState &d, Wavefront &wf, C
   uint32_t per_lane_bytes = d.num_elems * d.elem_size;
   std::vector<ClusterLdsTarget> targets;
   size_t target_count = 1;
-  if (d.cluster_multicast) {
+  const bool cluster_downgrades_to_ordinary = d.cluster_multicast && wf.cluster_size() <= 1;
+  if (d.cluster_multicast && !cluster_downgrades_to_ordinary) {
     targets = resolve_lds_write_targets(d, wf, cu);
     target_count = targets.size();
   }
@@ -104,7 +105,7 @@ MemoryAccessCompletion complete_lds_dst_load(VectorMemState &d, Wavefront &wf, C
     }
   });
 
-  if (!d.cluster_multicast) {
+  if (!d.cluster_multicast || cluster_downgrades_to_ordinary) {
     write_lds_dst_load_direct(d, cu, per_lane_bytes);
     return MemoryAccessCompletion::Complete;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.h
@@ -13,7 +13,9 @@
 #include "rocjitsu/vm/amdgpu/wavefront.h"
 
 #include <cstdint>
+#include <functional>
 #include <queue>
+#include <utility>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -22,6 +24,13 @@ class L1ScalarCache;
 class L1VectorCache;
 class L2Cache;
 class Lds;
+
+enum class MemoryAccessCompletion {
+  Complete,
+  Deferred,
+};
+
+using MemoryAccessDeferredCompletion = std::function<void()>;
 
 /// @brief Base class for a memory pipeline stage (scalar, global, or local).
 ///
@@ -45,13 +54,11 @@ public:
 
   /// @brief Issue a memory instruction to this pipeline.
   ///
-  /// In functional mode, memory accesses complete synchronously: the load
-  /// or store is initiated and completed within this call, and the wait
-  /// counter is incremented then immediately decremented so that a
-  /// subsequent s_waitcnt sees the operation as already done.  This
-  /// eliminates the two-tick deferred pipeline that previously allowed
-  /// ALU instructions to read destination VGPRs between issue and
-  /// writeback — a hazard that real hardware prevents via scoreboarding.
+  /// In functional mode, memory accesses normally complete synchronously:
+  /// the load or store is initiated and completed within this call, and the
+  /// wait counter is released only after complete_access() finishes all
+  /// writeback work.  A timing backend may return Deferred and release the
+  /// counter later through finish_completed_access().
   void issue(Instruction *inst, Wavefront &wf) {
     WaitCounterType issue_counter = counter_type_;
     if (auto *state = inst->data()) {
@@ -69,9 +76,15 @@ public:
     }
     wf.wait_counters().increment(issue_counter);
     initiate_access(*inst, wf);
-    complete_access(*inst, wf);
-    wf.release_wait_counter(issue_counter);
-    delete inst;
+    // The wait counter pins wf/inst ownership until this callback releases it.
+    // ComputeUnitCore retires ENDING wavefronts only after wait_counters().empty(),
+    // so a deferred backend must invoke this exactly once while that counter is held.
+    MemoryAccessDeferredCompletion deferred_completion = [this, inst, &wf, issue_counter]() {
+      finish_completed_access(inst, wf, issue_counter);
+    };
+    MemoryAccessCompletion completion = complete_access(*inst, wf, std::move(deferred_completion));
+    if (completion == MemoryAccessCompletion::Complete)
+      finish_completed_access(inst, wf, issue_counter);
   }
 
   /// @brief Advance the pipeline by one cycle (no-op in functional mode).
@@ -83,7 +96,15 @@ public:
 
 protected:
   virtual void initiate_access(Instruction &inst, Wavefront &wf) = 0;
-  virtual void complete_access(Instruction &inst, Wavefront &wf) = 0;
+  /// Return Complete and do not call complete, or return Deferred and call it
+  /// exactly once after the memory response is ready for architectural writeback.
+  virtual MemoryAccessCompletion complete_access(Instruction &inst, Wavefront &wf,
+                                                 MemoryAccessDeferredCompletion complete) = 0;
+
+  void finish_completed_access(Instruction *inst, Wavefront &wf, WaitCounterType counter) {
+    wf.release_wait_counter(counter);
+    delete inst;
+  }
 
   WaitCounterType counter_type_;
   std::queue<PipelineEntry> issued_;
@@ -102,7 +123,8 @@ public:
 
 protected:
   void initiate_access(Instruction &inst, Wavefront &wf) override;
-  void complete_access(Instruction &inst, Wavefront &wf) override;
+  MemoryAccessCompletion complete_access(Instruction &inst, Wavefront &wf,
+                                         MemoryAccessDeferredCompletion complete) override;
 
 private:
   L1ScalarCache *l1_;
@@ -118,7 +140,8 @@ public:
 
 protected:
   void initiate_access(Instruction &inst, Wavefront &wf) override;
-  void complete_access(Instruction &inst, Wavefront &wf) override;
+  MemoryAccessCompletion complete_access(Instruction &inst, Wavefront &wf,
+                                         MemoryAccessDeferredCompletion complete) override;
 
 private:
   L1VectorCache *l1_;
@@ -132,7 +155,8 @@ public:
 
 protected:
   void initiate_access(Instruction &inst, Wavefront &wf) override;
-  void complete_access(Instruction &inst, Wavefront &wf) override;
+  MemoryAccessCompletion complete_access(Instruction &inst, Wavefront &wf,
+                                         MemoryAccessDeferredCompletion complete) override;
 
 private:
   Lds *lds_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.h
@@ -25,7 +25,7 @@ class L1VectorCache;
 class L2Cache;
 class Lds;
 
-enum class MemoryAccessCompletion {
+enum class [[nodiscard]] MemoryAccessCompletion {
   Complete,
   Deferred,
 };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
@@ -167,6 +167,18 @@ public:
   /// @brief Set the per-WG LDS base offset.
   void set_lds_base(uint32_t base) { lds_base_ = base; }
 
+  /// @brief Return this workgroup's rank within its cluster.
+  uint32_t cluster_rank() const { return cluster_rank_; }
+
+  /// @brief Return the number of workgroups in this workgroup's cluster.
+  uint32_t cluster_size() const { return cluster_size_; }
+
+  /// @brief Set cluster placement metadata computed by the command processor.
+  void set_cluster_info(uint32_t rank, uint32_t size) {
+    cluster_rank_ = rank;
+    cluster_size_ = size == 0 ? 1 : size;
+  }
+
   /// @brief Return the SGPR register file allocation.
   /// @returns Const reference to the SGPR allocation slice.
   const RegAllocation &sgpr_alloc() const { return sgpr_alloc_; }
@@ -427,6 +439,8 @@ public:
     wg_id_ = 0;
     dispatch_id_ = 0;
     process_id_ = 0;
+    cluster_rank_ = 0;
+    cluster_size_ = 1;
     num_sgprs_ = 0;
     num_vgprs_ = 0;
     sgpr_alloc_ = {};
@@ -459,12 +473,14 @@ protected:
             uint32_t max_vgprs)
       : cu_(cu), wf_id_(wf_id), wf_size_(wf_size), max_sgprs_(max_sgprs), max_vgprs_(max_vgprs) {}
 
-  ComputeUnitCore &cu_;      ///< Parent CU (permanent, set at construction).
-  uint32_t wf_id_ = 0;       ///< Slot index within the CU (permanent).
-  uint32_t wg_id_ = 0;       ///< Workgroup ID (set per dispatch).
-  uint32_t dispatch_id_ = 0; ///< Dispatch ID (set per dispatch, unique per dispatch).
-  uint32_t process_id_ = 0;  ///< Owning process ID (PASID analog, set per dispatch).
-  uint32_t lds_base_ = 0;    ///< Per-WG LDS base offset (set per dispatch).
+  ComputeUnitCore &cu_;       ///< Parent CU (permanent, set at construction).
+  uint32_t wf_id_ = 0;        ///< Slot index within the CU (permanent).
+  uint32_t wg_id_ = 0;        ///< Workgroup ID (set per dispatch).
+  uint32_t dispatch_id_ = 0;  ///< Dispatch ID (set per dispatch, unique per dispatch).
+  uint32_t process_id_ = 0;   ///< Owning process ID (PASID analog, set per dispatch).
+  uint32_t lds_base_ = 0;     ///< Per-WG LDS base offset (set per dispatch).
+  uint32_t cluster_rank_ = 0; ///< Workgroup rank inside the dispatch cluster.
+  uint32_t cluster_size_ = 1; ///< Number of workgroups in the dispatch cluster.
 
   uint32_t wf_size_ = 0;   ///< Lanes per wavefront (ISA-fixed).
   uint32_t num_sgprs_ = 0; ///< Allocated scalar registers (set at dispatch).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/workgroup_key.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/workgroup_key.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#ifndef ROCJITSU_VM_AMDGPU_WORKGROUP_KEY_H_
+#define ROCJITSU_VM_AMDGPU_WORKGROUP_KEY_H_
+
+#include <cstdint>
+
+namespace rocjitsu {
+namespace amdgpu {
+
+inline constexpr uint64_t wg_key(uint32_t dispatch_id, uint32_t wg_id) {
+  return (uint64_t(dispatch_id) << 32) | wg_id;
+}
+
+} // namespace amdgpu
+} // namespace rocjitsu
+
+#endif // ROCJITSU_VM_AMDGPU_WORKGROUP_KEY_H_

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
@@ -293,8 +293,7 @@ void RaceDetectorPlugin::onAmdgpuRouteMemoryInstruction(const Instruction &inst,
     if (d.lds_dst) {
       uint32_t perLaneBytes = d.num_elems * d.elem_size;
       if (d.cluster_multicast && d.cluster_mcast_mask != 0) {
-        uint32_t selfMask =
-            wf.cluster_rank() < amdgpu::kClusterMulticastMaskBits ? (1u << wf.cluster_rank()) : 0;
+        uint32_t selfMask = amdgpu::cluster_multicast_rank_mask(wf.cluster_rank());
         uint32_t peerMask = d.cluster_mcast_mask & ~selfMask;
         if (peerMask != 0)
           warn_cluster_peer_writes_ignored_once();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
@@ -18,6 +18,8 @@
 
 namespace rocjitsu::plugins::race_detector {
 
+namespace {
+
 void warn_cluster_peer_writes_ignored_once() {
   static std::once_flag warned;
   std::call_once(warned, [] {
@@ -25,6 +27,8 @@ void warn_cluster_peer_writes_ignored_once() {
         "race detector does not model cluster LDS multicast peer writes; peer writes are ignored");
   });
 }
+
+} // namespace
 
 std::optional<MarkedPc> findConflict(const RaceViolation &v, RaceDetector &detector) {
   auto make = [&](auto eid) -> MarkedPc {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
@@ -6,15 +6,25 @@
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
 #include "rocjitsu/vm/amdgpu/wavefront.h"
+#include "util/log.h"
 
 #include "rocjitsu/vm/plugins/race_detector/core/common_register.h"
 #include "rocjitsu/vm/plugins/race_detector/core/wave_race_state.h"
 
 #include <cassert>
 #include <format>
+#include <mutex>
 #include <sstream>
 
 namespace rocjitsu::plugins::race_detector {
+
+void warn_cluster_peer_writes_ignored_once() {
+  static std::once_flag warned;
+  std::call_once(warned, [] {
+    util::Logger::warn(
+        "race detector does not model cluster LDS multicast peer writes; peer writes are ignored");
+  });
+}
 
 std::optional<MarkedPc> findConflict(const RaceViolation &v, RaceDetector &detector) {
   auto make = [&](auto eid) -> MarkedPc {
@@ -282,10 +292,20 @@ void RaceDetectorPlugin::onAmdgpuRouteMemoryInstruction(const Instruction &inst,
     auto &d = *inst.data_as<amdgpu::VectorMemState>();
     if (d.lds_dst) {
       uint32_t perLaneBytes = d.num_elems * d.elem_size;
+      if (d.cluster_multicast && d.cluster_mcast_mask != 0) {
+        uint32_t selfMask =
+            wf.cluster_rank() < amdgpu::kClusterMulticastMaskBits ? (1u << wf.cluster_rank()) : 0;
+        uint32_t peerMask = d.cluster_mcast_mask & ~selfMask;
+        if (peerMask != 0)
+          warn_cluster_peer_writes_ignored_once();
+        if ((d.cluster_mcast_mask & selfMask) == 0)
+          return;
+      }
       uint32_t ldsAddrs[64];
       for (uint32_t lane = 0; lane < wf.wf_size(); ++lane)
-        ldsAddrs[lane] = d.lds_base + lane * perLaneBytes;
-      rs->registerLdsEvent(wf.pc, MemoryEventType::GLOBAL_TO_LDS, {}, wf.exec(), wf.wf_size(),
+        ldsAddrs[lane] =
+            d.lds_per_lane_addr ? d.per_lane_lds_addr[lane] : d.lds_base + lane * perLaneBytes;
+      rs->registerLdsEvent(wf.pc, MemoryEventType::GLOBAL_TO_LDS, {}, d.lane_mask, wf.wf_size(),
                            std::span<const uint32_t>(ldsAddrs, wf.wf_size()), perLaneBytes);
     } else if (d.is_load && d.dst_reg_base >= wf.vgpr_alloc().base) {
       uint32_t logicalBase = d.dst_reg_base - wf.vgpr_alloc().base;

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -22,6 +22,8 @@ RJ_DIAGNOSTIC_POP
 #include <bit>
 #include <cstdint>
 #include <cstring>
+#include <limits>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -38,7 +40,8 @@ struct VmFixture {
   SoC *soc_ptr = nullptr;
   amdgpu::GpuMemory *gpu_mem = nullptr;
 
-  VmFixture(const std::string &arch = "cdna3", uint32_t num_cus = 1, uint32_t num_wf_slots = 10) {
+  VmFixture(const std::string &arch = "cdna3", uint32_t num_cus = 1, uint32_t num_wf_slots = 10,
+            uint32_t lds_size_kb = 64) {
     std::string cu_range = "cu[0:" + std::to_string(num_cus) + "]";
     std::string links;
     for (uint32_t i = 0; i < num_cus; ++i) {
@@ -66,7 +69,9 @@ struct VmFixture {
                        R"("},)"
                        R"({"key":"sgprs_per_wf","value":"104"},)"
                        R"({"key":"vgprs_per_wf","value":"256"},)"
-                       R"({"key":"lds_size_kb","value":"64"})"
+                       R"({"key":"lds_size_kb","value":")" +
+                       std::to_string(lds_size_kb) +
+                       R"("})"
                        R"(]}]}]}]},"links":[)" +
                        links + R"(]}})";
     auto loaded = config::load_config_from_string(json, rocjitsu::kEmbeddedSchema);
@@ -103,31 +108,6 @@ struct VmFixture {
     return addr;
   }
 };
-
-struct AmdExtKernelDispatchPacketForTest {
-  uint16_t header = 0;
-  uint8_t amd_format = 0;
-  uint8_t setup = 0;
-  uint16_t workgroup_size_x = 0;
-  uint16_t workgroup_size_y = 0;
-  uint16_t workgroup_size_z = 0;
-  uint16_t reserved0 = 0;
-  uint32_t cluster_count_x = 0;
-  uint16_t cluster_count_y = 0;
-  uint16_t cluster_count_z = 0;
-  uint8_t cluster_size_x = 0;
-  uint8_t cluster_size_y = 0;
-  uint8_t cluster_size_z = 0;
-  uint8_t perf_hint = 0;
-  uint32_t private_segment_size = 0;
-  uint32_t group_segment_size = 0;
-  uint64_t kernel_object = 0;
-  void *kernarg_address = nullptr;
-  hsa_signal_t dep_signal{};
-  hsa_signal_t completion_signal{};
-};
-
-static_assert(sizeof(AmdExtKernelDispatchPacketForTest) == 64);
 
 void step_until_halted(simdojo::SimulationEngine &engine,
                        std::initializer_list<amdgpu::ComputeUnitCore *> cus,
@@ -352,9 +332,9 @@ TEST_P(IsaTest, VendorSpecificExtKernelDispatch) {
   const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
   uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
 
-  AmdExtKernelDispatchPacketForTest ext{};
+  test::AmdExtKernelDispatchPacketForTest ext{};
   ext.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
-  ext.amd_format = 3; // HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH.
+  ext.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
   ext.setup = 1;
   ext.workgroup_size_x = 64;
   ext.workgroup_size_y = 1;
@@ -375,6 +355,161 @@ TEST_P(IsaTest, VendorSpecificExtKernelDispatch) {
 
   EXPECT_EQ(f.cp()->dispatched_count(), 1u);
   EXPECT_GE(f.cu()->num_wfs(), 1u);
+}
+
+TEST_P(IsaTest, VendorSpecificExtKernelDispatchReadsDependencySignalFromGpuMemory) {
+  VmFixture f(arch(), 1, 8);
+
+  const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
+  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
+  constexpr uint64_t kDepSignal = 0x7000;
+  constexpr uint32_t kSignalValueOffset = 8;
+  f.mem()->write64(kDepSignal + kSignalValueOffset, 1);
+
+  test::AmdExtKernelDispatchPacketForTest ext{};
+  ext.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
+  ext.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
+  ext.setup = 1;
+  ext.workgroup_size_x = 64;
+  ext.workgroup_size_y = 1;
+  ext.workgroup_size_z = 1;
+  ext.cluster_count_x = 1;
+  ext.cluster_count_y = 1;
+  ext.cluster_count_z = 1;
+  ext.cluster_size_x = 1;
+  ext.cluster_size_y = 1;
+  ext.cluster_size_z = 1;
+  ext.dep_signal.handle = kDepSignal;
+  ext.kernel_object = ko;
+
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.submit(ext);
+  (void)f.engine->step();
+  EXPECT_EQ(f.cp()->dispatched_count(), 0u);
+
+  f.mem()->write64(kDepSignal + kSignalValueOffset, 0);
+  f.engine->run();
+  EXPECT_EQ(f.cp()->dispatched_count(), 1u);
+}
+
+TEST(ClusterDispatchTest, RejectsClusterThatCannotFitWithoutSpinning) {
+  VmFixture f("gfx1250", 1, 1);
+
+  const uint32_t code[] = {0xBFB00000u}; // s_endpgm
+  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch_clustered(ko, /*cluster_count_x=*/1, /*cluster_size_x=*/2,
+                           /*workgroup_size_x=*/32);
+
+  EXPECT_THROW((void)f.engine->step(), std::runtime_error);
+  EXPECT_FALSE(f.cu()->has_active_wfs());
+  EXPECT_TRUE(f.cp()
+                  ->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0,
+                                        /*mcast_mask=*/0x3)
+                  .empty());
+}
+
+TEST(ClusterDispatchTest, AccountsForPerWorkgroupLdsAlignmentWhenPlanningCluster) {
+  VmFixture f("gfx1250", 1, 3, /*lds_size_kb=*/1);
+
+  const uint32_t code[] = {0xBFB00000u}; // s_endpgm
+  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.dispatch_clustered(ko, /*cluster_count_x=*/1, /*cluster_size_x=*/3,
+                           /*workgroup_size_x=*/32, /*kernarg_addr=*/0,
+                           /*group_segment_size=*/257);
+
+  EXPECT_THROW((void)f.engine->step(), std::runtime_error);
+  EXPECT_FALSE(f.cu()->has_active_wfs());
+}
+
+TEST(ClusterDispatchTest, ReclaimsLdsBetweenClusterWaves) {
+  VmFixture f("cdna3", 2, 1, /*lds_size_kb=*/1);
+
+  const uint32_t code[] = {SOPP_S_ENDPGM};
+  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
+  constexpr uint64_t kSignal = 0x7000;
+  constexpr uint32_t kSignalValueOffset = 8;
+  f.mem()->write64(kSignal + kSignalValueOffset, 1);
+
+  test::AmdExtKernelDispatchPacketForTest ext{};
+  ext.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
+  ext.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
+  ext.setup = 1;
+  ext.workgroup_size_x = 32;
+  ext.workgroup_size_y = 1;
+  ext.workgroup_size_z = 1;
+  ext.cluster_count_x = 2;
+  ext.cluster_count_y = 1;
+  ext.cluster_count_z = 1;
+  ext.cluster_size_x = 2;
+  ext.cluster_size_y = 1;
+  ext.cluster_size_z = 1;
+  ext.group_segment_size = 769;
+  ext.kernel_object = ko;
+  ext.completion_signal.handle = kSignal;
+
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.submit(ext);
+
+  EXPECT_NO_THROW(f.engine->run());
+  EXPECT_EQ(f.mem()->read64(kSignal + kSignalValueOffset), 0u);
+  EXPECT_FALSE(f.cu(0)->has_active_wfs());
+  EXPECT_FALSE(f.cu(1)->has_active_wfs());
+}
+
+TEST(ClusterDispatchTest, RejectsExtKernelDispatchWithZeroClusterShape) {
+  VmFixture f("cdna3", 1, 8);
+
+  const uint32_t code[] = {SOPP_S_ENDPGM};
+  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
+
+  test::AmdExtKernelDispatchPacketForTest ext{};
+  ext.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
+  ext.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
+  ext.setup = 1;
+  ext.workgroup_size_x = 32;
+  ext.workgroup_size_y = 1;
+  ext.workgroup_size_z = 1;
+  ext.cluster_count_x = 0;
+  ext.cluster_count_y = 1;
+  ext.cluster_count_z = 1;
+  ext.cluster_size_x = 2;
+  ext.cluster_size_y = 1;
+  ext.cluster_size_z = 1;
+  ext.kernel_object = ko;
+
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.submit(ext);
+
+  EXPECT_THROW((void)f.engine->step(), std::runtime_error);
+}
+
+TEST(ClusterDispatchTest, RejectsExtKernelDispatchGridOverflow) {
+  VmFixture f("cdna3", 1, 8);
+
+  const uint32_t code[] = {SOPP_S_ENDPGM};
+  uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
+
+  test::AmdExtKernelDispatchPacketForTest ext{};
+  ext.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
+  ext.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
+  ext.setup = 1;
+  ext.workgroup_size_x = 64;
+  ext.workgroup_size_y = 1;
+  ext.workgroup_size_z = 1;
+  ext.cluster_count_x = std::numeric_limits<uint32_t>::max();
+  ext.cluster_count_y = 1;
+  ext.cluster_count_z = 1;
+  ext.cluster_size_x = 2;
+  ext.cluster_size_y = 1;
+  ext.cluster_size_z = 1;
+  ext.kernel_object = ko;
+
+  test::AqlQueue queue(f.mem(), f.cp());
+  queue.submit(ext);
+
+  EXPECT_THROW((void)f.engine->step(), std::runtime_error);
 }
 
 TEST_P(IsaTest, DispatchCreatesWavefronts) {

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -332,7 +332,7 @@ TEST_P(IsaTest, VendorSpecificExtKernelDispatch) {
   const uint32_t code[] = {SOPP_S_NOP, SOPP_S_ENDPGM};
   uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
 
-  test::AmdExtKernelDispatchPacketForTest ext{};
+  amdgpu::AmdExtKernelDispatchPacket ext{};
   ext.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
   ext.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
   ext.setup = 1;
@@ -366,7 +366,7 @@ TEST_P(IsaTest, VendorSpecificExtKernelDispatchReadsDependencySignalFromGpuMemor
   constexpr uint32_t kSignalValueOffset = 8;
   f.mem()->write64(kDepSignal + kSignalValueOffset, 1);
 
-  test::AmdExtKernelDispatchPacketForTest ext{};
+  amdgpu::AmdExtKernelDispatchPacket ext{};
   ext.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
   ext.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
   ext.setup = 1;
@@ -432,7 +432,7 @@ TEST(ClusterDispatchTest, ReclaimsLdsBetweenClusterWaves) {
   constexpr uint32_t kSignalValueOffset = 8;
   f.mem()->write64(kSignal + kSignalValueOffset, 1);
 
-  test::AmdExtKernelDispatchPacketForTest ext{};
+  amdgpu::AmdExtKernelDispatchPacket ext{};
   ext.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
   ext.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
   ext.setup = 1;
@@ -464,7 +464,7 @@ TEST(ClusterDispatchTest, RejectsExtKernelDispatchWithZeroClusterShape) {
   const uint32_t code[] = {SOPP_S_ENDPGM};
   uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
 
-  test::AmdExtKernelDispatchPacketForTest ext{};
+  amdgpu::AmdExtKernelDispatchPacket ext{};
   ext.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
   ext.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
   ext.setup = 1;
@@ -491,7 +491,7 @@ TEST(ClusterDispatchTest, RejectsExtKernelDispatchGridOverflow) {
   const uint32_t code[] = {SOPP_S_ENDPGM};
   uint64_t ko = f.write_kernel(0x1000, code, sizeof(code));
 
-  test::AmdExtKernelDispatchPacketForTest ext{};
+  amdgpu::AmdExtKernelDispatchPacket ext{};
   ext.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
   ext.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
   ext.setup = 1;

--- a/emulation/rocjitsu/tests/aql_queue.h
+++ b/emulation/rocjitsu/tests/aql_queue.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "rocjitsu/vm/amdgpu/amd_ext_aql_packet.h"
 #include "rocjitsu/vm/amdgpu/command_processor.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 
@@ -17,10 +18,13 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 RJ_DIAGNOSTIC_POP
 
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <thread>
 
 namespace rocjitsu::test {
+
+using AmdExtKernelDispatchPacketForTest = amdgpu::AmdExtKernelDispatchPacket;
 
 /// Simulates what ROCR's user-mode AqlQueue does: manages a ring buffer,
 /// writes AQL packets, and rings the doorbell. Does NOT load kernels --
@@ -69,6 +73,12 @@ public:
     cp_->engine()->schedule_event_now(cp_->doorbell_event());
   }
 
+  void submit(const AmdExtKernelDispatchPacketForTest &pkt) {
+    hsa_kernel_dispatch_packet_t raw{};
+    std::memcpy(&raw, &pkt, sizeof(pkt));
+    submit(raw);
+  }
+
   /// Build and submit a kernel dispatch packet.
   void dispatch(uint64_t kernel_object, uint32_t grid_size_x, uint16_t workgroup_size_x = 64,
                 uint64_t kernarg_addr = 0) {
@@ -81,6 +91,29 @@ public:
     pkt.grid_size_x = grid_size_x;
     pkt.grid_size_y = 1;
     pkt.grid_size_z = 1;
+    pkt.kernel_object = kernel_object;
+    pkt.kernarg_address = reinterpret_cast<void *>(kernarg_addr);
+    submit(pkt);
+  }
+
+  /// Build and submit an AMD extended kernel dispatch packet with cluster shape.
+  void dispatch_clustered(uint64_t kernel_object, uint32_t cluster_count_x, uint8_t cluster_size_x,
+                          uint16_t workgroup_size_x = 64, uint64_t kernarg_addr = 0,
+                          uint32_t group_segment_size = 0) {
+    AmdExtKernelDispatchPacketForTest pkt{};
+    pkt.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
+    pkt.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
+    pkt.setup = 1;
+    pkt.workgroup_size_x = workgroup_size_x;
+    pkt.workgroup_size_y = 1;
+    pkt.workgroup_size_z = 1;
+    pkt.cluster_count_x = cluster_count_x;
+    pkt.cluster_count_y = 1;
+    pkt.cluster_count_z = 1;
+    pkt.cluster_size_x = cluster_size_x;
+    pkt.cluster_size_y = 1;
+    pkt.cluster_size_z = 1;
+    pkt.group_segment_size = group_segment_size;
     pkt.kernel_object = kernel_object;
     pkt.kernarg_address = reinterpret_cast<void *>(kernarg_addr);
     submit(pkt);

--- a/emulation/rocjitsu/tests/aql_queue.h
+++ b/emulation/rocjitsu/tests/aql_queue.h
@@ -24,8 +24,6 @@ RJ_DIAGNOSTIC_POP
 
 namespace rocjitsu::test {
 
-using AmdExtKernelDispatchPacketForTest = amdgpu::AmdExtKernelDispatchPacket;
-
 /// Simulates what ROCR's user-mode AqlQueue does: manages a ring buffer,
 /// writes AQL packets, and rings the doorbell. Does NOT load kernels --
 /// that's the runtime's job. Tests write kernel descriptors and code
@@ -73,7 +71,7 @@ public:
     cp_->engine()->schedule_event_now(cp_->doorbell_event());
   }
 
-  void submit(const AmdExtKernelDispatchPacketForTest &pkt) {
+  void submit(const amdgpu::AmdExtKernelDispatchPacket &pkt) {
     hsa_kernel_dispatch_packet_t raw{};
     std::memcpy(&raw, &pkt, sizeof(pkt));
     submit(raw);
@@ -100,7 +98,7 @@ public:
   void dispatch_clustered(uint64_t kernel_object, uint32_t cluster_count_x, uint8_t cluster_size_x,
                           uint16_t workgroup_size_x = 64, uint64_t kernarg_addr = 0,
                           uint32_t group_segment_size = 0) {
-    AmdExtKernelDispatchPacketForTest pkt{};
+    amdgpu::AmdExtKernelDispatchPacket pkt{};
     pkt.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
     pkt.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
     pkt.setup = 1;

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -10,13 +10,16 @@
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/operand.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/vds.h"
+#include "rocjitsu/isa/arch/amdgpu/gfx1250/vglobal.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/vimage.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/vop1.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/vop2.h"
 #include "rocjitsu/isa/arch/amdgpu/gfx1250/vop3.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/vm/amdgpu/cluster_lds_multicast.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
+#include "rocjitsu/vm/amdgpu/dispatch_entry.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/lds_barrier_cell.h"
 #include "rocjitsu/vm/amdgpu/mem_state.h"
@@ -48,8 +51,10 @@ RJ_DIAGNOSTIC_POP
 #include <fstream>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -90,6 +95,29 @@ constexpr uint32_t kSdmaSubopCopyLinear = 0;
 constexpr uint32_t kSdmaSubopFence64 = 2;
 constexpr uint32_t kSdmaSubopPollMem64 = 5;
 
+class TestMemoryInstruction : public Instruction {
+public:
+  explicit TestMemoryInstruction(std::unique_ptr<DynamicInstState> state)
+      : Instruction("test_mem", nullptr) {
+    flags_ |= MEMORY_OP;
+    set_data(std::move(state));
+  }
+};
+
+class DeferredClusterLdsMulticastEngine : public amdgpu::ClusterLdsMulticastEngine {
+public:
+  amdgpu::ClusterLdsMulticastResult
+  submit(amdgpu::ClusterLdsMulticastTransaction submitted,
+         amdgpu::ClusterLdsMulticastCompletion submitted_completion) override {
+    txn = std::move(submitted);
+    completion = std::move(submitted_completion);
+    return amdgpu::ClusterLdsMulticastResult::Deferred;
+  }
+
+  amdgpu::ClusterLdsMulticastTransaction txn;
+  amdgpu::ClusterLdsMulticastCompletion completion;
+};
+
 struct Gfx1250Sim {
   config::LoadedConfig loaded;
   SoC *soc = nullptr;
@@ -97,6 +125,15 @@ struct Gfx1250Sim {
   std::unique_ptr<simdojo::SimulationEngine> engine;
 
   Gfx1250Sim() : loaded(config::load_config(kGfx1250ConfigPath, rocjitsu::kEmbeddedSchema)) {
+    build();
+  }
+
+  explicit Gfx1250Sim(const std::string &config_json)
+      : loaded(config::load_config_from_string(config_json, rocjitsu::kEmbeddedSchema)) {
+    build();
+  }
+
+  void build() {
     soc = loaded.soc();
     memory = loaded.memory();
     engine = std::make_unique<simdojo::SimulationEngine>(loaded.engine_config);
@@ -144,6 +181,36 @@ struct Gfx1250Sim {
     return addr;
   }
 };
+
+std::string make_single_se_gfx1250_config(uint32_t num_cus) {
+  std::string cu_range = "cu[0:" + std::to_string(num_cus) + "]";
+  std::string links;
+  for (uint32_t i = 0; i < num_cus; ++i) {
+    if (i > 0)
+      links += ",";
+    links += R"({"src":"xcd0.cp.req_)" + std::to_string(i) + R"(","dst":"xcd0.se0.cu)" +
+             std::to_string(i) + R"(.cpl","latency":1,"weight":2})";
+    links += R"(,{"src":"xcd0.se0.cu)" + std::to_string(i) + R"(.req","dst":"xcd0.l2.cpl_)" +
+             std::to_string(i) + R"(","latency":1,"weight":10})";
+  }
+
+  return R"({"max_ticks":10000,"num_threads":1,"vm":{"arch":"gfx1250"},)"
+         R"("topology":{"root":{"name":"soc","type":"soc","children":[)"
+         R"({"name":"vram","type":"gpu_memory"},)"
+         R"({"name":"xcd0","type":"xcd","children":[)"
+         R"({"name":"l2","type":"l2_cache"},)"
+         R"({"name":"cp","type":"command_processor"},)"
+         R"({"name":"se0","type":"shader_engine","children":[)"
+         R"({"name":")" +
+         cu_range +
+         R"(","type":"compute_unit","config":[)"
+         R"({"key":"num_wf_slots","value":"80"},)"
+         R"({"key":"sgprs_per_wf","value":"128"},)"
+         R"({"key":"vgprs_per_wf","value":"1024"},)"
+         R"({"key":"lds_size_kb","value":"160"})"
+         R"(]}]}]}]},"links":[)" +
+         links + R"(]}})";
+}
 
 class HostSdmaQueueForTest {
 public:
@@ -1114,6 +1181,628 @@ TEST(Gfx1250ExecutionTest, Wave32ScalarVccHiWritePreservesUpperHalf) {
   cu->execute_instruction(inst.get(), *wf);
 
   EXPECT_EQ(wf->vcc(), 0xffff0000'00000000ULL);
+}
+
+TEST(Gfx1250ExecutionTest, ClusterLoadsDecodeAndPopulateVectorMemState) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0x3u);
+  wf->set_lds_base(cu->allocate_lds(256));
+  wf->set_m0(0xffff0003u);
+
+  constexpr uint64_t kGlobalBase = 0x180000u;
+  write_wave_sgpr(*cu, *wf, 0, static_cast<uint32_t>(kGlobalBase));
+  write_wave_sgpr(*cu, *wf, 1, static_cast<uint32_t>(kGlobalBase >> 32));
+
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  auto write_vgpr_lane_offsets = [&](uint32_t reg, uint32_t stride) {
+    cu->write_vgpr(vgpr_base + reg, 0, 0);
+    cu->write_vgpr(vgpr_base + reg, 1, stride);
+  };
+  auto write_vgpr_lane_indices = [&](uint32_t reg) {
+    cu->write_vgpr(vgpr_base + reg, 0, 0);
+    cu->write_vgpr(vgpr_base + reg, 1, 1);
+  };
+
+  struct LoadCase {
+    std::array<uint32_t, 3> words;
+    std::string_view mnemonic;
+    uint32_t num_elems;
+    uint32_t dst_reg;
+    bool scale_offset;
+  };
+
+  const LoadCase load_cases[] = {
+      {{0xEE19C000u, 0x00000001u, 0x00000000u}, "cluster_load_b32", 1, 1, false},
+      {{0xEE1A0000u, 0x00000000u, 0x00000002u}, "cluster_load_b64", 2, 0, false},
+      {{0xEE1A4000u, 0x00010002u, 0x00000000u}, "cluster_load_b128", 4, 2, true},
+  };
+
+  for (const LoadCase &tc : load_cases) {
+    if (tc.scale_offset)
+      write_vgpr_lane_indices(0);
+    else
+      write_vgpr_lane_offsets(tc.words[2] & 0xffu, 16);
+
+    auto inst = decode_gfx1250(tc.words, tc.mnemonic);
+    ASSERT_NE(inst, nullptr);
+    inst->execute(*inst, wf);
+    auto *state = inst->data_as<amdgpu::VectorMemState>();
+    ASSERT_NE(state, nullptr);
+    EXPECT_EQ(state->tag(), amdgpu::GLOBAL_MEM);
+    EXPECT_EQ(state->dst_reg_base, vgpr_base + tc.dst_reg);
+    EXPECT_EQ(state->elem_size, 4u);
+    EXPECT_EQ(state->num_elems, tc.num_elems);
+    EXPECT_TRUE(state->is_load);
+    EXPECT_EQ(state->wait_counter_type, amdgpu::WaitCounterType::LOADCNT);
+    EXPECT_FALSE(state->lds_dst);
+    EXPECT_FALSE(state->cluster_multicast);
+    EXPECT_EQ(state->lane_mask, 0x3u);
+    EXPECT_EQ(state->per_lane_addr[0], kGlobalBase);
+    EXPECT_EQ(state->per_lane_addr[1], kGlobalBase + 16);
+  }
+
+  struct AsyncCase {
+    std::array<uint32_t, 3> words;
+    std::string_view mnemonic;
+    uint32_t elem_size;
+    uint32_t num_elems;
+    uint32_t lds_addr_reg;
+    uint32_t global_stride;
+    uint32_t lds_stride;
+    uint32_t offset;
+    bool scale_offset;
+    bool cluster_multicast;
+  };
+
+  const AsyncCase async_cases[] = {
+      {{0xEE1A8000u, 0x00000000u, 0x00000000u},
+       "cluster_load_async_to_lds_b8",
+       1,
+       1,
+       0,
+       1,
+       1,
+       0,
+       false,
+       true},
+      {{0xEE180000u, 0x00000000u, 0x00000800u},
+       "global_load_async_to_lds_b32",
+       4,
+       1,
+       0,
+       16,
+       16,
+       8,
+       false,
+       false},
+      {{0xEE1AC000u, 0x00000000u, 0x00000800u},
+       "cluster_load_async_to_lds_b32",
+       4,
+       1,
+       0,
+       16,
+       16,
+       8,
+       false,
+       true},
+      {{0xEE1B0000u, 0x00000004u, 0x00000004u},
+       "cluster_load_async_to_lds_b64",
+       4,
+       2,
+       4,
+       16,
+       16,
+       0,
+       false,
+       true},
+      {{0xEE1B4000u, 0x00010001u, 0x00000000u},
+       "cluster_load_async_to_lds_b128",
+       4,
+       4,
+       1,
+       16,
+       16,
+       0,
+       true,
+       true},
+  };
+
+  for (const AsyncCase &tc : async_cases) {
+    if (tc.scale_offset) {
+      write_vgpr_lane_indices(0);
+      write_vgpr_lane_offsets(tc.lds_addr_reg, 16);
+    } else {
+      write_vgpr_lane_offsets(tc.lds_addr_reg, tc.global_stride);
+    }
+
+    auto inst = decode_gfx1250(tc.words, tc.mnemonic);
+    ASSERT_NE(inst, nullptr);
+    inst->execute(*inst, wf);
+    auto *state = inst->data_as<amdgpu::VectorMemState>();
+    ASSERT_NE(state, nullptr);
+    EXPECT_EQ(state->tag(), amdgpu::GLOBAL_MEM);
+    EXPECT_EQ(state->elem_size, tc.elem_size);
+    EXPECT_EQ(state->num_elems, tc.num_elems);
+    EXPECT_TRUE(state->is_load);
+    EXPECT_TRUE(state->lds_dst);
+    EXPECT_TRUE(state->lds_per_lane_addr);
+    EXPECT_EQ(state->lds_base, wf->lds_base());
+    EXPECT_EQ(state->cluster_multicast, tc.cluster_multicast);
+    EXPECT_EQ(state->cluster_mcast_mask, tc.cluster_multicast ? 0x3u : 0u);
+    EXPECT_EQ(state->wait_counter_type, amdgpu::WaitCounterType::ASYNCCNT);
+    EXPECT_EQ(state->lane_mask, 0x3u);
+    EXPECT_EQ(state->per_lane_addr[0], kGlobalBase + tc.offset);
+    EXPECT_EQ(state->per_lane_addr[1], kGlobalBase + tc.offset + tc.global_stride);
+    EXPECT_EQ(state->per_lane_lds_addr[0], wf->lds_base() + tc.offset);
+    EXPECT_EQ(state->per_lane_lds_addr[1], wf->lds_base() + tc.offset + tc.lds_stride);
+  }
+}
+
+TEST(Gfx1250ExecutionTest, DispatchEntryClusterMathCoversMultiDimensionalShapes) {
+  amdgpu::DispatchEntry entry{};
+  entry.grid_wgs_x = 4;
+  entry.grid_wgs_y = 4;
+  entry.grid_wgs_z = 4;
+  entry.cluster_count_x = 2;
+  entry.cluster_count_y = 2;
+  entry.cluster_count_z = 2;
+  entry.cluster_size_x = 2;
+  entry.cluster_size_y = 2;
+  entry.cluster_size_z = 2;
+
+  EXPECT_TRUE(entry.cluster_grid_is_complete());
+  EXPECT_EQ(entry.cluster_size(), 8u);
+  EXPECT_EQ(entry.cluster_rank_for_local_wg(0), 0u);
+  EXPECT_EQ(entry.cluster_rank_for_local_wg(5), 3u);
+  EXPECT_EQ(entry.cluster_rank_for_local_wg(21), 7u);
+  EXPECT_EQ(entry.cluster_peer_local_wg_id(0, 0), 0u);
+  EXPECT_EQ(entry.cluster_peer_local_wg_id(0, 1), 1u);
+  EXPECT_EQ(entry.cluster_peer_local_wg_id(0, 2), 4u);
+  EXPECT_EQ(entry.cluster_peer_local_wg_id(0, 3), 5u);
+  EXPECT_EQ(entry.cluster_peer_local_wg_id(0, 4), 16u);
+  EXPECT_EQ(entry.cluster_peer_local_wg_id(0, 7), 21u);
+  EXPECT_EQ(entry.cluster_peer_local_wg_id(42, 0), 42u);
+  EXPECT_EQ(entry.cluster_peer_local_wg_id(42, 7), 63u);
+  EXPECT_EQ(entry.cluster_base_local_wg_id_for_ordinal(0), 0u);
+  EXPECT_EQ(entry.cluster_base_local_wg_id_for_ordinal(1), 2u);
+  EXPECT_EQ(entry.cluster_base_local_wg_id_for_ordinal(2), 8u);
+  EXPECT_EQ(entry.cluster_base_local_wg_id_for_ordinal(4), 32u);
+
+  entry.grid_wgs_x = 3;
+  entry.grid_wgs_y = 2;
+  entry.grid_wgs_z = 1;
+  entry.cluster_count_x = 2;
+  entry.cluster_count_y = 2;
+  entry.cluster_count_z = 1;
+  entry.cluster_size_x = 2;
+  entry.cluster_size_y = 1;
+  entry.cluster_size_z = 1;
+  EXPECT_FALSE(entry.cluster_grid_is_complete());
+  EXPECT_THROW((void)entry.cluster_peer_local_wg_id(2, 1), std::logic_error);
+}
+
+TEST(Gfx1250ExecutionTest, ClusterLdsMulticastTransactionCapturesRemapState) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(9, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_dispatch_id(7);
+  wf->set_cluster_info(/*rank=*/1, /*size=*/4);
+  wf->set_lds_base(0x100);
+
+  amdgpu::VectorMemState state(amdgpu::GLOBAL_MEM);
+  state.elem_size = 4;
+  state.num_elems = 2;
+  state.wait_counter_type = amdgpu::WaitCounterType::ASYNCCNT;
+  state.lds_base = wf->lds_base();
+  state.lds_per_lane_addr = true;
+  state.cluster_mcast_mask = 0xa;
+  state.wf_size = 32;
+  state.lane_mask = 0x3;
+  state.per_lane_lds_addr[0] = state.lds_base + 0x10;
+  state.per_lane_lds_addr[1] = state.lds_base + 0x24;
+  state.response_data.resize(state.wf_size * state.num_elems * state.elem_size);
+
+  std::vector<amdgpu::ClusterLdsTarget> targets = {{cu, /*wg_id=*/11, /*lds_base=*/0x400,
+                                                    /*cluster_rank=*/3}};
+  auto txn = amdgpu::make_cluster_lds_multicast_transaction(state, *wf, std::move(targets));
+
+  EXPECT_EQ(txn.dispatch_id, 7u);
+  EXPECT_EQ(txn.source_wg_id, 9u);
+  EXPECT_EQ(txn.source_cluster_rank, 1u);
+  EXPECT_EQ(txn.source_lds_base, 0x100u);
+  EXPECT_EQ(txn.mcast_mask, 0xau);
+  EXPECT_EQ(txn.wait_counter_type, amdgpu::WaitCounterType::ASYNCCNT);
+  EXPECT_EQ(txn.bytes_per_lane, 8u);
+  ASSERT_EQ(txn.targets.size(), 1u);
+  EXPECT_EQ(txn.targets[0].wg_id, 11u);
+  EXPECT_EQ(amdgpu::cluster_lds_lane_addr(txn, 0, txn.targets[0].lds_base), 0x410u);
+  EXPECT_EQ(amdgpu::cluster_lds_lane_addr(txn, 1, txn.targets[0].lds_base), 0x424u);
+  EXPECT_THROW((void)amdgpu::remap_cluster_lds_addr(0x100, 0x400, 0xfc), std::runtime_error);
+}
+
+TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineWritesSelectedTargets) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  cu->clear_lds();
+
+  amdgpu::ClusterLdsMulticastTransaction txn{};
+  txn.source_lds_base = 0x40;
+  txn.bytes_per_lane = 4;
+  txn.wf_size = 4;
+  txn.lane_mask = 0x5;
+  txn.per_lane_addr = true;
+  txn.per_lane_lds_addr[0] = 0x44;
+  txn.per_lane_lds_addr[2] = 0x4c;
+  txn.payload.resize(txn.wf_size * txn.bytes_per_lane);
+  const uint32_t lane0 = 0x11223344;
+  const uint32_t lane2 = 0xaabbccdd;
+  std::memcpy(&txn.payload[0 * txn.bytes_per_lane], &lane0, sizeof(lane0));
+  std::memcpy(&txn.payload[2 * txn.bytes_per_lane], &lane2, sizeof(lane2));
+  txn.targets = {{cu, /*wg_id=*/0, /*lds_base=*/0x200, /*cluster_rank=*/0},
+                 {cu, /*wg_id=*/1, /*lds_base=*/0x300, /*cluster_rank=*/1}};
+
+  amdgpu::ImmediateClusterLdsMulticastEngine engine;
+  bool deferred_callback_called = false;
+  EXPECT_EQ(engine.submit(std::move(txn), [&]() { deferred_callback_called = true; }),
+            amdgpu::ClusterLdsMulticastResult::Complete);
+  EXPECT_FALSE(deferred_callback_called);
+  EXPECT_EQ(cu->lds().read32(0x204), lane0);
+  EXPECT_EQ(cu->lds().read32(0x20c), lane2);
+  EXPECT_EQ(cu->lds().read32(0x304), lane0);
+  EXPECT_EQ(cu->lds().read32(0x30c), lane2);
+  EXPECT_EQ(cu->lds().read32(0x208), 0u);
+}
+
+TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineRejectsUndersizedPayload) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+
+  amdgpu::ClusterLdsMulticastTransaction txn{};
+  txn.bytes_per_lane = 4;
+  txn.wf_size = 2;
+  txn.lane_mask = 0x3;
+  txn.payload.resize(4);
+  txn.targets = {{cu, /*wg_id=*/0, /*lds_base=*/0x200, /*cluster_rank=*/0}};
+
+  amdgpu::ImmediateClusterLdsMulticastEngine engine;
+  EXPECT_THROW((void)engine.submit(std::move(txn), []() {}), std::runtime_error);
+}
+
+TEST(Gfx1250ExecutionTest, ClusterLdsPinPreventsAllocatorReuseUntilClusterCompletes) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+
+  EXPECT_EQ(cu->allocate_lds(257), 0u);
+  cu->pin_lds_until_cluster_retired(7);
+  cu->retire_halted_wfs();
+
+  EXPECT_EQ(cu->allocate_lds(257), 512u);
+  cu->unpin_lds_for_cluster(7);
+  cu->retire_halted_wfs();
+  EXPECT_EQ(cu->allocate_lds(257), 0u);
+}
+
+TEST(Gfx1250ExecutionTest, DeferredClusterLdsMulticastHoldsAsyncCounterUntilCallback) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_dispatch_id(3);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobalAddr = 0x9000;
+  constexpr uint32_t kLoadedValue = 0x12345678;
+  for (uint32_t byte = 0; byte < sizeof(kLoadedValue); ++byte) {
+    sim.memory->write8(kGlobalAddr + byte,
+                       static_cast<uint8_t>((kLoadedValue >> (byte * 8)) & 0xffu));
+  }
+
+  auto state = std::make_unique<amdgpu::VectorMemState>(amdgpu::GLOBAL_MEM);
+  state->elem_size = 4;
+  state->num_elems = 1;
+  state->is_load = true;
+  state->wait_counter_type = amdgpu::WaitCounterType::ASYNCCNT;
+  state->lds_dst = true;
+  state->lds_per_lane_addr = true;
+  state->lds_base = wf->lds_base();
+  state->wf_size = 32;
+  state->lane_mask = 0x1;
+  state->exec_mask = 0x1;
+  state->per_lane_addr[0] = kGlobalAddr;
+  state->per_lane_lds_addr[0] = wf->lds_base() + 0x20;
+
+  DeferredClusterLdsMulticastEngine deferred_engine;
+  cu->set_cluster_lds_multicast_engine(&deferred_engine);
+  amdgpu::GlobalMemPipeline pipeline(&cu->l1_vector(), cu->l2());
+  pipeline.issue(new TestMemoryInstruction(std::move(state)), *wf);
+
+  EXPECT_EQ(wf->wait_counters().asynccnt, 1u);
+  ASSERT_TRUE(static_cast<bool>(deferred_engine.completion));
+  EXPECT_EQ(deferred_engine.txn.wait_counter_type, amdgpu::WaitCounterType::ASYNCCNT);
+  EXPECT_EQ(deferred_engine.txn.bytes_per_lane, 4u);
+  ASSERT_EQ(deferred_engine.txn.targets.size(), 1u);
+  EXPECT_EQ(deferred_engine.txn.targets[0].cu, cu);
+  EXPECT_EQ(deferred_engine.txn.payload.size(), 32u * sizeof(kLoadedValue));
+  uint32_t payload_value = 0;
+  std::memcpy(&payload_value, deferred_engine.txn.payload.data(), sizeof(payload_value));
+  EXPECT_EQ(payload_value, kLoadedValue);
+
+  deferred_engine.completion();
+  EXPECT_EQ(wf->wait_counters().asynccnt, 0u);
+  cu->set_cluster_lds_multicast_engine(nullptr);
+}
+
+TEST(Gfx1250SimulationTest, ClusterLdsTargetsCoversMasksAndLifetime) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  constexpr uint32_t lds_bytes_per_wg = 256;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch_clustered(kernel_object, /*cluster_count_x=*/1, /*cluster_size_x=*/2,
+                           /*workgroup_size_x=*/32, /*kernarg_addr=*/0, lds_bytes_per_wg);
+
+  ASSERT_TRUE(sim.engine->step());
+
+  auto all = sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0, /*mcast_mask=*/0x3);
+  ASSERT_EQ(all.size(), 2u);
+  EXPECT_EQ(all[0].wg_id, 0u);
+  EXPECT_EQ(all[1].wg_id, 1u);
+
+  auto self = sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0, /*mcast_mask=*/0x1);
+  ASSERT_EQ(self.size(), 1u);
+  EXPECT_EQ(self[0].wg_id, 0u);
+
+  auto peer = sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0, /*mcast_mask=*/0x2);
+  ASSERT_EQ(peer.size(), 1u);
+  EXPECT_EQ(peer[0].wg_id, 1u);
+
+  auto peer_from_rank1 =
+      sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/1, /*mcast_mask=*/0x1);
+  ASSERT_EQ(peer_from_rank1.size(), 1u);
+  EXPECT_EQ(peer_from_rank1[0].wg_id, 0u);
+
+  auto zero_mask = sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0, /*mcast_mask=*/0);
+  ASSERT_EQ(zero_mask.size(), 1u);
+  EXPECT_EQ(zero_mask[0].wg_id, 0u);
+
+  auto out_of_range =
+      sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0, /*mcast_mask=*/0x4);
+  ASSERT_EQ(out_of_range.size(), 1u);
+  EXPECT_EQ(out_of_range[0].wg_id, 0u);
+
+  auto mixed_range =
+      sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0, /*mcast_mask=*/0x5);
+  ASSERT_EQ(mixed_range.size(), 1u);
+  EXPECT_EQ(mixed_range[0].wg_id, 0u);
+
+  EXPECT_TRUE(sim.cp()
+                  ->cluster_lds_targets(/*dispatch_id=*/999, /*wg_id=*/0,
+                                        /*mcast_mask=*/0x3)
+                  .empty());
+
+  sim.engine->run();
+  EXPECT_TRUE(sim.cp()
+                  ->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0,
+                                        /*mcast_mask=*/0x3)
+                  .empty());
+}
+
+TEST(Gfx1250SimulationTest, ClusterLdsTargetsUseMultiDimensionalClusterPlacement) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  constexpr uint32_t lds_bytes_per_wg = 256;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
+
+  test::AmdExtKernelDispatchPacketForTest pkt{};
+  pkt.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
+  pkt.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
+  pkt.setup = 2;
+  pkt.workgroup_size_x = 32;
+  pkt.workgroup_size_y = 1;
+  pkt.workgroup_size_z = 1;
+  pkt.cluster_count_x = 2;
+  pkt.cluster_count_y = 2;
+  pkt.cluster_count_z = 1;
+  pkt.cluster_size_x = 2;
+  pkt.cluster_size_y = 2;
+  pkt.cluster_size_z = 1;
+  pkt.group_segment_size = lds_bytes_per_wg;
+  pkt.kernel_object = kernel_object;
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.submit(pkt);
+  ASSERT_TRUE(sim.engine->step());
+
+  auto cluster0 = sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0, /*mcast_mask=*/0xf);
+  ASSERT_EQ(cluster0.size(), 4u);
+  EXPECT_EQ(cluster0[0].wg_id, 0u);
+  EXPECT_EQ(cluster0[1].wg_id, 1u);
+  EXPECT_EQ(cluster0[2].wg_id, 4u);
+  EXPECT_EQ(cluster0[3].wg_id, 5u);
+
+  auto targets = sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/5, /*mcast_mask=*/0x5);
+  ASSERT_EQ(targets.size(), 2u);
+  EXPECT_EQ(targets[0].wg_id, 0u);
+  EXPECT_EQ(targets[1].wg_id, 4u);
+
+  auto source = sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/5, /*mcast_mask=*/0x8);
+  ASSERT_EQ(source.size(), 1u);
+  EXPECT_EQ(source[0].wg_id, 5u);
+
+  constexpr uint32_t kValue = 0xfeed1234;
+  amdgpu::ClusterLdsMulticastTransaction txn{};
+  txn.source_lds_base = source[0].lds_base;
+  txn.bytes_per_lane = sizeof(kValue);
+  txn.wf_size = 1;
+  txn.lane_mask = 0x1;
+  txn.per_lane_addr = true;
+  txn.per_lane_lds_addr[0] = source[0].lds_base + 0x10;
+  txn.payload.resize(sizeof(kValue));
+  std::memcpy(txn.payload.data(), &kValue, sizeof(kValue));
+  txn.targets = targets;
+
+  amdgpu::ImmediateClusterLdsMulticastEngine engine;
+  bool deferred_callback_called = false;
+  EXPECT_EQ(engine.submit(std::move(txn), [&]() { deferred_callback_called = true; }),
+            amdgpu::ClusterLdsMulticastResult::Complete);
+  EXPECT_FALSE(deferred_callback_called);
+  EXPECT_EQ(targets[0].cu->lds().read32(targets[0].lds_base + 0x10), kValue);
+  EXPECT_EQ(targets[1].cu->lds().read32(targets[1].lds_base + 0x10), kValue);
+  EXPECT_EQ(source[0].cu->lds().read32(source[0].lds_base + 0x10), 0u);
+
+  sim.engine->run();
+}
+
+TEST(Gfx1250SimulationTest, ClusterLdsRemapUsesNonIdentityPeerLdsBase) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  constexpr uint32_t lds_bytes_per_wg = 256;
+  constexpr uint32_t cluster_size = 8;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+
+  Gfx1250Sim sim(make_single_se_gfx1250_config(/*num_cus=*/4));
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch_clustered(kernel_object, /*cluster_count_x=*/1, cluster_size,
+                           /*workgroup_size_x=*/32, /*kernarg_addr=*/0, lds_bytes_per_wg);
+  ASSERT_TRUE(sim.engine->step());
+
+  struct RemapCase {
+    amdgpu::ClusterLdsTarget source;
+    amdgpu::ClusterLdsTarget target;
+  };
+  std::optional<RemapCase> remap_case;
+  for (uint32_t wg_id = 0; wg_id < cluster_size && !remap_case; ++wg_id) {
+    auto source = sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, wg_id, /*mcast_mask=*/0);
+    ASSERT_EQ(source.size(), 1u);
+    ASSERT_NE(source[0].cu, nullptr);
+
+    auto targets = sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, wg_id,
+                                                 /*mcast_mask=*/(1u << cluster_size) - 1);
+    for (const auto &target : targets) {
+      if (target.wg_id == wg_id)
+        continue;
+      if (target.cu == source[0].cu && target.lds_base != source[0].lds_base) {
+        remap_case = RemapCase{source[0], target};
+        break;
+      }
+    }
+  }
+  ASSERT_TRUE(remap_case.has_value());
+  const auto source = remap_case->source;
+  const auto target = remap_case->target;
+  ASSERT_NE(target.cu, nullptr);
+  EXPECT_EQ(target.cu, source.cu);
+  EXPECT_NE(target.lds_base, source.lds_base);
+
+  constexpr uint32_t kValue = 0x13579bdf;
+  amdgpu::ClusterLdsMulticastTransaction txn{};
+  txn.source_lds_base = source.lds_base;
+  txn.bytes_per_lane = sizeof(kValue);
+  txn.wf_size = 1;
+  txn.lane_mask = 0x1;
+  txn.per_lane_addr = true;
+  txn.per_lane_lds_addr[0] = source.lds_base + 0x20;
+  txn.payload.resize(sizeof(kValue));
+  std::memcpy(txn.payload.data(), &kValue, sizeof(kValue));
+  txn.targets = {target};
+
+  amdgpu::ImmediateClusterLdsMulticastEngine engine;
+  EXPECT_EQ(engine.submit(std::move(txn), []() {}), amdgpu::ClusterLdsMulticastResult::Complete);
+  EXPECT_EQ(target.cu->lds().read32(target.lds_base + 0x20), kValue);
+  EXPECT_EQ(source.cu->lds().read32(source.lds_base + 0x20), 0u);
+
+  sim.engine->run();
+}
+
+TEST(Gfx1250SimulationTest, RejectsUnsupportedClusterSize) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch_clustered(kernel_object, /*cluster_count_x=*/1,
+                           /*cluster_size_x=*/amdgpu::kClusterMulticastMaskBits + 1,
+                           /*workgroup_size_x=*/32);
+
+  EXPECT_THROW((void)sim.engine->step(), std::runtime_error);
+}
+
+TEST(Gfx1250SimulationTest, RejectsIncompleteClusterGrid) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch_clustered(kernel_object, /*cluster_count_x=*/1, /*cluster_size_x=*/2,
+                           /*workgroup_size_x=*/0);
+
+  EXPECT_THROW((void)sim.engine->step(), std::runtime_error);
+}
+
+TEST(Gfx1250SimulationTest, ClusterLoadAsyncToLdsMulticastsAcrossClusterWorkgroups) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  constexpr uint64_t input_addr = 0x2000;
+  constexpr uint32_t lds_bytes_per_wg = 256;
+
+  const uint32_t code[] = {
+      0xBE8000FFu,    static_cast<uint32_t>(input_addr), // s_mov_b32 s0, input_addr
+      0xBE810080u,                                       // s_mov_b32 s1, 0
+      0xBF068002u,                                       // s_cmp_eq_u32 s2, 0 (WG id)
+      0xBF840006u,                                       // s_cbranch_scc0 +6
+      0xBEFD0083u,                                       // s_mov_b32 m0, 0x3
+      0x30000082u,                                       // v_lshlrev_b32_e32 v0, 2, v0
+      0xEE1AC000u,    0x00000000u,
+      0x00000000u, // cluster_load_async_to_lds_b32 v0, v0, s[0:1]
+      0xBFCA0000u, // s_wait_asynccnt 0
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
+  for (uint32_t byte = 0; byte < 256; ++byte)
+    sim.memory->write8(input_addr + byte, static_cast<uint8_t>(0x40u + byte));
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch_clustered(kernel_object, /*cluster_count_x=*/1, /*cluster_size_x=*/2,
+                           /*workgroup_size_x=*/32, /*kernarg_addr=*/0, lds_bytes_per_wg);
+  ASSERT_TRUE(sim.engine->step());
+
+  auto targets = sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0, /*mcast_mask=*/0x3);
+  ASSERT_EQ(targets.size(), 2u);
+  ASSERT_NE(targets[0].cu, nullptr);
+  ASSERT_NE(targets[1].cu, nullptr);
+  EXPECT_NE(targets[0].cu, targets[1].cu);
+  sim.engine->run();
+  EXPECT_TRUE(sim.cp()
+                  ->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0,
+                                        /*mcast_mask=*/0x3)
+                  .empty());
+
+  auto read_unaligned_input = [&](uint32_t byte_offset) {
+    uint32_t value = 0;
+    for (uint32_t byte = 0; byte < 4; ++byte)
+      value |= static_cast<uint32_t>(sim.memory->read8(input_addr + byte_offset + byte))
+               << (byte * 8);
+    return value;
+  };
+
+  for (uint32_t lane = 0; lane < 32; ++lane) {
+    uint32_t value0 = targets[0].cu->lds().read32(targets[0].lds_base + lane * 4);
+    uint32_t value1 = targets[1].cu->lds().read32(targets[1].lds_base + lane * 4);
+    uint32_t wg0_value = read_unaligned_input(lane * 4);
+    EXPECT_EQ(value0, value1) << "lane " << lane;
+    EXPECT_EQ(value0, wg0_value) << "lane " << lane;
+  }
 }
 
 TEST(Gfx1250ExecutionTest, TensorDmaD2CopiesGlobalAndLds) {

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -1536,6 +1536,52 @@ TEST(Gfx1250ExecutionTest, DeferredClusterLdsMulticastHoldsAsyncCounterUntilCall
   cu->set_cluster_lds_multicast_engine(nullptr);
 }
 
+TEST(Gfx1250ExecutionTest, ClusterLdsFallbackSkipsSelfWhenMaskExcludesSource) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(/*wg_id=*/3, /*pc=*/0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_dispatch_id(17);
+  wf->set_lds_base(cu->allocate_lds(256));
+  wf->set_cluster_info(/*rank=*/1, /*size=*/2);
+
+  constexpr uint64_t kGlobalAddr = 0x9100;
+  constexpr uint32_t kLoadedValue = 0xabcdef01;
+  for (uint32_t byte = 0; byte < sizeof(kLoadedValue); ++byte) {
+    sim.memory->write8(kGlobalAddr + byte,
+                       static_cast<uint8_t>((kLoadedValue >> (byte * 8)) & 0xffu));
+  }
+
+  auto state = std::make_unique<amdgpu::VectorMemState>(amdgpu::GLOBAL_MEM);
+  state->elem_size = 4;
+  state->num_elems = 1;
+  state->is_load = true;
+  state->wait_counter_type = amdgpu::WaitCounterType::ASYNCCNT;
+  state->lds_dst = true;
+  state->lds_per_lane_addr = true;
+  state->lds_base = wf->lds_base();
+  state->wf_size = 32;
+  state->lane_mask = 0x1;
+  state->exec_mask = 0x1;
+  state->cluster_multicast = true;
+  state->cluster_mcast_mask = 0x1; // Selects rank 0, not the source rank 1.
+  state->per_lane_addr[0] = kGlobalAddr;
+  state->per_lane_lds_addr[0] = wf->lds_base() + 0x20;
+
+  DeferredClusterLdsMulticastEngine deferred_engine;
+  cu->set_cluster_lds_multicast_engine(&deferred_engine);
+  amdgpu::GlobalMemPipeline pipeline(&cu->l1_vector(), cu->l2());
+  pipeline.issue(new TestMemoryInstruction(std::move(state)), *wf);
+
+  EXPECT_EQ(wf->wait_counters().asynccnt, 1u);
+  ASSERT_TRUE(static_cast<bool>(deferred_engine.completion));
+  EXPECT_TRUE(deferred_engine.txn.targets.empty());
+
+  deferred_engine.completion();
+  EXPECT_EQ(wf->wait_counters().asynccnt, 0u);
+  cu->set_cluster_lds_multicast_engine(nullptr);
+}
+
 TEST(Gfx1250SimulationTest, ClusterLdsTargetsCoversMasksAndLifetime) {
   constexpr uint64_t kernel_addr = 0x10000;
   constexpr uint32_t lds_bytes_per_wg = 256;
@@ -1573,8 +1619,7 @@ TEST(Gfx1250SimulationTest, ClusterLdsTargetsCoversMasksAndLifetime) {
 
   auto out_of_range =
       sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0, /*mcast_mask=*/0x4);
-  ASSERT_EQ(out_of_range.size(), 1u);
-  EXPECT_EQ(out_of_range[0].wg_id, 0u);
+  EXPECT_TRUE(out_of_range.empty());
 
   auto mixed_range =
       sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0, /*mcast_mask=*/0x5);

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -1239,6 +1239,7 @@ TEST(Gfx1250ExecutionTest, ClusterLoadsDecodeAndPopulateVectorMemState) {
     EXPECT_EQ(state->wait_counter_type, amdgpu::WaitCounterType::LOADCNT);
     EXPECT_FALSE(state->lds_dst);
     EXPECT_FALSE(state->cluster_multicast);
+    EXPECT_TRUE(state->request_force_l1_bypass);
     EXPECT_EQ(state->lane_mask, 0x3u);
     EXPECT_EQ(state->per_lane_addr[0], kGlobalBase);
     EXPECT_EQ(state->per_lane_addr[1], kGlobalBase + 16);
@@ -1332,16 +1333,17 @@ TEST(Gfx1250ExecutionTest, ClusterLoadsDecodeAndPopulateVectorMemState) {
     EXPECT_EQ(state->lds_base, wf->lds_base());
     EXPECT_EQ(state->cluster_multicast, tc.cluster_multicast);
     EXPECT_EQ(state->cluster_mcast_mask, tc.cluster_multicast ? 0x3u : 0u);
+    EXPECT_EQ(state->request_force_l1_bypass, tc.cluster_multicast);
     EXPECT_EQ(state->wait_counter_type, amdgpu::WaitCounterType::ASYNCCNT);
     EXPECT_EQ(state->lane_mask, 0x3u);
     EXPECT_EQ(state->per_lane_addr[0], kGlobalBase + tc.offset);
     EXPECT_EQ(state->per_lane_addr[1], kGlobalBase + tc.offset + tc.global_stride);
-    EXPECT_EQ(state->per_lane_lds_addr[0], wf->lds_base() + tc.offset);
-    EXPECT_EQ(state->per_lane_lds_addr[1], wf->lds_base() + tc.offset + tc.lds_stride);
+    EXPECT_EQ(state->per_lane_lds_addr[0], wf->lds_base());
+    EXPECT_EQ(state->per_lane_lds_addr[1], wf->lds_base() + tc.lds_stride);
   }
 }
 
-TEST(Gfx1250ExecutionTest, GlobalStoreAsyncFromLdsAppliesIoffsetToLdsSource) {
+TEST(Gfx1250ExecutionTest, GlobalStoreAsyncFromLdsKeepsIoffsetOnGlobalDestination) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
   auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
@@ -1359,8 +1361,8 @@ TEST(Gfx1250ExecutionTest, GlobalStoreAsyncFromLdsAppliesIoffsetToLdsSource) {
   const uint32_t vgpr_base = wf->vgpr_alloc().base;
   cu->write_vgpr(vgpr_base, 0, 0);
   cu->write_vgpr(vgpr_base, 1, 16);
-  cu->lds().write32(wf->lds_base() + kIoffset, kLane0Value);
-  cu->lds().write32(wf->lds_base() + 16 + kIoffset, kLane1Value);
+  cu->lds().write32(wf->lds_base(), kLane0Value);
+  cu->lds().write32(wf->lds_base() + 16, kLane1Value);
 
   auto inst =
       decode_gfx1250({0xEE190000u, 0x00000000u, 0x00000800u}, "global_store_async_from_lds_b32");
@@ -1445,6 +1447,8 @@ TEST(Gfx1250ExecutionTest, ClusterLdsMulticastTransactionCapturesRemapState) {
   state.cluster_mcast_mask = 0xa;
   state.wf_size = 32;
   state.lane_mask = 0x3;
+  state.per_lane_addr[0] = 0x8000;
+  state.per_lane_addr[1] = 0x8020;
   state.per_lane_lds_addr[0] = state.lds_base + 0x10;
   state.per_lane_lds_addr[1] = state.lds_base + 0x24;
   state.response_data.resize(state.wf_size * state.num_elems * state.elem_size);
@@ -1460,6 +1464,9 @@ TEST(Gfx1250ExecutionTest, ClusterLdsMulticastTransactionCapturesRemapState) {
   EXPECT_EQ(txn.mcast_mask, 0xau);
   EXPECT_EQ(txn.wait_counter_type, amdgpu::WaitCounterType::ASYNCCNT);
   EXPECT_EQ(txn.bytes_per_lane, 8u);
+  // Retained for deferred/timing backends that model global request coalescing.
+  EXPECT_EQ(txn.per_lane_global_addr[0], 0x8000u);
+  EXPECT_EQ(txn.per_lane_global_addr[1], 0x8020u);
   ASSERT_EQ(txn.targets.size(), 1u);
   EXPECT_EQ(txn.targets[0].wg_id, 11u);
   EXPECT_EQ(amdgpu::cluster_lds_lane_addr(txn, 0, txn.targets[0].lds_base), 0x410u);
@@ -1467,19 +1474,36 @@ TEST(Gfx1250ExecutionTest, ClusterLdsMulticastTransactionCapturesRemapState) {
   EXPECT_THROW((void)amdgpu::remap_cluster_lds_addr(0x100, 0x400, 0xfc), std::runtime_error);
 }
 
-TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineWritesSelectedTargets) {
+TEST(Gfx1250ExecutionTest, ClusterLdsSourceRankSelectionCoversDefaultAndMasks) {
+  amdgpu::ClusterLdsMulticastTransaction txn{};
+  txn.source_cluster_rank = 2;
+
+  txn.mcast_mask = 0;
+  EXPECT_TRUE(amdgpu::cluster_lds_source_rank_selected(txn));
+
+  txn.mcast_mask = amdgpu::cluster_multicast_rank_mask(2);
+  EXPECT_TRUE(amdgpu::cluster_lds_source_rank_selected(txn));
+
+  txn.mcast_mask = amdgpu::cluster_multicast_rank_mask(1);
+  EXPECT_FALSE(amdgpu::cluster_lds_source_rank_selected(txn));
+}
+
+TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineWritesOnlyIssuingParticipant) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
   cu->clear_lds();
 
   amdgpu::ClusterLdsMulticastTransaction txn{};
-  txn.source_lds_base = 0x40;
+  txn.source_wg_id = 1;
+  txn.source_cluster_rank = 1;
+  txn.source_lds_base = 0x300;
+  txn.mcast_mask = 0x3;
   txn.bytes_per_lane = 4;
   txn.wf_size = 4;
   txn.lane_mask = 0x5;
   txn.per_lane_addr = true;
-  txn.per_lane_lds_addr[0] = 0x44;
-  txn.per_lane_lds_addr[2] = 0x4c;
+  txn.per_lane_lds_addr[0] = 0x304;
+  txn.per_lane_lds_addr[2] = 0x30c;
   txn.payload.resize(txn.wf_size * txn.bytes_per_lane);
   const uint32_t lane0 = 0x11223344;
   const uint32_t lane2 = 0xaabbccdd;
@@ -1493,11 +1517,80 @@ TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineWritesSelectedTarge
   EXPECT_EQ(engine.submit(std::move(txn), [&]() { deferred_callback_called = true; }),
             amdgpu::ClusterLdsMulticastResult::Complete);
   EXPECT_FALSE(deferred_callback_called);
-  EXPECT_EQ(cu->lds().read32(0x204), lane0);
-  EXPECT_EQ(cu->lds().read32(0x20c), lane2);
+  EXPECT_EQ(cu->lds().read32(0x204), 0u);
+  EXPECT_EQ(cu->lds().read32(0x20c), 0u);
   EXPECT_EQ(cu->lds().read32(0x304), lane0);
   EXPECT_EQ(cu->lds().read32(0x30c), lane2);
   EXPECT_EQ(cu->lds().read32(0x208), 0u);
+}
+
+TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineSkipsUnissuedSelectedPeer) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  cu->clear_lds();
+
+  constexpr uint32_t kValue = 0x55667788;
+  amdgpu::ClusterLdsMulticastTransaction txn{};
+  txn.source_wg_id = 1;
+  txn.source_cluster_rank = 1;
+  txn.source_lds_base = 0x300;
+  txn.mcast_mask = 0x1; // Selects rank 0, not the issuing rank 1.
+  txn.bytes_per_lane = sizeof(kValue);
+  txn.wf_size = 1;
+  txn.lane_mask = 0x1;
+  txn.per_lane_addr = true;
+  txn.per_lane_lds_addr[0] = 0x310;
+  txn.payload.resize(sizeof(kValue));
+  std::memcpy(txn.payload.data(), &kValue, sizeof(kValue));
+  txn.targets = {{cu, /*wg_id=*/0, /*lds_base=*/0x200, /*cluster_rank=*/0}};
+
+  amdgpu::ImmediateClusterLdsMulticastEngine engine;
+  EXPECT_EQ(engine.submit(std::move(txn), []() {}), amdgpu::ClusterLdsMulticastResult::Complete);
+  EXPECT_EQ(cu->lds().read32(0x210), 0u);
+  EXPECT_EQ(cu->lds().read32(0x310), 0u);
+}
+
+TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineUsesRecipientOwnedDestinations) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  cu->clear_lds();
+
+  constexpr uint32_t kWg0Value = 0x11112222;
+  constexpr uint32_t kWg1Value = 0x33334444;
+
+  auto make_txn = [&](uint32_t wg_id, uint32_t rank, uint32_t lds_base, uint32_t lds_offset,
+                      uint32_t value) {
+    amdgpu::ClusterLdsMulticastTransaction txn{};
+    txn.source_wg_id = wg_id;
+    txn.source_cluster_rank = rank;
+    txn.source_lds_base = lds_base;
+    txn.mcast_mask = 0x3;
+    txn.bytes_per_lane = sizeof(value);
+    txn.wf_size = 1;
+    txn.lane_mask = 0x1;
+    txn.per_lane_addr = true;
+    txn.per_lane_lds_addr[0] = lds_base + lds_offset;
+    txn.payload.resize(sizeof(value));
+    std::memcpy(txn.payload.data(), &value, sizeof(value));
+    txn.targets = {{cu, /*wg_id=*/0, /*lds_base=*/0x100, /*cluster_rank=*/0},
+                   {cu, /*wg_id=*/1, /*lds_base=*/0x200, /*cluster_rank=*/1}};
+    return txn;
+  };
+
+  amdgpu::ImmediateClusterLdsMulticastEngine engine;
+  EXPECT_EQ(engine.submit(make_txn(/*wg_id=*/0, /*rank=*/0, /*lds_base=*/0x100,
+                                   /*lds_offset=*/0x10, kWg0Value),
+                          []() {}),
+            amdgpu::ClusterLdsMulticastResult::Complete);
+  EXPECT_EQ(engine.submit(make_txn(/*wg_id=*/1, /*rank=*/1, /*lds_base=*/0x200,
+                                   /*lds_offset=*/0x30, kWg1Value),
+                          []() {}),
+            amdgpu::ClusterLdsMulticastResult::Complete);
+
+  EXPECT_EQ(cu->lds().read32(0x110), kWg0Value);
+  EXPECT_EQ(cu->lds().read32(0x230), kWg1Value);
+  EXPECT_EQ(cu->lds().read32(0x210), 0u);
+  EXPECT_EQ(cu->lds().read32(0x130), 0u);
 }
 
 TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineRejectsUndersizedPayload) {
@@ -1630,6 +1723,70 @@ TEST(Gfx1250ExecutionTest, NonClusterClusterLdsLoadDowngradesToOrdinaryAsyncToLd
   cu->set_cluster_lds_multicast_engine(nullptr);
 }
 
+TEST(Gfx1250ExecutionTest, ClusterLoadRequestBypassesStaleL1VectorLine) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_dispatch_id(6);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobalAddr = 0xa000;
+  constexpr uint32_t kOldValue = 0x11111111;
+  constexpr uint32_t kNewValue = 0x22222222;
+  for (uint32_t byte = 0; byte < sizeof(kOldValue); ++byte) {
+    sim.memory->write8(kGlobalAddr + byte, static_cast<uint8_t>((kOldValue >> (byte * 8)) & 0xffu));
+  }
+
+  uint64_t addrs[64] = {};
+  addrs[0] = kGlobalAddr;
+  uint8_t l1_fill[64 * sizeof(kOldValue)] = {};
+  cu->l1_vector().load(addrs, /*lane_mask=*/0x1, /*elem_size=*/4, /*num_elems=*/1, l1_fill,
+                       amdgpu::Mtype::RW, /*non_temporal=*/false,
+                       /*request_l1_bypass=*/false, /*vmid=*/0);
+  uint32_t filled_value = 0;
+  std::memcpy(&filled_value, l1_fill, sizeof(filled_value));
+  ASSERT_EQ(filled_value, kOldValue);
+
+  cu->l2()->write(kGlobalAddr, reinterpret_cast<const uint8_t *>(&kNewValue), sizeof(kNewValue),
+                  amdgpu::Mtype::RW, /*vmid=*/0);
+
+  amdgpu::GlobalMemPipeline pipeline(&cu->l1_vector(), cu->l2());
+
+  auto ordinary = std::make_unique<amdgpu::VectorMemState>(amdgpu::GLOBAL_MEM);
+  ordinary->elem_size = 4;
+  ordinary->num_elems = 1;
+  ordinary->is_load = true;
+  ordinary->wait_counter_type = amdgpu::WaitCounterType::LOADCNT;
+  ordinary->wf_size = 32;
+  ordinary->lane_mask = 0x1;
+  ordinary->exec_mask = 0x1;
+  ordinary->dst_reg_base = wf->vgpr_alloc().base;
+  ordinary->per_lane_addr[0] = kGlobalAddr;
+  pipeline.issue(new TestMemoryInstruction(std::move(ordinary)), *wf);
+  EXPECT_EQ(cu->read_vgpr(wf->vgpr_alloc().base, 0), kOldValue);
+
+  auto cluster = std::make_unique<amdgpu::VectorMemState>(amdgpu::GLOBAL_MEM);
+  cluster->elem_size = 4;
+  cluster->num_elems = 1;
+  cluster->is_load = true;
+  cluster->wait_counter_type = amdgpu::WaitCounterType::ASYNCCNT;
+  cluster->request_force_l1_bypass = true;
+  cluster->lds_dst = true;
+  cluster->lds_per_lane_addr = true;
+  cluster->lds_base = wf->lds_base();
+  cluster->wf_size = 32;
+  cluster->lane_mask = 0x1;
+  cluster->exec_mask = 0x1;
+  cluster->cluster_multicast = true;
+  cluster->cluster_mcast_mask = 0x1;
+  cluster->per_lane_addr[0] = kGlobalAddr;
+  cluster->per_lane_lds_addr[0] = wf->lds_base() + 0x40;
+  pipeline.issue(new TestMemoryInstruction(std::move(cluster)), *wf);
+
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + 0x40), kNewValue);
+}
+
 TEST(Gfx1250ExecutionTest, ClusterLdsFallbackSkipsSelfWhenMaskExcludesSource) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
@@ -1740,7 +1897,7 @@ TEST(Gfx1250SimulationTest, ClusterLdsTargetsUseMultiDimensionalClusterPlacement
   Gfx1250Sim sim;
   uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
 
-  test::AmdExtKernelDispatchPacketForTest pkt{};
+  amdgpu::AmdExtKernelDispatchPacket pkt{};
   pkt.header = HSA_PACKET_TYPE_VENDOR_SPECIFIC;
   pkt.amd_format = amdgpu::kHsaAmdPacketTypeExtKernelDispatch;
   pkt.setup = 2;
@@ -1778,7 +1935,10 @@ TEST(Gfx1250SimulationTest, ClusterLdsTargetsUseMultiDimensionalClusterPlacement
 
   constexpr uint32_t kValue = 0xfeed1234;
   amdgpu::ClusterLdsMulticastTransaction txn{};
+  txn.source_wg_id = source[0].wg_id;
+  txn.source_cluster_rank = source[0].cluster_rank;
   txn.source_lds_base = source[0].lds_base;
+  txn.mcast_mask = 0x8;
   txn.bytes_per_lane = sizeof(kValue);
   txn.wf_size = 1;
   txn.lane_mask = 0x1;
@@ -1786,21 +1946,21 @@ TEST(Gfx1250SimulationTest, ClusterLdsTargetsUseMultiDimensionalClusterPlacement
   txn.per_lane_lds_addr[0] = source[0].lds_base + 0x10;
   txn.payload.resize(sizeof(kValue));
   std::memcpy(txn.payload.data(), &kValue, sizeof(kValue));
-  txn.targets = targets;
+  txn.targets = source;
 
   amdgpu::ImmediateClusterLdsMulticastEngine engine;
   bool deferred_callback_called = false;
   EXPECT_EQ(engine.submit(std::move(txn), [&]() { deferred_callback_called = true; }),
             amdgpu::ClusterLdsMulticastResult::Complete);
   EXPECT_FALSE(deferred_callback_called);
-  EXPECT_EQ(targets[0].cu->lds().read32(targets[0].lds_base + 0x10), kValue);
-  EXPECT_EQ(targets[1].cu->lds().read32(targets[1].lds_base + 0x10), kValue);
-  EXPECT_EQ(source[0].cu->lds().read32(source[0].lds_base + 0x10), 0u);
+  EXPECT_EQ(targets[0].cu->lds().read32(targets[0].lds_base + 0x10), 0u);
+  EXPECT_EQ(targets[1].cu->lds().read32(targets[1].lds_base + 0x10), 0u);
+  EXPECT_EQ(source[0].cu->lds().read32(source[0].lds_base + 0x10), kValue);
 
   sim.engine->run();
 }
 
-TEST(Gfx1250SimulationTest, ClusterLdsRemapUsesNonIdentityPeerLdsBase) {
+TEST(Gfx1250SimulationTest, ClusterLdsDoesNotRemapIntoNonParticipatingPeerLdsBase) {
   constexpr uint64_t kernel_addr = 0x10000;
   constexpr uint32_t lds_bytes_per_wg = 256;
   constexpr uint32_t cluster_size = 8;
@@ -1843,7 +2003,10 @@ TEST(Gfx1250SimulationTest, ClusterLdsRemapUsesNonIdentityPeerLdsBase) {
 
   constexpr uint32_t kValue = 0x13579bdf;
   amdgpu::ClusterLdsMulticastTransaction txn{};
+  txn.source_wg_id = source.wg_id;
+  txn.source_cluster_rank = source.cluster_rank;
   txn.source_lds_base = source.lds_base;
+  txn.mcast_mask = (1u << cluster_size) - 1;
   txn.bytes_per_lane = sizeof(kValue);
   txn.wf_size = 1;
   txn.lane_mask = 0x1;
@@ -1855,7 +2018,7 @@ TEST(Gfx1250SimulationTest, ClusterLdsRemapUsesNonIdentityPeerLdsBase) {
 
   amdgpu::ImmediateClusterLdsMulticastEngine engine;
   EXPECT_EQ(engine.submit(std::move(txn), []() {}), amdgpu::ClusterLdsMulticastResult::Complete);
-  EXPECT_EQ(target.cu->lds().read32(target.lds_base + 0x20), kValue);
+  EXPECT_EQ(target.cu->lds().read32(target.lds_base + 0x20), 0u);
   EXPECT_EQ(source.cu->lds().read32(source.lds_base + 0x20), 0u);
 
   sim.engine->run();
@@ -1888,7 +2051,7 @@ TEST(Gfx1250SimulationTest, RejectsIncompleteClusterGrid) {
   EXPECT_THROW((void)sim.engine->step(), std::runtime_error);
 }
 
-TEST(Gfx1250SimulationTest, ClusterLoadAsyncToLdsMulticastsAcrossClusterWorkgroups) {
+TEST(Gfx1250SimulationTest, ClusterLoadAsyncToLdsDoesNotWriteMaskExcludedParticipant) {
   constexpr uint64_t kernel_addr = 0x10000;
   constexpr uint64_t input_addr = 0x2000;
   constexpr uint32_t lds_bytes_per_wg = 256;
@@ -1896,9 +2059,7 @@ TEST(Gfx1250SimulationTest, ClusterLoadAsyncToLdsMulticastsAcrossClusterWorkgrou
   const uint32_t code[] = {
       0xBE8000FFu,    static_cast<uint32_t>(input_addr), // s_mov_b32 s0, input_addr
       0xBE810080u,                                       // s_mov_b32 s1, 0
-      0xBF068002u,                                       // s_cmp_eq_u32 s2, 0 (WG id)
-      0xBF840006u,                                       // s_cbranch_scc0 +6
-      0xBEFD0083u,                                       // s_mov_b32 m0, 0x3
+      0xBEFD0081u,                                       // s_mov_b32 m0, 0x1
       0x30000082u,                                       // v_lshlrev_b32_e32 v0, 2, v0
       0xEE1AC000u,    0x00000000u,
       0x00000000u, // cluster_load_async_to_lds_b32 v0, v0, s[0:1]
@@ -1939,8 +2100,58 @@ TEST(Gfx1250SimulationTest, ClusterLoadAsyncToLdsMulticastsAcrossClusterWorkgrou
     uint32_t value0 = targets[0].cu->lds().read32(targets[0].lds_base + lane * 4);
     uint32_t value1 = targets[1].cu->lds().read32(targets[1].lds_base + lane * 4);
     uint32_t wg0_value = read_unaligned_input(lane * 4);
-    EXPECT_EQ(value0, value1) << "lane " << lane;
     EXPECT_EQ(value0, wg0_value) << "lane " << lane;
+    EXPECT_EQ(value1, 0u) << "lane " << lane;
+  }
+}
+
+TEST(Gfx1250SimulationTest, ClusterLoadAsyncToLdsWritesEachIssuingParticipant) {
+  constexpr uint64_t kernel_addr = 0x10000;
+  constexpr uint64_t input_addr = 0x2400;
+  constexpr uint32_t lds_bytes_per_wg = 256;
+
+  const uint32_t code[] = {
+      0xBE8000FFu,    static_cast<uint32_t>(input_addr), // s_mov_b32 s0, input_addr
+      0xBE810080u,                                       // s_mov_b32 s1, 0
+      0xBEFD0083u,                                       // s_mov_b32 m0, 0x3
+      0x30000082u,                                       // v_lshlrev_b32_e32 v0, 2, v0
+      0xEE1AC000u,    0x00000000u,
+      0x00000000u, // cluster_load_async_to_lds_b32 v0, v0, s[0:1]
+      0xBFCA0000u, // s_wait_asynccnt 0
+      S_ENDPGM_GFX12,
+  };
+
+  Gfx1250Sim sim;
+  uint64_t kernel_object = sim.write_kernel(kernel_addr, code, std::size(code), 128);
+  for (uint32_t byte = 0; byte < 256; ++byte)
+    sim.memory->write8(input_addr + byte, static_cast<uint8_t>(0x80u + byte));
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch_clustered(kernel_object, /*cluster_count_x=*/1, /*cluster_size_x=*/2,
+                           /*workgroup_size_x=*/32, /*kernarg_addr=*/0, lds_bytes_per_wg);
+  ASSERT_TRUE(sim.engine->step());
+
+  auto targets = sim.cp()->cluster_lds_targets(/*dispatch_id=*/1, /*wg_id=*/0, /*mcast_mask=*/0x3);
+  ASSERT_EQ(targets.size(), 2u);
+  ASSERT_NE(targets[0].cu, nullptr);
+  ASSERT_NE(targets[1].cu, nullptr);
+  EXPECT_NE(targets[0].cu, targets[1].cu);
+  sim.engine->run();
+
+  auto read_unaligned_input = [&](uint32_t byte_offset) {
+    uint32_t value = 0;
+    for (uint32_t byte = 0; byte < 4; ++byte)
+      value |= static_cast<uint32_t>(sim.memory->read8(input_addr + byte_offset + byte))
+               << (byte * 8);
+    return value;
+  };
+
+  for (uint32_t lane = 0; lane < 32; ++lane) {
+    uint32_t value0 = targets[0].cu->lds().read32(targets[0].lds_base + lane * 4);
+    uint32_t value1 = targets[1].cu->lds().read32(targets[1].lds_base + lane * 4);
+    uint32_t expected_value = read_unaligned_input(lane * 4);
+    EXPECT_EQ(value0, expected_value) << "lane " << lane;
+    EXPECT_EQ(value1, expected_value) << "lane " << lane;
   }
 }
 

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -1588,6 +1588,48 @@ TEST(Gfx1250ExecutionTest, OrdinaryLdsDstLoadWritesDirectlyAndCompletesAsyncCoun
   cu->set_cluster_lds_multicast_engine(nullptr);
 }
 
+TEST(Gfx1250ExecutionTest, NonClusterClusterLdsLoadDowngradesToOrdinaryAsyncToLds) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_dispatch_id(5);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobalAddr = 0x9080;
+  constexpr uint32_t kLoadedValue = 0x78563412;
+  for (uint32_t byte = 0; byte < sizeof(kLoadedValue); ++byte) {
+    sim.memory->write8(kGlobalAddr + byte,
+                       static_cast<uint8_t>((kLoadedValue >> (byte * 8)) & 0xffu));
+  }
+
+  auto state = std::make_unique<amdgpu::VectorMemState>(amdgpu::GLOBAL_MEM);
+  state->elem_size = 4;
+  state->num_elems = 1;
+  state->is_load = true;
+  state->wait_counter_type = amdgpu::WaitCounterType::ASYNCCNT;
+  state->lds_dst = true;
+  state->lds_per_lane_addr = true;
+  state->lds_base = wf->lds_base();
+  state->wf_size = 32;
+  state->lane_mask = 0x1;
+  state->exec_mask = 0x1;
+  state->cluster_multicast = true;
+  state->cluster_mcast_mask = 0x2; // Excludes rank 0, but non-clustered loads downgrade.
+  state->per_lane_addr[0] = kGlobalAddr;
+  state->per_lane_lds_addr[0] = wf->lds_base() + 0x24;
+
+  DeferredClusterLdsMulticastEngine deferred_engine;
+  cu->set_cluster_lds_multicast_engine(&deferred_engine);
+  amdgpu::GlobalMemPipeline pipeline(&cu->l1_vector(), cu->l2());
+  pipeline.issue(new TestMemoryInstruction(std::move(state)), *wf);
+
+  EXPECT_EQ(wf->wait_counters().asynccnt, 0u);
+  EXPECT_FALSE(static_cast<bool>(deferred_engine.completion));
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + 0x24), kLoadedValue);
+  cu->set_cluster_lds_multicast_engine(nullptr);
+}
+
 TEST(Gfx1250ExecutionTest, ClusterLdsFallbackSkipsSelfWhenMaskExcludesSource) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -1341,6 +1341,49 @@ TEST(Gfx1250ExecutionTest, ClusterLoadsDecodeAndPopulateVectorMemState) {
   }
 }
 
+TEST(Gfx1250ExecutionTest, GlobalStoreAsyncFromLdsAppliesIoffsetToLdsSource) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_exec(0x3u);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  constexpr uint64_t kGlobalBase = 0x190000u;
+  constexpr uint32_t kLane0Value = 0x12345678u;
+  constexpr uint32_t kLane1Value = 0xabcdef01u;
+  constexpr uint32_t kIoffset = 8;
+  write_wave_sgpr(*cu, *wf, 0, static_cast<uint32_t>(kGlobalBase));
+  write_wave_sgpr(*cu, *wf, 1, static_cast<uint32_t>(kGlobalBase >> 32));
+
+  const uint32_t vgpr_base = wf->vgpr_alloc().base;
+  cu->write_vgpr(vgpr_base, 0, 0);
+  cu->write_vgpr(vgpr_base, 1, 16);
+  cu->lds().write32(wf->lds_base() + kIoffset, kLane0Value);
+  cu->lds().write32(wf->lds_base() + 16 + kIoffset, kLane1Value);
+
+  auto inst =
+      decode_gfx1250({0xEE190000u, 0x00000000u, 0x00000800u}, "global_store_async_from_lds_b32");
+  ASSERT_NE(inst, nullptr);
+  inst->execute(*inst, wf);
+  auto *state = inst->data_as<amdgpu::VectorMemState>();
+  ASSERT_NE(state, nullptr);
+  EXPECT_EQ(state->tag(), amdgpu::GLOBAL_MEM);
+  EXPECT_FALSE(state->is_load);
+  EXPECT_EQ(state->wait_counter_type, amdgpu::WaitCounterType::ASYNCCNT);
+  EXPECT_EQ(state->lane_mask, 0x3u);
+  EXPECT_EQ(state->per_lane_addr[0], kGlobalBase + kIoffset);
+  EXPECT_EQ(state->per_lane_addr[1], kGlobalBase + 16 + kIoffset);
+  ASSERT_GE(state->store_data.size(), 8u);
+
+  uint32_t lane0_value = 0;
+  uint32_t lane1_value = 0;
+  std::memcpy(&lane0_value, &state->store_data[0], sizeof(lane0_value));
+  std::memcpy(&lane1_value, &state->store_data[4], sizeof(lane1_value));
+  EXPECT_EQ(lane0_value, kLane0Value);
+  EXPECT_EQ(lane1_value, kLane1Value);
+}
+
 TEST(Gfx1250ExecutionTest, DispatchEntryClusterMathCoversMultiDimensionalShapes) {
   amdgpu::DispatchEntry entry{};
   entry.grid_wgs_x = 4;
@@ -1381,7 +1424,6 @@ TEST(Gfx1250ExecutionTest, DispatchEntryClusterMathCoversMultiDimensionalShapes)
   entry.cluster_size_y = 1;
   entry.cluster_size_z = 1;
   EXPECT_FALSE(entry.cluster_grid_is_complete());
-  EXPECT_THROW((void)entry.cluster_peer_local_wg_id(2, 1), std::logic_error);
 }
 
 TEST(Gfx1250ExecutionTest, ClusterLdsMulticastTransactionCapturesRemapState) {
@@ -1399,6 +1441,7 @@ TEST(Gfx1250ExecutionTest, ClusterLdsMulticastTransactionCapturesRemapState) {
   state.wait_counter_type = amdgpu::WaitCounterType::ASYNCCNT;
   state.lds_base = wf->lds_base();
   state.lds_per_lane_addr = true;
+  state.cluster_multicast = true;
   state.cluster_mcast_mask = 0xa;
   state.wf_size = 32;
   state.lane_mask = 0x3;
@@ -1472,6 +1515,25 @@ TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineRejectsUndersizedPa
   EXPECT_THROW((void)engine.submit(std::move(txn), []() {}), std::runtime_error);
 }
 
+TEST(Gfx1250ExecutionTest, ImmediateClusterLdsMulticastEngineRejectsOutOfRangeTarget) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+
+  amdgpu::ClusterLdsMulticastTransaction txn{};
+  txn.source_lds_base = 0;
+  txn.bytes_per_lane = 4;
+  txn.wf_size = 1;
+  txn.lane_mask = 0x1;
+  txn.per_lane_addr = true;
+  txn.per_lane_lds_addr[0] = 0;
+  txn.payload.resize(4);
+  txn.targets = {{cu, /*wg_id=*/0, static_cast<uint32_t>(cu->lds().size_bytes()) - 2,
+                  /*cluster_rank=*/0}};
+
+  amdgpu::ImmediateClusterLdsMulticastEngine engine;
+  EXPECT_THROW((void)engine.submit(std::move(txn), []() {}), std::runtime_error);
+}
+
 TEST(Gfx1250ExecutionTest, ClusterLdsPinPreventsAllocatorReuseUntilClusterCompletes) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
@@ -1486,7 +1548,7 @@ TEST(Gfx1250ExecutionTest, ClusterLdsPinPreventsAllocatorReuseUntilClusterComple
   EXPECT_EQ(cu->allocate_lds(257), 0u);
 }
 
-TEST(Gfx1250ExecutionTest, DeferredClusterLdsMulticastHoldsAsyncCounterUntilCallback) {
+TEST(Gfx1250ExecutionTest, OrdinaryLdsDstLoadWritesDirectlyAndCompletesAsyncCounter) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
   auto *wf = cu->dispatch_wf(/*wg_id=*/0, /*pc=*/0, kGfx1250ScalarSlots, 32);
@@ -1520,19 +1582,9 @@ TEST(Gfx1250ExecutionTest, DeferredClusterLdsMulticastHoldsAsyncCounterUntilCall
   amdgpu::GlobalMemPipeline pipeline(&cu->l1_vector(), cu->l2());
   pipeline.issue(new TestMemoryInstruction(std::move(state)), *wf);
 
-  EXPECT_EQ(wf->wait_counters().asynccnt, 1u);
-  ASSERT_TRUE(static_cast<bool>(deferred_engine.completion));
-  EXPECT_EQ(deferred_engine.txn.wait_counter_type, amdgpu::WaitCounterType::ASYNCCNT);
-  EXPECT_EQ(deferred_engine.txn.bytes_per_lane, 4u);
-  ASSERT_EQ(deferred_engine.txn.targets.size(), 1u);
-  EXPECT_EQ(deferred_engine.txn.targets[0].cu, cu);
-  EXPECT_EQ(deferred_engine.txn.payload.size(), 32u * sizeof(kLoadedValue));
-  uint32_t payload_value = 0;
-  std::memcpy(&payload_value, deferred_engine.txn.payload.data(), sizeof(payload_value));
-  EXPECT_EQ(payload_value, kLoadedValue);
-
-  deferred_engine.completion();
   EXPECT_EQ(wf->wait_counters().asynccnt, 0u);
+  EXPECT_FALSE(static_cast<bool>(deferred_engine.completion));
+  EXPECT_EQ(cu->lds().read32(wf->lds_base() + 0x20), kLoadedValue);
   cu->set_cluster_lds_multicast_engine(nullptr);
 }
 

--- a/emulation/rocjitsu/tests/race-detector/race_detector_tests.cpp
+++ b/emulation/rocjitsu/tests/race-detector/race_detector_tests.cpp
@@ -409,6 +409,18 @@ TEST(RaceDetector, LdsCrossWave_GlobalLoadToLdsWriteMissingVmcnt) {
   EXPECT_TRUE(b.hasVgprRace(1));
 }
 
+TEST(RaceDetector, GlobalToLdsHonorsLaneMask) {
+  RaceTestBuilder b(/*numWaves=*/2, /*vgprs=*/8, /*sgprs=*/8, /*waveSize=*/4);
+  b.globalToLds(/*wave=*/0, /*ldsAddrs=*/{0, 4, 8, 12}, /*bytesPerLane=*/4,
+                /*exec=*/0x1);
+
+  b.checkLdsRead(/*wave=*/1, /*lane=*/0, /*addr=*/4, /*bytes=*/4);
+  EXPECT_FALSE(b.hasRace());
+
+  b.checkLdsRead(/*wave=*/1, /*lane=*/0, /*addr=*/0, /*bytes=*/4);
+  EXPECT_TRUE(b.hasLdsRace(0));
+}
+
 TEST(RaceDetector, LdsSameWave_MultiLaneReadOk) {
   // All lanes read same LDS byte after write+waitcnt → safe.
   // Multiple lanes reading same address is not a race.


### PR DESCRIPTION
## Motivation

Add gfx1250 cluster load multicast support, including cluster-aware dispatch placement, AMD extended AQL packet parsing, cluster LDS multicast writeback, generated decode plumbing, and focused tests.
  
## Technical Details

The implementation models workgroup clusters at dispatch time because cluster load multicast depends on knowing the complete peer set, each peer workgroup’s CU, and each peer LDS base. Cluster shapes are validated up front, and the current implementation caps clusters at 16 workgroups to match the hardware multicast mask width.

Cluster dispatch reuses the normal wavefront initialization path so regular and clustered launches keep the same SGPR setup, EXEC mask initialization, plugin callbacks, and completion accounting. The clustered path only adds placement metadata and LDS lifetime management.

LDS multicast is routed through a `ClusterLdsMulticastTransaction` and engine interface instead of directly embedding peer writes in the memory pipeline. The default engine completes synchronously, but the transaction boundary preserves enough information for a future timing/fabric model to defer completion and hold ASYNCCNT until all target LDS writes are visible.

Peer LDS addresses are remapped from the source workgroup’s LDS window into each target workgroup’s actual LDS allocation. This avoids assuming identical LDS bases across CUs and keeps multicast semantics tied to workgroup-local LDS addresses.

## JIRA ID

N/A

## Test Plan

Unit tests + local CTS-style tests.
Regenerated all isas just in case.

## Test Result

All good.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
