### PR TITLE
feat: [rocshmem] add wave-level broadcast

### DIFF
--- a/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
@@ -395,13 +395,34 @@ __host__ void rocshmem_ctx_ulonglong_broadcast(
     rocshmem_ctx_t ctx, rocshmem_team_t team, unsigned long long *dest,
     const unsigned long long *source, int nelems, int pe_root);
 
+/**
+ * @name ROCSHMEM_CTX_BROADCASTMEM_WG
+ * @brief Perform a broadcast between PEs in the active set. The caller
+ * is blocked until the broadcast completes.
+ *
+ * This function must be called as a work-group collective.
+ *
+ * @param[in] ctx          The ROCSHMEM context associated with this operation.
+ * @param[in] team         The team participating in the collective.
+ * @param[in] dest         Destination address. Must be an address on the
+ *                         symmetric heap.
+ * @param[in] source       Source address. Must be an address on the symmetric
+ *                         heap.
+ * @param[in] nelement     Size of buffer to participate in the broadcast.
+ * @param[in] PE_root      Root PE (relative to team) from which to broadcast.
+ * 
+ *
+ * @return void
+ */
+__device__ void rocshmem_ctx_broadcastmem_wg(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              void *dest, const void *source, int nelement, int PE_root);
 
 /**
  * @name ROCSHMEM_CTX_TYPE_BROADCAST_WAVE
  * @brief Perform a broadcast between PEs in the active set. The caller
  * is blocked until the broadcast completes.
  *
- * This function must be called as a wave collective.
+ * This function must be called as a work-group collective.
  *
  * @param[in] ctx          The ROCSHMEM context associated with this operation.
  * @param[in] team         The team participating in the collective.
@@ -413,8 +434,20 @@ __host__ void rocshmem_ctx_ulonglong_broadcast(
  * @param[in] PE_root      Root PE (relative to team) from which to broadcast.
  * 
  *
- * @return int; zero when successful, non-zero otherwise
+ * @return int; zero when sucessful, non-zero otherwise
  */
+__device__ int rocshmem_ctx_float_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              float *dest, const float *source, int nelement, int PE_root);
+
+__device__ int rocshmem_ctx_double_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              double *dest, const double *source, int nelement, int PE_root);
+
+__device__ int rocshmem_ctx_char_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              char *dest, const char *source, int nelement, int PE_root);
+
+__device__ int rocshmem_ctx_schar_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              signed char *dest, const signed char *source, int nelement, int PE_root);
+
 __device__ int rocshmem_ctx_short_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
               short *dest, const short *source, int nelement, int PE_root);
 
@@ -427,12 +460,20 @@ __device__ int rocshmem_ctx_long_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_tea
 __device__ int rocshmem_ctx_longlong_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
               long long *dest, const long long *source, int nelement, int PE_root);
 
-__device__ int rocshmem_ctx_float_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              float *dest, const float *source, int nelement, int PE_root);
+__device__ int rocshmem_ctx_uchar_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              unsigned char *dest, const unsigned char *source, int nelement, int PE_root);
 
-__device__ int rocshmem_ctx_double_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-              double *dest, const double *source, int nelement, int PE_root);
+__device__ int rocshmem_ctx_ushort_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              unsigned short *dest, const unsigned short *source, int nelement, int PE_root);
 
+__device__ int rocshmem_ctx_uint_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              unsigned int *dest, const unsigned int *source, int nelement, int PE_root);
+
+__device__ int rocshmem_ctx_ulong_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              unsigned long *dest, const unsigned long *source, int nelement, int PE_root);
+
+__device__ int rocshmem_ctx_ulonglong_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              unsigned long long *dest, const unsigned long long *source, int nelement, int PE_root);
 
 /**
  * @name ROCSHMEM_CTX_BROADCASTMEM_WAVE

--- a/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
@@ -397,6 +397,66 @@ __host__ void rocshmem_ctx_ulonglong_broadcast(
 
 
 /**
+ * @name ROCSHMEM_CTX_TYPE_BROADCAST_WAVE
+ * @brief Perform a broadcast between PEs in the active set. The caller
+ * is blocked until the broadcast completes.
+ *
+ * This function must be called as a work-group collective.
+ *
+ * @param[in] ctx          The ROCSHMEM context associated with this operation.
+ * @param[in] team         The team participating in the collective.
+ * @param[in] dest         Destination address. Must be an address on the
+ *                         symmetric heap.
+ * @param[in] source       Source address. Must be an address on the symmetric
+                           heap.
+ * @param[in] nelement     Number of elements to participate in the broadcast.
+ * @param[in] PE_root      Root PE (relative to team) from which to broadcast.
+ * 
+ *
+ * @return int; zero when sucessful, non-zero otherwise
+ */
+__device__ int rocshmem_ctx_short_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              short *dest, const short *source, int nelement, int PE_root);
+
+__device__ int rocshmem_ctx_int_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              int *dest, const int *source, int nelement, int PE_root);
+
+__device__ int rocshmem_ctx_long_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              long *dest, const long *source, int nelement, int PE_root);
+
+__device__ int rocshmem_ctx_longlong_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              long long *dest, const long long *source, int nelement, int PE_root);
+
+__device__ int rocshmem_ctx_float_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              float *dest, const float *source, int nelement, int PE_root);
+
+__device__ int rocshmem_ctx_double_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              double *dest, const double *source, int nelement, int PE_root);
+
+
+/**
+ * @name ROCSHMEM_CTX_BROADCASTMEM_WAVE
+ * @brief Perform a broadcast between PEs in the active set. The caller
+ * is blocked until the broadcast completes.
+ *
+ * This function must be called as a work-group collective.
+ *
+ * @param[in] ctx          The ROCSHMEM context associated with this operation.
+ * @param[in] team         The team participating in the collective.
+ * @param[in] dest         Destination address. Must be an address on the
+ *                         symmetric heap.
+ * @param[in] source       Source address. Must be an address on the symmetric
+                           heap.
+ * @param[in] nelement     Size of buffer to participate in the broadcast.
+ * @param[in] PE_root      Root PE (relative to team) from which to broadcast.
+ * 
+ *
+ * @return int; zero when sucessful, non-zero otherwise
+ */
+__device__ int rocshmem_ctx_broadcastmem_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              void *dest, const void *source, int nelement, int PE_root);
+
+/**
  * @name SHMEM_FCOLLECT
  * @brief Concatenates blocks of data from multiple PEs to an array in every
  * PE participating in the collective routine.
@@ -1391,6 +1451,7 @@ ATTR_NO_INLINE int rocshmem_ctx_double_max_reduce_on_stream(
 ATTR_NO_INLINE int rocshmem_ctx_double_prod_reduce_on_stream(
   rocshmem_ctx_t ctx, rocshmem_team_t team,
   double *dest, const double *source, int nreduce, hipStream_t stream);
+
 }  // namespace rocshmem
 
 #endif  // LIBRARY_INCLUDE_ROCSHMEM_COLL_HPP

--- a/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
@@ -401,19 +401,19 @@ __host__ void rocshmem_ctx_ulonglong_broadcast(
  * @brief Perform a broadcast between PEs in the active set. The caller
  * is blocked until the broadcast completes.
  *
- * This function must be called as a work-group collective.
+ * This function must be called as a wave collective.
  *
  * @param[in] ctx          The ROCSHMEM context associated with this operation.
  * @param[in] team         The team participating in the collective.
  * @param[in] dest         Destination address. Must be an address on the
  *                         symmetric heap.
  * @param[in] source       Source address. Must be an address on the symmetric
-                           heap.
+ *                         heap.
  * @param[in] nelement     Number of elements to participate in the broadcast.
  * @param[in] PE_root      Root PE (relative to team) from which to broadcast.
  * 
  *
- * @return int; zero when sucessful, non-zero otherwise
+ * @return int; zero when successful, non-zero otherwise
  */
 __device__ int rocshmem_ctx_short_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
               short *dest, const short *source, int nelement, int PE_root);
@@ -439,19 +439,19 @@ __device__ int rocshmem_ctx_double_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_t
  * @brief Perform a broadcast between PEs in the active set. The caller
  * is blocked until the broadcast completes.
  *
- * This function must be called as a work-group collective.
+ * This function must be called as a wave collective.
  *
  * @param[in] ctx          The ROCSHMEM context associated with this operation.
  * @param[in] team         The team participating in the collective.
  * @param[in] dest         Destination address. Must be an address on the
  *                         symmetric heap.
  * @param[in] source       Source address. Must be an address on the symmetric
-                           heap.
+ *                         heap.
  * @param[in] nelement     Size of buffer to participate in the broadcast.
  * @param[in] PE_root      Root PE (relative to team) from which to broadcast.
  * 
  *
