### PR TITLE
[ROCM-26423] Fix driver version buffer

### DIFF
--- a/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
@@ -640,7 +640,10 @@ amdsmi_status_t smi_amdgpu_get_driver_version(amd::smi::AMDSmiGPUDevice* device,
   std::string empty = "";
   std::strncpy(version, empty.c_str(), len - 1);
   openFileAndModifyBuffer("/sys/module/amdgpu/version", version, static_cast<size_t>(len));
-  if (version[0] == '\0') return AMDSMI_STATUS_DIRECTORY_NOT_FOUND;
+  if (version[0] == '\0') {
+    std::strncpy(version, "N/A", len - 1);
+    version[len - 1] = '\0';
+  }
 
   return status;
 }


### PR DESCRIPTION
amdsmi_get_gpu_driver_info (amd_smi_utils.cc): When /sys/module/amdgpu/version is absent (in-tree KMD builds without MODULE_VERSION()), populate driver_version with "N/A" and return success instead of AMDSMI_STATUS_DIRECTORY_NOT_FOUND. 

This also fixes a secondary bug where the early-return prevented driver_name and driver_date from being populated. Verified by bind-mounting /dev/null over the version file to simulate the missing-file scenario.