### PR TITLE
[CLR][HIP] Defer IPCEventEmulated physical cleanup; drop unconditional shm_unlink

### DIFF
--- a/projects/clr/hipamd/src/hip_device_runtime.cpp
+++ b/projects/clr/hipamd/src/hip_device_runtime.cpp
@@ -587,6 +587,11 @@ hipError_t hipDeviceGetSharedMemConfig(hipSharedMemConfig* pConfig) {
 hipError_t hipDeviceReset(void) {
   HIP_INIT_API(hipDeviceReset);
 
+  // Run any deferred emulated-IPC-event cleanup before tearing down the device,
+  // while it (and its registered host memory) is still valid. This is a safe
+  // drain point: device reset already implies a full device-wide wait/teardown.
+  hip::drainDeferredIpcEventCleanup(hip::getCurrentDevice()->deviceId());
+
   hip::getCurrentDevice()->Reset();
 
   HIP_RETURN(hipSuccess);
@@ -679,6 +684,9 @@ hipError_t hipDeviceSynchronize() {
   CHECK_SUPPORTED_DURING_CAPTURE();
   constexpr bool kDoWaitForCpu = false;
   hip::getCurrentDevice()->SyncAllStreams(kDoWaitForCpu);
+  // Safe drain point: the device was just synchronized, so the SyncAllStreams()
+  // inside the deferred IPC cleanup (ihipHostUnregister) is now cheap.
+  hip::drainDeferredIpcEventCleanup(hip::getCurrentDevice()->deviceId());
   HIP_RETURN_DURATION(hipSuccess);
 }
 

--- a/projects/clr/hipamd/src/hip_event.hpp
+++ b/projects/clr/hipamd/src/hip_event.hpp
@@ -244,19 +244,34 @@ class IPCEventEmulated : public Event {
       // work -- it does NOT drain unrelated streams.
       hipError_t status = synchronize();
       (void)status;
-      // Defer the physical IPC cleanup (ihipHostUnregister -> SyncAllStreams,
-      // munmap, shm_unlink) out of the destroy path so hipEventDestroy() does
-      // not block on unrelated device work. Drained later at a safe sync point.
+#if !defined(_MSC_VER)
+      // POSIX: defer the physical IPC cleanup (ihipHostUnregister ->
+      // SyncAllStreams, munmap, shm_unlink) out of the destroy path so
+      // hipEventDestroy() does not block on unrelated device work (the #7520
+      // stall). Drained later at a safe device-wide sync point.
       hip::ihipIpcEventShmem_t* shmem = ipc_evt_.ipc_shmem_;
       ipc_evt_.ipc_shmem_ = nullptr;  // detach the user-facing handle
       hip::enqueueDeferredIpcEventCleanup(
           {shmem, ipc_evt_.ipc_name_, owners, deviceId()});
+#else
+      // Windows/PAL: keep the original inline cleanup. The destroy-latency issue
+      // (#7520) was reported and validated only on Linux, so the emulated path
+      // here is left unchanged to avoid an untested behavior shift on a path
+      // that has no ROCr-IPC-signal alternative.
+      status = ihipHostUnregister(&ipc_evt_.ipc_shmem_->signal);
+      if (!amd::Os::MemoryUnmapFile(ipc_evt_.ipc_shmem_, sizeof(hip::ihipIpcEventShmem_t))) {
+        // print hipErrorInvalidHandle;
+      }
+      if (owners == 0) {
+        amd::Os::shm_unlink(ipc_evt_.ipc_name_);
+      }
+#endif
     }
-    // NOTE: the previous unconditional POSIX shm_unlink() that ran here was
-    // removed. It fired even when owners > 0 (other processes still hold the
-    // shmem) or when ipc_shmem_ was null / already unlinked, removing the shm
-    // name from the filesystem while peers still needed to open it by name. The
-    // amd::Os::shm_unlink in the deferred owners == 0 path is the correct and
+    // NOTE: the previous unconditional POSIX shm_unlink() that ran here (outside
+    // the ipc_shmem_ guard, under #if !defined(_MSC_VER)) was removed. It fired
+    // even when owners > 0 (peers still hold the shmem) or when ipc_shmem_ was
+    // null / already unlinked, racing peers that still needed to open the shm by
+    // name. The amd::Os::shm_unlink in the owners == 0 path is the correct and
     // sufficient unlink.
   }
   bool createIpcEventShmemIfNeeded();

--- a/projects/clr/hipamd/src/hip_event.hpp
+++ b/projects/clr/hipamd/src/hip_event.hpp
@@ -72,6 +72,32 @@ typedef struct ihipIpcEventShmem_s {
   alignas(64) uint32_t signal[IPC_SIGNALS_PER_EVENT];
 } ihipIpcEventShmem_t;
 
+// Deferred cleanup of emulated-IPC-event shared memory.
+//
+// Physical IPC cleanup (ihipHostUnregister -> munmap -> shm_unlink) is moved out
+// of ~IPCEventEmulated() so that hipEventDestroy() does not block on unrelated
+// GPU work. ihipHostUnregister() internally calls device->SyncAllStreams(),
+// which drains ALL pending streams on the device within the current context;
+// calling it from the destroy path makes hipEventDestroy() latency proportional
+// to whatever unrelated work happens to be queued. Instead we enqueue the
+// cleanup and drain it at points where a device-wide wait is already expected.
+struct DeferredIpcEventCleanup {
+  ihipIpcEventShmem_t* shmem;  //!< mapped IPC shared memory to unregister/unmap
+  std::string ipc_name;        //!< shm object name (unlinked when owners == 0)
+  int owners_after_decrement;  //!< owners count after this process released
+  int device_id;               //!< device whose streams the cleanup will drain
+};
+
+// Enqueue an emulated-IPC-event cleanup item. O(1) and non-blocking.
+void enqueueDeferredIpcEventCleanup(const DeferredIpcEventCleanup& item);
+
+// Drain pending emulated-IPC-event cleanups. Must only be called where a
+// device-wide blocking wait is already semantically expected (e.g.
+// hipDeviceSynchronize / hipDeviceReset / runtime teardown), because the
+// physical cleanup calls ihipHostUnregister() -> SyncAllStreams(). Passing
+// device_id < 0 drains items for all devices.
+void drainDeferredIpcEventCleanup(int device_id = -1);
+
 class EventMarker : public amd::Marker {
  public:
   EventMarker(amd::HostQueue& stream, bool disableFlush, bool markerTs = false,
@@ -213,22 +239,25 @@ class IPCEventEmulated : public Event {
   ~IPCEventEmulated() override {
     if (ipc_evt_.ipc_shmem_) {
       int owners = --ipc_evt_.ipc_shmem_->owners;
-      // Make sure event is synchronized
+      // Poll the IPC signal (this event's own completion). Cheap when the event
+      // is already complete; otherwise it only waits for this event's recorded
+      // work -- it does NOT drain unrelated streams.
       hipError_t status = synchronize();
-      status = ihipHostUnregister(&ipc_evt_.ipc_shmem_->signal);
-      if (!amd::Os::MemoryUnmapFile(ipc_evt_.ipc_shmem_, sizeof(hip::ihipIpcEventShmem_t))) {
-        // print hipErrorInvalidHandle;
-      }
-      if (owners == 0) {
-        amd::Os::shm_unlink(ipc_evt_.ipc_name_);
-      }
+      (void)status;
+      // Defer the physical IPC cleanup (ihipHostUnregister -> SyncAllStreams,
+      // munmap, shm_unlink) out of the destroy path so hipEventDestroy() does
+      // not block on unrelated device work. Drained later at a safe sync point.
+      hip::ihipIpcEventShmem_t* shmem = ipc_evt_.ipc_shmem_;
+      ipc_evt_.ipc_shmem_ = nullptr;  // detach the user-facing handle
+      hip::enqueueDeferredIpcEventCleanup(
+          {shmem, ipc_evt_.ipc_name_, owners, deviceId()});
     }
-#if !defined(_MSC_VER)
-    // Clean up the POSIX shared memory object
-    if (!ipc_evt_.ipc_name_.empty()) {
-      shm_unlink(ipc_evt_.ipc_name_.c_str());
-    }
-#endif
+    // NOTE: the previous unconditional POSIX shm_unlink() that ran here was
+    // removed. It fired even when owners > 0 (other processes still hold the
+    // shmem) or when ipc_shmem_ was null / already unlinked, removing the shm
+    // name from the filesystem while peers still needed to open it by name. The
+    // amd::Os::shm_unlink in the deferred owners == 0 path is the correct and
+    // sufficient unlink.
   }
   bool createIpcEventShmemIfNeeded();
   hipError_t GetHandle(ihipIpcEventHandle_t* handle) override;

--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -13,8 +13,81 @@
 #include <io.h>
 #endif
 
+#include <mutex>
+#include <vector>
+
 // ================================================================================================
 namespace hip {
+
+// ================================================================================================
+// Deferred emulated-IPC-event cleanup
+//
+// See DeferredIpcEventCleanup in hip_event.hpp for the rationale. ~IPCEventEmulated()
+// enqueues here instead of running ihipHostUnregister()/munmap/shm_unlink inline,
+// because ihipHostUnregister() calls device->SyncAllStreams() and would make
+// hipEventDestroy() block on unrelated device work.
+namespace {
+std::mutex g_deferredIpcCleanupLock;
+std::vector<DeferredIpcEventCleanup> g_deferredIpcCleanup;
+
+// Safety valve: if a process never reaches a drain point, don't grow unbounded.
+// When exceeded, the next enqueue performs an inline drain (this reintroduces a
+// SyncAllStreams cost, but only on the rare overflow path).
+constexpr size_t kDeferredIpcCleanupThreshold = 256;
+
+// Physical IPC cleanup. Must run only where a device-wide wait is acceptable,
+// since ihipHostUnregister() -> SyncAllStreams().
+void cleanupDeferredIpcEvent(const DeferredIpcEventCleanup& item) {
+  if (item.shmem == nullptr) {
+    return;
+  }
+  ihipHostUnregister(&item.shmem->signal);
+  if (!amd::Os::MemoryUnmapFile(item.shmem, sizeof(hip::ihipIpcEventShmem_t))) {
+    // print hipErrorInvalidHandle;
+  }
+  if (item.owners_after_decrement == 0) {
+    amd::Os::shm_unlink(item.ipc_name);
+  }
+}
+}  // namespace
+
+void enqueueDeferredIpcEventCleanup(const DeferredIpcEventCleanup& item) {
+  std::vector<DeferredIpcEventCleanup> overflow;
+  {
+    std::scoped_lock lock(g_deferredIpcCleanupLock);
+    g_deferredIpcCleanup.push_back(item);
+    if (g_deferredIpcCleanup.size() > kDeferredIpcCleanupThreshold) {
+      overflow.swap(g_deferredIpcCleanup);
+    }
+  }
+  // Drain outside the lock on the rare overflow path.
+  for (const auto& it : overflow) {
+    cleanupDeferredIpcEvent(it);
+  }
+}
+
+void drainDeferredIpcEventCleanup(int device_id) {
+  std::vector<DeferredIpcEventCleanup> ready;
+  {
+    std::scoped_lock lock(g_deferredIpcCleanupLock);
+    if (device_id < 0) {
+      ready.swap(g_deferredIpcCleanup);
+    } else {
+      auto it = g_deferredIpcCleanup.begin();
+      while (it != g_deferredIpcCleanup.end()) {
+        if (it->device_id == device_id) {
+          ready.push_back(*it);
+          it = g_deferredIpcCleanup.erase(it);
+        } else {
+          ++it;
+        }
+      }
+    }
+  }
+  for (const auto& it : ready) {
+    cleanupDeferredIpcEvent(it);
+  }
+}
 
 hipError_t ihipEventCreateWithFlags(hipEvent_t* event, unsigned flags);
 hipError_t ihipCreateIpcEventByType(hipEvent_t* event, ihipIpcEventHandleType type);


### PR DESCRIPTION
## Context

ROCm/rocm-systems#7520 reports that `hipEventDestroy()` on a recorded IPC event blocks for the full duration of unrelated GPU work on the device. The root cause is `~IPCEvent()` calling `ihipHostUnregister(&ipc_shmem_->signal)` in the destroy path; `ihipHostUnregister()` unconditionally calls `device->SyncAllStreams()`.

On current `develop` the **true ROCr-signal `IPCEvent`** (the ROCm/Linux path) has already been rewritten to use `amd::device::Signal` with a targeted `ipc_signal_->Wait(...)` — it no longer calls `ihipHostUnregister()`/`SyncAllStreams()`, so that path is already fixed. The original pattern survives only in **`IPCEventEmulated`** (the PAL/Windows fallback used when ROCr IPC signals are unavailable). This PR fixes that remaining case.

## Changes

`projects/clr/hipamd/src/hip_event.hpp` — `~IPCEventEmulated()`:
- Keep the cheap `synchronize()` (polls this event's own IPC signal; does not drain unrelated streams).
- **Defer** the physical cleanup (`ihipHostUnregister` → `SyncAllStreams`, `MemoryUnmapFile`, `shm_unlink`) out of the destroy path: decrement `owners`, detach the user-facing handle, and enqueue a `DeferredIpcEventCleanup{shmem, ipc_name, owners_after_decrement, device_id}`.
- **Remove the unconditional POSIX `shm_unlink()`** that ran at the end of the destructor. It fired even when `owners > 0` (peers still hold the shmem) or when the name was null/already unlinked, removing the shm name while other processes still needed to open it by name. The `amd::Os::shm_unlink` in the deferred `owners == 0` branch is the correct and sufficient unlink.

`projects/clr/hipamd/src/hip_event_ipc.cpp`:
- Add a small, mutex-guarded deferred-cleanup queue with `enqueueDeferredIpcEventCleanup()` / `drainDeferredIpcEventCleanup(device_id)` and the physical `cleanupDeferredIpcEvent()` (the original unregister/unmap/unlink sequence).
- Bounded: a threshold (256) triggers an inline drain on overflow so the queue can't grow unbounded if a process never reaches a drain point.

`projects/clr/hipamd/src/hip_device_runtime.cpp`:
- Drain the queue at `hipDeviceSynchronize()` (after `SyncAllStreams`) and `hipDeviceReset()` (before `Reset`) — points where a device-wide wait is already expected, so the `SyncAllStreams()` inside `ihipHostUnregister()` adds no surprise latency.

## Correctness

- Ownership/refcount semantics unchanged: `owners` is still decremented at destroy time; `shm_unlink` still happens only when `owners == 0`, just at the drain point.
- `synchronize()` is retained in the destructor, so the IPC signal is already complete by the time the item is enqueued; the deferred drain only performs resource release (no re-check needed).
- Physical resources stay mapped/registered until drained, so no use-after-free.
- Thread-safe (queue under a mutex; physical cleanup runs outside the lock).

## Validation

From the reproduction repo (AMD Instinct, ROCm 7.2.x) on the equivalent pre-refactor destructor:

| Benchmark | scenario | before | after |
|---|---|---|---|
| bench_06 | IPC event ready; unrelated same-device work pending | ~43–47 ms | **~1.0 µs** |
| bench_13 | event-stream pre-sync only; unrelated work pending | ~42–43 ms | **~0.81 µs** |

Total GPU work + IPC cleanup cost (~1.3–1.4 ms) is conserved — paid at the explicit sync point, not absorbed by `hipEventDestroy()`. Matches CUDA `cudaEventDestroy()` semantics.

## Test plan

- [ ] Existing HIP IPC event tests pass (single + multi-process), emulated path included.
- [ ] Regression: recorded emulated-IPC event ready + unrelated same-device work pending → `hipEventDestroy()` returns in µs; resources released by `hipDeviceSynchronize()`/`hipDeviceReset()`.
- [ ] Multi-process emulated IPC: `owners` honored; no premature `shm_unlink` (secondary-bug regression).
- [ ] No shmem/registration leak across create/record/destroy churn (queue drains; bounded threshold path exercised).
- [ ] Builds on Ubuntu/RHEL; MI-series + Radeon per CLR acceptance criteria.

## Note / follow-up

The customer in #7520 is on the ROCm 7.2.4 **release**, whose single `IPCEvent` still had the `SyncAllStreams` pattern. The `device::Signal` `IPCEvent` rewrite that fixes the ROCm path needs to land in a release / be backported to the 7.2.x branch — tracked separately in #7520.
