### PR TITLE
[hipfile][ais-check] Add unit test suite and CI workflow

### DIFF
--- a/.github/workflows/hipfile-ais-check.yml
+++ b/.github/workflows/hipfile-ais-check.yml
@@ -1,0 +1,53 @@
+# Run the ais-check unit test suite
+
+name: "hipFile ais-check tests"
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'projects/hipfile/tools/ais-check/**'
+      - '.github/workflows/hipfile-ais-check.yml'
+  pull_request:
+    paths:
+      - 'projects/hipfile/tools/ais-check/**'
+      - '.github/workflows/hipfile-ais-check.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hipfile-ais-check:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Floor matches pyproject's requires-python; "3.x" floats to the
+        # latest stable release so new versions are covered without edits.
+        python-version: ["3.10", "3.x"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: |
+            projects/hipfile/tools/ais-check
+            .github/workflows
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python packages
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pytest
+
+      - name: Run ais-check tests
+        run: |
+          cd projects/hipfile/tools/ais-check/tests
+          python -m pytest

--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -9,6 +9,9 @@ on:
       - '.github/workflows/hipfile-*.yml'
       - '!**/*.md'
       - '!**/*.rst'
+      # ais-check is a self-contained Python tool with no dependency on the C++
+      # library, so its changes shouldn't trigger the full C++ build/test.
+      - '!projects/hipfile/tools/ais-check/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/hipfile-pylint.yml
+++ b/.github/workflows/hipfile-pylint.yml
@@ -41,6 +41,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pylint
           python -m pip install black
+          python -m pip install pytest
           pip install -r projects/hipfile/docs/sphinx/requirements.in
 
       - name: Lint all Python files

--- a/projects/hipfile/tools/ais-check/tests/README.md
+++ b/projects/hipfile/tools/ais-check/tests/README.md
@@ -1,0 +1,36 @@
+# ais-check tests
+
+Unit tests for the `ais-check` tool. They are fully hermetic: every system
+touchpoint (kernel config files, `/proc/kallsyms`, environment variables,
+`glob` over `/opt/rocm`, and `ctypes.CDLL`) is faked with `monkeypatch`, so the
+suite runs and produces identical results on any machine — no ROCm install,
+GPU, or special privileges required.
+
+## Running
+
+From the repository root:
+
+```
+pip install pytest
+cd projects/hipfile/tools/ais-check/tests
+python3 -m pytest
+```
+
+## Layout
+
+| File | Covers |
+|------|--------|
+| `conftest.py` | Loads the extensionless `ais-check` script as an importable `ais_check` module (via `SourceFileLoader`) and exposes it as a fixture. |
+| `test_p2pdma.py` | `kernel_supports_p2pdma()` — each config source, missing/`=m`/commented options, and the "no configs found" warning. |
+| `test_find_hip_runtimes.py` | `find_hip_runtimes()` — env-var search paths, symlink dedup, soname handling, and literal matching of glob metacharacters. |
+| `test_hip_runtime_ais.py` | `hip_runtime_supports_ais()` — symbol probing via a fake HIP handle, old-runtime and load-failure paths, and the three-part symbol success check. |
+| `test_amdgpu.py` | `amdgpu_supports_ais()` — symbol present/absent and the not-found/permission-denied branches. |
+| `test_main.py` | `main()` — the exit-code contract and `-q`/`-v` output behavior. |
+
+## Notes
+
+- The `ais_check` fixture imports the script as a module, which means
+  `if __name__ == "__main__"` does not run `main()` at import time.
+- Tests patch attributes on the loaded module (e.g. `ais_check.os.uname`,
+  `ais_check.ctypes.CDLL`), so the real environment never leaks in — capturing
+  the original `glob.glob` before patching avoids recursion.

--- a/projects/hipfile/tools/ais-check/tests/conftest.py
+++ b/projects/hipfile/tools/ais-check/tests/conftest.py
@@ -1,0 +1,32 @@
+"""
+Shared test fixtures for the ais-check suite.
+
+The tool ships as an executable named ``ais-check`` (no ``.py`` extension and a
+hyphen), so it cannot be imported with a normal ``import`` statement. This shim
+loads it from source as a module named ``ais_check`` and exposes it as a
+session-scoped fixture.
+"""
+
+import importlib.util
+import os
+from importlib.machinery import SourceFileLoader
+
+import pytest
+
+_SCRIPT_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "ais-check")
+
+
+def _load_ais_check():
+    # The script has no .py extension, so spec_from_file_location can't infer a
+    # loader; supply a source loader explicitly.
+    loader = SourceFileLoader("ais_check", _SCRIPT_PATH)
+    spec = importlib.util.spec_from_loader("ais_check", loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="session")
+def ais_check():
+    """The ais-check script loaded as an importable module."""
+    return _load_ais_check()

