### PR TITLE
[rocprofiler-compute] refactor calc_metrics_data

### DIFF
--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -794,7 +794,7 @@ class db_analysis(OmniAnalyze_Base):
             gfx_arch = self._runs[workload_path].sys_info.iloc[0]["gpu_arch"]
             arch_config = self._arch_configs[gfx_arch]
 
-            # Build table_id -> title map (e.g. 201 -> "Wavefront").
+            # Build table_id -> title map (e.g. 700 -> "Wavefront", 701 -> "Wavefront Launch Stats").
             table_names_map: dict[int, str] = {}
             for panel_config in arch_config.panel_configs.values():
                 table_names_map[panel_config["id"]] = panel_config["title"]

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -778,67 +778,71 @@ class db_analysis(OmniAnalyze_Base):
         metrics_info_data_per_workload: dict[str, pd.DataFrame] = {}
         metric_expression_data_per_workload: dict[str, pd.DataFrame] = {}
 
+        non_expression_columns = {
+            "Metric",
+            "Channel",
+            "Unit",
+            "Description",
+            "Type",
+            "Xfer",
+            "Coherency",
+            "Transaction",
+            "Percent of Peak",
+        }
+
         for workload_path in self._pmc_df_per_workload.keys():
             gfx_arch = self._runs[workload_path].sys_info.iloc[0]["gpu_arch"]
-            # for example 201 -> Wavefront
-            table_names_map = dict()
-            for panel_config in self._arch_configs[gfx_arch].panel_configs.values():
+            arch_config = self._arch_configs[gfx_arch]
+
+            # Build table_id -> title map (e.g. 201 -> "Wavefront").
+            table_names_map: dict[int, str] = {}
+            for panel_config in arch_config.panel_configs.values():
                 table_names_map[panel_config["id"]] = panel_config["title"]
                 for source in panel_config["data source"]:
