### PR TITLE
fix (hip-tests): Fix unsafe Catch2 macros in multithreaded tests

### DIFF
--- a/projects/hip-tests/catch/unit/memory/hipMallocFromPoolAsync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMallocFromPoolAsync.cc
@@ -9,8 +9,20 @@
 #include <limits>
 
 static bool thread_results[NUMBER_OF_THREADS];
+// Detail about why a worker thread failed, reported by the parent after join.
+struct MThreadOutcome {
+  hipError_t error;   //!< First HIP error seen, hipSuccess if none
+  int iteration;      //!< Iteration the failure was seen on, -1 if none
+  int mismatchCount;  //!< Number of elements that did not match
+  int mismatchIndex;  //!< Index of the first mismatching element
+  int expected;
+  int actual;
+};
+static MThreadOutcome thread_outcome[NUMBER_OF_THREADS];
 static constexpr int streamPerAsic = 2;
 static hipMemPool_t mem_pool_common;
+// The common mempool tests operate on the default device.
+static constexpr int kCommonMpoolDevice = 0;
 
 /**
  * @addtogroup hipMallocFromPoolAsync hipMallocFromPoolAsync
@@ -178,8 +190,11 @@ static bool checkMempoolMultStreamSync(int N) {
  * for all the streams to complete and validate result.
  */
 static bool checkMempoolMultStreamConcurrentExec(int N, bool useDefStrm = true) {
-  streamMemAllocTest testObj[3] = {streamMemAllocTest(N), streamMemAllocTest(N),
-                                   streamMemAllocTest(N)};
+  // Distinct seeds: these three objects run concurrently on three streams out of
+  // one shared mempool, so their data must differ for aliasing to be detectable.
+  streamMemAllocTest testObj[3] = {streamMemAllocTest(N, false, 0),
+                                   streamMemAllocTest(N, false, 1),
+                                   streamMemAllocTest(N, false, 2)};
   // create multiple streams
   hipStream_t testStreams[3];
   HIP_CHECK(hipStreamCreate(&testStreams[0]));
@@ -473,23 +488,51 @@ static bool test_hipMallocFromPoolAsync_MThread(enum eTestValue testtype) {
 }
 
 static void thread_Test2(hipMemPool_t mempool, hipStream_t stream, int N, int threadNum) {
-  streamMemAllocTest testObj(N, true);
+  MThreadOutcome& out = thread_outcome[threadNum];
+  // The common mempool belongs to kCommonMpoolDevice. A worker thread starts on
+  // the default device, so pin it explicitly rather than relying on that.
+  hipError_t err = hipSetDevice(kCommonMpoolDevice);
+  if (err != hipSuccess) {
+    out.error = err;
+    thread_results[threadNum] = false;
+    return;
+  }
+  // Seed the data with threadNum so every thread computes different values.
+  streamMemAllocTest testObj(N, true, threadNum);
   // Create host buffer with test data
   testObj.createHostBufferWithData();
   // Use the common mempool
   testObj.useCommonMempool(mempool);
-  bool results = true;
-  for (int iter = 0; iter < LAUNCH_ITERATIONS; iter++) {
+  bool results = testObj.hasHostBufs();
+  for (int iter = 0; results && (iter < LAUNCH_ITERATIONS); iter++) {
+    out.iteration = iter;
     // Allocate memory and initialize it on stream
     testObj.allocFromMempool(stream);
+    if (!testObj.hasDevBufs()) {
+      results = false;
+      break;
+    }
     testObj.transferToMempool(stream);
     testObj.runKernel(stream);
     testObj.transferFromMempool(stream);
     testObj.freeDevBuf(stream);
     // verify and validate
-    HIP_CHECK_THREAD(hipStreamSynchronize(stream));
+    err = hipStreamSynchronize(stream);
+    if (err != hipSuccess) {
+      out.error = err;
+      results = false;
+      break;
+    }
     results = testObj.validateResultThreadSafe();
     if (!results) {
+      out.mismatchCount = testObj.mismatchCount();
+      out.mismatchIndex = testObj.mismatchIndex();
+      out.expected = testObj.mismatchExpected();
+      out.actual = testObj.mismatchActual();
+      break;
+    }
+    if (TestContext::get().hasErrorOccured()) {
+      results = false;
       break;
     }
   }
@@ -503,13 +546,15 @@ static bool test_hipMallocFromPoolAsync_MThread_CommonMpool(enum eTestValue test
   constexpr int N = 1 << 20;
   std::vector<std::thread> tests;
   hipStream_t stream[NUMBER_OF_THREADS];
+  // The pool and the streams must live on the same device
+  HIP_CHECK(hipSetDevice(kCommonMpoolDevice));
   // Create common mempool
   if (bUseDefault) {
-    HIP_CHECK(hipDeviceGetDefaultMemPool(&mem_pool_common, 0));
+    HIP_CHECK(hipDeviceGetDefaultMemPool(&mem_pool_common, kCommonMpoolDevice));
   } else {
     hipMemPoolProps pool_props{};
     pool_props.allocType = hipMemAllocationTypePinned;
-    pool_props.location.id = 0;
+    pool_props.location.id = kCommonMpoolDevice;
     pool_props.location.type = hipMemLocationTypeDevice;
     HIP_CHECK(hipMemPoolCreate(&mem_pool_common, &pool_props));
   }
@@ -521,6 +566,7 @@ static bool test_hipMallocFromPoolAsync_MThread_CommonMpool(enum eTestValue test
   // Initialize and create streams
   for (int idx = 0; idx < NUMBER_OF_THREADS; idx++) {
     thread_results[idx] = false;
+    thread_outcome[idx] = MThreadOutcome{hipSuccess, -1, 0, -1, 0, 0};
     HIP_CHECK(hipStreamCreate(&stream[idx]));
   }
   // Spawn the test threads
@@ -535,7 +581,16 @@ static bool test_hipMallocFromPoolAsync_MThread_CommonMpool(enum eTestValue test
   // Wait for thread and destroy stream
   bool status = true;
   for (int idx = 0; idx < NUMBER_OF_THREADS; idx++) {
-    status = status & thread_results[idx];
+    // Report which thread failed and why.
+    const MThreadOutcome& out = thread_outcome[idx];
+    INFO("Worker thread " << idx << ": " << (thread_results[idx] ? "pass" : "FAIL")
+                          << ", iteration " << out.iteration << " of " << LAUNCH_ITERATIONS
+                          << ", hip error: " << hipGetErrorString(out.error)
+                          << ", mismatching elements: " << out.mismatchCount << " of " << N
+                          << ", first at index " << out.mismatchIndex << " (expected "
+                          << out.expected << ", got " << out.actual << ")");
+    CHECK(thread_results[idx]);
+    status = status && thread_results[idx];
     HIP_CHECK(hipStreamDestroy(stream[idx]));
   }
   // Destroy common mempool

--- a/projects/hip-tests/catch/unit/memory/mempool_common.hh
+++ b/projects/hip-tests/catch/unit/memory/mempool_common.hh
@@ -304,10 +304,20 @@ class streamMemAllocTest {
   size_t byte_size;
   hipMemPool_t mem_pool;
   bool threadSafe;
+  int seed;  //!< Offsets this instance's data so it differs from every other instance
+  // Details of the first mismatch seen by validateResult*(), for reporting.
+  int mismatch_count = 0;
+  int mismatch_index = -1;
+  int mismatch_expected = 0;
+  int mismatch_actual = 0;
 
  public:
-  explicit streamMemAllocTest(int N, bool threadSafe = false)
-      : size(N), threadSafe(threadSafe) {
+  // @param seed makes the data of concurrent instances distinct. Instances that
+  // share a memory pool must use different seeds, otherwise every instance
+  // computes identical values and a buffer handed to two users at once produces
+  // the expected result anyway.
+  explicit streamMemAllocTest(int N, bool threadSafe = false, int seed = 0)
+      : size(N), threadSafe(threadSafe), seed(seed) {
     byte_size = N*sizeof(int);
     A_h = B_h = C_h = nullptr;
     A_d = B_d = C_d = nullptr;
@@ -328,8 +338,8 @@ class streamMemAllocTest {
     }
     // set data to host
     for (int i = 0; i < size; i++) {
-      A_h[i] = 2*i + 1;  // Odd
-      B_h[i] = 2*i;      // Even
+      A_h[i] = 2*i + 1 + seed;  // Odd, based on the seed
+      B_h[i] = 2*i;             // Even
       C_h[i] = 0;
     }
   }
@@ -362,8 +372,18 @@ class streamMemAllocTest {
       HIP_CHECK_OPT_THREAD(threadSafe, hipMemPoolSetAttribute(mem_pool, attr, &value));
     }
   }
+  // True once createHostBufferWithData() has allocated every host buffer.
+  bool hasHostBufs() const {
+    return (A_h != nullptr) && (B_h != nullptr) && (C_h != nullptr);
+  }
+  // True once allocFromMempool()/allocFromDefMempool() has allocated every device buffer.
+  bool hasDevBufs() const {
+    return (A_d != nullptr) && (B_d != nullptr) && (C_d != nullptr);
+  }
   // allocate device memory from mempool.
   void allocFromMempool(hipStream_t stream) {
+    // Reset before allocating.
+    A_d = B_d = C_d = nullptr;
     HIP_CHECK_OPT_THREAD(threadSafe, hipMallocFromPoolAsync(reinterpret_cast<void**>(&A_d),
               byte_size, mem_pool, stream));
     HIP_CHECK_OPT_THREAD(threadSafe, hipMallocFromPoolAsync(reinterpret_cast<void**>(&B_d),
@@ -380,6 +400,7 @@ class streamMemAllocTest {
   }
   // allocate from default mempool.
   void allocFromDefMempool(hipStream_t stream) {
+    A_d = B_d = C_d = nullptr;
     HIP_CHECK_OPT_THREAD(threadSafe, hipMallocAsync(reinterpret_cast<void**>(&A_d),
               byte_size, stream));
     HIP_CHECK_OPT_THREAD(threadSafe, hipMallocAsync(reinterpret_cast<void**>(&B_d),
@@ -389,6 +410,11 @@ class streamMemAllocTest {
   }
   // Execute Kernel to process input data and wait for it.
   void runKernel(hipStream_t stream) {
+    // bail out here and let the caller report the error.
+    REQUIRE_OPT_THREAD(threadSafe, hasDevBufs());
+    if (!hasDevBufs()) {
+      return;
+    }
     int blocks = (size % THREADS_PER_BLOCK == 0) ? (size / THREADS_PER_BLOCK)
                                                  : ((size / THREADS_PER_BLOCK) + 1);
     hipLaunchKernelGGL(HipTest::vectorADD, dim3(blocks), dim3(THREADS_PER_BLOCK), 0, stream,
@@ -403,6 +429,7 @@ class streamMemAllocTest {
   }
   // Validate the data returned from device.
   bool validateResult() {
+    REQUIRE(hasHostBufs());
     for (int i = 0; i < size; i++) {
       auto res = A_h[i] + B_h[i];
       REQUIRE(res == C_h[i]);
@@ -412,14 +439,28 @@ class streamMemAllocTest {
   // Thread-safe variant of validateResult(): returns a bool instead of using a
   // Catch2 macro, so it is safe to call from worker threads.
   bool validateResultThreadSafe() {
+    mismatch_count = 0;
+    mismatch_index = -1;
+    if (!hasHostBufs()) {
+      return false;
+    }
     for (int i = 0; i < size; i++) {
       auto res = A_h[i] + B_h[i];
       if (res != C_h[i]) {
-        return false;
+        if (mismatch_count == 0) {
+          mismatch_index = i;
+          mismatch_expected = res;
+          mismatch_actual = C_h[i];
+        }
+        mismatch_count++;
       }
     }
-    return true;
+    return (mismatch_count == 0);
   }
+  int mismatchCount() const { return mismatch_count; }
+  int mismatchIndex() const { return mismatch_index; }
+  int mismatchExpected() const { return mismatch_expected; }
+  int mismatchActual() const { return mismatch_actual; }
   // Free device memory
   void freeDevBuf(hipStream_t stream) {
     HIP_CHECK_OPT_THREAD(threadSafe, hipFreeAsync(reinterpret_cast<void*>(A_d), stream));
@@ -435,6 +476,7 @@ class streamMemAllocTest {
     free(A_h);
     free(B_h);
     free(C_h);
+    A_h = B_h = C_h = nullptr;
   }
 };
 

--- a/projects/hip-tests/catch/unit/multiThread/hipMultiThreadStreams1.cc
+++ b/projects/hip-tests/catch/unit/multiThread/hipMultiThreadStreams1.cc
@@ -18,14 +18,18 @@ unsigned threadsPerBlock = 256;
 // Designed to stress a small number of simple smoke tests
 
 template <typename T = float, class P = HipTest::Unpinned, class C = HipTest::Memcpy>
-void simpleVectorAdd(size_t numElements, int iters, hipStream_t stream) {
+void simpleVectorAdd(size_t numElements, int iters, hipStream_t stream, bool threadSafe = false) {
   using HipTest::MemTraits;
   size_t Nbytes = numElements * sizeof(T);
 
   T *A_d, *B_d, *C_d;
   T *A_h, *B_h, *C_h;
 
-  HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, N, P::isPinned);
+  if (threadSafe) {
+    HipTest::initArraysT(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, N, P::isPinned);
+  } else {
+    HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, N, P::isPinned);
+  }
   for (size_t i = 0; i < numElements; i++) {
     A_h[i] = 1000.0f;
     B_h[i] = 2000.0f;
@@ -52,16 +56,25 @@ void simpleVectorAdd(size_t numElements, int iters, hipStream_t stream) {
 
     hipLaunchKernelGGL(HipTest::vectorADDReverse, dim3(blocks), dim3(threadsPerBlock), 0, 0,
                        static_cast<const T*>(A_d), static_cast<const T*>(B_d), C_d, numElements);
-    HIP_CHECK(hipGetLastError());
+    HIP_CHECK_OPT_THREAD(threadSafe, hipGetLastError());
 
     MemTraits<C>::Copy(C_h, C_d, Nbytes, hipMemcpyDeviceToHost, stream);
 
     HIPCHECK(hipDeviceSynchronize());
 
-    HipTest::checkVectorADD(A_h, B_h, C_h, numElements);
+    if (threadSafe) {
+      size_t mismatchCount = HipTest::checkVectorADD(A_h, B_h, C_h, numElements, true, false);
+      REQUIRE_THREAD(mismatchCount == 0);
+    } else {
+      HipTest::checkVectorADD(A_h, B_h, C_h, numElements);
+    }
   }
 
-  HipTest::freeArrays(A_d, B_d, C_d, A_h, B_h, C_h, P::isPinned);
+  if (threadSafe) {
+    HipTest::freeArraysT(A_d, B_d, C_d, A_h, B_h, C_h, P::isPinned);
+  } else {
+    HipTest::freeArrays(A_d, B_d, C_d, A_h, B_h, C_h, P::isPinned);
+  }
   HIPCHECK(hipDeviceSynchronize());
 }
 
@@ -70,11 +83,13 @@ void test_multiThread_1(hipStream_t stream0, hipStream_t stream1, bool serialize
   size_t numElements = N;
 
   // Test 2 threads operating on same stream:
-  std::thread t1(simpleVectorAdd<T, HipTest::Pinned, C>, numElements, p_iters /*iters*/, stream0);
+  std::thread t1(simpleVectorAdd<T, HipTest::Pinned, C>, numElements, p_iters /*iters*/, stream0,
+                 true);
   if (serialize) {
     t1.join();
   }
-  std::thread t2(simpleVectorAdd<T, HipTest::Pinned, C>, numElements, p_iters /*iters*/, stream1);
+  std::thread t2(simpleVectorAdd<T, HipTest::Pinned, C>, numElements, p_iters /*iters*/, stream1,
+                 true);
   if (serialize) {
     t2.join();
   }
@@ -84,6 +99,7 @@ void test_multiThread_1(hipStream_t stream0, hipStream_t stream1, bool serialize
     t2.join();
   }
 
+  HIP_CHECK_THREAD_FINALIZE();
   HIPCHECK(hipDeviceSynchronize());
 };
 

--- a/projects/hip-tests/catch/unit/multiThread/hipMultiThreadStreams1.cc
+++ b/projects/hip-tests/catch/unit/multiThread/hipMultiThreadStreams1.cc
@@ -63,8 +63,7 @@ void simpleVectorAdd(size_t numElements, int iters, hipStream_t stream, bool thr
     HIPCHECK(hipDeviceSynchronize());
 
     if (threadSafe) {
-      size_t mismatchCount = HipTest::checkVectorADD(A_h, B_h, C_h, numElements, true, false);
-      REQUIRE_THREAD(mismatchCount == 0);
+      HipTest::checkVectorADDT(A_h, B_h, C_h, numElements);
     } else {
       HipTest::checkVectorADD(A_h, B_h, C_h, numElements);
     }

--- a/projects/hip-tests/catch/unit/multiThread/hipMultiThreadStreams2.cc
+++ b/projects/hip-tests/catch/unit/multiThread/hipMultiThreadStreams2.cc
@@ -34,7 +34,7 @@ void run1(size_t size, hipStream_t stream) {
   HIPCHECK(hipMemcpyAsync(Bh, Ah, size, hipMemcpyHostToHost, stream));
   HIPCHECK(hipMemcpyAsync(Cd, Bh, size, hipMemcpyHostToDevice, stream));
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Inc), dim3(N / 500), dim3(500), 0, stream, Cd);
-  HIP_CHECK(hipGetLastError());
+  HIPCHECK(hipGetLastError());
   HIPCHECK(hipMemcpyAsync(Dd, Cd, size, hipMemcpyDeviceToDevice, stream));
   HIPCHECK(hipMemcpyAsync(Eh, Dd, size, hipMemcpyDeviceToHost, stream));
   HIPCHECK(hipDeviceSynchronize());
@@ -76,9 +76,9 @@ void run(size_t size, hipStream_t stream1, hipStream_t stream2) {
   HIPCHECK(hipMemcpyAsync(Cd, Bh, size, hipMemcpyHostToDevice, stream1));
   HIPCHECK(hipMemcpyAsync(Cdd, Bhh, size, hipMemcpyHostToDevice, stream2));
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Inc), dim3(N / 500), dim3(500), 0, stream1, Cd);
-  HIP_CHECK(hipGetLastError());
+  HIPCHECK(hipGetLastError());
   hipLaunchKernelGGL(HIP_KERNEL_NAME(Inc), dim3(N / 500), dim3(500), 0, stream2, Cdd);
-  HIP_CHECK(hipGetLastError());
+  HIPCHECK(hipGetLastError());
   HIPCHECK(hipMemcpyAsync(Dd, Cd, size, hipMemcpyDeviceToDevice, stream1));
   HIPCHECK(hipMemcpyAsync(Ddd, Cdd, size, hipMemcpyDeviceToDevice, stream2));
   HIPCHECK(hipMemcpyAsync(Eh, Dd, size, hipMemcpyDeviceToHost, stream1));

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetDevice.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetDevice.cc
@@ -125,12 +125,13 @@ static bool validateStreamGetDevice() {
   int gpu = 0;
   hipDevice_t device_from_stream;
   hipStream_t stream;
-  HIP_CHECK(hipStreamCreate(&stream));
-  HIP_CHECK(hipStreamGetDevice(stream, &device_from_stream));
-  HIP_CHECK(hipStreamDestroy(stream));
-
-  REQUIRE(device_from_stream == gpu);
-  return true;
+  // Runs on worker threads: avoid thread-unsafe Catch2 macros. Fold the status
+  // into the return value and let the main thread validate it via REQUIRE.
+  bool res = (hipStreamCreate(&stream) == hipSuccess);
+  res = res && (hipStreamGetDevice(stream, &device_from_stream) == hipSuccess);
+  res = res && (hipStreamDestroy(stream) == hipSuccess);
+  res = res && (device_from_stream == gpu);
+  return res;
 }
 
 static void thread_Test(int threadNum) { thread_results[threadNum] = validateStreamGetDevice(); }

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetDevice.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetDevice.cc
@@ -127,10 +127,14 @@ static bool validateStreamGetDevice() {
   hipStream_t stream;
   // Runs on worker threads: avoid thread-unsafe Catch2 macros. Fold the status
   // into the return value and let the main thread validate it via REQUIRE.
-  bool res = (hipStreamCreate(&stream) == hipSuccess);
-  res = res && (hipStreamGetDevice(stream, &device_from_stream) == hipSuccess);
-  res = res && (hipStreamDestroy(stream) == hipSuccess);
+  if (hipStreamCreate(&stream) != hipSuccess) {
+    return false;
+  }
+  bool res = (hipStreamGetDevice(stream, &device_from_stream) == hipSuccess);
   res = res && (device_from_stream == gpu);
+  // Always destroy the stream once created, regardless of earlier failures, to
+  // avoid leaking it.
+  res = (hipStreamDestroy(stream) == hipSuccess) && res;
   return res;
 }
 

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetDevice.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetDevice.cc
@@ -9,7 +9,6 @@
 #include <hip_test_checkers.hh>
 
 #define NUMBER_OF_THREADS 10
-static bool thread_results[NUMBER_OF_THREADS];
 
 /**
  * @addtogroup hipStreamGetDevice hipStreamGetDevice
@@ -121,46 +120,32 @@ HIP_TEST_CASE(Unit_hipStreamGetDevice_Usecase) {
  *    - HIP_VERSION >= 5.6
  */
 
-static bool validateStreamGetDevice() {
+static void validateStreamGetDevice() {
   int gpu = 0;
   hipDevice_t device_from_stream;
   hipStream_t stream;
-  // Runs on worker threads: avoid thread-unsafe Catch2 macros. Fold the status
-  // into the return value and let the main thread validate it via REQUIRE.
-  if (hipStreamCreate(&stream) != hipSuccess) {
-    return false;
-  }
-  bool res = (hipStreamGetDevice(stream, &device_from_stream) == hipSuccess);
-  res = res && (device_from_stream == gpu);
-  // Always destroy the stream once created, regardless of earlier failures, to
-  // avoid leaking it.
-  res = (hipStreamDestroy(stream) == hipSuccess) && res;
-  return res;
+  HIP_CHECK_THREAD(hipStreamCreate(&stream));
+  HIP_CHECK_THREAD(hipStreamGetDevice(stream, &device_from_stream));
+  HIP_CHECK_THREAD(hipStreamDestroy(stream));
+
+  REQUIRE_THREAD(device_from_stream == gpu);
 }
 
-static void thread_Test(int threadNum) { thread_results[threadNum] = validateStreamGetDevice(); }
-
-static bool test_hipStreamGetDevice_MThread() {
+static void test_hipStreamGetDevice_MThread() {
   std::vector<std::thread> tests;
 
   // Spawn the test threads
   for (int idx = 0; idx < NUMBER_OF_THREADS; idx++) {
-    thread_results[idx] = false;
-    tests.push_back(std::thread(thread_Test, idx));
+    tests.push_back(std::thread(validateStreamGetDevice));
   }
   // Wait for all threads to complete
   for (std::thread& t : tests) {
     t.join();
   }
-  // Wait for thread
-  bool status = true;
-  for (int idx = 0; idx < NUMBER_OF_THREADS; idx++) {
-    status = status & thread_results[idx];
-  }
-  return status;
+  HIP_CHECK_THREAD_FINALIZE();
 }
 
-HIP_TEST_CASE(Unit_hipStreamGetDevice_MThread) { REQUIRE(true == test_hipStreamGetDevice_MThread()); }
+HIP_TEST_CASE(Unit_hipStreamGetDevice_MThread) { test_hipStreamGetDevice_MThread(); }
 
 /**
  * Test Description

--- a/projects/hip-tests/catch/unit/stream/hipStreamGetId.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamGetId.cc
@@ -133,7 +133,7 @@ void launchFunction() {
   streamIds.push_back(streamId);
   mutex.unlock();
 
-  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK_THREAD(hipStreamDestroy(stream));
 }
 
 /**

--- a/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamLegacy_Ext.cc
@@ -500,14 +500,14 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_MultiDeviceMultiOperation) {
  * Local helper function to copy data from host to device
  */
 static void copyFromHostToDevice(int* hostArr, int* devArr) {
-  HIP_CHECK(hipMemcpyAsync(devArr, hostArr, getNBytes(), hipMemcpyHostToDevice, hipStreamLegacy));
+  HIP_CHECK_THREAD(hipMemcpyAsync(devArr, hostArr, getNBytes(), hipMemcpyHostToDevice, hipStreamLegacy));
 }
 
 /*
  * Local helper function to copy data from device to host
  */
 static void copyFromDeviceToHost(int* devArr, int* hostArr) {
-  HIP_CHECK(hipMemcpyAsync(hostArr, devArr, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
+  HIP_CHECK_THREAD(hipMemcpyAsync(hostArr, devArr, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
 }
 
 /**
@@ -553,6 +553,7 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoThreadsEachOneDiffOperation) {
 
   std::thread D2H_Thread(copyFromDeviceToHost, devArr, hostArrDst);
   D2H_Thread.join();
+  HIP_CHECK_THREAD_FINALIZE();
   HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
   for (int i = 0; i < getN(); i++) {
@@ -634,8 +635,8 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoDevicesEachOneDiffOperation) {
  * Local helper function to copy data from device 0 to device 1
  */
 static void operationsInDev0(int* devArrDev0, int* devArrDev1) {
-  HIP_CHECK(hipSetDevice(0));
-  HIP_CHECK(hipMemcpyPeerAsync(devArrDev1, 1,  // des
+  HIP_CHECK_THREAD(hipSetDevice(0));
+  HIP_CHECK_THREAD(hipMemcpyPeerAsync(devArrDev1, 1,  // des
                                devArrDev0, 0,  // src
                                getNBytes(), hipStreamLegacy));
 }
@@ -644,8 +645,8 @@ static void operationsInDev0(int* devArrDev0, int* devArrDev1) {
  * Local helper function to copy data from device to host
  */
 static void operationsInDev1(int* devArrDev1, int* hostArrDst) {
-  HIP_CHECK(hipSetDevice(1));
-  HIP_CHECK(hipMemcpyAsync(hostArrDst, devArrDev1, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
+  HIP_CHECK_THREAD(hipSetDevice(1));
+  HIP_CHECK_THREAD(hipMemcpyAsync(hostArrDst, devArrDev1, getNBytes(), hipMemcpyDeviceToHost, hipStreamLegacy));
 }
 
 /**
@@ -696,6 +697,7 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoThreadsInTwoDevicesEachOneDiffOperation) {
   dev0Thread.join();
   std::thread dev1Thread(operationsInDev1, devArrDev1, hostArrDst);
   dev1Thread.join();
+  HIP_CHECK_THREAD_FINALIZE();
   HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
   for (int i = 0; i < getN(); i++) {

--- a/projects/hip-tests/catch/unit/stream/hipStreamLegacy_compiler_options.cc
+++ b/projects/hip-tests/catch/unit/stream/hipStreamLegacy_compiler_options.cc
@@ -67,14 +67,14 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_WithSptCompilerOption) {
  * Local helper function to copy data from host to device
  */
 static void copyHostToDevice(int* hostArr, int* devArr) {
-  HIP_CHECK(hipMemcpyAsync(devArr, hostArr, NBYTES, hipMemcpyHostToDevice, hipStreamLegacy));
+  HIP_CHECK_THREAD(hipMemcpyAsync(devArr, hostArr, NBYTES, hipMemcpyHostToDevice, hipStreamLegacy));
 }
 
 /*
  * Local helper function to copy data from device to host
  */
 static void copyDeviceToHost(int* devArr, int* hostArr) {
-  HIP_CHECK(hipMemcpyAsync(hostArr, devArr, NBYTES, hipMemcpyDeviceToHost, hipStreamLegacy));
+  HIP_CHECK_THREAD(hipMemcpyAsync(hostArr, devArr, NBYTES, hipMemcpyDeviceToHost, hipStreamLegacy));
 }
 
 /**
@@ -118,6 +118,7 @@ HIP_TEST_CASE(Unit_hipStreamLegacy_TwoThreadsDiffOperationWithSptCompOption) {
   H2D_Thread.join();
   std::thread D2H_Thread(copyDeviceToHost, devArr, hostArrDst);
   D2H_Thread.join();
+  HIP_CHECK_THREAD_FINALIZE();
   HIP_CHECK(hipStreamSynchronize(hipStreamLegacy));
 
   for (int i = 0; i < N; i++) {

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdTsts.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdTsts.cc
@@ -195,30 +195,30 @@ static void HIPRT_CB CallBackFunctn(hipStream_t strm, hipError_t err, void* ChkV
 static void EventSync() {
   int *Ad = nullptr, *Ah = nullptr, NumElms = 4096, CONST_NUM = 123;
   int blockSize = 32, peak_clk;
-  HIP_CHECK(hipMalloc(&Ad, NumElms * sizeof(int)));
+  HIP_CHECK_THREAD(hipMalloc(&Ad, NumElms * sizeof(int)));
   Ah = new int[NumElms];
   for (int i = 0; i < NumElms; ++i) {
     Ah[i] = CONST_NUM;
   }
   // creating event objects
   hipEvent_t start, end;
-  HIP_CHECK(hipEventCreate(&start));
-  HIP_CHECK(hipEventCreate(&end));
-  HIP_CHECK(hipMemcpy(Ad, Ah, NumElms * sizeof(int), hipMemcpyHostToDevice));
+  HIP_CHECK_THREAD(hipEventCreate(&start));
+  HIP_CHECK_THREAD(hipEventCreate(&end));
+  HIP_CHECK_THREAD(hipMemcpy(Ad, Ah, NumElms * sizeof(int), hipMemcpyHostToDevice));
   dim3 dimBlock(blockSize, 1, 1);
   dim3 dimGrid((NumElms + blockSize - 1) / blockSize, 1, 1);
-  HIP_CHECK(hipEventRecord(start, hipStreamPerThread));
+  HIP_CHECK_THREAD(hipEventRecord(start, hipStreamPerThread));
   if (IsGfx11()) {
-    HIP_CHECK(hipDeviceGetAttribute(&peak_clk, hipDeviceAttributeWallClockRate, 0));
+    HIP_CHECK_THREAD(hipDeviceGetAttribute(&peak_clk, hipDeviceAttributeWallClockRate, 0));
     StreamPerThrd_gfx11<<<dimGrid, dimBlock, 0, hipStreamPerThread>>>(Ad, NULL, NumElms, peak_clk,
                                                                       0);
   } else {
-    HIP_CHECK(hipDeviceGetAttribute(&peak_clk, hipDeviceAttributeClockRate, 0));
+    HIP_CHECK_THREAD(hipDeviceGetAttribute(&peak_clk, hipDeviceAttributeClockRate, 0));
     StreamPerThrd<<<dimGrid, dimBlock, 0, hipStreamPerThread>>>(Ad, NULL, NumElms, peak_clk, 0);
   }
-  HIP_CHECK(hipEventRecord(end, hipStreamPerThread));
-  HIP_CHECK(hipEventSynchronize(end));
-  HIP_CHECK(hipMemcpy(Ah, Ad, NumElms * sizeof(int), hipMemcpyDeviceToHost));
+  HIP_CHECK_THREAD(hipEventRecord(end, hipStreamPerThread));
+  HIP_CHECK_THREAD(hipEventSynchronize(end));
+  HIP_CHECK_THREAD(hipMemcpy(Ah, Ad, NumElms * sizeof(int), hipMemcpyDeviceToHost));
   int MisMatch = 0;
   for (int i = 0; i < NumElms; ++i) {
     if (Ah[i] != (CONST_NUM + 10)) {
@@ -226,16 +226,17 @@ static void EventSync() {
     }
   }
   delete[] Ah;
-  HIP_CHECK(hipFree(Ad));
+  HIP_CHECK_THREAD(hipFree(Ad));
   if (MisMatch) {
-    WARN("Data Mismatch observed!!\n");
+    // WARN is a thread-unsafe Catch2 macro; use printf from the worker thread.
+    printf("Data Mismatch observed!!\n");
     IfTestPassed = false;
   } else {
     IfTestPassed = true;
   }
 
-  HIP_CHECK(hipEventDestroy(start));
-  HIP_CHECK(hipEventDestroy(end));
+  HIP_CHECK_THREAD(hipEventDestroy(start));
+  HIP_CHECK_THREAD(hipEventDestroy(end));
 }
 
 /* Launch a kernel in hipStreamPerThread, while it is in flight check for
@@ -390,6 +391,7 @@ HIP_TEST_CASE(Unit_hipStreamPerThread_EvtRcrdMThrd) {
   for (auto& th : threads) {
     th.join();
   }
+  HIP_CHECK_THREAD_FINALIZE();
   REQUIRE(IfTestPassed);
 }
 

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdTsts.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThrdTsts.cc
@@ -22,6 +22,7 @@
 */
 #include <vector>
 #include <thread>
+#include <atomic>
 #include <chrono>
 #ifdef _WIN32
 #include <Windows.h>
@@ -42,7 +43,7 @@ using namespace cooperative_groups;
 #endif
 
 
-static bool IfTestPassed = false;
+static std::atomic<bool> IfTestPassed{false};
 // kernel
 __global__ void StreamPerThrd(int* Ad, int* Ad1, size_t n, int Pk_Clk, int Wait, int WaitEvnt = 0) {
   size_t index = blockIdx.x * blockDim.x + threadIdx.x;
@@ -231,8 +232,6 @@ static void EventSync() {
     // WARN is a thread-unsafe Catch2 macro; use printf from the worker thread.
     printf("Data Mismatch observed!!\n");
     IfTestPassed = false;
-  } else {
-    IfTestPassed = true;
   }
 
   HIP_CHECK_THREAD(hipEventDestroy(start));

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThread_Basic.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThread_Basic.cc
@@ -56,12 +56,13 @@ HIP_TEST_CASE(Unit_hipStreamPerThread_StreamQuery) {
   std::vector<std::thread> threads(MAX_THREAD_CNT);
 
   for (auto& th : threads) {
-    th = std::thread([]() { HIP_CHECK(hipStreamQuery(hipStreamPerThread)); });
+    th = std::thread([]() { HIP_CHECK_THREAD(hipStreamQuery(hipStreamPerThread)); });
   }
 
   for (auto& th : threads) {
     th.join();
   }
+  HIP_CHECK_THREAD_FINALIZE();
   REQUIRE(true);
 }
 
@@ -70,12 +71,13 @@ HIP_TEST_CASE(Unit_hipStreamPerThread_StreamSynchronize) {
   std::vector<std::thread> threads(MAX_THREAD_CNT);
 
   for (auto& th : threads) {
-    th = std::thread([]() { HIP_CHECK(hipStreamSynchronize(hipStreamPerThread)); });
+    th = std::thread([]() { HIP_CHECK_THREAD(hipStreamSynchronize(hipStreamPerThread)); });
   }
 
   for (auto& th : threads) {
     th.join();
   }
+  HIP_CHECK_THREAD_FINALIZE();
   REQUIRE(true);
 }
 

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThread_DeviceReset.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThread_DeviceReset.cc
@@ -28,11 +28,11 @@ static void Copy_to_device() {
   for (unsigned int i = 0; i < ele_size; ++i) {
     A_h[i] = 123;
   }
-  HIP_CHECK(
+  HIP_CHECK_THREAD(
       hipMemcpyAsync(A_d, A_h, ele_size * sizeof(int), hipMemcpyHostToDevice, hipStreamPerThread));
   // Clean up
-  HIP_CHECK(hipHostFree(A_h));
-  HIP_CHECK(hipFree(A_d));
+  HIP_CHECK_THREAD(hipHostFree(A_h));
+  HIP_CHECK_THREAD(hipFree(A_d));
 }
 
 HIP_TEST_CASE(Unit_hipStreamPerThread_DeviceReset_1) {
@@ -46,6 +46,7 @@ HIP_TEST_CASE(Unit_hipStreamPerThread_DeviceReset_1) {
     th.join();
   }
 
+  HIP_CHECK_THREAD_FINALIZE();
   HIP_CHECK(hipDeviceReset());
 }
 

--- a/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThread_MultiThread.cc
+++ b/projects/hip-tests/catch/unit/streamperthread/hipStreamPerThread_MultiThread.cc
@@ -13,17 +13,20 @@ static void Copy_to_device() {
   int* A_h = nullptr;
   int* A_d = nullptr;
 
-  HIP_CHECK(hipHostMalloc(&A_h, ele_size * sizeof(int)));
-  HIP_CHECK(hipMalloc(&A_d, ele_size * sizeof(int)));
+  // Threads are detached (no join), so there is no point to call
+  // HIP_CHECK_THREAD_FINALIZE. Use the abort-based HIPCHECK which does not touch
+  // thread-unsafe Catch2 state.
+  HIPCHECK(hipHostMalloc(&A_h, ele_size * sizeof(int)));
+  HIPCHECK(hipMalloc(&A_d, ele_size * sizeof(int)));
 
   for (unsigned int i = 0; i < ele_size; ++i) {
     A_h[i] = 123;
   }
-  HIP_CHECK(
+  HIPCHECK(
       hipMemcpyAsync(A_d, A_h, ele_size * sizeof(int), hipMemcpyHostToDevice, hipStreamPerThread));
   // Clean up
-  HIP_CHECK(hipHostFree(A_h));
-  HIP_CHECK(hipFree(A_d));
+  HIPCHECK(hipHostFree(A_h));
+  HIPCHECK(hipFree(A_d));
 }
 
 /*

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -1089,8 +1089,11 @@ class vmm_resize_class {
   void* ptrVmm;
   std::vector<hipMemGenericAllocationHandle_t> vhandle;
   std::vector<size_t> vsize;
-  // When true, use thread-safe check macros (call HIP_CHECK_THREAD_FINALIZE
-  // after joining). Set for objects constructed on worker threads.
+  // When true, the worker-thread-reachable paths (object construction via
+  // allocate_vmm() and free_vmm()) use thread-safe check macros; the caller must
+  // call HIP_CHECK_THREAD_FINALIZE after joining the worker threads. grow_vmm()
+  // is exercised only by single-threaded tests and intentionally keeps the plain
+  // Catch2 macros (it is never invoked from a worker thread).
   bool threadSafe = false;
   // allocate initial VMM memory chunk
   void allocate_vmm(hipDeviceptr_t* ptr, hipDevice_t device, size_t size) {

--- a/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
+++ b/projects/hip-tests/catch/unit/virtualMemoryManagement/hipMemSetGetAccess.cc
@@ -1089,51 +1089,54 @@ class vmm_resize_class {
   void* ptrVmm;
   std::vector<hipMemGenericAllocationHandle_t> vhandle;
   std::vector<size_t> vsize;
+  // When true, use thread-safe check macros (call HIP_CHECK_THREAD_FINALIZE
+  // after joining). Set for objects constructed on worker threads.
+  bool threadSafe = false;
   // allocate initial VMM memory chunk
-  int allocate_vmm(hipDeviceptr_t* ptr, hipDevice_t device, size_t size) {
+  void allocate_vmm(hipDeviceptr_t* ptr, hipDevice_t device, size_t size) {
     size_t granularity = 0;
     hipMemAllocationProp prop{};
     prop.type = hipMemAllocationTypePinned;
     prop.location.type = hipMemLocationTypeDevice;
     prop.location.id = device;  // Current Devices
-    HIP_CHECK(
+    HIP_CHECK_OPT_THREAD(threadSafe,
         hipMemGetAllocationGranularity(&granularity, &prop, hipMemAllocationGranularityMinimum));
-    REQUIRE(granularity > 0);
+    REQUIRE_OPT_THREAD(threadSafe, granularity > 0);
     size_t size_rounded = ((granularity + size - 1) / granularity) * granularity;
     hipMemGenericAllocationHandle_t handle;
     // Allocate physical memory
-    HIP_CHECK(hipMemCreate(&handle, size_rounded, &prop, 0));
+    HIP_CHECK_OPT_THREAD(threadSafe, hipMemCreate(&handle, size_rounded, &prop, 0));
     // Store the handle for future reference
     vhandle.push_back(handle);
     vsize.push_back(size_rounded);
     // Allocate virtual address range
-    HIP_CHECK(hipMemAddressReserve(&ptrVmm, size_rounded, 0, 0, 0));
-    HIP_CHECK(hipMemMap(ptrVmm, size_rounded, 0, handle, 0));
+    HIP_CHECK_OPT_THREAD(threadSafe, hipMemAddressReserve(&ptrVmm, size_rounded, 0, 0, 0));
+    HIP_CHECK_OPT_THREAD(threadSafe, hipMemMap(ptrVmm, size_rounded, 0, handle, 0));
     // Set access
     hipMemAccessDesc accessDesc = {};
     accessDesc.location.type = hipMemLocationTypeDevice;
     accessDesc.location.id = device;
     accessDesc.flags = hipMemAccessFlagsProtReadWrite;
     // Make the address accessible to GPU device
-    HIP_CHECK(hipMemSetAccess(ptrVmm, size_rounded, &accessDesc, 1));
+    HIP_CHECK_OPT_THREAD(threadSafe, hipMemSetAccess(ptrVmm, size_rounded, &accessDesc, 1));
     *ptr = reinterpret_cast<hipDeviceptr_t>(ptrVmm);
     current_size_tot += size;
     current_size_rounded_tot += size_rounded;
-    return 0;
   }
 
  public:
-  vmm_resize_class(hipDeviceptr_t* ptr, hipDevice_t device, size_t size)
+  vmm_resize_class(hipDeviceptr_t* ptr, hipDevice_t device, size_t size, bool threadSafe_ = false)
       : current_size_tot(0), current_size_rounded_tot(0) {
+    threadSafe = threadSafe_;
     allocate_vmm(ptr, device, size);
   }
   // Free all VMM
   void free_vmm() {
     for (hipMemGenericAllocationHandle_t& myhandle : vhandle) {
-      HIP_CHECK(hipMemRelease(myhandle));
+      HIP_CHECK_OPT_THREAD(threadSafe, hipMemRelease(myhandle));
     }
-    HIP_CHECK(hipMemUnmap(ptrVmm, current_size_rounded_tot));
-    HIP_CHECK(hipMemAddressFree(ptrVmm, current_size_rounded_tot));
+    HIP_CHECK_OPT_THREAD(threadSafe, hipMemUnmap(ptrVmm, current_size_rounded_tot));
+    HIP_CHECK_OPT_THREAD(threadSafe, hipMemAddressFree(ptrVmm, current_size_rounded_tot));
   }
   // grow memory chunk
   int grow_vmm(hipDeviceptr_t* ptr, hipDevice_t device, size_t size) {
@@ -1263,19 +1266,19 @@ void test_thread(hipDevice_t device) {
   constexpr int N = DATA_SIZE;
   size_t buffer_size = N * sizeof(int);
   // Create VMM Object of size buffer_size
-  vmm_resize_class vmmobj(&ptr, device, buffer_size);
+  vmm_resize_class vmmobj(&ptr, device, buffer_size, true);
   // Inititalize Host Buffer
   int* ptrA_h = static_cast<int*>(malloc(buffer_size));
-  REQUIRE(ptrA_h != nullptr);
+  REQUIRE_THREAD(ptrA_h != nullptr);
   for (int idx = 0; idx < N; idx++) {
     ptrA_h[idx] = idx;
   }
   // Copy to VMM
   CTX_CREATE();
-  HIP_CHECK(hipMemcpyHtoD(ptr, ptrA_h, buffer_size));
+  HIP_CHECK_THREAD(hipMemcpyHtoD(ptr, ptrA_h, buffer_size));
   int* ptrB_h = static_cast<int*>(malloc(buffer_size));
-  REQUIRE(ptrB_h != nullptr);
-  HIP_CHECK(hipMemcpyDtoH(ptrB_h, ptr, buffer_size));
+  REQUIRE_THREAD(ptrB_h != nullptr);
+  HIP_CHECK_THREAD(hipMemcpyDtoH(ptrB_h, ptr, buffer_size));
   bool bPassed = true;
   for (int idx = 0; idx < N; idx++) {
     if (ptrB_h[idx] != idx) {
@@ -1320,6 +1323,7 @@ HIP_TEST_CASE(Unit_hipMemSetAccess_Multithreaded) {
   for (int i = 0; i < NUM_THREADS; i++) {
     T[i].join();
   }
+  HIP_CHECK_THREAD_FINALIZE();
   REQUIRE(1 == bTestPassed.load());
   CTX_DESTROY();
 }


### PR DESCRIPTION
## Motivation

Catch2 assertion macros (REQUIRE/CHECK) and HIP_CHECK (which ends in REQUIRE) are not thread-safe; invoking them from worker threads corrupts Catch2 internal state and surfaces as failures/crashes under ASAN.

## Technical Details

Convert the multithreaded tests in the stream, streamperthread, module, multithread and event folders to use the thread-safe variants:

- HIP_CHECK -> HIP_CHECK_THREAD and REQUIRE/CHECK -> REQUIRE_THREAD in code paths executed by worker threads.

- Shared helpers called from both single- and multi-threaded contexts use the HIP_CHECK_OPT_THREAD / REQUIRE_OPT_THREAD wrappers with a runtime threadSafe flag.

- Add HIP_CHECK_THREAD_FINALIZE() after joining worker threads to propagate deferred failures back to Catch2.

Also add HIP_CHECK_OPT_THREAD / REQUIRE_OPT_THREAD to hip_test_common.hh.

## JIRA ID

JIRA ID : AIRUNTIME-2352

## Test Plan

Tests should pass under ASAN

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
