### PR TITLE
[rocprofiler-compute] Log resolved tarball path in nightly ROCm install

### DIFF
--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -153,7 +153,7 @@ jobs:
         run: |
           set -e
           TARBALL_ROCM_VERSION=$(ls /opt/*.tar.gz | grep -Eo '*([0-9]+\.[0-9]+\.[0-9]+)*')
-          echo "Using tarball: ${{ env.ROCM_PATH }}-${TARBALL_ROCM_VERSION}-multiarch.tar.gz"
+          echo "Using tarball: $(ls /opt/*.tar.gz)"
           tar -xf ${{ env.ROCM_PATH }}-${TARBALL_ROCM_VERSION}-multiarch.tar.gz -C ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }}
           ln -s ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} ${{ env.ROCM_PATH }}
           echo "ROCm installed to: ${{ env.ROCM_PATH }}"

--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -153,6 +153,7 @@ jobs:
         run: |
           set -e
           TARBALL_ROCM_VERSION=$(ls /opt/*.tar.gz | grep -Eo '*([0-9]+\.[0-9]+\.[0-9]+)*')
+          echo "Using tarball: ${{ env.ROCM_PATH }}-${TARBALL_ROCM_VERSION}-multiarch.tar.gz"
           tar -xf ${{ env.ROCM_PATH }}-${TARBALL_ROCM_VERSION}-multiarch.tar.gz -C ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }}
           ln -s ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} ${{ env.ROCM_PATH }}
           echo "ROCm installed to: ${{ env.ROCM_PATH }}"


### PR DESCRIPTION
## Motivation

Surface which ROCm nightly tarball the CI job resolved before extraction,
making nightly ROCm install failures easier to triage from the logs.

## Technical Details

- Echo the multiarch tarball filename in the "Install Latest Nightly ROCm"
  step before the tar extraction.

## JIRA ID


## Test Plan

Trigger the rocprofiler-compute CI workflow and confirm the tarball path
is printed in the "Install Latest Nightly ROCm" step log.

## Test Result


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.