--- a/projects/hipfile/tools/ais-check/tests/pytest.ini
+++ b/projects/hipfile/tools/ais-check/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = .
+python_files = test_*.py

--- a/projects/hipfile/tools/ais-check/tests/test_amdgpu.py
+++ b/projects/hipfile/tools/ais-check/tests/test_amdgpu.py
@@ -1,0 +1,51 @@
+"""Tests for amdgpu_supports_ais()."""
+
+# pylint: disable=missing-function-docstring
+
+import io
+
+
+def _patch_open(monkeypatch, ais_check, *, content=None, exc=None):
+    def fake_open(path, *_args, **_kwargs):
+        assert path == "/proc/kallsyms"
+        if exc is not None:
+            raise exc
+        return io.StringIO(content)
+
+    monkeypatch.setattr(ais_check, "open", fake_open, raising=False)
+
+
+def test_symbol_present(monkeypatch, ais_check):
+    _patch_open(
+        monkeypatch,
+        ais_check,
+        content="0000 t some_symbol\n0000 t kfd_ais_rw_file\n",
+    )
+
+    assert ais_check.amdgpu_supports_ais() is True
+
+
+def test_symbol_absent(monkeypatch, ais_check):
+    _patch_open(monkeypatch, ais_check, content="0000 t some_symbol\n0000 t other\n")
+
+    assert ais_check.amdgpu_supports_ais() is False
+
+
+def test_empty_kallsyms(monkeypatch, ais_check):
+    _patch_open(monkeypatch, ais_check, content="")
+
+    assert ais_check.amdgpu_supports_ais() is False
+
+
+def test_file_not_found_warns(monkeypatch, capsys, ais_check):
+    _patch_open(monkeypatch, ais_check, exc=FileNotFoundError())
+
+    assert ais_check.amdgpu_supports_ais() is False
+    assert "file not found" in capsys.readouterr().err
+
+
+def test_permission_denied_warns(monkeypatch, capsys, ais_check):
+    _patch_open(monkeypatch, ais_check, exc=PermissionError())
+
+    assert ais_check.amdgpu_supports_ais() is False
+    assert "permission denied" in capsys.readouterr().err

