### PR TITLE
refactor(hipfile): Guard system-test workspace cleanup against empty path

### DIFF
--- a/.github/workflows/hipfile-ci-system.yml
+++ b/.github/workflows/hipfile-ci-system.yml
@@ -230,6 +230,9 @@ jobs:
           fi
       - name: Cleanup self-hosted runner workspace
         if: ${{ always() }}
+        shell: bash
+        # ${VAR:?} aborts if GITHUB_WORKSPACE is unset/empty, so a missing value
+        # can never let the glob expand to `/*` and wipe the persistent runner.
         run: |
           shopt -s dotglob
-          rm -rf ${GITHUB_WORKSPACE}/*
+          rm -rf "${GITHUB_WORKSPACE:?}"/*


### PR DESCRIPTION
## Motivation

This is a cleanup fix suggested by Copilot in #7566

## Technical Details

Harden the self-hosted runner cleanup in the system-test workflow: quote the path and add bash's ${VAR:?} guard so an unset or empty GITHUB_WORKSPACE aborts the step instead of letting the glob expand to `/*` and wipe the persistent runner.

## JIRA ID

AIHIPFILE-154

## Test Plan

CI passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
