### PR TITLE
rocprofiler-register: fix deadlock error

### DIFF
--- a/projects/rocprofiler-register/source/lib/rocprofiler-register/details/checked_lock.hpp
+++ b/projects/rocprofiler-register/source/lib/rocprofiler-register/details/checked_lock.hpp
@@ -1,0 +1,90 @@
+// MIT License
+//
+// Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <mutex>
+#include <thread>
+#include <atomic>
+
+namespace rocprofiler_register
+{
+namespace common
+{
+// A non-recursive mutex wrapper that:
+//   - serializes concurrent callers (one proceeds, others block)
+//   - detects recursive acquisition by the same thread and reports it via
+//     the `recursive` flag rather than deadlocking or silently succeeding
+//
+// Usage (scoped_lock style):
+//
+//   static checked_mutex mtx;
+//   checked_lock lk{mtx};
+//   if(lk.recursive) return ROCP_REG_DEADLOCK;
+//   // ... protected work ...
+
+struct checked_mutex
+{
+    std::mutex              mtx    = {};
+    std::atomic<std::thread::id> owner  = {};
+};
+
+struct checked_lock
+{
+    explicit checked_lock(checked_mutex& cm)
+    : m_cm{ cm }
+    {
+        const auto self = std::this_thread::get_id();
+        // Check for recursive entry before blocking on the mutex.
+        // If this thread already owns the mutex the owner field equals self.
+        recursive = (cm.owner.load(std::memory_order_acquire) == self);
+        if(!recursive)
+        {
+            cm.mtx.lock();
+            cm.owner.store(self, std::memory_order_release);
+        }
+    }
+
+    ~checked_lock()
+    {
+        if(!recursive)
+        {
+            m_cm.owner.store(std::thread::id{}, std::memory_order_release);
+            m_cm.mtx.unlock();
+        }
+    }
+
+    checked_lock(const checked_lock&)            = delete;
+    checked_lock& operator=(const checked_lock&) = delete;
+    checked_lock(checked_lock&&)                 = delete;
+    checked_lock& operator=(checked_lock&&)      = delete;
+
+    // true  → the calling thread already held the lock (recursion detected)
+    // false → the lock was freshly acquired
+    bool recursive = false;
+
+private:
+    checked_mutex& m_cm;
+};
+
+}  // namespace common
+}  // namespace rocprofiler_register

--- a/projects/rocprofiler-register/source/lib/rocprofiler-register/rocprofiler_register.cpp
+++ b/projects/rocprofiler-register/source/lib/rocprofiler-register/rocprofiler_register.cpp
@@ -22,6 +22,7 @@
 
 #include <rocprofiler-register/rocprofiler-register.h>
 
+#include "details/checked_lock.hpp"
 #include "details/dl.hpp"
 #include "details/environment.hpp"
 #include "details/filesystem.hpp"
@@ -528,27 +529,12 @@ struct registered_library_api_table
 constexpr auto instance_bits     = sizeof(uint64_t) * 8;  // bits in instance_counters
 constexpr auto max_instances     = instance_bits * ROCP_REG_LAST;
 constexpr auto library_seq       = std::make_index_sequence<ROCP_REG_LAST>{};
-auto           global_count      = std::atomic<uint32_t>{ 0 };
 auto           import_info       = rocp_reg_get_imports(library_seq);
 auto           instance_counters = std::array<std::atomic_uint64_t, ROCP_REG_LAST>{};
 auto           registered =
     std::array<std::optional<registered_library_api_table>, max_instances>{};
-
-struct scoped_count
-{
-    scoped_count()
-    : value{ ++global_count }
-    { }
-
-    ~scoped_count() { --global_count; }
-
-    scoped_count(const scoped_count&)     = delete;
-    scoped_count(scoped_count&&) noexcept = delete;
-    scoped_count& operator=(const scoped_count&) = delete;
-    scoped_count& operator=(scoped_count&&) noexcept = delete;
-
-    uint32_t value = 0;
-};
+// Serialises concurrent callers and detects (disallowed) recursive re-entry.
+auto registration_mutex = common::checked_mutex{};
 
 std::optional<registered_library_api_table>*
 rocp_add_registered_library_api_table(const char*                        common_name,
@@ -564,17 +550,18 @@ rocp_add_registered_library_api_table(const char*                        common_
                              lib_version,
                              api_tables_len);
 
-    constexpr auto rocattach_name = supported_library_trait<ROCP_REG_ROCATTACH>::common_name;
-    const bool     is_rocattach   = (std::string_view{ common_name } == rocattach_name);
+    constexpr auto rocattach_name =
+        supported_library_trait<ROCP_REG_ROCATTACH>::common_name;
+    const bool is_rocattach = (std::string_view{ common_name } == rocattach_name);
 
     auto _tables = std::vector<void*>{};
     _tables.reserve(api_tables_len);
     for(uint64_t i = 0; i < api_tables_len; ++i)
         _tables.emplace_back(api_tables[i]);
 
-    auto _entry = registered_library_api_table{
-        false, common_name, import_func, lib_version, std::move(_tables), instance_val
-    };
+    auto _entry =
+        registered_library_api_table{ false,       common_name,        import_func,
+                                      lib_version, std::move(_tables), instance_val };
 
     if(is_rocattach)
     {
@@ -605,8 +592,8 @@ rocp_add_registered_library_api_table(const char*                        common_
 rocprofiler_register_error_code_t
 rocp_invoke_registrations(bool invoke_all)
 {
-    auto _count = scoped_count{};
-    if(_count.value > 1) return ROCP_REG_DEADLOCK;
+    auto _lk = common::checked_lock{ registration_mutex };
+    if(_lk.recursive) return ROCP_REG_DEADLOCK;
 
     for(auto& itr : registered)
     {
@@ -747,8 +734,8 @@ rocprofiler_register_library_api_table(
         return ROCP_REG_NO_TOOLS;
     }
 
-    auto _count = scoped_count{};
-    if(_count.value > 1) return ROCP_REG_DEADLOCK;
+    auto _lk = common::checked_lock{ registration_mutex };
+    if(_lk.recursive) return ROCP_REG_DEADLOCK;
 
     auto _scan_result = rocp_reg_scan_for_tools();
 


### PR DESCRIPTION
- With attachment, it is now possible for new API tables to be registered while invoking all previous registrations
  - Previously, this would always result in ROCP_REG_DEADLOCK
  - A checked_lock is now used which allows multiple threads but still disallows recursion

## Motivation

Fixes an intermittent error in rocattach-execute tests that could occur if roctx was registered during attachment

Also ran `make format` which hadn't been done for a bit, evidently.
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

Previously rocprofiler-register did not have to worry about multithreaded scenarios, so had a simple "no deadlock" check provided that also acted as a (very strict) mutex. This upgrades that check to allow for multiple threads while still giving the same error if the same thread accesses the lock.

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Ran rocattach-execute tests ~200 times locally
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

All passes no errors detected
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
