### PR TITLE
docs(hipfile): standardize Sphinx/Doxygen config and fix API reference rendering

### DIFF
--- a/projects/hipfile/.readthedocs.yaml
+++ b/projects/hipfile/.readthedocs.yaml
@@ -10,9 +10,14 @@ formats: []
 
 python:
   install:
-    - requirements: projects/hipfile/docs/sphinx/requirements.in
+    - requirements: projects/hipfile/docs/sphinx/requirements.txt
 
 build:
   os: ubuntu-24.04
   tools:
     python: "3.12"
+  apt_packages:
+    - doxygen
+  jobs:
+    pre_build:
+      - cd projects/hipfile/docs/doxygen && doxygen Doxyfile

--- a/projects/hipfile/docs/conf.py
+++ b/projects/hipfile/docs/conf.py
@@ -1,104 +1,52 @@
 # Configuration file for the Sphinx documentation builder.
 #
-# For a full list of Sphinx configuration options, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-
-# Pylint is NOT happy with the naming scheme ROCm chose in ROCmDocs
-# pylint: disable=invalid-name
-
-"""This file is for configuring hipFile documentation"""
 
 import re
 
-from pathlib import Path
-from sphinx.errors import ConfigError
-
-# -- Version information -----------------------------------------------------
-
-
-def get_version_info(filepath):
-    """Get the version from the header"""
-
-    with open(filepath, "r", encoding="utf-8") as f:
-        content = f.read()
-
-    version_pattern = (
-        r"^#define\s+HIPFILE_VERSION_MAJOR\s+(\d+)\s*$|"
-        r"^#define\s+HIPFILE_VERSION_MINOR\s+(\d+)\s*$|"
-        r"^#define\s+HIPFILE_VERSION_PATCH\s+(\d+)\s*$"
-    )
-
-    matches = re.findall(version_pattern, content, re.MULTILINE)
-
-    if len(matches) != 3:
-        raise ValueError("Couldn't find all VERSION numbers in " + filepath)
-
-    major, minor, patch = [match for match in matches if any(match)]
-
-    return major[0], minor[1], patch[2]
+# Single source of truth for the version is the library's CMakeLists.txt.
+with open("../CMakeLists.txt", encoding="utf-8") as f:
+    _cmake = f.read()
 
 
-version_major, version_minor, version_patch = get_version_info("../include/hipfile.h")
-version_number = f"{version_major}.{version_minor}.{version_patch}"
-left_nav_title = f"hipFile {version_number} documentation"
+def _cmake_version_part(part):
+    match = re.search(rf"set\(AIS_LIBRARY_{part}\s+(\d+)\)", _cmake)
+    if not match:
+        raise ValueError(f"AIS_LIBRARY_{part} not found in CMakeLists.txt")
+    return match.group(1)
 
-# -- Project information -----------------------------------------------------
+
+version_number = (
+    f"{_cmake_version_part('MAJOR')}."
+    f"{_cmake_version_part('MINOR')}."
+    f"{_cmake_version_part('PATCH')}"
+)
 
 project = "hipFile"
 author = "Advanced Micro Devices, Inc."
-# pylint: disable=redefined-builtin
-copyright = "Copyright (c) Advanced Micro Devices, Inc. All rights reserved."
-# pylint: enable=redefined-builtin
+copyright = "2024-2026, Advanced Micro Devices, Inc."
 version = version_number
 release = version_number
+html_title = f"hipFile {version_number} documentation"
 
-# -- General configuration ---------------------------------------------------
+extensions = [
+    "rocm_docs",
+    "sphinxcontrib.mermaid",
+    "breathe",
+]
+
+# breathe renders the doxygen XML referenced by the reference/api-*.rst pages
+breathe_projects = {"hipfile": "doxygen/xml"}
+breathe_default_project = "hipfile"
+
+# let the C/C++ domain ignore the export macro so `HIPFILE_API int foo(void)` parses cleanly
+c_id_attributes = ["HIPFILE_API"]
+cpp_id_attributes = ["HIPFILE_API"]
+
+exclude_patterns = ["_build", "_diffs", "Thumbs.db", ".DS_Store"]
 
 html_theme = "rocm_docs_theme"
 html_theme_options = {"flavor": "rocm"}
-html_title = f"hipFile {version_number} documentation"
-suppress_warnings = ["etoc.toctree"]
-external_toc_path = "./sphinx/_toc.yml"
+
+external_toc_path = "sphinx/_toc.yml"
 external_projects_current_project = "hipfile"