--- a/projects/hipfile/tools/ais-check/tests/test_find_hip_runtimes.py
+++ b/projects/hipfile/tools/ais-check/tests/test_find_hip_runtimes.py
@@ -1,0 +1,162 @@
+"""Tests for find_hip_runtimes()."""
+
+# The isolated_env fixture is requested by name (pytest's dependency-injection
+# idiom), which pylint reads as a redefinition/unused arg. Test names document
+# themselves.
+# pylint: disable=missing-function-docstring,redefined-outer-name,unused-argument
+
+import glob as real_glob
+
+import pytest
+
+_LIB = "libamdhip64.so.6"
+
+
+@pytest.fixture
+def isolated_env(monkeypatch, ais_check):
+    """
+    Strip env vars the function consults, neutralize the hard-coded /opt/rocm
+    globs (so a real ROCm install on the dev box can't leak in), and make
+    find_library return nothing. Tests opt back into whatever they need.
+    """
+    for var in ("LD_LIBRARY_PATH", "ROCM_HOME", "ROCM_PATH", "HIP_PATH"):
+        monkeypatch.delenv(var, raising=False)
+
+    original_glob = real_glob.glob
+
+    def filtered_glob(pattern, *args, **kwargs):
+        if pattern.startswith("/opt/rocm"):
+            return []
+        return original_glob(pattern, *args, **kwargs)
+
+    monkeypatch.setattr(ais_check.glob, "glob", filtered_glob)
+    monkeypatch.setattr(ais_check.ctypes.util, "find_library", lambda _name: None)
+
+
+def _make_lib(directory, name=_LIB):
+    directory.mkdir(parents=True, exist_ok=True)
+    lib = directory / name
+    lib.write_bytes(b"\x7fELF")
+    return lib
+
+
+def test_empty_when_nothing_found(ais_check, isolated_env):
+    assert ais_check.find_hip_runtimes() == {}
+
+
+def test_ld_library_path(monkeypatch, tmp_path, ais_check, isolated_env):
+    lib = _make_lib(tmp_path / "libs")
+    monkeypatch.setenv("LD_LIBRARY_PATH", str(tmp_path / "libs"))
+
+    result = ais_check.find_hip_runtimes()
+
+    assert result == {str(lib): False}
+
+
+def test_ld_library_path_skips_empty_entries(
+    monkeypatch, tmp_path, ais_check, isolated_env
+):
+    lib = _make_lib(tmp_path / "libs")
+    # Leading/trailing/double colons produce empty entries that must be ignored.
+    monkeypatch.setenv("LD_LIBRARY_PATH", f"::{tmp_path / 'libs'}::")
+
+    assert ais_check.find_hip_runtimes() == {str(lib): False}
+
+
+@pytest.mark.parametrize("var", ["ROCM_HOME", "ROCM_PATH", "HIP_PATH"])
+def test_rocm_env_vars_lib_and_lib64(
+    monkeypatch, tmp_path, ais_check, isolated_env, var
+):
+    lib = _make_lib(tmp_path / "lib")
+    lib64 = _make_lib(tmp_path / "lib64")
+    monkeypatch.setenv(var, str(tmp_path))
+
+    result = ais_check.find_hip_runtimes()
+
+    assert set(result) == {str(lib), str(lib64)}
+    assert all(v is False for v in result.values())
+
+
+def test_values_initialized_false(monkeypatch, tmp_path, ais_check, isolated_env):
+    _make_lib(tmp_path / "libs")
+    monkeypatch.setenv("LD_LIBRARY_PATH", str(tmp_path / "libs"))
+
+    assert all(v is False for v in ais_check.find_hip_runtimes().values())
+
+
+def test_nonexistent_dirs_are_skipped(monkeypatch, tmp_path, ais_check, isolated_env):
+    monkeypatch.setenv("LD_LIBRARY_PATH", str(tmp_path / "does-not-exist"))
+
+    assert ais_check.find_hip_runtimes() == {}
+
+
+def test_symlinks_dedup_via_realpath(monkeypatch, tmp_path, ais_check, isolated_env):
+    real_dir = tmp_path / "real"
+    real_lib = _make_lib(real_dir)
+
+    # An unversioned symlink in another dir pointing at the same file.
+    link_dir = tmp_path / "link"
+    link_dir.mkdir()
+    link = link_dir / "libamdhip64.so"
+    link.symlink_to(real_lib)
+
+    monkeypatch.setenv("LD_LIBRARY_PATH", f"{real_dir}:{link_dir}")
+
+    result = ais_check.find_hip_runtimes()
+
+    # Both discovered paths resolve to the one real file -> single entry.
+    assert result == {str(real_lib): False}
+
+
+def test_find_library_soname_kept_as_is(monkeypatch, ais_check, isolated_env):
+    monkeypatch.setattr(
+        ais_check.ctypes.util, "find_library", lambda _name: "libamdhip64.so.6"
+    )
+
+    result = ais_check.find_hip_runtimes()
+
+    # A bare soname (not absolute) is preserved verbatim for CDLL-by-name.
+    assert result == {"libamdhip64.so.6": False}
+
+
+def test_find_library_absolute_path_resolved(
+    monkeypatch, tmp_path, ais_check, isolated_env
+):
+    lib = _make_lib(tmp_path / "cache")
+    monkeypatch.setattr(ais_check.ctypes.util, "find_library", lambda _name: str(lib))
+
+    assert ais_check.find_hip_runtimes() == {str(lib): False}
+
+
+def test_glob_metacharacters_in_env_matched_literally(
+    monkeypatch, tmp_path, ais_check, isolated_env
+):
+    """
+    A directory whose name contains a glob metacharacter must be matched
+    literally (the CodeQL-driven glob.escape hardening), not interpreted.
+    """
+    star_dir = tmp_path / "wei*rd"
+    lib = _make_lib(star_dir)
+    # A sibling whose name DOES match the wildcard expansion of 'wei*rd'. If the
+    # directory component is not glob.escape()d, the literal '*' is interpreted
+    # and this decoy's lib leaks into the result, failing the assertion below.
+    decoy = tmp_path / "weiDECOYrd"
+    _make_lib(decoy)
+
+    monkeypatch.setenv("LD_LIBRARY_PATH", str(star_dir))
+
+    result = ais_check.find_hip_runtimes()
+
+    assert result == {str(lib): False}
+
+
+def test_unversioned_and_versioned_both_matched(
+    monkeypatch, tmp_path, ais_check, isolated_env
+):
+    versioned = _make_lib(tmp_path / "libs", "libamdhip64.so.6")
+    unversioned = _make_lib(tmp_path / "libs", "libamdhip64.so")
+    monkeypatch.setenv("LD_LIBRARY_PATH", str(tmp_path / "libs"))
+
+    result = ais_check.find_hip_runtimes()
+
+    assert set(result) == {str(versioned), str(unversioned)}

