### PR TITLE
[hipfile] Fix IWYU issues and add CI action

### DIFF
--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -229,3 +229,22 @@ jobs:
       cxx_standard: ${{ matrix.cxx_standard }}
       platform: ${{ matrix.supported_platforms }}
       rocm_version: ${{ matrix.rocm_versions }}
+
+  # include-what-you-use findings are compiler- and standard-independent, so run
+  # the analysis exactly once against a single fixed image rather than fanning
+  # out across the build matrix. This job is advisory: IWYU runs in launcher
+  # mode and never fails the build, so it only surfaces suggestions. Change the
+  # image key below to retarget the ROCm version (the combo must exist in
+  # Precheck's matrix).
+  iwyu:
+    if: >-
+      ${{
+        !cancelled() && (
+          needs.build_CI_image.result == 'success' ||
+          needs.build_CI_image.result == 'skipped'
+        )
+      }}
+    needs: [Precheck, build_CI_image]
+    uses: ./.github/workflows/hipfile-iwyu.yml
+    with:
+      ci_image: ${{ fromJSON(needs.Precheck.outputs.ci_images)['ubuntu-7.2.2'].ci_image }}

--- a/.github/workflows/hipfile-iwyu.yml
+++ b/.github/workflows/hipfile-iwyu.yml
@@ -1,0 +1,134 @@
+name: hipfile-iwyu
+run-name: Run include-what-you-use analysis on hipFile
+
+env:
+  AIS_INPUT_CI_IMAGE: ${{ inputs.ci_image }}
+  AIS_HIP_ARCHITECTURES: gfx950;gfx1201;gfx1200;gfx1101;gfx1100;gfx1030;gfx942;gfx90a;gfx908
+
+on:
+  workflow_call:
+    inputs:
+      ci_image:
+        description: "Full CI image name & tag"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  iwyu:
+    name: iwyu
+    runs-on: [ubuntu-24.04]
+    steps:
+      - name: Set AIS CI container name
+        # On non-pull_request triggering workflows, AIS_PR_NUMBER may be empty.
+        run: |
+          echo "AIS_PR_NUMBER=$(echo "${GITHUB_REF}" | sed 's|[^0-9]||g')" >> "${GITHUB_ENV}"
+      - name: Compute container name
+        run: |
+          echo "AIS_CONTAINER_NAME=${AIS_PR_NUMBER:=${GITHUB_RUN_ID}}_${GITHUB_JOB}_iwyu" >> "${GITHUB_ENV}"
+      - name: Fetching code repository...
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          path: rocm-systems
+          sparse-checkout: |
+            projects/hipfile
+            .github/workflows
+      - name: Authenticating to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Starting Docker Container
+        run: |
+          docker run \
+            -dt \
+            --rm \
+            --pull always \
+            -v ${GITHUB_WORKSPACE}:/mnt/ais:ro \
+            --name "${AIS_CONTAINER_NAME}" \
+            "${AIS_INPUT_CI_IMAGE}"
+      - name: Make copy of the code repository and create build directories
+        # Single quotes necessary to ensure string/command substitutions happen
+        # in the container and not on the host.
+        run: |
+          docker exec \
+            -t \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cp -R /mnt/ais /ais
+              mkdir -p /ais/build/hipfile
+            '
+      - name: Generate build files for hipFile with IWYU enabled
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cmake \
+                -DCMAKE_BUILD_TYPE=Debug \
+                -DCMAKE_CXX_COMPILER=amdclang++ \
+                -DCMAKE_HIP_ARCHITECTURES="${{ env.AIS_HIP_ARCHITECTURES }}" \
+                -DCMAKE_HIP_PLATFORM=amd \
+                -DAIS_USE_IWYU=ON \
+                ../../rocm-systems/projects/hipfile
+            '
+      - name: Compile hipFile with IWYU (advisory)
+        # IWYU runs as part of compilation via CMAKE_CXX_INCLUDE_WHAT_YOU_USE.
+        # It emits suggestions on stderr but, in launcher mode, never changes the
+        # compiler's exit status -- so a normal build both compiles the code and
+        # collects IWYU findings. This job is advisory: it must never fail the CI
+        # run, so the build is tee'd to a log and the step always succeeds.
+        # `set -o pipefail` is intentionally NOT used for that reason.
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cmake --build . --parallel 2>&1 | tee /ais/build/hipfile/iwyu.log
+            ' || echo "Build returned non-zero; IWYU findings (if any) are reported below."
+      - name: Summarize IWYU findings
+        # Extract just the IWYU advisory blocks from the build log and post them
+        # to the job summary. Always runs and always exits 0.
+        run: |
+          docker exec \
+            -t \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              awk "/should add these lines:/,/^---\$/" /ais/build/hipfile/iwyu.log > /ais/build/hipfile/iwyu-findings.txt || true
+            '
+          docker cp "${AIS_CONTAINER_NAME}:/ais/build/hipfile/iwyu-findings.txt" ./iwyu-findings.txt || true
+          {
+            echo "## include-what-you-use findings (advisory)"
+            echo ""
+            if [ -s ./iwyu-findings.txt ]; then
+              echo "IWYU suggested include changes. These are advisory only and do not fail CI."
+              echo ""
+              echo '```'
+              cat ./iwyu-findings.txt
+              echo '```'
+            else
+              echo "No IWYU findings. :tada:"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+      - name: Upload IWYU findings artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: iwyu-findings
+          path: ./iwyu-findings.txt
+          if-no-files-found: ignore
+      - name: Cleanup & Stop the Docker container
+        if: ${{ always() }}
+        run: |
+          if docker inspect "${AIS_CONTAINER_NAME}" >/dev/null 2>&1; then
+            docker stop "${AIS_CONTAINER_NAME}"
+          else
+            echo "Container ${AIS_CONTAINER_NAME} does not exist; skipping stop"
+          fi

--- a/projects/hipfile/cmake/AISIWYU.cmake
+++ b/projects/hipfile/cmake/AISIWYU.cmake
@@ -13,6 +13,28 @@ option(AIS_USE_IWYU "Run include-what-you-use when compiling" OFF)
 
 if(AIS_USE_IWYU)
     find_program(IWYU_EXE NAMES include-what-you-use REQUIRED)
-    set(CMAKE_C_INCLUDE_WHAT_YOU_USE ${IWYU_EXE})
-    set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${IWYU_EXE})
+
+    # GoogleTest/GoogleMock expose their public API through umbrella headers
+    # (gtest/gtest.h, gmock/gmock.h) but define symbols in private sub-headers.
+    # Without a mapping, IWYU suggests including those private headers and
+    # confuses the quoted vs. angle-bracket spellings. This mapping file
+    # redirects all gtest/gmock private headers to the public umbrella headers.
+    # libstdc++/glibc declare some symbols in private bits/* headers that IWYU
+    # would otherwise suggest including directly (e.g. <bits/chrono.h> for
+    # std::chrono, <bits/statx-generic.h> for statx). These are not part of the
+    # bundled IWYU mappings, so redirect them to their public headers.
+    set(IWYU_MAPPINGS
+        "${CMAKE_CURRENT_LIST_DIR}/iwyu-gtest.imp"
+        "${CMAKE_CURRENT_LIST_DIR}/iwyu-libc.imp")
+
+    set(IWYU_COMMAND ${IWYU_EXE})
+    foreach(mapping IN LISTS IWYU_MAPPINGS)
+        if(NOT EXISTS "${mapping}")
+            message(FATAL_ERROR "IWYU mapping file not found: ${mapping}")
+        endif()
+        list(APPEND IWYU_COMMAND -Xiwyu --mapping_file=${mapping})
+    endforeach()
+
+    set(CMAKE_C_INCLUDE_WHAT_YOU_USE ${IWYU_COMMAND})
+    set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${IWYU_COMMAND})
 endif()

