### PR TITLE
[hipfile] Add CodeQL C/C++ analysis to CI

### DIFF
--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -229,3 +229,25 @@ jobs:
       cxx_standard: ${{ matrix.cxx_standard }}
       platform: ${{ matrix.supported_platforms }}
       rocm_version: ${{ matrix.rocm_versions }}
+
+  # CodeQL C/C++ findings are compiler- and standard-independent, so run the
+  # analysis exactly once against a single fixed image rather than fanning out
+  # across the build matrix. Change the image key below to retarget the ROCm
+  # version (the combo must exist in Precheck's matrix). Python and Actions are
+  # covered repo-wide by codeql.yml; this closes the C/C++ gap.
+  codeql:
+    if: >-
+      ${{
+        !cancelled() && (
+          needs.build_CI_image.result == 'success' ||
+          needs.build_CI_image.result == 'skipped'
+        )
+      }}
+    needs: [Precheck, build_CI_image]
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    uses: ./.github/workflows/hipfile-codeql.yml
+    with:
+      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.2'].ci_image }}

--- a/.github/workflows/hipfile-codeql.yml
+++ b/.github/workflows/hipfile-codeql.yml
@@ -1,0 +1,85 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+name: hipfile-codeql
+run-name: Run CodeQL C/C++ analysis on hipFile
+
+# CodeQL's C/C++ extractor works by tracing the real compiler invocations, so
+# init -> build -> analyze must all run in the SAME environment. We therefore
+# run the whole job inside the prebuilt hipFile CI image (job-level container),
+# rather than the host-runner + `docker exec` pattern used by hipfile-clang-tidy
+# (the tracer's environment would not reach a compiler launched in a separate
+# `docker exec` process).
+#
+# Python and GitHub Actions are already covered repo-wide by codeql.yml; this
+# workflow exists to close the C/C++ gap, which needs an observed build.
+
+env:
+  # A single arch is enough: CodeQL traces the host compilation (done once
+  # regardless of arch count); extra gfx targets only recompile device code,
+  # which the C/C++ extractor does not analyze.
+  AIS_HIP_ARCHITECTURES: gfx942
+
+on:
+  workflow_call:
+    inputs:
+      ci_image:
+        description: "Full CI image name & tag"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  # required to pull the CI image from GHCR
+  packages: read
+  # required to upload analysis results
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (c-cpp)
+    runs-on: [ubuntu-24.04]
+    timeout-minutes: 45
+    container:
+      image: ${{ inputs.ci_image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Fetching code repository...
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          sparse-checkout: |
+            projects/hipfile
+
+      - name: Configure Git safe directory
+        shell: bash
+        run: git config --global --add safe.directory '*'
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          languages: c-cpp
+          build-mode: manual
+          queries: security-extended,security-and-quality
+
+      - name: Configure and build hipFile
+        # Plain build (no clang-tidy): we only want CodeQL to observe the
+        # compiler. Debug build type keeps optimizations off so the extracted
+        # database is closer to the source.
+        shell: bash
+        run: |
+          cmake \
+            -B /tmp/build \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_CXX_COMPILER=amdclang++ \
+            -DCMAKE_HIP_ARCHITECTURES="${{ env.AIS_HIP_ARCHITECTURES }}" \
+            -DCMAKE_HIP_PLATFORM=amd \
+            projects/hipfile
+          cmake --build /tmp/build --parallel
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4.35.3
+        with:
+          category: "/hipfile/language:c-cpp"


### PR DESCRIPTION
## Motivation

The repo-wide codeql.yml only scans Python and GitHub Actions; C/C++ is uncovered because CodeQL needs to observe a real compiler build to analyze it. Add a reusable hipfile-codeql.yml that runs init -> build -> analyze inside the prebuilt hipFile CI image (job-level container, not the host + docker exec pattern used by clang-tidy, since the extractor's compiler tracing must share the build environment).

## Technical Details

Wire it into hipfile-ci-toplevel.yml as a single codeql job gated on the CI image, run once against ubuntu-7.2.2 since findings are compiler- and standard-independent. Uses the security-extended,security-and-quality query suite and a single gfx arch (host compilation is traced once; extra device-code targets add nothing for the C/C++ extractor).

## JIRA ID

AIHIPFILE-161

## Test Plan

CodeQL CI passes

## Test Result

Passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
