### PR TITLE
[hipfile] Install relocatable unit tests to support TheRock packaging

### DIFF
--- a/projects/hipfile/CMakeLists.txt
+++ b/projects/hipfile/CMakeLists.txt
@@ -234,6 +234,19 @@ option(AIS_INSTALL_EXAMPLES "Install example programs" ON)
 #------------------
 option(AIS_INSTALL_TOOLS "Install tool programs" ON)
 
+#------------------
+# Test programs
+#------------------
+# Whether to install the relocatable unit-test assets (binaries + ctest files)
+# so the suite can run from an installed/packaged tree. Default OFF, separate
+# from the build of the tests, matching the convention used by sibling projects
+# (e.g. rocprofiler-systems' ROCPROFSYS_INSTALL_TESTING). Installing the tests
+# requires building them, so enabling this forces BUILD_TESTING on.
+option(AIS_INSTALL_TESTS "Install unit-test programs" OFF)
+if(AIS_INSTALL_TESTS)
+    set(BUILD_TESTING ON CACHE BOOL "Build testing (forced on by AIS_INSTALL_TESTS)" FORCE)
+endif()
+
 #------
 # docs
 #------
@@ -319,4 +332,12 @@ endif()
 # Set up installs (must come AFTER target creation)
 #-----------------------------------------------------------------------------
 include(AISUseROCmCMake)
+# Install the relocatable unit-test assets (binaries + a self-locating
+# CTestTestfile.cmake) so the suite can run from an installed/packaged tree.
+# Gated on AIS_INSTALL_TESTS (which forces BUILD_TESTING on above, so the test
+# targets exist). Must come after the test targets are created
+# (add_subdirectory(test) above).
+if(AIS_INSTALL_TESTS)
+    include(AISInstallTests)
+endif()
 include(AISInstall)

--- a/projects/hipfile/INSTALL.md
+++ b/projects/hipfile/INSTALL.md
@@ -126,6 +126,7 @@ Options
 |------|-------|-------|
 |AIS\_BUILD\_DOCS|OFF|Build API documentation (requires Doxygen)|
 |AIS\_INSTALL\_EXAMPLES|ON|Install example programs|
+|AIS\_INSTALL\_TESTS|OFF|Install a relocatable unit-test tree (run with `ctest --test-dir <prefix>/share/hipfile/test`)|
 |AIS\_USE\_CLANG\_TIDY|OFF|Run the `clang-tidy` tool (clang only)|
 |AIS\_USE\_CODE\_COVERAGE|OFF|Generate code coverage information when tests are run (clang only)|
 |AIS\_USE\_IWYU|OFF|Run the `include-what-you-use` tool (clang only)|

