### PR TITLE
Recognize GFX11 wildcard bundles in rocm-bootstrap

### DIFF
--- a/python/rocm-bootstrap/README.md
+++ b/python/rocm-bootstrap/README.md
@@ -39,18 +39,18 @@ gfx1100
 
 $ rocm-bootstrap-detect --hierarchy
 gfx1201 gfx12_0 gfx12
-gfx1100 gfx11_0 gfx11
+gfx1100 gfx110x gfx11
 
 $ rocm-bootstrap-detect --verbose
 Detected 2 AMD GPU(s):
 
   Node 1: gfx1201  major=12 minor=0 stepping=1  PCI=0x7550
-    sub-family: gfx12_0 (GFX12.0 (RDNA 4))  generic: gfx12-generic
-    family: gfx12 (GFX12)
+    sub-family: gfx12_0 (RDNA4)  generic: gfx12-generic
+    family: gfx12 (RDNA4)
 
   Node 2: gfx1100  major=11 minor=0 stepping=0  PCI=0x7448
-    sub-family: gfx11_0 (GFX11.0 (RDNA 3))
-    family: gfx11 (GFX11 (RDNA 3))  generic: gfx11-generic
+    sub-family: gfx110x (RDNA3)
+    family: gfx11 (RDNA3)  generic: gfx11-generic
 ```
 
 ### Environment variables
@@ -86,7 +86,7 @@ from rocm_bootstrap import packaging_chain, lookup_target
 
 target_b, sf_b, fam_b = packaging_chain("gfx1151")
 # target_b.key  = "gfx1151"   (PackagingLevel.TARGET)
-# sf_b.key      = "gfx11_5"   (PackagingLevel.SUB_FAMILY)
+# sf_b.key      = "gfx115x"   (PackagingLevel.SUB_FAMILY)
 # fam_b.key     = "gfx11"     (PackagingLevel.FAMILY)
 ```
 
@@ -98,8 +98,8 @@ from rocm_bootstrap import lookup_target, lookup_bundle
 t = lookup_target("gfx942")
 # GfxTarget(name='gfx942', major=9, minor=4, stepping=2, xnack=SUPPORTED)
 
-b = lookup_bundle("gfx11_5")
-# TargetBundle(key='gfx11_5', level=SUB_FAMILY, ...)
+b = lookup_bundle("gfx115x")
+# TargetBundle(key='gfx115x', level=SUB_FAMILY, ...)
 # b.members -> (gfx1150, gfx1151, gfx1152, gfx1153)
 # b.llvm_generic -> None  (gfx11-generic is at family level)
 ```
@@ -113,7 +113,7 @@ families = all_bundles(PackagingLevel.FAMILY)
 # 4 bundles: gfx9, gfx10, gfx11, gfx12
 
 sub_families = all_bundles(PackagingLevel.SUB_FAMILY)
-# 9 bundles: gfx9_0, gfx9_4, gfx9_5, gfx10_1, ...
+# 9 bundles: gfx9_0, gfx9_4, gfx9_5, gfx10_1, gfx110x, ...
 ```
 
 ### Package naming
@@ -121,13 +121,13 @@ sub_families = all_bundles(PackagingLevel.SUB_FAMILY)
 ```python
 from rocm_bootstrap import bundle_names, device_dist_name, lookup_bundle
 
-b = lookup_bundle("gfx11_5")
+b = lookup_bundle("gfx12_5")
 names = bundle_names(b)
-# names.dist_name   = "gfx11-5"   (pip/wheel safe)
-# names.module_name = "gfx11_5"   (Python identifier)
+# names.dist_name   = "gfx12-5"   (pip/wheel safe)
+# names.module_name = "gfx12_5"   (Python identifier)
 
 device_dist_name("rocm-sdk-device", b)
-# "rocm-sdk-device-gfx11-5"
+# "rocm-sdk-device-gfx12-5"
 ```
 
 ### Sysfs decoding

