### PR TITLE
[kpack] Keep xnack-variant Tensile kernels in per-arch artifacts

### DIFF
--- a/shared/kpack/python/rocm_kpack/artifact_splitter.py
+++ b/shared/kpack/python/rocm_kpack/artifact_splitter.py
@@ -35,6 +35,19 @@ def strip_target_features(target: str) -> str:
     return target[:colon_pos] if colon_pos >= 0 else target
 
 
+def base_arch(arch: str) -> str:
+    """Reduce an architecture id to its bare base, dropping feature suffixes.
+
+    Handles both the ELF bundle/colon form ('gfx942:xnack+') and the
+    Tensile-style hyphen form found in kernel-database filenames
+    ('gfx90a-xnack-'). The bare base arch is the unit of artifact sharding
+    and of --gpu-targets matching, so xnack+/- variants of an in-scope base
+    arch must collapse onto it rather than be treated as distinct targets.
+    """
+    # Normalize the hyphen feature form to the colon form, then strip features.
+    return strip_target_features(arch.replace("-xnack", ":xnack"))
+
+
 @dataclass
 class ExtractedKernel:
     """Represents a kernel extracted from a fat binary."""
@@ -103,6 +116,15 @@ class FileClassificationVisitor:
         for handler in self.database_handlers:
             arch = handler.detect(file_path, prefix_path)
             if arch:
