### PR TITLE
rocr: experimental HW-investigation patches (doorbell poke + gfx125x trampoline disable)

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -256,6 +256,16 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   /// @brief Get HSA queue ID for core dump filtering
   HSA_QUEUEID aql_queue_id() const { return queue_id_; }
 
+  /// @brief EXPERIMENTAL: Re-ring ("poke") the hardware doorbell of this queue
+  /// using the most recently written doorbell value, without enqueuing any new
+  /// work. This is a no-op (returns false) if the queue is inactive, no
+  /// doorbell value has been written yet, or the queue has no outstanding work
+  /// (read index has caught up to the write index). Intended to be driven by
+  /// the background doorbell-poke thread while the GPU is draining queued work.
+  ///
+  /// @return true if the doorbell was rung, false otherwise.
+  bool PokeDoorbell();
+
  protected:
   bool _IsA(Queue::rtti_t id) const override { return id == &rtti_id(); }
 
@@ -330,6 +340,13 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
 
   // Indicates if queue is active
   std::atomic<bool> active_;
+
+  // EXPERIMENTAL doorbell-poke support. last_doorbell_value_ caches the most
+  // recent value written to the hardware doorbell (updated by StoreRelaxed) so
+  // the background poke thread can re-ring the doorbell with the same value.
+  // doorbell_value_valid_ guards against poking before the first real ring.
+  std::atomic<uint64_t> last_doorbell_value_{0};
+  std::atomic<bool> doorbell_value_valid_{false};
 
   // Handle of agent, which queue is attached to
   GpuAgent* agent_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -60,6 +60,12 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <thread>
+#include <unordered_set>
+
 #include "core/inc/runtime.h"
 #include "core/inc/amd_memory_region.h"
 #include "core/inc/signal.h"