--- a/projects/hipfile/tools/ais-check/tests/test_hip_runtime_ais.py
+++ b/projects/hipfile/tools/ais-check/tests/test_hip_runtime_ais.py
@@ -1,0 +1,177 @@
+"""Tests for hip_runtime_supports_ais()."""
+
+# The FakeHip double mirrors the HIP C API: its method names must match the
+# camelCase symbols ais-check resolves, and it writes back through ctypes
+# byref() pointers via the _obj member (the only way to emulate an out-param).
+# Both are deliberate, so silence the corresponding pylint checks here.
+# pylint: disable=missing-function-docstring,invalid-name,protected-access
+# pylint: disable=too-many-instance-attributes,too-many-arguments,too-few-public-methods
+# pylint: disable=redefined-outer-name,unused-argument
+
+import pytest
+
+_AIS_SYMBOLS = frozenset({b"hipAmdFileWrite", b"hipAmdFileRead"})
+
+
+class _Method:
+    """Callable that tolerates argtypes/restype attribute assignment."""
+
+    def __init__(self, fn):
+        self._fn = fn
+        self.argtypes = None
+        self.restype = None
+
+    def __call__(self, *args):
+        return self._fn(*args)
+
+
+class FakeHip:
+    """
+    Stand-in for a ctypes.CDLL handle. Only the attributes a given test wants
+    are defined; anything missing raises AttributeError, matching a HIP runtime
+    too old to export a symbol. The fake methods accept argtypes/restype
+    assignment (as ctypes _FuncPtr objects do) and ignore it.
+    """
+
+    def __init__(
+        self,
+        *,
+        version=60000000,
+        version_err=0,
+        present_symbols=_AIS_SYMBOLS,
+        proc_err=0,
+        proc_status=0,
+        null_ptr=False,
+        omit_get_proc_address=False,
+        omit_runtime_version=False
+    ):
+        self._version = version
+        self._version_err = version_err
+        self._present = set(present_symbols)
+        self._proc_err = proc_err
+        self._proc_status = proc_status
+        self._null_ptr = null_ptr
+
+        if not omit_runtime_version:
+            self.hipRuntimeGetVersion = _Method(self._runtime_get_version)
+        self.hipGetErrorString = _Method(self._get_error_string)
+        if not omit_get_proc_address:
+            self.hipGetProcAddress = _Method(self._get_proc_address)
+
+    def _runtime_get_version(self, version_ptr):
+        version_ptr._obj.value = self._version
+        return self._version_err
+
+    def _get_error_string(self, _err):
+        return b"fake error"
+
+    def _get_proc_address(self, symbol, func_ptr, _version, _flags, status_ptr):
+        status_ptr._obj.value = self._proc_status
+        if symbol in self._present and not self._null_ptr:
+            func_ptr._obj.value = 0xDEAD0000
+        else:
+            func_ptr._obj.value = None
+        return self._proc_err
+
+
+@pytest.fixture
+def patch_runtimes(monkeypatch, ais_check):
+    """Helper to stub find_hip_runtimes() and ctypes.CDLL together."""
+
+    def install(handles):
+        # handles: dict of path -> FakeHip (or an exception instance to raise)
+        monkeypatch.setattr(
+            ais_check, "find_hip_runtimes", lambda: dict.fromkeys(handles, False)
+        )
+
+        def fake_cdll(path, *_args, **_kwargs):
+            obj = handles[path]
+            if isinstance(obj, Exception):
+                raise obj
+            return obj
+
+        monkeypatch.setattr(ais_check.ctypes, "CDLL", fake_cdll)
+
+    return install
+
+
+def test_library_with_both_symbols_supported(patch_runtimes, ais_check):
+    patch_runtimes({"/opt/rocm/lib/libamdhip64.so": FakeHip()})
+
+    assert ais_check.hip_runtime_supports_ais() == {
+        "/opt/rocm/lib/libamdhip64.so": True
+    }
+
+
+def test_library_missing_one_symbol_not_supported(patch_runtimes, ais_check):
+    patch_runtimes(
+        {"/lib/libamdhip64.so": FakeHip(present_symbols={b"hipAmdFileRead"})}
+    )
+
+    assert ais_check.hip_runtime_supports_ais() == {"/lib/libamdhip64.so": False}
+
+
+def test_cdll_load_failure_skipped(patch_runtimes, ais_check):
+    patch_runtimes({"/bad/libamdhip64.so": OSError("cannot load")})
+
+    assert ais_check.hip_runtime_supports_ais() == {"/bad/libamdhip64.so": False}
+
+
+def test_old_runtime_missing_get_proc_address(patch_runtimes, ais_check):
+    # Resolving hipGetProcAddress raises AttributeError -> treated as not capable.
+    patch_runtimes({"/old/libamdhip64.so": FakeHip(omit_get_proc_address=True)})
+
+    assert ais_check.hip_runtime_supports_ais() == {"/old/libamdhip64.so": False}
+
+
+def test_runtime_version_error_reported(patch_runtimes, capsys, ais_check):
+    patch_runtimes({"/lib/libamdhip64.so": FakeHip(version_err=3)})
+
+    result = ais_check.hip_runtime_supports_ais()
+
+    assert result == {"/lib/libamdhip64.so": False}
+    err = capsys.readouterr().err
+    assert "hipRuntimeGetVersion failed" in err
+    assert "/lib/libamdhip64.so" in err
+
+
+def test_proc_address_err_code_fails(patch_runtimes, ais_check):
+    patch_runtimes({"/lib/libamdhip64.so": FakeHip(proc_err=1)})
+
+    assert ais_check.hip_runtime_supports_ais() == {"/lib/libamdhip64.so": False}
+
+
+def test_proc_address_nonzero_status_fails(patch_runtimes, ais_check):
+    patch_runtimes({"/lib/libamdhip64.so": FakeHip(proc_status=2)})
+
+    assert ais_check.hip_runtime_supports_ais() == {"/lib/libamdhip64.so": False}
+
+
+def test_proc_address_null_pointer_fails(patch_runtimes, ais_check):
+    patch_runtimes({"/lib/libamdhip64.so": FakeHip(null_ptr=True)})
+
+    assert ais_check.hip_runtime_supports_ais() == {"/lib/libamdhip64.so": False}
+
+
+def test_multiple_libraries_mixed_support(patch_runtimes, ais_check):
+    patch_runtimes(
+        {
+            "/a/libamdhip64.so": FakeHip(),
+            "/b/libamdhip64.so": FakeHip(present_symbols=set()),
+            "/c/libamdhip64.so": FakeHip(),
+        }
+    )
+
+    result = ais_check.hip_runtime_supports_ais()
+
+    assert result == {
+        "/a/libamdhip64.so": True,
+        "/b/libamdhip64.so": False,
+        "/c/libamdhip64.so": True,
+    }
+
+
+def test_no_libraries_found(patch_runtimes, ais_check):
+    patch_runtimes({})
+
+    assert ais_check.hip_runtime_supports_ais() == {}