--- a/projects/hipfile/cmake/iwyu-gtest.imp
+++ b/projects/hipfile/cmake/iwyu-gtest.imp
@@ -1,0 +1,9 @@
+[
+  { "include": ["@[\"<]gtest/gtest-.*[\">]", "private", "<gtest/gtest.h>", "public"] },
+  { "include": ["@[\"<]gtest/internal/.*", "private", "<gtest/gtest.h>", "public"] },
+  { "include": ["@[\"<]gtest/gtest_pred_impl.h[\">]", "private", "<gtest/gtest.h>", "public"] },
+  { "include": ["\"gtest/gtest.h\"", "private", "<gtest/gtest.h>", "public"] },
+  { "include": ["@[\"<]gmock/gmock-.*[\">]", "private", "<gmock/gmock.h>", "public"] },
+  { "include": ["@[\"<]gmock/internal/.*", "private", "<gmock/gmock.h>", "public"] },
+  { "include": ["\"gmock/gmock.h\"", "private", "<gmock/gmock.h>", "public"] }
+]

--- a/projects/hipfile/cmake/iwyu-libc.imp
+++ b/projects/hipfile/cmake/iwyu-libc.imp
@@ -1,0 +1,4 @@
+[
+  { "include": ["<bits/chrono.h>", "private", "<chrono>", "public"] },
+  { "include": ["@<bits/statx.*\\.h>", "private", "<sys/stat.h>", "public"] }
+]

