### PR TITLE
[rocprofiler-systems] Increase roctx-runtime-instrument timeout to 180 seconds

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/test_roctx.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_roctx.py
@@ -109,9 +109,12 @@ class TestROCTx(RocprofsysTest):
             "sys_run",
             pytest.param(
                 "runtime_instrument",
-                marks=pytest.mark.ci_disable(
-                    "all"
-                ),  # TODO: Remove once TheRock switches to CTest
+                marks=[
+                    pytest.mark.ci_disable(
+                        "all"
+                    ),  # TODO: Remove once TheRock switches to CTest
+                    pytest.mark.timeout(180),
+                ],
             ),
         ],
     )

--- a/projects/rocprofiler-systems/tests/pytest/test_roctx.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_roctx.py
@@ -110,9 +110,6 @@ class TestROCTx(RocprofsysTest):
             pytest.param(
                 "runtime_instrument",
                 marks=[
-                    pytest.mark.ci_disable(
-                        "all"
-                    ),  # TODO: Remove once TheRock switches to CTest
                     pytest.mark.timeout(180),
                 ],
             ),


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

On TheRock, `roctx-runtime-instrument` takes around `120` seconds to pass, which is equal to the set timeout for the test.
This translates to this test occasionally failing on TheRock, hence it had to be disabled:
```
    Start 296: roctx-runtime-instrument
2/3 Test #296: roctx-runtime-instrument ............   Passed  118.74 sec
```

The fix is to increase it to 180 seconds.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Increase `roctx-runtime-instrument` test timeout to 180 seconds.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

AIPROFSYST-522

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

Untested, needs to be promoted to TheRock as it is specific to TheRock CI runners (the regex that blocks this test from running needs to be removed).

## Test Result

<!-- Briefly summarize test outcomes. -->

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
