### PR TITLE
Mingsun/backport ipc to 7.2

### DIFF
--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -146,6 +146,8 @@ void Device::AddSafeStream(Stream* event_stream, Stream* wait_stream) {
 
 // ================================================================================================
 void Device::Reset() {
+  // Free any deferred IPC-event signals before tearing the device down.
+  DrainDeferredIpcSignals();
   {
     amd::ScopedLock lock(lock_);
     auto it = mem_pools_.begin();
@@ -294,6 +296,57 @@ void Device::SyncAllStreams(bool cpu_wait, bool wait_blocking_streams_only) {
   }
   // Release freed memory for all memory pools on the device
   ReleaseFreedMemory();
+  // All of this device's work has been waited on, so the deferred IPC signals' barriers are
+  // complete; freeing them here won't block.
+  DrainDeferredIpcSignals();
+}
+
+// ================================================================================================
+void Device::CleanupDeferredIpcSignal(const DeferredIpcSignal& item) {
+  if (item.signal != nullptr) {
+    // Only armed signals (event != null) have an in-flight barrier to wait on; waiting on a
+    // never-recorded signal (still at its initial value) would hang forever.
+    if (item.event != nullptr) {
+      item.signal->Wait(1, amd::device::Signal::Condition::Lt, UINT64_MAX);
+    }
+    delete item.signal;
+  }
+  if (item.event != nullptr) {
+    item.event->release();
+  }
+}
+
+// ================================================================================================
+void Device::EnqueueDeferredIpcSignal(amd::device::Signal* signal, amd::Event* event) {
+  std::vector<DeferredIpcSignal> overflow;
+  {
+    std::scoped_lock lock(deferredIpcLock_);
+    // The queue is bounded by kDeferredIpcDrainThreshold; reserve up front (the buffer is
+    // moved out on each drain/overflow swap, so reserve again whenever it is empty) to avoid
+    // repeated reallocations as events are destroyed between drains.
+    if (deferredIpcSignals_.empty()) {
+      deferredIpcSignals_.reserve(kDeferredIpcDrainThreshold);
+    }
+    deferredIpcSignals_.push_back({signal, event});
+    if (deferredIpcSignals_.size() >= kDeferredIpcDrainThreshold) {
+      overflow.swap(deferredIpcSignals_);  // bounded: drain inline on overflow
+    }
+  }
+  for (const auto& item : overflow) {
+    CleanupDeferredIpcSignal(item);
+  }
+}
+
+// ================================================================================================
+void Device::DrainDeferredIpcSignals() {
+  std::vector<DeferredIpcSignal> pending;
+  {
+    std::scoped_lock lock(deferredIpcLock_);
+    pending.swap(deferredIpcSignals_);
+  }
+  for (const auto& item : pending) {
+    CleanupDeferredIpcSignal(item);
+  }
 }
 
 // ================================================================================================
@@ -321,6 +374,10 @@ bool Device::existsActiveStreamForDevice() {
 
 // ================================================================================================
 Device::~Device() {
+  // Free any IPC signals still queued for deferred cleanup (e.g. events destroyed without a
+  // subsequent device sync) so they don't leak when the device goes away.
+  DrainDeferredIpcSignals();
+
   if ((IS_LINUX || !DEBUG_HIP_MEM_POOL_VMHEAP) && (default_mem_pool_ != nullptr)) {
     default_mem_pool_->release();
   }

--- a/projects/clr/hipamd/src/hip_event.cpp
+++ b/projects/clr/hipamd/src/hip_event.cpp
@@ -289,7 +289,15 @@ hipError_t ihipEventCreateWithFlags(hipEvent_t* event, unsigned flags) {
   if (!illegalFlags) {
     hip::Event* e = nullptr;
     if (flags & hipEventInterprocess) {
-      e = new hip::IPCEvent();
+      auto* dev = g_devices[hip::getCurrentDevice()->deviceId()]->devices()[0];
+      // Probe whether the device supports IPC signals
+      auto* probe = dev->createIpcSignal();
+      if (probe != nullptr) {
+        delete probe;
+        e = new hip::IPCEvent(flags);
+      } else {
+        e = new hip::IPCEventEmulated(flags);
+      }
     } else {
       if (AMD_DIRECT_DISPATCH) {
         e = new hip::EventDD(flags);
@@ -312,6 +320,44 @@ hipError_t ihipEventCreateWithFlags(hipEvent_t* event, unsigned flags) {
     return hipErrorInvalidValue;
   }
   return hipSuccess;
+}
+
+// ================================================================================================
+// Create an IPC event of a specific implementation type (ROCr or Emulated).
+// Used by hipIpcOpenEventHandle to match the opener to the exporter's type.
+hipError_t ihipCreateIpcEventByType(hipEvent_t* event, ihipIpcEventHandleType type) {
+  constexpr uint32_t kIpcEventFlags = hipEventDisableTiming | hipEventInterprocess;
+
+  hip::Event* e = nullptr;
+  switch (type) {
+    case kIpcEventHandleROCr:
+      e = new hip::IPCEvent(kIpcEventFlags);
+      break;
+    case kIpcEventHandleEmulated:
+      e = new hip::IPCEventEmulated(kIpcEventFlags);
+      break;
+    default:
+      return hipErrorInvalidValue;
+  }
+
+  if (e == nullptr) {
+    return hipErrorOutOfMemory;
+  }
+
+  *event = reinterpret_cast<hipEvent_t>(e);
+  std::unique_lock lock(hip::eventSetLock);
+  hip::eventSet.insert(*event);
+  return hipSuccess;
+}
+
+// ================================================================================================
+// Destroy an event created by ihipCreateIpcEventByType (removes from eventSet + deletes).
+void ihipDestroyIpcEvent(hipEvent_t event) {
+  if (event == nullptr) return;
+  std::unique_lock lock(hip::eventSetLock);
+  hip::eventSet.erase(event);
+  lock.unlock();
+  delete reinterpret_cast<hip::Event*>(event);
 }
 
 // ================================================================================================

--- a/projects/clr/hipamd/src/hip_event.cpp
+++ b/projects/clr/hipamd/src/hip_event.cpp
@@ -172,6 +172,9 @@ int64_t EventDD::time(bool getStartTs) const {
 }
 // ================================================================================================
 hipError_t Event::streamWaitCommand(amd::Command*& command, hip::Stream* stream) {
+  // Guard event_ against concurrent record/sync. Graph stream-wait nodes call
+  // this directly (not via the locked streamWait path); lock_ is recursive.
+  amd::ScopedLock lock(lock_);
   amd::Command::EventWaitList eventWaitList;
   if (event_ != nullptr) {
     eventWaitList.push_back(event_);
@@ -209,6 +212,9 @@ hipError_t Event::streamWait(hip::Stream* stream, uint flags) {
 // ================================================================================================
 hipError_t Event::recordCommand(amd::Command*& command, amd::HostQueue* stream, uint32_t ext_flags,
                                 bool batch_flush) {
+  // Guard event state against concurrent access. Graph event-record nodes call
+  // this directly (not via the locked addMarker path); lock_ is recursive.
+  amd::ScopedLock lock(lock_);
   if (command == nullptr) {
     int32_t releaseFlags =
         ((ext_flags == 0) ? flags_ : ext_flags) &
@@ -228,6 +234,9 @@ hipError_t Event::recordCommand(amd::Command*& command, amd::HostQueue* stream, 
 
 // ================================================================================================
 hipError_t Event::enqueueRecordCommand(hip::Stream* stream, amd::Command* command) {
+  // Guard event_ release/replace against concurrent access. Graph event-record
+  // nodes call this directly (not via locked addMarker); lock_ is recursive.
+  amd::ScopedLock lock(lock_);
   command->enqueue();
   if (event_ == &command->event()) {
     return hipSuccess;

--- a/projects/clr/hipamd/src/hip_event.hpp
+++ b/projects/clr/hipamd/src/hip_event.hpp
@@ -186,19 +186,23 @@ class EventDD : public Event {
   virtual int64_t time(bool getStartTs) const;
 };
 
-class IPCEvent : public Event {
-  // IPC Events
+/// Emulated IPC event using POSIX shared memory + stream write/wait value.
+/// Used on PAL/Windows path where ROCr IPC signals are unavailable.
+class IPCEventEmulated : public Event {
+  /// IPC event metadata structure
   struct ihipIpcEvent_t {
-    std::string ipc_name_;
-    int ipc_fd_;
-    ihipIpcEventShmem_t* ipc_shmem_;
-    ihipIpcEvent_t() : ipc_name_("dummy"), ipc_fd_(0), ipc_shmem_(nullptr) {}
-    void setipcname(const char* name) { ipc_name_ = std::string(name); }
+    std::string ipc_name_;                //!< Name of the shared memory object for IPC
+    ihipIpcEventShmem_t* ipc_shmem_;      //!< Pointer to mapped IPC shared memory structure
+
+    ihipIpcEvent_t() : ipc_shmem_(nullptr) {
+      ipc_name_.reserve(32);  // Reserve space for typical IPC name "/hip_<pid>_<counter>"
+    }
   };
   ihipIpcEvent_t ipc_evt_;
 
  public:
-  ~IPCEvent() {
+  explicit IPCEventEmulated(uint32_t flags = hipEventInterprocess) : Event(flags) {}
+  ~IPCEventEmulated() override {
     if (ipc_evt_.ipc_shmem_) {
       int owners = --ipc_evt_.ipc_shmem_->owners;
       // Make sure event is synchronized
@@ -213,29 +217,55 @@ class IPCEvent : public Event {
     }
 #if !defined(_MSC_VER)
     // Clean up the POSIX shared memory object
-    if (!ipc_evt_.ipc_name_.empty() && ipc_evt_.ipc_name_ != "dummy") {
+    if (!ipc_evt_.ipc_name_.empty()) {
       shm_unlink(ipc_evt_.ipc_name_.c_str());
     }
 #endif
   }
-  IPCEvent() : Event(hipEventInterprocess) {}
   bool createIpcEventShmemIfNeeded();
-  hipError_t GetHandle(ihipIpcEventHandle_t* handle);
-  hipError_t OpenHandle(ihipIpcEventHandle_t* handle);
-  hipError_t synchronize();
-  hipError_t query();
+  hipError_t GetHandle(ihipIpcEventHandle_t* handle) override;
+  hipError_t OpenHandle(ihipIpcEventHandle_t* handle) override;
+  hipError_t synchronize() override;
+  hipError_t query() override;
 
-  hipError_t streamWait(hip::Stream* stream, uint flags);
+  hipError_t streamWait(hip::Stream* stream, uint flags) override;
 
   hipError_t recordCommand(amd::Command*& command, amd::HostQueue* queue, uint32_t flags = 0,
                            bool batch_flush = true) override;
-  hipError_t enqueueRecordCommand(hip::Stream* stream, amd::Command* command);
+  hipError_t enqueueRecordCommand(hip::Stream* stream, amd::Command* command) override;
 };
 
 
 struct CallbackData {
   int previous_read_index;
   hip::ihipIpcEventShmem_t* shmem;
+};
+
+/// True IPC event backed by a device::Signal with IPC capability.
+/// On ROCm, this uses ROCr IPC signals
+/// Record dispatches a standard barrier with an internal tracking signal, then
+/// registers an async handler that sets the IPC signal to 0 when work completes.
+/// StreamWait dispatches a barrier with the IPC signal as dep_signal;
+/// the GPU waits until the signal reaches 0 before proceeding.
+class IPCEvent : public Event {
+  amd::device::Signal* ipc_signal_;
+
+ public:
+  explicit IPCEvent(uint32_t flags = hipEventInterprocess)
+      : Event(flags), ipc_signal_(nullptr) {}
+  ~IPCEvent() override;
+
+  hipError_t GetHandle(ihipIpcEventHandle_t* handle) override;
+  hipError_t OpenHandle(ihipIpcEventHandle_t* handle) override;
+  hipError_t synchronize() override;
+  hipError_t query() override;
+  hipError_t streamWait(hip::Stream* stream, uint flags) override;
+  hipError_t recordCommand(amd::Command*& command, amd::HostQueue* queue, uint32_t flags = 0,
+                           bool batch_flush = true) override;
+  hipError_t enqueueRecordCommand(hip::Stream* stream, amd::Command* command) override;
+
+ private:
+  hipError_t createIpcSignalIfNeeded();
 };
 }  // namespace hip
 

--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -230,15 +230,14 @@ hipError_t IPCEvent::createIpcSignalIfNeeded() {
 
 IPCEvent::~IPCEvent() {
   if (ipc_signal_ != nullptr) {
-    // If the event was recorded (signal armed), wait for any in-flight barrier
-    // to finish before destroying the signal; otherwise the GPU could write to
-    // freed memory.  Skip the wait when the signal was never recorded (still at
-    // its initial value) — waiting would hang forever.
-    if (event_ != nullptr) {
-      ipc_signal_->Wait(1, amd::device::Signal::Condition::Lt, UINT64_MAX);
-    }
-    delete ipc_signal_;
+    // Transfer the signal (and the record marker's event) to the owning device's
+    // deferred-cleanup queue, which waits for the barrier and frees them at the next device
+    // sync/reset (or on overflow).
+    g_devices[deviceId()]->EnqueueDeferredIpcSignal(ipc_signal_, event_);
     ipc_signal_ = nullptr;
+    // Ownership of event_ is transferred to the deferred queue; clear it so the base ~Event()
+    // does not release it (the deferred cleanup will).
+    event_ = nullptr;
   }
 }
 

--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -31,8 +31,10 @@
 namespace hip {
 
 hipError_t ihipEventCreateWithFlags(hipEvent_t* event, unsigned flags);
+hipError_t ihipCreateIpcEventByType(hipEvent_t* event, ihipIpcEventHandleType type);
+void ihipDestroyIpcEvent(hipEvent_t event);
 
-bool IPCEvent::createIpcEventShmemIfNeeded() {
+bool IPCEventEmulated::createIpcEventShmemIfNeeded() {
   if (ipc_evt_.ipc_shmem_) {
     // ipc_shmem_ already created, no need to create it again
     return true;
@@ -72,7 +74,7 @@ bool IPCEvent::createIpcEventShmemIfNeeded() {
 }
 
 // ================================================================================================
-hipError_t IPCEvent::query() {
+hipError_t IPCEventEmulated::query() {
   if (ipc_evt_.ipc_shmem_) {
     int prev_read_idx = ipc_evt_.ipc_shmem_->read_index;
     int offset = (prev_read_idx % IPC_SIGNALS_PER_EVENT);
@@ -85,7 +87,7 @@ hipError_t IPCEvent::query() {
 }
 
 // ================================================================================================
-hipError_t IPCEvent::synchronize() {
+hipError_t IPCEventEmulated::synchronize() {
   if (ipc_evt_.ipc_shmem_) {
     int prev_read_idx = ipc_evt_.ipc_shmem_->read_index;
     if (prev_read_idx >= 0) {
@@ -100,24 +102,24 @@ hipError_t IPCEvent::synchronize() {
 }
 
 // ================================================================================================
-hipError_t IPCEvent::streamWait(hip::Stream* stream, uint flags) {
-  int offset = ipc_evt_.ipc_shmem_->read_index;
-  hipError_t status =
-      ihipStreamOperation(reinterpret_cast<hipStream_t>(stream), ROCCLR_COMMAND_STREAM_WAIT_VALUE,
-                          &(ipc_evt_.ipc_shmem_->signal[offset]), 0, 1, 1, sizeof(uint32_t));
-  return status;
+hipError_t IPCEventEmulated::streamWait(hip::Stream* stream, uint flags) {
+  const int offset = ipc_evt_.ipc_shmem_->read_index;
+  return ihipStreamOperation(
+      reinterpret_cast<hipStream_t>(stream),
+      ROCCLR_COMMAND_STREAM_WAIT_VALUE,
+      &(ipc_evt_.ipc_shmem_->signal[offset]), 0, 1, 1,
+      sizeof(uint32_t));
 }
 
 // ================================================================================================
-hipError_t IPCEvent::recordCommand(amd::Command*& command, amd::HostQueue* stream, uint32_t flags,
-                                   bool batch_flush) {
+hipError_t IPCEventEmulated::recordCommand(amd::Command*& command, amd::HostQueue* stream,
+                                           uint32_t flags, bool batch_flush) {
   command = new amd::Marker(*stream, kMarkerDisableFlush);
   return hipSuccess;
 }
 
 // ================================================================================================
-hipError_t IPCEvent::enqueueRecordCommand(hip::Stream* stream, amd::Command* command) {
-  amd::Event& tEvent = command->event();
+hipError_t IPCEventEmulated::enqueueRecordCommand(hip::Stream* stream, amd::Command* command) {
   createIpcEventShmemIfNeeded();
   int write_index = ipc_evt_.ipc_shmem_->write_index++;
   int offset = write_index % IPC_SIGNALS_PER_EVENT;
@@ -155,19 +157,21 @@ hipError_t IPCEvent::enqueueRecordCommand(hip::Stream* stream, amd::Command* com
 }
 
 // ================================================================================================
-hipError_t IPCEvent::GetHandle(ihipIpcEventHandle_t* handle) {
+hipError_t IPCEventEmulated::GetHandle(ihipIpcEventHandle_t* handle) {
   if (!createIpcEventShmemIfNeeded()) {
     return hipErrorInvalidValue;
   }
   ipc_evt_.ipc_shmem_->owners_device_id = deviceId();
   ipc_evt_.ipc_shmem_->owners_process_id = amd::Os::getProcessId();
-  memset(handle->shmem_name, 0, HIP_IPC_HANDLE_SIZE);
+  handle->type = kIpcEventHandleEmulated;
+  handle->creator_pid = static_cast<int32_t>(amd::Os::getProcessId());
+  memset(handle->shmem_name, 0, IHIP_IPC_EVENT_HANDLE_SIZE);
   ipc_evt_.ipc_name_.copy(handle->shmem_name, std::string::npos);
   return hipSuccess;
 }
 
 // ================================================================================================
-hipError_t IPCEvent::OpenHandle(ihipIpcEventHandle_t* handle) {
+hipError_t IPCEventEmulated::OpenHandle(ihipIpcEventHandle_t* handle) {
   ipc_evt_.ipc_name_ = handle->shmem_name;
   if (!amd::Os::MemoryMapFileTruncated(ipc_evt_.ipc_name_.c_str(),
                                        (const void**)&(ipc_evt_.ipc_shmem_),
@@ -189,6 +193,167 @@ hipError_t IPCEvent::OpenHandle(ihipIpcEventHandle_t* handle) {
 }
 
 // ================================================================================================
+// IPCEvent implementation (true IPC signals for supported backends)
+// Record: standard barrier + async handler sets IPC signal to 0 when GPU work completes
+// StreamWait: barrier packet with IPC signal as dep_signal (GPU waits until signal reaches 0)
+// ================================================================================================
+
+hipError_t IPCEvent::createIpcSignalIfNeeded() {
+  if (ipc_signal_ != nullptr) {
+    return hipSuccess;
+  }
+
+  auto* dev = g_devices[deviceId()]->devices()[0];
+  ipc_signal_ = dev->createIpcSignal();
+  if (ipc_signal_ == nullptr) {
+    return hipErrorInvalidValue;
+  }
+
+  const auto ws = (flags_ & hipEventBlockingSync)
+      ? amd::device::Signal::WaitState::Blocked
+      : amd::device::Signal::WaitState::Active;
+  if (!ipc_signal_->Init(*dev, 1, ws)) {
+    delete ipc_signal_;
+    ipc_signal_ = nullptr;
+    return hipErrorInvalidValue;
+  }
+
+  return hipSuccess;
+}
+
+IPCEvent::~IPCEvent() {
+  if (ipc_signal_ != nullptr) {
+    // If the event was recorded (signal armed), wait for any in-flight barrier
+    // to finish before destroying the signal; otherwise the GPU could write to
+    // freed memory.  Skip the wait when the signal was never recorded (still at
+    // its initial value) — waiting would hang forever.
+    if (event_ != nullptr) {
+      ipc_signal_->Wait(1, amd::device::Signal::Condition::Lt, UINT64_MAX);
+    }
+    delete ipc_signal_;
+    ipc_signal_ = nullptr;
+  }
+}
+
+// ================================================================================================
+hipError_t IPCEvent::GetHandle(ihipIpcEventHandle_t* handle) {
+  auto status = createIpcSignalIfNeeded();
+  if (status != hipSuccess) {
+    return status;
+  }
+
+  handle->type = kIpcEventHandleROCr;
+  handle->creator_pid = static_cast<int32_t>(amd::Os::getProcessId());
+  if (!ipc_signal_->IpcExport(handle->ipc_signal_handle, IHIP_IPC_EVENT_HANDLE_SIZE)) {
+    return hipErrorInvalidValue;
+  }
+
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t IPCEvent::OpenHandle(ihipIpcEventHandle_t* handle) {
+  if (handle->type != kIpcEventHandleROCr) {
+    return hipErrorInvalidValue;
+  }
+
+  if (static_cast<int32_t>(amd::Os::getProcessId()) == handle->creator_pid) {
+    return hipErrorInvalidContext;
+  }
+
+  auto* dev = g_devices[deviceId()]->devices()[0];
+  ipc_signal_ = dev->createIpcSignal();
+  if (ipc_signal_ == nullptr) {
+    return hipErrorInvalidValue;
+  }
+
+  if (!ipc_signal_->IpcImport(handle->ipc_signal_handle, IHIP_IPC_EVENT_HANDLE_SIZE, dev)) {
+    delete ipc_signal_;
+    ipc_signal_ = nullptr;
+    return hipErrorInvalidValue;
+  }
+
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t IPCEvent::recordCommand(amd::Command*& command, amd::HostQueue* stream,
+                                   uint32_t flags, bool batch_flush) {
+  auto status = createIpcSignalIfNeeded();
+  if (status != hipSuccess) {
+    return status;
+  }
+
+  auto* marker = new amd::Marker(*stream, kMarkerDisableFlush);
+  marker->setIpcCompletionSignal(ipc_signal_);
+  command = marker;
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t IPCEvent::enqueueRecordCommand(hip::Stream* stream, amd::Command* command) {
+  // Re-arm the signal; GPU barrier will decrement to 0 when work completes
+  ipc_signal_->Reset(1);
+
+  command->enqueue();
+
+  if (event_ != nullptr) {
+    event_->release();
+  }
+  event_ = &command->event();
+
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t IPCEvent::synchronize() {
+  amd::ScopedLock lock(lock_);
+
+  if (ipc_signal_ == nullptr) {
+    return hipSuccess;
+  }
+
+  ipc_signal_->Wait(1, amd::device::Signal::Condition::Lt, UINT64_MAX);
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t IPCEvent::query() {
+  amd::ScopedLock lock(lock_);
+
+  if (ipc_signal_ == nullptr) {
+    return hipSuccess;
+  }
+
+  if (ipc_signal_->Load() >= 1) {
+    return hipErrorNotReady;
+  }
+  return hipSuccess;
+}
+
+// ================================================================================================
+hipError_t IPCEvent::streamWait(hip::Stream* stream, uint flags) {
+  amd::ScopedLock lock(lock_);
+
+  if (ipc_signal_ == nullptr) {
+    return hipSuccess;
+  }
+
+  if (ipc_signal_->Load() < 1) {
+    return hipSuccess;
+  }
+
+  // Dispatch a barrier that waits on the IPC signal as dep_signal
+  auto* marker = new amd::Marker(*stream, kMarkerDisableFlush);
+  marker->setIpcDepSignal(ipc_signal_);
+  marker->enqueue();
+  return hipSuccess;
+}
+
+// ================================================================================================
+// HIP API functions for IPC events
+// ================================================================================================
+
 hipError_t hipIpcGetEventHandle(hipIpcEventHandle_t* handle, hipEvent_t event) {
   HIP_INIT_API(hipIpcGetEventHandle, handle, event);
 
@@ -207,19 +372,21 @@ hipError_t hipIpcOpenEventHandle(hipEvent_t* event, hipIpcEventHandle_t handle) 
     HIP_RETURN(hipErrorInvalidValue);
   }
 
-  status = ihipEventCreateWithFlags(event, hipEventDisableTiming | hipEventInterprocess);
+  auto* const iHandle = reinterpret_cast<ihipIpcEventHandle_t*>(&handle);
+
+  // Select event implementation based on the handle's type field rather than
+  // a runtime probe — the opener must match the exporter's implementation.
+  status = ihipCreateIpcEventByType(event, iHandle->type);
   if (status != hipSuccess) {
     HIP_RETURN(status);
   }
 
-  hip::Event* e = reinterpret_cast<hip::Event*>(*event);
-  ihipIpcEventHandle_t* iHandle = reinterpret_cast<ihipIpcEventHandle_t*>(&handle);
-
-  status = e->OpenHandle(iHandle);
-  // Free the event in case of failure
-  if (status != hipSuccess) {
-    delete e;
+  auto* const e = reinterpret_cast<hip::Event*>(*event);
+  const auto open_status = e->OpenHandle(iHandle);
+  if (open_status != hipSuccess) {
+    ihipDestroyIpcEvent(*event);
+    *event = nullptr;
   }
-  HIP_RETURN(status);
+  HIP_RETURN(open_status);
 }
 }  // namespace hip

--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -274,7 +274,7 @@ hipError_t IPCEvent::OpenHandle(ihipIpcEventHandle_t* handle) {
     return hipErrorInvalidValue;
   }
 
-  if (!ipc_signal_->IpcImport(handle->ipc_signal_handle, IHIP_IPC_EVENT_HANDLE_SIZE, dev)) {
+  if (!ipc_signal_->IpcImport(handle->ipc_signal_handle, IHIP_IPC_EVENT_HANDLE_SIZE)) {
     delete ipc_signal_;
     ipc_signal_ = nullptr;
     return hipErrorInvalidValue;

--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -75,6 +75,7 @@ bool IPCEventEmulated::createIpcEventShmemIfNeeded() {
 
 // ================================================================================================
 hipError_t IPCEventEmulated::query() {
+  amd::ScopedLock lock(lock_);
   if (ipc_evt_.ipc_shmem_) {
     int prev_read_idx = ipc_evt_.ipc_shmem_->read_index;
     int offset = (prev_read_idx % IPC_SIGNALS_PER_EVENT);
@@ -88,6 +89,7 @@ hipError_t IPCEventEmulated::query() {
 
 // ================================================================================================
 hipError_t IPCEventEmulated::synchronize() {
+  amd::ScopedLock lock(lock_);
   if (ipc_evt_.ipc_shmem_) {
     int prev_read_idx = ipc_evt_.ipc_shmem_->read_index;
     if (prev_read_idx >= 0) {
@@ -103,6 +105,7 @@ hipError_t IPCEventEmulated::synchronize() {
 
 // ================================================================================================
 hipError_t IPCEventEmulated::streamWait(hip::Stream* stream, uint flags) {
+  amd::ScopedLock lock(lock_);
   const int offset = ipc_evt_.ipc_shmem_->read_index;
   return ihipStreamOperation(
       reinterpret_cast<hipStream_t>(stream),
@@ -114,12 +117,14 @@ hipError_t IPCEventEmulated::streamWait(hip::Stream* stream, uint flags) {
 // ================================================================================================
 hipError_t IPCEventEmulated::recordCommand(amd::Command*& command, amd::HostQueue* stream,
                                            uint32_t flags, bool batch_flush) {
+  amd::ScopedLock lock(lock_);
   command = new amd::Marker(*stream, kMarkerDisableFlush);
   return hipSuccess;
 }
 
 // ================================================================================================
 hipError_t IPCEventEmulated::enqueueRecordCommand(hip::Stream* stream, amd::Command* command) {
+  amd::ScopedLock lock(lock_);
   createIpcEventShmemIfNeeded();
   int write_index = ipc_evt_.ipc_shmem_->write_index++;
   int offset = write_index % IPC_SIGNALS_PER_EVENT;
@@ -158,6 +163,7 @@ hipError_t IPCEventEmulated::enqueueRecordCommand(hip::Stream* stream, amd::Comm
 
 // ================================================================================================
 hipError_t IPCEventEmulated::GetHandle(ihipIpcEventHandle_t* handle) {
+  amd::ScopedLock lock(lock_);
   if (!createIpcEventShmemIfNeeded()) {
     return hipErrorInvalidValue;
   }
@@ -172,6 +178,7 @@ hipError_t IPCEventEmulated::GetHandle(ihipIpcEventHandle_t* handle) {
 
 // ================================================================================================
 hipError_t IPCEventEmulated::OpenHandle(ihipIpcEventHandle_t* handle) {
+  amd::ScopedLock lock(lock_);
   ipc_evt_.ipc_name_ = handle->shmem_name;
   if (!amd::Os::MemoryMapFileTruncated(ipc_evt_.ipc_name_.c_str(),
                                        (const void**)&(ipc_evt_.ipc_shmem_),
@@ -279,6 +286,8 @@ hipError_t IPCEvent::OpenHandle(ihipIpcEventHandle_t* handle) {
 // ================================================================================================
 hipError_t IPCEvent::recordCommand(amd::Command*& command, amd::HostQueue* stream,
                                    uint32_t flags, bool batch_flush) {
+  amd::ScopedLock lock(lock_);
+
   auto status = createIpcSignalIfNeeded();
   if (status != hipSuccess) {
     return status;
@@ -292,6 +301,19 @@ hipError_t IPCEvent::recordCommand(amd::Command*& command, amd::HostQueue* strea
 
 // ================================================================================================
 hipError_t IPCEvent::enqueueRecordCommand(hip::Stream* stream, amd::Command* command) {
+  amd::ScopedLock lock(lock_);
+
+  // A single shared IPC signal cannot represent overlapping recordings, and the
+  // consumer is attached to this exact signal (it cannot be rotated). So we must
+  // serialize re-recordings: wait for the previous record's GPU work to drain
+  // before re-arming, otherwise the absolute Reset(1) races with the prior
+  // barrier's pending decrement and a waiter can wake on the wrong recording.
+  // Skip the wait on the first record (signal still at its initial value, never
+  // decremented) — waiting there would hang forever.
+  if (event_ != nullptr) {
+    ipc_signal_->Wait(1, amd::device::Signal::Condition::Lt, UINT64_MAX);
+  }
+
   // Re-arm the signal; GPU barrier will decrement to 0 when work completes
   ipc_signal_->Reset(1);
 

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -90,13 +90,23 @@ struct UserObject;
 class Stream;
 
 #define IHIP_IPC_EVENT_HANDLE_SIZE 32
-#define IHIP_IPC_EVENT_RESERVED_SIZE LP64_SWITCH(28,24)
+
+enum ihipIpcEventHandleType : uint32_t {
+    kIpcEventHandleEmulated = 0,
+    kIpcEventHandleROCr     = 1,
+};
+
 typedef struct ihipIpcEventHandle_st {
-    //hsa_amd_ipc_signal_t ipc_handle;  ///< ipc signal handle on ROCr
-    //char ipc_handle[IHIP_IPC_EVENT_HANDLE_SIZE];
-    //char reserved[IHIP_IPC_EVENT_RESERVED_SIZE];
-    char shmem_name[IHIP_IPC_EVENT_HANDLE_SIZE];
-}ihipIpcEventHandle_t;
+    ihipIpcEventHandleType type;
+    int32_t creator_pid;
+    union {
+        char shmem_name[IHIP_IPC_EVENT_HANDLE_SIZE];
+        char ipc_signal_handle[IHIP_IPC_EVENT_HANDLE_SIZE];
+    };
+} ihipIpcEventHandle_t;
+
+static_assert(sizeof(ihipIpcEventHandle_t) <= sizeof(hipIpcEventHandle_t),
+              "ihipIpcEventHandle_t exceeds hipIpcEventHandle_t storage");
 
 const char* ihipGetErrorName(hipError_t hip_error);
 }

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -48,6 +48,10 @@
 #define KCYN "\x1B[36m"
 #define KWHT "\x1B[37m"
 
+namespace amd::device {
+class Signal;
+}
+
 template <typename T> T ReturnPtrValue(T* ptr) { return (ptr != nullptr) ? *ptr : nullptr; }
 
 namespace hip{
@@ -604,6 +608,16 @@ public:
       isActive_ = true;
     }
 
+    // Destroying a recorded IPC event must wait for the GPU barrier that decrements the
+    // event's IPC signal before the signal can be freed (otherwise the GPU could write to
+    // freed memory).
+
+    /// Transfer an IPC signal (and its record marker's event, may be null) to this device's
+    /// deferred-cleanup queue. Frees inline if the queue grows past its bound.
+    void EnqueueDeferredIpcSignal(amd::device::Signal* signal, amd::Event* event);
+    /// Wait for the pending barriers of all deferred IPC signals on this device and free them.
+    void DrainDeferredIpcSignals();
+
     bool GetActiveStatus() {
       amd::ScopedLock lock(lock_);
       /// Either stream is active or device is active
@@ -678,6 +692,19 @@ public:
       registeredGraphicsResources_.clear();
       mappedGraphicsResources_.clear();
     }
+
+    struct DeferredIpcSignal {
+      amd::device::Signal* signal;  //!< IPC signal to free once its barrier completes
+      amd::Event* event;            //!< record marker's event (non-null => signal was armed)
+    };
+    /// Wait for an armed signal's in-flight barrier, then free the signal and release its event.
+    static void CleanupDeferredIpcSignal(const DeferredIpcSignal& item);
+
+    std::mutex deferredIpcLock_;                        //!< Guards deferredIpcSignals_
+    std::vector<DeferredIpcSignal> deferredIpcSignals_; //!< Signals awaiting deferred cleanup
+    /// Drain inline once the queue reaches this many entries, bounding memory if an app
+    /// destroys many IPC events without an intervening device sync.
+    static constexpr size_t kDeferredIpcDrainThreshold = 256;
   };
 
   /// Thread Local Storage Variables Aggregator Class

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -1084,6 +1084,23 @@ bool Device::IpcAttach(const char* handle, size_t mem_size, size_t mem_offset, u
   if (mem_obj_exist == nullptr) {
     // Add the original mem_ptr to the MemObjMap with newly created amd_mem_obj
     amd::MemObjMap::AddMemObj(amd_mem_obj->getSvmPtr(), amd_mem_obj);
+  } else if (mem_obj_exist->ipcShared()) {
+    // Stale IPC import at the same VA. The app freed memory on the
+    // exporter side and reallocated at the same VA without the importer calling
+    // hipIpcCloseMemHandle. Replace the stale object with the new mapping.
+    void* old_ptr = mem_obj_exist->getSvmPtr();
+    void* new_ptr = amd_mem_obj->getSvmPtr();
+    amd::MemObjMap::RemoveIpcHandleMemObj(mem_obj_exist);
+    amd::MemObjMap::RemoveMemObj(old_ptr);
+
+    if (old_ptr == new_ptr) {
+      // Clear ipcShared to prevent the destructor from calling ipc_memory_detach,
+      // which would unmap the new (valid) mapping at this VA.
+      mem_obj_exist->setIpcShared(false);
+    }
+    // Different VA: destructor will call ipc_memory_detach to unmap the old VA.
+    mem_obj_exist->release();
+    amd::MemObjMap::AddMemObj(new_ptr, amd_mem_obj);
   } else {
     amd_mem_obj->release();
     amd_mem_obj = mem_obj_exist;

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1741,6 +1741,9 @@ class Device : public RuntimeObject {
   ///! Allocates a device signal object
   virtual device::Signal* createSignal() const = 0;
 
+  ///! Allocates an IPC-capable signal, or returns nullptr if unsupported
+  virtual device::Signal* createIpcSignal() const { return nullptr; }
+
   //! Return true if initialized external API interop, otherwise false
   virtual bool bindExternalDevice(
       uint flags,             //!< Enum val. for ext.API type: GL, D3D10, etc.

--- a/projects/clr/rocclr/device/devsignal.hpp
+++ b/projects/clr/rocclr/device/devsignal.hpp
@@ -65,14 +65,10 @@ class Signal : public amd::HeapObject {
   virtual bool IpcExport(void* handle, size_t handle_size) { return false; }
 
   // Initializes this signal from an IPC handle (alternative to Init for imported signals)
-  virtual bool IpcImport(const void* handle, size_t handle_size,
-                         const amd::Device* dev = nullptr) { return false; }
+  virtual bool IpcImport(const void* handle, size_t handle_size) { return false; }
 
   // Return the handle to the underlying amd_signal_t object
   virtual void* getHandle() { return nullptr; }
-
-  // Return a GPU-accessible handle (may differ from getHandle for IPC signals)
-  virtual void* getGpuHandle() { return getHandle(); }
 };
 
 };  // namespace amd::device

--- a/projects/clr/rocclr/device/devsignal.hpp
+++ b/projects/clr/rocclr/device/devsignal.hpp
@@ -58,8 +58,21 @@ class Signal : public amd::HeapObject {
   // Atomically sets the current value of the signal
   virtual void Reset(uint64_t value) {}
 
+  // Atomically loads the current value of the signal
+  virtual uint64_t Load() { return 0; }
+
+  // Exports the signal as an IPC handle into the provided buffer
+  virtual bool IpcExport(void* handle, size_t handle_size) { return false; }
+
+  // Initializes this signal from an IPC handle (alternative to Init for imported signals)
+  virtual bool IpcImport(const void* handle, size_t handle_size,
+                         const amd::Device* dev = nullptr) { return false; }
+
   // Return the handle to the underlying amd_signal_t object
   virtual void* getHandle() { return nullptr; }
+
+  // Return a GPU-accessible handle (may differ from getHandle for IPC signals)
+  virtual void* getGpuHandle() { return getHandle(); }
 };
 
 };  // namespace amd::device

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -3320,6 +3320,9 @@ void Device::getGlobalCUMask(std::string cuMaskStr) {
 device::Signal* Device::createSignal() const { return new roc::Signal(); }
 
 // ================================================================================================
+device::Signal* Device::createIpcSignal() const { return new roc::IpcSignal(); }
+
+// ================================================================================================
 hsa_status_t Device::BackendErrorCallBackHandler(const hsa_amd_event_t* event, void* data) {
   cl_int gpu_error = CL_SUCCESS;
   switch (event->event_type) {

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -421,7 +421,8 @@ class Device : public NullDevice {
     return nullptr;
   }
 
-  virtual device::Signal* createSignal() const;
+  virtual device::Signal* createSignal() const override;
+  virtual device::Signal* createIpcSignal() const override;
 
   //! Acquire external graphics API object in the host thread
   //! Needed for OpenGL objects on CPU device

--- a/projects/clr/rocclr/device/rocm/rocrctx.cpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.cpp
@@ -100,6 +100,8 @@ bool Hsa::LoadLib() {
   GET_ROCR_SYMBOL(hsa_amd_ipc_memory_create)
   GET_ROCR_SYMBOL(hsa_amd_ipc_memory_attach)
   GET_ROCR_SYMBOL(hsa_amd_ipc_memory_detach)
+  GET_ROCR_SYMBOL(hsa_amd_ipc_signal_create)
+  GET_ROCR_SYMBOL(hsa_amd_ipc_signal_attach)
   GET_ROCR_SYMBOL(hsa_amd_signal_create)
   GET_ROCR_SYMBOL(hsa_amd_register_system_event_handler)
   GET_ROCR_SYMBOL(hsa_amd_queue_set_priority)

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -109,6 +109,8 @@ struct RocrEntryPoints {
   decltype(hsa_amd_ipc_memory_create)* hsa_amd_ipc_memory_create_;
   decltype(hsa_amd_ipc_memory_attach)* hsa_amd_ipc_memory_attach_;
   decltype(hsa_amd_ipc_memory_detach)* hsa_amd_ipc_memory_detach_;
+  decltype(hsa_amd_ipc_signal_create)* hsa_amd_ipc_signal_create_;
+  decltype(hsa_amd_ipc_signal_attach)* hsa_amd_ipc_signal_attach_;
   decltype(hsa_amd_signal_create)* hsa_amd_signal_create_;
   decltype(hsa_amd_register_system_event_handler)* hsa_amd_register_system_event_handler_;
   decltype(hsa_amd_queue_set_priority)* hsa_amd_queue_set_priority_;
@@ -409,6 +411,13 @@ class Hsa : public amd::AllStatic {
   }
   static hsa_status_t ipc_memory_detach(void* mapped_ptr) {
     return ROCR_DYN(hsa_amd_ipc_memory_detach)(mapped_ptr);
+  }
+  static hsa_status_t ipc_signal_create(hsa_signal_t signal, hsa_amd_ipc_signal_t* handle) {
+    return ROCR_DYN(hsa_amd_ipc_signal_create)(signal, handle);
+  }
+  static hsa_status_t ipc_signal_attach(const hsa_amd_ipc_signal_t* handle,
+                                        hsa_signal_t* signal) {
+    return ROCR_DYN(hsa_amd_ipc_signal_attach)(handle, signal);
   }
   static hsa_status_t signal_create(hsa_signal_value_t initial_value, uint32_t num_consumers,
     const hsa_agent_t* consumers, uint64_t attributes, hsa_signal_t* signal) {

--- a/projects/clr/rocclr/device/rocm/rocsignal.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.cpp
@@ -92,7 +92,7 @@ bool IpcSignal::IpcExport(void* handle, size_t handle_size) {
   return true;
 }
 
-bool IpcSignal::IpcImport(const void* handle, size_t handle_size, const amd::Device* dev) {
+bool IpcSignal::IpcImport(const void* handle, size_t handle_size) {
   if (handle_size < sizeof(hsa_amd_ipc_signal_t)) {
     return false;
   }
@@ -102,15 +102,6 @@ bool IpcSignal::IpcImport(const void* handle, size_t handle_size, const amd::Dev
   hsa_status_t status = Hsa::ipc_signal_attach(&ipc_handle, &signal_);
   if (status != HSA_STATUS_SUCCESS) {
     return false;
-  }
-
-  // Lock the imported signal memory for GPU access.
-  // The IPC signal is CPU-only after dma-buf import.
-  if (dev != nullptr) {
-    auto* rocDev = static_cast<const roc::Device*>(dev);
-    constexpr size_t kSignalAbiSize = 4096;
-    gpu_ptr_ = rocDev->hostLock(reinterpret_cast<void*>(signal_.handle),
-                                kSignalAbiSize, amd::Device::kNoAtomics);
   }
 
   ws_ = WaitState::Active;

--- a/projects/clr/rocclr/device/rocm/rocsignal.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.cpp
@@ -46,4 +46,75 @@ uint64_t Signal::Wait(uint64_t value, device::Signal::Condition c, uint64_t time
 
 void Signal::Reset(uint64_t value) { Hsa::signal_store_screlease(signal_, value); }
 
+// ================================================================================================
+// IpcSignal implementation
+// ================================================================================================
+
+IpcSignal::~IpcSignal() {
+  if (gpu_ptr_ != nullptr) {
+    Hsa::memory_unlock(reinterpret_cast<void*>(signal_.handle));
+  }
+  if (signal_.handle != 0) {
+    Hsa::signal_destroy(signal_);
+  }
+}
+
+bool IpcSignal::Init(const amd::Device& dev, uint64_t init, device::Signal::WaitState ws) {
+  hsa_status_t status = Hsa::signal_create(init, 0, nullptr, HSA_AMD_SIGNAL_IPC, &signal_);
+  if (status != HSA_STATUS_SUCCESS) {
+    return false;
+  }
+  ws_ = ws;
+  return true;
+}
+
+uint64_t IpcSignal::Wait(uint64_t value, device::Signal::Condition c, uint64_t timeout) {
+  return Hsa::signal_wait_scacquire(signal_, static_cast<hsa_signal_condition_t>(c), value,
+                                    timeout, static_cast<hsa_wait_state_t>(ws_));
+}
+
+void IpcSignal::Reset(uint64_t value) { Hsa::signal_store_screlease(signal_, value); }
+
+uint64_t IpcSignal::Load() {
+  return Hsa::signal_load_relaxed(signal_);
+}
+
+bool IpcSignal::IpcExport(void* handle, size_t handle_size) {
+  if (handle_size < sizeof(hsa_amd_ipc_signal_t)) {
+    return false;
+  }
+  hsa_amd_ipc_signal_t ipc_handle;
+  hsa_status_t status = Hsa::ipc_signal_create(signal_, &ipc_handle);
+  if (status != HSA_STATUS_SUCCESS) {
+    return false;
+  }
+  memcpy(handle, &ipc_handle, sizeof(ipc_handle));
+  return true;
+}
+
+bool IpcSignal::IpcImport(const void* handle, size_t handle_size, const amd::Device* dev) {
+  if (handle_size < sizeof(hsa_amd_ipc_signal_t)) {
+    return false;
+  }
+  hsa_amd_ipc_signal_t ipc_handle;
+  memcpy(&ipc_handle, handle, sizeof(ipc_handle));
+
+  hsa_status_t status = Hsa::ipc_signal_attach(&ipc_handle, &signal_);
+  if (status != HSA_STATUS_SUCCESS) {
+    return false;
+  }
+
+  // Lock the imported signal memory for GPU access.
+  // The IPC signal is CPU-only after dma-buf import.
+  if (dev != nullptr) {
+    auto* rocDev = static_cast<const roc::Device*>(dev);
+    constexpr size_t kSignalAbiSize = 4096;
+    gpu_ptr_ = rocDev->hostLock(reinterpret_cast<void*>(signal_.handle),
+                                kSignalAbiSize, amd::Device::kNoAtomics);
+  }
+
+  ws_ = WaitState::Active;
+  return true;
+}
+
 };  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocsignal.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.cpp
@@ -51,9 +51,6 @@ void Signal::Reset(uint64_t value) { Hsa::signal_store_screlease(signal_, value)
 // ================================================================================================
 
 IpcSignal::~IpcSignal() {
-  if (gpu_ptr_ != nullptr) {
-    Hsa::memory_unlock(reinterpret_cast<void*>(signal_.handle));
-  }
   if (signal_.handle != 0) {
     Hsa::signal_destroy(signal_);
   }

--- a/projects/clr/rocclr/device/rocm/rocsignal.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.hpp
@@ -58,12 +58,8 @@ class IpcSignal : public device::Signal {
   void Reset(uint64_t value) override;
   uint64_t Load() override;
   bool IpcExport(void* handle, size_t handle_size) override;
-  bool IpcImport(const void* handle, size_t handle_size,
-                 const amd::Device* dev = nullptr) override;
+  bool IpcImport(const void* handle, size_t handle_size) override;
   void* getHandle() override { return reinterpret_cast<void*>(signal_.handle); }
-  void* getGpuHandle() override {
-    return gpu_ptr_ ? gpu_ptr_ : reinterpret_cast<void*>(signal_.handle);
-  }
 };
 
 };  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocsignal.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.hpp
@@ -41,4 +41,29 @@ class Signal : public device::Signal {
   void* getHandle() override { return reinterpret_cast<void*>(signal_.handle); }
 };
 
+//! IPC-capable signal using hsa_amd_ipc_signal_create/attach.
+//! Used directly as completion_signal / dep_signal on AQL barrier packets.
+class IpcSignal : public device::Signal {
+ private:
+  hsa_signal_t signal_;
+  void* gpu_ptr_ = nullptr;  // GPU-accessible pointer from memory_lock (if needed)
+
+ public:
+  IpcSignal() { signal_.handle = 0; }
+  ~IpcSignal() override;
+
+  bool Init(const amd::Device& dev, uint64_t init, device::Signal::WaitState ws) override;
+
+  uint64_t Wait(uint64_t value, device::Signal::Condition c, uint64_t timeout) override;
+  void Reset(uint64_t value) override;
+  uint64_t Load() override;
+  bool IpcExport(void* handle, size_t handle_size) override;
+  bool IpcImport(const void* handle, size_t handle_size,
+                 const amd::Device* dev = nullptr) override;
+  void* getHandle() override { return reinterpret_cast<void*>(signal_.handle); }
+  void* getGpuHandle() override {
+    return gpu_ptr_ ? gpu_ptr_ : reinterpret_cast<void*>(signal_.handle);
+  }
+};
+
 };  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocsignal.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsignal.hpp
@@ -46,7 +46,6 @@ class Signal : public device::Signal {
 class IpcSignal : public device::Signal {
  private:
   hsa_signal_t signal_;
-  void* gpu_ptr_ = nullptr;  // GPU-accessible pointer from memory_lock (if needed)
 
  public:
   IpcSignal() { signal_.handle = 0; }

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -4052,13 +4052,13 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
       hsa_signal_t ipc_s{0};
       if (vcmd.ipcCompletionSignal() != nullptr) {
         ipc_s.handle = static_cast<uint64_t>(
-            reinterpret_cast<uintptr_t>(vcmd.ipcCompletionSignal()->getGpuHandle()));
+            reinterpret_cast<uintptr_t>(vcmd.ipcCompletionSignal()->getHandle()));
       }
 
       if (vcmd.ipcDepSignal() != nullptr) {
         hsa_signal_t s;
         s.handle = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(
-            vcmd.ipcDepSignal()->getGpuHandle()));
+            vcmd.ipcDepSignal()->getHandle()));
         WaitCompleteSignal(s);
       } else if (timestamp_ != nullptr || ipc_s.handle != 0) {
         // IPC event record: if ipc_s is non-zero, first dispatch a NOP barrier with

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -4035,7 +4035,8 @@ void VirtualGPU::submitNativeFn(amd::NativeFnCommand& cmd) {}
 
 // ================================================================================================
 void VirtualGPU::submitMarker(amd::Marker& vcmd) {
-  if (AMD_DIRECT_DISPATCH || vcmd.profilingInfo().marker_ts_) {
+  if (AMD_DIRECT_DISPATCH || vcmd.profilingInfo().marker_ts_ ||
+      vcmd.ipcCompletionSignal() != nullptr || vcmd.ipcDepSignal() != nullptr) {
     // Make sure VirtualGPU has an exclusive access to the resources
     amd::ScopedLock lock(execution());
     if (vcmd.CpuWaitRequested()) {
@@ -4047,10 +4048,31 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
       flush(vcmd.GetBatchHead());
     } else {
       profilingBegin(vcmd);
-      if (timestamp_ != nullptr) {
-        const Settings& settings = dev().settings();
-        int32_t releaseFlags = vcmd.getCommandEntryScope();
+      const Settings& settings = dev().settings();
+      hsa_signal_t ipc_s{0};
+      if (vcmd.ipcCompletionSignal() != nullptr) {
+        ipc_s.handle = static_cast<uint64_t>(
+            reinterpret_cast<uintptr_t>(vcmd.ipcCompletionSignal()->getGpuHandle()));
+      }
 
+      if (vcmd.ipcDepSignal() != nullptr) {
+        hsa_signal_t s;
+        s.handle = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(
+            vcmd.ipcDepSignal()->getGpuHandle()));
+        WaitCompleteSignal(s);
+      } else if (timestamp_ != nullptr || ipc_s.handle != 0) {
+        // IPC event record: if ipc_s is non-zero, first dispatch a NOP barrier with
+        // the IPC signal as completion_signal; it fires when prior work completes.
+        if (ipc_s.handle != 0) {
+          if (settings.barrier_value_packet_) {
+            dispatchBarrierValuePacket(kBarrierVendorPacketNopScopeHeader, false, hsa_signal_t{0}, 0,
+                                       0, HSA_SIGNAL_CONDITION_EQ, true, ipc_s);
+          } else {
+            dispatchBarrierPacket(kNopPacketHeader, true, ipc_s);
+          }
+        }
+
+        int32_t releaseFlags = vcmd.getCommandEntryScope();
         if (releaseFlags == Device::CacheState::kCacheStateIgnore) {
           if (settings.barrier_value_packet_ && vcmd.profilingInfo().marker_ts_) {
             dispatchBarrierValuePacket(kBarrierVendorPacketNopScopeHeader, true);

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -1377,6 +1377,9 @@ class ExternalSemaphoreCmd : public Command {
 
 
 class Marker : public Command {
+  device::Signal* ipc_completion_signal_ = nullptr;
+  device::Signal* ipc_dep_signal_ = nullptr;
+
  public:
   //! Create a new Marker
   Marker(HostQueue& queue, bool userVisible, const EventWaitList& eventWaitList = nullWaitList,
@@ -1384,6 +1387,14 @@ class Marker : public Command {
       : Command(queue, userVisible ? CL_COMMAND_MARKER : 0, eventWaitList, 0, waitingEvent) {
     cpu_wait_ = cpu_wait;
   }
+
+  //! Attach an IPC signal as completion_signal on the barrier packet (for event record)
+  void setIpcCompletionSignal(device::Signal* s) { ipc_completion_signal_ = s; }
+  device::Signal* ipcCompletionSignal() const { return ipc_completion_signal_; }
+
+  //! Attach an IPC signal as dep_signal on the barrier packet (for stream wait)
+  void setIpcDepSignal(device::Signal* s) { ipc_dep_signal_ = s; }
+  device::Signal* ipcDepSignal() const { return ipc_dep_signal_; }
 
   //! The actual command implementation.
   virtual void submit(device::VirtualDevice& device) { device.submitMarker(*this); }

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventIpc.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventIpc.cc
@@ -26,6 +26,10 @@ THE SOFTWARE.
 #include <hip_test_kernels.hh>
 
 #include <hip_test_common.hh>
+#include <utils.hh>
+
+#include <chrono>
+#include <cstring>
 
 /**
  * @addtogroup hipEventCreateWithFlags hipEventCreateWithFlags
@@ -122,6 +126,83 @@ TEST_CASE("Unit_hipEventIpc") {
 
   HipTest::checkVectorADD(A_h, B_h, C_h, N, true);
   HipTest::freeArrays(A_d, B_d, C_d, A_h, B_h, C_h, false);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Verify that hipEventDestroy() on an interprocess (IPC) event is non-blocking.
+ *    Destroying a still-pending IPC event must NOT wait for the event's own GPU work
+ *    to finish (matching CUDA's cudaEventDestroy() semantics). The IPC signal is handed
+ *    to a per-device deferred-cleanup queue and freed at the next device-wide sync,
+ *    so destroy returns in ~microseconds rather than ~the full kernel duration.
+ * Test source
+ * ------------------------
+ *  - unit/event/Unit_hipEventIpc.cc
+ * Test requirements
+ * ------------------------
+ *  - Device supports the true (ROCr) IPC-signal path; the emulated IPC path
+ *    (PAL/Windows) is skipped because its destroy is blocking by design.
+ *  - HIP_VERSION >= 7.0
+ */
+HIP_TEST_CASE(Unit_hipEventIpc_DestroyNonBlocking) {
+  hipDeviceProp_t props;
+  HIP_CHECK(hipGetDeviceProperties(&props, 0));
+  if (!props.ipcEventSupported) {
+    HIP_SKIP_TEST("Device does not support IPC events");
+  }
+
+  // Non-blocking destroy only applies to the true ROCr IPC-signal path. The emulated path
+  // (used when ROCr IPC signals are unavailable, e.g. PAL/Windows) intentionally waits for
+  // the event's GPU work in ~IPCEventEmulated(), so destroy is blocking there by design.
+  // Distinguish the two by the IPC handle's leading type word (0 == emulated, 1 == ROCr),
+  // which mirrors the runtime backend selection in hipEventCreateWithFlags().
+  {
+    hipEvent_t probe;
+    HIP_CHECK(hipEventCreateWithFlags(&probe, hipEventInterprocess | hipEventDisableTiming));
+    hipIpcEventHandle_t handle{};
+    HIP_CHECK(hipIpcGetEventHandle(&handle, probe));
+    uint32_t handleType = 0;
+    static_assert(sizeof(handleType) <= sizeof(handle), "IPC handle smaller than its type word");
+    std::memcpy(&handleType, &handle, sizeof(handleType));
+    HIP_CHECK(hipEventDestroy(probe));
+    constexpr uint32_t kEmulatedIpcEvent = 0;
+    if (handleType == kEmulatedIpcEvent) {
+      HIP_SKIP_TEST("Device uses emulated IPC events; destroy is blocking by design");
+    }
+  }
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  hipEvent_t event;
+  HIP_CHECK(hipEventCreateWithFlags(&event, hipEventInterprocess | hipEventDisableTiming));
+
+  // Keep the GPU busy so the event's recorded work is still in flight at destroy time. Use a
+  // long delay so a non-blocking destroy (microseconds) sits far below the threshold and a
+  // blocking destroy (~the full kernel) sits far above it, well clear of any timing jitter.
+  const std::chrono::milliseconds delay(isQuickLevel() ? 2000 : 5000);
+  LaunchDelayKernel(delay, stream);
+  HIP_CHECK(hipEventRecord(event, stream));
+
+  // The event completes only behind the long delay kernel, so it must read as pending.
+  HIP_CHECK_ERROR(hipEventQuery(event), hipErrorNotReady);
+
+  // The call under test: destroy must return immediately, not block for the kernel.
+  const auto t0 = std::chrono::steady_clock::now();
+  HIP_CHECK(hipEventDestroy(event));
+  const auto t1 = std::chrono::steady_clock::now();
+  const auto destroy_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+
+  INFO("hipEventDestroy took " << destroy_ms << " ms; delay kernel is " << delay.count() << " ms");
+  // A non-blocking destroy is sub-millisecond; the pre-fix blocking destroy took ~the full
+  // kernel duration. Half the kernel time cleanly separates the two while tolerating jitter.
+  REQUIRE(destroy_ms < delay.count() / 2);
+
+  // Drain the per-device deferred IPC-signal cleanup queue now that the work can complete.
+  HIP_CHECK(hipDeviceSynchronize());
+  HIP_CHECK(hipStreamDestroy(stream));
 }
 
 /**


### PR DESCRIPTION
 ## Motivation                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                 
  Backport the develop fix for ROCm/rocm-systems issue #7520 to                                                                                                                                                                                                  
  release/rocm-rel-7.2.                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                 
  On 7.2.x, `hipEventDestroy()` on a recorded interprocess event                                                                                                                                                                                                 
  (`hipEventInterprocess | hipEventDisableTiming`) blocks the calling CPU thread                                                                                                                                                                                 
  for the full duration of *unrelated* GPU work on the same device (10–100+ ms),                                                                                                                                                                                 
  even when the event itself is already complete. The cause is `~IPCEvent()`                                                                                                                                                                                     
  calling `ihipHostUnregister()` → `g_devices[...]->SyncAllStreams()`, a                                                                                                                                                                                         
  device-wide drain. CUDA's `cudaEventDestroy()` does not block this way. This is                                                                                                                                                                                
  harmful to LMCache/vLLM-style cross-process inference workloads, which create and                                                                                                                                                                              
  destroy IPC events around live GPU queues. This PR brings the already-merged                                                                                                                                                                                   
  develop fix to the 7.2 release branch.                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                 
  ## Technical Details                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                 
  Backport of three develop commits, each as its own commit here (titles match the                                                                                                                                                                               
  develop commits; every commit body documents the 7.2 conflict resolution /                                                                                                                                                                                     
  adaptations):                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                 
  - #5575 (`20e6861335`) — Replace emulated IPC events with true ROCr IPC signals.                                                                                                                                                                               
    The new `IPCEvent` is backed by an `amd::device::Signal` wrapping a ROCr IPC                                                                                                                                                                                 
    signal; its destructor waits only on the event's own signal and frees it — no                                                                                                                                                                                
    `ihipHostUnregister`/`SyncAllStreams`/`shm_unlink` — removing the device-wide                                                                                                                                                                                
    drain. The old shmem implementation is preserved as `IPCEventEmulated`                                                                                                                                                                                       
    (PAL/Windows fallback, selected when `createIpcSignal()` is unavailable).                                                                                                                                                                                    
  - #6786 (`4e4809ab3a`) — Serialize IPC event re-recording to avoid a signal                                                                                                                                                                                    
    re-arm race, plus recursive-lock guards for graph event-record/stream-wait                                                                                                                                                                                   
    nodes.                                                                                                                                                                                                                                                       
  - #6734 (`5f3b3a6` / `853b19a`) — Drop `getGpuHandle()`/`gpu_ptr_`; standardize                                                                                                                                                                                
    on `getHandle()` for IPC signal handles.                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                 
  7.2 adaptations (also detailed per commit):                                                                                                                                                                                                                    
  - Locking: 7.2 `Event` uses a recursive `amd::Monitor`, so the new methods use                                                                                                                                                                                 
    `amd::ScopedLock` instead of `std::scoped_lock`.                                                                                                                                                                                                             
  - `WaitCompleteSignal`: reverted to 7.2's `barrier_packet_.dep_signal[0]`                                                                                                                                                                                      
    mechanism (`HwQueueTracker::AddDynamicQueueWait`/`dynamic_queue_waits_` do not                                                                                                                                                                               
    exist on 7.2).                                                                                                                                                                                                                                               
  - `submitMarker`: kept 7.2's structure and injected only the IPC-signal handling.                                              
  - `rocrctx.hpp/.cpp`: added only the `ipc_signal_create`/`ipc_signal_attach`                                                                                                                                                                                   
    wrappers (mirroring `ipc_memory_*`), not develop's full header.                                                                                                                                                                                              
  - ROCr `runtime.cpp` left unchanged: #6734's `HSA_MEMORY_ACCESS_NONE → RW` fix                                                                                                                                                                                 
    targets develop's `hsaKmt`-based `IPCAttach`, but 7.2's `IPCAttach` is a                                                                                                                                                                                     
    different libdrm (`amdgpu_bo_va_op`) path that already maps RW, so the access                                                                                                                                                                                
    fix is a no-op on 7.2.                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                 
  Scope: CLR-only — only `libamdhip64` changes; no `libhsa-runtime64` rebuild                                                                                                                                                                                    
  required.                                                                                                                      
                                                                                                                                                                                                                                                                 
  ## JIRA ID                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                 
 GitHub issue #7520                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                 
  ## Test Plan                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                 
  Built `libamdhip64` from this branch in a ROCm 7.2 container (gfx1201 /                                                                                                                                                                                        
  Radeon RX 9070 XT) and `LD_PRELOAD`-ed it over the stock 7.2.0 runtime. Ran the                                               
  issue reporter's standalone benchmarks (single process):                                                                                                                                                                                                       
  - `bench_06` — decisive control: record IPC event, `hipEventSynchronize` +                                                                                                                                                                                     
    `hipEventQuery` to confirm it is ready, launch ~30 ms of unrelated work on                                                                                                                                                                                   
    another (non-blocking) stream, confirm the event is still ready, then time                                                                                                                                                                                   
    `hipEventDestroy`.

## Test Result

  - `bench_06` `hipEventDestroy`: ~31 ms (stock 7.2.0) → ~0.9 ms (this branch);
    the event was verified ready (query ready=50/50) both before and after the
    unrelated launch, so the previous cost was entirely the unrelated-work drain.
  - `bench_13`: ~30 ms → ~0.9 ms; the unrelated-work cost is no longer absorbed by
    destroy — it moves to the explicit synchronization point (total cost
    conserved).
  - Matches develop/7.14 behavior on the same benchmarks (`bench_06` ~0.9 ms).
  - Normal (non-IPC) event destroy unchanged (~µs).
  - Out of scope: destroy of a *still-pending* event continues to wait on the
    event's own work, identical to develop/7.14 (full deferral is a separate
    change).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
