### PR TITLE
[hipfile] Sanitizer hardening

### DIFF
--- a/projects/hipfile/cmake/AISSanitizers.cmake
+++ b/projects/hipfile/cmake/AISSanitizers.cmake
@@ -32,12 +32,12 @@ function(ais_add_sanitizers target)
         target_compile_options(${target} PRIVATE
             $<$<COMPILE_LANGUAGE:CXX>:-fsanitize=${SANITIZER_LIST}>
             $<$<COMPILE_LANGUAGE:CXX>:-fno-sanitize=unsigned-integer-overflow>
-            $<$<COMPILE_LANGUAGE:CXX>:-fno-sanitize-recover=integer>
+            $<$<COMPILE_LANGUAGE:CXX>:-fno-sanitize-recover=${SANITIZER_LIST}>
         )
         target_link_options(${target} PRIVATE
             -Xarch_host -fsanitize=${SANITIZER_LIST}
             -Xarch_host -fno-sanitize=unsigned-integer-overflow
-            -Xarch_host -fno-sanitize-recover=integer
+            -Xarch_host -fno-sanitize-recover=${SANITIZER_LIST}
         )
     endif()
 

--- a/projects/hipfile/src/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/src/amd_detail/batch/batch.cpp
@@ -10,12 +10,14 @@
 #include "hipfile.h"
 #include "state.h"
 
+#include <bit>
 #include <cstddef>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <sstream>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -66,18 +68,22 @@ BatchOperation::BatchOperation(std::unique_ptr<const hipFileIOParams_t> params,
         throw std::invalid_argument(msg.str());
     }
 
-    // Check OpCode
-    if (io_params->opcode != hipFileBatchRead && io_params->opcode != hipFileBatchWrite) {
+    // Check OpCode. A C caller may pass a value outside the enum's valid range,
+    // and an lvalue-to-rvalue load of such a value as the enum type is undefined
+    // behavior. Reinterpret the bits as the underlying integer type instead.
+    auto opcode = std::bit_cast<std::underlying_type_t<hipFileOpcode_t>>(io_params->opcode);
+    if (opcode != hipFileBatchRead && opcode != hipFileBatchWrite) {
         std::stringstream msg;
-        msg << "Bad opcode specified. Value: " << io_params->opcode;
+        msg << "Bad opcode specified. Value: " << opcode;
         msg << ". Cookie: " << io_params->cookie;
         throw std::invalid_argument(msg.str());
     }
 
-    // Check Batch Mode
-    if (io_params->mode != hipFileBatch) {
+    // Check Batch Mode (reinterpret the bits as the underlying integer, see above).
+    auto mode = std::bit_cast<std::underlying_type_t<hipFileBatchMode_t>>(io_params->mode);
+    if (mode != hipFileBatch) {
         std::stringstream msg;
-        msg << "Invalid Batch mode specified. Value: " << io_params->mode;
+        msg << "Invalid Batch mode specified. Value: " << mode;
         msg << ". Cookie: " << io_params->cookie;
         throw std::invalid_argument(msg.str());
     }

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -18,11 +18,13 @@
 #include "state.h"
 #include "stats.h"
 
+#include <bit>
 #include <cerrno>
 #include <cstdint>
 #include <hip/hip_runtime_api.h>
 #include <memory>
 #include <stdexcept>
+#include <type_traits>
 #include <utility>
 #include <vector>
 #include <sys/types.h>
@@ -77,7 +79,11 @@ try {
         return {hipFileInvalidValue, hipSuccess};
     }
 
-    switch (descr->type) {
+    // A C caller may pass a type outside the enum's valid range, and an
+    // lvalue-to-rvalue load of such a value as the enum type is undefined
+    // behavior. Reinterpret the bits as the underlying integer type instead.
+    auto type = std::bit_cast<std::underlying_type_t<hipFileFileHandleType_t>>(descr->type);
+    switch (type) {
         case hipFileHandleTypeOpaqueFD: {
             UnregisteredFile uf{descr->handle.fd};
             *fh = Context<DriverState>::get()->registerFile(std::move(uf));

--- a/projects/hipfile/test/amd_detail/handle.cpp
+++ b/projects/hipfile/test/amd_detail/handle.cpp
@@ -8,6 +8,7 @@
 #include "hipfile.h"
 #include "hipfile-test.h"
 #include "hipfile-warnings.h"
+#include "invalid-enum.h"
 #include "msys.h"
 #include "mmountinfo.h"
 #include "mountinfo.h"
@@ -310,6 +311,19 @@ TEST_F(HipFileHandle, register_handle_userspace_fs_not_supported)
     hipFileDescr_t  rfd{};
 
     rfd.type      = hipFileHandleTypeUserspaceFS;
+    rfd.handle.fd = 0xBADF00D;
+
+    ASSERT_EQ(hipFileHandleRegister(&fh, &rfd), HipFileOpError(hipFileIONotSupported));
+}
+
+// A type outside the enum's valid range must be rejected, not crash or invoke
+// undefined behavior when loaded.
+TEST_F(HipFileHandle, register_handle_invalid_type_not_supported)
+{
+    hipFileHandle_t fh{};
+    hipFileDescr_t  rfd{};
+
+    rfd.type      = invalidEnum<hipFileFileHandleType_t>(maxEnum<hipFileFileHandleType_t>());
     rfd.handle.fd = 0xBADF00D;
 
     ASSERT_EQ(hipFileHandleRegister(&fh, &rfd), HipFileOpError(hipFileIONotSupported));


### PR DESCRIPTION
## Motivation

This PR addresses two concerns:

1. A C caller may pass an enum value outside the enum's valid range. For an unscoped enum, that valid range is the smallest bit-field covering its enumerators -- not the full range of the underlying integer type -- so an lvalue-to-rvalue load of an out-of-range value as the enum type is undefined behavior, even when the value fits in the underlying int.

2. Only the integer, address, and leak sanitizers are guaranteed to change the returned error code from ctest. The address and leak sanitizers do this implicitly and we set `-fno-sanitize-recover` for the integer sanitizer. This allows other sanitization problems to sail through unflagged.

## Technical Details

For item 1:

Read such values through the underlying integer type via std::bit_cast before comparing or switching on them:

- BatchOperation parameter validation (opcode, mode)
- hipFileHandleRegister (descr->type)

Add a negative test for hipFileHandleRegister that passes an out-of-range handle type and confirms it is rejected with hipFileIONotSupported.

This only covers entry points that receive the enum by pointer or struct field, where the load happens in code we control. Functions that take an enum by value (e.g. hipFileGetOpErrorString) load it in the dispatch shim before reaching the implementation; hardening those would require changing the dispatch-table ABI and is left for later.

For item 2:

Extend -fno-sanitize-recover from `integer` to the full sanitizer list. Recoverable UBSan checks print a diagnostic and continue, leaving the process exit code unchanged -- so a test could execute undefined behavior, log it to stderr, and still report PASS. Only integer overflow was previously fatal.

Keying the no-recover flag off SANITIZER_LIST keeps the enabled checks and the fatal checks in lockstep, so any future UBSan violation fails the build instead of scrolling by as an ignored warning.

## JIRA ID

AIHIPFILE-154

## Test Plan

Sanitizers pass (confirmed locally since no sanitizer CI action yet)

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
