### PR TITLE
[ROCM-26347] Removed automatic install of Rust for rust interface

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -61,9 +61,6 @@ levels as strings instead of dictionary objects**.
 - **Renamed "AINIC version" to "ionic version" in `amd-smi version` output**.  
   - The label now correctly reflects that it shows the ionic kernel driver version.
 
-- **Changed build process for rust interface to require Rust**.  
-  - The build process previsouly attempted to install rust automatically if it wasn't already present if the BUILD_RUST_WRAPPER option was enabled. This respresented a security risk, so users must now ensure that Rust is already installed before building amd-smi with the BUILD_RUST_WRAPPER option.
-
 ### Removed
 
 - **Removed the non-functional `--decode` flag from `amd-smi ras`**. Out-of-band CPER decoding is available via `amd-smi ras --afid --cper-file <path>` or `--afid --folder <DIR>`.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -61,6 +61,9 @@ levels as strings instead of dictionary objects**.
 - **Renamed "AINIC version" to "ionic version" in `amd-smi version` output**.  
   - The label now correctly reflects that it shows the ionic kernel driver version.
 
+- **Changed build process for rust interface to require Rust**.  
+  - The build process previsouly attempted to install rust automatically if it wasn't already present if the BUILD_RUST_WRAPPER option was enabled. This respresented a security risk, so users must now ensure that Rust is already installed before building amd-smi with the BUILD_RUST_WRAPPER option.
+
 ### Removed
 
 - **Removed the non-functional `--decode` flag from `amd-smi ras`**. Out-of-band CPER decoding is available via `amd-smi ras --afid --cper-file <path>` or `--afid --folder <DIR>`.

--- a/projects/amdsmi/docs/install/build.md
+++ b/projects/amdsmi/docs/install/build.md
@@ -32,6 +32,10 @@ required:
 * Python (3.6.8 or later)
 * virtualenv -- `python3 -m pip install virtualenv`
 
+Users that wish to also build the AMD SMI Rust interface will also need the following components:
+
+* Rust (1.56 or later)
+
 ## Build steps
 
 1. Clone the rocm-systems repository to your local Linux machine

--- a/projects/amdsmi/rust-interface/CMakeLists.txt
+++ b/projects/amdsmi/rust-interface/CMakeLists.txt
@@ -63,7 +63,19 @@ add_custom_target(amdsmi_rust_source ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/sou
 find_program(CARGO_EXECUTABLE NAMES cargo)
 
 if(NOT CARGO_EXECUTABLE)
-    message(FATAL_ERROR "Cargo not found. Install Rust from https://rustup.rs before building the Rust interface.")
+    set(_CARGO_FALLBACK "$ENV{HOME}/.cargo/bin/cargo")
+    if(EXISTS "${_CARGO_FALLBACK}")
+        message(
+            WARNING
+            "cargo not found on PATH; using ${_CARGO_FALLBACK}. Add ~/.cargo/bin to PATH to suppress this warning."
+        )
+        set(CARGO_EXECUTABLE "${_CARGO_FALLBACK}")
+    else()
+        message(
+            FATAL_ERROR
+            "Cargo not found. Install Rust from https://rustup.rs and ensure ~/.cargo/bin is on your PATH."
+        )
+    endif()
 endif()
 
 # Determine the Cargo build command

--- a/projects/amdsmi/rust-interface/CMakeLists.txt
+++ b/projects/amdsmi/rust-interface/CMakeLists.txt
@@ -63,18 +63,7 @@ add_custom_target(amdsmi_rust_source ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/sou
 find_program(CARGO_EXECUTABLE NAMES cargo)
 
 if(NOT CARGO_EXECUTABLE)
-    message(STATUS "Cargo not found. Installing Rust and Cargo...")
-    execute_process(
-        COMMAND /bin/sh -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
-        RESULT_VARIABLE result
-    )
-
-    if(result)
-        message(FATAL_ERROR "Failed to install Rust and Cargo.")
-    endif()
-
-    # Add Cargo to the PATH
-    set(CARGO_EXECUTABLE "$ENV{HOME}/.cargo/bin/cargo")
+    message(FATAL_ERROR "Cargo not found. Install Rust from https://rustup.rs before building the Rust interface.")
 endif()
 
 # Determine the Cargo build command

--- a/projects/amdsmi/rust-interface/Dockerfile
+++ b/projects/amdsmi/rust-interface/Dockerfile
@@ -25,7 +25,12 @@ RUN apt update --yes \
         && rm -rf /var/cache/apt/ /var/lib/apt/lists/*
 
 # install Rust toolchain
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+RUN curl -sSf -o /tmp/rustup-init https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init \
+    && curl -sSf -o /tmp/rustup-init.sha256 https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init.sha256 \
+    && sha256sum -c /tmp/rustup-init.sha256 \
+    && chmod +x /tmp/rustup-init \
+    && /tmp/rustup-init -y --default-toolchain stable \
+    && rm /tmp/rustup-init /tmp/rustup-init.sha256
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR /src

--- a/projects/amdsmi/rust-interface/Dockerfile
+++ b/projects/amdsmi/rust-interface/Dockerfile
@@ -25,12 +25,14 @@ RUN apt update --yes \
         && rm -rf /var/cache/apt/ /var/lib/apt/lists/*
 
 # install Rust toolchain
-RUN curl -sSf -o /tmp/rustup-init https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init \
-    && curl -sSf -o /tmp/rustup-init.sha256 https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init.sha256 \
-    && sha256sum -c /tmp/rustup-init.sha256 \
-    && chmod +x /tmp/rustup-init \
-    && /tmp/rustup-init -y --default-toolchain stable \
-    && rm /tmp/rustup-init /tmp/rustup-init.sha256
+# The .sha256 file lists a relative path (./rustup-init), so verify from the same dir.
+WORKDIR /tmp
+RUN curl -sSf -O https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init \
+    && curl -sSf -O https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init.sha256 \
+    && sha256sum -c rustup-init.sha256 \
+    && chmod +x rustup-init \
+    && ./rustup-init -y --default-toolchain stable \
+    && rm rustup-init rustup-init.sha256
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR /src


### PR DESCRIPTION
## Motivation
Potential supply chain vulnerability by attempting to install rust if not detected.

## Technical Details
changed automatic installation to required prerequisite which fails the build process if rust is not already present.

## JIRA ID
ROCM-26347
