### PR TITLE
fix(rocr): Bound code-object relocation writes and reject null segments

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -790,14 +790,31 @@ bool Segment::IsAddressInSegment(uint64_t addr)
   return vaddr <= addr && addr < vaddr + size;
 }
 
-void Segment::Copy(uint64_t addr, const void* src, size_t size)
+bool Segment::IsAddressInSegment(uint64_t addr, size_t copy_size)
+{
+  if (addr < vaddr) { return false; }
+  const uint64_t offset = addr - vaddr;
+  // Overflow-safe check of offset + copy_size <= size.
+  return offset <= size && copy_size <= size - offset;
+}
+
+bool Segment::Copy(uint64_t addr, const void* src, size_t size)
 {
   // loader must do copies before freezing.
   assert(!frozen);
 
   if (size > 0) {
+    // addr/size can be derived from attacker-controlled code-object fields
+    // (e.g. a relocation's section sh_addr + r_offset). Offset() only asserts
+    // the start address via IsAddressInSegment() and that assert compiles out
+    // under NDEBUG, so validate the entire destination range here to prevent a
+    // heap out-of-bounds write when loading a crafted code object.
+    if (!IsAddressInSegment(addr, size)) {
+      return false;
+    }
     owner->context()->SegmentCopy(segment, agent, ptr, Offset(addr), src, size);
   }
+  return true;
 }
 
 void Segment::Print(std::ostream& out)