- * @return int; zero when sucessful, non-zero otherwise
+ * @return int; zero when successful, non-zero otherwise
  */
 __device__ int rocshmem_ctx_broadcastmem_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
               void *dest, const void *source, int nelement, int PE_root);

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -753,9 +753,9 @@ TestColl() {
   ExecTest  "teamreducescatter" 4      1            64        32768
   ExecTest  "teamreducescatter" 8      1            64        32768
 
-  if [[ $TEST != ro* ]]; then #AIROCSHMEM-432: wave tests not supported on RO
+  if [[ $TEST != ro* ]]; then #AIROCSHMEM-409: wave tests not supported on RO
     ExecTest  "broadcast_wave"   2       1            64        32768
-  else echo "Skip:   *_wave (AIROCSHMEM-408: wave tests not supported on RO)"; fi
+  else echo "Skip:   *_wave (AIROCSHMEM-409: wave tests not supported on RO)"; fi
 }
 
 TestOnStream() {

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -164,6 +164,7 @@ declare -A TEST_NUMBERS=(
   ["host_wait_until_any_status"]="147"
   ["host_wait_until_some_status"]="148"
   ["teamreducescatter"]="149"
+  ["broadcast_wave"]="150"
 )
 
 # Detect which runtime to use
@@ -751,6 +752,7 @@ TestColl() {
   ExecTest  "teamreducescatter" 2      1            64        32768
   ExecTest  "teamreducescatter" 4      1            64        32768
   ExecTest  "teamreducescatter" 8      1            64        32768
+  ExecTest  "broadcast_wave"   2       1            64        32768
 }
 
 TestOnStream() {

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -752,7 +752,10 @@ TestColl() {
   ExecTest  "teamreducescatter" 2      1            64        32768
   ExecTest  "teamreducescatter" 4      1            64        32768
   ExecTest  "teamreducescatter" 8      1            64        32768
-  ExecTest  "broadcast_wave"   2       1            64        32768
+
+  if [[ $TEST != ro* ]]; then #AIROCSHMEM-432: wave tests not supported on RO
+    ExecTest  "broadcast_wave"   2       1            64        32768
+  else echo "Skip:   *_wave (AIROCSHMEM-408: wave tests not supported on RO)"; fi
 }
 
 TestOnStream() {

--- a/projects/rocshmem/src/context.hpp
+++ b/projects/rocshmem/src/context.hpp
@@ -444,6 +444,13 @@ class Context {
                                     const size_t* start_coord, const size_t* boundary,
                                     int ndim, size_t element_size, int root, uint64_t flags);
 
+  template <typename T>
+  __device__ int broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team, \
+                                T *dest, const T *source, int nelement, int PE_root);
+
+  __device__ int broadcastmem_wave(rocshmem_ctx_t ctx, rocshmem_team_t team, \
+                               void *dest, const void *source, int nelement, int PE_root);
+
   // Rooted SUM Reduction operations
   // Rooted MAX Reduction operations
   /**************************************************************************

--- a/projects/rocshmem/src/context.hpp
+++ b/projects/rocshmem/src/context.hpp
@@ -251,6 +251,13 @@ class Context {
                             int pe_start, int log_pe_stride, int pe_size,
                             long* p_sync);  // NOLINT(runtime/int)
 
+  template <typename T>
+  __device__ int broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+                                T *dest, const T *source, int nelement, int PE_root);
+
+  __device__ int broadcastmem_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+                               void *dest, const void *source, int nelement, int PE_root);
+
   __device__ void putmem_wg(void* dest, const void* source, size_t nelems,
                             int pe);
 
@@ -443,13 +450,6 @@ class Context {
                                     const size_t* dst_strides, const size_t* src_strides,
                                     const size_t* start_coord, const size_t* boundary,
                                     int ndim, size_t element_size, int root, uint64_t flags);
-
-  template <typename T>
-  __device__ int broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team, \
-                                T *dest, const T *source, int nelement, int PE_root);
-
-  __device__ int broadcastmem_wave(rocshmem_ctx_t ctx, rocshmem_team_t team, \
-                               void *dest, const void *source, int nelement, int PE_root);
 
   // Rooted SUM Reduction operations
   // Rooted MAX Reduction operations

--- a/projects/rocshmem/src/context.hpp
+++ b/projects/rocshmem/src/context.hpp
@@ -243,11 +243,11 @@ class Context {
                            int nelems);
 
   template <typename T>
-  __device__ void broadcast(rocshmem_team_t team, T* dest, const T* source,
+  __device__ void broadcast_wg(rocshmem_team_t team, T* dest, const T* source,
                             int nelems, int pe_root);
 
   template <typename T>
-  __device__ void broadcast(T* dest, const T* source, int nelems, int pe_root,
+  __device__ void broadcast_wg(T* dest, const T* source, int nelems, int pe_root,
                             int pe_start, int log_pe_stride, int pe_size,
                             long* p_sync);  // NOLINT(runtime/int)
 

--- a/projects/rocshmem/src/context.hpp
+++ b/projects/rocshmem/src/context.hpp
@@ -251,12 +251,15 @@ class Context {
                             int pe_start, int log_pe_stride, int pe_size,
                             long* p_sync);  // NOLINT(runtime/int)
 
-  template <typename T>
-  __device__ int broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-                                T *dest, const T *source, int nelement, int PE_root);
+  __device__ void broadcastmem_wg(rocshmem_team_t team, void *dest, const void *source, 
+                                  int nelement, int PE_root);
 
-  __device__ int broadcastmem_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
-                               void *dest, const void *source, int nelement, int PE_root);
+  template <typename T>
+  __device__ int broadcast_wave(rocshmem_team_t team, T *dest, const T *source, 
+                                int nelement, int PE_root);
+
+  __device__ int broadcastmem_wave(rocshmem_team_t team, void *dest, const void *source, 
+                                   int nelement, int PE_root);
 
   __device__ void putmem_wg(void* dest, const void* source, size_t nelems,
                             int pe);

--- a/projects/rocshmem/src/context_device.cpp
+++ b/projects/rocshmem/src/context_device.cpp
@@ -293,9 +293,14 @@ __device__ void Context::getmem_nbi_wave(void* dest, const void* source,
   DISPATCH(getmem_nbi_wave(dest, source, size, pe));
 }
 
-__device__ int Context::broadcastmem_wave([[maybe_unused]] rocshmem_ctx_t ctx, rocshmem_team_t team, 
-                              void *dest, const void *source, int nelement, int PE_root){
+__device__ int Context::broadcastmem_wave(rocshmem_team_t team, void *dest, const void *source, 
+                                          int nelement, int PE_root){
   DISPATCH_RET(broadcastmem_wave(team, dest, source, nelement, PE_root));
+}
+
+__device__ void Context::broadcastmem_wg(rocshmem_team_t team, void *dest, const void *source, 
+                                        int nelement, int PE_root){
+  DISPATCH(broadcastmem_wg(team, dest, source, nelement, PE_root));
 }
 
 #define CONTEXT_PUTMEM_SIGNAL_DEF(SUFFIX, STATS_SUFFIX)                                           \

--- a/projects/rocshmem/src/context_device.cpp
+++ b/projects/rocshmem/src/context_device.cpp
@@ -293,6 +293,11 @@ __device__ void Context::getmem_nbi_wave(void* dest, const void* source,
   DISPATCH(getmem_nbi_wave(dest, source, size, pe));
 }
 
+__device__ int Context::broadcastmem_wave([[maybe_unused]] rocshmem_ctx_t ctx, rocshmem_team_t team, 
+                              void *dest, const void *source, int nelement, int PE_root){
+  DISPATCH_RET(broadcastmem_wave(team, dest, source, nelement, PE_root));
+}
+
 #define CONTEXT_PUTMEM_SIGNAL_DEF(SUFFIX, STATS_SUFFIX)                                           \
   __device__ void Context::putmem_signal##SUFFIX(void *dest, const void *source, size_t nelems,   \
                                                  uint64_t *sig_addr, uint64_t signal, int sig_op, \

--- a/projects/rocshmem/src/context_tmpl_device.hpp
+++ b/projects/rocshmem/src/context_tmpl_device.hpp
@@ -856,6 +856,13 @@ __device__ inline int Context::tile_min_reduce_wg(rocshmem_team_t team, void* ds
   DISPATCH_RET(tile_min_reduce_wg(team, dst_data, src_data, dst_strides, src_strides,
                                   start_coord, boundary, ndim, element_size, root, flags));
 }
+
+template <typename T>
+__device__ int Context::broadcast_wave([[maybe_unused]] rocshmem_ctx_t ctx, rocshmem_team_t team, 
+                              T *dest, const T *source, int nelement, int PE_root){
+  DISPATCH_RET(broadcast_wave<T>(team, dest, source, nelement, PE_root));
+}
+
 }  // namespace rocshmem
 
 #endif  // LIBRARY_SRC_CONTEXT_TMPL_DEVICE_HPP_

--- a/projects/rocshmem/src/context_tmpl_device.hpp
+++ b/projects/rocshmem/src/context_tmpl_device.hpp
@@ -202,7 +202,7 @@ __device__ void Context::fcollect(rocshmem_team_t team, T *dest,
 }
 
 template <typename T>
-__device__ void Context::broadcast(rocshmem_team_t team, T *dest,
+__device__ void Context::broadcast_wg(rocshmem_team_t team, T *dest,
                                    const T *source, int nelems, int pe_root) {
   if (nelems == 0) {
     return;
@@ -212,11 +212,11 @@ __device__ void Context::broadcast(rocshmem_team_t team, T *dest,
     ctxStats.incStat(NUM_BROADCAST);
   }
 
-  DISPATCH(broadcast<T>(team, dest, source, nelems, pe_root));
+  DISPATCH(broadcast_wg<T>(team, dest, source, nelems, pe_root));
 }
 
 template <typename T>
-__device__ void Context::broadcast(T *dest, const T *source, int nelems,
+__device__ void Context::broadcast_wg(T *dest, const T *source, int nelems,
                                    int pe_root, int pe_start, int log_pe_stride,
                                    int pe_size,
                                    long *p_sync) {  // NOLINT(runtime/int)
@@ -228,7 +228,7 @@ __device__ void Context::broadcast(T *dest, const T *source, int nelems,
     ctxStats.incStat(NUM_BROADCAST);
   }
 
-  DISPATCH(broadcast<T>(dest, source, nelems, pe_root, pe_start, log_pe_stride,
+  DISPATCH(broadcast_wg<T>(dest, source, nelems, pe_root, pe_start, log_pe_stride,
                         pe_size, p_sync));
 }
 

--- a/projects/rocshmem/src/context_tmpl_device.hpp
+++ b/projects/rocshmem/src/context_tmpl_device.hpp
@@ -858,7 +858,7 @@ __device__ inline int Context::tile_min_reduce_wg(rocshmem_team_t team, void* ds
 }
 
 template <typename T>
-__device__ int Context::broadcast_wave([[maybe_unused]] rocshmem_ctx_t ctx, rocshmem_team_t team, 
+__device__ int Context::broadcast_wave(rocshmem_team_t team, 
                               T *dest, const T *source, int nelement, int PE_root){
   DISPATCH_RET(broadcast_wave<T>(team, dest, source, nelement, PE_root));
 }

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -289,6 +289,17 @@ class GDAContext : public Context {
   __device__ void internal_get_broadcast_wave(T *dst, const T *src, int nelems,
       int pe_root, ActiveWFInfo &wf_info);  // NOLINT(runtime/int)
 
+  __device__ void internal_broadcastmem_wave(void *dst, const void *src,
+    int nelems, int pe_root, int pe_start, int stride, int pe_size,
+    long *p_sync);
+
+  __device__ void internal_get_broadcastmem_wave(void *dst, const void *src,
+    int nelems, int pe_root, ActiveWFInfo &wf_info);
+
+  __device__ void internal_put_broadcastmem_wave(void *dst, const void *src,
+    int nelems, int pe_root, int pe_start, int stride, int pe_size,
+    ActiveWFInfo &wf_info);
+
   template <typename T>
   __device__ void fcollect_linear(rocshmem_team_t team, T *dest,
       const T *source, int nelems);

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -149,7 +149,7 @@ class GDAContext : public Context {
                                    int nreduce);
 
   template <typename T>
-  __device__ void broadcast(rocshmem_team_t team, T *dest, const T *source,
+  __device__ void broadcast_wg(rocshmem_team_t team, T *dest, const T *source,
                             int nelems, int pe_root);
 
   template <typename T>
@@ -264,16 +264,16 @@ class GDAContext : public Context {
 
   //internal functions used by collective operations
   template <typename T>
-  __device__ void internal_broadcast(T *dest, const T *source, int nelems,
+  __device__ void internal_broadcast_wg(T *dest, const T *source, int nelems,
       int pe_root, int pe_start, int stride, int pe_size, long *p_sync);  // NOLINT(runtime/int)
 
   template <typename T>
-  __device__ void internal_put_broadcast(T *dst, const T *src, int nelems,
+  __device__ void internal_put_broadcast_wg(T *dst, const T *src, int nelems,
       int pe_root, int PE_start, int logPE_stride, int PE_size,
       ActiveWFInfo &wf_info);  // NOLINT(runtime/int)
 
   template <typename T>
-  __device__ void internal_get_broadcast(T *dst, const T *src, int nelems,
+  __device__ void internal_get_broadcast_wg(T *dst, const T *src, int nelems,
       int pe_root, ActiveWFInfo &wf_info);  // NOLINT(runtime/int)
 
   template <typename T>

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -152,6 +152,9 @@ class GDAContext : public Context {
   __device__ void broadcast_wg(rocshmem_team_t team, T *dest, const T *source,
                             int nelems, int pe_root);
 
+  __device__ void broadcastmem_wg(rocshmem_team_t team, void *dest, const void* source, 
+                                  int nelement, int PE_root);
+
   template <typename T>
   __device__ int broadcast_wave(rocshmem_team_t team,
                                 T *dest, const T* source, int nelement, int PE_root);
@@ -263,17 +266,14 @@ class GDAContext : public Context {
  private:
 
   //internal functions used by collective operations
-  template <typename T>
-  __device__ void internal_broadcast_wg(T *dest, const T *source, int nelems,
+  __device__ void internal_broadcastmem_wg(void *dest, const void *source, int nelems,
       int pe_root, int pe_start, int stride, int pe_size, long *p_sync);  // NOLINT(runtime/int)
 
-  template <typename T>
-  __device__ void internal_put_broadcast_wg(T *dst, const T *src, int nelems,
+  __device__ void internal_put_broadcastmem_wg(void *dst, const void *src, int nelems,
       int pe_root, int PE_start, int logPE_stride, int PE_size,
       ActiveWFInfo &wf_info);  // NOLINT(runtime/int)
 
-  template <typename T>
-  __device__ void internal_get_broadcast_wg(T *dst, const T *src, int nelems,
+  __device__ void internal_get_broadcastmem_wg(void *dst, const void *src, int nelems,
       int pe_root, ActiveWFInfo &wf_info);  // NOLINT(runtime/int)
 
   template <typename T>

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -153,6 +153,13 @@ class GDAContext : public Context {
                             int nelems, int pe_root);
 
   template <typename T>
+  __device__ int broadcast_wave(rocshmem_team_t team,
+                                T *dest, const T* source, int nelement, int PE_root);
+
+  __device__ int broadcastmem_wave(rocshmem_team_t team,
+                                void *dest, const void* source, int nelement, int PE_root);
+
+  template <typename T>
   __device__ void alltoall(rocshmem_team_t team, T *dest, const T *source,
                            int nelems);
 

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -277,6 +277,19 @@ class GDAContext : public Context {
       int pe_root, ActiveWFInfo &wf_info);  // NOLINT(runtime/int)
 
   template <typename T>
+  __device__ void internal_broadcast_wave(T *dest, const T *source, int nelems,
+      int pe_root, int pe_start, int stride, int pe_size, long *p_sync);  // NOLINT(runtime/int)
+
+  template <typename T>
+  __device__ void internal_put_broadcast_wave(T *dst, const T *src, int nelems,
+      int pe_root, int PE_start, int logPE_stride, int PE_size,
+      ActiveWFInfo &wf_info);  // NOLINT(runtime/int)
+
+  template <typename T>
+  __device__ void internal_get_broadcast_wave(T *dst, const T *src, int nelems,
+      int pe_root, ActiveWFInfo &wf_info);  // NOLINT(runtime/int)
+
+  template <typename T>
   __device__ void fcollect_linear(rocshmem_team_t team, T *dest,
       const T *source, int nelems);
 

--- a/projects/rocshmem/src/gda/context_gda_device_coll.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device_coll.cpp
@@ -356,4 +356,56 @@ __device__ void GDAContext::internal_broadcastmem_wave(void *dst, const void *sr
   internal_sync_wave(constmem.my_pe, pe_start, stride, pe_size, p_sync, wf_info);
 }
 
+__device__ void GDAContext::internal_put_broadcastmem_wg(void *dst, const void *src,
+    int nelems, int pe_root, int pe_start, int stride, int pe_size,
+    ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
+  if (constmem.my_pe == pe_root) {
+    int finish = pe_start + stride * pe_size;
+    for (int i = pe_start; i < finish; i += stride) {
+      if (constmem.my_pe != i)
+        internal_putmem_nbi_wg(dst, src, nelems, i, i, wf_info);
+    }
+    memcpy_wg<MemcpyKind::Put>(dst, const_cast<void *>(src), nelems);
+  }
+}
+
+__device__ void GDAContext::internal_get_broadcastmem_wg(void *dst, const void *src, int nelems,
+    int pe_root, ActiveWFInfo &wf_info){
+  if (constmem.my_pe == pe_root) {
+    memcpy_wg<MemcpyKind::Put>(dst, const_cast<void *>(src), nelems);
+  } else {
+    internal_getmem_wg(dst, src, nelems, pe_root, pe_root, wf_info);
+  }
+}
+
+__device__ void GDAContext::broadcastmem_wg(rocshmem_team_t team, void *dst,
+    const void *src, int nelems, int pe_root) {
+  GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
+
+  int stride = team_obj->tinfo_wrt_world->stride;
+  int pe_start = team_obj->tinfo_wrt_world->pe_start;
+  int pe_size = team_obj->tinfo_wrt_world->size;
+  long *p_sync = team_obj->bcast_pSync;
+
+  // Passed pe_root is relative to team, convert to world root
+  int pe_root_world = team_obj->get_pe_in_world(pe_root);
+  internal_broadcastmem_wg(dst, src, nelems, pe_root_world, pe_start, stride,
+               pe_size, p_sync);
+}
+
+__device__ void GDAContext::internal_broadcastmem_wg(void *dst, const void *src,
+    int nelems, int pe_root, int pe_start, int stride, int pe_size,
+    long *p_sync) {  // NOLINT(runtime/int)
+  ActiveWFInfo wf_info(ctx_id_, ThreadScope::wg);
+  if (constmem.num_pes < 4) { //TODO: optimized for IPC
+    internal_put_broadcastmem_wg(dst, src, nelems, pe_root, pe_start, stride,
+      pe_size, wf_info);
+  } else {
+    internal_get_broadcastmem_wg(dst, src, nelems, pe_root, wf_info);
+  }
+
+  // Synchronize on completion of broadcast
+  internal_sync_wg(constmem.my_pe, pe_start, stride, pe_size, p_sync, wf_info);
+}
+
 }  // namespace rocshmem

--- a/projects/rocshmem/src/gda/context_gda_device_coll.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device_coll.cpp
@@ -296,4 +296,14 @@ __device__ void GDAContext::barrier_wg(rocshmem_team_t team) {
   __syncthreads();
 }
 
+__device__ int GDAContext::broadcastmem_wave([[maybe_unused]] rocshmem_team_t team,
+                                          [[maybe_unused]] void *dest, 
+                                          [[maybe_unused]] const void* source, 
+                                          [[maybe_unused]] int nelement, 
+                                          [[maybe_unused]] int PE_root) {
+  LOGD_WARN("Broadcastmem Wave API not implemented for GDA backend");
+  return ROCSHMEM_ERROR;
+}
+
+
 }  // namespace rocshmem

--- a/projects/rocshmem/src/gda/context_gda_device_coll.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device_coll.cpp
@@ -296,14 +296,66 @@ __device__ void GDAContext::barrier_wg(rocshmem_team_t team) {
   __syncthreads();
 }
 
-__device__ int GDAContext::broadcastmem_wave([[maybe_unused]] rocshmem_team_t team,
-                                          [[maybe_unused]] void *dest, 
-                                          [[maybe_unused]] const void* source, 
-                                          [[maybe_unused]] int nelement, 
-                                          [[maybe_unused]] int PE_root) {
-  LOGD_WARN("Broadcastmem Wave API not implemented for GDA backend");
-  return ROCSHMEM_ERROR;
+__device__ void GDAContext::internal_put_broadcastmem_wave(void *dst, const void *src,
+    int nelems, int pe_root, int pe_start, int stride, int pe_size,
+    ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
+  if (constmem.my_pe == pe_root) {
+    int finish = pe_start + stride * pe_size;
+    for (int i = pe_start; i < finish; i += stride) {
+      if (i != constmem.my_pe) {
+        internal_putmem_nbi_wave(dst, src, nelems, i, i, wf_info);
+      }
+    }
+    memcpy_wave<MemcpyKind::Put>(dst, const_cast<void *>(src), nelems);
+  }
 }
+
+__device__ void GDAContext::internal_get_broadcastmem_wave(void *dst, const void *src,
+    int nelems, int pe_root, ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
+  if (constmem.my_pe != pe_root) {
+    internal_getmem_wave(dst, src, nelems, pe_root, pe_root, wf_info);
+  } else {
+    memcpy_wave<MemcpyKind::Get>(dst, const_cast<void *>(src), nelems);
+  }
+}
+
+__device__ int GDAContext::broadcastmem_wave(rocshmem_team_t team, void *dest, 
+    const void* source, int nelement, int PE_root) {
+  if (dest == nullptr || 
+    source == nullptr || 
+    team == ROCSHMEM_TEAM_INVALID)
+    return ROCSHMEM_ERROR;
+
+  GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
+
+  int stride = team_obj->tinfo_wrt_world->stride;
+  int pe_start = team_obj->tinfo_wrt_world->pe_start;
+  int pe_size = team_obj->tinfo_wrt_world->size;
+  long *p_sync = team_obj->bcast_pSync;
+
+  // Passed pe_root is relative to team, convert to world root
+  int pe_root_world = team_obj->get_pe_in_world(PE_root);
+  internal_broadcastmem_wave(dest, source, nelement, pe_root_world, pe_start, stride,
+               pe_size, p_sync);
+  return ROCSHMEM_SUCCESS;
+}
+
+__device__ void GDAContext::internal_broadcastmem_wave(void *dst, const void *src,
+    int nelems, int pe_root, int pe_start, int stride, int pe_size,
+    long *p_sync) {  // NOLINT(runtime/int)
+
+  ActiveWFInfo wf_info(ctx_id_, ThreadScope::wg);
+  if (constmem.num_pes < 4) { //TODO: optimized for IPC
+    internal_put_broadcastmem_wave(dst, src, nelems, pe_root, pe_start, stride,
+      pe_size, wf_info);
+  } else {
+    internal_get_broadcastmem_wave(dst, src, nelems, pe_root, wf_info);
+  }
+
+  // Synchronize on completion of broadcast
+  internal_sync_wave(constmem.my_pe, pe_start, stride, pe_size, p_sync, wf_info);
+}
+
 
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/gda/context_gda_device_coll.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device_coll.cpp
@@ -356,6 +356,4 @@ __device__ void GDAContext::internal_broadcastmem_wave(void *dst, const void *sr
   internal_sync_wave(constmem.my_pe, pe_start, stride, pe_size, p_sync, wf_info);
 }
 
-
-
 }  // namespace rocshmem

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -725,7 +725,7 @@ __device__ void GDAContext::internal_broadcast_wave(T *dst, const T *src,
 }
 
 template <typename T>
-__device__ void GDAContext::internal_put_broadcast(T *dst, const T *src,
+__device__ void GDAContext::internal_put_broadcast_wg(T *dst, const T *src,
     int nelems, int pe_root, int pe_start, int stride, int pe_size,
     ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
   if (constmem.my_pe == pe_root) {
@@ -739,7 +739,7 @@ __device__ void GDAContext::internal_put_broadcast(T *dst, const T *src,
 }
 
 template <typename T>
-__device__ void GDAContext::internal_get_broadcast(T *dst, const T *src,
+__device__ void GDAContext::internal_get_broadcast_wg(T *dst, const T *src,
     int nelems, int pe_root, ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
   if (constmem.my_pe == pe_root) {
     memcpy_wg<MemcpyKind::Put>(dst, const_cast<T *>(src), nelems * sizeof(T));
@@ -749,7 +749,7 @@ __device__ void GDAContext::internal_get_broadcast(T *dst, const T *src,
 }
 
 template <typename T>
-__device__ void GDAContext::broadcast(rocshmem_team_t team, T *dst,
+__device__ void GDAContext::broadcast_wg(rocshmem_team_t team, T *dst,
     const T *src, int nelems, int pe_root) {
   GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
 
@@ -760,20 +760,20 @@ __device__ void GDAContext::broadcast(rocshmem_team_t team, T *dst,
 
   // Passed pe_root is relative to team, convert to world root
   int pe_root_world = team_obj->get_pe_in_world(pe_root);
-  internal_broadcast<T>(dst, src, nelems, pe_root_world, pe_start, stride,
+  internal_broadcast_wg<T>(dst, src, nelems, pe_root_world, pe_start, stride,
                pe_size, p_sync);
 }
 
 template <typename T>
-__device__ void GDAContext::internal_broadcast(T *dst, const T *src,
+__device__ void GDAContext::internal_broadcast_wg(T *dst, const T *src,
     int nelems, int pe_root, int pe_start, int stride, int pe_size,
     long *p_sync) {  // NOLINT(runtime/int)
   ActiveWFInfo wf_info(ctx_id_, ThreadScope::wg);
   if (constmem.num_pes < 4) { //TODO: optimized for IPC
-    internal_put_broadcast(dst, src, nelems, pe_root, pe_start, stride,
+    internal_put_broadcast_wg(dst, src, nelems, pe_root, pe_start, stride,
       pe_size, wf_info);
   } else {
-    internal_get_broadcast(dst, src, nelems, pe_root, wf_info);
+    internal_get_broadcast_wg(dst, src, nelems, pe_root, wf_info);
   }
 
   // Synchronize on completion of broadcast

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -1478,8 +1478,6 @@ __device__ inline int GDAContext::tile_min_reduce_wg([[maybe_unused]] rocshmem_t
   return ROCSHMEM_ERROR;
 }
 
-
-
 // Rooted SUM Reduction operations
 // Rooted MAX Reduction operations
 // Rooted MIN Reduction operations

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -725,30 +725,6 @@ __device__ void GDAContext::internal_broadcast_wave(T *dst, const T *src,
 }
 
 template <typename T>
-__device__ void GDAContext::internal_put_broadcast_wg(T *dst, const T *src,
-    int nelems, int pe_root, int pe_start, int stride, int pe_size,
-    ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
-  if (constmem.my_pe == pe_root) {
-    int finish = pe_start + stride * pe_size;
-    for (int i = pe_start; i < finish; i += stride) {
-      if (constmem.my_pe != i)
-        internal_putmem_nbi_wg(dst, src, nelems * sizeof(T), i, i, wf_info);
-    }
-    memcpy_wg<MemcpyKind::Put>(dst, const_cast<T *>(src), nelems * sizeof(T));
-  }
-}
-
-template <typename T>
-__device__ void GDAContext::internal_get_broadcast_wg(T *dst, const T *src,
-    int nelems, int pe_root, ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
-  if (constmem.my_pe == pe_root) {
-    memcpy_wg<MemcpyKind::Put>(dst, const_cast<T *>(src), nelems * sizeof(T));
-  } else {
-    internal_getmem_wg(dst, src, nelems * sizeof(T), pe_root, pe_root, wf_info);
-  }
-}
-
-template <typename T>
 __device__ void GDAContext::broadcast_wg(rocshmem_team_t team, T *dst,
     const T *src, int nelems, int pe_root) {
   GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
@@ -760,24 +736,8 @@ __device__ void GDAContext::broadcast_wg(rocshmem_team_t team, T *dst,
 
   // Passed pe_root is relative to team, convert to world root
   int pe_root_world = team_obj->get_pe_in_world(pe_root);
-  internal_broadcast_wg<T>(dst, src, nelems, pe_root_world, pe_start, stride,
+  internal_broadcastmem_wg(dst, src, nelems * sizeof(T), pe_root_world, pe_start, stride,
                pe_size, p_sync);
-}
-
-template <typename T>
-__device__ void GDAContext::internal_broadcast_wg(T *dst, const T *src,
-    int nelems, int pe_root, int pe_start, int stride, int pe_size,
-    long *p_sync) {  // NOLINT(runtime/int)
-  ActiveWFInfo wf_info(ctx_id_, ThreadScope::wg);
-  if (constmem.num_pes < 4) { //TODO: optimized for IPC
-    internal_put_broadcast_wg(dst, src, nelems, pe_root, pe_start, stride,
-      pe_size, wf_info);
-  } else {
-    internal_get_broadcast_wg(dst, src, nelems, pe_root, wf_info);
-  }
-
-  // Synchronize on completion of broadcast
-  internal_sync_wg(constmem.my_pe, pe_start, stride, pe_size, p_sync, wf_info);
 }
 
 template <typename T>

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -701,6 +701,16 @@ __device__ void GDAContext::broadcast(rocshmem_team_t team, T *dst,
 }
 
 template <typename T>
+__device__ int GDAContext::broadcast_wave([[maybe_unused]] rocshmem_team_t team,
+                                          [[maybe_unused]] T *dest, 
+                                          [[maybe_unused]] const T* source, 
+                                          [[maybe_unused]] int nelement, 
+                                          [[maybe_unused]] int PE_root) {
+  LOGD_WARN("Broadcast Wave API not implemented for GDA backend");
+  return ROCSHMEM_ERROR;
+}
+
+template <typename T>
 __device__ void GDAContext::internal_broadcast(T *dst, const T *src,
     int nelems, int pe_root, int pe_start, int stride, int pe_size,
     long *p_sync) {  // NOLINT(runtime/int)
@@ -1413,6 +1423,8 @@ __device__ inline int GDAContext::tile_min_reduce_wg([[maybe_unused]] rocshmem_t
   LOGD_WARN("Tile API not implemented for GDA backend");
   return ROCSHMEM_ERROR;
 }
+
+
 
 // Rooted SUM Reduction operations
 // Rooted MAX Reduction operations

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -661,6 +661,70 @@ __device__ int GDAContext::reduce_scatter_wg(rocshmem_team_t team, T *dest,
 }
 
 template <typename T>
+__device__ void GDAContext::internal_put_broadcast_wave(T *dst, const T *src,
+    int nelems, int pe_root, int pe_start, int stride, int pe_size,
+    ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
+  if (constmem.my_pe == pe_root) {
+    int finish = pe_start + stride * pe_size;
+    for (int i = pe_start; i < finish; i += stride) {
+      if (i != constmem.my_pe) {
+        internal_putmem_nbi_wave(dst, src, nelems * sizeof(T), i, i, wf_info);
+      }
+    }
+    memcpy_wave<MemcpyKind::Put>(dst, const_cast<T *>(src), nelems * sizeof(T));
+  }
+}
+
+template <typename T>
+__device__ void GDAContext::internal_get_broadcast_wave(T *dst, const T *src,
+    int nelems, int pe_root, ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
+  if (constmem.my_pe != pe_root) {
+    internal_getmem_wave(dst, src, nelems * sizeof(T), pe_root, pe_root, wf_info);
+  } else {
+    memcpy_wave<MemcpyKind::Get>(dst, const_cast<T *>(src), nelems * sizeof(T));
+  }
+}
+
+template <typename T>
+__device__ int GDAContext::broadcast_wave(rocshmem_team_t team, T *dest, 
+    const T* source, int nelement, int PE_root) {
+  if (dest == nullptr || 
+    source == nullptr || 
+    team == ROCSHMEM_TEAM_INVALID)
+    return ROCSHMEM_ERROR;
+
+  GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
+
+  int stride = team_obj->tinfo_wrt_world->stride;
+  int pe_start = team_obj->tinfo_wrt_world->pe_start;
+  int pe_size = team_obj->tinfo_wrt_world->size;
+  long *p_sync = team_obj->bcast_pSync;
+
+  // Passed pe_root is relative to team, convert to world root
+  int pe_root_world = team_obj->get_pe_in_world(PE_root);
+  internal_broadcast_wave<T>(dest, source, nelement, pe_root_world, pe_start, stride,
+               pe_size, p_sync);
+  return ROCSHMEM_SUCCESS;
+}
+
+template <typename T>
+__device__ void GDAContext::internal_broadcast_wave(T *dst, const T *src,
+    int nelems, int pe_root, int pe_start, int stride, int pe_size,
+    long *p_sync) {  // NOLINT(runtime/int)
+
+  ActiveWFInfo wf_info(ctx_id_, ThreadScope::wg);
+  if (constmem.num_pes < 4) { //TODO: optimized for IPC
+    internal_put_broadcast_wave(dst, src, nelems, pe_root, pe_start, stride,
+      pe_size, wf_info);
+  } else {
+    internal_get_broadcast_wave(dst, src, nelems, pe_root, wf_info);
+  }
+
+  // Synchronize on completion of broadcast
+  internal_sync_wave(constmem.my_pe, pe_start, stride, pe_size, p_sync, wf_info);
+}
+
+template <typename T>
 __device__ void GDAContext::internal_put_broadcast(T *dst, const T *src,
     int nelems, int pe_root, int pe_start, int stride, int pe_size,
     ActiveWFInfo &wf_info) {  // NOLINT(runtime/int)
@@ -698,16 +762,6 @@ __device__ void GDAContext::broadcast(rocshmem_team_t team, T *dst,
   int pe_root_world = team_obj->get_pe_in_world(pe_root);
   internal_broadcast<T>(dst, src, nelems, pe_root_world, pe_start, stride,
                pe_size, p_sync);
-}
-
-template <typename T>
-__device__ int GDAContext::broadcast_wave([[maybe_unused]] rocshmem_team_t team,
-                                          [[maybe_unused]] T *dest, 
-                                          [[maybe_unused]] const T* source, 
-                                          [[maybe_unused]] int nelement, 
-                                          [[maybe_unused]] int PE_root) {
-  LOGD_WARN("Broadcast Wave API not implemented for GDA backend");
-  return ROCSHMEM_ERROR;
 }
 
 template <typename T>

--- a/projects/rocshmem/src/ipc/context_ipc_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.hpp
@@ -149,6 +149,13 @@ class IPCContext : public Context {
                             int nelems, int pe_root);
 
   template <typename T>
+  __device__ int broadcast_wave(rocshmem_team_t team,
+                                T *dest, const T *source, int nelement, int PE_root);
+
+  __device__ int broadcastmem_wave(rocshmem_team_t team,
+                                void *dest, const void *source, int nelement, int PE_root);
+
+  template <typename T>
   __device__ void alltoall(rocshmem_team_t team, T *dest, const T *source,
                            int nelems);
 
@@ -372,6 +379,29 @@ class IPCContext : public Context {
   template <typename T>
   __device__ void internal_get_broadcast(T *dst, const T *src, int nelems,
                                          int pe_root);  // NOLINT(runtime/int)
+
+  __device__ void internal_broadcastmem_wave(void *dst, const void *src, int nelems,
+                                      int pe_root, int pe_start,
+                                      int stride, int pe_size,
+                                      long *p_sync);
+
+  __device__ void internal_put_broadcastmem_wave(void *dst, const void *src, int nelems, 
+                                                 int pe_root, int pe_start, int stride, int pe_size);
+
+  __device__ void internal_get_broadcastmem_wave(void *dst, const void *src, int nelems, int pe_root);
+
+  template <typename T>
+  __device__ void internal_broadcast_wave(T *dst, const T *src, int nelems,
+                                      int pe_root, int pe_start,
+                                      int stride, int pe_size,
+                                      long *p_sync);
+  
+  template <typename T>
+  __device__ void internal_put_broadcast_wave(T *dst, const T *src, int nelems, 
+                                                 int pe_root, int pe_start, int stride, int pe_size);
+
+  template <typename T>
+  __device__ void internal_get_broadcast_wave(T *dst, const T *src, int nelems, int pe_root);
 
   template <typename T>
   __device__ void fcollect_linear(rocshmem_team_t team, T *dest,

--- a/projects/rocshmem/src/ipc/context_ipc_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.hpp
@@ -148,6 +148,9 @@ class IPCContext : public Context {
   __device__ void broadcast_wg(rocshmem_team_t team, T *dest, const T *source,
                             int nelems, int pe_root);
 
+  __device__ void broadcastmem_wg(rocshmem_team_t team,
+                                void *dest, const void *source, int nelement, int PE_root);
+
   template <typename T>
   __device__ int broadcast_wave(rocshmem_team_t team,
                                 T *dest, const T *source, int nelement, int PE_root);
@@ -366,18 +369,15 @@ class IPCContext : public Context {
   IpcImpl *ipcImpl{nullptr};
 
   //internal functions used by collective operations
-  template <typename T>
-  __device__ void internal_broadcast_wg(T *dest, const T *source, int nelems, int pe_root,
+  __device__ void internal_broadcastmem_wg(void *dest, const void *source, int nelems, int pe_root,
                                      int pe_start, int stride, int pe_size,
                                      long *p_sync);  // NOLINT(runtime/int)
 
-  template <typename T>
-  __device__ void internal_put_broadcast_wg(T *dst, const T *src, int nelems,
+  __device__ void internal_put_broadcastmem_wg(void *dst, const void *src, int nelems,
                                          int pe_root, int PE_start,
                                          int logPE_stride, int PE_size);  // NOLINT(runtime/int)
 
-  template <typename T>
-  __device__ void internal_get_broadcast_wg(T *dst, const T *src, int nelems,
+  __device__ void internal_get_broadcastmem_wg(void *dst, const void *src, int nelems,
                                          int pe_root);  // NOLINT(runtime/int)
 
   __device__ void internal_broadcastmem_wave(void *dst, const void *src, int nelems,

--- a/projects/rocshmem/src/ipc/context_ipc_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.hpp
@@ -145,7 +145,7 @@ class IPCContext : public Context {
                                    int nreduce);
 
   template <typename T>
-  __device__ void broadcast(rocshmem_team_t team, T *dest, const T *source,
+  __device__ void broadcast_wg(rocshmem_team_t team, T *dest, const T *source,
                             int nelems, int pe_root);
 
   template <typename T>
@@ -367,17 +367,17 @@ class IPCContext : public Context {
 
   //internal functions used by collective operations
   template <typename T>
-  __device__ void internal_broadcast(T *dest, const T *source, int nelems, int pe_root,
+  __device__ void internal_broadcast_wg(T *dest, const T *source, int nelems, int pe_root,
                                      int pe_start, int stride, int pe_size,
                                      long *p_sync);  // NOLINT(runtime/int)
 
   template <typename T>
-  __device__ void internal_put_broadcast(T *dst, const T *src, int nelems,
+  __device__ void internal_put_broadcast_wg(T *dst, const T *src, int nelems,
                                          int pe_root, int PE_start,
                                          int logPE_stride, int PE_size);  // NOLINT(runtime/int)
 
   template <typename T>
-  __device__ void internal_get_broadcast(T *dst, const T *src, int nelems,
+  __device__ void internal_get_broadcast_wg(T *dst, const T *src, int nelems,
                                          int pe_root);  // NOLINT(runtime/int)
 
   __device__ void internal_broadcastmem_wave(void *dst, const void *src, int nelems,

--- a/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
@@ -269,6 +269,12 @@ __device__ void IPCContext::internal_broadcastmem_wave(void *dst, const void *sr
 
 __device__ int IPCContext::broadcastmem_wave(rocshmem_team_t team,
                               void *dest, const void *source, int nelement, int PE_root) {
+
+  if (dest == nullptr || 
+    source == nullptr || 
+    team == ROCSHMEM_TEAM_INVALID)
+    return ROCSHMEM_ERROR;
+
   IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
 
   int stride = team_obj->tinfo_wrt_world->stride;
@@ -283,7 +289,7 @@ __device__ int IPCContext::broadcastmem_wave(rocshmem_team_t team,
 
   internal_broadcastmem_wave(dest, source, nelement, pe_root_world, 
                               pe_start, stride, pe_size, p_sync);
-  return 0;
+  return ROCSHMEM_SUCCESS;
 }
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
@@ -239,18 +239,14 @@ __device__ void IPCContext::internal_put_broadcastmem_wave(
   if (my_pe == pe_root) {
     int finish = pe_start + stride * pe_size;
     for (int i = pe_start; i < finish; i += stride) {
-      if (i != my_pe) {
         putmem_nbi_wave(dst, src, nelems, i);
-      }
     }
   }
 }
 
 __device__ void IPCContext::internal_get_broadcastmem_wave(
   void *dst, const void *src, int nelems, int pe_root) {
-  if (my_pe != pe_root) {
     getmem_wave(dst, src, nelems, pe_root);
-  }
 }
 
 __device__ void IPCContext::internal_broadcastmem_wave(void *dst, const void *src, int nelems,

--- a/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
@@ -252,7 +252,7 @@ __device__ void IPCContext::internal_get_broadcastmem_wave(
 __device__ void IPCContext::internal_broadcastmem_wave(void *dst, const void *src, int nelems,
                                       int pe_root, int pe_start,
                                       int stride, int pe_size,
-                                      [[maybe_unused]] long *p_sync) {  // NOLINT(runtime/int)
+                                      long *p_sync) {  // NOLINT(runtime/int)
   if (num_pes < 4) {
     internal_put_broadcastmem_wave(dst, src, nelems, pe_root, pe_start, stride, pe_size);
   } else {
@@ -280,8 +280,6 @@ __device__ int IPCContext::broadcastmem_wave(rocshmem_team_t team,
 
   // Passed pe_root is relative to team, convert to world root
   int pe_root_world = team_obj->get_pe_in_world(PE_root);
-  // internal_broadcast_wave<T>(dest, source, nelement, pe_root_world, 
-  //                             pe_start, stride, pe_size, p_sync);
 
   internal_broadcastmem_wave(dest, source, nelement, pe_root_world, 
                               pe_start, stride, pe_size, p_sync);

--- a/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
@@ -233,4 +233,57 @@ __device__ void IPCContext::barrier_wg(rocshmem_team_t team) {
   __syncthreads();
 }
 
+__device__ void IPCContext::internal_put_broadcastmem_wave(
+    void *dst, const void *src, int nelems, int pe_root, int pe_start,
+    int stride, int pe_size) {  // NOLINT(runtime/int)
+  if (my_pe == pe_root) {
+    int finish = pe_start + stride * pe_size;
+    for (int i = pe_start; i < finish; i += stride) {
+      if (i != my_pe) {
+        putmem_nbi_wave(dst, src, nelems, i);
+      }
+    }
+  }
+}
+
+__device__ void IPCContext::internal_get_broadcastmem_wave(
+  void *dst, const void *src, int nelems, int pe_root) {
+  if (my_pe != pe_root) {
+    getmem_wave(dst, src, nelems, pe_root);
+  }
+}
+
+__device__ void IPCContext::internal_broadcastmem_wave(void *dst, const void *src, int nelems,
+                                      int pe_root, int pe_start,
+                                      int stride, int pe_size,
+                                      [[maybe_unused]] long *p_sync) {  // NOLINT(runtime/int)
+  if (num_pes < 4) {
+    internal_put_broadcastmem_wave(dst, src, nelems, pe_root, pe_start, stride, pe_size);
+  } else {
+    internal_get_broadcastmem_wave(dst, src, nelems, pe_root);
+  }
+
+  // Synchronize on completion of broadcast
+  internal_sync_wave(my_pe, pe_start, stride, pe_size, p_sync);
+}
+
+__device__ int IPCContext::broadcastmem_wave(rocshmem_team_t team,
+                              void *dest, const void *source, int nelement, int PE_root) {
+  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
+
+  int stride = team_obj->tinfo_wrt_world->stride;
+  int pe_start = team_obj->tinfo_wrt_world->pe_start;
+  int pe_size = team_obj->tinfo_wrt_world->size;
+  long *p_sync = team_obj->bcast_pSync;
+
+  // Passed pe_root is relative to team, convert to world root
+  int pe_root_world = team_obj->get_pe_in_world(PE_root);
+  // internal_broadcast_wave<T>(dest, source, nelement, pe_root_world, 
+  //                             pe_start, stride, pe_size, p_sync);
+
+  internal_broadcastmem_wave(dest, source, nelement, pe_root_world, 
+                              pe_start, stride, pe_size, p_sync);
+  return 0;
+}
+
 }  // namespace rocshmem

--- a/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
@@ -266,9 +266,7 @@ __device__ void IPCContext::internal_broadcastmem_wave(void *dst, const void *sr
 __device__ int IPCContext::broadcastmem_wave(rocshmem_team_t team,
                               void *dest, const void *source, int nelement, int PE_root) {
 
-  if (dest == nullptr || 
-    source == nullptr || 
-    team == ROCSHMEM_TEAM_INVALID)
+  if (dest == nullptr || source == nullptr || team == ROCSHMEM_TEAM_INVALID)
     return ROCSHMEM_ERROR;
 
   IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
@@ -284,6 +282,52 @@ __device__ int IPCContext::broadcastmem_wave(rocshmem_team_t team,
   internal_broadcastmem_wave(dest, source, nelement, pe_root_world, 
                               pe_start, stride, pe_size, p_sync);
   return ROCSHMEM_SUCCESS;
+}
+
+__device__ void IPCContext::internal_put_broadcastmem_wg(
+    void *dst, const void *src, int nelems, int pe_root, int pe_start,
+    int stride, int pe_size) {  // NOLINT(runtime/int)
+  if (my_pe == pe_root) {
+    int finish = pe_start + stride * pe_size;
+    for (int i = pe_start; i < finish; i += stride) {
+        putmem_nbi_wg(dst, src, nelems, i);
+    }
+  }
+}
+
+__device__ void IPCContext::internal_get_broadcastmem_wg(
+  void *dst, const void *src, int nelems, int pe_root) {
+    getmem_wg(dst, src, nelems, pe_root);
+}
+
+__device__ void IPCContext::internal_broadcastmem_wg(void *dst, const void *src, int nelems,
+                                      int pe_root, int pe_start,
+                                      int stride, int pe_size,
+                                      long *p_sync) {  // NOLINT(runtime/int)
+  if (num_pes < 4) {
+    internal_put_broadcastmem_wg(dst, src, nelems, pe_root, pe_start, stride, pe_size);
+  } else {
+    internal_get_broadcastmem_wg(dst, src, nelems, pe_root);
+  }
+
+  // Synchronize on completion of broadcast
+  internal_sync_wg(my_pe, pe_start, stride, pe_size, p_sync);
+}
+
+__device__ void IPCContext::broadcastmem_wg(rocshmem_team_t team,
+                              void *dest, const void *source, int nelement, int PE_root) {
+  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
+
+  int stride = team_obj->tinfo_wrt_world->stride;
+  int pe_start = team_obj->tinfo_wrt_world->pe_start;
+  int pe_size = team_obj->tinfo_wrt_world->size;
+  long *p_sync = team_obj->bcast_pSync;
+
+  // Passed pe_root is relative to team, convert to world root
+  int pe_root_world = team_obj->get_pe_in_world(PE_root);
+
+  internal_broadcastmem_wg(dest, source, nelement, pe_root_world, 
+                              pe_start, stride, pe_size, p_sync);
 }
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -540,6 +540,11 @@ __device__ void IPCContext::internal_get_broadcast_wave(
 template <typename T>
 __device__ int IPCContext::broadcast_wave(rocshmem_team_t team,
                               T *dest, const T *source, int nelement, int PE_root) {
+  if (dest == nullptr || 
+    source == nullptr || 
+    team == ROCSHMEM_TEAM_INVALID)
+    return ROCSHMEM_ERROR;
+
   IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
 
   int stride = team_obj->tinfo_wrt_world->stride;
@@ -554,7 +559,7 @@ __device__ int IPCContext::broadcast_wave(rocshmem_team_t team,
 
   internal_broadcastmem_wave(dest, source, nelement * sizeof(T), pe_root_world, 
                               pe_start, stride, pe_size, p_sync);
-  return 0;
+  return ROCSHMEM_SUCCESS;
 }
 
 template <typename T>

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -524,9 +524,7 @@ __device__ void IPCContext::internal_put_broadcast_wave(T *dst, const T *src, in
   if (my_pe == pe_root) {
     int finish = pe_start + stride * pe_size;
     for (int i = pe_start; i < finish; i += stride) {
-      if (i != my_pe) {
         put_nbi_wave(dst, src, nelems, i);
-      }
     }
   }
 }

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -551,42 +551,8 @@ __device__ void IPCContext::broadcast_wg(rocshmem_team_t team, T *dst,
 
   // Passed pe_root is relative to team, convert to world root
   int pe_root_world = team_obj->get_pe_in_world(pe_root);
-  internal_broadcast_wg<T>(dst, src, nelems, pe_root_world, pe_start, stride,
+  internal_broadcastmem_wg(dst, src, nelems * sizeof(T), pe_root_world, pe_start, stride,
                pe_size, p_sync);
-}
-
-template <typename T>
-__device__ void IPCContext::internal_put_broadcast_wg(
-    T *dst, const T *src, int nelems, int pe_root, int pe_start,
-    int stride, int pe_size) {  // NOLINT(runtime/int)
-  if (my_pe == pe_root) {
-    int finish = pe_start + stride * pe_size;
-    for (int i = pe_start; i < finish; i += stride) {
-        put_nbi_wg(dst, src, nelems, i);
-    }
-  }
-}
-
-template <typename T>
-__device__ void IPCContext::internal_get_broadcast_wg(
-  T *dst, const T *src, int nelems, int pe_root) {  // NOLINT(runtime/int)
-    get_wg(dst, src, nelems, pe_root);
-}
-
-template <typename T>
-__device__ void IPCContext::internal_broadcast_wg(T *dst, const T *src, int nelems,
-                                      int pe_root, int pe_start,
-                                      int stride, int pe_size,
-                                      long *p_sync) {  // NOLINT(runtime/int)
-  if (constmem.num_pes < 4) {
-    internal_put_broadcast_wg(dst, src, nelems, pe_root, pe_start, stride,
-                           pe_size);
-  } else {
-    internal_get_broadcast_wg(dst, src, nelems, pe_root);
-  }
-
-  // Synchronize on completion of broadcast
-  internal_sync_wg(constmem.my_pe, pe_start, stride, pe_size, p_sync);
 }
 
 template <typename T>

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -485,40 +485,6 @@ __device__ int IPCContext::reduce_scatter_wg(rocshmem_team_t team, T *dest,
 }
 
 template <typename T>
-__device__ void IPCContext::internal_put_broadcast(
-    T *dst, const T *src, int nelems, int pe_root, int pe_start,
-    int stride, int pe_size) {  // NOLINT(runtime/int)
-  if (constmem.my_pe == pe_root) {
-    int finish = pe_start + stride * pe_size;
-    for (int i = pe_start; i < finish; i += stride) {
-        put_nbi_wg(dst, src, nelems, i);
-    }
-  }
-}
-
-template <typename T>
-__device__ void IPCContext::internal_get_broadcast(
-  T *dst, const T *src, int nelems, int pe_root) {  // NOLINT(runtime/int)
-    get_wg(dst, src, nelems, pe_root);
-}
-
-template <typename T>
-__device__ void IPCContext::broadcast(rocshmem_team_t team, T *dst,
-                                      const T *src, int nelems, int pe_root) {
-  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
-
-  int stride = team_obj->tinfo_wrt_world->stride;
-  int pe_start = team_obj->tinfo_wrt_world->pe_start;
-  int pe_size = team_obj->tinfo_wrt_world->size;
-  long *p_sync = team_obj->bcast_pSync;
-
-  // Passed pe_root is relative to team, convert to world root
-  int pe_root_world = team_obj->get_pe_in_world(pe_root);
-  internal_broadcast<T>(dst, src, nelems, pe_root_world, pe_start, stride,
-               pe_size, p_sync);
-}
-
-template <typename T>
 __device__ void IPCContext::internal_put_broadcast_wave(T *dst, const T *src, int nelems, int pe_root, int pe_start,
     int stride, int pe_size) {  // NOLINT(runtime/int)
   if (my_pe == pe_root) {
@@ -563,7 +529,7 @@ __device__ void IPCContext::internal_broadcast_wave(T *dst, const T *src, int ne
                                       int pe_root, int pe_start,
                                       int stride, int pe_size,
                                       long *p_sync) {  // NOLINT(runtime/int)
-  if (num_pes < 4) {
+  if (constmem.num_pes < 4) {
     internal_put_broadcast_wave<T>(dst, src, nelems, pe_root, pe_start, stride, pe_size);
   } else {
     internal_get_broadcast_wave<T>(dst, src, nelems, pe_root);
@@ -572,17 +538,51 @@ __device__ void IPCContext::internal_broadcast_wave(T *dst, const T *src, int ne
   // Synchronize on completion of broadcast
   internal_sync_wave(my_pe, pe_start, stride, pe_size, p_sync);
 }
+  
+template <typename T>
+__device__ void IPCContext::broadcast_wg(rocshmem_team_t team, T *dst,
+                                      const T *src, int nelems, int pe_root) {
+  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
+
+  int stride = team_obj->tinfo_wrt_world->stride;
+  int pe_start = team_obj->tinfo_wrt_world->pe_start;
+  int pe_size = team_obj->tinfo_wrt_world->size;
+  long *p_sync = team_obj->bcast_pSync;
+
+  // Passed pe_root is relative to team, convert to world root
+  int pe_root_world = team_obj->get_pe_in_world(pe_root);
+  internal_broadcast_wg<T>(dst, src, nelems, pe_root_world, pe_start, stride,
+               pe_size, p_sync);
+}
 
 template <typename T>
-__device__ void IPCContext::internal_broadcast(T *dst, const T *src, int nelems,
+__device__ void IPCContext::internal_put_broadcast_wg(
+    T *dst, const T *src, int nelems, int pe_root, int pe_start,
+    int stride, int pe_size) {  // NOLINT(runtime/int)
+  if (my_pe == pe_root) {
+    int finish = pe_start + stride * pe_size;
+    for (int i = pe_start; i < finish; i += stride) {
+        put_nbi_wg(dst, src, nelems, i);
+    }
+  }
+}
+
+template <typename T>
+__device__ void IPCContext::internal_get_broadcast_wg(
+  T *dst, const T *src, int nelems, int pe_root) {  // NOLINT(runtime/int)
+    get_wg(dst, src, nelems, pe_root);
+}
+
+template <typename T>
+__device__ void IPCContext::internal_broadcast_wg(T *dst, const T *src, int nelems,
                                       int pe_root, int pe_start,
                                       int stride, int pe_size,
                                       long *p_sync) {  // NOLINT(runtime/int)
   if (constmem.num_pes < 4) {
-    internal_put_broadcast(dst, src, nelems, pe_root, pe_start, stride,
+    internal_put_broadcast_wg(dst, src, nelems, pe_root, pe_start, stride,
                            pe_size);
   } else {
-    internal_get_broadcast(dst, src, nelems, pe_root);
+    internal_get_broadcast_wg(dst, src, nelems, pe_root);
   }
 
   // Synchronize on completion of broadcast

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -519,6 +519,60 @@ __device__ void IPCContext::broadcast(rocshmem_team_t team, T *dst,
 }
 
 template <typename T>
+__device__ void IPCContext::internal_put_broadcast_wave(T *dst, const T *src, int nelems, int pe_root, int pe_start,
+    int stride, int pe_size) {  // NOLINT(runtime/int)
+  if (my_pe == pe_root) {
+    int finish = pe_start + stride * pe_size;
+    for (int i = pe_start; i < finish; i += stride) {
+      if (i != my_pe) {
+        put_nbi_wave(dst, src, nelems, i);
+      }
+    }
+  }
+}
+
+template <typename T>
+__device__ void IPCContext::internal_get_broadcast_wave(
+  T *dst, const T *src, int nelems, int pe_root) {
+    get_wave(dst, src, nelems, pe_root);
+}
+
+template <typename T>
+__device__ int IPCContext::broadcast_wave(rocshmem_team_t team,
+                              T *dest, const T *source, int nelement, int PE_root) {
+  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
+
+  int stride = team_obj->tinfo_wrt_world->stride;
+  int pe_start = team_obj->tinfo_wrt_world->pe_start;
+  int pe_size = team_obj->tinfo_wrt_world->size;
+  long *p_sync = team_obj->bcast_pSync;
+
+  // Passed pe_root is relative to team, convert to world root
+  int pe_root_world = team_obj->get_pe_in_world(PE_root);
+  // internal_broadcast_wave<T>(dest, source, nelement, pe_root_world, 
+  //                             pe_start, stride, pe_size, p_sync);
+
+  internal_broadcastmem_wave(dest, source, nelement * sizeof(T), pe_root_world, 
+                              pe_start, stride, pe_size, p_sync);
+  return 0;
+}
+
+template <typename T>
+__device__ void IPCContext::internal_broadcast_wave(T *dst, const T *src, int nelems,
+                                      int pe_root, int pe_start,
+                                      int stride, int pe_size,
+                                      [[maybe_unused]] long *p_sync) {  // NOLINT(runtime/int)
+  if (num_pes < 4) {
+    internal_put_broadcast_wave<T>(dst, src, nelems, pe_root, pe_start, stride, pe_size);
+  } else {
+    internal_get_broadcast_wave<T>(dst, src, nelems, pe_root);
+  }
+
+  // Synchronize on completion of broadcast
+  internal_sync_wave(my_pe, pe_start, stride, pe_size, p_sync);
+}
+
+template <typename T>
 __device__ void IPCContext::internal_broadcast(T *dst, const T *src, int nelems,
                                       int pe_root, int pe_start,
                                       int stride, int pe_size,

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -554,11 +554,9 @@ __device__ int IPCContext::broadcast_wave(rocshmem_team_t team,
 
   // Passed pe_root is relative to team, convert to world root
   int pe_root_world = team_obj->get_pe_in_world(PE_root);
-  // internal_broadcast_wave<T>(dest, source, nelement, pe_root_world, 
-  //                             pe_start, stride, pe_size, p_sync);
-
-  internal_broadcastmem_wave(dest, source, nelement * sizeof(T), pe_root_world, 
+  internal_broadcast_wave<T>(dest, source, nelement, pe_root_world, 
                               pe_start, stride, pe_size, p_sync);
+
   return ROCSHMEM_SUCCESS;
 }
 
@@ -566,7 +564,7 @@ template <typename T>
 __device__ void IPCContext::internal_broadcast_wave(T *dst, const T *src, int nelems,
                                       int pe_root, int pe_start,
                                       int stride, int pe_size,
-                                      [[maybe_unused]] long *p_sync) {  // NOLINT(runtime/int)
+                                      long *p_sync) {  // NOLINT(runtime/int)
   if (num_pes < 4) {
     internal_put_broadcast_wave<T>(dst, src, nelems, pe_root, pe_start, stride, pe_size);
   } else {

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
@@ -795,4 +795,20 @@ __device__ int ROContext::tile_collective_wait([[maybe_unused]] rocshmem_team_t 
   return ROCSHMEM_ERROR;
 }
 
+__device__ void ROContext::broadcastmem_wg(rocshmem_team_t team, void *dest,
+                                     const void *source, int nelems, int pe_root) {
+  if (is_thread_zero_in_block()) {
+    ROTeam *team_obj{reinterpret_cast<ROTeam *>(team)};
+
+    build_queue_element(RO_NET_TEAM_BROADCAST, dest, const_cast<void *>(source),
+                        nelems, 0, 0, 0, pe_root, nullptr, nullptr,
+                        (intptr_t)team_obj->mpi_comm, ro_net_win_id, block_handle, true,
+                        get_status_flag(), is_default_ctx, ROCSHMEM_SUM,
+                        RO_NET_CHAR);
+  }
+
+  __syncthreads();
+}
+
+
 }  // namespace rocshmem

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
@@ -573,6 +573,15 @@ __device__ uint64_t broadcast(bool lowest_active, uint64_t value) {
   return broadcast_lds(lowest_active, value);
 }
 
+__device__ int ROContext::broadcastmem_wave([[maybe_unused]] rocshmem_team_t team,
+                                        [[maybe_unused]] void *dest, 
+                                        [[maybe_unused]] const void* source, 
+                                        [[maybe_unused]] int nelement, 
+                                        [[maybe_unused]] int PE_root) {
+  LOGD_WARN("Broadcastmem Wave API not implemented for reverse offload backend");
+  return ROCSHMEM_ERROR;
+}
+
 __device__ bool enough_space(BlockHandle *h, uint64_t required) {
   return (h->queue_size - (h->write_index - h->read_index)) >= required;
 }

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
@@ -158,6 +158,9 @@ class ROContext : public Context {
                             int pe_start, int log_pe_stride, int pe_size,
                             long *p_sync);  // NOLINT(runtime/int)
 
+  __device__ void broadcastmem_wg(rocshmem_team_t team, void *dest, const void *source,
+                            int nelems, int pe_root);
+                            
   template <typename T>
   __device__ int broadcast_wave(rocshmem_team_t team,
                                 T *dest, const T* source, int nelement, int PE_root);

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
@@ -150,11 +150,11 @@ class ROContext : public Context {
   __device__ void amo_xor(void *dst, T value, int pe);
 
   template <typename T>
-  __device__ void broadcast(rocshmem_team_t team, T *dest, const T *source,
+  __device__ void broadcast_wg(rocshmem_team_t team, T *dest, const T *source,
                             int nelems, int pe_root);
 
   template <typename T>
-  __device__ void broadcast(T *dest, const T *source, int nelems, int pe_root,
+  __device__ void broadcast_wg(T *dest, const T *source, int nelems, int pe_root,
                             int pe_start, int log_pe_stride, int pe_size,
                             long *p_sync);  // NOLINT(runtime/int)
 

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
@@ -368,7 +368,7 @@ class ROContext : public Context {
                                     const size_t* start_coord, const size_t* boundary,
                                     int ndim, size_t element_size, int root, uint64_t flags);
 
-  // Rooted SUM Reduction operations  
+  // Rooted SUM Reduction operations
   // Rooted MAX Reduction operations
   // Rooted MIN Reduction operations
  private:

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
@@ -159,6 +159,13 @@ class ROContext : public Context {
                             long *p_sync);  // NOLINT(runtime/int)
 
   template <typename T>
+  __device__ int broadcast_wave(rocshmem_team_t team,
+                                T *dest, const T* source, int nelement, int PE_root);
+
+  __device__ int broadcastmem_wave(rocshmem_team_t team,
+                                  void *dest, const void* source, int nelement, int PE_root);
+
+  template <typename T>
   __device__ void alltoall(rocshmem_team_t team, T *dest, const T *source,
                            int nelems);
 
@@ -361,7 +368,7 @@ class ROContext : public Context {
                                     const size_t* start_coord, const size_t* boundary,
                                     int ndim, size_t element_size, int root, uint64_t flags);
 
-  // Rooted SUM Reduction operations
+  // Rooted SUM Reduction operations  
   // Rooted MAX Reduction operations
   // Rooted MIN Reduction operations
  private:

--- a/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
@@ -348,6 +348,16 @@ __device__ void ROContext::broadcast(rocshmem_team_t team, T *dest,
 }
 
 template <typename T>
+__device__ int ROContext::broadcast_wave([[maybe_unused]] rocshmem_team_t team,
+                                        [[maybe_unused]] T *dest, 
+                                        [[maybe_unused]] const T* source, 
+                                        [[maybe_unused]] int nelement, 
+                                        [[maybe_unused]] int PE_root) {
+  LOGD_WARN("Broadcast Wave API not implemented for reverse offload backend");
+  return ROCSHMEM_ERROR;
+}
+
+template <typename T>
 __device__ void ROContext::alltoall(rocshmem_team_t team, T *dest,
                                     const T *source, int nelems) {
   if (!is_thread_zero_in_block()) {

--- a/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
@@ -329,7 +329,7 @@ __device__ int ROContext::reduce_scatter_wg(rocshmem_team_t team, T *dest,
 }
 
 template <typename T>
-__device__ void ROContext::broadcast(rocshmem_team_t team, T *dest,
+__device__ void ROContext::broadcast_wg(rocshmem_team_t team, T *dest,
                                      const T *source, int nelems, int pe_root) {
   if (!is_thread_zero_in_block()) {
     __syncthreads();

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -663,14 +663,30 @@ __device__ void rocshmem_broadcast_wg(rocshmem_ctx_t ctx,
   get_internal_ctx(ctx)->broadcast_wg<T>(team, dest, source, nelem, pe_root);
 }
 
-#define BROADCAST_WAVE_IMP_GEN(T, TNAME) \
-  __device__ int rocshmem_ctx_##TNAME##_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team, \
-    T *dest, const T *source, int nelement, int PE_root){                             \
-      return get_internal_ctx(ctx)->broadcast_wave<T>(ctx, team, dest, source, nelement, PE_root);}
+__device__ void rocshmem_ctx_broadcastmem_wg(rocshmem_ctx_t ctx, rocshmem_team_t team, 
+  void *dest, const void *source, int nelement, int PE_root) {      
+    LOGD_API("device::broadcastmem_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d, root=%d)",
+      ctx.ctx_opaque, team, dest, source, nelem, PE_root);
 
-__device__ int rocshmem_ctx_broadcastmem_wave(rocshmem_ctx_t ctx, rocshmem_team_t team, \
-  void *dest, const void *source, int nelement, int PE_root){                             \
-    return get_internal_ctx(ctx)->broadcastmem_wave(ctx, team, dest, source, nelement, PE_root);}
+    get_internal_ctx(ctx)->broadcastmem_wg(team, dest, source, nelement, PE_root);
+}
+
+template <typename T>
+__device__ int rocshmem_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest,
+                                       const T *source, int nelem, int pe_root) {
+  LOGD_API("device::broadcast_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d, root=%d)",
+    ctx.ctx_opaque, team, dest, source, nelem, pe_root);
+
+  return get_internal_ctx(ctx)->broadcast_wave<T>(team, dest, source, nelem, pe_root);
+}
+
+__device__ int rocshmem_ctx_broadcastmem_wave(rocshmem_ctx_t ctx, rocshmem_team_t team, 
+  void *dest, const void *source, int nelement, int PE_root) {      
+    LOGD_API("device::broadcastmem_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d, root=%d)",
+      ctx.ctx_opaque, team, dest, source, nelem, pe_root);
+
+    return get_internal_ctx(ctx)->broadcastmem_wave(team, dest, source, nelement, PE_root);
+}
 
 template <typename T>
 __device__ void rocshmem_ctx_alltoall_wg(rocshmem_ctx_t ctx,
@@ -1423,6 +1439,9 @@ __device__ int rocshmem_team_translate_pe(rocshmem_team_t src_team,
   template __device__ void rocshmem_broadcast_wg<T>(                           \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,     \
       int nelem, int pe_root);                                                 \
+  template __device__ int rocshmem_broadcast_wave<T>(                         \
+      rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,     \
+      int nelem, int pe_root);                                                 \
   template __device__ void rocshmem_ctx_alltoall_wg<T>(                        \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,     \
       int nelem);                                                              \
@@ -1759,6 +1778,12 @@ __device__ int rocshmem_team_translate_pe(rocshmem_team_t src_team,
       rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,     \
       int nelem, int pe_root) {                                               \
     rocshmem_broadcast_wg<T>(ctx, team, dest, source, nelem, pe_root);        \
+  }                                                                           \
+  __device__ int rocshmem_ctx_##TNAME##_broadcast_wave(                       \
+      rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,     \
+      int nelem, int pe_root) {                                               \
+    return rocshmem_broadcast_wave<T>(ctx, team, dest,                        \
+                                       source, nelem, pe_root);               \
   }                                                                           \
   __device__ void rocshmem_ctx_##TNAME##_alltoall_wg(                         \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,     \
@@ -2169,13 +2194,6 @@ INT_REDUCTION_ON_STREAM_KERNEL_GEN(short, short)
 
 FLOAT_REDUCTION_ON_STREAM_KERNEL_GEN(float, float)
 FLOAT_REDUCTION_ON_STREAM_KERNEL_GEN(double, double)
-
-BROADCAST_WAVE_IMP_GEN(int, int)
-BROADCAST_WAVE_IMP_GEN(short, short)
-BROADCAST_WAVE_IMP_GEN(long, long)
-BROADCAST_WAVE_IMP_GEN(long long, longlong)
-BROADCAST_WAVE_IMP_GEN(float, float)
-BROADCAST_WAVE_IMP_GEN(double, double)
 // clang-format on
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -663,6 +663,15 @@ __device__ void rocshmem_broadcast_wg(rocshmem_ctx_t ctx,
   get_internal_ctx(ctx)->broadcast<T>(team, dest, source, nelem, pe_root);
 }
 
+#define BROADCAST_WAVE_IMP_GEN(T, TNAME) \
+  __device__ int rocshmem_ctx_##TNAME##_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team, \
+    T *dest, const T *source, int nelement, int PE_root){                             \
+      return get_internal_ctx(ctx)->broadcast_wave<T>(ctx, team, dest, source, nelement, PE_root);}
+
+__device__ int rocshmem_ctx_broadcastmem_wave(rocshmem_ctx_t ctx, rocshmem_team_t team, \
+  void *dest, const void *source, int nelement, int PE_root){                             \
+    return get_internal_ctx(ctx)->broadcastmem_wave(ctx, team, dest, source, nelement, PE_root);}
+
 template <typename T>
 __device__ void rocshmem_ctx_alltoall_wg(rocshmem_ctx_t ctx,
                                          rocshmem_team_t team, T *dest,
@@ -2160,6 +2169,13 @@ INT_REDUCTION_ON_STREAM_KERNEL_GEN(short, short)
 
 FLOAT_REDUCTION_ON_STREAM_KERNEL_GEN(float, float)
 FLOAT_REDUCTION_ON_STREAM_KERNEL_GEN(double, double)
+
+BROADCAST_WAVE_IMP_GEN(int, int)
+BROADCAST_WAVE_IMP_GEN(short, short)
+BROADCAST_WAVE_IMP_GEN(long, long)
+BROADCAST_WAVE_IMP_GEN(long long, longlong)
+BROADCAST_WAVE_IMP_GEN(float, float)
+BROADCAST_WAVE_IMP_GEN(double, double)
 // clang-format on
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -660,7 +660,7 @@ __device__ void rocshmem_broadcast_wg(rocshmem_ctx_t ctx,
   LOGD_API("device::broadcast_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d, root=%d)",
     ctx.ctx_opaque, team, dest, source, nelem, pe_root);
 
-  get_internal_ctx(ctx)->broadcast<T>(team, dest, source, nelem, pe_root);
+  get_internal_ctx(ctx)->broadcast_wg<T>(team, dest, source, nelem, pe_root);
 }
 
 #define BROADCAST_WAVE_IMP_GEN(T, TNAME) \

--- a/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
+++ b/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
@@ -165,6 +165,7 @@ set(TEST_host_wait_until_all_status 146)
 set(TEST_host_wait_until_any_status 147)
 set(TEST_host_wait_until_some_status 148)
 set(TEST_teamreducescatter 149)
+set(TEST_broadcast_wave 150)
 
 # MPI should already be found by the parent CMakeLists.txt
 # Use standard CMake MPI variables set by find_package(MPI)
@@ -1065,6 +1066,11 @@ function(add_coll_tests)
     begin_test_group(CATEGORY "COLLECTIVE;TEAM" TIER comprehensive BACKENDS "all" GPUS "all")
         add_rocshmem_functional_test(NAME teamsplit2d RANKS 4 WORKGROUPS 1 THREADS 1)
     end_test_group()
+
+    # AIROCSHMEM-409: wave tests not supported on RO
+    begin_test_group(CATEGORY "COLLECTIVE;WAVE" TIER full BACKENDS "ipc;gda" GPUS "all")
+        add_rocshmem_functional_test(NAME broadcast_wave RANKS 2 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 32768)
+    end_test_group()
 endfunction()
 
 # Stream Tests
@@ -1101,7 +1107,8 @@ function(add_stream_tests)
     begin_test_group(CATEGORY "COLLECTIVE;STREAM" TIER full BACKENDS "all" GPUS "all")
         add_rocshmem_functional_test(NAME quiet_on_stream RANKS 2 WORKGROUPS 1 THREADS 1)
         add_rocshmem_functional_test(NAME sync_all_on_stream RANKS 2 WORKGROUPS 1 THREADS 1)
-        add_rocshmem_functional_test(NAME reduce_on_stream RANKS 2 WORKGROUPS 1 THREADS 1 MAX_MSG_SIZE 1048576)
+        add_rocshmem_functional_test(NAME reduce_on_stream RANKS 2 WORKGROUPS 1 THREADS 1 MAX_MSG_SIZE 1048576 
+            ENV_VARS "ROCSHMEM_MAX_NUM_CONTEXTS=1024;ROCSHMEM_MAX_NUM_HOST_CONTEXTS=1024")
         add_rocshmem_functional_test(NAME alltoallmem_on_stream RANKS 2 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 1048576)
         add_rocshmem_functional_test(NAME broadcastmem_on_stream RANKS 2 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 1048576)
     end_test_group()

--- a/projects/rocshmem/tests/functional_tests/broadcast_wave_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/broadcast_wave_tester.cpp
@@ -56,30 +56,34 @@ __global__ void BroadcastWaveTestKernel(int loop, int skip, long long int *start
                                   long long int *end_time, T1 *source_buf,
                                   T1 *dest_buf, int size,
                                   ShmemContextType ctx_type,
-                                  rocshmem_team_t *teams) {
+                                  rocshmem_team_t *teams, int wf_size) {
   __shared__ rocshmem_ctx_t ctx;
+  int t_id  = get_flat_block_id();
   int wg_id = get_flat_grid_id();
+  int wf_id = t_id / wf_size;
+  int wg_offset = wg_id * ((get_flat_block_size() - 1 ) / wf_size + 1);
 
-  rocshmem_wg_team_create_ctx(teams[wg_id], ctx_type, &ctx);
+  int flat_wf_id = wf_id + wg_offset;
+
+  rocshmem_wg_team_create_ctx(teams[flat_wf_id], ctx_type, &ctx);
 
   [[maybe_unused]] int n_pes = rocshmem_ctx_n_pes(ctx);
-  source_buf += wg_id * size;
-  dest_buf += wg_id * size;
+  source_buf += flat_wf_id * size;
+  dest_buf += flat_wf_id * size;
 
   __syncthreads();
 
   for (int i = 0; i < loop + skip; i++) {
-    if (i == skip && hipThreadIdx_x == 0) {
-      start_time[wg_id] = wall_clock64();
+    if (i == skip && t_id % wf_size == 0) {
+      start_time[flat_wf_id] = wall_clock64();
     }
-    if (threadIdx.x < warpSize)
-    wave_broadcast<T1>(ctx, teams[wg_id], dest_buf, source_buf, size, 0);
+    wave_broadcast<T1>(ctx, teams[flat_wf_id], dest_buf, source_buf, size, 0);
   }
 
   __syncthreads();
 
-  if (hipThreadIdx_x == 0) {
-    end_time[wg_id] = wall_clock64();
+  if (t_id % wf_size == 0) {
+    end_time[flat_wf_id] = wall_clock64();
   }
 
   rocshmem_wg_ctx_destroy(&ctx);
@@ -95,7 +99,7 @@ BroadcastWaveTester<T1>::BroadcastWaveTester(TesterArguments args)
   n_pes = rocshmem_team_n_pes(ROCSHMEM_TEAM_WORLD);
 
   // Total number of elements in src buffer
-  int total_elems = (max_msg_size / sizeof(T1)) * args.num_wgs ;
+  int total_elems = (max_msg_size / sizeof(T1)) * args.num_wgs * num_warps;
   int buff_size = total_elems * sizeof(T1);
 
   source_buf = (T1 *)alloc_test_buffer(buff_size, args.local_buf_type);
@@ -104,6 +108,11 @@ BroadcastWaveTester<T1>::BroadcastWaveTester(TesterArguments args)
   char* value{nullptr};
   if ((value = getenv("ROCSHMEM_MAX_NUM_TEAMS"))) {
     num_teams = atoi(value);
+  }
+
+  if (num_teams < num_warps){
+    printf("not enough teams for each wavefront, try increasing ROCSHMEM_MAX_NUM_TEAMS\n");
+    abort();
   }
 
   CHECK_HIP(hipMalloc(&bcast_wave_world_dup,
@@ -142,10 +151,10 @@ void BroadcastWaveTester<T1>::launchKernel(dim3 gridSize, dim3 blockSize,
   hipLaunchKernelGGL(BroadcastWaveTestKernel<T1>, gridSize, blockSize,
                      shared_bytes, stream, loop, args.skip,
                      start_time, end_time, source_buf, dest_buf,
-                     num_elems, _shmem_context, bcast_wave_world_dup);
+                     num_elems, _shmem_context, bcast_wave_world_dup, wf_size);
 
-  num_msgs = (loop + args.skip) * gridSize.x;
-  num_timed_msgs = loop * gridSize.x;
+  num_msgs = (loop + args.skip) * gridSize.x * num_warps;
+  num_timed_msgs = loop * gridSize.x * num_warps;
 }
 
 template <typename T1>
@@ -165,19 +174,13 @@ void BroadcastWaveTester<T1>::resetBuffers(size_t size) {
   for (unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
     for (unsigned int i = 0; i < static_cast<unsigned int>(num_elems); i++) {
       idx = wg_id * num_elems + i;
-      if constexpr (std::is_same<T1, char>::value ||
-                    std::is_same<T1, signed char>::value ||
-                    std::is_same<T1, unsigned char>::value) {
-        source_buf[idx] = static_cast<T1>('a' + n_pes + wg_id);
-        dest_buf[idx] = static_cast<T1>('a' + wg_id);
-      }
-      else if constexpr (std::is_floating_point<T1>::value) {
+      if constexpr (std::is_floating_point<T1>::value) {
         source_buf[idx] = static_cast<T1>(3.14 + n_pes + wg_id);
         dest_buf[idx] = static_cast<T1>(3.14 + wg_id);
       }
-      else if constexpr (std::is_integral<T1>::value) {
-        source_buf[idx] = static_cast<T1>(n_pes + wg_id);
-        dest_buf[idx] = static_cast<T1>(wg_id);
+      else {
+        source_buf[idx] = static_cast<T1>('a' + n_pes + wg_id);
+        dest_buf[idx] = static_cast<T1>('a' + wg_id);
       }
     }
   }
@@ -195,16 +198,11 @@ void BroadcastWaveTester<T1>::verifyResults(size_t size) {
   for (unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
     for (int i = 0; i < num_elems; i++) {
       idx = wg_id * num_elems + i;
-      if constexpr (std::is_same<T1, char>::value ||
-                    std::is_same<T1, signed char>::value ||
-                    std::is_same<T1, unsigned char>::value) {
-        expected = static_cast<T1>('a' + wg_id + n_pes);
-      }
-      else if constexpr (std::is_floating_point<T1>::value) {
+      if constexpr (std::is_floating_point<T1>::value) {
         expected = static_cast<T1>(3.14 + wg_id + n_pes);
       }
-      else if constexpr (std::is_integral<T1>::value) {
-        expected = static_cast<T1>(wg_id + n_pes);
+      else {
+        expected = static_cast<T1>('a' + wg_id + n_pes);
       }
       if (dest_buf[idx] != expected) {
         std::cerr << "Data validation error at idx " << idx << std::endl;

--- a/projects/rocshmem/tests/functional_tests/broadcast_wave_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/broadcast_wave_tester.cpp
@@ -1,0 +1,217 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+template <typename T>
+__device__ void wave_broadcast([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_unused]] rocshmem_team_t team,
+                                  [[maybe_unused]] T *dest, [[maybe_unused]] const T *source, [[maybe_unused]] int nelem,
+                                  [[maybe_unused]] int pe_root) {
+  return;
+}
+
+/* Define templates to call ROCSHMEM */
+#define BROADCAST_WAVE_DEF_GEN(T, TNAME)                                      \
+  template <>                                                                 \
+  __device__ void wave_broadcast<T>(                                       \
+      rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,    \
+      int nelem, int pe_root) {                                               \
+    rocshmem_ctx_##TNAME##_broadcast_wave(ctx, team, dest, source, nelem,     \
+                                         pe_root);                            \
+  }
+
+BROADCAST_WAVE_DEF_GEN(float, float)
+BROADCAST_WAVE_DEF_GEN(double, double)
+BROADCAST_WAVE_DEF_GEN(short, short)
+BROADCAST_WAVE_DEF_GEN(int, int)
+BROADCAST_WAVE_DEF_GEN(long, long)
+BROADCAST_WAVE_DEF_GEN(long long, longlong)
+
+rocshmem_team_t bcast_wave_world_dup;
+
+/******************************************************************************
+ * DEVICE TEST KERNEL
+ *****************************************************************************/
+template <typename T1>
+__global__ void BroadcastWaveTestKernel(int loop, int skip, long long int *start_time,
+                                  long long int *end_time, T1 *source_buf,
+                                  T1 *dest_buf, int size,
+                                  ShmemContextType ctx_type,
+                                  rocshmem_team_t *teams) {
+  __shared__ rocshmem_ctx_t ctx;
+  int wg_id = get_flat_grid_id();
+
+  rocshmem_wg_team_create_ctx(teams[wg_id], ctx_type, &ctx);
+
+  [[maybe_unused]] int n_pes = rocshmem_ctx_n_pes(ctx);
+  source_buf += wg_id * size;
+  dest_buf += wg_id * size;
+
+  __syncthreads();
+
+  for (int i = 0; i < loop + skip; i++) {
+    if (i == skip && hipThreadIdx_x == 0) {
+      start_time[wg_id] = wall_clock64();
+    }
+    if (threadIdx.x < warpSize)
+    wave_broadcast<T1>(ctx, teams[wg_id], dest_buf, source_buf, size, 0);
+  }
+
+  __syncthreads();
+
+  if (hipThreadIdx_x == 0) {
+    end_time[wg_id] = wall_clock64();
+  }
+
+  rocshmem_wg_ctx_destroy(&ctx);
+}
+
+/******************************************************************************
+ * HOST TESTER CLASS METHODS
+ *****************************************************************************/
+template <typename T1>
+BroadcastWaveTester<T1>::BroadcastWaveTester(TesterArguments args)
+    : Tester(args){
+  my_pe = rocshmem_team_my_pe(ROCSHMEM_TEAM_WORLD);
+  n_pes = rocshmem_team_n_pes(ROCSHMEM_TEAM_WORLD);
+
+  // Total number of elements in src buffer
+  int total_elems = (max_msg_size / sizeof(T1)) * args.num_wgs ;
+  int buff_size = total_elems * sizeof(T1);
+
+  source_buf = (T1 *)alloc_test_buffer(buff_size, args.local_buf_type);
+  dest_buf = (T1 *)alloc_test_buffer(buff_size);
+
+  char* value{nullptr};
+  if ((value = getenv("ROCSHMEM_MAX_NUM_TEAMS"))) {
+    num_teams = atoi(value);
+  }
+
+  CHECK_HIP(hipMalloc(&bcast_wave_world_dup,
+                      sizeof(rocshmem_team_t) * num_teams));
+}
+
+template <typename T1>
+BroadcastWaveTester<T1>::~BroadcastWaveTester() {
+  free_test_buffer(source_buf, args.local_buf_type);
+  free_test_buffer(dest_buf);
+  CHECK_HIP(hipFree(bcast_wave_world_dup));
+}
+
+template <typename T1>
+void BroadcastWaveTester<T1>::preLaunchKernel() {
+  bw_factor = n_pes;
+
+  for (int team_i = 0; team_i < num_teams; team_i++) {
+    bcast_wave_world_dup[team_i] = ROCSHMEM_TEAM_INVALID;
+    rocshmem_team_split_strided(ROCSHMEM_TEAM_WORLD, 0, 1, n_pes, nullptr, 0,
+                                 &bcast_wave_world_dup[team_i]);
+    if (bcast_wave_world_dup[team_i] == ROCSHMEM_TEAM_INVALID) {
+      printf("Team %d is invalid!\n", team_i);
+      abort();
+    }
+  }
+}
+
+template <typename T1>
+void BroadcastWaveTester<T1>::launchKernel(dim3 gridSize, dim3 blockSize,
+                                           int loop, size_t size) {
+  size_t shared_bytes = 0;
+
+  int num_elems = size / sizeof(T1);
+
+  hipLaunchKernelGGL(BroadcastWaveTestKernel<T1>, gridSize, blockSize,
+                     shared_bytes, stream, loop, args.skip,
+                     start_time, end_time, source_buf, dest_buf,
+                     num_elems, _shmem_context, bcast_wave_world_dup);
+
+  num_msgs = (loop + args.skip) * gridSize.x;
+  num_timed_msgs = loop * gridSize.x;
+}
+
+template <typename T1>
+void BroadcastWaveTester<T1>::postLaunchKernel() {
+  for (int team_i = 0; team_i < num_teams; team_i++) {
+    rocshmem_team_destroy(bcast_wave_world_dup[team_i]);
+  }
+}
+
+template <typename T1>
+void BroadcastWaveTester<T1>::resetBuffers(size_t size) {
+
+  int num_elems = size / sizeof(T1);
+  [[maybe_unused]] int buff_size = num_elems * sizeof(T1) * args.num_wgs;
+  int idx = 0;
+
+  for (unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
+    for (unsigned int i = 0; i < static_cast<unsigned int>(num_elems); i++) {
+      idx = wg_id * num_elems + i;
+      if constexpr (std::is_same<T1, char>::value ||
+                    std::is_same<T1, signed char>::value ||
+                    std::is_same<T1, unsigned char>::value) {
+        source_buf[idx] = static_cast<T1>('a' + n_pes + wg_id);
+        dest_buf[idx] = static_cast<T1>('a' + wg_id);
+      }
+      else if constexpr (std::is_floating_point<T1>::value) {
+        source_buf[idx] = static_cast<T1>(3.14 + n_pes + wg_id);
+        dest_buf[idx] = static_cast<T1>(3.14 + wg_id);
+      }
+      else if constexpr (std::is_integral<T1>::value) {
+        source_buf[idx] = static_cast<T1>(n_pes + wg_id);
+        dest_buf[idx] = static_cast<T1>(wg_id);
+      }
+    }
+  }
+}
+
+template <typename T1>
+void BroadcastWaveTester<T1>::verifyResults(size_t size) {
+
+  int num_elems = size / sizeof(T1);
+  int idx = 0;
+  T1 expected;
+
+  // Verify correctness: all PEs (including root) receive source 
+  // buffer data in dest buffer
+  for (unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
+    for (int i = 0; i < num_elems; i++) {
+      idx = wg_id * num_elems + i;
+      if constexpr (std::is_same<T1, char>::value ||
+                    std::is_same<T1, signed char>::value ||
+                    std::is_same<T1, unsigned char>::value) {
+        expected = static_cast<T1>('a' + wg_id + n_pes);
+      }
+      else if constexpr (std::is_floating_point<T1>::value) {
+        expected = static_cast<T1>(3.14 + wg_id + n_pes);
+      }
+      else if constexpr (std::is_integral<T1>::value) {
+        expected = static_cast<T1>(wg_id + n_pes);
+      }
+      if (dest_buf[idx] != expected) {
+        std::cerr << "Data validation error at idx " << idx << std::endl;
+        std::cerr << "PE " << my_pe << " Got " << dest_buf[idx]
+        << ", Expected " << expected << std::endl;
+        exit(-1);
+      }
+    }
+  }
+}

--- a/projects/rocshmem/tests/functional_tests/broadcast_wave_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/broadcast_wave_tester.cpp
@@ -110,7 +110,7 @@ BroadcastWaveTester<T1>::BroadcastWaveTester(TesterArguments args)
     num_teams = atoi(value);
   }
 
