### PR TITLE
[hipfile] Use move semantics in a few places

### DIFF
--- a/projects/hipfile/src/amd_detail/backend.h
+++ b/projects/hipfile/src/amd_detail/backend.h
@@ -73,7 +73,7 @@ struct Backend {
     /// @param file_offset    Offset from the start of the file
     /// @param buffer_offset  Offset from the start of the buffer
     /// @return The eagerness "score"
-    virtual int score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,
+    virtual int score(const std::shared_ptr<IFile> &file, const std::shared_ptr<IBuffer> &buffer, size_t size,
                       hoff_t file_offset, hoff_t buffer_offset) const = 0;
 
     /// @brief Perform a read or write operation

--- a/projects/hipfile/src/amd_detail/backend/fallback.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fallback.cpp
@@ -42,8 +42,8 @@ using std::unique_ptr;
 static const size_t DefaultChunkSize = 16 * 1024 * 1024;
 
 int
-Fallback::score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
-                hoff_t buffer_offset) const
+Fallback::score(const std::shared_ptr<IFile> &file, const std::shared_ptr<IBuffer> &buffer, size_t size,
+                hoff_t file_offset, hoff_t buffer_offset) const
 {
     (void)buffer_offset;
     (void)file;

--- a/projects/hipfile/src/amd_detail/backend/fallback.h
+++ b/projects/hipfile/src/amd_detail/backend/fallback.h
@@ -29,8 +29,8 @@ struct Fallback : public Backend {
     using Backend::io;
     virtual ~Fallback() override = default;
 
-    int score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
-              hoff_t buffer_offset) const override;
+    int score(const std::shared_ptr<IFile> &file, const std::shared_ptr<IBuffer> &buffer, size_t size,
+              hoff_t file_offset, hoff_t buffer_offset) const override;
 
     void async_io(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t *size_p,
                   hoff_t *file_offset_p, hoff_t *buffer_offset_p, ssize_t *bytes_transferred_p,

--- a/projects/hipfile/src/amd_detail/backend/fastpath.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fastpath.cpp
@@ -129,8 +129,8 @@ using namespace std;
  */
 
 int
-Fastpath::score(shared_ptr<IFile> file, shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
-                hoff_t buffer_offset) const
+Fastpath::score(const shared_ptr<IFile> &file, const shared_ptr<IBuffer> &buffer, size_t size,
+                hoff_t file_offset, hoff_t buffer_offset) const
 {
     bool accept_io{true};
 

--- a/projects/hipfile/src/amd_detail/backend/fastpath.h
+++ b/projects/hipfile/src/amd_detail/backend/fastpath.h
@@ -30,8 +30,8 @@ namespace hipFile {
 struct Fastpath : public BackendWithFallback {
     virtual ~Fastpath() override = default;
 
-    int score(std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size, hoff_t file_offset,
-              hoff_t buffer_offset) const override;
+    int score(const std::shared_ptr<IFile> &file, const std::shared_ptr<IBuffer> &buffer, size_t size,
+              hoff_t file_offset, hoff_t buffer_offset) const override;
 
 protected:
     ssize_t _io_impl(IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -24,7 +24,7 @@ namespace hipFile {
 
 BatchOperation::BatchOperation(std::unique_ptr<const hipFileIOParams_t> params,
                                std::shared_ptr<IBuffer> _buffer, std::shared_ptr<IFile> _file)
-    : io_params{std::move(params)}, buffer{_buffer}, file{_file}
+    : io_params{std::move(params)}, buffer{std::move(_buffer)}, file{std::move(_file)}
 {
     // Cookie allows the user to track which operation caused the error.
     // It would be ideal if this could be passed as a member within the exception.

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -199,7 +199,7 @@ try {
         }
     }
 
-    return backend->io(type, file, buffer, size, file_offset, buffer_offset);
+    return backend->io(type, std::move(file), std::move(buffer), size, file_offset, buffer_offset);
 }
 catch (const DriverNotInitialized &) {
     return -hipFileDriverNotInitialized;

--- a/projects/hipfile/test/amd_detail/mbackend.h
+++ b/projects/hipfile/test/amd_detail/mbackend.h
@@ -16,7 +16,8 @@
 namespace hipFile {
 
 struct MBackend : Backend {
-    MOCK_METHOD(int, score, (std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t, hoff_t),
+    MOCK_METHOD(int, score,
+                (const std::shared_ptr<IFile> &, const std::shared_ptr<IBuffer> &, size_t, hoff_t, hoff_t),
                 (const, override));
     MOCK_METHOD(ssize_t, io,
                 (hipFile::IoType type, std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t,
@@ -29,7 +30,8 @@ struct MBackend : Backend {
 };
 
 struct MBackendWithFallback : BackendWithFallback {
-    MOCK_METHOD(int, score, (std::shared_ptr<IFile>, std::shared_ptr<IBuffer>, size_t, hoff_t, hoff_t),
+    MOCK_METHOD(int, score,
+                (const std::shared_ptr<IFile> &, const std::shared_ptr<IBuffer> &, size_t, hoff_t, hoff_t),
                 (const, override));
     MOCK_METHOD(ssize_t, _io_impl,
                 (IoType type, std::shared_ptr<IFile> file, std::shared_ptr<IBuffer> buffer, size_t size,


### PR DESCRIPTION
## Motivation

Coverity (currently down) flagged a few places where we could use move semantics to avoid refcount bumps.

## Technical Details

- Backend::score — pass by const ref. score() inspected its file and buffer arguments but never retained them, yet took them by value. Switched to const&, updating the base virtual, both the fastpath and fallback overrides, and the gmock mock in mbackend.h to keep signatures in sync.
- BatchOperation constructor — move sink params. The constructor copied its buffer and file parameters into members. These are pass-by-value sink parameters, so they are now std::moved into the members, matching the existing pattern in the AsyncOp and AsyncOpFallback constructors.
- hipFileIo — move into the final io() dispatch. The selected backend's io() call received file and buffer as lvalues even though it was their last use. Since the io()/_io_impl chain is already a by-value move-sink, they are now std::moved in, extending the move-only path all the way down to the syscall leaf.

## JIRA ID

AIHIPFILE-161

## Test Plan

CI Passes, manual ASAN verification

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
