### PR TITLE
[RCCL] enable WarpSpeed auto for grow communicators

### DIFF
--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -1727,7 +1727,7 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     }
   }
 #ifdef ENABLE_WARP_SPEED
-  comm->topo->warpSpeedEnabled = (rcclParamWarpSpeedForceEnable() > 0 || (!parent && rcclCanUseWarpSpeedAuto(comm, nNodes)));
+  comm->topo->warpSpeedEnabled = (rcclParamWarpSpeedForceEnable() > 0 || ((!parent || comm->isGrow) && rcclCanUseWarpSpeedAuto(comm, nNodes)));
 #endif
 
   // For single node communicators that do not uses the full xgmi links per gpu, i.e., nranks < 8


### PR DESCRIPTION
## Motivation

Grow tests fail on gfx950 because WarpSpeed is never enabled on grown (child) communicators. WarpSpeed auto-detection was only applied to top-level communicators, so any communicator created via the grow path ran without it, leading to the grow test failures.

## Technical Details

In `initTransportsRank` (projects/rccl/src/init.cc), the WarpSpeed auto-enable path was gated on `!parent`, which excludes grow communicators since they are created as children. The condition is relaxed to also cover grow communicators.

The explicit force-enable (`RCCL_WARP_SPEED_FORCE_ENABLE`) behavior is unchanged; only the auto path now applies to grow communicators.

## JIRA ID

Resolves AICOMRCCL-1335

## Test Plan

Run the RCCL grow communicator tests on gfx950.

## Test Result

All Grow tests passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
