### PR TITLE
[rocprofiler-compute] Overwrite workload folder on re-profile via --overwrite

### DIFF
--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -264,6 +264,27 @@ The output directory can be parameterized with the following keywords:
 If MPI rank is detected and the output directory does not include ``%rank%``,
 ROCm Compute Profiler appends ``/<rank>`` to avoid collisions across ranks.
 
+Each profiling run should use a fresh output directory. A workload directory
+holds the output of exactly one profile run, so profiling into a directory that
+already contains files stops with an error instead of silently mixing two runs.
+To re-profile in place, re-run with ``--overwrite``, which wipes the directory's
+existing contents first:
+
+.. code-block:: shell-session
+
+   $ rocprof-compute profile --name vcopy --overwrite -- ./vcopy -n 1048576 -b 256
+
+.. warning::
+
+   ``--overwrite`` deletes the existing contents of the target directory. It is
+   an explicit authorization to discard prior data; nothing is removed without
+   it.
+
+.. note::
+
+   CI jobs and automated runs should never reuse a workload directory; either each run
+   should profile into a fresh directory or runs should utilize ``--overwrite``.
+
 Examples:
 
 * Profiling without MPI:
@@ -834,24 +855,28 @@ To target a specific GPU device, use ``--device``:
    $ rocprof-compute profile --name my_bench --bench-only --device 2
 
 To regenerate benchmark data in an existing profiled workload directory, use
-``--output-directory`` to point at the workload path directly:
+``--output-directory`` to point at the workload path directly. Because this
+replaces the existing ``roofline.csv``, it requires ``--overwrite`` to authorize
+overwriting that file. Unlike a full profile, ``--bench-only`` replaces only
+``roofline.csv`` and leaves the rest of the workload (counter data, traces)
+untouched:
 
 .. code-block:: shell-session
 
-   $ rocprof-compute profile --bench-only --output-directory workloads/vcopy/MI300X_A1
+   $ rocprof-compute profile --bench-only --overwrite --output-directory workloads/vcopy/MI300X_A1
 
 .. note::
 
    ``--bench-only`` writes ``roofline.csv`` only; rendering a roofline
    chart additionally requires application performance counters from a
    ``--roof-only`` (or regular profile) run. The intended workflow is to
-   profile first, then re-run ``--bench-only`` against that workload
+   profile first, then re-run ``--bench-only --overwrite`` against that workload
    later to refresh stale peak values before analyzing:
 
    .. code-block:: shell-session
 
       $ rocprof-compute profile --name vcopy --roof-only -- ./vcopy
-      $ rocprof-compute profile --bench-only --output-directory workloads/vcopy/MI300X_A1
+      $ rocprof-compute profile --bench-only --overwrite --output-directory workloads/vcopy/MI300X_A1
       $ rocprof-compute analyze --path workloads/vcopy/MI300X_A1
 
 .. _torch-operator-mapping:

--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -265,10 +265,9 @@ If MPI rank is detected and the output directory does not include ``%rank%``,
 ROCm Compute Profiler appends ``/<rank>`` to avoid collisions across ranks.
 
 Each profiling run should use a fresh output directory. A workload directory
-holds the output of exactly one profile run, so profiling into a directory that
-already contains files stops with an error instead of silently mixing two runs.
-To re-profile in place, re-run with ``--overwrite``, which wipes the directory's
-existing contents first:
+holds the output of exactly one run, so profiling into a non-empty directory
+fails with an error rather than silently mixing runs. To re-profile in place,
+add ``--overwrite``, which clears the directory first:
 
 .. code-block:: shell-session
 
@@ -276,14 +275,13 @@ existing contents first:
 
 .. warning::
 
-   ``--overwrite`` deletes the existing contents of the target directory. It is
-   an explicit authorization to discard prior data; nothing is removed without
-   it.
+   ``--overwrite`` deletes the target directory's existing contents. Nothing is
+   removed without it.
 
 .. note::
 
-   Automated runs should never reuse a workload directory; either each run
-   should profile into a fresh directory or use ``--overwrite``.
+   Automated runs should never reuse a workload directory: profile into a fresh
+   directory each time, or pass ``--overwrite``.
 
 Examples:
 
