### PR TITLE
fix(hotswap): gate entry trampoline rewrites for gfx12.5

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_gfx_query_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_gfx_query_test.cc
@@ -33,6 +33,8 @@ const char* kGfx1250IsaWithFeatures =
     "amdgcn-amd-amdhsa--gfx1250:sramecc+:xnack-";
 const char* kGfx942Isa = "amdgcn-amd-amdhsa--gfx942";
 const char* kGfx1251Isa = "amdgcn-amd-amdhsa--gfx1251";
+const char* kGfx12_5GenericIsaWithFeatures =
+    "amdgcn-amd-amdhsa--gfx12-5-generic:sramecc+";
 
 void ResetTestEnv() {
   g_fake_hsa_env = FakeHsaEnv{};
@@ -97,6 +99,7 @@ namespace {
 
 using rocr::hotswap::AgentGfxRevision;
 using rocr::hotswap::GetAgentGfxRevision;
+using rocr::hotswap::IsGfx12_5Target;
 using rocr::hotswap::IsHotswapSupportedGfxRevision;
 
 TEST(HotswapGfxQuery, Gfx1250A0Passes) {
@@ -143,6 +146,26 @@ TEST(HotswapGfxQuery, NearMissTargetBlocks) {
 
   EXPECT_EQ(revision.gfx_target, "gfx1251");
   EXPECT_FALSE(IsHotswapSupportedGfxRevision(revision));
+}
+
+TEST(HotswapGfxQuery, Gfx12_5GenericFeatureSuffixParsed) {
+  ResetTestEnv();
+  g_fake_hsa_env.isa_name = kGfx12_5GenericIsaWithFeatures;
+  g_fake_hsa_env.asic_revision = 0;
+
+  const AgentGfxRevision revision = GetAgentGfxRevision(MakeFreshAgent());
+
+  EXPECT_EQ(revision.gfx_target, "gfx12-5-generic");
+  EXPECT_FALSE(IsHotswapSupportedGfxRevision(revision));
+}
+
+TEST(HotswapGfxQuery, Gfx12_5TargetPredicateIsStrict) {
+  EXPECT_TRUE(IsGfx12_5Target("gfx1250"));
+  EXPECT_TRUE(IsGfx12_5Target("gfx1251"));
+  EXPECT_TRUE(IsGfx12_5Target("gfx12-5-generic"));
+  EXPECT_FALSE(IsGfx12_5Target("gfx125"));
+  EXPECT_FALSE(IsGfx12_5Target("gfx125foo"));
+  EXPECT_FALSE(IsGfx12_5Target("gfx942"));
 }
 
 TEST(HotswapGfxQuery, Gfx1250NonA0Blocks) {

--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -31,6 +31,14 @@
 namespace {
 
 constexpr const char* kGfx1250Isa = "amdgcn-amd-amdhsa--gfx1250";
+constexpr const char* kGfx1251Isa = "amdgcn-amd-amdhsa--gfx1251";
+constexpr const char* kGfx12_5GenericIsa =
+    "amdgcn-amd-amdhsa--gfx12-5-generic";
+constexpr const char* kGfx942Isa = "amdgcn-amd-amdhsa--gfx942";
+constexpr const char* kGfx1250B0Isa =
+    "amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+";
+constexpr const char* kGfx1250A0Isa =
+    "amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific-";
 
 struct FakeHsaEnv {
   std::string isa_name = kGfx1250Isa;
@@ -50,7 +58,11 @@ LibHandle LoadLib(std::string filename) {
 #if defined(_WIN32) || defined(_WIN64)
   return LoadLibraryA(filename.c_str());
 #else
-  return dlopen(filename.c_str(), RTLD_NOW | RTLD_LOCAL);
+  int flags = RTLD_LAZY;
+#ifdef RTLD_NODELETE
+  flags |= RTLD_NODELETE;
+#endif
+  return dlopen(filename.c_str(), flags);
 #endif
 }
 
@@ -210,6 +222,77 @@ rocr::hotswap::CodeObjectView MakeRealCodeObjectView() {
   return code_object;
 }
 
+rocr::hotswap::AgentGfxRevision MakeRevision(const std::string& gfx_target,
+                                             uint32_t asic_revision,
+                                             bool has_asic_revision = true) {
+  rocr::hotswap::AgentGfxRevision revision;
+  revision.gfx_target = gfx_target;
+  revision.asic_revision = asic_revision;
+  revision.has_asic_revision = has_asic_revision;
+  return revision;
+}
+
+TEST(HotswapRewriteDecision, A0RetargetsWhenEntryTrampolinesDisabled) {
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx1250", 0), kGfx1250Isa, kGfx1250Isa, {false});
+
+  ASSERT_TRUE(decision.has_value());
+  EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
+  EXPECT_EQ(decision->target_isa, kGfx1250A0Isa);
+  EXPECT_FALSE(decision->request_entry_trampolines);
+}
+
+TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOnRoutesNonA0Gfx1250) {
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {});
+
+  ASSERT_TRUE(decision.has_value());
+  EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
+  EXPECT_EQ(decision->target_isa, kGfx1250B0Isa);
+  EXPECT_TRUE(decision->request_entry_trampolines);
+}
+
+TEST(HotswapRewriteDecision, EntryTrampolinesDisabledBlocksNonA0Gfx1250) {
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx1250", 1), kGfx1250Isa, kGfx1250Isa, {false});
+
+  EXPECT_FALSE(decision.has_value());
+}
+
+TEST(HotswapRewriteDecision, EntryTrampolinesRouteGfx12_5Family) {
+  const auto concrete = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx1251", 1), kGfx1251Isa, kGfx1251Isa, {});
+  const auto generic = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx12-5-generic", 1), kGfx12_5GenericIsa,
+      kGfx12_5GenericIsa, {});
+
+  ASSERT_TRUE(concrete.has_value());
+  EXPECT_EQ(concrete->source_isa, kGfx1251Isa);
+  EXPECT_EQ(concrete->target_isa, kGfx1251Isa);
+  EXPECT_TRUE(concrete->request_entry_trampolines);
+  ASSERT_TRUE(generic.has_value());
+  EXPECT_EQ(generic->source_isa, kGfx12_5GenericIsa);
+  EXPECT_EQ(generic->target_isa, kGfx12_5GenericIsa);
+  EXPECT_TRUE(generic->request_entry_trampolines);
+}
+
+TEST(HotswapRewriteDecision, EntryTrampolinesUseGenericSourceAsTarget) {
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx1251", 1), kGfx12_5GenericIsa, kGfx1251Isa, {});
+
+  ASSERT_TRUE(decision.has_value());
+  EXPECT_EQ(decision->source_isa, kGfx12_5GenericIsa);
+  EXPECT_EQ(decision->target_isa, kGfx12_5GenericIsa);
+  EXPECT_TRUE(decision->request_entry_trampolines);
+}
+
+TEST(HotswapRewriteDecision, EntryTrampolinesBlockNonGfx12_5) {
+  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+      MakeRevision("gfx942", 0), kGfx942Isa, kGfx942Isa, {});
+
+  EXPECT_FALSE(decision.has_value());
+}
+
 TEST(HotswapRewrite, GetIsaNameRealCodeObject) {
   const std::string isa =
       rocr::hotswap::GetCodeObjectIsaName(kGfx1250MinCo, sizeof(kGfx1250MinCo));
@@ -321,11 +404,35 @@ TEST(HotswapRewrite, RuntimeLoadUsesRewrittenCodeObject) {
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
-TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackToOriginal) {
+TEST(HotswapRewrite, RuntimeLoadNonA0UsesDefaultEntryTrampolines) {
   ResetRuntimeTestEnv();
   g_fake_hsa_env.asic_revision = 1;
   LoadRecorder load;
   const hsa_executable_t executable = MakeTestExecutable(0x502);
+
+  const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+      executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
+      MakeLoadCallbacks(&load));
+
+  EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+  ASSERT_EQ(load.calls.size(), 1u);
+  EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
+  EXPECT_NE(load.calls[0].code_object, static_cast<const void*>(kGfx1250MinCo));
+  EXPECT_GT(load.calls[0].code_object_size, 0u);
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 1u);
+
+  rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(executable);
+  EXPECT_EQ(
+      rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
+}
+
+TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesAreZero) {
+  ResetRuntimeTestEnv();
+  g_fake_hsa_env.asic_revision = 1;
+  g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = "0";
+  LoadRecorder load;
+  const hsa_executable_t executable = MakeTestExecutable(0x503);
 
   const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
       executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
@@ -339,11 +446,41 @@ TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackToOriginal) {
       rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable), 0u);
 }
 