--- a/projects/hipfile/examples/api/get-version.cpp
+++ b/projects/hipfile/examples/api/get-version.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <hipfile.h>
+#include <hip/hip_runtime_api.h>
 
 #include <cstdio>
 #include <cstdlib>

--- a/projects/hipfile/examples/async/roundtrip-async-multi-stream-registered.cpp
+++ b/projects/hipfile/examples/async/roundtrip-async-multi-stream-registered.cpp
@@ -43,16 +43,12 @@
 #include <hipfile.h>
 #include <hip/hip_runtime_api.h>
 
-#include <cerrno>
 #include <fcntl.h>
 #include <cinttypes>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 /// @brief Number of concurrent streams / slices.
 #ifndef NUM_STREAMS

--- a/projects/hipfile/examples/async/roundtrip-async-multi-stream.cpp
+++ b/projects/hipfile/examples/async/roundtrip-async-multi-stream.cpp
@@ -40,16 +40,12 @@
 #include <hipfile.h>
 #include <hip/hip_runtime_api.h>
 
-#include <cerrno>
 #include <fcntl.h>
 #include <cinttypes>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 /// @brief Number of concurrent streams / slices.
 #ifndef NUM_STREAMS

--- a/projects/hipfile/examples/async/roundtrip-async-nonblocking-stream.cpp
+++ b/projects/hipfile/examples/async/roundtrip-async-nonblocking-stream.cpp
@@ -41,12 +41,10 @@
 #include <cerrno>
 #include <fcntl.h>
 #include <cinttypes>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 /// @brief Size of the test payload in bytes. Override at compile time.

--- a/projects/hipfile/examples/async/roundtrip-async.cpp
+++ b/projects/hipfile/examples/async/roundtrip-async.cpp
@@ -39,12 +39,10 @@
 #include <cerrno>
 #include <fcntl.h>
 #include <cinttypes>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 /// @brief Size of the test payload in bytes. Override at compile time.

--- a/projects/hipfile/examples/basics/bufregister-write.cpp
+++ b/projects/hipfile/examples/basics/bufregister-write.cpp
@@ -25,17 +25,16 @@
 #include "examples_common.h"
 
 #include <hipfile.h>
+#include <hip/driver_types.h>
 #include <hip/hip_runtime_api.h>
 
 #include <cerrno>
 #include <fcntl.h>
 #include <cinttypes>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 /// @brief Size of the test payload in bytes. Override at compile time.

--- a/projects/hipfile/examples/basics/iterative-devmem-offset-read.cpp
+++ b/projects/hipfile/examples/basics/iterative-devmem-offset-read.cpp
@@ -39,12 +39,10 @@
 #include <cerrno>
 #include <fcntl.h>
 #include <cinttypes>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 /// @brief Hard cap on bytes consumed from INPUT. Override at compile time.

