### PR TITLE
Restore hostLock in ipc import

### DIFF
--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -277,7 +277,7 @@ hipError_t IPCEvent::OpenHandle(ihipIpcEventHandle_t* handle) {
     return hipErrorInvalidValue;
   }
 
-  if (!ipc_signal_->IpcImport(handle->ipc_signal_handle, IHIP_IPC_EVENT_HANDLE_SIZE)) {
+  if (!ipc_signal_->IpcImport(handle->ipc_signal_handle, IHIP_IPC_EVENT_HANDLE_SIZE, dev)) {
     delete ipc_signal_;
     ipc_signal_ = nullptr;
     return hipErrorInvalidValue;

--- a/projects/clr/rocclr/device/devsignal.hpp
+++ b/projects/clr/rocclr/device/devsignal.hpp
@@ -51,10 +51,14 @@ class Signal {
   virtual bool IpcExport(void* handle, size_t handle_size) { return false; }
 
   // Initializes this signal from an IPC handle (alternative to Init for imported signals)
-  virtual bool IpcImport(const void* handle, size_t handle_size) { return false; }
+  virtual bool IpcImport(const void* handle, size_t handle_size,
+                         const amd::Device* dev = nullptr) { return false; }
 
   // Return the handle to the underlying amd_signal_t object
   virtual void* getHandle() { return nullptr; }
+
+  // Return a GPU-accessible handle (may differ from getHandle for IPC signals)
+  virtual void* getGpuHandle() { return getHandle(); }
 };
 
 };  // namespace amd::device

--- a/projects/clr/rocclr/device/rocm/rocsignal.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.cpp
@@ -91,14 +91,15 @@ bool IpcSignal::IpcImport(const void* handle, size_t handle_size, const amd::Dev
   }
 
   // Lock the imported signal memory for GPU access.
-  // The IPC signal is CPU-only after dma-buf import; the packet processor
-  // (KFD compute VM) needs an explicit GPU-accessible RW mapping to write
-  // the completion signal value.
+  // The IPC signal is CPU-only after dma-buf import.
   if (dev != nullptr) {
     auto* rocDev = static_cast<const roc::Device*>(dev);
     constexpr size_t kSignalAbiSize = 4096;
     gpu_ptr_ = rocDev->hostLock(reinterpret_cast<void*>(signal_.handle),
-                                kSignalAbiSize, amd::Device::kNoAtomics);
+                                kSignalAbiSize, amd::Device::kAtomics);
+    if (gpu_ptr_ == nullptr) {
+       return false;
+    }
   }
 
   ws_ = WaitState::Active;

