### PR TITLE
[rocjitsu] Pin rocm's pip package

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -88,7 +88,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --pre \
             --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
-            "rocm[devel]"
+            "rocm[devel]==7.14.0a20260619"
 
           ROCM_ROOT="$(rocm-sdk path --root)"
           ROCM_LIB="$(rocm-sdk path --root)"/lib


### PR DESCRIPTION
## Motivation

Pin rocm nightly to 7.14.0a20260619. This is a good known version and we don't want that are not introduced from rocjitsu to introduce failures to CI.

## Technical Details

Pinning a package. I noticed that since version 7.14.0a20260620, the pytest corpus is failing. I'd like to temporarily pin to a known working version while looking into:

* figuring out what was the root cause for these failures
* a good way to automate updating this automatically

I'll update again every Monday manually until we have an automated way of dealing with this.

## JIRA ID

N/A

## Test Plan

CI tests.

## Test Result

CI test pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