--- a/projects/hipfile/examples/basics/iterative-read.cpp
+++ b/projects/hipfile/examples/basics/iterative-read.cpp
@@ -35,12 +35,10 @@
 #include <cerrno>
 #include <fcntl.h>
 #include <cinttypes>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 /// @brief Hard cap on bytes consumed from INPUT. Override at compile time.

--- a/projects/hipfile/examples/basics/no-bufregister-write.cpp
+++ b/projects/hipfile/examples/basics/no-bufregister-write.cpp
@@ -26,17 +26,16 @@
 #include "examples_common.h"
 
 #include <hipfile.h>
+#include <hip/driver_types.h>
 #include <hip/hip_runtime_api.h>
 
 #include <cerrno>
 #include <fcntl.h>
 #include <cinttypes>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 /// @brief Size of the test payload in bytes. Override at compile time.

--- a/projects/hipfile/examples/basics/no-odirect-write.cpp
+++ b/projects/hipfile/examples/basics/no-odirect-write.cpp
@@ -36,17 +36,16 @@
 #include "examples_common.h"
 
 #include <hipfile.h>
+#include <hip/driver_types.h>
 #include <hip/hip_runtime_api.h>
 
 #include <cerrno>
 #include <fcntl.h>
 #include <cinttypes>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 /// @brief Size of the test payload in bytes. Override at compile time.

--- a/projects/hipfile/examples/basics/roundtrip-verify.cpp
+++ b/projects/hipfile/examples/basics/roundtrip-verify.cpp
@@ -29,17 +29,16 @@
 #include "examples_common.h"
 
 #include <hipfile.h>
+#include <hip/driver_types.h>
 #include <hip/hip_runtime_api.h>
 
 #include <cerrno>
 #include <fcntl.h>
 #include <cinttypes>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 /// @brief Size of the test payload in bytes. Override at compile time.

--- a/projects/hipfile/examples/basics/subregion-write.cpp
+++ b/projects/hipfile/examples/basics/subregion-write.cpp
@@ -34,12 +34,10 @@
 #include <cerrno>
 #include <fcntl.h>
 #include <cinttypes>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 /// @brief Hard cap on bytes consumed from INPUT. Override at compile time.

--- a/projects/hipfile/examples/basics/various-mem-rw.cpp
+++ b/projects/hipfile/examples/basics/various-mem-rw.cpp
@@ -37,12 +37,10 @@
 #include <cerrno>
 #include <fcntl.h>
 #include <cinttypes>
-#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 /// @brief Hard cap on bytes consumed from INPUT. Override at compile time.

--- a/projects/hipfile/examples/common/examples_common.h
+++ b/projects/hipfile/examples/common/examples_common.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <sys/types.h>
 

--- a/projects/hipfile/examples/common/examples_common.h
+++ b/projects/hipfile/examples/common/examples_common.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 #include <sys/types.h>
 

--- a/projects/hipfile/src/amd_detail/api_trace/api-dispatch-interface.cpp
+++ b/projects/hipfile/src/amd_detail/api_trace/api-dispatch-interface.cpp
@@ -4,6 +4,12 @@
  */
 
 #include "api_trace/api-trace-internal.h"
+#include "hipfile-api-trace.h"
+#include "hipfile.h"
+
+#include <cstdint>
+#include <hip/hip_runtime_api.h>
+#include <sys/types.h>
 
 const char *
 hipFileGetOpErrorString(hipFileOpError_t status)

--- a/projects/hipfile/src/amd_detail/api_trace/api-trace.cpp
+++ b/projects/hipfile/src/amd_detail/api_trace/api-trace.cpp
@@ -4,8 +4,9 @@
  */
 
 #include "api_trace/api-trace-internal.h"
+#include "hipfile-api-trace.h"
 
-#include <array>
+#include <array> // IWYU pragma: keep
 #include <cstddef>
 
 #if defined(HIPFILE_ROCPROFILER_REGISTER) && HIPFILE_ROCPROFILER_REGISTER > 0

--- a/projects/hipfile/src/amd_detail/backend.cpp
+++ b/projects/hipfile/src/amd_detail/backend.cpp
@@ -4,9 +4,6 @@
  */
 
 #include "backend.h"