--- a/python/rocm-bootstrap/python/rocm_bootstrap/naming.py
+++ b/python/rocm-bootstrap/python/rocm_bootstrap/naming.py
@@ -29,10 +29,10 @@ class PackageNames:
     Attributes:
         dist_name: Name safe for Python distribution/wheel usage.
             Lowercase, uses hyphens as separators.
-            E.g., ``"gfx11-5"``, ``"gfx942"``.
+            E.g., ``"gfx12-5"``, ``"gfx942"``.
         module_name: Name safe for Python identifiers/modules.
             Uses underscores, no hyphens, no leading digits.
-            E.g., ``"gfx11_5"``, ``"gfx942"``.
+            E.g., ``"gfx12_5"``, ``"gfx942"``.
     """
 
     dist_name: str
@@ -63,8 +63,8 @@ def device_dist_name(prefix: str, bundle: TargetBundle) -> str:
 
     Examples::
 
-        device_dist_name("rocm-sdk-device", bundle_gfx11_5)
-        # -> "rocm-sdk-device-gfx11-5"
+        device_dist_name("rocm-sdk-device", bundle_gfx12_5)
+        # -> "rocm-sdk-device-gfx12-5"
 
         device_dist_name("amd-torch-device", bundle_gfx942)
         # -> "amd-torch-device-gfx942"
@@ -87,8 +87,8 @@ def device_module_name(prefix: str, bundle: TargetBundle) -> str:
 
     Examples::
 
-        device_module_name("rocm_sdk_device", bundle_gfx11_5)
-        # -> "rocm_sdk_device_gfx11_5"
+        device_module_name("rocm_sdk_device", bundle_gfx12_5)
+        # -> "rocm_sdk_device_gfx12_5"
 
     Args:
         prefix: Module name prefix (e.g., ``"rocm_sdk_device"``).

--- a/python/rocm-bootstrap/python/rocm_bootstrap/targets.py
+++ b/python/rocm-bootstrap/python/rocm_bootstrap/targets.py
@@ -10,7 +10,7 @@ literals derived from LLVM's canonical definitions:
 
 Every GFX target maps to a 3-level packaging hierarchy:
   target     -> sub-family -> family
-  gfx1151    -> gfx11_5    -> gfx11
+  gfx1151    -> gfx115x    -> gfx11
 
 Packages can exist at any level. A complete installation uses packages
 from all applicable levels (some may be empty/omitted).
@@ -18,7 +18,6 @@ from all applicable levels (some may be empty/omitted).
 
 from dataclasses import dataclass
 from enum import Enum
-
 
 # ---------------------------------------------------------------------------
 # Public types
@@ -73,7 +72,7 @@ class PackagingLevel(Enum):
     """Level in the 3-tier packaging hierarchy."""
 
     FAMILY = "family"  # gfx11   (major only)
-    SUB_FAMILY = "sub_family"  # gfx11_5 (major + minor)
+    SUB_FAMILY = "sub_family"  # gfx115x or gfx12_5 (major + minor)
     TARGET = "target"  # gfx1151 (specific)
 
 
@@ -81,16 +80,16 @@ class PackagingLevel(Enum):
 class TargetBundle:
     """A named group of targets at one level of the packaging hierarchy.
 
-    Bundles are structural — derived from the GFX version number encoding:
+    Bundles are structural groups derived from the GFX version number encoding:
 
     * **Family**: all targets sharing a major version.
     * **Sub-family**: all targets sharing major + minor.
     * **Target**: one specific target.
 
     Attributes:
-        key: Python module-safe identifier (e.g., ``"gfx11_5"``).
-            Uses underscores. The corresponding dist-safe name replaces
-            ``_`` with ``-`` (e.g., ``"gfx11-5"``).
+        key: Python module-safe identifier (e.g., ``"gfx115x"`` or
+            ``"gfx12_5"``). The corresponding dist-safe name replaces ``_``
+            with ``-`` (e.g., ``"gfx12-5"``).
         level: Which tier of the hierarchy this bundle represents.
         display_name: Human-readable label (e.g., ``"GFX11.5 (RDNA 3.5)"``).
         llvm_generic: LLVM generic target name if one covers this level
