### PR TITLE
[RCCL] docs: fix Docker build path, rccl-tests URL, refresh base image (AICOMRCCL-1351)

### DIFF
--- a/projects/rccl/docs/install/docker-install.rst
+++ b/projects/rccl/docs/install/docker-install.rst
@@ -13,6 +13,10 @@ To build the Docker image and run the container, follow these steps.
 
 #. Build the Docker image
 
+   The ``Dockerfile.ubuntu`` file is located in the ``docker`` directory of the
+   RCCL project. Run the following commands from the ``projects/rccl`` directory
+   of the rocm-systems repository.
+
    By default, the Dockerfile uses ``docker.io/rocm/dev-ubuntu-22.04:latest`` as the base Docker image.
    It then installs RCCL and rccl-tests (in both cases, it uses the version from the ``develop`` branch).
 
@@ -20,15 +24,15 @@ To build the Docker image and run the container, follow these steps.
 
    .. code-block:: shell
 
-      docker build -t rccl-tests -f Dockerfile.ubuntu --pull .
+      docker build -t rccl-tests -f docker/Dockerfile.ubuntu --pull .
 
    The base Docker image, rccl repository, rccl-tests repository, and GPU targets can be modified
-   by using ``--build-args`` in the ``docker build`` command above. For example, to use a different base Docker image for the MI250 GPU,
+   by using ``--build-arg`` in the ``docker build`` command above. For example, to use a different base Docker image and target a specific GPU architecture,
    use this command:
 
    .. code-block:: shell
 
-      docker build -t rccl-tests -f Dockerfile.ubuntu --build-arg="ROCM_IMAGE_NAME=rocm/dev-ubuntu-20.04" --build-arg="ROCM_IMAGE_TAG=6.2" --build-arg="GPU_TARGETS=gfx90a" --pull .
+      docker build -t rccl-tests -f docker/Dockerfile.ubuntu --build-arg="ROCM_IMAGE_NAME=rocm/dev-ubuntu-24.04" --build-arg="ROCM_IMAGE_TAG=6.4.2" --build-arg="GPU_TARGETS=gfx942" --pull .
 
 #. Launch an interactive Docker container on a system with AMD GPUs:
 
@@ -49,4 +53,4 @@ To build the Docker image and run the container, follow these steps.
 
       mpirun --allow-run-as-root -np 8 --mca pml ucx --mca btl ^openib -x NCCL_DEBUG=VERSION -x HSA_NO_SCRATCH_RECLAIM=1 /workspace/rccl-tests/build/all_reduce_perf -b 1 -e 16G -f 2 -g 1
 
-For more information on the rccl-tests options, see the `Usage guidelines <https://github.com/ROCm/rccl-tests#usage>`_ in the GitHub repository.
+For more information on the rccl-tests options, see the `Usage guidelines <https://github.com/ROCm/rocm-systems/tree/develop/projects/rccl-tests#usage>`_ in the GitHub repository.


### PR DESCRIPTION
## AICOMRCCL-1351 — RCCL docs: Docker install (docker-install.rst)

Part of the install-docs refresh under **AICOMRCCL-1297**. Detailed plan: [Confluence](https://amd.atlassian.net/wiki/spaces/MLSE/pages/1752136539).

### Changes
- **Fix the Dockerfile path** (x2): `-f Dockerfile.ubuntu` → `-f docker/Dockerfile.ubuntu` (the file lives in `docker/`).
- Add a note that the build commands run from `projects/rccl`.
- **Refresh the dated base-image example**: `rocm/dev-ubuntu-20.04` / `6.2` / `gfx90a` → `rocm/dev-ubuntu-24.04` / `6.4.2` / `gfx942`; fix `--build-args` typo → `--build-arg`.
- **Fix stale URL**: `ROCm/rccl-tests#usage` → `rocm-systems/.../projects/rccl-tests#usage`.

### Scope note
The bundled `docker/Dockerfile.ubuntu` build logic (clone/`cd`/cmake paths assume the old flat layout) is **not** changed here — that rewrite is a separate deferred build/infra follow-up. This PR corrects documentation text only.

### Verification
- `sphinx -n -W`: **zero warnings** for `docker-install.rst`.
- No old-repo URLs; dated base image removed.
