### PR TITLE
Add RCCL_MAX_PAT_NCHANNELS to cap PAT channel count

### DIFF
--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1081,6 +1081,10 @@ NCCL_PARAM(P2pLLThreshold, "P2P_LL_THRESHOLD", 8192);
 RCCL_PARAM(P2pNetThreshold, "P2P_NET_THRESHOLD", 131072);
 NCCL_PARAM(ChunkSize, "CHUNK_SIZE", 0);
 
+// Upper bound on the number of channels used by the PAT algorithm.
+// Set to <= 0 to disable the cap.
+RCCL_PARAM(MaxPatNchannels, "MAX_PAT_NCHANNELS", 4);
+
 
 // Need this temporary parameter to disable p2p batching to avoid some dips at 4MB - 32 MB message size at large scale
 // This parameter must be removed after further investigation,
@@ -2444,6 +2448,11 @@ static ncclResult_t topoGetAlgoInfo(
     }
   } else if (info->algorithm == NCCL_ALGO_PAT) {
     nc = (nBytes <= (32 << 10)) ? 1 : (nBytes <= (64 << 10)) ? 2 : (nBytes <= (1 << 20)) ? 4 : comm->nChannels;
+
+    int maxPatNChannels = rcclParamMaxPatNchannels();
+    if (maxPatNChannels > 0) {
+      nc = std::min(maxPatNChannels, nc);
+    }
 
     int minNChannels = ncclParamMinNchannels();
     int maxNChannels = ncclParamMaxNchannels();

--- a/projects/rccl/src/transport/generic.cc
+++ b/projects/rccl/src/transport/generic.cc
@@ -8,8 +8,13 @@
 #include "comm.h"
 #include "transport.h"
 #include "bootstrap.h"
+#include "param.h"
+#include <algorithm>
 
 NCCL_PARAM(MultiSegmentRegister, "MULTI_SEGMENT_REGISTER", 1);
+
+// Defined in enqueue.cc; caps the number of channels used by the PAT algorithm.
+RCCL_PARAM_DECLARE(MaxPatNchannels);
 
 ncclResult_t ncclTransportRingConnect(struct ncclComm* comm) {
   struct ringConnInfo {
@@ -67,19 +72,23 @@ fail:
 ncclResult_t ncclTransportPatConnect(struct ncclComm* comm) {
   ncclResult_t ret = ncclSuccess;
   if (comm && comm->nRanks > 1) {
+    // Only connect the channels that the PAT algorithm is allowed to use.
+    int nChannels = comm->nChannels;
+    int maxPatNChannels = rcclParamMaxPatNchannels();
+    if (maxPatNChannels > 0) nChannels = std::min(nChannels, maxPatNChannels);
     for (int mask=1; mask<comm->nRanks; mask<<=1) {
       int prevPeer = (comm->rank + mask) % comm->nRanks;
       int nextPeer = (comm->rank + comm->nRanks - mask) % comm->nRanks;
-      for (int c = 0; c < comm->nChannels; c++) {
+      for (int c = 0; c < nChannels; c++) {
         NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &prevPeer, 1, &nextPeer, 0), ret, fail); // ReduceScatter
       }
       NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_TREE], 0), ret, fail);
-      for (int c = 0; c < comm->nChannels; c++) {
+      for (int c = 0; c < nChannels; c++) {
         NCCLCHECKGOTO(ncclTransportP2pConnect(comm, c, 1, &nextPeer, 1, &prevPeer, 0), ret, fail); // AllGather
       }
       NCCLCHECKGOTO(ncclTransportP2pSetup(comm, &comm->graphs[NCCL_ALGO_TREE], 0), ret, fail);
     }
-    INFO(NCCL_INIT, "Connected binomial trees");
+    INFO(NCCL_INIT, "Connected binomial trees (PAT channels %d)", nChannels);
   }
 exit:
   return ret;


### PR DESCRIPTION
## Motivation

PAT peer-to-peer connections follow a recursive halving-doubling pattern. It can unnecessarily use a lot of connection, up to NCC_MAX_NCHANNELS, if not capped. 

## Technical Details

Introduce the RCCL_MAX_PAT_NCHANNELS env var (default 4) to bound the number of channels used by the PAT algorithm, applied before the existing MIN/MAX_NCHANNELS clamps. Set to <= 0 to disable the cap.

## JIRA ID

AICOMRCCL-957

## Test Plan

Test PAT connections/QPs usage

## Test Result

Connections/QPs match expectation

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
