### PR TITLE
[rocprofiler-compute] Update CI to use new tarballs and output TheRock manifest

### DIFF
--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -158,6 +158,10 @@ jobs:
           echo "ROCm installed to: ${{ env.ROCM_PATH }}"
           echo "✅ ROCm Installation Complete!"
 
+      - name: Output TheRock Manifest
+        run: |
+          cat ${{ env.ROCM_PATH }}/share/therock/therock_manifest.json
+
       - name: Install Python Requirements
         working-directory: projects/rocprofiler-compute
         run: |

--- a/.github/workflows/rocprofiler-compute-ghcr.yml
+++ b/.github/workflows/rocprofiler-compute-ghcr.yml
@@ -1,4 +1,4 @@
-name: Publish GHCR Packages for rocprofiler-compute CI Images
+name: rocprofiler-compute GHCR Packages for CI Images
 
 on:
   workflow_dispatch:
@@ -80,22 +80,6 @@ jobs:
           fi
           echo "docker_file=${DOCKER_FILE}" >> $GITHUB_OUTPUT
 
-      - name: Get the latest build of The Rock tarball
-        id: therock
-        run: |
-          sudo apt-get install -y python3-pip
-          python3 -m pip install -U pip
-          python3 -m pip install -U awscli
-          export PATH=~/.local/bin:$PATH
-          KEY=$(aws s3api list-objects-v2 \
-                --bucket therock-nightly-tarball \
-                --no-sign-request \
-                --output json \
-                --query "sort_by(Contents[?contains(Key, 'linux-${{ matrix.gpu }}')], &LastModified)[-1].Key")
-          KEY=${KEY//\"/}
-          test -n "$KEY" || { echo "No ${{ matrix.gpu }} tarball found"; exit 1; }
-          echo "tarball=${KEY}" >> $GITHUB_OUTPUT
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
@@ -113,7 +97,6 @@ jobs:
             DISTRO=${{ steps.setup_vars_gfx.outputs.distro_image }}
             VERSION=${{ matrix.system.version }}
             GPU_TYPE=${{ matrix.gpu }}
-            GPU_TARBALL=${{ steps.therock.outputs.tarball }}
           tags: |
             ghcr.io/rocm/rocprofiler-${{ matrix.system.distro }}:${{ matrix.system.version }}-compute-ci-${{ matrix.gpu }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -130,7 +113,6 @@ jobs:
             DISTRO=${{ steps.setup_vars_gfx.outputs.distro_image }}
             VERSION=${{ matrix.system.version }}
             GPU_TYPE=${{ matrix.gpu }}
-            GPU_TARBALL=${{ steps.therock.outputs.tarball }}
           tags: |
             ghcr.io/rocm/rocprofiler-${{ matrix.system.distro }}:${{ matrix.system.version }}-compute-ci-${{ matrix.gpu }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/projects/rocprofiler-compute/docker/Dockerfile.opensuse.ci
+++ b/projects/rocprofiler-compute/docker/Dockerfile.opensuse.ci
@@ -30,16 +30,17 @@ RUN zypper --non-interactive update -y && \
 
 # The Rock Tarball
 ARG GPU_TYPE=""
-ARG GPU_TARBALL=""
-RUN if [ -n "$GPU_TYPE" ] && [ -n "$GPU_TARBALL" ]; then \
-        VERSION=$(echo "$GPU_TARBALL" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
-        if [ -z "$VERSION" ]; then \
-            echo "Error: Could not extract version from GPU_TARBALL ('$GPU_TARBALL')." >&2; \
-            exit 1; \
-        fi; \
-        python3 -m pip install -U awscli; \
-        aws s3 cp "s3://therock-nightly-tarball/${GPU_TARBALL}" rocm-${VERSION}-${GPU_TYPE}.tar.gz --no-sign-request; \
-        mv rocm-${VERSION}-${GPU_TYPE}.tar.gz /opt/rocm-${VERSION}-${GPU_TYPE}.tar.gz; \
+RUN if [ -n "${GPU_TYPE}" ]; then \
+        TARBALL=$(curl -fsSL "https://rocm.nightlies.amd.com/tarball-multi-arch/" | \
+            grep -oE "\"name\": \"therock-dist-linux-${GPU_TYPE}-[^\"]+\", \"mtime\": [0-9.]+" | \
+            sort -t' ' -k4 -g | \
+            tail -1 | \
+            sed 's/.*"name": "\([^"]*\)".*/\1/'); \
+        test -n "${TARBALL}" || { echo "Error: no therock-dist-linux-${GPU_TYPE}-* tarball found" >&2; exit 1; }; \
+        VERSION=$(echo "${TARBALL}" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
+        test -n "${VERSION}" || { echo "Error: could not extract version from '${TARBALL}'" >&2; exit 1; }; \
+        curl -fSL "https://rocm.nightlies.amd.com/tarball-multi-arch/${TARBALL}" \
+            -o "/opt/rocm-${VERSION}-${GPU_TYPE}.tar.gz"; \
     fi
 
 WORKDIR /home

--- a/projects/rocprofiler-compute/docker/Dockerfile.rhel.ci
+++ b/projects/rocprofiler-compute/docker/Dockerfile.rhel.ci
@@ -23,16 +23,17 @@ RUN yum groupinstall -y "Development Tools" && \
 
 # The Rock Tarball
 ARG GPU_TYPE=""
-ARG GPU_TARBALL=""
-RUN if [ -n "$GPU_TYPE" ] && [ -n "$GPU_TARBALL" ]; then \
-        VERSION=$(echo "$GPU_TARBALL" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
-        if [ -z "$VERSION" ]; then \
-            echo "Error: Could not extract version from GPU_TARBALL ('$GPU_TARBALL')." >&2; \
-            exit 1; \
-        fi; \
-        python3 -m pip install -U awscli; \
-        aws s3 cp "s3://therock-nightly-tarball/${GPU_TARBALL}" rocm-${VERSION}-${GPU_TYPE}.tar.gz --no-sign-request; \
-        mv rocm-${VERSION}-${GPU_TYPE}.tar.gz /opt/rocm-${VERSION}-${GPU_TYPE}.tar.gz; \
+RUN if [ -n "${GPU_TYPE}" ]; then \
+        TARBALL=$(curl -fsSL "https://rocm.nightlies.amd.com/tarball-multi-arch/" | \
+            grep -oE "\"name\": \"therock-dist-linux-${GPU_TYPE}-[^\"]+\", \"mtime\": [0-9.]+" | \
+            sort -t' ' -k4 -g | \
+            tail -1 | \
+            sed 's/.*"name": "\([^"]*\)".*/\1/'); \
+        test -n "${TARBALL}" || { echo "Error: no therock-dist-linux-${GPU_TYPE}-* tarball found" >&2; exit 1; }; \
+        VERSION=$(echo "${TARBALL}" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
+        test -n "${VERSION}" || { echo "Error: could not extract version from '${TARBALL}'" >&2; exit 1; }; \
+        curl -fSL "https://rocm.nightlies.amd.com/tarball-multi-arch/${TARBALL}" \
+            -o "/opt/rocm-${VERSION}-${GPU_TYPE}.tar.gz"; \
     fi
 
 WORKDIR /home

--- a/projects/rocprofiler-compute/docker/Dockerfile.ubuntu.ci
+++ b/projects/rocprofiler-compute/docker/Dockerfile.ubuntu.ci
@@ -38,17 +38,17 @@ RUN OS_VERSION=$(grep '^VERSION_ID=' /etc/os-release | cut -d'=' -f2 | tr -d '"'
 
 # The Rock Tarball
 ARG GPU_TYPE=""
-ARG GPU_TARBALL=""
-RUN if [ -n "$GPU_TYPE" ] && [ -n "$GPU_TARBALL" ]; then \
-        VERSION=$(echo "$GPU_TARBALL" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
-        if [ -z "$VERSION" ]; then \
-            echo "Error: Could not extract version from GPU_TARBALL ('$GPU_TARBALL')." >&2; \
-            exit 1; \
-        fi; \
-        pip install --upgrade pip; \
-        pip install awscli --break-system-packages; \
-        aws s3 cp "s3://therock-nightly-tarball/${GPU_TARBALL}" rocm-${VERSION}-${GPU_TYPE}.tar.gz --no-sign-request; \
-        mv rocm-${VERSION}-${GPU_TYPE}.tar.gz /opt/rocm-${VERSION}-${GPU_TYPE}.tar.gz; \
+RUN if [ -n "${GPU_TYPE}" ]; then \
+        TARBALL=$(curl -fsSL "https://rocm.nightlies.amd.com/tarball-multi-arch/" | \
+            grep -oE "\"name\": \"therock-dist-linux-${GPU_TYPE}-[^\"]+\", \"mtime\": [0-9.]+" | \
+            sort -t' ' -k4 -g | \
+            tail -1 | \
+            sed 's/.*"name": "\([^"]*\)".*/\1/'); \
+        test -n "${TARBALL}" || { echo "Error: no therock-dist-linux-${GPU_TYPE}-* tarball found" >&2; exit 1; }; \
+        VERSION=$(echo "${TARBALL}" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
+        test -n "${VERSION}" || { echo "Error: could not extract version from '${TARBALL}'" >&2; exit 1; }; \
+        curl -fSL "https://rocm.nightlies.amd.com/tarball-multi-arch/${TARBALL}" \
+            -o "/opt/rocm-${VERSION}-${GPU_TYPE}.tar.gz"; \
     fi
 
 ENV LC_ALL=C.UTF-8


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Output version information on TheRock tarball after extraction, update tarball fetch logic to use new indexes instead of old index that is no longer maintained.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated `.github/workflows/rocprofiler-compute-continuous-integration.yml` to output therock_manifest.json
- Updated `.github/workflows/rocprofiler-ghcr.yml` to remove GPU_TARBALL key logic
- Updated `Dockerifle.*.ci` files in `rocprofiler-systems/docker` directory to use CloudFront instead of AWS API to fetch latest tarball

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Ensure new images build and lead to no regressions due to newer version
  - https://github.com/ROCm/rocm-systems/actions/runs/27835239447
- Ensure that therock_manifest.json contains the latest changes

## Test Result

<!-- Briefly summarize test outcomes. -->
- Tests pass, new tarball contains latest rocm-systems submodule

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
