### PR TITLE
fix(rocr): Bound code-object segment loads against allocation

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
@@ -716,6 +716,11 @@ namespace elf {
 
       const char* data() override { assert(buffer); return buffer; }
       uint64_t size() override;
+      // Size in bytes of the raw backing buffer this image was initialized
+      // from, or 0 if the image is not buffer-backed. Unlike size(), this is
+      // not derived from attacker-controlled ELF header fields and is therefore
+      // safe to use for bounds checks.
+      size_t getBufferSize() const { return bufferSize; }
 
       bool push();
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -1486,8 +1486,10 @@ hsa_status_t ExecutableImpl::LoadSegmentV1(hsa_agent_t agent,
     if (s->imageSize() > s->memSize()) {
       return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
     }
+    // Reject a segment whose file contents cannot be sourced from within the
+    // backing image (crafted p_offset). See ROCM-26177 finding #1.
     const char* segment_data = s->data();
-    if (!segment_data) {
+    if (s->imageSize() > 0 && segment_data == nullptr) {
       return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
     }
     void* ptr = context_->SegmentAlloc(segment, agent, s->memSize(), s->align(), true);
@@ -1511,10 +1513,32 @@ hsa_status_t ExecutableImpl::LoadSegmentV2(const code::Segment *data_segment,
   if (data_segment->imageSize() > data_segment->memSize()) {
     return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   }
-  const char* segment_data = data_segment->data();
-  if (!segment_data) {
+  // The combined code segment allocation is sized from the last data segment
+  // only (see LoadSegmentsV2). A crafted code object with non-monotonic,
+  // overlapping, or out-of-range p_vaddr values could otherwise drive the copy
+  // below past the end of that allocation (heap OOB write). Bound the copy
+  // destination [offset, offset + imageSize) against the allocation explicitly,
+  // since Segment::Offset() only asserts the start address and compiles out
+  // under NDEBUG. See ROCM-26177 finding #1.
+  const uint64_t seg_vaddr = data_segment->vaddr();
+  const uint64_t base_vaddr = load_segment->VAddr();
+  const size_t alloc_size = load_segment->Size();
+  if (seg_vaddr < base_vaddr) {
     return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   }
+  const uint64_t offset = seg_vaddr - base_vaddr;
+  if (offset > alloc_size ||
+      data_segment->imageSize() > alloc_size - offset) {
+    return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+  }
+
+  // Reject a segment whose file contents cannot be sourced from within the
+  // backing image (crafted p_offset). See ROCM-26177 finding #1.
+  const char* segment_data = data_segment->data();
+  if (data_segment->imageSize() > 0 && segment_data == nullptr) {
+    return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
+  }
+
   load_segment->Copy(data_segment->vaddr(), segment_data,
                      data_segment->imageSize());
 


### PR DESCRIPTION
## Summary

Builds on #6996. The p_filesz <= p_memsz check added there closes one heap out-of-bounds write variant, but the segment loader still trusts two other attacker-controlled fields when loading an untrusted code object:

- p_vaddr: LoadSegmentsV2 sizes the combined code-segment allocation from the last data segment only, then copies each segment at its own p_vaddr. Non-monotonic, overlapping, or out-of-range p_vaddr values can drive the per-segment copy past the end of the allocation (CWE-787).
- p_offset: GElfSegment::data() returns elf->data() + p_offset with no bound against the backing buffer, so the loader memcpy can read heap memory adjacent to the image into the destination (CWE-125 / cross-allocation disclosure).

Fixes:
- LoadSegmentV2: validate the copy destination [offset, offset+imageSize) against the destination allocation size before copying.
- GElfSegment::data(): bound p_offset and p_offset+p_filesz against the raw buffer size; return nullptr when out of range.
- LoadSegmentV1/V2: reject a segment whose data() is null (unsourceable).

Addresses ROCM-26177 finding #1 (and the SWSPLAT-24378 p_offset read path).

## JIRA ID

JIRA ID : ROCM-26177

## Test plan

- [ ] Load a normal code object / run an existing kernel; confirm no regression.
- [ ] Load a crafted code object with out-of-range p_vaddr or p_offset; confirm rejection with HSA_STATUS_ERROR_INVALID_CODE_OBJECT.