### PR TITLE
[rocprofiler-sdk] Fix PMC after-kernel packet ordering

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/tests/aql_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/aql/tests/aql_test.cpp
@@ -164,6 +164,52 @@ TEST(aql_profile, packet_generation_single)
     hsa_shut_down();
 }
 
+TEST(aql_profile, counter_after_packets_stop_before_read)
+{
+    ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);
+
+    struct HsaShutdownGuard
+    {
+        ~HsaShutdownGuard() { hsa_shut_down(); }
+    } cleanup;
+
+    rocprofiler::test_init();
+
+    auto agents = rocprofiler::hsa::get_queue_controller()->get_supported_agents();
+    ASSERT_GT(agents.size(), 0);
+
+    size_t tested_agents = 0;
+
+    for(const auto& [_, agent] : agents)
+    {
+        auto metrics = rocprofiler::findDeviceMetrics(agent, {"SQ_WAVES"});
+        if(metrics.empty()) continue;
+
+        CounterPacketConstruct pkt(agent.get_rocp_agent()->id, metrics);
+        auto                   test_pkt =
+            pkt.construct_packet(rocprofiler::get_api_table(), rocprofiler::get_ext_table());
+
+        ASSERT_TRUE(test_pkt);
+        ASSERT_FALSE(test_pkt->empty);
+
+        constexpr uint64_t stop_marker = 0x53544f50;  // "STOP"
+        constexpr uint64_t read_marker = 0x52454144;  // "READ"
+
+        test_pkt->packets.stop_packet.completion_signal = hsa_signal_t{.handle = stop_marker};
+        test_pkt->packets.read_packet.completion_signal = hsa_signal_t{.handle = read_marker};
+
+        test_pkt->populate_after();
+
+        ASSERT_EQ(test_pkt->after_krn_pkt.size(), 2);
+        EXPECT_EQ(test_pkt->after_krn_pkt.at(0).completion_signal.handle, stop_marker);
+        EXPECT_EQ(test_pkt->after_krn_pkt.at(1).completion_signal.handle, read_marker);
+
+        ++tested_agents;
+    }
+
+    EXPECT_GT(tested_agents, 0);
+}
+
 TEST(aql_profile, packet_generation_multi)
 {
     ASSERT_EQ(hsa_init(), HSA_STATUS_SUCCESS);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/aql_packet.hpp
@@ -167,8 +167,8 @@ public:
     void populate_after() override
     {
         if(empty) return;
-        after_krn_pkt.push_back(packets.read_packet);
         after_krn_pkt.push_back(packets.stop_packet);
+        after_krn_pkt.push_back(packets.read_packet);
     };
 
     aqlprofile_pmc_aql_packets_t packets{};


### PR DESCRIPTION
## Motivation

Fix a potential rocprofv3 hang during PMC counter collection.

When profiling with counters such as SQ_WAVES, rocprofiler injects AQL packets around kernel dispatches to start, stop, and read counter collection. The after-kernel packet order should finalize counter collection before reading the results.

The previous order emitted the read packet before the stop packet, which could leave the queue waiting on a counter read before the collection had been stopped/finalized.

## Technical Details

Update `CounterAQLPacket::populate_after()` so the after-kernel PMC packet sequence is:

`stop -> read`

instead of:

`read -> stop`

This makes the full counter collection sequence:

`start -> kernel -> stop -> read`

which matches the expected start/stop/read flow for PMC collection.

Also add a regression test in `aql_test.cpp` to verify that `CounterAQLPacket::populate_after()` emits the stop packet before the read packet. The test marks the stop/read packets with unique completion-signal handles and checks the generated `after_krn_pkt` ordering without enqueueing packets.

## JIRA ID

ROCM-21782

## Test Plan

- run AQL packet tests.
- Manually validate the original rocprofv3 PMC hang reproducer with `--pmc SQ_WAVES`.

## Test Result

- `counter_after_packets_stop_before_read` passes.
- Existing AQL packet tests pass.
- Manual rocprofv3 PMC validation no longer reproduces the hang

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
