### PR TITLE
[roctjistu] Fix RDNA3-4 dispatch metadata handling

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/checkpoint.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/checkpoint.cpp
@@ -8,6 +8,7 @@
 #include "checkpoint_generated.h"
 #include "flatbuffers/flatbuffers.h"
 
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 #include <stdexcept>
@@ -95,6 +96,38 @@ VirtualMachine::Config config_from_checkpoint(const fb::SimulationConfig *fb_con
   return vm_config;
 }
 
+std::vector<uint8_t> serialize_vgprs(const amdgpu::ComputeUnitCore &cu,
+                                     const amdgpu::Wavefront &wf) {
+  const size_t num_vgprs = cu.vgpr_allocation_block_size();
+  const size_t saved_lanes = wf.wf_size();
+  const size_t physical_lanes = cu.vgpr_lanes_per_reg();
+  const size_t saved_stride = saved_lanes * sizeof(uint32_t);
+  const size_t physical_stride = physical_lanes * sizeof(uint32_t);
+  std::vector<uint8_t> serialized(num_vgprs * saved_stride);
+  const uint8_t *src = cu.vgpr_data(wf.vgpr_alloc().base);
+  for (size_t reg = 0; reg < num_vgprs; ++reg) {
+    std::memcpy(serialized.data() + reg * saved_stride, src + reg * physical_stride, saved_stride);
+  }
+  return serialized;
+}
+
+void restore_vgprs(amdgpu::ComputeUnitCore &cu, amdgpu::Wavefront &wf,
+                   const flatbuffers::Vector<uint8_t> &serialized) {
+  const size_t num_vgprs = cu.vgpr_allocation_block_size();
+  const size_t saved_lanes = wf.wf_size();
+  const size_t physical_lanes = cu.vgpr_lanes_per_reg();
+  const size_t saved_stride = saved_lanes * sizeof(uint32_t);
+  const size_t physical_stride = physical_lanes * sizeof(uint32_t);
+  uint8_t *dst = cu.vgpr_data(wf.vgpr_alloc().base);
+  for (size_t reg = 0; reg < num_vgprs; ++reg) {
+    const size_t src_offset = reg * saved_stride;
+    if (src_offset >= serialized.size())
+      break;
+    const size_t copy_size = std::min(saved_stride, serialized.size() - src_offset);
+    std::memcpy(dst + reg * physical_stride, serialized.data() + src_offset, copy_size);
+  }
+}
+
 } // namespace
 
 void save_checkpoint(const std::string &path, const SoC &soc, uint64_t tick,
@@ -117,9 +150,8 @@ void save_checkpoint(const std::string &path, const SoC &soc, uint64_t tick,
 
           auto sgprs_vec =
               builder.CreateVector(cu->sgpr_data(w->sgpr_alloc().base), w->num_sgprs());
-          size_t vgpr_bytes = static_cast<size_t>(cu->vgpr_allocation_block_size()) *
-                              static_cast<size_t>(w->wf_size()) * sizeof(uint32_t);
-          auto vgprs_vec = builder.CreateVector(cu->vgpr_data(w->vgpr_alloc().base), vgpr_bytes);
+          auto vgprs = serialize_vgprs(*cu, *w);
+          auto vgprs_vec = builder.CreateVector(vgprs);
 
           auto wfs = fb::CreateWavefrontState(builder, w->wf_id(), w->wg_id(), w->pc, w->exec(),
                                               w->vcc(), w->m0(), w->is_halted(), w->status_raw(),
@@ -232,7 +264,19 @@ LoadedConfig restore_checkpoint(const std::string &path) {
               wf_state->sgprs() ? wf_state->sgprs()->size() : cu->config().sgprs_per_wf;
           uint32_t num_vgprs = cu->config().vgprs_per_wf;
 
-          auto *wf = cu->dispatch_wf(wf_state->wg_id(), wf_state->pc(), num_sgprs, num_vgprs);
+          uint32_t wave_size = cu->wf_size();
+          if (auto *vgprs = wf_state->vgprs()) {
+            const size_t bytes_per_wave =
+                static_cast<size_t>(cu->vgpr_allocation_block_size()) * sizeof(uint32_t);
+            if (bytes_per_wave != 0 && vgprs->size() % bytes_per_wave == 0) {
+              const size_t saved_wave_size = vgprs->size() / bytes_per_wave;
+              if (saved_wave_size == 32 || saved_wave_size == 64)
+                wave_size = static_cast<uint32_t>(saved_wave_size);
+            }
+          }
+
+          auto *wf =
+              cu->dispatch_wf(wf_state->wg_id(), wf_state->pc(), num_sgprs, num_vgprs, wave_size);
           if (!wf)
             throw std::runtime_error("Failed to dispatch wavefront during checkpoint restoration");
 
@@ -252,10 +296,7 @@ LoadedConfig restore_checkpoint(const std::string &path) {
           }
 
           if (auto *vgprs = wf_state->vgprs()) {
-            size_t vgpr_bytes = static_cast<size_t>(cu->vgpr_allocation_block_size()) *
-                                static_cast<size_t>(wf->wf_size()) * sizeof(uint32_t);
-            size_t copy_size = std::min<size_t>(vgprs->size(), vgpr_bytes);
-            std::memcpy(cu->vgpr_data(wf->vgpr_alloc().base), vgprs->data(), copy_size);
+            restore_vgprs(*cu, *wf, *vgprs);
           }
         }
       }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -460,13 +460,17 @@ std::unordered_map<std::string, FactoryFn> &factories() {
         gran = 8;
       cp->set_vgpr_granularity(gran);
       bool packed = (arch == ROCJITSU_CODE_ARCH_CDNA3 || arch == ROCJITSU_CODE_ARCH_CDNA4 ||
-                     arch == ROCJITSU_CODE_ARCH_GFX1250);
+                     arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ||
+                     arch == ROCJITSU_CODE_ARCH_RDNA4 || arch == ROCJITSU_CODE_ARCH_GFX1250);
       cp->set_packed_tid(packed);
       const bool gfx11_plus_sdma =
           arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ||
           arch == ROCJITSU_CODE_ARCH_RDNA4 || arch == ROCJITSU_CODE_ARCH_GFX1250;
-      cp->set_sdma_packet_dialect(gfx11_plus_sdma ? amdgpu::SdmaPacketDialect::Gfx11Plus
-                                                  : amdgpu::SdmaPacketDialect::Legacy);
+      if (arch == ROCJITSU_CODE_ARCH_GFX1250)
+        cp->set_sdma_packet_dialect(amdgpu::SdmaPacketDialect::Gfx1250);
+      else
+        cp->set_sdma_packet_dialect(gfx11_plus_sdma ? amdgpu::SdmaPacketDialect::Gfx11Plus
+                                                    : amdgpu::SdmaPacketDialect::Legacy);
       return cp;
     };
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/tensor_dma.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/tensor_dma.h
@@ -224,12 +224,13 @@ inline void copy_bytes(const TensorDmaDescriptor &desc, Wavefront &wf, uint64_t 
   }
 
   const uint32_t lds_addr = wf.lds_base() + desc.lds_base + static_cast<uint32_t>(lds_byte);
+  const uint32_t vmid = wf.process_id();
   for (uint32_t byte = 0; byte < desc.elem_size; ++byte) {
     if (store_from_lds) {
       if (in_bounds)
-        memory->write8(global_addr + byte, wf.cu().lds().read8(lds_addr + byte));
+        memory->write8(global_addr + byte, wf.cu().lds().read8(lds_addr + byte), vmid);
     } else {
-      const uint8_t value = in_bounds ? memory->read8(global_addr + byte) : 0;
+      const uint8_t value = in_bounds ? memory->read8(global_addr + byte, vmid) : 0;
       wf.cu().lds().write8(lds_addr + byte, value);
     }
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -10,6 +10,7 @@
 
 #include "rocjitsu/base/rj_compiler.h"
 #include "rocjitsu/kmd/linux/amdgpu_properties.h"
+#include "rocjitsu/kmd/linux/kfd_process.h"
 #include "rocjitsu/kmd/linux/remote_driver.h"
 #include "rocjitsu/kmd/linux/rpc.h"
 #include "rocjitsu/kmd/linux/simulated_driver.h"
@@ -1060,17 +1061,39 @@ int fcntl(int fd, int cmd, ...) {
 
 void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
   assert(InterposerContext::real.ready());
-  if (auto *remote = InterposerContext::ctx.remote_lookup(fd))
-    return remote->mmap(addr, length, prot, flags, offset);
+  // Daemon-backed and local simulated GPU fds own their mmap semantics. Forward
+  // those calls first, then invalidate host VMA snapshots used by GPU page-table
+  // translations when a mapping actually changes.
+  if (auto *remote = InterposerContext::ctx.remote_lookup(fd)) {
+    void *ret = remote->mmap(addr, length, prot, flags, offset);
+    if (ret != MAP_FAILED)
+      rocjitsu::KfdProcess::notify_host_mappings_changed();
+    return ret;
+  }
 
-  if (auto *drv = InterposerContext::ctx.lookup(fd))
-    return drv->mmap(addr, length, prot, flags, offset);
+  if (auto *drv = InterposerContext::ctx.lookup(fd)) {
+    void *ret = drv->mmap(addr, length, prot, flags, offset);
+    if (ret != MAP_FAILED)
+      rocjitsu::KfdProcess::notify_host_mappings_changed();
+    return ret;
+  }
 
   if (InterposerContext::ctx.is_drm(fd)) {
-    if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()))
-      return remote->mmap(addr, length, prot, flags, offset);
-    if (auto *drv = InterposerContext::ctx.driver())
-      return drv->mmap(addr, length, prot, flags, offset);
+    // Synthetic DRM fds in daemon mode do not have local mmap state; route them
+    // through the remote KFD driver so dma-buf imports get a real host mapping.
+    if (auto *remote =
+            InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd())) {
+      void *ret = remote->mmap(addr, length, prot, flags, offset);
+      if (ret != MAP_FAILED)
+        rocjitsu::KfdProcess::notify_host_mappings_changed();
+      return ret;
+    }
+    if (auto *drv = InterposerContext::ctx.driver()) {
+      void *ret = drv->mmap(addr, length, prot, flags, offset);
+      if (ret != MAP_FAILED)
+        rocjitsu::KfdProcess::notify_host_mappings_changed();
+      return ret;
+    }
   }
 
   if (fd < 0 && (flags & MAP_FIXED) && prot != PROT_NONE && addr) {
@@ -1087,11 +1110,15 @@ void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
 #ifdef MADV_POPULATE_WRITE
         InterposerContext::real.madvise(raw, length, MADV_POPULATE_WRITE);
 #endif
+        rocjitsu::KfdProcess::notify_host_mappings_changed();
         return raw;
       }
     }
   }
-  return InterposerContext::real.mmap(addr, length, prot, flags, fd, offset);
+  void *ret = InterposerContext::real.mmap(addr, length, prot, flags, fd, offset);
+  if (ret != MAP_FAILED)
+    rocjitsu::KfdProcess::notify_host_mappings_changed();
+  return ret;
 }
 
 int mprotect(void *addr, size_t length, int prot) {
@@ -1101,7 +1128,10 @@ int mprotect(void *addr, size_t length, int prot) {
     errno = EPERM;
     return -1;
   }
-  return InterposerContext::real.mprotect(addr, length, prot);
+  int ret = InterposerContext::real.mprotect(addr, length, prot);
+  if (ret == 0)
+    rocjitsu::KfdProcess::notify_host_mappings_changed();
+  return ret;
 }
 
 int madvise(void *addr, size_t length, int advice) {
@@ -1116,16 +1146,25 @@ int munmap(void *addr, size_t length) {
   assert(InterposerContext::real.ready());
   if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd())) {
     int ret = remote->munmap(addr, length);
-    if (ret != -ENOENT)
+    if (ret != -ENOENT) {
+      if (ret == 0)
+        rocjitsu::KfdProcess::notify_host_mappings_changed();
       return ret;
+    }
   }
   auto *drv = InterposerContext::ctx.driver();
   if (drv) {
     int ret = drv->munmap(addr, length);
-    if (ret != -ENOENT)
+    if (ret != -ENOENT) {
+      if (ret == 0)
+        rocjitsu::KfdProcess::notify_host_mappings_changed();
       return ret;
+    }
   }
-  return InterposerContext::real.munmap(addr, length);
+  int ret = InterposerContext::real.munmap(addr, length);
+  if (ret == 0)
+    rocjitsu::KfdProcess::notify_host_mappings_changed();
+  return ret;
 }
 
 // -- libdrm interposition --

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -15,9 +15,13 @@
 #include "rocjitsu/kmd/linux/events.h"
 #include "rocjitsu/vm/amdgpu/mtype.h"
 
+#include <algorithm>
+#include <atomic>
 #include <cstdint>
+#include <cstdio>
 #include <mutex>
 #include <shared_mutex>
+#include <sys/mman.h>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -58,6 +62,7 @@ public:
     uint64_t gpu_va = 0;
     uint64_t size = 0;
     void *host_ptr = nullptr;
+    bool host_ptr_owned = false;
     uint32_t flags = 0;
     uint64_t handle = 0;
     int memfd = -1;
@@ -102,10 +107,14 @@ public:
   /// @brief Per-page translation entry, mirroring HW PTE fields.
   /// @details Stores the host pointer for VA→PA translation and the PTE MTYPE
   /// that the GPU MMU uses to override instruction-level caching. On real
-  /// AMDGPU hardware, PTE bits 57:55 encode MTYPE per page.
+  /// AMDGPU hardware, PTE bits 57:55 encode MTYPE per page. Host permission
+  /// bits are a map-time fast rejection for USERPTR/imported memory; GpuMemory
+  /// still revalidates the live host VMA before returning a raw host pointer.
   struct PageTableEntry {
     uint8_t *host_ptr = nullptr;
     amdgpu::Mtype mtype = amdgpu::Mtype::RW;
+    bool host_readable = false;
+    bool host_writable = false;
   };
 
   /// @brief Per-process GPU page table (GPU VA page number → PTE).
@@ -117,21 +126,113 @@ public:
   static constexpr uint64_t kPageShift = 12;
   static constexpr uint64_t kPageSize = 1ULL << kPageShift;
 
