### PR TITLE
ci(hipfile): Add push + workflow_dispatch triggers to main CI

### DIFF
--- a/.github/workflows/hipfile-ci-toplevel.yml
+++ b/.github/workflows/hipfile-ci-toplevel.yml
@@ -12,6 +12,15 @@ on:
       # ais-check is a self-contained Python tool with no dependency on the C++
       # library, so its changes shouldn't trigger the full C++ build/test.
       - '!projects/hipfile/tools/ais-check/**'
+  push:
+    branches: [develop]
+    paths:
+      - 'projects/hipfile/**'
+      - '.github/workflows/hipfile-*.yml'
+      - '!**/*.md'
+      - '!**/*.rst'
+      - '!projects/hipfile/tools/ais-check/**'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,6 +32,10 @@ permissions:
 
 jobs:
   Precheck:
+    # Forks that sync develop must not run org-only infrastructure (self-hosted
+    # AMD runners, GHCR image push). On a fork this job is skipped, and every
+    # downstream job is gated on it via `needs`, so the whole run no-ops.
+    if: github.repository == 'ROCm/rocm-systems'
     runs-on: [ubuntu-24.04]
     outputs:
       changed_dockerfile: ${{ steps.ci-flags.outputs.changed_dockerfile }}
@@ -96,13 +109,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Git fetch base ref
+        if: ${{ github.event_name == 'pull_request' }}
         working-directory: rocm-systems
         run: git fetch origin "${GITHUB_BASE_REF}"
       - name: Set CI Flags
         working-directory: rocm-systems/projects/hipfile
         id: ci-flags
+        # Only a pull_request diffs against its base to detect Dockerfile changes
+        # (which build a private, PR-namespaced image to test before merge). On
+        # push/workflow_dispatch the canonical latest-rocm images have already
+        # been (re)published by hipfile-image-update.yml on the triggering merge,
+        # so force changed_dockerfile=0 to reuse them rather than rebuild.
         run: |
-          echo "changed_dockerfile=$(./util/files-changed.sh "origin/${GITHUB_BASE_REF}" HEAD 'projects/hipfile/util/docker/DOCKERFILE.*')" >> "${GITHUB_OUTPUT}"
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            changed_dockerfile="$(./util/files-changed.sh "origin/${GITHUB_BASE_REF}" HEAD 'projects/hipfile/util/docker/DOCKERFILE.*')"
+          else
+            changed_dockerfile=0
+          fi
+          echo "changed_dockerfile=${changed_dockerfile}" >> "${GITHUB_OUTPUT}"
       - name: Sanity-check util script test suites
         # Ensure the util scripts work as expected before using them.
         working-directory: rocm-systems/projects/hipfile


### PR DESCRIPTION
## Motivation

We need to add a push trigger to hipFile's CI, like other libraries in rocm-systems

## Technical Details

- Add `push` (develop) and `workflow_dispatch` triggers to the hipFile CI workflow, alongside the existing `pull_request` trigger. This matches the push + pull_request convention used across rocm-systems, enables status badges on develop, and provides post-merge validation of the full matrix.
- Make the Dockerfile-change detection event-aware: only a `pull_request` diffs against its base ref (to build a private, PR-namespaced image for pre-merge testing). On push/dispatch, `changed_dockerfile` is forced to 0 so CI reuses the canonical `latest-rocm` images.

- `GITHUB_BASE_REF` only exists on `pull_request`; the short-circuit avoids diffing against an empty base on push/dispatch.
- The canonical `latest-rocm` images are (re)published by `hipfile-image-update.yml` on the triggering merge, so push-CI reusing them is correct and avoids a double-publish race on the shared tag/cache.
- Concurrency keys on `github.ref`, so push (refs/heads/develop) and PR runs don't cancel each other across event types.

## JIRA ID

AIHIPFILE-27

## Test Plan

- [ ] Util test suites pass: `ci-matrices.sh`, `ci-images.sh`, `build-ci-images-matrix.sh` (all `--test`)
- [ ] PR run still diffs against base and builds namespaced images on a Dockerfile change
- [ ] Push to develop runs the full matrix, reuses latest-rocm images, and skips the image-build job
- [ ] Status badge reflects develop post-merge state

## Test Result

We'll see!

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
