### PR TITLE
[hipfile][ci] Add `concurrency:` to some actions

### DIFF
--- a/.github/workflows/hipfile-clang-format.yml
+++ b/.github/workflows/hipfile-clang-format.yml
@@ -17,6 +17,10 @@ on:
       - 'projects/hipfile/.clang-format'
       - '.github/workflows/hipfile-clang-format.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/hipfile-cmakelint.yml
+++ b/.github/workflows/hipfile-cmakelint.yml
@@ -17,6 +17,10 @@ on:
       - 'projects/hipfile/.cmakelintrc'
       - '.github/workflows/hipfile-cmakelint.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/hipfile-codespell.yml
+++ b/.github/workflows/hipfile-codespell.yml
@@ -15,6 +15,10 @@ on:
       - 'projects/hipfile/**'
       - '.github/workflows/hipfile-*.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/hipfile-pylint.yml
+++ b/.github/workflows/hipfile-pylint.yml
@@ -15,6 +15,10 @@ on:
       - 'projects/hipfile/**/ais-check'
       - '.github/workflows/hipfile-pylint.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/hipfile-shellcheck.yml
+++ b/.github/workflows/hipfile-shellcheck.yml
@@ -13,6 +13,10 @@ on:
       - 'projects/hipfile/**.sh'
       - '.github/workflows/hipfile-shellcheck.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Motivation

Some of our GitHub actions were missing the concurrency block

## Technical Details

These independently triggered actions were missing a concurrency block:
* hipfile-clang-format.yml
* hipfile-cmakelint.yml
* hipfile-codespell.yml
* hipfile-pylint.yml
* hipfile-shellcheck.yml

## JIRA ID

N/A

## Test Plan

CI passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
