### PR TITLE
[rocprofiler-systems]: Fix sampling rate for Roctx tests

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/test_roctx.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_roctx.py
@@ -134,8 +134,13 @@ class TestROCTx(RocprofsysTest):
         self,
         roctx_env: dict[str, str],
         roctx_rules: list[Path],
+        gpu_info,
     ):
         env = roctx_env.copy()
+        if "apu" in gpu_info.categories:
+            # APUs share host memory and report metrics less frequently, so
+            # increase the process sampling rate to capture enough amd-smi samples.
+            env["ROCPROFSYS_PROCESS_SAMPLING_FREQ"] = "1000"
         categories = ["rocm_marker_api"]
         if env["ROCPROFSYS_TRACE_LEGACY"] == "ON":
             labels = self.roctx_legacy_labels()

--- a/projects/rocprofiler-systems/tests/pytest/test_roctx.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_roctx.py
@@ -29,6 +29,7 @@ def roctx_env() -> dict[str, str]:
         "ROCPROFSYS_TRACE_LEGACY": "ON",
         "ROCPROFSYS_ROCM_DOMAINS": "hip_runtime_api,marker_api,kernel_dispatch",
         "ROCPROFSYS_AMD_SMI_METRICS": "busy,temp,power,mem_usage,gfx_clock,mem_clock",
+        "ROCPROFSYS_PROCESS_SAMPLING_FREQ": "1000",
     }
 
 
@@ -134,13 +135,8 @@ class TestROCTx(RocprofsysTest):
         self,
         roctx_env: dict[str, str],
         roctx_rules: list[Path],
-        gpu_info,
     ):
         env = roctx_env.copy()
-        if "apu" in gpu_info.categories:
-            # APUs share host memory and report metrics less frequently, so
-            # increase the process sampling rate to capture enough amd-smi samples.
-            env["ROCPROFSYS_PROCESS_SAMPLING_FREQ"] = "1000"
         categories = ["rocm_marker_api"]
         if env["ROCPROFSYS_TRACE_LEGACY"] == "ON":
             labels = self.roctx_legacy_labels()


### PR DESCRIPTION
## Motivation

The roctx sampling test intermittently fails on APUs with "Less than expected number of captured amd-smi samples" because the example runs for too short a wall-clock time to collect enough samples. At the default 100 Hz, capturing exactly 5 samples implies the workload's effective lifetime was only ~50 ms.

## Technical Details

- Set `ROCPROFSYS_PROCESS_SAMPLING_FREQ=1000` in the shared `roctx_env` fixture so all `roctx` tests run the process sampler at the maximum rate, increasing the number of amd-smi samples captured during the short-lived workload.

- Follow-up worth noting: the `roctx` example is too small to be a robust source of sampling data. A more durable fix would extend the workload's runtime (e.g. an iteration/duration argument), but that requires parameterizing the marker count/depth expectations the test asserts, so it's deliberately out of scope here.

## JIRA ID

AIPROFSYST-555

## Test Plan

Manual test verification on `gfx1151`.

## Test Result

255: E   ✅ Validation query passed for 'rocpd_pmc_event_7a795ddcb72e04e543006561c4fd3393': Check for amd-smi GFX busy samples
255: E   ⏭️  Skipping 'Check for amd-smi UMC busy samples' on 'rocpd_pmc_event_7a795ddcb72e04e543006561c4fd3393' (requires 'umc_activity', not available)
255: E   ⏭️  Skipping 'Check for amd-smi MM busy samples' on 'rocpd_pmc_event_7a795ddcb72e04e543006561c4fd3393' (requires 'mm_activity', not available)
255: E   ❌ ERROR: Less than expected number of captured amd-smi-temperature samples! (Table: 'rocpd_pmc_event_7a795ddcb72e04e543006561c4fd3393')
255: E      Expected: greater_than 5, Got: 0
255: E   ✅ Validation query passed for 'rocpd_pmc_event_7a795ddcb72e04e543006561c4fd3393': Check for amd-smi monitoring GPU power consumption
255: E   ✅ Validation query passed for 'rocpd_pmc_event_7a795ddcb72e04e543006561c4fd3393': Check for amd-smi monitoring GPU memory usage

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