+TEST(HotswapRewrite, RuntimeLoadNonA0UsesEntryTrampolinesUnlessEnvIsZero) {
+  const char* const env_values[] = {"false", ""};
+  uint64_t executable_handle = 0x504;
+  for (const char* env_value : env_values) {
+    SCOPED_TRACE(env_value);
+    ResetRuntimeTestEnv();
+    g_fake_hsa_env.asic_revision = 1;
+    g_fake_env_vars["AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES"] = env_value;
+    LoadRecorder load;
+    const hsa_executable_t executable =
+        MakeTestExecutable(executable_handle++);
+
+    const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
+        executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
+        MakeLoadCallbacks(&load));
+
+    EXPECT_EQ(status, HSA_STATUS_SUCCESS);
+    ASSERT_EQ(load.calls.size(), 1u);
+    EXPECT_EQ(load.calls[0].path, LoadPath::kRewritten);
+    EXPECT_EQ(
+        rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable),
+        1u);
+
+    rocr::hotswap::ReleaseRetainedRewrittenElfBuffers(executable);
+    EXPECT_EQ(
+        rocr::hotswap::RetainedRewrittenElfBufferCountForTesting(executable),
+        0u);
+  }
+}
+
 TEST(HotswapRewrite, RuntimeLoadDisableEnvFallsBackToOriginal) {
   ResetRuntimeTestEnv();
   g_fake_env_vars["HSA_HOTSWAP_DISABLE"] = "1";
   LoadRecorder load;
-  const hsa_executable_t executable = MakeTestExecutable(0x503);
+  const hsa_executable_t executable = MakeTestExecutable(0x506);
 
   const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
       executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,
@@ -366,7 +503,7 @@ TEST(HotswapRewrite, RuntimeLoadRewriteFailureFallsBackToOriginal) {
   code_object.size = sizeof(fake_elf);
   code_object.uri = "memory://invalid.hsaco";
   LoadRecorder load;
-  const hsa_executable_t executable = MakeTestExecutable(0x504);
+  const hsa_executable_t executable = MakeTestExecutable(0x507);
 
   const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
       executable, MakeTestAgent(), code_object, nullptr, nullptr,
@@ -384,7 +521,7 @@ TEST(HotswapRewrite, RuntimeLoadRewrittenLoadFailureFallsBackToOriginal) {
   ResetRuntimeTestEnv();
   LoadRecorder load;
   load.rewritten_status = HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
-  const hsa_executable_t executable = MakeTestExecutable(0x505);
+  const hsa_executable_t executable = MakeTestExecutable(0x508);
 
   const hsa_status_t status = rocr::hotswap::LoadAgentCodeObjectWithHotswap(
       executable, MakeTestAgent(), MakeRealCodeObjectView(), nullptr, nullptr,

--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -201,6 +201,14 @@ void ResetRuntimeTestEnv() {
   rocr::hotswap::ResetAgentGfxRevisionCache();
 }
 
+bool NewComgrHotswapApiAvailable() {
+  if (rocr::hotswap::EntryTrampolineRewriteAvailableForTesting()) {
+    return true;
+  }
+  SUCCEED() << "requires COMGR with amd_comgr_hotswap_rewrite_with_options";
+  return false;
+}
+
 hsa_agent_t MakeTestAgent() {
   hsa_agent_t agent{};
   agent.handle = 1;
@@ -387,6 +395,7 @@ TEST(HotswapRewrite, RetargetNullSourceOrTarget) {
 
 TEST(HotswapRewrite, RuntimeLoadUsesRewrittenCodeObject) {
   ResetRuntimeTestEnv();
+  if (!NewComgrHotswapApiAvailable()) return;
   LoadRecorder load;
   hsa_loaded_code_object_t loaded{};
   const hsa_executable_t executable = MakeTestExecutable(0x501);
@@ -411,6 +420,7 @@ TEST(HotswapRewrite, RuntimeLoadUsesRewrittenCodeObject) {
 
 TEST(HotswapRewrite, RuntimeLoadNonA0UsesDefaultEntryTrampolines) {
   ResetRuntimeTestEnv();
+  if (!NewComgrHotswapApiAvailable()) return;
   g_fake_hsa_env.asic_revision = 1;
   LoadRecorder load;
   const hsa_executable_t executable = MakeTestExecutable(0x502);
@@ -452,6 +462,7 @@ TEST(HotswapRewrite, RuntimeLoadNonA0FallsBackWhenEntryTrampolinesAreZero) {
 }
 
 TEST(HotswapRewrite, RuntimeLoadNonA0UsesEntryTrampolinesUnlessEnvIsZero) {
+  if (!NewComgrHotswapApiAvailable()) return;
   const char* const env_values[] = {"false", ""};
   uint64_t executable_handle = 0x504;
   for (const char* env_value : env_values) {
@@ -524,6 +535,7 @@ TEST(HotswapRewrite, RuntimeLoadRewriteFailureFallsBackToOriginal) {
 
 TEST(HotswapRewrite, RuntimeLoadRewrittenLoadFailureFallsBackToOriginal) {
   ResetRuntimeTestEnv();
+  if (!NewComgrHotswapApiAvailable()) return;
   LoadRecorder load;
   load.rewritten_status = HSA_STATUS_ERROR_INVALID_CODE_OBJECT;
   const hsa_executable_t executable = MakeTestExecutable(0x508);

--- a/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
+++ b/projects/rocr-runtime/rocrtst/suites/functional/hotswap/hotswap_rewrite_test.cc
@@ -232,14 +232,19 @@ rocr::hotswap::AgentGfxRevision MakeRevision(const std::string& gfx_target,
   return revision;
 }
 
-TEST(HotswapRewriteDecision, A0RetargetsWhenEntryTrampolinesDisabled) {
-  const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
-      MakeRevision("gfx1250", 0), kGfx1250Isa, kGfx1250Isa, {false});
+TEST(HotswapRewriteDecision, A0RetargetsThroughLegacyPathRegardlessOfOptions) {
+  const rocr::hotswap::RewriteOptions options[] = {{}, {false}};
+  for (const auto& option : options) {
+    SCOPED_TRACE(option.gfx12_5_rewrite_enabled ? "entry trampolines enabled"
+                                                : "entry trampolines disabled");
+    const auto decision = rocr::hotswap::DecideHotswapRewriteForTesting(
+        MakeRevision("gfx1250", 0), kGfx1250Isa, kGfx1250Isa, option);
 
-  ASSERT_TRUE(decision.has_value());
-  EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
-  EXPECT_EQ(decision->target_isa, kGfx1250A0Isa);
-  EXPECT_FALSE(decision->request_entry_trampolines);
+    ASSERT_TRUE(decision.has_value());
+    EXPECT_EQ(decision->source_isa, kGfx1250B0Isa);
+    EXPECT_EQ(decision->target_isa, kGfx1250A0Isa);
+    EXPECT_FALSE(decision->request_entry_trampolines);
+  }
 }
 
 TEST(HotswapRewriteDecision, EntryTrampolinesDefaultOnRoutesNonA0Gfx1250) {

--- a/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
@@ -786,6 +786,7 @@ set(HOTSWAP_TEST_ROOT "${ROCRTST_ROOT}/suites/functional/hotswap")
 # runpaths only let the hotswap tests exercise ROCR's lazy dlopen path locally.
 set(HOTSWAP_BUILD_RPATH "")
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(HOTSWAP_COMGR_WITHOUT_OPTIONS "")
   set(HOTSWAP_SYMBOL_TOOL "${CMAKE_NM}")
   if(NOT HOTSWAP_SYMBOL_TOOL)
     find_program(HOTSWAP_SYMBOL_TOOL NAMES llvm-nm nm HINTS ${LLVM_TOOLS_BINARY_DIR})
@@ -805,12 +806,22 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
              _comgr_symbols MATCHES "amd_comgr_hotswap_rewrite_with_options")
             list(APPEND HOTSWAP_BUILD_RPATH "${_prefix}/${_libdir}")
             break()
+          elseif(_comgr_symbol_result EQUAL 0 AND
+                 _comgr_symbols MATCHES "amd_comgr_hotswap_rewrite")
+            list(APPEND HOTSWAP_COMGR_WITHOUT_OPTIONS "${_comgr_library}")
           endif()
         endif()
       endforeach()
     endforeach()
   endforeach()
   list(REMOVE_DUPLICATES HOTSWAP_BUILD_RPATH)
+  list(REMOVE_DUPLICATES HOTSWAP_COMGR_WITHOUT_OPTIONS)
+  if(NOT HOTSWAP_BUILD_RPATH AND HOTSWAP_COMGR_WITHOUT_OPTIONS)
+    message(WARNING
+      "Found COMGR without amd_comgr_hotswap_rewrite_with_options: "
+      "${HOTSWAP_COMGR_WITHOUT_OPTIONS}. hotswap_rewrite requires a "
+      "ROCm/llvm-project#3008-capable COMGR for local test RPATH setup.")
+  endif()
 endif()
 
 set(HOTSWAP_GFX1250_ASM "${HOTSWAP_TEST_ROOT}/fixtures/gfx1250_min.s")

--- a/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/CMakeLists.txt
@@ -802,7 +802,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
             OUTPUT_VARIABLE _comgr_symbols
             ERROR_QUIET)
           if(_comgr_symbol_result EQUAL 0 AND
-             _comgr_symbols MATCHES "amd_comgr_hotswap_rewrite")
+             _comgr_symbols MATCHES "amd_comgr_hotswap_rewrite_with_options")
             list(APPEND HOTSWAP_BUILD_RPATH "${_prefix}/${_libdir}")
             break()
           endif()

--- a/projects/rocr-runtime/runtime/docs/data/env_variables.rst
+++ b/projects/rocr-runtime/runtime/docs/data/env_variables.rst
@@ -105,6 +105,12 @@
       - | 0, ``false``, ``off``, ``no``, ``n``, or ``f``: Disable HotSwap diagnostic logging.
         | Any other non-empty value: Enable HotSwap diagnostic logging.
 
+    * - | ``AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES``
+        | Controls whether ROCr requests COMGR entry-trampoline HotSwap rewriting for gfx12.5 targets.
+      - ``1``
+      - | 0: Disable entry-trampoline rewrites.
+        | Unset or any other value, including empty: Enable entry-trampoline rewrites for gfx125* and ``gfx12-5-generic`` targets.
+
     * - | ``HSA_ENABLE_DXG_DETECTION``
         | Controls detection of the DXG driver (/dev/dxg) on WSL2.
       - ``1``

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
@@ -46,6 +46,7 @@
 #include <cstddef>
 #include <cstdlib>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "core/inc/amd_hsa_loader.hpp"
@@ -54,12 +55,24 @@
 namespace rocr {
 namespace hotswap {
 
+struct AgentGfxRevision;
+
 using OwnedElfBuffer = std::unique_ptr<void, decltype(&std::free)>;
 
 struct CodeObjectView {
   const void* data = nullptr;
   size_t size = 0;
   std::string uri;
+};
+
+struct RewriteOptions {
+  bool gfx12_5_rewrite_enabled = true;
+};
+
+struct RewriteDecision {
+  std::string source_isa;
+  std::string target_isa;
+  bool request_entry_trampolines = false;
 };
 
 using LoadOriginalCodeObjectFn = hsa_status_t (*)(
@@ -82,7 +95,8 @@ std::string GetCodeObjectIsaName(const void* elf_data, size_t elf_size);
 
 bool RetargetCodeObject(const void* elf_data, size_t elf_size,
                         const char* source_isa, const char* target_isa,
-                        OwnedElfBuffer* out_elf_buffer, size_t* out_elf_size);
+                        OwnedElfBuffer* out_elf_buffer, size_t* out_elf_size,
+                        bool request_entry_trampolines = false);
 
 bool TryRetargetCodeObject(const CodeObjectView& code_object, hsa_agent_t agent,
                            OwnedElfBuffer* out_elf_buffer,
@@ -103,6 +117,9 @@ void RetainRewrittenElfBuffer(hsa_executable_t executable,
 void ReleaseRetainedRewrittenElfBuffers(hsa_executable_t executable);
 
 #ifdef ROCR_HOTSWAP_TESTING
+std::optional<RewriteDecision> DecideHotswapRewriteForTesting(
+    const AgentGfxRevision& gfx, const std::string& source_isa,
+    const std::string& target_isa, const RewriteOptions& options);
 size_t RetainedRewrittenElfBufferCountForTesting(hsa_executable_t executable);
 #endif
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap.hpp
@@ -121,6 +121,7 @@ std::optional<RewriteDecision> DecideHotswapRewriteForTesting(
     const AgentGfxRevision& gfx, const std::string& source_isa,
     const std::string& target_isa, const RewriteOptions& options);
 size_t RetainedRewrittenElfBufferCountForTesting(hsa_executable_t executable);
+bool EntryTrampolineRewriteAvailableForTesting();
 #endif
 
 }  // namespace hotswap

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap_gfx_query.hpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/hotswap_gfx_query.hpp
@@ -62,6 +62,7 @@ struct AgentGfxRevision {
 
 std::string GetAgentIsaName(hsa_agent_t agent);
 std::string ExtractGfxTarget(const std::string& isa_name);
+bool IsGfx12_5Target(const std::string& gfx_target);
 AgentGfxRevision GetAgentGfxRevision(hsa_agent_t agent);
 void ResetAgentGfxRevisionCache();
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -98,6 +98,7 @@ bool IsHotswapDisabledByEnv() { return IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE"); 
 
 bool IsGfx12_5RewriteRequested() {
   constexpr char kEnvName[] = "AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES";
+  // Default-on policy owned by ROCR: only literal "0" opts out.
   return !os::IsEnvVarSet(kEnvName) || os::GetEnvVar(kEnvName) != "0";
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -69,6 +69,15 @@ namespace {
 std::mutex g_retained_rewritten_elf_buffers_mutex;
 std::unordered_map<uint64_t, std::vector<OwnedElfBuffer>> g_retained_rewritten_elf_buffers;
 
+constexpr char kGfx1250[] = "gfx1250";
+constexpr char kGfx1250B0Feature[] = ":gfx1250-b0-specific+";
+constexpr char kGfx1250A0Feature[] = ":gfx1250-b0-specific-";
+
+enum class Gfx1250Stepping {
+  kB0,
+  kA0,
+};
+
 bool IsEnvFlagEnabled(const char* name) {
   if (!os::IsEnvVarSet(name)) {
     return false;
@@ -87,6 +96,11 @@ bool IsEnvFlagEnabled(const char* name) {
 
 bool IsHotswapDisabledByEnv() { return IsEnvFlagEnabled("HSA_HOTSWAP_DISABLE"); }
 
+bool IsGfx12_5RewriteRequested() {
+  constexpr char kEnvName[] = "AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES";
+  return !os::IsEnvVarSet(kEnvName) || os::GetEnvVar(kEnvName) != "0";
+}
+
 bool IsVerboseLoggingEnabled() {
   static const bool verbose = IsEnvFlagEnabled("HSA_HOTSWAP_VERBOSE");
   return verbose;
@@ -103,8 +117,14 @@ struct ComgrData {
   uint64_t handle;
 };
 
+struct ComgrHotswapRewriteOptions {
+  size_t size;
+  uint64_t flags;
+};
+
 constexpr int kComgrStatusSuccess = 0;
 constexpr int kComgrDataKindExecutable = 0x8;
+constexpr uint64_t kComgrHotswapRewriteFlagEntryTrampolines = 0x1;
 
 struct ComgrApi {
   os::LibHandle lib = nullptr;
@@ -115,6 +135,10 @@ struct ComgrApi {
   int (*get_data_isa_name)(ComgrData data, size_t* size, char* isa_name) = nullptr;
   int (*hotswap_rewrite)(ComgrData input, const char* source_isa_name, const char* target_isa_name,
                          ComgrData* output) = nullptr;
+  int (*hotswap_rewrite_with_options)(ComgrData input, const char* source_isa_name,
+                                      const char* target_isa_name,
+                                      const ComgrHotswapRewriteOptions* rewrite_options,
+                                      ComgrData* output) = nullptr;
 };
 
 template <typename T> bool ResolveComgrSymbol(os::LibHandle lib, const char* name, T* symbol) {
@@ -129,7 +153,9 @@ bool ResolveComgrApi(os::LibHandle lib, ComgrApi* api) {
       ResolveComgrSymbol(lib, "amd_comgr_set_data", &api->set_data) &&
       ResolveComgrSymbol(lib, "amd_comgr_get_data", &api->get_data) &&
       ResolveComgrSymbol(lib, "amd_comgr_get_data_isa_name", &api->get_data_isa_name) &&
-      ResolveComgrSymbol(lib, "amd_comgr_hotswap_rewrite", &api->hotswap_rewrite);
+      ResolveComgrSymbol(lib, "amd_comgr_hotswap_rewrite", &api->hotswap_rewrite) &&
+      ResolveComgrSymbol(lib, "amd_comgr_hotswap_rewrite_with_options",
+                         &api->hotswap_rewrite_with_options);
 }
 
 std::string GetRuntimeLibraryDirectory() {
@@ -227,6 +253,60 @@ ComgrApi* GetComgrApi() {
   return ready ? &api : nullptr;
 }
 
+const char* Gfx1250SteppingFeature(Gfx1250Stepping stepping) {
+  return stepping == Gfx1250Stepping::kB0 ? kGfx1250B0Feature
+                                          : kGfx1250A0Feature;
+}
+
+std::string WithGfx1250SteppingFeature(const std::string& isa_name,
+                                       Gfx1250Stepping stepping) {
+  if (ExtractGfxTarget(isa_name) != kGfx1250 ||
+      isa_name.find(kGfx1250B0Feature) != std::string::npos ||
+      isa_name.find(kGfx1250A0Feature) != std::string::npos) {
+    return isa_name;
+  }
+  return isa_name + Gfx1250SteppingFeature(stepping);
+}
+
+bool HasCandidateHotswapRewrite(const AgentGfxRevision& gfx,
+                                const RewriteOptions& options) {
+  return IsHotswapSupportedGfxRevision(gfx) ||
+         (options.gfx12_5_rewrite_enabled &&
+          IsGfx12_5Target(gfx.gfx_target));
+}
+
+std::optional<RewriteDecision> DecideHotswapRewrite(
+    const AgentGfxRevision& gfx, const std::string& source_isa,
+    const std::string& target_isa, const RewriteOptions& options) {
+  if (source_isa.empty() || target_isa.empty()) {
+    return std::nullopt;
+  }
+
+  const std::string source_gfx = ExtractGfxTarget(source_isa);
+  const std::string target_gfx = ExtractGfxTarget(target_isa);
+  if (IsHotswapSupportedGfxRevision(gfx) && source_gfx == kGfx1250 &&
+      target_gfx == kGfx1250) {
+    return RewriteDecision{
+        WithGfx1250SteppingFeature(source_isa, Gfx1250Stepping::kB0),
+        WithGfx1250SteppingFeature(target_isa, Gfx1250Stepping::kA0),
+        false};
+  }
+
+  if (!options.gfx12_5_rewrite_enabled ||
+      !IsGfx12_5Target(gfx.gfx_target) || !IsGfx12_5Target(source_gfx)) {
+    return std::nullopt;
+  }
+
+  RewriteDecision decision{source_isa, source_isa, true};
+  if (source_gfx == kGfx1250) {
+    decision.source_isa =
+        WithGfx1250SteppingFeature(source_isa, Gfx1250Stepping::kB0);
+    decision.target_isa =
+        WithGfx1250SteppingFeature(source_isa, Gfx1250Stepping::kB0);
+  }
+  return decision;
+}
+
 }  // namespace
 
 std::string GetCodeObjectIsaName(const void* elf_data, size_t elf_size) {
@@ -261,12 +341,12 @@ std::string GetCodeObjectIsaName(const void* elf_data, size_t elf_size) {
 
 namespace {
 
-bool IsAgentEligibleForHotswap(hsa_agent_t agent) {
-  const AgentGfxRevision gfx = GetAgentGfxRevision(agent);
+bool IsAgentEligibleForHotswap(const AgentGfxRevision& gfx,
+                               const RewriteOptions& options) {
   HOTSWAP_LOG("hotswap: agent gfx=%s asic_revision=%u (valid=%s)\n",
               gfx.gfx_target.empty() ? "?" : gfx.gfx_target.c_str(), gfx.asic_revision,
               gfx.has_asic_revision ? "yes" : "no");
-  return IsHotswapSupportedGfxRevision(gfx);
+  return HasCandidateHotswapRewrite(gfx, options);
 }
 
 void LogRewrittenCodeObjectLoadFailure(hsa_status_t status) {
@@ -280,7 +360,7 @@ void LogRewrittenCodeObjectLoadFailure(hsa_status_t status) {
 
 bool RetargetCodeObject(const void* elf_data, size_t elf_size, const char* source_isa,
                         const char* target_isa, OwnedElfBuffer* out_elf_buffer,
-                        size_t* out_elf_size) {
+                        size_t* out_elf_size, bool request_entry_trampolines) {
   ComgrApi* api = GetComgrApi();
   if (!api || !elf_data || elf_size == 0 || !source_isa || !target_isa || !out_elf_buffer ||
       !out_elf_size) {
@@ -298,7 +378,16 @@ bool RetargetCodeObject(const void* elf_data, size_t elf_size, const char* sourc
   }
 
   ComgrData output = {};
-  const int status = api->hotswap_rewrite(input, source_isa, target_isa, &output);
+  int status = kComgrStatusSuccess;
+  if (request_entry_trampolines) {
+    const ComgrHotswapRewriteOptions options{
+        sizeof(ComgrHotswapRewriteOptions),
+        kComgrHotswapRewriteFlagEntryTrampolines};
+    status = api->hotswap_rewrite_with_options(input, source_isa, target_isa,
+                                               &options, &output);
+  } else {
+    status = api->hotswap_rewrite(input, source_isa, target_isa, &output);
+  }
   api->release_data(input);
   if (status != kComgrStatusSuccess) {
     HOTSWAP_LOG("hotswap: COMGR rewrite failed for %s -> %s (rc=%d)\n", source_isa, target_isa,
@@ -333,24 +422,35 @@ bool RetargetCodeObject(const void* elf_data, size_t elf_size, const char* sourc
 
 bool TryRetargetCodeObject(const CodeObjectView& code_object, hsa_agent_t agent,
                            OwnedElfBuffer* out_elf_buffer, size_t* out_elf_size) {
-  if (IsHotswapDisabledByEnv() || !code_object.data || code_object.size == 0 ||
-      !IsAgentEligibleForHotswap(agent)) {
+  if (IsHotswapDisabledByEnv() || !code_object.data || code_object.size == 0) {
+    return false;
+  }
+
+  const AgentGfxRevision gfx = GetAgentGfxRevision(agent);
+  const RewriteOptions options{IsGfx12_5RewriteRequested()};
+  if (!IsAgentEligibleForHotswap(gfx, options)) {
     return false;
   }
 
   const std::string source_isa = GetCodeObjectIsaName(code_object.data, code_object.size);
   const std::string target_isa = GetAgentIsaName(agent);
-  if (source_isa.empty() || target_isa.empty()) {
-    HOTSWAP_LOG("hotswap: rewrite skipped, empty isa (src='%s' tgt='%s')\n", source_isa.c_str(),
-                target_isa.c_str());
+  const std::optional<RewriteDecision> decision =
+      DecideHotswapRewrite(gfx, source_isa, target_isa, options);
+  if (!decision) {
+    HOTSWAP_LOG("hotswap: rewrite skipped, no decision (src='%s' tgt='%s')\n",
+                source_isa.c_str(), target_isa.c_str());
     return false;
   }
 
-  const bool rewritten = RetargetCodeObject(code_object.data, code_object.size, source_isa.c_str(),
-                                            target_isa.c_str(), out_elf_buffer, out_elf_size);
-  HOTSWAP_LOG("hotswap: rewrite src=%s tgt=%s in=%zu out=%zu changed=%d\n", source_isa.c_str(),
-              target_isa.c_str(), code_object.size, rewritten ? *out_elf_size : 0,
-              rewritten ? 1 : 0);
+  const bool rewritten =
+      RetargetCodeObject(code_object.data, code_object.size,
+                         decision->source_isa.c_str(), decision->target_isa.c_str(),
+                         out_elf_buffer, out_elf_size,
+                         decision->request_entry_trampolines);
+  HOTSWAP_LOG("hotswap: rewrite src=%s tgt=%s entry_trampolines=%d in=%zu out=%zu changed=%d\n",
+              decision->source_isa.c_str(), decision->target_isa.c_str(),
+              decision->request_entry_trampolines, code_object.size,
+              rewritten ? *out_elf_size : 0, rewritten ? 1 : 0);
   return rewritten;
 }
 
@@ -413,6 +513,12 @@ void ReleaseRetainedRewrittenElfBuffers(hsa_executable_t executable) {
 }
 
 #ifdef ROCR_HOTSWAP_TESTING
+std::optional<RewriteDecision> DecideHotswapRewriteForTesting(
+    const AgentGfxRevision& gfx, const std::string& source_isa,
+    const std::string& target_isa, const RewriteOptions& options) {
+  return DecideHotswapRewrite(gfx, source_isa, target_isa, options);
+}
+
 size_t RetainedRewrittenElfBufferCountForTesting(hsa_executable_t executable) {
   std::scoped_lock lock(g_retained_rewritten_elf_buffers_mutex);
   const auto it = g_retained_rewritten_elf_buffers.find(executable.handle);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap.cpp
@@ -149,14 +149,20 @@ template <typename T> bool ResolveComgrSymbol(os::LibHandle lib, const char* nam
 
 bool ResolveComgrApi(os::LibHandle lib, ComgrApi* api) {
   api->lib = lib;
-  return ResolveComgrSymbol(lib, "amd_comgr_create_data", &api->create_data) &&
+  const bool base_api_ready =
+      ResolveComgrSymbol(lib, "amd_comgr_create_data", &api->create_data) &&
       ResolveComgrSymbol(lib, "amd_comgr_release_data", &api->release_data) &&
       ResolveComgrSymbol(lib, "amd_comgr_set_data", &api->set_data) &&
       ResolveComgrSymbol(lib, "amd_comgr_get_data", &api->get_data) &&
       ResolveComgrSymbol(lib, "amd_comgr_get_data_isa_name", &api->get_data_isa_name) &&
-      ResolveComgrSymbol(lib, "amd_comgr_hotswap_rewrite", &api->hotswap_rewrite) &&
-      ResolveComgrSymbol(lib, "amd_comgr_hotswap_rewrite_with_options",
-                         &api->hotswap_rewrite_with_options);
+      ResolveComgrSymbol(lib, "amd_comgr_hotswap_rewrite", &api->hotswap_rewrite);
+  if (!base_api_ready) {
+    return false;
+  }
+
+  ResolveComgrSymbol(lib, "amd_comgr_hotswap_rewrite_with_options",
+                     &api->hotswap_rewrite_with_options);
+  return true;
 }
 
 std::string GetRuntimeLibraryDirectory() {
@@ -381,6 +387,11 @@ bool RetargetCodeObject(const void* elf_data, size_t elf_size, const char* sourc
   ComgrData output = {};
   int status = kComgrStatusSuccess;
   if (request_entry_trampolines) {
+    if (!api->hotswap_rewrite_with_options) {
+      api->release_data(input);
+      HOTSWAP_LOG("hotswap: COMGR entry-trampoline rewrite entry point unavailable\n");
+      return false;
+    }
     const ComgrHotswapRewriteOptions options{
         sizeof(ComgrHotswapRewriteOptions),
         kComgrHotswapRewriteFlagEntryTrampolines};
@@ -524,6 +535,11 @@ size_t RetainedRewrittenElfBufferCountForTesting(hsa_executable_t executable) {
   std::scoped_lock lock(g_retained_rewritten_elf_buffers_mutex);
   const auto it = g_retained_rewritten_elf_buffers.find(executable.handle);
   return it == g_retained_rewritten_elf_buffers.end() ? 0 : it->second.size();
+}
+
+bool EntryTrampolineRewriteAvailableForTesting() {
+  ComgrApi* api = GetComgrApi();
+  return api && api->hotswap_rewrite_with_options;
 }
 #endif
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap_gfx_query.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hotswap_gfx_query.cpp
@@ -44,6 +44,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstddef>
 #include <mutex>
 #include <unordered_map>
 
@@ -85,8 +86,26 @@ std::string ExtractGfxTarget(const std::string& isa_name) {
   }
 
   auto end = std::find_if_not(isa_name.begin() + pos, isa_name.end(),
-                              [](unsigned char c) { return std::isalnum(c); });
+                              [](unsigned char c) {
+                                return std::isalnum(c) || c == '-';
+                              });
   return isa_name.substr(pos, end - isa_name.begin() - pos);
+}
+
+bool IsGfx12_5Target(const std::string& gfx_target) {
+  constexpr char kGfx125Prefix[] = "gfx125";
+  constexpr char kGfx12_5Generic[] = "gfx12-5-generic";
+  constexpr size_t kGfx125PrefixLen = sizeof(kGfx125Prefix) - 1;
+  if (gfx_target == kGfx12_5Generic) {
+    return true;
+  }
+  if (gfx_target.size() <= kGfx125PrefixLen ||
+      gfx_target.compare(0, kGfx125PrefixLen, kGfx125Prefix) != 0) {
+    return false;
+  }
+  return std::all_of(gfx_target.begin() + kGfx125PrefixLen,
+                     gfx_target.end(),
+                     [](unsigned char c) { return std::isdigit(c); });
 }
 
 namespace {


### PR DESCRIPTION
## JIRA ID

JIRA ID - ROCM-27304

## Stack
Layer 2 of the rocm-systems HotSwap stack, paired with ROCm/llvm-project#3008.
- Previous layer: ROCm/rocm-systems#7577
- This layer: rocm-systems loader gating and COMGR request selection for the gfx12.5 entry-trampoline path
- Final layer: ROCm/rocm-systems#7592

## Summary
- Keep rocm-systems limited to loader routing and COMGR source/target ISA-pair construction; COMGR owns validation and all code-object transformations after the call.
- Use ROCm/llvm-project#3008's explicit COMGR options API: ROCr calls `amd_comgr_hotswap_rewrite_with_options` with `AMD_COMGR_HOTSWAP_REWRITE_FLAG_ENTRY_TRAMPOLINES` when it requests entry trampolines, and keeps `amd_comgr_hotswap_rewrite` for legacy/default rewrites.
- Keep `AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES` as the ROCr policy knob: default enabled in ROCr, literal `0` disables, unset/empty/any other value enables the entry-trampoline request.
- Cover concrete `gfx125*` targets and `gfx12-5-generic` while keeping non-gfx12.5 agents and source code objects unchanged.
- Follow ROCm/rocm-systems#7581 by keeping the entry-trampoline path keyed to the code-object ISA rather than using this path for processor retargeting.
- Preserve the existing gfx1250 A0 source/target ISA pair and leave pass selection to COMGR.
- Add unit and loader-path coverage for the local routing behavior without testing COMGR pass internals.

## Testing
- `git diff --check`
- `cmake --build build-rocrtst-hotswap-review --target hotswap_rewrite -j 8`
- `ctest --test-dir build-rocrtst-hotswap-review -R hotswap --output-on-failure`
- `cmake --build build-rocr-hotswap --target hsa-runtime64 -j 8`