### PR TITLE
rocprof-sys-launch-compiler: Add sccache to known wrappers

### DIFF
--- a/projects/rocprofiler-systems/scripts/rocprof-sys-launch-compiler
+++ b/projects/rocprofiler-systems/scripts/rocprof-sys-launch-compiler
@@ -105,10 +105,11 @@ fi
 # Known wrappers that may appear before the actual compiler
 KNOWN_WRAPPERS=(
     "resource_info.py"  # TheRock build profiling
-    "ccache"            # Compiler cache
+    "ccache"            # Compiler cache (ccache)
+    "sccache"           # Compiler cache (sccache)
 )
 
-CCACHE_PREFIX=""
+CACHE_PREFIX=""
 ACTUAL_COMPILER="${1}"
 CURRENT_BASENAME="$(basename "${1}")"
 
@@ -119,9 +120,9 @@ for wrapper in "${KNOWN_WRAPPERS[@]}"; do
             echo "but no underlying command was specified as the next argument." >&2
             exit 1
         fi
-        # Preserve ccache so we can re-apply it to the rocprofiler-systems compiler
-        if [[ "${wrapper}" == "ccache" ]]; then
-            CCACHE_PREFIX="${1}"
+        # Preserve cache wrapper so we can re-apply it to the rocprofiler-systems compiler
+        if [[ "${wrapper}" == "ccache" || "${wrapper}" == "sccache" ]]; then
+            CACHE_PREFIX="${1}"
         fi
         shift
         ACTUAL_COMPILER="${1}"
@@ -150,10 +151,10 @@ else
         export LIBRARY_PATH=${LLVM_LIB_DIR}:${LIBRARY_PATH}
     fi
 
-    # Use ccache with the rocprofiler-systems compiler if ccache was originally requested
-    if [ -n "${CCACHE_PREFIX}" ]; then
-        debug-message ${CCACHE_PREFIX} ${ROCPROFSYS_COMPILER} $@
-        ${CCACHE_PREFIX} ${ROCPROFSYS_COMPILER} $@
+    # Use cache wrapper with the rocprofiler-systems compiler if one was originally requested
+    if [ -n "${CACHE_PREFIX}" ]; then
+        debug-message ${CACHE_PREFIX} ${ROCPROFSYS_COMPILER} $@
+        ${CACHE_PREFIX} ${ROCPROFSYS_COMPILER} $@
     else
         debug-message ${ROCPROFSYS_COMPILER} $@
         ${ROCPROFSYS_COMPILER} $@


### PR DESCRIPTION
  ## Problem

  `rocprof-sys-launch-compiler` uses `RULE_LAUNCH_COMPILE` to intercept  all compiler invocations and redirect them through the rocprofiler-systems  compiler (hipcc). It has a `KNOWN_WRAPPERS` list to handle compiler  launchers that may appear before the actual compiler in the command line.
  Previously only `"ccache"` was in `KNOWN_WRAPPERS`. When `CMAKE_CXX_COMPILER_LAUNCHER=sccache` is set, the compile rule becomes:  `rocprof-sys-launch-compiler  <clang++> sccache <clang++> [flags]`
  The script saw `sccache` as `$1` after the two required args, didn't recognize it as a wrapper, set `ACTUAL_COMPILER="sccache"`, and fell into the `CXX_COMPILER != ACTUAL_COMPILER` branch — executing `eval sccache clang++ [flags]` directly instead of redirecting through hipcc. This meant the compilation ran without HIP include directories,
causing:
```
 fatal error: 'hip/hip_runtime.h' file not found
```

## Fix

  Add `"sccache"` to `KNOWN_WRAPPERS` with the same prefix-preservation  logic as `"ccache"`. Rename `CCACHE_PREFIX` → `CACHE_PREFIX` to reflect that it handles both launchers. When either wrapper is detected, it is saved and re-applied to the rocprofiler-systems compiler invocation.

  ## Observed in

  This failure was observed in TheRock CI when enabling sccache for the multi-arch build pipeline: 
  - Failing build: https://github.com/ROCm/TheRock/actions/runs/27752438762/job/82159954186
    (profiler-apps stage, `hip/hip_runtime.h` not found across all HIP examples)
  - Fixed by this change: https://github.com/ROCm/TheRock/actions/runs/27808027261/job/82640863644
    (profiler-apps stage passes)

 ## Test Plan

  - Triggered  TheRock multi-arch Linux build with  `-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache` and verifed the `profiler-apps` stage passed (rocprofiler-systems-examples
        builds without `hip/hip_runtime.h` errors)


- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