-#include "buffer.h"
-#include "file.h"
-#include "io.h"
 
 #include <cstddef>
 #include <exception>
@@ -14,8 +11,13 @@
 #include <stdexcept>
 #include <sys/types.h>
 #include <system_error>
-#include <unistd.h>
 #include <utility>
+
+namespace hipFile {
+class IBuffer;
+class IFile;
+enum class IoType;
+}
 
 using namespace hipFile;
 

--- a/projects/hipfile/src/amd_detail/backend/asyncop-fallback.cpp
+++ b/projects/hipfile/src/amd_detail/backend/asyncop-fallback.cpp
@@ -11,9 +11,11 @@
 #include "hip.h"
 #include "sys.h"
 
+#include <algorithm>
 #include <memory>
 #include <new>
 #include <syslog.h>
+#include <utility>
 
 namespace hipFile {
 class IFile;

--- a/projects/hipfile/src/amd_detail/backend/fastpath.cpp
+++ b/projects/hipfile/src/amd_detail/backend/fastpath.cpp
@@ -13,13 +13,12 @@
 #include "io.h"
 #include "stats.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <cstddef>
 #include <cstdint>
 #include <exception>
-#include <fcntl.h>
 #include <hip/hip_runtime_api.h>
-#include <linux/stat.h>
 #include <memory>
 #include <stdexcept>
 #include <system_error>

--- a/projects/hipfile/src/amd_detail/context.cpp
+++ b/projects/hipfile/src/amd_detail/context.cpp
@@ -6,7 +6,7 @@
 #include "context.h"
 #include "hip.h"
 #include "state.h"
-#include "stats.h"
+#include "stats.h" // IWYU pragma: keep
 #include "sys.h"
 
 namespace hipFile {

--- a/projects/hipfile/src/amd_detail/context.h
+++ b/projects/hipfile/src/amd_detail/context.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include "hipfile-warnings.h"
-#include "stats.h"
+#include "stats.h" // IWYU pragma: keep
 
 #include <stdexcept>
 #ifdef AIS_TESTING

--- a/projects/hipfile/src/amd_detail/file.cpp
+++ b/projects/hipfile/src/amd_detail/file.cpp
@@ -10,13 +10,14 @@
 #include "passkey.h"
 #include "sys.h"
 
+#include <cerrno>
 #include <fcntl.h>
 #include <utility>
 #include <string>
+#include <sys/stat.h>
 #include <sys/sysmacros.h>
 #include <syslog.h>
 #include <system_error>
-#include <unistd.h>
 
 using namespace std;
 

--- a/projects/hipfile/src/amd_detail/file.h
+++ b/projects/hipfile/src/amd_detail/file.h
@@ -9,6 +9,7 @@
 #include "hipfile.h"
 #include "mountinfo.h"
 
+#include <cstdint>
 #include <linux/stat.h>
 #include <memory>
 #include <optional>

--- a/projects/hipfile/src/amd_detail/hipfile-stats.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile-stats.cpp
@@ -6,7 +6,10 @@
 #include "include_internal/hipfile-stats.h"
 #include "stats.h"
 
+#include <cerrno>
 #include <sstream>
+#include <string>
+#include <system_error>
 #include <unistd.h>
 
 using namespace hipFile;

--- a/projects/hipfile/src/amd_detail/hipfile.cpp
+++ b/projects/hipfile/src/amd_detail/hipfile.cpp
@@ -21,7 +21,9 @@
 #include <cerrno>
 #include <cstdint>
 #include <hip/hip_runtime_api.h>
+#include <initializer_list>
 #include <memory>
+#include <new>
 #include <stdexcept>
 #include <utility>
 #include <vector>

--- a/projects/hipfile/src/amd_detail/state.cpp
+++ b/projects/hipfile/src/amd_detail/state.cpp
@@ -7,8 +7,6 @@
 #include "backend/fastpath.h"
 #include "batch/batch.h"
 #include "buffer.h"
-#include "configuration.h"
-#include "context.h"
 #include "file.h"
 #include "state.h"
 #include "stream.h"

--- a/projects/hipfile/src/amd_detail/stats.cpp
+++ b/projects/hipfile/src/amd_detail/stats.cpp
@@ -5,19 +5,27 @@
 
 #include "configuration.h"
 #include "context.h"
+#include "file-descriptor.h"
 #include "hip.h"
+#include "io.h"
 #include "stats.h"
 #include "sys.h"
 
 #include <cerrno>
+#include <cstdio>
+#include <cstring>
 #include <fcntl.h>
+#include <functional>
 #include <iomanip>
+#include <new>
 #include <poll.h>
 #include <sstream>
+#include <string>
+#include <system_error>
 #include <unistd.h>
-#include <sys/eventfd.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
+#include <sys/uio.h>
 #include <sys/un.h>
 
 static int

--- a/projects/hipfile/src/amd_detail/stats.h
+++ b/projects/hipfile/src/amd_detail/stats.h
@@ -7,16 +7,18 @@
 #include "buffer.h"
 #include "file.h"
 #include "file-descriptor.h"
+#include "hipfile.h"
 #include "io.h"
 
 #include <array>
 #include <algorithm>
 #include <atomic>
 #include <chrono>
-#include <functional>
+#include <cstdint>
 #include <memory>
 #include <numeric>
 #include <ostream>
+#include <sys/types.h>
 #include <thread>
 #include <tuple>
 #include <type_traits>

--- a/projects/hipfile/test/amd_detail/api_trace.cpp
+++ b/projects/hipfile/test/amd_detail/api_trace.cpp
@@ -13,10 +13,8 @@
 
 #include "hipfile.h"
 #include "hipfile-api-trace.h"
-#include "hipfile-test.h"
 #include "hipfile-warnings.h"
 
-#include <cstddef>
 #include <gtest/gtest.h>
 
 // The accessor lives in `namespace hipFile` and is normally consumed via

--- a/projects/hipfile/test/amd_detail/backend.cpp
+++ b/projects/hipfile/test/amd_detail/backend.cpp
@@ -13,6 +13,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <memory>
+#include <stdexcept>
+#include <sys/types.h>
 
 using namespace hipFile;
 

--- a/projects/hipfile/test/amd_detail/batch/batch.cpp
+++ b/projects/hipfile/test/amd_detail/batch/batch.cpp
@@ -18,7 +18,6 @@
 #include <cstdio>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <utility>

--- a/projects/hipfile/test/amd_detail/buffer.cpp
+++ b/projects/hipfile/test/amd_detail/buffer.cpp
@@ -13,14 +13,12 @@
 #include "state.h"
 
 #include <array>
-#include <cstddef>
 #include <cstdint>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <hip/hip_runtime_api.h>
 #include <limits>
 #include <memory>
-#include <stdexcept>
 
 using namespace hipFile;
 

--- a/projects/hipfile/test/amd_detail/configuration.cpp
+++ b/projects/hipfile/test/amd_detail/configuration.cpp
@@ -11,7 +11,6 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <optional>
 #include <string>
 
 using namespace hipFile;

--- a/projects/hipfile/test/amd_detail/fallback.cpp
+++ b/projects/hipfile/test/amd_detail/fallback.cpp
@@ -35,10 +35,10 @@
 #include <hip/driver_types.h>
 #include <memory>
 #include <stdexcept>
-#include <string>
 #include <sys/mman.h>
 #include <system_error>
 #include <unistd.h>
+#include <utility>
 #include <vector>
 
 using namespace hipFile;

--- a/projects/hipfile/test/amd_detail/handle.cpp
+++ b/projects/hipfile/test/amd_detail/handle.cpp
@@ -14,7 +14,6 @@
 #include "state.h"
 
 #include <cerrno>
-#include <cstring>
 #include <fcntl.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/projects/hipfile/test/amd_detail/hipfile-stats.cpp
+++ b/projects/hipfile/test/amd_detail/hipfile-stats.cpp
@@ -3,12 +3,16 @@
  * SPDX-License-Identifier: MIT
  */
 #include "hipfile-test.h"
+#include "hipfile-warnings.h"
 #include "include_internal/hipfile-stats.h"
 #include "msys.h"
 #include "stats.h"
 
+#include <cerrno>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <ostream>
+#include <system_error>
 
 using namespace hipFile;
 using ::testing::StrictMock;

--- a/projects/hipfile/test/amd_detail/stats.cpp
+++ b/projects/hipfile/test/amd_detail/stats.cpp
@@ -3,16 +3,24 @@
  * SPDX-License-Identifier: MIT
  */
 
+#include "context.h"
 #include "hipfile-test.h"
+#include "hipfile-warnings.h"
+#include "io.h"
 #include "mconfiguration.h"
 #include "mhip.h"
 #include "mstats.h"
 #include "stats.h"
 #include "msys.h"
 
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <sstream>
+#include <string>
+#include <system_error>
 
 using namespace hipFile;
 

--- a/projects/hipfile/test/system/amd/io.cpp
+++ b/projects/hipfile/test/system/amd/io.cpp
@@ -12,7 +12,6 @@
 #include "test-options.h"
 
 #include <array>
-#include <cstdlib>
 #include <gtest/gtest.h>
 #include <hip/hip_runtime_api.h>
 #include <string>

--- a/projects/hipfile/tools/ais-stats/ais-stats.cpp
+++ b/projects/hipfile/tools/ais-stats/ais-stats.cpp
@@ -6,6 +6,7 @@
 #include "include_internal/hipfile-stats.h"
 #include <iostream>
 #include <unistd.h>
+#include <cstdlib>
 #include <cstring>
 
 static void

--- a/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
+++ b/projects/hipfile/util/docker/DOCKERFILE.ais_ci_ubuntu
@@ -95,6 +95,7 @@ RUN apt update && \
         doxygen \
         gdb \
         git \
+        iwyu \
         libmount-dev \
         llvm-dev \
         python3.12-dev \


### PR DESCRIPTION
## Motivation

We should include only what we use. This makes the code more robust and avoids wasted CI time as the compiler parses unnecessary header files.

## Technical Details

Run include-what-you-use over hipFile and apply the verified findings, add mapping files to suppress structural false positives, and wire an advisory (non-blocking) IWYU job into the top-level CI.

Include fixes (library, tests, examples, tools):
- Add directly-used headers and drop unused/transitive ones across src/amd_detail, test/amd_detail, examples, and tools/ais-stats.
- Prefer C++ header forms (<cstdint>, <cstdio>, <cerrno>) in C++ files.
- Replace full includes with forward declarations in backend.cpp where only pointers/by-value declarations are used.

IWYU configuration (cmake/AISIWYU.cmake):
- Add cmake/iwyu-gtest.imp mapping GoogleTest/GoogleMock private sub-headers to their public umbrella headers, eliminating the spurious quoted-vs-angle gtest.h suggestions and gmock.h remove/re-add churn.
- Add cmake/iwyu-libc.imp mapping libstdc++/glibc private headers (<bits/chrono.h> -> <chrono>, <bits/statx*.h> -> <sys/stat.h>).
- Fail configure with a clear error if a mapping file is missing.

Pragmas for unavoidable false positives:
- "// IWYU pragma: keep" on stats.h in context.h/context.cpp, where the std::derived_from constraint requires the complete type.
- "// IWYU pragma: keep" on <array> in api-trace.cpp, used only under HIPFILE_ROCPROFILER_REGISTER (a config IWYU does not see enabled).

CI:
- Add .github/workflows/hipfile-iwyu.yml: compile-only, runs once against a fixed image, surfaces findings to the job summary and an artifact, and never fails the build (IWYU runs in launcher mode).
- Install the iwyu package in DOCKERFILE.ais_ci_ubuntu.
- Wire the advisory job into hipfile-ci-toplevel.yml.

Verified warning-free builds, clang-format-clean sources, and 522/522 unit tests passing throughout.

## JIRA ID

AIHIPFILE-161

## Test Plan

New and old CI needs to pass

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
