### PR TITLE
[hipfile] Make examples build and run under sanitizers

### DIFF
--- a/projects/hipfile/examples/async/CMakeLists.txt
+++ b/projects/hipfile/examples/async/CMakeLists.txt
@@ -19,7 +19,13 @@ foreach(example ${ASYNC_EXAMPLES})
     add_executable(${example} "${example}.cpp")
     target_compile_features(${example} PRIVATE cxx_std_${AIS_CXX_STANDARD})
     set_target_properties(${example} PROPERTIES CXX_EXTENSIONS OFF)
-    target_compile_options(${example} PRIVATE -Wall -Wextra -fno-sanitize=all)
+    target_compile_options(${example} PRIVATE -Wall -Wextra)
+    # hipfile is instrumented when the sanitizers are on; an uninstrumented
+    # executable linked against it dies at load with undefined __asan_*/__tsan_*
+    # symbols. Instrument the example too so it pulls in the sanitizer runtime.
+    if(AIS_USE_SANITIZERS OR AIS_USE_THREAD_SANITIZER)
+        ais_add_sanitizers(${example})
+    endif()
 
     if(CMAKE_HIP_PLATFORM STREQUAL "amd")
         target_compile_definitions(${example} PRIVATE __HIP_PLATFORM_AMD__)

--- a/projects/hipfile/examples/basics/CMakeLists.txt
+++ b/projects/hipfile/examples/basics/CMakeLists.txt
@@ -22,7 +22,13 @@ foreach(example ${BASICS_EXAMPLES})
     add_executable(${example} "${example}.cpp")
     target_compile_features(${example} PRIVATE cxx_std_17)
     set_target_properties(${example} PROPERTIES CXX_EXTENSIONS OFF)
-    target_compile_options(${example} PRIVATE -Wall -Wextra -fno-sanitize=all)
+    target_compile_options(${example} PRIVATE -Wall -Wextra)
+    # hipfile is instrumented when the sanitizers are on; an uninstrumented
+    # executable linked against it dies at load with undefined __asan_*/__tsan_*
+    # symbols. Instrument the example too so it pulls in the sanitizer runtime.
+    if(AIS_USE_SANITIZERS OR AIS_USE_THREAD_SANITIZER)
+        ais_add_sanitizers(${example})
+    endif()
 
     if(CMAKE_HIP_PLATFORM STREQUAL "amd")
         target_compile_definitions(${example} PRIVATE __HIP_PLATFORM_AMD__)

--- a/projects/hipfile/examples/common/CMakeLists.txt
+++ b/projects/hipfile/examples/common/CMakeLists.txt
@@ -9,7 +9,13 @@
 add_library(examples_common STATIC examples_common.cpp)
 target_compile_features(examples_common PRIVATE cxx_std_${AIS_CXX_STANDARD})
 set_target_properties(examples_common PROPERTIES CXX_EXTENSIONS OFF)
-target_compile_options(examples_common PRIVATE -Wall -Wextra -fno-sanitize=all)
+target_compile_options(examples_common PRIVATE -Wall -Wextra)
+# hipfile is instrumented when the sanitizers are on; this static lib is linked
+# into the example executables, so instrument it to match and avoid an
+# instrumentation mismatch.
+if(AIS_USE_SANITIZERS OR AIS_USE_THREAD_SANITIZER)
+    ais_add_sanitizers(examples_common)
+endif()
 target_include_directories(examples_common PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if(CMAKE_HIP_PLATFORM STREQUAL "amd")


### PR DESCRIPTION
## Motivation

The hand-wired example targets (examples/common, basics, async) were compiled with -fno-sanitize=all and never linked the sanitizer runtime. When the build was configured with AIS_USE_SANITIZERS or AIS_USE_THREAD_SANITIZER, libhipfile gets instrumented, so loading an uninstrumented example against it failed at runtime with undefined symbols like __asan_option_detect_stack_use_after_return.

## Technical Details

Drop the -fno-sanitize=all flag (which did nothing useful here, since these targets bypass ais_add_executable and never had sanitizers turned on in the first place) and call ais_add_sanitizers() when the sanitizers are enabled, matching how libhipfile is built. Plain (non-sanitizer) builds are unchanged.

## JIRA ID

AIHIPFILE-154

## Test Plan

CI passes, manual verification that examples build & run under ASAN/TSAN

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
