### PR TITLE
rocr: Fix VMM mem-pool OOM by retaining KFD backing allocation

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -617,17 +617,22 @@ hsa_status_t KfdDriver::Unmap(const core::DriverMemoryHandle& handle, void *mem,
 hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
                                               const core::Agent& agent,
                                               core::DriverMemoryHandle* handle, uint64_t* offset) {
-  // Create handle by exporting and importing the memory from the owning agent.
+  // Obtain a driver memory handle for the owning agent that can be used for CPU-address
+  // lookup and on-demand export.
+  //
+  // The original KFD allocation (@p mem) is retained as the backing store and is released
+  // when the owning MemoryHandle is destroyed (see Runtime::MemoryHandle::~MemoryHandle).
+  // We intentionally do NOT free the KFD allocation here, nor do we re-export it: doing so
+  // (the previous behavior) forced every allocation through a duplicate DRM import and
+  // released the backing BO, which led to excessive device-memory consumption / spurious
+  // out-of-memory failures on some GPUs.
   (void)va;
 
   int source_fd = -1;
 
-  /*
-   * On Linux, export via KFD first (EXPORT_MEMORY_FLAGS_KFD_DMABUF) so the KFD section of the
-   * AMDGPU driver has a BO entry, then import into DRM. Re-export from DRM for the shareable fd.
-   * On Windows, KFD export and DRM export are equivalent.
-   */
-
+  // Export via KFD so the AMDGPU driver has a BO entry, then import it back (passing @p mem
+  // so the thunk recognizes the buffer belongs to this process and avoids a duplicate
+  // device allocation - "bypass import"). The transient fd is closed immediately.
   core::DriverMemoryHandle kfd_alloc = {};
   kfd_alloc.handle = reinterpret_cast<uint64_t>(mem);
   kfd_alloc.size = size;
@@ -647,36 +652,17 @@ hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
     return ret;
   assert(targetHandle.size == size);
 
-  int shareable_fd = source_fd;
-#if defined(__linux__)
-  // Re-export from DRM; the KFD fd was transient and is already closed.
-  ret = ExportMemoryHandle(agent, targetHandle, core::ShareType::DMABUF_FD, 0,
-                           &shareable_fd);
-  if (ret != HSA_STATUS_SUCCESS) {
-    DestroyMemoryHandle(&targetHandle);
-    return ret;
-  }
-  /*
-   * We converted mem into a driver handle. The driver handle will keep the reference count
-   * inside the KMD so we can free the original KFD allocation.
-   */
-  if (HSAKMT_CALL(hsaKmtFreeMemory(mem, size)) != HSAKMT_STATUS_SUCCESS) {
-    DestroyMemoryHandle(&targetHandle);
-    rocr::os::DmaBufClose(shareable_fd);
-    return HSA_STATUS_ERROR;
-  }
-#endif
-
   const auto devhandle = static_cast<const GpuAgent&>(agent).libThunkDev();
   const auto memhandle = reinterpret_cast<HsaMemoryObjectHandle>(targetHandle.handle);
   if (HSAKMT_CALL(hsaKmtMemoryGetCpuAddr(devhandle, memhandle, &handle->mmap_offset)) != HSAKMT_STATUS_SUCCESS) {
     DestroyMemoryHandle(&targetHandle);
-    rocr::os::DmaBufClose(shareable_fd);
     return HSA_STATUS_ERROR;
   }
 
   handle->handle = targetHandle.handle;
-  handle->dmabuf_fd = shareable_fd;
+  handle->dmabuf_fd = -1;  // No persistent fd; shareable fds are exported on demand.
+  handle->driver_specific.kfd.kfd_handle =
+      reinterpret_cast<uint64_t>(mem);  // Retained backing allocation.
   handle->size = size;
   return HSA_STATUS_SUCCESS;
 }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -74,7 +74,21 @@ struct DriverMemoryHandle {
   int dmabuf_fd{-1};
   uint64_t mmap_offset{0};
   size_t size{0};
-  hsa_fabric_handle_t fabric_handle{};
+
+  /// @brief Driver-specific members.
+  ///
+  /// Exactly one union member is valid at a time, selected by the @ref core::Driver that
+  /// owns the handle. Each driver type contributes its own struct.
+  union DriverSpecific {
+    /// @brief Members specific to @ref KfdDriver.
+    struct Kfd {
+      hsa_fabric_handle_t fabric_handle;
+      /// For locally-owned allocations, the retained KFD backing allocation (virtual
+      /// address). 0 for imported handles. The backing allocation is the source of truth
+      /// and is released when the owning MemoryHandle is destroyed.
+      uint64_t kfd_handle;
+    } kfd;
+  } driver_specific{};
 
   bool IsValid() const { return handle != 0; }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -3943,11 +3943,33 @@ Runtime::MappedHandleAllowedAgent::MappedHandleAllowedAgent(
   if (memHandle->imported && memHandle->is_fabric_handle) {
     status = targetAgent->driver().ImportMemoryHandle(
         *targetAgent, &driver_handle, ShareType::FABRIC_HANDLE,
-        &memHandle->driver_handle.fabric_handle);
-  } else {
+        &memHandle->driver_handle.driver_specific.kfd.fabric_handle);
+  } else if (memHandle->imported) {
     status = targetAgent->driver().ImportMemoryHandle(
         *targetAgent, &driver_handle, ShareType::DMABUF_FD,
         &memHandle->driver_handle.dmabuf_fd);
+  } else {
+    // Locally-owned allocation. Export a transient dma-buf from the retained KFD backing
+    // allocation and import it into the target agent. For the owning agent, pass the backing
+    // pointer so the thunk avoids a duplicate device allocation (bypass import).
+    Agent* ownerAgent = memHandle->agentOwner();
+    void* owner_mem = reinterpret_cast<void*>(memHandle->driver_handle.driver_specific.kfd.kfd_handle);
+    int dmabuf_fd = -1;
+    uint64_t export_offset = 0;
+    core::DriverMemoryHandle kfd_alloc = {};
+    kfd_alloc.handle = memHandle->driver_handle.driver_specific.kfd.kfd_handle;
+    kfd_alloc.size = memHandle->driver_handle.size;
+    status = ownerAgent->driver().ExportMemoryHandle(
+        *ownerAgent, kfd_alloc, ShareType::DMABUF_FD,
+        EXPORT_MEMORY_FLAGS_KFD_DMABUF, &dmabuf_fd, &export_offset);
+    if (status == HSA_STATUS_SUCCESS) {
+      void* reuse = (targetAgent == ownerAgent) ? owner_mem : nullptr;
+      status = targetAgent->driver().ImportMemoryHandle(
+          *targetAgent, &driver_handle, ShareType::DMABUF_FD, &dmabuf_fd, reuse);
+#if defined(__linux__)
+      rocr::os::DmaBufClose(dmabuf_fd);
+#endif
+    }
   }
   if (status != HSA_STATUS_SUCCESS)
     throw AMD::hsa_exception(status, "Failed to import memory");
@@ -4066,15 +4088,24 @@ Runtime::MemoryHandle::MemoryHandle(hsa_fabric_handle_t fabric_handle)
   : region(nullptr),
     ref_count(1),
     use_count(0),
-    driver_handle({.dmabuf_fd = -1, .fabric_handle = fabric_handle}),
+    driver_handle({.dmabuf_fd = -1, .driver_specific = {.kfd = {.fabric_handle = fabric_handle}}}),
     imported(true),
     is_fabric_handle(true),
     alloc_flag(MemoryRegion::AllocateNoFlags) {
 }
 
 Runtime::MemoryHandle::~MemoryHandle() {
+  // Capture the retained backing allocation before DestroyMemoryHandle clears the handle.
+  void* owner_mem = reinterpret_cast<void*>(driver_handle.driver_specific.kfd.kfd_handle);
+  size_t owner_size = driver_handle.size;
+
   if (driver_handle.handle != 0 && region != nullptr)
     agentOwner()->driver().DestroyMemoryHandle(&driver_handle);
+
+  // Release the KFD backing allocation for locally-owned handles. Imported handles have
+  // no backing allocation (owner_mem == 0) and region == nullptr.
+  if (owner_mem != nullptr && region != nullptr)
+    region->Free(owner_mem, owner_size);
 }
 
 


### PR DESCRIPTION
The UALink rework (4584915208) converted every VMM allocation into a DRM-imported BO at create time (export -> import -> re-export) and freed the original KFD allocation, making the imported handle the source of truth. On gfx1250 this self-import + free path over-consumes device memory and then fails the import, so hipMallocAsync (stream-ordered mem pools) returns hipErrorOutOfMemory even when ample VRAM is free.

Retain the KFD allocation as the backing store instead:
- CreateShareableHandle no longer re-exports or frees the KFD allocation; it keeps it (via DriverMemoryHandle::kfd.kfd_handle) and only performs a bypass import to obtain the CPU-address offset. Shareable fds are exported on demand.
- MappedHandleAllowedAgent exports a transient dma-buf from the retained backing allocation per agent, using a bypass import for the owning agent to avoid duplicate device allocations.
- ~MemoryHandle releases the backing allocation via region->Free.

Also group driver-specific members (fabric_handle, kfd_handle) into a per-driver union (DriverMemoryHandle::DriverSpecific::Kfd).