### PR TITLE
rocr: Fix coredump generation to pipes, and to file on lustrefs

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
@@ -631,9 +631,49 @@ struct LoadSegmentBuilder : public SegmentBuilder {
 
 // Write core dump to a file descriptor (for pipe handler)
 namespace {
+
+// Advance the write pointer in FD by SEEK bytes.  If FD is a regular file
+// (IS_REG_FILE is true), then use lseek(2).  Any non-written byte is
+// implicitly 0.  If FD is a pipe (IS_REG_FILE is false), then write null
+// bytes until we have advanced to the desired point.
+// When explicitly copying null bytes, use COPY_BUFFER (of size
+// COPY_BUFFER_SIZE).
+//
+// On error, return -1, with errno set to indicate the error.  On success
+// return the amount of bytes we have advanced in on the file descriptor.
+ssize_t seek_to(int fd, bool is_reg_file, size_t seek, unsigned char *copy_buffer, size_t copy_buffer_size) {
+  if (is_reg_file) {
+    // For regular files, we can skip forward (implicitly fills with 0s).
+    off_t r = lseek(fd, seek, SEEK_CUR);
+    if (r == -1) {
+      return -1;
+    }
+    return seek;
+  } else {
+    // Clear the copy buffer, so we have valid null bytes to write to the
+    // stream.
+    ::memset(copy_buffer, 0, std::min<size_t>(copy_buffer_size, seek));
+    ssize_t written = 0;
+
+    while (seek > 0) {
+      auto c = std::min<size_t>(seek, copy_buffer_size);
+      ssize_t r = write(fd, copy_buffer, c);
+      if (r == -1 && errno != EINTR) {
+          return -1;
+      }
+      if (r != -1) {
+          written += r;
+          seek -= r;
+      }
+    }
+    return written;
+  }
+}
+
 // Use size_limit of -1 for no limit (e.g, for pipes)
 hsa_status_t write_core_dump_to_fd(int fd, const SegmentsInfo& segments,
                                           size_t size_limit, bool show_progress) {
+  size_t total_written = 0;
   if (!segments.size()) return HSA_STATUS_SUCCESS;
   auto copy_buffer = std::make_unique<unsigned char[]>(MAX_BUFFER_SIZE);
   SegmentInfo front = segments.front();
@@ -675,10 +715,12 @@ hsa_status_t write_core_dump_to_fd(int fd, const SegmentsInfo& segments,
   ehdr.e_shnum = 0;
   ehdr.e_shstrndx = 0;
 
-  if (write(fd, &ehdr, sizeof(ehdr)) != sizeof(ehdr)) {
-    perror("Failed to write ELF header to pipe");
+  ssize_t r = write(fd, &ehdr, sizeof(ehdr));
+  if (r != sizeof(ehdr)) {
+    perror("Failed to write ELF header");
     return HSA_STATUS_ERROR;
   }
+  total_written += r;
 
   // Write program headers
   std::vector<Elf64_Phdr> phdrs;
@@ -718,63 +760,63 @@ hsa_status_t write_core_dump_to_fd(int fd, const SegmentsInfo& segments,
   }
 
   // Write all program headers
-  if (is_reg_file) {
-    // For regular files, use pwrite to write at specific offset
-    for (size_t i = 0; i < phdrs.size(); i++) {
-      off_t phdr_offset = sizeof(Elf64_Ehdr) + i * sizeof(Elf64_Phdr);
-      if (pwrite(fd, &phdrs[i], sizeof(Elf64_Phdr), phdr_offset) != sizeof(Elf64_Phdr)) {
-        perror("Failed to write program header");
-        return HSA_STATUS_ERROR;
-      }
+  for (const auto& phdr : phdrs) {
+    r = write(fd, &phdr, sizeof(phdr));
+    if (r != sizeof(phdr)) {
+      perror("Failed to write program header");
+      return HSA_STATUS_ERROR;
     }
-  } else {
-    // For pipes, use sequential write
-    for (const auto& phdr : phdrs) {
-      if (write(fd, &phdr, sizeof(phdr)) != sizeof(phdr)) {
-        perror("Failed to write program header to pipe");
-        return HSA_STATUS_ERROR;
-      }
-    }
+    total_written += r;
   }
 
   // Write segment data
   for (size_t idx = 0; idx < segments.size(); idx++) {
     const SegmentInfo& seg = segments[idx];
     const Elf64_Phdr& phdr = phdrs[idx];
+    // Segments must be seen in file position order.
+    assert(total_written <= phdr.p_offset);
 
-    // Check if this segment would exceed size limit
-    if (size_limit != -1 && (phdr.p_offset + phdr.p_filesz > size_limit)) {
-      if (show_progress) {
-        fprintf(stderr, "Core file size limit reached, truncating at segment %zu\n", idx);
+    // There might be padding between two consecutive sections.  Insert the
+    // necessary padding to respect the desired alignment.
+    if (total_written < phdr.p_offset) {
+      r = seek_to(fd, is_reg_file, phdr.p_offset - total_written,
+                  copy_buffer.get (), MAX_BUFFER_SIZE);
+      if (r < 0) {
+        perror("Failed to write to the core dump");
+        return HSA_STATUS_ERROR;
       }
-      // Stop writing segments but return success - we wrote valid headers
-      return HSA_STATUS_SUCCESS;
+      total_written += r;
     }
+    assert(total_written == phdr.p_offset);
 
     size_t remaining = phdr.p_filesz;
     while (remaining > 0) {
+      assert(total_written == phdr.p_offset + phdr.p_filesz - remaining);
       size_t curr_chunk = std::min(remaining, MAX_BUFFER_SIZE);
+
+      // Check if this segment would exceed size limit.  If so stop where we
+      // are.
+      if (size_limit != -1 && (total_written + curr_chunk > size_limit)) {
+        if (show_progress) {
+          fprintf(stderr, "Core file size limit reached, truncating at segment %zu\n", idx);
+        }
+        // Stop writing segments but return success - we wrote valid headers
+        // and data so far.
+        return HSA_STATUS_SUCCESS;
+      }
+
       hsa_status_t st = seg.builder->Read(copy_buffer.get(), curr_chunk,
                                           phdr.p_vaddr + phdr.p_filesz - remaining);
       if (st != HSA_STATUS_SUCCESS) {
         return st;
       }
 
-      if (is_reg_file) {
-        // For regular files, use pwrite to write at specific offset
-        if (pwrite(fd, copy_buffer.get(), curr_chunk,
-            phdr.p_offset + phdr.p_filesz - remaining) !=
-                                                        (ssize_t)curr_chunk) {
-          perror("Failed to write segment data");
-          return HSA_STATUS_ERROR;
-        }
-      } else {
-        // For pipes, use sequential write
-        if (write(fd, copy_buffer.get(), curr_chunk) != (ssize_t)curr_chunk) {
-          perror("Failed to write segment data to pipe");
-          return HSA_STATUS_ERROR;
-        }
+      r = write(fd, copy_buffer.get(), curr_chunk);
+      if (r != (ssize_t)curr_chunk) {
+        perror("Failed to write segment data");
+        return HSA_STATUS_ERROR;
       }
+      total_written += r;
       remaining -= curr_chunk;
     }
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/lnx/amd_core_dump.cpp
@@ -644,7 +644,6 @@ hsa_status_t write_core_dump_to_fd(int fd, const SegmentsInfo& segments,
     return HSA_STATUS_SUCCESS;
   }
 
-  // Use posix_fallocate for regular files
   struct stat fd_stat;
   bool is_reg_file = false;
   if (fstat(fd, &fd_stat) == 0 && S_ISREG(fd_stat.st_mode)) {
@@ -679,14 +678,6 @@ hsa_status_t write_core_dump_to_fd(int fd, const SegmentsInfo& segments,
   if (write(fd, &ehdr, sizeof(ehdr)) != sizeof(ehdr)) {
     perror("Failed to write ELF header to pipe");
     return HSA_STATUS_ERROR;
-  }
-
-  if (is_reg_file) {
-    int error = posix_fallocate(fd, sizeof(Elf64_Ehdr), segments.size() * sizeof(Elf64_Phdr));
-    if (error != 0) {
-      fprintf(stderr, "Failed to allocate file: %s\n", strerror(error));
-      return HSA_STATUS_ERROR;
-    }
   }
 
   // Write program headers
@@ -758,14 +749,6 @@ hsa_status_t write_core_dump_to_fd(int fd, const SegmentsInfo& segments,
       }
       // Stop writing segments but return success - we wrote valid headers
       return HSA_STATUS_SUCCESS;
-    }
-
-    if (is_reg_file) {
-      int error = posix_fallocate(fd, phdr.p_offset, phdr.p_filesz);
-      if (error != 0) {
-        fprintf(stderr, "Failed to allocate file: %s\n", strerror(error));
-        return HSA_STATUS_ERROR;
-      }
     }
 
     size_t remaining = phdr.p_filesz;


### PR DESCRIPTION
## Motivation

This PR addresses 2 issues, with one series.

It was reported that coredump generation does not work on some file systems, such as [lustre](https://www.lustre.org/) (quite popular on HPC environments).

The ROCr runtime also has the ability to pipe the core dump content to a custom program.  However, coredumps produced that way are invalid, as reported by failed ROCgdb testsuite when exercising this functionality.

## Technical Details

For the lustre issue, it is caused by uses of the `posix_fallocate` call.  This is not supported on lustre.  Those call is not necessary anyway, drop them.

For the second issue, it is caused by the runtime failing to insert the required padding between sections.  As a result, section contents end up at invalid offsets in the coredump.  See the second patch of the series for further details.

## JIRA ID

- ROCM-25819
- AILIROCR-521

## Test Plan

Validate using ROCgdb's testsuite.  Testing coredump dumped to pipes requires to use https://github.com/ROCm/ROCgdb/pull/160.

## Test Result

Pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
