### PR TITLE
[hipfile] Force -pthread when building hipFile tests

### DIFF
--- a/projects/hipfile/test/CMakeLists.txt
+++ b/projects/hipfile/test/CMakeLists.txt
@@ -47,6 +47,8 @@ ais_add_test_executable(
 )
 target_link_libraries(hipfile_tests PRIVATE GTest::gtest)
 target_link_libraries(hipfile_tests PRIVATE GTest::gtest_main)
+target_compile_options(hipfile_tests PRIVATE -pthread)
+target_link_options(hipfile_tests PRIVATE -pthread)
 
 ais_gtest_discover_tests(
     hipfile_tests
@@ -61,6 +63,8 @@ ais_add_test_executable(
     SYSINCLS ${TEST_SYSINCLS}
 )
 target_link_libraries(hipfile_system_tests PRIVATE GTest::gtest)
+target_compile_options(hipfile_system_tests PRIVATE -pthread)
+target_link_options(hipfile_system_tests PRIVATE -pthread)
 
 ais_gtest_discover_tests(
     hipfile_system_tests

--- a/projects/hipfile/test/amd_detail/CMakeLists.txt
+++ b/projects/hipfile/test/amd_detail/CMakeLists.txt
@@ -50,6 +50,8 @@ ais_add_test_executable(
 # Add gtest
 target_link_libraries(internal_tests PRIVATE GTest::gmock)
 target_link_libraries(internal_tests PRIVATE GTest::gtest)
+target_compile_options(internal_tests PRIVATE -pthread)
+target_link_options(internal_tests PRIVATE -pthread)
 
 ais_gtest_discover_tests(
     internal_tests


### PR DESCRIPTION
## Motivation

ASAN runs on TheRock complain that they can't see pthreads symbols, possibly due to unfortunate combinations of linker, OS, libc, CMake, etc.

Forcing -pthread ensures that the symbols should always be visible.

Should resolve https://github.com/ROCm/TheRock/issues/5898

Take 2 on https://github.com/ROCm/rocm-systems/pull/7387

## Technical Details

Adds -pthreads to `hipfile_tests`, `hipfile_system_tests`, and `internal_tests`, both compile and link options.

## JIRA ID

AIHIPFILE-27
ROCM-1261
Fixes ROCM-26499

## Test Plan

Manual verification of -pthread by compiling with -v

## Test Result

It's there

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