@@ -854,12 +852,11 @@ To target a specific GPU device, use ``--device``:
 
    $ rocprof-compute profile --name my_bench --bench-only --device 2
 
-To regenerate benchmark data in an existing profiled workload directory, use
-``--output-directory`` to point at the workload path directly. Because this
-replaces the existing ``roofline.csv``, it requires ``--overwrite`` to authorize
-overwriting that file. Unlike a full profile, ``--bench-only`` replaces only
-``roofline.csv`` and leaves the rest of the workload (counter data, traces)
-untouched:
+To regenerate benchmark data in an existing workload directory, point
+``--output-directory`` at the workload path. This replaces the existing
+``roofline.csv``, so it requires ``--overwrite``. Unlike a full profile,
+``--bench-only`` replaces only ``roofline.csv`` and leaves the rest of the
+workload (counter data, traces) untouched:
 
 .. code-block:: shell-session
 

--- a/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/profile/mode.rst
@@ -282,8 +282,8 @@ existing contents first:
 
 .. note::
 
-   CI jobs and automated runs should never reuse a workload directory; either each run
-   should profile into a fresh directory or runs should utilize ``--overwrite``.
+   Automated runs should never reuse a workload directory; either each run
+   should profile into a fresh directory or use ``--overwrite``.
 
 Examples:
 

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -306,11 +306,10 @@ Examples:
         default=False,
         action="store_true",
         help=(
-            "\t\t\tAuthorize overwriting an existing workload directory.\n"
-            "\t\t\tWithout this flag, profiling into a directory that already\n"
-            "\t\t\tcontains profile data errors out instead of mixing runs.\n"
-            "\t\t\tEach profiling run should use a fresh output directory; use\n"
-            "\t\t\tthis flag only when intentionally re-profiling in place."
+            "\t\t\tOverwrite an existing workload directory.\n"
+            "\t\t\tWithout it, profiling into a non-empty directory fails\n"
+            "\t\t\tinstead of mixing runs. Use a fresh directory per run;\n"
+            "\t\t\tpass this flag only to re-profile in place."
         ),
     )
     profile_group.add_argument(

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -248,7 +248,8 @@ Examples:
         dest="name",
         help=(
             "\t\t\tAssign a name to workload.\n"
-            "\t\t\t--name will be ignored if used together with --output-directory."
+            "\t\t\t--name will be ignored if used together with --output-directory.\n"
+            "\t\t\tUse --overwrite to re-profile into an existing directory."
         ),
     )
     profile_group.add_argument(
@@ -294,7 +295,8 @@ Examples:
             "\t\t\t   %%rank%%: MPI process rank\n"
             '\t\t\t   %%env{NAME}%%: Environment variable "NAME"\n'
             "\t\t\t(DEFAULT: <current-working-directory>/workloads/<name>/%%gpumodel%%) without MPI,\n"  # noqa: E501
-            "\t\t\t <current-working-directory>/workloads/<name>/%%rank%% with MPI.)"
+            "\t\t\t <current-working-directory>/workloads/<name>/%%rank%% with MPI.)\n"
+            "\t\t\tUse --overwrite to re-profile into an existing directory."
         ),
     )
     profile_group.add_argument(

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -298,6 +298,20 @@ Examples:
         ),
     )
     profile_group.add_argument(
+        "--overwrite",
+        dest="overwrite",
+        required=False,
+        default=False,
+        action="store_true",
+        help=(
+            "\t\t\tAuthorize overwriting an existing workload directory.\n"
+            "\t\t\tWithout this flag, profiling into a directory that already\n"
+            "\t\t\tcontains profile data errors out instead of mixing runs.\n"
+            "\t\t\tEach profiling run should use a fresh output directory; use\n"
+            "\t\t\tthis flag only when intentionally re-profiling in place."
+        ),
+    )
+    profile_group.add_argument(
         "--kokkos-trace",
         dest="kokkos_trace",
         required=False,

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -574,8 +574,7 @@ class RocProfCompute:
                 console_error(
                     f"Workload directory '{output_dir}' is not empty. Re-run "
                     "with --overwrite to wipe it and re-profile, or choose a "
-                    "different --output-directory. Each profiling run should "
-                    "use a fresh output directory."
+                    "different --output-directory."
                 )
             console_warning(
                 f"--overwrite: clearing existing workload directory {output_dir}"

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -553,33 +553,24 @@ class RocProfCompute:
         )
 
     @staticmethod
-    def _clear_directory_contents(output_dir: Path) -> None:
-        """Remove everything inside a directory, preserving the directory."""
-        for child in output_dir.iterdir():
-            if child.is_dir() and not child.is_symlink():
-                shutil.rmtree(child)
-            else:
-                child.unlink()
-
-    def _prepare_workload_directory(self, output_dir: Path) -> None:
+    def prepare_workload_directory(output_dir: Path, overwrite: bool) -> None:
         """Enforce single-run ownership of the workload directory.
 
         A workload directory holds the output of exactly one profile run, so
         profiling refuses to write into a non-empty directory unless the user
         has authorized overwriting it with --overwrite, in which case the
-        existing contents are wiped so the new run starts clean.
+        existing directory is removed so the new run starts clean.
         """
         if output_dir.is_dir() and any(output_dir.iterdir()):
-            if not getattr(self.__args, "overwrite", False):
+            if not overwrite:
                 console_error(
-                    f"Workload directory '{output_dir}' is not empty. Re-run "
-                    "with --overwrite to wipe it and re-profile, or choose a "
-                    "different --output-directory."
+                    f"Existing workload directory {output_dir} is not empty, "
+                    "please use --overwrite"
                 )
             console_warning(
-                f"--overwrite: clearing existing workload directory {output_dir}"
+                f"clearing existing directory {output_dir} due to --overwrite"
             )
-            self._clear_directory_contents(output_dir)
+            shutil.rmtree(output_dir)
 
         output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -603,7 +594,9 @@ class RocProfCompute:
             console_error(str(e))
 
         # Validate and prepare the workload directory before profiling.
-        self._prepare_workload_directory(Path(self.__args.output_directory))
+        self.prepare_workload_directory(
+            Path(self.__args.output_directory), self.__args.overwrite
+        )
 
         # enable file-based logging
         setup_file_handler(self.__args.loglevel, self.__args.output_directory)
@@ -724,8 +717,8 @@ class RocProfCompute:
         existing_roofline = roofline_csv.is_file()
         if existing_roofline and not getattr(self.__args, "overwrite", False):
             console_error(
-                f"'{roofline_csv}' already exists. Re-run with --overwrite to "
-                "regenerate it, or choose a different --output-directory."
+                f"{roofline_csv} already exists, please use --overwrite to "
+                "regenerate it"
             )
         console_log(
             "roofline",
@@ -752,7 +745,7 @@ class RocProfCompute:
             shutil.move(str(tmp_csv), str(roofline_csv))
 
         if existing_roofline:
-            console_log("roofline", f"Overwrote existing {roofline_csv}")
+            console_warning(f"Overwrote existing {roofline_csv}")
 
         console_log(
             "roofline",

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -554,12 +554,8 @@ class RocProfCompute:
 
     @staticmethod
     def prepare_workload_directory(output_dir: Path, overwrite: bool) -> None:
-        """Enforce single-run ownership of the workload directory.
-
-        A workload directory holds the output of exactly one profile run, so
-        profiling refuses to write into a non-empty directory unless the user
-        has authorized overwriting it with --overwrite, in which case the
-        existing directory is removed so the new run starts clean.
+        """Error if the output directory is non-empty unless overwrite is set,
+        in which case its contents are removed before profiling.
         """
         if output_dir.is_dir() and any(output_dir.iterdir()):
             if not overwrite:
@@ -568,9 +564,13 @@ class RocProfCompute:
                     "please use --overwrite"
                 )
             console_warning(
-                f"clearing existing directory {output_dir} due to --overwrite"
+                f"Clearing existing directory {output_dir} due to --overwrite"
             )
-            shutil.rmtree(output_dir)
+            for child in output_dir.iterdir():
+                if child.is_dir() and not child.is_symlink():
+                    shutil.rmtree(child)
+                else:
+                    child.unlink()
 
         output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/projects/rocprofiler-compute/src/rocprof_compute_base.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_base.py
@@ -552,6 +552,38 @@ class RocProfCompute:
             self.__soc[self.__mspec.gpu_arch],
         )
 
+    @staticmethod
+    def _clear_directory_contents(output_dir: Path) -> None:
+        """Remove everything inside a directory, preserving the directory."""
+        for child in output_dir.iterdir():
+            if child.is_dir() and not child.is_symlink():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+
+    def _prepare_workload_directory(self, output_dir: Path) -> None:
+        """Enforce single-run ownership of the workload directory.
+
+        A workload directory holds the output of exactly one profile run, so
+        profiling refuses to write into a non-empty directory unless the user
+        has authorized overwriting it with --overwrite, in which case the
+        existing contents are wiped so the new run starts clean.
+        """
+        if output_dir.is_dir() and any(output_dir.iterdir()):
+            if not getattr(self.__args, "overwrite", False):
+                console_error(
+                    f"Workload directory '{output_dir}' is not empty. Re-run "
+                    "with --overwrite to wipe it and re-profile, or choose a "
+                    "different --output-directory. Each profiling run should "
+                    "use a fresh output directory."
+                )
+            console_warning(
+                f"--overwrite: clearing existing workload directory {output_dir}"
+            )
+            self._clear_directory_contents(output_dir)
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+
     @demarcate
     def run_profiler(self) -> None:
         self.print_graphic()
@@ -571,13 +603,8 @@ class RocProfCompute:
         except WorkloadCommandError as e:
             console_error(str(e))
 
-        # Create workload directory if it does not exist
-        p = Path(self.__args.output_directory)
-        if not p.exists():
-            try:
-                p.mkdir(parents=True, exist_ok=False)
-            except FileExistsError:
-                console_error("Directory already exists.")
+        # Validate and prepare the workload directory before profiling.
+        self._prepare_workload_directory(Path(self.__args.output_directory))
 
         # enable file-based logging
         setup_file_handler(self.__args.loglevel, self.__args.output_directory)
@@ -696,6 +723,11 @@ class RocProfCompute:
 
         roofline_csv = output_dir / "roofline.csv"
         existing_roofline = roofline_csv.is_file()
+        if existing_roofline and not getattr(self.__args, "overwrite", False):
+            console_error(
+                f"'{roofline_csv}' already exists. Re-run with --overwrite to "
+                "regenerate it, or choose a different --output-directory."
+            )
         console_log(
             "roofline",
             f"Running roofline microbenchmark on device {self.__args.device}",
@@ -721,7 +753,7 @@ class RocProfCompute:
             shutil.move(str(tmp_csv), str(roofline_csv))
 
         if existing_roofline:
-            console_warning(f"Overwrote existing {roofline_csv}")
+            console_log("roofline", f"Overwrote existing {roofline_csv}")
 
         console_log(
             "roofline",

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -1250,7 +1250,8 @@ def test_roof_workload_dir_validation(binary_handler_profile_rocprof_compute):
 def test_roofline_kernel_filter(binary_handler_profile_rocprof_compute):
     """
     Test roofline multi-attempt profiling with `--kernel`
-    Expect to be able to re-profile from same workload if kernels are valid.
+    Expect to be able to re-profile into the same workload directory (with
+    --overwrite) if kernels are valid.
 
     Roofline now takes in a dataframe that should already have filtering applied.
     Any invald kernels should be handled prior to roof activity.
@@ -1265,13 +1266,15 @@ def test_roofline_kernel_filter(binary_handler_profile_rocprof_compute):
         "--device",
         "0",
         "--roof-only",
+        "--overwrite",
     ]
     workload_dir = common.get_output_dir()
 
     returncode = binary_handler_profile_rocprof_compute(  # noqa: F841
         config, workload_dir, options, check_success=True, roof=True
     )
-    # Don't clean output dir, use same workload
+    # Wipe the directory where applicable with --overwrite, then
+    # Re-profile into the same workload directory
     # Test only non-existent kernel: result should be passing
     # Dataframe given to roofline should just be all available kernels with no filtering
     options_bad = options.copy()
@@ -1288,7 +1291,7 @@ def test_roofline_kernel_filter(binary_handler_profile_rocprof_compute):
     )
     assert returncode == 0
 
-    # Test one good kernel using existing profiling data
+    # Test one good kernel, re-profiling the same directory with --overwrite
     # Result should be passing as usual
     options_good = options.copy()
     options_good.extend(["--kernel", config["kernel_name_1"]])
@@ -1297,7 +1300,7 @@ def test_roofline_kernel_filter(binary_handler_profile_rocprof_compute):
     )
     assert returncode == 0
 