--- a/projects/hipfile/tools/ais-check/tests/test_main.py
+++ b/projects/hipfile/tools/ais-check/tests/test_main.py
@@ -1,0 +1,120 @@
+"""Tests for main(): the argument parsing, output, and exit-code contract."""
+
+# The stub_checks fixture is requested by name (pytest dependency injection),
+# which pylint reads as redefinition/unused. Test names are self-documenting.
+# pylint: disable=missing-function-docstring,redefined-outer-name,unused-argument
+
+from collections import namedtuple
+
+import pytest
+
+_UNAME = namedtuple("uname_result", "sysname nodename release version machine")
+
+
+@pytest.fixture
+def stub_checks(monkeypatch, ais_check):
+    """
+    Stub the three component checks plus os.uname so main() runs hermetically.
+    Returns a setter that fixes each component's support and the HIP library map.
+    """
+
+    def configure(*, p2pdma=True, amdgpu=True, hip_libraries=None):
+        if hip_libraries is None:
+            hip_libraries = {"/opt/rocm/lib/libamdhip64.so": True}
+        monkeypatch.setattr(ais_check, "kernel_supports_p2pdma", lambda: p2pdma)
+        monkeypatch.setattr(ais_check, "amdgpu_supports_ais", lambda: amdgpu)
+        monkeypatch.setattr(
+            ais_check, "hip_runtime_supports_ais", lambda: dict(hip_libraries)
+        )
+        monkeypatch.setattr(
+            ais_check.os,
+            "uname",
+            lambda: _UNAME("Linux", "host", "6.6.0", "#1 SMP", "x86_64"),
+        )
+
+    return configure
+
+
+def _run(monkeypatch, ais_check, argv):
+    monkeypatch.setattr(ais_check.sys, "argv", ["ais-check", *argv])
+    return ais_check.main()
+
+
+def test_all_supported_exit_zero(monkeypatch, stub_checks, ais_check):
+    stub_checks()
+    assert _run(monkeypatch, ais_check, []) == 0
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"p2pdma": False},
+        {"amdgpu": False},
+        {"hip_libraries": {"/opt/rocm/lib/libamdhip64.so": False}},
+        {"hip_libraries": {}},
+    ],
+)
+def test_any_missing_component_exit_nonzero(
+    monkeypatch, stub_checks, ais_check, kwargs
+):
+    stub_checks(**kwargs)
+    assert _run(monkeypatch, ais_check, []) != 0
+
+
+def test_hip_runtime_true_if_any_library_supported(monkeypatch, stub_checks, ais_check):
+    stub_checks(
+        hip_libraries={
+            "/a/libamdhip64.so": False,
+            "/b/libamdhip64.so": True,
+        }
+    )
+    assert _run(monkeypatch, ais_check, []) == 0
+
+
+def test_default_output_lists_components(monkeypatch, capsys, stub_checks, ais_check):
+    stub_checks()
+    _run(monkeypatch, ais_check, [])
+
+    out = capsys.readouterr().out
+    assert "AIS support in:" in out
+    assert "Kernel P2PDMA support" in out
+    assert "HIP runtime" in out
+    assert "amdgpu" in out
+    # The uname banner is printed.
+    assert "Linux host 6.6.0" in out
+
+
+def test_quiet_suppresses_output(monkeypatch, capsys, stub_checks, ais_check):
+    stub_checks()
+    rc = _run(monkeypatch, ais_check, ["-q"])
+
+    assert rc == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_quiet_still_returns_failure_code(monkeypatch, capsys, stub_checks, ais_check):
+    stub_checks(p2pdma=False)
+    rc = _run(monkeypatch, ais_check, ["--quiet"])
+
+    assert rc != 0
+    assert capsys.readouterr().out == ""
+
+
+def test_verbose_lists_libraries(monkeypatch, capsys, stub_checks, ais_check):
+    stub_checks(
+        hip_libraries={
+            "/opt/rocm/lib/libamdhip64.so.6": True,
+            "/usr/lib/libamdhip64.so": False,
+        }
+    )
+    _run(monkeypatch, ais_check, ["-v"])
+
+    out = capsys.readouterr().out
+    assert "Found these HIP libraries" in out
+    assert "/opt/rocm/lib/libamdhip64.so.6 (AIS supported)" in out
+    assert "/usr/lib/libamdhip64.so (AIS NOT supported)" in out
+
+
+def test_quiet_and_verbose_mutually_exclusive(monkeypatch, ais_check):
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, ais_check, ["-q", "-v"])

