### PR TITLE
[profiler-hub] Add profilers section to pr_category_label.py

### DIFF
--- a/.github/scripts/pr_category_label.py
+++ b/.github/scripts/pr_category_label.py
@@ -68,7 +68,7 @@ def compute_desired_labels(file_paths: list) -> set:
             elif parts[0] == "shared":
                 desired_labels.add(f"shared: {parts[1]}")
             elif parts[0] == "profilers":
-                desired_labels.add(f"profilers: {parts[1]}")
+                desired_labels.add(f"project: {parts[1]}")
     logger.debug(f"Desired labels based on changes: {desired_labels}")
     return desired_labels
 

--- a/.github/scripts/pr_category_label.py
+++ b/.github/scripts/pr_category_label.py
@@ -38,14 +38,24 @@ from github_cli_client import GitHubCLIClient
 
 logger = logging.getLogger(__name__)
 
+
 def parse_arguments(argv: Optional[List[str]] = None) -> argparse.Namespace:
     """Parse command-line arguments."""
-    parser = argparse.ArgumentParser(description="Apply labels based on PR's changed files.")
-    parser.add_argument("--repo", required=True, help="Full repository name (e.g., org/repo)")
+    parser = argparse.ArgumentParser(
+        description="Apply labels based on PR's changed files."
+    )
+    parser.add_argument(
+        "--repo", required=True, help="Full repository name (e.g., org/repo)"
+    )
     parser.add_argument("--pr", required=True, type=int, help="Pull request number")
-    parser.add_argument("--dry-run", action="store_true", help="Print results without writing to GITHUB_OUTPUT.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print results without writing to GITHUB_OUTPUT.",
+    )
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     return parser.parse_args(argv)
+
 
 def compute_desired_labels(file_paths: list) -> set:
     """Determine the desired labels based on the changed files."""
@@ -57,10 +67,15 @@ def compute_desired_labels(file_paths: list) -> set:
                 desired_labels.add(f"project: {parts[1]}")
             elif parts[0] == "shared":
                 desired_labels.add(f"shared: {parts[1]}")
+            elif parts[0] == "profilers":
+                desired_labels.add(f"profilers: {parts[1]}")
     logger.debug(f"Desired labels based on changes: {desired_labels}")
     return desired_labels
 
-def output_labels(existing_labels: List[str], desired_labels: List[str], dry_run: bool) -> None:
+
+def output_labels(
+    existing_labels: List[str], desired_labels: List[str], dry_run: bool
+) -> None:
     """Output the labels to add/remove to GITHUB_OUTPUT or log them in dry-run mode."""
     to_add = sorted(desired_labels - set(existing_labels))
     logger.debug(f"Labels to add: {to_add}")
@@ -69,24 +84,27 @@ def output_labels(existing_labels: List[str], desired_labels: List[str], dry_run
     else:
         output_file = os.environ.get("GITHUB_OUTPUT")
         if output_file:
-            with open(output_file, 'a') as f:
+            with open(output_file, "a") as f:
                 print(f"label_add={','.join(to_add)}", file=f)
             logger.info(f"Wrote to GITHUB_OUTPUT: add={','.join(to_add)}")
         else:
-            print("GITHUB_OUTPUT environment variable not set. Outputs cannot be written.")
+            print(
+                "GITHUB_OUTPUT environment variable not set. Outputs cannot be written."
+            )
             sys.exit(1)
+
 
 def main(argv=None) -> None:
     """Main function to execute the PR auto label logic."""
     args = parse_arguments(argv)
-    logging.basicConfig(
-        level=logging.DEBUG if args.debug else logging.INFO
-    )
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
     client = GitHubCLIClient()
     changed_files = [file for file in client.get_changed_files(args.repo, int(args.pr))]
 
     if not changed_files:
-        logger.warning("REST API failed or returned no changed files. Falling back to SHA-based Git diff...")
+        logger.warning(
+            "REST API failed or returned no changed files. Falling back to SHA-based Git diff..."
+        )
         try:
             pr_data = os.popen(f"gh api repos/{args.repo}/pulls/{args.pr}").read()
             pr = json.loads(pr_data)
@@ -104,6 +122,7 @@ def main(argv=None) -> None:
     existing_labels = client.get_existing_labels_on_pr(args.repo, int(args.pr))
     desired_labels = compute_desired_labels(changed_files)
     output_labels(existing_labels, desired_labels, args.dry_run)
+
 
 if __name__ == "__main__":
     main()

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - id: label-the-PR
-      uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+      uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
We noticed that `profilers/profiler-hub` PRs do not automatically add the GitHub label for the project

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Updated `pr_category_label.py` to add a new section for `profilers`
  - Since `profiler-hub` lives in `profilers/*` instead of `projects/*`, the current logic was unable to pick these changes up
  - This will also extend to other profiler components once they are migrated from `projects/*` to `profilers/*` directory
- Various pre-commit formatting changes to `pr_category_label.py` 
- Updated `labeller.yml` to use new version of `actions/labeler` that uses Node24 to address Node20 warnings in CI

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
- Local testing using #6686 as a reference profiler-hub PR

## Test Result

<!-- Briefly summarize test outcomes. -->
- Using #6686 as a reference, testing locally using `--dry-run` option shows that the `profilers: profiler-hub` label would be added
<img width="1899" height="377" alt="image" src="https://github.com/user-attachments/assets/48975982-986f-4c60-af9a-c7f13bc9b71c" />


## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