@@ -1880,6 +1897,9 @@ hsa_status_t ExecutableImpl::ApplyStaticRelocation(hsa_agent_t agent, amd::hsa::
   code::RelocationSection* rsec = rel->section();
   code::Section* sec = rsec->targetSection();
   Segment* rseg = SectionSegment(agent, sec);
+  // SectionSegment() returns nullptr when no loaded segment covers the target
+  // section (crafted sh_info/sh_addr); reject rather than dereferencing it.
+  if (!rseg) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
   size_t reladdr = sec->addr() + rel->offset();
   switch (rel->type()) {
     case R_AMDGPU_V1_32_LOW:
@@ -1917,14 +1937,14 @@ hsa_status_t ExecutableImpl::ApplyStaticRelocation(hsa_agent_t agent, amd::hsa::
       switch (rel->type()) {
         case R_AMDGPU_V1_32_HIGH:
           addr32 = uint32_t((addr >> 32) & 0xFFFFFFFF);
-          rseg->Copy(reladdr, &addr32, sizeof(addr32));
+          if (!rseg->Copy(reladdr, &addr32, sizeof(addr32))) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
           break;
         case R_AMDGPU_V1_32_LOW:
           addr32 = uint32_t(addr & 0xFFFFFFFF);
-          rseg->Copy(reladdr, &addr32, sizeof(addr32));
+          if (!rseg->Copy(reladdr, &addr32, sizeof(addr32))) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
           break;
         case R_AMDGPU_V1_64:
-          rseg->Copy(reladdr, &addr, sizeof(addr));
+          if (!rseg->Copy(reladdr, &addr, sizeof(addr))) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
           break;
         default:
           return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
@@ -1959,7 +1979,7 @@ hsa_status_t ExecutableImpl::ApplyStaticRelocation(hsa_agent_t agent, amd::hsa::
       status = context_->SamplerCreate(agent, &hsa_sampler_descriptor, &hsa_sampler);
       if (status != HSA_STATUS_SUCCESS) { return status; }
       assert(hsa_sampler.handle);
-      rseg->Copy(reladdr, &hsa_sampler, sizeof(hsa_sampler));
+      if (!rseg->Copy(reladdr, &hsa_sampler, sizeof(hsa_sampler))) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
       break;
     }
 
@@ -2022,7 +2042,7 @@ hsa_status_t ExecutableImpl::ApplyStaticRelocation(hsa_agent_t agent, amd::hsa::
                                   NULL, // TODO: image_data?
                                   &hsa_image);
       if (status != HSA_STATUS_SUCCESS) { return status; }
-      rseg->Copy(reladdr, &hsa_image, sizeof(hsa_image));
+      if (!rseg->Copy(reladdr, &hsa_image, sizeof(hsa_image))) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
       break;
     }
 
@@ -2046,6 +2066,9 @@ hsa_status_t ExecutableImpl::ApplyDynamicRelocationSection(hsa_agent_t agent, am
 hsa_status_t ExecutableImpl::ApplyDynamicRelocation(hsa_agent_t agent, amd::hsa::code::Relocation *rel)
 {
   Segment* relSeg = VirtualAddressSegment(rel->offset());
+  // VirtualAddressSegment() returns nullptr when no loaded segment covers the
+  // attacker-controlled r_offset; reject rather than dereferencing it.
+  if (!relSeg) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
   uint64_t symAddr = 0;
   switch (rel->symbol()->type()) {
     case STT_OBJECT:
@@ -2053,6 +2076,7 @@ hsa_status_t ExecutableImpl::ApplyDynamicRelocation(hsa_agent_t agent, amd::hsa:
     case STT_FUNC:
     {
       Segment* symSeg = VirtualAddressSegment(rel->symbol()->value());
+      if (!symSeg) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
       symAddr = reinterpret_cast<uint64_t>(symSeg->Address(rel->symbol()->value()));
       break;
     }
@@ -2084,7 +2108,7 @@ hsa_status_t ExecutableImpl::ApplyDynamicRelocation(hsa_agent_t agent, amd::hsa:
       }
 
       uint32_t symAddr32 = uint32_t((symAddr >> 32) & 0xFFFFFFFF);
-      relSeg->Copy(rel->offset(), &symAddr32, sizeof(symAddr32));
+      if (!relSeg->Copy(rel->offset(), &symAddr32, sizeof(symAddr32))) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
       break;
     }
 
@@ -2096,7 +2120,7 @@ hsa_status_t ExecutableImpl::ApplyDynamicRelocation(hsa_agent_t agent, amd::hsa:
       }
 
       uint32_t symAddr32 = uint32_t(symAddr & 0xFFFFFFFF);
-      relSeg->Copy(rel->offset(), &symAddr32, sizeof(symAddr32));
+      if (!relSeg->Copy(rel->offset(), &symAddr32, sizeof(symAddr32))) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
       break;
     }
 
@@ -2108,7 +2132,7 @@ hsa_status_t ExecutableImpl::ApplyDynamicRelocation(hsa_agent_t agent, amd::hsa:
       }
 
       uint32_t symAddr32 = uint32_t(symAddr);
-      relSeg->Copy(rel->offset(), &symAddr32, sizeof(symAddr32));
+      if (!relSeg->Copy(rel->offset(), &symAddr32, sizeof(symAddr32))) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
       break;
     }
 
@@ -2119,7 +2143,7 @@ hsa_status_t ExecutableImpl::ApplyDynamicRelocation(hsa_agent_t agent, amd::hsa:
         return HSA_STATUS_ERROR_VARIABLE_UNDEFINED;
       }
 
-      relSeg->Copy(rel->offset(), &symAddr, sizeof(symAddr));
+      if (!relSeg->Copy(rel->offset(), &symAddr, sizeof(symAddr))) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
       break;
     }
 
@@ -2127,7 +2151,7 @@ hsa_status_t ExecutableImpl::ApplyDynamicRelocation(hsa_agent_t agent, amd::hsa:
     {
       int64_t baseDelta = reinterpret_cast<uint64_t>(relSeg->Address(0)) - relSeg->VAddr();
       uint64_t relocatedAddr = baseDelta + rel->addend();
-      relSeg->Copy(rel->offset(), &relocatedAddr, sizeof(relocatedAddr));
+      if (!relSeg->Copy(rel->offset(), &relocatedAddr, sizeof(relocatedAddr))) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
       break;
     }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -794,8 +794,10 @@ bool Segment::IsAddressInSegment(uint64_t addr, size_t copy_size)
 {
   if (addr < vaddr) { return false; }
   const uint64_t offset = addr - vaddr;
-  // Overflow-safe check of offset + copy_size <= size.
-  return offset <= size && copy_size <= size - offset;
+  // Mirror the 1-arg bound (offset < size, i.e. addr < vaddr + size). Express
+  // the exclusive end offset + copy_size <= size without overflow via
+  // copy_size <= size - offset (equivalent to addr + copy_size <= vaddr + size).
+  return offset < size && copy_size <= size - offset;
 }
 
 bool Segment::Copy(uint64_t addr, const void* src, size_t size)
@@ -1524,6 +1526,8 @@ hsa_status_t ExecutableImpl::LoadSegmentV1(hsa_agent_t agent,
     void* ptr = context_->SegmentAlloc(segment, agent, s->memSize(), s->align(), true);
     if (!ptr) { return HSA_STATUS_ERROR_OUT_OF_RESOURCES; }
     new_seg = std::make_shared<Segment>(this, agent, segment, ptr, s->memSize(), s->vaddr(), s->offset());
+    // Copy() return unchecked: imageSize <= memSize was validated above and the
+    // destination is this segment's own [vaddr, vaddr + imageSize) range.
     new_seg->Copy(s->vaddr(), segment_data, s->imageSize());
     objects.push_back(new_seg);
 
@@ -1769,6 +1773,8 @@ hsa_status_t ExecutableImpl::LoadDefinitionSymbol(hsa_agent_t agent,
       // removed.
       uint64_t target_address = sym->GetSection()->addr() + sym->SectionOffset() + ((size_t)(&((amd_kernel_code_t*)0)->runtime_loader_kernel_symbol));
       uint64_t source_value = (uint64_t) (uintptr_t) &kernel_symbol->debug_info;
+      // Copy() return unchecked: debugger backdoor for compiler-generated kernel
+      // symbols; target is a fixed offsetof within the symbol's loaded section.
       SymbolSegment(agent, sym)->Copy(target_address, &source_value, sizeof(source_value));
   } else {
     assert(!"Unexpected symbol type in LoadDefinitionSymbol");
@@ -1900,6 +1906,8 @@ hsa_status_t ExecutableImpl::ApplyStaticRelocation(hsa_agent_t agent, amd::hsa::
   // SectionSegment() returns nullptr when no loaded segment covers the target
   // section (crafted sh_info/sh_addr); reject rather than dereferencing it.
   if (!rseg) { return HSA_STATUS_ERROR_INVALID_CODE_OBJECT; }
+  // sec->addr() + rel->offset() can wrap on crafted input; Copy()'s range check
+  // rejects any wrapped destination that falls outside the target segment.
   size_t reladdr = sec->addr() + rel->offset();
   switch (rel->type()) {
     case R_AMDGPU_V1_32_LOW:

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
@@ -433,7 +433,14 @@ public:
   bool Freeze();
 
   bool IsAddressInSegment(uint64_t addr);
-  void Copy(uint64_t addr, const void* src, size_t size);
+  // Range-checked variant: returns true only if the whole [addr, addr + size)
+  // region lies within this segment (overflow-safe).
+  bool IsAddressInSegment(uint64_t addr, size_t size);
+  // Returns false (and performs no copy) when [addr, addr + size) is not fully
+  // contained in the segment, so a crafted code object cannot drive an
+  // out-of-bounds write. Callers that source addr/size from the code object
+  // (e.g. relocations) must check the result.
+  bool Copy(uint64_t addr, const void* src, size_t size);
   void Print(std::ostream& out) override;
   void Destroy() override;
 };


### PR DESCRIPTION
## Summary

Continuation of the ROCm code-object loader hardening work (untrusted .hsaco / code-object parsing). This addresses a vulnerability in the relocation application path not covered by existing segment-load / ELF-parser fixes (#6994, #6995, #6996, #6998, #7541, #7542).

`ExecutableImpl::ApplyStaticRelocation()` and `ApplyDynamicRelocation()` write resolved addresses into a loaded segment at offsets taken from attacker-controlled code-object fields without validating the destination range. In addition, null segment pointers were dereferenced unconditionally.

Fix:
- Add an overflow-safe `Segment::IsAddressInSegment(addr, size)` range check.
- `Segment::Copy()` validates the entire `[addr, addr + size)` destination.
- Reject null target/symbol segments and treat refused copy as `HSA_STATUS_ERROR_INVALID_CODE_OBJECT`.

## JIRA ID

JIRA ID : ROCM-26177

## Test plan

- [x] `g++ -fsyntax-only` of `loader/executable.cpp` passes (no new warnings).
- [ ] Load a normal code object / run an existing kernel; confirm no regression.
- [ ] Load a crafted code object with an out-of-range relocation offset; confirm rejection with HSA_STATUS_ERROR_INVALID_CODE_OBJECT.