### PR TITLE
[hotswap] Install and link libhsa-hotswap tool

### DIFF
--- a/projects/hotswap/CMakeLists.txt
+++ b/projects/hotswap/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(hotswap LANGUAGES CXX)
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -39,6 +41,11 @@ target_include_directories(hsa-hotswap PRIVATE
 target_link_libraries(hsa-hotswap PRIVATE amd_comgr)
 set_target_properties(hsa-hotswap PROPERTIES
   POSITION_INDEPENDENT_CODE ON)
+
+install(TARGETS hsa-hotswap
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # Test executable
 add_executable(hotswap_test tests/hotswap_test.cpp hotswap.cpp)

--- a/projects/hotswap/CMakeLists.txt
+++ b/projects/hotswap/CMakeLists.txt
@@ -12,6 +12,7 @@ set(HSA_RUNTIME_INC "${CMAKE_CURRENT_SOURCE_DIR}/../rocr-runtime/runtime/hsa-run
 
 # COMGR is required — provides amd_comgr_hotswap_rewrite.
 find_package(amd_comgr CONFIG REQUIRED)
+find_package(hsa-runtime64 CONFIG REQUIRED)
 
 find_path(HSA_INCLUDE_DIR hsa.h PATHS ${HSA_RUNTIME_INC} NO_DEFAULT_PATH REQUIRED)
 
@@ -38,7 +39,10 @@ target_include_directories(hsa-hotswap PRIVATE
   ${HSA_RUNTIME_INC}/..
 )
 
-target_link_libraries(hsa-hotswap PRIVATE amd_comgr)
+target_link_libraries(hsa-hotswap PRIVATE
+  amd_comgr
+  hsa-runtime64::hsa-runtime64
+)
 set_target_properties(hsa-hotswap PROPERTIES
   POSITION_INDEPENDENT_CODE ON)
 


### PR DESCRIPTION
ISSUE ID: ROCm/llvm-project#3000

## Stack
Layer 1 of the rocm-systems hotswap stack, paired with ROCm/llvm-project#3007.
- This layer: make rocm-systems build, link, and install `libhsa-hotswap.so`
- Layer 2: ROCm/rocm-systems#7593
- Layer 3: ROCm/rocm-systems#7592

## Summary
- Install `libhsa-hotswap.so` from `projects/hotswap` so TheRock can package it.
- Link the hotswap HSA tool against `hsa-runtime64::hsa-runtime64`.
- Keep `libhsa-hotswap.so` as the runtime HSA tools library while COMGR provides the rewrite API.

## Testing
- `cmake -S projects/hotswap -B build-hotswap-reorder-layer1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -Damd_comgr_DIR=/home/harsh/llvm-pr3000-refactor/build-comgr-displacement-shared/lib/cmake/amd_comgr -Dhsa-runtime64_DIR=/opt/rocm-7.2.0/lib/cmake/hsa-runtime64`
- `cmake --build build-hotswap-reorder-layer1 --target hsa-hotswap hotswap_test hotswap_tool_test --parallel 32`
- `cmake --install build-hotswap-reorder-layer1 --prefix build-hotswap-reorder-layer1/install-check`

Full hotswap CTest is run at layer 2, where the same-ISA passthrough and entry-trampoline gating behavior are introduced.