### PR TITLE
dbgapi memcache cleanups

### DIFF
--- a/projects/rocdbgapi/src/agent.cpp
+++ b/projects/rocdbgapi/src/agent.cpp
@@ -48,6 +48,7 @@ agent_t::agent_t (amd_dbgapi_agent_id_t agent_id, process_t &process,
                    : architecture->get_apertures (os_agent_info)),
     m_architecture (architecture), m_process (process),
     m_memory_cache (
+      *this,
       [this] (agent_address_t address, void *read, const void *write,
               size_t size)
       {

--- a/projects/rocdbgapi/src/agent.h
+++ b/projects/rocdbgapi/src/agent.h
@@ -63,7 +63,7 @@ private:
   const architecture_t *const m_architecture;
   process_t &m_process;
 
-  mutable memory_cache_t<agent_address_t> m_memory_cache;
+  mutable memory_cache_t m_memory_cache;
 
 public:
   agent_t (amd_dbgapi_agent_id_t agent_id, process_t &process,

--- a/projects/rocdbgapi/src/agent.h
+++ b/projects/rocdbgapi/src/agent.h
@@ -112,14 +112,14 @@ public:
                                                   void *buffer,
                                                   size_t size) const
   {
-    return m_memory_cache.read_global_memory (address, buffer, size);
+    return m_memory_cache.read_agent_memory (address, buffer, size);
   }
 
   [[nodiscard]] size_t write_agent_memory_partial (agent_address_t address,
                                                    const void *buffer,
                                                    size_t size) const
   {
-    return m_memory_cache.write_global_memory (address, buffer, size);
+    return m_memory_cache.write_agent_memory (address, buffer, size);
   }
 
   template <typename T>

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -766,7 +766,7 @@ void
 memory_cache_t<AddressType>::prefetch (AddressType address,
                                        amd_dbgapi_size_t size)
 {
-  if (policy == policy_t::uncached || size == 0)
+  if (size == 0)
     return;
 
   dbgapi_assert (address < (address + size) && "invalid size");
@@ -815,7 +815,7 @@ memory_cache_t<AddressType>::write_back (AddressType address,
                                          amd_dbgapi_size_t size)
 {
   std::exception_ptr exception;
-  if (policy != policy_t::write_back || size == 0)
+  if (size == 0)
     return;
 
   dbgapi_assert (address < (address + size) && "invalid size");
@@ -937,8 +937,8 @@ memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
   auto begin = m_cache_line_map.lower_bound (first_line);
   auto end = m_cache_line_map.upper_bound (last_line);
 
-  /* If uncached or there are no cache lines affected by this access.  */
-  if (policy == policy_t::uncached || begin == end)
+  /* If there are no cache lines affected by this access.  */
+  if (begin == end)
     return m_xfer_global_memory (address, read, write, size);
 
   /* For cached accesses, handle one cache line at a time.  */
@@ -976,10 +976,6 @@ memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
   else
     {
       memcpy (&cache_line.m_data[0] + offset, write, size);
-
-      if (policy != policy_t::write_back)
-        return m_xfer_global_memory (address, nullptr, write, size);
-
       cache_line.m_dirty = true;
     }
 

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -726,8 +726,8 @@ memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size)
 
   try
     {
-      m_xfer_global_memory (cache_line_begin, &staging_buffer[0], nullptr,
-                            cache_line_end - cache_line_begin);
+      m_xfer_agent_memory (cache_line_begin, &staging_buffer[0], nullptr,
+                           cache_line_end - cache_line_begin);
     }
   catch (const memory_error_t &)
     {
@@ -813,13 +813,12 @@ memory_cache_t::write_back (agent_address_t address, amd_dbgapi_size_t size)
 
       try
         {
-          size_t xfer_size = m_xfer_global_memory (
+          size_t xfer_size = m_xfer_agent_memory (
             cache_line_address, nullptr, &staging_buffer[0], request_size);
 
           if (xfer_size != request_size)
-            throw memory_access_error_t (
-              /* FIXME_lmoriche:  */
-              address_space_t::global (), cache_line_address + xfer_size);
+            throw memory_access_error_t (m_agent.agent_address_space (),
+                                         cache_line_address + xfer_size);
         }
       catch (const process_exited_exception_t &)
         {
@@ -862,15 +861,23 @@ memory_cache_t::discard (agent_address_t address, amd_dbgapi_size_t size,
 }
 
 size_t
-memory_cache_t::xfer_global_memory (agent_address_t address, void *read,
-                                    const void *write, size_t size)
+memory_cache_t::xfer_agent_memory (agent_address_t address, void *read,
+                                   const void *write, size_t size)
 {
   if (size == 0)
     return 0;
 
-  /* Clamp to the end of the global address space.  */
-  if (address > (address + size))
-    size = agent_address_t{} - address;
+  /* Clamp to the end of the agent address space.  */
+  auto max = m_agent.agent_address_space ().last_address ();
+  if (address > max)
+    throw memory_access_error_t (m_agent.agent_address_space (), address);
+  /* Clamp SIZE so that the last accessed byte (ADDRESS + SIZE - 1)
+     does not exceed MAX, the last representable address.  The
+     comparison is in terms of the last byte rather than a byte count,
+     because the count MAX - ADDRESS + 1 would wrap to zero when
+     ADDRESS is 0 and MAX is std::numeric_limits<decltype(max)>::max.  */
+  if (size - 1 > max - address)
+    size = static_cast<size_t> (max - address) + 1;
 
   auto first_line = utils::align_down (address, cache_line_size);
   auto last_line = utils::align_down (address + size - 1, cache_line_size);
@@ -881,7 +888,7 @@ memory_cache_t::xfer_global_memory (agent_address_t address, void *read,
 
   /* If there are no cache lines affected by this access.  */
   if (begin == end)
-    return m_xfer_global_memory (address, read, write, size);
+    return m_xfer_agent_memory (address, read, write, size);
 
   /* For cached accesses, handle one cache line at a time.  */
   if (first_line != last_line)
@@ -892,7 +899,7 @@ memory_cache_t::xfer_global_memory (agent_address_t address, void *read,
           auto limit = utils::align_up (ptr + 1, cache_line_size);
           auto request_size = std::min (limit, ptr + size) - ptr;
 
-          auto xfer_size = xfer_global_memory (ptr, read, write, request_size);
+          auto xfer_size = xfer_agent_memory (ptr, read, write, request_size);
 
           ptr += xfer_size;
           if (read != nullptr)

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -695,55 +695,6 @@ host_address_space_t::convert (const wave_t &wave,
 }
 
 template <typename AddressType>
-void
-memory_cache_t<AddressType>::fetch_cache_line (cache_line_t &cache_line,
-                                               AddressType address) const
-{
-  dbgapi_assert (!cache_line.m_dirty);
-
-  size_t xfer_size = m_xfer_global_memory (address, &cache_line.m_data[0],
-                                           nullptr, cache_line.m_data.size ());
-
-  if (xfer_size != cache_line.m_data.size ())
-    throw memory_access_error_t (
-      /* FIXME_lmoriche:  */
-      address_space_t::global (), address + cache_line_size);
-
-  cache_line.m_dirty = false;
-}
-
-template <typename AddressType>
-void
-memory_cache_t<AddressType>::commit_cache_line (cache_line_t &cache_line,
-                                                AddressType address) const
-{
-  if (!cache_line.m_dirty)
-    return;
-
-  size_t xfer_size = m_xfer_global_memory (
-    address, nullptr, &cache_line.m_data[0], cache_line.m_data.size ());
-
-  if (xfer_size != cache_line.m_data.size ())
-    throw memory_access_error_t (
-      /* FIXME_lmoriche:  */
-      address_space_t::global (), address + xfer_size);
-
-  cache_line.m_dirty = false;
-}
-
-template <typename AddressType>
-void
-memory_cache_t<AddressType>::allocate_0_cache_line (
-  cache_line_t &cache_line) const
-{
-  dbgapi_assert (!cache_line.m_dirty);
-
-  memset (&cache_line.m_data[0], '\0', cache_line.m_data.size ());
-
-  cache_line.m_dirty = false;
-}
-
-template <typename AddressType>
 bool
 memory_cache_t<AddressType>::contains_all (AddressType address,
                                            amd_dbgapi_size_t size) const

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -694,10 +694,9 @@ host_address_space_t::convert (const wave_t &wave,
   throw api_error_t (AMD_DBGAPI_STATUS_ERROR_INVALID_ADDRESS_SPACE_CONVERSION);
 }
 
-template <typename AddressType>
 bool
-memory_cache_t<AddressType>::contains_all (AddressType address,
-                                           amd_dbgapi_size_t size) const
+memory_cache_t::contains_all (agent_address_t address,
+                              amd_dbgapi_size_t size) const
 {
   dbgapi_assert (address < (address + size) && "invalid size");
   auto cache_line_begin = utils::align_down (address, cache_line_size);
@@ -712,10 +711,8 @@ memory_cache_t<AddressType>::contains_all (AddressType address,
   return true;
 }
 
-template <typename AddressType>
 void
-memory_cache_t<AddressType>::prefetch (AddressType address,
-                                       amd_dbgapi_size_t size)
+memory_cache_t::prefetch (agent_address_t address, amd_dbgapi_size_t size)
 {
   if (size == 0)
     return;
@@ -760,10 +757,8 @@ memory_cache_t<AddressType>::prefetch (AddressType address,
     }
 }
 
-template <typename AddressType>
 void
-memory_cache_t<AddressType>::write_back (AddressType address,
-                                         amd_dbgapi_size_t size)
+memory_cache_t::write_back (agent_address_t address, amd_dbgapi_size_t size)
 {
   std::exception_ptr exception;
   if (size == 0)
@@ -844,11 +839,9 @@ memory_cache_t<AddressType>::write_back (AddressType address,
     std::rethrow_exception (exception);
 }
 
-template <typename AddressType>
 void
-memory_cache_t<AddressType>::discard (AddressType address,
-                                      amd_dbgapi_size_t size,
-                                      [[maybe_unused]] bool force_discard)
+memory_cache_t::discard (agent_address_t address, amd_dbgapi_size_t size,
+                         [[maybe_unused]] bool force_discard)
 {
   if (size == 0)
     return;
@@ -868,18 +861,16 @@ memory_cache_t<AddressType>::discard (AddressType address,
     }
 }
 
-template <typename AddressType>
 size_t
-memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
-                                                 void *read, const void *write,
-                                                 size_t size)
+memory_cache_t::xfer_global_memory (agent_address_t address, void *read,
+                                    const void *write, size_t size)
 {
   if (size == 0)
     return 0;
 
   /* Clamp to the end of the global address space.  */
   if (address > (address + size))
-    size = AddressType{} - address;
+    size = agent_address_t{} - address;
 
   auto first_line = utils::align_down (address, cache_line_size);
   auto last_line = utils::align_down (address + size - 1, cache_line_size);
@@ -932,8 +923,6 @@ memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
 
   return size;
 }
-
-template class memory_cache_t<agent_address_t>;
 
 } /* namespace amd::dbgapi */
 

--- a/projects/rocdbgapi/src/memory.cpp
+++ b/projects/rocdbgapi/src/memory.cpp
@@ -983,7 +983,6 @@ memory_cache_t<AddressType>::xfer_global_memory (AddressType address,
 }
 
 template class memory_cache_t<agent_address_t>;
-template class memory_cache_t<host_address_t>;
 
 } /* namespace amd::dbgapi */
 

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -606,10 +606,6 @@ private:
   std::map<AddressType, cache_line_t> m_cache_line_map;
   delegate_fn_type const m_xfer_global_memory;
 
-  void fetch_cache_line (cache_line_t &cache_line, AddressType address) const;
-  void commit_cache_line (cache_line_t &cache_line, AddressType address) const;
-  void allocate_0_cache_line (cache_line_t &cache_line) const;
-
   size_t xfer_global_memory (AddressType address, void *read,
                              const void *write, size_t size);
 

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -587,14 +587,14 @@ public:
    the cache is flushed.  Accesses to uncached lines are forwarded
    directly to memory.  */
 
-template <typename AddressType> class memory_cache_t
+class memory_cache_t
 {
 public:
   static constexpr size_t cache_line_size = 64;
 
 private:
   using delegate_fn_type
-    = std::function<size_t (AddressType /* address */, void * /* read */,
+    = std::function<size_t (agent_address_t /* address */, void * /* read */,
                             const void * /* write */, size_t /* size */)>;
 
   struct cache_line_t
@@ -603,10 +603,10 @@ private:
     bool m_dirty{ false };
   };
 
-  std::map<AddressType, cache_line_t> m_cache_line_map;
+  std::map<agent_address_t, cache_line_t> m_cache_line_map;
   delegate_fn_type const m_xfer_global_memory;
 
-  size_t xfer_global_memory (AddressType address, void *read,
+  size_t xfer_global_memory (agent_address_t address, void *read,
                              const void *write, size_t size);
 
 public:
@@ -616,29 +616,29 @@ public:
   }
   ~memory_cache_t () { dbgapi_assert (m_cache_line_map.empty ()); }
 
-  bool contains_all (AddressType address, amd_dbgapi_size_t size) const;
+  bool contains_all (agent_address_t address, amd_dbgapi_size_t size) const;
 
   /* Create cache lines if not already valid, and immediately fill them in.  */
-  void prefetch (AddressType address, amd_dbgapi_size_t size);
+  void prefetch (agent_address_t address, amd_dbgapi_size_t size);
 
   /* Discard all cache lines in the specified range.  If FORCE_DISCARD
      is true, dirty lines are silently dropped.  Otherwise it is an error to
      discarded dirty cache lines.  */
-  void discard (AddressType address = 0,
+  void discard (agent_address_t address = 0,
                 amd_dbgapi_size_t size = amd_dbgapi_size_t (-1),
                 bool force_discard = false);
 
   /* Write dirty lines back to memory.  */
-  void write_back (AddressType address = 0,
+  void write_back (agent_address_t address = 0,
                    amd_dbgapi_size_t size = amd_dbgapi_size_t (-1));
 
-  [[nodiscard]] size_t read_global_memory (AddressType address, void *buffer,
-                                           size_t size)
+  [[nodiscard]] size_t read_global_memory (agent_address_t address,
+                                           void *buffer, size_t size)
   {
     return xfer_global_memory (address, buffer, nullptr, size);
   }
 
-  [[nodiscard]] size_t write_global_memory (AddressType address,
+  [[nodiscard]] size_t write_global_memory (agent_address_t address,
                                             const void *buffer, size_t size)
   {
     return xfer_global_memory (address, nullptr, buffer, size);

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -582,10 +582,10 @@ public:
                  void *value) const;
 };
 
-/* A memory cache.  Writes to cached lines are write-back: data is
-   immediately updated in the cache, and later updated in memory when
-   the cache is flushed.  Accesses to uncached lines are forwarded
-   directly to memory.  */
+/* A cache for agent memory.  Writes to cached lines are write-back:
+   data is immediately updated in the cache, and later updated in
+   memory when the cache is flushed.  Accesses to uncached lines are
+   forwarded directly to memory.  */
 
 class memory_cache_t
 {
@@ -603,15 +603,18 @@ private:
     bool m_dirty{ false };
   };
 
-  std::map<agent_address_t, cache_line_t> m_cache_line_map;
-  delegate_fn_type const m_xfer_global_memory;
+  /* The agent which this cache is for.  */
+  const agent_t &m_agent;
 
-  size_t xfer_global_memory (agent_address_t address, void *read,
-                             const void *write, size_t size);
+  std::map<agent_address_t, cache_line_t> m_cache_line_map;
+  delegate_fn_type const m_xfer_agent_memory;
+
+  size_t xfer_agent_memory (agent_address_t address, void *read,
+                            const void *write, size_t size);
 
 public:
-  memory_cache_t (delegate_fn_type xfer_global_memory)
-    : m_xfer_global_memory (std::move (xfer_global_memory))
+  memory_cache_t (const agent_t &agent, delegate_fn_type xfer_agent_memory)
+    : m_agent (agent), m_xfer_agent_memory (std::move (xfer_agent_memory))
   {
   }
   ~memory_cache_t () { dbgapi_assert (m_cache_line_map.empty ()); }
@@ -632,16 +635,16 @@ public:
   void write_back (agent_address_t address = 0,
                    amd_dbgapi_size_t size = amd_dbgapi_size_t (-1));
 
-  [[nodiscard]] size_t read_global_memory (agent_address_t address,
-                                           void *buffer, size_t size)
+  [[nodiscard]] size_t read_agent_memory (agent_address_t address,
+                                          void *buffer, size_t size)
   {
-    return xfer_global_memory (address, buffer, nullptr, size);
+    return xfer_agent_memory (address, buffer, nullptr, size);
   }
 
-  [[nodiscard]] size_t write_global_memory (agent_address_t address,
-                                            const void *buffer, size_t size)
+  [[nodiscard]] size_t write_agent_memory (agent_address_t address,
+                                           const void *buffer, size_t size)
   {
-    return xfer_global_memory (address, nullptr, buffer, size);
+    return xfer_agent_memory (address, nullptr, buffer, size);
   }
 };
 

--- a/projects/rocdbgapi/src/memory.h
+++ b/projects/rocdbgapi/src/memory.h
@@ -582,24 +582,15 @@ public:
                  void *value) const;
 };
 
+/* A memory cache.  Writes to cached lines are write-back: data is
+   immediately updated in the cache, and later updated in memory when
+   the cache is flushed.  Accesses to uncached lines are forwarded
+   directly to memory.  */
+
 template <typename AddressType> class memory_cache_t
 {
 public:
-  enum class policy_t
-  {
-    /* If uncached is used, data is immediately written to global memory, and
-       is not written to the cache.  */
-    uncached = 0,
-    /* If write-through is used, data is written both to global memory and to
-       the cache.  */
-    write_through,
-    /* If write-back is used, data is immediately updated in the cache, and
-       later updated in memory when the cache is flushed.  */
-    write_back
-  };
-
   static constexpr size_t cache_line_size = 64;
-  static constexpr policy_t policy = policy_t::write_back;
 
 private:
   using delegate_fn_type

--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -291,9 +291,8 @@ void
 process_t::read_string (host_address_t address, std::string *string,
                         size_t size) const
 {
-  constexpr size_t cache_line_size
-    = memory_cache_t<host_address_t>::cache_line_size;
-  constexpr size_t chunk_size = 4 * cache_line_size;
+  constexpr size_t host_cache_line_size = 64;
+  constexpr size_t chunk_size = 4 * host_cache_line_size;
 
   dbgapi_assert (string && "invalid argument");
 
@@ -306,8 +305,9 @@ process_t::read_string (host_address_t address, std::string *string,
          which could read less than a chunk if the start address is not
          cache line aligned.  */
 
-      static_assert (utils::is_power_of_two (cache_line_size));
-      size_t request_size = chunk_size - (address & (cache_line_size - 1));
+      static_assert (utils::is_power_of_two (host_cache_line_size));
+      size_t request_size
+        = chunk_size - (address & (host_cache_line_size - 1));
 
       size_t xfer_size
         = read_host_memory_partial (address, staging_buffer, request_size);


### PR DESCRIPTION
## Motivation

Memcache cleanups, developed while working on the memory cache performance improvement patches.  These patches stand on their own.  They end up fixing a FIXME, and a GCC compilation problem, too.

## Technical Details

See individual commit logs.

## Test Plan

Run ROCgdb gdb.rocm/ tests.

## Test Result

Test results good.
