### PR TITLE
[AMD-SMI] Add test-substance and anti-gaming review checks

### DIFF
--- a/projects/amdsmi/.claude/context/CONTEXT.md
+++ b/projects/amdsmi/.claude/context/CONTEXT.md
@@ -128,3 +128,17 @@ Disambiguation: violation status (MI300+, time %) ≠ throttle_status (older gen
 
 Retired / reserved VRAM pages — "bad pages" and "retired pages" are the **same set**, same struct `amdsmi_retired_page_record_t` (amdsmi.h:1945-1958), via `amdsmi_get_gpu_bad_page_info()` / `amdsmi_get_gpu_memory_reserved_pages()`. State is the `amdsmi_memory_page_status_t` enum: **PENDING** (flagged, awaiting retirement window) → **RESERVED** (retired, unavailable) or **UNRESERVABLE** (failed). amd-smi reports address/size/status only — the **error class (CE vs UE) driving retirement is not captured or exposed** here; CE/UE counts live separately in `amdsmi_get_gpu_ecc_count()` (see docs/conceptual/ras.md).
 Disambiguation: bad pages ≡ retired pages (one set, status enum distinguishes pending/reserved/unreservable); error class is NOT part of it — use ECC count for CE/UE.
+
+### released vs unreleased symbol (ABI baseline)
+
+A symbol's ABI is **frozen** only once it ships in a released package tag
+(`git tag 'amdsmi_pkg_ver-*'`, e.g. the last shipped is the highest `sort -V`), **not**
+when it lands on `develop`. "Unreleased / this-cycle" = a symbol **absent** at the last
+`amdsmi_pkg_ver-*` tag (header path inside the tag is `include/amd_smi/amdsmi.h`, no
+`projects/amdsmi/` prefix) → renaming/removing it is **not** a real ABI break.
+The CI ABI check (`tests/abi_check/abi_check.py`) diffs against `origin/develop`, so it
+labels intra-cycle churn as `ABI BREAKAGE` even when nothing shipped. Three distinct
+version schemes coexist: lib `AMDSMI_LIB_VERSION_*` (amdsmi.h), the package tag (real
+freeze point), and the ROCm/TheRock bundle (CHANGELOG.md top section).
+Disambiguation: "released" = present at last package tag (frozen ABI); base branch
+`develop` ≠ a release; lib version ≠ package tag ≠ ROCm/TheRock version.

--- a/projects/amdsmi/.claude/context/CONTEXT.md
+++ b/projects/amdsmi/.claude/context/CONTEXT.md
@@ -132,13 +132,12 @@ Disambiguation: bad pages ≡ retired pages (one set, status enum distinguishes 
 ### released vs unreleased symbol (ABI baseline)
 
 A symbol's ABI is **frozen** only once it ships in a released package tag
-(`git tag 'amdsmi_pkg_ver-*'`, e.g. the last shipped is the highest `sort -V`), **not**
-when it lands on `develop`. "Unreleased / this-cycle" = a symbol **absent** at the last
-`amdsmi_pkg_ver-*` tag (header path inside the tag is `include/amd_smi/amdsmi.h`, no
-`projects/amdsmi/` prefix) → renaming/removing it is **not** a real ABI break.
-The CI ABI check (`tests/abi_check/abi_check.py`) diffs against `origin/develop`, so it
-labels intra-cycle churn as `ABI BREAKAGE` even when nothing shipped. Three distinct
-version schemes coexist: lib `AMDSMI_LIB_VERSION_*` (amdsmi.h), the package tag (real
-freeze point), and the ROCm/TheRock bundle (CHANGELOG.md top section).
+(`amdsmi_pkg_ver-*`), **not** when it lands on `develop`. "Unreleased / this-cycle" =
+a symbol **absent** at the last `amdsmi_pkg_ver-*` tag → renaming or removing it is
+**not** a real ABI break, even though the CI ABI check (which diffs against `develop`)
+labels it one. Three distinct version schemes coexist: lib `AMDSMI_LIB_VERSION_*`
+(amdsmi.h), the package tag (real freeze point), and the ROCm/TheRock bundle
+(CHANGELOG.md top section).
 Disambiguation: "released" = present at last package tag (frozen ABI); base branch
 `develop` ≠ a release; lib version ≠ package tag ≠ ROCm/TheRock version.
+The diff procedure lives in the architecture agent's *ABI Release Baseline*.

--- a/projects/amdsmi/.claude/skills/amdsmi-commit-and-pr-conventions/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-commit-and-pr-conventions/SKILL.md
@@ -49,7 +49,7 @@ Signed-off-by: Full Name <email@amd.com>
 
 Rules:
 
-- Blank line after the subject; keep every body line under 80 columns.
+- Blank line after the subject; wrap body at 72 columns.
 - Each bullet starts with a verb (Add, Fix, Remove, Refactor, Implement).
 - Include the "why" only when it is not self-evident from the change.
 - **No JIRA ticket references in the commit body.** Reference the code/behavior,

--- a/projects/amdsmi/.claude/skills/amdsmi-commit-and-pr-conventions/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-commit-and-pr-conventions/SKILL.md
@@ -49,7 +49,7 @@ Signed-off-by: Full Name <email@amd.com>
 
 Rules:
 
-- Blank line after the subject; wrap body at 72 columns.
+- Blank line after the subject; keep every body line under 80 columns.
 - Each bullet starts with a verb (Add, Fix, Remove, Refactor, Implement).
 - Include the "why" only when it is not self-evident from the change.
 - **No JIRA ticket references in the commit body.** Reference the code/behavior,

--- a/projects/amdsmi/.claude/skills/amdsmi-release-sanity-check/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-release-sanity-check/SKILL.md
@@ -28,6 +28,11 @@ set is `git log <release-sha>..origin/develop -- .` from `projects/amdsmi`.
 Confirm `AMDSMI_LIB_VERSION_*` in `include/amd_smi/amdsmi.h` moved if behavior
 changed.
 
+This SHA scopes the *feature / changelog* audit. For an **ABI** question
+specifically (is a symbol rename or removal a real break?), the authoritative
+freeze point is the last `amdsmi_pkg_ver-*` package tag, not the TheRock SHA —
+see the architecture agent's *ABI Release Baseline*.
+
 ## 2. The Sanity Sweep
 
 | Check | Command / method | Red flag |
@@ -52,3 +57,9 @@ changed.
 | Trusting a conflict-free rebase | Resolve every export/doc name against the post-rebase interface |
 | Committing a regen from a stale image | Use the pinned image; reproduce the committed wrapper first |
 | "It imports for me" as proof | Installed package may differ from the tree — static-check the source |
+
+---
+
+*Validation status: grounded in an observed release miss (a cascade gap plus a
+rename break that passed a clean merge). A formal RED/GREEN pressure test per the
+`writing-skills` skill is still pending.*

--- a/projects/amdsmi/.claude/skills/amdsmi-release-sanity-check/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-release-sanity-check/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: amdsmi-release-sanity-check
+description: "Use when auditing amd-smi for a release or release candidate, sanity-checking everything that changed since the last ROCm/TheRock release, verifying a version bump, or before merging/cutting a release branch. Catches API cascade gaps (header/wrapper present but Python interface/__init__ missing), semantic breaks that survive a clean rebase/merge, stale-image wrapper regeneration, and silent CHANGELOG/doc drift."
+---
+
+# Release Sanity Check — amd-smi
+
+Audit everything that changed since the last release for the failure modes that
+pass CI and a clean `git merge` but still ship broken. Clean merge ≠ correct.
+
+**Core principle:** Diff against the *release boundary*, not against `develop`'s
+tip. A textually clean rebase can be semantically broken.
+
+## When to Use
+
+- Cutting or reviewing a release / RC branch, or a version bump
+- "Sanity check what changed since the last release"
+- After a rebase that touched header, wrapper, or Python interface files
+
+**Don't use when:** reviewing a single small PR (use `amdsmi-changelog-automation`
++ the `project-layout` rule). This skill is release-scope.
+
+## 1. Establish the Release Boundary
+
+Find the last amd-smi shipped via TheRock
+(`https://github.com/ROCm/TheRock/releases`) — note its `develop` SHA. The audit
+set is `git log <release-sha>..origin/develop -- .` from `projects/amdsmi`.
+Confirm `AMDSMI_LIB_VERSION_*` in `include/amd_smi/amdsmi.h` moved if behavior
+changed.
+
+## 2. The Sanity Sweep
+
+| Check | Command / method | Red flag |
+|-------|------------------|----------|
+| **Cascade gap** | For each new `amdsmi_*` in the header, grep all 5 layers (header → `amd_smi.cc` → `amdsmi_wrapper.py` → `amdsmi_interface.py` → `__init__.py`) | Present in header/wrapper, **absent** in `amdsmi_interface.py`/`__init__.py` → unreachable from `from amdsmi import ...` |
+| **Semantic rename break** | Static-resolve every `from .amdsmi_interface import X` in `__init__.py` against functions actually defined there; grep docs/changelog for the old name | Export/doc references a name a rebase renamed elsewhere — zero git conflict, runtime `ImportError` |
+| **Wrapper drift** | Regenerate with `tools/update_wrapper.sh` (Python) using the **canonical pinned Docker image**, never a stale local one | Diff vs committed wrapper ≠ ∅. Cross-check that Python and Rust wrappers agree with the header before trusting either |
+| **CHANGELOG conventions** | `grep -nP '^- \*\*.*\*\*[^ ]*$' CHANGELOG.md` in the unreleased section | Missing two-trailing-space Sphinx hard break; entry in wrong section (see `amdsmi-changelog-automation`) |
+| **Doc vs code** | New public API or CLI flag without a docs/reference entry | User-facing change, zero docs |
+| **Version bump** | Behavior changed but `AMDSMI_LIB_VERSION_*` unchanged | Stale version |
+
+> **Wrapper trap:** `update_wrapper.sh` tags its image by Dockerfile hash. A
+> stale local image silently emits spurious bindings; the pinned canonical image
+> reproduces the committed wrapper byte-for-byte. Non-empty regen diff → suspect
+> the image before the header.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Diffing against `develop` tip, not the release SHA | Anchor on TheRock's released SHA |
+| Trusting a conflict-free rebase | Resolve every export/doc name against the post-rebase interface |
+| Committing a regen from a stale image | Use the pinned image; reproduce the committed wrapper first |
+| "It imports for me" as proof | Installed package may differ from the tree — static-check the source |

--- a/projects/amdsmi/.github/agents/amdsmi-review-architecture.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-architecture.agent.md
@@ -21,6 +21,42 @@ Project structure and API cascade path are stored in repo memories.
 - **API renames**: Must cascade: header → C impl → wrapper → interface → CLI → docs. Repo memories contain the full cascade checklist.
 - **Packaging:** Owned by the build subagent — only flag packaging issues here if they indicate an architectural problem (e.g., tight coupling between layers).
 
+## ABI Release Baseline
+
+A symbol's ABI is frozen only once it ships in a **released** package, not when it
+lands on `develop`. There are three independent version schemes — don't conflate
+them:
+
+| Scheme | Source | Meaning |
+|--------|--------|---------|
+| Lib version `MAJOR.MINOR.RELEASE` | `include/amd_smi/amdsmi.h` (`AMDSMI_LIB_VERSION_*`) | MAJOR = ABI-breaking header change; MINOR = API change, no header break; RELEASE = PM-set CSP point release |
+| Package tag `amdsmi_pkg_ver-*` | `git tag` | **The real ABI freeze points** — every shipped artifact |
+| ROCm / TheRock release | `CHANGELOG.md` top section / ROCm/TheRock releases | Downstream bundle version (different numbering) |
+
+**The CI gap.** `tests/abi_check/abi_check.py` (driven by `abi-compliance-check.yml`)
+diffs `amdsmi.h` against the **base branch** (`origin/develop`) and applies a
+`MAJOR/MINOR ABI BREAKAGE` label. It has no notion of "has this shipped yet," so a
+symbol **added this same unreleased cycle** gets labeled as a break when renamed or
+removed — even though no released artifact ever exposed it. That is **not** a real
+ABI break.
+
+**The rule.** Renaming/removing/changing a symbol is ABI-safe when that symbol is
+**absent at the last released package tag**. Diff against the tag, not `develop`:
+
+```bash
+LAST=$(git tag --list 'amdsmi_pkg_ver-*' | grep -vE -- '-(cherrypicked|sohbodas)' \
+       | sed 's/.*-//' | sort -V | tail -1)
+# in-tag header path has NO projects/amdsmi/ prefix
+git show "amdsmi_pkg_ver-$LAST:include/amd_smi/amdsmi.h" | grep "<symbol>"
+# absent  => added this cycle  => ABI-safe to change/remove
+# present => shipped/frozen     => removal/rename is a real ❌ ABI break
+```
+
+When a CI `ABI BREAKAGE` label fires on a symbol that is **absent at the last
+release tag**, downgrade it: the diff is intra-cycle churn, not a shipped-ABI break.
+Treat a real break (symbol present at the tag) as **❌ BLOCKING** unless the lib
+`MAJOR` was bumped to match.
+
 ## Your Job
 
 1. Verify API cascade integrity — changes propagate through all layers
@@ -28,6 +64,8 @@ Project structure and API cascade path are stored in repo memories.
 3. Identify design pattern violations or inconsistencies
 4. Flag unnecessary coupling or missing abstractions in changed code
 5. Verify `tools/generator.py` sync when C API changes
+6. For symbol removals/renames, apply the **ABI Release Baseline** rule before
+   escalating (or downgrading) any `ABI BREAKAGE` signal
 
 ## Structural Smells (flag aggressively)
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-architecture.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-architecture.agent.md
@@ -23,15 +23,10 @@ Project structure and API cascade path are stored in repo memories.
 
 ## ABI Release Baseline
 
-A symbol's ABI is frozen only once it ships in a **released** package, not when it
-lands on `develop`. There are three independent version schemes — don't conflate
-them:
-
-| Scheme | Source | Meaning |
-|--------|--------|---------|
-| Lib version `MAJOR.MINOR.RELEASE` | `include/amd_smi/amdsmi.h` (`AMDSMI_LIB_VERSION_*`) | MAJOR = ABI-breaking header change; MINOR = API change, no header break; RELEASE = PM-set CSP point release |
-| Package tag `amdsmi_pkg_ver-*` | `git tag` | **The real ABI freeze points** — every shipped artifact |
-| ROCm / TheRock release | `CHANGELOG.md` top section / ROCm/TheRock releases | Downstream bundle version (different numbering) |
+A symbol's ABI is frozen only once it ships in a **released** package (the last
+`amdsmi_pkg_ver-*` tag), not when it lands on `develop`. CONTEXT.md's *released vs
+unreleased symbol* entry defines the three version schemes; the diff procedure is
+here.
 
 **The CI gap.** `tests/abi_check/abi_check.py` (driven by `abi-compliance-check.yml`)
 diffs `amdsmi.h` against the **base branch** (`origin/develop`) and applies a
