### PR TITLE
[hipfile] Make clang-tidy warning-free and add a CI gate

### DIFF
--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -273,3 +273,20 @@ jobs:
     uses: ./.github/workflows/hipfile-sanitizers.yml
     with:
       ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.2'].ci_image }}
+
+  # clang-tidy findings are compiler- and standard-independent, so run the
+  # analysis exactly once against a single fixed image rather than fanning out
+  # across the build matrix. Change the image key below to retarget the ROCm
+  # version (the combo must exist in Precheck's matrix).
+  clang_tidy:
+    if: >-
+      ${{
+        !cancelled() && (
+          needs.build_CI_image.result == 'success' ||
+          needs.build_CI_image.result == 'skipped'
+        )
+      }}
+    needs: [Precheck, build_CI_image]
+    uses: ./.github/workflows/hipfile-clang-tidy.yml
+    with:
+      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.2'].ci_image }}

--- a/.github/workflows/hipfile-clang-tidy.yml
+++ b/.github/workflows/hipfile-clang-tidy.yml
@@ -1,0 +1,100 @@
+name: hipfile-clang-tidy
+run-name: Run clang-tidy analysis on hipFile
+
+env:
+  AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
+  AIS_HIP_ARCHITECTURES: gfx950;gfx1201;gfx1200;gfx1101;gfx1100;gfx1030;gfx942;gfx90a;gfx908
+
+on:
+  workflow_call:
+    inputs:
+      ci_image:
+        description: "Full CI image name & tag"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  clang_tidy:
+    name: clang-tidy
+    runs-on: [ubuntu-24.04]
+    steps:
+      - name: Set AIS CI container name
+        # On non-pull_request triggering workflows, AIS_PR_NUMBER may be empty.
+        run: |
+          echo "AIS_PR_NUMBER=$(echo "${GITHUB_REF}" | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
+      - name: Compute container name
+        run: |
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER:=${GITHUB_RUN_ID}}_${GITHUB_JOB}_clang_tidy" >> "${GITHUB_ENV}"
+      - name: Fetching code repository...
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: rocm-systems
+          sparse-checkout: |
+            projects/hipfile
+            .github/workflows
+      - name: Authenticating to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Starting Docker Container
+        run: |
+          docker run \
+            -dt \
+            --rm \
+            --pull always \
+            -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
+            --name "${AIS_CONTAINER_NAME}" \
+            "${AIS_INPUT_CI_IMAGE}"
+      - name: Make copy of the code repository and create build directories
+        # Single quotes necessary to ensure string/command substitutions happen
+        # in the container and not on the host.
+        run: |
+          docker exec \
+            -t \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cp -R /mnt/ais /ais
+              mkdir -p /ais/build/hipfile
+            '
+      - name: Generate build files for hipFile with clang-tidy enabled
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cmake \
+                -DCMAKE_BUILD_TYPE=Debug \
+                -DCMAKE_CXX_COMPILER=amdclang++ \
+                -DCMAKE_HIP_ARCHITECTURES="${{ env.AIS_HIP_ARCHITECTURES }}" \
+                -DCMAKE_HIP_PLATFORM=amd \
+                -DAIS_USE_CLANG_TIDY=ON \
+                ../../rocm-systems/projects/hipfile
+            '
+      - name: Compile hipFile with clang-tidy
+        # clang-tidy runs as part of compilation via CMAKE_CXX_CLANG_TIDY.
+        # AISClangTidy.cmake passes -warnings-as-errors=*, so any finding fails
+        # the build. No tests are run; we only care about clang-tidy diagnostics.
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cmake --build . --parallel
+            '
+      - name: Cleanup & Stop the Docker container
+        if: ${{ always() }}
+        run: |
+          if docker inspect "${AIS_CONTAINER_NAME}" >/dev/null 2>&1; then
+            docker stop "${AIS_CONTAINER_NAME}"
+          else
+            echo "Container ${AIS_CONTAINER_NAME} does not exist; skipping stop"
+          fi

--- a/projects/hipfile/cmake/AISUseGTest.cmake
+++ b/projects/hipfile/cmake/AISUseGTest.cmake
@@ -82,6 +82,17 @@ foreach(gtest_target GTest::gtest GTest::gmock)
         set_property(TARGET ${gtest_target} APPEND PROPERTY
             INTERFACE_LINK_LIBRARIES Threads::Threads)
     endif()
