### PR TITLE
Preserve wheel member permissions during spliting

### DIFF
--- a/shared/kpack/python/rocm_kpack/wheel_splitter.py
+++ b/shared/kpack/python/rocm_kpack/wheel_splitter.py
@@ -15,6 +15,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import time
 import zipfile
 from collections import defaultdict
@@ -406,6 +407,32 @@ def zip_wheel(source_dir: Path, output_path: Path) -> None:
                 zf.write(file_path, arcname)
 
 
+def _extract_wheel_preserving_permissions(
+    wheel_path: Path, destination_dir: Path
+) -> None:
+    """Extract a wheel while restoring Unix mode bits from zip metadata.
+
+    Python's zipfile extraction intentionally does not apply the Unix mode bits
+    stored in ZipInfo.external_attr. Wheels can contain executables, so restore
+    those bits before later copy/repack steps preserve the extracted tree.
+    """
+    deferred_directory_modes: list[tuple[Path, int]] = []
+    with zipfile.ZipFile(wheel_path, "r") as zf:
+        for member in zf.infolist():
+            extracted_path = Path(zf.extract(member, destination_dir))
+            mode = stat.S_IMODE(member.external_attr >> 16)
+            if mode == 0:
+                continue
+            if member.is_dir():
+                deferred_directory_modes.append((extracted_path, mode))
+            else:
+                extracted_path.chmod(mode)
+
+    for directory_path, mode in deferred_directory_modes:
+        if directory_path.exists():
+            directory_path.chmod(mode)
+
+
 def _extract_single_binary(
     fat_binary_path: Path,
     overlay_relative_path: str,
@@ -685,8 +712,7 @@ class WheelSplitter:
             temp_dir.mkdir()
             if self.verbose:
                 print(f"Extracting {input_path} to {temp_dir}")
-            with zipfile.ZipFile(input_path, "r") as zf:
-                zf.extractall(temp_dir)
+            _extract_wheel_preserving_permissions(input_path, temp_dir)
             return temp_dir, True
         else:
             raise InvalidWheelError(

--- a/shared/kpack/tests/test_wheel_splitter.py
+++ b/shared/kpack/tests/test_wheel_splitter.py
@@ -34,7 +34,6 @@ from rocm_kpack.wheel_splitter import (
     zip_wheel,
 )
 
-
 # =============================================================================
 # Fixtures
 # =============================================================================
@@ -674,12 +673,23 @@ class TestGenerateRecord:
 
 
 class TestWheelArchivePermissions:
-    def test_extract_and_repack_preserves_exact_executable_mode(self, tmp_path: Path):
+    def test_extract_and_repack_preserves_exact_executable_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         from rocm_kpack.binutils import Toolchain
 
         input_wheel = tmp_path / "input.whl"
         executable_path = "torch/bin/torch_shm_manager"
         plain_path = "torch/__init__.py"
+        extracted_root = input_wheel.parent / (input_wheel.stem + ".tmp_extract")
+        chmod_calls: dict[str, int] = {}
+        path_type = type(tmp_path)
+        original_chmod = path_type.chmod
+
+        def recording_chmod(self: Path, mode: int) -> None:
+            chmod_calls[self.relative_to(extracted_root).as_posix()] = mode
+            if os.name != "nt":
+                original_chmod(self, mode)
 
         with zipfile.ZipFile(input_wheel, "w") as zf:
             executable_info = zipfile.ZipInfo(executable_path)
@@ -689,6 +699,8 @@ class TestWheelArchivePermissions:
             plain_info = zipfile.ZipInfo(plain_path)
             plain_info.external_attr = (stat.S_IFREG | 0o640) << 16
             zf.writestr(plain_info, b"# torch\n")
+
+        monkeypatch.setattr(path_type, "chmod", recording_chmod)
 
         splitter = WheelSplitter(
             device_package_prefix="amd-torch-device",
@@ -707,6 +719,12 @@ class TestWheelArchivePermissions:
             zip_wheel(extracted_dir, output_wheel)
         finally:
             shutil.rmtree(extracted_dir)
+
+        assert chmod_calls[executable_path] == 0o751
+        assert chmod_calls[plain_path] == 0o640
+
+        if os.name == "nt":
+            return
 
         with zipfile.ZipFile(output_wheel, "r") as zf:
             output_executable_mode = stat.S_IMODE(

--- a/shared/kpack/tests/test_wheel_splitter.py
+++ b/shared/kpack/tests/test_wheel_splitter.py
@@ -712,8 +712,11 @@ class TestWheelArchivePermissions:
 
         try:
             extracted_executable = extracted_dir / executable_path
-            assert stat.S_IMODE(extracted_executable.stat().st_mode) == 0o751
-            assert stat.S_IMODE((extracted_dir / plain_path).stat().st_mode) == 0o640
+            if os.name != "nt":
+                assert stat.S_IMODE(extracted_executable.stat().st_mode) == 0o751
+                assert (
+                    stat.S_IMODE((extracted_dir / plain_path).stat().st_mode) == 0o640
+                )
 
             output_wheel = tmp_path / "output.whl"
             zip_wheel(extracted_dir, output_wheel)

--- a/shared/kpack/tests/test_wheel_splitter.py
+++ b/shared/kpack/tests/test_wheel_splitter.py
@@ -9,6 +9,8 @@ split pipeline.
 import hashlib
 import os
 import shutil
+import stat
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -29,6 +31,7 @@ from rocm_kpack.wheel_splitter import (
     generate_record,
     generate_wheel_file,
     parse_wheel_identity,
+    zip_wheel,
 )
 
 
@@ -668,6 +671,51 @@ class TestGenerateRecord:
         test_line = [l for l in lines if "test.py" in l][0]
         assert f"sha256={expected_hash}" in test_line
         assert f",{len(test_content)}" in test_line
+
+
+class TestWheelArchivePermissions:
+    def test_extract_and_repack_preserves_exact_executable_mode(self, tmp_path: Path):
+        from rocm_kpack.binutils import Toolchain
+
+        input_wheel = tmp_path / "input.whl"
+        executable_path = "torch/bin/torch_shm_manager"
+        plain_path = "torch/__init__.py"
+
+        with zipfile.ZipFile(input_wheel, "w") as zf:
+            executable_info = zipfile.ZipInfo(executable_path)
+            executable_info.external_attr = (stat.S_IFREG | 0o751) << 16
+            zf.writestr(executable_info, b"#!/bin/sh\n")
+
+            plain_info = zipfile.ZipInfo(plain_path)
+            plain_info.external_attr = (stat.S_IFREG | 0o640) << 16
+            zf.writestr(plain_info, b"# torch\n")
+
+        splitter = WheelSplitter(
+            device_package_prefix="amd-torch-device",
+            overlay_root="torch/",
+            toolchain=Toolchain(),
+        )
+        extracted_dir, is_temporary = splitter._resolve_input(input_wheel)
+        assert is_temporary
+
+        try:
+            extracted_executable = extracted_dir / executable_path
+            assert stat.S_IMODE(extracted_executable.stat().st_mode) == 0o751
+            assert stat.S_IMODE((extracted_dir / plain_path).stat().st_mode) == 0o640
+
+            output_wheel = tmp_path / "output.whl"
+            zip_wheel(extracted_dir, output_wheel)
+        finally:
+            shutil.rmtree(extracted_dir)
+
+        with zipfile.ZipFile(output_wheel, "r") as zf:
+            output_executable_mode = stat.S_IMODE(
+                zf.getinfo(executable_path).external_attr >> 16
+            )
+            output_plain_mode = stat.S_IMODE(zf.getinfo(plain_path).external_attr >> 16)
+
+        assert output_executable_mode == 0o751
+        assert output_plain_mode == 0o640
 
 
 class TestKpackSearchPattern:


### PR DESCRIPTION
Python's zipfile extraction does not apply Unix mode bits from ZipInfo metadata. When  kpack splits a wheel input, like PyTorch, executables have been repacked without execute permissions, see https://github.com/ROCm/TheRock/issues/5965.

With this the wheel splitter is restoring member modes while resolving wheel inputs so the existing copy and repack flow preserves the original wheel metadata. Furthermore, adds coverage that uses a nonstandard executable mode to verify exact mode preservation rather than a fixed chmod value.

Fixes https://github.com/ROCm/TheRock/issues/5965.

Assisted-by: Codex <codex@openai.com>