### PR TITLE
Fix ISA feature matching for gfx1250

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -197,7 +197,10 @@ GpuAgent::GpuAgent(HSAuint32 node, const HsaNodeProperties& node_props, bool xna
                              node_props.EngineId.ui32.Stepping), sramecc, xnack);
   }
 
-  assert(isa_ != nullptr && "ISA registry inconsistency.");
+  if (!isa_) {
+    throw AMD::hsa_exception(HSA_STATUS_ERROR_INVALID_ISA,
+                             "Agent creation failed.\nNo ISA variant matched requested feature state.\n");
+  }
 
   supported_isas_.push_back(isa_);
   if (!isa_->GetIsaGeneric().empty()) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/isa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/isa.cpp
@@ -250,14 +250,17 @@ const Isa *IsaRegistry::GetIsa(const std::string &full_name) {
 }
 
 const Isa *IsaRegistry::GetIsa(const Isa::Version &version, IsaFeature sramecc, IsaFeature xnack) {
+  auto feature_matches = [](IsaFeature registered, IsaFeature requested) {
+    return registered == IsaFeature::Unsupported ||
+           registered == IsaFeature::Any ||
+           registered == requested;
+  };
   auto isareg_iter = std::find_if(GetSupportedIsas().begin(),
                                   GetSupportedIsas().end(),
                                   [&](const IsaMap::value_type& isareg) {
                                     return isareg.second.GetVersion() == version &&
-                                        (isareg.second.GetSramecc() == IsaFeature::Unsupported ||
-                                         isareg.second.GetSramecc() == sramecc) &&
-                                        (isareg.second.GetXnack() == IsaFeature::Unsupported ||
-                                         isareg.second.GetXnack() == xnack);
+                                        feature_matches(isareg.second.GetSramecc(), sramecc) &&
+                                        feature_matches(isareg.second.GetXnack(), xnack);
                                   });
   return isareg_iter == GetSupportedIsas().end() ?
                                               nullptr : &isareg_iter->second;


### PR DESCRIPTION
## Summary
- fix ISA lookup for gfx1250/gfx1251 entries registered with `IsaFeature::Any`
- add a defensive runtime error if GPU agent creation cannot resolve an ISA variant
- validated the patched runtime on a gfx1250 system with `rocminfo` and the shipped HIP empty-kernel gate

## Regression Source
This is a follow-up fix for the regression introduced by #7300.

PR #4975 originally added `gfx1250` to the ISA registry as:

```cpp
ISAREG_ENTRY_GEN("gfx1250", 12, 5, 0, unsupported, unsupported, 32, "gfx12-generic")
```

That shape worked with the existing feature-qualified lookup because `Unsupported` was already treated as a match for concrete runtime feature requests.

PR #7300 then changed the registration to support gfx12.5 generic code objects:

```cpp
ISAREG_ENTRY_GEN("gfx1250", 12, 5, 0, any, any, 32, "gfx12-5-generic")
ISAREG_ENTRY_GEN("gfx1251", 12, 5, 1, any, any, 32, "gfx12-5-generic")
```

That exposed a pre-existing mismatch in `IsaRegistry::GetIsa(version, sramecc, xnack)`: the lookup accepted `Unsupported` or exact equality only. It did not treat a registered `Any` feature as compatible with a concrete requested feature state.

On some systems, agent creation requests a concrete feature state, for example disabled/disabled. The registered `gfx1250` entry is now any/any, so the lookup returned `nullptr`. `GpuAgent::GpuAgent` then assumed `isa_` was valid and dereferenced it during `hsa_init`, causing `rocminfo` and HIP startup to segfault in `libhsa-runtime64.so.1`.

## Fix
This PR updates the feature-qualified ISA lookup so registered wildcard-style feature states match concrete runtime requests:

- `Unsupported` still matches, preserving existing behavior.
- `Any` now also matches a concrete requested feature state.
- Exact feature matches continue to work as before.
- The requested feature state is not treated as a wildcard, which avoids accidentally selecting an arbitrary enabled/disabled-specific ISA when the caller asks for `Any`.

It also replaces the release-build-only `assert(isa_ != nullptr)` with a runtime guard that raises `HSA_STATUS_ERROR_INVALID_ISA`. That prevents future ISA table mismatches from becoming a null-pointer crash.

## gfx1250 Validation
Validated using the TheRock gfx1250 build that previously failed.

Artifacts/logs are preserved under:

Validation results:

- Built patched `hsa-runtime64` from this PR branch at commit `55f6578b18bafb40888b97fe6df04e9771ed18df`.
- `ldd` confirmed the test binaries loaded the patched `libhsa-runtime64.so.1` from the PR build.
- `rocminfo` using the ROCm `rocminfo` binary exited `0` and reported `4` `gfx1250` agents.
- Shipped HIP gate passed: `KernelTest Unit_hipEmptyKernel`, `ROCR_VISIBLE_DEVICES=0`, `1 test case passed`.
- No new `rocminfo`/HIP segfault appeared in the post-run `dmesg` tail.

## Earlier Local Checks
- `git diff --check`
- `custom-ai-secret-scan --repo-root .codex_tmp/rocm-systems-develop`