+
+    # Mark GoogleTest's headers as system includes so consumers pull them in
+    # via -isystem. clang-tidy suppresses diagnostics from system headers by
+    # default, which keeps GoogleTest's macros and templates from polluting our
+    # test builds with warnings we can't fix. The SYSTEM keyword passed to
+    # FetchContent_Declare only takes effect on CMake >= 3.25, and a system
+    # find_package(GTest) is not guaranteed to mark them either, so set the
+    # property here directly to cover every path.
+    set_target_properties(${gtest_target} PROPERTIES
+        INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+            "$<TARGET_PROPERTY:${gtest_target},INTERFACE_INCLUDE_DIRECTORIES>")
 endforeach()
 
 include(GoogleTest)

--- a/projects/hipfile/examples/async/roundtrip-async-multi-stream-registered.cpp
+++ b/projects/hipfile/examples/async/roundtrip-async-multi-stream-registered.cpp
@@ -80,15 +80,15 @@ static_assert((SLICE_SIZE % BLOCK_ALIGN) == 0, "SLICE_SIZE must be a multiple of
  * must outlive submission. */
 struct slice_state {
     void       *devbuf;
-    bool        buf_registered;
     hipStream_t stream;
-    bool        stream_created;
-    bool        stream_registered;
     size_t      io_size;
     hoff_t      file_offset;
     hoff_t      buf_offset;
     ssize_t     bytes_read;
     ssize_t     bytes_written;
+    bool        buf_registered;
+    bool        stream_created;
+    bool        stream_registered;
 };
 
 int
@@ -232,19 +232,13 @@ main(int argc, char *argv[])
      * file has undefined coherence per open(2); closing first sidesteps that
      * and also flushes file-size metadata for the fresh open() in the hasher.
      * Then hash the full TOTAL_SIZE and compare. */
-    if (close_file(write_path, wfd, whandle)) {
-        wfd          = -1;
-        whandle_open = false;
+    if (close_file(write_path, wfd, whandle))
         goto close_rfile;
-    }
     wfd          = -1;
     whandle_open = false;
 
-    if (close_file(read_path, rfd, rhandle)) {
-        rfd          = -1;
-        rhandle_open = false;
+    if (close_file(read_path, rfd, rhandle))
         goto cleanup_slices;
-    }
     rfd          = -1;
     rhandle_open = false;
 

--- a/projects/hipfile/examples/async/roundtrip-async-multi-stream.cpp
+++ b/projects/hipfile/examples/async/roundtrip-async-multi-stream.cpp
@@ -70,14 +70,14 @@ static_assert((SLICE_SIZE % BLOCK_ALIGN) == 0, "SLICE_SIZE must be a multiple of
  * must outlive submission. */
 struct slice_state {
     void       *devbuf;
-    bool        buf_registered;
     hipStream_t stream;
-    bool        stream_created;
     size_t      io_size;
     hoff_t      file_offset;
     hoff_t      buf_offset;
     ssize_t     bytes_read;
     ssize_t     bytes_written;
+    bool        buf_registered;
+    bool        stream_created;
 };
 
 int
@@ -212,19 +212,13 @@ main(int argc, char *argv[])
      * file has undefined coherence per open(2); closing first sidesteps that
      * and also flushes file-size metadata for the fresh open() in the hasher.
      * Then hash the full TOTAL_SIZE and compare. */
-    if (close_file(write_path, wfd, whandle)) {
-        wfd          = -1;
-        whandle_open = false;
+    if (close_file(write_path, wfd, whandle))
         goto close_rfile;
-    }
     wfd          = -1;
     whandle_open = false;
 
-    if (close_file(read_path, rfd, rhandle)) {
-        rfd          = -1;
-        rhandle_open = false;
+    if (close_file(read_path, rfd, rhandle))
         goto cleanup_slices;
-    }
     rfd          = -1;
     rhandle_open = false;
 

--- a/projects/hipfile/examples/async/roundtrip-async.cpp
+++ b/projects/hipfile/examples/async/roundtrip-async.cpp
@@ -179,19 +179,13 @@ main(int argc, char *argv[])
      * file has undefined coherence per open(2); closing first sidesteps that
      * and also flushes file-size metadata for the fresh open() in the hasher.
      * Then hash and compare. */
-    if (close_file(write_path, wfd, whandle)) {
-        wfd          = -1;
-        whandle_open = false;
+    if (close_file(write_path, wfd, whandle))
         goto close_rfile;
-    }
     wfd          = -1;
     whandle_open = false;
 
-    if (close_file(read_path, rfd, rhandle)) {
-        rfd          = -1;
-        rhandle_open = false;
+    if (close_file(read_path, rfd, rhandle))
         goto deregister_buf;
-    }
     rfd          = -1;
     rhandle_open = false;
 

--- a/projects/hipfile/test/amd_detail/async.cpp
+++ b/projects/hipfile/test/amd_detail/async.cpp
@@ -499,8 +499,10 @@ TEST_P(FallbackAsyncIO, attemptToQueueCleanupOnStreamSubmissionFailure)
     EXPECT_CALL(*mstream, fixedBufferOffset).Times(AnyNumber()).WillRepeatedly(Return(false));
 
     auto op_data = malloc(sizeof(AsyncOpFallback));
+    // NOLINTNEXTLINE(clang-analyzer-unix.Malloc): freed via mocked hipHostFree on cleanup
     ASSERT_NE(op_data, nullptr);
     auto bounce_buffer = malloc(size);
+    // NOLINTNEXTLINE(clang-analyzer-unix.Malloc): freed via mocked hipHostFree on cleanup
     ASSERT_NE(bounce_buffer, nullptr);
     EXPECT_CALL(mhip, hipHostMalloc).WillOnce(Return(op_data)).WillOnce(Return(bounce_buffer));
     EXPECT_CALL(mhip, hipHostGetDevicePointer(Eq(bounce_buffer), _))

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -303,6 +303,7 @@ TEST_F(HipFileStatsPerGpuStatsV1, GetHistograms)
     auto [readSize, readCount, readTime, readError]     = stats.getHistograms(IoType::Read);
     auto [writeSize, writeCount, writeTime, writeError] = stats.getHistograms(IoType::Write);
     auto [invalidSize, invalidCount, invalidTime, invalidError] =
+        // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange): invalid value tests rejection
         stats.getHistograms(static_cast<IoType>(-1));
     ASSERT_EQ(&stats.ioSizeBytes[0], readSize);
     ASSERT_EQ(&stats.ioCount[0], readCount);
@@ -324,6 +325,7 @@ TEST_F(HipFileStatsV1, getPerGpuStats)
 {
     StatsV1 stats{};
     ASSERT_EQ(nullptr, stats.getPerGpuStats(StatsV1::MaxGpus, StatsBackend::Fastpath));
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange): invalid value tests rejection
     ASSERT_EQ(nullptr, stats.getPerGpuStats(0, static_cast<StatsBackend>(-1)));
 }
 


### PR DESCRIPTION
## Motivation

Resolve every clang-tidy finding in hipFile and add a workflow that keeps the project clean going forward. With AISClangTidy.cmake passing -warnings-as-errors=*, a clean build now proves there are no remaining diagnostics.

## Technical Details

Source/build fixes:
- examples/async: reorder slice_state fields in the two multi-stream examples to group trailing bools, eliminating excessive struct padding (optin.performance.Padding).
- examples/async: drop dead stores in the close_file error branches of all three roundtrip examples; the assignments were never read because the goto skips the cleanup block that reads them (deadcode.DeadStores).
- cmake/AISUseGTest.cmake: mark GoogleTest include dirs as SYSTEM so clang-tidy suppresses diagnostics from its headers on every path (the SYSTEM keyword on FetchContent_Declare only applies to CMake >= 3.25, and a system find_package(GTest) may not mark them at all).
- test/stats.cpp: NOLINT the two intentional out-of-range enum casts that verify input rejection (optin.core.EnumCastOutOfRange).
- test/async.cpp: NOLINT two malloc sites whose ownership transfers to AsyncOpFallback and is freed via the mocked hipHostFree during async cleanup; verified leak-free under ASAN (unix.Malloc false positive).

CI:
- Add hipfile-clang-tidy.yml, a reusable workflow that compiles hipFile with -DAIS_USE_CLANG_TIDY=ON inside the CI container (no tests; we only care about clang-tidy diagnostics).
- Wire it into hipfile-ci-toplevel.yml as a run-once job, pinned to a single fixed image rather than fanning out across the build matrix since findings are compiler- and standard-independent.

## JIRA ID

AIHIPFILE-161

## Test Plan

CI passes with no clang-tidy issues

## Test Result

Passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
