### PR TITLE
hsakmt: Fix shmem leak in reserved_aperture_release

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -708,29 +708,17 @@ static void reserved_aperture_release(manageable_aperture_t *app,
 		/* Reset NUMA policy */
 		mbind(address, MemorySizeInBytes, MPOL_DEFAULT, NULL, 0, 0);
 
+		/* Unmap first to release kernel shmem refcount */
+		munmap(address, MemorySizeInBytes);
+
 		/* Remove any CPU mapping, but keep the address range reserved */
 		mmap_ret = mmap(address, MemorySizeInBytes, PROT_NONE,
 			MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED,
 			-1, 0);
 		if (mmap_ret == MAP_FAILED && errno == ENOMEM) {
-			/* When mmap count reaches max_map_count, any mmap will
-			 * fail. Reduce the count with munmap then map it as
-			 * NORESERVE immediately.
-			 */
-			if (munmap(address, MemorySizeInBytes) == 0) {
-				/* After unmapping, try mmap again and handle failure
-				 * */
-				mmap_ret = mmap(address, MemorySizeInBytes, PROT_NONE,
-						MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED,
-						-1, 0);
-				if (mmap_ret == MAP_FAILED) {
-					/* Handle mmap failure gracefully, log if needed */
-					pr_err("Failed to remap memory after unmap\n");
-				}
-			} else {
-				/* Handle munmap failure if needed */
-				pr_err("Failed to unmap memory\n");
-			}
+			mmap_ret = mmap(address, MemorySizeInBytes, PROT_NONE,
+					MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED,
+					-1, 0);
 		}
 	}
 }


### PR DESCRIPTION
  When releasing CPU-accessible memory allocated with MAP_SHARED,
  reserved_aperture_release() only remapped the region with MAP_FIXED
  but did not call munmap() first. This left the kernel shmem refcount
  unreleased, causing memory to accumulate until OOM.

  Add munmap() before mmap() to properly release the kernel shmem
  reference, matching the pattern used by mmap_aperture_release().

  Fixes: ROCM-23563

  ## Motivation

  Fix OOM kills during KFDMemoryTest.BigSysBufferStressTest on MI210 caused by shmem leak.

  ## Technical Details

  `reserved_aperture_release()` in `projects/rocr-runtime/libhsakmt/src/fmm.c` calls `mmap(..., MAP_FIXED)` to remap freed memory as PROT_NONE. For MAP_SHARED allocations, this doesn't decrement the kernel
  shmem refcount - only `munmap()` does. Added `munmap()` before the `mmap()` call to release the refcount first.

  ## JIRA ID

  Resolves ROCM-23563

  ## Test Plan

  Run `kfdtest --gtest_filter='*BigSysBufferStressTest*'` on MI210 and monitor shmem via `/proc/meminfo`.

  ## Test Result

  - **Before fix:** OOM killed after iteration 1, shmem grew from 43 MiB to 246 GiB
  - **After fix:** All 4 iterations passed (1254s), shmem returned to baseline (~10 MiB)

  ## Submission Checklist

  - [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.