### PR TITLE
hotswap: make libhsa-hotswap.so the sole HSA_TOOLS_LIB tool

### DIFF
--- a/projects/clr/rocclr/device/hotswap.hpp
+++ b/projects/clr/rocclr/device/hotswap.hpp
@@ -27,7 +27,8 @@ namespace amd {
 namespace hotswap {
 
 // On when this tool is loaded via HSA_TOOLS_LIB (name must match ROCR LoadTools).
-inline constexpr const char* kHotswapToolLib = "libamd_comgr_hotswap_tool.so";
+// The tool ships from rocm-systems as libhsa-hotswap.so (moved out of comgr).
+inline constexpr const char* kHotswapToolLib = "libhsa-hotswap.so";
 
 inline bool Enabled() {
   const char* tools_lib = std::getenv("HSA_TOOLS_LIB");

--- a/projects/hotswap/CMakeLists.txt
+++ b/projects/hotswap/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
 project(hotswap LANGUAGES CXX)
 
+include(GNUInstallDirs)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -10,6 +12,8 @@ set(HSA_RUNTIME_INC "${CMAKE_CURRENT_SOURCE_DIR}/../rocr-runtime/runtime/hsa-run
 
 # COMGR is required — provides amd_comgr_hotswap_rewrite.
 find_package(amd_comgr CONFIG REQUIRED)
+# HSA runtime is required — the tool calls hsa_agent_get_info / hsa_isa_* etc.
+find_package(hsa-runtime64 CONFIG REQUIRED)
 
 find_path(HSA_INCLUDE_DIR hsa.h PATHS ${HSA_RUNTIME_INC} NO_DEFAULT_PATH REQUIRED)
 
@@ -36,9 +40,18 @@ target_include_directories(hsa-hotswap PRIVATE
   ${HSA_RUNTIME_INC}/..
 )
 
-target_link_libraries(hsa-hotswap PRIVATE amd_comgr)
+target_link_libraries(hsa-hotswap PRIVATE
+  amd_comgr
+  hsa-runtime64::hsa-runtime64
+)
 set_target_properties(hsa-hotswap PROPERTIES
   POSITION_INDEPENDENT_CODE ON)
+
+# Install so TheRock can package libhsa-hotswap.so (the HSA_TOOLS_LIB tool).
+install(TARGETS hsa-hotswap
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # Test executable
 add_executable(hotswap_test tests/hotswap_test.cpp hotswap.cpp)

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -2714,12 +2714,13 @@ void Runtime::LoadTools() {
               getpid(), rocp_reg_status, rocprofiler_register_error_string(rocp_reg_status));
     }
 
-    // rocprofiler-register (v3) provides tracing only; the comgr hotswap tool must
+    // rocprofiler-register (v3) provides tracing only; the hotswap tool must
     // intercept and modify HSA calls (it wraps hsa_code_object_reader_create_from_memory),
     // which requires the v1 HSA_TOOLS_LIB path. Allow v1 registration specifically for
     // that first-party tool so it loads via HSA_TOOLS_LIB alone, without re-enabling v1
-    // for other tools. General v1 behavior is otherwise unchanged.
-    static constexpr const char* kHotswapToolLib = "libamd_comgr_hotswap_tool.so";
+    // for other tools. General v1 behavior is otherwise unchanged. The tool now ships
+    // from rocm-systems as libhsa-hotswap.so (moved out of comgr).
+    static constexpr const char* kHotswapToolLib = "libhsa-hotswap.so";
     bool allow_v1_registration =
         flag().tools_lib_names().find(kHotswapToolLib) != std::string::npos;
     if (os::IsEnvVarSet("HSA_TOOLS_ROCPROFILER_V1_TOOLS")) {


### PR DESCRIPTION
Title: [hotswap] Make libhsa-hotswap.so the sole HSA_TOOLS_LIB hotswap tool

---

## Motivation

Complete the move of the HSA hotswap tool out of COMGR: make rocm-systems'
`projects/hotswap` `libhsa-hotswap.so` the single `HSA_TOOLS_LIB` hotswap tool,
correctly keyed and packaged. Paired with the COMGR-side removal
(ROCm/llvm-project#NNN).

## Technical Details

- Re-key the `HSA_TOOLS_LIB` allowlist / forwarding gate to the moved tool name:
  - `projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp:2722` —
    `kHotswapToolLib` → `"libhsa-hotswap.so"` (was `"libamd_comgr_hotswap_tool.so"`).
  - `projects/clr/rocclr/device/hotswap.hpp:30` — same re-key.
- `projects/hotswap/CMakeLists.txt`:
  - `find_package(hsa-runtime64 CONFIG REQUIRED)` + link `hsa-runtime64::hsa-runtime64`
    (resolves the `hsa_agent_get_info` / `hsa_isa_*` symbols the tool calls).
  - `install(TARGETS hsa-hotswap ...)` so the tool is packaged by downstream
    builds (TheRock).

The tool itself (`hotswap_tool.cpp`, `hotswap_gfx_query.*`, `hotswap.cpp`) already
lives here; this change finalizes it as the sole tool.

## JIRA ID
N/A
<!-- TODO: Resolves SWDEV-xxxxx -->

## Test Plan

Build via TheRock with `THEROCK_ENABLE_HOTSWAP=ON`; confirm `libhsa-hotswap.so`
is packaged in the core-runtime artifact / `rocm_sdk_core` wheel, links
`libamd_comgr.so` + `libhsa-runtime64`, and that ROCr loads it via `HSA_TOOLS_LIB`
alone (v1 allowlist matches the new name).

## Test Result

`libhsa-hotswap.so` builds and stages to `core-runtime/.../lib`; `ldd -r` resolves
the `hsa_*` symbols; the built `libhsa-runtime64.so` contains 1 reference to
`libhsa-hotswap.so` and 0 to the old `libamd_comgr_hotswap_tool.so`.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
