### PR TITLE
Install Kernel Trampolines

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/blit_shaders/blit_copyAligned.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/blit_shaders/blit_copyAligned.s
@@ -104,6 +104,9 @@ enable_sgpr_kernarg_segment_ptr = 1
 compute_pgm_rsrc1_sgprs = CopyAlignedRsrc1SGPRs
 compute_pgm_rsrc1_vgprs = CopyAlignedRsrc1VGPRs
 
+  .if (.amdgcn.gfx_generation_number == 12 && .amdgcn.gfx_generation_minor == 5)
+    v_nop
+  .endif
 
   s_load_dwordx4  s[4:7], s[0:1], 0x0
   s_load_dwordx4  s[8:11], s[0:1], 0x10

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/blit_shaders/blit_copyMisaligned.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/blit_shaders/blit_copyMisaligned.s
@@ -110,6 +110,10 @@ CopyMisaligned:
   compute_pgm_rsrc2_tgid_x_en = 1
   enable_sgpr_kernarg_segment_ptr = 1
 
+  .if (.amdgcn.gfx_generation_number == 12 && .amdgcn.gfx_generation_minor == 5)
+    v_nop
+  .endif
+
   s_load_dwordx4  s[4:7], s[0:1], 0x0
   s_load_dwordx4  s[8:11], s[0:1], 0x10
   s_load_dwordx4  s[12:15], s[0:1], 0x20

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/blit_shaders/blit_fill.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/blit_shaders/blit_fill.s
@@ -104,6 +104,10 @@ Fill:
     compute_pgm_rsrc2_tgid_x_en = 1
     enable_sgpr_kernarg_segment_ptr = 1
 
+    .if (.amdgcn.gfx_generation_number == 12 && .amdgcn.gfx_generation_minor == 5)
+      v_nop
+    .endif
+
     s_load_dwordx4  s[4:7], s[0:1], 0x0
     s_load_dwordx4  s[8:11], s[0:1], 0x10
     S_WAITCNT_KMCNT

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -175,6 +175,58 @@ void LoaderOptions::PrintHelp(std::ostream& out) const
 
 static const char *LOADER_DUMP_PREFIX = "amdcode";
 
+// Kernel-entry trampoline (gfx1250 / RDNA4).
+//
+// We cannot reserve space immediately in front of each kernel entry: that would
+// require a non-uniform relayout of the loaded code segment, which breaks every
+// intra-segment PC-relative reference the compiler baked in. Instead we allocate
+// a separate *executable* region (AMDGPU_HSA_SEGMENT_CODE_AGENT, which carries
+// AllocateExecutable in the loader context) and, for each kernel, emit a stub
+// that jumps to the real entry; the kernel descriptor's entry offset is then
+// rewritten so dispatch lands in the stub first.
+//
+// The jump is absolute (the pool is not within S_BRANCH range of the code), so
+// the stub loads the 64-bit entry address into a scratch SGPR pair and sets PC.
+// s[100:101] is a safe fixed scratch: RDNA gives every wave 128 physical SGPRs and
+// these indices are well above the preloaded user+system SGPRs (<= ~20), so they
+// are never a live kernel input -- the kernel writes them before it reads them.
+//
+// Dual entry points: a kernel exposes two entries, at E and E+256, where E is
+// kd + kernel_code_entry_byte_offset. Consumers of the second entry compute it as
+// (descriptor entry) + 256, so after we point the descriptor at the stub the two
+// stub entries must keep the same 256-byte spacing. We therefore reserve a
+// 512-byte slot per kernel: stub[0] (at slot+0) jumps to E, stub[1] (at slot+256)
+// jumps to E+256. The descriptor is rewritten to land on stub[0].
+//
+// gfx1250 encodings verified with: llvm-mc --arch=amdgcn --mcpu=gfx1250 --show-encoding
+//   global_wb   <scope:SCOPE_CU>       ->   0xEE0B007C, 0x00000000, 0x00000000
+//   v_nop        (padding)              ->  0x7E000000
+//   s_mov_b32    s100, <lit> + literal  ->  0xBEE400FF
+//   s_mov_b32    s101, <lit> + literal  ->  0xBEE500FF
+//   s_set_pc_i64 s[100:101]             ->  0xBE804864
+//   s_code_end   (padding)              ->  0xBF9F0000
+static constexpr size_t kTrampolineStubStride = AMD_ISA_ALIGN_BYTES;        // 256: one stub, entry-aligned
+static constexpr size_t kTrampolineEntriesPerKernel = 2;                    // entries at E and E+256
+static constexpr size_t kTrampolineEntrySpacing = AMD_ISA_ALIGN_BYTES;      // 256: matches kernel's E..E+256
+static constexpr size_t kTrampolineSlotStride =
+    kTrampolineStubStride * kTrampolineEntriesPerKernel;                    // 512 per kernel
+
+static void BuildTrampolineGfx1250(uint8_t* buf, uint64_t target) {
+  auto* w = reinterpret_cast<uint32_t*>(buf);
+
+  w[0] = 0xEE0B007C;                          // global_wb <scope:SCOPE_CU>
+  w[1] = 0x00000000;                          // padding
+  w[2] = 0x00000000;                          // padding
+  w[3] = 0x7E000000;                          // v_nop (padding)
+  w[4] = 0xBEE400FF;                          // s_mov_b32 s100, target_lo
+  w[5] = static_cast<uint32_t>(target);
+  w[6] = 0xBEE500FF;                          // s_mov_b32 s101, target_hi
+  w[7] = static_cast<uint32_t>(target >> 32);
+  w[8] = 0xBE804864;                          // s_set_pc_i64 s[100:101]
+  for (size_t i = 9; i < kTrampolineStubStride / sizeof(uint32_t); ++i)
+    w[i] = 0xBF9F0000;                        // s_code_end (prefetch-safe padding)
+}
+
 Loader* Loader::Create(Context* context)
 {
   return new AmdHsaCodeLoader(context);
@@ -1255,6 +1307,11 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
     return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   }
 