+  // GPU page-table entries may point at arbitrary host USERPTR or imported
+  // mappings. Track host VMA permissions so the simulator falls back to sparse
+  // memory instead of dereferencing pages that are PROT_NONE, read-only, or
+  // have been unmapped. The interposer bumps the host-mapping epoch after
+  // successful mmap/mprotect/munmap calls so cached snapshots do not survive
+  // VMA permission changes.
+  struct HostPageAccess {
+    bool readable = false;
+    bool writable = false;
+  };
+
+  struct HostMappingRange {
+    uintptr_t start = 0;
+    uintptr_t end = 0;
+    HostPageAccess access;
+  };
+
+  struct HostMappingsSnapshot {
+    std::vector<HostMappingRange> ranges;
+
+    HostPageAccess access_for(const void *ptr) const {
+      const auto page = reinterpret_cast<uintptr_t>(ptr) & ~(kPageSize - 1);
+      const uintptr_t page_end = page + kPageSize;
+      if (page_end < page)
+        return {};
+      auto it = std::upper_bound(
+          ranges.begin(), ranges.end(), page,
+          [](uintptr_t value, const HostMappingRange &range) { return value < range.start; });
+      if (it == ranges.begin())
+        return {};
+      --it;
+      if (page >= it->start && page_end <= it->end)
+        return it->access;
+      return {};
+    }
+  };
+
+  static HostMappingsSnapshot read_host_mappings() {
+    HostMappingsSnapshot snapshot;
+    FILE *maps = std::fopen("/proc/self/maps", "re");
+    if (!maps)
+      return snapshot;
+
+    char line[512];
+    while (std::fgets(line, sizeof(line), maps)) {
+      unsigned long long start = 0;
+      unsigned long long end = 0;
+      char perms[5] = {};
+      if (std::sscanf(line, "%llx-%llx %4s", &start, &end, perms) != 3)
+        continue;
+      if (end <= start)
+        continue;
+      snapshot.ranges.push_back({static_cast<uintptr_t>(start),
+                                 static_cast<uintptr_t>(end),
+                                 {.readable = perms[0] == 'r', .writable = perms[1] == 'w'}});
+    }
+    std::fclose(maps);
+    std::sort(
+        snapshot.ranges.begin(), snapshot.ranges.end(),
+        [](const HostMappingRange &a, const HostMappingRange &b) { return a.start < b.start; });
+    return snapshot;
+  }
+
+  static HostPageAccess host_page_access(const void *ptr) {
+    return read_host_mappings().access_for(ptr);
+  }
+
+  static bool host_page_readable(const void *ptr) { return host_page_access(ptr).readable; }
+
+  static uint64_t host_mappings_generation() {
+    return host_mappings_epoch().load(std::memory_order_acquire);
+  }
+
+  static void notify_host_mappings_changed() {
+    host_mappings_epoch().fetch_add(1, std::memory_order_acq_rel);
+  }
+
   /// @brief Map host pages into this process's GPU page table.
   /// @param mtype PTE MTYPE for these pages (derived from allocation flags).
   void map_pages(uint64_t gpu_va, void *host_ptr, size_t size,
                  amdgpu::Mtype mtype = amdgpu::Mtype::RW) {
+    if (size == 0)
+      return;
     std::unique_lock lock(page_table_mutex_);
     auto *base = static_cast<uint8_t *>(host_ptr);
-    for (size_t off = 0; off < size; off += kPageSize)
-      page_table_[(gpu_va + off) >> kPageShift] = {base + off, mtype};
+    const uint64_t first_page = gpu_va & ~(kPageSize - 1);
+    const uint64_t end_va = gpu_va + size;
+    const HostMappingsSnapshot host_mappings = read_host_mappings();
+    for (uint64_t page_va = first_page; page_va < end_va; page_va += kPageSize) {
+      auto *translation_base =
+          reinterpret_cast<uint8_t *>(reinterpret_cast<uintptr_t>(base) + page_va - gpu_va);
+      const uint64_t access_va = page_va < gpu_va ? gpu_va : page_va;
+      const HostPageAccess access = host_mappings.access_for(base + (access_va - gpu_va));
+      page_table_[page_va >> kPageShift] = {translation_base, mtype, access.readable,
+                                            access.writable};
+    }
   }
 
   /// @brief Unmap pages from this process's GPU page table.
   void unmap_pages(uint64_t gpu_va, size_t size) {
+    if (size == 0)
+      return;
     std::unique_lock lock(page_table_mutex_);
-    for (size_t off = 0; off < size; off += kPageSize)
-      page_table_.erase((gpu_va + off) >> kPageShift);
+    const uint64_t first_page = gpu_va & ~(kPageSize - 1);
+    const uint64_t end_va = gpu_va + size;
+    for (uint64_t page_va = first_page; page_va < end_va; page_va += kPageSize)
+      page_table_.erase(page_va >> kPageShift);
   }
 
   mutable std::shared_mutex page_table_mutex_;
@@ -171,6 +272,10 @@ public:
   RuntimeState runtime_state_;
 
 private:
+  static std::atomic<uint64_t> &host_mappings_epoch() {
+    static std::atomic<uint64_t> epoch{1};
+    return epoch;
+  }
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
@@ -471,10 +471,11 @@ int SimulatedDriver::close(uint32_t process_id) {
       leaked_bytes += alloc.size;
       if (trace_enabled)
         leaked_handles.push_back(handle);
-      if (alloc.host_ptr && !(alloc.flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR)) {
+      if (alloc.host_ptr && alloc.host_ptr_owned) {
         unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
         syscall(SYS_munmap, alloc.host_ptr, alloc.size);
         alloc.host_ptr = nullptr;
+        alloc.host_ptr_owned = false;
       }
       if (alloc.memfd >= 0) {
         {
@@ -845,6 +846,7 @@ void *SimulatedDriver::dispatch_mmap(KfdProcess &proc, void *addr, size_t length
     return alloc.host_ptr;
 
   void *host_ptr;
+  bool host_ptr_owned = true;
 
   if (alloc.memfd >= 0) {
     if (length > alloc.size) {
@@ -893,6 +895,7 @@ void *SimulatedDriver::dispatch_mmap(KfdProcess &proc, void *addr, size_t length
     }
     if (reuse_pages) {
       host_ptr = addr;
+      host_ptr_owned = false;
     } else {
       int mflags = MAP_ANONYMOUS;
       mflags |= (flags & MAP_SHARED) ? MAP_SHARED : MAP_PRIVATE;
@@ -905,6 +908,7 @@ void *SimulatedDriver::dispatch_mmap(KfdProcess &proc, void *addr, size_t length
   }
 
   alloc.host_ptr = host_ptr;
+  alloc.host_ptr_owned = host_ptr_owned;
 
   util::Logger::vm([&](auto &os) {
     os << std::format("mmap: gpu_va={:#x} host_ptr={:#x} size={} flags={:#x}"
@@ -957,6 +961,7 @@ int SimulatedDriver::dispatch_munmap(KfdProcess &proc, void *addr, size_t length
       unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
       syscall(SYS_munmap, addr, length);
       alloc.host_ptr = nullptr;
+      alloc.host_ptr_owned = false;
       return 0;
     }
   }
@@ -1092,6 +1097,7 @@ int SimulatedDriver::alloc_memory_ioctl(KfdProcess &proc, void *arg) {
               safe_mmap(nullptr, alloc.size, PROT_READ | PROT_WRITE, MAP_SHARED, alloc.memfd, 0);
           if (mapped != MAP_FAILED) {
             alloc.host_ptr = mapped;
+            alloc.host_ptr_owned = true;
             map_to_gpu(proc, va, alloc.host_ptr, alloc.size, alloc_mtype);
           }
         }
@@ -1199,8 +1205,11 @@ int SimulatedDriver::free_memory_ioctl(KfdProcess &proc, void *arg) {
         proc.imported_dmabufs_.erase(dmabuf_it);
       }
     }
-    if (alloc.host_ptr && !alloc.user_va)
+    if (alloc.host_ptr)
       unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
+    if (alloc.host_ptr && alloc.host_ptr_owned) {
+      syscall(SYS_munmap, alloc.host_ptr, alloc.size);
+    }
     if (alloc.memfd >= 0) {
       {
         std::lock_guard<std::mutex> lk(owned_fds_mutex_);
@@ -1392,6 +1401,13 @@ int SimulatedDriver::import_dmabuf_ioctl(KfdProcess &proc, void *arg) {
   if (dupfd < 0)
     return -errno;
 
+  auto *host_ptr = safe_mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, dupfd, 0);
+  if (host_ptr == MAP_FAILED) {
+    const int saved_errno = errno;
+    syscall(SYS_close, dupfd);
+    return -saved_errno;
+  }
+
   uint64_t handle;
   {
     std::lock_guard<std::mutex> lk(proc.alloc_mutex_);
@@ -1401,16 +1417,15 @@ int SimulatedDriver::import_dmabuf_ioctl(KfdProcess &proc, void *arg) {
     alloc.size = size;
     alloc.flags = KFD_IOC_ALLOC_MEM_FLAGS_GTT | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
     alloc.handle = handle;
-    alloc.user_va = true;
     alloc.imported = true;
     alloc.dmabuf_fd = dupfd;
-    alloc.host_ptr = reinterpret_cast<void *>(args->va_addr);
+    alloc.host_ptr = host_ptr;
+    alloc.host_ptr_owned = true;
     proc.allocations_[handle] = alloc;
   }
 
   if (args->va_addr)
-    map_to_gpu(proc, args->va_addr, reinterpret_cast<void *>(args->va_addr), size,
-               amdgpu::Mtype::UC);
+    map_to_gpu(proc, args->va_addr, host_ptr, size, amdgpu::Mtype::UC);
 
   KfdProcess::ImportedDmabuf info{};
   info.handle = handle;
@@ -1479,22 +1494,16 @@ int SimulatedDriver::ipc_export_handle_ioctl(KfdProcess &proc, void *arg) {
                          "true sharing)");
       }
 
-      {
-        std::unique_lock ptlk(proc.page_table_mutex_);
-        auto *old_base = static_cast<uint8_t *>(alloc.host_ptr);
-        auto *new_base = static_cast<uint8_t *>(new_host_ptr);
-        for (size_t off = 0; off < alloc.size; off += KfdProcess::kPageSize) {
-          uint64_t page_num = (alloc.gpu_va + off) >> KfdProcess::kPageShift;
-          auto pt_it = proc.page_table_.find(page_num);
-          if (pt_it != proc.page_table_.end() && pt_it->second.host_ptr == old_base + off)
-            pt_it->second.host_ptr = new_base + off;
-        }
+      if (alloc.gpu_va != 0) {
+        proc.unmap_pages(alloc.gpu_va, alloc.size);
+        map_to_gpu(proc, alloc.gpu_va, new_host_ptr, alloc.size, pte_mtype_for_flags(alloc.flags));
       }
 
-      if (!(alloc.flags & KFD_IOC_ALLOC_MEM_FLAGS_USERPTR))
+      if (alloc.host_ptr_owned)
         syscall(SYS_munmap, alloc.host_ptr, alloc.size);
 
       alloc.host_ptr = new_host_ptr;
+      alloc.host_ptr_owned = true;
       alloc.memfd = promoted_fd;
       {
         std::lock_guard<std::mutex> flk(owned_fds_mutex_);
@@ -1629,6 +1638,7 @@ int SimulatedDriver::ipc_import_handle_ioctl(KfdProcess &proc, void *arg) {
     alloc.flags = alloc_flags;
     alloc.handle = handle;
     alloc.host_ptr = host_ptr;
+    alloc.host_ptr_owned = true;
     alloc.memfd = dup_fd;
     alloc.gpu_id = source_gpu_id;
     alloc.imported = true;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -12,6 +12,7 @@ RJ_DIAGNOSTIC_POP
 
 #include "simdojo/sim/message.h"
 #include "simdojo/sim/simulation.h"
+#include "util/bit.h"
 #include "util/log.h"
 
 #include <algorithm>
@@ -62,11 +63,10 @@ static_assert(sizeof(AmdExtKernelDispatchPacket) == 64);
 
 uint32_t nonzero_or_one(uint32_t v) { return v == 0 ? 1 : v; }
 
-uint32_t read_memory_u32(GpuMemory *memory, uint64_t addr) {
-  uint32_t value = 0;
-  for (uint32_t i = 0; i < sizeof(value); ++i)
-    value |= static_cast<uint32_t>(memory->read8(addr + i)) << (i * 8);
-  return value;
+uint32_t dispatch_grid_workgroups(uint32_t grid_size, uint32_t workgroup_size) {
+  if (workgroup_size == 0)
+    return 1;
+  return util::ceil_div(grid_size, workgroup_size);
 }
 
 bool sgpr_count_is_descriptor_encoded(rj_code_arch_t arch, uint32_t sgpr_gran) {
@@ -83,6 +83,50 @@ bool sgpr_count_is_descriptor_encoded(rj_code_arch_t arch, uint32_t sgpr_gran) {
     return false;
   default:
     return true;
+  }
+}
+
+uint32_t kernel_dispatch_wave_size(rj_code_arch_t arch, uint32_t kernel_code_properties) {
+  using namespace rocr::llvm::amdhsa;
+
+  switch (arch) {
+  case ROCJITSU_CODE_ARCH_CDNA1:
+  case ROCJITSU_CODE_ARCH_CDNA2:
+  case ROCJITSU_CODE_ARCH_CDNA3:
+  case ROCJITSU_CODE_ARCH_CDNA4:
+    return 64;
+  case ROCJITSU_CODE_ARCH_RDNA1:
+  case ROCJITSU_CODE_ARCH_RDNA2:
+  case ROCJITSU_CODE_ARCH_RDNA3:
+  case ROCJITSU_CODE_ARCH_RDNA3_5:
+  case ROCJITSU_CODE_ARCH_RDNA4:
+    return AMDHSA_BITS_GET(kernel_code_properties, KERNEL_CODE_PROPERTY_ENABLE_WAVEFRONT_SIZE32)
+               ? 32
+               : 64;
+  case ROCJITSU_CODE_ARCH_GFX1250:
+    return 32;
+  default:
+    // Non-AMDGPU or invalid enum values are not expected here, but keep the
+    // legacy wave64 fallback for internal tests that leave the arch unset.
+    return 64;
+  }
+}
+
+uint32_t descriptor_vgpr_granularity_for_wavefront(rj_code_arch_t arch, uint32_t wave_size,
+                                                   uint32_t fallback_granularity) {
+  // This is the AMDHSA kernel descriptor encoding granularity for
+  // COMPUTE_PGM_RSRC1.GRANULATED_WORKITEM_VGPR_COUNT, not the physical VGPR
+  // allocation block size. LLVM's AMDGPUBaseInfo::getVGPREncodingGranule
+  // encodes GFX10-GFX12 Wave64 descriptors in blocks of 4 VGPRs.
+  switch (arch) {
+  case ROCJITSU_CODE_ARCH_RDNA1:
+  case ROCJITSU_CODE_ARCH_RDNA2:
+  case ROCJITSU_CODE_ARCH_RDNA3:
+  case ROCJITSU_CODE_ARCH_RDNA3_5:
+  case ROCJITSU_CODE_ARCH_RDNA4:
+    return wave_size == 32 ? 8 : 4;
+  default:
+    return std::max(fallback_granularity, 1u);
   }
 }
 
@@ -165,7 +209,7 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
 
       uint64_t preload_addr = pkt.kernarg_addr + static_cast<uint64_t>(preload_offset) * 4;
       for (uint32_t i = 0; i < preload_length; ++i)
-        cu->write_sgpr(sbase + idx + i, read_memory_u32(memory_, preload_addr + i * 4));
+        cu->write_sgpr(sbase + idx + i, read_gpu_u32(preload_addr + i * 4, pkt.process_id));
       util::Logger::vm("CP: init_wf kernarg preload s[", idx, ":", idx + preload_length - 1,
                        "] length=", preload_length, " offset=", preload_offset, " sbase=", sbase);
       idx += preload_length;
@@ -219,20 +263,24 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
   //   0 = v0 only (workitem_id_x)
   //   1 = v0 + v1 (workitem_id_x, workitem_id_y)
   //   2 = v0 + v1 + v2 (workitem_id_x, workitem_id_y, workitem_id_z)
-  // On packed-TID targets (CDNA3/4 and gfx1250): v0[9:0]=X,
-  // v0[19:10]=Y, v0[29:20]=Z. v1/v2 are not written. Kernel extracts
-  // components via bit masks.
+  // On packed-TID targets (CDNA3/4 and GFX11+): v0[9:0]=X, v0[19:10]=Y,
+  // v0[29:20]=Z. TIDIG_COMP_CNT still controls how many TID VGPRs are
+  // allocated; the one-VGPR case carries the full packed tuple in v0.
   uint32_t vbase = wf->vgpr_alloc().base;
-  uint32_t workitem_base = wf_index_in_wg * cu->wf_size();
+  uint32_t wave_size = wf->wf_size();
+  uint32_t workitem_base = wf_index_in_wg * wave_size;
   uint32_t wg_x = pkt.workgroup_size_x > 0 ? pkt.workgroup_size_x : 1;
   uint32_t wg_y = pkt.workgroup_size_y > 0 ? pkt.workgroup_size_y : 1;
   uint32_t wg_xy = wg_x * wg_y;
-  for (uint32_t lane = 0; lane < cu->wf_size(); ++lane) {
+  for (uint32_t lane = 0; lane < wave_size; ++lane) {
     uint32_t flat_id = workitem_base + lane;
     uint32_t id_x = flat_id % wg_x;
     uint32_t id_y = (flat_id / wg_x) % wg_y;
     uint32_t id_z = flat_id / wg_xy;
-    if (packed_tid_ && pkt.enable_vgpr_workitem_id > 0) {
+    if (packed_tid_) {
+      // Packed-TID targets always seed the complete X/Y/Z tuple in v0. When
+      // TID VGPRs are not enabled, TIDIG_COMP_CNT is encoded as zero, so this
+      // path does not need an extra enable_vgpr_workitem_id gate.
       uint32_t packed = (id_x & 0x3FFu) | ((id_y & 0x3FFu) << 10) | ((id_z & 0x3FFu) << 20);
       cu->write_vgpr(vbase, lane, packed);
     } else {
@@ -254,11 +302,11 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
     uint64_t scratch_pool = pkt.scratch_backing_addr;
     if (scratch_pool == 0)
       scratch_pool = 0x1'0000'0000ULL;
-    uint64_t per_wave_size = static_cast<uint64_t>(pkt.private_segment_fixed_size) * cu->wf_size();
+    uint64_t per_wave_size = static_cast<uint64_t>(pkt.private_segment_fixed_size) * wave_size;
     uint32_t wg_total_size = static_cast<uint32_t>(pkt.workgroup_size_x) *
                              std::max<uint16_t>(1, pkt.workgroup_size_y) *
                              std::max<uint16_t>(1, pkt.workgroup_size_z);
-    uint32_t waves_per_wg = (wg_total_size + cu->wf_size() - 1) / cu->wf_size();
+    uint32_t waves_per_wg = util::ceil_div(wg_total_size, wave_size);
     uint64_t global_wave_idx = static_cast<uint64_t>(global_wg_id) * waves_per_wg + wf_index_in_wg;
     uint64_t wave_scratch = scratch_pool + global_wave_idx * per_wave_size;
 
@@ -557,12 +605,12 @@ uint32_t CommandProcessor::dispatch_workgroups(DispatchEntry &entry) {
     wg_wavefronts.reserve(entry.wfs_per_workgroup);
     for (uint32_t w = 0; w < entry.wfs_per_workgroup; ++w) {
       Wavefront *wf = cu->dispatch_wf(global_wg_id, entry.kernel_entry_pc, entry.sgprs_per_wf,
-                                      entry.vgprs_per_wf);
+                                      entry.vgprs_per_wf, entry.wave_size);
       assert(wf && "dispatch_wf failed after can_accept_workgroup returned true");
       wf->set_lds_base(lds_base);
       wf->set_dispatch_id(entry.dispatch_id);
       wf->set_process_id(entry.process_id);
-      wf->set_exec(initial_exec_mask_for_wave(entry, w, cu->wf_size()));
+      wf->set_exec(initial_exec_mask_for_wave(entry, global_wg_id, w, entry.wave_size));
       init_wavefront_regs(cu, wf, entry, global_wg_id, w);
       wg_wavefronts.push_back(wf);
     }
@@ -702,21 +750,24 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
       AMDHSA_BITS_GET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT);
   uint32_t sgpr_gran =
       AMDHSA_BITS_GET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT);
-  uint32_t vgprs = (vgpr_gran + 1) * vgpr_granularity_;
   rj_code_arch_t arch = cus_.empty() ? ROCJITSU_CODE_ARCH_CDNA1 : cus_[0]->config().arch;
+  uint32_t wave_size = kernel_dispatch_wave_size(arch, kd.kernel_code_properties);
+  uint32_t vgprs = (vgpr_gran + 1) *
+                   descriptor_vgpr_granularity_for_wavefront(arch, wave_size, vgpr_granularity_);
   uint32_t sgprs = sgpr_count_is_descriptor_encoded(arch, sgpr_gran) ? (sgpr_gran + 1) * 8 : 0;
   uint32_t user_sgprs = AMDHSA_BITS_GET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT);
   uint64_t entry_pc = pkt.kernel_object + static_cast<uint64_t>(kd.kernel_code_entry_byte_offset);
 
   uint32_t wg_size =
       static_cast<uint32_t>(pkt.workgroup_size_x) * pkt.workgroup_size_y * pkt.workgroup_size_z;
-  uint32_t wave_size = cus_.empty() ? 64 : cus_[0]->wf_size();
-  uint32_t wfs_per_wg = (wg_size + wave_size - 1) / wave_size;
+  uint32_t wfs_per_wg = util::ceil_div(wg_size, wave_size);
 
   uint32_t num_dims = pkt.setup & 0x3;
-  uint32_t grid_wgs_x = pkt.workgroup_size_x > 0 ? pkt.grid_size_x / pkt.workgroup_size_x : 1;
-  uint32_t grid_wgs_y = pkt.workgroup_size_y > 0 ? pkt.grid_size_y / pkt.workgroup_size_y : 1;
-  uint32_t grid_wgs_z = pkt.workgroup_size_z > 0 ? pkt.grid_size_z / pkt.workgroup_size_z : 1;
+  uint32_t grid_wgs_x = dispatch_grid_workgroups(pkt.grid_size_x, pkt.workgroup_size_x);
+  uint32_t grid_wgs_y =
+      num_dims >= 2 ? dispatch_grid_workgroups(pkt.grid_size_y, pkt.workgroup_size_y) : 1;
+  uint32_t grid_wgs_z =
+      num_dims >= 3 ? dispatch_grid_workgroups(pkt.grid_size_z, pkt.workgroup_size_z) : 1;
   uint32_t total_wgs = grid_wgs_x * grid_wgs_y * grid_wgs_z;
 
   DispatchEntry dp{};
@@ -724,6 +775,7 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   dp.queue_id = queue.queue_id;
   dp.process_id = queue.process_id;
   dp.kernel_entry_pc = entry_pc;
+  dp.wave_size = wave_size;
   dp.total_wgs = total_wgs;
   dp.dispatched_wgs = 0;
   dp.completed_wgs = 0;
@@ -753,6 +805,9 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   }
 
   dp.workgroup_id_offset = workgroup_id_offset_;
+  dp.grid_size_x = pkt.grid_size_x;
+  dp.grid_size_y = (num_dims >= 2) ? pkt.grid_size_y : 1;
+  dp.grid_size_z = (num_dims >= 3) ? pkt.grid_size_z : 1;
   // For WG ID decomposition, use the dispatch dimensionality (setup field).
   // A 1D dispatch flattens the entire grid into workgroup_id_x.
   dp.grid_wgs_x = (num_dims <= 1) ? total_wgs : grid_wgs_x;
@@ -1274,8 +1329,10 @@ constexpr uint32_t POLL_REGMEM_SIZE = 6;
 constexpr uint32_t ATOMIC_SIZE = 8;
 constexpr uint32_t CONST_FILL_SIZE = 5;
 constexpr uint32_t TIMESTAMP_SIZE = 3;
+// Source of truth: ROCR's sdma_registers.h defines SDMA_PKT_GCR as
+// 5 dwords and SDMA_PKT_GCR_GFX1250 as 6 dwords.
 constexpr uint32_t GCR_SIZE = 5;
-constexpr uint32_t GCR_GFX11_PLUS_SIZE = 6;
+constexpr uint32_t GCR_GFX1250_SIZE = 6;
 constexpr uint32_t COPY_LINEAR_WAITSIGNAL_GFX11_PLUS_SIZE = 19;
 constexpr uint32_t FENCE_64B_GFX11_PLUS_SIZE = 5;
 constexpr uint32_t POLL_MEM_64B_GFX11_PLUS_SIZE = 8;
@@ -1672,7 +1729,7 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         else
           l2->invalidate_all();
       }
-      pkt_dwords = uses_gfx11_plus_sdma_packets() ? sdma::GCR_GFX11_PLUS_SIZE : sdma::GCR_SIZE;
+      pkt_dwords = uses_gfx1250_sdma_packets() ? sdma::GCR_GFX1250_SIZE : sdma::GCR_SIZE;
       break;
     }
     case sdma::OP_HDP_FLUSH:

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -69,6 +69,7 @@ struct HwQueue {
 enum class SdmaPacketDialect {
   Legacy,
   Gfx11Plus,
+  Gfx1250,
 };
 
 /// @brief AMDGPU command processor that dispatches wavefronts to compute units.
@@ -213,7 +214,12 @@ private:
   }
 
   bool uses_gfx11_plus_sdma_packets() const {
-    return sdma_packet_dialect_ == SdmaPacketDialect::Gfx11Plus;
+    return sdma_packet_dialect_ == SdmaPacketDialect::Gfx11Plus ||
+           sdma_packet_dialect_ == SdmaPacketDialect::Gfx1250;
+  }
+
+  bool uses_gfx1250_sdma_packets() const {
+    return sdma_packet_dialect_ == SdmaPacketDialect::Gfx1250;
   }
 
   GpuMemory *memory_ = nullptr;
@@ -230,7 +236,7 @@ private:
   uint32_t workgroup_id_offset_ = 0;
   uint32_t vgpr_granularity_ = 8;
   bool packed_tid_ = false;
-  // GFX11+ SDMA GCR keeps the same opcode but changes packet size/layout, so
+  // gfx1250 SDMA GCR keeps the same opcode but changes packet size/layout, so
   // the decoder cannot infer this dialect from the packet header alone.
   SdmaPacketDialect sdma_packet_dialect_ = SdmaPacketDialect::Legacy;
   uint32_t next_dispatch_id_ = 1;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -25,6 +25,7 @@
 #include <cstring>
 #include <memory>
 #include <stdexcept>
+#include <string_view>
 
 namespace rocjitsu {
 namespace amdgpu {
@@ -91,9 +92,14 @@ std::unique_ptr<ComputeUnitCore> ComputeUnitCore::create(std::string name, const
   throw std::runtime_error("Unsupported architecture for ComputeUnit");
 }
 
-Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t sgprs,
-                                        uint32_t vgprs) {
+Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t sgprs, uint32_t vgprs,
+                                        uint32_t wave_size) {
   assert(wfs_.size() == config_.num_wf_slots && "wavefront slots not properly initialized");
+  if (wave_size == 0)
+    wave_size = wf_size_;
+  if (wave_size == 0 || wave_size > vgpr_lanes_per_reg())
+    return nullptr;
+
   // Free register allocations from previously halted wavefronts before claiming
   // a new slot. This is needed so SGPR/VGPR blocks can be reused. However, we
   // must NOT reset the LDS allocator here — that would zero next_lds_alloc_
@@ -125,7 +131,7 @@ Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t sg
   // values from previous kernel runs.
   std::fill(&sgpr_file_[sgpr_base], &sgpr_file_[sgpr_base] + config_.sgprs_per_wf, 0u);
   std::memset(vgpr_data(static_cast<uint32_t>(vgpr_base)), 0,
-              vgpr_allocation_block_size() * wf_size_ * sizeof(uint32_t));
+              vgpr_allocation_block_size() * vgpr_lanes_per_reg() * sizeof(uint32_t));
 
   // Invalidate the L1 scalar cache so this wavefront reads fresh kernel
   // arguments from L2/memory rather than stale lines from a prior kernel.
@@ -133,13 +139,14 @@ Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t sg
   l1_scalar_.invalidate_all();
 
   auto *wf = wfs_[slot].get();
+  wf->wf_size_ = wave_size;
   wf->wg_id_ = wg_id;
   wf->pc = pc;
   wf->sgpr_alloc_ = {static_cast<uint32_t>(sgpr_base), sgprs};
   wf->vgpr_alloc_ = {static_cast<uint32_t>(vgpr_base), vgprs};
   wf->num_sgprs_ = sgprs;
   wf->num_vgprs_ = vgprs;
-  wf->exec_ = wf_size_ == 64 ? ~0ULL : (1ULL << wf_size_) - 1;
+  wf->exec_ = wave_size == 64 ? ~0ULL : (1ULL << wave_size) - 1;
   wf->vcc_ = 0;
   wf->m0_ = 0;
   wf->set_apertures(shared_aperture_base_, shared_aperture_limit_, private_aperture_base_,
@@ -313,6 +320,7 @@ void ComputeUnitCore::update_wf_states() {
       continue;
     uint32_t did = w->dispatch_id();
     uint32_t wg = w->wg_id();
+
     bool all_at_barrier = true;
     for (auto &w2 : wfs_) {
       if (w2->dispatch_id() == did && w2->wg_id() == wg && w2->state() != WfState::HALTED &&

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -98,9 +98,12 @@ public:
   /// @param pc Kernel entry point (byte address).
   /// @param sgprs Number of scalar registers to allocate.
   /// @param vgprs Number of vector registers to allocate.
+  /// @param wave_size Lanes in the dispatched wavefront. Zero selects the
+  ///                  compute unit's default wave size.
   /// @returns Pointer to the activated wavefront, or nullptr if no free slot
   ///          or insufficient register space.
-  Wavefront *dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t sgprs, uint32_t vgprs);
+  Wavefront *dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t sgprs, uint32_t vgprs,
+                         uint32_t wave_size = 0);
 
   /// @brief Execute one instruction on the next active wavefront.
   /// @retval true An instruction was executed.
@@ -328,9 +331,10 @@ public:
   // TODO(newling) consider cmake flag to build without plugins, this call
   // overhead might be non-negligible.
   uint32_t read_sgpr(uint32_t reg_idx) const {
-    if (auto *wf = sgpr_to_wave_[reg_idx]) {
+    if (reg_idx >= sgpr_to_wave_.size())
+      return 0;
+    if (auto *wf = sgpr_to_wave_[reg_idx])
       plugin_group_->onAmdgpuReadSgpr(wf, reg_idx);
-    }
     return sgpr_file_[reg_idx];
   }
 
@@ -374,6 +378,13 @@ public:
 
   /// @brief Number of physical VGPR registers in one allocation block.
   virtual uint32_t vgpr_allocation_block_size() const = 0;
+
+  /// @brief Number of lane elements physically stored for each VGPR slot.
+  ///
+  /// Wave32 dispatches use only the low active lanes, but the backing register
+  /// file can still reserve a wider physical slot so wave32 and wave64 share
+  /// the same SIMD storage layout.
+  virtual uint32_t vgpr_lanes_per_reg() const = 0;
 
   /// @brief Typed view of a single VGPR as the file's @c simdojo::VectorReg.
   /// @details The abstract CU exposes the VGPR file only as a byte pointer
@@ -548,8 +559,9 @@ private:
 
 /// @brief ISA-parameterized compute unit owning the typed VGPR register file.
 ///
-/// @details The Isa trait provides WF_SIZE which sets the VectorReg element
-/// count, so each VGPR holds one uint32_t lane per wavefront thread.
+/// @details VGPR storage reserves one 64-lane physical slot per register. The
+/// active lanes for a dispatch still come from the kernel descriptor and are
+/// stored on each Wavefront, so wave32 uses the low half of the slot.
 /// Pre-allocates all wavefront slots as IsaWavefront<Isa> instances.
 ///
 /// @tparam Mode Execution mode (FUNCTIONAL or CLOCKED).
@@ -557,7 +569,7 @@ private:
 template <simdojo::ExecMode Mode, GpuIsa Isa>
 class IsaExecComputeUnit : public ExecComputeUnit<Mode> {
 public:
-  using Vgpr = simdojo::VectorReg<Isa::WF_SIZE, uint32_t>;
+  using Vgpr = simdojo::VectorReg<64, uint32_t>;
 
   /// @brief Construct an ISA-parameterized compute unit.
   /// @param name Human-readable name (e.g., "cu0").
@@ -628,6 +640,7 @@ protected:
 
 public:
   uint32_t vgpr_allocation_block_size() const override { return vgprs_per_block_; }
+  uint32_t vgpr_lanes_per_reg() const override { return 64; }
 
 protected:
   /// @brief Execute one instruction on the given wavefront.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/dispatch_entry.h
@@ -25,6 +25,7 @@ struct DispatchEntry {
   uint32_t process_id = 0;
 
   uint64_t kernel_entry_pc = 0;
+  uint32_t wave_size = 64;
   uint32_t wfs_per_workgroup = 1;
   uint32_t sgprs_per_wf = 104;
   uint32_t vgprs_per_wf = 256;
@@ -36,6 +37,9 @@ struct DispatchEntry {
   uint64_t dispatch_ptr = 0;
   uint64_t queue_ptr = 0;
   uint32_t workgroup_id_offset = 0;
+  uint32_t grid_size_x = 0;
+  uint32_t grid_size_y = 1;
+  uint32_t grid_size_z = 1;
   uint32_t grid_wgs_x = 0;
   uint32_t grid_wgs_y = 1;
   uint32_t grid_wgs_z = 1;
@@ -63,9 +67,37 @@ struct DispatchEntry {
   bool is_non_kernel() const { return total_wgs == 0; }
 };
 
+inline uint32_t dispatch_dim(uint32_t value) { return value == 0 ? 1u : value; }
+
+inline uint32_t dispatch_wg_dim(uint16_t value) { return value == 0 ? 1u : value; }
+
 inline uint32_t dispatch_workgroup_size(const DispatchEntry &entry) {
-  auto dim = [](uint16_t value) -> uint32_t { return value == 0 ? 1u : value; };
-  return dim(entry.workgroup_size_x) * dim(entry.workgroup_size_y) * dim(entry.workgroup_size_z);
+  return dispatch_wg_dim(entry.workgroup_size_x) * dispatch_wg_dim(entry.workgroup_size_y) *
+         dispatch_wg_dim(entry.workgroup_size_z);
+}
+
+inline uint32_t active_dim_workitems(uint32_t grid_size, uint32_t wg_id, uint32_t wg_size) {
+  if (grid_size == 0)
+    return 0;
+  const uint64_t start = static_cast<uint64_t>(wg_id) * wg_size;
+  if (start >= grid_size)
+    return 0;
+  const uint64_t remaining = grid_size - start;
+  return static_cast<uint32_t>(remaining < wg_size ? remaining : wg_size);
+}
+
+inline uint32_t active_workitems_in_workgroup(const DispatchEntry &entry, uint32_t global_wg_id) {
+  const uint32_t relative_wg_id = global_wg_id >= entry.workgroup_id_offset
+                                      ? global_wg_id - entry.workgroup_id_offset
+                                      : global_wg_id;
+  const uint32_t grid_wgs_x = dispatch_dim(entry.grid_wgs_x);
+  const uint32_t grid_wgs_y = dispatch_dim(entry.grid_wgs_y);
+  const uint32_t wg_x = relative_wg_id % grid_wgs_x;
+  const uint32_t wg_y = (relative_wg_id / grid_wgs_x) % grid_wgs_y;
+  const uint32_t wg_z = relative_wg_id / (grid_wgs_x * grid_wgs_y);
+  return active_dim_workitems(entry.grid_size_x, wg_x, dispatch_wg_dim(entry.workgroup_size_x)) *
+         active_dim_workitems(entry.grid_size_y, wg_y, dispatch_wg_dim(entry.workgroup_size_y)) *
+         active_dim_workitems(entry.grid_size_z, wg_z, dispatch_wg_dim(entry.workgroup_size_z));
 }
 
 inline uint64_t wave_lane_mask(uint32_t wave_size) {
@@ -76,15 +108,38 @@ inline uint64_t wave_lane_mask(uint32_t wave_size) {
   return (1ULL << wave_size) - 1;
 }
 
-inline uint64_t initial_exec_mask_for_wave(const DispatchEntry &entry, uint32_t wf_index_in_wg,
-                                           uint32_t wave_size) {
-  uint32_t wg_size = dispatch_workgroup_size(entry);
-  uint32_t first_lane = wf_index_in_wg * wave_size;
-  if (first_lane >= wg_size)
-    return 0;
-  uint32_t remaining = wg_size - first_lane;
-  uint32_t active_lanes = remaining < wave_size ? remaining : wave_size;
-  return wave_lane_mask(active_lanes);
+inline uint64_t initial_exec_mask_for_wave(const DispatchEntry &entry, uint32_t global_wg_id,
+                                           uint32_t wf_index_in_wg, uint32_t wave_size) {
+  const uint32_t relative_wg_id = global_wg_id >= entry.workgroup_id_offset
+                                      ? global_wg_id - entry.workgroup_id_offset
+                                      : global_wg_id;
+  const uint32_t grid_wgs_x = dispatch_dim(entry.grid_wgs_x);
+  const uint32_t grid_wgs_y = dispatch_dim(entry.grid_wgs_y);
+  const uint32_t wg_x = relative_wg_id % grid_wgs_x;
+  const uint32_t wg_y = (relative_wg_id / grid_wgs_x) % grid_wgs_y;
+  const uint32_t wg_z = relative_wg_id / (grid_wgs_x * grid_wgs_y);
+  const uint32_t workgroup_size_x = dispatch_wg_dim(entry.workgroup_size_x);
+  const uint32_t workgroup_size_y = dispatch_wg_dim(entry.workgroup_size_y);
+  const uint32_t workgroup_size_z = dispatch_wg_dim(entry.workgroup_size_z);
+  const uint32_t workgroup_xy = workgroup_size_x * workgroup_size_y;
+
+  uint64_t mask = 0;
+  const uint32_t lanes = wave_size > 64 ? 64 : wave_size;
+  for (uint32_t lane = 0; lane < lanes; ++lane) {
+    const uint32_t flat_id = wf_index_in_wg * wave_size + lane;
+    const uint32_t id_z = flat_id / workgroup_xy;
+    if (id_z >= workgroup_size_z)
+      continue;
+    const uint32_t id_y = (flat_id / workgroup_size_x) % workgroup_size_y;
+    const uint32_t id_x = flat_id % workgroup_size_x;
+    const uint64_t global_x = static_cast<uint64_t>(wg_x) * workgroup_size_x + id_x;
+    const uint64_t global_y = static_cast<uint64_t>(wg_y) * workgroup_size_y + id_y;
+    const uint64_t global_z = static_cast<uint64_t>(wg_z) * workgroup_size_z + id_z;
+    if (global_x < entry.grid_size_x && global_y < entry.grid_size_y &&
+        global_z < entry.grid_size_z)
+      mask |= 1ULL << lane;
+  }
+  return mask;
 }
 
 /// @brief Per-queue state for the command processor.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -12,6 +12,7 @@
 #include "simdojo/sim/component.h"
 #include "util/log.h"
 
+#include <algorithm>
 #include <cstring>
 #include <format>
 #include <memory>
@@ -40,11 +41,9 @@ public:
       auto &hdr = msg->header();
       auto *data = reinterpret_cast<uint8_t *>(msg->payload());
       if (hdr.op == simdojo::MessageOp::READ) {
-        for (uint32_t i = 0; i < hdr.size_bytes; ++i)
-          data[i] = read8(hdr.addr + i);
+        read_bytes(hdr.addr, data, hdr.size_bytes);
       } else if (hdr.op == simdojo::MessageOp::WRITE) {
-        for (uint32_t i = 0; i < hdr.size_bytes; ++i)
-          write8(hdr.addr + i, data[i]);
+        write_bytes(hdr.addr, data, hdr.size_bytes);
       }
       hdr.op = simdojo::MessageOp::RESPONSE;
     });
@@ -76,7 +75,7 @@ public:
 
   /// @brief Resolve a GPU VA to a host pointer via the given VMID's page table.
   uint8_t *resolve_host_ptr(uint64_t addr, uint32_t vmid = 0) const {
-    return translate(addr, vmid);
+    return translate_read(addr, vmid);
   }
 
   /// @brief Look up PTE MTYPE for a GPU VA in the given VMID's page table.
@@ -99,7 +98,9 @@ public:
 
   uint32_t fetch32(uint64_t addr, uint32_t vmid = 0) const { return read32(addr, vmid); }
 
-  uint8_t *translate_debug(uint64_t addr, uint32_t vmid) const { return translate(addr, vmid); }
+  uint8_t *translate_debug(uint64_t addr, uint32_t vmid) const {
+    return translate_read(addr, vmid);
+  }
 
   std::string debug_page_table_info(uint32_t vmid, uint64_t page_key) const {
     std::shared_lock lk(vmid_mutex_);
@@ -124,13 +125,30 @@ public:
   }
 
   uint8_t read8(uint64_t addr, uint32_t vmid = 0) const {
-    if (auto *p = translate(addr, vmid))
+    if (auto *p = translate_read(addr, vmid))
       return p[addr & PAGE_MASK];
     return SparseMemory::read8(addr);
   }
 
+  void read_bytes(uint64_t addr, uint8_t *dst, uint32_t size, uint32_t vmid = 0) const {
+    uint32_t copied = 0;
+    while (copied < size) {
+      const uint64_t ea = addr + copied;
+      const uint32_t page_offset = ea & PAGE_MASK;
+      const uint32_t page_remaining = static_cast<uint32_t>(PAGE_SIZE - page_offset);
+      const uint32_t chunk = std::min(size - copied, page_remaining);
+      if (auto *p = translate_read(ea, vmid)) {
+        std::memcpy(dst + copied, p + page_offset, chunk);
+      } else {
+        for (uint32_t i = 0; i < chunk; ++i)
+          dst[copied + i] = SparseMemory::read8(ea + i);
+      }
+      copied += chunk;
+    }
+  }
+
   uint16_t read16(uint64_t addr, uint32_t vmid = 0) const {
-    if (auto *p = translate(addr, vmid); p && (addr & PAGE_MASK) + 2 <= PAGE_SIZE) {
+    if (auto *p = translate_read(addr, vmid); p && (addr & PAGE_MASK) + 2 <= PAGE_SIZE) {
       uint16_t val;
       std::memcpy(&val, p + (addr & PAGE_MASK), 2);
       return val;
@@ -139,7 +157,7 @@ public:
   }
 
   uint32_t read32(uint64_t addr, uint32_t vmid = 0) const {
-    if (auto *p = translate(addr, vmid); p && (addr & PAGE_MASK) + 4 <= PAGE_SIZE) {
+    if (auto *p = translate_read(addr, vmid); p && (addr & PAGE_MASK) + 4 <= PAGE_SIZE) {
       uint32_t val;
       std::memcpy(&val, p + (addr & PAGE_MASK), 4);
       return val;
@@ -148,7 +166,7 @@ public:
   }
 
   uint64_t read64(uint64_t addr, uint32_t vmid = 0) const {
-    if (auto *p = translate(addr, vmid); p && (addr & PAGE_MASK) + 8 <= PAGE_SIZE) {
+    if (auto *p = translate_read(addr, vmid); p && (addr & PAGE_MASK) + 8 <= PAGE_SIZE) {
       uint64_t val;
       std::memcpy(&val, p + (addr & PAGE_MASK), 8);
       return val;
@@ -157,15 +175,32 @@ public:
   }
 
   void write8(uint64_t addr, uint8_t val, uint32_t vmid = 0) {
-    if (auto *p = translate(addr, vmid)) {
+    if (auto *p = translate_write(addr, vmid)) {
       p[addr & PAGE_MASK] = val;
       return;
     }
     SparseMemory::write8(addr, val);
   }
 
+  void write_bytes(uint64_t addr, const uint8_t *src, uint32_t size, uint32_t vmid = 0) {
+    uint32_t copied = 0;
+    while (copied < size) {
+      const uint64_t ea = addr + copied;
+      const uint32_t page_offset = ea & PAGE_MASK;
+      const uint32_t page_remaining = static_cast<uint32_t>(PAGE_SIZE - page_offset);
+      const uint32_t chunk = std::min(size - copied, page_remaining);
+      if (auto *p = translate_write(ea, vmid)) {
+        std::memcpy(p + page_offset, src + copied, chunk);
+      } else {
+        for (uint32_t i = 0; i < chunk; ++i)
+          SparseMemory::write8(ea + i, src[copied + i]);
+      }
+      copied += chunk;
+    }
+  }
+
   void write16(uint64_t addr, uint16_t val, uint32_t vmid = 0) {
-    if (auto *p = translate(addr, vmid); p && (addr & PAGE_MASK) + 2 <= PAGE_SIZE) {
+    if (auto *p = translate_write(addr, vmid); p && (addr & PAGE_MASK) + 2 <= PAGE_SIZE) {
       std::memcpy(p + (addr & PAGE_MASK), &val, 2);
       return;
     }
@@ -173,7 +208,7 @@ public:
   }
 
   void write32(uint64_t addr, uint32_t val, uint32_t vmid = 0) {
-    if (auto *p = translate(addr, vmid); p && (addr & PAGE_MASK) + 4 <= PAGE_SIZE) {
+    if (auto *p = translate_write(addr, vmid); p && (addr & PAGE_MASK) + 4 <= PAGE_SIZE) {
       std::memcpy(p + (addr & PAGE_MASK), &val, 4);
       return;
     }
@@ -181,7 +216,7 @@ public:
   }
 
   void write64(uint64_t addr, uint64_t val, uint32_t vmid = 0) {
-    if (auto *p = translate(addr, vmid); p && (addr & PAGE_MASK) + 8 <= PAGE_SIZE) {
+    if (auto *p = translate_write(addr, vmid); p && (addr & PAGE_MASK) + 8 <= PAGE_SIZE) {
       std::memcpy(p + (addr & PAGE_MASK), &val, 8);
       return;
     }
@@ -194,9 +229,19 @@ private:
     std::shared_mutex *mutex = nullptr;
   };
 
-  uint8_t *translate(uint64_t addr, uint32_t vmid) const {
+  enum class HostAccess { Read, Write };
+
+  uint8_t *translate_read(uint64_t addr, uint32_t vmid) const {
+    return translate(addr, vmid, HostAccess::Read);
+  }
+
+  uint8_t *translate_write(uint64_t addr, uint32_t vmid) const {
+    return translate(addr, vmid, HostAccess::Write);
+  }
+
+  uint8_t *translate(uint64_t addr, uint32_t vmid, HostAccess access) const {
     if (vmid == 0)
-      return passthrough_ ? reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK) : nullptr;
+      return passthrough_host_ptr(addr, access);
     {
       std::shared_lock lk(vmid_mutex_);
       auto it = vmid_table_.find(vmid);
@@ -204,20 +249,50 @@ private:
         auto &entry = it->second;
         std::shared_lock pt_lk(*entry.mutex);
         auto pt_it = entry.page_table->find(addr >> PAGE_SHIFT);
-        if (pt_it != entry.page_table->end())
-          return pt_it->second.host_ptr;
+        if (pt_it != entry.page_table->end()) {
+          const auto &pte = pt_it->second;
+          const bool map_time_allowed =
+              access == HostAccess::Read ? pte.host_readable : pte.host_writable;
+          if (!map_time_allowed)
+            return nullptr;
+          auto *host_addr = pte.host_ptr + (addr & PAGE_MASK);
+          const auto host_access = host_page_access(host_addr);
+          const bool live_allowed =
+              access == HostAccess::Read ? host_access.readable : host_access.writable;
+          return live_allowed ? pte.host_ptr : nullptr;
+        }
       }
     }
-    static constexpr uint64_t kUserSpaceLimit = 0x800000000000ULL;
-    if (passthrough_ && addr < kUserSpaceLimit)
-      return reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
-    return nullptr;
+    return passthrough_host_ptr(addr, access);
+  }
+
+  uint8_t *passthrough_host_ptr(uint64_t addr, HostAccess access) const {
+    if (!passthrough_ || addr >= kUserSpaceLimit)
+      return nullptr;
+    auto *page = reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
+    const auto host_access = host_page_access(page);
+    const bool allowed = access == HostAccess::Read ? host_access.readable : host_access.writable;
+    return allowed ? page : nullptr;
+  }
+
+  KfdProcess::HostPageAccess host_page_access(const void *ptr) const {
+    const uint64_t generation = KfdProcess::host_mappings_generation();
+    std::lock_guard lock(host_mappings_mutex_);
+    if (host_mappings_generation_ != generation) {
+      host_mappings_snapshot_ = KfdProcess::read_host_mappings();
+      host_mappings_generation_ = generation;
+    }
+    return host_mappings_snapshot_.access_for(ptr);
   }
 
   simdojo::Port *cpl_ = nullptr;
   mutable std::shared_mutex vmid_mutex_;
   std::unordered_map<uint32_t, VmidEntry> vmid_table_;
+  mutable std::mutex host_mappings_mutex_;
+  mutable KfdProcess::HostMappingsSnapshot host_mappings_snapshot_;
+  mutable uint64_t host_mappings_generation_ = 0;
   bool passthrough_ = false;
+  static constexpr uint64_t kUserSpaceLimit = 0x800000000000ULL;
 };
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/hbm_controller.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/hbm_controller.h
@@ -57,13 +57,11 @@ public:
   }
 
   void read(uint64_t addr, uint8_t *dst, uint32_t size, uint32_t vmid = 0) {
-    for (uint32_t i = 0; i < size; ++i)
-      dst[i] = memory_->read8(addr + i, vmid);
+    memory_->read_bytes(addr, dst, size, vmid);
   }
 
   void write(uint64_t addr, const uint8_t *src, uint32_t size, uint32_t vmid = 0) {
-    for (uint32_t i = 0; i < size; ++i)
-      memory_->write8(addr + i, src[i], vmid);
+    memory_->write_bytes(addr, src, size, vmid);
   }
 
   /// @brief Read a 32-bit dword (little-endian).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
@@ -6,7 +6,6 @@
 #include "util/log.h"
 
 #include <algorithm>
-#include <atomic>
 #include <bit>
 #include <cassert>
 #include <cstring>
@@ -17,18 +16,12 @@ namespace amdgpu {
 void L2Cache::send_backing(uint64_t addr, uint8_t *data, uint32_t size, simdojo::MessageOp op,
                            uint32_t vmid) {
   if (backing_memory_) {
-    if (op == simdojo::MessageOp::WRITE) {
-      static std::atomic<uint64_t> wb_count{0};
-      const uint64_t count = wb_count.fetch_add(1, std::memory_order_relaxed) + 1;
-      if (count <= 3)
-        util::Logger::vm("L2 writeback(backing) #", count, " addr=0x", std::hex, addr,
-                         " size=", std::dec, size);
-      for (uint32_t i = 0; i < size; ++i)
-        backing_memory_->write8(addr + i, data[i], vmid);
-    } else {
-      for (uint32_t i = 0; i < size; ++i)
-        data[i] = backing_memory_->read8(addr + i, vmid);
-    }
+    // Bulk backing-memory helpers are intentionally silent; cache-level
+    // eviction logging stays in ensure_line().
+    if (op == simdojo::MessageOp::WRITE)
+      backing_memory_->write_bytes(addr, data, size, vmid);
+    else
+      backing_memory_->read_bytes(addr, data, size, vmid);
     return;
   }
   assert(req_port_ != nullptr && "L2Cache: req_port_ not set");

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/spi.h
@@ -81,13 +81,15 @@ public:
       std::vector<Wavefront *> wg_wfs;
       wg_wfs.reserve(wg.entry->wfs_per_workgroup);
       for (uint32_t w = 0; w < wg.entry->wfs_per_workgroup; ++w) {
-        Wavefront *wf = cu->dispatch_wf(wg.global_wg_id, wg.entry->kernel_entry_pc,
-                                        wg.entry->sgprs_per_wf, wg.entry->vgprs_per_wf);
+        Wavefront *wf =
+            cu->dispatch_wf(wg.global_wg_id, wg.entry->kernel_entry_pc, wg.entry->sgprs_per_wf,
+                            wg.entry->vgprs_per_wf, wg.entry->wave_size);
         assert(wf && "dispatch_wf failed after select_cu returned a CU");
         wf->set_lds_base(lds_base);
         wf->set_dispatch_id(wg.entry->dispatch_id);
         wf->set_process_id(wg.entry->process_id);
-        wf->set_exec(initial_exec_mask_for_wave(*wg.entry, w, cu->wf_size()));
+        wf->set_exec(
+            initial_exec_mask_for_wave(*wg.entry, wg.global_wg_id, w, wg.entry->wave_size));
         init_wf(cu, wf, *wg.entry, wg.global_wg_id, w);
         wg_wfs.push_back(wf);
       }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/wavefront.h
@@ -59,9 +59,9 @@ struct RegAllocation {
 /// A slot is considered dispatched (active) when it has a nonzero register
 /// allocation (sgpr_alloc_.count > 0). After clear(), the slot is idle.
 ///
-/// wf_size and max register counts come from the ISA struct and are fixed
-/// at construction. num_sgprs and num_vgprs are the per-dispatch allocation
-/// sizes set from code object metadata.
+/// max register counts come from the ISA struct and are fixed at construction.
+/// wf_size, num_sgprs, and num_vgprs are per-dispatch values set from code
+/// object metadata.
 ///
 /// Derives from ThreadContext so that instruction execute() methods can
 /// static_cast the ThreadContext& parameter to Wavefront&.
@@ -70,7 +70,7 @@ public:
   ~Wavefront() override = default;
 
   /// @brief Return the number of lanes per wavefront.
-  /// @returns Lanes per wavefront (ISA-fixed).
+  /// @returns Lanes per wavefront for the active dispatch.
   uint32_t wf_size() const { return wf_size_; }
 
   /// @brief Return the ISA maximum SGPRs per wavefront.
@@ -279,6 +279,13 @@ public:
       state_ = WfState::WAITCNT;
   }
 
+  /// @brief Set the LGKMCNT target (S_WAITCNT_LGKMCNT).
+  void set_wait_target_lgkmcnt(uint8_t threshold) {
+    wait_target_.lgkmcnt = threshold;
+    if (!wait_satisfied())
+      state_ = WfState::WAITCNT;
+  }
+
   /// @brief Set the STORECNT target (GFX11+ S_WAITCNT_VSCNT / S_WAIT_STORECNT).
   void set_wait_target_storecnt(uint8_t threshold) {
     wait_target_.vscnt = threshold;
@@ -338,10 +345,12 @@ public:
     using namespace std::string_view_literals;
     std::string_view name{counter_name};
     auto t = static_cast<uint8_t>(threshold);
-    if (name == "wait_loadcnt")
+    if (name == "wait_loadcnt" || name == "waitcnt_vmcnt")
       set_wait_target_loadcnt(t);
-    else if (name == "wait_storecnt")
+    else if (name == "wait_storecnt" || name == "waitcnt_vscnt")
       set_wait_target_storecnt(t);
+    else if (name == "wait_lgkmcnt" || name == "waitcnt_lgkmcnt")
+      set_wait_target_lgkmcnt(t);
     else if (name == "wait_dscnt")
       set_wait_target_dscnt(t);
     else if (name == "wait_kmcnt")
@@ -350,7 +359,7 @@ public:
       set_wait_target_tensorcnt(t);
     else if (name == "wait_asynccnt")
       set_wait_target_asynccnt(t);
-    else if (name == "wait_expcnt") {
+    else if (name == "wait_expcnt" || name == "waitcnt_expcnt") {
       wait_target_.expcnt = static_cast<uint8_t>(threshold & 0x07);
       if (!wait_satisfied())
         state_ = WfState::WAITCNT;
@@ -452,7 +461,7 @@ protected:
   /// @brief Construct a wavefront bound to a CU slot.
   /// @param cu Parent compute unit (permanent binding).
   /// @param wf_id Slot index within the CU (permanent binding).
-  /// @param wf_size Lanes per wavefront (ISA-fixed).
+  /// @param wf_size Default lanes per wavefront.
   /// @param max_sgprs Maximum SGPRs per wavefront (ISA-fixed).
   /// @param max_vgprs Maximum VGPRs per wavefront (ISA-fixed).
   Wavefront(ComputeUnitCore &cu, uint32_t wf_id, uint32_t wf_size, uint32_t max_sgprs,
@@ -466,7 +475,7 @@ protected:
   uint32_t process_id_ = 0;  ///< Owning process ID (PASID analog, set per dispatch).
   uint32_t lds_base_ = 0;    ///< Per-WG LDS base offset (set per dispatch).
 
-  uint32_t wf_size_ = 0;   ///< Lanes per wavefront (ISA-fixed).
+  uint32_t wf_size_ = 0;   ///< Lanes per wavefront for the active dispatch.
   uint32_t num_sgprs_ = 0; ///< Allocated scalar registers (set at dispatch).
   uint32_t num_vgprs_ = 0; ///< Allocated vector registers (set at dispatch).
   uint32_t max_sgprs_ = 0; ///< ISA maximum SGPRs per wavefront.

--- a/emulation/rocjitsu/lib/util/include/util/data_types.h
+++ b/emulation/rocjitsu/lib/util/include/util/data_types.h
@@ -320,12 +320,17 @@ inline float fp8_e4m3_to_f32(uint8_t v) {
 inline uint8_t f32_to_fp8_e4m3(float val) {
   uint32_t f = std::bit_cast<uint32_t>(val);
   uint32_t sign = (f >> 24) & 0x80;
-  int32_t exp = static_cast<int32_t>((f >> 23) & 0xFF) - 127 + 7;
+  if (std::isnan(val))
+    return static_cast<uint8_t>(sign | 0x7F);
+  int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
+  if (f_exp == 0xFF)
+    return static_cast<uint8_t>(sign | 0x7F);
+  int32_t exp = f_exp - 127 + 7;
   uint32_t mant = (f >> 20) & 0x7;
   if (exp <= 0)
     return static_cast<uint8_t>(sign);
-  if (exp >= 15)
-    return static_cast<uint8_t>(sign | 0x7E); // max normal
+  if (exp > 15 || (exp == 15 && mant >= 7))
+    return static_cast<uint8_t>(sign | 0x7F);
   return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
 }
 
@@ -337,7 +342,7 @@ inline uint8_t f32_to_fp8_e4m3_rne(float val) {
   int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
   uint32_t f_mant = f & 0x7FFFFF;
   if (f_exp == 0xFF)
-    return static_cast<uint8_t>(sign | 0x7E);
+    return static_cast<uint8_t>(sign | 0x7F);
   int32_t exp = f_exp - 127 + 7;
   if (exp <= 0) {
     if (exp < -3)
@@ -356,7 +361,7 @@ inline uint8_t f32_to_fp8_e4m3_rne(float val) {
     return static_cast<uint8_t>(sign | (result & 0x7));
   }
   if (exp > 15)
-    return static_cast<uint8_t>(sign | 0x7E);
+    return static_cast<uint8_t>(sign | 0x7F);
   uint32_t round_bit = (f_mant >> 19) & 1;
   uint32_t sticky = (f_mant & 0x7FFFF) ? 1 : 0;
   uint32_t mant = (f_mant >> 20) & 0x7;
@@ -366,7 +371,7 @@ inline uint8_t f32_to_fp8_e4m3_rne(float val) {
     exp += 1;
   }
   if (exp > 15 || (exp == 15 && mant >= 7))
-    return static_cast<uint8_t>(sign | 0x7E);
+    return static_cast<uint8_t>(sign | 0x7F);
   return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
 }
 
@@ -378,7 +383,7 @@ inline uint8_t f32_to_fp8_e4m3_sr(float val, uint32_t seed) {
   int32_t f_exp = static_cast<int32_t>((f >> 23) & 0xFF);
   uint32_t f_mant = f & 0x7FFFFF;
   if (f_exp == 0xFF)
-    return static_cast<uint8_t>(sign | 0x7E);
+    return static_cast<uint8_t>(sign | 0x7F);
   int32_t exp = f_exp - 127 + 7;
   if (exp <= 0) {
     uint32_t full_mant = f_mant | 0x800000;
@@ -396,7 +401,7 @@ inline uint8_t f32_to_fp8_e4m3_sr(float val, uint32_t seed) {
     return static_cast<uint8_t>(sign | (result & 0x7));
   }
   if (exp > 15)
-    return static_cast<uint8_t>(sign | 0x7E);
+    return static_cast<uint8_t>(sign | 0x7F);
   uint32_t trunc_bits = f_mant & 0xFFFFF;
   uint32_t random_add = seed >> 12;
   uint32_t mant = (f_mant >> 20) & 0x7;
@@ -408,7 +413,7 @@ inline uint8_t f32_to_fp8_e4m3_sr(float val, uint32_t seed) {
     }
   }
   if (exp > 15 || (exp == 15 && mant >= 7))
-    return static_cast<uint8_t>(sign | 0x7E);
+    return static_cast<uint8_t>(sign | 0x7F);
   return static_cast<uint8_t>(sign | (static_cast<uint32_t>(exp) << 3) | mant);
 }
 

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -6,6 +6,7 @@
 #include "embedded_schema.h"
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
+#include "rocjitsu/kmd/linux/kfd_process.h"
 #include "rocjitsu/vm/rj_vm.h"
 #include "rocjitsu/vm/soc.h"
 
@@ -19,10 +20,13 @@ RJ_DIAGNOSTIC_POP
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <array>
 #include <bit>
 #include <cstdint>
 #include <cstring>
 #include <string>
+#include <sys/mman.h>
 #include <vector>
 
 namespace {
@@ -38,7 +42,8 @@ struct VmFixture {
   SoC *soc_ptr = nullptr;
   amdgpu::GpuMemory *gpu_mem = nullptr;
 
-  VmFixture(const std::string &arch = "cdna3", uint32_t num_cus = 1, uint32_t num_wf_slots = 10) {
+  VmFixture(const std::string &arch = "cdna3", uint32_t num_cus = 1, uint32_t num_wf_slots = 10,
+            uint32_t sgprs_per_wf = 104) {
     std::string cu_range = "cu[0:" + std::to_string(num_cus) + "]";
     std::string links;
     for (uint32_t i = 0; i < num_cus; ++i) {
@@ -64,7 +69,9 @@ struct VmFixture {
                        R"({"key":"num_wf_slots","value":")" +
                        std::to_string(num_wf_slots) +
                        R"("},)"
-                       R"({"key":"sgprs_per_wf","value":"104"},)"
+                       R"({"key":"sgprs_per_wf","value":")" +
+                       std::to_string(sgprs_per_wf) +
+                       R"("},)"
                        R"({"key":"vgprs_per_wf","value":"256"},)"
                        R"({"key":"lds_size_kb","value":"64"})"
                        R"(]}]}]}]},"links":[)" +
@@ -87,15 +94,20 @@ struct VmFixture {
   /// Write a kernel descriptor + instructions to GPU memory per AMDHSA ABI.
   /// Returns the kernel_object address.
   uint64_t write_kernel(uint64_t addr, const void *code, size_t code_size, uint32_t sgprs = 104,
-                        uint32_t vgprs = 256, uint32_t user_sgprs = 2) {
+                        uint32_t vgprs = 256, uint32_t user_sgprs = 2,
+                        uint32_t kernel_code_properties = 0, uint32_t vgpr_encoding_granule = 8,
+                        uint32_t enable_vgpr_workitem_id = 0) {
     using namespace rocr::llvm::amdhsa;
     kernel_descriptor_t kd{};
     kd.kernel_code_entry_byte_offset = sizeof(kernel_descriptor_t);
     AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
-                    ((vgprs / 8) - 1));
+                    ((vgprs / vgpr_encoding_granule) - 1));
     AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
                     ((sgprs / 8) - 1));
     AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, user_sgprs);
+    AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_ENABLE_VGPR_WORKITEM_ID,
+                    enable_vgpr_workitem_id);
+    kd.kernel_code_properties = kernel_code_properties;
 
     mem()->load_image(reinterpret_cast<const uint8_t *>(&kd), sizeof(kd), addr);
     mem()->load_image(static_cast<const uint8_t *>(code), code_size,
@@ -186,6 +198,164 @@ TEST(GpuMemoryTest, SparsePages) {
   EXPECT_EQ(mem->read32(0x0), 42u);
   EXPECT_EQ(mem->read32(0x100000), 99u);
   EXPECT_EQ(mem->read32(0x50000), 0u);
+}
+
+TEST(GpuMemoryTest, LowPassthroughPointersFallBackToSparseMemory) {
+  constexpr uint32_t kProcessId = 7;
+  constexpr uint64_t kNullGuardGpuVa = 0x1000;
+  constexpr uint64_t kMmapMinAddrGpuVa = 0x10000;
+  constexpr uint64_t kHighGpuVa = 0x20000;
+
+  amdgpu::GpuMemory mem("test_mem");
+  mem.set_passthrough(true);
+  KfdProcess process(kProcessId);
+  mem.register_process(kProcessId, &process.page_table_, &process.page_table_mutex_);
+
+  process.map_pages(kNullGuardGpuVa, reinterpret_cast<void *>(kNullGuardGpuVa),
+                    KfdProcess::kPageSize);
+  EXPECT_EQ(mem.resolve_host_ptr(kNullGuardGpuVa + 0x980, kProcessId), nullptr);
+  mem.write8(kNullGuardGpuVa + 0x980, 0x5a, kProcessId);
+  EXPECT_EQ(mem.read8(kNullGuardGpuVa + 0x980, kProcessId), 0x5au);
+
+  if (!KfdProcess::host_page_readable(reinterpret_cast<void *>(kMmapMinAddrGpuVa))) {
+    process.map_pages(kMmapMinAddrGpuVa, reinterpret_cast<void *>(kMmapMinAddrGpuVa),
+                      KfdProcess::kPageSize);
+    EXPECT_EQ(mem.resolve_host_ptr(kMmapMinAddrGpuVa + 0xe80, kProcessId), nullptr);
+    mem.write8(kMmapMinAddrGpuVa + 0xe80, 0xc3, kProcessId);
+    EXPECT_EQ(mem.read8(kMmapMinAddrGpuVa + 0xe80, kProcessId), 0xc3u);
+  }
+
+  alignas(4096) std::array<uint8_t, 4096> host_page{};
+  process.map_pages(kHighGpuVa, host_page.data(), host_page.size());
+  EXPECT_EQ(mem.resolve_host_ptr(kHighGpuVa + 4, kProcessId), host_page.data());
+  mem.write8(kHighGpuVa + 4, 0xa5, kProcessId);
+  EXPECT_EQ(host_page[4], 0xa5u);
+
+  mem.unregister_process(kProcessId);
+}
+
+TEST(GpuMemoryTest, InaccessibleHostMappingsFallBackToSparseMemory) {
+  constexpr uint32_t kProcessId = 7;
+  constexpr uint64_t kGpuVa = 0x40000;
+
+  void *reserved =
+      mmap(nullptr, KfdProcess::kPageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(reserved, MAP_FAILED);
+
+  amdgpu::GpuMemory mem("test_mem");
+  mem.set_passthrough(true);
+  KfdProcess process(kProcessId);
+  mem.register_process(kProcessId, &process.page_table_, &process.page_table_mutex_);
+
+  process.map_pages(kGpuVa, reserved, KfdProcess::kPageSize);
+  EXPECT_EQ(mem.resolve_host_ptr(kGpuVa + 0x680, kProcessId), nullptr);
+  mem.write8(kGpuVa + 0x680, 0x7b, kProcessId);
+  EXPECT_EQ(mem.read8(kGpuVa + 0x680, kProcessId), 0x7bu);
+
+  mem.unregister_process(kProcessId);
+  EXPECT_EQ(munmap(reserved, KfdProcess::kPageSize), 0);
+}
+
+TEST(GpuMemoryTest, HostPageAccessReflectsProtectionChanges) {
+  void *page = mmap(nullptr, KfdProcess::kPageSize, PROT_READ | PROT_WRITE,
+                    MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(page, MAP_FAILED);
+
+  auto access = KfdProcess::host_page_access(page);
+  EXPECT_TRUE(access.readable);
+  EXPECT_TRUE(access.writable);
+
+  ASSERT_EQ(mprotect(page, KfdProcess::kPageSize, PROT_NONE), 0);
+  access = KfdProcess::host_page_access(page);
+  EXPECT_FALSE(access.readable);
+  EXPECT_FALSE(access.writable);
+
+  EXPECT_EQ(munmap(page, KfdProcess::kPageSize), 0);
+}
+
+TEST(GpuMemoryTest, PageTableTranslationReflectsProtectionChanges) {
+  constexpr uint32_t kProcessId = 7;
+  constexpr uint64_t kGpuVa = 0x50000;
+  constexpr uint32_t kOffset = 0x120;
+
+  auto *page = static_cast<uint8_t *>(mmap(nullptr, KfdProcess::kPageSize, PROT_READ | PROT_WRITE,
+                                           MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+  ASSERT_NE(page, MAP_FAILED);
+  page[kOffset] = 0x5a;
+
+  amdgpu::GpuMemory mem("test_mem");
+  mem.set_passthrough(true);
+  KfdProcess process(kProcessId);
+  mem.register_process(kProcessId, &process.page_table_, &process.page_table_mutex_);
+  process.map_pages(kGpuVa, page, KfdProcess::kPageSize);
+
+  EXPECT_EQ(mem.read8(kGpuVa + kOffset, kProcessId), 0x5au);
+
+  ASSERT_EQ(mprotect(page, KfdProcess::kPageSize, PROT_READ), 0);
+  KfdProcess::notify_host_mappings_changed();
+  mem.write8(kGpuVa + kOffset, 0x7b, kProcessId);
+  EXPECT_EQ(page[kOffset], 0x5au);
+
+  ASSERT_EQ(mprotect(page, KfdProcess::kPageSize, PROT_NONE), 0);
+  KfdProcess::notify_host_mappings_changed();
+  EXPECT_EQ(mem.read8(kGpuVa + kOffset, kProcessId), 0x7bu);
+
+  mem.unregister_process(kProcessId);
+  EXPECT_EQ(munmap(page, KfdProcess::kPageSize), 0);
+  KfdProcess::notify_host_mappings_changed();
+}
+
+TEST(GpuMemoryTest, ReadWriteBytesSpanMappedAndSparsePages) {
+  constexpr size_t kPageSize = static_cast<size_t>(KfdProcess::kPageSize);
+  constexpr uint32_t kProcessId = 7;
+  constexpr uint64_t kShortGpuVa = 0x80000;
+  constexpr uint64_t kLongGpuVa = 0x90000;
+
+  amdgpu::GpuMemory mem("test_mem");
+  mem.set_passthrough(true);
+  KfdProcess process(kProcessId);
+  mem.register_process(kProcessId, &process.page_table_, &process.page_table_mutex_);
+
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, kPageSize> host_page{};
+  process.map_pages(kShortGpuVa, host_page.data(), host_page.size());
+
+  std::array<uint8_t, 16> short_src{};
+  for (size_t i = 0; i < short_src.size(); ++i)
+    short_src[i] = static_cast<uint8_t>(0x20 + i);
+  mem.write_bytes(kShortGpuVa + kPageSize - 8, short_src.data(),
+                  static_cast<uint32_t>(short_src.size()), kProcessId);
+
+  EXPECT_TRUE(std::equal(short_src.begin(), short_src.begin() + 8, host_page.end() - 8));
+  for (size_t i = 0; i < 8; ++i)
+    EXPECT_EQ(mem.read8(kShortGpuVa + kPageSize + i, kProcessId), short_src[8 + i]);
+
+  std::array<uint8_t, 16> short_out{};
+  mem.read_bytes(kShortGpuVa + kPageSize - 8, short_out.data(),
+                 static_cast<uint32_t>(short_out.size()), kProcessId);
+  EXPECT_EQ(short_out, short_src);
+
+  alignas(KfdProcess::kPageSize) std::array<uint8_t, kPageSize> middle_page{};
+  process.map_pages(kLongGpuVa + kPageSize, middle_page.data(), middle_page.size());
+
+  std::array<uint8_t, kPageSize + 16> long_src{};
+  for (size_t i = 0; i < long_src.size(); ++i)
+    long_src[i] = static_cast<uint8_t>((i * 17) & 0xff);
+  mem.write_bytes(kLongGpuVa + kPageSize - 8, long_src.data(),
+                  static_cast<uint32_t>(long_src.size()), kProcessId);
+
+  for (size_t i = 0; i < 8; ++i)
+    EXPECT_EQ(mem.read8(kLongGpuVa + kPageSize - 8 + i, kProcessId), long_src[i]);
+  EXPECT_TRUE(
+      std::equal(long_src.begin() + 8, long_src.begin() + 8 + kPageSize, middle_page.begin()));
+  for (size_t i = 0; i < 8; ++i)
+    EXPECT_EQ(mem.read8(kLongGpuVa + 2 * kPageSize + i, kProcessId), long_src[8 + kPageSize + i]);
+
+  std::array<uint8_t, kPageSize + 16> long_out{};
+  mem.read_bytes(kLongGpuVa + kPageSize - 8, long_out.data(),
+                 static_cast<uint32_t>(long_out.size()), kProcessId);
+  EXPECT_EQ(long_out, long_src);
+
+  mem.unregister_process(kProcessId);
 }
 
 TEST(VmLifecycleTest, CreateAndDestroy) {
@@ -290,6 +460,72 @@ TEST_P(IsaTest, RegisterAccess) {
   EXPECT_EQ(cu->read_vgpr(vb + 1, 0), 100u);
   EXPECT_EQ(cu->read_vgpr(vb + 1, 63), 200u);
   EXPECT_EQ(cu->read_vgpr(vb + 1, 1), 0u);
+}
+
+TEST(RdnaDispatchTest, DescriptorControlsWaveSizeAndVgprGranularity) {
+  using namespace rocr::llvm::amdhsa;
+
+  const uint32_t code[] = {SOPP_S_ENDPGM};
+  uint32_t wave32_props = 0;
+  AMDHSA_BITS_SET(wave32_props, KERNEL_CODE_PROPERTY_ENABLE_WAVEFRONT_SIZE32, 1);
+
+  {
+    VmFixture f("rdna4", 1, 10, 128);
+    uint64_t ko = f.write_kernel(0x1000, code, sizeof(code), 104, 64, 2, wave32_props, 8);
+    test::AqlQueue queue(f.mem(), f.cp());
+    queue.dispatch(ko, 32, 32);
+    step_until_halted(*f.engine, {f.cu()});
+
+    auto *wf = f.cu()->wf(0);
+    ASSERT_NE(wf, nullptr);
+    EXPECT_EQ(wf->wf_size(), 32u);
+    EXPECT_EQ(wf->num_vgprs(), 64u);
+  }
+
+  {
+    VmFixture f("rdna4", 1, 10, 128);
+    uint64_t ko = f.write_kernel(0x2000, code, sizeof(code), 104, 64, 2, 0, 4);
+    test::AqlQueue queue(f.mem(), f.cp());
+    queue.dispatch(ko, 64, 64);
+    step_until_halted(*f.engine, {f.cu()});
+
+    auto *wf = f.cu()->wf(0);
+    ASSERT_NE(wf, nullptr);
+    EXPECT_EQ(wf->wf_size(), 64u);
+    EXPECT_EQ(wf->num_vgprs(), 64u);
+  }
+}
+
+TEST(RdnaDispatchTest, PackedTidInitializesV0WithWorkitemTuple) {
+  const uint32_t code[] = {SOPP_S_ENDPGM};
+
+  for (const std::string &arch : {std::string("rdna3"), std::string("rdna4")}) {
+    SCOPED_TRACE(arch);
+    VmFixture f(arch, 1, 10, 128);
+    uint64_t ko = f.write_kernel(0x1000, code, sizeof(code), 104, 32, 2, 0, 4, 2);
+
+    test::AqlQueue queue(f.mem(), f.cp());
+    hsa_kernel_dispatch_packet_t pkt{};
+    pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+    pkt.setup = 3;
+    pkt.workgroup_size_x = 8;
+    pkt.workgroup_size_y = 4;
+    pkt.workgroup_size_z = 2;
+    pkt.grid_size_x = 8;
+    pkt.grid_size_y = 4;
+    pkt.grid_size_z = 2;
+    pkt.kernel_object = ko;
+    queue.submit(pkt);
+    step_until_halted(*f.engine, {f.cu()});
+
+    auto *wf = f.cu()->wf(0);
+    ASSERT_NE(wf, nullptr);
+    const uint32_t vbase = wf->vgpr_alloc().base;
+    EXPECT_EQ(f.cu()->read_vgpr(vbase, 0), 0u);
+    EXPECT_EQ(f.cu()->read_vgpr(vbase, 9), 1u | (1u << 10));
+    EXPECT_EQ(f.cu()->read_vgpr(vbase, 40), (1u << 10) | (1u << 20));
+    EXPECT_EQ(f.cu()->read_vgpr(vbase, 63), 7u | (3u << 10) | (1u << 20));
+  }
 }
 
 TEST_P(IsaTest, RegisterFileIsolation) {

--- a/emulation/rocjitsu/tests/aql_queue.h
+++ b/emulation/rocjitsu/tests/aql_queue.h
@@ -38,7 +38,7 @@ public:
            uint64_t ring_addr = DEFAULT_RING_ADDR, uint32_t ring_size = DEFAULT_RING_SIZE,
            uint64_t read_ptr_addr = DEFAULT_READ_PTR_ADDR,
            uint64_t write_ptr_addr = DEFAULT_WRITE_PTR_ADDR,
-           uint64_t doorbell_addr = DEFAULT_DOORBELL_ADDR)
+           uint64_t doorbell_addr = DEFAULT_DOORBELL_ADDR, uint32_t process_id = 0)
       : memory_(memory), cp_(cp), ring_addr_(ring_addr), ring_size_(ring_size),
         read_ptr_addr_(read_ptr_addr), write_ptr_addr_(write_ptr_addr),
         doorbell_addr_(doorbell_addr) {
@@ -48,6 +48,7 @@ public:
     memory_->load_image(reinterpret_cast<const uint8_t *>(&zero), 8, doorbell_addr_);
 
     amdgpu::HwQueue hw{};
+    hw.process_id = process_id;
     hw.queue_id = 1;
     hw.ring_base_va = ring_addr_;
     hw.ring_size = ring_size_;

--- a/emulation/rocjitsu/tests/config_test.cpp
+++ b/emulation/rocjitsu/tests/config_test.cpp
@@ -86,7 +86,7 @@ TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {
   EXPECT_EQ(rdna4.soc()->num_xcds(), 1u);
   EXPECT_EQ(rdna4.soc()->xcd(0)->num_shader_engines(), 4u);
   EXPECT_EQ(rdna4.soc()->xcd(0)->shader_engine(0)->num_compute_units(), 16u);
-  EXPECT_FALSE(rdna4.soc()->xcd(0)->command_processor()->packed_tid());
+  EXPECT_TRUE(rdna4.soc()->xcd(0)->command_processor()->packed_tid());
   EXPECT_EQ(rdna4.soc()->xcd(0)->command_processor()->sdma_packet_dialect(),
             amdgpu::SdmaPacketDialect::Gfx11Plus);
 
@@ -120,7 +120,7 @@ TEST(ConfigLoaderTest, LoadRdnaKmdConfigs) {
   EXPECT_EQ(rdna3.soc()->num_xcds(), 1u);
   EXPECT_EQ(rdna3.soc()->xcd(0)->num_shader_engines(), 6u);
   EXPECT_EQ(rdna3.soc()->xcd(0)->shader_engine(0)->num_compute_units(), 16u);
-  EXPECT_FALSE(rdna3.soc()->xcd(0)->command_processor()->packed_tid());
+  EXPECT_TRUE(rdna3.soc()->xcd(0)->command_processor()->packed_tid());
   EXPECT_EQ(rdna3.soc()->xcd(0)->command_processor()->sdma_packet_dialect(),
             amdgpu::SdmaPacketDialect::Gfx11Plus);
 }
@@ -393,6 +393,66 @@ TEST(CheckpointTest, SaveAndRestoreAccVgprs) {
                                        cdna3::Isa::MAX_ACC_VGPRS_PER_WF - 1,
                                    0),
             0xDEADBEEFu);
+
+  std::filesystem::remove(path);
+}
+
+TEST(CheckpointTest, SaveAndRestoreWave32Vgprs) {
+  const char *json = R"({"max_ticks":10000,"num_threads":1,
+    "vm":{"arch":"rdna3"},
+    "topology":{
+      "root":{
+        "name":"soc","type":"soc",
+        "children":[
+          {"name":"vram","type":"gpu_memory"},
+          {"name":"xcd0","type":"xcd","children":[
+            {"name":"l2","type":"l2_cache"},
+            {"name":"cp","type":"command_processor"},
+            {"name":"se0","type":"shader_engine","children":[
+              {"name":"cu[0:1]","type":"compute_unit","config":[
+                {"key":"num_wf_slots","value":"1"},
+                {"key":"sgprs_per_wf","value":"104"},
+                {"key":"vgprs_per_wf","value":"64"},
+                {"key":"lds_size_kb","value":"64"}
+              ]}
+            ]}
+          ]}
+        ]
+      },
+      "links":[
+        {"src":"xcd0.cp.req_0","dst":"xcd0.se0.cu0.cpl","latency":1,"weight":2},
+        {"src":"xcd0.se0.cu0.req","dst":"xcd0.l2.cpl_0","latency":1,"weight":10}
+      ]
+    }
+  })";
+
+  auto loaded = config::load_config_from_string(json, rocjitsu::kEmbeddedSchema);
+  auto *cu = loaded.soc()->xcd(0)->shader_engine(0)->compute_unit(0);
+  ASSERT_NE(cu, nullptr);
+
+  auto *wf = cu->dispatch_wf(0, 0, 32, cu->config().vgprs_per_wf, 32);
+  ASSERT_NE(wf, nullptr);
+  const uint32_t base = wf->vgpr_alloc().base;
+  cu->write_vgpr(base + 0, 31, 0x12345678u);
+  cu->write_vgpr(base + 33, 31, 0xA5A50021u);
+  cu->write_vgpr(base + 63, 0, 0xDEADBEEFu);
+
+  const char *path = "/tmp/rocjitsu_test_checkpoint_wave32_vgpr.bin";
+  config::save_checkpoint(path, *loaded.soc(), 42, loaded.engine_config);
+  ASSERT_TRUE(std::filesystem::exists(path));
+
+  auto restored = config::restore_checkpoint(path);
+  auto *restored_vm = dynamic_cast<VirtualMachine *>(restored.build_result.root.get());
+  ASSERT_NE(restored_vm, nullptr);
+  auto *restored_cu = restored_vm->soc()->xcd(0)->shader_engine(0)->compute_unit(0);
+  ASSERT_NE(restored_cu, nullptr);
+  auto *restored_wf = restored_cu->wf(0);
+  ASSERT_NE(restored_wf, nullptr);
+  const uint32_t restored_base = restored_wf->vgpr_alloc().base;
+  EXPECT_EQ(restored_wf->wf_size(), 32u);
+  EXPECT_EQ(restored_cu->read_vgpr(restored_base + 0, 31), 0x12345678u);
+  EXPECT_EQ(restored_cu->read_vgpr(restored_base + 33, 31), 0xA5A50021u);
+  EXPECT_EQ(restored_cu->read_vgpr(restored_base + 63, 0), 0xDEADBEEFu);
 
   std::filesystem::remove(path);
 }

--- a/emulation/rocjitsu/tests/data_types_test.cpp
+++ b/emulation/rocjitsu/tests/data_types_test.cpp
@@ -206,13 +206,21 @@ TEST(Fp8E4M3, KeyValues) {
   EXPECT_EQ(util::fp8_e4m3_to_f32(0x79), 288.0f);
 }
 
+TEST(Fp8E4M3, PlainNarrowSpecialValues) {
+  EXPECT_EQ(util::f32_to_fp8_e4m3(std::numeric_limits<float>::quiet_NaN()), 0x7F);
+  EXPECT_EQ(util::f32_to_fp8_e4m3(std::numeric_limits<float>::infinity()), 0x7F);
+  EXPECT_EQ(util::f32_to_fp8_e4m3(256.0f), 0x78);
+  EXPECT_EQ(util::f32_to_fp8_e4m3(448.0f), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3(500.0f), 0x7F);
+}
+
 TEST(Fp8E4M3, RneNarrow) {
   EXPECT_EQ(util::f32_to_fp8_e4m3_rne(std::numeric_limits<float>::quiet_NaN()), 0x7F);
-  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(std::numeric_limits<float>::infinity()), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(std::numeric_limits<float>::infinity()), 0x7F);
   EXPECT_EQ(util::f32_to_fp8_e4m3_rne(0.0f), 0x00);
   EXPECT_EQ(util::f32_to_fp8_e4m3_rne(1.0f), 0x38);
   EXPECT_EQ(util::f32_to_fp8_e4m3_rne(448.0f), 0x7E);
-  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(500.0f), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(500.0f), 0x7F);
   // Denorm overflow: largest denorm (code 7 = 7*2^-9) rounds up to
   // smallest normal (code 8 = 2^-6) for values just above midpoint.
   float largest_denorm = util::fp8_e4m3_to_f32(0x07);
@@ -235,9 +243,12 @@ TEST(Fp8E4M3, RneExp15) {
   EXPECT_EQ(util::f32_to_fp8_e4m3_rne(280.0f), 0x79);
   // 304.0 is midpoint between 288 (m=1) and 320 (m=2) — RNE to even (m=2)
   EXPECT_EQ(util::f32_to_fp8_e4m3_rne(304.0f), 0x7A);
-  // Values above 448 saturate to 0x7E (max finite, not NaN 0x7F)
+  // Values up to the midpoint above 448 round to max finite. Values that round
+  // into the invalid mant=7 code become the E4M3FN NaN encoding.
   EXPECT_EQ(util::f32_to_fp8_e4m3_rne(449.0f), 0x7E);
-  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(1000.0f), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(464.0f), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(480.0f), 0x7F);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_rne(1000.0f), 0x7F);
 }
 
 TEST(Fp8E4M3, SrExp15) {
@@ -247,16 +258,19 @@ TEST(Fp8E4M3, SrExp15) {
     uint8_t code = 0x78 | m;
     EXPECT_EQ(util::f32_to_fp8_e4m3_sr(kExp15Values[m], 0), code) << "sr m=" << m;
   }
-  // Values above max saturate to 0x7E
-  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(500.0f, 0), 0x7E);
-  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(500.0f, 0xFFFFFFFF), 0x7E);
+  // Stochastic rounding can still choose max finite below the overflow
+  // boundary, but an invalid mant=7 result is encoded as NaN.
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(449.0f, 0), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(449.0f, 0xFFFFFFFF), 0x7F);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(500.0f, 0), 0x7F);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(500.0f, 0xFFFFFFFF), 0x7F);
 }
 
 TEST(Fp8E4M3, SrNarrow) {
   uint8_t r = util::f32_to_fp8_e4m3_sr(1.0f, 0);
   EXPECT_EQ(r, 0x38);
   EXPECT_EQ(util::f32_to_fp8_e4m3_sr(std::numeric_limits<float>::quiet_NaN(), 0), 0x7F);
-  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(std::numeric_limits<float>::infinity(), 0), 0x7E);
+  EXPECT_EQ(util::f32_to_fp8_e4m3_sr(std::numeric_limits<float>::infinity(), 0), 0x7F);
 }
 
 TEST(Fp8E4M3, SrDenormRoundTrip) {

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -576,7 +576,7 @@ TEST(Gfx1250ConfigTest, ConfigLoadsTopology) {
   EXPECT_EQ(cu->config().lds_size_kb, kGfx1250LdsSizeKb);
   EXPECT_EQ(soc->xcd(0)->command_processor()->vgpr_granularity(), kGfx1250VgprEncodingGranule);
   EXPECT_EQ(soc->xcd(0)->command_processor()->sdma_packet_dialect(),
-            amdgpu::SdmaPacketDialect::Gfx11Plus);
+            amdgpu::SdmaPacketDialect::Gfx1250);
 }
 
 TEST(Gfx1250SdmaTest, PollMem64WaitsForFull64BitCondition) {
@@ -1113,6 +1113,69 @@ TEST(Gfx1250ExecutionTest, TensorDmaD2CopiesGlobalAndLds) {
     const uint32_t actual = read_global_u32(*sim.memory, kStoreGlobal + i * 4);
     EXPECT_EQ(actual, 0x22000000u + i * 0x303u);
   }
+}
+
+TEST(Gfx1250ExecutionTest, TensorDmaUsesWaveProcessForGlobalMemory) {
+  Gfx1250Sim sim;
+  sim.memory->set_passthrough(true);
+
+  constexpr uint32_t kProcessId = 1250;
+  constexpr uint32_t kElements = 4;
+  constexpr uint64_t kLoadGlobal = 0x1000;
+  constexpr uint64_t kStoreGlobal = 0x2000;
+  alignas(4096) std::array<uint8_t, 4096> load_page{};
+  alignas(4096) std::array<uint8_t, 4096> store_page{};
+  KfdProcess process(kProcessId);
+  sim.memory->register_process(kProcessId, &process.page_table_, &process.page_table_mutex_);
+  process.map_pages(kLoadGlobal, load_page.data(), load_page.size());
+  process.map_pages(kStoreGlobal, store_page.data(), store_page.size());
+
+  auto write_host_u32 = [](std::array<uint8_t, 4096> &page, uint32_t offset, uint32_t value) {
+    for (uint32_t byte = 0; byte < 4; ++byte)
+      page[offset + byte] = static_cast<uint8_t>(value >> (byte * 8));
+  };
+  auto read_host_u32 = [](const std::array<uint8_t, 4096> &page, uint32_t offset) {
+    uint32_t value = 0;
+    for (uint32_t byte = 0; byte < 4; ++byte)
+      value |= static_cast<uint32_t>(page[offset + byte]) << (byte * 8);
+    return value;
+  };
+  for (uint32_t i = 0; i < kElements; ++i)
+    write_host_u32(load_page, i * 4, 0x81000000u + i);
+
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  wf->set_process_id(kProcessId);
+  wf->set_lds_base(cu->allocate_lds(256));
+
+  write_tensor_dma_d0(*cu, *wf, 0, kLoadGlobal);
+  write_tensor_dma_d0(*cu, *wf, 8, kStoreGlobal);
+  write_wave_sgpr(*cu, *wf, 12, 2u << 16);        // i32 elements.
+  write_wave_sgpr(*cu, *wf, 13, kElements << 16); // Tensor dim0.
+  write_wave_sgpr(*cu, *wf, 14, 0);
+  write_wave_sgpr(*cu, *wf, 15, kElements << 16); // Tile dim0.
+  write_wave_sgpr(*cu, *wf, 16, 0);
+  write_wave_sgpr(*cu, *wf, 17, 0);
+  write_wave_sgpr(*cu, *wf, 18, 0);
+  write_wave_sgpr(*cu, *wf, 19, 0);
+
+  const std::array<uint32_t, 3> load_words = {0xd0710001u, 0x7c000000u, 0x7c7c0c00u};
+  gfx1250::TensorLoadToLdsVimage load_inst(load_words.data());
+  load_inst.execute_impl(*wf);
+  for (uint32_t i = 0; i < kElements; ++i)
+    EXPECT_EQ(cu->lds().read32(wf->lds_base() + i * 4), 0x81000000u + i);
+
+  for (uint32_t i = 0; i < kElements; ++i)
+    cu->lds().write32(wf->lds_base() + i * 4, 0x82000000u + i);
+
+  const std::array<uint32_t, 3> store_words = {0xd0714001u, 0x7c000000u, 0x7c7c0c08u};
+  gfx1250::TensorStoreFromLdsVimage store_inst(store_words.data());
+  store_inst.execute_impl(*wf);
+  for (uint32_t i = 0; i < kElements; ++i)
+    EXPECT_EQ(read_host_u32(store_page, i * 4), 0x82000000u + i);
+
+  sim.memory->unregister_process(kProcessId);
 }
 
 TEST(Gfx1250ExecutionTest, TensorDmaDecodeExecuteCoversLoadStoreD2D4Forms) {
@@ -2072,11 +2135,11 @@ TEST(Gfx1250SimulationTest, DispatchesEndpgmThroughConfig) {
   EXPECT_TRUE(sim.cu()->wf(0)->is_halted());
 }
 
-TEST(Gfx1250SimulationTest, MultiWaveDispatchPacksWorkitemIdsInV0) {
+TEST(Gfx1250SimulationTest, MultiWaveDispatchPacksWorkitemIdsInV0WithOneTidVgpr) {
   Gfx1250Sim sim;
   const uint32_t code[] = {S_ENDPGM_GFX12};
-  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code), 104, 32, 2, false,
-                                            false, false, 0, 0, 0, 0, 1);
+  uint64_t kernel_object =
+      sim.write_kernel(0x10000, code, std::size(code), 104, 32, 2, false, false, false);
 
   test::AqlQueue queue(sim.memory, sim.cp());
   hsa_kernel_dispatch_packet_t pkt{};
@@ -2145,6 +2208,70 @@ TEST(Gfx1250SimulationTest, PartialWorkgroupMasksTailWaveExec) {
   EXPECT_EQ(exec_masks, expected);
 }
 
+TEST(Gfx1250SimulationTest, PartialGridTailMasksFinalWorkgroupExec) {
+  Gfx1250Sim sim;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code));
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch(kernel_object, 33, 32);
+  step_until_xcd_halted(sim);
+
+  std::vector<uint64_t> exec_masks;
+  for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
+    auto *se = sim.xcd()->shader_engine(se_idx);
+    for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx) {
+      auto *cu = se->compute_unit(cu_idx);
+      for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
+        auto *wf = cu->wf(wf_idx);
+        if (wf && wf->sgpr_alloc().count > 0)
+          exec_masks.push_back(wf->exec());
+      }
+    }
+  }
+
+  std::sort(exec_masks.begin(), exec_masks.end());
+  const std::vector<uint64_t> expected{1ULL, 0xFFFFFFFFULL};
+  EXPECT_EQ(exec_masks, expected);
+}
+
+TEST(Gfx1250SimulationTest, Partial2DGridTailMasksNonContiguousExecLanes) {
+  Gfx1250Sim sim;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code));
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 2;
+  pkt.workgroup_size_x = 8;
+  pkt.workgroup_size_y = 2;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 13;
+  pkt.grid_size_y = 2;
+  pkt.grid_size_z = 1;
+  pkt.kernel_object = kernel_object;
+  queue.submit(pkt);
+  step_until_xcd_halted(sim);
+
+  std::vector<uint64_t> exec_masks;
+  for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
+    auto *se = sim.xcd()->shader_engine(se_idx);
+    for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx) {
+      auto *cu = se->compute_unit(cu_idx);
+      for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
+        auto *wf = cu->wf(wf_idx);
+        if (wf && wf->sgpr_alloc().count > 0)
+          exec_masks.push_back(wf->exec());
+      }
+    }
+  }
+
+  std::sort(exec_masks.begin(), exec_masks.end());
+  const std::vector<uint64_t> expected{0x1F1FULL, 0xFFFFULL};
+  EXPECT_EQ(exec_masks, expected);
+}
+
 TEST(Gfx1250SimulationTest, DispatchPreloadsKernargDwordsIntoUserSgprs) {
   using namespace rocr::llvm::amdhsa;
 
@@ -2177,6 +2304,54 @@ TEST(Gfx1250SimulationTest, DispatchPreloadsKernargDwordsIntoUserSgprs) {
   EXPECT_EQ(read_wave_sgpr64(*sim.cu(), *wf, 0), kKernargAddr);
   EXPECT_EQ(sim.cu()->read_sgpr(sbase + 2), args.first);
   EXPECT_EQ(sim.cu()->read_sgpr(sbase + 3), args.second);
+}
+
+TEST(Gfx1250SimulationTest, DispatchPreloadsKernargThroughProcessPageTable) {
+  using namespace rocr::llvm::amdhsa;
+
+  constexpr uint32_t kProcessId = 1252;
+  constexpr uint64_t kKernelAddr = 0x10000;
+  constexpr uint64_t kKernargAddr = 0x400000;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+  struct Args {
+    uint32_t skip;
+    uint32_t first;
+    uint32_t second;
+  } args{0x11111111u, 0x22222222u, 0x33333333u};
+  const Args sparse_sentinel{0xaaaaaaaau, 0xbbbbbbbbu, 0xccccccccu};
+  alignas(4096) std::array<uint8_t, 4096> kernarg_page{};
+  std::memcpy(kernarg_page.data(), &args, sizeof(args));
+
+  uint32_t kernel_code_properties = 0;
+  AMDHSA_BITS_SET(kernel_code_properties, KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR, 1);
+
+  Gfx1250Sim sim;
+  KfdProcess process(kProcessId);
+  sim.memory->register_process(kProcessId, &process.page_table_, &process.page_table_mutex_);
+  process.map_pages(kKernargAddr, kernarg_page.data(), kernarg_page.size());
+  sim.memory->load_image(reinterpret_cast<const uint8_t *>(&sparse_sentinel),
+                         sizeof(sparse_sentinel), kKernargAddr);
+  uint64_t kernel_object =
+      sim.write_kernel(kKernelAddr, code, std::size(code), 104, 32, 4, false, false, false,
+                       kernel_code_properties, sizeof(args), 2, 1);
+
+  test::AqlQueue queue(sim.memory, sim.cp(), test::AqlQueue::DEFAULT_RING_ADDR,
+                       test::AqlQueue::DEFAULT_RING_SIZE, test::AqlQueue::DEFAULT_READ_PTR_ADDR,
+                       test::AqlQueue::DEFAULT_WRITE_PTR_ADDR,
+                       test::AqlQueue::DEFAULT_DOORBELL_ADDR, kProcessId);
+  queue.dispatch(kernel_object, 32, 32, kKernargAddr);
+  step_until_halted(*sim.engine, *sim.cu());
+
+  ASSERT_EQ(sim.cu()->num_wfs(), 1u);
+  auto *wf = sim.cu()->wf(0);
+  ASSERT_NE(wf, nullptr);
+  uint32_t sbase = wf->sgpr_alloc().base;
+  EXPECT_EQ(wf->process_id(), kProcessId);
+  EXPECT_EQ(read_wave_sgpr64(*sim.cu(), *wf, 0), kKernargAddr);
+  EXPECT_EQ(sim.cu()->read_sgpr(sbase + 2), args.first);
+  EXPECT_EQ(sim.cu()->read_sgpr(sbase + 3), args.second);
+
+  sim.memory->unregister_process(kProcessId);
 }
 
 TEST(Gfx1250SimulationTest, DispatchPreloadsKernargWhenDescriptorSizeIsUnknown) {

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -85,6 +85,8 @@ protected:
     soc->wire_backing(engine_->topology());
     engine_->build();
     engine_->register_as_primary();
+    memory_ = soc->memory();
+    ASSERT_NE(memory_, nullptr);
 
     driver_->setup_topology(loaded_.device, num_xcds);
     int fd = driver_->open();
@@ -99,6 +101,7 @@ protected:
   rocjitsu::config::LoadedConfig loaded_;
   std::unique_ptr<simdojo::SimulationEngine> engine_;
   rocjitsu::SimulatedDriver *driver_ = nullptr;
+  rocjitsu::amdgpu::GpuMemory *memory_ = nullptr;
 };
 
 TEST_F(KfdIoctlTest, SetMemoryPolicy) {
@@ -259,6 +262,74 @@ TEST_F(KfdIoctlTest, ImportDmabufAndQueryInfo) {
 
   munmap(addr, kSize);
   close(memfd);
+}
+
+TEST_F(KfdIoctlTest, ImportDmabufMapsFdBackingAtGpuVa) {
+  constexpr size_t kSize = 4096;
+  constexpr uint64_t kGpuVa = 0x1001200000ULL;
+  int memfd = static_cast<int>(syscall(SYS_memfd_create, "kfd_dmabuf_backing_test", MFD_CLOEXEC));
+  ASSERT_GE(memfd, 0);
+  ASSERT_EQ(ftruncate(memfd, kSize), 0);
+
+  auto *addr =
+      static_cast<uint8_t *>(mmap(nullptr, kSize, PROT_READ | PROT_WRITE, MAP_SHARED, memfd, 0));
+  ASSERT_NE(addr, MAP_FAILED);
+  addr[0x34] = 0xAB;
+
+  kfd_ioctl_import_dmabuf_args import_args{};
+  import_args.dmabuf_fd = memfd;
+  import_args.gpu_id = kGpuId;
+  import_args.va_addr = kGpuVa;
+
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_IMPORT_DMABUF, &import_args), 0);
+  ASSERT_NE(import_args.handle, 0u);
+  EXPECT_EQ(memory_->read8(kGpuVa + 0x34, driver_->local_process_id()), 0xAB);
+
+  memory_->write8(kGpuVa + 0x80, 0x5C, driver_->local_process_id());
+  EXPECT_EQ(addr[0x80], 0x5C);
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = import_args.handle;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
+
+  addr[0x90] = 0x11;
+  EXPECT_EQ(memory_->read8(kGpuVa + 0x90, driver_->local_process_id()), 0u);
+  memory_->write8(kGpuVa + 0x90, 0x77, driver_->local_process_id());
+  EXPECT_EQ(addr[0x90], 0x11);
+  EXPECT_EQ(memory_->read8(kGpuVa + 0x90, driver_->local_process_id()), 0x77u);
+
+  munmap(addr, kSize);
+  close(memfd);
+}
+
+TEST_F(KfdIoctlTest, UnalignedUserptrMapsGpuVaToMatchingHostBytes) {
+  std::vector<uint8_t> backing(8192, 0);
+  uint8_t *userptr = backing.data() + 123;
+  userptr[0] = 0x3A;
+  userptr[17] = 0x4B;
+  userptr[4100] = 0x5C;
+
+  kfd_ioctl_alloc_memory_of_gpu_args alloc_args{};
+  alloc_args.va_addr = reinterpret_cast<uint64_t>(userptr);
+  alloc_args.size = 5000;
+  alloc_args.gpu_id = kGpuId;
+  alloc_args.flags = KFD_IOC_ALLOC_MEM_FLAGS_USERPTR | KFD_IOC_ALLOC_MEM_FLAGS_WRITABLE;
+
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_ALLOC_MEMORY_OF_GPU, &alloc_args), 0);
+  ASSERT_NE(alloc_args.handle, 0u);
+  ASSERT_EQ(alloc_args.va_addr, reinterpret_cast<uint64_t>(userptr));
+
+  const uint32_t pid = driver_->local_process_id();
+  EXPECT_EQ(memory_->read8(alloc_args.va_addr, pid), 0x3A);
+  EXPECT_EQ(memory_->read8(alloc_args.va_addr + 17, pid), 0x4B);
+  EXPECT_EQ(memory_->read8(alloc_args.va_addr + 4100, pid), 0x5C);
+
+  memory_->write8(alloc_args.va_addr + 33, 0x6D, pid);
+  EXPECT_EQ(userptr[33], 0x6D);
+
+  kfd_ioctl_free_memory_of_gpu_args free_args{};
+  free_args.handle = alloc_args.handle;
+  EXPECT_EQ(driver_->ioctl(AMDKFD_IOC_FREE_MEMORY_OF_GPU, &free_args), 0);
 }
 
 TEST_F(KfdIoctlTest, SvmSetAndGetAttributes) {

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -245,6 +245,52 @@ TEST_P(CuFactoryTest, CreatesSuccessfully) {
   EXPECT_EQ(cu->arch(), arch);
 }
 
+TEST(ComputeUnitRuntimeTest, OutOfRangeSgprReadReturnsZero) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache l2("test_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_RDNA3;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 104;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  auto cu = amdgpu::ComputeUnitCore::create("test_cu", cfg, &mem, &l2);
+  ASSERT_NE(cu, nullptr);
+  EXPECT_EQ(cu->read_sgpr(cfg.sgprs_per_wf), 0u);
+  EXPECT_EQ(cu->read_sgpr(cfg.sgprs_per_wf + 64), 0u);
+}
+
+TEST(ComputeUnitRuntimeTest, WaitCounterAliasesUpdateTargets) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache l2("test_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_RDNA4;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 128;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  auto cu = amdgpu::ComputeUnitCore::create("test_cu", cfg, &mem, &l2);
+  ASSERT_NE(cu, nullptr);
+  auto *wf = cu->dispatch_wf(0, 0, 104, 32, 64);
+  ASSERT_NE(wf, nullptr);
+
+  wf->wait_counters().lgkmcnt = 6;
+  wf->set_wait_counter("waitcnt_vmcnt", 3);
+  wf->set_wait_counter("waitcnt_vscnt", 4);
+  wf->set_wait_counter("waitcnt_lgkmcnt", 5);
+  wf->set_wait_counter("waitcnt_expcnt", 0x1f);
+
+  EXPECT_EQ(wf->wait_target().vmcnt, 3u);
+  EXPECT_EQ(wf->wait_target().vscnt, 4u);
+  EXPECT_EQ(wf->wait_target().lgkmcnt, 5u);
+  EXPECT_EQ(wf->wait_target().expcnt, 7u);
+  EXPECT_EQ(wf->state(), amdgpu::WfState::WAITCNT);
+}
+
 TEST(CuFactoryTest, CdnaAccVgprsDoNotAliasNextWaveSlot) {
   for (rj_code_arch_t arch :
        {ROCJITSU_CODE_ARCH_CDNA2, ROCJITSU_CODE_ARCH_CDNA3, ROCJITSU_CODE_ARCH_CDNA4}) {


### PR DESCRIPTION
## Motivation

IREE-emitted RDNA kernels rely on packed TID values in v0, and wave64 RDNA descriptors encode VGPR counts differently from the runtime’s previous fixed granularity assumption. Without these fixes, dispatch setup can initialize the wrong workitem IDs or under/overcompute VGPR allocation, causing otherwise valid RDNA3/RDNA4 kernels to fail in simulation.

## Technical Details

- Enable packed workitem IDs for RDNA3/RDNA3.5/RDNA4 configs.
- Use 64-lane physical VGPR storage while keeping wave size as per-dispatch runtime state. This decouples the register-file layout from the ISA default wave size, allowing RDNA wave32 and wave64 kernels to share one CU/register-file representation. Wave32 dispatches use only the low active lanes via wf_size/EXEC masks, while wave64 dispatches have storage for lanes 32-63. This also gives checkpoint/restore and SIMD helpers a stable maximum-width VGPR layout without changing architectural VGPR counts.
- Decode AMDHSA VGPR descriptor counts using the wave-size-specific GFX11+ granularity.
- Add coverage for packed workitem IDs when only one TID VGPR is allocated.

The interposer now keeps the simulator’s view of host VMAs in sync with process mapping changes. GPU page-table entries can point at USERPTR or imported dma-buf host mappings, but those mappings may later become `PROT_NONE`, read-only, or unmapped. After successful `mmap`, `mprotect`, and `munmap` calls, the interposer invalidates the cached host-mapping snapshot so GPU memory translation can refresh permissions and fall back to sparse simulator memory instead of dereferencing inaccessible host pages.

In the daemon mode, synthetic DRM fds do not have local mmap state, so DRM mmap requests are forwarded through the remote KFD driver. This gives imported dma-buf mappings real host backing while preserving the same host-VMA permission tracking path as local simulation.

## JIRA ID

N/A

## Test Plan

Unit tests + local smoke tests.

## Test Result

All good.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