@@ -461,16 +460,16 @@ BUNDLE_GFX10_3 = TargetBundle(
     members=(GFX1030, GFX1031, GFX1032, GFX1033, GFX1034, GFX1035, GFX1036),
 )
 
-BUNDLE_GFX11_0 = TargetBundle(
-    key="gfx11_0",
+BUNDLE_GFX110X = TargetBundle(
+    key="gfx110x",
     level=_SF,
     display_name="RDNA3",
     llvm_generic=None,
     members=(GFX1100, GFX1101, GFX1102, GFX1103),
 )
 
-BUNDLE_GFX11_5 = TargetBundle(
-    key="gfx11_5",
+BUNDLE_GFX115X = TargetBundle(
+    key="gfx115x",
     level=_SF,
     display_name="RDNA3.5",
     llvm_generic=None,
@@ -611,8 +610,8 @@ ALL_SUB_FAMILIES: tuple[TargetBundle, ...] = (
     BUNDLE_GFX9_5,
     BUNDLE_GFX10_1,
     BUNDLE_GFX10_3,
-    BUNDLE_GFX11_0,
-    BUNDLE_GFX11_5,
+    BUNDLE_GFX110X,
+    BUNDLE_GFX115X,
     BUNDLE_GFX12_0,
     BUNDLE_GFX12_5,
 )
@@ -621,8 +620,15 @@ ALL_SUB_FAMILIES: tuple[TargetBundle, ...] = (
 _FAMILY_TO_SUB_FAMILIES: dict[str, tuple[TargetBundle, ...]] = {
     "gfx9": (BUNDLE_GFX9_0, BUNDLE_GFX9_4, BUNDLE_GFX9_5),
     "gfx10": (BUNDLE_GFX10_1, BUNDLE_GFX10_3),
-    "gfx11": (BUNDLE_GFX11_0, BUNDLE_GFX11_5),
+    "gfx11": (BUNDLE_GFX110X, BUNDLE_GFX115X),
     "gfx12": (BUNDLE_GFX12_0, BUNDLE_GFX12_5),
+}
+
+# Legacy sub-family keys retained for callers that used the structural
+# major_minor spelling before the ROCm package naming converged on gfx*X.
+_BUNDLE_KEY_ALIASES: dict[str, str] = {
+    "gfx11_0": "gfx110x",
+    "gfx11_5": "gfx115x",
 }
 
 
@@ -702,6 +708,12 @@ def _build_lookups() -> None:
         for sf in sfs:
             _FAMILY_BY_SUB_FAMILY[sf.key] = fam
 
+    # Register compatibility aliases after canonical keys are present.
+    for alias, canonical_key in _BUNDLE_KEY_ALIASES.items():
+        if alias in _BUNDLE_BY_KEY:
+            raise RuntimeError(f"Bundle alias {alias} conflicts with a canonical key")
+        _BUNDLE_BY_KEY[alias] = _BUNDLE_BY_KEY[canonical_key]
+
 
 _build_lookups()
 
@@ -738,7 +750,7 @@ def lookup_bundle(key: str) -> TargetBundle:
     Works for all levels (family, sub-family, target).
 
     Args:
-        key: Bundle key (e.g., ``"gfx11"``, ``"gfx11_5"``, ``"gfx1151"``).
+        key: Bundle key (e.g., ``"gfx11"``, ``"gfx115x"``, ``"gfx1151"``).
 
     Returns:
         The :class:`TargetBundle` instance.
@@ -767,7 +779,7 @@ def packaging_chain(
 
         packaging_chain("gfx1151") == (
             TargetBundle("gfx1151", TARGET, ...),
-            TargetBundle("gfx11_5", SUB_FAMILY, ...),
+            TargetBundle("gfx115x", SUB_FAMILY, ...),
             TargetBundle("gfx11", FAMILY, ...),
         )
 
@@ -823,14 +835,15 @@ def all_bundles(level: PackagingLevel | None = None) -> tuple[TargetBundle, ...]
     Returns:
         Tuple of :class:`TargetBundle` instances.
     """
+    target_bundles = tuple(_BUNDLE_BY_KEY[t.name] for t in ALL_TARGETS)
     if level is None:
-        return tuple(_BUNDLE_BY_KEY.values())
+        return ALL_FAMILIES + ALL_SUB_FAMILIES + target_bundles
     if level == PackagingLevel.FAMILY:
         return ALL_FAMILIES
     if level == PackagingLevel.SUB_FAMILY:
         return ALL_SUB_FAMILIES
     # TARGET level
-    return tuple(b for b in _BUNDLE_BY_KEY.values() if b.level == PackagingLevel.TARGET)
+    return target_bundles
 
 
 def parse_gfx_target_version(gtv: int) -> GfxTarget:

--- a/python/rocm-bootstrap/python/rocm_bootstrap/tests/test_detect.py
+++ b/python/rocm-bootstrap/python/rocm_bootstrap/tests/test_detect.py
@@ -21,7 +21,6 @@ from rocm_bootstrap.targets import (
 )
 from rocm_bootstrap.tests.conftest import FakePlatform
 
-
 # ---------------------------------------------------------------------------
 # KFD properties parser unit tests
 # ---------------------------------------------------------------------------
@@ -276,7 +275,7 @@ class TestCliHierarchy:
     def test_single_gpu(self, fake_platform: FakePlatform, capsys):
         fake_platform.add_gpu_node(1, lookup_target("gfx1151"))
         main(["--hierarchy"])
-        assert capsys.readouterr().out == "gfx1151 gfx11_5 gfx11\n"
+        assert capsys.readouterr().out == "gfx1151 gfx115x gfx11\n"
 
     def test_no_gpus(self, fake_platform: FakePlatform, capsys):
         main(["--hierarchy"])
@@ -308,7 +307,7 @@ class TestCliVerbose:
         main(["-v"])
         out = capsys.readouterr().out
         assert "gfx1151" in out
-        assert "gfx11_5" in out
+        assert "gfx115x" in out
         assert "gfx11" in out
         assert "sub-family" in out
         assert "family" in out

--- a/python/rocm-bootstrap/python/rocm_bootstrap/tests/test_naming.py
+++ b/python/rocm-bootstrap/python/rocm_bootstrap/tests/test_naming.py
@@ -24,7 +24,6 @@ from rocm_bootstrap.targets import (
     lookup_bundle,
 )
 
-
 # ---------------------------------------------------------------------------
 # Explicit naming expectations for each bundle level
 # ---------------------------------------------------------------------------
@@ -56,8 +55,8 @@ class TestSubFamilyNames:
             ("gfx9_5", "gfx9-5", "gfx9_5"),
             ("gfx10_1", "gfx10-1", "gfx10_1"),
             ("gfx10_3", "gfx10-3", "gfx10_3"),
-            ("gfx11_0", "gfx11-0", "gfx11_0"),
-            ("gfx11_5", "gfx11-5", "gfx11_5"),
+            ("gfx110x", "gfx110x", "gfx110x"),
+            ("gfx115x", "gfx115x", "gfx115x"),
             ("gfx12_0", "gfx12-0", "gfx12_0"),
             ("gfx12_5", "gfx12-5", "gfx12_5"),
         ],
@@ -146,12 +145,13 @@ class TestDeviceDistName:
         "prefix,key,expected",
         [
             ("rocm-sdk-device", "gfx11", "rocm-sdk-device-gfx11"),
-            ("rocm-sdk-device", "gfx11_5", "rocm-sdk-device-gfx11-5"),
+            ("rocm-sdk-device", "gfx115x", "rocm-sdk-device-gfx115x"),
             ("rocm-sdk-device", "gfx1151", "rocm-sdk-device-gfx1151"),
             ("rocm-sdk-device", "gfx9_4", "rocm-sdk-device-gfx9-4"),
             ("rocm-sdk-device", "gfx942", "rocm-sdk-device-gfx942"),
             ("rocm-sdk-device", "gfx90a", "rocm-sdk-device-gfx90a"),
             ("amd-torch-device", "gfx1100", "amd-torch-device-gfx1100"),
+            ("amd-torch-device", "gfx110x", "amd-torch-device-gfx110x"),
             ("amd-torch-device", "gfx12_0", "amd-torch-device-gfx12-0"),
         ],
     )
@@ -174,7 +174,7 @@ class TestDeviceModuleName:
         "prefix,key,expected",
         [
             ("rocm_sdk_device", "gfx11", "rocm_sdk_device_gfx11"),
-            ("rocm_sdk_device", "gfx11_5", "rocm_sdk_device_gfx11_5"),
+            ("rocm_sdk_device", "gfx115x", "rocm_sdk_device_gfx115x"),
             ("rocm_sdk_device", "gfx1151", "rocm_sdk_device_gfx1151"),
             ("rocm_sdk_device", "gfx9_4", "rocm_sdk_device_gfx9_4"),
             ("rocm_sdk_device", "gfx90a", "rocm_sdk_device_gfx90a"),
@@ -202,7 +202,7 @@ class TestDeviceModuleName:
 class TestIsValidDistName:
     @pytest.mark.parametrize(
         "name",
-        ["gfx11", "gfx9-4", "rocm-sdk-device-gfx11-5", "my.package", "a"],
+        ["gfx11", "gfx9-4", "rocm-sdk-device-gfx115x", "my.package", "a"],
     )
     def test_valid(self, name):
         assert is_valid_dist_name(name)
@@ -218,7 +218,7 @@ class TestIsValidDistName:
 class TestIsValidModuleName:
     @pytest.mark.parametrize(
         "name",
-        ["gfx11", "gfx9_4", "rocm_sdk_device_gfx11_5", "_private", "a"],
+        ["gfx11", "gfx9_4", "rocm_sdk_device_gfx115x", "_private", "a"],
     )
     def test_valid(self, name):
         assert is_valid_module_name(name)

--- a/python/rocm-bootstrap/python/rocm_bootstrap/tests/test_targets.py
+++ b/python/rocm-bootstrap/python/rocm_bootstrap/tests/test_targets.py
@@ -19,7 +19,6 @@ from rocm_bootstrap.targets import (
     parse_gfx_target_version,
 )
 
-
 # ---------------------------------------------------------------------------
 # Hierarchy structure invariants
 # ---------------------------------------------------------------------------
@@ -253,12 +252,19 @@ class TestLookupBundle:
         assert b.level == PackagingLevel.FAMILY
 
     def test_sub_family(self):
-        b = lookup_bundle("gfx11_5")
+        b = lookup_bundle("gfx115x")
         assert b.level == PackagingLevel.SUB_FAMILY
 
     def test_target(self):
         b = lookup_bundle("gfx1151")
         assert b.level == PackagingLevel.TARGET
+
+    @pytest.mark.parametrize(
+        "alias,canonical_key",
+        [("gfx11_0", "gfx110x"), ("gfx11_5", "gfx115x")],
+    )
+    def test_legacy_sub_family_aliases(self, alias, canonical_key):
+        assert lookup_bundle(alias) is lookup_bundle(canonical_key)
 
     def test_unknown_raises(self):
         with pytest.raises(ValueError, match="Unknown bundle key"):
@@ -274,8 +280,8 @@ class TestPackagingChain:
     @pytest.mark.parametrize(
         "target_name,expected_sf_key,expected_fam_key",
         [
-            ("gfx1151", "gfx11_5", "gfx11"),
-            ("gfx1100", "gfx11_0", "gfx11"),
+            ("gfx1151", "gfx115x", "gfx11"),
+            ("gfx1100", "gfx110x", "gfx11"),
             ("gfx942", "gfx9_4", "gfx9"),
             ("gfx950", "gfx9_5", "gfx9"),
             ("gfx90a", "gfx9_0", "gfx9"),
@@ -318,7 +324,7 @@ class TestBundleForTarget:
 
     def test_sub_family_level(self):
         b = bundle_for_target("gfx1151", PackagingLevel.SUB_FAMILY)
-        assert b.key == "gfx11_5"
+        assert b.key == "gfx115x"
 
     def test_family_level(self):
         b = bundle_for_target("gfx1151", PackagingLevel.FAMILY)
@@ -380,12 +386,12 @@ class TestLLVMGenericAssignments:
     def test_gfx11_family_has_gfx11_generic(self):
         assert lookup_bundle("gfx11").llvm_generic == "gfx11-generic"
 
-    def test_gfx11_0_no_generic(self):
+    def test_gfx110x_no_generic(self):
         """gfx11-generic is at family level, not sub-family."""
-        assert lookup_bundle("gfx11_0").llvm_generic is None
+        assert lookup_bundle("gfx110x").llvm_generic is None
 
-    def test_gfx11_5_no_generic(self):
-        assert lookup_bundle("gfx11_5").llvm_generic is None
+    def test_gfx115x_no_generic(self):
+        assert lookup_bundle("gfx115x").llvm_generic is None
 
     def test_gfx12_0_has_gfx12_generic(self):
         assert lookup_bundle("gfx12_0").llvm_generic == "gfx12-generic"

--- a/shared/kpack/python/rocm_kpack/database_handlers.py
+++ b/shared/kpack/python/rocm_kpack/database_handlers.py
@@ -12,7 +12,6 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional, List
 
-
 # Compile regex patterns once at module level
 # Matches architecture IDs like gfx908, gfx90a, gfx942-xnack+, gfx90a-xnack-
 # Note: Tensile filenames use hyphens (gfx90a-xnack+), not colons (gfx90a:xnack+)
@@ -178,19 +177,21 @@ class AotritonHandler(DatabaseHandler):
     AOTriton ships precompiled kernel images in per-architecture directories:
         lib/aotriton.images/amd-gfx942/flash/attn_fwd/kernel.aks2
         lib/aotriton.images/amd-gfx11xx/flash/bwd_kernel_dk_dv/kernel.aks2
+        lib/aotriton.images/amd-gfx110x/flash/bwd_kernel_dk_dv/kernel.aks2
 
-    Architecture directories use family names (gfx11xx, gfx120x) for ISA
-    families, and specific chip names (gfx942, gfx90a, gfx950) for others.
+    Architecture directories use family/sub-family names (gfx11xx, gfx110x,
+    gfx115x, gfx120x) for shared ISA assets, and specific chip names
+    (gfx942, gfx90a, gfx950) for others.
 
     Returns bundle keys from the rocm-bootstrap hierarchy:
-        gfx11xx → gfx11 (family), gfx120x → gfx12_0 (sub-family),
-        gfx942 → gfx942 (target), etc.
+        gfx11xx → gfx11 (family), gfx110x → gfx110x (sub-family),
+        gfx120x → gfx12_0 (sub-family), gfx942 → gfx942 (target), etc.
     """
 
     # Mapping from aotriton directory suffixes to rocm-bootstrap bundle keys.
-    # Entries are only needed for family/sub-family patterns that differ from
-    # the raw directory name. Target-level names (gfx942, gfx90a, etc.) pass
-    # through unchanged since they are already valid bundle keys.
+    # Entries are only needed for patterns that differ from the raw directory
+    # name. Already-valid keys (gfx110x, gfx942, gfx90a, etc.) pass through
+    # unchanged.
     _BUNDLE_MAP = {
         "gfx11xx": "gfx11",
         "gfx120x": "gfx12_0",
@@ -206,7 +207,7 @@ class AotritonHandler(DatabaseHandler):
         Pattern: */aotriton.images/amd-gfx*/...
 
         Returns:
-            Bundle key (e.g., 'gfx11', 'gfx12_0', 'gfx942') or None.
+            Bundle key (e.g., 'gfx11', 'gfx110x', 'gfx12_0', 'gfx942') or None.
         """
         path_str = self._relative_path(path, prefix_root)
         path_parts = Path(path_str).parts

--- a/shared/kpack/tests/test_database_handlers.py
+++ b/shared/kpack/tests/test_database_handlers.py
@@ -105,8 +105,7 @@ class TestRocBLASHandler:
     def test_detect_arch_subdir_co(self, handler, prefix_root):
         """Per-arch subdirectory layout: .co file under library/<arch>/."""
         file_path = (
-            prefix_root
-            / "lib/rocblas/library/gfx942/TensileLibrary_Type_HH_gfx942.co"
+            prefix_root / "lib/rocblas/library/gfx942/TensileLibrary_Type_HH_gfx942.co"
         )
         file_path.parent.mkdir(parents=True)
         file_path.touch()
@@ -128,9 +127,7 @@ class TestRocBLASHandler:
 
     def test_detect_arch_subdir_manifest(self, handler, prefix_root):
         """Per-arch subdirectory layout: TensileManifest.txt under library/<arch>/."""
-        file_path = (
-            prefix_root / "lib/rocblas/library/gfx90a/TensileManifest.txt"
-        )
+        file_path = prefix_root / "lib/rocblas/library/gfx90a/TensileManifest.txt"
         file_path.parent.mkdir(parents=True)
         file_path.touch()
 
@@ -139,10 +136,7 @@ class TestRocBLASHandler:
 
     def test_detect_arch_subdir_xnack(self, handler, prefix_root):
         """Per-arch subdirectory layout with xnack variant."""
-        file_path = (
-            prefix_root
-            / "lib/rocblas/library/gfx942-xnack+/TensileLibrary.co"
-        )
+        file_path = prefix_root / "lib/rocblas/library/gfx942-xnack+/TensileLibrary.co"
         file_path.parent.mkdir(parents=True)
         file_path.touch()
 
@@ -284,9 +278,7 @@ class TestHipBLASLtHandler:
 
     def test_detect_arch_subdir_manifest(self, handler, prefix_root):
         """Per-arch subdirectory layout: manifest .txt under library/<arch>/."""
-        file_path = (
-            prefix_root / "lib/hipblaslt/library/gfx1100/TensileManifest.txt"
-        )
+        file_path = prefix_root / "lib/hipblaslt/library/gfx1100/TensileManifest.txt"
         file_path.parent.mkdir(parents=True)
         file_path.touch()
 
@@ -444,6 +436,7 @@ class TestAotritonHandler:
 
         Family/sub-family patterns are mapped to bundle keys:
             gfx11xx → gfx11, gfx120x → gfx12_0.
+            gfx110x and gfx115x are already valid sub-family bundle keys.
         Target names pass through unchanged.
         """
         test_cases = [
@@ -451,6 +444,8 @@ class TestAotritonHandler:
             ("amd-gfx942", "gfx942"),
             ("amd-gfx950", "gfx950"),
             ("amd-gfx11xx", "gfx11"),
+            ("amd-gfx110x", "gfx110x"),
+            ("amd-gfx115x", "gfx115x"),
             ("amd-gfx120x", "gfx12_0"),
         ]
 

--- a/shared/kpack/tests/test_wheel_splitter.py
+++ b/shared/kpack/tests/test_wheel_splitter.py
@@ -31,7 +31,6 @@ from rocm_kpack.wheel_splitter import (
     parse_wheel_identity,
 )
 
-
 # =============================================================================
 # Fixtures
 # =============================================================================
@@ -244,6 +243,19 @@ class TestGenerateDeviceMetadata:
         # gfx12_0 becomes gfx12-0 in dist name (underscore to hyphen)
         assert "Name: amd-torch-device-gfx12-0" in metadata
 
+    def test_gfx11_sub_family_level(self):
+        identity = WheelIdentity(
+            name="torch",
+            version="2.10.0+rocm7.1",
+            python_tag="cp313",
+            abi_tag="cp313",
+            platform_tag="manylinux_2_28_x86_64",
+            dist_info_name="torch-2.10.0+rocm7.1.dist-info",
+        )
+        metadata = generate_device_metadata(identity, "gfx110x", "amd-torch-device", [])
+        assert "Name: amd-torch-device-gfx110x" in metadata
+        assert "Summary: AMD device kernels (RDNA3)" in metadata
+
     def test_with_device_requires_dist(self):
         identity = WheelIdentity(
             name="torch",
@@ -344,7 +356,13 @@ class TestBundleKeyToDistName:
         )
 
     def test_sub_family_level(self):
-        # Underscore in bundle key becomes hyphen in dist name
+        assert (
+            _bundle_key_to_dist_name("amd-torch-device", "gfx110x")
+            == "amd-torch-device-gfx110x"
+        )
+
+    def test_structural_sub_family_level(self):
+        # Underscore in bundle key becomes hyphen in dist name.
         assert (
             _bundle_key_to_dist_name("amd-torch-device", "gfx12_0")
             == "amd-torch-device-gfx12-0"
@@ -448,7 +466,7 @@ class TestRewriteHostMetadata:
     def test_chain_with_family_wheel(self, tmp_path: Path):
         staging, identity = self._make_host_staging(tmp_path)
         splitter = self._make_splitter()
-        # gfx1100 chain: gfx1100 -> gfx11_0 -> gfx11
+        # gfx1100 chain: gfx1100 -> gfx110x -> gfx11
         # If gfx11 and gfx1100 both have device wheels:
         splitter._rewrite_host_metadata(staging, identity, {"gfx1100", "gfx11"})
 
@@ -469,6 +487,25 @@ class TestRewriteHostMetadata:
         )
         assert (
             'Requires-Dist: amd-torch-device-gfx1100 == 2.10.0+rocm7.1; extra == "device-all"'
+            in metadata
+        )
+
+    def test_chain_with_gfx110x_wheel(self, tmp_path: Path):
+        staging, identity = self._make_host_staging(tmp_path)
+        splitter = self._make_splitter()
+        splitter._rewrite_host_metadata(staging, identity, {"gfx1100", "gfx110x"})
+
+        metadata = (staging / identity.dist_info_name / "METADATA").read_text()
+        assert (
+            'Requires-Dist: amd-torch-device-gfx1100 == 2.10.0+rocm7.1; extra == "device-gfx1100"'
+            in metadata
+        )
+        assert (
+            'Requires-Dist: amd-torch-device-gfx110x == 2.10.0+rocm7.1; extra == "device-gfx1100"'
+            in metadata
+        )
+        assert (
+            'Requires-Dist: amd-torch-device-gfx110x == 2.10.0+rocm7.1; extra == "device-all"'
             in metadata
         )
 


### PR DESCRIPTION
Newer PyTorch wheels carry shared device assets under gfx110x and gfx115x bundle keys, introduced with splitting the existing gfx11 package in AOTriton 0.12b. So far, rocm-bootstrap only exposed the structural gfx11_0 and gfx11_5 keys, so kpack failed while rewriting split wheel metadata when it asked rocm-bootstrap to resolve gfx110x or gfx115x.

This patch makes the wildcard GFX11 sub-family keys canonical, while keeping the old structural keys as lookup aliases, and keeping `all_bundles()` to enumerate only canonical bundles. Furthermore, extents the wheel-splitter tests for the pass-through the gfx110x/gfx115x path.

Resolves https://github.com/ROCm/TheRock/issues/5858.

Assisted-by: Codex <codex@openai.com>