+  // Kernel-entry trampolines (gfx1250). Gate on this code object's ISA and reset
+  // the per-object fixup list collected by LoadDefinitionSymbol.
+  trampoline_enabled_gfx1250_ = codeIsa.find("gfx1250") != std::string::npos;
+  kd_fixups_.clear();
+
   uint32_t majorVersion, minorVersion;
   if (!code->GetCodeObjectVersion(&majorVersion, &minorVersion)) {
     logger_ << "LoaderError: failed to determine code object's version\n";
@@ -1314,6 +1371,14 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
 
   status = ApplyRelocations(agent, code.get());
   if (status != HSA_STATUS_SUCCESS) { return status; }
+
+  // Emit kernel-entry trampolines into the host shadow now that the image is
+  // final (post-relocation) and still unfrozen. The single Freeze DMA carries
+  // them to device along with the rewritten descriptors.
+  if (trampoline_enabled_gfx1250_ && !kd_fixups_.empty()) {
+    status = InstallTrampolinesGfx1250(agent);
+    if (status != HSA_STATUS_SUCCESS) { return status; }
+  }
 
   code.reset();
 
@@ -1425,6 +1490,49 @@ hsa_status_t ExecutableImpl::LoadSegmentV2(const code::Segment *data_segment,
   return HSA_STATUS_SUCCESS;
 }
 
+hsa_status_t ExecutableImpl::InstallTrampolinesGfx1250(hsa_agent_t agent) {
+  const size_t n = kd_fixups_.size();
+  const size_t pool = n * kTrampolineSlotStride;
+
+  // AMDGPU_HSA_SEGMENT_CODE_AGENT yields *executable* device memory: the loader
+  // context backs it with RegionMemory(..., is_code=true), which sets
+  // core::MemoryRegion::AllocateExecutable (see amd_loader_context.cpp).
+  void* ptr = context_->SegmentAlloc(AMDGPU_HSA_SEGMENT_CODE_AGENT, agent, pool,
+                                     AMD_ISA_ALIGN_BYTES, /*zero=*/true);
+  if (!ptr) return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+
+  // vaddr == 0: Address()/Copy() index by raw byte offset into the pool.
+  auto tramp = std::make_shared<Segment>(this, agent, AMDGPU_HSA_SEGMENT_CODE_AGENT,
+                                         ptr, pool, /*vaddr=*/0, /*storage_offset=*/0);
+  objects.push_back(tramp);               // freed via Destroy() in ~ExecutableImpl
+  trampoline_segments_.push_back(tramp);  // frozen in ExecutableImpl::Freeze
+
+  for (size_t i = 0; i < n; ++i) {
+    const KdFixup& f = kd_fixups_[i];
+    const uint64_t slot_off = i * kTrampolineSlotStride;
+    // Device addresses are valid pre-Freeze (RegionMemory::ptr_ is set at alloc).
+    const uint64_t kd_dev    = reinterpret_cast<uint64_t>(f.code_seg->Address(f.kd_vaddr));
+    const uint64_t entry_dev = reinterpret_cast<uint64_t>(f.code_seg->Address(f.kd_vaddr + f.entry_off));
+
+    // Emit one stub per kernel entry, preserving the E..E+256 spacing: stub[e] is
+    // at slot+e*256 and jumps to entry_dev + e*256.
+    for (size_t e = 0; e < kTrampolineEntriesPerKernel; ++e) {
+      const uint64_t stub_off = slot_off + e * kTrampolineEntrySpacing;
+      uint8_t blob[kTrampolineStubStride];
+      BuildTrampolineGfx1250(blob, entry_dev + e * kTrampolineEntrySpacing);
+      tramp->Copy(stub_off, blob, sizeof(blob));  // -> trampoline host shadow
+    }
+
+    // Redirect dispatch onto stub[0]: kernel_object(kd_dev) + new_off == stub[0],
+    // so the second-entry consumer's (stub[0] + 256) lands on stub[1].
+    const uint64_t stub0_dev = reinterpret_cast<uint64_t>(tramp->Address(slot_off));
+    int64_t new_off = static_cast<int64_t>(stub0_dev) - static_cast<int64_t>(kd_dev);
+    f.code_seg->Copy(f.kd_vaddr + llvm::amdhsa::KERNEL_CODE_ENTRY_BYTE_OFFSET_OFFSET,
+                     &new_off, sizeof(new_off)); // -> code host shadow
+  }
+  return HSA_STATUS_SUCCESS;
+}
+
 hsa_status_t ExecutableImpl::LoadSymbol(hsa_agent_t agent,
                                         code::Symbol* sym,
                                         uint32_t majorVersion)
@@ -1472,6 +1580,13 @@ hsa_status_t ExecutableImpl::LoadDefinitionSymbol(hsa_agent_t agent,
     // V3.
     llvm::amdhsa::kernel_descriptor_t kd;
     sym->GetSection()->getData(sym->SectionOffset(), &kd, sizeof(kd));
+
+    if (trampoline_enabled_gfx1250_) {
+      // Record this descriptor; the trampoline is installed after relocations.
+      // sym->VAddr() is the descriptor's ELF vaddr (matches SymbolAddress below).
+      kd_fixups_.push_back({ SymbolSegment(agent, sym), sym->VAddr(),
+                             kd.kernel_code_entry_byte_offset });
+    }
 
     uint32_t kernarg_segment_size = kd.kernarg_size; // FIXME: If 0 then the compiler is not specifying the size.
     uint32_t kernarg_segment_alignment = 16;         // FIXME: Use the minumum HSA required alignment.
@@ -1952,6 +2067,13 @@ hsa_status_t ExecutableImpl::Freeze(const char *options) {
     for (auto &ls : lco->LoadedSegments()) {
       ls->Freeze();
     }
+  }
+
+  // Trampoline pools are not part of any LoadedCodeObject's segment list
+  // (that must stay size==1 for v2+); freeze them explicitly so their host->device
+  // DMA and code-cache invalidation happen alongside the code segments.
+  for (auto &ts : trampoline_segments_) {
+    ts->Freeze();
   }
 
   state_ = HSA_EXECUTABLE_STATE_FROZEN;

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -201,6 +201,18 @@ static const char *LOADER_DUMP_PREFIX = "amdcode";
 //   s_code_end   (padding)              ->  0xBF9F0000
 static constexpr size_t kTrampolineStubStride = AMD_ISA_ALIGN_BYTES;        // 256: one stub, entry-aligned
 
+// The CP (CPC) instruction-prefetches forward from a kernel's entry PC when it
+// dispatches. Because dispatch now lands on a stub inside our pool, that prefetch
+// reads ahead from the stub and would run off the end of the pool into the next,
+// unmapped page -- a CPC read page/permission fault (observed on gfx1250). The
+// prefetch length is per-kernel: COMPUTE_PGM_RSRC3.INST_PREF_SIZE (6 bits, GFX11+)
+// counts 128-byte instruction-cache lines to prefetch ahead of the entry. We size
+// a trailing guard from the largest INST_PREF_SIZE in the pool so the prefetch from
+// any stub always lands in mapped, readable memory inside this same allocation. The
+// guard is never executed (the stub sets PC away first); it only needs to be present
+// and readable, which the allocation's zero-fill already guarantees.
+static constexpr size_t kInstPrefUnitBytes = 128;                          // GFX11+ CP I$ prefetch line size
+
 static void BuildTrampolineGfx1250(uint8_t* buf, uint64_t target) {
   auto* w = reinterpret_cast<uint32_t*>(buf);
 
@@ -1489,7 +1501,18 @@ hsa_status_t ExecutableImpl::LoadSegmentV2(const code::Segment *data_segment,
 
 hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
   const size_t n = kd_fixups_.size();
-  const size_t pool = n * kTrampolineStubStride;
+
+  // Size the trailing prefetch guard from the largest CP instruction-prefetch
+  // window among this pool's kernels (INST_PREF_SIZE lines * 128 B), plus one
+  // stub stride of slack for end-of-window line rounding. Because the stubs are
+  // packed and the last one sits at the end of the pool, a guard >= the max
+  // per-kernel reach covers the forward prefetch from every stub.
+  uint32_t max_pref_lines = 0;
+  for (const auto& f : kd_fixups_)
+    max_pref_lines = std::max(max_pref_lines, f.inst_pref);
+  const size_t guard =
+      static_cast<size_t>(max_pref_lines) * kInstPrefUnitBytes + kTrampolineStubStride;
+  const size_t pool = n * kTrampolineStubStride + guard;
 
   // AMDGPU_HSA_SEGMENT_CODE_AGENT yields *executable* device memory: the loader
   // context backs it with RegionMemory(..., is_code=true), which sets
@@ -1521,6 +1544,9 @@ hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
     f.code_seg->Copy(f.kd_vaddr + llvm::amdhsa::KERNEL_CODE_ENTRY_BYTE_OFFSET_OFFSET,
                      &new_off, sizeof(new_off)); // -> code host shadow
   }
+
+  // The prefetch guard is left as the allocation's zero-fill (zero=true): it is
+  // committed and readable -- all the CP prefetch needs -- and is never executed.
   return HSA_STATUS_SUCCESS;
 }
 
@@ -1575,8 +1601,12 @@ hsa_status_t ExecutableImpl::LoadDefinitionSymbol(hsa_agent_t agent,
     if (trampoline_enabled_gfx125x_) {
       // Record this descriptor; the trampoline is installed after relocations.
       // sym->VAddr() is the descriptor's ELF vaddr (matches SymbolAddress below).
+      // INST_PREF_SIZE (GFX11+) = number of 128B I$ lines the CP prefetches ahead
+      // of the entry; captured here to size the trampoline's prefetch guard.
+      uint32_t inst_pref = AMDHSA_BITS_GET(kd.compute_pgm_rsrc3,
+          rocr::llvm::amdhsa::COMPUTE_PGM_RSRC3_GFX10_PLUS_INST_PREF_SIZE);
       kd_fixups_.push_back({ SymbolSegment(agent, sym), sym->VAddr(),
-                             kd.kernel_code_entry_byte_offset });
+                             kd.kernel_code_entry_byte_offset, inst_pref });
     }
 
     uint32_t kernarg_segment_size = kd.kernarg_size; // FIXME: If 0 then the compiler is not specifying the size.

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -175,7 +175,7 @@ void LoaderOptions::PrintHelp(std::ostream& out) const
 
 static const char *LOADER_DUMP_PREFIX = "amdcode";
 
-// Kernel-entry trampoline (gfx1250 / RDNA4).
+// Kernel-entry trampoline (gfx125x / RDNA4).
 //
 // We cannot reserve space immediately in front of each kernel entry: that would
 // require a non-uniform relayout of the loaded code segment, which breaks every
@@ -215,6 +215,13 @@ static void BuildTrampolineGfx1250(uint8_t* buf, uint64_t target) {
   w[8] = 0xBE804864;                          // s_set_pc_i64 s[100:101]
   for (size_t i = 9; i < kTrampolineStubStride / sizeof(uint32_t); ++i)
     w[i] = 0xBF9F0000;                        // s_code_end (prefetch-safe padding)
+}
+
+// gfx12.5 family: CO v3+ reports either a generic mach name (gfx12-5-generic) or
+// discrete targets (gfx1250, gfx1251, …) in the amdgcn-amd-amdhsa--<target> ISA string.
+static bool CodeObjectIsaIsGfx125Family(const std::string& codeIsa) {
+  if (codeIsa.find("gfx12-5-generic") != std::string::npos) return true;
+  return codeIsa.find("gfx125") != std::string::npos;
 }
 
 Loader* Loader::Create(Context* context)
@@ -1297,9 +1304,9 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
     return HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   }
 
