### PR TITLE
[rocprofiler-compute] Add TheRock docker build templates

### DIFF
--- a/projects/rocprofiler-compute/README.md
+++ b/projects/rocprofiler-compute/README.md
@@ -52,8 +52,8 @@ python3 -m pip install -r requirements-development.txt
 
 ## Testing
 
-Populate the <usename> variable in `docker/docker-compose.therock.tarball.yml`.
-Populate the <rocm_build_image> variable in `docker/Dockerfile.therock.tarball` based on latest ROCm CI build information.
+Populate the <username> variable in `docker/docker-compose.therock.tarball.yml`.
+Populate the <tarball_name> variable in `docker/Dockerfile.therock.tarball` (see the comment there for the naming convention and nightly index).
 
 To quickly get the environment (bash shell) for building and testing, run the following commands:
 * `cd docker`

--- a/projects/rocprofiler-compute/README.md
+++ b/projects/rocprofiler-compute/README.md
@@ -52,13 +52,13 @@ python3 -m pip install -r requirements-development.txt
 
 ## Testing
 
-Populate the <usename> variable in `docker/docker-compose.customrocmtest.yml`.
-Populate the <rocm_build_image> variable in `docker/Dockerfile.customrocmtest` based on latest ROCm CI build information.
+Populate the <usename> variable in `docker/docker-compose.therock.tarball.yml`.
+Populate the <rocm_build_image> variable in `docker/Dockerfile.therock.tarball` based on latest ROCm CI build information.
 
 To quickly get the environment (bash shell) for building and testing, run the following commands:
 * `cd docker`
-* If the docker image is not available on the machine, then build the image, otherwise skip this step: `docker compose -f docker-compose.customrocmtest.yml build`
-* Launch the container, and check the name of the container: `docker compose -f docker-compose.customrocmtest.yml up --force-recreate -d `
+* If the docker image is not available on the machine, then build the image, otherwise skip this step: `docker compose -f docker-compose.therock.tarball.yml build`
+* Launch the container, and check the name of the container: `docker compose -f docker-compose.therock.tarball.yml up --force-recreate -d `
 * Run bash shell on the launched container: `docker exec -it <container_name> bash`
 * If testing is done, kill the container: `docker container kill <container_name>`
 

--- a/projects/rocprofiler-compute/docker/Dockerfile.therock.tarball
+++ b/projects/rocprofiler-compute/docker/Dockerfile.therock.tarball
@@ -5,13 +5,13 @@ FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y curl
 
 # Define the tarball name as a variable
-# Check https://therock-nightly-tarball.s3.amazonaws.com/index.html for latest builds
-# Use therock-dist-linux-gfx<arch>-dcgpu-<rocm-version>.tar.gz naming convention
+# Check https://rocm.nightlies.amd.com/tarball-multi-arch/ for latest builds
+# Use therock-dist-linux-gfx<arch>-<dgpu|dcgpu|all>-<rocm-version>.tar.gz naming convention
 ARG TARBALL_NAME=<tarball_name>
 
 # Install ROCm from TheRock Nightly build
 RUN mkdir -p /rocm && \
-    curl -fLO https://therock-nightly-tarball.s3.amazonaws.com/${TARBALL_NAME} && \
+    curl -fLO https://rocm.nightlies.amd.com/tarball-multi-arch/${TARBALL_NAME} && \
     tar -xf ${TARBALL_NAME} -C /rocm && \
     rm ${TARBALL_NAME}
 