-extensions = ["rocm_docs", "rocm_docs.doxygen", "sphinx_design"]
-exclude_patterns = ["README.md"]
-
-# -- Doxygen configuration ---------------------------------------------------
-
-doxygen_root = "doxygen"
-doxysphinx_enabled = True
-doxygen_project = {
-    "name": "hipFile C API reference",
-    "path": "doxygen/xml",
-}
-
-
-def generate_doxyfile(app, _):
-    """Process Doxyfile (normally done with CMake)"""
-
-    doxyfile_in = Path(app.confdir) / doxygen_root / "Doxyfile.in"
-    doxyfile_out = Path(app.confdir) / doxygen_root / "Doxyfile"
-
-    if not doxyfile_in.exists():
-        raise ConfigError(f"Missing Doxyfile.in at {doxyfile_in}")
-
-    with open(doxyfile_in, encoding="utf-8") as f:
-        content = f.read()
-
-    # Fix up version
-    content = content.replace("@AIS_LIBRARY_VERSION@", version_number)
-
-    # Fix up Doxygen markup location
-    content = content.replace("@AIS_DOXYFILE_INPUT@", "../../include/hipfile.h")
-
-    with open(doxyfile_out, "w", encoding="utf-8") as f:
-        f.write(content)
-
-
-# -- Sphinx Setup ------------------------------------------------------------
-
-
-def setup(app):
-    """Sphinx setup"""
-    app.connect("config-inited", generate_doxyfile, priority=100)
-    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/projects/hipfile/docs/doxygen/Doxyfile
+++ b/projects/hipfile/docs/doxygen/Doxyfile
@@ -1,0 +1,32 @@
+# Doxyfile 1.9.8
+
+DOXYFILE_ENCODING      = UTF-8
+
+PROJECT_NAME           = "hipFile"
+PROJECT_BRIEF          = "hipFile API documentation"
+OUTPUT_DIRECTORY       = "."
+
+OPTIMIZE_OUTPUT_FOR_C  = YES
+EXTRACT_ALL            = NO
+EXTRACT_STATIC         = YES
+TYPEDEF_HIDES_STRUCT   = YES
+
+ALIASES  = hipfile_error_return="A hipFileError_t struct that holds both hipFile and HIP error values"
+ALIASES += hipfile_handle_param="Opaque file handle for GPU IO operations"
+ALIASES += buffer_base_param="Base address of the GPU buffer"
+ALIASES += batch_handle_param="Opaque handle for batch operations"
+ALIASES += hipstream_param="The stream used for async IO requests"
+ALIASES += hipstream_if_null="If NULL, this request will be synchronous"
+ALIASES += max_io_size_note="@note The maximum IO size is determined by the Linux kernel and is currently 2^31 - the system page size"
+ALIASES += warn_not_implemented="@warning This function is only a stub on AMD and will always return an error (typically `hipFileInternalError` with `hip_drv_err` set to `hipSuccess`)"
+ALIASES += warn_not_implemented_void="@warning This function is only a stub on AMD and has no effect"
+
+INPUT                  = ../../include/hipfile.h
+INPUT_ENCODING         = UTF-8
+RECURSIVE              = NO
+
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+GENERATE_XML           = YES
+XML_OUTPUT             = xml
+GENERATE_LATEX         = NO

--- a/projects/hipfile/docs/reference/api-async.rst
+++ b/projects/hipfile/docs/reference/api-async.rst
@@ -23,14 +23,11 @@ transfer parameters are known at registration time.
 .. doxygengroup:: stream_flags
    :content-only:
 
-Asynchronous read and write
-***************************
+Asynchronous I/O and stream registration functions
+*************************************************
 
-.. doxygenfunction:: hipFileReadAsync
-.. doxygenfunction:: hipFileWriteAsync
+Functions to enqueue non-blocking reads and writes on HIP streams and to
+register and deregister streams with the hipFile driver.
 
-Stream registration
-*******************
-
-.. doxygenfunction:: hipFileStreamRegister
-.. doxygenfunction:: hipFileStreamDeregister
+.. doxygengroup:: async
+   :content-only:

--- a/projects/hipfile/docs/reference/api-batch.rst
+++ b/projects/hipfile/docs/reference/api-batch.rst
@@ -21,27 +21,12 @@ tear down batch handles. All batch types and functions belong to the
 For related API surfaces, see :doc:`/reference/api-synchronous-io`,
 :doc:`/reference/api-async`, and :doc:`/reference/api-errors`.
 