@@ -44,8 +39,10 @@ ABI break.
 **absent at the last released package tag**. Diff against the tag, not `develop`:
 
 ```bash
-LAST=$(git tag --list 'amdsmi_pkg_ver-*' | grep -vE -- '-(cherrypicked|sohbodas)' \
-       | sed 's/.*-//' | sort -V | tail -1)
+# latest released package tag; the anchored regex keeps only bare X.Y.Z tags,
+# dropping any suffix (-cherrypicked, -rcN, personal tags)
+LAST=$(git tag --list 'amdsmi_pkg_ver-*' \
+       | grep -oP 'amdsmi_pkg_ver-\K[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
 # in-tag header path has NO projects/amdsmi/ prefix
 git show "amdsmi_pkg_ver-$LAST:include/amd_smi/amdsmi.h" | grep "<symbol>"
 # absent  => added this cycle  => ABI-safe to change/remove

--- a/projects/amdsmi/.github/agents/amdsmi-review-skeptic.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-skeptic.agent.md
@@ -34,7 +34,7 @@ When given a **diff and changed files**, review the code through a skeptic lens.
 - New C API functions: Must justify the full cascade cost (header → impl → wrapper → interface → CLI → docs)
 - New Python wrappers: Is the underlying C function actually needed by Python consumers?
 - Build system changes: Does this add complexity to an already complex packaging story (RPM/DEB + pip + system install)?
-- Internal "backward-compat" aliases: keeping a deprecated alias or old code path "for compatibility" when the symbol is internal with no external users is incomplete cleanup, not courtesy → ❌ BLOCKING.
+- Internal "backward-compat" aliases: keeping a deprecated alias or old code path "for compatibility" is incomplete cleanup, not courtesy, when the symbol is internal (`static` / file-scope / `_`-prefixed Python, or absent at the last `amdsmi_pkg_ver-*` tag) with no downstream callers. Flag it as blocking.
 
 ### Mode 2: Rebuttal Review (Round 2 — Thorough mode only)
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-skeptic.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-skeptic.agent.md
@@ -34,6 +34,7 @@ When given a **diff and changed files**, review the code through a skeptic lens.
 - New C API functions: Must justify the full cascade cost (header → impl → wrapper → interface → CLI → docs)
 - New Python wrappers: Is the underlying C function actually needed by Python consumers?
 - Build system changes: Does this add complexity to an already complex packaging story (RPM/DEB + pip + system install)?
+- Internal "backward-compat" aliases: keeping a deprecated alias or old code path "for compatibility" when the symbol is internal with no external users is incomplete cleanup, not courtesy → ❌ BLOCKING.
 
 ### Mode 2: Rebuttal Review (Round 2 — Thorough mode only)
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-tests.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-tests.agent.md
@@ -50,6 +50,20 @@ Project structure and test directories are stored in repo memories.
 8. **Evaluate testability as a design property** — hard-to-test code is a design smell. When code is difficult to test (hidden dependencies, global state, monolithic functions), flag it and suggest a more testable structure (pure functions, explicit inputs, narrow interfaces).
 9. **Challenge redundant tests** — excessive or duplicated tests that test implementation details rather than behavior should be flagged for consolidation. Tests should specify behavior, not mirror the implementation.
 
+## Test Substance
+
+Presence is not coverage. For any test claimed to cover new behavior, ask the **mutation question**: *what single change to the source would make this test fail?* If there is no clear answer, it is coverage padding — ⚠️ IMPORTANT, or ❌ BLOCKING when it is the only "test" for new behavior. AI-generated tells worth a closer read: phantom methods/attributes that do not exist in the source, and mock-only assertions that still pass against a no-op implementation.
+
+## Anti-Gaming (never weaken a test to green CI)
+
+Disabling, skipping, or weakening a test to make CI pass is never valid. When a PR changes product code **and** the same diff does any of the following without a stated justification, it is ❌ BLOCKING:
+
+- Adds an entry to `tests/amd_smi_test/amdsmitst.exclude` or widens `GTEST_EXCLUDE` via `tests/amd_smi_test/detect_asic_filter.sh`
+- Adds a `DISABLED_` prefix to a GTest case
+- Adds `@unittest.skip` / `pytest.mark.skip` (or comments out a test body)
+
+A genuine reason (test invalid on this ASIC, behavior intentionally removed) is fine when stated; a silent exclusion that happens to green a failing lane is not.
+
 ## CI Evidence (when available)
 
 If the orchestrator provides CI run data, use it to:

--- a/projects/amdsmi/.github/agents/amdsmi-review-tests.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-tests.agent.md
@@ -52,15 +52,16 @@ Project structure and test directories are stored in repo memories.
 
 ## Test Substance
 
-Presence is not coverage. For any test claimed to cover new behavior, ask the **mutation question**: *what single change to the source would make this test fail?* If there is no clear answer, it is coverage padding — ⚠️ IMPORTANT, or ❌ BLOCKING when it is the only "test" for new behavior. AI-generated tells worth a closer read: phantom methods/attributes that do not exist in the source, and mock-only assertions that still pass against a no-op implementation.
+The Systems PR Bot only confirms a test *file* exists; this section is your check that the file actually exercises the new behavior. Presence is not coverage. For any test claimed to cover new behavior, ask the **mutation question**: *what single change to the source would make this test fail?* If there is no clear answer, it is coverage padding — ⚠️ IMPORTANT, or ❌ BLOCKING when it is the only "test" for new behavior. AI-generated tells worth a closer read: phantom methods/attributes that do not exist in the source, and mock-only assertions that still pass against a no-op implementation.
 
 ## Anti-Gaming (never weaken a test to green CI)
 
 Disabling, skipping, or weakening a test to make CI pass is never valid. When a PR changes product code **and** the same diff does any of the following without a stated justification, it is ❌ BLOCKING:
 
-- Adds an entry to `tests/amd_smi_test/amdsmitst.exclude` or widens `GTEST_EXCLUDE` via `tests/amd_smi_test/detect_asic_filter.sh`
+- Adds an entry to `tests/amd_smi_test/amdsmitst.exclude`, or changes the ASIC-detection / filter-routing in `tests/amd_smi_test/detect_asic_filter.sh` to send more runs into a wider `GTEST_EXCLUDE`
+- Renames a test source to `*.cc.disabled` (or any non-`.cc`/`.cpp` extension) so `aux_source_directory` silently drops it from the build (the repo already carries `ainic.cc.disabled`)
 - Adds a `DISABLED_` prefix to a GTest case
-- Adds `@unittest.skip` / `pytest.mark.skip` (or comments out a test body)
+- Adds `self.skipTest()` (the dominant idiom in this repo) / `raise unittest.SkipTest` / a `@unittest.skip`/`skipIf`/`skipUnless` decorator / `pytest.mark.skip`, or comments out a test body
 
 A genuine reason (test invalid on this ASIC, behavior intentionally removed) is fine when stated; a silent exclusion that happens to green a failing lane is not.
 


### PR DESCRIPTION
## Motivation

The review subagents check that tests exist and that scope is justified, but nothing guards against tests that pass without constraining behavior, or against silently excluding a failing test to green CI. These gaps were surfaced by the ROCm-wide PR-quality rubric (ROCm/TheRock#5734).

## Technical Details

**Test review** (`projects/amdsmi/.github/agents/amdsmi-review-tests.agent.md`):
- Add a **Test Substance** section: the mutation question ("what single source change would make this test fail?") plus phantom-method and mock-only-no-op tells
- Add an **Anti-Gaming** section: a product-code change that also adds to `amdsmitst.exclude`, widens `GTEST_EXCLUDE`, or adds a `DISABLED_`/`skip` without justification is BLOCKING

**Skeptic review** (`projects/amdsmi/.github/agents/amdsmi-review-skeptic.agent.md`):
- Flag an internal-only deprecated alias kept "for compatibility" (no external users) as incomplete cleanup, not courtesy

## JIRA ID

N/A — agent tooling, no ticket.

## Test Plan

- Agent-instruction (Markdown) change only; no build or runtime impact
- Verified the cited hooks (`amdsmitst.exclude`, `detect_asic_filter.sh`) exist and severity markers match each agent's existing table

## Test Result

- pre-commit hooks pass (no code files in scope)
