### PR TITLE
rocr/aie: Fix memory handle export logic and update shareable handle creation

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -921,10 +921,9 @@ hsa_status_t XdnaDriver::Unmap(const core::DriverMemoryHandle& handle, void *mem
 hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
                                                const core::Agent& agent,
                                                core::DriverMemoryHandle* handle, uint64_t* offset) {
-  // The actual VA mapping is deferred to Map() during hsa_amd_vmem_set_access; this only
-  // produces a driver-independent shareable handle.
   (void)va;
   (void)agent;
+
   // Find BO handle; mem is the BO handle; see AllocateMemory.
   auto bo_handle = FindBOHandle(mem);
   if (!bo_handle.IsValid()) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -826,13 +826,13 @@ hsa_status_t XdnaDriver::ExportMemoryHandle(const core::Agent& agent, const core
 
   switch (type) {
   case core::ShareType::DMABUF_FD: {
-    auto bo_handle = FindBOHandle(const_cast<void*>(reinterpret_cast<const void*>(&handle)));
-    if (!bo_handle.IsValid()) {
+    // handle.handle is the kernel BO handle populated by CreateShareableHandle.
+    if (!handle.IsValid()) {
       return HSA_STATUS_ERROR_INVALID_ALLOCATION;
     }
 
     drm_prime_handle export_params = {};
-    export_params.handle = bo_handle.handle;
+    export_params.handle = handle.handle;
     export_params.flags = DRM_RDWR;
     export_params.fd = -1;
     hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_PRIME_HANDLE_TO_FD, &export_params);
@@ -921,6 +921,10 @@ hsa_status_t XdnaDriver::Unmap(const core::DriverMemoryHandle& handle, void *mem
 hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
                                                const core::Agent& agent,
                                                core::DriverMemoryHandle* handle, uint64_t* offset) {
+  // The actual VA mapping is deferred to Map() during hsa_amd_vmem_set_access; this only
+  // produces a driver-independent shareable handle.
+  (void)va;
+
   // Find BO handle; mem is the BO handle; see AllocateMemory.
   auto bo_handle = FindBOHandle(mem);
   if (!bo_handle.IsValid()) {
@@ -945,17 +949,9 @@ hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
     return err;
   }
 
-  // Map memory to the virtual address.
-  void* mapped_ptr = mmap(va, size, PROT_READ | PROT_WRITE, MAP_FIXED | MAP_SHARED, fd_,
-                          get_bo_info_args.map_offset);
-  if (mapped_ptr == MAP_FAILED) {
-    close(params.fd);
-    return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
-  }
-
   handle->handle = bo_handle.handle;
   handle->dmabuf_fd = params.fd;
-  handle->mmap_offset = 0;
+  handle->mmap_offset = get_bo_info_args.map_offset;
   handle->size = size;
   *offset = 0;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -924,7 +924,7 @@ hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
   // The actual VA mapping is deferred to Map() during hsa_amd_vmem_set_access; this only
   // produces a driver-independent shareable handle.
   (void)va;
-
+  (void)agent;
   // Find BO handle; mem is the BO handle; see AllocateMemory.
   auto bo_handle = FindBOHandle(mem);
   if (!bo_handle.IsValid()) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -959,6 +959,12 @@ hsa_status_t XdnaDriver::CreateShareableHandle(void* va, void* mem, size_t size,
 }
 
 hsa_status_t XdnaDriver::DestroyMemoryHandle(core::DriverMemoryHandle* handle) {
+  // Close the dmabuf_fd.
+  if (handle->dmabuf_fd >= 0) {
+    close(handle->dmabuf_fd);
+  }
+
+  // Close the BO handle.
   drm_gem_close close_params = {};
   close_params.handle = handle->handle;
   hsa_status_t err = xdna_ioctl(fd_, DRM_IOCTL_GEM_CLOSE, &close_params);


### PR DESCRIPTION
## Motivation

https://github.com/ROCm/rocm-systems/pull/6471 changed where mmap happens and that broke some of the XDNA vmem tests.

## Technical Details

This PR uses the BO handle as it is stored in `DriverMemoryHandle` directly. It also avoids mmap which will explicitly happen later in runtime.cpp.

## JIRA ID

NA

## Test Plan

./rocrtst64 and https://github.com/ROCm/rocm-systems/tree/users/ypapadop-amd/aie-tests/projects/rocr-runtime/rocrtst/suites/aie

## Test Result

Success

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
