### PR TITLE
[hipfile] Fix UB in abs() on HIP file I/O status codes

### DIFF
--- a/projects/hipfile/src/amd_detail/hip.cpp
+++ b/projects/hipfile/src/amd_detail/hip.cpp
@@ -130,7 +130,9 @@ Hip::hipAmdFileRead(hipAmdFileHandle_t handle, void *devicePtr, uint64_t size, i
     auto hip_error{(*hipAmdFileReadPtr)(handle, devicePtr, size, file_offset, &bytes_read, &status)};
 
     if (status) {
-        throw std::system_error(abs(status), std::generic_category());
+        // Widen before abs(): abs(INT_MIN) overflows int (UB). int64_t holds the magnitude safely.
+        throw std::system_error(static_cast<int>(std::abs(static_cast<int64_t>(status))),
+                                std::generic_category());
     }
     else if (hip_error) {
         throw Hip::RuntimeError(hip_error);
@@ -153,7 +155,9 @@ Hip::hipAmdFileWrite(hipAmdFileHandle_t handle, void *devicePtr, uint64_t size, 
     auto hip_error{(*hipAmdFileWritePtr)(handle, devicePtr, size, file_offset, &bytes_written, &status)};
 
     if (status) {
-        throw std::system_error(abs(status), std::generic_category());
+        // Widen before abs(): abs(INT_MIN) overflows int (UB). int64_t holds the magnitude safely.
+        throw std::system_error(static_cast<int>(std::abs(static_cast<int64_t>(status))),
+                                std::generic_category());
     }
     else if (hip_error) {
         throw Hip::RuntimeError(hip_error);


### PR DESCRIPTION
## Motivation

We should not have undefined behavior in the library

## Technical Details

abs(status) in hipAmdFileRead() and hipAmdFileWrite() resolved to the int overload. For status == INT_MIN, abs() overflows int, which is undefined behavior. Widen to int64_t before taking the absolute value so the magnitude is always representable.

This is admittedly an edge case.

## JIRA ID

AIHIPFILE-154

## Test Plan

CI passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
