### PR TITLE
[rocprofiler-sdk][gfx1250 PC sampling] Add gfx1250 stochastic PC sampling validators

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/output/CMakeLists.txt
@@ -27,6 +27,7 @@ set(TOOL_OUTPUT_HEADERS
     output_config.hpp
     output_key.hpp
     output_stream.hpp
+    pc_sampling_pc_correction.hpp
     statistics.hpp
     stream_info.hpp
     timestamps.hpp
@@ -49,6 +50,7 @@ set(TOOL_OUTPUT_SOURCES
     output_config.cpp
     output_key.cpp
     output_stream.cpp
+    pc_sampling_pc_correction.cpp
     statistics.cpp
     tmp_file_buffer.cpp
     tmp_file.cpp)

--- a/projects/rocprofiler-sdk/source/lib/output/metadata.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/metadata.hpp
@@ -27,6 +27,7 @@
 #include "host_symbol_info.hpp"
 #include "kernel_symbol_info.hpp"
 #include "pc_sample_transform.hpp"
+#include "pc_sampling_pc_correction.hpp"
 
 #include "lib/att-tool/att_lib_wrapper.hpp"
 #include "lib/common/container/small_vector.hpp"
@@ -184,6 +185,9 @@ struct metadata
     metadata& operator=(const metadata&) = delete;
     metadata& operator=(metadata&&) noexcept = delete;
 
+    // PC sampling reported-PC correction (gfx1250 stochastic).
+    pc_correction::PCCorrectionManager& pc_correction() { return pc_correction_mgr; }
+
     // Loads all counters supported on agents. Used by the 'rocprofv3-avail' tool.
     void init(inprocess);
 
@@ -255,6 +259,10 @@ private:
     std::vector<std::string> instruction_decoder = {};
     std::vector<std::string> instruction_comment = {};
     std::map<inst_t, size_t> indexes             = {};
+
+    // Declared after `decoder` so the reference the manager stores is bound to a
+    // fully-constructed member.
+    pc_correction::PCCorrectionManager pc_correction_mgr{decoder};
 };
 
 template <typename Tp>

--- a/projects/rocprofiler-sdk/source/lib/output/pc_sample_transform.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/pc_sample_transform.hpp
@@ -86,6 +86,14 @@ struct rocprofiler_tool_pc_sampling_stochastic_record_t
     rocprofiler_pc_sampling_record_stochastic_v0_t pc_sample_record;
     int64_t                                        inst_index;
 
+    // PC correction debug retention. When PC correction mutates a sample, it
+    // writes the corrected value into pc_sample_record.pc.code_object_offset
+    // (and the apply hook re-resolves inst_index), stashing the originals here
+    // beforehand. NOT serialized today -- defaults of 0 / -1 mean "no
+    // correction applied". Kept for optional opt-in debug exposure later.
+    uint64_t original_pc_offset  = 0;
+    int64_t  original_inst_index = -1;
+
     rocprofiler_tool_pc_sampling_stochastic_record_t(
         rocprofiler_pc_sampling_record_stochastic_v0_t record,
         int64_t                                        index)
@@ -96,6 +104,11 @@ struct rocprofiler_tool_pc_sampling_stochastic_record_t
     template <typename ArchiveT>
     void save(ArchiveT& ar) const
     {
+        // original schema unchanged: the corrected PC is already in
+        // pc_sample_record.pc.code_object_offset and the corrected inst_index in
+        // inst_index, so downstream writers see corrected values transparently.
+        // original_pc_offset / original_inst_index are intentionally not emitted today
+        // (kept for later debug exposure).
         ar(cereal::make_nvp("record", pc_sample_record));
         ar(cereal::make_nvp("inst_index", inst_index));
     }
@@ -105,6 +118,7 @@ struct rocprofiler_tool_pc_sampling_stats
 {
     uint64_t valid_samples   = 0;
     uint64_t invalid_samples = 0;
+    uint64_t dropped_samples = 0;  // suppressed by PC correction (CorrectionResult::Drop)
 };
 
 }  // namespace tool

--- a/projects/rocprofiler-sdk/source/lib/output/pc_sampling_pc_correction.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/pc_sampling_pc_correction.cpp
@@ -32,8 +32,8 @@
 // buffer/callback shared across all devices, with no convenient per-sample
 // "which agent emitted this" field. On a mixed system (e.g. gfx950 + gfx1250),
 // every sample therefore runs through the gate. The cost is bounded:
-//   - A process-wide flag (any_gfx1250_agent_pc_sampled) short-circuits the
-//     entire path when no gfx1250 agent is being sampled.
+//   - PCCorrectionManager::enabled() short-circuits the entire path when
+//     correction is disabled (env-var toggle) or no gfx1250 agent is configured.
 //   - Classifications are built ONLY for code objects on gfx1250 agents, so a
 //     non-gfx1250 sample misses the classification map and passes through.
 // A per-device-buffer refactor would remove this overhead but is a separate,