--- a/projects/clr/rocclr/device/rocm/rocsignal.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.cpp
@@ -37,6 +37,9 @@ void Signal::Reset(uint64_t value) { Hsa::signal_store_screlease(signal_, value)
 // ================================================================================================
 
 IpcSignal::~IpcSignal() {
+  if (gpu_ptr_ != nullptr) {
+    Hsa::memory_unlock(reinterpret_cast<void*>(signal_.handle));
+  }
   if (signal_.handle != 0) {
     Hsa::signal_destroy(signal_);
   }
@@ -75,7 +78,7 @@ bool IpcSignal::IpcExport(void* handle, size_t handle_size) {
   return true;
 }
 
-bool IpcSignal::IpcImport(const void* handle, size_t handle_size) {
+bool IpcSignal::IpcImport(const void* handle, size_t handle_size, const amd::Device* dev) {
   if (handle_size < sizeof(hsa_amd_ipc_signal_t)) {
     return false;
   }
@@ -85,6 +88,17 @@ bool IpcSignal::IpcImport(const void* handle, size_t handle_size) {
   hsa_status_t status = Hsa::ipc_signal_attach(&ipc_handle, &signal_);
   if (status != HSA_STATUS_SUCCESS) {
     return false;
+  }
+
+  // Lock the imported signal memory for GPU access.
+  // The IPC signal is CPU-only after dma-buf import; the packet processor
+  // (KFD compute VM) needs an explicit GPU-accessible RW mapping to write
+  // the completion signal value.
+  if (dev != nullptr) {
+    auto* rocDev = static_cast<const roc::Device*>(dev);
+    constexpr size_t kSignalAbiSize = 4096;
+    gpu_ptr_ = rocDev->hostLock(reinterpret_cast<void*>(signal_.handle),
+                                kSignalAbiSize, amd::Device::kNoAtomics);
   }
 
   ws_ = WaitState::Active;

--- a/projects/clr/rocclr/device/rocm/rocsignal.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.hpp
@@ -32,6 +32,7 @@ class Signal : public device::Signal {
 class IpcSignal : public device::Signal {
  private:
   hsa_signal_t signal_;
+  void* gpu_ptr_ = nullptr;  // GPU-accessible pointer from memory_lock (if needed)
 
  public:
   IpcSignal() { signal_.handle = 0; }
@@ -43,8 +44,12 @@ class IpcSignal : public device::Signal {
   void Reset(uint64_t value) override;
   uint64_t Load() override;
   bool IpcExport(void* handle, size_t handle_size) override;
-  bool IpcImport(const void* handle, size_t handle_size) override;
+  bool IpcImport(const void* handle, size_t handle_size,
+                 const amd::Device* dev = nullptr) override;
   void* getHandle() override { return reinterpret_cast<void*>(signal_.handle); }
+  void* getGpuHandle() override {
+    return gpu_ptr_ ? gpu_ptr_ : reinterpret_cast<void*>(signal_.handle);
+  }
 };
 
 };  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -4654,13 +4654,13 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
     hsa_signal_t ipc_s{0};
     if (vcmd.ipcCompletionSignal() != nullptr) {
       ipc_s.handle = static_cast<uint64_t>(
-          reinterpret_cast<uintptr_t>(vcmd.ipcCompletionSignal()->getHandle()));
+          reinterpret_cast<uintptr_t>(vcmd.ipcCompletionSignal()->getGpuHandle()));
     }
 
     if (vcmd.ipcDepSignal() != nullptr) {
       hsa_signal_t s;
       s.handle = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(
-          vcmd.ipcDepSignal()->getHandle()));
+          vcmd.ipcDepSignal()->getGpuHandle()));
       WaitCompleteSignal(s);
     } else if (timestamp_ != nullptr || vcmd.profilingInfo().marker_ts_ || ipc_s.handle != 0) {
       // Skip a redundant barrier when this marker records the same client event as

--- a/projects/hip-tests/catch/config/configs/unit/device.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/device.yaml
@@ -355,10 +355,7 @@ device:
   Unit_hipGetDriverEntryPoint_spt_Positive: *level_2
   Unit_hipGetDriverEntryPoint_spt_Negative: *level_2
   Unit_hipGetProcAddress_IPC_Memory: *level_2
-  Unit_hipGetProcAddress_IPC_Event:
-    <<: *level_2
-    # AIRUNTIME-2336: temporarily disabled (subprocess aborted intermittently in CI)
-    disabled: [amd_windows, amd_wsl, amd_linux]
+  Unit_hipGetProcAddress_IPC_Event: *level_2
   Unit_hipIpcOpenMemHandle_Negative_Open_In_Creating_Process:
     <<: *level_2
     # Note: Windows disabled


### PR DESCRIPTION
## Motivation

Fix the test Unit_hipGetProcAddress_IPC_Event in CI/PSDBs

## Technical Details

The imported signal memory from another process is usually host allocated and it needs GPU/KFD access during the event record where the imported signal is used as completion signal and is written by the device upon completion of the prior work.

## JIRA ID

AIRUNTIME-2336

## Test Plan

The above test should pass in CI and on all ASICs

## Test Result

PASS

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