-Data types
-**********
+Batch I/O types and functions
+*****************************
 
-Enumerations, structures, and handles used by batch I/O operations.
+Enumerations, structures, and handles used by batch I/O operations, together
+with the functions to create, submit, poll, cancel, and destroy batch I/O
+contexts.
 
-.. doxygenenum:: hipFileOpcode_t
-.. doxygenenum:: hipFileStatus_t
-.. doxygenenum:: hipFileBatchMode_t
-.. doxygenstruct:: hipFileIOParams_t
-   :members:
-.. doxygenstruct:: hipFileIOEvents_t
-   :members:
-.. doxygentypedef:: hipFileBatchHandle_t
-
-Batch lifecycle functions
-*************************
-
-Create, submit, poll, cancel, and destroy batch I/O contexts.
-
-.. doxygenfunction:: hipFileBatchIOSetUp
-.. doxygenfunction:: hipFileBatchIOSubmit
-.. doxygenfunction:: hipFileBatchIOGetStatus
-.. doxygenfunction:: hipFileBatchIOCancel
-.. doxygenfunction:: hipFileBatchIODestroy
+.. doxygengroup:: batch
+   :content-only:

--- a/projects/hipfile/docs/reference/api-driver.rst
+++ b/projects/hipfile/docs/reference/api-driver.rst
@@ -10,69 +10,22 @@ Functions and types for initializing and shutting down the GPU IO driver, queryi
 
 For a walkthrough of performing I/O after the driver is open, see :doc:`/tutorials/copy-a-file`.
 
-Version macros
-**************
+Driver lifecycle and properties
+*****************************
 
-.. doxygendefine:: HIPFILE_VERSION_MAJOR
-.. doxygendefine:: HIPFILE_VERSION_MINOR
-.. doxygendefine:: HIPFILE_VERSION_PATCH
+Driver property and flag types and the functions to open and close the GPU IO
+driver, query the library reference count, and query or modify driver
+properties. See the Doxygen descriptions for current implementation status.
 
-Data types
-**********
+.. doxygengroup:: driver
+   :content-only:
 
-Driver property and flag types used by the lifecycle and configuration functions.
-
-.. doxygenstruct:: hipFileDriverProps_t
-   :members:
-
-.. doxygenenum:: hipFileDriverStatusFlags_t
-.. doxygenenum:: hipFileDriverControlFlags_t
-.. doxygenenum:: hipFileFeatureFlags_t
-
-Configuration parameter enumerations
-************************************
-
-Selectors passed to the parameter getter and setter functions.
-
-.. doxygenenum:: hipFileSizeTConfigParameter_t
-.. doxygenenum:: hipFileBoolConfigParameter_t
-.. doxygenenum:: hipFileStringConfigParameter_t
-
-Driver lifecycle
-****************
-
-Open and close the GPU IO driver and query the reference count.
-
-.. doxygenfunction:: hipFileDriverOpen
-.. doxygenfunction:: hipFileDriverClose
-.. doxygenfunction:: hipFileUseCount
-
-Driver properties
-*****************
-
-Query and modify driver properties. See the Doxygen descriptions for current implementation status.
-
-.. doxygenfunction:: hipFileDriverGetProperties
-.. doxygenfunction:: hipFileDriverSetPollMode
-.. doxygenfunction:: hipFileDriverSetMaxDirectIOSize
-.. doxygenfunction:: hipFileDriverSetMaxCacheSize
-.. doxygenfunction:: hipFileDriverSetMaxPinnedMemSize
-
-Version query
-*************
-
-.. doxygenfunction:: hipFileGetVersion
-
-Configuration parameter getters
+Core versioning and configuration
 *******************************
 
-.. doxygenfunction:: hipFileGetParameterSizeT
-.. doxygenfunction:: hipFileGetParameterBool
-.. doxygenfunction:: hipFileGetParameterString
+Version macros, the offset type, configuration parameter selectors, and the
+functions to query the library version and read or write configuration
+parameters.
 
-Configuration parameter setters
-*******************************
-
-.. doxygenfunction:: hipFileSetParameterSizeT
-.. doxygenfunction:: hipFileSetParameterBool
-.. doxygenfunction:: hipFileSetParameterString
+.. doxygengroup:: core
+   :content-only:

--- a/projects/hipfile/docs/reference/api-file-and-buffer.rst
+++ b/projects/hipfile/docs/reference/api-file-and-buffer.rst
@@ -6,36 +6,16 @@
 File handle, buffer, and RDMA API reference
 *******************************************
 
-This page documents the hipFile functions and types for registering and deregistering file handles and GPU memory buffers with the hipFile driver. 
+This page documents the hipFile functions and types for registering and deregistering file handles and GPU memory buffers with the hipFile driver.
 
 For a walkthrough of synchronous reads and writes using registered handles and buffers, see :doc:`/tutorials/copy-a-file`. For the synchronous read and write function signatures, see :doc:`/reference/api-synchronous-io`.
 
+File handle and buffer types and functions
+*****************************************
 
-File handle types
-*****************
+File handle types, the filesystem operations structure, and the functions for
+registering and deregistering file handles and GPU memory buffers with the
+hipFile driver.
 
-.. doxygenenum:: hipFileFileHandleType_t
-
-.. doxygenstruct:: hipFileDescr_t
-   :members:
-
-.. doxygentypedef:: hipFileHandle_t
-
-
-Filesystem operations
-*********************
-
-.. doxygenstruct:: hipFileFSOps_t
-   :members:
-
-File handle registration
-************************
-
-.. doxygenfunction:: hipFileHandleRegister
-.. doxygenfunction:: hipFileHandleDeregister
-
-Buffer registration
-*******************
-
-.. doxygenfunction:: hipFileBufRegister
-.. doxygenfunction:: hipFileBufDeregister
+.. doxygengroup:: file
+   :content-only:

--- a/projects/hipfile/docs/reference/api-synchronous-io.rst
+++ b/projects/hipfile/docs/reference/api-synchronous-io.rst
@@ -10,14 +10,11 @@ Synchronous read and write API reference
 
 Before calling these functions, register the file handle with ``hipFileHandleRegister`` and the GPU buffer with ``hipFileBufRegister``. See :doc:`/reference/api-file-and-buffer` for registration details and :doc:`/tutorials/copy-a-file` for a usage walkthrough.
 
-Offset type
-***********
+Offset type and functions
+************************
 
-.. doxygentypedef:: hoff_t
+The offset type used by the synchronous read and write functions, and the
+functions themselves.
 
-Functions
-*********
-
-.. doxygenfunction:: hipFileRead
-
-.. doxygenfunction:: hipFileWrite
+.. doxygengroup:: sync
+   :content-only:

--- a/projects/hipfile/include/hipfile.h
+++ b/projects/hipfile/include/hipfile.h
@@ -67,6 +67,8 @@ extern "C" {
  * @defgroup batch Batch API
  *
  * @defgroup async Async API
+ *
+ * @defgroup sync Synchronous I/O API
  */
 
 // ***********************************************************************
@@ -95,7 +97,7 @@ extern "C" {
 
 /*!
  * @brief Platform-independent offset type
- * @ingroup core
+ * @ingroup sync
  */
 #ifdef _WIN32
 typedef __int64 hoff_t;
@@ -503,7 +505,7 @@ hipFileError_t hipFileBufDeregister(const void *buffer_base);
 
 /*!
  * @brief Synchronously read data from a file into a GPU buffer
- * @ingroup file
+ * @ingroup sync
  *
  * @param [in] fh            \hipfile_handle_param
  * @param [in] buffer_base   \buffer_base_param
@@ -523,7 +525,7 @@ ssize_t hipFileRead(hipFileHandle_t fh, void *buffer_base, size_t size, hoff_t f
 
 /*!
  * @brief Synchronously write data from a GPU buffer to a file
- * @ingroup file
+ * @ingroup sync
  *
  * @param [in] fh            \hipfile_handle_param
  * @param [in] buffer_base   \buffer_base_param


### PR DESCRIPTION
Standardizes the hipFile Sphinx and Doxygen configuration to match other components, and fixes API reference rendering failures caused by the `HIPFILE_API` visibility macro blocking name-based Doxygen XML lookup.

AIHIPFILE-41

## Changes

- Replace custom `Doxyfile.in` + Sphinx hook pattern with a static `Doxyfile` and simplified `conf.py`; version sourced from `CMakeLists.txt`
- Switch all API reference pages from `doxygenfunction` directives to `doxygengroup` directives — group-based lookup is unaffected by the `HIPFILE_API` macro
- Add `@defgroup sync` to `hipfile.h`; retag `hoff_t`, `hipFileRead`, and `hipFileWrite` to `@ingroup sync`