-    # Test one good and one nonexistent kernel using existing profiling data
+    # Test one good and one nonexistent kernel, re-profiling
     # Result should be passing as usual
     options_both = options.copy()
     options_both.extend([


### PR DESCRIPTION
## Motivation

Re-profiling into an existing workload directory silently mixes runs, basically a second profile overwrites only the files whose names collide and leaves the rest in place, so analyze can consume a mix of old and new data with no error or warning.

What surfaced this was running `profile -> analyze -> profile --roof-only -k <kernel> -> analyze`. it produced a roofline containing every kernel instead of the selected one, because analyze reused a stale `pmc_perf.csv` left behind by the first analyze. Stale perfmon configs, orphan `results_*.csv`, traces, and `roofline.csv` are all left behind the same way, and this is because a workload directory has no owner and no lifecycle rule.

This PR gives the workload directory one owner and one rule where re-profiling in place requires explicit user authorization

Running `rocprofiler-compute/rocprof-compute profile --name vcopy -VVV --device 0 -- tests/vcopy -n 1048576 -b 256` twice back to back gives:
<img width="934" height="364" alt="image" src="https://github.com/user-attachments/assets/a8312028-2299-4bb7-b25b-9bdcb64308f1" />


## Technical Details

- Add `--overwrite` to profile mode (`src/argparser.py`).
- `run_profiler()` now validates the output directory before profiling
  (`src/rocprof_compute_base.py`): if the directory is non-empty and
  `--overwrite` is absent, it errors and asks the user to re-run with
  `--overwrite` or choose a different `--output-directory`; with `--overwrite`
  it wipes the directory contents and profiles clean. Treating any non-empty
  directory as occupied avoids hardcoding a list of "profile data" filenames.
- `--bench-only` no longer overwrites `roofline.csv` with only an after-the-fact
  warning. It now errors before running the benchmark if `roofline.csv` exists
  and `--overwrite` is absent; with `--overwrite` it replaces only `roofline.csv`
  and leaves the rest of the workload untouched.
- Update `test_roofline_kernel_filter` to pass `--overwrite` on its re-profiles,
  since it intentionally re-profiles into the same directory four times.
- Docs: documented the fresh-directory-per-run expectation, `--overwrite`, and
  automated-run guidance in `docs/how-to/profile/mode.rst`.

## JIRA ID

AIPROFCOMP-253

## Test Plan

- `ruff check` and `ruff format --check` on all changed files.
- pytest (real GPU, gfx950): `test_roofline_kernel_filter`, `test_bench_only_basic`,
  `test_roof_workload_dir_validation`, `test_path`.
- Manual: profile into a fresh dir (succeeds), re-profile same dir without
  `--overwrite` (errors), re-profile with `--overwrite` (wipes and succeeds).
- Manual: `--bench-only` into a dir with existing `roofline.csv` without
  `--overwrite` (errors) and with `--overwrite` (replaces only `roofline.csv`).
- Original reproducer: `profile --roof-only -> analyze -> profile --roof-only
  -k vgprbound --overwrite -> analyze` on the `occupancy` workload.

## Test Result

- ruff check / format: all passed.
- pytest: 4 passed (test_roofline_kernel_filter, test_bench_only_basic,
  test_roof_workload_dir_validation, test_path).
- Manual directory policy: fresh profile exit 0; re-profile without `--overwrite`
  exit 1 ("is not empty. Re-run with --overwrite ..."); re-profile with
  `--overwrite` wiped the dir (seeded sentinel removed) and exited 0.
- Manual `--bench-only`: existing `roofline.csv` without `--overwrite` exit 1
  ("'roofline.csv' already exists ..."); with `--overwrite` regenerated only
  `roofline.csv` while unrelated files were preserved.
- Reproducer fixed: after the first analyze leaves a stale `pmc_perf.csv` with all
  4 kernels, the re-profile now errors without `--overwrite`; with `--overwrite`
  the final analyze processes only the filtered kernel

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