--- a/projects/hipfile/cmake/AISInstallTests.cmake
+++ b/projects/hipfile/cmake/AISInstallTests.cmake
@@ -1,0 +1,127 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# Install hipFile unit-test assets so the suite can be run from an installed,
+# relocatable tree (e.g. a packaged TheRock test artifact), not just the build
+# tree.
+#
+# The problem:
+#   gtest_discover_tests() writes ctest fragments that reference the test
+#   executables (and the CMake GoogleTest helper) by ABSOLUTE build-tree paths,
+#   so they are not relocatable and cannot be shipped in an artifact.
+#
+# The approach (mirrors rocm-systems/projects/hip-tests):
+#   Install the unit-test binaries to a known share/ location and ship a small,
+#   self-locating CTestTestfile pair:
+#     share/hipfile/test/CTestTestfile.cmake          -> include(script/hipfile_discover.cmake)
+#     share/hipfile/test/script/hipfile_discover.cmake -> discovery + add_test
+#   ctest evaluates an include()'d file in full scripting mode, so the discover
+#   script locates ITSELF via file(REAL_PATH ${CMAKE_CURRENT_LIST_FILE}),
+#   computes the runtime library path RELATIVE to that location, enumerates each
+#   binary's GoogleTest cases at ctest-run time, and emits one add_test per case.
+#
+# Why discovery is deferred to ctest-run time (not build/install time):
+#   The test machine is the one place the binary is guaranteed to run. Enumerating
+#   at build or install time couples this to whether that environment can launch
+#   the binary (and resolve its shared libs) -- which is not guaranteed in TheRock
+#   (libs come from sibling subprojects' staged artifacts). At ctest-run time the
+#   tree is fully assembled and the relative library path resolves.
+#
+# Why one add_test PER CASE (not per binary):
+#   Some hipFile tests share process-global state (the Context<DriverState>
+#   singleton) and leak across cases; they only pass when each case runs in its
+#   own process. This preserves the per-case isolation gtest_discover_tests gives.
+#
+# Run with:
+#   ctest --test-dir <install>/share/hipfile/test -L unit
+#
+# Scope: UNIT tests only. The "system" tests require a HIP-capable GPU and the
+# "stress" tests are gdb-wrapped concurrency testers; both are intentionally
+# excluded and continue to run from the build tree on dedicated runners.
+#
+# NOTE: This module deliberately does NOT use CPack / rocm_package_setup_component.
+# In TheRock, hipFile is consumed through the stage/dist/artifact-toml flow. The
+# plain install(COMPONENT tests) below is honored by both that flow and the
+# standalone build.
+
+include_guard(GLOBAL)
+
+# Relative install destination for the unit-test binaries + ctest files.
+set(HIPFILE_TEST_INSTALL_DIR "share/hipfile/test")
+
+# Collect the unit-test targets that exist in this configuration, with the label
+# suffix to attach to each binary's cases.
+#   - hipfile_tests : defined only when UNIT_TEST_SOURCE_FILES is non-empty,
+#                     which today is the NVIDIA build (cufile-api-compat); on
+#                     AMD the unit tests live entirely in internal_tests (see
+#                     test/CMakeLists.txt).
+#   - internal_tests: only defined when building the AMD detail (see
+#                     test/amd_detail/CMakeLists.txt).
+set(_unit_targets)
+set(_unit_suffixes)
+if(TARGET hipfile_tests)
+    list(APPEND _unit_targets hipfile_tests)
+    list(APPEND _unit_suffixes hipfile)
+endif()
+if(TARGET internal_tests)
+    list(APPEND _unit_targets internal_tests)
+    list(APPEND _unit_suffixes internal)
+endif()
+
+if(NOT _unit_targets)
+    message(STATUS "hipFile: no unit-test targets to install")
+    return()
+endif()
+
+# Install the unit-test executables. RPATH is intentionally left to the normal
+# install machinery (and, under TheRock, its RPATH fixup): the discover script
+# also sets LD_LIBRARY_PATH relative to the installed location, which is the
+# authoritative mechanism and keeps the tree relocatable regardless of RPATH.
+install(
+    TARGETS ${_unit_targets}
+    RUNTIME DESTINATION "${HIPFILE_TEST_INSTALL_DIR}"
+    COMPONENT tests
+)
+
+# Build the per-binary discovery blocks for the discover script. Each binary's
+# cases are listed at ctest-run time and turned into isolated add_test entries.
+# We bake in only the binary NAME and label SUFFIX; all paths are resolved at
+# run time relative to the script's own location.
+set(_discover_blocks "")
+list(LENGTH _unit_targets _n)
+math(EXPR _last "${_n} - 1")
+foreach(_i RANGE ${_last})
+    list(GET _unit_targets ${_i} _name)
+    list(GET _unit_suffixes ${_i} _suffix)
+    string(APPEND _discover_blocks
+        "_hipfile_discover_binary(\"${_name}\" \"${_suffix}\")\n")
+endforeach()
+
+# Generate the discover script (configure time; contains NO absolute paths).
+configure_file(
+    "${CMAKE_CURRENT_LIST_DIR}/hipfile_discover.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/hipfile_discover.cmake"
+    @ONLY
+)
+
+# Install the discover script under script/ and a tiny top-level CTestTestfile
+# that includes it via a relative path (ctest resolves include() relative to the
+# test directory when invoked with --test-dir).
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/hipfile_discover.cmake"
+    DESTINATION "${HIPFILE_TEST_INSTALL_DIR}/script"
+    COMPONENT tests
+)
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/hipfile_test_CTestTestfile.cmake"
+    "# hipFile unit tests -- relocatable. Generated by AISInstallTests.cmake.\n"
+    "include(script/hipfile_discover.cmake)\n"
+)
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/hipfile_test_CTestTestfile.cmake"
+    DESTINATION "${HIPFILE_TEST_INSTALL_DIR}"
+    COMPONENT tests
+    RENAME "CTestTestfile.cmake"
+)
+
+message(STATUS "hipFile: will install relocatable unit tests to ${HIPFILE_TEST_INSTALL_DIR}: ${_unit_targets}")

