### PR TITLE
[rocprofiler-compute] remove pct_of_peak from roofline yaml gfx11

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx115x/0400_roofline.yaml
+++ b/projects/rocprofiler-compute/src/rocprof_compute_soc/analysis_configs/gfx115x/0400_roofline.yaml
@@ -34,22 +34,18 @@ Panel Config:
           value: SUM(GL1C_GL2_REQ_READ_32B_sum*32 + GL1C_GL2_REQ_READ_64B_sum*64 + GL1C_GL2_REQ_READ_128B_sum*128 + GL1C_GL2_REQ_WRITE_32B_sum*32 + GL1C_GL2_REQ_WRITE_64B_sum*64) / (SUM(End_Timestamp - Start_Timestamp) / 1e9)
           unit: Bytes/s
           peak: $L2Bw_empirical_peak * 1e9
-          pct_of_peak: true
         GL1 Cache BW:
           value: 64 * SUM(TCP_GL1_REQ_READ_sum + TCP_GL1_REQ_WRITE_sum) / (SUM(End_Timestamp - Start_Timestamp) / 1e9)
           unit: Bytes/s
           peak: $L1Bw_empirical_peak * 1e9
-          pct_of_peak: true
         GL0 Cache BW (TCP Cache):
           value: 64 * SUM(TCP_REQ_sum) / (SUM(End_Timestamp - Start_Timestamp) / 1e9)
           unit: Bytes/s
           peak: $L0Bw_empirical_peak * 1e9
-          pct_of_peak: true
         LDS BW:
           value: SUM((SQC_LDS_IDX_ACTIVE_sum - SQC_LDS_BANK_CONFLICT_sum) * 4 * $lds_banks_per_cu) / (SUM(End_Timestamp - Start_Timestamp) / 1e9)
           unit: Bytes/s
           peak: $LDSBw_empirical_peak * 1e9
-          pct_of_peak: true
 
   - metric_table:
       id: 402

--- a/projects/rocprofiler-compute/src/utils/.config_hashes.json
+++ b/projects/rocprofiler-compute/src/utils/.config_hashes.json
@@ -1,12 +1,12 @@
 {
-"archs": {
+  "archs": {
     "gfx115x": {
       "files": {
         "0000_top_stats.yaml": "9d2d844dd3e3cbd6743c5a7f4ada6dcc",
         "0100_system_info.yaml": "09a09ab73c94db93d40eba5068ae06ca",
         "0200_system_speed_of_light.yaml": "9bc05bd5b55e530de462265617e0597d",
         "0300_memory_chart.yaml": "794a2d37f49e6927aa3b7616cd969c9c",
-        "0400_roofline.yaml": "c3d8d967f3f6a5749f4cfb02b3a34e2a",
+        "0400_roofline.yaml": "21ea161971a0c87bbfa5add6999ccff6",
         "0500_command_processor_cpc.yaml": "2b853d2df2c9c7afe11f41bf92ab1b5b",
         "0600_workgroup_manager_spi.yaml": "cee979ca8ead219d99a08b1c512d8c3d",
         "0700_workgroup_processor.yaml": "984b23d6c4db0936de5d144262ae9636",


### PR DESCRIPTION
## Motivation

Correction of error in #7048 
#6941 removed the `pct_of_peak` field from the roofline yamls, #7048 incorrectly added the field back in gfx115x.

## Technical Details

remove `pct_of_peak` field in roofline as this field is not used.

## JIRA ID

N/A

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
