### PR TITLE
[rocjitsu] rocjitsu-core-team owns rocjitsu CI scripts.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 /.azuredevops/                                                        @ROCm/external-ci
 /.github/                                                             @ROCm/rocm-systems-reviewers
 /.github/workflows/hipfile-*.yml                                      @ROCm/hipfile-reviewers
+/.github/workflows/rocjitsu-*.yml                                     @ROCm/rocjitsu-core-team
 
 # Project-specific ownership
 /projects/amdsmi/                                                     @ROCm/smi-reviewers


### PR DESCRIPTION
## Motivation

Make rocjitsu-core-team own the rocjitsu CI scripts.

## Technical Details

This will avoid unnecessarily pulling in rocm-systems reviewers to review rocjitsu CI specific scripts.

## JIRA ID

N/A.

## Test Plan

Code ownership change, no test plan should be required.

## Test Result

N/A.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
