### PR TITLE
[RCCL] docs: monorepo clone/build steps + repo-ref cleanup (AICOMRCCL-1350)

### DIFF
--- a/projects/rccl/docs/install/building-installing.rst
+++ b/projects/rccl/docs/install/building-installing.rst
@@ -151,21 +151,23 @@ monorepo:
     git sparse-checkout set projects/rccl
     git checkout develop
 
-After the checkout completes, initialize the RCCL build submodules:
-
-.. code-block:: shell
-
-    git submodule update --init --recursive --depth=1
-
-Then build the library from the ``projects/rccl`` directory:
+For the default RCCL build on the ``develop`` branch, no ``git submodule`` step is
+required. Then build the library from the ``projects/rccl`` directory:
 
 .. code-block:: shell
 
     cd projects/rccl
     mkdir build
     cd build
-    cmake ../..
+    cmake ..
     make -j 16      # Or some other suitable number of parallel jobs
+
+.. note::
+
+    Optional rocSHMEM builds are configured separately and do not use RCCL git
+    submodules. Use ``./install.sh --rocshmem`` or pass ``-DENABLE_ROCSHMEM=ON``
+    together with ``-DROCSHMEM_INSTALL_DIR=<prefix>`` or
+    ``-DROCSHMEM_SOURCE_DIR=<path>``.
 
 You can substitute a different installation path by providing the path as a parameter
 to ``CMAKE_INSTALL_PREFIX``, for example:

--- a/projects/rccl/docs/install/building-installing.rst
+++ b/projects/rccl/docs/install/building-installing.rst
@@ -164,10 +164,8 @@ required. Then build the library from the ``projects/rccl`` directory:
 
 .. note::
 
-    Optional rocSHMEM builds are configured separately and do not use RCCL git
-    submodules. Use ``./install.sh --rocshmem`` or pass ``-DENABLE_ROCSHMEM=ON``
-    together with ``-DROCSHMEM_INSTALL_DIR=<prefix>`` or
-    ``-DROCSHMEM_SOURCE_DIR=<path>``.
+    To build RCCL with optional rocSHMEM support, see the
+    `rocSHMEM documentation <https://rocm.docs.amd.com/projects/rocSHMEM/en/latest/>`_.
 
 You can substitute a different installation path by providing the path as a parameter
 to ``CMAKE_INSTALL_PREFIX``, for example:

--- a/projects/rccl/docs/install/building-installing.rst
+++ b/projects/rccl/docs/install/building-installing.rst
@@ -164,8 +164,10 @@ required. Then build the library from the ``projects/rccl`` directory:
 
 .. note::
 
-    To build RCCL with optional rocSHMEM support, see the
-    `rocSHMEM documentation <https://rocm.docs.amd.com/projects/rocSHMEM/en/latest/>`_.
+    Optional rocSHMEM builds are configured separately and do not use RCCL git
+    submodules. Use ``./install.sh --rocshmem`` or pass ``-DENABLE_ROCSHMEM=ON``
+    together with ``-DROCSHMEM_INSTALL_DIR=<prefix>`` or
+    ``-DROCSHMEM_SOURCE_DIR=<path>``.
 
 You can substitute a different installation path by providing the path as a parameter
 to ``CMAKE_INSTALL_PREFIX``, for example:

--- a/projects/rccl/docs/install/building-installing.rst
+++ b/projects/rccl/docs/install/building-installing.rst
@@ -169,6 +169,13 @@ required. Then build the library from the ``projects/rccl`` directory:
     together with ``-DROCSHMEM_INSTALL_DIR=<prefix>`` or
     ``-DROCSHMEM_SOURCE_DIR=<path>``.
 
+    rocSHMEM support drives RCCL's GPU Direct Async (GDA) AllToAll path, which is
+    validated only on supported GDA platforms (gfx942-class systems with a
+    supported multi-node NIC and driver setup). Building with ``--rocshmem`` on
+    other GPU architectures is not a supported configuration and may fail. For
+    the GDA NIC and driver requirements, see the
+    `rocSHMEM documentation <https://rocm.docs.amd.com/projects/rocSHMEM/en/latest/install.html#gda-nic-dependencies>`_.
+
 You can substitute a different installation path by providing the path as a parameter
 to ``CMAKE_INSTALL_PREFIX``, for example:
 

