### PR TITLE
[CLR][HIP] Defer IPCEvent physical cleanup; drop unconditional shm_unlink (7.2.x backport)

### DIFF
--- a/projects/clr/hipamd/src/hip_device_runtime.cpp
+++ b/projects/clr/hipamd/src/hip_device_runtime.cpp
@@ -585,6 +585,11 @@ hipError_t hipDeviceGetSharedMemConfig(hipSharedMemConfig* pConfig) {
 hipError_t hipDeviceReset(void) {
   HIP_INIT_API(hipDeviceReset);
 
+  // Run any deferred IPC-event cleanup before tearing down the device, while it
+  // (and its registered host memory) is still valid. This is a safe drain point:
+  // device reset already implies a full device-wide wait/teardown.
+  hip::drainDeferredIpcEventCleanup(hip::getCurrentDevice()->deviceId());
+
   hip::getCurrentDevice()->Reset();
 
   HIP_RETURN(hipSuccess);
@@ -675,6 +680,9 @@ hipError_t hipDeviceSynchronize() {
   CHECK_SUPPORTED_DURING_CAPTURE();
   constexpr bool kDoWaitForCpu = false;
   hip::getCurrentDevice()->SyncAllStreams(kDoWaitForCpu);
+  // Safe drain point: the device was just synchronized, so the SyncAllStreams()
+  // inside the deferred IPC cleanup (ihipHostUnregister) is now cheap.
+  hip::drainDeferredIpcEventCleanup(hip::getCurrentDevice()->deviceId());
   HIP_RETURN_DURATION(hipSuccess);
 }
 

--- a/projects/clr/hipamd/src/hip_event.hpp
+++ b/projects/clr/hipamd/src/hip_event.hpp
@@ -83,6 +83,31 @@ typedef struct ihipIpcEventShmem_s {
   uint32_t signal[IPC_SIGNALS_PER_EVENT];
 } ihipIpcEventShmem_t;
 
+// Deferred cleanup of IPC-event shared memory.
+//
+// Physical IPC cleanup (ihipHostUnregister -> munmap -> shm_unlink) is moved out
+// of ~IPCEvent() so that hipEventDestroy() does not block on unrelated GPU work.
+// ihipHostUnregister() internally calls device->SyncAllStreams(), which drains
+// ALL pending streams on the device within the current context; calling it from
+// the destroy path makes hipEventDestroy() latency proportional to whatever
+// unrelated work happens to be queued. Instead we enqueue the cleanup and drain
+// it at points where a device-wide wait is already expected.
+struct DeferredIpcEventCleanup {
+  ihipIpcEventShmem_t* shmem;  //!< mapped IPC shared memory to unregister/unmap
+  std::string ipc_name;        //!< shm object name (unlinked when owners == 0)
+  int owners_after_decrement;  //!< owners count after this process released
+  int device_id;               //!< device whose streams the cleanup will drain
+};
+
+// Enqueue an IPC-event cleanup item. O(1) and non-blocking.
+void enqueueDeferredIpcEventCleanup(const DeferredIpcEventCleanup& item);
+
+// Drain pending IPC-event cleanups. Must only be called where a device-wide
+// blocking wait is already semantically expected (e.g. hipDeviceSynchronize /
+// hipDeviceReset / runtime teardown), because the physical cleanup calls
+// ihipHostUnregister() -> SyncAllStreams(). device_id < 0 drains all devices.
+void drainDeferredIpcEventCleanup(int device_id = -1);
+
 class EventMarker : public amd::Marker {
  public:
   EventMarker(amd::HostQueue& stream, bool disableFlush, bool markerTs = false,
@@ -201,22 +226,25 @@ class IPCEvent : public Event {
   ~IPCEvent() {
     if (ipc_evt_.ipc_shmem_) {
       int owners = --ipc_evt_.ipc_shmem_->owners;
-      // Make sure event is synchronized
+      // Poll the IPC signal (this event's own completion). Cheap when the event
+      // is already complete; otherwise it only waits for this event's recorded
+      // work -- it does NOT drain unrelated streams.
       hipError_t status = synchronize();
-      status = ihipHostUnregister(&ipc_evt_.ipc_shmem_->signal);
-      if (!amd::Os::MemoryUnmapFile(ipc_evt_.ipc_shmem_, sizeof(hip::ihipIpcEventShmem_t))) {
-        // print hipErrorInvalidHandle;
-      }
-      if (owners == 0) {
-        amd::Os::shm_unlink(ipc_evt_.ipc_name_);
-      }
+      (void)status;
+      // Defer the physical IPC cleanup (ihipHostUnregister -> SyncAllStreams,
+      // munmap, shm_unlink) out of the destroy path so hipEventDestroy() does
+      // not block on unrelated device work. Drained later at a safe sync point.
+      hip::ihipIpcEventShmem_t* shmem = ipc_evt_.ipc_shmem_;
+      ipc_evt_.ipc_shmem_ = nullptr;  // detach the user-facing handle
+      hip::enqueueDeferredIpcEventCleanup(
+          {shmem, ipc_evt_.ipc_name_, owners, deviceId()});
     }
-#if !defined(_MSC_VER)
-    // Clean up the POSIX shared memory object
-    if (!ipc_evt_.ipc_name_.empty() && ipc_evt_.ipc_name_ != "dummy") {
-      shm_unlink(ipc_evt_.ipc_name_.c_str());
-    }
-#endif
+    // NOTE: the previous unconditional POSIX shm_unlink() that ran here was
+    // removed. It fired even when owners > 0 (other processes still hold the
+    // shmem) or when ipc_shmem_ was null / already unlinked, removing the shm
+    // name from the filesystem while peers still needed to open it by name. The
+    // amd::Os::shm_unlink in the deferred owners == 0 path is the correct and
+    // sufficient unlink.
   }
   IPCEvent() : Event(hipEventInterprocess) {}
   bool createIpcEventShmemIfNeeded();

--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -27,8 +27,81 @@
 #include <io.h>
 #endif
 
+#include <mutex>
+#include <vector>
+
 // ================================================================================================
 namespace hip {
+
+// ================================================================================================
+// Deferred IPC-event cleanup
+//
+// See DeferredIpcEventCleanup in hip_event.hpp for the rationale. ~IPCEvent()
+// enqueues here instead of running ihipHostUnregister()/munmap/shm_unlink inline,
+// because ihipHostUnregister() calls device->SyncAllStreams() and would make
+// hipEventDestroy() block on unrelated device work.
+namespace {
+std::mutex g_deferredIpcCleanupLock;
+std::vector<DeferredIpcEventCleanup> g_deferredIpcCleanup;
+
+// Safety valve: if a process never reaches a drain point, don't grow unbounded.
+// When exceeded, the next enqueue performs an inline drain (this reintroduces a
+// SyncAllStreams cost, but only on the rare overflow path).
+constexpr size_t kDeferredIpcCleanupThreshold = 256;
+
+// Physical IPC cleanup. Must run only where a device-wide wait is acceptable,
+// since ihipHostUnregister() -> SyncAllStreams().
+void cleanupDeferredIpcEvent(const DeferredIpcEventCleanup& item) {
+  if (item.shmem == nullptr) {
+    return;
+  }
+  ihipHostUnregister(&item.shmem->signal);
+  if (!amd::Os::MemoryUnmapFile(item.shmem, sizeof(hip::ihipIpcEventShmem_t))) {
+    // print hipErrorInvalidHandle;
+  }
+  if (item.owners_after_decrement == 0) {
+    amd::Os::shm_unlink(item.ipc_name);
+  }
+}
+}  // namespace
+
+void enqueueDeferredIpcEventCleanup(const DeferredIpcEventCleanup& item) {
+  std::vector<DeferredIpcEventCleanup> overflow;
+  {
+    std::scoped_lock lock(g_deferredIpcCleanupLock);
+    g_deferredIpcCleanup.push_back(item);
+    if (g_deferredIpcCleanup.size() > kDeferredIpcCleanupThreshold) {
+      overflow.swap(g_deferredIpcCleanup);
+    }
+  }
+  // Drain outside the lock on the rare overflow path.
+  for (const auto& it : overflow) {
+    cleanupDeferredIpcEvent(it);
+  }
+}
+
+void drainDeferredIpcEventCleanup(int device_id) {
+  std::vector<DeferredIpcEventCleanup> ready;
+  {
+    std::scoped_lock lock(g_deferredIpcCleanupLock);
+    if (device_id < 0) {
+      ready.swap(g_deferredIpcCleanup);
+    } else {
+      auto it = g_deferredIpcCleanup.begin();
+      while (it != g_deferredIpcCleanup.end()) {
+        if (it->device_id == device_id) {
+          ready.push_back(*it);
+          it = g_deferredIpcCleanup.erase(it);
+        } else {
+          ++it;
+        }
+      }
+    }
+  }
+  for (const auto& it : ready) {
+    cleanupDeferredIpcEvent(it);
+  }
+}
 
 hipError_t ihipEventCreateWithFlags(hipEvent_t* event, unsigned flags);
 


### PR DESCRIPTION
## Context

Backport of the IPC-event `hipEventDestroy()` latency fix to `release/rocm-rel-7.2`. See ROCm/rocm-systems#7520 for the full root cause.

On 7.2.x, destroying a recorded IPC event (`hipEventInterprocess`) blocks the calling thread for the full duration of **unrelated** GPU work on the same device, even when the event is already complete. Root cause: `IPCEvent::~IPCEvent()` calls `ihipHostUnregister(&ipc_shmem_->signal)` in the destroy path, and `ihipHostUnregister()` unconditionally calls `g_devices[deviceId]->SyncAllStreams()` (a full device drain). There is also a secondary bug: an unconditional POSIX `shm_unlink()` at the destructor tail that fires even when `owners > 0` (peers still hold the shmem) or the name was already unlinked.

## Why a minimal backport (not #5575)

`develop` already fixes this comprehensively by replacing emulated IPC events with true ROCr IPC signals (#5575) — but that is a **cross-component** change (clr `hipamd` + `rocclr/device/rocm` + `rocr-runtime` HSA IPC signal create/attach) and is not a clean cherry-pick to 7.2.x. This PR is a **self-contained, low-risk** fix for the 7.2.x line with **no ROCr/rocclr dependency**.

## Change

- `~IPCEvent()`: keep the cheap `synchronize()` (polls this event's own signal; does not drain unrelated streams), then **defer** the physical cleanup (`ihipHostUnregister` / `MemoryUnmapFile` / `shm_unlink`) into a bounded, mutex-guarded queue instead of running it inline.
- **Remove** the unconditional POSIX `shm_unlink()` (the `amd::Os::shm_unlink` in the deferred `owners == 0` path is correct and sufficient).
- Drain the queue at `hipDeviceSynchronize()` (after `SyncAllStreams`) and `hipDeviceReset()` (before `Reset`) — points where a device-wide wait is already expected, so the `SyncAllStreams()` inside `ihipHostUnregister()` adds no surprise latency. Bounded threshold (256) inline-drains on overflow.

Ownership/refcount semantics unchanged; resources stay mapped/registered until drained (no use-after-free); thread-safe.

## Validation

From the reproduction repo (AMD Instinct, ROCm 7.2.x): `hipEventDestroy()` ~43–47 ms → **~1 µs** (bench_06/13). Total GPU + IPC cleanup cost (~1.3–1.4 ms) is conserved — paid at the explicit sync point, not absorbed by `hipEventDestroy()`. Matches CUDA `cudaEventDestroy()` semantics.

## Test plan

- [ ] Existing HIP IPC event tests pass (single + multi-process).
- [ ] Recorded IPC event ready + unrelated same-device work pending → `hipEventDestroy()` returns in µs; resources released by `hipDeviceSynchronize()`/`hipDeviceReset()`.
- [ ] Multi-process: `owners` honored; no premature `shm_unlink` (secondary-bug regression).
- [ ] No shmem/registration leak across create/record/destroy churn.

Relates to: ROCm/rocm-systems#7520 · equivalent develop fix for the emulated path: ROCm/rocm-systems#7523