--- a/projects/hipfile/tools/ais-check/tests/test_p2pdma.py
+++ b/projects/hipfile/tools/ais-check/tests/test_p2pdma.py
@@ -1,0 +1,110 @@
+"""Tests for kernel_supports_p2pdma()."""
+
+# Test functions are self-documenting by name; docstrings add noise.
+# pylint: disable=missing-function-docstring
+
+import io
+from collections import namedtuple
+
+import pytest
+
+_UNAME = namedtuple("uname_result", "sysname nodename release version machine")
+
+
+def _fake_uname(release="6.6.0-test"):
+    return _UNAME("Linux", "host", release, "#1 SMP", "x86_64")
+
+
+def _install_fake_openers(monkeypatch, ais_check, files):
+    """
+    Redirect both ``open`` (builtins) and ``gzip.open`` so that only the paths
+    present in ``files`` are readable; everything else raises OSError, matching
+    a missing config file.
+    """
+
+    def opener(path, *_args, **_kwargs):
+        if path in files:
+            return io.StringIO(files[path])
+        raise OSError(f"no such file: {path}")
+
+    monkeypatch.setattr(ais_check, "open", opener, raising=False)
+    monkeypatch.setattr(ais_check.gzip, "open", opener)
+
+
+@pytest.mark.parametrize(
+    "config_path",
+    [
+        "/boot/config-6.6.0-test",
+        "/lib/modules/6.6.0-test/build/.config",
+        "/proc/config.gz",
+    ],
+)
+def test_supported_from_each_source(monkeypatch, ais_check, config_path):
+    monkeypatch.setattr(ais_check.os, "uname", _fake_uname)
+    _install_fake_openers(
+        monkeypatch,
+        ais_check,
+        {config_path: "CONFIG_FOO=y\nCONFIG_PCI_P2PDMA=y\nCONFIG_BAR=m\n"},
+    )
+
+    assert ais_check.kernel_supports_p2pdma() is True
+
+
+def test_config_present_but_option_absent(monkeypatch, ais_check):
+    monkeypatch.setattr(ais_check.os, "uname", _fake_uname)
+    _install_fake_openers(
+        monkeypatch,
+        ais_check,
+        {"/boot/config-6.6.0-test": "CONFIG_FOO=y\nCONFIG_BAR=m\n"},
+    )
+
+    assert ais_check.kernel_supports_p2pdma() is False
+
+
+def test_option_as_module_does_not_count(monkeypatch, ais_check):
+    monkeypatch.setattr(ais_check.os, "uname", _fake_uname)
+    _install_fake_openers(
+        monkeypatch,
+        ais_check,
+        {"/boot/config-6.6.0-test": "CONFIG_PCI_P2PDMA=m\n"},
+    )
+
+    assert ais_check.kernel_supports_p2pdma() is False
+
+
+def test_option_commented_out_does_not_count(monkeypatch, ais_check):
+    monkeypatch.setattr(ais_check.os, "uname", _fake_uname)
+    _install_fake_openers(
+        monkeypatch,
+        ais_check,
+        {"/boot/config-6.6.0-test": "# CONFIG_PCI_P2PDMA is not set\n"},
+    )
+
+    assert ais_check.kernel_supports_p2pdma() is False
+
+
+def test_no_configs_found_warns_on_stderr(monkeypatch, capsys, ais_check):
+    monkeypatch.setattr(ais_check.os, "uname", _fake_uname)
+    _install_fake_openers(monkeypatch, ais_check, {})
+
+    assert ais_check.kernel_supports_p2pdma() is False
+    assert "No kernel config files found!" in capsys.readouterr().err
+
+
+def test_first_matching_source_wins(monkeypatch, ais_check):
+    """
+    A readable /boot config without the option followed by /proc/config.gz with
+    it should still report supported (the loop must consult all sources, not
+    bail after the first readable one).
+    """
+    monkeypatch.setattr(ais_check.os, "uname", _fake_uname)
+    _install_fake_openers(
+        monkeypatch,
+        ais_check,
+        {
+            "/boot/config-6.6.0-test": "CONFIG_FOO=y\n",
+            "/proc/config.gz": "CONFIG_PCI_P2PDMA=y\n",
+        },
+    )
+
+    assert ais_check.kernel_supports_p2pdma() is True


