### PR TITLE
rocjitsu: fix kernarg preload DBT entries and refactor tests cmake

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -25,7 +25,6 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
-#include <limits>
 #include <memory>
 #include <optional>
 #include <span>
@@ -37,6 +36,8 @@
 namespace rocjitsu {
 
 namespace {
+
+inline constexpr uint64_t kKernargPreloadSkipBytes = 256;
 
 EncodingTranslateFn select_encoding_translator(rj_code_arch_t guest, rj_code_arch_t host) {
   if (guest == ROCJITSU_CODE_ARCH_CDNA4 && host == ROCJITSU_CODE_ARCH_RDNA4)
@@ -125,6 +126,40 @@ void append_diagnostics(std::vector<TranslationDiagnostic> &dst,
   return offsets;
 }
 
+[[nodiscard]] std::vector<uint64_t>
+kernel_hardware_entry_offsets(std::span<const KdTranslation> kernels) {
+  std::vector<uint64_t> offsets;
+  offsets.reserve(kernels.size() * 2);
+  for (const KdTranslation &kernel : kernels) {
+    offsets.push_back(kernel.entry_text_offset);
+    if (kernel.has_kernarg_preload)
+      offsets.push_back(kernel.kernarg_preload_entry_text_offset);
+  }
+
+  std::ranges::sort(offsets);
+  offsets.erase(std::ranges::unique(offsets).begin(), offsets.end());
+  return offsets;
+}
+
+[[nodiscard]] std::vector<uint64_t> kernel_block_leaders(std::span<const KdTranslation> kernels,
+                                                         std::span<const uint8_t> text) {
+  std::vector<uint64_t> offsets;
+  offsets.reserve(kernels.size() * 2);
+  for (const KdTranslation &kernel : kernels) {
+    offsets.push_back(kernel.entry_text_offset);
+    // AMDHSA kernarg preloading is descriptor-controlled. When
+    // kernarg_preload_spec_length is non-zero, compatible CP firmware starts at
+    // KERNEL_CODE_ENTRY_BYTE_OFFSET + 256. That address is a real hardware entry,
+    // not merely padding, so split a block there and seed reachability from it.
+    if (kernel.has_kernarg_preload && kernel.kernarg_preload_entry_text_offset < text.size())
+      offsets.push_back(kernel.kernarg_preload_entry_text_offset);
+  }
+
+  std::ranges::sort(offsets);
+  offsets.erase(std::ranges::unique(offsets).begin(), offsets.end());
+  return offsets;
+}
+
 struct KernelTranslationScope {
   KdTranslation *translation = nullptr;
   BasicBlock *entry = nullptr;
@@ -133,9 +168,18 @@ struct KernelTranslationScope {
 
 [[nodiscard]] std::vector<BasicBlock *>
 reachable_kernel_blocks(const std::vector<std::unique_ptr<BasicBlock>> &blocks, BasicBlock &entry,
-                        const std::unordered_set<uint64_t> &kernel_entries) {
+                        const std::unordered_set<uint64_t> &kernel_entries,
+                        const std::unordered_set<uint64_t> &own_entries) {
   std::unordered_set<const BasicBlock *> reachable;
   std::vector<BasicBlock *> stack{&entry};
+  for (const uint64_t own_entry : own_entries) {
+    if (own_entry == entry.start_offset())
+      continue;
+    if (BasicBlock *extra_entry = block_for_offset(blocks, own_entry);
+        extra_entry != nullptr && extra_entry != &entry) {
+      stack.push_back(extra_entry);
+    }
+  }
 
   while (!stack.empty()) {
     BasicBlock *block = stack.back();
@@ -146,7 +190,7 @@ reachable_kernel_blocks(const std::vector<std::unique_ptr<BasicBlock>> &blocks, 
     for (BasicBlock *succ : block->successors()) {
       if (succ == nullptr)
         continue;
-      if (succ->start_offset() != entry.start_offset() &&
+      if (!own_entries.contains(succ->start_offset()) &&
           kernel_entries.contains(succ->start_offset()))
         continue;
       stack.push_back(succ);
@@ -170,7 +214,8 @@ kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks
   if (entries.empty())
     return scopes;
 
-  std::unordered_set<uint64_t> entry_set(entries.begin(), entries.end());
+  const auto hardware_entries = kernel_hardware_entry_offsets(kernels);
+  std::unordered_set<uint64_t> entry_set(hardware_entries.begin(), hardware_entries.end());
   std::vector<KdTranslation *> ordered_kernels;
   ordered_kernels.reserve(kernels.size());
   std::unordered_set<uint64_t> seen_entries;
@@ -188,8 +233,15 @@ kernel_translation_scopes(const std::vector<std::unique_ptr<BasicBlock>> &blocks
     BasicBlock *entry = block_for_offset(blocks, kernel->entry_text_offset);
     if (entry == nullptr)
       continue;
+    std::unordered_set<uint64_t> own_entries{kernel->entry_text_offset};
+    if (kernel->has_kernarg_preload) {
+      if (block_for_offset(blocks, kernel->kernarg_preload_entry_text_offset) == nullptr)
+        continue;
+      own_entries.insert(kernel->kernarg_preload_entry_text_offset);
+    }
 
-    scopes.push_back({kernel, entry, reachable_kernel_blocks(blocks, *entry, entry_set)});
+    scopes.push_back(
+        {kernel, entry, reachable_kernel_blocks(blocks, *entry, entry_set, own_entries)});
   }
   return scopes;
 }
@@ -269,9 +321,10 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
   }
 
   const auto entry_offsets = kernel_entry_offsets(descriptor_translations);
+  const auto block_leaders = kernel_block_leaders(descriptor_translations, text);
   // Phase 2: build a CFG over .text and reduce each descriptor root to the
   // source blocks that this kernel owns in the initial relocation strategy.
-  auto blocks = BasicBlock::build(obj, *decoder, entry_offsets);
+  auto blocks = BasicBlock::build(obj, *decoder, block_leaders);
   auto scopes = kernel_translation_scopes(blocks, descriptor_translations);
 
   if (scopes.size() != entry_offsets.size()) {
@@ -313,6 +366,27 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     return true;
   };
 
+  auto write_words_at = [](std::vector<uint8_t> &dst, uint64_t offset,
+                           std::span<const uint32_t> words) {
+    if (words.empty())
+      return;
+    std::memcpy(dst.data() + offset, words.data(), words.size() * sizeof(uint32_t));
+  };
+
+  auto write_launch_stub = [&](KernelTextLayout &layout, uint64_t stub_offset,
+                               uint64_t target_offset) {
+    uint64_t cursor = stub_offset;
+    write_words_at(translated_text, cursor, layout.translation->prologue_words);
+    cursor += layout.translation->prologue_words.size() * sizeof(uint32_t);
+
+    const auto branch_dwords = compute_sopp_branch_simm16(cursor, target_offset);
+    if (!branch_dwords)
+      return false;
+    const uint32_t branch = build_s_branch(*branch_dwords, host_arch_);
+    write_words_at(translated_text, cursor, std::span<const uint32_t>(&branch, 1));
+    return true;
+  };
+
   // Phase 3: fail shared reachable text up front. The plan deliberately keeps
   // duplication/removal of public references out of this first implementation.
   std::unordered_set<const BasicBlock *> translated_blocks;
@@ -343,6 +417,17 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     KernelTextLayout layout;
     layout.translation = scope.translation;
     layout.source_entry = scope.translation->entry_text_offset;
+    const bool has_kernarg_preload = scope.translation->has_kernarg_preload;
+    const uint64_t source_preload_entry = scope.translation->kernarg_preload_entry_text_offset;
+    const uint64_t prologue_bytes = scope.translation->prologue_words.size() * sizeof(uint32_t);
+    const uint64_t launch_stub_bytes = prologue_bytes + sizeof(uint32_t);
+    if (has_kernarg_preload && launch_stub_bytes > kKernargPreloadSkipBytes) {
+      append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                   "kernel descriptor prologue does not fit in the 256-byte kernarg preload "
+                   "compatibility window; leaving code object unchanged",
+                   layout.source_entry);
+      return leave_unchanged();
+    }
 
     // The entry block is not necessarily the first reachable source block. The
     // relocated body is compact, so compute the entry delta from emitted block
@@ -366,15 +451,54 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
       return leave_unchanged();
     }
 
-    const uint64_t body_padding =
-        padding_for_residue(translated_text.size() + entry_delta, layout.source_entry % 256, 256);
-    append_nop_padding(translated_text, body_padding, host_arch_);
+    if (has_kernarg_preload) {
+      // Kernarg-preload kernels have two hardware-visible entries:
+      //
+      //   compat_firmware_entry:
+      //     <compatibility preload words>
+      //     s_branch common_entry
+      //     ... // firmware_entry is 256 bytes after compat_firmware_entry
+      //   firmware_entry:
+      //     <preloaded-kernarg path words>
+      //     s_branch common_entry
+      //   common_entry:
+      //     ...
+      //
+      // Compatible CP firmware enters at descriptor entry + 256 when
+      // kernarg_preload_spec_length is non-zero. Older/incompatible firmware
+      // enters at the descriptor entry. DBT relocates the original source
+      // blocks normally, then synthesizes a fresh launch window:
+      //
+      //   new_compat_firmware_entry:
+      //     <descriptor ABI prologue words>
+      //     s_branch compat_firmware_entry_translated
+      //     ... // new_firmware_entry is exactly 256 bytes later
+      //   new_firmware_entry:
+      //     <descriptor ABI prologue words>
+      //     s_branch firmware_entry_translated
+      //
+      // The descriptor is redirected to new_compat_firmware_entry. Compatible
+      // firmware still adds 256 and lands on new_firmware_entry; older firmware
+      // executes the compatibility stub. The original 256-byte source window is
+      // no longer preserved as layout padding, because the ABI requirement is
+      // the pair of legal entries, not the original physical bytes.
+      const uint64_t launch_padding =
+          padding_for_residue(translated_text.size(), layout.source_entry % 256, 256);
+      append_nop_padding(translated_text, launch_padding, host_arch_);
+      layout.target_entry = translated_text.size();
+      const uint64_t launch_end =
+          layout.target_entry + kKernargPreloadSkipBytes + launch_stub_bytes;
+      append_nop_padding(translated_text, launch_end - translated_text.size(), host_arch_);
+    } else {
+      const uint64_t body_padding =
+          padding_for_residue(translated_text.size() + entry_delta, layout.source_entry % 256, 256);
+      append_nop_padding(translated_text, body_padding, host_arch_);
+    }
 
     layout.body_begin = translated_text.size();
     uint64_t cursor = layout.body_begin;
     layout.blocks.reserve(scope.blocks.size());
     for (BasicBlock *block : scope.blocks) {
-      cursor = preserve_entry_skip_window_offset(layout, *block, cursor);
       layout.blocks.push_back({.block = block,
                                .source_start = block->start_offset(),
                                .source_end = block->end_offset(),
@@ -399,7 +523,24 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     }
     layout.target_body_entry = *body_entry;
 
-    if (!scope.translation->prologue_words.empty()) {
+    if (has_kernarg_preload) {
+      auto preload_body_entry = target_for_source_offset(layout, source_preload_entry);
+      if (!preload_body_entry) {
+        append_error(result.diagnostics, DiagnosticKind::KernelDescriptor,
+                     "kernarg preload firmware entry offset is not present in the relocated body",
+                     source_preload_entry);
+        return leave_unchanged();
+      }
+      if (!write_launch_stub(layout, layout.target_entry, layout.target_body_entry) ||
+          !write_launch_stub(layout, layout.target_entry + kKernargPreloadSkipBytes,
+                             *preload_body_entry)) {
+        append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
+                     "kernel descriptor preload launch-window branch range exceeds s_branch "
+                     "simm16; leaving code object unchanged",
+                     layout.source_entry);
+        return leave_unchanged();
+      }
+    } else if (!scope.translation->prologue_words.empty()) {
       // Descriptor prologues are hardware entry points. Align the cave prologue
       // to the original entry residue, then branch into the relocated body.
       const uint64_t prologue_padding =

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/binary_translator.cpp
@@ -380,11 +380,9 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
     cursor += layout.translation->prologue_words.size() * sizeof(uint32_t);
 
     const auto branch_dwords = compute_sopp_branch_simm16(cursor, target_offset);
-    if (!branch_dwords)
-      return false;
+    assert(branch_dwords && "kernarg preload launch-window branch must fit in s_branch simm16");
     const uint32_t branch = build_s_branch(*branch_dwords, host_arch_);
     write_words_at(translated_text, cursor, std::span<const uint32_t>(&branch, 1));
-    return true;
   };
 
   // Phase 3: fail shared reachable text up front. The plan deliberately keeps
@@ -531,15 +529,9 @@ TranslatedCodeObject BinaryTranslator::translate(const AmdGpuCodeObject &obj) {
                      source_preload_entry);
         return leave_unchanged();
       }
-      if (!write_launch_stub(layout, layout.target_entry, layout.target_body_entry) ||
-          !write_launch_stub(layout, layout.target_entry + kKernargPreloadSkipBytes,
-                             *preload_body_entry)) {
-        append_error(result.diagnostics, DiagnosticKind::ResourceLimit,
-                     "kernel descriptor preload launch-window branch range exceeds s_branch "
-                     "simm16; leaving code object unchanged",
-                     layout.source_entry);
-        return leave_unchanged();
-      }
+      write_launch_stub(layout, layout.target_entry, layout.target_body_entry);
+      write_launch_stub(layout, layout.target_entry + kKernargPreloadSkipBytes,
+                        *preload_body_entry);
     } else if (!scope.translation->prologue_words.empty()) {
       // Descriptor prologues are hardware entry points. Align the cave prologue
       // to the original entry residue, then branch into the relocated body.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -43,6 +43,7 @@ static_assert(sizeof(KD) == 64, "AMDHSA kernel descriptor size changed");
 
 constexpr uint32_t kMaxVgprGranulatedField = 63;
 constexpr uint32_t kMaxSgprGranulatedField = 15;
+constexpr uint64_t kKernargPreloadSkipBytes = 256;
 constexpr uint16_t kScalarOperandTtmpBase = 108;
 constexpr uint16_t kTtmpRdna4GridYz = 7;
 constexpr uint16_t kTtmpRdna4GridX = 9;
@@ -526,7 +527,7 @@ translate_one_descriptor(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
   result.target_body_entry_text_offset = entry_text_offset;
   result.has_kernarg_preload = kernarg_preload_length(src) != 0;
   result.kernarg_preload_entry_text_offset =
-      result.has_kernarg_preload ? entry_text_offset + 256u : entry_text_offset;
+      result.has_kernarg_preload ? entry_text_offset + kKernargPreloadSkipBytes : entry_text_offset;
 
   // The source descriptor encodes the guest launch wave size. The target
   // descriptor must request a wave size the host can actually launch. We do not

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.cpp
@@ -335,6 +335,10 @@ void visit_kernel_descriptors(std::span<const uint8_t> image, uint64_t text_offs
   return AMDHSA_BITS_GET(desc.compute_pgm_rsrc2, kd::COMPUTE_PGM_RSRC2_USER_SGPR_COUNT);
 }
 
+[[nodiscard]] uint32_t kernarg_preload_length(const KD &desc) {
+  return AMDHSA_BITS_GET(desc.kernarg_preload, kd::KERNARG_PRELOAD_SPEC_LENGTH);
+}
+
 [[nodiscard]] int16_t workgroup_id_sgpr(const KD &desc, uint32_t dimension) {
   const uint32_t rsrc2 = desc.compute_pgm_rsrc2;
   const bool enabled[3] = {
@@ -520,6 +524,9 @@ translate_one_descriptor(rj_code_arch_t guest_arch, rj_code_arch_t host_arch,
   result.entry_text_offset = entry_text_offset;
   result.target_entry_text_offset = entry_text_offset;
   result.target_body_entry_text_offset = entry_text_offset;
+  result.has_kernarg_preload = kernarg_preload_length(src) != 0;
+  result.kernarg_preload_entry_text_offset =
+      result.has_kernarg_preload ? entry_text_offset + 256u : entry_text_offset;
 
   // The source descriptor encodes the guest launch wave size. The target
   // descriptor must request a wave size the host can actually launch. We do not

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/dbt/kernel_descriptor_translator.h
@@ -35,6 +35,19 @@ struct KdTranslation {
   /// @brief Original .text-relative kernel entry decoded from the source descriptor.
   uint64_t entry_text_offset = 0;
 
+  /// @brief True when the source descriptor requests CP kernarg preloading.
+  ///
+  /// @details AMDHSA uses kernarg_preload_spec_length != 0 to request that
+  /// compatible CP firmware copy dwords from the kernarg segment into User SGPRs
+  /// before entering the kernel. When this is enabled, compatible firmware starts
+  /// execution at KERNEL_CODE_ENTRY_BYTE_OFFSET + 256 while older/incompatible
+  /// firmware starts at KERNEL_CODE_ENTRY_BYTE_OFFSET. DBT must therefore treat
+  /// both source addresses as legal hardware entries for this kernel.
+  bool has_kernarg_preload = false;
+
+  /// @brief Source .text-relative entry used by compatible kernarg-preload firmware.
+  uint64_t kernarg_preload_entry_text_offset = 0;
+
   /// @brief New .text-relative kernel entry after DBT rewrites .text.
   ///
   /// @details This is the final launch address written into

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.cpp
@@ -14,8 +14,6 @@ namespace rocjitsu {
 
 namespace {
 
-inline constexpr uint64_t kKernargPreloadSkipBytes = 256;
-
 [[nodiscard]] uint32_t text_word_at(std::span<const uint8_t> text, uint64_t offset) {
   uint32_t word = 0;
   if (offset + sizeof(word) <= text.size())
@@ -61,25 +59,6 @@ void append_nop_padding(std::vector<uint8_t> &text, uint64_t byte_count, rj_code
                                            uint64_t alignment) {
   const uint64_t current_residue = current_offset % alignment;
   return (target_residue + alignment - current_residue) % alignment;
-}
-
-[[nodiscard]] uint64_t preserve_entry_skip_window_offset(const KernelTextLayout &layout,
-                                                         const BasicBlock &block, uint64_t cursor) {
-  if (block.start_offset() < layout.source_entry)
-    return cursor;
-
-  // Kernels with kernarg preloading have two valid hardware entry paths:
-  // incompatible firmware executes the descriptor entry and branches around the
-  // preload compatibility prologue, while compatible firmware adds 256 bytes to
-  // KERNEL_CODE_ENTRY_BYTE_OFFSET and starts at the real body directly. Local
-  // body compaction must therefore keep the first 256 bytes after the descriptor
-  // entry stable. Otherwise compatible firmware lands in the middle of compacted
-  // translated code with the preloaded SGPR ABI assumed but not honored.
-  const uint64_t source_delta = block.start_offset() - layout.source_entry;
-  if (source_delta > kKernargPreloadSkipBytes)
-    return cursor;
-
-  return std::max(cursor, layout.body_begin + source_delta);
 }
 
 [[nodiscard]] std::optional<uint64_t> target_for_source_offset(const KernelTextLayout &layout,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/kernel_text_layout.h
@@ -67,9 +67,6 @@ void append_nop_padding(std::vector<uint8_t> &text, uint64_t byte_count, rj_code
 [[nodiscard]] uint64_t padding_for_residue(uint64_t current_offset, uint64_t target_residue,
                                            uint64_t alignment);
 
-[[nodiscard]] uint64_t preserve_entry_skip_window_offset(const KernelTextLayout &layout,
-                                                         const BasicBlock &block, uint64_t cursor);
-
 [[nodiscard]] std::optional<uint64_t> target_for_source_offset(const KernelTextLayout &layout,
                                                                uint64_t source_offset);
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -425,12 +425,13 @@ if(HSA_RUNTIME64)
             )
         endif()
 
+        set(RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE cdna4_to_cdna3_dispatch_test)
         add_executable(
-            cdna4_to_cdna3_dispatch_test
+            ${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}
             dbt/cdna4_to_cdna3_dispatch_test.cpp
         )
         target_include_directories(
-            cdna4_to_cdna3_dispatch_test
+            ${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}
             PRIVATE
                 ${CMAKE_SOURCE_DIR}/lib/rocjitsu/include
                 ${CMAKE_SOURCE_DIR}/lib/rocjitsu/src
@@ -438,7 +439,7 @@ if(HSA_RUNTIME64)
                 ${RJ_HSA_INCLUDE_DIR}
         )
         target_link_libraries(
-            cdna4_to_cdna3_dispatch_test
+            ${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}
             PRIVATE
                 ${RJ_OBJECT_LIBS}
                 util
@@ -447,85 +448,59 @@ if(HSA_RUNTIME64)
                 GTest::gtest_main
         )
         target_link_options(
-            cdna4_to_cdna3_dispatch_test
+            ${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}
             PRIVATE -Wl,-rpath,${RJ_HSA_LIBRARY_DIR}
         )
         target_compile_definitions(
-            cdna4_to_cdna3_dispatch_test
+            ${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}
             PRIVATE HAS_HOST_AMDGPU=1 KERNEL_DIR="${KERNEL_OUTPUT_DIR}"
         )
-        add_dependencies(cdna4_to_cdna3_dispatch_test device_kernels)
-        rj_configure_target(cdna4_to_cdna3_dispatch_test TEST)
+        add_dependencies(${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE} device_kernels)
+        rj_configure_target(${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE} TEST)
 
-        add_test(
-            NAME "Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulTranslates"
-            COMMAND
-                cdna4_to_cdna3_dispatch_test
-                --gtest_filter=Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulTranslates
-            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        set(RJ_CDNA4_TO_CDNA3_TRANSLATE_TESTS
+            DynamicCopyLoopTranslates
+            TritonDynamicMatmulTranslates
+            TritonBufferAsyncMatmulTranslates
+            TritonFlashAttentionNoAsyncTranslates
+            TritonFlashAttentionBufferAsyncTranslates
         )
-        set_tests_properties(
-            "Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulTranslates"
-            PROPERTIES TIMEOUT 120
-        )
-
-        if(HAS_CDNA3_GPU)
+        foreach(_test_name IN LISTS RJ_CDNA4_TO_CDNA3_TRANSLATE_TESTS)
             add_test(
-                NAME "Cdna4ToCdna3DispatchTest.DynamicCopyLoopDispatchAndRun"
+                NAME "Cdna4ToCdna3DispatchTest.${_test_name}"
                 COMMAND
-                    cdna4_to_cdna3_dispatch_test
-                    --gtest_filter=Cdna4ToCdna3DispatchTest.DynamicCopyLoopDispatchAndRun
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            )
-            add_test(
-                NAME
-                    "Cdna4ToCdna3DispatchTest.TritonDynamicMatmulDispatchAndRun"
-                COMMAND
-                    cdna4_to_cdna3_dispatch_test
-                    --gtest_filter=Cdna4ToCdna3DispatchTest.TritonDynamicMatmulDispatchAndRun
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            )
-            add_test(
-                NAME
-                    "Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulDispatchAndRun"
-                COMMAND
-                    cdna4_to_cdna3_dispatch_test
-                    --gtest_filter=Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulDispatchAndRun
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            )
-            add_test(
-                NAME
-                    "Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulConservativeLivenessDispatchAndRun"
-                COMMAND
-                    cdna4_to_cdna3_dispatch_test
-                    --gtest_filter=Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulConservativeLivenessDispatchAndRun
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            )
-            add_test(
-                NAME
-                    "Cdna4ToCdna3DispatchTest.TritonFlashAttentionNoAsyncDispatchAndRun"
-                COMMAND
-                    cdna4_to_cdna3_dispatch_test
-                    --gtest_filter=Cdna4ToCdna3DispatchTest.TritonFlashAttentionNoAsyncDispatchAndRun
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            )
-            add_test(
-                NAME
-                    "Cdna4ToCdna3DispatchTest.TritonFlashAttentionBufferAsyncDispatchAndRun"
-                COMMAND
-                    cdna4_to_cdna3_dispatch_test
-                    --gtest_filter=Cdna4ToCdna3DispatchTest.TritonFlashAttentionBufferAsyncDispatchAndRun
+                    ${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}
+                    --gtest_filter=Cdna4ToCdna3DispatchTest.${_test_name}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             )
             set_tests_properties(
-                "Cdna4ToCdna3DispatchTest.DynamicCopyLoopDispatchAndRun"
-                "Cdna4ToCdna3DispatchTest.TritonDynamicMatmulDispatchAndRun"
-                "Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulDispatchAndRun"
-                "Cdna4ToCdna3DispatchTest.TritonBufferAsyncMatmulConservativeLivenessDispatchAndRun"
-                "Cdna4ToCdna3DispatchTest.TritonFlashAttentionNoAsyncDispatchAndRun"
-                "Cdna4ToCdna3DispatchTest.TritonFlashAttentionBufferAsyncDispatchAndRun"
+                "Cdna4ToCdna3DispatchTest.${_test_name}"
                 PROPERTIES TIMEOUT 120
             )
+        endforeach()
+
+        if(HAS_CDNA3_GPU)
+            set(RJ_CDNA4_TO_CDNA3_DISPATCH_RUN_TESTS
+                DynamicCopyLoopDispatchAndRun
+                TritonDynamicMatmulDispatchAndRun
+                TritonBufferAsyncMatmulDispatchAndRun
+                TritonBufferAsyncMatmulConservativeLivenessDispatchAndRun
+                TritonFlashAttentionNoAsyncDispatchAndRun
+                TritonFlashAttentionBufferAsyncDispatchAndRun
+            )
+            foreach(_test_name IN LISTS RJ_CDNA4_TO_CDNA3_DISPATCH_RUN_TESTS)
+                add_test(
+                    NAME "Cdna4ToCdna3DispatchTest.${_test_name}"
+                    COMMAND
+                        ${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}
+                        --gtest_filter=Cdna4ToCdna3DispatchTest.${_test_name}
+                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                )
+                set_tests_properties(
+                    "Cdna4ToCdna3DispatchTest.${_test_name}"
+                    PROPERTIES TIMEOUT 120
+                )
+            endforeach()
             message(
                 STATUS
                 "CDNA4->CDNA3 dispatch tests enabled (CDNA3 GPU detected)"

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -141,6 +141,7 @@ using TestKernelDescriptor = rocr::llvm::amdhsa::kernel_descriptor_t;
 constexpr size_t kKernelDescriptorSize = sizeof(TestKernelDescriptor);
 constexpr size_t kKernelDescriptorEntryOffset =
     offsetof(TestKernelDescriptor, kernel_code_entry_byte_offset);
+constexpr uint64_t kKernargPreloadSkipBytes = 256;
 
 void write_kernel_descriptor_entry_offset(void *descriptor, int64_t entry_offset) {
   auto *bytes = static_cast<uint8_t *>(descriptor);
@@ -1433,7 +1434,7 @@ TEST(BinaryTranslator, SynthesizesKernargPreloadEntrySkipWindow) {
   ASSERT_FALSE(translated.text_sections().empty());
 
   const auto *text = translated.text_sections()[0];
-  ASSERT_GT(text->size(), 256u);
+  ASSERT_GT(text->size(), kKernargPreloadSkipBytes);
   const auto *target_words = reinterpret_cast<const uint32_t *>(text->data());
   EXPECT_EQ(target_words[0], build_s_branch(64, ROCJITSU_CODE_ARCH_CDNA3))
       << "old firmware enters the synthesized compatibility stub, which branches to the "
@@ -1458,6 +1459,90 @@ TEST(BinaryTranslator, SynthesizesKernargPreloadEntrySkipWindow) {
   EXPECT_EQ(target_kd->kernel_code_entry_byte_offset, source_kd->kernel_code_entry_byte_offset)
       << "the descriptor is redirected to the synthesized compatibility entry; compatible "
          "firmware still reaches the synthesized +256 entry by adding the ABI skip";
+}
+
+TEST(BinaryTranslator, SynthesizesKernargPreloadEntrySkipWindowWithDescriptorPrologue) {
+  constexpr uint64_t kSourceEntryBytes = 512;
+  constexpr size_t kSourceEntryWord = kSourceEntryBytes / sizeof(uint32_t);
+  constexpr size_t kSourcePreloadEntryWord =
+      (kSourceEntryBytes + kKernargPreloadSkipBytes) / sizeof(uint32_t);
+  constexpr uint16_t kScalarOperandTtmpBase = 108;
+  constexpr uint16_t kTtmpRdna4GridX = 9;
+
+  std::vector<uint32_t> words(kSourcePreloadEntryWord + 1,
+                              build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA4));
+  words[0] = build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4);
+  words[kSourceEntryWord] = build_s_branch(63, ROCJITSU_CODE_ARCH_CDNA4);
+  words[kSourcePreloadEntryWord] = build_s_endpgm(ROCJITSU_CODE_ARCH_CDNA4);
+
+  auto image = make_minimal_amdgpu_elf_with_descriptor_after_text(words);
+  enable_workgroup_id_x_sgpr(image);
+
+  AmdGpuCodeObject source_layout(image.data(), image.size());
+  ASSERT_TRUE(source_layout.is_valid());
+  ASSERT_FALSE(source_layout.text_sections().empty());
+  const auto *source_text = source_layout.text_sections()[0];
+  const auto *source_rodata = find_section(source_layout, ".rodata");
+  ASSERT_NE(source_rodata, nullptr);
+  ASSERT_GE(source_rodata->size(), sizeof(rocr::llvm::amdhsa::kernel_descriptor_t));
+
+  auto *source_kd = reinterpret_cast<rocr::llvm::amdhsa::kernel_descriptor_t *>(
+      image.data() + source_rodata->sectionOffset());
+  AMDHSA_BITS_SET(source_kd->kernarg_preload, rocr::llvm::amdhsa::KERNARG_PRELOAD_SPEC_LENGTH, 1);
+  source_kd->kernel_code_entry_byte_offset =
+      static_cast<int64_t>(source_text->vaddr() + kSourceEntryBytes) -
+      static_cast<int64_t>(source_rodata->vaddr());
+
+  AmdGpuCodeObject co(image.data(), image.size());
+  ASSERT_TRUE(co.is_valid());
+
+  BinaryTranslator translator(ROCJITSU_CODE_ARCH_CDNA4, ROCJITSU_CODE_ARCH_RDNA4);
+  auto result = translator.translate(co);
+  ASSERT_TRUE(result.ok()) << (result.diagnostics.empty() ? ""
+                                                          : result.diagnostics.front().message);
+
+  AmdGpuCodeObject translated(result.elf_bytes.data(), result.elf_bytes.size());
+  ASSERT_TRUE(translated.is_valid());
+  ASSERT_FALSE(translated.text_sections().empty());
+
+  const auto *text = translated.text_sections()[0];
+  ASSERT_GT(text->size(), kKernargPreloadSkipBytes + 3 * sizeof(uint32_t));
+  const auto *target_words = reinterpret_cast<const uint32_t *>(text->data());
+
+  const uint32_t workgroup_id_x_prologue =
+      build_s_mov_b32(0, kScalarOperandTtmpBase + kTtmpRdna4GridX, ROCJITSU_CODE_ARCH_RDNA4);
+  const uint32_t prologue_delay = build_s_delay_alu(kDelayAluSaluDep1, ROCJITSU_CODE_ARCH_RDNA4);
+  const auto expect_launch_stub = [&](size_t word_index, int16_t branch_offset) {
+    EXPECT_EQ(target_words[word_index], workgroup_id_x_prologue)
+        << "the synthesized kernarg-preload launch stub must materialize descriptor ABI SGPRs "
+           "before branching into the relocated body";
+    EXPECT_EQ(target_words[word_index + 1], prologue_delay)
+        << "the synthesized launch stub must preserve scalar producer/consumer hazards";
+    EXPECT_EQ(target_words[word_index + 2], build_s_branch(branch_offset, ROCJITSU_CODE_ARCH_RDNA4))
+        << "the synthesized launch stub branches only after the descriptor ABI prologue";
+  };
+  expect_launch_stub(0, 64);
+  expect_launch_stub(kKernargPreloadSkipBytes / sizeof(uint32_t), 1);
+
+  EXPECT_EQ(target_words[67], build_s_branch(0, ROCJITSU_CODE_ARCH_RDNA4))
+      << "the original compatibility source entry is translated in the compact body";
+  EXPECT_EQ(target_words[68], build_s_endpgm(ROCJITSU_CODE_ARCH_RDNA4))
+      << "the original preloaded-kernarg source entry is translated in the compact body";
+
+  const auto *target_rodata = find_section(translated, ".rodata");
+  ASSERT_NE(target_rodata, nullptr);
+  ASSERT_GE(target_rodata->size(), sizeof(rocr::llvm::amdhsa::kernel_descriptor_t));
+  const auto *target_kd = reinterpret_cast<const rocr::llvm::amdhsa::kernel_descriptor_t *>(
+      translated.image_data() + target_rodata->sectionOffset());
+  const int64_t target_entry_text_offset = static_cast<int64_t>(target_rodata->vaddr()) +
+                                           target_kd->kernel_code_entry_byte_offset -
+                                           static_cast<int64_t>(text->vaddr());
+  EXPECT_EQ(target_entry_text_offset, 0)
+      << "the descriptor must be redirected from the moved source entry to the synthesized "
+         "compatibility launch stub";
+  EXPECT_NE(target_kd->kernel_code_entry_byte_offset, source_kd->kernel_code_entry_byte_offset)
+      << "the source descriptor entry is deliberately nonzero, so this assertion proves the "
+         "descriptor was repointed rather than passing because both entries were zero";
 }
 
 TEST(InstructionBuilder, PatchPcrelBranchOffsetInRange) {

--- a/emulation/rocjitsu/tests/dbt/translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/translate_test.cpp
@@ -1402,11 +1402,18 @@ TEST(BinaryTranslator, LocalCaveIgnoresUnreachableTextTail) {
          "after the large unreachable .text tail";
 }
 
-TEST(BinaryTranslator, PreservesKernargPreloadEntrySkipWindow) {
+TEST(BinaryTranslator, SynthesizesKernargPreloadEntrySkipWindow) {
   auto image = make_large_amdgpu_elf_with_waitcnt_entry();
   AmdGpuCodeObject source_layout(image.data(), image.size());
   ASSERT_TRUE(source_layout.is_valid());
   ASSERT_FALSE(source_layout.text_sections().empty());
+  const auto *source_rodata = find_section(source_layout, ".rodata");
+  ASSERT_NE(source_rodata, nullptr);
+  ASSERT_GE(source_rodata->size(), sizeof(rocr::llvm::amdhsa::kernel_descriptor_t));
+
+  auto *source_kd = reinterpret_cast<rocr::llvm::amdhsa::kernel_descriptor_t *>(
+      image.data() + source_rodata->sectionOffset());
+  AMDHSA_BITS_SET(source_kd->kernarg_preload, rocr::llvm::amdhsa::KERNARG_PRELOAD_SPEC_LENGTH, 1);
 
   const auto *source_text = source_layout.text_sections()[0];
   auto *source_words = reinterpret_cast<uint32_t *>(image.data() + source_text->sectionOffset());
@@ -1428,13 +1435,29 @@ TEST(BinaryTranslator, PreservesKernargPreloadEntrySkipWindow) {
   const auto *text = translated.text_sections()[0];
   ASSERT_GT(text->size(), 256u);
   const auto *target_words = reinterpret_cast<const uint32_t *>(text->data());
-  EXPECT_EQ(target_words[0], build_s_branch(63, ROCJITSU_CODE_ARCH_CDNA3))
-      << "the compatibility prologue must still branch over the 256-byte preload skip window";
+  EXPECT_EQ(target_words[0], build_s_branch(64, ROCJITSU_CODE_ARCH_CDNA3))
+      << "old firmware enters the synthesized compatibility stub, which branches to the "
+         "translated compatibility source entry";
   for (size_t i = 1; i < 64; ++i)
     EXPECT_EQ(target_words[i], build_s_nop(0, ROCJITSU_CODE_ARCH_CDNA3))
-        << "preload skip window padding word " << i << " must remain executable padding";
-  EXPECT_EQ(target_words[64], 0xBF810000u)
-      << "compatible firmware starts at descriptor entry + 256 when kernargs are preloaded";
+        << "the synthesized launch window must keep the compatible firmware entry exactly 256 "
+           "bytes after the descriptor entry";
+  EXPECT_EQ(target_words[64], build_s_branch(1, ROCJITSU_CODE_ARCH_CDNA3))
+      << "compatible firmware enters at descriptor entry + 256 and branches to the translated "
+         "preloaded-kernarg source entry";
+  EXPECT_EQ(target_words[65], build_s_branch(0, ROCJITSU_CODE_ARCH_CDNA3))
+      << "the original compatibility source block is translated in the compact body";
+  EXPECT_EQ(target_words[66], 0xBF810000u)
+      << "the original compatible-firmware source entry is translated in the compact body";
+
+  const auto *target_rodata = find_section(translated, ".rodata");
+  ASSERT_NE(target_rodata, nullptr);
+  ASSERT_GE(target_rodata->size(), sizeof(rocr::llvm::amdhsa::kernel_descriptor_t));
+  const auto *target_kd = reinterpret_cast<const rocr::llvm::amdhsa::kernel_descriptor_t *>(
+      translated.image_data() + target_rodata->sectionOffset());
+  EXPECT_EQ(target_kd->kernel_code_entry_byte_offset, source_kd->kernel_code_entry_byte_offset)
+      << "the descriptor is redirected to the synthesized compatibility entry; compatible "
+         "firmware still reaches the synthesized +256 entry by adding the ABI skip";
 }
 
 TEST(InstructionBuilder, PatchPcrelBranchOffsetInRange) {


### PR DESCRIPTION
Kernels supporting kernarg-preloading have two entry points, one for old firmware that doesn't support kernarg-preloading and a new one for firmware that supports it. It look something like:

```
^actual_entry:
  // load kernargs into user sgprs
  <words>
  s_branch ^common_entry
  s_nop
  ... // padding to make actual_entry and preload_entry 256 bytes apart
^preload_entry:
  // kernargs are already in user sgprs
  <words>
  s_branch ^common_entry
^common_entry:
  ...
```

this patch adds proper support for it. The way we do it is by treating `actual_entry` and `preload_entry` both as kernel entry points and builds new entry points when rewriting:

```
^new_compat_actual_entry:
  <descriptor ABI prologue words>
  s_branch ^actual_entry
  s_nop
  ... // new_compat_firmware_entry is exactly 256 bytes later
^new_firmware_entry:
  <descriptor ABI prologue words>
  s_branch ^firmware_entry
```

This prologue is always added in front of a kernel to preserve the kernarg preloading 256 byte firmware contract.

Also refactors tests/CMakeLists.txt to make some tests that weren't running before run properly.