### PR TITLE
Reverse barrier wait settings

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/sqtt_builder.h
+++ b/projects/rocprofiler-sdk/source/lib/aqlprofile/pm4/sqtt_builder.h
@@ -463,7 +463,7 @@ public:
                     uint32_t token_mask =
                         (config->occupancy_mode)
                             ? Primitives::sqtt_token_mask_occupancy_value()
-                            : Primitives::sqtt_token_mask_on_value(xcc_number_ > 1);
+                            : Primitives::sqtt_token_mask_on_value(xcc_number_ <= 1);
                     if(((1 << global_se) & config->se_mask) == 0)
                         token_mask = Primitives::sqtt_token_mask_off_value();
 


### PR DESCRIPTION
## Motivation

exclude barrier wait should be set for gfx1201, not gfx1250

## JIRA ID

AIPROFSDK-923

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
