### PR TITLE
RCCL: net_ib_cast/ainic: prevent using uninitialized nreqs value

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -98,13 +98,9 @@ static ncclResult_t IbCastPrintWr(struct ibv_send_wr* wr, char* wrStr) {
 ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, int startQpIndex, bool wrrSched, bool useWriteOp) {
   struct ncclIbRequest** reqs = comm->sendReqs[slot];
   volatile struct ncclIbSendFifo* slots = comm->ctsFifo[slot];
-  int nreqs = slots[0].nreqs;
+  int nreqs = comm->useCtsOffload ? 1 : slots[0].nreqs;
   uint64_t nowNs = 0;
   if (nreqs > NCCL_NET_IB_MAX_RECVS) return ncclInternalError;
-
-  if (comm->useCtsOffload) {
-    nreqs = 1;
-  }
 
   TRACE(NCCL_NET, "NET/IB: %s: Posting a send request (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d)", __func__, reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs);
 


### PR DESCRIPTION
## Motivation

In IbCastMultiSend, nreqs was read from shared memory (slots[0].nreqs) before the useCtsOffload override check. When CTS
  offload is enabled, the value from shared memory is uninitialised. This could cause a spurious ncclInternalError.
  
## Technical Details
  Collapsed the two-step assignment into a single ternary in IbCastMultiSend (net_ib_cast/p2p.cc):
  This ensures nreqs is always initialised to its correct value before the bounds check runs.
## JIRA ID
N/A

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