-  if (num_teams < num_warps){
+  if (num_teams < num_warps * args.num_wgs){
     printf("not enough teams for each wavefront, try increasing ROCSHMEM_MAX_NUM_TEAMS\n");
     abort();
   }

--- a/projects/rocshmem/tests/functional_tests/broadcast_wave_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/broadcast_wave_tester.cpp
@@ -65,7 +65,7 @@ __global__ void BroadcastWaveTestKernel(int loop, int skip, long long int *start
 
   int flat_wf_id = wf_id + wg_offset;
 
-  rocshmem_wg_team_create_ctx(teams[flat_wf_id], ctx_type, &ctx);
+  rocshmem_wg_ctx_create(ctx_type, &ctx);
 
   [[maybe_unused]] int n_pes = rocshmem_ctx_n_pes(ctx);
   source_buf += flat_wf_id * size;
@@ -112,7 +112,7 @@ BroadcastWaveTester<T1>::BroadcastWaveTester(TesterArguments args)
 
   if (num_teams < num_warps * args.num_wgs){
     printf("not enough teams for each wavefront, try increasing ROCSHMEM_MAX_NUM_TEAMS\n");
-    abort();
+    exit(0);
   }
 
   CHECK_HIP(hipMalloc(&bcast_wave_world_dup,

--- a/projects/rocshmem/tests/functional_tests/broadcast_wave_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/broadcast_wave_tester.hpp
@@ -1,0 +1,72 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#ifndef _BROADCAST_WAVE_TESTER_HPP_
+#define _BROADCAST_WAVE_TESTER_HPP_
+
+#include <functional>
+#include <utility>
+
+#include "tester.hpp"
+
+using namespace rocshmem;
+
+/************* *****************************************************************
+ * HOST TESTER CLASS
+ *****************************************************************************/
+template <typename T1>
+class BroadcastWaveTester : public Tester {
+ public:
+  explicit BroadcastWaveTester(TesterArguments args);
+  virtual ~BroadcastWaveTester();
+
+ protected:
+  virtual void resetBuffers(size_t size) override;
+
+  virtual void preLaunchKernel() override;
+
+  virtual void launchKernel(dim3 gridSize, dim3 blockSize, int loop,
+                            size_t size) override;
+
+  virtual void postLaunchKernel() override;
+
+  virtual void verifyResults(size_t size) override;
+
+  T1 *source_buf;
+  T1 *dest_buf;
+
+ private:
+  int my_pe = 0;
+  int n_pes = 0;
+  /**
+   * This constant should equal ROCSHMEM_MAX_NUM_TEAMS - 1.
+   * The default value for the maximum number of teams is 40.
+   */
+  int num_teams = 39;
+  rocshmem_team_t *bcast_wave_world_dup;
+};
+
+#include "broadcast_wave_tester.cpp"
+
+#endif

--- a/projects/rocshmem/tests/functional_tests/test_wrapper.sh
+++ b/projects/rocshmem/tests/functional_tests/test_wrapper.sh
@@ -203,6 +203,16 @@ if [[ "$BACKEND" == "ro" ]]; then
     esac
 fi
 
+# AIROCSHMEM-418: wave tests not supported on RO
+if [[ "$BACKEND" == "ro" ]]; then
+    case "$TEST_NAME" in
+        *_wave)
+            echo "Skip: $TEST_NAME (AIROCSHMEM-409: wave tests not supported on RO)"
+            exit $SKIP_CODE
+            ;;
+    esac
+fi
+
 # Check GPU availability
 if command -v amd-smi >/dev/null && amd-smi version 2>&1 >/dev/null; then
     NUM_GPUS=$(amd-smi list | grep GPU | wc -l)

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -79,6 +79,7 @@
 #include "host_ctx_create_tester.hpp"
 #include "team_split_2d_tester.hpp"
 #include "host_team_sync_barrier_tester.hpp"
+#include "broadcast_wave_tester.hpp"
 
 #include "backend_bc.hpp"
 extern Backend* backend;
@@ -148,6 +149,7 @@ Tester::Tester(TesterArguments args) : args(args) {
         max_msg_size = args.max_volume_size / args.num_wgs;
         break;
       case TeamBroadcastTestType:
+      case BroadcastWaveTestType:
       case TeamReductionTestType:
       case TeamReduceScatterTestType:
       case TeamFCollectTestType:
@@ -318,6 +320,13 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
       testers.push_back(new TeamBroadcastTester<double>(args));
       testers.push_back(new TeamBroadcastTester<char>(args));
       testers.push_back(new TeamBroadcastTester<unsigned char>(args));
+      break;
+    case BroadcastWaveTestType:
+      test_name = "Broadcast Wave Test";
+      testers.push_back(new BroadcastWaveTester<int>(args));
+      testers.push_back(new BroadcastWaveTester<long long>(args));
+      testers.push_back(new BroadcastWaveTester<float>(args));
+      testers.push_back(new BroadcastWaveTester<double>(args));
       break;
     case TeamAllToAllTestType:
       test_name = "Alltoall Test";
@@ -1040,6 +1049,7 @@ bool Tester::peLaunchesKernel() {
     case TileAllgatherTestType:
     case TileAllgatherWaveTestType:
     case TileAllgatherWGTestType:
+    case BroadcastWaveTestType:
       is_launcher = true;
       break;
     case HostPutmemTestType:

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -102,6 +102,7 @@ Tester::Tester(TesterArguments args) : args(args) {
     case WAVEGetNBITestType:
     case WAVEPutTestType:
     case WAVEPutNBITestType:
+    case BroadcastWaveTestType:
       num_timers = args.num_wgs * num_warps;
       break;
     default:

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -191,8 +191,9 @@
   X(HostWaitUntilAllStatus,    146)  \
   X(HostWaitUntilAnyStatus,    147)  \
   X(HostWaitUntilSomeStatus,   148)  \
-  X(TeamReduceScatter,         149)
-  
+  X(TeamReduceScatter,         149)  \
+  X(BroadcastWave,             150)
+
 #define _ROCSHMEM_ENUM_ENTRY(name, val) name##TestType = val,
 enum TestType {
   ROCSHMEM_FOREACH_TEST_TYPE(_ROCSHMEM_ENUM_ENTRY)

--- a/projects/rocshmem/utils/header_files_gen/COLL.py
+++ b/projects/rocshmem/utils/header_files_gen/COLL.py
@@ -115,6 +115,31 @@ def generate_broadcast_api():
     for type_, tname_ in types:
         expanded_code += broadcast_api(type_, tname_)
 
+    expanded_code += """
+
+/**
+ * @name ROCSHMEM_CTX_BROADCASTMEM_WG
+ * @brief Perform a broadcast between PEs in the active set. The caller
+ * is blocked until the broadcast completes.
+ *
+ * This function must be called as a work-group collective.
+ *
+ * @param[in] ctx          The ROCSHMEM context associated with this operation.
+ * @param[in] team         The team participating in the collective.
+ * @param[in] dest         Destination address. Must be an address on the
+ *                         symmetric heap.
+ * @param[in] source       Source address. Must be an address on the symmetric
+ *                         heap.
+ * @param[in] nelement     Size of buffer to participate in the broadcast.
+ * @param[in] PE_root      Root PE (relative to team) from which to broadcast.
+ * 
+ *
+ * @return void
+ */
+__device__ void rocshmem_ctx_broadcastmem_wg(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              void *dest, const void *source, int nelement, int PE_root);\n
+"""
+
     return expanded_code
 
 
@@ -295,16 +320,7 @@ def generate_broadcast_wave_api():
  * @return int; zero when sucessful, non-zero otherwise
  */\n"""
 
-    all_types = [
-        ("short", "short"),
-        ("int", "int"),
-        ("long", "long"),
-        ("long long", "longlong"),
-        ("float", "float"),
-        ("double", "double")
-    ]
-
-    for type_, tname_ in all_types:
+    for type_, tname_ in types:
         expanded_code += broadcast_wave_api(type_, tname_)
 
     expanded_code += """

--- a/projects/rocshmem/utils/header_files_gen/COLL.py
+++ b/projects/rocshmem/utils/header_files_gen/COLL.py
@@ -62,7 +62,7 @@ def generate_alltoall_api():
  * @param[in] dest         Destination address. Must be an address on the
  *                         symmetric heap.
  * @param[in] source       Source address. Must be an address on the symmetric
-                           heap.
+ *                         heap.
  * @param[in] nelems       Number of data blocks transferred per pair of PEs.
  *
  * @return void
@@ -100,15 +100,15 @@ def generate_broadcast_api():
  * @param[in] dest         Destination address. Must be an address on the
  *                         symmetric heap.
  * @param[in] source       Source address. Must be an address on the symmetric
-                           heap.
+ *                         heap.
  * @param[in] nelement     Size of the buffer to participate in the broadcast.
  * @param[in] PE_root      Zero-based ordinal of the PE, with respect to the
-                           active set, from which the data is copied
+ *                         active set, from which the data is copied
  * @param[in] PE_start     PE to start the reduction.
  * @param[in] logPE_stride Stride of PEs participating in the reduction.
  * @param[in] PE_size      Number PEs participating in the reduction.
  * @param[in] pSync        Temporary sync buffer provided to ROCSHMEM. Must
-                           be of size at least ROCSHMEM_REDUCE_SYNC_SIZE.
+ *                         be of size at least ROCSHMEM_REDUCE_SYNC_SIZE.
  *
  * @return void
  */\n"""
@@ -139,7 +139,7 @@ def generate_fcollect_api():
  * @param[in] dest         Destination address. Must be an address on the
  *                         symmetric heap.
  * @param[in] source       Source address. Must be an address on the symmetric
-                           heap.
+ *                         heap.
  * @param[in] nelems       Number of data blocks in source array.
  *
  * @return void
@@ -198,7 +198,7 @@ def generate_reduction_api():
  * @param[in] dest         Destination address. Must be an address on the
  *                         symmetric heap.
  * @param[in] source       Source address. Must be an address on the symmetric
-                           heap.
+ *                         heap.
  * @param[in] nreduce      Size of the buffer to participate in the reduction.
  *
  * @return int (Zero on successful local completion. Nonzero otherwise.)
@@ -231,14 +231,14 @@ def generate_reduce_on_stream_api():
 /**
  * @name ROCSHMEM_REDUCE_ON_STREAM
  * @brief Performs a reduction across all PEs in a team on the specified HIP
-  * stream.
+ * stream.
  *
  * @param[in] ctx          The ROCSHMEM context associated with this operation.
  * @param[in] team         The team participating in the collective.
  * @param[in] dest         Destination address. Must be an address on the
  *                         symmetric heap.
  * @param[in] source       Source address. Must be an address on the symmetric
-                           heap.
+ *                         heap.
  * @param[in] nreduce      Size of the buffer to participate in the reduction.
  * @param[in] stream       HIP stream on which the reduction is issued.
  *
@@ -287,7 +287,7 @@ def generate_broadcast_wave_api():
  * @param[in] dest         Destination address. Must be an address on the
  *                         symmetric heap.
  * @param[in] source       Source address. Must be an address on the symmetric
-                           heap.
+ *                         heap.
  * @param[in] nelement     Number of elements to participate in the broadcast.
  * @param[in] PE_root      Root PE (relative to team) from which to broadcast.
  * 
@@ -304,9 +304,32 @@ def generate_broadcast_wave_api():
         ("double", "double")
     ]
 
-
     for type_, tname_ in all_types:
         expanded_code += broadcast_wave_api(type_, tname_)
+
+    expanded_code += """
+/**
+ * @name ROCSHMEM_CTX_BROADCASTMEM_WAVE
+ * @brief Perform a broadcast between PEs in the active set. The caller
+ * is blocked until the broadcast completes.
+ *
+ * This function must be called as a wave collective.
+ *
+ * @param[in] ctx          The ROCSHMEM context associated with this operation.
+ * @param[in] team         The team participating in the collective.
+ * @param[in] dest         Destination address. Must be an address on the
+ *                         symmetric heap.
+ * @param[in] source       Source address. Must be an address on the symmetric
+ *                         heap.
+ * @param[in] nelement     Size of buffer to participate in the broadcast.
+ * @param[in] PE_root      Root PE (relative to team) from which to broadcast.
+ * 
+ *
+ * @return int; zero when successful, non-zero otherwise
+ */
+__device__ int rocshmem_ctx_broadcastmem_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,
+              void *dest, const void *source, int nelement, int PE_root);
+"""
 
     return expanded_code
 

--- a/projects/rocshmem/utils/header_files_gen/COLL.py
+++ b/projects/rocshmem/utils/header_files_gen/COLL.py
@@ -267,6 +267,49 @@ def generate_reduce_on_stream_api():
     return expanded_code
 
 
+def broadcast_wave_api(T, TNAME):
+    return (
+        f"__device__ int rocshmem_ctx_{TNAME}_broadcast_wave(rocshmem_ctx_t ctx, rocshmem_team_t team,\n"
+        f"              {T} *dest, const {T} *source, int nelement, int PE_root);\n\n"
+    )
+
+def generate_broadcast_wave_api():
+    expanded_code = """
+/**
+ * @name ROCSHMEM_CTX_TYPE_BROADCAST_WAVE
+ * @brief Perform a broadcast between PEs in the active set. The caller
+ * is blocked until the broadcast completes.
+ *
+ * This function must be called as a work-group collective.
+ *
+ * @param[in] ctx          The ROCSHMEM context associated with this operation.
+ * @param[in] team         The team participating in the collective.
+ * @param[in] dest         Destination address. Must be an address on the
+ *                         symmetric heap.
+ * @param[in] source       Source address. Must be an address on the symmetric
+                           heap.
+ * @param[in] nelement     Number of elements to participate in the broadcast.
+ * @param[in] PE_root      Root PE (relative to team) from which to broadcast.
+ * 
+ *
+ * @return int; zero when sucessful, non-zero otherwise
+ */\n"""
+
+    all_types = [
+        ("short", "short"),
+        ("int", "int"),
+        ("long", "long"),
+        ("long long", "longlong"),
+        ("float", "float"),
+        ("double", "double")
+    ]
+
+
+    for type_, tname_ in all_types:
+        expanded_code += broadcast_wave_api(type_, tname_)
+
+    return expanded_code
+
 def write_to_file(filename, content):
     with open(filename, 'w') as file:
         file.write(content)
@@ -287,7 +330,8 @@ namespace rocshmem {
         generate_broadcast_api() +
         generate_fcollect_api() +
         generate_reduction_api() +
-        generate_reduce_on_stream_api()
+        generate_reduce_on_stream_api() +
+        generate_broadcast_wave_api()
     )
 
     expanded_code += """


### PR DESCRIPTION
## Motivation

Develop `nvshmemx_##TYPE##_broadcast_warp()` and `nvshmemx_broadcastmem_warp()`to provide wave-level broadcast capabilities in rocSHMEM, matching NVSHMEM's API and semantics.

## Technical Details

Add wave-level broadcast implementation 
- `rocshmem_ctx_##TYPE##_broadcast_wave()` 
- `rocshmem_ctx_broadcastmem_wave()` 

Add broadcast mem wg
- `rocshmem_ctx_broadcastmem_wg()`

## JIRA ID

JIRA ID: AIROCSHMEM-432

## Test Plan

- [x] Use functional test to test the operation

## Test Result

- [x] Test matches broadcast_wg verification result

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