--- a/projects/rccl/docs/install/building-installing.rst
+++ b/projects/rccl/docs/install/building-installing.rst
@@ -37,10 +37,10 @@ Quick start RCCL build
 ----------------------
 
 RCCL directly depends on the HIP runtime plus the HIP-Clang compiler, which are part of the ROCm software stack.
-For ROCm installation instructions, see the :doc:`rocm:install/rocm`.
+For ROCm installation instructions, see the :doc:`ROCm installation guide <rocm-install-on-linux:install/quick-start>`.
 
-Use the `install.sh helper script <https://github.com/ROCm/rccl/blob/develop/install.sh>`_,
-located in the root directory of the RCCL repository,
+Use the `install.sh helper script <https://github.com/ROCm/rocm-systems/blob/develop/projects/rccl/install.sh>`_,
+located in the ``projects/rccl`` directory of the rocm-systems repository,
 to build and install RCCL with a single command. It uses hard-coded configurations that can be specified directly
 when using cmake. However, it's a great way to get started quickly and provides an
 example of how to build and install RCCL.
@@ -79,25 +79,23 @@ The RCCL build and installation helper script options are as follows:
           --debug-fast            Build debug library with lto optimization disabled (fast build times)
        -d|--dependencies          Install RCCL dependencies
           --device-linker         Build with assembly-extract device linker (default)
-          --disable-colltrace     Build without collective trace
           --disable-roctx         Build without ROCTX logging
+          --disable-sym-kernels   Disable symmetric memory kernels
           --disable-warp-speed    Disable WARP_SPEED kernel optimizations
           --dump-asm              Disassemble code and dump assembly with inline code
        -c|--enable-code-coverage  Enable code coverage
           --enable_backtrace      Build with custom backtrace support
           --enable-mpi-tests      Enable MPI-based tests (requires --debug and MPI installation; set MPI_PATH if not in /opt/ompi)
-       -f|--fast                  Quick-build RCCL (local gpu arch only, no backtrace, and collective trace support)
+       -f|--fast                  Quick-build RCCL (local gpu arch only, no backtrace)
           --force-reduce-pipeline Force reduce_copy sw pipeline to be used for every reduce-based collectives and datatypes
-          --generate-sym-kernels  Generate symmetric memory kernels (default: OFF)
        -h|--help                  Prints this help message
        -i|--install               Install RCCL library (see --prefix argument below)
-       -j|--jobs                  Specify how many parallel compilation jobs to run (16 by default)
+       -j|--jobs                  Specify how many parallel compilation jobs to run (32 by default)
           --kernel-resource-use   Dump GPU kernel resource usage (e.g., VGPRs, scratch, spill) at link stage
        -l|--local_gpu_only        Only compile for local GPU architecture
           --log-trace             Build with log trace enabled (i.e. NCCL_DEBUG=TRACE)
           --no_clean              Don't delete files if they already exist
           --no-device-linker      Disable device linker, use standard -fgpu-rdc
-          --npkit-enable          Compile with npkit enabled
           --openmp-test-enable    Enable OpenMP in rccl unit tests
        -p|--package_build         Build RCCL package
           --prefix                Specify custom directory to install RCCL to (default: `/opt/rocm`)
@@ -133,29 +131,41 @@ The RCCL build and installation helper script options are as follows:
 
 .. tip::
 
-    By default, the RCCL install script builds all the GPU targets that are defined in ``DEFAULT_GPUS`` in `CMakeLists.txt <https://github.com/ROCm/rccl/blob/develop/CMakeLists.txt>`_.
+    By default, the RCCL install script builds all the GPU targets that are defined in ``DEFAULT_GPUS`` in `CMakeLists.txt <https://github.com/ROCm/rocm-systems/blob/develop/projects/rccl/CMakeLists.txt>`_.
     To target specific GPUs and potentially reduce the build time, use ``--amdgpu_targets`` along with
     a semicolon (``;``) separated string list of the GPU targets.
 
 Building the library using CMake
 ================================
 
