### PR TITLE
[rocprofiler-systems] Update TheRock tarballs to use new index

### DIFF
--- a/.github/workflows/rocprofiler-systems-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-systems-continuous-integration.yml
@@ -152,6 +152,10 @@ jobs:
           echo "ROCm installed to: ${{ env.ROCM_PATH }}"
           echo "✅ ROCm Installation Complete!"
 
+      - name: Output TheRock Manifest
+        run: |
+          cat ${{ env.ROCM_PATH }}/share/therock/therock_manifest.json
+
       - name: Install Python Test Dependencies
         timeout-minutes: 10
         shell: bash

--- a/.github/workflows/rocprofiler-systems-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-systems-continuous-integration.yml
@@ -146,9 +146,8 @@ jobs:
         run: |
           set -e
           mkdir ${{ env.ROCM_PATH }}
-          TARBALL_ROCM_VERSION=$(ls /opt/*.tar.gz | grep -Eo '*([0-9]+\.[0-9]+\.[0-9]+)*')
+          TARBALL_ROCM_VERSION=$(ls /opt/*.tar.gz | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
           tar -xf ${{ env.ROCM_PATH }}-${TARBALL_ROCM_VERSION}-multiarch.tar.gz -C ${{ env.ROCM_PATH }}
-          ln -s ${{ env.ROCM_PATH }}-${{ env.ROCM_VERSION }} ${{ env.ROCM_PATH }}
           echo "ROCm installed to: ${{ env.ROCM_PATH }}"
           echo "✅ ROCm Installation Complete!"
 

--- a/.github/workflows/rocprofiler-systems-ghcr.yml
+++ b/.github/workflows/rocprofiler-systems-ghcr.yml
@@ -100,22 +100,6 @@ jobs:
           fi
           echo "docker_file=${DOCKER_FILE}" >> $GITHUB_OUTPUT
 
-      - name: Get the latest build of The Rock tarball
-        id: therock
-        run: |
-          sudo apt-get install -y python3-pip
-          python3 -m pip install -U pip
-          python3 -m pip install -U awscli
-          export PATH=~/.local/bin:$PATH
-          KEY=$(aws s3api list-objects-v2 \
-                --bucket therock-nightly-tarball \
-                --no-sign-request \
-                --output json \
-                --query "sort_by(Contents[?contains(Key, 'linux-${{ matrix.gpu }}')], &LastModified)[-1].Key")
-          KEY=${KEY//\"/}
-          test -n "$KEY" || { echo "No ${{ matrix.gpu }} tarball found"; exit 1; }
-          echo "tarball=${KEY}" >> $GITHUB_OUTPUT
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
@@ -134,9 +118,7 @@ jobs:
           build-args: |
             DISTRO=${{ steps.setup_vars_gfx.outputs.distro_image }}
             VERSION=${{ matrix.system.version }}
-            TYPE=${{ matrix.gpu }}
             GPU_TYPE=${{ matrix.gpu }}
-            GPU_TARBALL=${{ steps.therock.outputs.tarball }}
             NJOBS=2
             ELFUTILS_DOWNLOAD_VERSION=0.188
           tags: |
@@ -155,9 +137,7 @@ jobs:
           build-args: |
             DISTRO=${{ steps.setup_vars_gfx.outputs.distro_image }}
             VERSION=${{ matrix.system.version }}
-            TYPE=${{ matrix.gpu }}
             GPU_TYPE=${{ matrix.gpu }}
-            GPU_TARBALL=${{ steps.therock.outputs.tarball }}
             NJOBS=2
             ELFUTILS_DOWNLOAD_VERSION=0.188
           tags: |

--- a/projects/rocprofiler-systems/docker/Dockerfile.opensuse.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.opensuse.ci
@@ -59,16 +59,17 @@ RUN if python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)"
 
 # The Rock Tarball
 ARG GPU_TYPE=""
-ARG GPU_TARBALL=""
-RUN if [ -n "$GPU_TYPE" ] && [ -n "$GPU_TARBALL" ]; then \
-        VERSION=$(echo "$GPU_TARBALL" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
-        if [ -z "$VERSION" ]; then \
-            echo "Error: Could not extract version from GPU_TARBALL ('$GPU_TARBALL')." >&2; \
-            exit 1; \
-        fi; \
-        python3 -m pip install -U awscli; \
-        aws s3 cp "s3://therock-nightly-tarball/${GPU_TARBALL}" rocm-${VERSION}-${GPU_TYPE}.tar.gz --no-sign-request; \
-        mv rocm-${VERSION}-${GPU_TYPE}.tar.gz /opt/rocm-${VERSION}-${GPU_TYPE}.tar.gz; \
+RUN if [ -n "${GPU_TYPE}" ]; then \
+        TARBALL=$(curl -fsSL "https://rocm.nightlies.amd.com/tarball-multi-arch/" | \
+            grep -oE "\"name\": \"therock-dist-linux-${GPU_TYPE}-[^\"]+\", \"mtime\": [0-9.]+" | \
+            sort -t' ' -k4 -g | \
+            tail -1 | \
+            sed 's/.*"name": "\([^"]*\)".*/\1/'); \
+        test -n "${TARBALL}" || { echo "Error: no therock-dist-linux-${GPU_TYPE}-* tarball found" >&2; exit 1; }; \
+        VERSION=$(echo "${TARBALL}" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
+        test -n "${VERSION}" || { echo "Error: could not extract version from '${TARBALL}'" >&2; exit 1; }; \
+        curl -fSL "https://rocm.nightlies.amd.com/tarball-multi-arch/${TARBALL}" \
+            -o "/opt/rocm-${VERSION}-${GPU_TYPE}.tar.gz"; \
     fi
 
 WORKDIR /home

--- a/projects/rocprofiler-systems/docker/Dockerfile.rhel.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.rhel.ci
@@ -70,16 +70,17 @@ RUN if python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)"
 
 # The Rock Tarball
 ARG GPU_TYPE=""