--- a/projects/rocprofiler-compute/docker/Dockerfile.therock.wheel
+++ b/projects/rocprofiler-compute/docker/Dockerfile.therock.wheel
@@ -1,0 +1,54 @@
+# Use a base image
+FROM ubuntu:22.04
+
+# Update package list and install prerequisites
+RUN apt-get update && apt-get install -y \
+    curl software-properties-common cmake locales git \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update
+
+# Generate the desired locale
+RUN locale-gen en_US.UTF-8
+
+# Install Python 3.12 and pip (use non-interactive to avoid timezone prompt)
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3.12 python3.12-venv python3.12-dev python3-pip libsqlite3-dev
+
+# Install ROCm from the multi-arch nightly index. GFX_ARCH selects which GPU
+# kernels are bundled via the device-* extra (e.g. gfx942 = MI300A/MI300X, or
+# use "all" for every arch). Available extras:
+#   https://github.com/ROCm/TheRock/blob/main/RELEASES.md#supported-python-device--install-extras
+# Pin a dated nightly via ROCM_VERSION for reproducibility; bump it manually to
+# update. Browse available versions at https://rocm.nightlies.amd.com/whl-multi-arch/rocm/
+ARG ROCM_VERSION=<rocm_version>
+ARG GFX_ARCH=<gfx_arch>
+RUN rm -rf /rocm-venv && python3.12 -m venv /rocm-venv && \
+    /rocm-venv/bin/pip install --upgrade pip && \
+    /rocm-venv/bin/pip install \
+        --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+        "rocm[profiler,devel,libraries,device-${GFX_ARCH}]==${ROCM_VERSION}"
+
+# Expand the devel tree and link the per-GPU device kernels (.kpack) into it.
+RUN /rocm-venv/bin/rocm-sdk init
+
+# Set ROCm environment variables pointing at the devel root, which is the
+# complete merged tree (bin/include/lib + linked device kernels).
+ENV ROCM_PATH="/rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel" \
+    HIP_PATH="/rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel" \
+    HIP_DEVICE_LIB_PATH="/rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel/lib/llvm/amdgcn/bitcode" \
+    PATH="/rocm-venv/bin:/rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel/bin:${PATH}" \
+    LD_LIBRARY_PATH="/rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel/lib:/rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib:${LD_LIBRARY_PATH}"
+
+# Install any rocprofiler-compute dependencies specified in requirements.txt
+COPY projects/rocprofiler-compute/requirements.txt /app/projects/rocprofiler-compute/requirements.txt
+COPY projects/rocprofiler-compute/requirements-test.txt /app/projects/rocprofiler-compute/requirements-test.txt
+COPY projects/rocprofiler-compute/requirements-development.txt /app/projects/rocprofiler-compute/requirements-development.txt
+RUN /rocm-venv/bin/pip install -r /app/projects/rocprofiler-compute/requirements.txt -r /app/projects/rocprofiler-compute/requirements-test.txt -r /app/projects/rocprofiler-compute/requirements-development.txt
+
+# Set the working directory
+WORKDIR /app/projects/rocprofiler-compute
+
+# Allows running git commands in /app
+RUN git config --global --add safe.directory /app
+
+# Run interactive bash shell
+CMD ["/bin/bash"]

--- a/projects/rocprofiler-compute/docker/Dockerfile.therock.wheel.pytorch
+++ b/projects/rocprofiler-compute/docker/Dockerfile.therock.wheel.pytorch
@@ -1,0 +1,58 @@
+# Use a base image
+FROM ubuntu:22.04
+
+# Update package list and install prerequisites
+RUN apt-get update && apt-get install -y \
+    curl software-properties-common cmake locales git \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update
+
+# Generate the desired locale
+RUN locale-gen en_US.UTF-8
+
+# Install Python 3.12 and pip (use non-interactive to avoid timezone prompt)
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y python3.12 python3.12-venv python3.12-dev python3-pip libsqlite3-dev
+
+# Install ROCm + PyTorch from the unified multi-arch nightly index. GFX_ARCH
+# selects the device kernels via the [device-*] extra (e.g. gfx942 = MI300X/
+# MI300A, or "all" for every arch). torch's device extra auto-pulls the matching
+# rocm-sdk core/libraries/device packages; the rocm[profiler,devel] extras add
+# the rocprofiler tools and headers needed to build rocprofiler-compute. Pin a
+# dated nightly via ROCM_VERSION for reproducibility; bump it manually to update.
+# Browse versions at https://rocm.nightlies.amd.com/whl-multi-arch/rocm/
+ARG ROCM_VERSION=<rocm_version>
+ARG GFX_ARCH=<gfx_arch>
+RUN rm -rf /rocm-venv && python3.12 -m venv /rocm-venv && \
+    /rocm-venv/bin/pip install --upgrade pip && \
+    /rocm-venv/bin/pip install \
+        --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+        "rocm[profiler,devel,libraries,device-${GFX_ARCH}]==${ROCM_VERSION}" \
+        "torch[device-${GFX_ARCH}]" \
+        "torchvision[device-${GFX_ARCH}]" \
+        torchaudio
+
+# Expand the devel tree and link the per-GPU device kernels (.kpack) into it.
+RUN /rocm-venv/bin/rocm-sdk init
+
+# Set ROCm environment variables pointing at the devel root, which is the
+# complete merged tree (bin/include/lib + linked device kernels).
+ENV ROCM_PATH="/rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel" \
+    HIP_PATH="/rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel" \
+    HIP_DEVICE_LIB_PATH="/rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel/lib/llvm/amdgcn/bitcode" \
+    PATH="/rocm-venv/bin:/rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel/bin:${PATH}" \
+    LD_LIBRARY_PATH="/rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel/lib:/rocm-venv/lib/python3.12/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib:${LD_LIBRARY_PATH}"
+
+# Install any rocprofiler-compute dependencies specified in requirements.txt
+COPY projects/rocprofiler-compute/requirements.txt /app/projects/rocprofiler-compute/requirements.txt
+COPY projects/rocprofiler-compute/requirements-test.txt /app/projects/rocprofiler-compute/requirements-test.txt
+COPY projects/rocprofiler-compute/requirements-development.txt /app/projects/rocprofiler-compute/requirements-development.txt
+RUN /rocm-venv/bin/pip install -r /app/projects/rocprofiler-compute/requirements.txt -r /app/projects/rocprofiler-compute/requirements-test.txt -r /app/projects/rocprofiler-compute/requirements-development.txt
+
+# Set the working directory
+WORKDIR /app/projects/rocprofiler-compute
+
+# Allows running git commands in /app
+RUN git config --global --add safe.directory /app
+
+# Run interactive bash shell
+CMD ["/bin/bash"]

