### PR TITLE
[rocjitsu] Fix wave32 VCC scalar writes

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
@@ -190,13 +190,13 @@ public:
   /// @param val New EXEC mask value.
   void set_exec(uint64_t val) { exec_ = val & lane_mask(); }
 
-  /// @brief Return the vector condition code.
-  /// @returns VCC register value.
+  /// @brief Return the VCC scalar register pair.
+  /// @returns Raw VCC register value.
   uint64_t vcc() const { return vcc_; }
 
-  /// @brief Set the vector condition code.
+  /// @brief Set the VCC scalar register pair.
   /// @param val New VCC value.
-  void set_vcc(uint64_t val) { vcc_ = val & lane_mask(); }
+  void set_vcc(uint64_t val) { vcc_ = val; }
 
   /// @brief Return the M0 special register.
   /// @returns M0 register value.

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -1039,6 +1039,27 @@ TEST(Gfx1250ExecutionTest, VCmpGtU32Wave32ExplicitSdstPreservesHighSgpr) {
   EXPECT_EQ(wf->vcc(), 0x12345678u);
 }
 
+TEST(Gfx1250ExecutionTest, Wave32ScalarVccHiWritePreservesUpperHalf) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  ASSERT_EQ(wf->wf_size(), 32u);
+  wf->set_exec(0xffff0000u);
+  wf->set_vcc(0);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+
+  const uint32_t words[] = {0x8c6b7e6bu, 0}; // s_or_b32 vcc_hi, vcc_hi, exec_lo
+  std::unique_ptr<Instruction> inst(decoder->decode(words));
+  ASSERT_NE(inst, nullptr);
+  ASSERT_EQ(std::string_view(inst->mnemonic()), "s_or_b32");
+  cu->execute_instruction(inst.get(), *wf);
+
+  EXPECT_EQ(wf->vcc(), 0xffff0000'00000000ULL);
+}
+
 TEST(Gfx1250ExecutionTest, TensorDmaD2CopiesGlobalAndLds) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();


### PR DESCRIPTION
## Motivation

Found this while investigating gfx1250 FPSan SWMMAC tests that timed out under the emulator. Sampling the stuck kernel showed it spinning around scalar mask code where s_or_b32 vcc_hi, vcc_hi, exec_lo should update the upper half of VCC, but the value never persisted.

## Technical Details

The root cause was that `Wavefront::set_vcc()` masked every write with `lane_mask()`. That is correct for `EXEC`, but not for `VCC`: `VCC` is a scalar register pair, and scalar instructions can explicitly read/write `VCC_LO` and `VCC_HI` even in wave32 mode. Masking by active lane width incorrectly discarded all `VCC_HI` writes.

## JIRA ID

N/A

## Test Plan

Run unit tests and fpsan gfx1250 tests.

## Test Result

All good.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
