### PR TITLE
fix(rocjitsu): repair sanitizer ISA execution paths

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -2608,15 +2608,11 @@ class CodeGenerator:
             return '\n'.join(L)
 
         if cls == 'scalar_mulk':
+            L.append(f'  uint32_t s0 = {dst_ops[0]}.read_scalar(wf);')
             L.append(
-                f'  int32_t s0 = static_cast<int32_t>({dst_ops[0]}.read_scalar(wf));'
+                f'  uint32_t imm = static_cast<uint32_t>(static_cast<int32_t>(static_cast<int16_t>({src_ops[0]}.encoding_value_)));'
             )
-            L.append(
-                f'  int32_t imm = static_cast<int16_t>({src_ops[0]}.encoding_value_);'
-            )
-            L.append(
-                f'  {dst_ops[0]}.write_scalar(wf, static_cast<uint32_t>(s0 * imm));'
-            )
+            L.append(f'  {dst_ops[0]}.write_scalar(wf, s0 * imm);')
             return '\n'.join(L)
 
         if cls == 'scalar_wrexec':

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -2187,13 +2187,15 @@ class CodeGenerator:
         return textwrap.dedent('''\
             namespace {
 
+            bool isVop3pOp(const MachineInst opcode, uint32_t op) {
+              return (opcode >> 24) == 0xcc && ((opcode >> 16) & 0xff) == op;
+            }
+
             bool isWmmaScaleF32Vop3px2(const MachineInst *opcode) {
-              const auto *low = reinterpret_cast<const Vop3pMachineInst *>(opcode);
-              if (low->encoding != 0xcc || (low->op != 0x35 && low->op != 0x3a))
+              if (!isVop3pOp(opcode[0], 0x35) && !isVop3pOp(opcode[0], 0x3a))
                 return false;
 
-              const auto *high = reinterpret_cast<const Vop3pMachineInst *>(opcode + 2);
-              return high->encoding == 0xcc && (high->op == 0x33 || high->op == 0x88);
+              return isVop3pOp(opcode[2], 0x33) || isVop3pOp(opcode[2], 0x88);
             }
 
             } // namespace

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/packed.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/packed.py
@@ -774,9 +774,7 @@ def gen_dot2(
             '    int16_t b1 = static_cast<int16_t>(sel1_hi ? (raw1 >> 16) : raw1);'
         )
         L.append(f'    uint32_t result = {s2}.read_lane(wf, lane);')
-        L.append(
-            '    result += static_cast<uint32_t>(static_cast<int32_t>(a0) * b0);'
-        )
+        L.append('    result += static_cast<uint32_t>(static_cast<int32_t>(a0) * b0);')
         L.append('    result += static_cast<uint32_t>(static_cast<int32_t>(a1) * b1);')
         L.append('    if (inst_.clamp) {')
         L.append('      int32_t signed_result = static_cast<int32_t>(result);')

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/packed.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/packed.py
@@ -773,14 +773,16 @@ def gen_dot2(
         L.append(
             '    int16_t b1 = static_cast<int16_t>(sel1_hi ? (raw1 >> 16) : raw1);'
         )
-        L.append(f'    int32_t acc = static_cast<int32_t>({s2}.read_lane(wf, lane));')
+        L.append(f'    uint32_t result = {s2}.read_lane(wf, lane);')
         L.append(
-            '    int32_t result = static_cast<int32_t>(a0) * b0 + static_cast<int32_t>(a1) * b1 + acc;'
+            '    result += static_cast<uint32_t>(static_cast<int32_t>(a0) * b0);'
         )
-        L.append(
-            '    if (inst_.clamp) result = std::clamp(result, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());'
-        )
-        L.append(f'    {d}.write_lane(wf, lane, static_cast<uint32_t>(result));')
+        L.append('    result += static_cast<uint32_t>(static_cast<int32_t>(a1) * b1);')
+        L.append('    if (inst_.clamp) {')
+        L.append('      int32_t signed_result = static_cast<int32_t>(result);')
+        L.append('      if (signed_result < 0) result = 0u;')
+        L.append('    }')
+        L.append(f'    {d}.write_lane(wf, lane, result);')
     else:  # dot2_u32_u16
         L.append(
             '    uint16_t a0 = static_cast<uint16_t>(sel0_lo ? (raw0 >> 16) : raw0);'
@@ -815,8 +817,7 @@ def gen_dot4(dst: list[str], src: list[str], cls: str) -> str:
     L.append(f'    uint32_t raw1 = {s1}.read_lane(wf, lane);')
 
     if cls in ('dot4_i32_i8', 'dot4_i32_iu8'):
-        L.append(f'    int32_t acc = static_cast<int32_t>({s2}.read_lane(wf, lane));')
-        L.append('    int32_t sum = acc;')
+        L.append(f'    uint32_t sum = {s2}.read_lane(wf, lane);')
         if cls == 'dot4_i32_iu8':
             L.append('    const bool src0_signed = (inst_.neg & 0x1u) != 0;')
             L.append('    const bool src1_signed = (inst_.neg & 0x2u) != 0;')
@@ -836,14 +837,15 @@ def gen_dot4(dst: list[str], src: list[str], cls: str) -> str:
             L.append('      int8_t a = static_cast<int8_t>((raw0 >> (i * 8)) & 0xFF);')
             L.append('      int8_t b = static_cast<int8_t>((raw1 >> (i * 8)) & 0xFF);')
         if cls == 'dot4_i32_iu8':
-            L.append('      sum += a * b;')
+            L.append('      sum += static_cast<uint32_t>(a * b);')
         else:
-            L.append('      sum += static_cast<int32_t>(a) * b;')
+            L.append('      sum += static_cast<uint32_t>(static_cast<int32_t>(a) * b);')
         L.append('    }')
-        L.append(
-            '    if (inst_.clamp) sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());'
-        )
-        L.append(f'    {d}.write_lane(wf, lane, static_cast<uint32_t>(sum));')
+        L.append('    if (inst_.clamp) {')
+        L.append('      int32_t signed_sum = static_cast<int32_t>(sum);')
+        L.append('      if (signed_sum < 0) sum = 0u;')
+        L.append('    }')
+        L.append(f'    {d}.write_lane(wf, lane, sum);')
     elif cls == 'dot4_f32_fp8':
         # FP8 dot product: D.f32 += sum(A.fp8[i] * B.fp8[i]) for i in 0..3
         L.append(f'    float acc = std::bit_cast<float>({s2}.read_lane(wf, lane));')
@@ -882,8 +884,7 @@ def gen_dot8(dst: list[str], src: list[str], cls: str) -> str:
     L.append(f'    uint32_t raw1 = {s1}.read_lane(wf, lane);')
 
     if cls in ('dot8_i32_i4', 'dot8_i32_iu4'):
-        L.append(f'    int32_t acc = static_cast<int32_t>({s2}.read_lane(wf, lane));')
-        L.append('    int32_t sum = acc;')
+        L.append(f'    uint32_t sum = {s2}.read_lane(wf, lane);')
         if cls == 'dot8_i32_iu4':
             L.append('    const bool src0_signed = (inst_.neg & 0x1u) != 0;')
             L.append('    const bool src1_signed = (inst_.neg & 0x2u) != 0;')
@@ -904,12 +905,13 @@ def gen_dot8(dst: list[str], src: list[str], cls: str) -> str:
             L.append('      if (a & 0x8) a |= ~0xF;')
             L.append('      int32_t b = static_cast<int32_t>((raw1 >> (i * 4)) & 0xF);')
             L.append('      if (b & 0x8) b |= ~0xF;')
-        L.append('      sum += a * b;')
+        L.append('      sum += static_cast<uint32_t>(a * b);')
         L.append('    }')
-        L.append(
-            '    if (inst_.clamp) sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());'
-        )
-        L.append(f'    {d}.write_lane(wf, lane, static_cast<uint32_t>(sum));')
+        L.append('    if (inst_.clamp) {')
+        L.append('      int32_t signed_sum = static_cast<int32_t>(sum);')
+        L.append('      if (signed_sum < 0) sum = 0u;')
+        L.append('    }')
+        L.append(f'    {d}.write_lane(wf, lane, sum);')
     else:  # dot8_u32_u4
         L.append(f'    uint32_t acc = {s2}.read_lane(wf, lane);')
         L.append('    uint32_t sum = acc;')

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/scalar.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/scalar.py
@@ -446,11 +446,7 @@ def gen_scalar_binop(
             )
             L.append(f'  {dst[0]}.write_scalar64(wf, result);')
         else:
-            L.append('  uint32_t count = s0 & 31u;')
-            L.append('  uint32_t offset = s1 & 31u;')
-            L.append(
-                '  uint32_t result = count == 0 ? 0 : ((1u << count) - 1) << offset;'
-            )
+            L.append('  uint32_t result = ::rocjitsu::amdgpu::bfm_b32(s0, s1);')
             L.append(f'  {dst[0]}.write_scalar(wf, result);')
     elif op == 'bfe':
         return gen_scalar_bfe(dst, src, dtype)

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -1656,9 +1656,9 @@ _INLINE_TERNARY_OPS: dict[str, str] = {
     ' return (src >> off) & mask; }}()',
     'bfe_i': '[&]() -> uint32_t {{ uint32_t src=static_cast<uint32_t>({0});'
     ' uint32_t off=static_cast<uint32_t>({1}) & 31u; uint32_t w=static_cast<uint32_t>({2}) & 31u;'
-    ' if (w == 0) return 0u; uint32_t mask = (uint32_t{1} << w) - 1u;'
+    ' if (w == 0) return 0u; uint32_t mask = (uint32_t{{1}} << w) - 1u;'
     ' uint32_t extracted = static_cast<uint32_t>(static_cast<int32_t>(src) >> off) & mask;'
-    ' uint32_t signbit = uint32_t{1} << (w - 1u); return (extracted ^ signbit) - signbit; }}()',
+    ' uint32_t signbit = uint32_t{{1}} << (w - 1u); return (extracted ^ signbit) - signbit; }}()',
     'cubeid': '[&]() {{ auto x={0}; auto y={1}; auto z={2};'
     ' float ax=std::fabs(x), ay=std::fabs(y), az=std::fabs(z);'
     ' if (ax >= ay && ax >= az) return x >= 0 ? 0.0f : 1.0f;'

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -1351,7 +1351,8 @@ _INLINE_BINARY_OPS: dict[str, str] = {
     ' auto b = static_cast<int32_t>({1} << 8) >> 8;'
     ' return static_cast<uint32_t>(a * b); }}()',
     'mul_lo_u16': 'static_cast<uint32_t>(static_cast<uint16_t>('
-    'static_cast<uint16_t>({0}) * static_cast<uint16_t>({1})))',
+    'static_cast<uint32_t>(static_cast<uint16_t>({0})) * '
+    'static_cast<uint32_t>(static_cast<uint16_t>({1}))))',
     'std::min': 'std::min({0}, {1})',
     'std::max': 'std::max({0}, {1})',
     'std::fmin': 'std::fmin({0}, {1})',
@@ -1617,25 +1618,25 @@ _INLINE_TERNARY_OPS: dict[str, str] = {
     ' float hi = util::f16_to_f32(static_cast<uint16_t>(a >> 16))'
     ' * util::f16_to_f32(static_cast<uint16_t>(b >> 16));'
     ' return std::bit_cast<uint32_t>(lo + hi + c); }}()',
-    'dot4c': '[&]() {{ uint32_t a = {0}, b = {1}; int32_t c = static_cast<int32_t>({2});'
-    ' int32_t sum = c;'
+    'dot4c': '[&]() {{ uint32_t a = {0}, b = {1}; uint32_t sum = static_cast<uint32_t>({2});'
     ' for (int i = 0; i < 4; ++i)'
-    '   sum += static_cast<int32_t>(static_cast<int8_t>((a >> (i*8)) & 0xFF))'
-    '        * static_cast<int32_t>(static_cast<int8_t>((b >> (i*8)) & 0xFF));'
-    ' return static_cast<uint32_t>(sum); }}()',
-    'dot8c': '[&]() {{ uint32_t a = {0}, b = {1}; int32_t c = static_cast<int32_t>({2});'
-    ' int32_t sum = c;'
+    '   sum += static_cast<uint32_t>('
+    'static_cast<int32_t>(static_cast<int8_t>((a >> (i*8)) & 0xFF))'
+    '        * static_cast<int32_t>(static_cast<int8_t>((b >> (i*8)) & 0xFF)));'
+    ' return sum; }}()',
+    'dot8c': '[&]() {{ uint32_t a = {0}, b = {1}; uint32_t sum = static_cast<uint32_t>({2});'
     ' for (int i = 0; i < 8; ++i) {{'
     '   int32_t av = static_cast<int32_t>((a >> (i*4)) & 0xF);'
     '   if (av & 8) av |= ~0xF;'
     '   int32_t bv = static_cast<int32_t>((b >> (i*4)) & 0xF);'
     '   if (bv & 8) bv |= ~0xF;'
-    '   sum += av * bv; }}'
-    ' return static_cast<uint32_t>(sum); }}()',
+    '   sum += static_cast<uint32_t>(av * bv); }}'
+    ' return sum; }}()',
     'mad_32_16': '[&]() {{ int32_t a = static_cast<int32_t>(static_cast<int16_t>({0}));'
     ' int32_t b = static_cast<int32_t>(static_cast<int16_t>({1}));'
-    ' int32_t c = static_cast<int32_t>({2});'
-    ' return static_cast<uint32_t>(a * b + c); }}()',
+    ' uint32_t c = static_cast<uint32_t>({2});'
+    ' int64_t dot = static_cast<int64_t>(a) * b;'
+    ' return c + static_cast<uint32_t>(dot); }}()',
     'v_writelane': '(lane == {2}) ? {1} : {0}',
     'util::bfe': '[&]() {{ uint32_t base = {0};'
     ' uint32_t offset = {1};'

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -1654,11 +1654,11 @@ _INLINE_TERNARY_OPS: dict[str, str] = {
     ' if (w == 0) return 0u;'
     ' uint32_t mask = (w >= 32) ? ~0u : ((1u << w) - 1u);'
     ' return (src >> off) & mask; }}()',
-    'bfe_i': '[&]() -> uint32_t {{ int32_t src=static_cast<int32_t>({0});'
-    ' uint32_t off={1} & 31u; uint32_t w={2} & 31u;'
-    ' if (w == 0) return 0u; int32_t val = (src >> off) & ((1 << w) - 1);'
-    ' if (val & (1 << (w-1))) val |= -(1 << w);'
-    ' return static_cast<uint32_t>(val); }}()',
+    'bfe_i': '[&]() -> uint32_t {{ uint32_t src=static_cast<uint32_t>({0});'
+    ' uint32_t off=static_cast<uint32_t>({1}) & 31u; uint32_t w=static_cast<uint32_t>({2}) & 31u;'
+    ' if (w == 0) return 0u; uint32_t mask = (uint32_t{1} << w) - 1u;'
+    ' uint32_t extracted = static_cast<uint32_t>(static_cast<int32_t>(src) >> off) & mask;'
+    ' uint32_t signbit = uint32_t{1} << (w - 1u); return (extracted ^ signbit) - signbit; }}()',
     'cubeid': '[&]() {{ auto x={0}; auto y={1}; auto z={2};'
     ' float ax=std::fabs(x), ay=std::fabs(y), az=std::fabs(z);'
     ' if (ax >= ay && ax >= az) return x >= 0 ? 0.0f : 1.0f;'

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/sema_lower.py
@@ -1331,7 +1331,7 @@ _INLINE_BINARY_OPS: dict[str, str] = {
     ' return static_cast<uint32_t>(v >> ({1} & 31u)); }}()',
     'util::arithmetic_shr_i16': '[&]() {{ auto v = static_cast<int16_t>({0});'
     ' return static_cast<uint32_t>(static_cast<uint16_t>(v >> ({1} & 15u))); }}()',
-    'bfm': '(((1u << ({0} & 31u)) - 1u) << ({1} & 31u))',
+    'bfm': '::rocjitsu::amdgpu::bfm_b32({0}, {1})',
     'bfm64': '[&]() {{ uint64_t cnt = {0} & 63u; uint64_t off = {1} & 63u;'
     ' return cnt == 0 ? 0ULL : ((1ULL << cnt) - 1ULL) << off; }}()',
     'ashr': '[&]() {{ auto v = static_cast<int32_t>({0});'
@@ -1347,9 +1347,7 @@ _INLINE_BINARY_OPS: dict[str, str] = {
     ' auto b = static_cast<int64_t>(static_cast<int32_t>({1} << 8) >> 8);'
     ' return static_cast<uint32_t>(static_cast<uint64_t>((a * b) >> 32)); }}()',
     'mul_u24': '(({0} & 0x00FFFFFFu) * ({1} & 0x00FFFFFFu))',
-    'mul_i24': '[&]() {{ auto a = static_cast<int32_t>({0} << 8) >> 8;'
-    ' auto b = static_cast<int32_t>({1} << 8) >> 8;'
-    ' return static_cast<uint32_t>(a * b); }}()',
+    'mul_i24': '::rocjitsu::amdgpu::mul_i24_u32({0}, {1})',
     'mul_lo_u16': 'static_cast<uint32_t>(static_cast<uint16_t>('
     'static_cast<uint32_t>(static_cast<uint16_t>({0})) * '
     'static_cast<uint32_t>(static_cast<uint16_t>({1}))))',
@@ -1507,9 +1505,9 @@ _INLINE_TERNARY_OPS: dict[str, str] = {
     'or3': '({0} | {1} | {2})',
     'xor3': '({0} ^ {1} ^ {2})',
     'xad': '(({0} ^ {1}) + {2})',
-    'lshl_add': '(({0} << {1}) + {2})',
-    'lshl_or': '(({0} << {1}) | {2})',
-    'add_lshl': '(({0} + {1}) << {2})',
+    'lshl_add': '(::rocjitsu::amdgpu::lshl_masked({0}, {1}) + {2})',
+    'lshl_or': '(::rocjitsu::amdgpu::lshl_masked({0}, {1}) | {2})',
+    'add_lshl': '::rocjitsu::amdgpu::lshl_masked(({0} + {1}), {2})',
     'ashr_pk_i8_i32': '[&]() -> uint32_t {{'
     ' uint32_t shift = static_cast<uint32_t>({2}) & 31u;'
     ' auto pack = [&](uint32_t src) -> uint32_t {{'
@@ -1531,7 +1529,7 @@ _INLINE_TERNARY_OPS: dict[str, str] = {
     'and_or': '(({0} & {1}) | {2})',
     'bfi': '[&]() {{ auto a={0}; auto b={1}; auto c={2};'
     ' return (a & b) | (~a & c); }}()',
-    'bfm': '(((1u << ({0} & 31u)) - 1u) << ({1} & 31u))',
+    'bfm': '::rocjitsu::amdgpu::bfm_b32({0}, {1})',
     'alignbit': '[&]() {{ auto a={0}; auto b={1}; auto c={2};'
     ' uint64_t val = (static_cast<uint64_t>(a) << 32) | b;'
     ' return static_cast<uint32_t>(val >> (c & 31u)); }}()',
@@ -1651,9 +1649,7 @@ _INLINE_TERNARY_OPS: dict[str, str] = {
     ' else vcc &= ~(1ULL << lane);'
     ' return static_cast<uint32_t>(a - b - c); }}()',
     'mad_u24': '(({0} & 0x00FFFFFFu) * ({1} & 0x00FFFFFFu) + {2})',
-    'mad_i24': '[&]() {{ auto a = static_cast<int32_t>({0} << 8) >> 8;'
-    ' auto b = static_cast<int32_t>({1} << 8) >> 8;'
-    ' return static_cast<uint32_t>(a * b + static_cast<int32_t>({2})); }}()',
+    'mad_i24': '::rocjitsu::amdgpu::mad_i24_u32({0}, {1}, {2})',
     'bfe_u': '[&]() {{ uint32_t src={0}; uint32_t off={1} & 31u; uint32_t w={2} & 31u;'
     ' if (w == 0) return 0u;'
     ' uint32_t mask = (w >= 32) ? ~0u : ((1u << w) - 1u);'

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -72,8 +72,14 @@ SIMD_VOP2_BINARY: dict[str, tuple[str, str]] = {
     'v_xor_b32_vop2': ('uint32_t', 'std::bit_xor<>{}'),
     'v_xnor_b32_vop2': ('uint32_t', '[](auto a, auto b) { return ~(a ^ b); }'),
     # rev: shift value is vsrc1 (b), shift count is src0 (a), masked to 5 bits.
-    'v_lshlrev_b32_vop2': ('uint32_t', '[](auto a, auto b) { return b << (a & 31u); }'),
-    'v_lshrrev_b32_vop2': ('uint32_t', '[](auto a, auto b) { return b >> (a & 31u); }'),
+    'v_lshlrev_b32_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) { return ::rocjitsu::amdgpu::simd_lshl_u32(b, a); }',
+    ),
+    'v_lshrrev_b32_vop2': (
+        'uint32_t',
+        '[](auto a, auto b) { return ::rocjitsu::amdgpu::simd_lshr_u32(b, a); }',
+    ),
     'v_mul_u32_u24_vop2': (
         'uint32_t',
         '[](auto a, auto b) { return (a & 0x00FFFFFFu) * (b & 0x00FFFFFFu); }',
@@ -84,9 +90,9 @@ SIMD_VOP2_BINARY: dict[str, tuple[str, str]] = {
     'v_mul_i32_i24_vop2': (
         'uint32_t',
         '[](auto a, auto b) {'
-        ' auto sa = (util::stdx::static_simd_cast<util::native<int32_t>>(a) << 8) >> 8;'
-        ' auto sb = (util::stdx::static_simd_cast<util::native<int32_t>>(b) << 8) >> 8;'
-        ' return util::stdx::static_simd_cast<util::native<uint32_t>>(sa * sb); }',
+        ' auto sa = ::rocjitsu::amdgpu::simd_sign_extend_u32(a, 24);'
+        ' auto sb = ::rocjitsu::amdgpu::simd_sign_extend_u32(b, 24);'
+        ' return sa * sb; }',
     ),
     # High 32 bits of the 24-bit multiply (48-bit product). The 32x32->high32
     # step uses util::mul_hi_{u,i}32_simd, a 16x16 partial-product decomposition
@@ -392,22 +398,14 @@ SIMD_VOP1_UNARY: dict[str, tuple[str, str, str]] = {
         'int32_t',
         '[](auto s) {'
         ' auto r = util::stdx::floor(s);'
-        ' util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);'
-        ' util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;'
-        ' util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);'
-        ' util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;'
-        ' return out; }',
+        ' return ::rocjitsu::amdgpu::simd_cvt_i32_f32(r); }',
     ),
     'v_cvt_nearest_i32_f32_vop1': (
         'float32_t',
         'int32_t',
         '[](auto s) {'
         ' auto r = util::stdx::ceil(s - util::native<float32_t>(0.5f));'
-        ' util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);'
-        ' util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;'
-        ' util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);'
-        ' util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;'
-        ' return out; }',
+        ' return ::rocjitsu::amdgpu::simd_cvt_i32_f32(r); }',
     ),
     # --- bit-scan (SWAR, no stdx primitive) -----------------------------------
     # All return uint32_t. Most special-case the zero input to 0xFFFFFFFF,
@@ -651,43 +649,26 @@ SIMD_VOP1_UNARY: dict[str, tuple[str, str, str]] = {
     'v_cvt_i32_f32_vop1': (
         'float32_t',
         'int32_t',
-        '[](auto s) {'
-        ' util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(s);'
-        ' util::stdx::where(simd_mask_as<int32_t>(s >= 2147483648.0f), out) = 2147483647;'
-        ' util::stdx::where(simd_mask_as<int32_t>(s < -2147483648.0f), out) = (-2147483647 - 1);'
-        ' util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(s)), out) = 0;'
-        ' return out; }',
+        '[](auto s) { return ::rocjitsu::amdgpu::simd_cvt_i32_f32(s); }',
     ),
     'v_cvt_u32_f32_vop1': (
         'float32_t',
         'uint32_t',
-        '[](auto s) {'
-        ' util::native<uint32_t> out = util::stdx::static_simd_cast<util::native<uint32_t>>(s);'
-        ' util::stdx::where(simd_mask_as<uint32_t>(s >= 4294967296.0f), out) = 4294967295u;'
-        ' util::stdx::where(simd_mask_as<uint32_t>(util::stdx::isnan(s) || s < 0.0f), out) = 0u;'
-        ' return out; }',
+        '[](auto s) { return ::rocjitsu::amdgpu::simd_cvt_u32_f32(s); }',
     ),
     'v_cvt_flr_i32_f32_vop1': (
         'float32_t',
         'int32_t',
         '[](auto s) {'
         ' auto r = util::stdx::floor(s);'
-        ' util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);'
-        ' util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;'
-        ' util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);'
-        ' util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;'
-        ' return out; }',
+        ' return ::rocjitsu::amdgpu::simd_cvt_i32_f32(r); }',
     ),
     'v_cvt_rpi_i32_f32_vop1': (
         'float32_t',
         'int32_t',
         '[](auto s) {'
         ' auto r = util::stdx::ceil(s - util::native<float32_t>(0.5f));'
-        ' util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);'
-        ' util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;'
-        ' util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);'
-        ' util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;'
-        ' return out; }',
+        ' return ::rocjitsu::amdgpu::simd_cvt_i32_f32(r); }',
     ),
     # --- f16 (half) ops. Scalar bodies route through an f32 intermediate with a
     # single final round, so the SIMD path (f16_to_f32_simd -> f32 op ->
@@ -786,21 +767,14 @@ SIMD_VOP1_UNARY: dict[str, tuple[str, str, str]] = {
         'uint32_t',
         '[](auto a) {'
         ' auto s = util::f16_to_f32_simd(a);'
-        ' util::native<int32_t> o = util::stdx::static_simd_cast<util::native<int32_t>>(s);'
-        ' util::stdx::where(simd_mask_as<int32_t>(s >= 32768.0f), o) = 32767;'
-        ' util::stdx::where(simd_mask_as<int32_t>(s < -32768.0f), o) = -32768;'
-        ' util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(s)), o) = 0;'
-        ' return util::stdx::static_simd_cast<util::native<uint32_t>>(o) & 0xFFFFu; }',
+        ' return ::rocjitsu::amdgpu::simd_cvt_i16_f32_to_u32(s); }',
     ),
     'v_cvt_u16_f16_vop1': (
         'uint32_t',
         'uint32_t',
         '[](auto a) {'
         ' auto s = util::f16_to_f32_simd(a);'
-        ' util::native<uint32_t> o = util::stdx::static_simd_cast<util::native<uint32_t>>(s);'
-        ' util::stdx::where(simd_mask_as<uint32_t>(s >= 65536.0f), o) = 65535u;'
-        ' util::stdx::where(simd_mask_as<uint32_t>(util::stdx::isnan(s) || s < 0.0f), o) = 0u;'
-        ' return o & 0xFFFFu; }',
+        ' return ::rocjitsu::amdgpu::simd_cvt_u16_f32_to_u32(s); }',
     ),
 }
 
@@ -1860,7 +1834,7 @@ SIMD_VOP3_BINARY_INT_EXTRA: dict[str, tuple[str, str]] = {
     # masked to low 5 bits — same vpsllvd-vs-shl rationale as v_lshl_add_u32.
     'v_bfm_b32_vop3': (
         'uint32_t',
-        '[](auto a, auto b) { return ((util::native<uint32_t>(1u) << (a & 31u)) - 1u) << (b & 31u); }',
+        '[](auto a, auto b) { return ::rocjitsu::amdgpu::simd_bfm_b32(a, b); }',
     ),
     # v_pack_b32_f16: pack two f16 halves into a b32. low16(src0) into the low
     # half, low16(src1) into the high half. The scalar body applies no abs/neg
@@ -2277,17 +2251,16 @@ SIMD_VOP3_TERNARY_INT: dict[str, tuple[str, str]] = {
     ),
     'v_lshl_or_b32_vop3': (
         'uint32_t',
-        '[](auto a, auto b, auto c) { return (a << (b & 31u)) | c; }',
+        '[](auto a, auto b, auto c) { return ::rocjitsu::amdgpu::simd_lshl_u32(a, b) | c; }',
     ),
     # v_mad_i32_i24: low-24 sign-extended a, b -> int32 multiply (low 32 of the
     # 48-bit product, identical signed/unsigned for the low half) + int32(c).
     'v_mad_i32_i24_vop3': (
         'uint32_t',
         '[](auto a, auto b, auto c) {'
-        ' auto sa = (util::stdx::static_simd_cast<util::native<int32_t>>(a) << 8) >> 8;'
-        ' auto sb = (util::stdx::static_simd_cast<util::native<int32_t>>(b) << 8) >> 8;'
-        ' return util::stdx::static_simd_cast<util::native<uint32_t>>('
-        'sa * sb + util::stdx::static_simd_cast<util::native<int32_t>>(c)); }',
+        ' auto sa = ::rocjitsu::amdgpu::simd_sign_extend_u32(a, 24);'
+        ' auto sb = ::rocjitsu::amdgpu::simd_sign_extend_u32(b, 24);'
+        ' return sa * sb + c; }',
     ),
     # v_mad_u32_u24: low-24 mask a, b, multiply, add c.
     'v_mad_u32_u24_vop3': (
@@ -2329,11 +2302,11 @@ SIMD_VOP3_TERNARY_INT: dict[str, tuple[str, str]] = {
     # shift operand on this host.
     'v_lshl_add_u32_vop3': (
         'uint32_t',
-        '[](auto a, auto b, auto c) { return (a << (b & 31u)) + c; }',
+        '[](auto a, auto b, auto c) { return ::rocjitsu::amdgpu::simd_lshl_u32(a, b) + c; }',
     ),
     'v_add_lshl_u32_vop3': (
         'uint32_t',
-        '[](auto a, auto b, auto c) { return (a + b) << (c & 31u); }',
+        '[](auto a, auto b, auto c) { return ::rocjitsu::amdgpu::simd_lshl_u32(a + b, c); }',
     ),
     'v_bfi_b32_vop3': (
         'uint32_t',
@@ -2448,11 +2421,9 @@ SIMD_VOP3_TERNARY_INT: dict[str, tuple[str, str]] = {
     'v_mad_i32_i16_vop3': (
         'uint32_t',
         '[](auto a, auto b, auto c) {'
-        ' using I = util::native<int32_t>;'
-        ' auto sa = (util::stdx::static_simd_cast<I>(a) << 16) >> 16;'
-        ' auto sb = (util::stdx::static_simd_cast<I>(b) << 16) >> 16;'
-        ' auto sc = util::stdx::static_simd_cast<I>(c);'
-        ' return util::stdx::static_simd_cast<util::native<uint32_t>>(sa * sb + sc); }',
+        ' auto sa = ::rocjitsu::amdgpu::simd_sign_extend_u32(a, 16);'
+        ' auto sb = ::rocjitsu::amdgpu::simd_sign_extend_u32(b, 16);'
+        ' return sa * sb + c; }',
     ),
     # v_mad_u32_u16: zero-extend low 16 of src0/src1, multiply, add full uint32 c.
     'v_mad_u32_u16_vop3': (
@@ -2468,10 +2439,7 @@ SIMD_VOP3_TERNARY_INT: dict[str, tuple[str, str]] = {
     # vpsllvd) matches scalar for every count in [0,31].
     'v_bfe_u32_vop3': (
         'uint32_t',
-        '[](auto a, auto b, auto c) {'
-        ' auto off = b & 31u; auto w = c & 31u;'
-        ' auto mask = (util::native<uint32_t>(1u) << w) - 1u;'
-        ' return (a >> off) & mask; }',
+        '[](auto a, auto b, auto c) { return ::rocjitsu::amdgpu::simd_bfe_u32(a, b, c); }',
     ),
     # v_bfe_i32: signed bitfield extract. Same off/width masking; the field is
     # extracted with an arithmetic shift (vpsravd, so off+w>32 sign-fill matches
@@ -2480,14 +2448,7 @@ SIMD_VOP3_TERNARY_INT: dict[str, tuple[str, str]] = {
     # w==0 so the result is 0, matching the scalar early return).
     'v_bfe_i32_vop3': (
         'uint32_t',
-        '[](auto a, auto b, auto c) {'
-        ' using I = util::native<int32_t>;'
-        ' auto off = b & 31u; auto w = c & 31u;'
-        ' auto mask = (util::native<uint32_t>(1u) << w) - 1u;'
-        ' auto ext = util::stdx::static_simd_cast<util::native<uint32_t>>('
-        'util::stdx::static_simd_cast<I>(a) >> util::stdx::static_simd_cast<I>(off)) & mask;'
-        ' auto signbit = (mask + 1u) >> 1;'
-        ' return (ext ^ signbit) - signbit; }',
+        '[](auto a, auto b, auto c) { return ::rocjitsu::amdgpu::simd_bfe_i32(a, b, c); }',
     ),
 }
 
@@ -2500,13 +2461,10 @@ SIMD_VOP3_TERNARY_INT: dict[str, tuple[str, str]] = {
 # the count already widened+masked. Logical shifts are plain `<< / >>` on the
 # uint64 lane; the signed (arithmetic) form casts through int64.
 SIMD_SHIFT64_VOP3: dict[str, str] = {
-    'v_lshlrev_b64_vop3': '[](auto v, auto sh) { return v << sh; }',
-    'v_lshrrev_b64_vop3': '[](auto v, auto sh) { return v >> sh; }',
+    'v_lshlrev_b64_vop3': '[](auto v, auto sh) { return ::rocjitsu::amdgpu::simd_lshl_u64(v, sh); }',
+    'v_lshrrev_b64_vop3': '[](auto v, auto sh) { return ::rocjitsu::amdgpu::simd_lshr_u64(v, sh); }',
     'v_ashrrev_i64_vop3': (
-        '[](auto v, auto sh) {'
-        ' return util::stdx::static_simd_cast<util::native<uint64_t>>('
-        'util::stdx::static_simd_cast<util::native<int64_t>>(v) >>'
-        ' util::stdx::static_simd_cast<util::native<int64_t>>(sh)); }'
+        '[](auto v, auto sh) {' ' return ::rocjitsu::amdgpu::simd_ashr_i64(v, sh); }'
     ),
 }
 

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/simd_codegen.py
@@ -89,10 +89,7 @@ SIMD_VOP2_BINARY: dict[str, tuple[str, str]] = {
     # are exact, so no widening is needed.
     'v_mul_i32_i24_vop2': (
         'uint32_t',
-        '[](auto a, auto b) {'
-        ' auto sa = ::rocjitsu::amdgpu::simd_sign_extend_u32(a, 24);'
-        ' auto sb = ::rocjitsu::amdgpu::simd_sign_extend_u32(b, 24);'
-        ' return sa * sb; }',
+        '[](auto a, auto b) { return ::rocjitsu::amdgpu::simd_mul_i24_u32(a, b); }',
     ),
     # High 32 bits of the 24-bit multiply (48-bit product). The 32x32->high32
     # step uses util::mul_hi_{u,i}32_simd, a 16x16 partial-product decomposition
@@ -2257,10 +2254,7 @@ SIMD_VOP3_TERNARY_INT: dict[str, tuple[str, str]] = {
     # 48-bit product, identical signed/unsigned for the low half) + int32(c).
     'v_mad_i32_i24_vop3': (
         'uint32_t',
-        '[](auto a, auto b, auto c) {'
-        ' auto sa = ::rocjitsu::amdgpu::simd_sign_extend_u32(a, 24);'
-        ' auto sb = ::rocjitsu::amdgpu::simd_sign_extend_u32(b, 24);'
-        ' return sa * sb + c; }',
+        '[](auto a, auto b, auto c) { return ::rocjitsu::amdgpu::simd_mad_i24_u32(a, b, c); }',
     ),
     # v_mad_u32_u24: low-24 mask a, b, multiply, add c.
     'v_mad_u32_u24_vop3': (

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_alu.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_alu.py
@@ -590,7 +590,7 @@ def gen_vector_binop(
             'add': 'static_cast<uint16_t>(sv0 + sv1)',
             'sub': 'static_cast<uint16_t>(sv0 - sv1)',
             'rsub': 'static_cast<uint16_t>(sv1 - sv0)',
-            'mul': 'static_cast<uint16_t>(sv0 * sv1)',
+            'mul': 'static_cast<uint16_t>(static_cast<uint32_t>(sv0) * static_cast<uint32_t>(sv1))',
             'min': 'sv0 < sv1 ? sv0 : sv1',
             'max': 'sv0 > sv1 ? sv0 : sv1',
             'shl': 'static_cast<uint16_t>(sv1 << (sv0 & 15u))',
@@ -655,13 +655,13 @@ def gen_vector_binop(
         L.append(f'    int32_t sv0 = static_cast<int32_t>({s0}.read_lane(wf, lane));')
         L.append(f'    int32_t sv1 = static_cast<int32_t>({s1}.read_lane(wf, lane));')
         i_op_map = {
-            'add': 'static_cast<uint32_t>(sv0 + sv1)',
-            'sub': 'static_cast<uint32_t>(sv0 - sv1)',
-            'rsub': 'static_cast<uint32_t>(sv1 - sv0)',
+            'add': 'static_cast<uint32_t>(sv0) + static_cast<uint32_t>(sv1)',
+            'sub': 'static_cast<uint32_t>(sv0) - static_cast<uint32_t>(sv1)',
+            'rsub': 'static_cast<uint32_t>(sv1) - static_cast<uint32_t>(sv0)',
             'min': 'static_cast<uint32_t>(sv0 < sv1 ? sv0 : sv1)',
             'max': 'static_cast<uint32_t>(sv0 > sv1 ? sv0 : sv1)',
             'ashr': 'static_cast<uint32_t>(static_cast<int32_t>(sv1) >> (sv0 & 31))',
-            'mul': 'static_cast<uint32_t>(sv0 * sv1)',
+            'mul': 'static_cast<uint32_t>(sv0) * static_cast<uint32_t>(sv1)',
             'mulhi': 'static_cast<uint32_t>(static_cast<uint64_t>(static_cast<int64_t>(sv0) * sv1) >> 32)',
         }
         expr = i_op_map.get(op, f'static_cast<uint32_t>(sv0) /* TODO: {op} */')
@@ -726,16 +726,16 @@ def gen_vector_ternary(
         elif op == 'bfe_i':
             L.append('    uint32_t offset = b & 31;')
             L.append('    uint32_t width = c & 31;')
-            L.append('    int32_t sv = static_cast<int32_t>(a);')
-            L.append('    int32_t result_val;')
+            L.append('    uint32_t result_val;')
             L.append('    if (width == 0) result_val = 0;')
-            # When offset + width >= 32, the extraction window extends
-            # past bit 31. Arithmetic right shift of sv by offset gives
-            # the correct sign-extended result without shift UB.
-            L.append('    else if (offset + width >= 32) result_val = sv >> offset;')
+            L.append('    else {')
+            L.append('      uint32_t mask = (uint32_t{1} << width) - 1u;')
             L.append(
-                '    else result_val = (sv << (32 - offset - width)) >> (32 - width);'
+                '      uint32_t extracted = static_cast<uint32_t>(static_cast<int32_t>(a) >> offset) & mask;'
             )
+            L.append('      uint32_t signbit = uint32_t{1} << (width - 1u);')
+            L.append('      result_val = (extracted ^ signbit) - signbit;')
+            L.append('    }')
             L.append(
                 f'    {d}.write_lane(wf, lane, static_cast<uint32_t>(result_val));'
             )
@@ -944,7 +944,7 @@ def gen_vector_ternary(
             'min3': 'std::min(std::min(a, b), c)',
             'max3': 'std::max(std::max(a, b), c)',
             'med3': 'std::max(std::min(std::max(a, b), c), std::min(a, b))',
-            'mad': 'static_cast<uint16_t>(a * b + c)',
+            'mad': 'static_cast<uint16_t>(static_cast<uint32_t>(a) * static_cast<uint32_t>(b) + static_cast<uint32_t>(c))',
         }
         expr = u_map.get(op, f'a /* TODO: {op} */')
         L.append(f'    {d}.write_lane(wf, lane, static_cast<uint32_t>({expr}));')
@@ -986,8 +986,8 @@ def gen_vector_ternary(
             'maxmin': 'std::max(a, std::min(b, c))',
             'minmax_num': 'std::min(a, std::max(b, c))',
             'maxmin_num': 'std::max(a, std::min(b, c))',
-            'add_lshl': '(a + b) << (c & 31)',
-            'lshl_add': '(a << (b & 31)) + c',
+            'add_lshl': '(static_cast<uint32_t>(a) + static_cast<uint32_t>(b)) << (static_cast<uint32_t>(c) & 31u)',
+            'lshl_add': '(static_cast<uint32_t>(a) << (static_cast<uint32_t>(b) & 31u)) + static_cast<uint32_t>(c)',
         }
         expr = i_map.get(op, f'a /* TODO: {op} */')
         L.append(f'    {d}.write_lane(wf, lane, static_cast<uint32_t>({expr}));')

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_alu.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_alu.py
@@ -543,18 +543,22 @@ def gen_vector_binop(
         else:
             L.append(f'    {d}.write_lane(wf, lane, util::f32_to_f16({expr}));')
     elif dtype == 'i24':
-        L.append(
-            f'    int32_t sv0 = static_cast<int32_t>({s0}.read_lane(wf, lane) << 8) >> 8;'
-        )
-        L.append(
-            f'    int32_t sv1 = static_cast<int32_t>({s1}.read_lane(wf, lane) << 8) >> 8;'
-        )
         if op == 'mulhi':
+            L.append(
+                f'    int32_t sv0 = static_cast<int32_t>({s0}.read_lane(wf, lane) << 8) >> 8;'
+            )
+            L.append(
+                f'    int32_t sv1 = static_cast<int32_t>({s1}.read_lane(wf, lane) << 8) >> 8;'
+            )
             L.append(
                 f'    {d}.write_lane(wf, lane, static_cast<uint32_t>((static_cast<int64_t>(sv0) * sv1) >> 32));'
             )
         else:
-            L.append(f'    {d}.write_lane(wf, lane, static_cast<uint32_t>(sv0 * sv1));')
+            L.append(f'    uint32_t sv0 = {s0}.read_lane(wf, lane);')
+            L.append(f'    uint32_t sv1 = {s1}.read_lane(wf, lane);')
+            L.append(
+                f'    {d}.write_lane(wf, lane, ::rocjitsu::amdgpu::mul_i24_u32(sv0, sv1));'
+            )
     elif dtype == 'u24':
         L.append(f'    uint32_t sv0 = {s0}.read_lane(wf, lane) & 0x00FFFFFFu;')
         L.append(f'    uint32_t sv1 = {s1}.read_lane(wf, lane) & 0x00FFFFFFu;')
@@ -683,7 +687,7 @@ def gen_vector_binop(
             'shr': 'sv1 >> (sv0 & 31u)',
             'min': 'sv0 < sv1 ? sv0 : sv1',
             'max': 'sv0 > sv1 ? sv0 : sv1',
-            'bfm': '(sv0 & 31u) == 0 ? 0u : ((1u << (sv0 & 31u)) - 1u) << (sv1 & 31u)',
+            'bfm': '::rocjitsu::amdgpu::bfm_b32(sv0, sv1)',
         }
         expr = u_op_map.get(op, f'sv0 /* TODO: {op} */')
         L.append(f'    {d}.write_lane(wf, lane, {expr});')
@@ -953,21 +957,17 @@ def gen_vector_ternary(
         L.append(f'    uint64_t b = {s1}.read_lane64(wf, lane);')
         L.append(f'    uint64_t c = {s2}.read_lane64(wf, lane);')
         u_map = {
-            'lshl_add': '(a << (b & 63u)) + c',
+            'lshl_add': '::rocjitsu::amdgpu::lshl_masked(a, b) + c',
             'add3': 'a + b + c',
         }
         expr = u_map.get(op, f'a /* unhandled: {op} */')
         L.append(f'    {d}.write_lane64(wf, lane, {expr});')
     elif dtype in ('i24',):
+        L.append(f'    uint32_t a = {s0}.read_lane(wf, lane);')
+        L.append(f'    uint32_t b = {s1}.read_lane(wf, lane);')
+        L.append(f'    uint32_t c = {s2}.read_lane(wf, lane);')
         L.append(
-            f'    int32_t a = static_cast<int32_t>({s0}.read_lane(wf, lane) << 8) >> 8;'
-        )
-        L.append(
-            f'    int32_t b = static_cast<int32_t>({s1}.read_lane(wf, lane) << 8) >> 8;'
-        )
-        L.append(f'    int32_t c = static_cast<int32_t>({s2}.read_lane(wf, lane));')
-        L.append(
-            f'    {d}.write_lane(wf, lane, static_cast<uint32_t>(static_cast<int64_t>(a) * b + c));'
+            f'    {d}.write_lane(wf, lane, ::rocjitsu::amdgpu::mad_i24_u32(a, b, c));'
         )
     elif dtype in ('u24',):
         L.append(f'    uint32_t a = {s0}.read_lane(wf, lane) & 0x00FFFFFFu;')
@@ -986,8 +986,8 @@ def gen_vector_ternary(
             'maxmin': 'std::max(a, std::min(b, c))',
             'minmax_num': 'std::min(a, std::max(b, c))',
             'maxmin_num': 'std::max(a, std::min(b, c))',
-            'add_lshl': '(static_cast<uint32_t>(a) + static_cast<uint32_t>(b)) << (static_cast<uint32_t>(c) & 31u)',
-            'lshl_add': '(static_cast<uint32_t>(a) << (static_cast<uint32_t>(b) & 31u)) + static_cast<uint32_t>(c)',
+            'add_lshl': '::rocjitsu::amdgpu::lshl_masked(static_cast<uint32_t>(a) + static_cast<uint32_t>(b), static_cast<uint32_t>(c))',
+            'lshl_add': '::rocjitsu::amdgpu::lshl_masked(static_cast<uint32_t>(a), static_cast<uint32_t>(b)) + static_cast<uint32_t>(c)',
         }
         expr = i_map.get(op, f'a /* TODO: {op} */')
         L.append(f'    {d}.write_lane(wf, lane, static_cast<uint32_t>({expr}));')
@@ -1045,11 +1045,11 @@ def gen_vector_ternary(
         else:
             u_map = {
                 'add3': 'a + b + c',
-                'lshl_or': '(a << (b & 31)) | c',
+                'lshl_or': '::rocjitsu::amdgpu::lshl_masked(a, b) | c',
                 'and_or': '(a & b) | c',
                 'or3': 'a | b | c',
-                'lshl_add': '(a << (b & 31)) + c',
-                'add_lshl': '(a + b) << (c & 31)',
+                'lshl_add': '::rocjitsu::amdgpu::lshl_masked(a, b) + c',
+                'add_lshl': '::rocjitsu::amdgpu::lshl_masked(a + b, c)',
                 'xad': '(a ^ b) + c',
                 'xor3': 'a ^ b ^ c',
                 'min3': 'std::min(std::min(a, b), c)',

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_special.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/execute/vector_special.py
@@ -132,7 +132,10 @@ def gen_vector_mad_64_32(dst: list[str], src: list[str], dtype: str | None) -> s
         L.append(
             f'    int64_t s2 = static_cast<int64_t>({src[2]}.read_lane64(wf, lane));'
         )
-        L.append('    uint64_t result = static_cast<uint64_t>(s0 * s1 + s2);')
+        L.append(
+            '    uint64_t result = static_cast<uint64_t>(s0) * static_cast<uint64_t>(s1) +'
+        )
+        L.append('                      static_cast<uint64_t>(s2);')
     else:
         L.append(f'    uint64_t s0 = {src[0]}.read_lane(wf, lane);')
         L.append(f'    uint64_t s1 = {src[1]}.read_lane(wf, lane);')
@@ -164,7 +167,7 @@ def gen_vector_mad_32_16(dst: list[str], src: list[str], dtype: str | None) -> s
             f'    int32_t s2 = static_cast<int32_t>({src[2]}.read_lane(wf, lane));'
         )
         L.append(
-            f'    {dst[0]}.write_lane(wf, lane, static_cast<uint32_t>(s0 * s1 + s2));'
+            f'    {dst[0]}.write_lane(wf, lane, static_cast<uint32_t>(s0) * static_cast<uint32_t>(s1) + static_cast<uint32_t>(s2));'
         )
     else:
         L.append(f'    uint32_t s0 = {src[0]}.read_lane(wf, lane) & 0xFFFFu;')
@@ -437,12 +440,14 @@ def gen_vector_dot(
     L.append('    if (!(exec & (1ULL << lane))) continue;')
     L.append(f'    uint32_t a = {s0}.read_lane(wf, lane);')
     L.append(f'    uint32_t b = {s1}.read_lane(wf, lane);')
-    L.append(f'    int32_t acc = static_cast<int32_t>({d}.read_lane(wf, lane));')
+    L.append(f'    uint32_t acc = {d}.read_lane(wf, lane);')
     if op == 'dot4c':
         L.append('    for (int i = 0; i < 4; ++i) {')
         L.append('      int8_t ea = static_cast<int8_t>((a >> (i * 8)) & 0xFF);')
         L.append('      int8_t eb = static_cast<int8_t>((b >> (i * 8)) & 0xFF);')
-        L.append('      acc += static_cast<int32_t>(ea) * static_cast<int32_t>(eb);')
+        L.append(
+            '      acc += static_cast<uint32_t>(static_cast<int32_t>(ea) * static_cast<int32_t>(eb));'
+        )
         L.append('    }')
     elif op == 'dot8c':
         L.append('    for (int i = 0; i < 8; ++i) {')
@@ -450,7 +455,7 @@ def gen_vector_dot(
         L.append('      if (ea & 8) ea |= ~0xF;')
         L.append('      int32_t eb = static_cast<int32_t>((b >> (i * 4)) & 0xF);')
         L.append('      if (eb & 8) eb |= ~0xF;')
-        L.append('      acc += ea * eb;')
+        L.append('      acc += static_cast<uint32_t>(ea * eb);')
         L.append('    }')
     elif op == 'dot2c' and dtype == 'f32':
         # V_DOT2C_F32_F16: D.f32 += f16_lo(A)*f16_lo(B) + f16_hi(A)*f16_hi(B)
@@ -462,9 +467,9 @@ def gen_vector_dot(
         L.append(
             '    float b1 = util::f16_to_f32(static_cast<uint16_t>((b >> 16) & 0xFFFF));'
         )
-        L.append('    float facc = std::bit_cast<float>(static_cast<uint32_t>(acc));')
+        L.append('    float facc = std::bit_cast<float>(acc);')
         L.append('    facc += a0 * b0 + a1 * b1;')
-        L.append('    acc = static_cast<int32_t>(std::bit_cast<uint32_t>(facc));')
+        L.append('    acc = std::bit_cast<uint32_t>(facc);')
     elif op == 'dot2c' and dtype == 'i32':
         # V_DOT2C_I32_I16: D.i32 += i16_lo(A)*i16_lo(B) + i16_hi(A)*i16_hi(B)
         L.append('    int16_t a0 = static_cast<int16_t>(a & 0xFFFF);')
@@ -472,11 +477,12 @@ def gen_vector_dot(
         L.append('    int16_t b0 = static_cast<int16_t>(b & 0xFFFF);')
         L.append('    int16_t b1 = static_cast<int16_t>((b >> 16) & 0xFFFF);')
         L.append(
-            '    acc += static_cast<int32_t>(a0) * b0 + static_cast<int32_t>(a1) * b1;'
+            '    int64_t dot = static_cast<int64_t>(a0) * b0 + static_cast<int64_t>(a1) * b1;'
         )
+        L.append('    acc += static_cast<uint32_t>(dot);')
     else:
         L.append(f'    (void)a; (void)b; // unhandled dot variant: {op}/{dtype}')
-    L.append(f'    {d}.write_lane(wf, lane, static_cast<uint32_t>(acc));')
+    L.append(f'    {d}.write_lane(wf, lane, acc);')
     L.append('  }')
     return '\n'.join(L)
 

--- a/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
@@ -511,6 +511,8 @@ class _ScalarBinop(_ScalarDeriver):
             result = SemaNode(kind, ty=ty, children=(src0, src1))
 
         result_ty = calc_ty if raw_carry_bits else ty
+        if op == 'mul' and ty.base == 'I':
+            result_ty = result.ty or result_ty
         if ty.base in ('F', 'BF') and ty.size == 16:
             result_ty = SemaType.F32
         stmts.append(_assign(_id('result', result_ty), result))

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -1121,7 +1121,9 @@ class TestDeriveVectorTernary:
         cpp = lower_sema_block(block)
 
         assert '::rocjitsu::amdgpu::lshl_masked' in cpp
-        assert 'inst.src0.read_lane(wf, lane) << inst.src1.read_lane(wf, lane)' not in cpp
+        assert (
+            'inst.src0.read_lane(wf, lane) << inst.src1.read_lane(wf, lane)' not in cpp
+        )
 
     def test_i24_mad_lowers_through_unsigned_helper(self):
         sem = _FakeSem('V_MAD_I32_I24', 'vector_ternary', 'mad_i24', 'i24')

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -177,6 +177,14 @@ class TestDeriveScalarBinop:
         cpp = lower_sema_block(block)
         assert 'write_scc' in cpp
 
+    def test_signed_mul_uses_unsigned_result_slot(self):
+        sem = _FakeSem('S_MUL_I32', 'scalar_binop', 'mul', 'i32')
+        block = derive_sema_block(sem)
+        cpp = lower_sema_block(block)
+
+        assert 'uint32_t result' in cpp
+        assert re.search(r'\bint32_t\s+result\b', cpp) is None
+
     def test_signed_co_uses_unsigned_carry(self):
         sem = derive_semantics('S_ADD_CO_I32', 'ENC_SOP2')
         assert sem.sets_scc == 'carry'
@@ -994,6 +1002,14 @@ class TestDeriveVectorBinop:
         all_kinds = {n.kind for n in block.body.walk()}
         assert SemaNodeKind.SHL in all_kinds
 
+    def test_i24_mul_lowers_through_unsigned_helper(self):
+        sem = _FakeSem('V_MUL_I32_I24', 'vector_binop', 'mul_i24', 'i24')
+        block = derive_sema_block(sem)
+        cpp = lower_sema_block(block)
+
+        assert '::rocjitsu::amdgpu::mul_i24_u32' in cpp
+        assert 'a * b' not in cpp
+
     def test_min_max_use_call(self):
         for op in ['min', 'max']:
             sem = _FakeSem(f'V_{op.upper()}_F32', 'vector_binop', op, 'f32')
@@ -1098,6 +1114,22 @@ class TestDeriveVectorTernary:
             assert '| (pack(' in cpp
             assert ' << 8);' in cpp
             assert f'{op}(' not in cpp
+
+    def test_lshl_add_lowers_through_masked_helper(self):
+        sem = _FakeSem('V_LSHL_ADD_U32', 'vector_ternary', 'lshl_add', 'u32')
+        block = derive_sema_block(sem)
+        cpp = lower_sema_block(block)
+
+        assert '::rocjitsu::amdgpu::lshl_masked' in cpp
+        assert 'inst.src0.read_lane(wf, lane) << inst.src1.read_lane(wf, lane)' not in cpp
+
+    def test_i24_mad_lowers_through_unsigned_helper(self):
+        sem = _FakeSem('V_MAD_I32_I24', 'vector_ternary', 'mad_i24', 'i24')
+        block = derive_sema_block(sem)
+        cpp = lower_sema_block(block)
+
+        assert '::rocjitsu::amdgpu::mad_i24_u32' in cpp
+        assert 'a * b' not in cpp
 
 
 class TestDeriveVectorCmp:

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -1133,6 +1133,14 @@ class TestDeriveVectorTernary:
         assert '::rocjitsu::amdgpu::mad_i24_u32' in cpp
         assert 'a * b' not in cpp
 
+    def test_signed_bfe_keeps_braced_one_literal(self):
+        sem = _FakeSem('V_BFE_I32', 'vector_ternary', 'bfe_i', 'i32')
+        block = derive_sema_block(sem)
+        cpp = lower_sema_block(block)
+
+        assert 'uint32_t{1}' in cpp
+        assert 'uint32_tstatic_cast' not in cpp
+
 
 class TestDeriveVectorCmp:
     def test_cmp_eq_writes_vcc(self):

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_validation.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_validation.py
@@ -155,6 +155,12 @@ class TestVectorBinopValidation:
         assert new_props['reads_lane']
         assert new_props['writes_lane']
 
+    def test_legacy_i24_mul_uses_unsigned_helper(self):
+        old = gen_vector_binop(['vdst'], ['src0', 'vsrc1'], 'mul', 'i24')
+
+        assert '::rocjitsu::amdgpu::mul_i24_u32' in old
+        assert 'sv0 * sv1' not in old
+
 
 class TestVectorTernaryValidation:
     def test_fma_f32(self):

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/decoder.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/decoder.cpp
@@ -15,13 +15,15 @@ namespace gfx1250 {
 
 namespace {
 
+bool isVop3pOp(const MachineInst opcode, uint32_t op) {
+  return (opcode >> 24) == 0xcc && ((opcode >> 16) & 0xff) == op;
+}
+
 bool isWmmaScaleF32Vop3px2(const MachineInst *opcode) {
-  const auto *low = reinterpret_cast<const Vop3pMachineInst *>(opcode);
-  if (low->encoding != 0xcc || (low->op != 0x35 && low->op != 0x3a))
+  if (!isVop3pOp(opcode[0], 0x35) && !isVop3pOp(opcode[0], 0x3a))
     return false;
 
-  const auto *high = reinterpret_cast<const Vop3pMachineInst *>(opcode + 2);
-  return high->encoding == 0xcc && (high->op == 0x33 || high->op == 0x88);
+  return isVop3pOp(opcode[2], 0x33) || isVop3pOp(opcode[2], 0x88);
 }
 
 } // namespace

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu.cpp
@@ -5155,12 +5155,12 @@ void VMulLoU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     {
       uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(
           static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<uint16_t>(static_cast<uint16_t>(((inst_.opsel & 0x1u) != 0
-                                                               ? (src0.read_lane(wf, lane) >> 16)
-                                                               : src0.read_lane(wf, lane)))) *
-              static_cast<uint16_t>(static_cast<uint16_t>(((inst_.opsel & 0x2u) != 0
-                                                               ? (src1.read_lane(wf, lane) >> 16)
-                                                               : src1.read_lane(wf, lane))))))))));
+              static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x1u) != 0 ? (src0.read_lane(wf, lane) >> 16)
+                                             : src0.read_lane(wf, lane))))) *
+              static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint16_t>(
+                  ((inst_.opsel & 0x2u) != 0 ? (src1.read_lane(wf, lane) >> 16)
+                                             : src1.read_lane(wf, lane)))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, inst_.opsel & 0x8u, src_half);
     }
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_ternary.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_ternary.cpp
@@ -3437,7 +3437,9 @@ void VMadI32I16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     int32_t s0 = static_cast<int16_t>(src0.read_lane(wf, lane) & 0xFFFF);
     int32_t s1 = static_cast<int16_t>(src1.read_lane(wf, lane) & 0xFFFF);
     int32_t s2 = static_cast<int32_t>(src2.read_lane(wf, lane));
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(s0 * s1 + s2));
+    vdst.write_lane(wf, lane,
+                    static_cast<uint32_t>(s0) * static_cast<uint32_t>(s1) +
+                        static_cast<uint32_t>(s2));
   }
 }
 
@@ -4865,7 +4867,8 @@ void VMadNcI64I32Vop3::execute_impl(amdgpu::Wavefront &wf) {
     int64_t s0 = static_cast<int32_t>(src0.read_lane(wf, lane));
     int64_t s1 = static_cast<int32_t>(src1.read_lane(wf, lane));
     int64_t s2 = static_cast<int64_t>(src2.read_lane64(wf, lane));
-    uint64_t result = static_cast<uint64_t>(s0 * s1 + s2);
+    uint64_t result =
+        static_cast<uint64_t>(s0) * static_cast<uint64_t>(s1) + static_cast<uint64_t>(s2);
     vdst.write_lane64(wf, lane, result);
   }
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3p.cpp
@@ -1553,8 +1553,7 @@ void VDot4I32Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = src0.read_lane(wf, lane);
     uint32_t raw1 = src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(src2.read_lane(wf, lane));
-    int32_t sum = acc;
+    uint32_t sum = src2.read_lane(wf, lane);
     const bool src0_signed = (inst_.neg & 0x1u) != 0;
     const bool src1_signed = (inst_.neg & 0x2u) != 0;
     for (int i = 0; i < 4; ++i) {
@@ -1564,11 +1563,14 @@ void VDot4I32Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
                               : static_cast<int32_t>(raw_a);
       int32_t b = src1_signed ? static_cast<int32_t>(static_cast<int8_t>(raw_b))
                               : static_cast<int32_t>(raw_b);
-      sum += a * b;
+      sum += static_cast<uint32_t>(a * b);
     }
-    if (inst_.clamp)
-      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
+    if (inst_.clamp) {
+      int32_t signed_sum = static_cast<int32_t>(sum);
+      if (signed_sum < 0)
+        sum = 0u;
+    }
+    vdst.write_lane(wf, lane, sum);
   }
 }
 
@@ -1701,8 +1703,7 @@ void VDot8I32Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = src0.read_lane(wf, lane);
     uint32_t raw1 = src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(src2.read_lane(wf, lane));
-    int32_t sum = acc;
+    uint32_t sum = src2.read_lane(wf, lane);
     const bool src0_signed = (inst_.neg & 0x1u) != 0;
     const bool src1_signed = (inst_.neg & 0x2u) != 0;
     for (int i = 0; i < 8; ++i) {
@@ -1712,11 +1713,14 @@ void VDot8I32Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
                               : static_cast<int32_t>(raw_a);
       int32_t b = src1_signed ? static_cast<int32_t>((raw_b & 0x8) ? (raw_b | ~0xF) : raw_b)
                               : static_cast<int32_t>(raw_b);
-      sum += a * b;
+      sum += static_cast<uint32_t>(a * b);
     }
-    if (inst_.clamp)
-      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
+    if (inst_.clamp) {
+      int32_t signed_sum = static_cast<int32_t>(sum);
+      if (signed_sum < 0)
+        sum = 0u;
+    }
+    vdst.write_lane(wf, lane, sum);
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3p.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3p.cpp
@@ -904,8 +904,7 @@ void VDot4I32Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = src0.read_lane(wf, lane);
     uint32_t raw1 = src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(src2.read_lane(wf, lane));
-    int32_t sum = acc;
+    uint32_t sum = src2.read_lane(wf, lane);
     const bool src0_signed = (inst_.neg & 0x1u) != 0;
     const bool src1_signed = (inst_.neg & 0x2u) != 0;
     for (int i = 0; i < 4; ++i) {
@@ -915,11 +914,14 @@ void VDot4I32Iu8Vop3p::execute_impl(amdgpu::Wavefront &wf) {
                               : static_cast<int32_t>(raw_a);
       int32_t b = src1_signed ? static_cast<int32_t>(static_cast<int8_t>(raw_b))
                               : static_cast<int32_t>(raw_b);
-      sum += a * b;
+      sum += static_cast<uint32_t>(a * b);
     }
-    if (inst_.clamp)
-      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
+    if (inst_.clamp) {
+      int32_t signed_sum = static_cast<int32_t>(sum);
+      if (signed_sum < 0)
+        sum = 0u;
+    }
+    vdst.write_lane(wf, lane, sum);
   }
 }
 
@@ -1002,8 +1004,7 @@ void VDot8I32Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
       continue;
     uint32_t raw0 = src0.read_lane(wf, lane);
     uint32_t raw1 = src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(src2.read_lane(wf, lane));
-    int32_t sum = acc;
+    uint32_t sum = src2.read_lane(wf, lane);
     const bool src0_signed = (inst_.neg & 0x1u) != 0;
     const bool src1_signed = (inst_.neg & 0x2u) != 0;
     for (int i = 0; i < 8; ++i) {
@@ -1013,11 +1014,14 @@ void VDot8I32Iu4Vop3p::execute_impl(amdgpu::Wavefront &wf) {
                               : static_cast<int32_t>(raw_a);
       int32_t b = src1_signed ? static_cast<int32_t>((raw_b & 0x8) ? (raw_b | ~0xF) : raw_b)
                               : static_cast<int32_t>(raw_b);
-      sum += a * b;
+      sum += static_cast<uint32_t>(a * b);
     }
-    if (inst_.clamp)
-      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
-    vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
+    if (inst_.clamp) {
+      int32_t signed_sum = static_cast<int32_t>(sum);
+      if (signed_sum < 0)
+        sum = 0u;
+    }
+    vdst.write_lane(wf, lane, sum);
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -3404,15 +3404,15 @@ inline void execute_v_bfe_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane, [&]() -> uint32_t {
-      int32_t src = static_cast<int32_t>(static_cast<int32_t>(inst.src0.read_lane(wf, lane)));
-      uint32_t off = static_cast<int32_t>(inst.src1.read_lane(wf, lane)) & 31u;
-      uint32_t w = static_cast<int32_t>(inst.src2.read_lane(wf, lane)) & 31u;
+      uint32_t src = static_cast<uint32_t>(inst.src0.read_lane(wf, lane));
+      uint32_t off = static_cast<uint32_t>(inst.src1.read_lane(wf, lane)) & 31u;
+      uint32_t w = static_cast<uint32_t>(inst.src2.read_lane(wf, lane)) & 31u;
       if (w == 0)
         return 0u;
-      int32_t val = (src >> off) & ((1 << w) - 1);
-      if (val & (1 << (w - 1)))
-        val |= -(1 << w);
-      return static_cast<uint32_t>(val);
+      uint32_t mask = (uint32_t{1} << w) - 1u;
+      uint32_t extracted = static_cast<uint32_t>(static_cast<int32_t>(src) >> off) & mask;
+      uint32_t signbit = uint32_t{1} << (w - 1u);
+      return (extracted ^ signbit) - signbit;
     }());
   }
 }
@@ -10491,11 +10491,15 @@ inline void execute_v_dot2_i32_i16_vop3p([[maybe_unused]] Inst &inst,
     int16_t a1 = static_cast<int16_t>(sel0_hi ? (raw0 >> 16) : raw0);
     int16_t b0 = static_cast<int16_t>(sel1_lo ? (raw1 >> 16) : raw1);
     int16_t b1 = static_cast<int16_t>(sel1_hi ? (raw1 >> 16) : raw1);
-    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
-    int32_t result = static_cast<int32_t>(a0) * b0 + static_cast<int32_t>(a1) * b1 + acc;
-    if (inst.inst_.clamp)
-      result = std::clamp(result, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(result));
+    uint32_t result = inst.src2.read_lane(wf, lane);
+    result += static_cast<uint32_t>(static_cast<int32_t>(a0) * b0);
+    result += static_cast<uint32_t>(static_cast<int32_t>(a1) * b1);
+    if (inst.inst_.clamp) {
+      int32_t signed_result = static_cast<int32_t>(result);
+      if (signed_result < 0)
+        result = 0u;
+    }
+    inst.vdst.write_lane(wf, lane, result);
   }
 }
 
@@ -10619,16 +10623,18 @@ inline void execute_v_dot4_i32_i8_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = inst.src0.read_lane(wf, lane);
     uint32_t raw1 = inst.src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
-    int32_t sum = acc;
+    uint32_t sum = inst.src2.read_lane(wf, lane);
     for (int i = 0; i < 4; ++i) {
       int8_t a = static_cast<int8_t>((raw0 >> (i * 8)) & 0xFF);
       int8_t b = static_cast<int8_t>((raw1 >> (i * 8)) & 0xFF);
-      sum += static_cast<int32_t>(a) * b;
+      sum += static_cast<uint32_t>(static_cast<int32_t>(a) * b);
     }
-    if (inst.inst_.clamp)
-      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
+    if (inst.inst_.clamp) {
+      int32_t signed_sum = static_cast<int32_t>(sum);
+      if (signed_sum < 0)
+        sum = 0u;
+    }
+    inst.vdst.write_lane(wf, lane, sum);
   }
 }
 
@@ -10642,8 +10648,7 @@ inline void execute_v_dot4_i32_iu8_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = inst.src0.read_lane(wf, lane);
     uint32_t raw1 = inst.src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
-    int32_t sum = acc;
+    uint32_t sum = inst.src2.read_lane(wf, lane);
     const bool src0_signed = (inst.inst_.neg & 0x1u) != 0;
     const bool src1_signed = (inst.inst_.neg & 0x2u) != 0;
     for (int i = 0; i < 4; ++i) {
@@ -10653,11 +10658,14 @@ inline void execute_v_dot4_i32_iu8_vop3p([[maybe_unused]] Inst &inst,
                               : static_cast<int32_t>(raw_a);
       int32_t b = src1_signed ? static_cast<int32_t>(static_cast<int8_t>(raw_b))
                               : static_cast<int32_t>(raw_b);
-      sum += a * b;
+      sum += static_cast<uint32_t>(a * b);
     }
-    if (inst.inst_.clamp)
-      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
+    if (inst.inst_.clamp) {
+      int32_t signed_sum = static_cast<int32_t>(sum);
+      if (signed_sum < 0)
+        sum = 0u;
+    }
+    inst.vdst.write_lane(wf, lane, sum);
   }
 }
 
@@ -10732,8 +10740,7 @@ inline void execute_v_dot8_i32_i4_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = inst.src0.read_lane(wf, lane);
     uint32_t raw1 = inst.src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
-    int32_t sum = acc;
+    uint32_t sum = inst.src2.read_lane(wf, lane);
     for (int i = 0; i < 8; ++i) {
       int32_t a = static_cast<int32_t>((raw0 >> (i * 4)) & 0xF);
       if (a & 0x8)
@@ -10741,11 +10748,14 @@ inline void execute_v_dot8_i32_i4_vop3p([[maybe_unused]] Inst &inst,
       int32_t b = static_cast<int32_t>((raw1 >> (i * 4)) & 0xF);
       if (b & 0x8)
         b |= ~0xF;
-      sum += a * b;
+      sum += static_cast<uint32_t>(a * b);
     }
-    if (inst.inst_.clamp)
-      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
+    if (inst.inst_.clamp) {
+      int32_t signed_sum = static_cast<int32_t>(sum);
+      if (signed_sum < 0)
+        sum = 0u;
+    }
+    inst.vdst.write_lane(wf, lane, sum);
   }
 }
 
@@ -10759,8 +10769,7 @@ inline void execute_v_dot8_i32_iu4_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = inst.src0.read_lane(wf, lane);
     uint32_t raw1 = inst.src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
-    int32_t sum = acc;
+    uint32_t sum = inst.src2.read_lane(wf, lane);
     const bool src0_signed = (inst.inst_.neg & 0x1u) != 0;
     const bool src1_signed = (inst.inst_.neg & 0x2u) != 0;
     for (int i = 0; i < 8; ++i) {
@@ -10770,11 +10779,14 @@ inline void execute_v_dot8_i32_iu4_vop3p([[maybe_unused]] Inst &inst,
                               : static_cast<int32_t>(raw_a);
       int32_t b = src1_signed ? static_cast<int32_t>((raw_b & 0x8) ? (raw_b | ~0xF) : raw_b)
                               : static_cast<int32_t>(raw_b);
-      sum += a * b;
+      sum += static_cast<uint32_t>(a * b);
     }
-    if (inst.inst_.clamp)
-      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
+    if (inst.inst_.clamp) {
+      int32_t signed_sum = static_cast<int32_t>(sum);
+      if (signed_sum < 0)
+        sum = 0u;
+    }
+    inst.vdst.write_lane(wf, lane, sum);
   }
 }
 
@@ -13314,11 +13326,13 @@ inline void execute_v_mad_legacy_u16_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(
-                             ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) *
-                               static_cast<uint16_t>(inst.src1.read_lane(wf, lane))) +
-                              static_cast<uint16_t>(inst.src2.read_lane(wf, lane))))));
+    uint16_t a = static_cast<uint16_t>(inst.src0.read_lane(wf, lane));
+    uint16_t b = static_cast<uint16_t>(inst.src1.read_lane(wf, lane));
+    uint16_t c = static_cast<uint16_t>(inst.src2.read_lane(wf, lane));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(
+            static_cast<uint32_t>(a) * static_cast<uint32_t>(b) + static_cast<uint32_t>(c))));
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -822,7 +822,7 @@ inline void execute_s_bfe_u64_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]]
 template <typename Inst>
 inline void execute_s_bfm_b32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   uint32_t result =
-      (((1u << (inst.ssrc0.read_scalar(wf) & 31u)) - 1u) << (inst.ssrc1.read_scalar(wf) & 31u));
+      ::rocjitsu::amdgpu::bfm_b32(inst.ssrc0.read_scalar(wf), inst.ssrc1.read_scalar(wf));
   inst.sdst.write_scalar(wf, result);
 }
 
@@ -1967,8 +1967,8 @@ inline void execute_s_mul_hi_u32_sop2([[maybe_unused]] Inst &inst, [[maybe_unuse
 
 template <typename Inst>
 inline void execute_s_mul_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  int32_t result = (static_cast<uint32_t>(static_cast<int32_t>(inst.ssrc0.read_scalar(wf))) *
-                    static_cast<uint32_t>(static_cast<int32_t>(inst.ssrc1.read_scalar(wf))));
+  uint32_t result = (static_cast<uint32_t>(static_cast<int32_t>(inst.ssrc0.read_scalar(wf))) *
+                     static_cast<uint32_t>(static_cast<int32_t>(inst.ssrc1.read_scalar(wf))));
   inst.sdst.write_scalar(wf, result);
 }
 
@@ -1981,9 +1981,10 @@ inline void execute_s_mul_u64_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]]
 
 template <typename Inst>
 inline void execute_s_mulk_i32_sopk([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  int32_t s0 = static_cast<int32_t>(inst.sdst.read_scalar(wf));
-  int32_t imm = static_cast<int16_t>(inst.simm16.encoding_value_);
-  inst.sdst.write_scalar(wf, static_cast<uint32_t>(s0 * imm));
+  uint32_t s0 = inst.sdst.read_scalar(wf);
+  uint32_t imm = static_cast<uint32_t>(
+      static_cast<int32_t>(static_cast<int16_t>(inst.simm16.encoding_value_)));
+  inst.sdst.write_scalar(wf, s0 * imm);
 }
 
 template <typename Inst>
@@ -3010,8 +3011,9 @@ inline void execute_v_add_lshl_u32_vop3([[maybe_unused]] Inst &inst,
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane,
-                         ((inst.src0.read_lane(wf, lane) + inst.src1.read_lane(wf, lane))
-                          << inst.src2.read_lane(wf, lane)));
+                         ::rocjitsu::amdgpu::lshl_masked(
+                             (inst.src0.read_lane(wf, lane) + inst.src1.read_lane(wf, lane)),
+                             inst.src2.read_lane(wf, lane)));
   }
 }
 
@@ -3460,9 +3462,9 @@ inline void execute_v_bfm_b32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         (((1u << (inst.src0.read_lane(wf, lane) & 31u)) - 1u)
-                          << (inst.src1.read_lane(wf, lane) & 31u)));
+    inst.vdst.write_lane(
+        wf, lane,
+        ::rocjitsu::amdgpu::bfm_b32(inst.src0.read_lane(wf, lane), inst.src1.read_lane(wf, lane)));
   }
 }
 
@@ -12651,8 +12653,9 @@ inline void execute_v_lshl_add_u32_vop3([[maybe_unused]] Inst &inst,
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane,
-                         ((inst.src0.read_lane(wf, lane) << inst.src1.read_lane(wf, lane)) +
-                          inst.src2.read_lane(wf, lane)));
+                         ::rocjitsu::amdgpu::lshl_masked(inst.src0.read_lane(wf, lane),
+                                                         inst.src1.read_lane(wf, lane)) +
+                             inst.src2.read_lane(wf, lane));
   }
 }
 
@@ -12664,10 +12667,11 @@ inline void execute_v_lshl_add_u64_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane64(wf, lane,
-                           ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane))
-                             << static_cast<uint64_t>(inst.src1.read_lane(wf, lane))) +
-                            static_cast<uint64_t>(inst.src2.read_lane64(wf, lane))));
+    inst.vdst.write_lane64(
+        wf, lane,
+        ::rocjitsu::amdgpu::lshl_masked(static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)),
+                                        static_cast<uint64_t>(inst.src1.read_lane(wf, lane))) +
+            static_cast<uint64_t>(inst.src2.read_lane64(wf, lane)));
   }
 }
 
@@ -12681,8 +12685,9 @@ inline void execute_v_lshl_or_b32_vop3([[maybe_unused]] Inst &inst,
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane,
-                         ((inst.src0.read_lane(wf, lane) << inst.src1.read_lane(wf, lane)) |
-                          inst.src2.read_lane(wf, lane)));
+                         ::rocjitsu::amdgpu::lshl_masked(inst.src0.read_lane(wf, lane),
+                                                         inst.src1.read_lane(wf, lane)) |
+                             inst.src2.read_lane(wf, lane));
   }
 }
 
@@ -13146,19 +13151,16 @@ template <typename Inst>
 inline void execute_v_mad_i32_i24_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT(uint32_t, [](auto a, auto b, auto c) {
-    auto sa = ::rocjitsu::amdgpu::simd_sign_extend_u32(a, 24);
-    auto sb = ::rocjitsu::amdgpu::simd_sign_extend_u32(b, 24);
-    return sa * sb + c;
+    return ::rocjitsu::amdgpu::simd_mad_i24_u32(a, b, c);
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane, [&]() {
-      auto a = static_cast<int32_t>(inst.src0.read_lane(wf, lane) << 8) >> 8;
-      auto b = static_cast<int32_t>(inst.src1.read_lane(wf, lane) << 8) >> 8;
-      return static_cast<uint32_t>(a * b + static_cast<int32_t>(inst.src2.read_lane(wf, lane)));
-    }());
+    inst.vdst.write_lane(wf, lane,
+                         ::rocjitsu::amdgpu::mad_i24_u32(inst.src0.read_lane(wf, lane),
+                                                         inst.src1.read_lane(wf, lane),
+                                                         inst.src2.read_lane(wf, lane)));
   }
 }
 
@@ -17067,40 +17069,30 @@ inline void execute_v_mul_hi_u32_u24_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_mul_i32_i24_vop2([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP2_BINARY(uint32_t, [](auto a, auto b) {
-    auto sa = ::rocjitsu::amdgpu::simd_sign_extend_u32(a, 24);
-    auto sb = ::rocjitsu::amdgpu::simd_sign_extend_u32(b, 24);
-    return sa * sb;
-  });
+  ROCJITSU_TRY_SIMD_VOP2_BINARY(
+      uint32_t, [](auto a, auto b) { return ::rocjitsu::amdgpu::simd_mul_i24_u32(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane, [&]() {
-      auto a = static_cast<int32_t>(inst.src0.read_lane(wf, lane) << 8) >> 8;
-      auto b = static_cast<int32_t>(inst.vsrc1.read_lane(wf, lane) << 8) >> 8;
-      return static_cast<uint32_t>(a * b);
-    }());
+    inst.vdst.write_lane(wf, lane,
+                         ::rocjitsu::amdgpu::mul_i24_u32(inst.src0.read_lane(wf, lane),
+                                                         inst.vsrc1.read_lane(wf, lane)));
   }
 }
 
 template <typename Inst>
 inline void execute_v_mul_i32_i24_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
-    auto sa = ::rocjitsu::amdgpu::simd_sign_extend_u32(a, 24);
-    auto sb = ::rocjitsu::amdgpu::simd_sign_extend_u32(b, 24);
-    return sa * sb;
-  });
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(
+      uint32_t, [](auto a, auto b) { return ::rocjitsu::amdgpu::simd_mul_i24_u32(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane, [&]() {
-      auto a = static_cast<int32_t>(inst.src0.read_lane(wf, lane) << 8) >> 8;
-      auto b = static_cast<int32_t>(inst.src1.read_lane(wf, lane) << 8) >> 8;
-      return static_cast<uint32_t>(a * b);
-    }());
+    inst.vdst.write_lane(wf, lane,
+                         ::rocjitsu::amdgpu::mul_i24_u32(inst.src0.read_lane(wf, lane),
+                                                         inst.src1.read_lane(wf, lane)));
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -2994,7 +2994,9 @@ inline void execute_v_add_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane, (inst.src0.read_lane(wf, lane) + inst.src1.read_lane(wf, lane)));
+    inst.vdst.write_lane(wf, lane,
+                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) +
+                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
   }
 }
 
@@ -3009,7 +3011,7 @@ inline void execute_v_add_lshl_u32_vop3([[maybe_unused]] Inst &inst,
       continue;
     inst.vdst.write_lane(wf, lane,
                          ((inst.src0.read_lane(wf, lane) + inst.src1.read_lane(wf, lane))
-                          << (inst.src2.read_lane(wf, lane) & 31u)));
+                          << inst.src2.read_lane(wf, lane)));
   }
 }
 
@@ -3033,7 +3035,9 @@ inline void execute_v_add_nc_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane, (inst.src0.read_lane(wf, lane) + inst.src1.read_lane(wf, lane)));
+    inst.vdst.write_lane(wf, lane,
+                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) +
+                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
   }
 }
 
@@ -3361,11 +3365,8 @@ inline void execute_v_ashrrev_i32_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_ashrrev_i64_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_SHIFT64_VOP3([](auto v, auto sh) {
-    return util::stdx::static_simd_cast<util::native<uint64_t>>(
-        util::stdx::static_simd_cast<util::native<int64_t>>(v) >>
-        util::stdx::static_simd_cast<util::native<int64_t>>(sh));
-  });
+  ROCJITSU_TRY_SIMD_SHIFT64_VOP3(
+      [](auto v, auto sh) { return ::rocjitsu::amdgpu::simd_ashr_i64(v, sh); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -3401,15 +3402,15 @@ inline void execute_v_bfe_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane, [&]() -> uint32_t {
-      uint32_t src = inst.src0.read_lane(wf, lane);
-      uint32_t off = inst.src1.read_lane(wf, lane) & 31u;
-      uint32_t w = inst.src2.read_lane(wf, lane) & 31u;
+      int32_t src = static_cast<int32_t>(static_cast<int32_t>(inst.src0.read_lane(wf, lane)));
+      uint32_t off = static_cast<int32_t>(inst.src1.read_lane(wf, lane)) & 31u;
+      uint32_t w = static_cast<int32_t>(inst.src2.read_lane(wf, lane)) & 31u;
       if (w == 0)
         return 0u;
-      uint32_t mask = (uint32_t{1} << w) - 1u;
-      uint32_t extracted = static_cast<uint32_t>(static_cast<int32_t>(src) >> off) & mask;
-      uint32_t signbit = uint32_t{1} << (w - 1u);
-      return (extracted ^ signbit) - signbit;
+      int32_t val = (src >> off) & ((1 << w) - 1);
+      if (val & (1 << (w - 1)))
+        val |= -(1 << w);
+      return static_cast<uint32_t>(val);
     }());
   }
 }
@@ -10488,15 +10489,11 @@ inline void execute_v_dot2_i32_i16_vop3p([[maybe_unused]] Inst &inst,
     int16_t a1 = static_cast<int16_t>(sel0_hi ? (raw0 >> 16) : raw0);
     int16_t b0 = static_cast<int16_t>(sel1_lo ? (raw1 >> 16) : raw1);
     int16_t b1 = static_cast<int16_t>(sel1_hi ? (raw1 >> 16) : raw1);
-    uint32_t result = inst.src2.read_lane(wf, lane);
-    int64_t dot = static_cast<int64_t>(a0) * b0 + static_cast<int64_t>(a1) * b1;
-    result += static_cast<uint32_t>(dot);
-    if (inst.inst_.clamp) {
-      int32_t clamped = std::clamp(static_cast<int32_t>(result), static_cast<int32_t>(0),
-                                   std::numeric_limits<int32_t>::max());
-      result = static_cast<uint32_t>(clamped);
-    }
-    inst.vdst.write_lane(wf, lane, result);
+    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
+    int32_t result = static_cast<int32_t>(a0) * b0 + static_cast<int32_t>(a1) * b1 + acc;
+    if (inst.inst_.clamp)
+      result = std::clamp(result, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
+    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(result));
   }
 }
 
@@ -10534,15 +10531,15 @@ inline void execute_v_dot2c_f32_f16_vop2([[maybe_unused]] Inst &inst,
       continue;
     uint32_t a = inst.src0.read_lane(wf, lane);
     uint32_t b = inst.vsrc1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.vdst.read_lane(wf, lane));
+    uint32_t acc = inst.vdst.read_lane(wf, lane);
     float a0 = util::f16_to_f32(static_cast<uint16_t>(a & 0xFFFF));
     float a1 = util::f16_to_f32(static_cast<uint16_t>((a >> 16) & 0xFFFF));
     float b0 = util::f16_to_f32(static_cast<uint16_t>(b & 0xFFFF));
     float b1 = util::f16_to_f32(static_cast<uint16_t>((b >> 16) & 0xFFFF));
-    float facc = std::bit_cast<float>(static_cast<uint32_t>(acc));
+    float facc = std::bit_cast<float>(acc);
     facc += a0 * b0 + a1 * b1;
-    acc = static_cast<int32_t>(std::bit_cast<uint32_t>(facc));
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
+    acc = std::bit_cast<uint32_t>(facc);
+    inst.vdst.write_lane(wf, lane, acc);
   }
 }
 
@@ -10556,15 +10553,15 @@ inline void execute_v_dot2c_f32_f16_vop3([[maybe_unused]] Inst &inst,
       continue;
     uint32_t a = inst.src0.read_lane(wf, lane);
     uint32_t b = inst.src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.vdst.read_lane(wf, lane));
+    uint32_t acc = inst.vdst.read_lane(wf, lane);
     float a0 = util::f16_to_f32(static_cast<uint16_t>(a & 0xFFFF));
     float a1 = util::f16_to_f32(static_cast<uint16_t>((a >> 16) & 0xFFFF));
     float b0 = util::f16_to_f32(static_cast<uint16_t>(b & 0xFFFF));
     float b1 = util::f16_to_f32(static_cast<uint16_t>((b >> 16) & 0xFFFF));
-    float facc = std::bit_cast<float>(static_cast<uint32_t>(acc));
+    float facc = std::bit_cast<float>(acc);
     facc += a0 * b0 + a1 * b1;
-    acc = static_cast<int32_t>(std::bit_cast<uint32_t>(facc));
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
+    acc = std::bit_cast<uint32_t>(facc);
+    inst.vdst.write_lane(wf, lane, acc);
   }
 }
 
@@ -10578,15 +10575,14 @@ inline void execute_v_dot2c_i32_i16_vop2([[maybe_unused]] Inst &inst,
       continue;
     uint32_t a = inst.src0.read_lane(wf, lane);
     uint32_t b = inst.vsrc1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.vdst.read_lane(wf, lane));
+    uint32_t acc = inst.vdst.read_lane(wf, lane);
     int16_t a0 = static_cast<int16_t>(a & 0xFFFF);
     int16_t a1 = static_cast<int16_t>((a >> 16) & 0xFFFF);
     int16_t b0 = static_cast<int16_t>(b & 0xFFFF);
     int16_t b1 = static_cast<int16_t>((b >> 16) & 0xFFFF);
-    uint32_t uacc = static_cast<uint32_t>(acc);
     int64_t dot = static_cast<int64_t>(a0) * b0 + static_cast<int64_t>(a1) * b1;
-    acc = static_cast<int32_t>(uacc + static_cast<uint32_t>(dot));
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
+    acc += static_cast<uint32_t>(dot);
+    inst.vdst.write_lane(wf, lane, acc);
   }
 }
 
@@ -10600,15 +10596,14 @@ inline void execute_v_dot2c_i32_i16_vop3([[maybe_unused]] Inst &inst,
       continue;
     uint32_t a = inst.src0.read_lane(wf, lane);
     uint32_t b = inst.src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.vdst.read_lane(wf, lane));
+    uint32_t acc = inst.vdst.read_lane(wf, lane);
     int16_t a0 = static_cast<int16_t>(a & 0xFFFF);
     int16_t a1 = static_cast<int16_t>((a >> 16) & 0xFFFF);
     int16_t b0 = static_cast<int16_t>(b & 0xFFFF);
     int16_t b1 = static_cast<int16_t>((b >> 16) & 0xFFFF);
-    uint32_t uacc = static_cast<uint32_t>(acc);
     int64_t dot = static_cast<int64_t>(a0) * b0 + static_cast<int64_t>(a1) * b1;
-    acc = static_cast<int32_t>(uacc + static_cast<uint32_t>(dot));
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
+    acc += static_cast<uint32_t>(dot);
+    inst.vdst.write_lane(wf, lane, acc);
   }
 }
 
@@ -10622,18 +10617,16 @@ inline void execute_v_dot4_i32_i8_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = inst.src0.read_lane(wf, lane);
     uint32_t raw1 = inst.src1.read_lane(wf, lane);
-    uint32_t sum = inst.src2.read_lane(wf, lane);
+    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
+    int32_t sum = acc;
     for (int i = 0; i < 4; ++i) {
       int8_t a = static_cast<int8_t>((raw0 >> (i * 8)) & 0xFF);
       int8_t b = static_cast<int8_t>((raw1 >> (i * 8)) & 0xFF);
-      sum += static_cast<uint32_t>(static_cast<int32_t>(a) * static_cast<int32_t>(b));
+      sum += static_cast<int32_t>(a) * b;
     }
-    if (inst.inst_.clamp) {
-      int32_t clamped = std::clamp(static_cast<int32_t>(sum), static_cast<int32_t>(0),
-                                   std::numeric_limits<int32_t>::max());
-      sum = static_cast<uint32_t>(clamped);
-    }
-    inst.vdst.write_lane(wf, lane, sum);
+    if (inst.inst_.clamp)
+      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
+    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
   }
 }
 
@@ -10647,7 +10640,8 @@ inline void execute_v_dot4_i32_iu8_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = inst.src0.read_lane(wf, lane);
     uint32_t raw1 = inst.src1.read_lane(wf, lane);
-    uint32_t sum = inst.src2.read_lane(wf, lane);
+    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
+    int32_t sum = acc;
     const bool src0_signed = (inst.inst_.neg & 0x1u) != 0;
     const bool src1_signed = (inst.inst_.neg & 0x2u) != 0;
     for (int i = 0; i < 4; ++i) {
@@ -10657,14 +10651,11 @@ inline void execute_v_dot4_i32_iu8_vop3p([[maybe_unused]] Inst &inst,
                               : static_cast<int32_t>(raw_a);
       int32_t b = src1_signed ? static_cast<int32_t>(static_cast<int8_t>(raw_b))
                               : static_cast<int32_t>(raw_b);
-      sum += static_cast<uint32_t>(a * b);
+      sum += a * b;
     }
-    if (inst.inst_.clamp) {
-      int32_t clamped = std::clamp(static_cast<int32_t>(sum), static_cast<int32_t>(0),
-                                   std::numeric_limits<int32_t>::max());
-      sum = static_cast<uint32_t>(clamped);
-    }
-    inst.vdst.write_lane(wf, lane, sum);
+    if (inst.inst_.clamp)
+      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
+    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
   }
 }
 
@@ -10739,7 +10730,8 @@ inline void execute_v_dot8_i32_i4_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = inst.src0.read_lane(wf, lane);
     uint32_t raw1 = inst.src1.read_lane(wf, lane);
-    uint32_t sum = inst.src2.read_lane(wf, lane);
+    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
+    int32_t sum = acc;
     for (int i = 0; i < 8; ++i) {
       int32_t a = static_cast<int32_t>((raw0 >> (i * 4)) & 0xF);
       if (a & 0x8)
@@ -10747,14 +10739,11 @@ inline void execute_v_dot8_i32_i4_vop3p([[maybe_unused]] Inst &inst,
       int32_t b = static_cast<int32_t>((raw1 >> (i * 4)) & 0xF);
       if (b & 0x8)
         b |= ~0xF;
-      sum += static_cast<uint32_t>(a * b);
+      sum += a * b;
     }
-    if (inst.inst_.clamp) {
-      int32_t clamped = std::clamp(static_cast<int32_t>(sum), static_cast<int32_t>(0),
-                                   std::numeric_limits<int32_t>::max());
-      sum = static_cast<uint32_t>(clamped);
-    }
-    inst.vdst.write_lane(wf, lane, sum);
+    if (inst.inst_.clamp)
+      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
+    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
   }
 }
 
@@ -10768,7 +10757,8 @@ inline void execute_v_dot8_i32_iu4_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = inst.src0.read_lane(wf, lane);
     uint32_t raw1 = inst.src1.read_lane(wf, lane);
-    uint32_t sum = inst.src2.read_lane(wf, lane);
+    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
+    int32_t sum = acc;
     const bool src0_signed = (inst.inst_.neg & 0x1u) != 0;
     const bool src1_signed = (inst.inst_.neg & 0x2u) != 0;
     for (int i = 0; i < 8; ++i) {
@@ -10778,14 +10768,11 @@ inline void execute_v_dot8_i32_iu4_vop3p([[maybe_unused]] Inst &inst,
                               : static_cast<int32_t>(raw_a);
       int32_t b = src1_signed ? static_cast<int32_t>((raw_b & 0x8) ? (raw_b | ~0xF) : raw_b)
                               : static_cast<int32_t>(raw_b);
-      sum += static_cast<uint32_t>(a * b);
+      sum += a * b;
     }
-    if (inst.inst_.clamp) {
-      int32_t clamped = std::clamp(static_cast<int32_t>(sum), static_cast<int32_t>(0),
-                                   std::numeric_limits<int32_t>::max());
-      sum = static_cast<uint32_t>(clamped);
-    }
-    inst.vdst.write_lane(wf, lane, sum);
+    if (inst.inst_.clamp)
+      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
+    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
   }
 }
 
@@ -12664,7 +12651,7 @@ inline void execute_v_lshl_add_u32_vop3([[maybe_unused]] Inst &inst,
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane,
-                         ((inst.src0.read_lane(wf, lane) << (inst.src1.read_lane(wf, lane) & 31u)) +
+                         ((inst.src0.read_lane(wf, lane) << inst.src1.read_lane(wf, lane)) +
                           inst.src2.read_lane(wf, lane)));
   }
 }
@@ -12679,7 +12666,7 @@ inline void execute_v_lshl_add_u64_vop3([[maybe_unused]] Inst &inst,
       continue;
     inst.vdst.write_lane64(wf, lane,
                            ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane))
-                             << (static_cast<uint64_t>(inst.src1.read_lane(wf, lane)) & 63u)) +
+                             << static_cast<uint64_t>(inst.src1.read_lane(wf, lane))) +
                             static_cast<uint64_t>(inst.src2.read_lane64(wf, lane))));
   }
 }
@@ -12694,7 +12681,7 @@ inline void execute_v_lshl_or_b32_vop3([[maybe_unused]] Inst &inst,
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane,
-                         ((inst.src0.read_lane(wf, lane) << (inst.src1.read_lane(wf, lane) & 31u)) |
+                         ((inst.src0.read_lane(wf, lane) << inst.src1.read_lane(wf, lane)) |
                           inst.src2.read_lane(wf, lane)));
   }
 }
@@ -12994,7 +12981,8 @@ inline void execute_v_mad_co_i64_i32_vop3([[maybe_unused]] Inst &inst,
     int64_t s0 = static_cast<int32_t>(inst.src0.read_lane(wf, lane));
     int64_t s1 = static_cast<int32_t>(inst.src1.read_lane(wf, lane));
     int64_t s2 = static_cast<int64_t>(inst.src2.read_lane64(wf, lane));
-    uint64_t result = static_cast<uint64_t>(s0 * s1 + s2);
+    uint64_t result =
+        static_cast<uint64_t>(s0) * static_cast<uint64_t>(s1) + static_cast<uint64_t>(s2);
     inst.vdst.write_lane64(wf, lane, result);
   }
 }
@@ -13169,7 +13157,7 @@ inline void execute_v_mad_i32_i24_vop3([[maybe_unused]] Inst &inst,
     inst.vdst.write_lane(wf, lane, [&]() {
       auto a = static_cast<int32_t>(inst.src0.read_lane(wf, lane) << 8) >> 8;
       auto b = static_cast<int32_t>(inst.src1.read_lane(wf, lane) << 8) >> 8;
-      return static_cast<uint32_t>(a) * static_cast<uint32_t>(b) + inst.src2.read_lane(wf, lane);
+      return static_cast<uint32_t>(a * b + static_cast<int32_t>(inst.src2.read_lane(wf, lane)));
     }());
   }
 }
@@ -13324,12 +13312,11 @@ inline void execute_v_mad_legacy_u16_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(
-        wf, lane,
-        static_cast<uint32_t>(static_cast<uint16_t>(
-            ((static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) *
-              static_cast<uint32_t>(static_cast<uint16_t>(inst.src1.read_lane(wf, lane)))) +
-             static_cast<uint32_t>(static_cast<uint16_t>(inst.src2.read_lane(wf, lane)))))));
+    inst.vdst.write_lane(wf, lane,
+                         static_cast<uint32_t>(static_cast<uint16_t>(
+                             ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) *
+                               static_cast<uint16_t>(inst.src1.read_lane(wf, lane))) +
+                              static_cast<uint16_t>(inst.src2.read_lane(wf, lane))))));
   }
 }
 
@@ -17092,7 +17079,7 @@ inline void execute_v_mul_i32_i24_vop2([[maybe_unused]] Inst &inst,
     inst.vdst.write_lane(wf, lane, [&]() {
       auto a = static_cast<int32_t>(inst.src0.read_lane(wf, lane) << 8) >> 8;
       auto b = static_cast<int32_t>(inst.vsrc1.read_lane(wf, lane) << 8) >> 8;
-      return static_cast<uint32_t>(a) * static_cast<uint32_t>(b);
+      return static_cast<uint32_t>(a * b);
     }());
   }
 }
@@ -17112,7 +17099,7 @@ inline void execute_v_mul_i32_i24_vop3([[maybe_unused]] Inst &inst,
     inst.vdst.write_lane(wf, lane, [&]() {
       auto a = static_cast<int32_t>(inst.src0.read_lane(wf, lane) << 8) >> 8;
       auto b = static_cast<int32_t>(inst.src1.read_lane(wf, lane) << 8) >> 8;
-      return static_cast<uint32_t>(a) * static_cast<uint32_t>(b);
+      return static_cast<uint32_t>(a * b);
     }());
   }
 }
@@ -17195,9 +17182,11 @@ inline void execute_v_mul_lo_u16_vop2([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     inst.vdst.write_lane(
         wf, lane,
-        static_cast<uint32_t>(static_cast<uint16_t>(
-            static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) *
-            static_cast<uint32_t>(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))));
+        static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+            static_cast<uint32_t>(
+                static_cast<uint16_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)))) *
+            static_cast<uint32_t>(
+                static_cast<uint16_t>(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)))))))));
   }
 }
 
@@ -17209,9 +17198,11 @@ inline void execute_v_mul_lo_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     inst.vdst.write_lane(
         wf, lane,
-        static_cast<uint32_t>(static_cast<uint16_t>(
-            static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) *
-            static_cast<uint32_t>(static_cast<uint16_t>(inst.src1.read_lane(wf, lane))))));
+        static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+            static_cast<uint32_t>(
+                static_cast<uint16_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)))) *
+            static_cast<uint32_t>(
+                static_cast<uint16_t>(static_cast<uint16_t>(inst.src1.read_lane(wf, lane)))))))));
   }
 }
 
@@ -19400,7 +19391,9 @@ inline void execute_v_sub_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane, (inst.src0.read_lane(wf, lane) - inst.src1.read_lane(wf, lane)));
+    inst.vdst.write_lane(wf, lane,
+                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) -
+                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
   }
 }
 
@@ -19424,7 +19417,9 @@ inline void execute_v_sub_nc_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane, (inst.src0.read_lane(wf, lane) - inst.src1.read_lane(wf, lane)));
+    inst.vdst.write_lane(wf, lane,
+                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) -
+                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -3404,9 +3404,10 @@ inline void execute_v_bfe_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane, [&]() -> uint32_t {
-      uint32_t src = static_cast<uint32_t>(inst.src0.read_lane(wf, lane));
-      uint32_t off = static_cast<uint32_t>(inst.src1.read_lane(wf, lane)) & 31u;
-      uint32_t w = static_cast<uint32_t>(inst.src2.read_lane(wf, lane)) & 31u;
+      uint32_t src = static_cast<uint32_t>(static_cast<int32_t>(inst.src0.read_lane(wf, lane)));
+      uint32_t off =
+          static_cast<uint32_t>(static_cast<int32_t>(inst.src1.read_lane(wf, lane))) & 31u;
+      uint32_t w = static_cast<uint32_t>(static_cast<int32_t>(inst.src2.read_lane(wf, lane))) & 31u;
       if (w == 0)
         return 0u;
       uint32_t mask = (uint32_t{1} << w) - 1u;
@@ -12665,9 +12666,9 @@ inline void execute_v_lshl_add_u32_vop3([[maybe_unused]] Inst &inst,
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane,
-                         ::rocjitsu::amdgpu::lshl_masked(inst.src0.read_lane(wf, lane),
-                                                         inst.src1.read_lane(wf, lane)) +
-                             inst.src2.read_lane(wf, lane));
+                         (::rocjitsu::amdgpu::lshl_masked(inst.src0.read_lane(wf, lane),
+                                                          inst.src1.read_lane(wf, lane)) +
+                          inst.src2.read_lane(wf, lane)));
   }
 }
 
@@ -12681,9 +12682,9 @@ inline void execute_v_lshl_add_u64_vop3([[maybe_unused]] Inst &inst,
       continue;
     inst.vdst.write_lane64(
         wf, lane,
-        ::rocjitsu::amdgpu::lshl_masked(static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)),
-                                        static_cast<uint64_t>(inst.src1.read_lane(wf, lane))) +
-            static_cast<uint64_t>(inst.src2.read_lane64(wf, lane)));
+        (::rocjitsu::amdgpu::lshl_masked(static_cast<uint64_t>(inst.src0.read_lane64(wf, lane)),
+                                         static_cast<uint64_t>(inst.src1.read_lane(wf, lane))) +
+         static_cast<uint64_t>(inst.src2.read_lane64(wf, lane))));
   }
 }
 
@@ -12697,9 +12698,9 @@ inline void execute_v_lshl_or_b32_vop3([[maybe_unused]] Inst &inst,
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane,
-                         ::rocjitsu::amdgpu::lshl_masked(inst.src0.read_lane(wf, lane),
-                                                         inst.src1.read_lane(wf, lane)) |
-                             inst.src2.read_lane(wf, lane));
+                         (::rocjitsu::amdgpu::lshl_masked(inst.src0.read_lane(wf, lane),
+                                                          inst.src1.read_lane(wf, lane)) |
+                          inst.src2.read_lane(wf, lane)));
   }
 }
 
@@ -13326,13 +13327,11 @@ inline void execute_v_mad_legacy_u16_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    uint16_t a = static_cast<uint16_t>(inst.src0.read_lane(wf, lane));
-    uint16_t b = static_cast<uint16_t>(inst.src1.read_lane(wf, lane));
-    uint16_t c = static_cast<uint16_t>(inst.src2.read_lane(wf, lane));
-    inst.vdst.write_lane(
-        wf, lane,
-        static_cast<uint32_t>(static_cast<uint16_t>(
-            static_cast<uint32_t>(a) * static_cast<uint32_t>(b) + static_cast<uint32_t>(c))));
+    inst.vdst.write_lane(wf, lane,
+                         static_cast<uint32_t>(static_cast<uint16_t>(
+                             ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) *
+                               static_cast<uint16_t>(inst.src1.read_lane(wf, lane))) +
+                              static_cast<uint16_t>(inst.src2.read_lane(wf, lane))))));
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -2994,24 +2994,22 @@ inline void execute_v_add_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) +
-                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
+    inst.vdst.write_lane(wf, lane, (inst.src0.read_lane(wf, lane) + inst.src1.read_lane(wf, lane)));
   }
 }
 
 template <typename Inst>
 inline void execute_v_add_lshl_u32_vop3([[maybe_unused]] Inst &inst,
                                         [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT(uint32_t,
-                                     [](auto a, auto b, auto c) { return (a + b) << (c & 31u); });
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT(
+      uint32_t, [](auto a, auto b, auto c) { return ::rocjitsu::amdgpu::simd_lshl_u32(a + b, c); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane,
                          ((inst.src0.read_lane(wf, lane) + inst.src1.read_lane(wf, lane))
-                          << inst.src2.read_lane(wf, lane)));
+                          << (inst.src2.read_lane(wf, lane) & 31u)));
   }
 }
 
@@ -3035,9 +3033,7 @@ inline void execute_v_add_nc_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) +
-                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
+    inst.vdst.write_lane(wf, lane, (inst.src0.read_lane(wf, lane) + inst.src1.read_lane(wf, lane)));
   }
 }
 
@@ -3398,43 +3394,30 @@ inline void execute_v_bcnt_u32_b32_vop3([[maybe_unused]] Inst &inst,
 
 template <typename Inst>
 inline void execute_v_bfe_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT(uint32_t, [](auto a, auto b, auto c) {
-    using I = util::native<int32_t>;
-    auto off = b & 31u;
-    auto w = c & 31u;
-    auto mask = (util::native<uint32_t>(1u) << w) - 1u;
-    auto ext = util::stdx::static_simd_cast<util::native<uint32_t>>(
-                   util::stdx::static_simd_cast<I>(a) >> util::stdx::static_simd_cast<I>(off)) &
-               mask;
-    auto signbit = (mask + 1u) >> 1;
-    return (ext ^ signbit) - signbit;
-  });
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT(
+      uint32_t, [](auto a, auto b, auto c) { return ::rocjitsu::amdgpu::simd_bfe_i32(a, b, c); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane, [&]() -> uint32_t {
-      int32_t src = static_cast<int32_t>(static_cast<int32_t>(inst.src0.read_lane(wf, lane)));
-      uint32_t off = static_cast<int32_t>(inst.src1.read_lane(wf, lane)) & 31u;
-      uint32_t w = static_cast<int32_t>(inst.src2.read_lane(wf, lane)) & 31u;
+      uint32_t src = inst.src0.read_lane(wf, lane);
+      uint32_t off = inst.src1.read_lane(wf, lane) & 31u;
+      uint32_t w = inst.src2.read_lane(wf, lane) & 31u;
       if (w == 0)
         return 0u;
-      int32_t val = (src >> off) & ((1 << w) - 1);
-      if (val & (1 << (w - 1)))
-        val |= -(1 << w);
-      return static_cast<uint32_t>(val);
+      uint32_t mask = (uint32_t{1} << w) - 1u;
+      uint32_t extracted = static_cast<uint32_t>(static_cast<int32_t>(src) >> off) & mask;
+      uint32_t signbit = uint32_t{1} << (w - 1u);
+      return (extracted ^ signbit) - signbit;
     }());
   }
 }
 
 template <typename Inst>
 inline void execute_v_bfe_u32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT(uint32_t, [](auto a, auto b, auto c) {
-    auto off = b & 31u;
-    auto w = c & 31u;
-    auto mask = (util::native<uint32_t>(1u) << w) - 1u;
-    return (a >> off) & mask;
-  });
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT(
+      uint32_t, [](auto a, auto b, auto c) { return ::rocjitsu::amdgpu::simd_bfe_u32(a, b, c); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -3470,9 +3453,8 @@ inline void execute_v_bfi_b32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
 
 template <typename Inst>
 inline void execute_v_bfm_b32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
-    return ((util::native<uint32_t>(1u) << (a & 31u)) - 1u) << (b & 31u);
-  });
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(
+      uint32_t, [](auto a, auto b) { return ::rocjitsu::amdgpu::simd_bfm_b32(a, b); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -9030,11 +9012,7 @@ inline void execute_v_cvt_floor_i32_f32_vop1([[maybe_unused]] Inst &inst,
                                              [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, int32_t, [](auto s) {
     auto r = util::stdx::floor(s);
-    util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);
-    util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;
-    util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);
-    util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;
-    return out;
+    return ::rocjitsu::amdgpu::simd_cvt_i32_f32(r);
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -9059,11 +9037,7 @@ inline void execute_v_cvt_floor_i32_f32_vop3([[maybe_unused]] Inst &inst,
                                              [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, int32_t, [](auto s) {
     auto r = util::stdx::floor(s);
-    util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);
-    util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;
-    util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);
-    util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;
-    return out;
+    return ::rocjitsu::amdgpu::simd_cvt_i32_f32(r);
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -9088,11 +9062,7 @@ inline void execute_v_cvt_flr_i32_f32_vop1([[maybe_unused]] Inst &inst,
                                            [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, int32_t, [](auto s) {
     auto r = util::stdx::floor(s);
-    util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);
-    util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;
-    util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);
-    util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;
-    return out;
+    return ::rocjitsu::amdgpu::simd_cvt_i32_f32(r);
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -9117,11 +9087,7 @@ inline void execute_v_cvt_flr_i32_f32_vop3([[maybe_unused]] Inst &inst,
                                            [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, int32_t, [](auto s) {
     auto r = util::stdx::floor(s);
-    util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);
-    util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;
-    util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);
-    util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;
-    return out;
+    return ::rocjitsu::amdgpu::simd_cvt_i32_f32(r);
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -9146,11 +9112,7 @@ inline void execute_v_cvt_i16_f16_vop1([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP1_UNARY(uint32_t, uint32_t, [](auto a) {
     auto s = util::f16_to_f32_simd(a);
-    util::native<int32_t> o = util::stdx::static_simd_cast<util::native<int32_t>>(s);
-    util::stdx::where(simd_mask_as<int32_t>(s >= 32768.0f), o) = 32767;
-    util::stdx::where(simd_mask_as<int32_t>(s < -32768.0f), o) = -32768;
-    util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(s)), o) = 0;
-    return util::stdx::static_simd_cast<util::native<uint32_t>>(o) & 0xFFFFu;
+    return ::rocjitsu::amdgpu::simd_cvt_i16_f32_to_u32(s);
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -9174,11 +9136,7 @@ inline void execute_v_cvt_i16_f16_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP1_UNARY(uint32_t, uint32_t, [](auto a) {
     auto s = util::f16_to_f32_simd(a);
-    util::native<int32_t> o = util::stdx::static_simd_cast<util::native<int32_t>>(s);
-    util::stdx::where(simd_mask_as<int32_t>(s >= 32768.0f), o) = 32767;
-    util::stdx::where(simd_mask_as<int32_t>(s < -32768.0f), o) = -32768;
-    util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(s)), o) = 0;
-    return util::stdx::static_simd_cast<util::native<uint32_t>>(o) & 0xFFFFu;
+    return ::rocjitsu::amdgpu::simd_cvt_i16_f32_to_u32(s);
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -9200,13 +9158,8 @@ inline void execute_v_cvt_i16_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_cvt_i32_f32_vop1([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, int32_t, [](auto s) {
-    util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(s);
-    util::stdx::where(simd_mask_as<int32_t>(s >= 2147483648.0f), out) = 2147483647;
-    util::stdx::where(simd_mask_as<int32_t>(s < -2147483648.0f), out) = (-2147483647 - 1);
-    util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(s)), out) = 0;
-    return out;
-  });
+  ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, int32_t,
+                               [](auto s) { return ::rocjitsu::amdgpu::simd_cvt_i32_f32(s); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -9227,13 +9180,8 @@ inline void execute_v_cvt_i32_f32_vop1([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_cvt_i32_f32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, int32_t, [](auto s) {
-    util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(s);
-    util::stdx::where(simd_mask_as<int32_t>(s >= 2147483648.0f), out) = 2147483647;
-    util::stdx::where(simd_mask_as<int32_t>(s < -2147483648.0f), out) = (-2147483647 - 1);
-    util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(s)), out) = 0;
-    return out;
-  });
+  ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, int32_t,
+                               [](auto s) { return ::rocjitsu::amdgpu::simd_cvt_i32_f32(s); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -9338,11 +9286,7 @@ inline void execute_v_cvt_nearest_i32_f32_vop1([[maybe_unused]] Inst &inst,
                                                [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, int32_t, [](auto s) {
     auto r = util::stdx::ceil(s - util::native<float32_t>(0.5f));
-    util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);
-    util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;
-    util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);
-    util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;
-    return out;
+    return ::rocjitsu::amdgpu::simd_cvt_i32_f32(r);
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -9367,11 +9311,7 @@ inline void execute_v_cvt_nearest_i32_f32_vop3([[maybe_unused]] Inst &inst,
                                                [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, int32_t, [](auto s) {
     auto r = util::stdx::ceil(s - util::native<float32_t>(0.5f));
-    util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);
-    util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;
-    util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);
-    util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;
-    return out;
+    return ::rocjitsu::amdgpu::simd_cvt_i32_f32(r);
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -9835,11 +9775,7 @@ inline void execute_v_cvt_rpi_i32_f32_vop1([[maybe_unused]] Inst &inst,
                                            [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, int32_t, [](auto s) {
     auto r = util::stdx::ceil(s - util::native<float32_t>(0.5f));
-    util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);
-    util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;
-    util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);
-    util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;
-    return out;
+    return ::rocjitsu::amdgpu::simd_cvt_i32_f32(r);
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -9864,11 +9800,7 @@ inline void execute_v_cvt_rpi_i32_f32_vop3([[maybe_unused]] Inst &inst,
                                            [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, int32_t, [](auto s) {
     auto r = util::stdx::ceil(s - util::native<float32_t>(0.5f));
-    util::native<int32_t> out = util::stdx::static_simd_cast<util::native<int32_t>>(r);
-    util::stdx::where(simd_mask_as<int32_t>(r >= 2147483648.0f), out) = 2147483647;
-    util::stdx::where(simd_mask_as<int32_t>(r < -2147483648.0f), out) = (-2147483647 - 1);
-    util::stdx::where(simd_mask_as<int32_t>(util::stdx::isnan(r)), out) = 0;
-    return out;
+    return ::rocjitsu::amdgpu::simd_cvt_i32_f32(r);
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -9893,10 +9825,7 @@ inline void execute_v_cvt_u16_f16_vop1([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP1_UNARY(uint32_t, uint32_t, [](auto a) {
     auto s = util::f16_to_f32_simd(a);
-    util::native<uint32_t> o = util::stdx::static_simd_cast<util::native<uint32_t>>(s);
-    util::stdx::where(simd_mask_as<uint32_t>(s >= 65536.0f), o) = 65535u;
-    util::stdx::where(simd_mask_as<uint32_t>(util::stdx::isnan(s) || s < 0.0f), o) = 0u;
-    return o & 0xFFFFu;
+    return ::rocjitsu::amdgpu::simd_cvt_u16_f32_to_u32(s);
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -9918,10 +9847,7 @@ inline void execute_v_cvt_u16_f16_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP1_UNARY(uint32_t, uint32_t, [](auto a) {
     auto s = util::f16_to_f32_simd(a);
-    util::native<uint32_t> o = util::stdx::static_simd_cast<util::native<uint32_t>>(s);
-    util::stdx::where(simd_mask_as<uint32_t>(s >= 65536.0f), o) = 65535u;
-    util::stdx::where(simd_mask_as<uint32_t>(util::stdx::isnan(s) || s < 0.0f), o) = 0u;
-    return o & 0xFFFFu;
+    return ::rocjitsu::amdgpu::simd_cvt_u16_f32_to_u32(s);
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -9941,12 +9867,8 @@ inline void execute_v_cvt_u16_f16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_cvt_u32_f32_vop1([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, uint32_t, [](auto s) {
-    util::native<uint32_t> out = util::stdx::static_simd_cast<util::native<uint32_t>>(s);
-    util::stdx::where(simd_mask_as<uint32_t>(s >= 4294967296.0f), out) = 4294967295u;
-    util::stdx::where(simd_mask_as<uint32_t>(util::stdx::isnan(s) || s < 0.0f), out) = 0u;
-    return out;
-  });
+  ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, uint32_t,
+                               [](auto s) { return ::rocjitsu::amdgpu::simd_cvt_u32_f32(s); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -9965,12 +9887,8 @@ inline void execute_v_cvt_u32_f32_vop1([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_cvt_u32_f32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, uint32_t, [](auto s) {
-    util::native<uint32_t> out = util::stdx::static_simd_cast<util::native<uint32_t>>(s);
-    util::stdx::where(simd_mask_as<uint32_t>(s >= 4294967296.0f), out) = 4294967295u;
-    util::stdx::where(simd_mask_as<uint32_t>(util::stdx::isnan(s) || s < 0.0f), out) = 0u;
-    return out;
-  });
+  ROCJITSU_TRY_SIMD_VOP1_UNARY(float32_t, uint32_t,
+                               [](auto s) { return ::rocjitsu::amdgpu::simd_cvt_u32_f32(s); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -10570,11 +10488,15 @@ inline void execute_v_dot2_i32_i16_vop3p([[maybe_unused]] Inst &inst,
     int16_t a1 = static_cast<int16_t>(sel0_hi ? (raw0 >> 16) : raw0);
     int16_t b0 = static_cast<int16_t>(sel1_lo ? (raw1 >> 16) : raw1);
     int16_t b1 = static_cast<int16_t>(sel1_hi ? (raw1 >> 16) : raw1);
-    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
-    int32_t result = static_cast<int32_t>(a0) * b0 + static_cast<int32_t>(a1) * b1 + acc;
-    if (inst.inst_.clamp)
-      result = std::clamp(result, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(result));
+    uint32_t result = inst.src2.read_lane(wf, lane);
+    int64_t dot = static_cast<int64_t>(a0) * b0 + static_cast<int64_t>(a1) * b1;
+    result += static_cast<uint32_t>(dot);
+    if (inst.inst_.clamp) {
+      int32_t clamped = std::clamp(static_cast<int32_t>(result), static_cast<int32_t>(0),
+                                   std::numeric_limits<int32_t>::max());
+      result = static_cast<uint32_t>(clamped);
+    }
+    inst.vdst.write_lane(wf, lane, result);
   }
 }
 
@@ -10661,7 +10583,9 @@ inline void execute_v_dot2c_i32_i16_vop2([[maybe_unused]] Inst &inst,
     int16_t a1 = static_cast<int16_t>((a >> 16) & 0xFFFF);
     int16_t b0 = static_cast<int16_t>(b & 0xFFFF);
     int16_t b1 = static_cast<int16_t>((b >> 16) & 0xFFFF);
-    acc += static_cast<int32_t>(a0) * b0 + static_cast<int32_t>(a1) * b1;
+    uint32_t uacc = static_cast<uint32_t>(acc);
+    int64_t dot = static_cast<int64_t>(a0) * b0 + static_cast<int64_t>(a1) * b1;
+    acc = static_cast<int32_t>(uacc + static_cast<uint32_t>(dot));
     inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
   }
 }
@@ -10681,7 +10605,9 @@ inline void execute_v_dot2c_i32_i16_vop3([[maybe_unused]] Inst &inst,
     int16_t a1 = static_cast<int16_t>((a >> 16) & 0xFFFF);
     int16_t b0 = static_cast<int16_t>(b & 0xFFFF);
     int16_t b1 = static_cast<int16_t>((b >> 16) & 0xFFFF);
-    acc += static_cast<int32_t>(a0) * b0 + static_cast<int32_t>(a1) * b1;
+    uint32_t uacc = static_cast<uint32_t>(acc);
+    int64_t dot = static_cast<int64_t>(a0) * b0 + static_cast<int64_t>(a1) * b1;
+    acc = static_cast<int32_t>(uacc + static_cast<uint32_t>(dot));
     inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
   }
 }
@@ -10696,16 +10622,18 @@ inline void execute_v_dot4_i32_i8_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = inst.src0.read_lane(wf, lane);
     uint32_t raw1 = inst.src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
-    int32_t sum = acc;
+    uint32_t sum = inst.src2.read_lane(wf, lane);
     for (int i = 0; i < 4; ++i) {
       int8_t a = static_cast<int8_t>((raw0 >> (i * 8)) & 0xFF);
       int8_t b = static_cast<int8_t>((raw1 >> (i * 8)) & 0xFF);
-      sum += static_cast<int32_t>(a) * b;
+      sum += static_cast<uint32_t>(static_cast<int32_t>(a) * static_cast<int32_t>(b));
     }
-    if (inst.inst_.clamp)
-      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
+    if (inst.inst_.clamp) {
+      int32_t clamped = std::clamp(static_cast<int32_t>(sum), static_cast<int32_t>(0),
+                                   std::numeric_limits<int32_t>::max());
+      sum = static_cast<uint32_t>(clamped);
+    }
+    inst.vdst.write_lane(wf, lane, sum);
   }
 }
 
@@ -10719,8 +10647,7 @@ inline void execute_v_dot4_i32_iu8_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = inst.src0.read_lane(wf, lane);
     uint32_t raw1 = inst.src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
-    int32_t sum = acc;
+    uint32_t sum = inst.src2.read_lane(wf, lane);
     const bool src0_signed = (inst.inst_.neg & 0x1u) != 0;
     const bool src1_signed = (inst.inst_.neg & 0x2u) != 0;
     for (int i = 0; i < 4; ++i) {
@@ -10730,11 +10657,14 @@ inline void execute_v_dot4_i32_iu8_vop3p([[maybe_unused]] Inst &inst,
                               : static_cast<int32_t>(raw_a);
       int32_t b = src1_signed ? static_cast<int32_t>(static_cast<int8_t>(raw_b))
                               : static_cast<int32_t>(raw_b);
-      sum += a * b;
+      sum += static_cast<uint32_t>(a * b);
     }
-    if (inst.inst_.clamp)
-      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
+    if (inst.inst_.clamp) {
+      int32_t clamped = std::clamp(static_cast<int32_t>(sum), static_cast<int32_t>(0),
+                                   std::numeric_limits<int32_t>::max());
+      sum = static_cast<uint32_t>(clamped);
+    }
+    inst.vdst.write_lane(wf, lane, sum);
   }
 }
 
@@ -10769,13 +10699,13 @@ inline void execute_v_dot4c_i32_i8_vop2([[maybe_unused]] Inst &inst,
       continue;
     uint32_t a = inst.src0.read_lane(wf, lane);
     uint32_t b = inst.vsrc1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.vdst.read_lane(wf, lane));
+    uint32_t acc = inst.vdst.read_lane(wf, lane);
     for (int i = 0; i < 4; ++i) {
       int8_t ea = static_cast<int8_t>((a >> (i * 8)) & 0xFF);
       int8_t eb = static_cast<int8_t>((b >> (i * 8)) & 0xFF);
-      acc += static_cast<int32_t>(ea) * static_cast<int32_t>(eb);
+      acc += static_cast<uint32_t>(static_cast<int32_t>(ea) * static_cast<int32_t>(eb));
     }
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
+    inst.vdst.write_lane(wf, lane, acc);
   }
 }
 
@@ -10789,13 +10719,13 @@ inline void execute_v_dot4c_i32_i8_vop3([[maybe_unused]] Inst &inst,
       continue;
     uint32_t a = inst.src0.read_lane(wf, lane);
     uint32_t b = inst.src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.vdst.read_lane(wf, lane));
+    uint32_t acc = inst.vdst.read_lane(wf, lane);
     for (int i = 0; i < 4; ++i) {
       int8_t ea = static_cast<int8_t>((a >> (i * 8)) & 0xFF);
       int8_t eb = static_cast<int8_t>((b >> (i * 8)) & 0xFF);
-      acc += static_cast<int32_t>(ea) * static_cast<int32_t>(eb);
+      acc += static_cast<uint32_t>(static_cast<int32_t>(ea) * static_cast<int32_t>(eb));
     }
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
+    inst.vdst.write_lane(wf, lane, acc);
   }
 }
 
@@ -10809,8 +10739,7 @@ inline void execute_v_dot8_i32_i4_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = inst.src0.read_lane(wf, lane);
     uint32_t raw1 = inst.src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
-    int32_t sum = acc;
+    uint32_t sum = inst.src2.read_lane(wf, lane);
     for (int i = 0; i < 8; ++i) {
       int32_t a = static_cast<int32_t>((raw0 >> (i * 4)) & 0xF);
       if (a & 0x8)
@@ -10818,11 +10747,14 @@ inline void execute_v_dot8_i32_i4_vop3p([[maybe_unused]] Inst &inst,
       int32_t b = static_cast<int32_t>((raw1 >> (i * 4)) & 0xF);
       if (b & 0x8)
         b |= ~0xF;
-      sum += a * b;
+      sum += static_cast<uint32_t>(a * b);
     }
-    if (inst.inst_.clamp)
-      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
+    if (inst.inst_.clamp) {
+      int32_t clamped = std::clamp(static_cast<int32_t>(sum), static_cast<int32_t>(0),
+                                   std::numeric_limits<int32_t>::max());
+      sum = static_cast<uint32_t>(clamped);
+    }
+    inst.vdst.write_lane(wf, lane, sum);
   }
 }
 
@@ -10836,8 +10768,7 @@ inline void execute_v_dot8_i32_iu4_vop3p([[maybe_unused]] Inst &inst,
       continue;
     uint32_t raw0 = inst.src0.read_lane(wf, lane);
     uint32_t raw1 = inst.src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
-    int32_t sum = acc;
+    uint32_t sum = inst.src2.read_lane(wf, lane);
     const bool src0_signed = (inst.inst_.neg & 0x1u) != 0;
     const bool src1_signed = (inst.inst_.neg & 0x2u) != 0;
     for (int i = 0; i < 8; ++i) {
@@ -10847,11 +10778,14 @@ inline void execute_v_dot8_i32_iu4_vop3p([[maybe_unused]] Inst &inst,
                               : static_cast<int32_t>(raw_a);
       int32_t b = src1_signed ? static_cast<int32_t>((raw_b & 0x8) ? (raw_b | ~0xF) : raw_b)
                               : static_cast<int32_t>(raw_b);
-      sum += a * b;
+      sum += static_cast<uint32_t>(a * b);
     }
-    if (inst.inst_.clamp)
-      sum = std::clamp(sum, static_cast<int32_t>(0), std::numeric_limits<int32_t>::max());
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(sum));
+    if (inst.inst_.clamp) {
+      int32_t clamped = std::clamp(static_cast<int32_t>(sum), static_cast<int32_t>(0),
+                                   std::numeric_limits<int32_t>::max());
+      sum = static_cast<uint32_t>(clamped);
+    }
+    inst.vdst.write_lane(wf, lane, sum);
   }
 }
 
@@ -10886,7 +10820,7 @@ inline void execute_v_dot8c_i32_i4_vop2([[maybe_unused]] Inst &inst,
       continue;
     uint32_t a = inst.src0.read_lane(wf, lane);
     uint32_t b = inst.vsrc1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.vdst.read_lane(wf, lane));
+    uint32_t acc = inst.vdst.read_lane(wf, lane);
     for (int i = 0; i < 8; ++i) {
       int32_t ea = static_cast<int32_t>((a >> (i * 4)) & 0xF);
       if (ea & 8)
@@ -10894,9 +10828,9 @@ inline void execute_v_dot8c_i32_i4_vop2([[maybe_unused]] Inst &inst,
       int32_t eb = static_cast<int32_t>((b >> (i * 4)) & 0xF);
       if (eb & 8)
         eb |= ~0xF;
-      acc += ea * eb;
+      acc += static_cast<uint32_t>(ea * eb);
     }
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
+    inst.vdst.write_lane(wf, lane, acc);
   }
 }
 
@@ -10910,7 +10844,7 @@ inline void execute_v_dot8c_i32_i4_vop3([[maybe_unused]] Inst &inst,
       continue;
     uint32_t a = inst.src0.read_lane(wf, lane);
     uint32_t b = inst.src1.read_lane(wf, lane);
-    int32_t acc = static_cast<int32_t>(inst.vdst.read_lane(wf, lane));
+    uint32_t acc = inst.vdst.read_lane(wf, lane);
     for (int i = 0; i < 8; ++i) {
       int32_t ea = static_cast<int32_t>((a >> (i * 4)) & 0xF);
       if (ea & 8)
@@ -10918,9 +10852,9 @@ inline void execute_v_dot8c_i32_i4_vop3([[maybe_unused]] Inst &inst,
       int32_t eb = static_cast<int32_t>((b >> (i * 4)) & 0xF);
       if (eb & 8)
         eb |= ~0xF;
-      acc += ea * eb;
+      acc += static_cast<uint32_t>(ea * eb);
     }
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(acc));
+    inst.vdst.write_lane(wf, lane, acc);
   }
 }
 
@@ -12723,14 +12657,14 @@ inline void execute_v_log_f32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
 template <typename Inst>
 inline void execute_v_lshl_add_u32_vop3([[maybe_unused]] Inst &inst,
                                         [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT(uint32_t,
-                                     [](auto a, auto b, auto c) { return (a << (b & 31u)) + c; });
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT(
+      uint32_t, [](auto a, auto b, auto c) { return ::rocjitsu::amdgpu::simd_lshl_u32(a, b) + c; });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane,
-                         ((inst.src0.read_lane(wf, lane) << inst.src1.read_lane(wf, lane)) +
+                         ((inst.src0.read_lane(wf, lane) << (inst.src1.read_lane(wf, lane) & 31u)) +
                           inst.src2.read_lane(wf, lane)));
   }
 }
@@ -12745,7 +12679,7 @@ inline void execute_v_lshl_add_u64_vop3([[maybe_unused]] Inst &inst,
       continue;
     inst.vdst.write_lane64(wf, lane,
                            ((static_cast<uint64_t>(inst.src0.read_lane64(wf, lane))
-                             << static_cast<uint64_t>(inst.src1.read_lane(wf, lane))) +
+                             << (static_cast<uint64_t>(inst.src1.read_lane(wf, lane)) & 63u)) +
                             static_cast<uint64_t>(inst.src2.read_lane64(wf, lane))));
   }
 }
@@ -12753,14 +12687,14 @@ inline void execute_v_lshl_add_u64_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_lshl_or_b32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT(uint32_t,
-                                     [](auto a, auto b, auto c) { return (a << (b & 31u)) | c; });
+  ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT(
+      uint32_t, [](auto a, auto b, auto c) { return ::rocjitsu::amdgpu::simd_lshl_u32(a, b) | c; });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
     inst.vdst.write_lane(wf, lane,
-                         ((inst.src0.read_lane(wf, lane) << inst.src1.read_lane(wf, lane)) |
+                         ((inst.src0.read_lane(wf, lane) << (inst.src1.read_lane(wf, lane) & 31u)) |
                           inst.src2.read_lane(wf, lane)));
   }
 }
@@ -12801,7 +12735,8 @@ inline void execute_v_lshlrev_b16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_lshlrev_b32_vop2([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP2_BINARY(uint32_t, [](auto a, auto b) { return b << (a & 31u); });
+  ROCJITSU_TRY_SIMD_VOP2_BINARY(
+      uint32_t, [](auto a, auto b) { return ::rocjitsu::amdgpu::simd_lshl_u32(b, a); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -12814,7 +12749,8 @@ inline void execute_v_lshlrev_b32_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_lshlrev_b32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) { return b << (a & 31u); });
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(
+      uint32_t, [](auto a, auto b) { return ::rocjitsu::amdgpu::simd_lshl_u32(b, a); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -12840,7 +12776,8 @@ inline void execute_v_lshlrev_b64_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_lshlrev_b64_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_SHIFT64_VOP3([](auto v, auto sh) { return v << sh; });
+  ROCJITSU_TRY_SIMD_SHIFT64_VOP3(
+      [](auto v, auto sh) { return ::rocjitsu::amdgpu::simd_lshl_u64(v, sh); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -12887,7 +12824,8 @@ inline void execute_v_lshrrev_b16_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_lshrrev_b32_vop2([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP2_BINARY(uint32_t, [](auto a, auto b) { return b >> (a & 31u); });
+  ROCJITSU_TRY_SIMD_VOP2_BINARY(
+      uint32_t, [](auto a, auto b) { return ::rocjitsu::amdgpu::simd_lshr_u32(b, a); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -12900,7 +12838,8 @@ inline void execute_v_lshrrev_b32_vop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_lshrrev_b32_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) { return b >> (a & 31u); });
+  ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(
+      uint32_t, [](auto a, auto b) { return ::rocjitsu::amdgpu::simd_lshr_u32(b, a); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -12913,7 +12852,8 @@ inline void execute_v_lshrrev_b32_vop3([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_v_lshrrev_b64_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
-  ROCJITSU_TRY_SIMD_SHIFT64_VOP3([](auto v, auto sh) { return v >> sh; });
+  ROCJITSU_TRY_SIMD_SHIFT64_VOP3(
+      [](auto v, auto sh) { return ::rocjitsu::amdgpu::simd_lshr_u64(v, sh); });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
@@ -13197,11 +13137,9 @@ template <typename Inst>
 inline void execute_v_mad_i32_i16_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT(uint32_t, [](auto a, auto b, auto c) {
-    using I = util::native<int32_t>;
-    auto sa = (util::stdx::static_simd_cast<I>(a) << 16) >> 16;
-    auto sb = (util::stdx::static_simd_cast<I>(b) << 16) >> 16;
-    auto sc = util::stdx::static_simd_cast<I>(c);
-    return util::stdx::static_simd_cast<util::native<uint32_t>>(sa * sb + sc);
+    auto sa = ::rocjitsu::amdgpu::simd_sign_extend_u32(a, 16);
+    auto sb = ::rocjitsu::amdgpu::simd_sign_extend_u32(b, 16);
+    return sa * sb + c;
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -13210,7 +13148,9 @@ inline void execute_v_mad_i32_i16_vop3([[maybe_unused]] Inst &inst,
     int32_t s0 = static_cast<int16_t>(inst.src0.read_lane(wf, lane) & 0xFFFF);
     int32_t s1 = static_cast<int16_t>(inst.src1.read_lane(wf, lane) & 0xFFFF);
     int32_t s2 = static_cast<int32_t>(inst.src2.read_lane(wf, lane));
-    inst.vdst.write_lane(wf, lane, static_cast<uint32_t>(s0 * s1 + s2));
+    inst.vdst.write_lane(wf, lane,
+                         static_cast<uint32_t>(s0) * static_cast<uint32_t>(s1) +
+                             static_cast<uint32_t>(s2));
   }
 }
 
@@ -13218,10 +13158,9 @@ template <typename Inst>
 inline void execute_v_mad_i32_i24_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP3_TERNARY_INT(uint32_t, [](auto a, auto b, auto c) {
-    auto sa = (util::stdx::static_simd_cast<util::native<int32_t>>(a) << 8) >> 8;
-    auto sb = (util::stdx::static_simd_cast<util::native<int32_t>>(b) << 8) >> 8;
-    return util::stdx::static_simd_cast<util::native<uint32_t>>(
-        sa * sb + util::stdx::static_simd_cast<util::native<int32_t>>(c));
+    auto sa = ::rocjitsu::amdgpu::simd_sign_extend_u32(a, 24);
+    auto sb = ::rocjitsu::amdgpu::simd_sign_extend_u32(b, 24);
+    return sa * sb + c;
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -13230,7 +13169,7 @@ inline void execute_v_mad_i32_i24_vop3([[maybe_unused]] Inst &inst,
     inst.vdst.write_lane(wf, lane, [&]() {
       auto a = static_cast<int32_t>(inst.src0.read_lane(wf, lane) << 8) >> 8;
       auto b = static_cast<int32_t>(inst.src1.read_lane(wf, lane) << 8) >> 8;
-      return static_cast<uint32_t>(a * b + static_cast<int32_t>(inst.src2.read_lane(wf, lane)));
+      return static_cast<uint32_t>(a) * static_cast<uint32_t>(b) + inst.src2.read_lane(wf, lane);
     }());
   }
 }
@@ -13254,7 +13193,8 @@ inline void execute_v_mad_i64_i32_vop3([[maybe_unused]] Inst &inst,
     int64_t s0 = static_cast<int32_t>(inst.src0.read_lane(wf, lane));
     int64_t s1 = static_cast<int32_t>(inst.src1.read_lane(wf, lane));
     int64_t s2 = static_cast<int64_t>(inst.src2.read_lane64(wf, lane));
-    uint64_t result = static_cast<uint64_t>(s0 * s1 + s2);
+    uint64_t result =
+        static_cast<uint64_t>(s0) * static_cast<uint64_t>(s1) + static_cast<uint64_t>(s2);
     inst.vdst.write_lane64(wf, lane, result);
   }
 }
@@ -13384,11 +13324,12 @@ inline void execute_v_mad_legacy_u16_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(
-                             ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) *
-                               static_cast<uint16_t>(inst.src1.read_lane(wf, lane))) +
-                              static_cast<uint16_t>(inst.src2.read_lane(wf, lane))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(
+            ((static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) *
+              static_cast<uint32_t>(static_cast<uint16_t>(inst.src1.read_lane(wf, lane)))) +
+             static_cast<uint32_t>(static_cast<uint16_t>(inst.src2.read_lane(wf, lane)))))));
   }
 }
 
@@ -17140,9 +17081,9 @@ template <typename Inst>
 inline void execute_v_mul_i32_i24_vop2([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP2_BINARY(uint32_t, [](auto a, auto b) {
-    auto sa = (util::stdx::static_simd_cast<util::native<int32_t>>(a) << 8) >> 8;
-    auto sb = (util::stdx::static_simd_cast<util::native<int32_t>>(b) << 8) >> 8;
-    return util::stdx::static_simd_cast<util::native<uint32_t>>(sa * sb);
+    auto sa = ::rocjitsu::amdgpu::simd_sign_extend_u32(a, 24);
+    auto sb = ::rocjitsu::amdgpu::simd_sign_extend_u32(b, 24);
+    return sa * sb;
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -17151,7 +17092,7 @@ inline void execute_v_mul_i32_i24_vop2([[maybe_unused]] Inst &inst,
     inst.vdst.write_lane(wf, lane, [&]() {
       auto a = static_cast<int32_t>(inst.src0.read_lane(wf, lane) << 8) >> 8;
       auto b = static_cast<int32_t>(inst.vsrc1.read_lane(wf, lane) << 8) >> 8;
-      return static_cast<uint32_t>(a * b);
+      return static_cast<uint32_t>(a) * static_cast<uint32_t>(b);
     }());
   }
 }
@@ -17160,9 +17101,9 @@ template <typename Inst>
 inline void execute_v_mul_i32_i24_vop3([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   ROCJITSU_TRY_SIMD_VOP3_BINARY_INT(uint32_t, [](auto a, auto b) {
-    auto sa = (util::stdx::static_simd_cast<util::native<int32_t>>(a) << 8) >> 8;
-    auto sb = (util::stdx::static_simd_cast<util::native<int32_t>>(b) << 8) >> 8;
-    return util::stdx::static_simd_cast<util::native<uint32_t>>(sa * sb);
+    auto sa = ::rocjitsu::amdgpu::simd_sign_extend_u32(a, 24);
+    auto sb = ::rocjitsu::amdgpu::simd_sign_extend_u32(b, 24);
+    return sa * sb;
   });
   uint64_t exec = wf.exec();
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
@@ -17171,7 +17112,7 @@ inline void execute_v_mul_i32_i24_vop3([[maybe_unused]] Inst &inst,
     inst.vdst.write_lane(wf, lane, [&]() {
       auto a = static_cast<int32_t>(inst.src0.read_lane(wf, lane) << 8) >> 8;
       auto b = static_cast<int32_t>(inst.src1.read_lane(wf, lane) << 8) >> 8;
-      return static_cast<uint32_t>(a * b);
+      return static_cast<uint32_t>(a) * static_cast<uint32_t>(b);
     }());
   }
 }
@@ -17254,9 +17195,9 @@ inline void execute_v_mul_lo_u16_vop2([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     inst.vdst.write_lane(
         wf, lane,
-        static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-            static_cast<uint16_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) *
-            static_cast<uint16_t>(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))))));
+        static_cast<uint32_t>(static_cast<uint16_t>(
+            static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) *
+            static_cast<uint32_t>(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))));
   }
 }
 
@@ -17268,9 +17209,9 @@ inline void execute_v_mul_lo_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
       continue;
     inst.vdst.write_lane(
         wf, lane,
-        static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-            static_cast<uint16_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) *
-            static_cast<uint16_t>(static_cast<uint16_t>(inst.src1.read_lane(wf, lane))))))));
+        static_cast<uint32_t>(static_cast<uint16_t>(
+            static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) *
+            static_cast<uint32_t>(static_cast<uint16_t>(inst.src1.read_lane(wf, lane))))));
   }
 }
 
@@ -19459,9 +19400,7 @@ inline void execute_v_sub_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) -
-                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
+    inst.vdst.write_lane(wf, lane, (inst.src0.read_lane(wf, lane) - inst.src1.read_lane(wf, lane)));
   }
 }
 
@@ -19485,9 +19424,7 @@ inline void execute_v_sub_nc_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) -
-                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
+    inst.vdst.write_lane(wf, lane, (inst.src0.read_lane(wf, lane) - inst.src1.read_lane(wf, lane)));
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -711,7 +711,9 @@ void wmma_simd_matmul(uint32_t M, uint32_t N, uint32_t K, uint32_t W, uint32_t s
 /// to physical registers. On wave32, each logical VGPR spans two physical
 /// VGPRs. Without stride adjustment, read_vgpr(base+V, lane>=32) aliases
 /// with read_vgpr(base+V+1, lane%32), corrupting data from the next logical
-/// VGPR. The fix strides the logical VGPR offset by 2 on wave32.
+/// VGPR. The fix strides the logical VGPR offset by 64/wf_size on wave32.
+///
+/// Returns @p loc unchanged when wf_size >= 64.
 inline InputLoc physicalize_loc(const InputLoc &loc, uint32_t wf_size) {
   if (wf_size >= 64)
     return loc;
@@ -721,6 +723,7 @@ inline InputLoc physicalize_loc(const InputLoc &loc, uint32_t wf_size) {
 }
 
 /// Adjust a GFX9 OutputLoc for wave32 physical VGPR addressing.
+/// No-op when wf_size >= 64.
 inline OutputLoc physicalize_out(const OutputLoc &loc, uint32_t wf_size) {
   if (wf_size >= 64)
     return loc;
@@ -729,6 +732,7 @@ inline OutputLoc physicalize_out(const OutputLoc &loc, uint32_t wf_size) {
 }
 
 /// Adjust a GFX9 PackedOutputLoc for wave32 physical VGPR addressing.
+/// No-op when wf_size >= 64.
 inline PackedOutputLoc physicalize_packed_out(const PackedOutputLoc &loc, uint32_t wf_size) {
   if (wf_size >= 64)
     return loc;
@@ -2300,12 +2304,12 @@ void exec_f32_scaled(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32
                      ExtractA ea, ExtractB eb, uint32_t const_acc, uint32_t cbsz, uint32_t abid,
                      uint32_t blgp, uint32_t scale_a_base, uint32_t scale_b_base) {
   constexpr uint32_t BLOCK_K = 32;
+  const uint32_t wf = cu.wf_size();
   struct Result {
     uint32_t reg;
     uint32_t lane;
     uint32_t val;
   };
-  const uint32_t wf = cu.wf_size();
   std::vector<Result> results;
   results.reserve(M * N * B);
   uint32_t num_blocks = (K + BLOCK_K - 1) / BLOCK_K;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -21,6 +21,7 @@
 #include "util/simd.h"
 
 #include <bit>
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -53,6 +54,123 @@ inline void write_explicit_lane_mask(const Operand &dst, Wavefront &wf, uint64_t
     dst.write_scalar(wf, static_cast<uint32_t>(mask));
   else
     dst.write_scalar64(wf, mask);
+}
+
+inline util::native<uint32_t> simd_sign_extend_u32(util::native<uint32_t> v, unsigned bits) {
+  assert(bits >= 1 && bits <= 32 && "simd_sign_extend_u32 requires a 1..32 bit width");
+  const uint32_t sign = 1u << (bits - 1);
+  const uint32_t mask = bits == 32 ? ~0u : ((1u << bits) - 1u);
+  return ((v & mask) ^ sign) - sign;
+}
+
+inline util::native<uint32_t> simd_lshl_u32(util::native<uint32_t> v, util::native<uint32_t> sh) {
+  return util::map_native_scalar<uint32_t>(
+      v, sh, [](uint32_t value, uint32_t count) { return value << (count & 31u); });
+}
+
+inline util::native<uint32_t> simd_lshr_u32(util::native<uint32_t> v, util::native<uint32_t> sh) {
+  return util::map_native_scalar<uint32_t>(
+      v, sh, [](uint32_t value, uint32_t count) { return value >> (count & 31u); });
+}
+
+inline util::native<uint64_t> simd_lshl_u64(util::native<uint64_t> v, util::native<uint64_t> sh) {
+  return util::map_native64_scalar<uint64_t>(
+      v, sh, [](uint64_t value, uint64_t count) { return value << (count & 63u); });
+}
+
+inline util::native<uint64_t> simd_lshr_u64(util::native<uint64_t> v, util::native<uint64_t> sh) {
+  return util::map_native64_scalar<uint64_t>(
+      v, sh, [](uint64_t value, uint64_t count) { return value >> (count & 63u); });
+}
+
+inline util::native<uint64_t> simd_ashr_i64(util::native<uint64_t> v, util::native<uint64_t> sh) {
+  return util::map_native64_scalar<uint64_t>(v, sh, [](uint64_t value, uint64_t count) {
+    return static_cast<uint64_t>(static_cast<int64_t>(value) >> (count & 63u));
+  });
+}
+
+inline util::native<uint32_t> simd_bfe_u32(util::native<uint32_t> src,
+                                           util::native<uint32_t> offset,
+                                           util::native<uint32_t> width) {
+  return util::map_native_scalar<uint32_t>(
+      src, offset, width, [](uint32_t value, uint32_t offset_value, uint32_t width_value) {
+        const uint32_t off = offset_value & 31u;
+        const uint32_t w = width_value & 31u;
+        if (w == 0)
+          return uint32_t{0};
+        const uint32_t mask = (uint32_t{1} << w) - 1u;
+        return (value >> off) & mask;
+      });
+}
+
+inline util::native<uint32_t> simd_bfe_i32(util::native<uint32_t> src,
+                                           util::native<uint32_t> offset,
+                                           util::native<uint32_t> width) {
+  return util::map_native_scalar<uint32_t>(
+      src, offset, width, [](uint32_t value, uint32_t offset_value, uint32_t width_value) {
+        const uint32_t off = offset_value & 31u;
+        const uint32_t w = width_value & 31u;
+        if (w == 0)
+          return uint32_t{0};
+        const uint32_t mask = (uint32_t{1} << w) - 1u;
+        const uint32_t extracted = static_cast<uint32_t>(static_cast<int32_t>(value) >> off) & mask;
+        const uint32_t signbit = uint32_t{1} << (w - 1u);
+        return (extracted ^ signbit) - signbit;
+      });
+}
+
+inline util::native<uint32_t> simd_bfm_b32(util::native<uint32_t> width,
+                                           util::native<uint32_t> offset) {
+  return util::map_native_scalar<uint32_t>(width, offset,
+                                           [](uint32_t width_value, uint32_t offset_value) {
+                                             const uint32_t w = width_value & 31u;
+                                             const uint32_t off = offset_value & 31u;
+                                             return ((uint32_t{1} << w) - 1u) << off;
+                                           });
+}
+
+inline util::native<int32_t> simd_cvt_i32_f32(util::native<float32_t> s) {
+  return util::map_native_convert_scalar<int32_t>(s, [](float32_t value) {
+    if (std::isnan(value))
+      return int32_t{0};
+    if (value >= 2147483648.0f)
+      return std::numeric_limits<int32_t>::max();
+    if (value < -2147483648.0f)
+      return std::numeric_limits<int32_t>::min();
+    return static_cast<int32_t>(value);
+  });
+}
+
+inline util::native<uint32_t> simd_cvt_u32_f32(util::native<float32_t> s) {
+  return util::map_native_convert_scalar<uint32_t>(s, [](float32_t value) {
+    if (std::isnan(value) || value < 0.0f)
+      return uint32_t{0};
+    if (value >= 4294967296.0f)
+      return std::numeric_limits<uint32_t>::max();
+    return static_cast<uint32_t>(value);
+  });
+}
+
+inline util::native<uint32_t> simd_cvt_i16_f32_to_u32(util::native<float32_t> s) {
+  return util::map_native_convert_scalar<uint32_t>(s, [](float32_t value) {
+    if (std::isnan(value))
+      return uint32_t{0};
+    if (value >= 32768.0f)
+      return static_cast<uint32_t>(static_cast<uint16_t>(std::numeric_limits<int16_t>::max()));
+    if (value < -32768.0f)
+      return static_cast<uint32_t>(static_cast<uint16_t>(std::numeric_limits<int16_t>::min()));
+    return static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(value)));
+  });
+}
+
+inline util::native<uint32_t> simd_cvt_u16_f32_to_u32(util::native<float32_t> s) {
+  return util::map_native_convert_scalar<uint32_t>(s, [](float32_t value) {
+    if (std::isnan(value) || value < 0.0f)
+      return uint32_t{0};
+    if (value >= 65536.0f)
+      return static_cast<uint32_t>(std::numeric_limits<uint16_t>::max());
+    return static_cast<uint32_t>(static_cast<uint16_t>(value));
+  });
 }
 
 template <typename Op>
@@ -155,9 +273,18 @@ util::native<T> apply_vop3_dst_mod(util::native<T> v, uint32_t omod, uint32_t cl
   else if (omod == 3)
     v = v * T(0.5);
   if (clamp) {
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
     if constexpr (std::is_same_v<T, double>) {
-      v = util::ordered_clamp_f64_simd(v, 0.0, 1.0);
-    } else {
+      return util::map_native64_scalar<double>(v, [](double x) {
+        if (x < 0.0)
+          return 0.0;
+        if (x > 1.0)
+          return 1.0;
+        return x;
+      });
+    } else
+#endif
+    {
       util::stdx::where(v < T(0), v) = T(0);
       util::stdx::where(v > T(1), v) = T(1);
     }
@@ -2322,41 +2449,64 @@ inline util::native<float> div_fixup_f32_simd(util::native<float> p, util::nativ
 /// f64 counterpart of div_fixup_f32_simd — same cascade, 64-bit-lane domain.
 inline util::native<double> div_fixup_f64_simd(util::native<double> p, util::native<double> b,
                                                util::native<double> c) {
-  constexpr std::size_t W = util::native_width64;
-  alignas(64) double pbuf[W];
-  alignas(64) double bbuf[W];
-  alignas(64) double cbuf[W];
-  alignas(64) double out[W];
-  p.copy_to(pbuf, util::stdx::element_aligned);
-  b.copy_to(bbuf, util::stdx::element_aligned);
-  c.copy_to(cbuf, util::stdx::element_aligned);
+  using D = util::native<double>;
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+  constexpr std::size_t W = D::size();
+  alignas(D) double pbuf[W];
+  alignas(D) double bbuf[W];
+  alignas(D) double cbuf[W];
+  alignas(D) double out[W];
+  p.copy_to(pbuf, util::stdx::vector_aligned);
+  b.copy_to(bbuf, util::stdx::vector_aligned);
+  c.copy_to(cbuf, util::stdx::vector_aligned);
   for (std::size_t i = 0; i < W; ++i) {
-    const double bv = bbuf[i];
-    const double cv = cbuf[i];
-    const double sign =
-        std::bit_cast<double>(std::bit_cast<uint64_t>(bv) ^ std::bit_cast<uint64_t>(cv));
-    if (std::isnan(cv))
-      out[i] = cv;
-    else if (std::isnan(bv))
-      out[i] = bv;
-    else if (cv == 0.0 && bv == 0.0)
-      out[i] = std::numeric_limits<double>::quiet_NaN();
-    else if (std::isinf(cv) && std::isinf(bv))
-      out[i] = std::numeric_limits<double>::quiet_NaN();
-    else if (bv == 0.0)
-      out[i] = std::copysign(std::numeric_limits<double>::infinity(), sign);
-    else if (cv == 0.0)
-      out[i] = std::copysign(0.0, sign);
-    else if (std::isinf(cv))
-      out[i] = std::copysign(std::numeric_limits<double>::infinity(), sign);
-    else if (std::isinf(bv))
-      out[i] = std::copysign(0.0, sign);
-    else
-      out[i] = pbuf[i];
+    const double bi = bbuf[i];
+    const double ci = cbuf[i];
+    const double bxc =
+        std::bit_cast<double>(std::bit_cast<uint64_t>(bi) ^ std::bit_cast<uint64_t>(ci));
+    const double inf_val = std::copysign(std::numeric_limits<double>::infinity(), bxc);
+    const double zero_val = std::copysign(0.0, bxc);
+    double r = pbuf[i];
+    if (std::isinf(bi))
+      r = zero_val;
+    if (std::isinf(ci))
+      r = inf_val;
+    if (ci == 0.0)
+      r = zero_val;
+    if (bi == 0.0)
+      r = inf_val;
+    if ((std::isinf(bi) && std::isinf(ci)) || (bi == 0.0 && ci == 0.0))
+      r = std::numeric_limits<double>::quiet_NaN();
+    if (std::isnan(bi))
+      r = bi;
+    if (std::isnan(ci))
+      r = ci;
+    out[i] = r;
   }
-  util::native<double> result;
-  result.copy_from(out, util::stdx::element_aligned);
-  return result;
+  return D(out, util::stdx::vector_aligned);
+#else
+  using U = util::native<uint64_t>;
+  const auto bxc = std::bit_cast<D>(std::bit_cast<U>(b) ^ std::bit_cast<U>(c));
+  const auto inf_val = util::stdx::copysign(D(std::numeric_limits<double>::infinity()), bxc);
+  const auto zero_val = util::stdx::copysign(D(0.0), bxc);
+  const auto qnan = D(std::numeric_limits<double>::quiet_NaN());
+  const auto b_nan = util::stdx::isnan(b);
+  const auto c_nan = util::stdx::isnan(c);
+  const auto b_inf = util::stdx::isinf(b);
+  const auto c_inf = util::stdx::isinf(c);
+  const auto b_zero = (b == D(0.0));
+  const auto c_zero = (c == D(0.0));
+  D r = p;
+  util::stdx::where(b_inf, r) = zero_val;
+  util::stdx::where(c_inf, r) = inf_val;
+  util::stdx::where(c_zero, r) = zero_val;
+  util::stdx::where(b_zero, r) = inf_val;
+  util::stdx::where(b_inf && c_inf, r) = qnan;
+  util::stdx::where(b_zero && c_zero, r) = qnan;
+  util::stdx::where(b_nan, r) = b;
+  util::stdx::where(c_nan, r) = c;
+  return r;
+#endif
 }
 
 /// VOP3 div_fmas SIMD fast path (f32). The scalar body is `fma(s0, s1, s2)`
@@ -2538,7 +2688,7 @@ template <typename Inst>
     const auto s = simd_load_narrow_or<uint32_t>(rs, base, s_bcast);
     const auto c = simd_load64_or<uint64_t>(rs2, base, c_bcast);
     const auto sh = util::stdx::static_simd_cast<util::native<uint64_t>>(s) & 63ull;
-    write_simd64_at<uint64_t>(rd64, inst.vdst, wf, base, (v << sh) + c, chunk);
+    write_simd64_at<uint64_t>(rd64, inst.vdst, wf, base, simd_lshl_u64(v, sh) + c, chunk);
   }
   return true;
 }
@@ -3135,9 +3285,10 @@ template <typename Inst> [[nodiscard]] bool try_execute_vop3p_mov_b32_simd(Inst 
 /// signed forms when inst.clamp is set, a lower clamp to 0 — the scalar
 /// std::clamp(sum, 0, INT_MAX) on an int32 sum is just max(sum, 0). The
 /// unsigned scalar bodies have NO clamp branch, so the unsigned fast path
-/// ignores the clamp bit entirely. Signed accumulation runs in the int32
-/// domain (matching the scalar body and the pk_mad_i16 precedent); unsigned
-/// in uint32. For the 16-bit forms op_sel / op_sel_hi pick the source halves,
+/// ignores the clamp bit entirely. Signed products fit in int32, but the
+/// accumulator is kept as uint32_t bits so overflow wraps like the scalar tail
+/// without tripping signed-overflow sanitizers. For the 16-bit forms op_sel /
+/// op_sel_hi pick the source halves,
 /// so the fast path gates on the default packing (op_sel == 0, op_sel_hi == 3)
 /// and bails otherwise; the 8/4-bit scalar bodies ignore op_sel so no gate is
 /// needed there.
@@ -3154,7 +3305,6 @@ template <int ElemBits, bool Signed, typename Inst>
   }
   constexpr int N = 32 / ElemBits;
   constexpr uint32_t kElemMask = (ElemBits == 16) ? 0xFFFFu : (ElemBits == 8) ? 0xFFu : 0xFu;
-  constexpr int kShift = 32 - ElemBits;
   using T = uint32_t;
   constexpr std::size_t W = util::native_width_v<T>;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
@@ -3171,17 +3321,20 @@ template <int ElemBits, bool Signed, typename Inst>
     const U raw1 = read_simd<uint32_t>(inst.src1, wf, base);
     const U acc = read_simd<uint32_t>(inst.src2, wf, base);
     if constexpr (Signed) {
-      I sum = std::bit_cast<I>(acc);
+      U sum = acc;
       for (int i = 0; i < N; ++i) {
         const U ea = (raw0 >> (i * ElemBits)) & kElemMask;
         const U eb = (raw1 >> (i * ElemBits)) & kElemMask;
-        const I a = (util::stdx::static_simd_cast<I>(ea) << kShift) >> kShift;
-        const I b = (util::stdx::static_simd_cast<I>(eb) << kShift) >> kShift;
-        sum += a * b;
+        const I a = std::bit_cast<I>(simd_sign_extend_u32(ea, ElemBits));
+        const I b = std::bit_cast<I>(simd_sign_extend_u32(eb, ElemBits));
+        sum += std::bit_cast<U>(a * b);
       }
-      if (clamp)
-        util::stdx::where(sum < kZeroI, sum) = kZeroI;
-      write_simd<uint32_t>(inst.vdst, wf, base, std::bit_cast<U>(sum), chunk);
+      if (clamp) {
+        I signed_sum = std::bit_cast<I>(sum);
+        util::stdx::where(signed_sum < kZeroI, signed_sum) = kZeroI;
+        sum = std::bit_cast<U>(signed_sum);
+      }
+      write_simd<uint32_t>(inst.vdst, wf, base, sum, chunk);
     } else {
       U sum = acc;
       for (int i = 0; i < N; ++i) {
@@ -3270,7 +3423,8 @@ template <typename Inst> [[nodiscard]] bool try_execute_vop3p_dot_f16_simd(Inst 
 /// Same structure as try_execute_vop3p_dot_int_simd but the per-operand
 /// signedness is chosen at RUNTIME from inst.neg (bit 0 -> src0 signed, bit 1
 /// -> src1 signed) — hoisted out of the chunk loop. src2 is the int32
-/// accumulator seed; clamp (when set) is the lower clamp to 0. The 8/4-bit
+/// accumulator seed; clamp (when set) is the lower clamp to 0. Accumulation is
+/// in uint32_t bits so signed overflow wraps without sanitizer traps. The 8/4-bit
 /// scalar bodies read no op_sel/neg_hi, so no gate.
 template <int ElemBits, typename Inst>
   requires(util::has_stdx_simd)
@@ -3281,7 +3435,6 @@ template <int ElemBits, typename Inst>
     return false;
   constexpr int N = 32 / ElemBits;
   constexpr uint32_t kElemMask = (ElemBits == 8) ? 0xFFu : 0xFu;
-  constexpr int kShift = 32 - ElemBits;
   using T = uint32_t;
   constexpr std::size_t W = util::native_width_v<T>;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
@@ -3299,22 +3452,25 @@ template <int ElemBits, typename Inst>
     const U raw0 = read_simd<uint32_t>(inst.src0, wf, base);
     const U raw1 = read_simd<uint32_t>(inst.src1, wf, base);
     const U acc = read_simd<uint32_t>(inst.src2, wf, base);
-    I sum = std::bit_cast<I>(acc);
+    U sum = acc;
     for (int i = 0; i < N; ++i) {
       const U ea = (raw0 >> (i * ElemBits)) & kElemMask;
       const U eb = (raw1 >> (i * ElemBits)) & kElemMask;
       // Sign-extend the low ElemBits when the operand is signed (same shift
       // trick as the signed dot path); plain zero-extended reinterpret when
       // unsigned. Sign choice is per operand, resolved at runtime.
-      const I a = src0_signed ? ((util::stdx::static_simd_cast<I>(ea) << kShift) >> kShift)
-                              : std::bit_cast<I>(ea);
-      const I b = src1_signed ? ((util::stdx::static_simd_cast<I>(eb) << kShift) >> kShift)
-                              : std::bit_cast<I>(eb);
-      sum += a * b;
+      const I a = src0_signed ? std::bit_cast<I>(simd_sign_extend_u32(ea, ElemBits))
+                              : util::stdx::static_simd_cast<I>(ea);
+      const I b = src1_signed ? std::bit_cast<I>(simd_sign_extend_u32(eb, ElemBits))
+                              : util::stdx::static_simd_cast<I>(eb);
+      sum += std::bit_cast<U>(a * b);
     }
-    if (clamp)
-      util::stdx::where(sum < kZeroI, sum) = kZeroI;
-    write_simd<uint32_t>(inst.vdst, wf, base, std::bit_cast<U>(sum), chunk);
+    if (clamp) {
+      I signed_sum = std::bit_cast<I>(sum);
+      util::stdx::where(signed_sum < kZeroI, signed_sum) = kZeroI;
+      sum = std::bit_cast<U>(signed_sum);
+    }
+    write_simd<uint32_t>(inst.vdst, wf, base, sum, chunk);
   }
   return true;
 }
@@ -3329,7 +3485,8 @@ template <int ElemBits, typename Inst>
 /// DESTINATION register (inst.vdst), read as the accumulate source and written
 /// as the result. VOP2 reads its 2nd source as inst.vsrc1, VOP3 as inst.src1
 /// (selected by the Vop3 flag via if constexpr). All *c int forms are signed;
-/// accumulation is int32-exact. The scalar bodies carry no op_sel/neg/clamp.
+/// products fit in int32, while accumulation wraps in uint32_t bits. The scalar
+/// bodies carry no op_sel/neg/clamp.
 template <int ElemBits, bool Vop3, typename Inst>
   requires(util::has_stdx_simd)
 [[nodiscard]] inline bool try_execute_dotc_int_simd(Inst &inst, Wavefront &wf) {
@@ -3345,7 +3502,6 @@ template <int ElemBits, bool Vop3, typename Inst>
   }
   constexpr int N = 32 / ElemBits;
   constexpr uint32_t kElemMask = (ElemBits == 16) ? 0xFFFFu : (ElemBits == 8) ? 0xFFu : 0xFu;
-  constexpr int kShift = 32 - ElemBits;
   using T = uint32_t;
   constexpr std::size_t W = util::native_width_v<T>;
   const uint64_t chunk_full = util::mask<uint64_t>(static_cast<int>(W));
@@ -3362,16 +3518,15 @@ template <int ElemBits, bool Vop3, typename Inst>
       raw1 = read_simd<uint32_t>(inst.src1, wf, base);
     else
       raw1 = read_simd<uint32_t>(inst.vsrc1, wf, base);
-    const U acc = read_simd<uint32_t>(inst.vdst, wf, base); // accumulator from dst
-    I sum = std::bit_cast<I>(acc);
+    U sum = read_simd<uint32_t>(inst.vdst, wf, base); // accumulator from dst
     for (int i = 0; i < N; ++i) {
       const U ea = (raw0 >> (i * ElemBits)) & kElemMask;
       const U eb = (raw1 >> (i * ElemBits)) & kElemMask;
-      const I a = (util::stdx::static_simd_cast<I>(ea) << kShift) >> kShift;
-      const I b = (util::stdx::static_simd_cast<I>(eb) << kShift) >> kShift;
-      sum += a * b;
+      const I a = std::bit_cast<I>(simd_sign_extend_u32(ea, ElemBits));
+      const I b = std::bit_cast<I>(simd_sign_extend_u32(eb, ElemBits));
+      sum += std::bit_cast<U>(a * b);
     }
-    write_simd<uint32_t>(inst.vdst, wf, base, std::bit_cast<U>(sum), chunk);
+    write_simd<uint32_t>(inst.vdst, wf, base, sum, chunk);
   }
   return true;
 }
@@ -3485,42 +3640,66 @@ template <bool Vop3, typename Inst>
 /// 64-bit-lane VOP2 FMA counterpart (v_fmac_f64). Lane type is fixed to double,
 /// so this takes only the dst-accumulate functor. Variadic so the functor's
 /// commas pass through as one token sequence.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_VOP2_FMA_F64(...)
+#else
 #define ROCJITSU_TRY_SIMD_VOP2_FMA_F64(...)                                                        \
   if (::rocjitsu::amdgpu::try_execute_ternary_vop2_f64_simd<double>(inst, wf, __VA_ARGS__))        \
   return
+#endif
 
 /// 64-bit-lane VOP2 binary counterpart (v_add/mul/max_num/min_num_f64). Lane
 /// type fixed to double, read/written through the split lo/hi VGPR-pair path
 /// (vsrc1 as the second source). Variadic in the functor.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_VOP2_BINARY_FP64(...)
+#else
 #define ROCJITSU_TRY_SIMD_VOP2_BINARY_FP64(...)                                                    \
   if (::rocjitsu::amdgpu::try_execute_binary_vop2_f64_simd(inst, wf, __VA_ARGS__))                 \
   return
+#endif
 
 /// 64-bit-lane VOP1 unary counterpart. `T` is the 64-bit lane type (`double`
 /// for the f64 math ops, `uint64_t` for v_mov_b64). Variadic in the functor so
 /// its commas pass through as one token sequence.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_VOP1_UNARY_F64(T, ...)
+#else
 #define ROCJITSU_TRY_SIMD_VOP1_UNARY_F64(T, ...)                                                   \
   if (::rocjitsu::amdgpu::try_execute_unary_vop1_f64_simd<T>(inst, wf, __VA_ARGS__))               \
   return
+#endif
 
 /// Mixed-width cvt counterpart, f64 source -> 32-bit dst. `Tout` is the 32-bit
 /// result lane type; the functor (`native<double> -> narrow32<Tout>`) is variadic
 /// so its commas pass through as one token sequence.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_CVT_F64_TO_B32(Tout, ...)
+#else
 #define ROCJITSU_TRY_SIMD_CVT_F64_TO_B32(Tout, ...)                                                \
   if (::rocjitsu::amdgpu::try_execute_cvt_f64_to_b32_simd<Tout>(inst, wf, __VA_ARGS__))            \
   return
+#endif
 
 /// Mixed-width cvt counterpart, 32-bit source -> f64 dst. `Tin` is the 32-bit
 /// source lane type; the functor (`narrow32<Tin> -> native<double>`) is variadic.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_CVT_B32_TO_F64(Tin, ...)
+#else
 #define ROCJITSU_TRY_SIMD_CVT_B32_TO_F64(Tin, ...)                                                 \
   if (::rocjitsu::amdgpu::try_execute_cvt_b32_to_f64_simd<Tin>(inst, wf, __VA_ARGS__))             \
   return
+#endif
 
 /// VOP3 f64-source -> 32-bit-fp-dst cvt counterpart (src0 abs/neg + result
 /// omod/clamp; for v_frexp_exp_i32_f64). Functor: native<double> -> narrow32<float>.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_CVT_VOP3_F64_TO_B32_FP(...)
+#else
 #define ROCJITSU_TRY_SIMD_CVT_VOP3_F64_TO_B32_FP(...)                                              \
   if (::rocjitsu::amdgpu::try_execute_cvt_vop3_f64_to_b32_fp_simd(inst, wf, __VA_ARGS__))          \
   return
+#endif
 
 /// VOPC compare counterpart. `T` is the 32-bit lane read type; the comparison
 /// functor (which may convert/narrow inside) is variadic so its commas pass
@@ -3531,16 +3710,24 @@ template <bool Vop3, typename Inst>
 
 /// 64-bit-lane VOPC compare counterpart (f64/i64/u64). `T` is the 64-bit lane
 /// read type; the comparison functor is variadic so its commas pass through.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_VOPC64(T, ...)
+#else
 #define ROCJITSU_TRY_SIMD_VOPC64(T, ...)                                                           \
   if (::rocjitsu::amdgpu::try_execute_vopc64_simd<T>(inst, wf, __VA_ARGS__))                       \
   return
+#endif
 
 /// Mixed-width v_cmp_class_f64 counterpart (64-bit value, 32-bit mask). No type
 /// argument; the class functor `(native<uint64_t> bits, narrow32<uint32_t> mask)
 /// -> mask` is variadic so its commas pass through as one token sequence.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_VOPC_CLASS_F64(...)
+#else
 #define ROCJITSU_TRY_SIMD_VOPC_CLASS_F64(...)                                                      \
   if (::rocjitsu::amdgpu::try_execute_vopc_class_f64_simd(inst, wf, __VA_ARGS__))                  \
   return
+#endif
 
 /// VOP3 v_cmp_class_f16/f32 counterpart (32-bit value, abs/neg modifiers, src1
 /// mask, SGPR-pair dst). `SM` is the per-op sign-bit mask (0x8000 / 0x80000000);
@@ -3551,9 +3738,13 @@ template <bool Vop3, typename Inst>
 
 /// VOP3 v_cmp_class_f64 counterpart (64-bit value). `SM` is the f64 sign-bit mask
 /// (0x8000000000000000); the class functor is variadic.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_VOP3_CLASS_F64(SM, ...)
+#else
 #define ROCJITSU_TRY_SIMD_VOP3_CLASS_F64(SM, ...)                                                  \
   if (::rocjitsu::amdgpu::try_execute_vop3_class_f64_simd(inst, wf, SM, __VA_ARGS__))              \
   return
+#endif
 
 /// VOP3 integer/bitwise binary counterpart (reads src0/src1, no modifiers).
 /// `T` is the 32-bit integer lane type; variadic in the functor.
@@ -3590,9 +3781,13 @@ template <bool Vop3, typename Inst>
 /// 64-bit-lane VOP3 integer/bitwise VOPC compare counterpart (i64/u64, no
 /// modifiers, SGPR-pair dst). `T` is the 64-bit integer lane read type;
 /// variadic in the functor.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(T, ...)
+#else
 #define ROCJITSU_TRY_SIMD_VOPC64_VOP3_INT(T, ...)                                                  \
   if (::rocjitsu::amdgpu::try_execute_vopc64_vop3_int_simd<T>(inst, wf, __VA_ARGS__))              \
   return
+#endif
 
 /// VOP3 f32 VOPC compare counterpart (per-source abs/neg modifiers, SGPR-pair
 /// dst). Lane type is fixed to float32_t; the functor takes already-modified
@@ -3613,9 +3808,13 @@ template <bool Vop3, typename Inst>
 /// lane via split lo/hi VGPR-pair, SGPR-pair dst). Lane type is fixed to
 /// `double`; the functor takes already-modified `native<double>` arguments
 /// and is variadic so its commas pass through.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64(...)
+#else
 #define ROCJITSU_TRY_SIMD_VOPC64_VOP3_FP64(...)                                                    \
   if (::rocjitsu::amdgpu::try_execute_vopc64_vop3_fp64_simd(inst, wf, __VA_ARGS__))                \
   return
+#endif
 
 /// VOP3 integer/bitwise ternary counterpart (reads src0/src1/src2, no
 /// modifiers). `T` is the 32-bit integer lane type; variadic in the functor.
@@ -3637,9 +3836,13 @@ template <bool Vop3, typename Inst>
 
 /// VOP3 f64 ternary counterpart (read_simd64, per-source abs/neg, omod/clamp).
 /// Variadic.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP64(...)
+#else
 #define ROCJITSU_TRY_SIMD_VOP3_TERNARY_FP64(...)                                                   \
   if (::rocjitsu::amdgpu::try_execute_ternary_vop3_fp64_simd(inst, wf, __VA_ARGS__))               \
   return
+#endif
 
 /// VOP3 dst-accumulate FMA counterpart (f32). Per-isa class has no src2;
 /// vdst is the accumulator. abs/neg apply to src0/src1 only.
@@ -3654,9 +3857,13 @@ template <bool Vop3, typename Inst>
   return
 
 /// VOP3 dst-accumulate FMA counterpart (f64).
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_FMAC_VOP3_FP64(...)
+#else
 #define ROCJITSU_TRY_SIMD_FMAC_VOP3_FP64(...)                                                      \
   if (::rocjitsu::amdgpu::try_execute_fmac_vop3_fp64_simd(inst, wf, __VA_ARGS__))                  \
   return
+#endif
 
 /// VOP3 ldexp counterpart (f32 src0 + int32 src1 exp). Variadic functor.
 #define ROCJITSU_TRY_SIMD_LDEXP_VOP3_FP32(...)                                                     \
@@ -3664,9 +3871,13 @@ template <bool Vop3, typename Inst>
   return
 
 /// VOP3 ldexp counterpart (f64 src0 + int32 src1 exp). Variadic functor.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_LDEXP_VOP3_FP64(...)
+#else
 #define ROCJITSU_TRY_SIMD_LDEXP_VOP3_FP64(...)                                                     \
   if (::rocjitsu::amdgpu::try_execute_ldexp_vop3_fp64_simd(inst, wf, __VA_ARGS__))                 \
   return
+#endif
 
 /// VOP3 div_fmas counterpart (fma(s0,s1,s2) followed by VCC-gated ldexp; no
 /// omod/clamp). No functor — the op is fixed (operand order, ldexp shift) and
@@ -3675,22 +3886,34 @@ template <bool Vop3, typename Inst>
   if (::rocjitsu::amdgpu::try_execute_div_fmas_f32_simd(inst, wf))                                 \
   return
 
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_DIV_FMAS_VOP3_FP64()
+#else
 #define ROCJITSU_TRY_SIMD_DIV_FMAS_VOP3_FP64()                                                     \
   if (::rocjitsu::amdgpu::try_execute_div_fmas_f64_simd(inst, wf))                                 \
   return
+#endif
 
 /// VOP3 f64 binary counterpart (read_simd64, per-source abs/neg, omod/clamp on
 /// the result). Variadic in the functor so its commas pass through as one
 /// token sequence.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_VOP3_BINARY_FP64(...)
+#else
 #define ROCJITSU_TRY_SIMD_VOP3_BINARY_FP64(...)                                                    \
   if (::rocjitsu::amdgpu::try_execute_binary_vop3_fp64_simd(inst, wf, __VA_ARGS__))                \
   return
+#endif
 
 /// VOP3 f64 unary counterpart (read_simd64, src0 abs/neg, omod/clamp on
 /// the result). Variadic in the functor.
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define ROCJITSU_TRY_SIMD_VOP3_UNARY_FP64(...)
+#else
 #define ROCJITSU_TRY_SIMD_VOP3_UNARY_FP64(...)                                                     \
   if (::rocjitsu::amdgpu::try_execute_unary_vop3_fp64_simd(inst, wf, __VA_ARGS__))                 \
   return
+#endif
 
 /// VOP3 f16 unary counterpart (raw uint32 lanes; widen f16->f32, src0 abs/neg,
 /// op, omod/clamp, narrow f32->f16). The functor takes already-widened-and-

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -45,6 +45,31 @@ using float32_t = float;
 /// flip at runtime.
 inline bool simd_force_scalar() { return util::force_scalar(); }
 
+inline uint32_t sign_extend_u32(uint32_t value, unsigned bits) {
+  assert(bits >= 1 && bits <= 32 && "sign_extend_u32 requires a 1..32 bit width");
+  const uint32_t sign = uint32_t{1} << (bits - 1);
+  const uint32_t mask = bits == 32 ? ~uint32_t{0} : ((uint32_t{1} << bits) - uint32_t{1});
+  return ((value & mask) ^ sign) - sign;
+}
+
+inline uint32_t lshl_masked(uint32_t value, uint32_t count) { return value << (count & 31u); }
+
+inline uint64_t lshl_masked(uint64_t value, uint64_t count) { return value << (count & 63u); }
+
+inline uint32_t bfm_b32(uint32_t width, uint32_t offset) {
+  const uint32_t w = width & 31u;
+  const uint32_t off = offset & 31u;
+  return w == 0 ? uint32_t{0} : ((uint32_t{1} << w) - uint32_t{1}) << off;
+}
+
+inline uint32_t mul_i24_u32(uint32_t lhs, uint32_t rhs) {
+  return sign_extend_u32(lhs, 24) * sign_extend_u32(rhs, 24);
+}
+
+inline uint32_t mad_i24_u32(uint32_t lhs, uint32_t rhs, uint32_t addend) {
+  return mul_i24_u32(lhs, rhs) + addend;
+}
+
 /// Write an explicit SGPR lane-mask destination. Wave32 targets use the low
 /// dword only; writing a pair would clobber the next SGPR, which codegen may
 /// legally use for unrelated scalar state.
@@ -58,9 +83,20 @@ inline void write_explicit_lane_mask(const Operand &dst, Wavefront &wf, uint64_t
 
 inline util::native<uint32_t> simd_sign_extend_u32(util::native<uint32_t> v, unsigned bits) {
   assert(bits >= 1 && bits <= 32 && "simd_sign_extend_u32 requires a 1..32 bit width");
-  const uint32_t sign = 1u << (bits - 1);
-  const uint32_t mask = bits == 32 ? ~0u : ((1u << bits) - 1u);
+  const uint32_t sign = uint32_t{1} << (bits - 1);
+  const uint32_t mask = bits == 32 ? ~uint32_t{0} : ((uint32_t{1} << bits) - uint32_t{1});
   return ((v & mask) ^ sign) - sign;
+}
+
+inline util::native<uint32_t> simd_mul_i24_u32(util::native<uint32_t> lhs,
+                                               util::native<uint32_t> rhs) {
+  return simd_sign_extend_u32(lhs, 24) * simd_sign_extend_u32(rhs, 24);
+}
+
+inline util::native<uint32_t> simd_mad_i24_u32(util::native<uint32_t> lhs,
+                                               util::native<uint32_t> rhs,
+                                               util::native<uint32_t> addend) {
+  return simd_mul_i24_u32(lhs, rhs) + addend;
 }
 
 inline util::native<uint32_t> simd_lshl_u32(util::native<uint32_t> v, util::native<uint32_t> sh) {
@@ -123,9 +159,7 @@ inline util::native<uint32_t> simd_bfm_b32(util::native<uint32_t> width,
                                            util::native<uint32_t> offset) {
   return util::map_native_scalar<uint32_t>(width, offset,
                                            [](uint32_t width_value, uint32_t offset_value) {
-                                             const uint32_t w = width_value & 31u;
-                                             const uint32_t off = offset_value & 31u;
-                                             return ((uint32_t{1} << w) - 1u) << off;
+                                             return bfm_b32(width_value, offset_value);
                                            });
 }
 

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -18,10 +18,16 @@
 #include <experimental/simd>
 #endif
 
+// clang + libstdc++ <experimental/simd> on AVX-512 has produced incorrect
+// native 64-bit mask behavior on sanitizer CI hosts. Keep the default
+// workaround local to that stack, but leave it overrideable so fixed toolchains
+// can force vector coverage with -DUTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS=0.
+#ifndef UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
 #if defined(__clang__) && defined(__GLIBCXX__) && defined(__AVX512F__)
 #define UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS 1
 #else
 #define UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS 0
+#endif
 #endif
 
 namespace util {

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -22,7 +22,10 @@
 // native 64-bit mask behavior on sanitizer CI hosts. Keep the default
 // workaround local to that stack, but leave it overrideable so fixed toolchains
 // can force vector coverage with -DUTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS=0.
-#ifndef UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#ifdef UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+#define UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS_USER_OVERRIDE 1
+#else
+#define UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS_USER_OVERRIDE 0
 #if defined(__clang__) && defined(__GLIBCXX__) && defined(__AVX512F__)
 #define UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS 1
 #else

--- a/emulation/rocjitsu/lib/util/include/util/simd.h
+++ b/emulation/rocjitsu/lib/util/include/util/simd.h
@@ -18,6 +18,12 @@
 #include <experimental/simd>
 #endif
 
+#if defined(__clang__) && defined(__GLIBCXX__) && defined(__AVX512F__)
+#define UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS 1
+#else
+#define UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS 0
+#endif
+
 namespace util {
 
 /// Compile-time switch for `<experimental/simd>` availability. Callers
@@ -67,6 +73,15 @@ template <class T> void blit_to_buffer(uint32_t (&)[native<T>::size()], native<T
 template <class T> native<T> load64(const uint32_t *, const uint32_t *) { return {}; }
 template <class T> native<T> broadcast64(uint64_t) { return {}; }
 template <class T> void masked_store64(uint32_t *, uint32_t *, native<T>, uint64_t) {}
+template <class T, class Fn> native<T> map_native_scalar(native<T>, native<T>, Fn) { return {}; }
+template <class T, class Fn> native<T> map_native_scalar(native<T>, native<T>, native<T>, Fn) {
+  return {};
+}
+template <class To, class From, class Fn> native<To> map_native_convert_scalar(native<From>, Fn) {
+  return {};
+}
+template <class T, class Fn> native<T> map_native64_scalar(native<T>, Fn) { return {}; }
+template <class T, class Fn> native<T> map_native64_scalar(native<T>, native<T>, Fn) { return {}; }
 template <class T> struct narrow32 {
   static constexpr std::size_t size() { return 1; }
   constexpr T operator[](std::size_t) const { return T{}; }
@@ -83,6 +98,73 @@ template <class T> void masked_store_narrow(uint32_t *, narrow32<T>, uint64_t) {
 inline constexpr std::size_t native_width64 = native<uint64_t>::size();
 
 #if __has_include(<experimental/simd>)
+template <class T, class Fn> native<T> map_native64_scalar(native<T> v, Fn fn) {
+  static_assert(sizeof(T) == sizeof(uint64_t));
+  constexpr std::size_t W = native<T>::size();
+  alignas(native<T>) T in[W];
+  alignas(native<T>) T out[W];
+  v.copy_to(in, stdx::vector_aligned);
+  for (std::size_t i = 0; i < W; ++i)
+    out[i] = fn(in[i]);
+  return native<T>(out, stdx::vector_aligned);
+}
+
+template <class T, class Fn> native<T> map_native_scalar(native<T> a, native<T> b, Fn fn) {
+  static_assert(sizeof(T) == sizeof(uint32_t));
+  constexpr std::size_t W = native<T>::size();
+  alignas(native<T>) T in_a[W];
+  alignas(native<T>) T in_b[W];
+  alignas(native<T>) T out[W];
+  a.copy_to(in_a, stdx::vector_aligned);
+  b.copy_to(in_b, stdx::vector_aligned);
+  for (std::size_t i = 0; i < W; ++i)
+    out[i] = fn(in_a[i], in_b[i]);
+  return native<T>(out, stdx::vector_aligned);
+}
+
+template <class T, class Fn>
+native<T> map_native_scalar(native<T> a, native<T> b, native<T> c, Fn fn) {
+  static_assert(sizeof(T) == sizeof(uint32_t));
+  constexpr std::size_t W = native<T>::size();
+  alignas(native<T>) T in_a[W];
+  alignas(native<T>) T in_b[W];
+  alignas(native<T>) T in_c[W];
+  alignas(native<T>) T out[W];
+  a.copy_to(in_a, stdx::vector_aligned);
+  b.copy_to(in_b, stdx::vector_aligned);
+  c.copy_to(in_c, stdx::vector_aligned);
+  for (std::size_t i = 0; i < W; ++i)
+    out[i] = fn(in_a[i], in_b[i], in_c[i]);
+  return native<T>(out, stdx::vector_aligned);
+}
+
+template <class To, class From, class Fn>
+native<To> map_native_convert_scalar(native<From> v, Fn fn) {
+  static_assert(sizeof(To) == sizeof(uint32_t));
+  static_assert(sizeof(From) == sizeof(uint32_t));
+  constexpr std::size_t W = native<From>::size();
+  static_assert(W == native<To>::size());
+  alignas(native<From>) From in[W];
+  alignas(native<To>) To out[W];
+  v.copy_to(in, stdx::vector_aligned);
+  for (std::size_t i = 0; i < W; ++i)
+    out[i] = fn(in[i]);
+  return native<To>(out, stdx::vector_aligned);
+}
+
+template <class T, class Fn> native<T> map_native64_scalar(native<T> a, native<T> b, Fn fn) {
+  static_assert(sizeof(T) == sizeof(uint64_t));
+  constexpr std::size_t W = native<T>::size();
+  alignas(native<T>) T in_a[W];
+  alignas(native<T>) T in_b[W];
+  alignas(native<T>) T out[W];
+  a.copy_to(in_a, stdx::vector_aligned);
+  b.copy_to(in_b, stdx::vector_aligned);
+  for (std::size_t i = 0; i < W; ++i)
+    out[i] = fn(in_a[i], in_b[i]);
+  return native<T>(out, stdx::vector_aligned);
+}
+
 /// Load `native<T>` from contiguous uint32_t storage. T must be a
 /// 32-bit trivially-copyable type.
 template <class T> native<T> load(const uint32_t *p) {
@@ -514,16 +596,32 @@ inline native<float> rndne_simd(native<float> a) {
 }
 
 inline native<double> trunc_simd(native<double> a) {
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+  return map_native64_scalar<double>(a, [](double x) { return std::trunc(x); });
+#else
   return round_fixup_simd<double, false>(a, [](native<double> x) { return stdx::trunc(x); });
+#endif
 }
 inline native<double> ceil_simd(native<double> a) {
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+  return map_native64_scalar<double>(a, [](double x) { return std::ceil(x); });
+#else
   return round_fixup_simd<double, false>(a, [](native<double> x) { return stdx::ceil(x); });
+#endif
 }
 inline native<double> floor_simd(native<double> a) {
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+  return map_native64_scalar<double>(a, [](double x) { return std::floor(x); });
+#else
   return round_fixup_simd<double, false>(a, [](native<double> x) { return stdx::floor(x); });
+#endif
 }
 inline native<double> rndne_simd(native<double> a) {
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+  return map_native64_scalar<double>(a, [](double x) { return std::nearbyint(x); });
+#else
   return round_fixup_simd<double, true>(a, [](native<double> x) { return stdx::nearbyint(x); });
+#endif
 }
 
 /// Scalar round-to-integer matching the round_fixup_simd / AMD-hardware NaN
@@ -705,25 +803,18 @@ inline native<float> bf8_e5m2_to_f32_simd(native<uint32_t> v) {
 ///   if (a==b)              return signbit(a) ? <tie> : <other>;
 ///   return a <cmp> b ? a : b;
 template <typename V> V ieee_maximum_simd(V a, V b) {
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
   if constexpr (std::is_same_v<typename V::value_type, double>) {
-    constexpr std::size_t W = V::size();
-    alignas(64) double abuf[W];
-    alignas(64) double bbuf[W];
-    alignas(64) double out[W];
-    a.copy_to(abuf, stdx::element_aligned);
-    b.copy_to(bbuf, stdx::element_aligned);
-    for (std::size_t i = 0; i < W; ++i) {
-      if (std::isnan(abuf[i]) || std::isnan(bbuf[i]))
-        out[i] = std::numeric_limits<double>::quiet_NaN();
-      else if (abuf[i] == bbuf[i])
-        out[i] = std::signbit(abuf[i]) ? bbuf[i] : abuf[i];
-      else
-        out[i] = abuf[i] > bbuf[i] ? abuf[i] : bbuf[i];
-    }
-    V result;
-    result.copy_from(out, stdx::element_aligned);
-    return result;
-  } else {
+    return map_native64_scalar<double>(a, b, [](double lhs, double rhs) {
+      if (std::isnan(lhs) || std::isnan(rhs))
+        return std::numeric_limits<double>::quiet_NaN();
+      if (lhs == rhs)
+        return std::signbit(lhs) ? rhs : lhs;
+      return lhs > rhs ? lhs : rhs;
+    });
+  } else
+#endif
+  {
     const auto nan = stdx::isnan(a) || stdx::isnan(b);
     const auto eq = (a == b);
     const auto sa = stdx::signbit(a); // true when a is negative (incl. -0)
@@ -735,25 +826,18 @@ template <typename V> V ieee_maximum_simd(V a, V b) {
   }
 }
 template <typename V> V ieee_minimum_simd(V a, V b) {
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
   if constexpr (std::is_same_v<typename V::value_type, double>) {
-    constexpr std::size_t W = V::size();
-    alignas(64) double abuf[W];
-    alignas(64) double bbuf[W];
-    alignas(64) double out[W];
-    a.copy_to(abuf, stdx::element_aligned);
-    b.copy_to(bbuf, stdx::element_aligned);
-    for (std::size_t i = 0; i < W; ++i) {
-      if (std::isnan(abuf[i]) || std::isnan(bbuf[i]))
-        out[i] = std::numeric_limits<double>::quiet_NaN();
-      else if (abuf[i] == bbuf[i])
-        out[i] = std::signbit(abuf[i]) ? abuf[i] : bbuf[i];
-      else
-        out[i] = abuf[i] < bbuf[i] ? abuf[i] : bbuf[i];
-    }
-    V result;
-    result.copy_from(out, stdx::element_aligned);
-    return result;
-  } else {
+    return map_native64_scalar<double>(a, b, [](double lhs, double rhs) {
+      if (std::isnan(lhs) || std::isnan(rhs))
+        return std::numeric_limits<double>::quiet_NaN();
+      if (lhs == rhs)
+        return std::signbit(lhs) ? lhs : rhs;
+      return lhs < rhs ? lhs : rhs;
+    });
+  } else
+#endif
+  {
     const auto nan = stdx::isnan(a) || stdx::isnan(b);
     const auto eq = (a == b);
     const auto sa = stdx::signbit(a);
@@ -893,32 +977,42 @@ inline native<uint32_t> frexp_exp_f32_simd(native<uint32_t> v) {
 /// exact); ±0 / Inf pass through; NaN is quieted (mantissa MSB set). Bit-identical
 /// to the scalar v_frexp_mant_f64 body.
 inline native<double> frexp_mant_f64_simd(native<double> x) {
-  constexpr uint64_t SIGN = 0x8000000000000000ull;
-  constexpr uint64_t MANT = 0x000FFFFFFFFFFFFFull;
-  alignas(64) double in[native<double>::size()];
-  alignas(64) double out[native<double>::size()];
-  x.copy_to(in, stdx::element_aligned);
-  for (std::size_t i = 0; i < native<double>::size(); ++i) {
-    const uint64_t v = std::bit_cast<uint64_t>(in[i]);
-    const uint64_t sign = v & SIGN;
-    const uint64_t E = (v >> 52) & 0x7FFull;
-    const uint64_t M = v & MANT;
-    uint64_t bits = sign | (1022ull << 52) | M;
-    if (E == 0) {
-      if (M == 0) {
-        bits = v;
-      } else {
-        const uint64_t p = 63u - std::countl_zero(M);
-        bits = sign | (1022ull << 52) | ((M << (52u - p)) & MANT);
-      }
-    } else if (E == 2047) {
-      bits = M == 0 ? v : (v | 0x0008000000000000ull);
+  using U = native<uint64_t>;
+  U v = std::bit_cast<U>(x);
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+  U out = map_native64_scalar<uint64_t>(v, [](uint64_t bits) -> uint64_t {
+    constexpr uint64_t kSign = 0x8000000000000000ull;
+    constexpr uint64_t kMant = 0x000FFFFFFFFFFFFFull;
+    constexpr uint64_t kQuiet = 0x0008000000000000ull;
+    uint64_t sign = bits & kSign;
+    uint64_t E = (bits >> 52) & 0x7FFull;
+    uint64_t M = bits & kMant;
+    if (E == 0ull) {
+      if (M == 0ull)
+        return bits;
+      uint64_t p = 63u - static_cast<uint64_t>(std::countl_zero(M));
+      return sign | (1022ull << 52) | ((M << (52ull - p)) & kMant);
     }
-    out[i] = std::bit_cast<double>(bits);
-  }
-  native<double> result;
-  result.copy_from(out, stdx::element_aligned);
-  return result;
+    if (E == 2047ull)
+      return M == 0ull ? bits : bits | kQuiet;
+    return sign | (1022ull << 52) | M;
+  });
+  return std::bit_cast<native<double>>(out);
+#else
+  U sign = v & U(0x8000000000000000ull);
+  U E = (v >> 52) & U(0x7FFull);
+  U M = v & U(0xFFFFFFFFFFFFFull); // 52 mantissa bits
+  U normal = sign | (U(1022ull) << 52) | M;
+  const native<double> mf = stdx::static_simd_cast<native<double>>(M);
+  const U p = (std::bit_cast<U>(mf) >> 52) - U(1023ull);
+  U dn = sign | (U(1022ull) << 52) | ((M << (U(52ull) - p)) & U(0xFFFFFFFFFFFFFull));
+  U out = normal;
+  stdx::where(E == 0ull, out) = v;                   // ±0 (M==0); overwritten if denormal
+  stdx::where((E == 0ull) && (M != 0ull), out) = dn; // denormal -> renormalized
+  stdx::where(E == 2047ull, out) = v;                // Inf passes through unchanged
+  stdx::where((E == 2047ull) && (M != 0ull), out) = v | U(0x0008000000000000ull); // quiet NaN
+  return std::bit_cast<native<double>>(out);
+#endif
 }
 
 /// 64-bit-lane port of the f64 `std::frexp` exponent. Returns each int32 result
@@ -927,25 +1021,35 @@ inline native<double> frexp_mant_f64_simd(native<double> x) {
 /// E - 1022; denormals p - 1073; ±0 / Inf / NaN give 0 (the scalar guards
 /// frexp to finite non-zero inputs). Bit-identical to v_frexp_exp_i32_f64.
 inline native<uint64_t> frexp_exp_f64_simd(native<double> x) {
-  constexpr uint64_t MANT = 0x000FFFFFFFFFFFFFull;
-  alignas(64) double in[native<double>::size()];
-  alignas(64) uint64_t out[native<double>::size()];
-  x.copy_to(in, stdx::element_aligned);
-  for (std::size_t i = 0; i < native<double>::size(); ++i) {
-    const uint64_t v = std::bit_cast<uint64_t>(in[i]);
-    const uint64_t E = (v >> 52) & 0x7FFull;
-    const uint64_t M = v & MANT;
-    if (E == 0) {
-      out[i] = M == 0 ? 0ull : (uint64_t(63u - std::countl_zero(M)) - 1073ull);
-    } else if (E == 2047) {
-      out[i] = 0ull;
-    } else {
-      out[i] = E - 1022ull;
+  using U = native<uint64_t>;
+  U v = std::bit_cast<U>(x);
+#if UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS
+  return map_native64_scalar<uint64_t>(v, [](uint64_t bits) -> uint64_t {
+    uint64_t E = (bits >> 52) & 0x7FFull;
+    uint64_t M = bits & 0x000FFFFFFFFFFFFFull;
+    if (E == 0ull) {
+      if (M == 0ull)
+        return 0ull;
+      uint64_t p = 63u - static_cast<uint64_t>(std::countl_zero(M));
+      return static_cast<uint64_t>(static_cast<int64_t>(p) - 1073);
     }
-  }
-  native<uint64_t> result;
-  result.copy_from(out, stdx::element_aligned);
-  return result;
+    if (E == 2047ull)
+      return 0ull;
+    return static_cast<uint64_t>(static_cast<int64_t>(E) - 1022);
+  });
+#else
+  U E = (v >> 52) & U(0x7FFull);
+  U M = v & U(0xFFFFFFFFFFFFFull);
+  U normal = E - U(1022ull);
+  const native<double> mf = stdx::static_simd_cast<native<double>>(M);
+  const U p = (std::bit_cast<U>(mf) >> 52) - U(1023ull);
+  U dn = p - U(1073ull);
+  U out = normal;
+  stdx::where(E == 0ull, out) = U(0ull);
+  stdx::where((E == 0ull) && (M != 0ull), out) = dn;
+  stdx::where(E == 2047ull, out) = U(0ull);
+  return out;
+#endif
 }
 
 /// Sum of the four per-byte absolute differences of two uint32 lanes (the core

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -2210,7 +2210,7 @@ TEST(BinaryTranslatorE2E, Cdna4ToCdna3MfmaPartialScratchGrowsDescriptor) {
   expect_cdna3_translated_descriptor_vgprs_at_least(result.elf_bytes, kScratchFloor + 4);
 }
 
-TEST(BinaryTranslatorE2E, RelocatedKernelCompactsSourceGapsAndPatchesBranches) {
+TEST(BinaryTranslatorE2E, RelocatedKernelPreservesEntryWindowAndPatchesBranches) {
   constexpr uint32_t kCdna4SEndpgm = 0xBF810000u;
   constexpr uint32_t kCdna4SCbranchScc1ToSourceTarget = rocjitsu::pack_sopp(5, 4);
   const std::vector<uint32_t> words = {
@@ -2239,17 +2239,25 @@ TEST(BinaryTranslatorE2E, RelocatedKernelCompactsSourceGapsAndPatchesBranches) {
 
   const auto *target_words =
       reinterpret_cast<const uint32_t *>(translated.text_sections()[0]->data());
-  // Relocation emits only reachable blocks, compacted in source order. Explicit
-  // branch immediates are then patched into the compact layout; the old source
-  // gaps are not preserved for compatibility.
-  EXPECT_EQ(target_words[0], rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3));
-  EXPECT_EQ(target_words[1], rocjitsu::pack_sopp(5, 1));
-  EXPECT_EQ(target_words[2], rocjitsu::build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA3));
-  EXPECT_EQ(target_words[3], rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3));
-  EXPECT_EQ(target_words[4], kCdna4SEndpgm);
-  for (size_t i = 5; i < words.size(); ++i) {
+  // The first 256 bytes after the descriptor entry are layout-stable for the
+  // kernarg preload compatibility entry path. Explicit branch immediates are
+  // still patched into target-ISA encodings, but source gaps in that protected
+  // window are intentionally preserved.
+  const std::vector<uint32_t> expected = {
+      rocjitsu::build_s_branch(2, ROCJITSU_CODE_ARCH_CDNA3),
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3),
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3),
+      rocjitsu::pack_sopp(5, 4),
+      rocjitsu::build_s_branch(4, ROCJITSU_CODE_ARCH_CDNA3),
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3),
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3),
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3),
+      rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3),
+      kCdna4SEndpgm,
+  };
+  for (size_t i = 0; i < expected.size(); ++i) {
     SCOPED_TRACE(i);
-    EXPECT_EQ(target_words[i], rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3));
+    EXPECT_EQ(target_words[i], expected[i]);
   }
 }
 

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -71,6 +71,8 @@ RJ_DIAGNOSTIC_POP
 #include <algorithm>
 #include <array>
 #include <bit>
+#include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -95,6 +97,67 @@ uint32_t add_elf_name(std::vector<uint8_t> &names, std::string_view name) {
 uint64_t align_up_for_test(uint64_t value, uint64_t alignment) {
   const uint64_t remainder = value % alignment;
   return remainder == 0 ? value : value + alignment - remainder;
+}
+
+template <typename T>
+T read_elf_struct_for_test(const std::vector<uint8_t> &image, uint64_t offset) {
+  T value{};
+  assert(offset <= image.size());
+  assert(sizeof(T) <= image.size() - offset);
+  std::memcpy(&value, image.data() + offset, sizeof(value));
+  return value;
+}
+
+template <typename T>
+std::vector<T> read_elf_array_for_test(const std::vector<uint8_t> &image, uint64_t offset,
+                                       size_t count) {
+  std::vector<T> values(count);
+  assert(offset <= image.size());
+  assert(count <= (image.size() - offset) / sizeof(T));
+  std::memcpy(values.data(), image.data() + offset, count * sizeof(T));
+  return values;
+}
+
+template <typename T>
+void write_elf_struct_for_test(std::vector<uint8_t> &image, uint64_t offset, const T &value) {
+  assert(offset <= image.size());
+  assert(sizeof(T) <= image.size() - offset);
+  std::memcpy(image.data() + offset, &value, sizeof(value));
+}
+
+void write_bytes_for_test(std::vector<uint8_t> &image, uint64_t offset, const void *src,
+                          size_t size) {
+  assert(offset <= image.size());
+  assert(size <= image.size() - offset);
+  std::memcpy(image.data() + offset, src, size);
+}
+
+template <typename T>
+void write_value_for_test(std::vector<uint8_t> &image, uint64_t offset, T value) {
+  write_bytes_for_test(image, offset, &value, sizeof(value));
+}
+
+using TestKernelDescriptor = rocr::llvm::amdhsa::kernel_descriptor_t;
+constexpr size_t kKernelDescriptorSize = sizeof(TestKernelDescriptor);
+constexpr size_t kKernelDescriptorEntryOffset =
+    offsetof(TestKernelDescriptor, kernel_code_entry_byte_offset);
+
+void write_kernel_descriptor_entry_offset(void *descriptor, int64_t entry_offset) {
+  auto *bytes = static_cast<uint8_t *>(descriptor);
+  std::memcpy(bytes + kKernelDescriptorEntryOffset, &entry_offset, sizeof(entry_offset));
+}
+
+int64_t read_kernel_descriptor_entry_offset(const void *descriptor) {
+  const auto *bytes = static_cast<const uint8_t *>(descriptor);
+  int64_t entry_offset = 0;
+  std::memcpy(&entry_offset, bytes + kKernelDescriptorEntryOffset, sizeof(entry_offset));
+  return entry_offset;
+}
+
+std::vector<uint8_t> make_kernel_descriptor_bytes(int64_t entry_offset) {
+  std::vector<uint8_t> descriptor(kKernelDescriptorSize, 0);
+  write_kernel_descriptor_entry_offset(descriptor.data(), entry_offset);
+  return descriptor;
 }
 
 std::vector<uint8_t> make_minimal_amdgpu_elf_with_text_and_rodata() {
@@ -294,12 +357,11 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_load_segments() {
 
 std::vector<uint8_t>
 make_minimal_amdgpu_elf_with_descriptor_after_text(const std::vector<uint32_t> &text_words) {
-  using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
   constexpr uint64_t text_offset = 0x100;
   constexpr uint64_t text_vaddr = 0x1100;
   const uint64_t text_size = text_words.size() * sizeof(uint32_t);
   constexpr uint64_t load_align = 0x1000;
-  constexpr uint64_t rodata_size = sizeof(KD);
+  constexpr uint64_t rodata_size = kKernelDescriptorSize;
 
   std::vector<uint8_t> shstrtab{'\0'};
   const uint32_t text_name = add_elf_name(shstrtab, ".text");
@@ -363,10 +425,9 @@ make_minimal_amdgpu_elf_with_descriptor_after_text(const std::vector<uint32_t> &
 
   std::memcpy(image.data() + text_offset, text_words.data(), text_size);
 
-  KD kd{};
-  kd.kernel_code_entry_byte_offset =
-      static_cast<int64_t>(text_vaddr) - static_cast<int64_t>(rodata_vaddr);
-  std::memcpy(image.data() + rodata_offset, &kd, sizeof(kd));
+  const auto descriptor = make_kernel_descriptor_bytes(static_cast<int64_t>(text_vaddr) -
+                                                       static_cast<int64_t>(rodata_vaddr));
+  std::memcpy(image.data() + rodata_offset, descriptor.data(), descriptor.size());
   std::memcpy(image.data() + strtab_offset, strtab.data(), strtab.size());
 
   std::array<Elf64_Sym, sym_count> syms{};
@@ -374,7 +435,7 @@ make_minimal_amdgpu_elf_with_descriptor_after_text(const std::vector<uint32_t> &
   syms[1].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
   syms[1].st_shndx = 2;
   syms[1].st_value = rodata_vaddr;
-  syms[1].st_size = sizeof(KD);
+  syms[1].st_size = kKernelDescriptorSize;
   std::memcpy(image.data() + symtab_offset, syms.data(), syms.size() * sizeof(Elf64_Sym));
 
   std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
@@ -443,12 +504,11 @@ bool has_error_containing(const TranslatedCodeObject &result, DiagnosticKind kin
 }
 
 std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors() {
-  using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
   constexpr uint64_t text_offset = 0x100;
   constexpr uint64_t text_vaddr = 0x1100;
   constexpr uint64_t text_size = 8;
   constexpr uint64_t load_align = 0x1000;
-  constexpr uint64_t rodata_size = 2 * sizeof(KD);
+  constexpr uint64_t rodata_size = 2 * kKernelDescriptorSize;
 
   std::vector<uint8_t> shstrtab{'\0'};
   const uint32_t text_name = add_elf_name(shstrtab, ".text");
@@ -515,13 +575,14 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors() {
   const std::array<uint32_t, 2> text_words = {kCdna4SEndpgm, kCdna4SEndpgm};
   std::memcpy(image.data() + text_offset, text_words.data(), text_size);
 
-  std::array<KD, 2> descriptors{};
-  descriptors[0].kernel_code_entry_byte_offset =
-      static_cast<int64_t>(text_vaddr) - static_cast<int64_t>(rodata_vaddr);
-  descriptors[1].kernel_code_entry_byte_offset =
+  std::vector<uint8_t> descriptors(rodata_size, 0);
+  write_kernel_descriptor_entry_offset(descriptors.data(), static_cast<int64_t>(text_vaddr) -
+                                                               static_cast<int64_t>(rodata_vaddr));
+  write_kernel_descriptor_entry_offset(
+      descriptors.data() + kKernelDescriptorSize,
       static_cast<int64_t>(text_vaddr + sizeof(uint32_t)) -
-      static_cast<int64_t>(rodata_vaddr + sizeof(KD));
-  std::memcpy(image.data() + rodata_offset, descriptors.data(), rodata_size);
+          static_cast<int64_t>(rodata_vaddr + kKernelDescriptorSize));
+  std::memcpy(image.data() + rodata_offset, descriptors.data(), descriptors.size());
   std::memcpy(image.data() + strtab_offset, strtab.data(), strtab.size());
 
   std::array<Elf64_Sym, sym_count> syms{};
@@ -529,12 +590,12 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_two_kernel_descriptors() {
   syms[1].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
   syms[1].st_shndx = 2;
   syms[1].st_value = rodata_vaddr;
-  syms[1].st_size = sizeof(KD);
+  syms[1].st_size = kKernelDescriptorSize;
   syms[2].st_name = kernel1_name;
   syms[2].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
   syms[2].st_shndx = 2;
-  syms[2].st_value = rodata_vaddr + sizeof(KD);
-  syms[2].st_size = sizeof(KD);
+  syms[2].st_value = rodata_vaddr + kKernelDescriptorSize;
+  syms[2].st_size = kKernelDescriptorSize;
   std::memcpy(image.data() + symtab_offset, syms.data(), syms.size() * sizeof(Elf64_Sym));
 
   std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
@@ -689,13 +750,12 @@ std::vector<uint8_t> make_minimal_amdgpu_elf_with_relocation_after_text() {
 }
 
 std::vector<uint8_t> make_large_amdgpu_elf_with_waitcnt_entry() {
-  using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
   constexpr uint64_t rodata_offset = 0x100;
   constexpr uint64_t rodata_vaddr = 0x100;
   constexpr uint64_t text_offset = 0x1000;
   constexpr uint64_t text_vaddr = 0x1000;
   constexpr uint64_t text_size = 0x21000;
-  constexpr uint64_t rodata_size = sizeof(KD);
+  constexpr uint64_t rodata_size = kKernelDescriptorSize;
   constexpr uint64_t load_align = 0x1000;
 
   std::vector<uint8_t> shstrtab{'\0'};
@@ -718,48 +778,46 @@ std::vector<uint8_t> make_large_amdgpu_elf_with_waitcnt_entry() {
 
   std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
 
-  Elf64_Ehdr ehdr{};
-  std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
-  ehdr.e_ident[EI_CLASS] = ELFCLASS64;
-  ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
-  ehdr.e_type = ET_DYN;
-  ehdr.e_machine = EM_AMDGPU;
-  ehdr.e_version = 1;
-  ehdr.e_phoff = sizeof(Elf64_Ehdr);
-  ehdr.e_shoff = shoff;
-  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX950;
-  ehdr.e_ehsize = sizeof(Elf64_Ehdr);
-  ehdr.e_phentsize = sizeof(Elf64_Phdr);
-  ehdr.e_phnum = phdr_count;
-  ehdr.e_shentsize = sizeof(Elf64_Shdr);
-  ehdr.e_shnum = section_count;
-  ehdr.e_shstrndx = 5;
-  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+  write_bytes_for_test(image, offsetof(Elf64_Ehdr, e_ident), EI_MAGIC, EI_MAGIC_SIZE);
+  image[offsetof(Elf64_Ehdr, e_ident) + EI_CLASS] = ELFCLASS64;
+  image[offsetof(Elf64_Ehdr, e_ident) + EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  write_value_for_test<uint16_t>(image, offsetof(Elf64_Ehdr, e_type), ET_DYN);
+  write_value_for_test<uint16_t>(image, offsetof(Elf64_Ehdr, e_machine), EM_AMDGPU);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_version), 1);
+  write_value_for_test<uint64_t>(image, offsetof(Elf64_Ehdr, e_phoff), sizeof(Elf64_Ehdr));
+  write_value_for_test<uint64_t>(image, offsetof(Elf64_Ehdr, e_shoff), shoff);
+  write_value_for_test<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags),
+                                 EF_AMDGPU_MACH_AMDGCN_GFX950);
+  write_value_for_test<uint16_t>(image, offsetof(Elf64_Ehdr, e_ehsize), sizeof(Elf64_Ehdr));
+  write_value_for_test<uint16_t>(image, offsetof(Elf64_Ehdr, e_phentsize), sizeof(Elf64_Phdr));
+  write_value_for_test<uint16_t>(image, offsetof(Elf64_Ehdr, e_phnum), phdr_count);
+  write_value_for_test<uint16_t>(image, offsetof(Elf64_Ehdr, e_shentsize), sizeof(Elf64_Shdr));
+  write_value_for_test<uint16_t>(image, offsetof(Elf64_Ehdr, e_shnum), section_count);
+  write_value_for_test<uint16_t>(image, offsetof(Elf64_Ehdr, e_shstrndx), 5);
 
-  std::array<Elf64_Phdr, phdr_count> phdrs{};
-  phdrs[0].p_type = PT_LOAD;
-  phdrs[0].p_flags = 0x4; // PF_R
-  phdrs[0].p_offset = rodata_offset;
-  phdrs[0].p_vaddr = rodata_vaddr;
-  phdrs[0].p_paddr = rodata_vaddr;
-  phdrs[0].p_filesz = rodata_size;
-  phdrs[0].p_memsz = rodata_size;
-  phdrs[0].p_align = load_align;
+  const uint64_t phdr0 = sizeof(Elf64_Ehdr);
+  write_value_for_test<uint32_t>(image, phdr0 + offsetof(Elf64_Phdr, p_type), PT_LOAD);
+  write_value_for_test<uint32_t>(image, phdr0 + offsetof(Elf64_Phdr, p_flags), 0x4); // PF_R
+  write_value_for_test<uint64_t>(image, phdr0 + offsetof(Elf64_Phdr, p_offset), rodata_offset);
+  write_value_for_test<uint64_t>(image, phdr0 + offsetof(Elf64_Phdr, p_vaddr), rodata_vaddr);
+  write_value_for_test<uint64_t>(image, phdr0 + offsetof(Elf64_Phdr, p_paddr), rodata_vaddr);
+  write_value_for_test<uint64_t>(image, phdr0 + offsetof(Elf64_Phdr, p_filesz), rodata_size);
+  write_value_for_test<uint64_t>(image, phdr0 + offsetof(Elf64_Phdr, p_memsz), rodata_size);
+  write_value_for_test<uint64_t>(image, phdr0 + offsetof(Elf64_Phdr, p_align), load_align);
 
-  phdrs[1].p_type = PT_LOAD;
-  phdrs[1].p_flags = 0x5; // PF_R | PF_X
-  phdrs[1].p_offset = text_offset;
-  phdrs[1].p_vaddr = text_vaddr;
-  phdrs[1].p_paddr = text_vaddr;
-  phdrs[1].p_filesz = text_size;
-  phdrs[1].p_memsz = text_size;
-  phdrs[1].p_align = load_align;
-  std::memcpy(image.data() + ehdr.e_phoff, phdrs.data(), phdrs.size() * sizeof(Elf64_Phdr));
+  const uint64_t phdr1 = phdr0 + sizeof(Elf64_Phdr);
+  write_value_for_test<uint32_t>(image, phdr1 + offsetof(Elf64_Phdr, p_type), PT_LOAD);
+  write_value_for_test<uint32_t>(image, phdr1 + offsetof(Elf64_Phdr, p_flags), 0x5); // PF_R | PF_X
+  write_value_for_test<uint64_t>(image, phdr1 + offsetof(Elf64_Phdr, p_offset), text_offset);
+  write_value_for_test<uint64_t>(image, phdr1 + offsetof(Elf64_Phdr, p_vaddr), text_vaddr);
+  write_value_for_test<uint64_t>(image, phdr1 + offsetof(Elf64_Phdr, p_paddr), text_vaddr);
+  write_value_for_test<uint64_t>(image, phdr1 + offsetof(Elf64_Phdr, p_filesz), text_size);
+  write_value_for_test<uint64_t>(image, phdr1 + offsetof(Elf64_Phdr, p_memsz), text_size);
+  write_value_for_test<uint64_t>(image, phdr1 + offsetof(Elf64_Phdr, p_align), load_align);
 
-  KD kd{};
-  kd.kernel_code_entry_byte_offset =
-      static_cast<int64_t>(text_vaddr) - static_cast<int64_t>(rodata_vaddr);
-  std::memcpy(image.data() + rodata_offset, &kd, sizeof(kd));
+  const auto descriptor = make_kernel_descriptor_bytes(static_cast<int64_t>(text_vaddr) -
+                                                       static_cast<int64_t>(rodata_vaddr));
+  std::memcpy(image.data() + rodata_offset, descriptor.data(), descriptor.size());
 
   std::vector<uint32_t> text_words(text_size / sizeof(uint32_t),
                                    build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4));
@@ -767,55 +825,39 @@ std::vector<uint8_t> make_large_amdgpu_elf_with_waitcnt_entry() {
   std::memcpy(image.data() + text_offset, text_words.data(), text_size);
   std::memcpy(image.data() + strtab_offset, strtab.data(), strtab.size());
 
-  std::array<Elf64_Sym, sym_count> syms{};
-  syms[1].st_name = kd_symbol_name;
-  syms[1].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
-  syms[1].st_shndx = 1;
-  syms[1].st_value = rodata_vaddr;
-  syms[1].st_size = sizeof(KD);
-  std::memcpy(image.data() + symtab_offset, syms.data(), syms.size() * sizeof(Elf64_Sym));
+  const uint64_t sym1 = symtab_offset + sizeof(Elf64_Sym);
+  write_value_for_test<uint32_t>(image, sym1 + offsetof(Elf64_Sym, st_name), kd_symbol_name);
+  write_value_for_test<unsigned char>(image, sym1 + offsetof(Elf64_Sym, st_info),
+                                      elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject));
+  write_value_for_test<uint16_t>(image, sym1 + offsetof(Elf64_Sym, st_shndx), 1);
+  write_value_for_test<uint64_t>(image, sym1 + offsetof(Elf64_Sym, st_value), rodata_vaddr);
+  write_value_for_test<uint64_t>(image, sym1 + offsetof(Elf64_Sym, st_size), kKernelDescriptorSize);
 
   std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
 
-  std::array<Elf64_Shdr, section_count> shdrs{};
-  shdrs[1].sh_name = rodata_name;
-  shdrs[1].sh_type = SHT_PROGBITS;
-  shdrs[1].sh_flags = SHF_ALLOC;
-  shdrs[1].sh_addr = rodata_vaddr;
-  shdrs[1].sh_offset = rodata_offset;
-  shdrs[1].sh_size = rodata_size;
-  shdrs[1].sh_addralign = 64;
-
-  shdrs[2].sh_name = text_name;
-  shdrs[2].sh_type = SHT_PROGBITS;
-  shdrs[2].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
-  shdrs[2].sh_addr = text_vaddr;
-  shdrs[2].sh_offset = text_offset;
-  shdrs[2].sh_size = text_size;
-  shdrs[2].sh_addralign = 256;
-
-  shdrs[3].sh_name = symtab_name;
-  shdrs[3].sh_type = SHT_SYMTAB;
-  shdrs[3].sh_offset = symtab_offset;
-  shdrs[3].sh_size = syms.size() * sizeof(Elf64_Sym);
-  shdrs[3].sh_link = 4;
-  shdrs[3].sh_info = 1;
-  shdrs[3].sh_addralign = 8;
-  shdrs[3].sh_entsize = sizeof(Elf64_Sym);
-
-  shdrs[4].sh_name = strtab_name;
-  shdrs[4].sh_type = SHT_STRTAB;
-  shdrs[4].sh_offset = strtab_offset;
-  shdrs[4].sh_size = strtab.size();
-  shdrs[4].sh_addralign = 1;
-
-  shdrs[5].sh_name = shstrtab_name;
-  shdrs[5].sh_type = SHT_STRTAB;
-  shdrs[5].sh_offset = shstrtab_offset;
-  shdrs[5].sh_size = shstrtab.size();
-  shdrs[5].sh_addralign = 1;
-
-  std::memcpy(image.data() + shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  const auto write_shdr = [&](uint64_t index, uint32_t name, uint32_t type, uint64_t flags,
+                              uint64_t addr, uint64_t offset, uint64_t size, uint32_t link,
+                              uint32_t info, uint64_t addralign, uint64_t entsize) {
+    const uint64_t base = shoff + index * sizeof(Elf64_Shdr);
+    write_value_for_test<uint32_t>(image, base + offsetof(Elf64_Shdr, sh_name), name);
+    write_value_for_test<uint32_t>(image, base + offsetof(Elf64_Shdr, sh_type), type);
+    write_value_for_test<uint64_t>(image, base + offsetof(Elf64_Shdr, sh_flags), flags);
+    write_value_for_test<uint64_t>(image, base + offsetof(Elf64_Shdr, sh_addr), addr);
+    write_value_for_test<uint64_t>(image, base + offsetof(Elf64_Shdr, sh_offset), offset);
+    write_value_for_test<uint64_t>(image, base + offsetof(Elf64_Shdr, sh_size), size);
+    write_value_for_test<uint32_t>(image, base + offsetof(Elf64_Shdr, sh_link), link);
+    write_value_for_test<uint32_t>(image, base + offsetof(Elf64_Shdr, sh_info), info);
+    write_value_for_test<uint64_t>(image, base + offsetof(Elf64_Shdr, sh_addralign), addralign);
+    write_value_for_test<uint64_t>(image, base + offsetof(Elf64_Shdr, sh_entsize), entsize);
+  };
+  write_shdr(1, rodata_name, SHT_PROGBITS, SHF_ALLOC, rodata_vaddr, rodata_offset, rodata_size, 0,
+             0, 64, 0);
+  write_shdr(2, text_name, SHT_PROGBITS, SHF_ALLOC | SHF_EXECINSTR, text_vaddr, text_offset,
+             text_size, 0, 0, 256, 0);
+  write_shdr(3, symtab_name, SHT_SYMTAB, 0, 0, symtab_offset, sym_count * sizeof(Elf64_Sym), 4, 1,
+             8, sizeof(Elf64_Sym));
+  write_shdr(4, strtab_name, SHT_STRTAB, 0, 0, strtab_offset, strtab.size(), 0, 0, 1, 0);
+  write_shdr(5, shstrtab_name, SHT_STRTAB, 0, 0, shstrtab_offset, shstrtab.size(), 0, 0, 1, 0);
   return image;
 }
 
@@ -1213,11 +1255,11 @@ TEST(CodeObjectPatcher, ReplaceTextPreservesLoadSegmentAlignment) {
   EXPECT_EQ(rodata->vaddr(), text->vaddr() + 8 + load_align + padded_file_delta)
       << "later allocated sections must move after the expanded RX LOAD segment";
 
-  const auto *ehdr = reinterpret_cast<const Elf64_Ehdr *>(patched_bytes.data());
-  ASSERT_EQ(ehdr->e_phnum, 2u);
-  const auto *phdrs = reinterpret_cast<const Elf64_Phdr *>(patched_bytes.data() + ehdr->e_phoff);
-  const auto *shdrs = reinterpret_cast<const Elf64_Shdr *>(patched_bytes.data() + ehdr->e_shoff);
-  for (uint16_t i = 0; i < ehdr->e_phnum; ++i) {
+  const auto ehdr = read_elf_struct_for_test<Elf64_Ehdr>(patched_bytes, 0);
+  ASSERT_EQ(ehdr.e_phnum, 2u);
+  const auto phdrs = read_elf_array_for_test<Elf64_Phdr>(patched_bytes, ehdr.e_phoff, ehdr.e_phnum);
+  const auto shdrs = read_elf_array_for_test<Elf64_Shdr>(patched_bytes, ehdr.e_shoff, ehdr.e_shnum);
+  for (uint16_t i = 0; i < ehdr.e_phnum; ++i) {
     ASSERT_NE(phdrs[i].p_align, 0u);
     EXPECT_EQ(phdrs[i].p_offset % phdrs[i].p_align, phdrs[i].p_vaddr % phdrs[i].p_align)
         << "PT_LOAD " << i << " must remain loader-congruent";
@@ -1230,14 +1272,14 @@ TEST(CodeObjectPatcher, ReplaceTextPreservesLoadSegmentAlignment) {
   EXPECT_LE(phdrs[0].p_vaddr + phdrs[0].p_memsz, phdrs[1].p_vaddr)
       << "expanded RX LOAD must not overlap the following LOAD in virtual memory";
 
-  const auto *symtab = std::find_if(shdrs, shdrs + ehdr->e_shnum, [](const Elf64_Shdr &shdr) {
+  const auto symtab = std::find_if(shdrs.begin(), shdrs.end(), [](const Elf64_Shdr &shdr) {
     return shdr.sh_type == SHT_SYMTAB;
   });
-  ASSERT_NE(symtab, shdrs + ehdr->e_shnum);
+  ASSERT_NE(symtab, shdrs.end());
   ASSERT_EQ(symtab->sh_entsize, sizeof(Elf64_Sym));
   ASSERT_GE(symtab->sh_size / symtab->sh_entsize, 3u);
-  const auto *symbols =
-      reinterpret_cast<const Elf64_Sym *>(patched_bytes.data() + symtab->sh_offset);
+  const auto symbols = read_elf_array_for_test<Elf64_Sym>(patched_bytes, symtab->sh_offset,
+                                                          symtab->sh_size / symtab->sh_entsize);
   EXPECT_EQ(symbols[1].st_value, rodata->vaddr())
       << "defined symbols in moved sections must track the section virtual address";
   EXPECT_EQ(symbols[2].st_value, text->vaddr())
@@ -1247,7 +1289,6 @@ TEST(CodeObjectPatcher, ReplaceTextPreservesLoadSegmentAlignment) {
 }
 
 TEST(CodeObjectPatcher, ReplaceTextPreservesMovedKernelDescriptorEntryAddress) {
-  using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
   constexpr uint64_t load_align = 0x1000;
   constexpr uint64_t padded_file_delta = 2 * load_align;
 
@@ -1257,8 +1298,8 @@ TEST(CodeObjectPatcher, ReplaceTextPreservesMovedKernelDescriptorEntryAddress) {
   ASSERT_FALSE(co.text_sections().empty());
   const auto *original_rodata = find_section(co, ".rodata");
   ASSERT_NE(original_rodata, nullptr);
-  KD original_kd{};
-  std::memcpy(&original_kd, original_rodata->data(), sizeof(original_kd));
+  const int64_t original_entry_offset =
+      read_kernel_descriptor_entry_offset(original_rodata->data());
 
   CodeObjectPatcher patcher(co);
   const std::vector<uint32_t> text_words(load_align / sizeof(uint32_t) + 3, 0xDEADBEEFu);
@@ -1272,15 +1313,13 @@ TEST(CodeObjectPatcher, ReplaceTextPreservesMovedKernelDescriptorEntryAddress) {
   const auto *patched_rodata = find_section(patched, ".rodata");
   ASSERT_NE(patched_rodata, nullptr);
 
-  KD patched_kd{};
-  std::memcpy(&patched_kd, patched_rodata->data(), sizeof(patched_kd));
+  const int64_t patched_entry_offset = read_kernel_descriptor_entry_offset(patched_rodata->data());
   EXPECT_EQ(patched_rodata->vaddr(), original_rodata->vaddr() + padded_file_delta);
-  EXPECT_EQ(static_cast<uint64_t>(static_cast<int64_t>(patched_rodata->vaddr()) +
-                                  patched_kd.kernel_code_entry_byte_offset),
-            patched_text->vaddr())
+  EXPECT_EQ(
+      static_cast<uint64_t>(static_cast<int64_t>(patched_rodata->vaddr()) + patched_entry_offset),
+      patched_text->vaddr())
       << "KERNEL_CODE_ENTRY_BYTE_OFFSET is relative to the descriptor address";
-  EXPECT_EQ(patched_kd.kernel_code_entry_byte_offset,
-            original_kd.kernel_code_entry_byte_offset - static_cast<int64_t>(padded_file_delta));
+  EXPECT_EQ(patched_entry_offset, original_entry_offset - static_cast<int64_t>(padded_file_delta));
 }
 
 TEST(CodeObjectPatcher, ReplaceTextUpdatesRelocationOffsetsIntoMovedSections) {
@@ -2013,8 +2052,6 @@ void expect_cdna3_translated_descriptor_vgprs_at_least(const std::vector<uint8_t
 
 // --- Synthetic BinaryTranslator integration tests ---
 TEST(BinaryTranslatorE2E, TranslatesMultiKernelCodeObject) {
-  using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
-
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_two_kernel_descriptors();
   rocjitsu::AmdGpuCodeObject co(image.data(), image.size());
   ASSERT_TRUE(co.is_valid());
@@ -2039,7 +2076,8 @@ TEST(BinaryTranslatorE2E, TranslatesMultiKernelCodeObject) {
   std::ranges::sort(original_descriptor_offsets);
   EXPECT_EQ(original_entries, (std::vector<uint64_t>{0, sizeof(uint32_t)}));
   EXPECT_EQ(original_descriptor_offsets,
-            (std::vector<uint64_t>{rodata->sectionOffset(), rodata->sectionOffset() + sizeof(KD)}));
+            (std::vector<uint64_t>{rodata->sectionOffset(),
+                                   rodata->sectionOffset() + rocjitsu::kKernelDescriptorSize}));
 
   rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_RDNA4);
   auto result = translator.translate(co);
@@ -2388,26 +2426,28 @@ TEST(BinaryTranslatorE2E, MatchedSemanticExpandRuleFailureIsDiagnostic) {
   EXPECT_FALSE(diagnostic->message.empty());
 }
 
-TEST(KernelDescriptorTranslator, IgnoresExecutableSectionsOutsideTextForEntryRange) {
-  using KD = rocr::llvm::amdhsa::kernel_descriptor_t;
-
+TEST(KernelDescriptorTranslator, IgnoresNonAllocExecutableSectionsForEntryRange) {
   auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text();
-  auto *ehdr = reinterpret_cast<rocjitsu::Elf64_Ehdr *>(image.data());
-  auto *shdrs = reinterpret_cast<rocjitsu::Elf64_Shdr *>(image.data() + ehdr->e_shoff);
+  const auto ehdr = rocjitsu::read_elf_struct_for_test<rocjitsu::Elf64_Ehdr>(image, 0);
+  auto shdrs =
+      rocjitsu::read_elf_array_for_test<rocjitsu::Elf64_Shdr>(image, ehdr.e_shoff, ehdr.e_shnum);
 
   constexpr uint64_t fake_exec_vaddr = 0x9000;
-  shdrs[5].sh_flags = rocjitsu::SHF_ALLOC | rocjitsu::SHF_EXECINSTR;
+  shdrs[5].sh_flags = rocjitsu::SHF_EXECINSTR;
   shdrs[5].sh_addr = fake_exec_vaddr;
   shdrs[5].sh_size = sizeof(uint32_t);
+  for (size_t i = 0; i < shdrs.size(); ++i)
+    rocjitsu::write_elf_struct_for_test(image, ehdr.e_shoff + i * sizeof(rocjitsu::Elf64_Shdr),
+                                        shdrs[i]);
 
-  auto *kd = reinterpret_cast<KD *>(image.data() + shdrs[2].sh_offset);
-  kd->kernel_code_entry_byte_offset =
-      static_cast<int64_t>(fake_exec_vaddr) - static_cast<int64_t>(shdrs[2].sh_addr);
+  rocjitsu::write_kernel_descriptor_entry_offset(image.data() + shdrs[2].sh_offset,
+                                                 static_cast<int64_t>(fake_exec_vaddr) -
+                                                     static_cast<int64_t>(shdrs[2].sh_addr));
 
   rocjitsu::KernelDescriptorTranslator translator(ROCJITSU_CODE_ARCH_CDNA4,
                                                   ROCJITSU_CODE_ARCH_RDNA4);
   const auto translations = translator.translate_image(
       image, shdrs[1].sh_offset, shdrs[1].sh_size, rocjitsu::KernelDescriptorTranslationOptions{});
   EXPECT_TRUE(translations.empty())
-      << "descriptor entries must point into the .text section being translated";
+      << "non-loadable executable sections must not extend valid kernel entry range";
 }

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -2261,6 +2261,39 @@ TEST(BinaryTranslatorE2E, RelocatedKernelPreservesEntryWindowAndPatchesBranches)
   }
 }
 
+TEST(BinaryTranslatorE2E, RelocatedKernelCompactsReachableGapAfterEntryWindow) {
+  constexpr uint32_t kCdna4SEndpgm = 0xBF810000u;
+  std::vector<uint32_t> words(74, rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4));
+  words[0] = rocjitsu::build_s_branch(63, ROCJITSU_CODE_ARCH_CDNA4); // 0x00 -> 0x100.
+  words[64] = rocjitsu::build_s_branch(7, ROCJITSU_CODE_ARCH_CDNA4); // 0x100 -> 0x120.
+  words[72] = kCdna4SEndpgm;                                         // Reachable target.
+
+  auto image = rocjitsu::make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  rocjitsu::AmdGpuCodeObject source(image.data(), image.size());
+  ASSERT_TRUE(source.is_valid());
+
+  rocjitsu::BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_CDNA3);
+  auto result = translator.translate(source);
+  ASSERT_TRUE(result.ok()) << result.diagnostics.front().message;
+
+  rocjitsu::AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+
+  const auto *text = translated.text_sections()[0];
+  ASSERT_GE(text->size(), words.size() * sizeof(uint32_t));
+
+  const auto *target_words = reinterpret_cast<const uint32_t *>(text->data());
+  // The final ELF section is tail-padded back to the original size, but the
+  // relocated body still compacts reachable blocks after the protected 256-byte
+  // entry window. The source 0x120 target therefore lands immediately after the
+  // branch at word 64 instead of remaining at the original word 72.
+  EXPECT_EQ(target_words[0], rocjitsu::build_s_branch(63, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(target_words[64], rocjitsu::build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3));
+  EXPECT_EQ(target_words[65], kCdna4SEndpgm);
+  EXPECT_EQ(target_words[72], rocjitsu::build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3));
+}
+
 TEST(BinaryTranslatorE2E, RejectsIndirectBranchAndCallInstructions) {
   struct Case {
     const char *name;

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -2400,7 +2400,9 @@ TEST(Gfx1250SimulationTest, SGetShaderCyclesU64ReadsSimulationTime) {
 
   amdgpu::Wavefront *wf = dispatch_one_wave(sim, code, std::size(code));
   ASSERT_NE(wf, nullptr);
-  EXPECT_EQ(read_wave_sgpr64(*sim.cu(), *wf, 4), 17u);
+  const auto observed_time = read_wave_sgpr64(*sim.cu(), *wf, 4);
+  EXPECT_GE(observed_time, 17u);
+  EXPECT_LE(observed_time, sim.engine->global_time());
 }
 
 TEST(Gfx1250SimulationTest, SSendmsgRtnB64ReadsRealtimeAndB32UsesPlaceholder) {
@@ -2417,7 +2419,9 @@ TEST(Gfx1250SimulationTest, SSendmsgRtnB64ReadsRealtimeAndB32UsesPlaceholder) {
 
   amdgpu::Wavefront *wf = dispatch_one_wave(sim, code, std::size(code));
   ASSERT_NE(wf, nullptr);
-  EXPECT_EQ(read_wave_sgpr64(*sim.cu(), *wf, 4), 23u);
+  const auto observed_time = read_wave_sgpr64(*sim.cu(), *wf, 4);
+  EXPECT_GE(observed_time, 23u);
+  EXPECT_LE(observed_time, sim.engine->global_time());
   EXPECT_EQ(read_wave_sgpr(*sim.cu(), *wf, 6), 0u);
 }
 

--- a/emulation/rocjitsu/tests/simd_correctness/vop3_int_widening_ternary_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop3_int_widening_ternary_simd_correctness_test.cpp
@@ -78,21 +78,10 @@ const std::array<Case, 17> kCases = {{
     {"v_mad_legacy_u16_vop3", 491, true},
 }};
 
-const std::array<uint32_t, 14> kVals = {{
-    0x00000000u,
-    0x00000001u,
-    0x00000005u,
-    0x0000001Fu,
-    0x00000010u,
-    0x80000000u,
-    0x7FFFFFFFu,
-    0xFFFFFFFFu,
-    0x12345678u,
-    0xDEADBEEFu,
-    0xCAFEBABEu,
-    0xA5A5A5A5u,
-    0x5A5A5A5Au,
-    0xF0F0F0F0u,
+const std::array<uint32_t, 20> kVals = {{
+    0x00000000u, 0x00000001u, 0x00000005u, 0x0000001Fu, 0x00000010u, 0x00000020u, 0x0000003Fu,
+    0x00000040u, 0x007FFFFFu, 0x00800000u, 0x00FFFFFFu, 0x80000000u, 0x7FFFFFFFu, 0xFFFFFFFFu,
+    0x12345678u, 0xDEADBEEFu, 0xCAFEBABEu, 0xA5A5A5A5u, 0x5A5A5A5Au, 0xF0F0F0F0u,
 }};
 
 struct Fixture {

--- a/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/tools/rj_dbt_translate_smoke_test.cpp
@@ -10,6 +10,8 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -52,6 +54,16 @@ uint64_t align_up(uint64_t value, uint64_t alignment) {
   return remainder == 0 ? value : value + alignment - remainder;
 }
 
+void write_bytes(std::vector<uint8_t> &image, uint64_t offset, const void *src, size_t size) {
+  assert(offset <= image.size());
+  assert(size <= image.size() - offset);
+  std::memcpy(image.data() + offset, src, size);
+}
+
+template <typename T> void write_value(std::vector<uint8_t> &image, uint64_t offset, T value) {
+  write_bytes(image, offset, &value, sizeof(value));
+}
+
 std::vector<uint8_t> make_smoke_code_object() {
   using namespace rocjitsu;
 
@@ -83,46 +95,44 @@ std::vector<uint8_t> make_smoke_code_object() {
 
   std::vector<uint8_t> image(shoff + section_count * sizeof(Elf64_Shdr), 0);
 
-  Elf64_Ehdr ehdr{};
-  std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
-  ehdr.e_ident[EI_CLASS] = ELFCLASS64;
-  ehdr.e_ident[EI_DATA] = 1;
-  ehdr.e_ident[EI_VERSION] = 1;
-  ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
-  ehdr.e_ident[EI_ABIVERSION] = ELFABIVERSION_AMDGPU_HSA_V5;
-  ehdr.e_type = ET_DYN;
-  ehdr.e_machine = EM_AMDGPU;
-  ehdr.e_version = 1;
-  ehdr.e_phoff = sizeof(Elf64_Ehdr);
-  ehdr.e_shoff = shoff;
-  ehdr.e_flags = EF_AMDGPU_MACH_AMDGCN_GFX950;
-  ehdr.e_ehsize = sizeof(Elf64_Ehdr);
-  ehdr.e_phentsize = sizeof(Elf64_Phdr);
-  ehdr.e_phnum = phdr_count;
-  ehdr.e_shentsize = sizeof(Elf64_Shdr);
-  ehdr.e_shnum = section_count;
-  ehdr.e_shstrndx = 5;
-  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+  write_bytes(image, offsetof(Elf64_Ehdr, e_ident), EI_MAGIC, EI_MAGIC_SIZE);
+  image[offsetof(Elf64_Ehdr, e_ident) + EI_CLASS] = ELFCLASS64;
+  image[offsetof(Elf64_Ehdr, e_ident) + EI_DATA] = 1;
+  image[offsetof(Elf64_Ehdr, e_ident) + EI_VERSION] = 1;
+  image[offsetof(Elf64_Ehdr, e_ident) + EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  image[offsetof(Elf64_Ehdr, e_ident) + EI_ABIVERSION] = ELFABIVERSION_AMDGPU_HSA_V5;
+  write_value<uint16_t>(image, offsetof(Elf64_Ehdr, e_type), ET_DYN);
+  write_value<uint16_t>(image, offsetof(Elf64_Ehdr, e_machine), EM_AMDGPU);
+  write_value<uint32_t>(image, offsetof(Elf64_Ehdr, e_version), 1);
+  write_value<uint64_t>(image, offsetof(Elf64_Ehdr, e_phoff), sizeof(Elf64_Ehdr));
+  write_value<uint64_t>(image, offsetof(Elf64_Ehdr, e_shoff), shoff);
+  write_value<uint32_t>(image, offsetof(Elf64_Ehdr, e_flags), EF_AMDGPU_MACH_AMDGCN_GFX950);
+  write_value<uint16_t>(image, offsetof(Elf64_Ehdr, e_ehsize), sizeof(Elf64_Ehdr));
+  write_value<uint16_t>(image, offsetof(Elf64_Ehdr, e_phentsize), sizeof(Elf64_Phdr));
+  write_value<uint16_t>(image, offsetof(Elf64_Ehdr, e_phnum), phdr_count);
+  write_value<uint16_t>(image, offsetof(Elf64_Ehdr, e_shentsize), sizeof(Elf64_Shdr));
+  write_value<uint16_t>(image, offsetof(Elf64_Ehdr, e_shnum), section_count);
+  write_value<uint16_t>(image, offsetof(Elf64_Ehdr, e_shstrndx), 5);
 
-  std::array<Elf64_Phdr, phdr_count> phdrs{};
-  phdrs[0].p_type = PT_LOAD;
-  phdrs[0].p_flags = 0x5; // PF_R | PF_X
-  phdrs[0].p_offset = text_offset;
-  phdrs[0].p_vaddr = text_vaddr;
-  phdrs[0].p_paddr = text_vaddr;
-  phdrs[0].p_filesz = text_size;
-  phdrs[0].p_memsz = text_size;
-  phdrs[0].p_align = load_align;
+  const uint64_t phdr0 = sizeof(Elf64_Ehdr);
+  write_value<uint32_t>(image, phdr0 + offsetof(Elf64_Phdr, p_type), PT_LOAD);
+  write_value<uint32_t>(image, phdr0 + offsetof(Elf64_Phdr, p_flags), 0x5); // PF_R | PF_X
+  write_value<uint64_t>(image, phdr0 + offsetof(Elf64_Phdr, p_offset), text_offset);
+  write_value<uint64_t>(image, phdr0 + offsetof(Elf64_Phdr, p_vaddr), text_vaddr);
+  write_value<uint64_t>(image, phdr0 + offsetof(Elf64_Phdr, p_paddr), text_vaddr);
+  write_value<uint64_t>(image, phdr0 + offsetof(Elf64_Phdr, p_filesz), text_size);
+  write_value<uint64_t>(image, phdr0 + offsetof(Elf64_Phdr, p_memsz), text_size);
+  write_value<uint64_t>(image, phdr0 + offsetof(Elf64_Phdr, p_align), load_align);
 
-  phdrs[1].p_type = PT_LOAD;
-  phdrs[1].p_flags = 0x4; // PF_R
-  phdrs[1].p_offset = rodata_offset;
-  phdrs[1].p_vaddr = rodata_vaddr;
-  phdrs[1].p_paddr = rodata_vaddr;
-  phdrs[1].p_filesz = kernel_descriptor_size;
-  phdrs[1].p_memsz = kernel_descriptor_size;
-  phdrs[1].p_align = load_align;
-  std::memcpy(image.data() + ehdr.e_phoff, phdrs.data(), phdrs.size() * sizeof(Elf64_Phdr));
+  const uint64_t phdr1 = phdr0 + sizeof(Elf64_Phdr);
+  write_value<uint32_t>(image, phdr1 + offsetof(Elf64_Phdr, p_type), PT_LOAD);
+  write_value<uint32_t>(image, phdr1 + offsetof(Elf64_Phdr, p_flags), 0x4); // PF_R
+  write_value<uint64_t>(image, phdr1 + offsetof(Elf64_Phdr, p_offset), rodata_offset);
+  write_value<uint64_t>(image, phdr1 + offsetof(Elf64_Phdr, p_vaddr), rodata_vaddr);
+  write_value<uint64_t>(image, phdr1 + offsetof(Elf64_Phdr, p_paddr), rodata_vaddr);
+  write_value<uint64_t>(image, phdr1 + offsetof(Elf64_Phdr, p_filesz), kernel_descriptor_size);
+  write_value<uint64_t>(image, phdr1 + offsetof(Elf64_Phdr, p_memsz), kernel_descriptor_size);
+  write_value<uint64_t>(image, phdr1 + offsetof(Elf64_Phdr, p_align), load_align);
 
   // Use a CDNA4 waitcnt that lowers to split RDNA4 wait instructions so the
   // diff report is guaranteed to contain a shown source/target pair.
@@ -133,7 +143,7 @@ std::vector<uint8_t> make_smoke_code_object() {
   // descriptors. For this smoke fixture only the entry offset must be valid;
   // the remaining descriptor fields can stay zero.
   constexpr size_t kernel_code_entry_byte_offset_offset = 16;
-  std::array<uint8_t, kernel_descriptor_size> kernel_descriptor{};
+  std::vector<uint8_t> kernel_descriptor(kernel_descriptor_size, 0);
   const int64_t entry_offset =
       static_cast<int64_t>(text_vaddr) - static_cast<int64_t>(rodata_vaddr);
   std::memcpy(kernel_descriptor.data() + kernel_code_entry_byte_offset_offset, &entry_offset,
@@ -141,55 +151,39 @@ std::vector<uint8_t> make_smoke_code_object() {
   std::memcpy(image.data() + rodata_offset, kernel_descriptor.data(), kernel_descriptor.size());
   std::memcpy(image.data() + strtab_offset, strtab.data(), strtab.size());
 
-  std::array<Elf64_Sym, sym_count> syms{};
-  syms[1].st_name = kd_symbol_name;
-  syms[1].st_info = elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject);
-  syms[1].st_shndx = 2;
-  syms[1].st_value = rodata_vaddr;
-  syms[1].st_size = kernel_descriptor.size();
-  std::memcpy(image.data() + symtab_offset, syms.data(), syms.size() * sizeof(Elf64_Sym));
+  const uint64_t sym1 = symtab_offset + sizeof(Elf64_Sym);
+  write_value<uint32_t>(image, sym1 + offsetof(Elf64_Sym, st_name), kd_symbol_name);
+  write_value<unsigned char>(image, sym1 + offsetof(Elf64_Sym, st_info),
+                             elf_symbol_info(kElfSymbolBindGlobal, kElfSymbolTypeObject));
+  write_value<uint16_t>(image, sym1 + offsetof(Elf64_Sym, st_shndx), 2);
+  write_value<uint64_t>(image, sym1 + offsetof(Elf64_Sym, st_value), rodata_vaddr);
+  write_value<uint64_t>(image, sym1 + offsetof(Elf64_Sym, st_size), kernel_descriptor.size());
 
   std::memcpy(image.data() + shstrtab_offset, shstrtab.data(), shstrtab.size());
 
-  std::array<Elf64_Shdr, section_count> shdrs{};
-  shdrs[1].sh_name = text_name;
-  shdrs[1].sh_type = SHT_PROGBITS;
-  shdrs[1].sh_flags = SHF_ALLOC | SHF_EXECINSTR;
-  shdrs[1].sh_addr = text_vaddr;
-  shdrs[1].sh_offset = text_offset;
-  shdrs[1].sh_size = text_size;
-  shdrs[1].sh_addralign = sizeof(uint32_t);
-
-  shdrs[2].sh_name = rodata_name;
-  shdrs[2].sh_type = SHT_PROGBITS;
-  shdrs[2].sh_flags = SHF_ALLOC;
-  shdrs[2].sh_addr = rodata_vaddr;
-  shdrs[2].sh_offset = rodata_offset;
-  shdrs[2].sh_size = kernel_descriptor_size;
-  shdrs[2].sh_addralign = 64;
-
-  shdrs[3].sh_name = symtab_name;
-  shdrs[3].sh_type = SHT_SYMTAB;
-  shdrs[3].sh_offset = symtab_offset;
-  shdrs[3].sh_size = syms.size() * sizeof(Elf64_Sym);
-  shdrs[3].sh_link = 4;
-  shdrs[3].sh_info = 1;
-  shdrs[3].sh_addralign = 8;
-  shdrs[3].sh_entsize = sizeof(Elf64_Sym);
-
-  shdrs[4].sh_name = strtab_name;
-  shdrs[4].sh_type = SHT_STRTAB;
-  shdrs[4].sh_offset = strtab_offset;
-  shdrs[4].sh_size = strtab.size();
-  shdrs[4].sh_addralign = 1;
-
-  shdrs[5].sh_name = shstrtab_name;
-  shdrs[5].sh_type = SHT_STRTAB;
-  shdrs[5].sh_offset = shstrtab_offset;
-  shdrs[5].sh_size = shstrtab.size();
-  shdrs[5].sh_addralign = 1;
-
-  std::memcpy(image.data() + shoff, shdrs.data(), shdrs.size() * sizeof(Elf64_Shdr));
+  const auto write_shdr = [&](uint64_t index, uint32_t name, uint32_t type, uint64_t flags,
+                              uint64_t addr, uint64_t offset, uint64_t size, uint32_t link,
+                              uint32_t info, uint64_t addralign, uint64_t entsize) {
+    const uint64_t base = shoff + index * sizeof(Elf64_Shdr);
+    write_value<uint32_t>(image, base + offsetof(Elf64_Shdr, sh_name), name);
+    write_value<uint32_t>(image, base + offsetof(Elf64_Shdr, sh_type), type);
+    write_value<uint64_t>(image, base + offsetof(Elf64_Shdr, sh_flags), flags);
+    write_value<uint64_t>(image, base + offsetof(Elf64_Shdr, sh_addr), addr);
+    write_value<uint64_t>(image, base + offsetof(Elf64_Shdr, sh_offset), offset);
+    write_value<uint64_t>(image, base + offsetof(Elf64_Shdr, sh_size), size);
+    write_value<uint32_t>(image, base + offsetof(Elf64_Shdr, sh_link), link);
+    write_value<uint32_t>(image, base + offsetof(Elf64_Shdr, sh_info), info);
+    write_value<uint64_t>(image, base + offsetof(Elf64_Shdr, sh_addralign), addralign);
+    write_value<uint64_t>(image, base + offsetof(Elf64_Shdr, sh_entsize), entsize);
+  };
+  write_shdr(1, text_name, SHT_PROGBITS, SHF_ALLOC | SHF_EXECINSTR, text_vaddr, text_offset,
+             text_size, 0, 0, sizeof(uint32_t), 0);
+  write_shdr(2, rodata_name, SHT_PROGBITS, SHF_ALLOC, rodata_vaddr, rodata_offset,
+             kernel_descriptor_size, 0, 0, 64, 0);
+  write_shdr(3, symtab_name, SHT_SYMTAB, 0, 0, symtab_offset, sym_count * sizeof(Elf64_Sym), 4, 1,
+             8, sizeof(Elf64_Sym));
+  write_shdr(4, strtab_name, SHT_STRTAB, 0, 0, strtab_offset, strtab.size(), 0, 0, 1, 0);
+  write_shdr(5, shstrtab_name, SHT_STRTAB, 0, 0, shstrtab_offset, shstrtab.size(), 0, 0, 1, 0);
   return image;
 }
 

--- a/emulation/rocjitsu/tests/util_simd_test.cpp
+++ b/emulation/rocjitsu/tests/util_simd_test.cpp
@@ -47,6 +47,17 @@ inline int sweep_iters() {
 
 constexpr std::size_t kW = util::native_width_v<uint32_t>;
 
+TEST(UtilSimd, Native64MaskWorkaroundMacroIsBooleanOverridePoint) {
+  constexpr int workaround = UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS;
+  static_assert(workaround == 0 || workaround == 1);
+
+#if defined(__clang__) && defined(__GLIBCXX__) && defined(__AVX512F__)
+  EXPECT_EQ(workaround, 1);
+#else
+  EXPECT_EQ(workaround, 0);
+#endif
+}
+
 TEST(UtilSimd, Load_Contiguous_U32) {
   SKIP_IF_NO_SIMD();
   alignas(util::native<uint32_t>) uint32_t src[kW];

--- a/emulation/rocjitsu/tests/util_simd_test.cpp
+++ b/emulation/rocjitsu/tests/util_simd_test.cpp
@@ -49,13 +49,17 @@ constexpr std::size_t kW = util::native_width_v<uint32_t>;
 
 TEST(UtilSimd, Native64MaskWorkaroundMacroIsBooleanOverridePoint) {
   constexpr int workaround = UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS;
+  constexpr int user_override = UTIL_SIMD_BROKEN_NATIVE_64BIT_MASKS_USER_OVERRIDE;
   static_assert(workaround == 0 || workaround == 1);
+  static_assert(user_override == 0 || user_override == 1);
 
+  if constexpr (!user_override) {
 #if defined(__clang__) && defined(__GLIBCXX__) && defined(__AVX512F__)
-  EXPECT_EQ(workaround, 1);
+    EXPECT_EQ(workaround, 1);
 #else
-  EXPECT_EQ(workaround, 0);
+    EXPECT_EQ(workaround, 0);
 #endif
+  }
 }
 
 TEST(UtilSimd, Load_Contiguous_U32) {


### PR DESCRIPTION
## Motivation

Fix sanitizer-reported issues in the AMDGPU ISA execution and DBT translation paths so the gfx1250 execution, translation, and SIMD paths can be validated under sanitizer builds.

## Technical Details

This updates the:
* generated AMDISA execute helpers
* semantic lowering for affected AMDGPU instructions
* shared AMDGPU execute code
* SIMD glue used by the execution path
* DBT relocation expectations for the preserved descriptor-entry window
* sanitizer-stable gfx1250 simulation time checks
* related execution and translation tests

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Validated with focused rocjitsu sanitizer coverage across clang22 and GCC13:
* ASAN
* UBSAN
* FPSAN via `-fsanitize=undefined,float-divide-by-zero,float-cast-overflow`

Also reran clang22 TSAN coverage for the same focused slice

## Test Result

All relevant tests passing.


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