@@ -77,6 +83,160 @@ namespace rocr {
 namespace AMD {
 
 #define SCRATCH_ALT_RATIO 4
+
+// ----------------------------------------------------------------------------
+// EXPERIMENTAL doorbell-poke support.
+//
+// When HSA_DOORBELL_POKE=1, a single background thread periodically re-rings
+// ("pokes") the hardware doorbell of every active compute queue that still has
+// outstanding work. This is used to study command-processor behavior while the
+// host is blocked waiting for the GPU to drain a long backlog of dispatches
+// (for example, while an application is blocked in hipDeviceSynchronize). It is
+// intended to be exercised together with rocprofv3.
+//
+// The poke replays the last value that the runtime legitimately wrote to the
+// doorbell, so it never advances or rewinds the queue; it merely nudges the CP.
+// ----------------------------------------------------------------------------
+namespace {
+
+class DoorbellPokeManager {
+ public:
+  static DoorbellPokeManager& instance() {
+    // Intentionally leaked: lives for the duration of the process.
+    static DoorbellPokeManager* mgr = new DoorbellPokeManager();
+    return *mgr;
+  }
+
+  bool enabled() const { return enabled_; }
+
+  void Register(AqlQueue* queue) {
+    if (!enabled_) return;
+    std::lock_guard<std::mutex> lock(mutex_);
+    queues_.insert(queue);
+    EnsureThreadStarted();
+  }
+
+  void Unregister(AqlQueue* queue) {
+    if (!enabled_) return;
+    std::lock_guard<std::mutex> lock(mutex_);
+    queues_.erase(queue);
+  }
+
+ private:
+  DoorbellPokeManager() {
+    const Flag& flag = core::Runtime::runtime_singleton_->flag();
+    enabled_ = flag.doorbell_poke();
+    interval_us_ = flag.doorbell_poke_interval_us();
+    verbose_ = flag.doorbell_poke_verbose();
+    if (enabled_) {
+      fprintf(stderr,
+              "[doorbell-poke] ENABLED: target interval = %u us%s\n",
+              interval_us_, verbose_ ? " (verbose)" : "");
+    }
+  }
+
+  // Caller must hold mutex_.
+  void EnsureThreadStarted() {
+    if (thread_started_) return;
+    thread_started_ = true;
+    run_.store(true, std::memory_order_release);
+    thread_ = std::thread(&DoorbellPokeManager::ThreadMain, this);
+  }
+
+  static void PreciseWaitUntil(std::chrono::steady_clock::time_point deadline) {
+    // Hybrid wait: sleep for the bulk of the interval (if it is long enough to
+    // make sleeping worthwhile) then busy-spin for the remainder so that small
+    // intervals such as the 10 us default are honored reasonably accurately.
+    constexpr auto kSpinSlack = std::chrono::microseconds(80);
+    auto now = std::chrono::steady_clock::now();
+    if (deadline - now > kSpinSlack) {
+      std::this_thread::sleep_for((deadline - now) - kSpinSlack);
+    }
+    while (std::chrono::steady_clock::now() < deadline) {
+      _mm_pause();
+    }
+  }
+
+  void ThreadMain();
+
+  std::mutex mutex_;
+  std::unordered_set<AqlQueue*> queues_;
+  std::thread thread_;
+  std::atomic<bool> run_{false};
+  bool thread_started_ = false;
+  bool enabled_ = false;
+  bool verbose_ = false;
+  uint32_t interval_us_ = 10;
+};
+
+void DoorbellPokeManager::ThreadMain() {
+  using clock = std::chrono::steady_clock;
+  const auto interval = std::chrono::microseconds(interval_us_);
+
+  uint64_t total_pokes = 0;
+  uint64_t window_pokes = 0;
+  bool draining = false;
+  clock::time_point window_start = clock::now();
+
+  while (run_.load(std::memory_order_acquire)) {
+    const clock::time_point loop_start = clock::now();
+    size_t poked = 0;
+
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      for (AqlQueue* queue : queues_) {
+        if (queue->PokeDoorbell()) ++poked;
+      }
+    }
+
+    total_pokes += poked;
+    window_pokes += poked;
+
+    if (poked > 0) {
+      if (!draining) {
+        draining = true;
+        window_start = loop_start;
+        window_pokes = poked;
+        fprintf(stderr,
+                "[doorbell-poke] started poking: outstanding GPU work detected "
+                "(total pokes so far = %lu)\n",
+                static_cast<unsigned long>(total_pokes));
+      }
+      if (verbose_) {
+        fprintf(stderr, "[doorbell-poke] poked %zu queue(s) (total = %lu)\n",
+                poked, static_cast<unsigned long>(total_pokes));
+      } else {
+        const auto elapsed = loop_start - window_start;
+        if (elapsed >= std::chrono::milliseconds(100)) {
+          const double elapsed_us =
+              std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
+          const double avg_us =
+              window_pokes ? (elapsed_us / static_cast<double>(window_pokes)) : 0.0;
+          fprintf(stderr,
+                  "[doorbell-poke] poking active: %lu pokes in last %.1f ms "
+                  "(~%.2f us/poke), cumulative = %lu\n",
+                  static_cast<unsigned long>(window_pokes), elapsed_us / 1000.0,
+                  avg_us, static_cast<unsigned long>(total_pokes));
+          window_start = loop_start;
+          window_pokes = 0;
+        }
+      }
+      PreciseWaitUntil(loop_start + interval);
+    } else {
+      if (draining) {
+        draining = false;
+        fprintf(stderr,
+                "[doorbell-poke] idle: no outstanding GPU work "
+                "(cumulative pokes = %lu)\n",
+                static_cast<unsigned long>(total_pokes));
+      }
+      // Nothing to poke; back off so we do not burn a core while idle.
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }
+}
+
+}  // namespace
 
 AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_size_pkts,
                    HSAuint32 node_id, ScratchInfo& scratch, core::HsaEventCallback callback,
@@ -344,6 +504,10 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
 
   active_ = true;
 
+  // EXPERIMENTAL: register with the background doorbell-poke thread (no-op
+  // unless HSA_DOORBELL_POKE=1).
+  DoorbellPokeManager::instance().Register(this);
+
   PM4IBGuard.Dismiss();
   RingGuard.Dismiss();
   QueueGuard.Dismiss();
@@ -352,6 +516,10 @@ AqlQueue::AqlQueue(core::SharedQueue* shared_queue, GpuAgent* agent, size_t req_
 }
 
 AqlQueue::~AqlQueue() {
+  // EXPERIMENTAL: stop the background doorbell-poke thread from touching this
+  // queue before any of its resources (doorbell, ring buffer) are torn down.
+  DoorbellPokeManager::instance().Unregister(this);
+
   agent_->UnregisterAqlQueue(this);
 
   // Remove error handler synchronously.
@@ -480,6 +648,11 @@ uint64_t AqlQueue::AddWriteIndexRelease(uint64_t value) {
 }
 
 void AqlQueue::StoreRelaxed(hsa_signal_value_t value) {
+  // EXPERIMENTAL: remember the last value written to the doorbell so the
+  // background doorbell-poke thread can replay it without advancing the queue.
+  last_doorbell_value_.store(uint64_t(value), std::memory_order_relaxed);
+  doorbell_value_valid_.store(true, std::memory_order_relaxed);
+
   if (core::Runtime::runtime_singleton_->thunkLoader()->IsDTIF() ||
         core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) {
     HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_id_, value));
@@ -490,6 +663,31 @@ void AqlQueue::StoreRelaxed(hsa_signal_value_t value) {
     /* signal_ is allocated as uncached so we do not need read-back to flush WC */
   }
   return;
+}
+
+bool AqlQueue::PokeDoorbell() {
+  // Only poke active queues that have already had a real doorbell ring.
+  if (!active_.load(std::memory_order_acquire)) return false;
+  if (!doorbell_value_valid_.load(std::memory_order_relaxed)) return false;
+
+  // Only poke while the GPU still has outstanding work on this queue: if the
+  // read index has caught up to the write index there is nothing in flight and
+  // re-ringing the doorbell would serve no purpose.
+  const uint64_t read = LoadReadIndexRelaxed();
+  const uint64_t write = LoadWriteIndexRelaxed();
+  if (read >= write) return false;
+
+  const hsa_signal_value_t value =
+      static_cast<hsa_signal_value_t>(last_doorbell_value_.load(std::memory_order_relaxed));
+
+  if (core::Runtime::runtime_singleton_->thunkLoader()->IsDTIF() ||
+      core::Runtime::runtime_singleton_->thunkLoader()->IsDXG()) {
+    HSAKMT_CALL(hsaKmtQueueRingDoorbell(queue_id_, value));
+  } else {
+    _mm_sfence();
+    *(signal_.hardware_doorbell_ptr) = uint64_t(value);
+  }
+  return true;
 }
 
 void AqlQueue::StoreRelease(hsa_signal_value_t value) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -349,6 +349,26 @@ class Flag {
     var = os::GetEnvVar("HSA_SDMA_LINEAR_B2B");
     sdma_linear_b2b_ = (var == "0") ? SDMA_DISABLE : ((var == "1") ? SDMA_ENABLE : SDMA_DEFAULT);
 
+    // EXPERIMENTAL: Periodically re-ring ("poke") the hardware doorbell of
+    // active compute (CP) queues from the host while the GPU is draining
+    // queued work (e.g. while the application is blocked in
+    // hipDeviceSynchronize). This is a hardware-behavior investigation knob
+    // intended to be used together with rocprofv3. Disabled by default.
+    var = os::GetEnvVar("HSA_DOORBELL_POKE");
+    doorbell_poke_ = (var == "1") ? true : false;
+
+    // EXPERIMENTAL: Interval, in microseconds, between successive doorbell
+    // pokes. Defaults to 10 us. Ignored unless HSA_DOORBELL_POKE=1.
+    var = os::GetEnvVar("HSA_DOORBELL_POKE_INTERVAL_US");
+    doorbell_poke_interval_us_ =
+        var.empty() ? 10 : static_cast<uint32_t>(strtoul(var.c_str(), nullptr, 0));
+    if (doorbell_poke_interval_us_ == 0) doorbell_poke_interval_us_ = 10;
+
+    // EXPERIMENTAL: When set, log every individual doorbell poke (very
+    // verbose). Otherwise a throttled summary is emitted while poking is
+    // active. Ignored unless HSA_DOORBELL_POKE=1.
+    var = os::GetEnvVar("HSA_DOORBELL_POKE_VERBOSE");
+    doorbell_poke_verbose_ = (var == "1") ? true : false;
   }
 
   void parse_masks(uint32_t maxGpu, uint32_t maxCU) {
@@ -493,6 +513,12 @@ class Flag {
 
   SDMA_OVERRIDE sdma_linear_b2b() const { return sdma_linear_b2b_; }
 
+  bool doorbell_poke() const { return doorbell_poke_; }
+
+  uint32_t doorbell_poke_interval_us() const { return doorbell_poke_interval_us_; }
+
+  bool doorbell_poke_verbose() const { return doorbell_poke_verbose_; }
+
   [[nodiscard]]
   bool core_dump_disable() const { return core_dump_disable_; }
 
@@ -573,6 +599,11 @@ class Flag {
   bool enable_dtif_;
   bool enable_dxg_detection_;
   SDMA_OVERRIDE sdma_linear_b2b_ = SDMA_DEFAULT;
+
+  // EXPERIMENTAL doorbell-poke controls (see Refresh()).
+  bool doorbell_poke_ = false;
+  uint32_t doorbell_poke_interval_us_ = 10;
+  bool doorbell_poke_verbose_ = false;
 
   SDMA_OVERRIDE enable_sdma_;
   SDMA_OVERRIDE enable_peer_sdma_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -1306,7 +1306,8 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
 
   // Kernel-entry trampolines (gfx125x). Gate on this code object's ISA and reset
   // the per-object fixup list collected by LoadDefinitionSymbol.
-  trampoline_enabled_gfx125x_ = CodeObjectIsaIsGfx125Family(codeIsa);
+  //trampoline_enabled_gfx125x_ = CodeObjectIsaIsGfx125Family(codeIsa);
+  trampoline_enabled_gfx125x_ = false;
   kd_fixups_.clear();
 
   uint32_t majorVersion, minorVersion;

--- a/projects/rocr-runtime/samples/doorbell_poke_test.cpp
+++ b/projects/rocr-runtime/samples/doorbell_poke_test.cpp
@@ -1,0 +1,91 @@
+// EXPERIMENTAL test driver for the HSA_DOORBELL_POKE feature.
+//
+// Enqueues a large number of GPU kernels into a single HIP stream and then
+// blocks the host in hipDeviceSynchronize while the GPU drains the backlog.
+// While the host is blocked, the patched HSA runtime (HSA_DOORBELL_POKE=1)
+// periodically re-rings the compute-queue doorbell. Run under rocprofv3.
+//
+// Build:
+//   hipcc -O2 doorbell_poke_test.cpp -o doorbell_poke_test
+//
+// Run (with the patched libhsa-runtime64.so on the library path):
+//   HSA_DOORBELL_POKE=1 HSA_DOORBELL_POKE_INTERVAL_US=10 \
+//     rocprofv3 --hip-trace -- ./doorbell_poke_test
+
+#include <hip/hip_runtime.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+#define HIP_CHECK(cmd)                                                                  \
+  do {                                                                                  \
+    hipError_t _e = (cmd);                                                              \
+    if (_e != hipSuccess) {                                                             \
+      fprintf(stderr, "HIP error %s at %s:%d\n", hipGetErrorString(_e), __FILE__,       \
+              __LINE__);                                                                \
+      std::exit(1);                                                                     \
+    }                                                                                   \
+  } while (0)
+
+// A deliberately non-trivial kernel so that 20000 dispatches take long enough
+// (a couple of seconds) for the periodic doorbell poking to be clearly
+// observable while the host is blocked in hipDeviceSynchronize.
+__global__ void busy_kernel(uint64_t* out, uint32_t iters) {
+  uint64_t acc = 0;
+  for (uint32_t i = 0; i < iters; ++i) {
+    acc += i * 2654435761ull;
+    acc ^= (acc << 13);
+    acc += (acc >> 7);
+  }
+  if (acc == 0xdeadbeefull) {  // never true, keeps the work from being optimized away
+    out[threadIdx.x] = acc;
+  }
+}
+
+int main(int argc, char** argv) {
+  int num_kernels = (argc > 1) ? std::atoi(argv[1]) : 20000;
+  uint32_t iters = (argc > 2) ? static_cast<uint32_t>(std::atoi(argv[2])) : 200000u;
+
+  int device = 0;
+  HIP_CHECK(hipSetDevice(device));
+  hipDeviceProp_t prop{};
+  HIP_CHECK(hipGetDeviceProperties(&prop, device));
+  printf("Device: %s (gcnArch=%s)\n", prop.name, prop.gcnArchName);
+
+  uint64_t* d_out = nullptr;
+  HIP_CHECK(hipMalloc(&d_out, sizeof(uint64_t) * 256));
+
+  // Single stream: all kernels are serialized on one compute queue.
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  const dim3 grid(1);
+  const dim3 block(64);
+
+  printf("Enqueuing %d kernels (iters=%u) into a single stream...\n", num_kernels, iters);
+  auto t_enqueue_start = std::chrono::steady_clock::now();
+  for (int i = 0; i < num_kernels; ++i) {
+    busy_kernel<<<grid, block, 0, stream>>>(d_out, iters);
+  }
+  HIP_CHECK(hipGetLastError());
+  auto t_enqueue_end = std::chrono::steady_clock::now();
+  double enqueue_ms =
+      std::chrono::duration<double, std::milli>(t_enqueue_end - t_enqueue_start).count();
+  printf("All kernels enqueued in %.1f ms. Calling hipDeviceSynchronize()...\n", enqueue_ms);
+  fflush(stdout);
+
+  auto t_sync_start = std::chrono::steady_clock::now();
+  HIP_CHECK(hipDeviceSynchronize());
+  auto t_sync_end = std::chrono::steady_clock::now();
+  double sync_ms =
+      std::chrono::duration<double, std::milli>(t_sync_end - t_sync_start).count();
+
+  printf("hipDeviceSynchronize() returned after %.1f ms.\n", sync_ms);
+  printf("Done.\n");
+
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipFree(d_out));
+  return 0;
+}


### PR DESCRIPTION
Experimental, opt-in patches used for hardware investigation. Opening as a **draft** — these are debug knobs, not production features. The two changes are independent and can be split into separate PRs on request.

---

## 1. Periodic doorbell poke for CP queues

While the host is blocked waiting for the GPU to drain queued work (e.g. in `hipDeviceSynchronize`), a background host thread periodically re-rings ("pokes") the hardware doorbell of each active compute queue. Intended to be exercised together with `rocprofv3`.

The poke replays the **last value the runtime legitimately wrote** to that queue's doorbell, so it never advances or rewinds the queue — it only nudges the CP. It fires only while the queue still has outstanding work (`read_index < write_index`), which is precisely the synchronize/drain window.

### Controls (env vars)
- `HSA_DOORBELL_POKE=1` — enable the feature (default: off).
- `HSA_DOORBELL_POKE_INTERVAL_US=N` — interval between pokes, microseconds (default: `10`).
- `HSA_DOORBELL_POKE_VERBOSE=1` — log every individual poke (default: throttled summary).

### Changes
- `core/util/flag.h` — parse the three new env vars.
- `core/inc/amd_aql_queue.h` / `core/runtime/amd_aql_queue.cpp`:
  - `AqlQueue::StoreRelaxed` caches the last doorbell value written.
  - New `AqlQueue::PokeDoorbell()` re-rings the HW doorbell when the queue is active and has outstanding work.
  - A `DoorbellPokeManager` singleton drives a single background thread (hybrid sleep+spin to honor short intervals); queues register on activation and unregister at destruction under a lock.
- `samples/doorbell_poke_test.cpp` — HIP driver: enqueues 20000 kernels into one stream, then `hipDeviceSynchronize`.

### Test plan
Verified on **nv48-ss** (gfx1201) with the patched `libhsa-runtime64.so` `LD_PRELOAD`ed under `rocprofv3 --hip-trace`:

```
HSA_DOORBELL_POKE=1 HSA_DOORBELL_POKE_INTERVAL_US=10 \
  rocprofv3 --hip-trace -- ./doorbell_poke_test 20000 20000
```

- [x] Poking runs continuously through the entire `hipDeviceSynchronize` (~3983 ms): **491,339 pokes at ~10.08 µs/poke**, then a clean `idle` once the GPU drains. rocprofv3 still produces its `results.db`.
- [x] `HSA_DOORBELL_POKE_INTERVAL_US=50` → measured ~50.07 µs/poke.
- [x] Feature disabled (env var unset) → zero pokes, no added work.

---

## 2. Force-disable gfx125x kernel-entry trampolines

Experimental: in `ExecutableImpl::LoadCodeObject`, unconditionally set `trampoline_enabled_gfx125x_ = false` (the ISA-gated assignment is commented out) to take the non-trampoline path for hardware investigation.

### Changes
- `loader/executable.cpp` — hard-code `trampoline_enabled_gfx125x_ = false`.
