### PR TITLE
[rocprofiler-systems] Report commit SHA in version banner when not on an exact tag

### DIFF
--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -51,31 +51,47 @@ set(BINARY_NAME_PREFIX "rocprof-sys")
 
 find_package(Git)
 
-if(Git_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+# ROCPROFSYS_GIT_DESCRIBE / ROCPROFSYS_GIT_REVISION may be provided on the command
+# line (e.g. tarball/CI builds with no git checkout); honor those if set.
+if(
+    NOT DEFINED ROCPROFSYS_GIT_DESCRIBE
+    AND NOT DEFINED ROCPROFSYS_GIT_REVISION
+    AND Git_FOUND
+)
+    # detect a git checkout via git itself rather than a literal .git directory so
+    # this works when the source is a subdirectory/submodule of a larger repo (the
+    # rocm-systems monorepo) where .git is not under PROJECT_SOURCE_DIR
     execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --tags
-        OUTPUT_VARIABLE ROCPROFSYS_GIT_DESCRIBE
+        COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        OUTPUT_VARIABLE ROCPROFSYS_GIT_REVISION
         OUTPUT_STRIP_TRAILING_WHITESPACE
-        RESULT_VARIABLE _GIT_DESCRIBE_RESULT
+        RESULT_VARIABLE _GIT_REVISION_RESULT
         ERROR_QUIET
     )
-    if(NOT _GIT_DESCRIBE_RESULT EQUAL 0)
+    if(_GIT_REVISION_RESULT EQUAL 0)
+        # Only record a tag when HEAD is *exactly* a tagged commit; otherwise leave
+        # it empty so the banner falls back to the full commit SHA instead of
+        # reporting a stale/nearest tag name that does not identify the source
         execute_process(
-            COMMAND ${GIT_EXECUTABLE} describe
+            COMMAND ${GIT_EXECUTABLE} describe --tags --exact-match
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
             OUTPUT_VARIABLE ROCPROFSYS_GIT_DESCRIBE
             OUTPUT_STRIP_TRAILING_WHITESPACE
             RESULT_VARIABLE _GIT_DESCRIBE_RESULT
             ERROR_QUIET
         )
+        if(NOT _GIT_DESCRIBE_RESULT EQUAL 0)
+            set(ROCPROFSYS_GIT_DESCRIBE "")
+        endif()
+    else()
+        set(ROCPROFSYS_GIT_REVISION "")
     endif()
-    execute_process(
-        COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
-        OUTPUT_VARIABLE ROCPROFSYS_GIT_REVISION
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-    )
-else()
-    set(ROCPROFSYS_GIT_DESCRIBE "v${ROCPROFSYS_VERSION}")
+endif()
+if(NOT DEFINED ROCPROFSYS_GIT_DESCRIBE)
+    set(ROCPROFSYS_GIT_DESCRIBE "")
+endif()
+if(NOT DEFINED ROCPROFSYS_GIT_REVISION)
     set(ROCPROFSYS_GIT_REVISION "")
 endif()
 

--- a/projects/rocprofiler-systems/CMakeLists.txt
+++ b/projects/rocprofiler-systems/CMakeLists.txt
@@ -63,7 +63,7 @@ if(
     # rocm-systems monorepo) where .git is not under PROJECT_SOURCE_DIR
     execute_process(
         COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
-        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
         OUTPUT_VARIABLE ROCPROFSYS_GIT_REVISION
         OUTPUT_STRIP_TRAILING_WHITESPACE
         RESULT_VARIABLE _GIT_REVISION_RESULT
@@ -75,7 +75,7 @@ if(
         # reporting a stale/nearest tag name that does not identify the source
         execute_process(
             COMMAND ${GIT_EXECUTABLE} describe --tags --exact-match
-            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
             OUTPUT_VARIABLE ROCPROFSYS_GIT_DESCRIBE
             OUTPUT_STRIP_TRAILING_WHITESPACE
             RESULT_VARIABLE _GIT_DESCRIBE_RESULT


### PR DESCRIPTION
## Motivation

When rocprofiler-systems starts it prints a version banner, e.g.:

```
rocprof-sys v1.3.0 (tag: v1.3.0, x86_64-linux-gnu, compiler: GNU v11.4.0, rocm: v7.2.x)
```

The `tag: v1.3.0` shown here does not exist in the repository. Builds that are not on an exact tagged commit reported a non-existent or stale tag name, making it impossible to identify the exact source used to produce the binary.

## Technical Details

The banner derived its `tag:` field from `git describe --tags` (nearest tag + offset) and fell back to a fabricated `v${VERSION}` when no `.git` directory was found under `PROJECT_SOURCE_DIR`. In the rocm-systems monorepo, `.git` lives at the repo root rather than the project subdirectory, so this **always** hit the fabricated fallback.

Changes in `CMakeLists.txt`:
- Detect the git checkout via `git` itself (using `WORKING_DIRECTORY`) instead of checking for a literal `.git` directory, so it works when the source is a subdirectory of a larger repo.
- Record a tag only when HEAD is an **exact** tag match (`git describe --tags --exact-match`); otherwise leave it empty so the banner reports the full commit SHA (`ROCPROFSYS_GIT_REVISION`) instead.
- Honor `ROCPROFSYS_GIT_DESCRIBE` / `ROCPROFSYS_GIT_REVISION` when provided on the command line, for tarball/CI builds with no checkout.

Resulting behavior:
- On an exact tag → `rocprof-sys v1.3.0 (tag: v1.3.0, ...)` (unchanged, correct).
- Non-tagged / dev / CI build → `rocprof-sys v1.7.0 (rev: <full-sha>, ...)` — no more fabricated tag.

## JIRA ID

Resolves AIPROFSYST-571

## Test Plan

- Reconfigured CMake in the monorepo checkout and inspected the computed git variables and the generated `defines.h`.
- Built the project to confirm it compiles and links.

## Test Result

- `git revision` populated with the full HEAD SHA; `git describe` empty (no fabricated `v1.7.0`).
- Generated `defines.h`: `ROCPROFSYS_GIT_REVISION` = full SHA, `ROCPROFSYS_GIT_DESCRIBE` = "".
- Core library builds and links cleanly.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.