-                    table_names_map[list(source.values())[0]["id"]] = list(
-                        source.values()
-                    )[0]["title"]
-            # Build metric data
-            non_expression_columns = [
-                "Metric",
-                "Channel",
-                "Unit",
-                "Description",
-                "Type",
-                "Xfer",
-                "Coherency",
-                "Transaction",
-                "Percent of Peak",
-            ]
-            metric_table_rows = [
-                (metric_id, metric_df, row)
-                for df_id, metric_df in self._arch_configs[gfx_arch].dfs.items()
-                if df_id != 402  # roofline points handled in calc_roofline_data
-                if set(metric_df.columns).intersection({"Metric", "Channel"})
-                for metric_id, row in metric_df.iterrows()
-            ]
+                    table = next(iter(source.values()))
+                    table_names_map[table["id"]] = table["title"]
+
+            # Build metric info and expression rows. Compute table-level fields
+            # (table_name, sub_table_name, value_columns) once per table.
+            metric_info_rows: list[MetricInfoRow] = []
+            expression_rows: list[ExpressionRow] = []
+            for table_id, metric_df in arch_config.dfs.items():
+                if table_id == 402:
+                    continue
+                if not set(metric_df.columns).intersection({"Metric", "Channel"}):
+                    continue
+                table_name = table_names_map[table_id // 100 * 100]
+                sub_table_name = table_names_map[table_id]
+                value_columns = [
+                    col
+                    for col in metric_df.columns
+                    if col not in non_expression_columns
+                ]
+                for metric_id, row in metric_df.iterrows():
+                    metric_info_rows.append(
+                        MetricInfoRow(
+                            name=row.get("Metric") or row["Channel"].strip(),
+                            metric_id=metric_id,
+                            description=row.get("Description"),
+                            unit=row.get("Unit"),
+                            pct_of_peak=row.get("Percent of Peak") is True,
+                            table_name=table_name,
+                            sub_table_name=sub_table_name,
+                        )
+                    )
+                    for value_name in value_columns:
+                        expression_rows.append(
+                            ExpressionRow(
+                                metric_id=metric_id,
+                                value_name=value_name,
+                                value=row[value_name].strip(),
+                            )
+                        )
+
             metrics_info_df = pd.DataFrame(
-                [
-                    MetricInfoRow(
-                        name=row.get("Metric") or row["Channel"].strip(),
-                        metric_id=metric_id,
-                        description=row.get("Description"),
-                        unit=row.get("Unit"),
-                        pct_of_peak=row.get("Percent of Peak") is True,
-                        table_name=table_names_map[int(metric_id.split(".")[0]) * 100],
-                        sub_table_name=table_names_map[
-                            int(metric_id.split(".")[0]) * 100
-                            + int(metric_id.split(".")[1])
-                        ],
-                    )
-                    for metric_id, _, row in metric_table_rows
-                ],
-                columns=MetricInfoRow._fields,
+                metric_info_rows, columns=MetricInfoRow._fields
             )
-            expression_df = pd.DataFrame(
-                [
-                    ExpressionRow(
-                        metric_id=metric_id,
-                        value_name=value_name,
-                        value=row[value_name].strip(),
-                    )
-                    for metric_id, metric_df, row in metric_table_rows
-                    for value_name in metric_df.drop(
-                        columns=non_expression_columns, errors="ignore"
-                    ).columns
-                ],
-                columns=ExpressionRow._fields,
-            )
+            expression_df = pd.DataFrame(expression_rows, columns=ExpressionRow._fields)
 
             metrics_info_data_per_workload[workload_path] = metrics_info_df
             metric_expression_data_per_workload[workload_path] = expression_df

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -794,7 +794,8 @@ class db_analysis(OmniAnalyze_Base):
             gfx_arch = self._runs[workload_path].sys_info.iloc[0]["gpu_arch"]
             arch_config = self._arch_configs[gfx_arch]
 
-            # Build table_id -> title map (e.g. 700 -> "Wavefront", 701 -> "Wavefront Launch Stats").
+            # Build table_id -> title map
+            # (e.g. 700 -> "Wavefront", 701 -> "Wavefront Launch Stats").
             table_names_map: dict[int, str] = {}
             for panel_config in arch_config.panel_configs.values():
                 table_names_map[panel_config["id"]] = panel_config["title"]

--- a/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
+++ b/projects/rocprofiler-compute/src/rocprof_compute_analyze/analysis_db.py
@@ -800,45 +800,46 @@ class db_analysis(OmniAnalyze_Base):
             for panel_config in arch_config.panel_configs.values():
                 table_names_map[panel_config["id"]] = panel_config["title"]
                 for source in panel_config["data source"]:
-                    table = next(iter(source.values()))
-                    table_names_map[table["id"]] = table["title"]
+                    for table in source.values():
+                        table_names_map[table["id"]] = table["title"]
 
-            # Build metric info and expression rows. Compute table-level fields
-            # (table_name, sub_table_name, value_columns) once per table.
-            metric_info_rows: list[MetricInfoRow] = []
-            expression_rows: list[ExpressionRow] = []
-            for table_id, metric_df in arch_config.dfs.items():
-                if table_id == 402:
-                    continue
-                if not set(metric_df.columns).intersection({"Metric", "Channel"}):
-                    continue
-                table_name = table_names_map[table_id // 100 * 100]
-                sub_table_name = table_names_map[table_id]
-                value_columns = [
-                    col
-                    for col in metric_df.columns
-                    if col not in non_expression_columns
-                ]
-                for metric_id, row in metric_df.iterrows():
-                    metric_info_rows.append(
-                        MetricInfoRow(
-                            name=row.get("Metric") or row["Channel"].strip(),
-                            metric_id=metric_id,
-                            description=row.get("Description"),
-                            unit=row.get("Unit"),
-                            pct_of_peak=row.get("Percent of Peak") is True,
-                            table_name=table_name,
-                            sub_table_name=sub_table_name,
-                        )
-                    )
-                    for value_name in value_columns:
-                        expression_rows.append(
-                            ExpressionRow(
-                                metric_id=metric_id,
-                                value_name=value_name,
-                                value=row[value_name].strip(),
-                            )
-                        )
+            # Collect metric tables with table-level fields (table_name,
+            # sub_table_name, value_columns) and rows computed once per table.
+            metric_tables = [
+                (
+                    table_names_map[table_id // 100 * 100],
+                    table_names_map[table_id],
+                    [c for c in metric_df.columns if c not in non_expression_columns],
+                    list(metric_df.iterrows()),
+                )
+                for table_id, metric_df in arch_config.dfs.items()
+                if table_id != 402  # roofline points handled in calc_roofline_data
+                if set(metric_df.columns).intersection({"Metric", "Channel"})
+            ]
+
+            metric_info_rows = [
+                MetricInfoRow(
+                    name=row.get("Metric") or row["Channel"].strip(),
+                    metric_id=metric_id,
+                    description=row.get("Description"),
+                    unit=row.get("Unit"),
+                    pct_of_peak=row.get("Percent of Peak") is True,
+                    table_name=table_name,
+                    sub_table_name=sub_table_name,
+                )
+                for table_name, sub_table_name, _value_columns, rows in metric_tables
+                for metric_id, row in rows
+            ]
+            expression_rows = [
+                ExpressionRow(
+                    metric_id=metric_id,
+                    value_name=value_name,
+                    value=row[value_name].strip(),
+                )
+                for _table_name, _sub_table_name, value_columns, rows in metric_tables
+                for metric_id, row in rows
+                for value_name in value_columns
+            ]
 
             metrics_info_df = pd.DataFrame(
                 metric_info_rows, columns=MetricInfoRow._fields

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -430,12 +430,37 @@ def test_calc_dataframe_expressions_empty_returns_assignable_series():
 # =============================================================================
 
 
-def test_calc_metrics_data_empty_filter_preserves_schema():
-    """With no metric tables, the output frames keep their columns."""
+def test_calc_metrics_data_builds_rows_and_preserves_schema():
+    """Metric tables expand into rows with table-level fields resolved once;
+    non-metric tables are skipped and the output frames keep their columns."""
     workload_path = "/fake/workload"
+    metric_df = pd.DataFrame(
+        {
+            "Metric": ["Grid Size"],
+            "Avg": [" 10 "],
+            "Min": [" 5 "],
+            "Max": [" 20 "],
+            "Unit": ["Work items"],
+            "Description": ["Grid size desc"],
+        },
+        index=pd.Index(["7.1.0"], name="Metric_ID"),
+    )
     arch_config = schema.ArchConfig()
-    # Only a non-metric table survives the filter (no Metric/Channel column).
-    arch_config.dfs = {1: pd.DataFrame({"from_csv": ["pmc_kernel_top.csv"]})}
+    # Table 1 has no Metric/Channel column and is skipped; table 701 maps to
+    # panel 700 (table_name) and sub-table 701 (sub_table_name).
+    arch_config.dfs = {
+        1: pd.DataFrame({"from_csv": ["pmc_kernel_top.csv"]}),
+        701: metric_df,
+    }
+    arch_config.panel_configs = {
+        700: {
+            "id": 700,
+            "title": "Wavefront",
+            "data source": [
+                {"metric_table": {"id": 701, "title": "Wavefront Launch Stats"}}
+            ],
+        }
+    }
 
     analyzer = db_analysis(MagicMock(), {})
     analyzer._pmc_df_per_workload = {workload_path: pd.DataFrame({"Counter1": [1]})}
@@ -446,14 +471,21 @@ def test_calc_metrics_data_empty_filter_preserves_schema():
 
     metrics_info, expressions = analyzer.calc_metrics_data()
 
-    assert metrics_info[workload_path].empty
-    assert "pct_of_peak" in metrics_info[workload_path].columns
-    assert "metric_id" in metrics_info[workload_path].columns
-    assert list(expressions[workload_path].columns) == [
-        "metric_id",
-        "value_name",
-        "value",
-    ]
+    info = metrics_info[workload_path]
+    assert "pct_of_peak" in info.columns
+    assert list(info["metric_id"]) == ["7.1.0"]
+    assert list(info["name"]) == ["Grid Size"]
+    assert list(info["table_name"]) == ["Wavefront"]
+    assert list(info["sub_table_name"]) == ["Wavefront Launch Stats"]
+    assert not bool(info["pct_of_peak"].iloc[0])
+
+    exprs = expressions[workload_path]
+    assert list(exprs.columns) == ["metric_id", "value_name", "value"]
+    # Metric/Unit/Description are non-expression columns, so only Avg/Min/Max
+    # expand into expression rows, stripped and in dataframe-column order.
+    assert list(exprs["value_name"]) == ["Avg", "Min", "Max"]
+    assert list(exprs["value"]) == ["10", "5", "20"]
+    assert set(exprs["metric_id"]) == {"7.1.0"}
 
 
 # =============================================================================

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -426,86 +426,12 @@ def test_calc_dataframe_expressions_empty_returns_assignable_series():
 
 
 # =============================================================================
-# calc_metrics_data + _iter_metric_table_rows tests
+# calc_metrics_data tests
 # =============================================================================
 
 
-@pytest.mark.parametrize(
-    "table_id, table_df, expected_ids",
-    [
-        pytest.param(
-            201,
-            pd.DataFrame(
-                {"Metric": ["Wavefronts"], "Avg": ["expr"]},
-                index=pd.Index(["2.1.0"], name="Metric_ID"),
-            ),
-            ["2.1.0"],
-            id="metric_table_included",
-        ),
-        pytest.param(
-            1801,
-            pd.DataFrame(
-                {"Channel": [" TCC "], "Avg": ["expr"]},
-                index=pd.Index(["18.1.0"], name="Metric_ID"),
-            ),
-            ["18.1.0"],
-            id="channel_table_included",
-        ),
-        pytest.param(
-            1,
-            pd.DataFrame({"from_csv": ["pmc_kernel_top.csv"]}),
-            [],
-            id="non_metric_table_skipped",
-        ),
-        pytest.param(
-            402,
-            pd.DataFrame(
-                {"Metric": ["FP32 FLOPs"], "Avg": ["expr"]},
-                index=pd.Index(["4.2.0"], name="Metric_ID"),
-            ),
-            [],
-            id="roofline_table_402_skipped",
-        ),
-    ],
-)
-def test_iter_metric_table_rows_table_inclusion(table_id, table_df, expected_ids):
-    """Only metric/channel tables yield rows; other dfs and roofline table 402
-    are skipped (so a config with no metric table yields nothing)."""
-    arch_config = schema.ArchConfig()
-    arch_config.dfs = {table_id: table_df}
-
-    rows = list(db_analysis._iter_metric_table_rows(arch_config))
-
-    assert [metric_id for metric_id, _df, _row in rows] == expected_ids
-
-
-def test_iter_metric_table_rows_yields_in_df_order_with_source_frame():
-    """Rows yield in df order, each carrying its own source frame."""
-    metric_df = pd.DataFrame(
-        {"Metric": ["Wavefronts"], "Avg": ["expr"]},
-        index=pd.Index(["2.1.0"], name="Metric_ID"),
-    )
-    channel_df = pd.DataFrame(
-        {"Channel": [" TCC "], "Avg": ["expr"]},
-        index=pd.Index(["18.1.0"], name="Metric_ID"),
-    )
-    arch_config = schema.ArchConfig()
-    arch_config.dfs = {
-        201: metric_df,
-        1: pd.DataFrame({"from_csv": ["pmc_kernel_top.csv"]}),
-        1801: channel_df,
-    }
-
-    rows = list(db_analysis._iter_metric_table_rows(arch_config))
-
-    assert [metric_id for metric_id, _df, _row in rows] == ["2.1.0", "18.1.0"]
-    assert rows[0][1] is metric_df
-    assert rows[1][1] is channel_df
-
-
-def test_calc_metrics_data_empty_filter_preserves_schema_and_warns():
-    """With no metric tables, the output frames keep their columns and a
-    warning is emitted."""
+def test_calc_metrics_data_empty_filter_preserves_schema():
+    """With no metric tables, the output frames keep their columns."""
     workload_path = "/fake/workload"
     arch_config = schema.ArchConfig()
     # Only a non-metric table survives the filter (no Metric/Channel column).
@@ -518,10 +444,7 @@ def test_calc_metrics_data_empty_filter_preserves_schema_and_warns():
     }
     analyzer._arch_configs = {"gfx942": arch_config}
 
-    with patch(
-        "rocprof_compute_analyze.analysis_db.console_warning"
-    ) as console_warning_mock:
-        metrics_info, expressions = analyzer.calc_metrics_data()
+    metrics_info, expressions = analyzer.calc_metrics_data()
 
     assert metrics_info[workload_path].empty
     assert "pct_of_peak" in metrics_info[workload_path].columns
@@ -531,7 +454,6 @@ def test_calc_metrics_data_empty_filter_preserves_schema_and_warns():
         "value_name",
         "value",
     ]
-    console_warning_mock.assert_called_once()
 
 
 # =============================================================================

--- a/projects/rocprofiler-compute/tests/test_analysis_db.py
+++ b/projects/rocprofiler-compute/tests/test_analysis_db.py
@@ -426,12 +426,86 @@ def test_calc_dataframe_expressions_empty_returns_assignable_series():
 
 
 # =============================================================================
-# calc_metrics_data tests
+# calc_metrics_data + _iter_metric_table_rows tests
 # =============================================================================
 
 
-def test_calc_metrics_data_empty_filter_preserves_schema():
-    """With no metric tables, the output frames keep their columns."""
+@pytest.mark.parametrize(
+    "table_id, table_df, expected_ids",
+    [
+        pytest.param(
+            201,
+            pd.DataFrame(
+                {"Metric": ["Wavefronts"], "Avg": ["expr"]},
+                index=pd.Index(["2.1.0"], name="Metric_ID"),
+            ),
+            ["2.1.0"],
+            id="metric_table_included",
+        ),
+        pytest.param(
+            1801,
+            pd.DataFrame(
+                {"Channel": [" TCC "], "Avg": ["expr"]},
+                index=pd.Index(["18.1.0"], name="Metric_ID"),
+            ),
+            ["18.1.0"],
+            id="channel_table_included",
+        ),
+        pytest.param(
+            1,
+            pd.DataFrame({"from_csv": ["pmc_kernel_top.csv"]}),
+            [],
+            id="non_metric_table_skipped",
+        ),
+        pytest.param(
+            402,
+            pd.DataFrame(
+                {"Metric": ["FP32 FLOPs"], "Avg": ["expr"]},
+                index=pd.Index(["4.2.0"], name="Metric_ID"),
+            ),
+            [],
+            id="roofline_table_402_skipped",
+        ),
+    ],
+)
+def test_iter_metric_table_rows_table_inclusion(table_id, table_df, expected_ids):
+    """Only metric/channel tables yield rows; other dfs and roofline table 402
+    are skipped (so a config with no metric table yields nothing)."""
+    arch_config = schema.ArchConfig()
+    arch_config.dfs = {table_id: table_df}
+
+    rows = list(db_analysis._iter_metric_table_rows(arch_config))
+
+    assert [metric_id for metric_id, _df, _row in rows] == expected_ids
+
+
+def test_iter_metric_table_rows_yields_in_df_order_with_source_frame():
+    """Rows yield in df order, each carrying its own source frame."""
+    metric_df = pd.DataFrame(
+        {"Metric": ["Wavefronts"], "Avg": ["expr"]},
+        index=pd.Index(["2.1.0"], name="Metric_ID"),
+    )
+    channel_df = pd.DataFrame(
+        {"Channel": [" TCC "], "Avg": ["expr"]},
+        index=pd.Index(["18.1.0"], name="Metric_ID"),
+    )
+    arch_config = schema.ArchConfig()
+    arch_config.dfs = {
+        201: metric_df,
+        1: pd.DataFrame({"from_csv": ["pmc_kernel_top.csv"]}),
+        1801: channel_df,
+    }
+
+    rows = list(db_analysis._iter_metric_table_rows(arch_config))
+
+    assert [metric_id for metric_id, _df, _row in rows] == ["2.1.0", "18.1.0"]
+    assert rows[0][1] is metric_df
+    assert rows[1][1] is channel_df
+
+
+def test_calc_metrics_data_empty_filter_preserves_schema_and_warns():
+    """With no metric tables, the output frames keep their columns and a
+    warning is emitted."""
     workload_path = "/fake/workload"
     arch_config = schema.ArchConfig()
     # Only a non-metric table survives the filter (no Metric/Channel column).
@@ -444,7 +518,10 @@ def test_calc_metrics_data_empty_filter_preserves_schema():
     }
     analyzer._arch_configs = {"gfx942": arch_config}
 
-    metrics_info, expressions = analyzer.calc_metrics_data()
+    with patch(
+        "rocprof_compute_analyze.analysis_db.console_warning"
+    ) as console_warning_mock:
+        metrics_info, expressions = analyzer.calc_metrics_data()
 
     assert metrics_info[workload_path].empty
     assert "pct_of_peak" in metrics_info[workload_path].columns
@@ -454,6 +531,7 @@ def test_calc_metrics_data_empty_filter_preserves_schema():
         "value_name",
         "value",
     ]
+    console_warning_mock.assert_called_once()
 
 
 # =============================================================================


### PR DESCRIPTION
## Motivation

Refactor `calc_metrics_data` to compute table-level fields once per table instead of redundantly per row, improving clarity and reducing repeated work.

The original implementation computed several values redundantly for every metric row:

1. **`table_name` / `sub_table_name`**: Parsed from `metric_id.split(".")` on every row, even though all rows in the same table share the same table name
2. **`value_columns`**: Called `metric_df.drop(columns=...).columns` for every row in the nested comprehension, recomputing the same column list repeatedly
3. **`non_expression_columns`**: Rebuilt the list on every workload iteration

## Technical Details

- Compute `table_name`, `sub_table_name`, `value_columns` once per table, not per row
- Use `table_id // 100 * 100` instead of parsing `metric_id.split(".")`
- Keep `MetricInfoRow` / `ExpressionRow` NamedTuples for schema safety
- Replace nested list comprehensions with explicit loops for clarity

## JIRA ID

N/A

## Test Plan

- Existing test_calc_metrics_data_empty_filter_preserves_schema passes
- CI passes

## Test Result

- [x] Existing test_calc_metrics_data_empty_filter_preserves_schema passes
- [ ] CI passes

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