@@ -84,7 +84,7 @@ build_classification(code_obj_decoder_t& decoder, rocprofiler_code_object_id_t c
     // sample's pc.code_object_offset and the offset add_symbol records.
     std::map<uint64_t, SymbolInfo> symbols = decoder.getSymbolMap(co_id);
 
-    for(const auto& [vaddr, sym] : symbols)
+    for(const auto& [_, sym] : symbols)
     {
         classification->add_symbol(sym.vaddr, sym.mem_size, [&](uint64_t voffset) {
             return decoder.get(co_id, voffset);

--- a/projects/rocprofiler-sdk/source/lib/output/pc_sampling_pc_correction.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/pc_sampling_pc_correction.cpp
@@ -46,6 +46,7 @@
 #include <algorithm>
 #include <array>
 #include <map>
+#include <mutex>
 #include <utility>
 
 namespace rocprofiler
@@ -251,19 +252,90 @@ bool
 PCCorrectionManager::should_correct(const rocprofiler_pc_sampling_record_stochastic_v0_t& s,
                                     std::string_view decoded_inst) const
 {
-    // TODO: hot-path gate (env-var flag, gfx1250 flag, PC-on-internal check,
-    // impossible-signal check).
-    (void) s;
-    (void) decoded_inst;
+    // Single enable gate: folds the env-var toggle and "a gfx1250 agent is being
+    // sampled" into one relaxed atomic read (set during configuration). Cheapest
+    // check, so it runs first.
+    if(!enabled()) return false;
+
+    // Condition 1: the reported PC lands on an internal or s_icache_inv. Uses the
+    // instruction string the tool already decoded for this sample -- no extra
+    // decoder call and no classification-map lookup on this path.
+    if(classify(decoded_inst) == Kind::EXT) return false;
+
+    // Condition 2: the snapshot carries a signal that is impossible for an
+    // internal instruction, meaning it leaked from an adjacent external.
+    //  - wave_issued: internals are never issued.
+    //  - reason_not_issued == ARBITER_NOT_WIN: internals are never arbitrated, so
+    //    they cannot lose arbitration. Any other reason (e.g. an
+    //    internal-instruction reason) is consistent with a healthy internal --
+    //    leave it alone.
+    if(s.wave_issued) return true;
+    if(s.snapshot.reason_not_issued ==
+       ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN)
+        return true;
+
     return false;
 }
 
 CorrectionResult
 PCCorrectionManager::correct(rocprofiler_tool_pc_sampling_stochastic_record_t& s) const
 {
-    // TODO: lookup + cascade; mutate s in place and return Keep, or return Drop
-    // for boundary / ambiguous samples.
-    (void) s;
+    const uint64_t co_id  = s.pc_sample_record.pc.code_object_id;
+    const uint64_t offset = s.pc_sample_record.pc.code_object_offset;
+
+    auto entry = lookup(co_id, offset);
+    if(!entry)
+    {
+        // should_correct already established this PC is on an internal, so a
+        // missing classification means the code-object bookkeeping raced or a
+        // future change decoupled the two checks. Keeping the sample untouched
+        // is safer than dropping one we don't understand. Warn once per process
+        // (rate-limited) so a broken invariant is visible without flooding logs.
+        static std::once_flag warn_once;
+        std::call_once(warn_once, [] {
+            ROCP_WARNING << "PC correction: classification missing for a sampled code object; "
+                            "sample(s) passed through unchanged";
+        });
+        return CorrectionResult::Keep;
+    }
+
+    const InstructionStreamWindow& w = *entry->window;
+
+    // Boundary samples: a window with no opening external (leading internals) or
+    // no closing external (trailing internals) cannot be corrected -- drop.
+    // Presence is tracked by the has_ext1/has_ext2 flags, not a zero-offset
+    // sentinel, because offset 0 is a valid load-relative offset.
+    if(!w.has_ext1 || !w.has_ext2) return CorrectionResult::Drop;
+
+    uint64_t corrected = 0;
+    if(w.M == 0)
+    {
+        // s_icache_inv-only chain: correct backward to the opening external.
+        corrected = w.ext1_offset;
+    }
+    else if(w.N == 0)
+    {
+        // Regular-internal-only chain: correct forward to the closing external.
+        corrected = w.ext2_offset;
+    }
+    else
+    {
+        // Mixed chain. Below the trailing-M boundary the reported PC is only
+        // reachable by the s_icache_inv mechanism -> correct backward to EXT1.
+        // At or above the boundary both mechanisms can produce it -> ambiguous,
+        // so drop.
+        const uint64_t trailing_m_boundary = w.ext2_offset - w.regular_internal_total_bytes;
+        if(offset < trailing_m_boundary)
+            corrected = w.ext1_offset;
+        else
+            return CorrectionResult::Drop;
+    }
+
+    // Stash originals for optional debug retention (not serialized in v1), then
+    // mutate in place. The caller re-resolves inst_index from the corrected PC.
+    s.original_pc_offset                     = offset;
+    s.original_inst_index                    = s.inst_index;
+    s.pc_sample_record.pc.code_object_offset = corrected;
     return CorrectionResult::Keep;
 }
 

--- a/projects/rocprofiler-sdk/source/lib/output/pc_sampling_pc_correction.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/pc_sampling_pc_correction.cpp
@@ -41,7 +41,12 @@
 
 #include "lib/output/pc_sampling_pc_correction.hpp"
 
+#include "lib/common/logging.hpp"
+
+#include <algorithm>
 #include <array>
+#include <map>
+#include <utility>
 
 namespace rocprofiler
 {
@@ -58,6 +63,35 @@ bool
 starts_with(std::string_view str, std::string_view prefix)
 {
     return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
+}
+
+// Walk every symbol of a code object and build its (unsorted) classification.
+// This is the only comgr-coupled layer: it adapts the real decoder into the
+// per-instruction `decode` callback consumed by
+// CodeObjectClassification::add_symbol. The window state machine itself lives
+// in add_symbol and is exercised directly by the unit tests with synthetic
+// instructions (no decoder needed) -- this adapter is intentionally thin.
+//
+// Returns the built-and-sorted classification, or an empty one if the code
+// object has no symbols (a survivable case, e.g. data-only objects).
+std::shared_ptr<const CodeObjectClassification>
+build_classification(code_obj_decoder_t& decoder, rocprofiler_code_object_id_t co_id)
+{
+    auto classification = std::make_shared<CodeObjectClassification>();
+
+    // Symbols are keyed by load-relative vaddr offset -- the same space as a
+    // sample's pc.code_object_offset and the offset add_symbol records.
+    std::map<uint64_t, SymbolInfo> symbols = decoder.getSymbolMap(co_id);
+
+    for(const auto& [vaddr, sym] : symbols)
+    {
+        classification->add_symbol(sym.vaddr, sym.mem_size, [&](uint64_t voffset) {
+            return decoder.get(co_id, voffset);
+        });
+    }
+
+    classification->sort();
+    return classification;
 }
 }  // namespace
 
@@ -86,23 +120,131 @@ classify(std::string_view inst)
     return Kind::EXT;
 }
 
-PCCorrectionManager::PCCorrectionManager()  = default;
+void
+CodeObjectClassification::add_symbol(uint64_t         symbol_vaddr,
+                                     uint64_t         symbol_size,
+                                     const decode_fn& decode)
+{
+    auto           window = std::make_shared<InstructionStreamWindow>();  // has_ext1=false
+    const uint64_t end    = symbol_vaddr + symbol_size;
+
+    for(uint64_t voff = symbol_vaddr; voff < end;)
+    {
+        std::unique_ptr<Instruction> inst = decode(voff);
+        if(!inst || inst->size == 0 || voff + inst->size > end) break;
+
+        switch(classify(inst->inst))
+        {
+            case Kind::EXT:
+                // Close the current window only if it actually opened on an
+                // external and captured at least one internal.
+                if(window->has_ext1 && (window->M > 0 || window->N > 0))
+                {
+                    window->ext2_offset = voff;
+                    window->has_ext2    = true;
+                }
+                // Open a fresh window with this external as the new EXT1.
+                window              = std::make_shared<InstructionStreamWindow>();
+                window->ext1_offset = voff;
+                window->has_ext1    = true;
+                break;
+            case Kind::REGULAR_INTERNAL:
+                window->M++;
+                window->regular_internal_total_bytes += inst->size;
+                entries.push_back({voff, window});
+                break;
+            case Kind::S_ICACHE_INV:
+                window->N++;
+                entries.push_back({voff, window});
+                break;
+        }
+
+        voff += inst->size;
+    }
+    // End of symbol: a still-open window keeps has_ext2 false (trailing
+    // internals). The local `window` goes out of scope; nothing else to do.
+}
+
+void
+CodeObjectClassification::sort()
+{
+    std::sort(entries.begin(), entries.end(), [](const InternalEntry& a, const InternalEntry& b) {
+        return a.offset < b.offset;
+    });
+}
+
+std::optional<InternalEntry>
+CodeObjectClassification::find(uint64_t offset) const
+{
+    auto it = std::lower_bound(
+        entries.begin(), entries.end(), offset, [](const InternalEntry& e, uint64_t off) {
+            return e.offset < off;
+        });
+    if(it == entries.end() || it->offset != offset) return std::nullopt;
+    return *it;
+}
+
+PCCorrectionManager::PCCorrectionManager(common::Synchronized<code_obj_decoder_t, true>& decoder)
+: decoder_(decoder)
+{}
+
 PCCorrectionManager::~PCCorrectionManager() = default;
 
 void
 PCCorrectionManager::build(const rocprofiler_callback_tracing_code_object_load_data_t& obj_data)
 {
-    // TODO: single-shot pass over the code object's symbol map; build, sort by
-    // offset, and publish a shared_ptr<const CodeObjectClassification>.
-    (void) obj_data;
+    const auto co_id = obj_data.code_object_id;
+
+    // Decode under the decoder's lock; the symbol walk only reads, but the
+    // synced decoder exposes mutation via wlock, so we take the writer lock.
+    auto classification = decoder_.wlock(
+        [&](auto& decoder) { return build_classification(decoder, co_id); });
+
+    if(classification->entries.empty())
+    {
+        // No internal-like instructions (or no symbols at all -- e.g. data-only
+        // code objects). Nothing to correct; publish nothing. A later sample
+        // for this code object will simply miss the map and pass through.
+        ROCP_INFO << "PC correction: no entries for code object " << co_id
+                  << "; classification not published";
+        return;
+    }
+
+    publish(co_id, std::move(classification));
+}
+
+void
+PCCorrectionManager::publish(rocprofiler_code_object_id_t                    co_id,
+                             std::shared_ptr<const CodeObjectClassification> classification)
+{
+    // Publish atomically: readers observe either no entry or the fully-built,
+    // sorted, immutable classification.
+    map_.wlock([&](auto& m) { m.insert_or_assign(co_id, std::move(classification)); });
 }
 
 void
 PCCorrectionManager::erase(rocprofiler_code_object_id_t co_id)
 {
-    // TODO: brief wlock + erase. In-flight readers stay safe via the
-    // shared_ptr<const ...> copy-out in the lookup path.
-    (void) co_id;
+    // Brief wlock + erase. Any in-flight reader already copied the shared_ptr
+    // out under lookup()'s rlock, so the classification stays alive past this
+    // erase until that reader releases it.
+    map_.wlock([&](auto& m) { m.erase(co_id); });
+}
+
+std::optional<InternalEntry>
+PCCorrectionManager::lookup(rocprofiler_code_object_id_t co_id, uint64_t offset) const
+{
+    // Step 1: brief rlock, copy the shared_ptr out. The copy keeps the
+    // classification alive even if the code object is concurrently unloaded.
+    std::shared_ptr<const CodeObjectClassification> classification;
+    map_.rlock([&](const auto& m) {
+        auto it = m.find(co_id);
+        if(it != m.end()) classification = it->second;
+    });
+    if(!classification) return std::nullopt;
+
+    // Step 2: lock-free binary search on the immutable, sorted entries vector.
+    return classification->find(offset);
 }
 
 bool

--- a/projects/rocprofiler-sdk/source/lib/output/pc_sampling_pc_correction.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/pc_sampling_pc_correction.cpp
@@ -1,0 +1,130 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// PC sampling reported-PC correction (gfx1250 stochastic sampling only).
+//
+// On gfx1250, stochastic PC samples whose snapshot lands on or near a run of
+// internal-like SALU instructions can report a silently-wrong PC: the reported
+// PC lands inside the run of internals, while the accompanying snapshot fields
+// (issue/arbitration signals) describe an adjacent external instruction. This
+// module reconstructs the intended PC from the surrounding instruction stream.
+//
+// Heterogeneous-system caveat: rocprofv3 uses a single PC sampling
+// buffer/callback shared across all devices, with no convenient per-sample
+// "which agent emitted this" field. On a mixed system (e.g. gfx950 + gfx1250),
+// every sample therefore runs through the gate. The cost is bounded:
+//   - A process-wide flag (any_gfx1250_agent_pc_sampled) short-circuits the
+//     entire path when no gfx1250 agent is being sampled.
+//   - Classifications are built ONLY for code objects on gfx1250 agents, so a
+//     non-gfx1250 sample misses the classification map and passes through.
+// A per-device-buffer refactor would remove this overhead but is a separate,
+// larger effort and is intentionally out of scope here.
+
+#include "lib/output/pc_sampling_pc_correction.hpp"
+
+#include <array>
+
+namespace rocprofiler
+{
+namespace tool
+{
+namespace pc_correction
+{
+namespace
+{
+// C++17 has no std::string_view::starts_with (that is C++20). This is the
+// project standard (see cmake/rocprofiler_options.cmake), so we provide a local
+// equivalent.
+bool
+starts_with(std::string_view str, std::string_view prefix)
+{
+    return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
+}
+}  // namespace
+
+Kind
+classify(std::string_view inst)
+{
+    // Start-small authoritative-on-gfx1250 list. Regular internals contribute to
+    // the snapshot PC correction factor; s_icache_inv does not. Extend the
+    // regular-internal list as the hardware-confirmed set grows (candidates:
+    // s_setprio, s_sendmsg, s_trap, s_clause). Erring toward EXT is safe: a
+    // missed internal means "no correction", never a corrupted healthy sample.
+    static constexpr std::array<std::string_view, 4> regular_internals = {
+        "s_nop",
+        "s_sleep",
+        "s_wait",  // prefix-matches all s_wait* variants
+        "s_barrier_wait",
+    };
+
+    if(starts_with(inst, "s_icache_inv")) return Kind::S_ICACHE_INV;
+
+    for(const auto& prefix : regular_internals)
+    {
+        if(starts_with(inst, prefix)) return Kind::REGULAR_INTERNAL;
+    }
+
+    return Kind::EXT;
+}
+
+PCCorrectionManager::PCCorrectionManager()  = default;
+PCCorrectionManager::~PCCorrectionManager() = default;
+
+void
+PCCorrectionManager::build(const rocprofiler_callback_tracing_code_object_load_data_t& obj_data)
+{
+    // TODO: single-shot pass over the code object's symbol map; build, sort by
+    // offset, and publish a shared_ptr<const CodeObjectClassification>.
+    (void) obj_data;
+}
+
+void
+PCCorrectionManager::erase(rocprofiler_code_object_id_t co_id)
+{
+    // TODO: brief wlock + erase. In-flight readers stay safe via the
+    // shared_ptr<const ...> copy-out in the lookup path.
+    (void) co_id;
+}
+
+bool
+PCCorrectionManager::should_correct(const rocprofiler_pc_sampling_record_stochastic_v0_t& s,
+                                    std::string_view decoded_inst) const
+{
+    // TODO: hot-path gate (env-var flag, gfx1250 flag, PC-on-internal check,
+    // impossible-signal check).
+    (void) s;
+    (void) decoded_inst;
+    return false;
+}
+
+CorrectionResult
+PCCorrectionManager::correct(rocprofiler_tool_pc_sampling_stochastic_record_t& s) const
+{
+    // TODO: lookup + cascade; mutate s in place and return Keep, or return Drop
+    // for boundary / ambiguous samples.
+    (void) s;
+    return CorrectionResult::Keep;
+}
+
+}  // namespace pc_correction
+}  // namespace tool
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/output/pc_sampling_pc_correction.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/pc_sampling_pc_correction.hpp
@@ -1,0 +1,220 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "lib/common/synchronized.hpp"
+
+#include <rocprofiler-sdk/callback_tracing.h>
+#include <rocprofiler-sdk/pc_sampling.h>
+
+#include <cstdint>
+#include <memory>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace rocprofiler
+{
+namespace tool
+{
+// Forward declarations — full definitions live in metadata.hpp /
+// pc_sample_transform.hpp. Only the names are needed here for the manager API.
+struct metadata;
+struct rocprofiler_tool_pc_sampling_stochastic_record_t;
+
+namespace pc_correction
+{
+/**
+ * @brief Alias for a code-object id.
+ *
+ * The SDK has no `rocprofiler_code_object_id_t` typedef; a code-object id is a
+ * plain uint64_t (see inst_t::code_object_id and rocprofiler_pc_t::code_object_id).
+ * This local alias documents intent at every use site.
+ */
+using rocprofiler_code_object_id_t = uint64_t;
+
+/**
+ * @brief Classification of a single decoded instruction within the
+ * EXT1 -> INT_CHAIN -> EXT2 framing.
+ */
+enum class Kind
+{
+    EXT,               ///< External (non-internal) instruction; bounds a chain.
+    REGULAR_INTERNAL,  ///< Internal contributing to the snapshot PC correction factor.
+    S_ICACHE_INV       ///< Internal NOT contributing to the correction factor.
+};
+
+/**
+ * @brief Outcome of applying correction to a sample.
+ */
+enum class CorrectionResult
+{
+    Keep,  ///< Sample is healthy or successfully corrected — write it out.
+    Drop   ///< Sample is unrecoverable — skip the ring-buffer write entirely.
+};
+
+/**
+ * @brief Classify a decoded instruction string by its opcode mnemonic prefix.
+ *
+ * The opcode list starts small and is extended as the authoritative
+ * internal-instruction set is confirmed. The safe direction is to err toward
+ * EXT: a missed internal means "no correction" for that sample, whereas a
+ * mis-classified EXT would corrupt otherwise-healthy samples.
+ *
+ * @param [in] inst Decoded instruction text (mnemonic + operands).
+ * @return The instruction's @ref Kind.
+ */
+Kind
+classify(std::string_view inst);
+
+/**
+ * @brief Test whether a gfx_target_version identifies a gfx1250 agent.
+ *
+ * Encoding (per the SDK agent API): major = (ver / 10000) % 100,
+ * minor = (ver / 100) % 100. gfx1250 -> major=12, minor=50 -> [125000, 125100).
+ *
+ * @param [in] gfx_target_version Packed gfx target version of the agent.
+ * @return true if @p gfx_target_version is in the gfx1250 range.
+ */
+constexpr bool
+is_gfx1250(uint32_t gfx_target_version)
+{
+    return gfx_target_version >= 125000u && gfx_target_version < 125100u;
+}
+
+/**
+ * @brief One "EXT1 -> INT_CHAIN -> EXT2" window.
+ *
+ * All internals inside the window share one shared_ptr<const
+ * InstructionStreamWindow>. Filled during the code-object walk; immutable once
+ * published.
+ */
+struct InstructionStreamWindow
+{
+    uint64_t ext1_offset                  = 0;  ///< Opening-EXT offset; 0 = sentinel "no EXT1".
+    uint64_t ext2_offset                  = 0;  ///< Closing-EXT offset; 0 = sentinel "no EXT2".
+    uint64_t regular_internal_total_bytes = 0;
+    uint16_t M                            = 0;  ///< Regular-internal count.
+    uint16_t N                            = 0;  ///< s_icache_inv count.
+
+    /// @var regular_internal_total_bytes
+    /// @brief Running sum of regular-internal instruction sizes in this window.
+    /// Bounds how far the snapshot PC correction factor can subtract back from
+    /// EXT2. s_icache_inv does not contribute and is excluded from this sum.
+    /// @var M
+    /// @brief Regular-internal count. The correction logic uses `M == 0` to
+    /// detect an s_icache_inv-only chain (correct backward to EXT1).
+    /// @var N
+    /// @brief s_icache_inv count. The correction logic uses `N == 0` to detect a
+    /// regular-internal-only chain (correct forward to EXT2).
+};
+
+/**
+ * @brief One entry per internal-like instruction (regular internal or s_icache_inv).
+ */
+struct InternalEntry
+{
+    uint64_t                                       offset = 0;  ///< Sort key.
+    std::shared_ptr<const InstructionStreamWindow> window;      ///< Owning window.
+};
+
+/**
+ * @brief Per code object classification.
+ *
+ * Built in one synchronous pass at code-object load, sorted by offset, then
+ * never modified.
+ */
+struct CodeObjectClassification
+{
+    std::vector<InternalEntry> entries;  ///< Sorted by offset; immutable after build.
+};
+
+/**
+ * @brief Per-code-object classification map.
+ *
+ * The inner map is a plain unordered_map; the Synchronized wrapper lives on the
+ * manager. The shared_ptr<const ...> value makes the reader path
+ * safe-by-construction — entries are published read-only and never mutated
+ * afterwards.
+ */
+using ClassificationMap =
+    std::unordered_map<rocprofiler_code_object_id_t,
+                       std::shared_ptr<const CodeObjectClassification>>;
+
+/**
+ * @brief Owns the per-code-object classification map and exposes the correction API.
+ *
+ * This class is the seam used by the rocprofv3 tool; the implementation details
+ * (the symbol walk, lookup, gating, and cascade) live as file-local free
+ * functions in the .cpp.
+ */
+class PCCorrectionManager
+{
+public:
+    PCCorrectionManager();
+    ~PCCorrectionManager();
+
+    PCCorrectionManager(const PCCorrectionManager&)            = delete;
+    PCCorrectionManager& operator=(const PCCorrectionManager&) = delete;
+
+    /**
+     * @brief Build the classification for a code object at load time.
+     *
+     * @param [in] obj_data Code-object load payload (rocprofiler_code_object_info_t
+     * in metadata.hpp is an alias for this type).
+     */
+    void build(const rocprofiler_callback_tracing_code_object_load_data_t& obj_data);
+
+    /**
+     * @brief Erase the classification for a code object at unload time.
+     *
+     * @param [in] co_id Id of the code object being unloaded.
+     */
+    void erase(rocprofiler_code_object_id_t co_id);
+
+    /**
+     * @brief Hot-path gate: decide whether a sample is a correction candidate.
+     *
+     * @param [in] s            The stochastic sample record.
+     * @param [in] decoded_inst Decoded instruction text at the sample's PC.
+     * @return true if the sample should be passed to @ref correct.
+     */
+    bool should_correct(const rocprofiler_pc_sampling_record_stochastic_v0_t& s,
+                        std::string_view decoded_inst) const;
+
+    /**
+     * @brief Hot-path correction: apply the cascade, mutating @p s in place on Keep.
+     *
+     * @param [in,out] s The tool sample record; its PC is mutated on a Keep
+     * correction.
+     * @return ::CorrectionResult indicating whether to keep or drop the sample.
+     */
+    CorrectionResult correct(rocprofiler_tool_pc_sampling_stochastic_record_t& s) const;
+
+private:
+    mutable common::Synchronized<ClassificationMap, true> map_;
+};
+
+}  // namespace pc_correction
+}  // namespace tool
+}  // namespace rocprofiler

--- a/projects/rocprofiler-sdk/source/lib/output/pc_sampling_pc_correction.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/pc_sampling_pc_correction.hpp
@@ -326,8 +326,18 @@ public:
     CorrectionResult correct(rocprofiler_tool_pc_sampling_stochastic_record_t& s) const;
 
 private:
-    common::Synchronized<code_obj_decoder_t, true>&       decoder_;
-    std::atomic<bool>                                     enabled_{false};
+    common::Synchronized<code_obj_decoder_t, true>& decoder_;
+
+    // Atomic because it is written on one thread and read on another: set once by
+    // the configuration thread via set_enabled(), then read on the sample-callback
+    // thread(s) by should_correct() for every sample. A plain bool with a
+    // concurrent cross-thread write+read is a data race (undefined behavior under
+    // the C++ memory model, and flagged by ThreadSanitizer), even though the write
+    // happens-before sampling in wall-clock terms. memory_order_relaxed is
+    // sufficient: the flag carries no other state, so there is nothing to
+    // synchronize-with; relaxed compiles to a plain load on x86/ARM.
+    std::atomic<bool> enabled_{false};
+
     mutable common::Synchronized<ClassificationMap, true> map_;
 };
 

--- a/projects/rocprofiler-sdk/source/lib/output/pc_sampling_pc_correction.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/pc_sampling_pc_correction.hpp
@@ -23,12 +23,18 @@
 #pragma once
 
 #include "lib/common/synchronized.hpp"
+#include "lib/output/pc_sample_transform.hpp"
 
 #include <rocprofiler-sdk/callback_tracing.h>
 #include <rocprofiler-sdk/pc_sampling.h>
+#include <rocprofiler-sdk/cxx/codeobj/code_printing.hpp>
 
+#include <atomic>
 #include <cstdint>
+#include <functional>
+#include <map>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <unordered_map>
 #include <vector>
@@ -37,13 +43,19 @@ namespace rocprofiler
 {
 namespace tool
 {
-// Forward declarations — full definitions live in metadata.hpp /
-// pc_sample_transform.hpp. Only the names are needed here for the manager API.
-struct metadata;
-struct rocprofiler_tool_pc_sampling_stochastic_record_t;
-
 namespace pc_correction
 {
+// The shared instruction decoder type used by the rocprofv3 tool. Aliased to
+// match metadata::code_obj_decoder_t without depending on metadata.hpp.
+using code_obj_decoder_t = rocprofiler::sdk::codeobj::disassembly::CodeobjAddressTranslate;
+
+// One decoded instruction, as produced by the code-object decoder.
+using Instruction = rocprofiler::sdk::codeobj::disassembly::Instruction;
+
+// Per-symbol kernel/symbol descriptor produced by the decoder (carries name,
+// faddr, vaddr, mem_size).
+using SymbolInfo = rocprofiler::sdk::codeobj::disassembly::SymbolInfo;
+
 /**
  * @brief Alias for a code-object id.
  *
@@ -111,12 +123,23 @@ is_gfx1250(uint32_t gfx_target_version)
  */
 struct InstructionStreamWindow
 {
-    uint64_t ext1_offset                  = 0;  ///< Opening-EXT offset; 0 = sentinel "no EXT1".
-    uint64_t ext2_offset                  = 0;  ///< Closing-EXT offset; 0 = sentinel "no EXT2".
+    uint64_t ext1_offset                  = 0;      ///< Opening-EXT offset (valid iff has_ext1).
+    uint64_t ext2_offset                  = 0;      ///< Closing-EXT offset (valid iff has_ext2).
+    bool     has_ext1                     = false;  ///< Window opened on an external.
+    bool     has_ext2                     = false;  ///< Window closed on an external.
     uint64_t regular_internal_total_bytes = 0;
     uint16_t M                            = 0;  ///< Regular-internal count.
     uint16_t N                            = 0;  ///< s_icache_inv count.
 
+    /// @var ext1_offset
+    /// @brief Offset of the external that opened this window. Only meaningful
+    /// when has_ext1 is true. Offset 0 is a legitimate value (the first
+    /// instruction of a symbol), so presence is tracked by has_ext1, not by a
+    /// magic-zero sentinel.
+    /// @var ext2_offset
+    /// @brief Offset of the external that closed this window. Only meaningful
+    /// when has_ext2 is true. As with ext1_offset, presence is tracked by the
+    /// has_ext2 flag rather than a magic-zero sentinel.
     /// @var regular_internal_total_bytes
     /// @brief Running sum of regular-internal instruction sizes in this window.
     /// Bounds how far the snapshot PC correction factor can subtract back from
@@ -142,11 +165,55 @@ struct InternalEntry
  * @brief Per code object classification.
  *
  * Built in one synchronous pass at code-object load, sorted by offset, then
- * never modified.
+ * never modified. The classification builds itself: @ref add_symbol walks a
+ * single symbol's instruction stream and appends the resulting entries, then
+ * @ref sort orders them for binary-search lookup via @ref find.
  */
 struct CodeObjectClassification
 {
-    std::vector<InternalEntry> entries;  ///< Sorted by offset; immutable after build.
+    /// Pulls one instruction at a given load-relative vaddr offset. Returns null
+    /// (or an instruction of size 0) to stop the walk. Production code wraps the
+    /// real decoder; tests return synthetic instructions (see @ref add_symbol).
+    using decode_fn = std::function<std::unique_ptr<Instruction>(uint64_t voffset)>;
+
+    std::vector<InternalEntry> entries;  ///< Sorted by offset (after @ref sort); immutable thereafter.
+
+    /**
+     * @brief Walk one symbol's instruction stream in a single pass, appending
+     * its internal-like entries to @ref entries.
+     *
+     * Implements the EXT1 -> INT_CHAIN -> EXT2 state machine for one symbol.
+     * All internals between two externals share one InstructionStreamWindow;
+     * the closing external back-fills ext2_offset and sets has_ext2. Leading
+     * internals (no preceding external) leave has_ext1 false; trailing internals
+     * (no following external before symbol end) leave has_ext2 false.
+     *
+     * Instructions are pulled through @p decode rather than from a decoder
+     * reference so this logic is unit-testable without comgr: production code
+     * wraps the real decoder, while tests return synthetic @ref Instruction
+     * objects. @p decode is a std::function (not a template) so this stays a
+     * regular out-of-line method; the type-erasure cost is irrelevant here since
+     * the walk runs at code-object load time, not on the sample hot path.
+     *
+     * @param [in] symbol_vaddr Symbol's load-relative vaddr offset (the same
+     *   space as a sample's `pc.code_object_offset`).
+     * @param [in] symbol_size  Symbol size in bytes; the walk stops at
+     *   symbol_vaddr + symbol_size.
+     * @param [in] decode       Instruction source; see @ref decode_fn.
+     */
+    void add_symbol(uint64_t symbol_vaddr, uint64_t symbol_size, const decode_fn& decode);
+
+    /// Sort @ref entries by offset. Call once after all symbols are added.
+    void sort();
+
+    /**
+     * @brief Binary-search for the entry at an exact offset.
+     *
+     * @param [in] offset A sample's `pc.code_object_offset`.
+     * @return The matching entry, or std::nullopt if no internal-like
+     *   instruction sits at @p offset. Requires @ref sort to have run.
+     */
+    std::optional<InternalEntry> find(uint64_t offset) const;
 };
 
 /**
@@ -164,18 +231,39 @@ using ClassificationMap =
 /**
  * @brief Owns the per-code-object classification map and exposes the correction API.
  *
- * This class is the seam used by the rocprofv3 tool; the implementation details
- * (the symbol walk, lookup, gating, and cascade) live as file-local free
- * functions in the .cpp.
+ * The manager is intentionally unaware of `metadata`: it is constructed with a
+ * reference to the shared instruction decoder and a single @c enabled flag.
+ * All enablement policy (env-var toggle, "a relevant agent is being sampled")
+ * is folded into that one flag by the wiring code, so the manager never sees
+ * config, gfx targets, or metadata.
  */
 class PCCorrectionManager
 {
 public:
-    PCCorrectionManager();
+    /**
+     * @brief Construct the manager.
+     *
+     * @param [in] decoder Shared instruction decoder, owned elsewhere (e.g. by
+     *   metadata). Used only to walk symbols at build time; the manager does
+     *   not take ownership and must not outlive @p decoder.
+     */
+    explicit PCCorrectionManager(common::Synchronized<code_obj_decoder_t, true>& decoder);
     ~PCCorrectionManager();
 
     PCCorrectionManager(const PCCorrectionManager&)            = delete;
     PCCorrectionManager& operator=(const PCCorrectionManager&) = delete;
+
+    /**
+     * @brief Enable or disable correction.
+     *
+     * Folds every enablement condition into one flag. Read (relaxed) on the
+     * hot path by @ref should_correct. Set once during configuration, before
+     * any samples are processed.
+     */
+    void set_enabled(bool enabled) { enabled_.store(enabled, std::memory_order_relaxed); }
+
+    /// @return Whether correction is currently enabled.
+    bool enabled() const { return enabled_.load(std::memory_order_relaxed); }
 
     /**
      * @brief Build the classification for a code object at load time.
@@ -186,11 +274,37 @@ public:
     void build(const rocprofiler_callback_tracing_code_object_load_data_t& obj_data);
 
     /**
+     * @brief Publish a pre-built classification for a code object.
+     *
+     * Separated from @ref build so tests can inject a synthetic classification
+     * without a comgr-backed decoder. Publishes under a brief wlock; readers
+     * observe either no entry or the fully-built one.
+     *
+     * @param [in] co_id          Code-object id.
+     * @param [in] classification Fully built, sorted, immutable classification.
+     */
+    void publish(rocprofiler_code_object_id_t                    co_id,
+                 std::shared_ptr<const CodeObjectClassification> classification);
+
+    /**
      * @brief Erase the classification for a code object at unload time.
      *
      * @param [in] co_id Id of the code object being unloaded.
      */
     void erase(rocprofiler_code_object_id_t co_id);
+
+    /**
+     * @brief Look up the internal-like entry at a sample's PC, if any.
+     *
+     * Pure read path: brief rlock on the map, copy the shared_ptr out, then
+     * lock-free binary search. The copy-out keeps the classification alive even
+     * if the code object is concurrently unloaded.
+     *
+     * @param [in] co_id  Code-object id.
+     * @param [in] offset Sample's `pc.code_object_offset`.
+     * @return The matching entry, or std::nullopt.
+     */
+    std::optional<InternalEntry> lookup(rocprofiler_code_object_id_t co_id, uint64_t offset) const;
 
     /**
      * @brief Hot-path gate: decide whether a sample is a correction candidate.
@@ -212,6 +326,8 @@ public:
     CorrectionResult correct(rocprofiler_tool_pc_sampling_stochastic_record_t& s) const;
 
 private:
+    common::Synchronized<code_obj_decoder_t, true>&       decoder_;
+    std::atomic<bool>                                     enabled_{false};
     mutable common::Synchronized<ClassificationMap, true> map_;
 };
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
@@ -145,6 +145,7 @@ struct config : output_config
     bool   spm_counter_collection        = get_env("ROCPROF_SPM_COUNTER_COLLECTION", false);
     bool   pc_sampling_host_trap         = false;
     bool   pc_sampling_stochastic        = false;
+    bool   pc_sampling_correction        = get_env("ROCPROF_PC_SAMPLING_CORRECTION", true);
     size_t pc_sampling_interval          = get_env("ROCPROF_PC_SAMPLING_INTERVAL", 1);
     rocprofiler_pc_sampling_method_t pc_sampling_method_value = ROCPROFILER_PC_SAMPLING_METHOD_NONE;
     rocprofiler_pc_sampling_unit_t   pc_sampling_unit_value   = ROCPROFILER_PC_SAMPLING_UNIT_NONE;
@@ -317,6 +318,7 @@ config::save(ArchiveT& ar) const
 
     CFG_SERIALIZE_MEMBER(pc_sampling_host_trap);
     CFG_SERIALIZE_MEMBER(pc_sampling_stochastic);
+    CFG_SERIALIZE_MEMBER(pc_sampling_correction);
     CFG_SERIALIZE_MEMBER(pc_sampling_method);
     CFG_SERIALIZE_MEMBER(pc_sampling_unit);
     CFG_SERIALIZE_MEMBER(pc_sampling_interval);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -971,6 +971,19 @@ code_object_tracing_callback(rocprofiler_callback_tracing_record_t record,
                tool::get_config().pc_sampling_stochastic)
             {
                 CHECK_NOTNULL(tool_metadata)->add_decoder(obj_data);
+
+                // PC correction: build the classification only for stochastic
+                // sampling on a gfx1250 agent (scope the build to agents that can
+                // exhibit the bug; see pc_sampling_pc_correction.hpp).
+                if(tool::get_config().pc_sampling_stochastic)
+                {
+                    const auto* agent = tool_metadata->get_agent(obj_data->rocp_agent);
+                    if(agent != nullptr &&
+                       rocprofiler::tool::pc_correction::is_gfx1250(agent->gfx_target_version))
+                    {
+                        tool_metadata->pc_correction().build(*obj_data);
+                    }
+                }
             }
 
             if(obj_data->storage_type == ROCPROFILER_CODE_OBJECT_STORAGE_TYPE_MEMORY &&
@@ -1045,6 +1058,18 @@ code_object_tracing_callback(rocprofiler_callback_tracing_record_t record,
         else if(record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD)
         {
             flush();
+
+            // PC correction: drop this code object's classification. flush()
+            // above (plus the SDK-side flush in flush_pc_sampling_buffers) drains
+            // all samples for this code object before unload, so no sample can
+            // still need the classification. erase() is a no-op for code objects
+            // that were never classified (non-stochastic / non-gfx1250).
+            if(tool::get_config().pc_sampling_stochastic)
+            {
+                auto* obj_data =
+                    static_cast<tool::rocprofiler_code_object_info_t*>(record.payload);
+                tool_metadata->pc_correction().erase(obj_data->code_object_id);
+            }
         }
     }
 
@@ -1567,6 +1592,9 @@ pc_sampling_callback(rocprofiler_context_id_t /* context_id*/,
     // count number of valid VS invalid samples delivered by this callback
     uint64_t valid_samples_cnt   = 0;
     uint64_t invalid_samples_cnt = 0;
+    // samples suppressed by PC correction (CorrectionResult::Drop): neither valid
+    // output nor an invalid HW sample, so counted separately.
+    uint64_t dropped_samples_cnt = 0;
 
     for(size_t i = 0; i < num_headers; i++)
     {
@@ -1600,9 +1628,34 @@ pc_sampling_callback(rocprofiler_context_id_t /* context_id*/,
                 auto* pc_sample = static_cast<rocprofiler_pc_sampling_record_stochastic_v0_t*>(
                     cur_header->payload);
 
+                const int64_t idx = get_instruction_index(pc_sample->pc);
+
                 auto pc_sample_tool_record =
-                    rocprofiler::tool::rocprofiler_tool_pc_sampling_stochastic_record_t(
-                        *pc_sample, get_instruction_index(pc_sample->pc));
+                    rocprofiler::tool::rocprofiler_tool_pc_sampling_stochastic_record_t(*pc_sample,
+                                                                                        idx);
+
+                // PC correction (gfx1250 stochastic only). The gate's common path
+                // is a string-prefix check on the already-decoded instruction; the
+                // classification map is touched at most once, only for a sample
+                // that passes the gate. idx < 0 means the PC could not be decoded,
+                // so there is nothing to classify -- skip correction.
+                auto& pc_correction_mgr = tool_metadata->pc_correction();
+                if(idx >= 0 &&
+                   pc_correction_mgr.should_correct(*pc_sample, tool_metadata->get_instruction(idx)))
+                {
+                    if(pc_correction_mgr.correct(pc_sample_tool_record) ==
+                       rocprofiler::tool::pc_correction::CorrectionResult::Drop)
+                    {
+                        // Unrecoverable sample: skip both the ring-buffer write and
+                        // the valid-sample counter.
+                        dropped_samples_cnt++;
+                        continue;
+                    }
+
+                    // Re-resolve inst_index from the corrected PC.
+                    pc_sample_tool_record.inst_index =
+                        get_instruction_index(pc_sample_tool_record.pc_sample_record.pc);
+                }
 
                 rocprofiler::tool::write_ring_buffer(pc_sample_tool_record,
                                                      domain_type::PC_SAMPLING_STOCHASTIC);
@@ -1619,11 +1672,12 @@ pc_sampling_callback(rocprofiler_context_id_t /* context_id*/,
         }
     }
 
-    // sum up number of valid/invalid samples for pc sampling stats
+    // sum up number of valid/invalid/dropped samples for pc sampling stats
     tool_metadata->pc_sampling_stats.wlock(
-        [valid_samples_cnt, invalid_samples_cnt](auto& pc_sampling_stats) {
+        [valid_samples_cnt, invalid_samples_cnt, dropped_samples_cnt](auto& pc_sampling_stats) {
             pc_sampling_stats.valid_samples += valid_samples_cnt;
             pc_sampling_stats.invalid_samples += invalid_samples_cnt;
+            pc_sampling_stats.dropped_samples += dropped_samples_cnt;
         });
 }
 
@@ -2184,6 +2238,17 @@ configure_pc_sampling_on_all_agents(uint64_t                        buffer_size,
                                                           *buffer_id,
                                                           flags),
                 "configure PC sampling");
+
+            // Enable PC correction iff a gfx1250 agent is being stochastically
+            // sampled and the env-var toggle (default on) allows it. Folding both
+            // conditions into the manager's single enable flag keeps the manager
+            // unaware of config and gfx targets.
+            if(method == ROCPROFILER_PC_SAMPLING_METHOD_STOCHASTIC &&
+               tool::get_config().pc_sampling_correction &&
+               rocprofiler::tool::pc_correction::is_gfx1250(itr->gfx_target_version))
+            {
+                tool_metadata->pc_correction().set_enabled(true);
+            }
         }
     }
     if(!config_match_found)

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -975,7 +975,8 @@ code_object_tracing_callback(rocprofiler_callback_tracing_record_t record,
                 // PC correction: build the classification only for stochastic
                 // sampling on a gfx1250 agent (scope the build to agents that can
                 // exhibit the bug; see pc_sampling_pc_correction.hpp).
-                if(tool::get_config().pc_sampling_stochastic)
+                if(tool::get_config().pc_sampling_stochastic &&
+                   tool::get_config().pc_sampling_correction)
                 {
                     const auto* agent = tool_metadata->get_agent(obj_data->rocp_agent);
                     if(agent != nullptr &&
@@ -1064,7 +1065,8 @@ code_object_tracing_callback(rocprofiler_callback_tracing_record_t record,
             // all samples for this code object before unload, so no sample can
             // still need the classification. erase() is a no-op for code objects
             // that were never classified (non-stochastic / non-gfx1250).
-            if(tool::get_config().pc_sampling_stochastic)
+            if(tool::get_config().pc_sampling_stochastic &&
+               tool::get_config().pc_sampling_correction)
             {
                 auto* obj_data =
                     static_cast<tool::rocprofiler_code_object_info_t*>(record.payload);

--- a/projects/rocprofiler-sdk/source/lib/tests/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/CMakeLists.txt
@@ -4,3 +4,4 @@
 add_subdirectory(buffering)
 add_subdirectory(common)
 add_subdirectory(codeobj)
+add_subdirectory(pc_sampling)

--- a/projects/rocprofiler-sdk/source/lib/tests/pc_sampling/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/source/lib/tests/pc_sampling/CMakeLists.txt
@@ -1,0 +1,25 @@
+#
+#   Tests for PC sampling reported-PC correction
+#
+project(rocprofiler-sdk-tests-pc-sampling LANGUAGES C CXX)
+
+set(pc_sampling_sources pc_sampling_pc_correction_test.cpp)
+
+add_executable(pc-sampling-pc-correction-tests)
+target_sources(pc-sampling-pc-correction-tests PRIVATE ${pc_sampling_sources})
+target_link_libraries(
+    pc-sampling-pc-correction-tests
+    PRIVATE rocprofiler-sdk::rocprofiler-sdk-headers
+            rocprofiler-sdk::rocprofiler-sdk-common-library
+            rocprofiler-sdk::rocprofiler-sdk-output-library
+            rocprofiler-sdk::rocprofiler-sdk-cereal
+            GTest::gtest
+            GTest::gtest_main)
+
+rocprofiler_add_unit_test(
+    TARGET pc-sampling-pc-correction-tests
+    SOURCES ${pc_sampling_sources}
+    ENVIRONMENT
+        "TEST_LOG_LEVEL=info"
+        "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}:${CMAKE_INSTALL_PREFIX}/lib:${CMAKE_INSTALL_PREFIX}/llvm/lib:${ROCM_PATH}/lib:${ROCM_PATH}/llvm/lib:$ENV{LD_LIBRARY_PATH}"
+    )

--- a/projects/rocprofiler-sdk/source/lib/tests/pc_sampling/pc_sampling_pc_correction_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/pc_sampling/pc_sampling_pc_correction_test.cpp
@@ -35,10 +35,12 @@
 
 using rocprofiler::tool::pc_correction::classify;
 using rocprofiler::tool::pc_correction::CodeObjectClassification;
+using rocprofiler::tool::pc_correction::CorrectionResult;
 using rocprofiler::tool::pc_correction::Instruction;
 using rocprofiler::tool::pc_correction::InternalEntry;
 using rocprofiler::tool::pc_correction::Kind;
 using rocprofiler::tool::pc_correction::PCCorrectionManager;
+using stochastic_record_t = rocprofiler::tool::rocprofiler_tool_pc_sampling_stochastic_record_t;
 
 namespace
 {
@@ -392,4 +394,191 @@ TEST(pc_correction_concurrency, ManyReadersOneWriter)
         t.join();
 
     EXPECT_TRUE(f.mgr.lookup(1, 4).has_value());
+}
+
+// ------------------------------------------------------------------
+// Gating tests (PCCorrectionManager::should_correct).
+// ------------------------------------------------------------------
+
+namespace
+{
+// Build a stochastic record with the gating-relevant fields set. wave_issued and
+// reason_not_issued are the two HW signals should_correct inspects.
+stochastic_record_t
+make_record(bool wave_issued, uint32_t reason_not_issued, uint64_t co_id = 0, uint64_t offset = 0)
+{
+    rocprofiler_pc_sampling_record_stochastic_v0_t rec{};
+    rec.wave_issued                 = wave_issued ? 1 : 0;
+    rec.snapshot.reason_not_issued  = reason_not_issued;
+    rec.pc.code_object_id           = co_id;
+    rec.pc.code_object_offset       = offset;
+    return stochastic_record_t{rec, /*inst_index*/ 0};
+}
+
+// A reason value that is consistent with a healthy internal (anything other than
+// ARBITER_NOT_WIN). 0 is the first enum value and is not ARBITER_NOT_WIN.
+constexpr uint32_t kReasonInternalOk = 0u;
+constexpr uint32_t kReasonArbiterNotWin =
+    ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN;
+}  // namespace
+
+TEST(pc_correction_gate, DisabledReturnsFalse)
+{
+    ManagerFixture f;  // enabled defaults false
+    auto           rec = make_record(/*wave_issued*/ true, kReasonInternalOk);
+    EXPECT_FALSE(f.mgr.should_correct(rec.pc_sample_record, "s_nop"));
+}
+
+TEST(pc_correction_gate, ExtInstructionFalse)
+{
+    ManagerFixture f;
+    f.mgr.set_enabled(true);
+    auto rec = make_record(/*wave_issued*/ true, kReasonInternalOk);
+    EXPECT_FALSE(f.mgr.should_correct(rec.pc_sample_record, "v_add_f32 v0, v1, v2"));
+}
+
+TEST(pc_correction_gate, HealthyInternalFalse)
+{
+    ManagerFixture f;
+    f.mgr.set_enabled(true);
+    // On an internal, but signals are consistent with a legitimate internal.
+    auto rec = make_record(/*wave_issued*/ false, kReasonInternalOk);
+    EXPECT_FALSE(f.mgr.should_correct(rec.pc_sample_record, "s_nop"));
+}
+
+TEST(pc_correction_gate, InternalWaveIssuedTrue)
+{
+    ManagerFixture f;
+    f.mgr.set_enabled(true);
+    // wave_issued is impossible for an internal -> leaked from adjacent external.
+    auto rec = make_record(/*wave_issued*/ true, kReasonInternalOk);
+    EXPECT_TRUE(f.mgr.should_correct(rec.pc_sample_record, "s_nop"));
+}
+
+TEST(pc_correction_gate, InternalArbiterNotWinTrue)
+{
+    ManagerFixture f;
+    f.mgr.set_enabled(true);
+    // reason ARBITER_NOT_WIN is impossible for a never-arbitrated internal.
+    auto rec = make_record(/*wave_issued*/ false, kReasonArbiterNotWin);
+    EXPECT_TRUE(f.mgr.should_correct(rec.pc_sample_record, "s_icache_inv"));
+}
+
+// ------------------------------------------------------------------
+// Cascade tests (PCCorrectionManager::correct). Each publishes a classification
+// for a single symbol, then corrects a record whose PC lands on a chosen
+// internal offset.
+// ------------------------------------------------------------------
+
+namespace
+{
+// Publish `insts` as one symbol at base 0 under `co_id`, then correct a record
+// whose PC lands at `offset`. Returns the result and leaves the mutated record
+// in `out_rec`.
+CorrectionResult
+correct_at(PCCorrectionManager&                          mgr,
+           uint64_t                                      co_id,
+           std::vector<std::pair<std::string, uint64_t>> insts,
+           uint64_t                                      offset,
+           stochastic_record_t&                          out_rec)
+{
+    mgr.publish(co_id,
+                std::make_shared<CodeObjectClassification>(build_single_symbol(std::move(insts))));
+    out_rec = make_record(/*wave_issued*/ true, kReasonInternalOk, co_id, offset);
+    return mgr.correct(out_rec);
+}
+}  // namespace
+
+TEST(pc_correction_cascade, M_Only_ForwardToEXT2)
+{
+    // EXT@0 s_nop@4 s_nop@8 EXT@12; sample at offset 4 -> forward to EXT2 (12).
+    ManagerFixture      f;
+    stochastic_record_t rec{make_record(false, 0)};
+    auto                result =
+        correct_at(f.mgr, 1, {{"v_add", 4}, {"s_nop", 4}, {"s_nop", 4}, {"v_mov", 4}}, 4, rec);
+    EXPECT_EQ(result, CorrectionResult::Keep);
+    EXPECT_EQ(rec.pc_sample_record.pc.code_object_offset, 12u);
+    EXPECT_EQ(rec.original_pc_offset, 4u);
+}
+
+TEST(pc_correction_cascade, N_Only_BackwardToEXT1)
+{
+    // EXT@0 inv@4 inv@8 EXT@12; sample at offset 8 -> backward to EXT1 (0).
+    ManagerFixture      f;
+    stochastic_record_t rec{make_record(false, 0)};
+    auto                result = correct_at(
+        f.mgr, 1, {{"v_add", 4}, {"s_icache_inv", 4}, {"s_icache_inv", 4}, {"v_mov", 4}}, 8, rec);
+    EXPECT_EQ(result, CorrectionResult::Keep);
+    EXPECT_EQ(rec.pc_sample_record.pc.code_object_offset, 0u);
+    EXPECT_EQ(rec.original_pc_offset, 8u);
+}
+
+TEST(pc_correction_cascade, Mixed_BelowBoundary_BackwardToEXT1)
+{
+    // EXT@0 inv@4 inv@8 s_nop@12 EXT@16: B=4, boundary = 16-4 = 12. Sample at
+    // offset 4 (< 12) -> backward to EXT1 (0).
+    ManagerFixture      f;
+    stochastic_record_t rec{make_record(false, 0)};
+    auto                result = correct_at(
+        f.mgr,
+        1,
+        {{"v_add", 4}, {"s_icache_inv", 4}, {"s_icache_inv", 4}, {"s_nop", 4}, {"v_mov", 4}},
+        4,
+        rec);
+    EXPECT_EQ(result, CorrectionResult::Keep);
+    EXPECT_EQ(rec.pc_sample_record.pc.code_object_offset, 0u);
+}
+
+TEST(pc_correction_cascade, Mixed_AtOrAboveBoundary_Drop)
+{
+    // EXT@0 inv@4 s_nop@8 EXT@12: B=4, boundary = 12-4 = 8. Sample at offset 8
+    // (>= 8) -> ambiguous -> drop. PC must be left unchanged.
+    ManagerFixture      f;
+    stochastic_record_t rec{make_record(false, 0)};
+    auto                result = correct_at(
+        f.mgr, 1, {{"v_add", 4}, {"s_icache_inv", 4}, {"s_nop", 4}, {"v_mov", 4}}, 8, rec);
+    EXPECT_EQ(result, CorrectionResult::Drop);
+    EXPECT_EQ(rec.pc_sample_record.pc.code_object_offset, 8u);  // unchanged
+}
+
+TEST(pc_correction_cascade, LeadingInternalsOrphan_Drop)
+{
+    // Symbol begins with internals (no EXT1). Sample at offset 0 -> drop.
+    ManagerFixture      f;
+    stochastic_record_t rec{make_record(false, 0)};
+    auto result = correct_at(f.mgr, 1, {{"s_nop", 4}, {"s_nop", 4}, {"v_add", 4}}, 0, rec);
+    EXPECT_EQ(result, CorrectionResult::Drop);
+}
+
+TEST(pc_correction_cascade, TrailingInternalsOrphan_Drop)
+{
+    // Symbol ends with internals (no EXT2). Sample at the last internal -> drop.
+    ManagerFixture      f;
+    stochastic_record_t rec{make_record(false, 0)};
+    auto result = correct_at(f.mgr, 1, {{"v_add", 4}, {"s_nop", 4}, {"s_nop", 4}}, 8, rec);
+    EXPECT_EQ(result, CorrectionResult::Drop);
+}
+
+TEST(pc_correction_cascade, BackwardToEXT1_AtOffsetZero)
+{
+    // Regression for the has_ext1/has_ext2 flags (vs a zero-offset sentinel):
+    // EXT1 legitimately at offset 0 must still be a valid correction target.
+    // EXT@0 inv@4 EXT@8; sample at 4 -> backward to EXT1 (0), NOT a drop.
+    ManagerFixture      f;
+    stochastic_record_t rec{make_record(false, 0)};
+    auto                result =
+        correct_at(f.mgr, 1, {{"v_add", 4}, {"s_icache_inv", 4}, {"v_mov", 4}}, 4, rec);
+    EXPECT_EQ(result, CorrectionResult::Keep);
+    EXPECT_EQ(rec.pc_sample_record.pc.code_object_offset, 0u);
+}
+
+TEST(pc_correction_cascade, LookupMiss_PassThroughKeep)
+{
+    // gate said yes but no classification exists for this CO -> keep unchanged.
+    ManagerFixture      f;
+    stochastic_record_t rec = make_record(/*wave_issued*/ true, kReasonInternalOk, /*co*/ 99, 4);
+    auto                result = f.mgr.correct(rec);
+    EXPECT_EQ(result, CorrectionResult::Keep);
+    EXPECT_EQ(rec.pc_sample_record.pc.code_object_offset, 4u);  // unchanged
+    EXPECT_EQ(rec.original_inst_index, -1);                     // no correction stashed
 }

--- a/projects/rocprofiler-sdk/source/lib/tests/pc_sampling/pc_sampling_pc_correction_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/pc_sampling/pc_sampling_pc_correction_test.cpp
@@ -1,0 +1,95 @@
+// MIT License
+//
+// Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "lib/output/pc_sampling_pc_correction.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string_view>
+
+using rocprofiler::tool::pc_correction::classify;
+using rocprofiler::tool::pc_correction::Kind;
+
+TEST(pc_correction_classify, Classify_NopIsRegular)
+{
+    EXPECT_EQ(classify("s_nop 0"), Kind::REGULAR_INTERNAL);
+}
+
+TEST(pc_correction_classify, Classify_SleepIsRegular)
+{
+    EXPECT_EQ(classify("s_sleep 1"), Kind::REGULAR_INTERNAL);
+}
+
+TEST(pc_correction_classify, Classify_WaitAllVariants)
+{
+    // All s_wait* variants resolve via the "s_wait" prefix.
+    static constexpr std::string_view wait_variants[] = {
+        "s_waitcnt 0",
+        "s_wait_loadcnt 0",
+        "s_wait_storecnt 0",
+        "s_wait_kmcnt 0",
+        "s_wait_alu 0",
+        "s_wait_idle",
+    };
+
+    for(auto inst : wait_variants)
+    {
+        EXPECT_EQ(classify(inst), Kind::REGULAR_INTERNAL) << "inst=" << inst;
+    }
+}
+
+TEST(pc_correction_classify, Classify_BarrierWaitIsRegular)
+{
+    EXPECT_EQ(classify("s_barrier_wait -1"), Kind::REGULAR_INTERNAL);
+}
+
+TEST(pc_correction_classify, Classify_IcacheInvIsS_icache_inv)
+{
+    EXPECT_EQ(classify("s_icache_inv"), Kind::S_ICACHE_INV);
+}
+
+TEST(pc_correction_classify, Classify_VAluIsExt)
+{
+    EXPECT_EQ(classify("v_add_f32_e32 v0, v1, v2"), Kind::EXT);
+}
+
+TEST(pc_correction_classify, Classify_SAluIsExt)
+{
+    EXPECT_EQ(classify("s_mov_b32 s0, 1"), Kind::EXT);
+}
+
+TEST(pc_correction_classify, Classify_BranchIsExt)
+{
+    EXPECT_EQ(classify("s_branch 8"), Kind::EXT);
+}
+
+TEST(pc_correction_classify, Classify_EndPgmIsExt)
+{
+    EXPECT_EQ(classify("s_endpgm"), Kind::EXT);
+}
+
+TEST(pc_correction_classify, Classify_SetPrioIsExt_Today)
+{
+    // s_setprio is a candidate internal pending hardware confirmation; until
+    // then it must classify as EXT (the safe direction).
+    EXPECT_EQ(classify("s_setprio 1"), Kind::EXT);
+}

--- a/projects/rocprofiler-sdk/source/lib/tests/pc_sampling/pc_sampling_pc_correction_test.cpp
+++ b/projects/rocprofiler-sdk/source/lib/tests/pc_sampling/pc_sampling_pc_correction_test.cpp
@@ -24,10 +24,63 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <string>
 #include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
 
 using rocprofiler::tool::pc_correction::classify;
+using rocprofiler::tool::pc_correction::CodeObjectClassification;
+using rocprofiler::tool::pc_correction::Instruction;
+using rocprofiler::tool::pc_correction::InternalEntry;
 using rocprofiler::tool::pc_correction::Kind;
+using rocprofiler::tool::pc_correction::PCCorrectionManager;
+
+namespace
+{
+// Pull instructions from a fixed synthetic stream, advancing on each call. The
+// builder addresses instructions by voffset; this fake ignores it and returns
+// the next instruction in sequence (the builder walks strictly forward), which
+// is exactly what add_symbol consumes. Each instruction is given the size the
+// test specifies so byte accounting (regular_internal_total_bytes) is exercised.
+struct FakeStream
+{
+    std::vector<std::pair<std::string, uint64_t>> insts;  // {text, size}
+    size_t                                        next = 0;
+
+    std::unique_ptr<Instruction> operator()(uint64_t /*voffset*/)
+    {
+        if(next >= insts.size()) return nullptr;
+        auto& [text, size] = insts[next++];
+        return std::make_unique<Instruction>(std::string{text}, size);
+    }
+
+    // Total byte span of the stream -- pass as the symbol size so the walk
+    // consumes every instruction.
+    uint64_t total_size() const
+    {
+        uint64_t sum = 0;
+        for(const auto& [text, size] : insts)
+            sum += size;
+        return sum;
+    }
+};
+
+// Build a single-symbol classification from a synthetic stream at symbol base 0.
+CodeObjectClassification
+build_single_symbol(std::vector<std::pair<std::string, uint64_t>> insts)
+{
+    FakeStream               stream{std::move(insts), 0};
+    CodeObjectClassification c;
+    c.add_symbol(0, stream.total_size(), [&](uint64_t v) { return stream(v); });
+    c.sort();
+    return c;
+}
+}  // namespace
 
 TEST(pc_correction_classify, Classify_NopIsRegular)
 {
@@ -92,4 +145,251 @@ TEST(pc_correction_classify, Classify_SetPrioIsExt_Today)
     // s_setprio is a candidate internal pending hardware confirmation; until
     // then it must classify as EXT (the safe direction).
     EXPECT_EQ(classify("s_setprio 1"), Kind::EXT);
+}
+
+// ------------------------------------------------------------------
+// Window-builder tests (CodeObjectClassification::add_symbol).
+// All offsets assume 4-byte instructions starting at symbol base 0 unless a
+// test specifies otherwise.
+// ------------------------------------------------------------------
+
+TEST(pc_correction_build, EmptyChain_NoEntries)
+{
+    // Back-to-back externals: no internals -> no entries.
+    auto c = build_single_symbol({{"v_add", 4}, {"v_mov", 4}});
+    EXPECT_TRUE(c.entries.empty());
+}
+
+TEST(pc_correction_build, NoEXT1_LeadingInternal)
+{
+    // Symbol starts with internals (no preceding external) -> has_ext1 false.
+    auto c = build_single_symbol({{"s_nop", 4}, {"s_nop", 4}, {"v_add", 4}});
+    ASSERT_EQ(c.entries.size(), 2u);
+    for(const auto& e : c.entries)
+        EXPECT_FALSE(e.window->has_ext1);
+}
+
+TEST(pc_correction_build, NoEXT2_TrailingInternal)
+{
+    // Symbol: EXT@0 s_nop@4 s_nop@8 with no closing external. The trailing
+    // internals' window opened on EXT@0 but never closes -> has_ext2 false,
+    // which the cascade treats as "drop". This also covers EXT1 legitimately at
+    // offset 0 (no magic-zero collision).
+    auto c = build_single_symbol({{"v_add", 4}, {"s_nop", 4}, {"s_nop", 4}});
+    ASSERT_EQ(c.entries.size(), 2u);
+    const auto& w = *c.entries[0].window;
+    EXPECT_TRUE(w.has_ext1);
+    EXPECT_EQ(w.ext1_offset, 0u);  // opened by EXT@0 -- a valid offset, not a sentinel
+    EXPECT_FALSE(w.has_ext2);      // never closed -> trailing internals
+}
+
+TEST(pc_correction_build, M_Only_ForwardChain)
+{
+    // EXT@0 s_nop@4 s_nop@8 EXT@12: regular-only chain, M=2 N=0 B=8.
+    auto c = build_single_symbol({{"v_add", 4}, {"s_nop", 4}, {"s_nop", 4}, {"v_mov", 4}});
+    ASSERT_EQ(c.entries.size(), 2u);
+    const auto& w = *c.entries[0].window;
+    EXPECT_EQ(w.M, 2u);
+    EXPECT_EQ(w.N, 0u);
+    EXPECT_EQ(w.regular_internal_total_bytes, 8u);
+    EXPECT_TRUE(w.has_ext1);
+    EXPECT_EQ(w.ext1_offset, 0u);  // EXT1 at offset 0 -- valid, not a sentinel
+    EXPECT_TRUE(w.has_ext2);
+    EXPECT_EQ(w.ext2_offset, 12u);
+}
+
+TEST(pc_correction_build, N_Only_BackwardChain)
+{
+    // EXT@0 inv@4 inv@8 EXT@12: inv-only chain, M=0 N=2 B=0.
+    auto c =
+        build_single_symbol({{"v_add", 4}, {"s_icache_inv", 4}, {"s_icache_inv", 4}, {"v_mov", 4}});
+    ASSERT_EQ(c.entries.size(), 2u);
+    const auto& w = *c.entries[0].window;
+    EXPECT_EQ(w.M, 0u);
+    EXPECT_EQ(w.N, 2u);
+    EXPECT_EQ(w.regular_internal_total_bytes, 0u);
+    EXPECT_TRUE(w.has_ext1);
+    EXPECT_EQ(w.ext1_offset, 0u);
+    EXPECT_TRUE(w.has_ext2);
+    EXPECT_EQ(w.ext2_offset, 12u);
+}
+
+TEST(pc_correction_build, Mixed_OrderAgnostic)
+{
+    // Order inside the chain doesn't matter, only the counts: both layouts give
+    // M=2 N=1 B=8.
+    auto a = build_single_symbol(
+        {{"v_add", 4}, {"s_nop", 4}, {"s_icache_inv", 4}, {"s_nop", 4}, {"v_mov", 4}});
+    auto b = build_single_symbol(
+        {{"v_add", 4}, {"s_icache_inv", 4}, {"s_nop", 4}, {"s_nop", 4}, {"v_mov", 4}});
+
+    ASSERT_FALSE(a.entries.empty());
+    ASSERT_FALSE(b.entries.empty());
+    const auto& wa = *a.entries[0].window;
+    const auto& wb = *b.entries[0].window;
+    EXPECT_EQ(wa.M, 2u);
+    EXPECT_EQ(wa.N, 1u);
+    EXPECT_EQ(wa.regular_internal_total_bytes, 8u);
+    EXPECT_EQ(wb.M, 2u);
+    EXPECT_EQ(wb.N, 1u);
+    EXPECT_EQ(wb.regular_internal_total_bytes, 8u);
+}
+
+TEST(pc_correction_build, VariableWidthInternal)
+{
+    // An 8-byte regular internal must contribute its actual size, not a fixed 4.
+    auto c = build_single_symbol({{"v_add", 4}, {"s_nop", 8}, {"v_mov", 4}});
+    ASSERT_EQ(c.entries.size(), 1u);
+    const auto& w = *c.entries[0].window;
+    EXPECT_EQ(w.M, 1u);
+    EXPECT_EQ(w.regular_internal_total_bytes, 8u);
+    EXPECT_EQ(w.ext2_offset, 12u);  // EXT after a 4B + 8B run
+}
+
+TEST(pc_correction_build, BackToBackEXTs)
+{
+    // EXT@0 EXT@4 EXT@8 s_nop@12 EXT@16: only the single internal yields an
+    // entry, in the window opened by EXT@8 and closed by EXT@16.
+    auto c =
+        build_single_symbol({{"v_a", 4}, {"v_b", 4}, {"v_c", 4}, {"s_nop", 4}, {"v_d", 4}});
+    ASSERT_EQ(c.entries.size(), 1u);
+    const auto& w = *c.entries[0].window;
+    EXPECT_EQ(w.M, 1u);
+    EXPECT_EQ(w.ext1_offset, 8u);
+    EXPECT_EQ(w.ext2_offset, 16u);
+    EXPECT_EQ(c.entries[0].offset, 12u);
+}
+
+TEST(pc_correction_build, EntriesSortedAcrossSymbols)
+{
+    // Two symbols added in ascending base order; entries must end up globally
+    // sorted by offset after sort().
+    CodeObjectClassification c;
+
+    FakeStream s2{{{"v_add", 4}, {"s_nop", 4}, {"v_mov", 4}}, 0};
+    c.add_symbol(100, s2.total_size(), [&](uint64_t v) { return s2(v); });
+
+    FakeStream s1{{{"v_add", 4}, {"s_nop", 4}, {"v_mov", 4}}, 0};
+    c.add_symbol(0, s1.total_size(), [&](uint64_t v) { return s1(v); });
+
+    c.sort();
+    ASSERT_EQ(c.entries.size(), 2u);
+    EXPECT_LT(c.entries[0].offset, c.entries[1].offset);
+    EXPECT_EQ(c.entries[0].offset, 4u);    // internal in symbol @ base 0
+    EXPECT_EQ(c.entries[1].offset, 104u);  // internal in symbol @ base 100
+}
+
+TEST(pc_correction_build, FindHitsAndMisses)
+{
+    // EXT@0 s_nop@4 s_nop@8 EXT@12: internals at 4 and 8.
+    auto c = build_single_symbol({{"v_add", 4}, {"s_nop", 4}, {"s_nop", 4}, {"v_mov", 4}});
+
+    EXPECT_TRUE(c.find(4).has_value());
+    EXPECT_TRUE(c.find(8).has_value());
+    EXPECT_FALSE(c.find(0).has_value());   // external, no entry
+    EXPECT_FALSE(c.find(12).has_value());  // external, no entry
+    EXPECT_FALSE(c.find(99).has_value());  // out of range
+}
+
+// ------------------------------------------------------------------
+// Manager publish / lookup / erase tests. These use the publish() seam so no
+// comgr-backed decoder is required; the decoder reference is a default-
+// constructed (empty) translator that build() never touches here.
+// ------------------------------------------------------------------
+
+namespace
+{
+// A manager bound to an empty decoder. Safe because these tests drive
+// publish()/lookup()/erase() directly and never call build().
+struct ManagerFixture
+{
+    rocprofiler::tool::pc_correction::code_obj_decoder_t        decoder_value{};
+    rocprofiler::common::Synchronized<
+        rocprofiler::tool::pc_correction::code_obj_decoder_t, true>
+                        decoder{std::move(decoder_value)};
+    PCCorrectionManager mgr{decoder};
+
+    std::shared_ptr<const CodeObjectClassification> make_classification()
+    {
+        auto c = std::make_shared<CodeObjectClassification>(
+            build_single_symbol({{"v_add", 4}, {"s_nop", 4}, {"v_mov", 4}}));
+        return c;
+    }
+};
+}  // namespace
+
+TEST(pc_correction_manager, PublishThenLookupHit)
+{
+    ManagerFixture f;
+    f.mgr.publish(42, f.make_classification());
+
+    auto hit = f.mgr.lookup(42, 4);  // s_nop @ offset 4
+    ASSERT_TRUE(hit.has_value());
+    EXPECT_EQ(hit->offset, 4u);
+}
+
+TEST(pc_correction_manager, LookupMissUnknownCO)
+{
+    ManagerFixture f;
+    f.mgr.publish(42, f.make_classification());
+    EXPECT_FALSE(f.mgr.lookup(7, 4).has_value());   // unknown CO id
+    EXPECT_FALSE(f.mgr.lookup(42, 0).has_value());  // external offset
+}
+
+TEST(pc_correction_manager, EraseRemovesClassification)
+{
+    ManagerFixture f;
+    f.mgr.publish(42, f.make_classification());
+    ASSERT_TRUE(f.mgr.lookup(42, 4).has_value());
+    f.mgr.erase(42);
+    EXPECT_FALSE(f.mgr.lookup(42, 4).has_value());
+}
+
+TEST(pc_correction_manager, EraseDoesNotInvalidateInFlightReader)
+{
+    ManagerFixture f;
+    f.mgr.publish(42, f.make_classification());
+
+    // Simulate the copy-out: lookup returns a copy of the InternalEntry (which
+    // holds a shared_ptr to the window). Erasing the CO must not invalidate it.
+    auto entry = f.mgr.lookup(42, 4);
+    ASSERT_TRUE(entry.has_value());
+    f.mgr.erase(42);
+
+    ASSERT_TRUE(entry->window != nullptr);
+    EXPECT_EQ(entry->offset, 4u);  // still valid after erase
+}
+
+// ------------------------------------------------------------------
+// Concurrency: publish/erase racing against many concurrent lookups. Run under
+// TSan to catch data races; without TSan this still exercises the locking.
+// ------------------------------------------------------------------
+
+TEST(pc_correction_concurrency, ManyReadersOneWriter)
+{
+    ManagerFixture f;
+    f.mgr.publish(1, f.make_classification());
+
+    constexpr int          kReaders = 8;
+    std::atomic<bool>      stop{false};
+    std::vector<std::thread> readers;
+    readers.reserve(kReaders);
+    for(int i = 0; i < kReaders; ++i)
+        readers.emplace_back([&] {
+            while(!stop.load(std::memory_order_relaxed))
+                (void) f.mgr.lookup(1, 4);
+        });
+
+    // Writer churns publish/erase on a different CO id concurrently.
+    for(int i = 0; i < 1000; ++i)
+    {
+        f.mgr.publish(2, f.make_classification());
+        f.mgr.erase(2);
+    }
+
+    stop.store(true, std::memory_order_relaxed);
+    for(auto& t : readers)
+        t.join();
+
+    EXPECT_TRUE(f.mgr.lookup(1, 4).has_value());
 }

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,15 +23,16 @@
 #
 
 set(PACKAGE_OUTPUT_DIR
-    ${ROCPROFILER_SDK_TESTS_BINARY_DIR}/pytest-packages/rocprofiler_sdk/pc_sampling/stochastic/csv
+    ${ROCPROFILER_SDK_TESTS_BINARY_DIR}/pytest-packages/rocprofiler_sdk/pc_sampling/stochastic/csv/gfx12
     )
 
-set(PC_SAMPLING_PYTHON_SOURCES __init__.py)
+set(PC_SAMPLING_PYTHON_SOURCES
+    __init__.py valu_instructions.py matrix_instructions.py vmem_instructions.py
+    flat_instructions.py lds_instructions.py dual_valu_instructions.py)
 
 foreach(_FILE ${PC_SAMPLING_PYTHON_SOURCES})
     configure_file(${CMAKE_CURRENT_LIST_DIR}/${_FILE} ${PACKAGE_OUTPUT_DIR}/${_FILE}
                    COPYONLY)
 endforeach()
 
-add_subdirectory(gfx9)
-add_subdirectory(gfx12)
+add_subdirectory(s_instructions)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/__init__.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/__init__.py
@@ -1,0 +1,79 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+import numpy as np
+import pandas as pd
+
+from .s_instructions import validate_s_instructions
+from .valu_instructions import validate_valu_instructions
+from .vmem_instructions import validate_vmem_instructions
+from .matrix_instructions import validate_matrix_instructions
+from .lds_instructions import validate_lds_instructions
+from .flat_instructions import validate_flat_instructions
+from .dual_valu_instructions import validate_dual_valu_instructions
+
+
+def validate_wave_count(df):
+    # Validating number of actives waves on a SIMD
+    assert (
+        (df["Wave_Count"] >= 1) & (df["Wave_Count"] <= 16)
+    ).all(), "Invalid Wave_Count"
+
+
+def validate_issued_instruction_type_other(samples):
+    # ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_OTHER type of instructions still to be determined
+    issued_type_other = samples[samples["Instruction_Type"] == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_OTHER"]
+    assert len(issued_type_other) == 0, "OTHER type of instruction observed first time"
+
+
+def validate_stochastic_samples_csv(df: pd.DataFrame):
+    # TODO: Once rocpd is ready, validate the number of invalid vs valid samples.
+
+    # only valid samples reside in df
+    valid_samples = df.copy()
+
+    validate_wave_count(valid_samples)
+
+    # The following checks assumes that we were able to decode
+    # the instruction, meaning a code object and dispatch must be known.
+    valid_samples = valid_samples[valid_samples["Dispatch_Id"] > 0]
+
+    # scalar, barrier, waitcnt, jump, message, branches (taken and not taken)
+    # are handled inside `validate_s_instructions` function
+    validate_s_instructions(valid_samples)
+    validate_valu_instructions(valid_samples)
+    validate_vmem_instructions(valid_samples)
+    validate_matrix_instructions(valid_samples)
+    validate_lds_instructions(valid_samples)
+    validate_flat_instructions(valid_samples)
+    validate_dual_valu_instructions(valid_samples)
+
+    # validating issued instructions for uncovered types
+    valid_samples_issued = valid_samples[
+        valid_samples["Wave_Issued_Instruction"] == True
+    ].copy()
+    validate_issued_instruction_type_other(valid_samples_issued)
+
+    # NOTE: LDS_DIRECT and DUAL_VALU exist on GFX12, so we do not assert they are absent

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/dual_valu_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/dual_valu_instructions.py
@@ -1,0 +1,92 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_dual_valu_instructions_issued(samples_issued):
+    """Validate issued dual VALU (v_dual_*) instructions.
+
+    Issued v_dual_* instructions should have:
+    - Instruction_Type == DUAL_VALU
+    """
+    # All issued instructions with type DUAL_VALU should start with v_dual_
+    issued_type_dual_valu = samples_issued[
+        samples_issued["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_DUAL_VALU"
+    ]
+    assert issued_type_dual_valu["Instruction"].apply(
+        lambda x: x.startswith("v_dual_")
+    ).all(), "All issued DUAL_VALU type instructions should start with v_dual_"
+
+    # All v_dual_ issued instructions should have DUAL_VALU instruction type
+    v_dual_issued = samples_issued[
+        samples_issued["Instruction"].apply(lambda x: x.startswith("v_dual_"))
+    ]
+    assert (
+        v_dual_issued["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_DUAL_VALU"
+    ).all(), "All issued v_dual_ instructions should have DUAL_VALU instruction type"
+
+
+def validate_dual_valu_instructions_stalled(samples):
+    """Validate not-issued (stalled) dual VALU (v_dual_*) instructions.
+
+    For v_dual_ instructions that were not issued, the stall reason must be one of:
+    - ARBITER_NOT_WIN (arbitration loss, dominant reason under contention)
+    - NO_INSTRUCTION_AVAILABLE
+    - OTHER_WAIT
+    - ALU_DEPENDENCY
+    """
+    v_dual_samples = samples[
+        samples["Instruction"].apply(lambda x: x.startswith("v_dual_"))
+    ]
+    v_dual_stalled = v_dual_samples[
+        v_dual_samples["Wave_Issued_Instruction"] == False
+    ]
+
+    if v_dual_stalled.empty:
+        return
+
+    # Stall reason must be one of ARBITER_NOT_WIN, NO_INSTRUCTION_AVAILABLE,
+    # or ARBITER_WIN_EX_STALL
+    allowed_stall_reasons = {
+        "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+        "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+        'ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT',
+        'ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY'
+    }
+    assert v_dual_stalled["Stall_Reason"].apply(
+        lambda x: x in allowed_stall_reasons
+    ).all(), (
+        "All stalled v_dual_ instructions should have an allowed stall reason. "
+        f"Unexpected reasons: "
+        f"{set(v_dual_stalled['Stall_Reason'].unique()) - allowed_stall_reasons}"
+    )
+
+
+def validate_dual_valu_instructions(samples):
+    """Validate dual VALU instructions (v_dual_*) for both issued and stalled samples."""
+    samples_issued = samples[samples["Wave_Issued_Instruction"]]
+    validate_dual_valu_instructions_issued(samples_issued)
+    validate_dual_valu_instructions_stalled(samples)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/flat_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/flat_instructions.py
@@ -1,0 +1,74 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_flat_instructions_issued(samples_issued):
+    # issued instruction with type == FLAT -> instruction starts with either flat_
+    issued_type_flat = samples_issued[
+        samples_issued["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_FLAT"
+    ]
+    assert (
+        issued_type_flat["Instruction"]
+        .apply(lambda x: x.startswith("flat_"))
+        .all()
+    )
+
+    # if issued instruction starts with flat_ -> its type must be FLAT
+    issued_flat = samples_issued[
+        samples_issued["Instruction"].apply(
+            lambda x: x.startswith("flat_")
+        )
+    ]
+    assert (
+        issued_flat["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_FLAT"
+    ).all()
+
+
+def validate_flat_instructions_stalled(samples):
+    global_flat_regex = r"^(flat)_"
+    flat_samples = samples[samples["Instruction"].str.match(global_flat_regex)]
+    flat_stalled = flat_samples[flat_samples["Wave_Issued_Instruction"] == False]
+
+    assert (
+        flat_stalled["Stall_Reason"]
+        .apply(
+            lambda x: x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            or x == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY"
+        )
+        .all()
+    )
+
+
+def validate_flat_instructions(samples):
+    samples_issued = samples[samples["Wave_Issued_Instruction"]]
+    validate_flat_instructions_issued(samples_issued)
+    validate_flat_instructions_stalled(samples)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/lds_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/lds_instructions.py
@@ -1,0 +1,72 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_lds_instructions_issued(samples_issued):
+    # issued instruction with type == LDS -> instruction starts with ds_
+    issued_type_lds = samples_issued[
+        samples_issued["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_LDS"
+    ]
+
+    # The PC sampling correction WA ensures no skid samples for s_wait_* instructions
+    # reach the validator. All issued LDS-typed samples must start with ds_.
+    assert issued_type_lds["Instruction"].apply(lambda x: x.startswith("ds_")).all(), (
+        "All issued LDS instructions must start with ds_ — "
+        "PC correction WA should have removed any s_wait_* skid samples"
+    )
+
+    # issued instruction starts with ds_ -> it must be LDS
+    issued_ds = samples_issued[
+        samples_issued["Instruction"].apply(lambda x: x.startswith("ds_"))
+    ]
+    assert (
+        issued_ds["Instruction_Type"] == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_LDS"
+    ).all()
+
+
+def validate_lds_instructions_stalled(samples):
+    lds_samples = samples[samples["Instruction"].apply(lambda x: x.startswith("ds_"))]
+    lds_stalled = lds_samples[lds_samples["Wave_Issued_Instruction"] == False]
+
+    assert (
+        lds_stalled["Stall_Reason"]
+        .apply(
+            lambda x: x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            or x == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY"
+        )
+        .all()
+    )
+
+
+def validate_lds_instructions(samples):
+    samples_issued = samples[samples["Wave_Issued_Instruction"]]
+    validate_lds_instructions_issued(samples_issued)
+    validate_lds_instructions_stalled(samples)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/matrix_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/matrix_instructions.py
@@ -1,0 +1,90 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_matrix_instructions_issued(samples_issued):
+    """
+    Validate issued matrix (v_wmma) instructions.
+
+    v_wmma instructions should have
+    Instruction_Type == MATRIX.
+    """
+    # All issued instructions with type MATRIX should start with v_wmma
+    issued_type_matrix = samples_issued[
+        samples_issued["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_MATRIX"
+    ]
+    assert issued_type_matrix["Instruction"].apply(
+        lambda x: x.startswith("v_wmma")
+    ).all(), "All issued MATRIX type instructions should start with v_wmma"
+
+    # All v_wmma issued instructions should have MATRIX instruction type
+    v_wmma_issued = samples_issued[
+        samples_issued["Instruction"].apply(lambda x: x.startswith("v_wmma"))
+    ]
+    assert (
+        v_wmma_issued["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_MATRIX"
+    ).all(), "All issued v_wmma instructions should have MATRIX instruction type"
+
+
+def validate_matrix_instructions_stalled(samples):
+    """
+    Validate not-issued (stalled) matrix (v_wmma) instructions.
+
+    For v_wmma instructions that were not issued:
+    - The dominant stall reason should be ARBITER_NOT_WIN (arbitration loss)
+    - Small percentages of NO_INSTRUCTION_AVAILABLE
+    """
+    v_wmma_samples = samples[
+        samples["Instruction"].apply(lambda x: x.startswith("v_wmma"))
+    ]
+    v_wmma_stalled = v_wmma_samples[
+        v_wmma_samples["Wave_Issued_Instruction"] == False
+    ]
+
+    if v_wmma_stalled.empty:
+        return
+
+    # Stall reason must be one of ARBITER_NOT_WIN, NO_INSTRUCTION_AVAILABLE,
+    # or ARBITER_WIN_EX_STALL
+    allowed_stall_reasons = {
+        "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+        "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+    }
+    assert v_wmma_stalled["Stall_Reason"].apply(
+        lambda x: x in allowed_stall_reasons
+    ).all(), (
+        "All stalled v_wmma instructions should have an allowed stall reason. "
+        f"Unexpected reasons: "
+        f"{set(v_wmma_stalled['Stall_Reason'].unique()) - allowed_stall_reasons}"
+    )
+
+
+def validate_matrix_instructions(samples):
+    """Validate matrix instructions (v_wmma) for both issued and stalled samples."""
+    samples_issued = samples[samples["Wave_Issued_Instruction"]]
+    validate_matrix_instructions_issued(samples_issued)
+    validate_matrix_instructions_stalled(samples)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,15 +23,24 @@
 #
 
 set(PACKAGE_OUTPUT_DIR
-    ${ROCPROFILER_SDK_TESTS_BINARY_DIR}/pytest-packages/rocprofiler_sdk/pc_sampling/stochastic/csv
+    ${ROCPROFILER_SDK_TESTS_BINARY_DIR}/pytest-packages/rocprofiler_sdk/pc_sampling/stochastic/csv/gfx12/s_instructions
     )
 
-set(PC_SAMPLING_PYTHON_SOURCES __init__.py)
+set(PC_SAMPLING_PYTHON_SOURCES
+    __init__.py
+    branch_instructions.py
+    waitcnt.py
+    other_instructions.py
+    scalar_instructions.py
+    internal_instructions.py
+    jump_instructions.py
+    message_instructions.py
+    barrier_instructions.py
+    clause_instructions.py
+    delay_alu_instructions.py
+    wakeup_instructions.py)
 
 foreach(_FILE ${PC_SAMPLING_PYTHON_SOURCES})
     configure_file(${CMAKE_CURRENT_LIST_DIR}/${_FILE} ${PACKAGE_OUTPUT_DIR}/${_FILE}
                    COPYONLY)
 endforeach()
-
-add_subdirectory(gfx9)
-add_subdirectory(gfx12)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/__init__.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/__init__.py
@@ -1,0 +1,155 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+from functools import partial
+
+from .branch_instructions import validate_branch_instructions
+from .waitcnt import validate_waitcnt
+from .other_instructions import validate_other_instructions
+from .scalar_instructions import validate_scalar_instructions
+from .internal_instructions import validate_internal_instructions
+from .jump_instructions import validate_jump_instructions
+from .message_instructions import validate_message_instructions
+from .barrier_instructions import validate_barrier_instructions
+from .delay_alu_instructions import validate_delay_alu_instructions
+from .clause_instructions import validate_clause_instructions
+from .wakeup_instructions import validate_wakeup_instructions
+
+# Using Prefix Tree to classify the instruction type
+# I did this instead of the regex becuase I wanted to try if we could
+# generalize this approach for other types of instructions.
+# The dream scenario: We have a giant list of all instructions and their
+# types. Then we parse the list and dynamically determine the checks
+# based on the instruction types.
+
+
+class TrieNode:
+    def __init__(self):
+        self.children = {}
+        self.instruction_type = None  # Store the instruction type at the leaf node
+
+
+class PrefixTree:
+    def __init__(self):
+        self.root = TrieNode()
+
+    def insert(self, full_prefix, instruction_type):
+        """Insert a prefix and its associated instruction type into the Trie."""
+        node = self.root
+        for char in full_prefix:
+            if char not in node.children:
+                node.children[char] = TrieNode()
+            node = node.children[char]
+        node.instruction_type = (
+            instruction_type  # Assign the instruction type at the leaf
+        )
+
+    def get_instruction_type(self, instruction):
+        """Get the list of instruction types based on the longest matching prefix."""
+        node = self.root
+        matched_types = []  # List to store matched types
+
+        # Traverse the instruction one character at a time
+        for char in instruction:
+            if char not in node.children:
+                break  # Stop if no match is found
+
+            node = node.children[char]
+
+            # If we reach a node that has an instruction type, store it
+            if node.instruction_type:
+                matched_types.append(node.instruction_type)
+
+        return matched_types
+
+
+instructions_with_types = [
+    ("s_", "SCALAR"),  # Scalar instructions (general category)
+    ("s_wait", "WAITCNT"),  # WAITCNT (specific)
+    ("s_sendmsg", "MESSAGE"),  # MESSAGE (specific)
+    ("s_barrier", "BARRIER"),  # BARRIER (specific)
+    ("s_swappc", "JUMP"),  # JUMP (specific)
+    ("s_setpc", "JUMP"),  # JUMP
+    ("s_branch", "BRANCH"),  # BRANCH
+    ("s_cbranch", "BRANCH"),  # BRANCH (conditional)
+    ("s_wakeup", "S_WAKEUP"),  # NO_INST type, but goes through the brmsg arbiter.
+    ("s_nop", "INTERNAL"),  # INTERNAL
+    ("s_sleep", "INTERNAL"),  # INTERNAL
+    ("s_clause", "CLAUSE"),  # CLAUSE (specific)
+    ("s_delay_alu", "DELAY_ALU"),  # DELAY_ALU (specific)
+]
+
+
+inst_type_verify_functions = {
+    "BRANCH": validate_branch_instructions,
+    "WAITCNT": validate_waitcnt,
+    "OTHER": validate_other_instructions,
+    "SCALAR": validate_scalar_instructions,
+    "INTERNAL": validate_internal_instructions,
+    "JUMP": validate_jump_instructions,
+    "MESSAGE": validate_message_instructions,
+    "BARRIER": validate_barrier_instructions,
+    "CLAUSE": validate_clause_instructions,
+    "DELAY_ALU": validate_delay_alu_instructions,
+    "S_WAKEUP": validate_wakeup_instructions,
+}
+
+
+# Function to classify instructions based on the Trie
+def classify_instruction_by_prefix(prefix_tree, instruction):
+    # extracting the base of the instruction (e.g., s_mov_*, v_mov_*, s_setpc_*, ...)
+    base_instruction = instruction.split()[0]
+
+    # Classify based on the Trie (general classification)
+    instruction_types = prefix_tree.get_instruction_type(base_instruction)
+
+    # aways use the specific type
+    return instruction_types[-1]
+
+
+def enforce_type_inheritance(sub_df, parent_df):
+    for col in parent_df.columns:
+        sub_df[col] = sub_df[col].astype(parent_df[col].dtype)
+    return sub_df
+
+
+def validate_s_instructions(df):
+    s_instructions = df[df["Instruction"].apply(lambda x: x.startswith("s_"))].copy()
+
+    # fill in the Prefi Tree
+    prefix_tree = PrefixTree()
+    for prefix, instruction_type in instructions_with_types:
+        prefix_tree.insert(prefix, instruction_type)
+
+    _classify_instruction_by_prefix = partial(classify_instruction_by_prefix, prefix_tree)
+    s_instructions["Instruction_Type_From_Name"] = s_instructions["Instruction"].apply(
+        _classify_instruction_by_prefix
+    )
+
+    for inst_type, subframe in s_instructions.groupby("Instruction_Type_From_Name"):
+        # subframe = enforce_type_inheritance(subframe, s_instructions)
+        if inst_type in inst_type_verify_functions:
+            # Pass all samples and filtered samples to the verification function.
+            inst_type_verify_functions[inst_type](df, subframe)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/barrier_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/barrier_instructions.py
@@ -1,0 +1,118 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def _split_barrier_samples(barrier_samples):
+    """Split barrier samples into s_barrier_signal and s_barrier_wait groups."""
+    s_barrier_signal = barrier_samples[
+        barrier_samples["Instruction"].str.startswith("s_barrier_signal")
+    ]
+    s_barrier_wait = barrier_samples[
+        barrier_samples["Instruction"].str.startswith("s_barrier_wait")
+    ]
+    return s_barrier_signal, s_barrier_wait
+
+
+def validate_barrier_signal(all_samples, s_barrier_signal_samples):
+    """Validate s_barrier_signal samples.
+
+    s_barrier_signal can be both issued and stalled:
+    - Issued: Instruction_Type must be BARRIER.
+    - Stalled: Stall reason must be NO_INSTRUCTION_AVAILABLE, ARBITER_NOT_WIN, or OTHER_WAIT.
+    """
+    # -- issued --
+    issued = s_barrier_signal_samples[
+        s_barrier_signal_samples["Wave_Issued_Instruction"]
+    ]
+
+    if not issued.empty:
+        # Cross-check: issued barrier samples from all_samples must match
+        barrier_type_issued = all_samples[
+            all_samples["Wave_Issued_Instruction"]
+            & (
+                all_samples["Instruction_Type"]
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_BARRIER"
+            )
+            & all_samples["Instruction"].str.startswith("s_barrier_signal")
+        ]
+        assert len(barrier_type_issued) == len(issued), (
+            f"Mismatch between barrier-type issued s_barrier_signal samples: "
+            f"{len(barrier_type_issued)} vs {len(issued)}"
+        )
+
+        assert (
+            issued["Instruction_Type"]
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_BARRIER"
+        ).all(), (
+            "Instruction_Type is not BARRIER for all issued s_barrier_signal samples."
+        )
+
+    # -- stalled --
+    stalled = s_barrier_signal_samples[
+        s_barrier_signal_samples["Wave_Issued_Instruction"] == False
+    ]
+
+    if not stalled.empty:
+        allowed_stall_reasons = {
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT"
+        }
+        invalid = ~stalled["Stall_Reason"].isin(allowed_stall_reasons)
+        assert not invalid.any(), (
+            f"Unexpected stall reasons for s_barrier_signal: "
+            f"{set(stalled.loc[invalid, 'Stall_Reason'].unique())}"
+        )
+
+
+def validate_barrier_wait(s_barrier_wait_samples):
+    """Validate s_barrier_wait samples.
+
+    s_barrier_wait is always stalled (issued=False).
+    Stall reason must be NO_INSTRUCTION_AVAILABLE, BARRIER_WAIT, OTHER_WAIT, or INTERNAL_INSTRUCTION.
+    """
+    assert (s_barrier_wait_samples["Wave_Issued_Instruction"] == False).all(), (
+        "issued is not False for all s_barrier_wait samples."
+    )
+
+    if not s_barrier_wait_samples.empty:
+        allowed_stall_reasons = {
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_BARRIER_WAIT",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_INTERNAL_INSTRUCTION"
+        }
+        invalid = ~s_barrier_wait_samples["Stall_Reason"].isin(allowed_stall_reasons)
+        assert not invalid.any(), (
+            f"Unexpected stall reasons for s_barrier_wait: "
+            f"{set(s_barrier_wait_samples.loc[invalid, 'Stall_Reason'].unique())}"
+        )
+
+
+def validate_barrier_instructions(all_samples, barrier_samples):
+    s_barrier_signal, s_barrier_wait = _split_barrier_samples(barrier_samples)
+
+    validate_barrier_signal(all_samples, s_barrier_signal)
+    validate_barrier_wait(s_barrier_wait)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/branch_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/branch_instructions.py
@@ -1,0 +1,144 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_issued_instruction_type_branch_taken(samples):
+    # issued instruction with type BRANCH_TAKEN -> instruction starts with either s_cbranch or s_branch
+    issued_type_branch_taken = samples[
+        (
+            samples["Instruction_Type"]
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_BRANCH_TAKEN"
+        )
+        & samples["Wave_Issued_Instruction"]
+    ]
+
+    # The PC sampling correction WA ensures no skid samples for internal or wait
+    # instructions reach the validator. All issued BRANCH_TAKEN samples must be
+    # actual branch instructions.
+    assert (
+        issued_type_branch_taken["Instruction"]
+        .apply(lambda x: x.startswith("s_branch") or x.startswith("s_cbranch"))
+        .all()
+    )
+    assert issued_type_branch_taken["Wave_Issued_Instruction"].all()
+
+    # if issued instruction starts with s_branch (unconditional branch) -> its type must be BRANCH_TAKEN
+    issued_s_branch = samples[
+        samples["Instruction"].apply(lambda x: x.startswith("s_branch"))
+        & samples["Wave_Issued_Instruction"]
+    ]
+    assert (
+        issued_s_branch["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_BRANCH_TAKEN"
+    ).all()
+
+    # see `validate_issued_instruction_type_branch_not_taken` for more info about s_cbranch checks
+
+
+def validate_issued_instruction_type_branch_not_taken(samples):
+    # issued instruction with type BRANCH_NOT_TAKEN -> instruction is conditional branch (starts s_cbranch)
+    issued_type_branch_not_taken = samples[
+        (
+            samples["Instruction_Type"]
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_BRANCH_NOT_TAKEN"
+        )
+        & samples["Wave_Issued_Instruction"]
+    ]
+    assert (
+        issued_type_branch_not_taken["Instruction"]
+        .apply(lambda x: x.startswith("s_cbranch"))
+        .all()
+    )
+    assert issued_type_branch_not_taken["Wave_Issued_Instruction"].all()
+
+    # if issued instruction starts with s_cbranch -> its type is either BRANCH_TAKEN on BRANCH_NOT_TAKEN
+    issued_s_cbranch = samples[
+        samples["Instruction"].apply(lambda x: x.startswith("s_cbranch"))
+        & samples["Wave_Issued_Instruction"]
+    ]
+    assert (
+        (
+            issued_s_cbranch["Instruction_Type"]
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_BRANCH_TAKEN"
+        )
+        | (
+            issued_s_cbranch["Instruction_Type"]
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_BRANCH_NOT_TAKEN"
+        )
+    ).all()
+
+
+def s_branch_not_issued(stalled_samples):
+    s_branch_stalled = stalled_samples[
+        stalled_samples["Instruction"].apply(lambda x: x.startswith("s_branch"))
+    ]
+
+    if len(s_branch_stalled) > 0:
+        # No ALUDEP observed so far for unconditional branches
+        assert (
+            s_branch_stalled["Stall_Reason"]
+            .apply(
+                lambda x: x
+                != "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY"
+            )
+            .all()
+        )
+
+
+def validate_stalled_branches(samples):
+    stalled_samples = samples[samples["Wave_Issued_Instruction"] == False]
+
+    assert (
+        stalled_samples["Stall_Reason"]
+        .apply(
+            lambda x: x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT"
+        )
+        .all()
+    )
+
+    # Further constraints for unconditional branches
+    s_branch_not_issued(stalled_samples)
+
+
+def validate_branch_instructions(all_samples, branch_samples):
+    """
+    Use all_samples to verify the ROCProfV3 determines `Instruction_Type` field properly.
+
+    Use filtered_samples to verify both issued and stalled branch instructions.
+    """
+    # For the issued branches, use all samples, as the called functions will do
+    # separation based on branch type (conditional or unconditional)
+    validate_issued_instruction_type_branch_taken(all_samples)
+    validate_issued_instruction_type_branch_not_taken(all_samples)
+
+    # stalled branches
+    validate_stalled_branches(branch_samples)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/clause_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/clause_instructions.py
@@ -1,0 +1,53 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_clause_instructions(all_samples, clause_samples):
+    """
+    Validate s_clause internal instruction.
+    """
+    total = len(clause_samples)
+    if total == 0:
+        return
+
+    # s_clause is never issued
+    assert (
+        clause_samples["Wave_Issued_Instruction"] == False
+    ).all(), (
+        f"s_clause should never be issued, but "
+        f"{(clause_samples['Wave_Issued_Instruction'] == True).sum()}/{total} "
+        f"samples have Wave_Issued_Instruction == True"
+    )
+
+    # Stall reason must be INTERNAL_INSTRUCTION or OTHER_WAIT
+    allowed_stall_reasons = {
+        "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_INTERNAL_INSTRUCTION",
+        "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+    }
+    invalid = ~clause_samples["Stall_Reason"].isin(allowed_stall_reasons)
+    assert not invalid.any(), (
+        f"Unexpected stall reasons for s_clause: "
+        f"{set(clause_samples.loc[invalid, 'Stall_Reason'].unique())}"
+    )

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/delay_alu_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/delay_alu_instructions.py
@@ -1,0 +1,57 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_delay_alu_instructions(all_samples, delay_alu_samples):
+    """
+    Validate s_delay_alu internal instructions.
+
+    s_delay_alu is a pseudo-instruction that is never issued to the execution pipeline.
+    The PC sampling correction WA ensures that no skid samples for s_delay_alu reach
+    the validator, so all s_delay_alu samples must appear as not-issued.
+    """
+    total = len(delay_alu_samples)
+    if total == 0:
+        return
+
+    assert (delay_alu_samples["Wave_Issued_Instruction"] == False).all(), (
+        f"s_delay_alu must never be issued to EX, but "
+        f"{(delay_alu_samples['Wave_Issued_Instruction'] == True).sum()}/{total} "
+        f"samples have Wave_Issued_Instruction == True"
+    )
+
+    # Stall reason must be one of the allowed reasons
+    allowed_stall_reasons = {
+        "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_INTERNAL_INSTRUCTION",
+        "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+        "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE"
+    }
+    assert delay_alu_samples["Stall_Reason"].apply(
+        lambda x: x in allowed_stall_reasons
+    ).all(), (
+        "All s_delay_alu instructions should have an allowed stall reason. "
+        f"Unexpected reasons: "
+        f"{set(delay_alu_samples['Stall_Reason'].unique()) - allowed_stall_reasons}"
+    )

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/internal_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/internal_instructions.py
@@ -1,0 +1,46 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_internal_instructions(all_samples, internal_samples):
+    # The PC sampling correction WA ensures that no skid samples for internal
+    # instructions reach the validator. All internal instructions must not be
+    # issued to EX and must carry a valid internal stall reason.
+    assert (internal_samples["Wave_Issued_Instruction"] == False).all(), (
+        "Internal instructions (s_nop, s_sleep) must not be issued to EX"
+    )
+
+    valid_stall = internal_samples["Stall_Reason"].isin(
+        {
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_INTERNAL_INSTRUCTION",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_SLEEP_WAIT",
+        }
+    )
+    assert valid_stall.all(), (
+        f"Internal instructions have unexpected stall reasons: "
+        f"{set(internal_samples.loc[~valid_stall, 'Stall_Reason'].unique())}"
+    )

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/jump_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/jump_instructions.py
@@ -1,0 +1,60 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_jump_instructions_issued(all_samples, jump_samples):
+    jump_type_samples_issued = all_samples[
+        all_samples["Wave_Issued_Instruction"]
+        & (
+            all_samples["Instruction_Type"]
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_JUMP"
+        )
+    ]
+
+    jump_samples_issued = jump_samples[jump_samples["Wave_Issued_Instruction"]]
+    # sanity check
+    assert len(jump_type_samples_issued) == len(jump_samples_issued)
+    # repeat checks from above
+    assert (
+        jump_samples_issued["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_JUMP"
+    ).all()
+
+
+def validate_jump_instructions_stalled(jump_samples):
+    jump_samples_stalled = jump_samples[jump_samples["Wave_Issued_Instruction"] == False]
+    assert (
+        jump_samples_stalled["Stall_Reason"]
+        .apply(
+            lambda x: x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE"
+        )
+        .all()
+    )
+
+
+def validate_jump_instructions(all_samples, jump_samples):
+    validate_jump_instructions_issued(all_samples, jump_samples)
+    validate_jump_instructions_stalled(jump_samples)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/message_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/message_instructions.py
@@ -1,0 +1,63 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_message_instructions_issued(all_samples, message_samples):
+    message_type_samples_issued = all_samples[
+        all_samples["Wave_Issued_Instruction"]
+        & (
+            all_samples["Instruction_Type"]
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_MESSAGE"
+        )
+    ]
+
+    message_samples_issued = message_samples[message_samples["Wave_Issued_Instruction"]]
+    # sanity check
+    assert len(message_type_samples_issued) == len(message_samples_issued)
+    # repeat checks from above
+    assert (
+        message_samples_issued["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_MESSAGE"
+    ).all()
+
+
+def validate_message_instructions_stalled(message_samples):
+    message_samples_stalled = message_samples[
+        message_samples["Wave_Issued_Instruction"] == False
+    ]
+    assert (
+        message_samples_stalled["Stall_Reason"]
+        .apply(
+            lambda x: x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE"
+            or x == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY"
+        )
+        .all()
+    )
+
+
+def validate_message_instructions(all_samples, message_samples):
+    validate_message_instructions_issued(all_samples, message_samples)
+    validate_message_instructions_stalled(message_samples)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/other_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/other_instructions.py
@@ -1,0 +1,64 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_other_instructions_issued(all_samples, other_samples):
+    other_type_samples_issued = all_samples[
+        all_samples["Wave_Issued_Instruction"]
+        & (
+            all_samples["Instruction_Type"]
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_OTHER"
+        )
+    ]
+
+    other_samples_issued = other_samples[other_samples["Wave_Issued_Instruction"]]
+    assert (
+        other_samples_issued["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_OTHER"
+    ).all()
+
+    assert len(other_type_samples_issued) == len(other_samples_issued)
+
+
+def validate_other_instructions_stalled(other_samples):
+    other_samples_stalled = other_samples[
+        other_samples["Wave_Issued_Instruction"] == False
+    ]
+
+    assert (
+        other_samples_stalled["Stall_Reason"]
+        .apply(
+            lambda x: x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+        )
+        .all()
+    )
+
+
+def validate_other_instructions(all_samples, filtered_samples):
+    validate_other_instructions_issued(all_samples, filtered_samples)
+    validate_other_instructions_stalled(filtered_samples)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/scalar_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/scalar_instructions.py
@@ -1,0 +1,80 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_scalar_instructions_issued(all_samples, scalar_samples):
+    # From all samples, extract samples with SCALAR type that are issued
+    scalar_type_samples_issued = all_samples[
+        (
+            all_samples["Instruction_Type"]
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_SCALAR"
+        )
+        & all_samples["Wave_Issued_Instruction"]
+    ]
+
+    # The PC sampling correction WA ensures no skid samples for internal or wait
+    # instructions reach the validator. All issued SCALAR samples must be genuine
+    # scalar instructions (not s_nop or s_wait_*).
+    assert not scalar_type_samples_issued["Instruction"].str.startswith("s_nop").any(), (
+        "s_nop must not appear as issued SCALAR — PC correction WA should have removed these"
+    )
+    assert not scalar_type_samples_issued["Instruction"].str.startswith("s_wait").any(), (
+        "s_wait_* must not appear as issued SCALAR — PC correction WA should have removed these"
+    )
+
+    # scalar_samples contains instructions starting with `s_`
+    scalar_samples_issued = scalar_samples[scalar_samples["Wave_Issued_Instruction"]]
+    # sanity check
+    assert len(scalar_type_samples_issued) == len(scalar_samples_issued)
+    # same checks as above
+    assert (
+        scalar_samples_issued["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_SCALAR"
+    ).all()
+
+
+def validate_scalar_instructions_stalled(scalar_samples):
+    scalar_samples_stalled = scalar_samples[
+        scalar_samples["Wave_Issued_Instruction"] == False
+    ]
+
+    assert (
+        scalar_samples_stalled["Stall_Reason"]
+        .apply(
+            lambda x: x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            or x == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY"
+        )
+        .all()
+    )
+
+
+def validate_scalar_instructions(all_samples, scalar_samples):
+    validate_scalar_instructions_issued(all_samples, scalar_samples)
+    validate_scalar_instructions_stalled(scalar_samples)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/waitcnt.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/waitcnt.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,18 +20,31 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-#
 
-set(PACKAGE_OUTPUT_DIR
-    ${ROCPROFILER_SDK_TESTS_BINARY_DIR}/pytest-packages/rocprofiler_sdk/pc_sampling/stochastic/csv
+from __future__ import absolute_import
+
+
+def validate_waitcnt(all_samples, waitcnt_samples):
+    s_waitcnt_samples = all_samples[
+        all_samples["Instruction"].apply(lambda x: x.startswith("s_wait"))
+    ]
+    # sanity check
+    assert len(s_waitcnt_samples) == len(waitcnt_samples)
+
+    # The PC sampling correction WA ensures that no skid samples for s_wait_*
+    # instructions reach the validator. s_wait_* instructions are never issued
+    # on GFX12, and ARBITER_NOT_WIN skid samples are also corrected away.
+    assert (waitcnt_samples["Wave_Issued_Instruction"] == False).all(), (
+        "s_wait_* instructions must never be issued on GFX12"
     )
 
-set(PC_SAMPLING_PYTHON_SOURCES __init__.py)
-
-foreach(_FILE ${PC_SAMPLING_PYTHON_SOURCES})
-    configure_file(${CMAKE_CURRENT_LIST_DIR}/${_FILE} ${PACKAGE_OUTPUT_DIR}/${_FILE}
-                   COPYONLY)
-endforeach()
-
-add_subdirectory(gfx9)
-add_subdirectory(gfx12)
+    # accepted stall reasons are
+    assert (
+        waitcnt_samples["Stall_Reason"]
+        .apply(
+            lambda x: x == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_WAITCNT"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE"
+        )
+        .all()
+    )

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/wakeup_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/s_instructions/wakeup_instructions.py
@@ -1,0 +1,57 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_wakeup_instructions(all_samples, wakeup_samples):
+    """Validate s_wakeup instructions.
+
+    s_wakeup is declared as NO_INST type but goes through the brmsg arbiter pipe.
+    When issued, Instruction_Type must be NO_INST.
+    When stalled, NO_INSTRUCTION_AVAILABLE or ARBITER_NOT_WIN are allowed.
+    """
+    # -- issued --
+    issued = wakeup_samples[wakeup_samples["Wave_Issued_Instruction"]]
+
+    if not issued.empty:
+        assert (
+            issued["Instruction_Type"]
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_NO_INST"
+        ).all(), (
+            "s_wakeup must have NO_INST instruction type when issued"
+        )
+
+    # -- stalled --
+    stalled = wakeup_samples[wakeup_samples["Wave_Issued_Instruction"] == False]
+
+    if not stalled.empty:
+        allowed_stall_reasons = {
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+        }
+        invalid = ~stalled["Stall_Reason"].isin(allowed_stall_reasons)
+        assert not invalid.any(), (
+            f"Unexpected stall reasons for s_wakeup: "
+            f"{set(stalled.loc[invalid, 'Stall_Reason'].unique())}"
+        )

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/valu_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/valu_instructions.py
@@ -1,0 +1,77 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_valu_instructions_issued(samples_issued):
+    # issued instruction with type == VALU -> instruction starts with v_
+    issued_type_valu = samples_issued[
+        samples_issued["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_VALU"
+    ]
+
+    # The PC sampling correction WA ensures no skid samples for s_delay_alu reach
+    # the validator. All issued VALU-typed samples must start with v_.
+    assert issued_type_valu["Instruction"].apply(lambda x: x.startswith("v_")).all(), (
+        "All issued VALU instructions must start with v_ — "
+        "PC correction WA should have removed any s_delay_alu skid samples"
+    )
+
+    # issued instruction starts with v_ and is not matrix instruction -> it must be VALU
+    issued_v = samples_issued[
+        samples_issued["Instruction"].apply(
+            lambda x: x.startswith("v_") and ("wmma" not in x) and ("dual" not in x)
+        )
+    ]
+    assert (
+        issued_v["Instruction_Type"] == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_VALU"
+    ).all()
+
+
+def validate_valu_instructions_stalled(samples):
+    valu_samples = samples[
+        samples["Instruction"].apply(lambda x: x.startswith("v_") and ("wmma" not in x) and ("dual" not in x))
+    ]
+    valu_stalled = valu_samples[valu_samples["Wave_Issued_Instruction"] == False]
+
+    assert (
+        valu_stalled["Stall_Reason"]
+        .apply(
+            lambda x: x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY"
+        )
+        .all()
+    )
+
+
+def validate_valu_instructions(samples):
+    samples_issued = samples[samples["Wave_Issued_Instruction"]]
+    validate_valu_instructions_issued(samples_issued)
+    validate_valu_instructions_stalled(samples)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/vmem_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/csv/gfx12/vmem_instructions.py
@@ -1,0 +1,83 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_vmem_instructions_issued(samples_issued):
+    # issued instruction with type == TEX (VMEM) -> instruction starts with global_ or buffer_
+    issued_type_texture = samples_issued[
+        samples_issued["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_TEX"
+    ]
+
+    # The PC sampling correction WA ensures no skid samples for s_wait_* instructions
+    # reach the validator. All issued TEX-typed samples must be genuine VMEM instructions.
+    assert (
+        issued_type_texture["Instruction"]
+        .apply(lambda x: x.startswith("global_") or x.startswith("buffer_"))
+        .all()
+    ), (
+        "All issued TEX/VMEM instructions must start with global_ or buffer_ — "
+        "PC correction WA should have removed any s_wait_* skid samples"
+    )
+
+    # issued instruction starts with global_ or buffer_ -> it must be TEX
+    issued_vmem = samples_issued[
+        samples_issued["Instruction"].apply(
+            lambda x: x.startswith("global_") or x.startswith("buffer_")
+        )
+    ]
+    assert (
+        issued_vmem["Instruction_Type"]
+        == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_TEX"
+    ).all()
+
+
+def validate_vmem_instructions_stalled(samples):
+    texture_samples = samples[
+        samples["Instruction"].apply(
+            lambda x: x.startswith("global_") or x.startswith("buffer_")
+        )
+    ]
+    texture_stalled = texture_samples[texture_samples["Wave_Issued_Instruction"] == False]
+
+    assert (
+        texture_stalled["Stall_Reason"]
+        .apply(
+            lambda x: x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE"
+            or x
+            == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            or x == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY"
+        )
+        .all()
+    )
+
+
+def validate_vmem_instructions(samples):
+    samples_issued = samples[samples["Wave_Issued_Instruction"]]
+    validate_vmem_instructions_issued(samples_issued)
+    validate_vmem_instructions_stalled(samples)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/CMakeLists.txt
@@ -34,3 +34,4 @@ foreach(_FILE ${PC_SAMPLING_PYTHON_SOURCES})
 endforeach()
 
 add_subdirectory(gfx9)
+add_subdirectory(gfx12)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/gfx12/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/gfx12/CMakeLists.txt
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,15 +23,13 @@
 #
 
 set(PACKAGE_OUTPUT_DIR
-    ${ROCPROFILER_SDK_TESTS_BINARY_DIR}/pytest-packages/rocprofiler_sdk/pc_sampling/stochastic/csv
+    ${ROCPROFILER_SDK_TESTS_BINARY_DIR}/pytest-packages/rocprofiler_sdk/pc_sampling/stochastic/json/gfx12
     )
 
-set(PC_SAMPLING_PYTHON_SOURCES __init__.py)
+set(PC_SAMPLING_PYTHON_SOURCES __init__.py arbiter_state.py s_instructions.py
+                               other_instructions.py)
 
 foreach(_FILE ${PC_SAMPLING_PYTHON_SOURCES})
     configure_file(${CMAKE_CURRENT_LIST_DIR}/${_FILE} ${PACKAGE_OUTPUT_DIR}/${_FILE}
                    COPYONLY)
 endforeach()
-
-add_subdirectory(gfx9)
-add_subdirectory(gfx12)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/gfx12/__init__.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/gfx12/__init__.py
@@ -1,0 +1,192 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+import numpy as np
+import pandas as pd
+from collections import defaultdict
+from .arbiter_state import validate_arbiter_state
+from .other_instructions import (
+    validate_valu_instructions,
+    validate_vmem_instructions,
+    validate_matrix_instructions,
+    validate_dual_valu_instructions,
+    validate_flat_instructions,
+    validate_lds_instructions,
+)
+from .s_instructions import (
+    validate_internal_instructions,
+    validate_barrier_instructions,
+    validate_waitcnt,
+    validate_branch_instructions,
+    validate_scalar_instructions,
+    validate_jump_instructions,
+    validate_message_instructions,
+    validate_other_s_instructions,
+    validate_s_wakeup,
+    validate_delay_alu_instructions,
+    validate_clause_instructions,
+)
+
+# Using Prefix Tree to classify the instruction type
+# I did this instead of the regex becuase I wanted to try if we could
+# generalize this approach for other types of instructions.
+# The dream scenario: We have a giant list of all instructions and their
+# types. Then we parse the list and dynamically determine the checks
+# based on the instruction types.
+
+
+# TODO: extract this outside of the file
+class TrieNode:
+    def __init__(self):
+        self.children = {}
+        self.instruction_type = None  # Store the instruction type at the leaf node
+
+
+class PrefixTree:
+    def __init__(self):
+        self.root = TrieNode()
+
+    def insert(self, full_prefix, instruction_type):
+        """Insert a prefix and its associated instruction type into the Trie."""
+        node = self.root
+        for char in full_prefix:
+            if char not in node.children:
+                node.children[char] = TrieNode()
+            node = node.children[char]
+        node.instruction_type = (
+            instruction_type  # Assign the instruction type at the leaf
+        )
+
+    def get_instruction_type(self, instruction):
+        """Get the list of instruction types based on the longest matching prefix."""
+        node = self.root
+        matched_types = []  # List to store matched types
+
+        # Traverse the instruction one character at a time
+        for char in instruction:
+            if char not in node.children:
+                break  # Stop if no match is found
+
+            node = node.children[char]
+
+            # If we reach a node that has an instruction type, store it
+            if node.instruction_type:
+                matched_types.append(node.instruction_type)
+
+        return matched_types
+
+
+instructions_with_types = [
+    ("s_", "SCALAR"),  # Scalar instructions (general category)
+    ("s_wait", "WAITCNT"),  # WAITCNT (specific) - GFX12 uses s_wait_loadcnt, s_wait_storecnt, etc.
+    ("s_sendmsg", "MESSAGE"),  # MESSAGE (specific)
+    ("s_barrier", "BARRIER"),  # BARRIER (specific)
+    ("s_swappc", "JUMP"),  # JUMP (specific)
+    ("s_setpc", "JUMP"),  # JUMP
+    ("s_branch", "BRANCH"),  # BRANCH
+    ("s_cbranch", "BRANCH"),  # BRANCH (conditional)
+    ("s_wakeup", "S_WAKEUP"),  # NO_INST type, but goes through the brmsg arbiter.
+    ("s_nop", "INTERNAL"),  # INTERNAL
+    ("s_sleep", "INTERNAL"),  # INTERNAL
+    ("s_clause", "CLAUSE"),  # CLAUSE (specific)
+    ("s_delay_alu", "DELAY_ALU"),  # DELAY_ALU (specific)
+    ("v_", "VALU"),  # VALU
+    ("v_wmma", "MATRIX"),  # MATRIX (GFX12 uses v_wmma)
+    ("v_dual_", "DUAL_VALU"),  # DUAL_VALU (GFX12 specific)
+    ("flat_", "FLAT"),  # FLAT
+    ("global_", "TEX"),  # TEX / VMEM
+    ("ds_", "LDS"),  # LDS
+    ("buffer_", "TEX"),  # TEX
+]
+
+
+inst_type_verify_functions = {
+    "BRANCH": validate_branch_instructions,
+    "WAITCNT": validate_waitcnt,
+    "OTHER": validate_other_s_instructions,
+    "S_WAKEUP": validate_s_wakeup,
+    "SCALAR": validate_scalar_instructions,
+    "INTERNAL": validate_internal_instructions,
+    "JUMP": validate_jump_instructions,
+    "MESSAGE": validate_message_instructions,
+    "BARRIER": validate_barrier_instructions,
+    "CLAUSE": validate_clause_instructions,
+    "DELAY_ALU": validate_delay_alu_instructions,
+    "VALU": validate_valu_instructions,
+    "MATRIX": validate_matrix_instructions,
+    "DUAL_VALU": validate_dual_valu_instructions,
+    "TEX": validate_vmem_instructions,
+    "FLAT": validate_flat_instructions,
+    "LDS": validate_lds_instructions,
+}
+
+
+def validate_stochastic_samples_json(data_json):
+    # fill in the Prefix Tree
+    prefix_tree = PrefixTree()
+    for prefix, instruction_type in instructions_with_types:
+        prefix_tree.insert(prefix, instruction_type)
+
+    instructions = data_json["strings"]["pc_sample_instructions"]
+    comments = data_json["strings"]["pc_sample_comments"]
+
+    insts_per_prefix_type = defaultdict(list)
+
+    for sample in data_json["buffer_records"]["pc_sample_stochastic"]:
+        inst_index = sample["inst_index"]
+        if inst_index == -1:
+            # Ignoring samples from blit kernels
+            continue
+        record = sample["record"]
+        # extend the record with the instruction
+        record["inst"] = instructions[inst_index]
+
+        # get the instruction type from prefix tree
+        inst_prefix_types = prefix_tree.get_instruction_type(record["inst"])
+        # each type must have a type
+        assert len(inst_prefix_types) > 0
+        # As more then one type can be matched, we take the last one as the most specific.
+        inst_prefix_type = inst_prefix_types[-1]
+        insts_per_prefix_type[inst_prefix_type].append(record)
+
+        # For each sample, we need to validate wave_cnt and arbiter state
+        wave_cnt = record["wave_cnt"]
+        assert wave_cnt >= 0 and wave_cnt <= 16, "Invalid wave count"
+
+        # arbiter state check
+        snapshot = record["snapshot"]
+        validate_arbiter_state(snapshot)
+
+    # Check now the instruction type and arb state correlation.
+    # We do that for all samples of a single instruction type all at once
+    # to minimize the number of functions calls (one call for all samples, instead of a function
+    # call per sample).
+    # Please note that each sample is iterated at most twice.
+    # The first time to group samples per instruction type, and the second time to validate samples.
+    for inst_prefix_type, sample_records in insts_per_prefix_type.items():
+        if inst_prefix_type in inst_type_verify_functions:
+            inst_type_verify_functions[inst_prefix_type](sample_records)
+        else:
+            assert False, f"Unhandle instruction type: {inst_prefix_type}"

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/gfx12/arbiter_state.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/gfx12/arbiter_state.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2023-2025 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,18 +20,39 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-#
 
-set(PACKAGE_OUTPUT_DIR
-    ${ROCPROFILER_SDK_TESTS_BINARY_DIR}/pytest-packages/rocprofiler_sdk/pc_sampling/stochastic/csv
+from __future__ import absolute_import
+
+
+def _check_pipe(snapshot, pipe_name):
+    """Validate issue/stall for a single arbiter pipe.
+
+    Allowed combinations per pipe:
+        issue=0, stall=0  (idle)
+        issue=1, stall=0  (issued)
+        issue=0, stall=1  (stalled)
+
+    The only disallowed combination is issue=1 AND stall=1.
+    """
+    issue = snapshot[f"arb_state_issue_{pipe_name}"]
+    stall = snapshot[f"arb_state_stall_{pipe_name}"]
+    assert not (issue == 1 and stall == 1), (
+        f"{pipe_name} arbiter state check failed: "
+        f"issue=1 and stall=1 is not allowed (issue={issue}, stall={stall})"
     )
 
-set(PC_SAMPLING_PYTHON_SOURCES __init__.py)
 
-foreach(_FILE ${PC_SAMPLING_PYTHON_SOURCES})
-    configure_file(${CMAKE_CURRENT_LIST_DIR}/${_FILE} ${PACKAGE_OUTPUT_DIR}/${_FILE}
-                   COPYONLY)
-endforeach()
+_PIPES = [
+    "valu",
+    "scalar",
+    "vmem_tex",
+    "lds",
+    "exp",
+    "lds_direct",
+    "brmsg",
+]
 
-add_subdirectory(gfx9)
-add_subdirectory(gfx12)
+
+def validate_arbiter_state(snapshot):
+    for pipe in _PIPES:
+        _check_pipe(snapshot, pipe)

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/gfx12/other_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/gfx12/other_instructions.py
@@ -1,0 +1,277 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_valu_instructions(sample_records):
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY",
+        ]
+    )
+    for record in sample_records:
+        assert record["inst"].startswith("v_"), "VALU instruction must start with 'v_'"
+
+        snapshot = record["snapshot"]
+        if record["wave_issued"] == 1:
+            # wave issued a VALU instruction
+            assert record["inst_type"] == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_VALU"
+            assert snapshot["arb_state_issue_valu"] == 1
+            assert snapshot["arb_state_stall_valu"] == 0
+        else:
+            # wave did not issue a VALU instruction
+            # inst_type is not relevant
+            stall_reason = snapshot["stall_reason"]
+            assert (
+                stall_reason in allowed_stall_reasons
+            ), f"Invalid stall reason for VALU instruction: {stall_reason}"
+
+            if (
+                stall_reason
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            ):
+                assert (
+                    snapshot["arb_state_issue_valu"] == 1
+                    or snapshot["arb_state_stall_valu"] == 1
+                ), "VALU pipe must have issued or stalled (at least one must be 1)"
+
+
+def validate_vmem_instructions(sample_records):
+    """Validate vector memory (VMEM/TEX) instructions that use global_ or buffer_ prefix."""
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY",
+        ]
+    )
+    for record in sample_records:
+        assert record["inst"].startswith("global_") or record["inst"].startswith(
+            "buffer_"
+        ), "TEX/VMEM instruction must start with 'global_' or 'buffer_'"
+
+        snapshot = record["snapshot"]
+        if record["wave_issued"] == 1:
+            assert (
+                record["inst_type"]
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_TEX"
+            ), "Invalid instruction type for TEX/VMEM instruction"
+            assert (
+                snapshot["arb_state_issue_vmem_tex"] == 1
+            ), "Arbiter must have issued vmem_tex"
+            assert (
+                snapshot["arb_state_stall_vmem_tex"] == 0
+            ), "Arbiter should not have stalled vmem_tex"
+        else:
+            stall_reason = snapshot["stall_reason"]
+            assert (
+                stall_reason in allowed_stall_reasons
+            ), f"Invalid stall reason for TEX/VMEM instruction: {stall_reason}"
+
+            if (
+                stall_reason
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            ):
+                assert (
+                    snapshot["arb_state_issue_vmem_tex"] == 1
+                    or snapshot["arb_state_stall_vmem_tex"] == 1
+                ), "VMEM_TEX pipe must have issued or stalled (at least one must be 1)"
+
+
+def validate_matrix_instructions(sample_records):
+    """
+    Validate matrix (v_wmma) instructions.
+
+    When issued, inst_type must be MATRIX and arbiter must have issued on valu pipe.
+    When stalled, ARBITER_NOT_WIN or NO_INSTRUCTION_AVAILABLE are allowed.
+    """
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+        ]
+    )
+    for record in sample_records:
+        assert record["inst"].startswith(
+            "v_wmma"
+        ), "MATRIX instruction must start with v_wmma"
+
+        snapshot = record["snapshot"]
+        if record["wave_issued"] == 1:
+            assert (
+                record["inst_type"]
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_MATRIX"
+            ), "Invalid instruction type for MATRIX instruction"
+            assert (
+                snapshot["arb_state_issue_valu"] == 1
+            ), "Arbiter must have issued valu for matrix instruction"
+            assert (
+                snapshot["arb_state_stall_valu"] == 0
+            ), "Arbiter should not have stalled valu for matrix instruction"
+        else:
+            stall_reason = snapshot["stall_reason"]
+            assert (
+                stall_reason in allowed_stall_reasons
+            ), (
+                f"Invalid stall reason for MATRIX instruction: {stall_reason}"
+            )
+
+            if (
+                stall_reason
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            ):
+                assert (
+                    snapshot["arb_state_issue_valu"] == 1
+                    or snapshot["arb_state_stall_valu"] == 1
+                ), "Arbiter must have issued or stalled valu for matrix instruction"
+
+
+def validate_dual_valu_instructions(sample_records):
+    """Validate dual VALU (v_dual_*) instructions.
+
+    When issued, inst_type must be DUAL_VALU and arbiter must have dual-issued VALU.
+    When stalled, ARBITER_NOT_WIN, NO_INSTRUCTION_AVAILABLE, OTHER_WAIT,
+    or ALU_DEPENDENCY are allowed.
+    """
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY",
+        ]
+    )
+    for record in sample_records:
+        assert record["inst"].startswith(
+            "v_dual_"
+        ), "DUAL_VALU instruction must start with v_dual_"
+
+        snapshot = record["snapshot"]
+        if record["wave_issued"] == 1:
+            assert (
+                record["inst_type"]
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_DUAL_VALU"
+            ), "Invalid instruction type for DUAL_VALU instruction"
+            # dual issue VALU implies arb_state_issue_valu == 1 and stall == 0
+            assert (
+                snapshot["arb_state_issue_valu"] == 1
+            ), "Arbiter must have issued VALU for dual VALU"
+            assert (
+                snapshot["arb_state_stall_valu"] == 0
+            ), "Arbiter should not have stalled VALU for dual VALU"
+        else:
+            stall_reason = snapshot["stall_reason"]
+            assert (
+                stall_reason in allowed_stall_reasons
+            ), (
+                f"Invalid stall reason for DUAL_VALU instruction: {stall_reason}"
+            )
+
+
+def validate_flat_instructions(sample_records):
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY",
+        ]
+    )
+    for record in sample_records:
+        assert record["inst"].startswith(
+            "flat_"
+        ), "FLAT instruction must start with 'flat_'"
+
+        snapshot = record["snapshot"]
+        if record["wave_issued"] == 1:
+            # wave issued a flat memory instruction
+            # flat pipe doesn't exist on GFX12; both lds and vmem_tex pipes are used
+            assert (
+                record["inst_type"] == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_FLAT"
+            ), "Invalid instruction type for FLAT instruction"
+            assert snapshot["arb_state_issue_lds"] == 1, "Arbiter must have issued lds"
+            assert snapshot["arb_state_stall_lds"] == 0, "Arbiter should not have stalled lds"
+            assert snapshot["arb_state_issue_vmem_tex"] == 1, "Arbiter must have issued vmem_tex"
+            assert snapshot["arb_state_stall_vmem_tex"] == 0, "Arbiter should not have stalled vmem_tex"
+        else:
+            stall_reason = snapshot["stall_reason"]
+            assert (
+                stall_reason in allowed_stall_reasons
+            ), f"Invalid stall reason for flat instruction: {stall_reason}"
+
+            if (
+                stall_reason
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            ):
+                assert (
+                    snapshot["arb_state_issue_vmem_tex"] == 1
+                    or snapshot["arb_state_stall_vmem_tex"] == 1
+                    or snapshot["arb_state_issue_lds"] == 1
+                    or snapshot["arb_state_stall_lds"] == 1
+                ), "LDS or VMEM_TEX pipe must have issued or stalled for flat ARBITER_NOT_WIN"
+
+
+def validate_lds_instructions(sample_records):
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY",
+        ]
+    )
+    for record in sample_records:
+        assert record["inst"].startswith("ds_"), "Invalid name of LDS instruction"
+
+        snapshot = record["snapshot"]
+        if record["wave_issued"] == 1:
+            # wave issued an LDS memory instruction
+            assert (
+                record["inst_type"] == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_LDS"
+            ), "Invalid instruction type for LDS instruction"
+            assert snapshot["arb_state_issue_lds"] == 1, "Arbiter issued lds"
+            assert snapshot["arb_state_stall_lds"] == 0, "EX should not stalled lds"
+
+            # TODO: add checks when LDS stalls flat, and vice versa
+            # ISSUE_LDS=1, STALL_LDS=0, ISSUE_FLAT=1 -> STALL_FLAT = 1
+        else:
+            # wave did not issue an LDS instruction
+            # inst_type is not relevant
+            stall_reason = snapshot["stall_reason"]
+            assert (
+                stall_reason in allowed_stall_reasons
+            ), f"Invalid stall reason for LDS instruction: {stall_reason}"
+
+            if (
+                stall_reason
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            ):
+                assert (
+                    snapshot["arb_state_issue_lds"] == 1
+                    or snapshot["arb_state_stall_lds"] == 1
+                ), "Arbiter must have issued or stalled LDS"

--- a/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/gfx12/s_instructions.py
+++ b/projects/rocprofiler-sdk/tests/pytest-packages/pc_sampling/stochastic/json/gfx12/s_instructions.py
@@ -1,0 +1,458 @@
+# MIT License
+#
+# Copyright (c) 2023-2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import absolute_import
+
+
+def validate_internal_instructions(sample_records):
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_INTERNAL_INSTRUCTION",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_SLEEP_WAIT",
+        ]
+    )
+
+    # The PC sampling correction WA ensures that no skid samples for internal
+    # instructions reach the validator. All internal instructions must not be
+    # issued to EX, and ARBITER_NOT_WIN skid samples are also corrected away.
+    for record in sample_records:
+        assert record["inst"].startswith("s_nop") or record["inst"].startswith(
+            "s_sleep"
+        ), f"Unexpected internal instruction: {record['inst']}"
+        assert (
+            record["wave_issued"] == 0
+        ), f"Internal instruction must not be issued to EX: {record['inst']}"
+        stall_reason = record["snapshot"]["stall_reason"]
+        assert (
+            stall_reason in allowed_stall_reasons
+        ), f"Invalid stall reason for internal instruction: {stall_reason}"
+
+
+def validate_waitcnt(sample_records):
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_WAITCNT",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+        ]
+    )
+
+    # The PC sampling correction WA ensures that no skid samples for s_wait_*
+    # instructions reach the validator. s_wait_* instructions are never issued on
+    # GFX12, and ARBITER_NOT_WIN skid samples are also corrected away.
+    for record in sample_records:
+        assert record["inst"].startswith("s_wait"), "Waitcnt must start with s_wait"
+        assert (
+            record["wave_issued"] == 0
+        ), f"s_wait_* must not be issued to EX: {record['inst']}"
+        stall_reason = record["snapshot"]["stall_reason"]
+        assert (
+            stall_reason in allowed_stall_reasons
+        ), f"Invalid stall reason for waitcnt: {stall_reason}"
+
+
+def validate_branch_instructions(sample_records):
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+        ]
+    )
+    allowed_stall_reasons_uncoditional_branches = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+        ]
+    )
+    for record in sample_records:
+        inst = record["inst"]
+        inst_type = record["inst_type"]
+        snapshot = record["snapshot"]
+        stall_reason = snapshot["stall_reason"]
+        assert inst.startswith("s_cbranch") or inst.startswith(
+            "s_branch"
+        ), "Branch must start with s_cbranch or s_branch"
+
+        if record["wave_issued"] == 1:
+            if inst.startswith("s_branch"):
+                # Uncoditional issued branch can only be branch taken
+                assert (
+                    inst_type == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_BRANCH_TAKEN"
+                ), "Unconditional branch must be taken"
+            else:
+                # Verifying issued branch instructions
+                assert (
+                    inst_type == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_BRANCH_TAKEN"
+                    or inst_type
+                    == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_BRANCH_NOT_TAKEN"
+                ), "Invalid branch type for conditional branch instruction"
+
+            assert (
+                snapshot["arb_state_issue_brmsg"] == 1
+                and snapshot["arb_state_stall_brmsg"] == 0
+            ), "Invalid arb state for issued branch instruction"
+
+        else:
+            # verifying not issued branch instructions
+            assert (
+                stall_reason in allowed_stall_reasons
+            ), f"Invalid stall reason for branch instruction: {stall_reason}"
+
+            if (
+                stall_reason
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            ):
+                assert (
+                    snapshot["arb_state_issue_brmsg"] == 1
+                    or snapshot["arb_state_stall_brmsg"] == 1
+                ), "Arbiter must have issued or stalled brmsg instruction"
+
+            # more specific checks for unconditional branches
+            if inst.startswith("s_branch"):
+                assert (
+                    stall_reason in allowed_stall_reasons_uncoditional_branches
+                ), "Invalid stall reason for unconditional branch instruction"
+
+
+def validate_scalar_instructions(sample_records):
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+        ]
+    )
+
+    for record in sample_records:
+        snapshot = record["snapshot"]
+        if record["wave_issued"] == 1:
+            assert (
+                record["inst_type"] == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_SCALAR"
+            ), "Invalid scalar instruction type"
+            assert (
+                snapshot["arb_state_issue_scalar"] == 1
+            ), "Arbiter must have issued scalar instruction"
+            assert (
+                snapshot["arb_state_stall_scalar"] == 0
+            ), "Arbiter must have stalled scalar instruction"
+        else:
+            stall_reason = snapshot["stall_reason"]
+            assert (
+                stall_reason in allowed_stall_reasons
+            ), f"Invalid stall reason for scalar instruction: {stall_reason}"
+
+            if (
+                stall_reason
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            ):
+                assert (
+                    snapshot["arb_state_issue_scalar"] == 1
+                    or snapshot["arb_state_stall_scalar"] == 1
+                ), "Arbiter must have issued or stalled scalar instruction"
+
+
+def _validate_barrier_signal(sample_records):
+    """Validate s_barrier_signal instructions.
+
+    s_barrier_signal can be issued (type=BARRIER, arb brmsg pipe).
+    When stalled, NO_INSTRUCTION_AVAILABLE, ARBITER_NOT_WIN, or OTHER_WAIT are allowed.
+    """
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+        ]
+    )
+    for record in sample_records:
+        assert record["inst"].startswith(
+            "s_barrier_signal"
+        ), "Barrier signal instruction must start with s_barrier_signal"
+        snapshot = record["snapshot"]
+        if record["wave_issued"] == 1:
+            assert (
+                record["inst_type"] == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_BARRIER"
+            ), "Invalid barrier signal instruction type"
+            assert (
+                snapshot["arb_state_issue_brmsg"] == 1
+            ), "Arbiter must have issued brmsg for barrier signal"
+            assert (
+                snapshot["arb_state_stall_brmsg"] == 0
+            ), "Arbiter must not have stalled brmsg for barrier signal"
+        else:
+            stall_reason = snapshot["stall_reason"]
+            assert (
+                stall_reason in allowed_stall_reasons
+            ), f"Invalid stall reason for barrier signal: {stall_reason}"
+
+            if (
+                stall_reason
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            ):
+                assert (
+                    snapshot["arb_state_issue_brmsg"] == 1
+                    or snapshot["arb_state_stall_brmsg"] == 1
+                ), "Arbiter must have issued or stalled brmsg for barrier signal"
+
+
+def _validate_barrier_wait(sample_records):
+    """Validate s_barrier_wait instructions.
+
+    s_barrier_wait is never issued.
+    Allowed stall reasons: NO_INSTRUCTION_AVAILABLE, BARRIER_WAIT,
+    OTHER_WAIT, INTERNAL_INSTRUCTION.
+    """
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_BARRIER_WAIT",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_INTERNAL_INSTRUCTION",
+        ]
+    )
+    for record in sample_records:
+        assert record["inst"].startswith(
+            "s_barrier_wait"
+        ), "Barrier wait instruction must start with s_barrier_wait"
+        assert (
+            record["wave_issued"] == 0
+        ), "s_barrier_wait should never be issued"
+        stall_reason = record["snapshot"]["stall_reason"]
+        assert (
+            stall_reason in allowed_stall_reasons
+        ), f"Invalid stall reason for barrier wait: {stall_reason}"
+
+
+def validate_barrier_instructions(sample_records):
+    """Validate barrier instructions by splitting into signal and wait."""
+    signal_records = [r for r in sample_records if r["inst"].startswith("s_barrier_signal")]
+    wait_records = [r for r in sample_records if r["inst"].startswith("s_barrier_wait")]
+
+    if signal_records:
+        _validate_barrier_signal(signal_records)
+    if wait_records:
+        _validate_barrier_wait(wait_records)
+
+
+def validate_jump_instructions(sample_records):
+    """Validate jump instructions (s_swappc, s_setpc, s_sleep).
+
+    When issued, inst_type must be JUMP and arbiter must have issued on brmsg pipe.
+    When stalled, only NO_INSTRUCTION_AVAILABLE is allowed.
+    """
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+        ]
+    )
+    for record in sample_records:
+        snapshot = record["snapshot"]
+        if record["wave_issued"] == 1:
+            assert (
+                record["inst_type"]
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_JUMP"
+            ), "Invalid jump instruction type"
+            assert (
+                snapshot["arb_state_issue_brmsg"] == 1
+            ), "Arbiter must have issued brmsg instruction for jump"
+            assert (
+                snapshot["arb_state_stall_brmsg"] == 0
+            ), "Arbiter must not have stalled brmsg instruction for jump"
+        else:
+            stall_reason = snapshot["stall_reason"]
+            assert (
+                stall_reason in allowed_stall_reasons
+            ), f"Invalid stall reason for jump instruction: {stall_reason}"
+
+
+def validate_message_instructions(sample_records):
+    """Validate message instructions (s_sendmsg).
+
+    When issued, inst_type must be MESSAGE and arbiter must have issued on brmsg pipe.
+    When stalled, NO_INSTRUCTION_AVAILABLE or ALU_DEPENDENCY are allowed.
+    """
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ALU_DEPENDENCY",
+        ]
+    )
+    for record in sample_records:
+        assert record["inst"].startswith(
+            "s_sendmsg"
+        ), "Message instruction must start with s_sendmsg"
+        snapshot = record["snapshot"]
+        if record["wave_issued"] == 1:
+            assert (
+                record["inst_type"]
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_MESSAGE"
+            ), "Invalid message instruction type"
+            assert (
+                snapshot["arb_state_issue_brmsg"] == 1
+            ), "Arbiter must have issued brmsg instruction for message"
+            assert (
+                snapshot["arb_state_stall_brmsg"] == 0
+            ), "Arbiter must not have stalled brmsg instruction for message"
+        else:
+            stall_reason = snapshot["stall_reason"]
+            assert (
+                stall_reason in allowed_stall_reasons
+            ), f"Invalid stall reason for message instruction: {stall_reason}"
+
+
+def validate_other_s_instructions(sample_records):
+    """Validate OTHER type scalar instructions.
+
+    When issued, inst_type must be OTHER.
+    When stalled, NO_INSTRUCTION_AVAILABLE or ARBITER_NOT_WIN are allowed.
+    """
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+        ]
+    )
+    for record in sample_records:
+        snapshot = record["snapshot"]
+        if record["wave_issued"] == 1:
+            assert (
+                record["inst_type"]
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_OTHER"
+            ), "Invalid OTHER instruction type"
+        else:
+            stall_reason = snapshot["stall_reason"]
+            assert (
+                stall_reason in allowed_stall_reasons
+            ), f"Invalid stall reason for OTHER instruction: {stall_reason}"
+
+
+def validate_s_wakeup(sample_records):
+    """Validate s_wakeup instructions.
+
+    s_wakeup is declared as NO_INST type but goes through the brmsg arbiter pipe.
+    When issued, inst_type must be NO_INST and arbiter must have issued on brmsg pipe.
+    When stalled, NO_INSTRUCTION_AVAILABLE or ARBITER_NOT_WIN are allowed.
+    """
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN",
+        ]
+    )
+    for record in sample_records:
+        assert record["inst"].startswith(
+            "s_wakeup"
+        ), "S_WAKEUP instruction must start with s_wakeup"
+        snapshot = record["snapshot"]
+        if record["wave_issued"] == 1:
+            assert (
+                record["inst_type"]
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_TYPE_NO_INST"
+            ), "s_wakeup must have NO_INST instruction type"
+            assert (
+                snapshot["arb_state_issue_brmsg"] == 1
+            ), "Arbiter must have issued brmsg for s_wakeup"
+            assert (
+                snapshot["arb_state_stall_brmsg"] == 0
+            ), "Arbiter must not have stalled brmsg for s_wakeup"
+        else:
+            stall_reason = snapshot["stall_reason"]
+            assert (
+                stall_reason in allowed_stall_reasons
+            ), f"Invalid stall reason for s_wakeup instruction: {stall_reason}"
+
+            if (
+                stall_reason
+                == "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_ARBITER_NOT_WIN"
+            ):
+                assert (
+                    snapshot["arb_state_issue_brmsg"] == 1
+                    or snapshot["arb_state_stall_brmsg"] == 1
+                ), "Arbiter must have issued or stalled brmsg for s_wakeup"
+
+
+def validate_delay_alu_instructions(sample_records):
+    """Validate s_delay_alu pseudo-instructions.
+
+    s_delay_alu must never be issued on GFX12. The PC sampling correction WA
+    ensures no skid samples for s_delay_alu reach the validator.
+    Allowed stall reasons: INTERNAL_INSTRUCTION, OTHER_WAIT, NO_INSTRUCTION_AVAILABLE.
+    """
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_INTERNAL_INSTRUCTION",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_NO_INSTRUCTION_AVAILABLE",
+        ]
+    )
+
+    for record in sample_records:
+        assert record["inst"].startswith(
+            "s_delay_alu"
+        ), "DELAY_ALU instruction must start with s_delay_alu"
+        assert (
+            record["wave_issued"] == 0
+        ), f"s_delay_alu must not be issued to EX: {record['inst']}"
+        stall_reason = record["snapshot"]["stall_reason"]
+        assert (
+            stall_reason in allowed_stall_reasons
+        ), (
+            f"Invalid stall reason for s_delay_alu: {stall_reason}"
+        )
+
+
+def validate_clause_instructions(sample_records):
+    """Validate s_clause internal instructions.
+
+    s_clause is never issued.
+    Allowed stall reasons: INTERNAL_INSTRUCTION, OTHER_WAIT.
+    """
+    allowed_stall_reasons = set(
+        [
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_INTERNAL_INSTRUCTION",
+            "ROCPROFILER_PC_SAMPLING_INSTRUCTION_NOT_ISSUED_REASON_OTHER_WAIT",
+        ]
+    )
+
+    total = len(sample_records)
+    if total == 0:
+        return
+
+    for record in sample_records:
+        assert record["inst"].startswith(
+            "s_clause"
+        ), "CLAUSE instruction must start with s_clause"
+        assert (
+            record["wave_issued"] == 0
+        ), "s_clause should never be issued"
+        stall_reason = record["snapshot"]["stall_reason"]
+        assert (
+            stall_reason in allowed_stall_reasons
+        ), (
+            f"Invalid stall reason for s_clause: {stall_reason}"
+        )

