### PR TITLE
[rocprofiler-systems] Skip shmem-pingpong tests if example binary is missing

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/test_shmem.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_shmem.py
@@ -93,10 +93,15 @@ class TestShmem(RocprofsysTest):
             pytest.param("sys_run", marks=pytest.mark.rocpd("shmem_env")),
         ],
     )
-    def test_pingpong(self, mode, shmem_env, shmem_validated, shmem_rules):
+    def test_pingpong(self, mode, shmem_env, shmem_validated, shmem_rules, rocprof_config):
         valid, reason = shmem_validated
         if not valid:
             pytest.skip(f"{reason}")
+
+        try:
+            rocprof_config.get_target_executable("shmem_pingpong")
+        except FileNotFoundError:
+            pytest.skip("shmem_pingpong binary not found")
 
         result = self.run_test(
             mode,


### PR DESCRIPTION
## Motivation

The `test_pingpong` test in `test_shmem.py` was failing in CI environments where the `shmem_pingpong` example binary had not been built or installed. Instead of a clean skip, the test would crash with an opaque `FileNotFoundError`, making it hard to distinguish a missing-binary situation from a genuine test regression.

## Technical Details

Added a pre-flight check at the start of `test_pingpong` that calls `rocprof_config.get_target_executable("shmem_pingpong")`. If the binary is absent, the test is skipped with the message `"shmem_pingpong binary not found"` rather than failing. The `rocprof_config` fixture was added to the method signature to enable this lookup. No test logic is changed for environments where the binary is present.

Changed file: `projects/rocprofiler-systems/tests/pytest/test_shmem.py`

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->
AIPROFSYST-557

## Test Plan

- [x] Verified test is skipped cleanly when `shmem_pingpong` binary is absent
- [x] Verified test still runs and passes when `shmem_pingpong` binary is present
- [x] Confirmed no other `test_shmem.py` test parametrizations are affected

## Test Result

Tests skip gracefully with `"shmem_pingpong binary not found"` when the binary is missing, rather than crashing.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.