-To build the library from source, follow these steps:
+RCCL has moved from the standalone ``ROCm/rccl`` repository into the
+``ROCm/rocm-systems`` monorepo, where it is located at ``projects/rccl``. Use a
+partial, sparse checkout so you only fetch the RCCL project instead of the entire
+monorepo:
 
 .. code-block:: shell
 
-    git clone --recursive https://github.com/ROCm/rccl.git
-    cd rccl
-    mkdir build
-    cd build
-    cmake ..
-    make -j 16      # Or some other suitable number of parallel jobs
+    git clone --no-checkout --filter=blob:none https://github.com/ROCm/rocm-systems.git
+    cd rocm-systems
+    git sparse-checkout init --cone
+    git sparse-checkout set projects/rccl
+    git checkout develop
 
-If you have already cloned the repository, you can checkout the external submodules manually.
+After the checkout completes, initialize the RCCL build submodules:
 
 .. code-block:: shell
 
     git submodule update --init --recursive --depth=1
+
+Then build the library from the ``projects/rccl`` directory:
+
+.. code-block:: shell
+
+    cd projects/rccl
+    mkdir build
+    cd build
+    cmake ../..
+    make -j 16      # Or some other suitable number of parallel jobs
 
 You can substitute a different installation path by providing the path as a parameter
 to ``CMAKE_INSTALL_PREFIX``, for example:
@@ -178,7 +188,7 @@ use this command to build the package on Debian-based distros:
 
 .. code-block:: shell
 
-    cd rccl/build
+    cd projects/rccl/build
     make package
     sudo dpkg -i *.deb
 
@@ -213,8 +223,8 @@ A list of the available environment variables for filtering appears at the top o
 See the `Googletest documentation <https://google.github.io/googletest/advanced.html#running-a-subset-of-the-tests>`_
 for more information on how to form advanced filters.
 
-There are also other performance and error-checking tests for RCCL. They are maintained separately at `<https://github.com/ROCm/rccl-tests>`_.
+There are also other performance and error-checking tests for RCCL. They are maintained separately at `rccl-tests <https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl-tests>`_.
 
 .. note::
 
-    For more information on how to build and run rccl-tests, see the `rccl-tests README file <https://github.com/ROCm/rccl-tests/blob/develop/README.md>`_ .
+    For more information on how to build and run rccl-tests, see the `rccl-tests README file <https://github.com/ROCm/rocm-systems/blob/develop/projects/rccl-tests/README.md>`_ .


### PR DESCRIPTION
## AICOMRCCL-1350 — RCCL docs: build from source (building-installing.rst)

Part of the install-docs refresh under **AICOMRCCL-1297**. Detailed plan: [Confluence](https://amd.atlassian.net/wiki/spaces/MLSE/pages/1752136539).

### Changes
- **Rewrite the clone/build section** for the monorepo: blobless partial clone + `sparse-checkout set projects/rccl`, submodule init (`mscclpp` + `json`, not rocSHMEM), then `cd projects/rccl` / `cmake ../..`.
- **Add migration note**: RCCL moved from `ROCm/rccl` into `ROCm/rocm-systems` (`projects/rccl`).
- **Fix stale standalone-repo URLs** → monorepo paths: `install.sh`, `CMakeLists.txt`, `rccl-tests`, `rccl-tests` README.
- **Fix preview-only link** `rocm:install/rocm` → `rocm-install-on-linux:install/quick-start`.
- **Sync the `install.sh` option block** with current `./install.sh --help`: removed `--disable-colltrace`, `--npkit-enable`, `--generate-sym-kernels`; added `--disable-sym-kernels`; `-j` default 16→32; corrected `-f|--fast` description.

### Verification
- `sphinx -n -W`: **zero warnings** for `building-installing.rst`; the `building-installing.rst:39 rocm:install/rocm` warning is gone.
- Option block now matches `--help` (0 live flags missing).
- New monorepo URLs return HTTP 200.