--- a/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/exec-mask-manipulation/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/exec-mask-manipulation/validate.py
@@ -65,12 +65,18 @@ def test_validate_pc_sampling_exec_mask_manipulation_json(
 def test_validate_pc_sampling_stochastic_specific_csv(
     input_csv: pd.DataFrame, input_agent_info_csv: pd.DataFrame
 ):
-    if tmp_disable_for_gfx12(input_agent_info_csv):
-        pytest.skip("Stochastic sampling specific checks are not implemented for GFX12")
-
-    from rocprofiler_sdk.pc_sampling.stochastic.csv.gfx9 import (
-        validate_stochastic_samples_csv,
-    )
+    if is_gfx12(input_agent_info_csv):
+        from rocprofiler_sdk.pc_sampling.stochastic.csv.gfx12 import (
+            validate_stochastic_samples_csv,
+        )
+    elif is_gfx9(input_agent_info_csv):
+        from rocprofiler_sdk.pc_sampling.stochastic.csv.gfx9 import (
+            validate_stochastic_samples_csv,
+        )
+    else:
+        pytest.skip(
+            "Stochastic sampling specific CSV checks are not implemented for this architecture"
+        )
 
     validate_stochastic_samples_csv(input_csv)
 
@@ -78,22 +84,28 @@ def test_validate_pc_sampling_stochastic_specific_csv(
 def test_validate_pc_sampling_stochastic_specific_json(
     input_json, input_agent_info_csv: pd.DataFrame
 ):
-    if tmp_disable_for_gfx12(input_agent_info_csv):
-        pytest.skip("Stochastic sampling specific checks are not implemented for GFX12")
-
-    from rocprofiler_sdk.pc_sampling.stochastic.json.gfx9 import (
-        validate_stochastic_samples_json,
-    )
+    if is_gfx12(input_agent_info_csv):
+        from rocprofiler_sdk.pc_sampling.stochastic.json.gfx12 import (
+            validate_stochastic_samples_json,
+        )
+    elif is_gfx9(input_agent_info_csv):
+        from rocprofiler_sdk.pc_sampling.stochastic.json.gfx9 import (
+            validate_stochastic_samples_json,
+        )
+    else:
+        pytest.skip(
+            "Stochastic sampling specific JSON checks are not implemented for this architecture"
+        )
 
     validate_stochastic_samples_json(input_json["rocprofiler-sdk-tool"])
 
 
-def tmp_disable_for_gfx12(input_agent_info_csv: pd.DataFrame):
-    """
-    If any of the agents are from GFX12 family, we temporarily disable
-    stochastic sampling specific checks, because they're not fully implemented.
-    """
+def is_gfx12(input_agent_info_csv: pd.DataFrame) -> bool:
     return input_agent_info_csv["Name"].str.contains("gfx12").any()
+
+
+def is_gfx9(input_agent_info_csv: pd.DataFrame) -> bool:
+    return input_agent_info_csv["Name"].str.contains(r"gfx9\d", regex=True).any()
 
 
 if __name__ == "__main__":

--- a/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/transpose-multiple-agents/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/pc-sampling/stochastic/transpose-multiple-agents/validate.py
@@ -50,12 +50,18 @@ def test_multi_agent_support(
 def test_validate_pc_sampling_stochastic_specific_csv(
     input_samples_csv: pd.DataFrame, input_agent_info_csv: pd.DataFrame
 ):
-    if tmp_disable_for_gfx12(input_agent_info_csv):
-        pytest.skip("Stochastic sampling specific checks are not implemented for GFX12")
-
-    from rocprofiler_sdk.pc_sampling.stochastic.csv.gfx9 import (
-        validate_stochastic_samples_csv,
-    )
+    if is_gfx12(input_agent_info_csv):
+        from rocprofiler_sdk.pc_sampling.stochastic.csv.gfx12 import (
+            validate_stochastic_samples_csv,
+        )
+    elif is_gfx9(input_agent_info_csv):
+        from rocprofiler_sdk.pc_sampling.stochastic.csv.gfx9 import (
+            validate_stochastic_samples_csv,
+        )
+    else:
+        pytest.skip(
+            "Stochastic sampling specific CSV checks are not implemented for this architecture"
+        )
 
     validate_stochastic_samples_csv(input_samples_csv)
 
@@ -63,22 +69,28 @@ def test_validate_pc_sampling_stochastic_specific_csv(
 def test_validate_pc_sampling_stochastic_specific_json(
     input_samples_json, input_agent_info_csv: pd.DataFrame
 ):
-    if tmp_disable_for_gfx12(input_agent_info_csv):
-        pytest.skip("Stochastic sampling specific checks are not implemented for GFX12")
-
-    from rocprofiler_sdk.pc_sampling.stochastic.json.gfx9 import (
-        validate_stochastic_samples_json,
-    )
+    if is_gfx12(input_agent_info_csv):
+        from rocprofiler_sdk.pc_sampling.stochastic.json.gfx12 import (
+            validate_stochastic_samples_json,
+        )
+    elif is_gfx9(input_agent_info_csv):
+        from rocprofiler_sdk.pc_sampling.stochastic.json.gfx9 import (
+            validate_stochastic_samples_json,
+        )
+    else:
+        pytest.skip(
+            "Stochastic sampling specific JSON checks are not implemented for this architecture"
+        )
 
     validate_stochastic_samples_json(input_samples_json["rocprofiler-sdk-tool"])
 
 
-def tmp_disable_for_gfx12(input_agent_info_csv: pd.DataFrame):
-    """
-    If any of the agents are from GFX12 family, we temporarily disable
-    stochastic sampling specific checks, because they're not fully implemented.
-    """
+def is_gfx12(input_agent_info_csv: pd.DataFrame) -> bool:
     return input_agent_info_csv["Name"].str.contains("gfx12").any()
+
+
+def is_gfx9(input_agent_info_csv: pd.DataFrame) -> bool:
+    return input_agent_info_csv["Name"].str.contains(r"gfx9\d", regex=True).any()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `csv/gfx12/` and `json/gfx12/` validator packages covering all gfx1250 instruction types: VALU, DUAL_VALU, MATRIX (`v_wmma`), VMEM (`global_`/`buffer_`), FLAT, LDS, and scalar instructions (branch, scalar, barrier signal/wait, `s_wait_*`, jump, message, internal, `s_delay_alu`, `s_clause`, `s_wakeup`)
- Replace `tmp_disable_for_gfx12()` skip in both stochastic test harnesses with `is_gfx12()`/`is_gfx9()` dispatch that actively runs the gfx1250 validators
- Register new `gfx12` subdirectories in stochastic `csv`/`json` CMakeLists

## Test plan

- [ ] Verify existing gfx9 stochastic tests still pass on gfx9 hardware (behavior unchanged via `is_gfx9()` dispatch)
- [ ] Verify gfx1250 stochastic tests no longer skip on gfx1250 hardware — `test_validate_pc_sampling_stochastic_specific_csv` and `test_validate_pc_sampling_stochastic_specific_json` execute and pass for both `exec-mask-manipulation` and `transpose-multiple-agents` test scenarios
- [ ] End-to-end hardware validation on gfx1250 comparing corrected vs. uncorrected runs of a known-affected kernel (planned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)