--- a/projects/rocprofiler-compute/docker/docker-compose.therock.tarball.yml
+++ b/projects/rocprofiler-compute/docker/docker-compose.therock.tarball.yml
@@ -1,0 +1,22 @@
+services:
+  rocprofiler-compute-therock-tarball-<username>: # service name
+    build:
+      context: ../../../
+      dockerfile: projects/rocprofiler-compute/docker/Dockerfile.therock.tarball
+    image: rocprofiler-compute-therock-tarball-<username>
+    # Uncomment for environments using ROCR_VISIBLE_DEVICES env. var. to forward it to container
+    # environment:
+    #   ROCR_VISIBLE_DEVICES: ${ROCR_VISIBLE_DEVICES}
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - ../../../:/app
+    ports:
+      - 8050:8050
+    tty: true
+    stdin_open: true
+    cap_add:
+      - SYS_PTRACE

--- a/projects/rocprofiler-compute/docker/docker-compose.therock.wheel.pytorch.yml
+++ b/projects/rocprofiler-compute/docker/docker-compose.therock.wheel.pytorch.yml
@@ -1,9 +1,9 @@
 services:
-  rocprofiler-compute-<username>: # service name
+  rocprofiler-compute-therock-wheel-pytorch-<username>: # service name
     build:
       context: ../../../
-      dockerfile: projects/rocprofiler-compute/docker/Dockerfile.customrocmtest
-    image: rocprofiler-compute-<username>
+      dockerfile: projects/rocprofiler-compute/docker/Dockerfile.therock.wheel.pytorch
+    image: rocprofiler-compute-therock-wheel-pytorch-<username>
     # Uncomment for environments using ROCR_VISIBLE_DEVICES env. var. to forward it to container
     # environment:
     #   ROCR_VISIBLE_DEVICES: ${ROCR_VISIBLE_DEVICES}

--- a/projects/rocprofiler-compute/docker/docker-compose.therock.wheel.yml
+++ b/projects/rocprofiler-compute/docker/docker-compose.therock.wheel.yml
@@ -1,0 +1,22 @@
+services:
+  rocprofiler-compute-therock-wheel-<username>: # service name
+    build:
+      context: ../../../
+      dockerfile: projects/rocprofiler-compute/docker/Dockerfile.therock.wheel
+    image: rocprofiler-compute-therock-wheel-<username>
+    # Uncomment for environments using ROCR_VISIBLE_DEVICES env. var. to forward it to container
+    # environment:
+    #   ROCR_VISIBLE_DEVICES: ${ROCR_VISIBLE_DEVICES}
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    security_opt:
+      - seccomp:unconfined
+    volumes:
+      - ../../../:/app
+    ports:
+      - 8050:8050
+    tty: true
+    stdin_open: true
+    cap_add:
+      - SYS_PTRACE


### PR DESCRIPTION
## Motivation

Provide reproducible docker build templates for testing rocprofiler-compute
against TheRock ROCm nightlies: the tarball install and the new multi-arch
wheel install (with and without PyTorch).

## Technical Details

- Rename the customrocmtest template to therock.tarball and point it at the
  multi-arch nightly tarball index https://rocm.nightlies.amd.com/tarball-multi-arch/.
- Add Dockerfile.therock.wheel + compose: installs ROCm from the unified
  multi-arch wheel index via rocm[...,device-<gfx>], expands the devel tree
  with rocm-sdk init.
- Add Dockerfile.therock.wheel.pytorch + compose: same index, installs
  torch/torchvision via [device-<gfx>] extras and torchaudio plain (no
  device-specific code, per TheRock docs).
- Templates use <username>, <rocm_version>, <gfx_arch> placeholders; port 8050.
- Update README testing steps for the renamed tarball template.

## JIRA ID

## Test Plan

- cd projects/rocprofiler-compute/docker
- Populate <username>, <rocm_version>, <gfx_arch> in the compose/Dockerfile.
- docker compose -f docker-compose.therock.wheel.yml build
- Launch the container and run the rocprofiler-compute unit tests.

## Test Result

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.