### PR TITLE
fix(hsakmt): Fix shmem leak in reserved_aperture_release

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -712,29 +712,15 @@ static void reserved_aperture_release(manageable_aperture_t *app,
 		/* Reset NUMA policy */
 		mbind(address, MemorySizeInBytes, MPOL_DEFAULT, NULL, 0, 0);
 
-		/* Remove any CPU mapping, but keep the address range reserved */
+		munmap(address, MemorySizeInBytes);
+
 		mmap_ret = mmap(address, MemorySizeInBytes, PROT_NONE,
 			MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED,
 			-1, 0);
 		if (mmap_ret == MAP_FAILED && errno == ENOMEM) {
-			/* When mmap count reaches max_map_count, any mmap will
-			 * fail. Reduce the count with munmap then map it as
-			 * NORESERVE immediately.
-			 */
-			if (munmap(address, MemorySizeInBytes) == 0) {
-				/* After unmapping, try mmap again and handle failure
-				 * */
-				mmap_ret = mmap(address, MemorySizeInBytes, PROT_NONE,
-						MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED,
-						-1, 0);
-				if (mmap_ret == MAP_FAILED) {
-					/* Handle mmap failure gracefully, log if needed */
-					pr_err("Failed to remap memory after unmap\n");
-				}
-			} else {
-				/* Handle munmap failure if needed */
-				pr_err("Failed to unmap memory\n");
-			}
+			mmap_ret = mmap(address, MemorySizeInBytes, PROT_NONE,
+					MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED,
+					-1, 0);
 		}
 	}
 }

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -712,8 +712,8 @@ static void reserved_aperture_release(manageable_aperture_t *app,
 		/* Reset NUMA policy */
 		mbind(address, MemorySizeInBytes, MPOL_DEFAULT, NULL, 0, 0);
 
+		/* Unmap first to drop shmem refcount for MAP_SHARED allocations */
 		munmap(address, MemorySizeInBytes);
-
 		mmap_ret = mmap(address, MemorySizeInBytes, PROT_NONE,
 			MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED,
 			-1, 0);

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -717,11 +717,8 @@ static void reserved_aperture_release(manageable_aperture_t *app,
 		mmap_ret = mmap(address, MemorySizeInBytes, PROT_NONE,
 			MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED,
 			-1, 0);
-		if (mmap_ret == MAP_FAILED && errno == ENOMEM) {
-			mmap_ret = mmap(address, MemorySizeInBytes, PROT_NONE,
-					MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED,
-					-1, 0);
-		}
+		if (mmap_ret == MAP_FAILED)
+			pr_warn("Failed to reserve VA range %p: %s\n", address, strerror(errno));
 	}
 }
 

--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -712,13 +712,19 @@ static void reserved_aperture_release(manageable_aperture_t *app,
 		/* Reset NUMA policy */
 		mbind(address, MemorySizeInBytes, MPOL_DEFAULT, NULL, 0, 0);
 
-		/* Unmap first to drop shmem refcount for MAP_SHARED allocations */
+		/*
+		 * Drop the CPU mapping to release shmem pages for MAP_SHARED
+		 * allocations, then re-reserve the VA range as PROT_NONE.
+		 * Callers hold fmm_mutex (see contract above), which serializes
+		 * this against aperture allocations, so no allocation can claim
+		 * the VA in the window between munmap() and mmap().
+		 */
 		munmap(address, MemorySizeInBytes);
 		mmap_ret = mmap(address, MemorySizeInBytes, PROT_NONE,
 			MAP_ANONYMOUS | MAP_NORESERVE | MAP_PRIVATE | MAP_FIXED,
 			-1, 0);
 		if (mmap_ret == MAP_FAILED)
-			pr_warn("Failed to reserve VA range %p: %s\n", address, strerror(errno));
+			pr_err("Failed to reserve VA range %p: %s\n", address, strerror(errno));
 	}
 }
 


### PR DESCRIPTION
  Add munmap() before mmap() to release kernel shmem refcount for MAP_SHARED allocations. Without this,
  reserved_aperture_release() leaves shmem pages pinned, causing OOM during repeated allocations.

Fixes: ROCM-23563

  ## Motivation

  KFDMemoryTest.BigSysBufferStressTest fails with OOM kills on MI210. Shmem grows unbounded across allocation iterations
  because MAP_SHARED memory is not properly released.

  ## Technical Details

  `reserved_aperture_release()` in `projects/rocr-runtime/libhsakmt/src/fmm.c` remaps freed memory as PROT_NONE using
  `mmap(..., MAP_FIXED)`. For MAP_SHARED allocations, this does not decrement the kernel shmem refcount - only `munmap()` does.
  Added `munmap()` before the `mmap()` call. Also simplified the ENOMEM retry path since memory is already unmapped.

  ## JIRA ID

  JIRA ID: ROCM-23563

  ## Test Plan

  Run `kfdtest --gtest_filter='*BigSysBufferStressTest*'` on MI210 and monitor shmem via `/proc/meminfo`.

  ## Test Result

  | Metric | Before Fix | After Fix |
  |--------|------------|-----------|
  | Iteration 1 | 1953 × 128MB | 1953 × 128MB |
  | Iteration 2 | OOM killed | 1953 × 128MB |
  | Iteration 3 | - | 1953 × 128MB |
  | Iteration 4 | - | 1953 × 128MB |
  | Shmem after | 246 GiB (leaked) | 20 MiB |
  | Result | FAILED | PASSED (899s) |

  ## Submission Checklist

  - [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
  
 **Unit Test Waiver:** This is a memory management bug fix in libhsakmt. The fix is validated by running `kfdtest --gtest_filter='*BigSysBufferStressTest*'` which
  exercises the affected code path. Adding a new unit test would require duplicating this existing coverage.