### PR DESCRIPTION
## Motivation

The ais-check tool is untested. We should add testing to ensure we don't break it as we work on the tool.

## Technical Details

Add a pytest-based test suite for the ais-check tool to guard against regressions as the script evolves. The tool reads real system state (kernel config, /proc/kallsyms, env vars, ROCm install paths, and the HIP runtime via ctypes), so every test fakes the system underneath with monkeypatch, keeping the suite fully hermetic — no ROCm, GPU, or special privileges required.

The 47 tests cover each component check independently:
- kernel_supports_p2pdma: each config source, missing/=m/commented options, and the "no configs found" warning
- find_hip_runtimes: env-var search paths, symlink dedup, soname handling, and literal matching of glob metacharacters
- hip_runtime_supports_ais: symbol probing via a fake HIP handle, old-runtime and load-failure paths, and the three-part symbol check
- amdgpu_supports_ais: symbol present/absent and error branches
- main: the exit-code contract and -q/-v output behavior

Because ais-check ships as an extensionless executable, a conftest.py shim loads it as an importable module via SourceFileLoader.

Add .github/workflows/hipfile-ais-check.yml to run the suite on changes under tools/ais-check. Uses a floor/ceiling Python matrix ("3.10" and latest stable via "3.x") to verify the >=3.10 range pyproject declares, with a concurrency group to cancel redundant in-progress runs.

Test instructions live in tools/ais-check/tests/README.md

## JIRA ID

AIHIPFILE-156

## Test Plan

The new GitHub action exercises the tests

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
