### PR TITLE
AIRUNTIME-2354 - Defer queue release to prevent deadlock for cu mask …

### DIFF
--- a/projects/clr/hipamd/src/hip_executionctx.cpp
+++ b/projects/clr/hipamd/src/hip_executionctx.cpp
@@ -237,7 +237,7 @@ hipError_t ExecutionCtx::recordEvent(hipEvent_t event) {
 
   // For single stream, use the existing addMarker path directly.
   if (snapshot.size() == 1) {
-    hipError_t err = e->addMarker(snapshot[0], nullptr, true);
+    hipError_t err = e->addMarker(snapshot[0], nullptr, !hip::Event::kBatchFlush);
     snapshot[0]->release();
     return err;
   }

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -221,6 +221,18 @@ Device::~Device() {
   delete xferQueue_;
   xferQueue_ = nullptr;
 
+  // Drain queues whose destroy was deferred from the async thread; safe here on
+  // the main thread before hsa_shut_down.
+  {
+    std::scoped_lock<std::mutex> lock(deferredQueueDestroyLock_);
+    for (hsa_queue_t* queue : deferredQueueDestroy_) {
+      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting deferred hardware queue %p ",
+              queue->base_address);
+      Hsa::queue_destroy(queue);
+    }
+    deferredQueueDestroy_.clear();
+  }
+
   for (auto& it : queuePool_) {
     for (auto qIter = it.begin(); qIter != it.end();) {
       hsa_queue_t* queue = qIter->first;
@@ -3438,7 +3450,7 @@ bool Device::ReleaseActiveQueue(hsa_queue_t* queue, amd::CommandQueue::Priority 
 
 // ================================================================================================
 void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMask, bool coop_queue,
-                          bool managed) {
+                          bool managed, bool defer_destroy) {
   // Defer cleanup operations outside the lock
   {  // Lock
     amd::ScopedLock l(active_queue_access_);
@@ -3462,9 +3474,19 @@ void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMas
   // hsa queues with cumask set and coop queues are not being reused. Hence, if the app uses such
   // queues, we need to destroy them when the queue is released.
   if (!cuMask.empty() || coop_queue) {
-    ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting CG enabled hardware queue %p ",
-            queue->base_address);
-    Hsa::queue_destroy(queue);
+    // Only non-coop CU-masked queues hit the blocking ~AqlQueue and can deadlock; coop queues
+    // are recycled synchronously via GWSRelease, so never defer them.
+    if (defer_destroy && !coop_queue) {
+      // Called from the async thread: defer the blocking destroy to ~Device to avoid self-deadlock.
+      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deferring CG enabled hardware queue %p destroy",
+              queue->base_address);
+      std::scoped_lock<std::mutex> lock(deferredQueueDestroyLock_);
+      deferredQueueDestroy_.push_back(queue);
+    } else {
+      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting CG enabled hardware queue %p ",
+              queue->base_address);
+      Hsa::queue_destroy(queue);
+    }
   }
 }
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -221,17 +221,8 @@ Device::~Device() {
   delete xferQueue_;
   xferQueue_ = nullptr;
 
-  // Drain queues whose destroy was deferred from the async thread; safe here on
-  // the main thread before hsa_shut_down.
-  {
-    std::scoped_lock<std::mutex> lock(deferredQueueDestroyLock_);
-    for (hsa_queue_t* queue : deferredQueueDestroy_) {
-      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting deferred hardware queue %p ",
-              queue->base_address);
-      Hsa::queue_destroy(queue);
-    }
-    deferredQueueDestroy_.clear();
-  }
+  // Final drain of deferred destroys on the main thread before hsa_shut_down.
+  DrainDeferredQueueDestroys();
 
   for (auto& it : queuePool_) {
     for (auto qIter = it.begin(); qIter != it.end();) {
@@ -3183,6 +3174,12 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
                                   bool dedicated_queue, hsa_queue_t* preferred,
                                   const std::unordered_set<uint64_t>* excluded_ids,
                                   void** metadata_ring_buffer) {
+  // App-thread context: flush queues deferred from the async thread once they
+  // reach the batch threshold, bounding live deferred queues.
+  if (DeferredQueueCount() >= kDeferredQueueDrainThreshold) {
+    DrainDeferredQueueDestroys();
+  }
+
   hsa_amd_queue_priority_t queue_priority;
   uint qIndex;
   switch (priority) {
@@ -3450,7 +3447,7 @@ bool Device::ReleaseActiveQueue(hsa_queue_t* queue, amd::CommandQueue::Priority 
 
 // ================================================================================================
 void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMask, bool coop_queue,
-                          bool managed, bool defer_destroy) {
+                          bool managed) {
   // Defer cleanup operations outside the lock
   {  // Lock
     amd::ScopedLock l(active_queue_access_);
@@ -3474,10 +3471,9 @@ void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMas
   // hsa queues with cumask set and coop queues are not being reused. Hence, if the app uses such
   // queues, we need to destroy them when the queue is released.
   if (!cuMask.empty() || coop_queue) {
-    // Only non-coop CU-masked queues hit the blocking ~AqlQueue and can deadlock; coop queues
-    // are recycled synchronously via GWSRelease, so never defer them.
-    if (defer_destroy && !coop_queue) {
-      // Called from the async thread: defer the blocking destroy to ~Device to avoid self-deadlock.
+    // On the async-events thread a non-coop ~AqlQueue self-deadlocks; defer it to an app thread.
+    // Coop queues are recycled synchronously via GWSRelease, so never defer them.
+    if (InAsyncSignalHandler() && !coop_queue) {
       ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deferring CG enabled hardware queue %p destroy",
               queue->base_address);
       std::scoped_lock<std::mutex> lock(deferredQueueDestroyLock_);
@@ -3487,6 +3483,25 @@ void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMas
               queue->base_address);
       Hsa::queue_destroy(queue);
     }
+  }
+}
+
+size_t Device::DeferredQueueCount() {
+  std::scoped_lock<std::mutex> lock(deferredQueueDestroyLock_);
+  return deferredQueueDestroy_.size();
+}
+
+void Device::DrainDeferredQueueDestroys() {
+  // Swap out the batch under lock, then destroy without holding it: queue_destroy
+  // is blocking and may run runtime callbacks.
+  std::vector<hsa_queue_t*> pending;
+  {
+    std::scoped_lock<std::mutex> lock(deferredQueueDestroyLock_);
+    pending.swap(deferredQueueDestroy_);
+  }
+  for (hsa_queue_t* queue : pending) {
+    ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting deferred hardware queue %p", queue->base_address);
+    Hsa::queue_destroy(queue);
   }
 }
 

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -669,6 +669,11 @@ class Device : public NullDevice {
 
   static constexpr int kDefaultNumaNode = -1;
 
+  //! Queues with destroy deferred from an async-handler-driven ~VirtualGPU, drained on app threads.
+  static constexpr size_t kDeferredQueueDrainThreshold = 8;
+  std::vector<hsa_queue_t*> deferredQueueDestroy_;
+  std::mutex deferredQueueDestroyLock_;
+
   bool SetSvmAttributesInt(const void* dev_ptr, size_t count, amd::MemoryAdvice advice,
                            bool first_alloc = false, bool use_cpu = false,
                            int numa_id = kDefaultNumaNode) const;
@@ -800,11 +805,6 @@ class Device : public NullDevice {
 
  public:
   std::atomic<uint> numOfVgpus_;  //!< Virtual gpu unique index
-
-  //! Queues with destroy deferred from an async-handler-driven ~VirtualGPU, drained on app threads.
-  static constexpr size_t kDeferredQueueDrainThreshold = 8;
-  std::vector<hsa_queue_t*> deferredQueueDestroy_;
-  std::mutex deferredQueueDestroyLock_;
 
   //! Returns the valid SDMA engine bitmask for the given operation type.
   uint32_t GetSdmaValidMask(HwQueueEngine engine_type) const {

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -27,8 +27,9 @@
 
 #include <atomic>
 #include <iostream>
-#include <vector>
 #include <memory>
+#include <mutex>
+#include <vector>
 
 /*! \addtogroup HSA
  *  @{
@@ -578,7 +579,7 @@ class Device : public NullDevice {
 
   //! Release HSA queue
   void releaseQueue(hsa_queue_t*, const std::vector<uint32_t>& cuMask = {}, bool coop_queue = false,
-                    bool managed = false);
+                    bool managed = false, bool defer_destroy = false);
 
   hsa_queue_t* AcquireActiveQueue(amd::CommandQueue::Priority priority,
                                    hsa_queue_t* preferred = nullptr,
@@ -792,6 +793,10 @@ class Device : public NullDevice {
 
  public:
   std::atomic<uint> numOfVgpus_;  //!< Virtual gpu unique index
+
+  //! Queues with destroy deferred from an async-handler-driven ~VirtualGPU, drained in ~Device.
+  std::vector<hsa_queue_t*> deferredQueueDestroy_;
+  std::mutex deferredQueueDestroyLock_;
 
   //! Returns the valid SDMA engine bitmask for the given operation type.
   uint32_t GetSdmaValidMask(HwQueueEngine engine_type) const {

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -579,7 +579,7 @@ class Device : public NullDevice {
 
   //! Release HSA queue
   void releaseQueue(hsa_queue_t*, const std::vector<uint32_t>& cuMask = {}, bool coop_queue = false,
-                    bool managed = false, bool defer_destroy = false);
+                    bool managed = false);
 
   hsa_queue_t* AcquireActiveQueue(amd::CommandQueue::Priority priority,
                                    hsa_queue_t* preferred = nullptr,
@@ -653,6 +653,13 @@ class Device : public NullDevice {
 
   //! Waits until all VirtualGPU QueuedAsyncHandlers are zero (30s timeout).
   void WaitForHsaAsyncHandlersIdle() override;
+
+  //! Destroy all queues whose destroy was deferred from the async-events thread.
+  //! Must only be called on an app thread (e.g. acquireQueue, ~Device).
+  void DrainDeferredQueueDestroys();
+
+  //! Current number of queues pending deferred destroy.
+  size_t DeferredQueueCount();
 
  private:
   bool create();
@@ -794,7 +801,8 @@ class Device : public NullDevice {
  public:
   std::atomic<uint> numOfVgpus_;  //!< Virtual gpu unique index
 
-  //! Queues with destroy deferred from an async-handler-driven ~VirtualGPU, drained in ~Device.
+  //! Queues with destroy deferred from an async-handler-driven ~VirtualGPU, drained on app threads.
+  static constexpr size_t kDeferredQueueDrainThreshold = 8;
   std::vector<hsa_queue_t*> deferredQueueDestroy_;
   std::mutex deferredQueueDestroyLock_;
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -374,8 +374,22 @@ void Timestamp::ExtractSignalTiming(ProfilingSignal* signal,
   signal->flags_.done_ = true;
 }
 
+// True while this thread is executing inside HsaAmdSignalHandler (the ROCr
+// async-events thread). Device::releaseQueue uses it to defer the blocking
+// queue_destroy off this thread and avoid a self-deadlock.
+namespace {
+thread_local bool tls_in_async_handler = false;
+struct AsyncHandlerScope {
+  AsyncHandlerScope() { tls_in_async_handler = true; }
+  ~AsyncHandlerScope() { tls_in_async_handler = false; }
+};
+}  // namespace
+
+bool InAsyncSignalHandler() { return tls_in_async_handler; }
+
 // ================================================================================================
 bool HsaAmdSignalHandler(hsa_signal_value_t value, void* arg) {
+  AsyncHandlerScope async_scope;
   Timestamp* ts = reinterpret_cast<Timestamp*>(arg);
 
   VirtualGPU* const gpu = ts->gpu();
@@ -403,11 +417,6 @@ bool HsaAmdSignalHandler(hsa_signal_value_t value, void* arg) {
 
   // Return false, so the callback will not be called again for this signal
   gpu->QueuedAsyncHandlers()--;
-  // If we are the last owner, defer the queue destroy: ~AqlQueue would block on
-  // this async thread waiting for a handler only this thread can dispatch.
-  if (gpu->referenceCount() == 1) {
-    gpu->SetReleaseDeferred(true);
-  }
   gpu->release();
   return false;
 }
@@ -2043,8 +2052,7 @@ VirtualGPU::~VirtualGPU() {
   }
 
   if (gpu_queue_ != nullptr) {
-    roc_device_.releaseQueue(gpu_queue_, cuMask_, cooperative_, /*managed=*/false,
-                             /*defer_destroy=*/releaseDeferred_);
+    roc_device_.releaseQueue(gpu_queue_, cuMask_, cooperative_);
   }
 
   if (hostcallBuffer_) {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -403,6 +403,11 @@ bool HsaAmdSignalHandler(hsa_signal_value_t value, void* arg) {
 
   // Return false, so the callback will not be called again for this signal
   gpu->QueuedAsyncHandlers()--;
+  // If we are the last owner, defer the queue destroy: ~AqlQueue would block on
+  // this async thread waiting for a handler only this thread can dispatch.
+  if (gpu->referenceCount() == 1) {
+    gpu->SetReleaseDeferred(true);
+  }
   gpu->release();
   return false;
 }
@@ -2038,7 +2043,8 @@ VirtualGPU::~VirtualGPU() {
   }
 
   if (gpu_queue_ != nullptr) {
-    roc_device_.releaseQueue(gpu_queue_, cuMask_, cooperative_);
+    roc_device_.releaseQueue(gpu_queue_, cuMask_, cooperative_, /*managed=*/false,
+                             /*defer_destroy=*/releaseDeferred_);
   }
 
   if (hostcallBuffer_) {

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -28,6 +28,9 @@ class Memory;
 struct ProfilingSignal;
 class Timestamp;
 
+//! True while the calling thread is inside HsaAmdSignalHandler (async-events thread).
+bool InAsyncSignalHandler();
+
 // Initial HSA signal value
 constexpr static hsa_signal_value_t kInitSignalValueOne = 1;
 
@@ -515,11 +518,6 @@ class VirtualGPU : public device::VirtualDevice {
   hsa_agent_t gpu_device() const { return gpu_device_; }
   hsa_queue_t* gpu_queue() { return gpu_queue_; }
 
-  //! Defer the blocking HSA queue_destroy to device teardown to avoid a
-  //! self-deadlock when ~VirtualGPU runs on the ROCr async-events thread.
-  void SetReleaseDeferred(bool defer) { releaseDeferred_ = defer; }
-  bool ReleaseDeferred() const { return releaseDeferred_; }
-
   //! Set the active HW queue and keep the metadata preloader in sync.
   void SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer = nullptr);
 
@@ -799,7 +797,6 @@ class VirtualGPU : public device::VirtualDevice {
   void* last_barrier_hw_event_ = nullptr;
   hsa_agent_t gpu_device_;  //!< Physical device
   hsa_queue_t* gpu_queue_;  //!< Active queue associated with a vgpu
-  bool releaseDeferred_ = false;  //!< Defer queue_destroy to device teardown (set by async handler)
   hsa_barrier_and_packet_t barrier_packet_ {};
   hsa_amd_barrier_value_packet_t barrier_value_packet_ {};
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -515,6 +515,11 @@ class VirtualGPU : public device::VirtualDevice {
   hsa_agent_t gpu_device() const { return gpu_device_; }
   hsa_queue_t* gpu_queue() { return gpu_queue_; }
 
+  //! Defer the blocking HSA queue_destroy to device teardown to avoid a
+  //! self-deadlock when ~VirtualGPU runs on the ROCr async-events thread.
+  void SetReleaseDeferred(bool defer) { releaseDeferred_ = defer; }
+  bool ReleaseDeferred() const { return releaseDeferred_; }
+
   //! Set the active HW queue and keep the metadata preloader in sync.
   void SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer = nullptr);
 
@@ -794,6 +799,7 @@ class VirtualGPU : public device::VirtualDevice {
   void* last_barrier_hw_event_ = nullptr;
   hsa_agent_t gpu_device_;  //!< Physical device
   hsa_queue_t* gpu_queue_;  //!< Active queue associated with a vgpu
+  bool releaseDeferred_ = false;  //!< Defer queue_destroy to device teardown (set by async handler)
   hsa_barrier_and_packet_t barrier_packet_ {};
   hsa_amd_barrier_value_packet_t barrier_value_packet_ {};
 

--- a/projects/hip-tests/catch/config/configs/unit/executionctx.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/executionctx.yaml
@@ -59,7 +59,6 @@ executionctx:
     <<: *level_2
   Unit_hipExecutionCtxRecordWaitEvent_Sanity:
     <<: *level_2
-    disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_hipExecutionCtxRecordEventFunctional:
     <<: *level_2
   Unit_hipExecutionCtxRecordWait_Blocking:


### PR DESCRIPTION
…queues

## Motivation
1. Self deadlock on async completion handler thread caused by recursive callbacks (HsaAmdSignalHandler in hip and DynamicQueueEventsHandler in rocr ). 
2. HsaAmdSignalHandler callback triggers a queue destroy call which calls AqlQueue destructor in rocr and deadlocks waiting for DynamicQueueEventsHandler which can't run since original callback HsaAmdSignalHandler has not finished.
3. Issue only seen when CU mask queues are released in the VirtualGPU destructor path due to async completion handler thread being the last owner.

## Technical Details
1. This change defers release of queues with CU mask when async completion handler is the last owner by using a thead_local var set in HsaAmdSignalHandler.
2.  The actual drain is done in ~Device or in acquireQueue path on main thread. 
3. a batch threshold of 8 is used to do drain in acquireQueue to avoid accumulation of multiple queues in deferred list.
4. Coop queues stay inline (recycled via non-blocking GWSRelease, so safe and
  must not be deferred).
## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
