### PR TITLE
[CLR] Protect queue_load_read_index_relaxed when not logging

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1717,7 +1717,10 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
   }
 
   uint64_t index = Hsa::queue_add_write_index_screlease(gpu_queue_, 1);
-  uint64_t read = Hsa::queue_load_read_index_relaxed(gpu_queue_);
+  // read index is only used for AQL logging below; avoid the atomic load otherwise
+  uint64_t read = IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)
+      ? Hsa::queue_load_read_index_relaxed(gpu_queue_)
+      : 0;
 
   setFenceDirty(true);
   auto cache_state = extractAqlBits(packetHeader, HSA_PACKET_HEADER_SCRELEASE_FENCE_SCOPE,
@@ -1818,7 +1821,10 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
   }
 
   uint64_t index = Hsa::queue_add_write_index_screlease(gpu_queue_, 1);
-  uint64_t read = Hsa::queue_load_read_index_relaxed(gpu_queue_);
+  // read index is only used for AQL logging below; avoid the atomic load otherwise
+  uint64_t read = IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)
+      ? Hsa::queue_load_read_index_relaxed(gpu_queue_)
+      : 0;
 
   TrackQueueProgress(barrier_value_packet_, index);
 


### PR DESCRIPTION
## Motivation

Functions dispatchBarrierPacket and dispatchBarrierValuePacket log the read index. However, we always call queue_load_read_index_relaxed regardless of logging status. This contributes to submission latency.

## Technical Details

Guard queue_load_read_index_relaxed when logging, set value to 0. 

## JIRA ID

ROCM-21854

## Test Plan

NA

## Test Result

NA

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
