### PR TITLE
[rocprofiler-systems] [AI-NIC] Fix missing PMC descriptions for 4 RDMA error counters

### DIFF
--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/cache_policy.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/collectors/nic/cache_policy.hpp
@@ -127,6 +127,38 @@ struct cache_policy
               trait::name<category::amd_smi_nic_tx_ucast_bytes>::description,
               LONG_DESCRIPTION, COMPONENT, "bytes", rocprofsys::trace_cache::ABSOLUTE,
               BLOCK, EXPRESSION, 0, 0, "{}" });
+
+        trace_cache::get_metadata_registry().add_pmc_info(
+            { agent_type::NIC, nic_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+              trait::name<category::amd_smi_nic_tx_rdma_ack_timeout>::value,
+              "NIC TX RDMA ACK Timeout",
+              trait::name<category::amd_smi_nic_tx_rdma_ack_timeout>::description,
+              LONG_DESCRIPTION, COMPONENT, "timeouts", rocprofsys::trace_cache::ABSOLUTE,
+              BLOCK, EXPRESSION, 0, 0, "{}" });
+
+        trace_cache::get_metadata_registry().add_pmc_info(
+            { agent_type::NIC, nic_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+              trait::name<category::amd_smi_nic_resp_tx_pkt_seq_err>::value,
+              "NIC RESP TX PKT SEQ Error",
+              trait::name<category::amd_smi_nic_resp_tx_pkt_seq_err>::description,
+              LONG_DESCRIPTION, COMPONENT, "errors", rocprofsys::trace_cache::ABSOLUTE,
+              BLOCK, EXPRESSION, 0, 0, "{}" });
+
+        trace_cache::get_metadata_registry().add_pmc_info(
+            { agent_type::NIC, nic_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+              trait::name<category::amd_smi_nic_req_rx_pkt_seq_err>::value,
+              "NIC REQ RX PKT SEQ Error",
+              trait::name<category::amd_smi_nic_req_rx_pkt_seq_err>::description,
+              LONG_DESCRIPTION, COMPONENT, "errors", rocprofsys::trace_cache::ABSOLUTE,
+              BLOCK, EXPRESSION, 0, 0, "{}" });
+
+        trace_cache::get_metadata_registry().add_pmc_info(
+            { agent_type::NIC, nic_id, TARGET_ARCH, EVENT_CODE, INSTANCE_ID,
+              trait::name<category::amd_smi_nic_req_rx_impl_nak_seq_err>::value,
+              "NIC REQ RX Impl NAK SEQ Error",
+              trait::name<category::amd_smi_nic_req_rx_impl_nak_seq_err>::description,
+              LONG_DESCRIPTION, COMPONENT, "errors", rocprofsys::trace_cache::ABSOLUTE,
+              BLOCK, EXPRESSION, 0, 0, "{}" });
     }
 
     /**


### PR DESCRIPTION
### Motivation

PR #7290 added the four RDMA error/timeout counters as tracks in
`initialize_tracks_metadata()`, but did not add the corresponding
`add_pmc_info()` calls in `initialize_pmc_metadata()`. At runtime this
caused `insert_pmc_event()` to fail silently for every sample of those
four counters:
[data_processor.cpp insert_pmc_event][warning] Insert PMC event failed! Error: non-existing PMC description agent id: , pmc name: nic_tx_rdma_ack_timeout

On a 4-node RCCL run this fired 20,832 times (5,208 per counter). The
result was zero `rocpd_info_pmc` rows and zero `pmc_event` rows for the
four counters, making them absent from the queryable counter table even
though sampling was otherwise working.
### Technical Details
Added four missing `add_pmc_info()` calls to `initialize_pmc_metadata()`
in `cache_policy.hpp`:
- `amd_smi_nic_tx_rdma_ack_timeout` — units: `"timeouts"`
- `amd_smi_nic_resp_tx_pkt_seq_err` — units: `"errors"`
- `amd_smi_nic_req_rx_pkt_seq_err` — units: `"errors"`
- `amd_smi_nic_req_rx_impl_nak_seq_err` — units: `"errors"`
`initialize_pmc_metadata()` now registers all 10 NIC PMC descriptions,
matching the 10 tracks registered by `initialize_tracks_metadata()`.

### JIRA ID

- ROCM-162
- ROCM-25722

### Test Plan

End-to-end coverage is provided in the follow-up PR (`users/ajanicijamd/ai-nic-logging-and-test`), which strengthens `ainic-rdma-rules.json` to validate all 10 NIC PMC names in the `rocpd_info_pmc_` table — the exact check that catches this regression. Verified locally with the AI NIC simulator (`SMI_NIC_SYSFS_ROOT`) against the v1.7.0 build: zero `insert_pmc_event` warnings, 10 rows in `rocpd_info_pmc_*`.

New tests will be added in https://github.com/ROCm/rocm-systems/pull/7291

## Test Result

Passed — no `Insert PMC event failed` warnings, all 10 `rocpd_info_pmc_` rows present.

## Submission Checklist
- [x] Look over the contributing guidelines at
  https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
