### PR TITLE
[hipfile] Add Release builds to CI

### DIFF
--- a/.github/workflows/hipfile-build.yml
+++ b/.github/workflows/hipfile-build.yml
@@ -141,7 +141,7 @@ jobs:
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               cp -R /mnt/ais /ais
-              mkdir -p /ais/build/hipfile
+              mkdir -p /ais/build/hipfile /ais/build/hipfile-release
             '
       - name: Generate build files for hipFile targeting the AMD platform (${{ inputs.cxx_compiler }})
         # ${SLES_BUILD_ID} is mentioned for all platforms to match current ROCm build implementation.
@@ -188,6 +188,47 @@ jobs:
           docker exec \
             -t \
             -w /ais/build/hipfile \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              ctest -V -L "unit" --parallel
+            '
+      # Release build for signal only: configure, build, and unit-test in a
+      # separate directory. The Debug build above remains the one that is
+      # packaged, install-tested, and handed to the downstream system tests.
+      # Packaging/coverage for Release is intentionally out of scope here.
+      - name: Generate Release build files for hipFile (${{ inputs.cxx_compiler }})
+        run: |
+          docker exec \
+            -e "_AIS_INPUT_CXX_COMPILER=${AIS_INPUT_CXX_COMPILER}" \
+            -t \
+            -w /ais/build/hipfile-release \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cmake \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_CXX_COMPILER="${_AIS_INPUT_CXX_COMPILER}" \
+                -DAIS_CXX_STANDARD="${{ env.AIS_INPUT_CXX_STANDARD }}" \
+                -DCMAKE_CXX_FLAGS="-Werror" \
+                -DCMAKE_HIP_ARCHITECTURES="${{ env.AIS_HIP_ARCHITECTURES }}" \
+                -DCMAKE_HIP_PLATFORM=amd \
+                -DROCM_VERSION="${ROCM_VERSION}" \
+                -DAIS_CAPABLE_DIR=/mnt/ais-fs \
+                ../../rocm-systems/projects/hipfile
+            '
+      - name: Build hipFile Release for the AMD platform (${{ inputs.cxx_compiler }})
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build/hipfile-release \
+            "${AIS_CONTAINER_NAME}" \
+            /bin/bash -c '
+              cmake --build . --parallel
+            '
+      - name: Test hipFile Release for the AMD platform (${{ inputs.cxx_compiler }})
+        run: |
+          docker exec \
+            -t \
+            -w /ais/build/hipfile-release \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
               ctest -V -L "unit" --parallel
@@ -359,7 +400,7 @@ jobs:
             -w /ais/build \
             "${AIS_CONTAINER_NAME}" \
             /bin/bash -c '
-              rm -rf hipfile
+              rm -rf hipfile hipfile-release
             '
       - name: Cleanup & Stop the Docker container
         if: ${{ always() }}


### PR DESCRIPTION
## Motivation

The build job previously configured, built, and unit-tested hipFile only in Debug. Add a Release configure/build/unit-test in a separate /ais/build/hipfile-release directory so we get Release signal without standing up a second container or touching the existing pipeline.

## Technical Details

The Debug build remains the one that is packaged, install-tested, and handed to the downstream system tests, so packaging, coverage, and the CTestTestfile.cmake absolute-path contract are all unaffected. Release packaging and coverage are intentionally out of scope.

Release steps are named with "Release" so a failing build type is obvious in the CI logs.

## JIRA ID

AIHIPFILE-27

## Test Plan

CI Passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