+                # Collapse feature variants onto the bare base arch. detect()
+                # returns the Tensile hyphen form for kernel objects (e.g.
+                # 'gfx90a-xnack-'), while gpu_targets and the per-arch shard key
+                # are bare ('gfx90a'). Without this, an xnack-suffixed kernel
+                # whose base arch IS in gpu_targets fails the membership check
+                # below and is dropped from both the generic and per-arch
+                # artifacts, even though no separate 'gfx90a-xnack-' build job
+                # exists to emit it (see ROCM-25535).
+                arch = base_arch(arch)
                 if self.gpu_targets is not None and arch not in self.gpu_targets:
                     if self.verbose:
                         print(
@@ -235,7 +257,7 @@ class ArtifactSplitter:
         self.database_handlers = database_handlers or []
         self.verbose = verbose
         self.gpu_targets: Optional[Set[str]] = (
-            {strip_target_features(t) for t in gpu_targets} if gpu_targets else None
+            {base_arch(t) for t in gpu_targets} if gpu_targets else None
         )
 
     def compute_kpack_search_pattern(self, binary_path: Path, prefix_root: Path) -> str:

--- a/shared/kpack/python/rocm_kpack/artifact_splitter.py
+++ b/shared/kpack/python/rocm_kpack/artifact_splitter.py
@@ -9,6 +9,7 @@ This module provides functionality to split TheRock build artifacts into:
 """
 
 import os
+import re
 import shutil
 from pathlib import Path
 from typing import List, Tuple, Dict, Optional, Set
@@ -35,9 +36,16 @@ def strip_target_features(target: str) -> str:
     return target[:colon_pos] if colon_pos >= 0 else target
 
 
+# Known LLVM AMDGPU target features that ride on a base arch, in either the
+# colon form (gfx942:xnack+) or the Tensile kernel-filename hyphen form
+# (gfx90a-xnack-). Normalizing the hyphen form to colon lets one colon-split
+# drop every feature variant regardless of how many features are present.
+_HYPHEN_FEATURE_RE = re.compile(r"-(xnack|sramecc)")
+
+
 def base_arch(arch: str) -> str:
-    """Strip features in colon or Tensile hyphen form (e.g. 'gfx90a-xnack-' -> 'gfx90a')."""
-    return strip_target_features(arch.replace("-xnack", ":xnack"))
+    """Strip known feature suffixes in colon or hyphen form (e.g. 'gfx90a-xnack-' -> 'gfx90a')."""
+    return strip_target_features(_HYPHEN_FEATURE_RE.sub(r":\1", arch))
 
 
 @dataclass

--- a/shared/kpack/python/rocm_kpack/artifact_splitter.py
+++ b/shared/kpack/python/rocm_kpack/artifact_splitter.py
@@ -36,15 +36,7 @@ def strip_target_features(target: str) -> str:
 
 
 def base_arch(arch: str) -> str:
-    """Reduce an architecture id to its bare base, dropping feature suffixes.
-
-    Handles both the ELF bundle/colon form ('gfx942:xnack+') and the
-    Tensile-style hyphen form found in kernel-database filenames
-    ('gfx90a-xnack-'). The bare base arch is the unit of artifact sharding
-    and of --gpu-targets matching, so xnack+/- variants of an in-scope base
-    arch must collapse onto it rather than be treated as distinct targets.
-    """
-    # Normalize the hyphen feature form to the colon form, then strip features.
+    """Strip features in colon or Tensile hyphen form (e.g. 'gfx90a-xnack-' -> 'gfx90a')."""
     return strip_target_features(arch.replace("-xnack", ":xnack"))
 
 
@@ -116,14 +108,9 @@ class FileClassificationVisitor:
         for handler in self.database_handlers:
             arch = handler.detect(file_path, prefix_path)
             if arch:
-                # Collapse feature variants onto the bare base arch. detect()
-                # returns the Tensile hyphen form for kernel objects (e.g.
-                # 'gfx90a-xnack-'), while gpu_targets and the per-arch shard key
-                # are bare ('gfx90a'). Without this, an xnack-suffixed kernel
-                # whose base arch IS in gpu_targets fails the membership check
-                # below and is dropped from both the generic and per-arch
-                # artifacts, even though no separate 'gfx90a-xnack-' build job
-                # exists to emit it (see ROCM-25535).
+                # detect() returns the Tensile hyphen form ('gfx90a-xnack-');
+                # collapse onto the bare base arch used by gpu_targets and the
+                # shard key so xnack variants are not dropped (ROCM-25535).
                 arch = base_arch(arch)
                 if self.gpu_targets is not None and arch not in self.gpu_targets:
                     if self.verbose:

--- a/shared/kpack/tests/test_artifact_splitter_integration.py
+++ b/shared/kpack/tests/test_artifact_splitter_integration.py
@@ -998,6 +998,78 @@ class TestArtifactSplitterIntegration:
             "gfx90a per-arch directory should not exist when filtered out"
         )
 
+    def test_gpu_targets_keeps_xnack_variant_database_files(self, toolchain, tmp_path):
+        """
+        Regression test for ROCM-25535.
+
+        Tensile kernel filenames encode xnack feature variants with a hyphen
+        (e.g. ``TensileLibrary_lazy_gfx90a-xnack-.hsaco``), so the database
+        handler reports the arch as ``gfx90a-xnack-``. ``--gpu-targets`` (and the
+        per-arch shard key) use the bare base arch ``gfx90a``. Before the fix,
+        the hyphen-form arch failed the gpu_targets membership check and the
+        kernel object was dropped from BOTH the per-arch and the generic
+        artifacts, even though no separate ``gfx90a-xnack-`` build job exists to
+        emit it. The xnack variants must collapse onto the bare base shard.
+        """
+        input_dir = tmp_path / "test_artifact"
+        input_dir.mkdir()
+
+        prefix = "math-libs/BLAS/rocBLAS/stage"
+        write_artifact_manifest(input_dir, [prefix])
+
+        lib_dir = input_dir / prefix / "lib" / "rocblas" / "library"
+        lib_dir.mkdir(parents=True)
+
+        # In-scope base arch: a bare .dat plus both xnack feature variants.
+        (lib_dir / "TensileLibrary_lazy_gfx90a.dat").write_text("mock gfx90a dat")
+        (lib_dir / "TensileLibrary_lazy_gfx90a-xnack-.hsaco").write_text(
+            "mock gfx90a xnack- kernels"
+        )
+        (lib_dir / "TensileLibrary_lazy_gfx90a-xnack+.hsaco").write_text(
+            "mock gfx90a xnack+ kernels"
+        )
+        # Out-of-scope arch, also with an xnack variant.
+        (lib_dir / "TensileLibrary_lazy_gfx1100.dat").write_text("mock gfx1100 dat")
+        (lib_dir / "TensileLibrary_lazy_gfx1100-xnack-.hsaco").write_text(
+            "mock gfx1100 xnack- kernels"
+        )
+
+        output_dir = tmp_path / "output"
+
+        splitter = ArtifactSplitter(
+            artifact_prefix="rocblas_lib",
+            toolchain=toolchain,
+            database_handlers=[RocBLASHandler()],
+            verbose=True,
+            gpu_targets=["gfx90a"],
+        )
+        splitter.split(input_dir, output_dir)
+
+        gfx90a_dir = output_dir / "rocblas_lib_gfx90a"
+        assert gfx90a_dir.exists(), "gfx90a per-arch directory should exist"
+
+        rel = prefix + "/lib/rocblas/library"
+        # The bare .dat AND both xnack-variant kernels collapse onto gfx90a.
+        dat = gfx90a_dir / rel / "TensileLibrary_lazy_gfx90a.dat"
+        xnack_minus = gfx90a_dir / rel / "TensileLibrary_lazy_gfx90a-xnack-.hsaco"
+        xnack_plus = gfx90a_dir / rel / "TensileLibrary_lazy_gfx90a-xnack+.hsaco"
+        assert dat.exists(), "bare gfx90a .dat should be in the gfx90a shard"
+        assert xnack_minus.exists(), "gfx90a-xnack- kernel must collapse onto gfx90a"
+        assert xnack_plus.exists(), "gfx90a-xnack+ kernel must collapse onto gfx90a"
+
+        # No spurious 'gfx90a-xnack-' shard should be created.
+        assert not (output_dir / "rocblas_lib_gfx90a-xnack-").exists()
+
+        # xnack variants must not leak into the generic artifact.
+        generic_dir = output_dir / "rocblas_lib_generic"
+        generic_xnack = generic_dir / rel / "TensileLibrary_lazy_gfx90a-xnack-.hsaco"
+        assert not generic_xnack.exists(), "per-arch kernels should not be in generic"
+
+        # Out-of-scope arch (and its xnack variant) is filtered out entirely.
+        assert not (output_dir / "rocblas_lib_gfx1100").exists()
+        generic_1100 = generic_dir / rel / "TensileLibrary_lazy_gfx1100-xnack-.hsaco"
+        assert not generic_1100.exists(), "filtered gfx1100 kernels should not be kept"
+
     def test_gpu_targets_filters_fat_binary_kernels(self, toolchain, tmp_path):
         """
         Test that gpu_targets filters code objects extracted from fat binaries.

--- a/shared/kpack/tests/test_artifact_splitter_integration.py
+++ b/shared/kpack/tests/test_artifact_splitter_integration.py
@@ -1002,14 +1002,9 @@ class TestArtifactSplitterIntegration:
         """
         Regression test for ROCM-25535.
 
-        Tensile kernel filenames encode xnack feature variants with a hyphen
-        (e.g. ``TensileLibrary_lazy_gfx90a-xnack-.hsaco``), so the database
-        handler reports the arch as ``gfx90a-xnack-``. ``--gpu-targets`` (and the
-        per-arch shard key) use the bare base arch ``gfx90a``. Before the fix,
-        the hyphen-form arch failed the gpu_targets membership check and the
-        kernel object was dropped from BOTH the per-arch and the generic
-        artifacts, even though no separate ``gfx90a-xnack-`` build job exists to
-        emit it. The xnack variants must collapse onto the bare base shard.
+        Tensile encodes xnack variants with a hyphen (gfx90a-xnack-), but
+        gpu_targets and the shard key are the bare base arch (gfx90a). The
+        variants must collapse onto the base shard instead of being dropped.
         """
         input_dir = tmp_path / "test_artifact"
         input_dir.mkdir()

--- a/shared/kpack/tests/test_artifact_splitter_integration.py
+++ b/shared/kpack/tests/test_artifact_splitter_integration.py
@@ -15,11 +15,39 @@ from rocm_kpack.artifact_splitter import (
     ArtifactSplitter,
     FileClassificationVisitor,
     ExtractedKernel,
+    base_arch,
 )
 from rocm_kpack.artifact_utils import read_artifact_manifest, write_artifact_manifest
 from rocm_kpack.database_handlers import MIOpenHandler, RocBLASHandler
 from rocm_kpack.tools.split_artifacts import batch_split, parse_artifact_name
 from rocm_kpack.tools.verify_artifacts import ArtifactVerifier
+
+
+class TestBaseArch:
+    """Unit tests for base_arch() feature-suffix normalization."""
+
+    @pytest.mark.parametrize(
+        "arch,expected",
+        [
+            # Bare base arch is unchanged.
+            ("gfx90a", "gfx90a"),
+            ("gfx942", "gfx942"),
+            # Tensile hyphen form (kernel-database filenames).
+            ("gfx90a-xnack-", "gfx90a"),
+            ("gfx90a-xnack+", "gfx90a"),
+            # ELF colon form (--gpu-targets / bundle ids).
+            ("gfx942:xnack+", "gfx942"),
+            ("gfx942:sramecc+:xnack-", "gfx942"),
+            # sramecc must also collapse, in both forms (review request: do not
+            # assume xnack is the only feature).
+            ("gfx90a-sramecc-", "gfx90a"),
+            ("gfx90a-sramecc+", "gfx90a"),
+            # Multiple hyphen-form features in one id.
+            ("gfx90a-sramecc+-xnack-", "gfx90a"),
+        ],
+    )
+    def test_strips_known_features(self, arch, expected):
+        assert base_arch(arch) == expected
 
 
 class TestArtifactSplitterIntegration:


### PR DESCRIPTION
## Motivation

Multi-arch ROCm packages were silently dropping xnack-variant Tensile kernel objects for datacenter GPUs, which broke rocBLAS at runtime on MI210 (gfx90a) and MI308 (gfx942) — the failures tracked in ROCM-25535. The kernels build correctly; they were lost at artifact-split time, so the defect only surfaces in packaged multi-arch builds, not in a single-arch developer build.

## Technical Details

The artifact splitter has two filtering paths. The fat-binary path normalizes architecture ids before matching against `--gpu-targets`; the database-handler path (rocBLAS/hipBLASLt/MIOpen Tensile files) did not. Tensile encodes xnack feature variants in filenames with a hyphen (`TensileLibrary_lazy_gfx90a-xnack-.hsaco`), so `DatabaseHandler.detect()` returns `gfx90a-xnack-`. `--gpu-targets` and the per-arch shard key are the bare base arch (`gfx90a`). The string `gfx90a-xnack-` is not in `{gfx90a}`, so the kernel failed the membership check in `FileClassificationVisitor` and was excluded from the per-arch artifact and from the generic artifact — and no separate `gfx90a-xnack-` build job exists to emit it elsewhere, so it was simply gone.

This PR adds a `base_arch()` helper that reduces an architecture id to its bare base, handling both the ELF colon form (`gfx942:xnack+`) and the Tensile hyphen form (`gfx90a-xnack-`). The database-handler path now normalizes the detected arch with `base_arch()` before the `gpu_targets` membership check and before using it as the shard key, so xnack+/- variants collapse onto the base-arch shard. The `gpu_targets` set construction is normalized the same way for symmetry.

Related (adjacent, not superseded by this change):

- ROCm/rocm-systems#7633 — guards the fat-binary split path against empty target matches; different path, complementary.
- ROCm/TheRock#6039 — fixes the fetch side (`fetch_artifacts.py`) to match colon-form xnack artifact variants; that is the ASAN/test-fetch consumer, not the nightly multi-arch tarball split addressed here.

## JIRA ID

Resolves ROCM-25535

## Test Plan

- Unit/integration (`shared/kpack`): new regression test `test_gpu_targets_keeps_xnack_variant_database_files` builds a `RocBLASHandler` layout with a bare `.dat` plus `gfx90a-xnack-` and `gfx90a-xnack+` kernels and an out-of-scope `gfx1100`, splits with `gpu_targets=["gfx90a"]`, and asserts the xnack variants land in the `gfx90a` shard, do not leak into generic, and do not spawn a spurious `gfx90a-xnack-` shard.
- Reproduction evidence (defect-fix): with the source fix stashed, the new test fails exactly as ROCM-25535 describes — both `gfx90a-xnack±` kernels are excluded from generic and absent from the shard (only the `.dat` moves). With the fix applied it passes.
- Command: `PYTHONPATH=shared/kpack/python python -m pytest shared/kpack/tests/test_database_handlers.py shared/kpack/tests/test_artifact_splitter_integration.py`

## Test Result

- Unit/integration: 84 relevant tests pass (database-handler + splitter-integration, including the new test). PR CI kpack lanes are green on ubuntu (3.10/3.12) and windows (3.10/3.12).
- End-to-end packaging validation (the path where the kernels were dropped): the fix was built through TheRock multi-arch CI ([run 27993529661](https://github.com/ROCm/TheRock/actions/runs/27993529661), building gfx90a + gfx94x together) and compared against a current unfixed `develop`/`main` multi-arch build ([run 27975666776](https://github.com/ROCm/TheRock/actions/runs/27975666776)), with both fetched via TheRock's installer for an apples-to-apples comparison.
- Static artifact diff (gfx90a): the unfixed build ships `librocblas.so` but the entire `lib/rocblas/library` tree is absent; the fix restores all 487 files, including the 174 hyphen-form `gfx90a-xnack±` kernels the un-normalized filter was dropping.

| build | gfx90a library files | gfx90a-xnack kernels |
| --- | --- | --- |
| baseline (27975666776) | 0 | 0 |
| fix (27993529661) | 487 | 174 |

- On-device functional (gfx90a / MI210-class, `rocminfo`-confirmed, `librocblas.so.5` resolving into the fetched tree): the unfixed build fails every Tensile-dispatching rocBLAS sample (sgemm, sgemm-strided-batched, c-dgeam, sscal, …) with `Cannot read .../library/TensileLibrary.dat`; only the non-Tensile samples pass. The fix build passes all non-fortran samples (fortran-* skipped for an unrelated missing `libgfortran.so.5`, identical in both builds).

| build | rocBLAS samples |
| --- | --- |
| baseline | 2 passed, 10 failed |
| fix | 12 passed, 0 failed |

- Scope confirmation: gfx942/MI308 is not affected — its Tensile kernels are packaged with plain `gfx942` names (no hyphen-form xnack token), so the buggy filter never matched them; on a gfx942 box both builds behaved identically. This matches the gfx942-passes / gfx90a-fails asymmetry reported on the original nightly.
- Not run locally: the fat-binary integration tests requiring LLVM `readelf`/`clang-offload-bundler` and `test_wheel_splitter.py` (needs optional `rocm-bootstrap`) — environment-limited, unrelated to this change.

## Risk

Level 3. Core build/packaging path; the change is narrow architecture-independent string normalization, well-covered by a reproducing unit test and confirmed end-to-end by a packaged multi-arch build plus an on-device rocBLAS run on the affected part (MI210). It alters which files land in per-arch shards only for arches whose Tensile kernels carry xnack suffixes (the datacenter parts), which is exactly what the e2e validation above exercises.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