-  // Kernel-entry trampolines (gfx1250). Gate on this code object's ISA and reset
+  // Kernel-entry trampolines (gfx125x). Gate on this code object's ISA and reset
   // the per-object fixup list collected by LoadDefinitionSymbol.
-  trampoline_enabled_gfx1250_ = codeIsa.find("gfx1250") != std::string::npos;
+  trampoline_enabled_gfx125x_ = CodeObjectIsaIsGfx125Family(codeIsa);
   kd_fixups_.clear();
 
   uint32_t majorVersion, minorVersion;
@@ -1365,8 +1372,8 @@ hsa_status_t ExecutableImpl::LoadCodeObject(
   // Emit kernel-entry trampolines into the host shadow now that the image is
   // final (post-relocation) and still unfrozen. The single Freeze DMA carries
   // them to device along with the rewritten descriptors.
-  if (trampoline_enabled_gfx1250_ && !kd_fixups_.empty()) {
-    status = InstallTrampolinesGfx1250(agent);
+  if (trampoline_enabled_gfx125x_ && !kd_fixups_.empty()) {
+    status = InstallTrampolinesGfx125x(agent);
     if (status != HSA_STATUS_SUCCESS) { return status; }
   }
 
@@ -1480,7 +1487,7 @@ hsa_status_t ExecutableImpl::LoadSegmentV2(const code::Segment *data_segment,
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t ExecutableImpl::InstallTrampolinesGfx1250(hsa_agent_t agent) {
+hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
   const size_t n = kd_fixups_.size();
   const size_t pool = n * kTrampolineStubStride;
 
@@ -1565,7 +1572,7 @@ hsa_status_t ExecutableImpl::LoadDefinitionSymbol(hsa_agent_t agent,
     llvm::amdhsa::kernel_descriptor_t kd;
     sym->GetSection()->getData(sym->SectionOffset(), &kd, sizeof(kd));
 
-    if (trampoline_enabled_gfx1250_) {
+    if (trampoline_enabled_gfx125x_) {
       // Record this descriptor; the trampoline is installed after relocations.
       // sym->VAddr() is the descriptor's ELF vaddr (matches SymbolAddress below).
       kd_fixups_.push_back({ SymbolSegment(agent, sym), sym->VAddr(),

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -186,17 +186,11 @@ static const char *LOADER_DUMP_PREFIX = "amdcode";
 // rewritten so dispatch lands in the stub first.
 //
 // The jump is absolute (the pool is not within S_BRANCH range of the code), so
-// the stub loads the 64-bit entry address into a scratch SGPR pair and sets PC.
+// the stub does a global cache writeback (SCOPE_CU) and a v_nop, then loads the
+// 64-bit entry address into a scratch SGPR pair and sets PC.
 // s[100:101] is a safe fixed scratch: RDNA gives every wave 128 physical SGPRs and
 // these indices are well above the preloaded user+system SGPRs (<= ~20), so they
 // are never a live kernel input -- the kernel writes them before it reads them.
-//
-// Dual entry points: a kernel exposes two entries, at E and E+256, where E is
-// kd + kernel_code_entry_byte_offset. Consumers of the second entry compute it as
-// (descriptor entry) + 256, so after we point the descriptor at the stub the two
-// stub entries must keep the same 256-byte spacing. We therefore reserve a
-// 512-byte slot per kernel: stub[0] (at slot+0) jumps to E, stub[1] (at slot+256)
-// jumps to E+256. The descriptor is rewritten to land on stub[0].
 //
 // gfx1250 encodings verified with: llvm-mc --arch=amdgcn --mcpu=gfx1250 --show-encoding
 //   global_wb   <scope:SCOPE_CU>       ->   0xEE0B007C, 0x00000000, 0x00000000
@@ -206,10 +200,6 @@ static const char *LOADER_DUMP_PREFIX = "amdcode";
 //   s_set_pc_i64 s[100:101]             ->  0xBE804864
 //   s_code_end   (padding)              ->  0xBF9F0000
 static constexpr size_t kTrampolineStubStride = AMD_ISA_ALIGN_BYTES;        // 256: one stub, entry-aligned
-static constexpr size_t kTrampolineEntriesPerKernel = 2;                    // entries at E and E+256
-static constexpr size_t kTrampolineEntrySpacing = AMD_ISA_ALIGN_BYTES;      // 256: matches kernel's E..E+256
-static constexpr size_t kTrampolineSlotStride =
-    kTrampolineStubStride * kTrampolineEntriesPerKernel;                    // 512 per kernel
 
 static void BuildTrampolineGfx1250(uint8_t* buf, uint64_t target) {
   auto* w = reinterpret_cast<uint32_t*>(buf);
@@ -1492,7 +1482,7 @@ hsa_status_t ExecutableImpl::LoadSegmentV2(const code::Segment *data_segment,
 
 hsa_status_t ExecutableImpl::InstallTrampolinesGfx1250(hsa_agent_t agent) {
   const size_t n = kd_fixups_.size();
-  const size_t pool = n * kTrampolineSlotStride;
+  const size_t pool = n * kTrampolineStubStride;
 
   // AMDGPU_HSA_SEGMENT_CODE_AGENT yields *executable* device memory: the loader
   // context backs it with RegionMemory(..., is_code=true), which sets
@@ -1509,24 +1499,18 @@ hsa_status_t ExecutableImpl::InstallTrampolinesGfx1250(hsa_agent_t agent) {
 
   for (size_t i = 0; i < n; ++i) {
     const KdFixup& f = kd_fixups_[i];
-    const uint64_t slot_off = i * kTrampolineSlotStride;
+    const uint64_t stub_off = i * kTrampolineStubStride;
     // Device addresses are valid pre-Freeze (RegionMemory::ptr_ is set at alloc).
     const uint64_t kd_dev    = reinterpret_cast<uint64_t>(f.code_seg->Address(f.kd_vaddr));
     const uint64_t entry_dev = reinterpret_cast<uint64_t>(f.code_seg->Address(f.kd_vaddr + f.entry_off));
+    const uint64_t stub_dev  = reinterpret_cast<uint64_t>(tramp->Address(stub_off));
 
-    // Emit one stub per kernel entry, preserving the E..E+256 spacing: stub[e] is
-    // at slot+e*256 and jumps to entry_dev + e*256.
-    for (size_t e = 0; e < kTrampolineEntriesPerKernel; ++e) {
-      const uint64_t stub_off = slot_off + e * kTrampolineEntrySpacing;
-      uint8_t blob[kTrampolineStubStride];
-      BuildTrampolineGfx1250(blob, entry_dev + e * kTrampolineEntrySpacing);
-      tramp->Copy(stub_off, blob, sizeof(blob));  // -> trampoline host shadow
-    }
+    uint8_t blob[kTrampolineStubStride];
+    BuildTrampolineGfx1250(blob, entry_dev);    // stub jumps to the real entry
+    tramp->Copy(stub_off, blob, sizeof(blob));  // -> trampoline host shadow
 
-    // Redirect dispatch onto stub[0]: kernel_object(kd_dev) + new_off == stub[0],
-    // so the second-entry consumer's (stub[0] + 256) lands on stub[1].
-    const uint64_t stub0_dev = reinterpret_cast<uint64_t>(tramp->Address(slot_off));
-    int64_t new_off = static_cast<int64_t>(stub0_dev) - static_cast<int64_t>(kd_dev);
+    // Redirect dispatch onto the stub: kernel_object(kd_dev) + new_off == stub.
+    int64_t new_off = static_cast<int64_t>(stub_dev) - static_cast<int64_t>(kd_dev);
     f.code_seg->Copy(f.kd_vaddr + llvm::amdhsa::KERNEL_CODE_ENTRY_BYTE_OFFSET_OFFSET,
                      &new_off, sizeof(new_off)); // -> code host shadow
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -217,8 +217,8 @@ static void BuildTrampolineGfx1250(uint8_t* buf, uint64_t target) {
   auto* w = reinterpret_cast<uint32_t*>(buf);
 
   w[0] = 0xEE0B007C;                          // global_wb <scope:SCOPE_CU>
-  w[1] = 0x00000000;                          // padding
-  w[2] = 0x00000000;                          // padding
+  w[1] = 0x00000000;                          // :
+  w[2] = 0x00000000;                          // :
   w[3] = 0x7E000000;                          // v_nop (padding)
   w[4] = 0xBEE400FF;                          // s_mov_b32 s100, target_lo
   w[5] = static_cast<uint32_t>(target);
@@ -1503,15 +1503,17 @@ hsa_status_t ExecutableImpl::InstallTrampolinesGfx125x(hsa_agent_t agent) {
   const size_t n = kd_fixups_.size();
 
   // Size the trailing prefetch guard from the largest CP instruction-prefetch
-  // window among this pool's kernels (INST_PREF_SIZE lines * 128 B), plus one
-  // stub stride of slack for end-of-window line rounding. Because the stubs are
-  // packed and the last one sits at the end of the pool, a guard >= the max
-  // per-kernel reach covers the forward prefetch from every stub.
+  // window among this pool's kernels (INST_PREF_SIZE lines * 128 B). The forward
+  // prefetch from the last stub reaches its_entry + INST_PREF_SIZE*128; since that
+  // stub's own slot (one stub stride) already lies inside the pool, only the
+  // remainder, (INST_PREF_SIZE*128 - stub_size), can spill past the pool and needs
+  // a guard. (Clamp to 0 when the window fits within a stub slot.)
   uint32_t max_pref_lines = 0;
   for (const auto& f : kd_fixups_)
     max_pref_lines = std::max(max_pref_lines, f.inst_pref);
+  const size_t pref_bytes = static_cast<size_t>(max_pref_lines) * kInstPrefUnitBytes;
   const size_t guard =
-      static_cast<size_t>(max_pref_lines) * kInstPrefUnitBytes + kTrampolineStubStride;
+      pref_bytes > kTrampolineStubStride ? pref_bytes - kTrampolineStubStride : 0;
   const size_t pool = n * kTrampolineStubStride + guard;
 
   // AMDGPU_HSA_SEGMENT_CODE_AGENT yields *executable* device memory: the loader

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
@@ -623,6 +623,10 @@ private:
   Segment* SymbolSegment(hsa_agent_t agent, amd::hsa::code::Symbol* sym);
   Segment* SectionSegment(hsa_agent_t agent, amd::hsa::code::Section* sec);
 
+  // gfx1250: allocate a separate executable region and emit, per kernel, a stub
+  // that jumps to the real entry, then redirect the kernel descriptor to it.
+  hsa_status_t InstallTrampolinesGfx1250(hsa_agent_t agent);
+
   amd::hsa::common::ReaderWriterLock rw_lock_;
   hsa_profile_t profile_;
   Context *context_;
@@ -637,6 +641,14 @@ private:
   std::vector<std::shared_ptr<ExecutableObject>> objects;
   std::shared_ptr<Segment> program_allocation_segment;
   std::vector<std::shared_ptr<LoadedCodeObjectImpl>> loaded_code_objects;
+
+  // Kernel-entry trampolines (gfx1250).
+  // kd_fixups_ is collected per-LoadCodeObject; trampoline_segments_ persists for
+  // the lifetime of the executable so it can be frozen and destroyed normally.
+  struct KdFixup { Segment* code_seg; uint64_t kd_vaddr; int64_t entry_off; };
+  bool trampoline_enabled_gfx1250_ = false;
+  std::vector<KdFixup> kd_fixups_;
+  std::vector<std::shared_ptr<Segment>> trampoline_segments_;
 };
 
 class AmdHsaCodeLoader : public Loader {

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
@@ -645,7 +645,7 @@ private:
   // Kernel-entry trampolines (gfx125x).
   // kd_fixups_ is collected per-LoadCodeObject; trampoline_segments_ persists for
   // the lifetime of the executable so it can be frozen and destroyed normally.
-  struct KdFixup { Segment* code_seg; uint64_t kd_vaddr; int64_t entry_off; };
+  struct KdFixup { Segment* code_seg; uint64_t kd_vaddr; int64_t entry_off; uint32_t inst_pref; };
   bool trampoline_enabled_gfx125x_ = false;
   std::vector<KdFixup> kd_fixups_;
   std::vector<std::shared_ptr<Segment>> trampoline_segments_;

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.hpp
@@ -623,9 +623,9 @@ private:
   Segment* SymbolSegment(hsa_agent_t agent, amd::hsa::code::Symbol* sym);
   Segment* SectionSegment(hsa_agent_t agent, amd::hsa::code::Section* sec);
 
-  // gfx1250: allocate a separate executable region and emit, per kernel, a stub
+  // gfx125x: allocate a separate executable region and emit, per kernel, a stub
   // that jumps to the real entry, then redirect the kernel descriptor to it.
-  hsa_status_t InstallTrampolinesGfx1250(hsa_agent_t agent);
+  hsa_status_t InstallTrampolinesGfx125x(hsa_agent_t agent);
 
   amd::hsa::common::ReaderWriterLock rw_lock_;
   hsa_profile_t profile_;
@@ -642,11 +642,11 @@ private:
   std::shared_ptr<Segment> program_allocation_segment;
   std::vector<std::shared_ptr<LoadedCodeObjectImpl>> loaded_code_objects;
 
-  // Kernel-entry trampolines (gfx1250).
+  // Kernel-entry trampolines (gfx125x).
   // kd_fixups_ is collected per-LoadCodeObject; trampoline_segments_ persists for
   // the lifetime of the executable so it can be frozen and destroyed normally.
   struct KdFixup { Segment* code_seg; uint64_t kd_vaddr; int64_t entry_off; };
-  bool trampoline_enabled_gfx1250_ = false;
+  bool trampoline_enabled_gfx125x_ = false;
   std::vector<KdFixup> kd_fixups_;
   std::vector<std::shared_ptr<Segment>> trampoline_segments_;
 };


### PR DESCRIPTION
- Install kernel trampolines
Author: Laurent Morichetti <Laurent.Morichetti@amd.com>

For gfx1250 code objects, redirect each kernel's dispatch entry through a
small trampoline so instrumentation can run before the real kernel code.

The trampoline cannot be placed in front of the kernel entry inside the
loaded code segment (that would require a non-uniform relayout, breaking
intra-segment PC-relative references). Instead, after relocations and
before Freeze, allocate a separate executable region (CODE_AGENT
segment, which carries AllocateExecutable) and, per kernel, emit a stub that
loads the real entry address into scratch s[100:101] and sets PC, then rewrite
the kernel descriptor's kernel_code_entry_byte_offset to land on the stub.

Kernels expose two entry points, at E and E+256; consumers of the second
entry compute it as (descriptor entry)+256. A 512-byte slot per kernel
preserves that spacing: stub[0] -> E, stub[1] (at +256) -> E+256, and
the descriptor is pointed at stub[0]. All writes go to the host shadow and
are carried to device by the existing Freeze DMA + code-cache invalidation.

Stub encodings verified with llvm-mc --mcpu=gfx1250.
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


Author: Laurent Morichetti <laurent.morichetti@amd.com>
gfx1250: use a single kernel-entry trampoline per kernel

Kernel-entry trampoline support (added upstream) reserved a 512-byte slot
per kernel and emitted two stubs, at E and E+256, to preserve the dual
entry-point spacing. The second entry point is no longer needed.

Emit a single 256-byte stub per kernel that jumps to the real entry and
point the descriptor at it. Drop the now-unused kTrampolineEntriesPerKernel,
kTrampolineEntrySpacing and kTrampolineSlotStride constants, the per-entry
loop, and the dual entry-point comment.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


Author: David Yat Sin <David.YatSin@amd.com>
gfx1250: size trampoline prefetch guard to INST_PREF_SIZE*128 - stub size

The CP instruction-prefetch from the last stub reaches entry +
INST_PREF_SIZE*128. That stub's own slot (one stub stride) already lies
inside the pool, so only the remainder, (INST_PREF_SIZE*128 - stub_size),
can spill past the pool end and needs a trailing guard. Size the guard to
that remainder (clamped to 0 when the prefetch window fits within a stub
slot) instead of INST_PREF_SIZE*128 + stub_size.
