### PR TITLE
clr: fix cached queue signal lifetime

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1094,7 +1094,49 @@ bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address para
 }
 
 // ================================================================================================
+void VirtualGPU::ClearCachedCompletionSignal() {
+  if (last_completion_signal_owner_ != nullptr) {
+    last_completion_signal_owner_->release();
+    last_completion_signal_owner_ = nullptr;
+  }
+  last_completion_signal_.handle = 0;
+}
+
+// ================================================================================================
+void VirtualGPU::ResetCachedQueueProgress() {
+  last_write_index_ = kInvalidQueueIndex;
+  last_packet_with_signal_index_ = kInvalidQueueIndex;
+  ClearCachedCompletionSignal();
+}
+
+// ================================================================================================
+void VirtualGPU::SetCachedCompletionSignal(hsa_signal_t signal, ProfilingSignal* owner) {
+  if (last_completion_signal_owner_ != owner) {
+    if (last_completion_signal_owner_ != nullptr) {
+      last_completion_signal_owner_->release();
+    }
+    last_completion_signal_owner_ = owner;
+    if (last_completion_signal_owner_ != nullptr) {
+      last_completion_signal_owner_->retain();
+    }
+  }
+  last_completion_signal_ = signal;
+}
+
+// ================================================================================================
+ProfilingSignal* VirtualGPU::GetCachedCompletionSignalOwner(hsa_signal_t signal) {
+  ProfilingSignal* owner = Barriers().GetLastSignal();
+  if ((owner == nullptr) || (owner->signal_.handle != signal.handle)) {
+    return nullptr;
+  }
+  return owner;
+}
+
+// ================================================================================================
 void VirtualGPU::SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer) {
+  if (gpu_queue_ != queue) {
+    ResetCachedQueueProgress();
+  }
   gpu_queue_ = queue;
   cached_read_dispatch_id_ = 0;
   metadata_preloader_.SetQueueBase(metadata_ring_buffer,
@@ -1982,6 +2024,7 @@ VirtualGPU::~VirtualGPU() {
   // Release any retained coalescing-window signal not freed via releaseGpuMemoryFence.
   {
     std::scoped_lock l(execution());
+    ResetCachedQueueProgress();
     SetCoalesceWindow(0, nullptr);
   }
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -694,6 +694,11 @@ class VirtualGPU : public device::VirtualDevice {
   //! Resets the current queue state. Note: should be called after AQL queue becomes idle
   void ResetQueueStates();
 
+  void ClearCachedCompletionSignal();
+  void ResetCachedQueueProgress();
+  void SetCachedCompletionSignal(hsa_signal_t signal, ProfilingSignal* owner);
+  ProfilingSignal* GetCachedCompletionSignalOwner(hsa_signal_t signal);
+
   //! Track the progress of the queue based on the last write index and completion signal.
   //! When skip_signal is true, only the write index is advanced and the completion signal
   //! is cleared. Used for graph pre-patched dispatches whose signals are externally
@@ -703,10 +708,11 @@ class VirtualGPU : public device::VirtualDevice {
                                  bool skip_signal = false) {
     last_write_index_ = index;
     if (skip_signal) {
-      last_completion_signal_.handle = 0;
+      ClearCachedCompletionSignal();
     } else if (packet.completion_signal.handle != 0) {
       last_packet_with_signal_index_ = index;
-      last_completion_signal_ = packet.completion_signal;
+      SetCachedCompletionSignal(packet.completion_signal,
+                                GetCachedCompletionSignalOwner(packet.completion_signal));
     }
   }
 
@@ -863,6 +869,7 @@ class VirtualGPU : public device::VirtualDevice {
   uint64_t last_packet_with_signal_index_ = kInvalidQueueIndex; //!< The last HW queue write index for a packet
                                               //!< with a completion signal
   hsa_signal_t last_completion_signal_{};     //!< The last completion signal
+  ProfilingSignal* last_completion_signal_owner_ = nullptr; //!< Retained owner of last signal
 
   //! SDMA engine affinity tracking for this VirtualGPU/stream
   uint32_t assigned_sdma_engine_ = 0;           //!< Assigned SDMA engine mask for all operations


### PR DESCRIPTION
Dynamic queue release can reuse a VirtualGPU after its cached completion signal owner has been released. Retain the ProfilingSignal backing the cached signal and reset cached queue progress when switching HW queues.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