-ARG GPU_TARBALL=""
-RUN if [ -n "$GPU_TYPE" ] && [ -n "$GPU_TARBALL" ]; then \
-        VERSION=$(echo "$GPU_TARBALL" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
-        if [ -z "$VERSION" ]; then \
-            echo "Error: Could not extract version from GPU_TARBALL ('$GPU_TARBALL')." >&2; \
-            exit 1; \
-        fi; \
-        python3 -m pip install -U awscli; \
-        aws s3 cp "s3://therock-nightly-tarball/${GPU_TARBALL}" rocm-${VERSION}-${GPU_TYPE}.tar.gz --no-sign-request; \
-        mv rocm-${VERSION}-${GPU_TYPE}.tar.gz /opt/rocm-${VERSION}-${GPU_TYPE}.tar.gz; \
+RUN if [ -n "${GPU_TYPE}" ]; then \
+        TARBALL=$(curl -fsSL "https://rocm.nightlies.amd.com/tarball-multi-arch/" | \
+            grep -oE "\"name\": \"therock-dist-linux-${GPU_TYPE}-[^\"]+\", \"mtime\": [0-9.]+" | \
+            sort -t' ' -k4 -g | \
+            tail -1 | \
+            sed 's/.*"name": "\([^"]*\)".*/\1/'); \
+        test -n "${TARBALL}" || { echo "Error: no therock-dist-linux-${GPU_TYPE}-* tarball found" >&2; exit 1; }; \
+        VERSION=$(echo "${TARBALL}" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
+        test -n "${VERSION}" || { echo "Error: could not extract version from '${TARBALL}'" >&2; exit 1; }; \
+        curl -fSL "https://rocm.nightlies.amd.com/tarball-multi-arch/${TARBALL}" \
+            -o "/opt/rocm-${VERSION}-${GPU_TYPE}.tar.gz"; \
     fi
 
 ARG ROCM_VERSION=""

--- a/projects/rocprofiler-systems/docker/Dockerfile.ubuntu.ci
+++ b/projects/rocprofiler-systems/docker/Dockerfile.ubuntu.ci
@@ -77,17 +77,17 @@ RUN if python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)"
 
 # The Rock Tarball
 ARG GPU_TYPE=""
-ARG GPU_TARBALL=""
-RUN if [ -n "$GPU_TYPE" ] && [ -n "$GPU_TARBALL" ]; then \
-        VERSION=$(echo "$GPU_TARBALL" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
-        if [ -z "$VERSION" ]; then \
-            echo "Error: Could not extract version from GPU_TARBALL ('$GPU_TARBALL')." >&2; \
-            exit 1; \
-        fi; \
-        pip install --upgrade pip; \
-        pip install awscli --break-system-packages; \
-        aws s3 cp "s3://therock-nightly-tarball/${GPU_TARBALL}" rocm-${VERSION}-${GPU_TYPE}.tar.gz --no-sign-request; \
-        mv rocm-${VERSION}-${GPU_TYPE}.tar.gz /opt/rocm-${VERSION}-${GPU_TYPE}.tar.gz; \
+RUN if [ -n "${GPU_TYPE}" ]; then \
+        TARBALL=$(curl -fsSL "https://rocm.nightlies.amd.com/tarball-multi-arch/" | \
+            grep -oE "\"name\": \"therock-dist-linux-${GPU_TYPE}-[^\"]+\", \"mtime\": [0-9.]+" | \
+            sort -t' ' -k4 -g | \
+            tail -1 | \
+            sed 's/.*"name": "\([^"]*\)".*/\1/'); \
+        test -n "${TARBALL}" || { echo "Error: no therock-dist-linux-${GPU_TYPE}-* tarball found" >&2; exit 1; }; \
+        VERSION=$(echo "${TARBALL}" | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p'); \
+        test -n "${VERSION}" || { echo "Error: could not extract version from '${TARBALL}'" >&2; exit 1; }; \
+        curl -fSL "https://rocm.nightlies.amd.com/tarball-multi-arch/${TARBALL}" \
+            -o "/opt/rocm-${VERSION}-${GPU_TYPE}.tar.gz"; \
     fi
 
 ARG ROCM_VERSION=""

--- a/projects/rocprofiler-systems/docker/build-docker-ci.sh
+++ b/projects/rocprofiler-systems/docker/build-docker-ci.sh
@@ -12,7 +12,6 @@ set -e
 : ${PUSH:=0}
 : ${PULL:=--pull}
 : ${GPU_TYPE:=""}
-: ${GPU_TARBALL:=""}
 : ${ROCM_VERSION:=""}
 
 verbose-run()
@@ -108,11 +107,6 @@ do
             GPU_TYPE=${1}
             reset-last
             ;;
-        "--gpu-tarball")
-            shift
-            GPU_TARBALL=${1}
-            reset-last
-            ;;
         "--rocm-version")
             shift
             ROCM_VERSION=${1}
@@ -194,7 +188,6 @@ do
         --build-arg PYTHON_VERSIONS=\"${PYTHON_VERSIONS}\" \
         --build-arg ELFUTILS_DOWNLOAD_VERSION=${ELFUTILS_VERSION} \
         --build-arg GPU_TYPE=${GPU_TYPE} \
-        --build-arg GPU_TARBALL=${GPU_TARBALL} \
         --build-arg ROCM_VERSION=${ROCM_VERSION}
 done
 


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Update tarball logic in Dockerfiles to use the new index to get the latest tarballs from TheRock

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated `Dockerfile.*.ci` files in `rocprofiler-systems` to grab tarballs from `rocm.nightlies.amd.com` instead of S3 buckets directly
- Updated `rocprofiler-systems-continuous-integration.yml` workflow file to output `therock_manifest.json` to show detailed information on TheRock version used, in addition to some cleanup in the ROCm install step
- Updated `projects/rocprofiler-systems/docker/build-docker-ci.sh` to remove references to removed GPU_TARBALL argument

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Ensure no regression issues with new Docker tarballs
- Make sure that `therock_manifest.json` output matches the latest from TheRock and not an older version

## Test Result

<!-- Briefly summarize test outcomes. -->
- Workflows pass, outputting the latest manifest information in `therock_manifest.json`

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