--- a/projects/hipfile/cmake/hipfile_discover.cmake.in
+++ b/projects/hipfile/cmake/hipfile_discover.cmake.in
@@ -1,0 +1,97 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Relocatable hipFile unit-test discovery, evaluated by ctest at run time.
+#
+# This file is include()'d from share/hipfile/test/CTestTestfile.cmake. ctest
+# evaluates an include()'d file in full scripting mode, so execute_process()/
+# foreach()/if() all run here (unlike the top-level CTestTestfile, which only
+# honors add_test/subdirs/include/set_tests_properties).
+#
+# All paths are resolved RELATIVE to this script's own location, so the tree is
+# fully relocatable. Generated from hipfile_discover.cmake.in by AISInstallTests.
+
+# Locate ourselves: <test_dir>/script/hipfile_discover.cmake -> <test_dir>.
+file(REAL_PATH "${CMAKE_CURRENT_LIST_FILE}" _hipfile_self)
+get_filename_component(_hipfile_script_dir "${_hipfile_self}" DIRECTORY)
+file(REAL_PATH "${_hipfile_script_dir}/.." _hipfile_test_dir)
+
+# Runtime library path, relative to the test dir:
+#   <test_dir> = <prefix>/share/hipfile/test  ->  <prefix>/lib is three up.
+# The bundled sysdeps (e.g. librocm_sysdeps_mount.so.1) live under
+# lib/rocm_sysdeps/lib in TheRock-style installs; harmless if absent elsewhere.
+set(_hipfile_libdir "${_hipfile_test_dir}/../../../lib")
+set(_hipfile_ld "${_hipfile_libdir}:${_hipfile_libdir}/rocm_sysdeps/lib")
+
+# Enumerate one binary's GoogleTest cases and register each as an isolated test.
+macro(_hipfile_discover_binary _bin_name _label_suffix)
+    set(_bin "${_hipfile_test_dir}/${_bin_name}")
+    if(NOT EXISTS "${_bin}")
+        message(FATAL_ERROR "hipFile: test binary not found: ${_bin}")
+    endif()
+
+    # The discovery launch needs the libraries on the path too. ctest evaluates
+    # this script with CMAKE_COMMAND unset, so `cmake -E env` is unavailable;
+    # set(ENV{...}) is the only lever. Save and restore the prior value so this
+    # script does not leave the ctest process environment mutated (each test's
+    # own ENVIRONMENT property, set below, governs the actual test runs).
+    #
+    # Track whether LD_LIBRARY_PATH was originally set: restoring an unset
+    # variable to "" leaves an empty path element, which the loader treats as the
+    # current directory. Unset it instead of blanking it.
+    if(DEFINED ENV{LD_LIBRARY_PATH})
+        set(_ld_was_set TRUE)
+        set(_saved_ld_library_path "$ENV{LD_LIBRARY_PATH}")
+    else()
+        set(_ld_was_set FALSE)
+    endif()
+    set(ENV{LD_LIBRARY_PATH} "${_hipfile_ld}")
+    execute_process(
+        COMMAND "${_bin}" --gtest_list_tests
+        WORKING_DIRECTORY "${_hipfile_test_dir}"
+        OUTPUT_VARIABLE _listing
+        RESULT_VARIABLE _rc
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(_ld_was_set)
+        set(ENV{LD_LIBRARY_PATH} "${_saved_ld_library_path}")
+    else()
+        unset(ENV{LD_LIBRARY_PATH})
+    endif()
+    if(NOT _rc EQUAL 0)
+        message(FATAL_ERROR "hipFile: failed to list tests in ${_bin} (exit ${_rc})")
+    endif()
+
+    # --gtest_list_tests prints a suite header per line ("Suite.") followed by
+    # its cases indented two spaces, each optionally trailed by a
+    # " # GetParam() = ..." annotation we discard. The full filter name is the
+    # suite header concatenated with the case name.
+    #
+    # Split the output into a list of lines. A literal ';' in the output (e.g.
+    # inside a GetParam() value) would otherwise be treated as a CMake list
+    # separator and corrupt the split, so escape ';' -> '\;' BEFORE turning
+    # newlines into the ';' separator (the same ordering CMake's own
+    # GoogleTestAddTests.cmake uses).
+    string(REPLACE ";" "\\;" _listing "${_listing}")
+    string(REPLACE "\n" ";" _lines "${_listing}")
+    set(_suite "")
+    foreach(_line IN LISTS _lines)
+        string(REGEX REPLACE " +#.*$" "" _line "${_line}")
+        if(_line MATCHES "^[^ ].*\\.$")
+            string(STRIP "${_line}" _suite)
+        elseif(_line MATCHES "^  +[^ ]")
+            string(STRIP "${_line}" _case)
+            set(_test "${_suite}${_case}")
+            add_test("${_test}" "${_bin}" "--gtest_filter=${_test}")
+            set_tests_properties("${_test}" PROPERTIES
+                TIMEOUT 300
+                LABELS "unit;${_label_suffix}"
+                ENVIRONMENT "LD_LIBRARY_PATH=${_hipfile_ld}"
+            )
+        endif()
+    endforeach()
+endmacro()
+
+# Per-binary discovery calls, baked in by AISInstallTests at configure time.
+@_discover_blocks@

--- a/projects/hipfile/test/CMakeLists.txt
+++ b/projects/hipfile/test/CMakeLists.txt
@@ -39,22 +39,32 @@ else()
     list(APPEND TEST_SYSINCLS ${HIPFILE_AMD_SOURCE_PATH})
 endif()
 
-ais_add_test_executable(
-    NAME hipfile_tests
-    DEPS hipfile
-    SRCS ${UNIT_TEST_SOURCE_FILES} ${SHARED_SOURCE_FILES}
-    SYSINCLS ${TEST_SYSINCLS}
-)
-target_link_libraries(hipfile_tests PRIVATE GTest::gtest)
-target_link_libraries(hipfile_tests PRIVATE GTest::gtest_main)
-target_compile_options(hipfile_tests PRIVATE -pthread)
-target_link_options(hipfile_tests PRIVATE -pthread)
+# hipfile_tests holds the platform-portable unit tests. Today those sources only
+# exist for NVIDIA (cufile-api-compat); on AMD the unit tests live entirely in
+# test/amd_detail (internal_tests), so this target would have zero gtest cases.
+# Only define it when it will actually contain tests -- gating on the source list
+# (rather than the platform) means the target reappears automatically if a
+# portable unit test is later added to UNIT_TEST_SOURCE_FILES.
+if(UNIT_TEST_SOURCE_FILES)
+    ais_add_test_executable(
+        NAME hipfile_tests
+        DEPS hipfile
+        SRCS ${UNIT_TEST_SOURCE_FILES} ${SHARED_SOURCE_FILES}
+        SYSINCLS ${TEST_SYSINCLS}
+    )
+    target_link_libraries(hipfile_tests PRIVATE GTest::gtest)
+    target_link_libraries(hipfile_tests PRIVATE GTest::gtest_main)
+    # -pthread is critical for sanitizer builds via TheRock
+    # NEVER REMOVE IT
+    target_compile_options(hipfile_tests PRIVATE -pthread)
+    target_link_options(hipfile_tests PRIVATE -pthread)
 
-ais_gtest_discover_tests(
-    hipfile_tests
-    PROPERTIES "LABELS;unit;LABELS;hipfile"
-    TEST_LIST hipfile_unit_tests
-)
+    ais_gtest_discover_tests(
+        hipfile_tests
+        PROPERTIES "LABELS;unit;LABELS;hipfile"
+        TEST_LIST hipfile_unit_tests
+    )
+endif()
 
 ais_add_test_executable(
     NAME hipfile_system_tests
@@ -63,6 +73,8 @@ ais_add_test_executable(
     SYSINCLS ${TEST_SYSINCLS}
 )
 target_link_libraries(hipfile_system_tests PRIVATE GTest::gtest)
+# -pthread is critical for sanitizer builds via TheRock
+# NEVER REMOVE IT
 target_compile_options(hipfile_system_tests PRIVATE -pthread)
 target_link_options(hipfile_system_tests PRIVATE -pthread)
 


### PR DESCRIPTION
## Motivation

hipFile is being integrated into TheRock, which builds, packages, and tests each component as a relocatable artifact rather than from its build tree. Our unit tests could only run in-place: gtest_discover_tests() bakes absolute build-tree paths into its ctest fragments, so the suite could not run from a packaged/installed location. This change makes the unit tests relocatable so TheRock (and any packaged install) can run them from the artifact, where the shared libraries come from sibling subprojects' staged output rather than our build tree.

## Technical Details

Add AIS_INSTALL_TESTS (default OFF) to install the unit-test suite as a relocatable tree. It installs the test binaries to share/hipfile/test and ships a self-locating discovery script (hipfile_discover.cmake) that, at ctest-run time, finds itself, derives the runtime library path relative to its own location, enumerates each binary's GoogleTest cases, and registers one add_test per case (preserving the per-case process isolation the build-tree discovery provides). Scope is unit tests only; system and stress tests still run from the build tree. Run with:
    ctest --test-dir <install>/share/hipfile/test -L unit

The option is separate from building the tests and defaults OFF, matching the convention sibling rocm-systems projects use for installable test suites (e.g. rocprofiler-systems' ROCPROFSYS_INSTALL_TESTING); since installing requires building, AIS_INSTALL_TESTS forces BUILD_TESTING on. TheRock opts in by passing -DAIS_INSTALL_TESTS=${THEROCK_BUILD_TESTING} when configuring the subproject.

Define hipfile_tests only when UNIT_TEST_SOURCE_FILES is non-empty so the AMD build (whose unit tests live entirely in internal_tests) does not ship an empty test binary.

CI: hipfile-build.yml installs the test tree to a staging prefix, MOVES it, and runs ctest from the new location, so relocatability regressions are caught on every PR here instead of surfacing downstream in TheRock. The step fails loudly if zero tests are discovered.

Document AIS_INSTALL_TESTS in INSTALL.md.

## JIRA ID

AIHIPFILE-27
ROCM-1261

## Test Plan

CI Passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
