### PR TITLE
Juwillia/amdsmi python matrix ci

### DIFF
--- a/.github/workflows/amdsmi-build.yml
+++ b/.github/workflows/amdsmi-build.yml
@@ -227,18 +227,6 @@ jobs:
         if: always()
         run: cat /tmp/test-results-${{ matrix.os }}/amd_smi_nodrm_ex.log || echo "No NoDRM example results"
 
-      - name: AMDSMI Python Version Matrix
-        if: ${{ always() && matrix.os == 'AlmaLinux8' }}
-        continue-on-error: true
-        run: |
-          set -uo pipefail
-          SCRIPT=$(find $GITHUB_WORKSPACE -path "*/projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py" | head -1)
-          python3 "$SCRIPT" python-matrix \
-            --results-dir "/tmp/test-results-${{ matrix.os }}" \
-            --amdsmi-path /opt/rocm/share/amd_smi \
-            --os-label "${{ matrix.os }}" \
-            --summary-file "$GITHUB_STEP_SUMMARY"
-
       - name: AMDSMI CI Summary
         if: always()
         run: |

--- a/.github/workflows/amdsmi-build.yml
+++ b/.github/workflows/amdsmi-build.yml
@@ -227,6 +227,18 @@ jobs:
         if: always()
         run: cat /tmp/test-results-${{ matrix.os }}/amd_smi_nodrm_ex.log || echo "No NoDRM example results"
 
+      - name: AMDSMI Python Version Matrix
+        if: ${{ always() && matrix.os == 'AlmaLinux8' }}
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          SCRIPT=$(find $GITHUB_WORKSPACE -path "*/projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py" | head -1)
+          python3 "$SCRIPT" python-matrix \
+            --results-dir "/tmp/test-results-${{ matrix.os }}" \
+            --amdsmi-path /opt/rocm/share/amd_smi \
+            --os-label "${{ matrix.os }}" \
+            --summary-file "$GITHUB_STEP_SUMMARY"
+
       - name: AMDSMI CI Summary
         if: always()
         run: |

--- a/.github/workflows/amdsmi-python-compat.yml
+++ b/.github/workflows/amdsmi-python-compat.yml
@@ -1,18 +1,22 @@
 # ---------------------------------------------------------------------------
 # AMD-SMI Python compatibility check.
 #
-# Builds and installs AMD-SMI on AlmaLinux8, then runs the installed Python
-# test suite (integration, unit, CLI) under every supported interpreter --
-# 3.6.8 (native) plus the latest patch of 3.7 through 3.14 -- and publishes a
-# per-version PASS/FAIL/SKIP table to the job summary. Runs as its own CI
-# check so a Python-version regression is visible independently of the
-# per-distro build matrix in amdsmi-build.yml.
+# Builds and installs AMD-SMI on each OS, then runs the installed Python test
+# suite (integration, unit, CLI) under every supported interpreter -- 3.6.8
+# plus the latest patch of 3.7 through 3.14 -- and publishes a per-version
+# PASS/FAIL/SKIP table to the job summary. Runs as its own CI check so a
+# Python-version regression is visible independently of the per-distro build
+# matrix in amdsmi-build.yml.
+#
+# Coverage spans two OS families so both glibc/toolchain worlds are exercised:
+#   - AlmaLinux8 ships Python 3.6.8 natively (el8).
+#   - Ubuntu22 has no system 3.6/3.7, so those are built from source.
 #
 # Interpreters are resolved by the `python-matrix` subcommand of
-# tests/amdsmi_build/run_amdsmi_build.py: a system pythonX.Y first, then a
-# uv-managed download, then a pyenv source build for versions uv cannot
-# supply (3.6.8, 3.7.x). AlmaLinux8 is used because it ships Python 3.6.8
-# natively.
+# tests/amdsmi_build/run_amdsmi_build.py in three tiers: a system pythonX.Y
+# first, then a uv-managed download (3.8-3.14), then a pyenv source build for
+# versions uv cannot supply (3.6.8, 3.7.x). A version that no tier can provide
+# is reported as SKIP rather than failing the run.
 # ---------------------------------------------------------------------------
 
 name: AMDSMI Python Compatibility
@@ -45,12 +49,17 @@ defaults:
 
 jobs:
   python-compat:
-    name: Python Compatibility (AlmaLinux8)
+    name: Python Compatibility on ${{ matrix.os }}
     runs-on:
       - self-hosted
       - ${{ vars.RUNNER_TYPE }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [Ubuntu22, AlmaLinux8]
     container:
-      image: ${{ vars.AlmaLinux8_DOCKER_IMAGE }}
+      image: ${{ vars[format('{0}_DOCKER_IMAGE', matrix.os)] }}
       options: --rm --privileged --device=/dev/kfd --device=/dev/dri --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --shm-size=64G --cap-add=SYS_MODULE -v /lib/modules:/lib/modules -u root
 
     steps:
@@ -79,43 +88,49 @@ jobs:
           echo "RUNNER_SCRIPT=$SCRIPT" >> $GITHUB_ENV
 
       # Build + install + wheel-verify. The python-matrix step below runs the
-      # *installed* test suite from /opt/rocm/share/amd_smi, so an install is
-      # a prerequisite. Distro quirks are autodetected from /etc/os-release.
+      # *installed* test suite from /opt/rocm/share/amd_smi, so an install is a
+      # prerequisite. The runner script autodetects the package manager and
+      # distro quirks (and installs the toolchain/headers pyenv needs to build
+      # CPython) from /etc/os-release.
       - name: Build and Install AMD-SMI
         run: |
           set -euo pipefail
           python3 "${{ env.RUNNER_SCRIPT }}" \
             --project-dir "${{ env.PROJECT_DIR }}" \
-            --os-label AlmaLinux8 \
-            --test-results-dir /tmp/test-results-python-compat
+            --os-label "${{ matrix.os }}" \
+            --test-results-dir "/tmp/test-results-python-compat-${{ matrix.os }}"
 
       # Runs the installed suite under 3.6.8 + latest 3.7..3.14 and writes the
-      # per-version table to the step summary. Exits non-zero (failing this
-      # check) only if a resolved interpreter's tests FAIL; versions that
-      # cannot be provided are reported as SKIP and do not fail the check.
+      # per-version table to the step summary. Exits non-zero only if a
+      # resolved interpreter's tests FAIL; versions that cannot be provided on
+      # this OS are reported as SKIP and do not fail the step.
       - name: Python Version Matrix
         run: |
           set -euo pipefail
           python3 "${{ env.RUNNER_SCRIPT }}" python-matrix \
-            --results-dir /tmp/test-results-python-compat \
+            --results-dir "/tmp/test-results-python-compat-${{ matrix.os }}" \
             --amdsmi-path /opt/rocm/share/amd_smi \
-            --os-label AlmaLinux8 \
+            --os-label "${{ matrix.os }}" \
             --summary-file "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Python Compatibility Results
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
-          name: amdsmi-python-compat-AlmaLinux8
-          path: /tmp/test-results-python-compat
+          name: amdsmi-python-compat-${{ matrix.os }}
+          path: /tmp/test-results-python-compat-${{ matrix.os }}
           if-no-files-found: warn
           retention-days: 7
 
       - name: Uninstall
         if: always()
         run: |
-          set -euo pipefail
-          dnf remove -y amd-smi-lib || true
+          set -uo pipefail
+          if command -v apt >/dev/null 2>&1; then
+            apt remove -y amd-smi-lib || true
+          elif command -v dnf >/dev/null 2>&1; then
+            dnf remove -y amd-smi-lib || true
+          fi
           rm -f /usr/local/bin/amd-smi
           if [ -d /opt/rocm/share/amd_smi ]; then
             rm -rf /opt/rocm/share/amd_smi

--- a/.github/workflows/amdsmi-python-compat.yml
+++ b/.github/workflows/amdsmi-python-compat.yml
@@ -1,0 +1,122 @@
+# ---------------------------------------------------------------------------
+# AMD-SMI Python compatibility check.
+#
+# Builds and installs AMD-SMI on AlmaLinux8, then runs the installed Python
+# test suite (integration, unit, CLI) under every supported interpreter --
+# 3.6.8 (native) plus the latest patch of 3.7 through 3.14 -- and publishes a
+# per-version PASS/FAIL/SKIP table to the job summary. Runs as its own CI
+# check so a Python-version regression is visible independently of the
+# per-distro build matrix in amdsmi-build.yml.
+#
+# Interpreters are resolved by the `python-matrix` subcommand of
+# tests/amdsmi_build/run_amdsmi_build.py: a system pythonX.Y first, then a
+# uv-managed download, then a pyenv source build for versions uv cannot
+# supply (3.6.8, 3.7.x). AlmaLinux8 is used because it ships Python 3.6.8
+# natively.
+# ---------------------------------------------------------------------------
+
+name: AMDSMI Python Compatibility
+
+on:
+  pull_request:
+    branches: [develop]
+    paths:
+      - 'projects/amdsmi/**'
+      - '.github/workflows/amdsmi-python-compat.yml'
+  push:
+    branches: [develop]
+    paths:
+      - 'projects/amdsmi/**'
+      - '.github/workflows/amdsmi-python-compat.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DEBIAN_FRONTEND: noninteractive
+  DEBCONF_NONINTERACTIVE_SEEN: true
+  BUILD_TYPE: Release
+  ROCM_DIR: /opt/rocm
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  python-compat:
+    name: Python Compatibility (AlmaLinux8)
+    runs-on:
+      - self-hosted
+      - ${{ vars.RUNNER_TYPE }}
+    container:
+      image: ${{ vars.AlmaLinux8_DOCKER_IMAGE }}
+      options: --rm --privileged --device=/dev/kfd --device=/dev/dri --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --shm-size=64G --cap-add=SYS_MODULE -v /lib/modules:/lib/modules -u root
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Mark workspace safe for git
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Set Project Directory
+        run: |
+          set -euo pipefail
+          TARGET_DIR=$(find $GITHUB_WORKSPACE -path "*/projects/amdsmi/CMakeLists.txt" -exec dirname {} \;)
+          if [ -z "$TARGET_DIR" ]; then
+            TARGET_DIR=$(find $GITHUB_WORKSPACE -maxdepth 2 -name "CMakeLists.txt" -exec dirname {} \; | head -n 1)
+          fi
+          echo "PROJECT_DIR=$TARGET_DIR" >> $GITHUB_ENV
+
+      - name: Locate Runner Script
+        run: |
+          set -euo pipefail
+          SCRIPT=$(find $GITHUB_WORKSPACE -path "*/projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py" | head -1)
+          if [ -z "$SCRIPT" ]; then
+            echo "ERROR: run_amdsmi_build.py not found"
+            exit 1
+          fi
+          echo "RUNNER_SCRIPT=$SCRIPT" >> $GITHUB_ENV
+
+      # Build + install + wheel-verify. The python-matrix step below runs the
+      # *installed* test suite from /opt/rocm/share/amd_smi, so an install is
+      # a prerequisite. Distro quirks are autodetected from /etc/os-release.
+      - name: Build and Install AMD-SMI
+        run: |
+          set -euo pipefail
+          python3 "${{ env.RUNNER_SCRIPT }}" \
+            --project-dir "${{ env.PROJECT_DIR }}" \
+            --os-label AlmaLinux8 \
+            --test-results-dir /tmp/test-results-python-compat
+
+      # Runs the installed suite under 3.6.8 + latest 3.7..3.14 and writes the
+      # per-version table to the step summary. Exits non-zero (failing this
+      # check) only if a resolved interpreter's tests FAIL; versions that
+      # cannot be provided are reported as SKIP and do not fail the check.
+      - name: Python Version Matrix
+        run: |
+          set -euo pipefail
+          python3 "${{ env.RUNNER_SCRIPT }}" python-matrix \
+            --results-dir /tmp/test-results-python-compat \
+            --amdsmi-path /opt/rocm/share/amd_smi \
+            --os-label AlmaLinux8 \
+            --summary-file "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Python Compatibility Results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: amdsmi-python-compat-AlmaLinux8
+          path: /tmp/test-results-python-compat
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Uninstall
+        if: always()
+        run: |
+          set -euo pipefail
+          dnf remove -y amd-smi-lib || true
+          rm -f /usr/local/bin/amd-smi
+          if [ -d /opt/rocm/share/amd_smi ]; then
+            rm -rf /opt/rocm/share/amd_smi
+          fi

--- a/projects/amdsmi/tests/amdsmi_build/README.md
+++ b/projects/amdsmi/tests/amdsmi_build/README.md
@@ -51,6 +51,7 @@ sudo python3 projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py \
 | `--skip-setuptools-upgrade` | Skip pip/setuptools/wheel upgrade |
 | `--install-more-itertools` | Install `more_itertools` (AzureLinux 3) |
 | `summarize <results-dir>` | (subcommand) Render the CI step summary |
+| `python-matrix` | (subcommand) Run the installed Python test suite under several interpreters |
 
 ## Supported distros
 

--- a/projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py
+++ b/projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py
@@ -1249,13 +1249,14 @@ def _summarize_cli(argv: List[str]) -> int:
 # install is exercised by every interpreter -- no per-version venvs or wheel
 # installs are required.
 #
-# Interpreters are resolved per requested minor version by (1) a system
-# pythonX.Y already on PATH -- which covers distro pythons uv cannot supply,
-# e.g. 3.6 on AlmaLinux8 -- then (2) a uv-managed download.  Versions that
-# neither source can provide are recorded as SKIP rather than failing.
+# Interpreters are resolved per requested version in three tiers: (1) a
+# system pythonX.Y on PATH (covers the native 3.6.8 on AlmaLinux8), then
+# (2) a uv-managed download (3.8-3.14), then (3) a pyenv source build for
+# versions uv cannot supply (3.6.8, 3.7.x).  A version is only recorded as
+# SKIP if all three tiers fail.
 # ---------------------------------------------------------------------------
 
-DEFAULT_PY_MATRIX_VERSIONS = "3.6 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14"
+DEFAULT_PY_MATRIX_VERSIONS = "3.6.8 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14"
 DEFAULT_AMDSMI_PATH = Path("/opt/rocm/share/amd_smi")
 DEFAULT_UV_VERSION = "0.11.23"
 PY_MATRIX_TEST_FILES = ("integration_test.py", "unit_tests.py", "cli_unit_test.py")
@@ -1297,6 +1298,17 @@ def minor_of(version: str) -> str:
     if not m:
         raise ValueError(f"Cannot parse minor version from {version!r}")
     return m.group(1)
+
+
+def _version_matches(got: str, requested: str) -> bool:
+    """True if interpreter version *got* satisfies the *requested* spec.
+
+    A patch-level request (``X.Y.Z``) requires an exact match; a minor
+    request (``X.Y``) matches any patch release of that minor.
+    """
+    if requested.count(".") >= 2:
+        return got == requested
+    return minor_of(got) == minor_of(requested)
 
 
 def _py_status_icon(status: str) -> str:
@@ -1412,25 +1424,164 @@ def ensure_uv(log_dir: Path, uv_version: str, install_dir: Path) -> Optional[Pat
     return uv_dest
 
 
+def _pyenv_build_dep_packages(pkg_manager: str) -> List[str]:
+    """Return the system packages pyenv needs to build CPython from source."""
+    if pkg_manager == "apt":
+        return [
+            "build-essential", "libssl-dev", "zlib1g-dev", "libbz2-dev",
+            "libreadline-dev", "libsqlite3-dev", "libffi-dev", "liblzma-dev",
+            "tk-dev", "uuid-dev", "xz-utils", "curl", "git",
+        ]
+    if pkg_manager == "dnf":
+        return [
+            "gcc", "make", "patch", "zlib-devel", "bzip2", "bzip2-devel",
+            "readline-devel", "sqlite", "sqlite-devel", "openssl-devel",
+            "tk-devel", "libffi-devel", "xz-devel", "findutils", "git", "curl",
+        ]
+    if pkg_manager == "zypper":
+        return [
+            "gcc", "make", "patch", "zlib-devel", "libbz2-devel",
+            "readline-devel", "sqlite3-devel", "libopenssl-devel",
+            "tk-devel", "libffi-devel", "xz-devel", "git", "curl",
+        ]
+    raise ValueError(f"Unsupported package manager for pyenv deps: {pkg_manager}")
+
+
+def _pkg_install_cmd(pkg_manager: str, packages: List[str]) -> List[str]:
+    """Build the install command for *packages* under *pkg_manager*."""
+    if pkg_manager == "apt":
+        return ["apt-get", "install", "-y", "--no-install-recommends"] + packages
+    if pkg_manager == "dnf":
+        return ["dnf", "install", "-y"] + packages
+    if pkg_manager == "zypper":
+        return ["zypper", "--non-interactive", "install"] + packages
+    raise ValueError(f"Unsupported package manager: {pkg_manager}")
+
+
+def ensure_pyenv(
+    log_dir: Path, pyenv_root: Path, pkg_manager: Optional[str]
+) -> Optional[Path]:
+    """Return a pyenv binary, cloning it (and its build deps) if needed.
+
+    pyenv builds CPython from source, covering versions uv cannot supply
+    (e.g. 3.6.8 and 3.7.x).  Build-dependency installation is best-effort.
+    """
+    on_path = shutil.which("pyenv")
+    if on_path:
+        print(f"python-matrix: using pyenv on PATH: {on_path}")
+        return Path(on_path)
+
+    pyenv_bin = pyenv_root / "bin" / "pyenv"
+    if not pyenv_bin.exists():
+        if pkg_manager:
+            try:
+                run_command(
+                    _pkg_install_cmd(
+                        pkg_manager, _pyenv_build_dep_packages(pkg_manager)
+                    ),
+                    name="pyenv-build-deps",
+                    retries=2,
+                    log_dir=log_dir,
+                )
+            except (CommandError, ValueError) as exc:
+                print(
+                    f"python-matrix: pyenv build-dep install failed "
+                    f"(continuing): {exc}"
+                )
+        pyenv_root.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            run_command(
+                [
+                    "git", "clone", "--depth", "1",
+                    "https://github.com/pyenv/pyenv.git", str(pyenv_root),
+                ],
+                name="pyenv-clone",
+                retries=2,
+                log_dir=log_dir,
+            )
+        except CommandError as exc:
+            print(f"python-matrix: failed to clone pyenv: {exc}")
+            return None
+
+    if pyenv_bin.exists():
+        print(f"python-matrix: pyenv ready at {pyenv_bin}")
+        return pyenv_bin
+    return None
+
+
+def resolve_via_pyenv(
+    version: str, pyenv_bin: Path, pyenv_root: Path, log_dir: Path
+) -> Tuple[Optional[str], str, str]:
+    """Build/locate *version* with pyenv. Returns ``(path, resolved, note)``."""
+    env = dict(os.environ)
+    env["PYENV_ROOT"] = str(pyenv_root)
+    env["PATH"] = str(pyenv_root / "bin") + os.pathsep + env.get("PATH", "")
+
+    # A bare minor (e.g. "3.7") must be resolved to a concrete patch release
+    # before pyenv can build it; an explicit "X.Y.Z" is used as-is.
+    if version.count(".") >= 2:
+        full = version
+    else:
+        try:
+            proc = subprocess.run(
+                [str(pyenv_bin), "latest", "-k", version],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                env=env,
+                timeout=60,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return None, "", f"pyenv latest failed for {version}: {exc}"
+        full = proc.stdout.strip()
+        if proc.returncode != 0 or not full:
+            return None, "", f"pyenv has no buildable release for {version}"
+
+    try:
+        run_command(
+            [str(pyenv_bin), "install", "-s", full],
+            name=f"pyenv-install-{full}",
+            env=env,
+            retries=1,
+            log_dir=log_dir,
+        )
+    except CommandError:
+        return None, "", f"pyenv could not build {full}"
+
+    interp = pyenv_root / "versions" / full / "bin" / "python3"
+    if interp.exists():
+        got = _query_interpreter_version(str(interp))
+        if got:
+            return str(interp), got, "pyenv"
+    return None, "", f"pyenv interpreter missing for {full}"
+
+
 def resolve_interpreter(
-    version: str, uv_bin: Optional[Path], log_dir: Path
+    version: str,
+    uv_bin: Optional[Path],
+    pyenv_bin: Optional[Path],
+    pyenv_root: Path,
+    log_dir: Path,
 ) -> Tuple[Optional[str], str, str]:
     """Resolve *version* to an interpreter path.
 
-    Returns ``(path_or_None, resolved_version, note)``.
+    Tries, in order: a system ``pythonX.Y`` on PATH, a uv-managed download,
+    then a pyenv source build.  Returns ``(path_or_None, resolved, note)``.
     """
     minor = minor_of(version)
 
-    # 1. System interpreter on PATH (pythonX.Y) -- covers distro pythons that
-    #    uv cannot provide (e.g. 3.6) and skips an unnecessary download.
+    # 1. System interpreter on PATH (pythonX.Y) -- covers distro pythons such
+    #    as the native 3.6.8 on AlmaLinux8 and skips an unnecessary download.
     cand = shutil.which(f"python{minor}")
     if cand:
         got = _query_interpreter_version(cand)
-        if got and minor_of(got) == minor:
+        if got and _version_matches(got, version):
             return cand, got, "system"
 
     # 2. uv-managed download (python-build-standalone) -- covers 3.8-3.14.
+    #    A uv miss is not fatal: fall through to the pyenv source build.
     if uv_bin is not None:
+        installed = True
         try:
             run_command(
                 [str(uv_bin), "python", "install", version],
@@ -1439,25 +1590,35 @@ def resolve_interpreter(
                 log_dir=log_dir,
             )
         except CommandError:
-            return None, "", f"uv could not install {version}"
-        try:
-            found = subprocess.run(
-                [str(uv_bin), "python", "find", version],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
-                text=True,
-                timeout=60,
-            )
-        except (OSError, subprocess.SubprocessError) as exc:
-            return None, "", f"uv find failed for {version}: {exc}"
-        out = found.stdout.strip()
-        path = out.splitlines()[0].strip() if out else ""
-        if found.returncode == 0 and path:
-            got = _query_interpreter_version(path)
-            if got and minor_of(got) == minor:
-                return path, got, "uv"
+            installed = False
+        if installed:
+            try:
+                found = subprocess.run(
+                    [str(uv_bin), "python", "find", version],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.DEVNULL,
+                    text=True,
+                    timeout=60,
+                )
+            except (OSError, subprocess.SubprocessError):
+                found = None
+            if found is not None and found.returncode == 0:
+                out = found.stdout.strip()
+                path = out.splitlines()[0].strip() if out else ""
+                if path:
+                    got = _query_interpreter_version(path)
+                    if got and _version_matches(got, version):
+                        return path, got, "uv"
 
-    return None, "", "not available via system PATH or uv"
+    # 3. pyenv source build -- covers versions uv lacks (e.g. 3.6.8, 3.7.x).
+    if pyenv_bin is not None:
+        path, resolved, note = resolve_via_pyenv(
+            version, pyenv_bin, pyenv_root, log_dir
+        )
+        if path is not None:
+            return path, resolved, note
+
+    return None, "", "not available via system PATH, uv, or pyenv"
 
 
 def _run_suite_for_interpreter(
@@ -1526,6 +1687,8 @@ def run_python_matrix(
     uv_version: str,
     log_dir: Path,
     summary_file: Optional[Path],
+    use_pyenv: bool = True,
+    pyenv_root: Optional[Path] = None,
 ) -> int:
     """Resolve interpreters, run the suite per version, emit a summary table.
 
@@ -1539,9 +1702,24 @@ def run_python_matrix(
     else:
         uv_bin = ensure_uv(log_dir, uv_version, log_dir / "uv")
         if uv_bin is None:
-            print("python-matrix: proceeding with system interpreters only (no uv)")
+            print("python-matrix: proceeding without uv (system/pyenv only)")
+        resolved_pyenv_root = pyenv_root or (Path.home() / ".pyenv")
+        pyenv_bin = None
+        if use_pyenv:
+            try:
+                pkg_manager: Optional[str] = detect_package_manager(None)
+            except RuntimeError:
+                pkg_manager = None
+            pyenv_bin = ensure_pyenv(log_dir, resolved_pyenv_root, pkg_manager)
+            if pyenv_bin is None:
+                print(
+                    "python-matrix: pyenv unavailable; versions uv/system "
+                    "cannot supply will be skipped"
+                )
         for ver in versions:
-            path, resolved, note = resolve_interpreter(ver, uv_bin, log_dir)
+            path, resolved, note = resolve_interpreter(
+                ver, uv_bin, pyenv_bin, resolved_pyenv_root, log_dir
+            )
             if path is None:
                 print(f"python-matrix: {ver} -> SKIP ({note})")
                 rows.append(PyVersionResult(requested=ver, status="SKIP", note=note))
@@ -1595,6 +1773,17 @@ def _python_matrix_cli(argv: List[str]) -> int:
     )
     parser.add_argument("--python-versions", default=DEFAULT_PY_MATRIX_VERSIONS)
     parser.add_argument("--uv-version", default=DEFAULT_UV_VERSION)
+    parser.add_argument(
+        "--pyenv-root",
+        type=Path,
+        default=None,
+        help="pyenv root for source builds (default: ~/.pyenv)",
+    )
+    parser.add_argument(
+        "--no-pyenv",
+        action="store_true",
+        help="Disable the pyenv source-build fallback (uv/system only)",
+    )
     parser.add_argument("--log-dir", type=Path, default=DEFAULT_LOG_DIR)
     parser.add_argument(
         "--summary-file",
@@ -1615,6 +1804,8 @@ def _python_matrix_cli(argv: List[str]) -> int:
         uv_version=args.uv_version,
         log_dir=args.log_dir,
         summary_file=args.summary_file,
+        use_pyenv=not args.no_pyenv,
+        pyenv_root=args.pyenv_root,
     )
 
 

--- a/projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py
+++ b/projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py
@@ -194,9 +194,9 @@ import shutil
 import subprocess
 import sys
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Tuple
 
 DEFAULT_LOG_DIR = Path("logs") / "amdsmi"
 
@@ -1238,10 +1238,392 @@ def _summarize_cli(argv: List[str]) -> int:
     return summarize_results(args.results_dir, args.os_label, args.summary_file)
 
 
+# ---------------------------------------------------------------------------
+# Multi-Python sanity sweep (the "python-matrix" subcommand)
+#
+# Builds/installs once, then runs the *installed* Python test suite under a
+# range of interpreters so CI produces per-version PASS/FAIL sanity data on a
+# real GPU.  The amdsmi package is a pure-ctypes wrapper around libamd_smi.so
+# (py-interface/setup.py.in: python_requires>=3.6, no ext_modules) and the
+# tests import it from $AMDSMI_PATH (tests/python_unittest/common.py), so one
+# install is exercised by every interpreter -- no per-version venvs or wheel
+# installs are required.
+#
+# Interpreters are resolved per requested minor version by (1) a system
+# pythonX.Y already on PATH -- which covers distro pythons uv cannot supply,
+# e.g. 3.6 on AlmaLinux8 -- then (2) a uv-managed download.  Versions that
+# neither source can provide are recorded as SKIP rather than failing.
+# ---------------------------------------------------------------------------
+
+DEFAULT_PY_MATRIX_VERSIONS = "3.6 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14"
+DEFAULT_AMDSMI_PATH = Path("/opt/rocm/share/amd_smi")
+DEFAULT_UV_VERSION = "0.11.23"
+PY_MATRIX_TEST_FILES = ("integration_test.py", "unit_tests.py", "cli_unit_test.py")
+
+
+@dataclass
+class PyVersionResult:
+    requested: str
+    status: str = "SKIP"  # "PASS" | "FAIL" | "SKIP"
+    interpreter: str = ""
+    resolved: str = ""
+    note: str = ""
+    failed_tests: List[str] = field(default_factory=list)
+
+
+def parse_python_versions(spec: str) -> List[str]:
+    """Parse a whitespace/comma separated version spec into a deduped list.
+
+    Accepts ``X.Y`` or ``X.Y.Z`` tokens; raises ValueError on anything else.
+    """
+    import re
+
+    out: List[str] = []
+    for tok in re.split(r"[,\s]+", spec.strip()):
+        if not tok:
+            continue
+        if not re.fullmatch(r"\d+\.\d+(?:\.\d+)?", tok):
+            raise ValueError(f"Invalid Python version token: {tok!r}")
+        if tok not in out:
+            out.append(tok)
+    return out
+
+
+def minor_of(version: str) -> str:
+    """Return the ``X.Y`` minor prefix of a version string."""
+    import re
+
+    m = re.match(r"^\s*(\d+\.\d+)", version)
+    if not m:
+        raise ValueError(f"Cannot parse minor version from {version!r}")
+    return m.group(1)
+
+
+def _py_status_icon(status: str) -> str:
+    return {
+        "PASS": ":white_check_mark:",
+        "FAIL": ":x:",
+        "SKIP": ":fast_forward:",
+    }.get(status, ":grey_question:")
+
+
+def render_python_matrix_summary(os_label: str, results: List[PyVersionResult]) -> str:
+    """Render a markdown table of per-interpreter results."""
+    n_pass = sum(1 for r in results if r.status == "PASS")
+    n_fail = sum(1 for r in results if r.status == "FAIL")
+    n_skip = sum(1 for r in results if r.status == "SKIP")
+
+    lines = [
+        f"## Python Version Matrix \u2014 {os_label}",
+        "",
+        "| Requested | Status | Interpreter | Detail |",
+        "| --- | --- | --- | --- |",
+    ]
+    for r in results:
+        interp = f"{r.resolved} ({r.interpreter})" if r.resolved else "\u2014"
+        detail = ("failed: " + ", ".join(r.failed_tests)) if r.failed_tests else r.note
+        lines.append(
+            f"| {r.requested} | {_py_status_icon(r.status)} {r.status} | {interp} | {detail} |"
+        )
+    lines += [
+        "",
+        f"**{n_pass} passed, {n_fail} failed, {n_skip} skipped** "
+        f"(of {len(results)} requested)",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _query_interpreter_version(python_bin: str) -> Optional[str]:
+    """Return ``X.Y.Z`` reported by *python_bin*, or None if it cannot run."""
+    try:
+        proc = subprocess.run(
+            [python_bin, "-c", "import sys;print('%d.%d.%d' % sys.version_info[:3])"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def ensure_uv(log_dir: Path, uv_version: str, install_dir: Path) -> Optional[Path]:
+    """Return a path to a uv binary, fetching a pinned release if not on PATH."""
+    on_path = shutil.which("uv")
+    if on_path:
+        print(f"python-matrix: using uv on PATH: {on_path}")
+        return Path(on_path)
+
+    import platform
+    import tarfile
+    import urllib.request
+
+    machine = platform.machine().lower()
+    arch = {
+        "x86_64": "x86_64",
+        "amd64": "x86_64",
+        "aarch64": "aarch64",
+        "arm64": "aarch64",
+    }.get(machine)
+    if arch is None:
+        print(f"python-matrix: unsupported arch {machine!r}; cannot fetch uv")
+        return None
+
+    triple = f"uv-{arch}-unknown-linux-gnu"
+    url = (
+        f"https://github.com/astral-sh/uv/releases/download/"
+        f"{uv_version}/{triple}.tar.gz"
+    )
+    install_dir.mkdir(parents=True, exist_ok=True)
+    tarball = install_dir / f"{triple}.tar.gz"
+    uv_dest = install_dir / "uv"
+    print(f"python-matrix: downloading uv {uv_version} from {url}")
+    try:
+        with urllib.request.urlopen(url, timeout=180) as resp, tarball.open("wb") as fh:
+            shutil.copyfileobj(resp, fh)
+        # Extract only the uv binary (by basename) to avoid tar path traversal.
+        with tarfile.open(tarball) as tf:
+            member = next(
+                (
+                    m
+                    for m in tf.getmembers()
+                    if m.isfile() and os.path.basename(m.name) == "uv"
+                ),
+                None,
+            )
+            if member is None:
+                print("python-matrix: uv binary not present in archive")
+                return None
+            src = tf.extractfile(member)
+            if src is None:
+                return None
+            with src, uv_dest.open("wb") as dst:
+                shutil.copyfileobj(src, dst)
+    except Exception as exc:  # best-effort: network/extract failure -> skip uv
+        print(f"python-matrix: failed to fetch uv: {exc}")
+        return None
+
+    uv_dest.chmod(0o755)
+    print(f"python-matrix: uv ready at {uv_dest}")
+    return uv_dest
+
+
+def resolve_interpreter(
+    version: str, uv_bin: Optional[Path], log_dir: Path
+) -> Tuple[Optional[str], str, str]:
+    """Resolve *version* to an interpreter path.
+
+    Returns ``(path_or_None, resolved_version, note)``.
+    """
+    minor = minor_of(version)
+
+    # 1. System interpreter on PATH (pythonX.Y) -- covers distro pythons that
+    #    uv cannot provide (e.g. 3.6) and skips an unnecessary download.
+    cand = shutil.which(f"python{minor}")
+    if cand:
+        got = _query_interpreter_version(cand)
+        if got and minor_of(got) == minor:
+            return cand, got, "system"
+
+    # 2. uv-managed download (python-build-standalone) -- covers 3.8-3.14.
+    if uv_bin is not None:
+        try:
+            run_command(
+                [str(uv_bin), "python", "install", version],
+                name=f"uv-install-{version}",
+                retries=2,
+                log_dir=log_dir,
+            )
+        except CommandError:
+            return None, "", f"uv could not install {version}"
+        try:
+            found = subprocess.run(
+                [str(uv_bin), "python", "find", version],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=60,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return None, "", f"uv find failed for {version}: {exc}"
+        out = found.stdout.strip()
+        path = out.splitlines()[0].strip() if out else ""
+        if found.returncode == 0 and path:
+            got = _query_interpreter_version(path)
+            if got and minor_of(got) == minor:
+                return path, got, "uv"
+
+    return None, "", "not available via system PATH or uv"
+
+
+def _run_suite_for_interpreter(
+    python_bin: str,
+    tests_dir: Path,
+    amdsmi_path: Path,
+    results_dir: Path,
+    version_tag: str,
+    log_dir: Path,
+) -> List[str]:
+    """Run the installed Python test suite under *python_bin*.
+
+    Returns the list of failing test files (empty == all passed/absent).
+    """
+    env = dict(os.environ)
+    env["AMDSMI_PATH"] = str(amdsmi_path)
+    # Prepend the install to PYTHONPATH so `import amdsmi` resolves to it
+    # under every interpreter (TheRock tarball layout keeps it off sys.path).
+    pp_parts = [str(amdsmi_path)]
+    if env.get("PYTHONPATH"):
+        pp_parts.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pp_parts)
+
+    # PATH shim so the `amd-smi` CLI subprocess (shebang: /usr/bin/env python3)
+    # spawned by cli_unit_test.py also runs under *python_bin*.
+    # Absolute so the shim resolves regardless of each test's working dir.
+    shim_dir = Path(os.path.abspath(str(log_dir))) / f"py-shim-{version_tag}"
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    shim = shim_dir / "python3"
+    try:
+        if shim.exists() or shim.is_symlink():
+            shim.unlink()
+        shim.symlink_to(python_bin)
+        env["PATH"] = str(shim_dir) + os.pathsep + env.get("PATH", "")
+    except OSError:
+        pass  # shim is best-effort; tests still run under python_bin directly
+
+    failed: List[str] = []
+    for test_file in PY_MATRIX_TEST_FILES:
+        script = tests_dir / test_file
+        if not script.exists():
+            continue
+        stem = test_file[:-3] if test_file.endswith(".py") else test_file
+        result_path = results_dir / f"python_{version_tag}_{stem}.log"
+        try:
+            run_command(
+                [python_bin, str(script), "-v"],
+                name=f"py{version_tag}-{stem}",
+                cwd=tests_dir,
+                env=env,
+                retries=1,
+                log_dir=log_dir,
+                result_file=result_path,
+            )
+        except CommandError:
+            failed.append(stem)
+    return failed
+
+
+def run_python_matrix(
+    versions: List[str],
+    tests_dir: Path,
+    amdsmi_path: Path,
+    results_dir: Path,
+    os_label: str,
+    uv_version: str,
+    log_dir: Path,
+    summary_file: Optional[Path],
+) -> int:
+    """Resolve interpreters, run the suite per version, emit a summary table.
+
+    Returns the number of versions that FAILED (skips do not count).
+    """
+    results_dir.mkdir(parents=True, exist_ok=True)
+    rows: List[PyVersionResult] = []
+
+    if not tests_dir.exists():
+        print(f"python-matrix: tests dir {tests_dir} does not exist; nothing to run")
+    else:
+        uv_bin = ensure_uv(log_dir, uv_version, log_dir / "uv")
+        if uv_bin is None:
+            print("python-matrix: proceeding with system interpreters only (no uv)")
+        for ver in versions:
+            path, resolved, note = resolve_interpreter(ver, uv_bin, log_dir)
+            if path is None:
+                print(f"python-matrix: {ver} -> SKIP ({note})")
+                rows.append(PyVersionResult(requested=ver, status="SKIP", note=note))
+                continue
+            print(f"python-matrix: {ver} -> {resolved} at {path} (via {note})")
+            failed = _run_suite_for_interpreter(
+                path, tests_dir, amdsmi_path, results_dir, ver, log_dir
+            )
+            rows.append(
+                PyVersionResult(
+                    requested=ver,
+                    status="FAIL" if failed else "PASS",
+                    interpreter=path,
+                    resolved=resolved,
+                    failed_tests=failed,
+                    note=note,
+                )
+            )
+
+    summary = render_python_matrix_summary(os_label, rows)
+    (results_dir / "python_matrix_summary.md").write_text(summary, encoding="utf-8")
+    if summary_file is not None:
+        with summary_file.open("a", encoding="utf-8") as fh:
+            fh.write(summary)
+
+    print("=" * 42)
+    print(summary)
+
+    n_fail = sum(1 for r in rows if r.status == "FAIL")
+    if n_fail:
+        failed_versions = ", ".join(r.requested for r in rows if r.status == "FAIL")
+        print(f"::error::Python matrix failures for {os_label}: {failed_versions}")
+    else:
+        print(f"python-matrix: all resolved interpreters PASSED for {os_label}")
+    return n_fail
+
+
+def _python_matrix_cli(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="run_amdsmi_build.py python-matrix",
+        description="Run the installed Python test suite under several interpreters.",
+    )
+    parser.add_argument("--results-dir", type=Path, required=True)
+    parser.add_argument("--os-label", default="local")
+    parser.add_argument("--amdsmi-path", type=Path, default=DEFAULT_AMDSMI_PATH)
+    parser.add_argument(
+        "--tests-dir",
+        type=Path,
+        default=None,
+        help="Default: <amdsmi-path>/tests/python_unittest",
+    )
+    parser.add_argument("--python-versions", default=DEFAULT_PY_MATRIX_VERSIONS)
+    parser.add_argument("--uv-version", default=DEFAULT_UV_VERSION)
+    parser.add_argument("--log-dir", type=Path, default=DEFAULT_LOG_DIR)
+    parser.add_argument(
+        "--summary-file",
+        type=Path,
+        default=None,
+        help="Append the markdown matrix to this file (e.g. $GITHUB_STEP_SUMMARY).",
+    )
+    args = parser.parse_args(argv)
+
+    versions = parse_python_versions(args.python_versions)
+    tests_dir = args.tests_dir or (args.amdsmi_path / "tests" / "python_unittest")
+    return run_python_matrix(
+        versions=versions,
+        tests_dir=tests_dir,
+        amdsmi_path=args.amdsmi_path,
+        results_dir=args.results_dir,
+        os_label=args.os_label,
+        uv_version=args.uv_version,
+        log_dir=args.log_dir,
+        summary_file=args.summary_file,
+    )
+
+
 def main() -> None:
     # `summarize` subcommand short-circuits before parse_args/sudo logic.
     if len(sys.argv) > 1 and sys.argv[1] == "summarize":
         sys.exit(0 if _summarize_cli(sys.argv[2:]) == 0 else 1)
+    if len(sys.argv) > 1 and sys.argv[1] == "python-matrix":
+        sys.exit(0 if _python_matrix_cli(sys.argv[2:]) == 0 else 1)
     cfg = parse_args()
 
     print(f"Using project directory: {cfg.project_dir}")

--- a/projects/amdsmi/tests/amdsmi_build/test_run_amdsmi_build.py
+++ b/projects/amdsmi/tests/amdsmi_build/test_run_amdsmi_build.py
@@ -192,5 +192,80 @@ class SummarizeTests(unittest.TestCase):
             self.assertIn(":x: CI Failed", summary.read_text())
 
 
+class ParsePythonVersionsTests(unittest.TestCase):
+    def test_space_separated(self):
+        self.assertEqual(
+            rab.parse_python_versions("3.8 3.9 3.10"), ["3.8", "3.9", "3.10"]
+        )
+
+    def test_comma_and_mixed_whitespace(self):
+        self.assertEqual(
+            rab.parse_python_versions(" 3.8 ,3.9\t3.10 "), ["3.8", "3.9", "3.10"]
+        )
+
+    def test_dedupes_preserving_order(self):
+        self.assertEqual(rab.parse_python_versions("3.10 3.10 3.9"), ["3.10", "3.9"])
+
+    def test_accepts_patch_level(self):
+        self.assertEqual(rab.parse_python_versions("3.10.2"), ["3.10.2"])
+
+    def test_empty_is_empty_list(self):
+        self.assertEqual(rab.parse_python_versions("   "), [])
+
+    def test_invalid_token_raises(self):
+        with self.assertRaises(ValueError):
+            rab.parse_python_versions("3 3.8")
+
+
+class MinorOfTests(unittest.TestCase):
+    def test_patch(self):
+        self.assertEqual(rab.minor_of("3.10.14"), "3.10")
+
+    def test_minor_only(self):
+        self.assertEqual(rab.minor_of("3.6"), "3.6")
+
+    def test_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            rab.minor_of("garbage")
+
+
+class RenderPythonMatrixTests(unittest.TestCase):
+    def _rows(self):
+        return [
+            rab.PyVersionResult(
+                requested="3.6",
+                status="PASS",
+                interpreter="/usr/bin/python3.6",
+                resolved="3.6.8",
+            ),
+            rab.PyVersionResult(
+                requested="3.7",
+                status="SKIP",
+                note="not available via system PATH or uv",
+            ),
+            rab.PyVersionResult(
+                requested="3.10",
+                status="FAIL",
+                interpreter="/root/.local/bin/python3.10",
+                resolved="3.10.14",
+                failed_tests=["unit_tests"],
+            ),
+        ]
+
+    def test_contains_header_and_label(self):
+        out = rab.render_python_matrix_summary("AlmaLinux8", self._rows())
+        self.assertIn("Python Version Matrix", out)
+        self.assertIn("AlmaLinux8", out)
+
+    def test_counts_line(self):
+        out = rab.render_python_matrix_summary("AlmaLinux8", self._rows())
+        self.assertIn("1 passed, 1 failed, 1 skipped", out)
+
+    def test_failed_test_name_and_resolved_shown(self):
+        out = rab.render_python_matrix_summary("AlmaLinux8", self._rows())
+        self.assertIn("unit_tests", out)
+        self.assertIn("3.6.8", out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/projects/amdsmi/tests/amdsmi_build/test_run_amdsmi_build.py
+++ b/projects/amdsmi/tests/amdsmi_build/test_run_amdsmi_build.py
@@ -267,5 +267,68 @@ class RenderPythonMatrixTests(unittest.TestCase):
         self.assertIn("3.6.8", out)
 
 
+class VersionMatchesTests(unittest.TestCase):
+    def test_exact_patch_match(self):
+        self.assertTrue(rab._version_matches("3.6.8", "3.6.8"))
+
+    def test_exact_patch_mismatch(self):
+        self.assertFalse(rab._version_matches("3.6.15", "3.6.8"))
+
+    def test_minor_request_matches_any_patch(self):
+        self.assertTrue(rab._version_matches("3.10.14", "3.10"))
+
+    def test_minor_request_mismatch(self):
+        self.assertFalse(rab._version_matches("3.9.18", "3.10"))
+
+
+class PyenvBuildDepsTests(unittest.TestCase):
+    def test_dnf_has_openssl_and_git(self):
+        pkgs = rab._pyenv_build_dep_packages("dnf")
+        self.assertIn("openssl-devel", pkgs)
+        self.assertIn("git", pkgs)
+
+    def test_apt_has_ssl_and_ffi(self):
+        pkgs = rab._pyenv_build_dep_packages("apt")
+        self.assertIn("libssl-dev", pkgs)
+        self.assertIn("libffi-dev", pkgs)
+
+    def test_zypper_supported(self):
+        self.assertIn("git", rab._pyenv_build_dep_packages("zypper"))
+
+    def test_unsupported_raises(self):
+        with self.assertRaises(ValueError):
+            rab._pyenv_build_dep_packages("brew")
+
+
+class PkgInstallCmdTests(unittest.TestCase):
+    def test_apt(self):
+        cmd = rab._pkg_install_cmd("apt", ["git"])
+        self.assertEqual(cmd[:3], ["apt-get", "install", "-y"])
+        self.assertIn("git", cmd)
+
+    def test_dnf(self):
+        self.assertEqual(rab._pkg_install_cmd("dnf", ["git"]), ["dnf", "install", "-y", "git"])
+
+    def test_zypper(self):
+        cmd = rab._pkg_install_cmd("zypper", ["git"])
+        self.assertEqual(cmd[:3], ["zypper", "--non-interactive", "install"])
+
+    def test_unsupported_raises(self):
+        with self.assertRaises(ValueError):
+            rab._pkg_install_cmd("brew", ["git"])
+
+
+class DefaultMatrixVersionsTests(unittest.TestCase):
+    def test_includes_368_and_314(self):
+        vers = rab.parse_python_versions(rab.DEFAULT_PY_MATRIX_VERSIONS)
+        self.assertIn("3.6.8", vers)
+        self.assertIn("3.14", vers)
+
+    def test_no_duplicate_minors(self):
+        vers = rab.parse_python_versions(rab.DEFAULT_PY_MATRIX_VERSIONS)
+        minors = [rab.minor_of(v) for v in vers]
+        self.assertEqual(len(minors), len(set(minors)))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

AMD-SMI's GPU CI built and tested the Python binding under only one
container-default interpreter per distro, so a regression that only manifests on
a specific Python version (e.g. a 3.10-vs-3.12 difference) could land undetected.
This adds a dedicated CI check that exercises the installed Python binding and
CLI across every supported interpreter on real hardware, producing per-version
pass/fail sanity data.

## Technical Details

**Runner script** (`projects/amdsmi/tests/amdsmi_build/run_amdsmi_build.py`):
- Add a `python-matrix` subcommand that runs the *installed* Python suite
  (`integration_test.py`, `unit_tests.py`, `cli_unit_test.py`) under a set of
  interpreters and emits a per-version PASS/FAIL/SKIP table to the step summary.
- Resolve each version in three tiers: a system `pythonX.Y`, then a pinned
  uv-managed download (3.8–3.14), then a pyenv source build for versions uv
  cannot supply (3.6.8, 3.7.x); a version no tier can provide is SKIP, not fail.
- Exercise one install per interpreter (the binding is a pure-`ctypes` wrapper
  imported from `$AMDSMI_PATH`), with a PATH shim so the `amd-smi` CLI subprocess
  also runs under the target interpreter. No per-version venv/wheel needed.
- Default versions `3.6.8 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14`; add
  `--python-versions`, `--pyenv-root`, `--no-pyenv`, `--uv-version` flags.

**Unit tests** (`projects/amdsmi/tests/amdsmi_build/test_run_amdsmi_build.py`):
- Cover the pure helpers: version parsing/matching, pyenv build-dep selection,
  package-manager install commands, and matrix-table rendering.

**Workflow** (`.github/workflows/amdsmi-python-compat.yml`):
- New `AMDSMI Python Compatibility` workflow as its own check, matrixed over
  `[Ubuntu22, AlmaLinux8]` so each OS surfaces independently and both
  glibc/toolchain worlds are covered (Alma ships 3.6.8 natively; Ubuntu builds
  3.6/3.7 from source).
- Builds + installs once per OS, then runs the `python-matrix` sweep; uploads
  per-OS result artifacts. `continue-on-error: true` so a self-hosted-runner
  container/network flake does not block the PR.

**Docs** (`projects/amdsmi/tests/amdsmi_build/README.md`):
- Document the `python-matrix` subcommand.

## JIRA ID

<!-- N/A -->

## Test Plan

- `python3 -m unittest test_run_amdsmi_build` — pure-helper unit tests.
- In the `amdsmi:almalinux8` CI container: build + install, then
  `run_amdsmi_build.py python-matrix` for `3.6.8 3.7`.
- Standalone validation of the uv tier (real download + `uv python install`) and
  the SKIP path for versions uv cannot supply.
- `pre-commit run` (codespell, check-yaml, end-of-file/whitespace) on the
  changed files.

## Test Result

- 42/42 unit tests pass.
- AlmaLinux8 container: 3.6.8 PASS via native `python3.6`, 3.7 PASS via a
  pyenv-built 3.7.17 — 2 passed, 0 failed, 0 skipped.
- uv tier: `uv python install 3.12` fetched 3.12.13 and the suite passed;
  uv-unavailable versions correctly reported SKIP (no crash).
- pre-commit and YAML validation pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.