### PR TITLE
[rocjitsu] Native DRM ioctls; harden daemon-mode KFD lifecycle

### DIFF
--- a/emulation/rocjitsu/CHANGELOG.md
+++ b/emulation/rocjitsu/CHANGELOG.md
@@ -11,9 +11,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   unmodified over the simulator; DRM device discovery and queries are handled at
   the syscall layer instead of by intercepting libdrm library symbols
 - **BREAKING:** `rj_vm_device_open()` now takes a connecting client's PID:
-  `rj_vm_device_open(vm, pid_t client_pid, uint32_t *process_id)`. Pass 0 in
-  local mode; a nonzero PID enables daemon-mode process reuse and cross-process
-  memory access
+  `rj_vm_device_open(vm, rj_client_pid_t client_pid, uint32_t *process_id)`. The
+  new `rj_client_pid_t` is a fixed-width (`int32_t`) typedef so the public header
+  stays OS- and ABI-width-agnostic. Pass 0 in local mode; a nonzero PID enables
+  daemon-mode process reuse and cross-process memory access
 
 ### Added
 - Daemon-mode multi-process client support: per-client process reuse,

--- a/emulation/rocjitsu/CHANGELOG.md
+++ b/emulation/rocjitsu/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to rocjitsu are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-06-23
+
+### Changed
+- Serve the amdgpu/DRM ioctl ABI natively so upstream libdrm_amdgpu runs
+  unmodified over the simulator; DRM device discovery and queries are handled at
+  the syscall layer instead of by intercepting libdrm library symbols
+- **BREAKING:** `rj_vm_device_open()` now takes a connecting client's PID:
+  `rj_vm_device_open(vm, pid_t client_pid, uint32_t *process_id)`. Pass 0 in
+  local mode; a nonzero PID enables daemon-mode process reuse and cross-process
+  memory access
+
+### Added
+- Daemon-mode multi-process client support: per-client process reuse,
+  client-PID identification via SO_PEERCRED, and cross-process GPU memory access
+- Vendored kernel DRM UAPI headers (drm.h, amdgpu_drm.h, drm_mode.h) for native
+  amdgpu ioctl struct fidelity
+
 ## [0.1.0] - 2026-06-04
 
 ### Added

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -21,7 +21,7 @@ unset(_RJ_ROCM_PATH_EXPLICIT)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(rj_default_compiler)
 
-project(rocm_jit_suite VERSION 0.1.0)
+project(rocm_jit_suite VERSION 0.2.0)
 
 include(rj_version)
 
@@ -55,6 +55,13 @@ endif()
 # HSA/KFD headers (local copies from rocr-runtime).
 set(HSA_INCLUDE_DIR
     "${PROJECT_SOURCE_DIR}/lib/rocjitsu/external_headers/hsa_headers"
+)
+
+# DRM/amdgpu UAPI headers (vendored kernel ABI, MIT-licensed). Lets the
+# interposer service the amdgpu DRM ioctl surface using the real kernel structs
+# instead of hand-mirrored copies, without depending on libdrm library types.
+set(DRM_INCLUDE_DIR
+    "${PROJECT_SOURCE_DIR}/lib/rocjitsu/external_headers/drm_headers/linux/uapi/drm"
 )
 
 include(rj_log)

--- a/emulation/rocjitsu/lib/rocjitsu/external_headers/drm_headers/linux/uapi/drm/amdgpu_drm.h
+++ b/emulation/rocjitsu/lib/rocjitsu/external_headers/drm_headers/linux/uapi/drm/amdgpu_drm.h
@@ -1,0 +1,1607 @@
+/* amdgpu_drm.h -- Public header for the amdgpu driver -*- linux-c -*-
+ *
+ * Copyright 2000 Precision Insight, Inc., Cedar Park, Texas.
+ * Copyright 2000 VA Linux Systems, Inc., Fremont, California.
+ * Copyright 2002 Tungsten Graphics, Inc., Cedar Park, Texas.
+ * Copyright 2014 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER(S) OR AUTHOR(S) BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * Authors:
+ *    Kevin E. Martin <martin@valinux.com>
+ *    Gareth Hughes <gareth@valinux.com>
+ *    Keith Whitwell <keith@tungstengraphics.com>
+ */
+
+#ifndef __AMDGPU_DRM_H__
+#define __AMDGPU_DRM_H__
+
+#include "drm.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#define DRM_AMDGPU_GEM_CREATE 0x00
+#define DRM_AMDGPU_GEM_MMAP 0x01
+#define DRM_AMDGPU_CTX 0x02
+#define DRM_AMDGPU_BO_LIST 0x03
+#define DRM_AMDGPU_CS 0x04
+#define DRM_AMDGPU_INFO 0x05
+#define DRM_AMDGPU_GEM_METADATA 0x06
+#define DRM_AMDGPU_GEM_WAIT_IDLE 0x07
+#define DRM_AMDGPU_GEM_VA 0x08
+#define DRM_AMDGPU_WAIT_CS 0x09
+#define DRM_AMDGPU_GEM_OP 0x10
+#define DRM_AMDGPU_GEM_USERPTR 0x11
+#define DRM_AMDGPU_WAIT_FENCES 0x12
+#define DRM_AMDGPU_VM 0x13
+#define DRM_AMDGPU_FENCE_TO_HANDLE 0x14
+#define DRM_AMDGPU_SCHED 0x15
+#define DRM_AMDGPU_USERQ 0x16
+#define DRM_AMDGPU_USERQ_SIGNAL 0x17
+#define DRM_AMDGPU_USERQ_WAIT 0x18
+
+#define DRM_IOCTL_AMDGPU_GEM_CREATE                                                                \
+  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_CREATE, union drm_amdgpu_gem_create)
+#define DRM_IOCTL_AMDGPU_GEM_MMAP                                                                  \
+  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_MMAP, union drm_amdgpu_gem_mmap)
+#define DRM_IOCTL_AMDGPU_CTX DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_CTX, union drm_amdgpu_ctx)
+#define DRM_IOCTL_AMDGPU_BO_LIST                                                                   \
+  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_BO_LIST, union drm_amdgpu_bo_list)
+#define DRM_IOCTL_AMDGPU_CS DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_CS, union drm_amdgpu_cs)
+#define DRM_IOCTL_AMDGPU_INFO DRM_IOW(DRM_COMMAND_BASE + DRM_AMDGPU_INFO, struct drm_amdgpu_info)
+#define DRM_IOCTL_AMDGPU_GEM_METADATA                                                              \
+  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_METADATA, struct drm_amdgpu_gem_metadata)
+#define DRM_IOCTL_AMDGPU_GEM_WAIT_IDLE                                                             \
+  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_WAIT_IDLE, union drm_amdgpu_gem_wait_idle)
+#define DRM_IOCTL_AMDGPU_GEM_VA                                                                    \
+  DRM_IOW(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_VA, struct drm_amdgpu_gem_va)
+#define DRM_IOCTL_AMDGPU_WAIT_CS                                                                   \
+  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_WAIT_CS, union drm_amdgpu_wait_cs)
+#define DRM_IOCTL_AMDGPU_GEM_OP                                                                    \
+  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_OP, struct drm_amdgpu_gem_op)
+#define DRM_IOCTL_AMDGPU_GEM_USERPTR                                                               \
+  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_GEM_USERPTR, struct drm_amdgpu_gem_userptr)
+#define DRM_IOCTL_AMDGPU_WAIT_FENCES                                                               \
+  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_WAIT_FENCES, union drm_amdgpu_wait_fences)
+#define DRM_IOCTL_AMDGPU_VM DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_VM, union drm_amdgpu_vm)
+#define DRM_IOCTL_AMDGPU_FENCE_TO_HANDLE                                                           \
+  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_FENCE_TO_HANDLE, union drm_amdgpu_fence_to_handle)
+#define DRM_IOCTL_AMDGPU_SCHED DRM_IOW(DRM_COMMAND_BASE + DRM_AMDGPU_SCHED, union drm_amdgpu_sched)
+#define DRM_IOCTL_AMDGPU_USERQ DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_USERQ, union drm_amdgpu_userq)
+#define DRM_IOCTL_AMDGPU_USERQ_SIGNAL                                                              \
+  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_USERQ_SIGNAL, struct drm_amdgpu_userq_signal)
+#define DRM_IOCTL_AMDGPU_USERQ_WAIT                                                                \
+  DRM_IOWR(DRM_COMMAND_BASE + DRM_AMDGPU_USERQ_WAIT, struct drm_amdgpu_userq_wait)
+
+/**
+ * DOC: memory domains
+ *
+ * %AMDGPU_GEM_DOMAIN_CPU	System memory that is not GPU accessible.
+ * Memory in this pool could be swapped out to disk if there is pressure.
+ *
+ * %AMDGPU_GEM_DOMAIN_GTT	GPU accessible system memory, mapped into the
+ * GPU's virtual address space via gart. Gart memory linearizes non-contiguous
+ * pages of system memory, allows GPU access system memory in a linearized
+ * fashion.
+ *
+ * %AMDGPU_GEM_DOMAIN_VRAM	Local video memory. For APUs, it is memory
+ * carved out by the BIOS.
+ *
+ * %AMDGPU_GEM_DOMAIN_GDS	Global on-chip data storage used to share data
+ * across shader threads.
+ *
+ * %AMDGPU_GEM_DOMAIN_GWS	Global wave sync, used to synchronize the
+ * execution of all the waves on a device.
+ *
+ * %AMDGPU_GEM_DOMAIN_OA	Ordered append, used by 3D or Compute engines
+ * for appending data.
+ *
+ * %AMDGPU_GEM_DOMAIN_DOORBELL	Doorbell. It is an MMIO region for
+ * signalling user mode queues.
+ */
+#define AMDGPU_GEM_DOMAIN_CPU 0x1
+#define AMDGPU_GEM_DOMAIN_GTT 0x2
+#define AMDGPU_GEM_DOMAIN_VRAM 0x4
+#define AMDGPU_GEM_DOMAIN_GDS 0x8
+#define AMDGPU_GEM_DOMAIN_GWS 0x10
+#define AMDGPU_GEM_DOMAIN_OA 0x20
+#define AMDGPU_GEM_DOMAIN_DOORBELL 0x40
+#define AMDGPU_GEM_DOMAIN_MASK                                                                     \
+  (AMDGPU_GEM_DOMAIN_CPU | AMDGPU_GEM_DOMAIN_GTT | AMDGPU_GEM_DOMAIN_VRAM |                        \
+   AMDGPU_GEM_DOMAIN_GDS | AMDGPU_GEM_DOMAIN_GWS | AMDGPU_GEM_DOMAIN_OA |                          \
+   AMDGPU_GEM_DOMAIN_DOORBELL)
+
+/* Flag that CPU access will be required for the case of VRAM domain */
+#define AMDGPU_GEM_CREATE_CPU_ACCESS_REQUIRED (1 << 0)
+/* Flag that CPU access will not work, this VRAM domain is invisible */
+#define AMDGPU_GEM_CREATE_NO_CPU_ACCESS (1 << 1)
+/* Flag that USWC attributes should be used for GTT */
+#define AMDGPU_GEM_CREATE_CPU_GTT_USWC (1 << 2)
+/* Flag that the memory should be in VRAM and cleared */
+#define AMDGPU_GEM_CREATE_VRAM_CLEARED (1 << 3)
+/* Flag that allocating the BO should use linear VRAM */
+#define AMDGPU_GEM_CREATE_VRAM_CONTIGUOUS (1 << 5)
+/* Flag that BO is always valid in this VM */
+#define AMDGPU_GEM_CREATE_VM_ALWAYS_VALID (1 << 6)
+/* Flag that BO sharing will be explicitly synchronized */
+#define AMDGPU_GEM_CREATE_EXPLICIT_SYNC (1 << 7)
+/* Flag that indicates allocating MQD gart on GFX9, where the mtype
+ * for the second page onward should be set to NC. It should never
+ * be used by user space applications.
+ */
+#define AMDGPU_GEM_CREATE_CP_MQD_GFX9 (1 << 8)
+/* Flag that BO may contain sensitive data that must be wiped before
+ * releasing the memory
+ */
+#define AMDGPU_GEM_CREATE_VRAM_WIPE_ON_RELEASE (1 << 9)
+/* Flag that BO will be encrypted and that the TMZ bit should be
+ * set in the PTEs when mapping this buffer via GPUVM or
+ * accessing it with various hw blocks
+ */
+#define AMDGPU_GEM_CREATE_ENCRYPTED (1 << 10)
+/* Flag that BO will be used only in preemptible context, which does
+ * not require GTT memory accounting
+ */
+#define AMDGPU_GEM_CREATE_PREEMPTIBLE (1 << 11)
+/* Flag that BO can be discarded under memory pressure without keeping the
+ * content.
+ */
+#define AMDGPU_GEM_CREATE_DISCARDABLE (1 << 12)
+/* Flag that BO is shared coherently between multiple devices or CPU threads.
+ * May depend on GPU instructions to flush caches to system scope explicitly.
+ *
+ * This influences the choice of MTYPE in the PTEs on GFXv9 and later GPUs and
+ * may override the MTYPE selected in AMDGPU_VA_OP_MAP.
+ */
+#define AMDGPU_GEM_CREATE_COHERENT (1 << 13)
+/* Flag that BO should not be cached by GPU. Coherent without having to flush
+ * GPU caches explicitly
+ *
+ * This influences the choice of MTYPE in the PTEs on GFXv9 and later GPUs and
+ * may override the MTYPE selected in AMDGPU_VA_OP_MAP.
+ */
+#define AMDGPU_GEM_CREATE_UNCACHED (1 << 14)
+/* Flag that BO should be coherent across devices when using device-level
+ * atomics. May depend on GPU instructions to flush caches to device scope
+ * explicitly, promoting them to system scope automatically.
+ *
+ * This influences the choice of MTYPE in the PTEs on GFXv9 and later GPUs and
+ * may override the MTYPE selected in AMDGPU_VA_OP_MAP.
+ */
+#define AMDGPU_GEM_CREATE_EXT_COHERENT (1 << 15)
+
+struct drm_amdgpu_gem_create_in {
+  /** the requested memory size */
+  __u64 bo_size;
+  /** physical start_addr alignment in bytes for some HW requirements */
+  __u64 alignment;
+  /** the requested memory domains */
+  __u64 domains;
+  /** allocation flags */
+  __u64 domain_flags;
+};
+
+struct drm_amdgpu_gem_create_out {
+  /** returned GEM object handle */
+  __u32 handle;
+  __u32 _pad;
+};
+
+union drm_amdgpu_gem_create {
+  struct drm_amdgpu_gem_create_in in;
+  struct drm_amdgpu_gem_create_out out;
+};
+
+/** Opcode to create new residency list.  */
+#define AMDGPU_BO_LIST_OP_CREATE 0
+/** Opcode to destroy previously created residency list */
+#define AMDGPU_BO_LIST_OP_DESTROY 1
+/** Opcode to update resource information in the list */
+#define AMDGPU_BO_LIST_OP_UPDATE 2
+
+struct drm_amdgpu_bo_list_in {
+  /** Type of operation */
+  __u32 operation;
+  /** Handle of list or 0 if we want to create one */
+  __u32 list_handle;
+  /** Number of BOs in list  */
+  __u32 bo_number;
+  /** Size of each element describing BO */
+  __u32 bo_info_size;
+  /** Pointer to array describing BOs */
+  __u64 bo_info_ptr;
+};
+
+struct drm_amdgpu_bo_list_entry {
+  /** Handle of BO */
+  __u32 bo_handle;
+  /** New (if specified) BO priority to be used during migration */
+  __u32 bo_priority;
+};
+
+struct drm_amdgpu_bo_list_out {
+  /** Handle of resource list  */
+  __u32 list_handle;
+  __u32 _pad;
+};
+
+union drm_amdgpu_bo_list {
+  struct drm_amdgpu_bo_list_in in;
+  struct drm_amdgpu_bo_list_out out;
+};
+
+/* context related */
+#define AMDGPU_CTX_OP_ALLOC_CTX 1
+#define AMDGPU_CTX_OP_FREE_CTX 2
+#define AMDGPU_CTX_OP_QUERY_STATE 3
+#define AMDGPU_CTX_OP_QUERY_STATE2 4
+#define AMDGPU_CTX_OP_GET_STABLE_PSTATE 5
+#define AMDGPU_CTX_OP_SET_STABLE_PSTATE 6
+
+/* GPU reset status */
+#define AMDGPU_CTX_NO_RESET 0
+/* this the context caused it */
+#define AMDGPU_CTX_GUILTY_RESET 1
+/* some other context caused it */
+#define AMDGPU_CTX_INNOCENT_RESET 2
+/* unknown cause */
+#define AMDGPU_CTX_UNKNOWN_RESET 3
+
+/* indicate gpu reset occurred after ctx created */
+#define AMDGPU_CTX_QUERY2_FLAGS_RESET (1 << 0)
+/* indicate vram lost occurred after ctx created */
+#define AMDGPU_CTX_QUERY2_FLAGS_VRAMLOST (1 << 1)
+/* indicate some job from this context once cause gpu hang */
+#define AMDGPU_CTX_QUERY2_FLAGS_GUILTY (1 << 2)
+/* indicate some errors are detected by RAS */
+#define AMDGPU_CTX_QUERY2_FLAGS_RAS_CE (1 << 3)
+#define AMDGPU_CTX_QUERY2_FLAGS_RAS_UE (1 << 4)
+/* indicate that the reset hasn't completed yet */
+#define AMDGPU_CTX_QUERY2_FLAGS_RESET_IN_PROGRESS (1 << 5)
+
+/* Context priority level */
+#define AMDGPU_CTX_PRIORITY_UNSET -2048
+#define AMDGPU_CTX_PRIORITY_VERY_LOW -1023
+#define AMDGPU_CTX_PRIORITY_LOW -512
+#define AMDGPU_CTX_PRIORITY_NORMAL 0
+/*
+ * When used in struct drm_amdgpu_ctx_in, a priority above NORMAL requires
+ * CAP_SYS_NICE or DRM_MASTER
+ */
+#define AMDGPU_CTX_PRIORITY_HIGH 512
+#define AMDGPU_CTX_PRIORITY_VERY_HIGH 1023
+
+/* select a stable profiling pstate for perfmon tools */
+#define AMDGPU_CTX_STABLE_PSTATE_FLAGS_MASK 0xf
+#define AMDGPU_CTX_STABLE_PSTATE_NONE 0
+#define AMDGPU_CTX_STABLE_PSTATE_STANDARD 1
+#define AMDGPU_CTX_STABLE_PSTATE_MIN_SCLK 2
+#define AMDGPU_CTX_STABLE_PSTATE_MIN_MCLK 3
+#define AMDGPU_CTX_STABLE_PSTATE_PEAK 4
+
+struct drm_amdgpu_ctx_in {
+  /** AMDGPU_CTX_OP_* */
+  __u32 op;
+  /** Flags */
+  __u32 flags;
+  __u32 ctx_id;
+  /** AMDGPU_CTX_PRIORITY_* */
+  __s32 priority;
+};
+
+union drm_amdgpu_ctx_out {
+  struct {
+    __u32 ctx_id;
+    __u32 _pad;
+  } alloc;
+
+  struct {
+    /** For future use, no flags defined so far */
+    __u64 flags;
+    /** Number of resets caused by this context so far. */
+    __u32 hangs;
+    /** Reset status since the last call of the ioctl. */
+    __u32 reset_status;
+  } state;
+
+  struct {
+    __u32 flags;
+    __u32 _pad;
+  } pstate;
+};
+
+union drm_amdgpu_ctx {
+  struct drm_amdgpu_ctx_in in;
+  union drm_amdgpu_ctx_out out;
+};
+
+/* user queue IOCTL operations */
+#define AMDGPU_USERQ_OP_CREATE 1
+#define AMDGPU_USERQ_OP_FREE 2
+
+/* queue priority levels */
+#define AMDGPU_USERQ_CREATE_FLAGS_QUEUE_PRIORITY_MASK 0x3
+#define AMDGPU_USERQ_CREATE_FLAGS_QUEUE_PRIORITY_SHIFT 0
+#define AMDGPU_USERQ_CREATE_FLAGS_QUEUE_PRIORITY_NORMAL_LOW 0
+#define AMDGPU_USERQ_CREATE_FLAGS_QUEUE_PRIORITY_LOW 1
+#define AMDGPU_USERQ_CREATE_FLAGS_QUEUE_PRIORITY_NORMAL_HIGH 2
+#define AMDGPU_USERQ_CREATE_FLAGS_QUEUE_PRIORITY_HIGH 3 /* admin only */
+/* for queues that need access to protected content */
+#define AMDGPU_USERQ_CREATE_FLAGS_QUEUE_SECURE (1 << 2)
+
+/*
+ * This structure is a container to pass input configuration
+ * info for all supported userqueue related operations.
+ * For operation AMDGPU_USERQ_OP_CREATE: user is expected
+ *  to set all fields, excep the parameter 'queue_id'.
+ * For operation AMDGPU_USERQ_OP_FREE: the only input parameter expected
+ *  to be set is 'queue_id', eveything else is ignored.
+ */
+struct drm_amdgpu_userq_in {
+  /** AMDGPU_USERQ_OP_* */
+  __u32 op;
+  /** Queue id passed for operation USERQ_OP_FREE */
+  __u32 queue_id;
+  /** the target GPU engine to execute workload (AMDGPU_HW_IP_*) */
+  __u32 ip_type;
+  /**
+   * @doorbell_handle: the handle of doorbell GEM object
+   * associated to this userqueue client.
+   */
+  __u32 doorbell_handle;
+  /**
+   * @doorbell_offset: 32-bit offset of the doorbell in the doorbell bo.
+   * Kernel will generate absolute doorbell offset using doorbell_handle
+   * and doorbell_offset in the doorbell bo.
+   */
+  __u32 doorbell_offset;
+  /**
+   * @flags: flags used for queue parameters
+   */
+  __u32 flags;
+
+  /**
+   * @queue_va: Virtual address of the GPU memory which holds the queue
+   * object. The queue holds the workload packets.
+   */
+  __u64 queue_va;
+  /**
+   * @queue_size: Size of the queue in bytes, this needs to be 256-byte
+   * aligned.
+   */
+  __u64 queue_size;
+  /**
+   * @rptr_va : Virtual address of the GPU memory which holds the ring RPTR.
+   * This object must be at least 8 byte in size and aligned to 8-byte offset.
+   */
+  __u64 rptr_va;
+  /**
+   * @wptr_va : Virtual address of the GPU memory which holds the ring WPTR.
+   * This object must be at least 8 byte in size and aligned to 8-byte offset.
+   *
+   * Queue, RPTR and WPTR can come from the same object, as long as the size
+   * and alignment related requirements are met.
+   */
+  __u64 wptr_va;
+  /**
+   * @mqd: MQD (memory queue descriptor) is a set of parameters which allow
+   * the GPU to uniquely define and identify a usermode queue.
+   *
+   * MQD data can be of different size for different GPU IP/engine and
+   * their respective versions/revisions, so this points to a __u64 *
+   * which holds IP specific MQD of this usermode queue.
+   */
+  __u64 mqd;
+  /**
+   * @size: size of MQD data in bytes, it must match the MQD structure
+   * size of the respective engine/revision defined in UAPI for ex, for
+   * gfx11 workloads, size = sizeof(drm_amdgpu_userq_mqd_gfx11).
+   */
+  __u64 mqd_size;
+};
+
+/* The structure to carry output of userqueue ops */
+struct drm_amdgpu_userq_out {
+  /**
+   * For operation AMDGPU_USERQ_OP_CREATE: This field contains a unique
+   * queue ID to represent the newly created userqueue in the system, otherwise
+   * it should be ignored.
+   */
+  __u32 queue_id;
+  __u32 _pad;
+};
+
+union drm_amdgpu_userq {
+  struct drm_amdgpu_userq_in in;
+  struct drm_amdgpu_userq_out out;
+};
+
+/* GFX V11 IP specific MQD parameters */
+struct drm_amdgpu_userq_mqd_gfx11 {
+  /**
+   * @shadow_va: Virtual address of the GPU memory to hold the shadow buffer.
+   * Use AMDGPU_INFO_IOCTL to find the exact size of the object.
+   */
+  __u64 shadow_va;
+  /**
+   * @csa_va: Virtual address of the GPU memory to hold the CSA buffer.
+   * Use AMDGPU_INFO_IOCTL to find the exact size of the object.
+   */
+  __u64 csa_va;
+};
+
+/* GFX V11 SDMA IP specific MQD parameters */
+struct drm_amdgpu_userq_mqd_sdma_gfx11 {
+  /**
+   * @csa_va: Virtual address of the GPU memory to hold the CSA buffer.
+   * This must be a from a separate GPU object, and use AMDGPU_INFO IOCTL
+   * to get the size.
+   */
+  __u64 csa_va;
+};
+
+/* GFX V11 Compute IP specific MQD parameters */
+struct drm_amdgpu_userq_mqd_compute_gfx11 {
+  /**
+   * @eop_va: Virtual address of the GPU memory to hold the EOP buffer.
+   * This must be a from a separate GPU object, and use AMDGPU_INFO IOCTL
+   * to get the size.
+   */
+  __u64 eop_va;
+};
+
+/* userq signal/wait ioctl */
+struct drm_amdgpu_userq_signal {
+  /**
+   * @queue_id: Queue handle used by the userq fence creation function
+   * to retrieve the WPTR.
+   */
+  __u32 queue_id;
+  __u32 pad;
+  /**
+   * @syncobj_handles: The list of syncobj handles submitted by the user queue
+   * job to be signaled.
+   */
+  __u64 syncobj_handles;
+  /**
+   * @num_syncobj_handles: A count that represents the number of syncobj handles in
+   * @syncobj_handles.
+   */
+  __u64 num_syncobj_handles;
+  /**
+   * @bo_read_handles: The list of BO handles that the submitted user queue job
+   * is using for read only. This will update BO fences in the kernel.
+   */
+  __u64 bo_read_handles;
+  /**
+   * @bo_write_handles: The list of BO handles that the submitted user queue job
+   * is using for write only. This will update BO fences in the kernel.
+   */
+  __u64 bo_write_handles;
+  /**
+   * @num_bo_read_handles: A count that represents the number of read BO handles in
+   * @bo_read_handles.
+   */
+  __u32 num_bo_read_handles;
+  /**
+   * @num_bo_write_handles: A count that represents the number of write BO handles in
+   * @bo_write_handles.
+   */
+  __u32 num_bo_write_handles;
+};
+
+struct drm_amdgpu_userq_fence_info {
+  /**
+   * @va: A gpu address allocated for each queue which stores the
+   * read pointer (RPTR) value.
+   */
+  __u64 va;
+  /**
+   * @value: A 64 bit value represents the write pointer (WPTR) of the
+   * queue commands which compared with the RPTR value to signal the
+   * fences.
+   */
+  __u64 value;
+};
+
+struct drm_amdgpu_userq_wait {
+  /**
+   * @waitq_id: Queue handle used by the userq wait IOCTL to retrieve the
+   * wait queue and maintain the fence driver references in it.
+   */
+  __u32 waitq_id;
+  __u32 pad;
+  /**
+   * @syncobj_handles: The list of syncobj handles submitted by the user queue
+   * job to get the va/value pairs.
+   */
+  __u64 syncobj_handles;
+  /**
+   * @syncobj_timeline_handles: The list of timeline syncobj handles submitted by
+   * the user queue job to get the va/value pairs at given @syncobj_timeline_points.
+   */
+  __u64 syncobj_timeline_handles;
+  /**
+   * @syncobj_timeline_points: The list of timeline syncobj points submitted by the
+   * user queue job for the corresponding @syncobj_timeline_handles.
+   */
+  __u64 syncobj_timeline_points;
+  /**
+   * @bo_read_handles: The list of read BO handles submitted by the user queue
+   * job to get the va/value pairs.
+   */
+  __u64 bo_read_handles;
+  /**
+   * @bo_write_handles: The list of write BO handles submitted by the user queue
+   * job to get the va/value pairs.
+   */
+  __u64 bo_write_handles;
+  /**
+   * @num_syncobj_timeline_handles: A count that represents the number of timeline
+   * syncobj handles in @syncobj_timeline_handles.
+   */
+  __u16 num_syncobj_timeline_handles;
+  /**
+   * @num_fences: This field can be used both as input and output. As input it defines
+   * the maximum number of fences that can be returned and as output it will specify
+   * how many fences were actually returned from the ioctl.
+   */
+  __u16 num_fences;
+  /**
+   * @num_syncobj_handles: A count that represents the number of syncobj handles in
+   * @syncobj_handles.
+   */
+  __u32 num_syncobj_handles;
+  /**
+   * @num_bo_read_handles: A count that represents the number of read BO handles in
+   * @bo_read_handles.
+   */
+  __u32 num_bo_read_handles;
+  /**
+   * @num_bo_write_handles: A count that represents the number of write BO handles in
+   * @bo_write_handles.
+   */
+  __u32 num_bo_write_handles;
+  /**
+   * @out_fences: The field is a return value from the ioctl containing the list of
+   * address/value pairs to wait for.
+   */
+  __u64 out_fences;
+};
+
+/* vm ioctl */
+#define AMDGPU_VM_OP_RESERVE_VMID 1
+#define AMDGPU_VM_OP_UNRESERVE_VMID 2
+
+struct drm_amdgpu_vm_in {
+  /** AMDGPU_VM_OP_* */
+  __u32 op;
+  __u32 flags;
+};
+
+struct drm_amdgpu_vm_out {
+  /** For future use, no flags defined so far */
+  __u64 flags;
+};
+
+union drm_amdgpu_vm {
+  struct drm_amdgpu_vm_in in;
+  struct drm_amdgpu_vm_out out;
+};
+
+/* sched ioctl */
+#define AMDGPU_SCHED_OP_PROCESS_PRIORITY_OVERRIDE 1
+#define AMDGPU_SCHED_OP_CONTEXT_PRIORITY_OVERRIDE 2
+
+struct drm_amdgpu_sched_in {
+  /* AMDGPU_SCHED_OP_* */
+  __u32 op;
+  __u32 fd;
+  /** AMDGPU_CTX_PRIORITY_* */
+  __s32 priority;
+  __u32 ctx_id;
+};
+
+union drm_amdgpu_sched {
+  struct drm_amdgpu_sched_in in;
+};
+
+/*
+ * This is not a reliable API and you should expect it to fail for any
+ * number of reasons and have fallback path that do not use userptr to
+ * perform any operation.
+ */
+#define AMDGPU_GEM_USERPTR_READONLY (1 << 0)
+#define AMDGPU_GEM_USERPTR_ANONONLY (1 << 1)
+#define AMDGPU_GEM_USERPTR_VALIDATE (1 << 2)
+#define AMDGPU_GEM_USERPTR_REGISTER (1 << 3)
+
+struct drm_amdgpu_gem_userptr {
+  __u64 addr;
+  __u64 size;
+  /* AMDGPU_GEM_USERPTR_* */
+  __u32 flags;
+  /* Resulting GEM handle */
+  __u32 handle;
+};
+
+/* SI-CI-VI: */
+/* same meaning as the GB_TILE_MODE and GL_MACRO_TILE_MODE fields */
+#define AMDGPU_TILING_ARRAY_MODE_SHIFT 0
+#define AMDGPU_TILING_ARRAY_MODE_MASK 0xf
+#define AMDGPU_TILING_PIPE_CONFIG_SHIFT 4
+#define AMDGPU_TILING_PIPE_CONFIG_MASK 0x1f
+#define AMDGPU_TILING_TILE_SPLIT_SHIFT 9
+#define AMDGPU_TILING_TILE_SPLIT_MASK 0x7
+#define AMDGPU_TILING_MICRO_TILE_MODE_SHIFT 12
+#define AMDGPU_TILING_MICRO_TILE_MODE_MASK 0x7
+#define AMDGPU_TILING_BANK_WIDTH_SHIFT 15
+#define AMDGPU_TILING_BANK_WIDTH_MASK 0x3
+#define AMDGPU_TILING_BANK_HEIGHT_SHIFT 17
+#define AMDGPU_TILING_BANK_HEIGHT_MASK 0x3
+#define AMDGPU_TILING_MACRO_TILE_ASPECT_SHIFT 19
+#define AMDGPU_TILING_MACRO_TILE_ASPECT_MASK 0x3
+#define AMDGPU_TILING_NUM_BANKS_SHIFT 21
+#define AMDGPU_TILING_NUM_BANKS_MASK 0x3
+
+/* GFX9 - GFX11: */
+#define AMDGPU_TILING_SWIZZLE_MODE_SHIFT 0
+#define AMDGPU_TILING_SWIZZLE_MODE_MASK 0x1f
+#define AMDGPU_TILING_DCC_OFFSET_256B_SHIFT 5
+#define AMDGPU_TILING_DCC_OFFSET_256B_MASK 0xFFFFFF
+#define AMDGPU_TILING_DCC_PITCH_MAX_SHIFT 29
+#define AMDGPU_TILING_DCC_PITCH_MAX_MASK 0x3FFF
+#define AMDGPU_TILING_DCC_INDEPENDENT_64B_SHIFT 43
+#define AMDGPU_TILING_DCC_INDEPENDENT_64B_MASK 0x1
+#define AMDGPU_TILING_DCC_INDEPENDENT_128B_SHIFT 44
+#define AMDGPU_TILING_DCC_INDEPENDENT_128B_MASK 0x1
+#define AMDGPU_TILING_SCANOUT_SHIFT 63
+#define AMDGPU_TILING_SCANOUT_MASK 0x1
+
+/* GFX12 and later: */
+#define AMDGPU_TILING_GFX12_SWIZZLE_MODE_SHIFT 0
+#define AMDGPU_TILING_GFX12_SWIZZLE_MODE_MASK 0x7
+/* These are DCC recompression setting for memory management: */
+#define AMDGPU_TILING_GFX12_DCC_MAX_COMPRESSED_BLOCK_SHIFT 3
+#define AMDGPU_TILING_GFX12_DCC_MAX_COMPRESSED_BLOCK_MASK 0x3 /* 0:64B, 1:128B, 2:256B */
+#define AMDGPU_TILING_GFX12_DCC_NUMBER_TYPE_SHIFT 5
+#define AMDGPU_TILING_GFX12_DCC_NUMBER_TYPE_MASK 0x7 /* CB_COLOR0_INFO.NUMBER_TYPE */
+#define AMDGPU_TILING_GFX12_DCC_DATA_FORMAT_SHIFT 8
+#define AMDGPU_TILING_GFX12_DCC_DATA_FORMAT_MASK 0x3f /* [0:4]:CB_COLOR0_INFO.FORMAT, [5]:MM */
+
+/* Set/Get helpers for tiling flags. */
+#define AMDGPU_TILING_SET(field, value)                                                            \
+  (((__u64)(value) & AMDGPU_TILING_##field##_MASK) << AMDGPU_TILING_##field##_SHIFT)
+#define AMDGPU_TILING_GET(value, field)                                                            \
+  (((__u64)(value) >> AMDGPU_TILING_##field##_SHIFT) & AMDGPU_TILING_##field##_MASK)
+
+#define AMDGPU_GEM_METADATA_OP_SET_METADATA 1
+#define AMDGPU_GEM_METADATA_OP_GET_METADATA 2
+
+/** The same structure is shared for input/output */
+struct drm_amdgpu_gem_metadata {
+  /** GEM Object handle */
+  __u32 handle;
+  /** Do we want get or set metadata */
+  __u32 op;
+  struct {
+    /** For future use, no flags defined so far */
+    __u64 flags;
+    /** family specific tiling info */
+    __u64 tiling_info;
+    __u32 data_size_bytes;
+    __u32 data[64];
+  } data;
+};
+
+struct drm_amdgpu_gem_mmap_in {
+  /** the GEM object handle */
+  __u32 handle;
+  __u32 _pad;
+};
+
+struct drm_amdgpu_gem_mmap_out {
+  /** mmap offset from the vma offset manager */
+  __u64 addr_ptr;
+};
+
+union drm_amdgpu_gem_mmap {
+  struct drm_amdgpu_gem_mmap_in in;
+  struct drm_amdgpu_gem_mmap_out out;
+};
+
+struct drm_amdgpu_gem_wait_idle_in {
+  /** GEM object handle */
+  __u32 handle;
+  /** For future use, no flags defined so far */
+  __u32 flags;
+  /** Absolute timeout to wait */
+  __u64 timeout;
+};
+
+struct drm_amdgpu_gem_wait_idle_out {
+  /** BO status:  0 - BO is idle, 1 - BO is busy */
+  __u32 status;
+  /** Returned current memory domain */
+  __u32 domain;
+};
+
+union drm_amdgpu_gem_wait_idle {
+  struct drm_amdgpu_gem_wait_idle_in in;
+  struct drm_amdgpu_gem_wait_idle_out out;
+};
+
+struct drm_amdgpu_wait_cs_in {
+  /* Command submission handle
+   * handle equals 0 means none to wait for
+   * handle equals ~0ull means wait for the latest sequence number
+   */
+  __u64 handle;
+  /** Absolute timeout to wait */
+  __u64 timeout;
+  __u32 ip_type;
+  __u32 ip_instance;
+  __u32 ring;
+  __u32 ctx_id;
+};
+
+struct drm_amdgpu_wait_cs_out {
+  /** CS status:  0 - CS completed, 1 - CS still busy */
+  __u64 status;
+};
+
+union drm_amdgpu_wait_cs {
+  struct drm_amdgpu_wait_cs_in in;
+  struct drm_amdgpu_wait_cs_out out;
+};
+
+struct drm_amdgpu_fence {
+  __u32 ctx_id;
+  __u32 ip_type;
+  __u32 ip_instance;
+  __u32 ring;
+  __u64 seq_no;
+};
+
+struct drm_amdgpu_wait_fences_in {
+  /** This points to uint64_t * which points to fences */
+  __u64 fences;
+  __u32 fence_count;
+  __u32 wait_all;
+  __u64 timeout_ns;
+};
+
+struct drm_amdgpu_wait_fences_out {
+  __u32 status;
+  __u32 first_signaled;
+};
+
+union drm_amdgpu_wait_fences {
+  struct drm_amdgpu_wait_fences_in in;
+  struct drm_amdgpu_wait_fences_out out;
+};
+
+#define AMDGPU_GEM_OP_GET_GEM_CREATE_INFO 0
+#define AMDGPU_GEM_OP_SET_PLACEMENT 1
+
+/* Sets or returns a value associated with a buffer. */
+struct drm_amdgpu_gem_op {
+  /** GEM object handle */
+  __u32 handle;
+  /** AMDGPU_GEM_OP_* */
+  __u32 op;
+  /** Input or return value */
+  __u64 value;
+};
+
+#define AMDGPU_VA_OP_MAP 1
+#define AMDGPU_VA_OP_UNMAP 2
+#define AMDGPU_VA_OP_CLEAR 3
+#define AMDGPU_VA_OP_REPLACE 4
+
+/* Delay the page table update till the next CS */
+#define AMDGPU_VM_DELAY_UPDATE (1 << 0)
+
+/* Mapping flags */
+/* readable mapping */
+#define AMDGPU_VM_PAGE_READABLE (1 << 1)
+/* writable mapping */
+#define AMDGPU_VM_PAGE_WRITEABLE (1 << 2)
+/* executable mapping, new for VI */
+#define AMDGPU_VM_PAGE_EXECUTABLE (1 << 3)
+/* partially resident texture */
+#define AMDGPU_VM_PAGE_PRT (1 << 4)
+/* MTYPE flags use bit 5 to 8 */
+#define AMDGPU_VM_MTYPE_MASK (0xf << 5)
+/* Default MTYPE. Pre-AI must use this.  Recommended for newer ASICs. */
+#define AMDGPU_VM_MTYPE_DEFAULT (0 << 5)
+/* Use Non Coherent MTYPE instead of default MTYPE */
+#define AMDGPU_VM_MTYPE_NC (1 << 5)
+/* Use Write Combine MTYPE instead of default MTYPE */
+#define AMDGPU_VM_MTYPE_WC (2 << 5)
+/* Use Cache Coherent MTYPE instead of default MTYPE */
+#define AMDGPU_VM_MTYPE_CC (3 << 5)
+/* Use UnCached MTYPE instead of default MTYPE */
+#define AMDGPU_VM_MTYPE_UC (4 << 5)
+/* Use Read Write MTYPE instead of default MTYPE */
+#define AMDGPU_VM_MTYPE_RW (5 << 5)
+/* don't allocate MALL */
+#define AMDGPU_VM_PAGE_NOALLOC (1 << 9)
+
+struct drm_amdgpu_gem_va {
+  /** GEM object handle */
+  __u32 handle;
+  __u32 _pad;
+  /** AMDGPU_VA_OP_* */
+  __u32 operation;
+  /** AMDGPU_VM_PAGE_* */
+  __u32 flags;
+  /** va address to assign . Must be correctly aligned.*/
+  __u64 va_address;
+  /** Specify offset inside of BO to assign. Must be correctly aligned.*/
+  __u64 offset_in_bo;
+  /** Specify mapping size. Must be correctly aligned. */
+  __u64 map_size;
+  /**
+   * vm_timeline_point is a sequence number used to add new timeline point.
+   */
+  __u64 vm_timeline_point;
+  /**
+   * The vm page table update fence is installed in given vm_timeline_syncobj_out
+   * at vm_timeline_point.
+   */
+  __u32 vm_timeline_syncobj_out;
+  /** the number of syncobj handles in @input_fence_syncobj_handles */
+  __u32 num_syncobj_handles;
+  /** Array of sync object handle to wait for given input fences */
+  __u64 input_fence_syncobj_handles;
+};
+
+#define AMDGPU_HW_IP_GFX 0
+#define AMDGPU_HW_IP_COMPUTE 1
+#define AMDGPU_HW_IP_DMA 2
+#define AMDGPU_HW_IP_UVD 3
+#define AMDGPU_HW_IP_VCE 4
+#define AMDGPU_HW_IP_UVD_ENC 5
+#define AMDGPU_HW_IP_VCN_DEC 6
+/*
+ * From VCN4, AMDGPU_HW_IP_VCN_ENC is re-used to support
+ * both encoding and decoding jobs.
+ */
+#define AMDGPU_HW_IP_VCN_ENC 7
+#define AMDGPU_HW_IP_VCN_JPEG 8
+#define AMDGPU_HW_IP_VPE 9
+#define AMDGPU_HW_IP_NUM 10
+
+#define AMDGPU_HW_IP_INSTANCE_MAX_COUNT 1
+
+#define AMDGPU_CHUNK_ID_IB 0x01
+#define AMDGPU_CHUNK_ID_FENCE 0x02
+#define AMDGPU_CHUNK_ID_DEPENDENCIES 0x03
+#define AMDGPU_CHUNK_ID_SYNCOBJ_IN 0x04
+#define AMDGPU_CHUNK_ID_SYNCOBJ_OUT 0x05
+#define AMDGPU_CHUNK_ID_BO_HANDLES 0x06
+#define AMDGPU_CHUNK_ID_SCHEDULED_DEPENDENCIES 0x07
+#define AMDGPU_CHUNK_ID_SYNCOBJ_TIMELINE_WAIT 0x08
+#define AMDGPU_CHUNK_ID_SYNCOBJ_TIMELINE_SIGNAL 0x09
+#define AMDGPU_CHUNK_ID_CP_GFX_SHADOW 0x0a
+
+struct drm_amdgpu_cs_chunk {
+  __u32 chunk_id;
+  __u32 length_dw;
+  __u64 chunk_data;
+};
+
+struct drm_amdgpu_cs_in {
+  /** Rendering context id */
+  __u32 ctx_id;
+  /**  Handle of resource list associated with CS */
+  __u32 bo_list_handle;
+  __u32 num_chunks;
+  __u32 flags;
+  /** this points to __u64 * which point to cs chunks */
+  __u64 chunks;
+};
+
+struct drm_amdgpu_cs_out {
+  __u64 handle;
+};
+
+union drm_amdgpu_cs {
+  struct drm_amdgpu_cs_in in;
+  struct drm_amdgpu_cs_out out;
+};
+
+/* Specify flags to be used for IB */
+
+/* This IB should be submitted to CE */
+#define AMDGPU_IB_FLAG_CE (1 << 0)
+
+/* Preamble flag, which means the IB could be dropped if no context switch */
+#define AMDGPU_IB_FLAG_PREAMBLE (1 << 1)
+
+/* Preempt flag, IB should set Pre_enb bit if PREEMPT flag detected */
+#define AMDGPU_IB_FLAG_PREEMPT (1 << 2)
+
+/* The IB fence should do the L2 writeback but not invalidate any shader
+ * caches (L2/vL1/sL1/I$). */
+#define AMDGPU_IB_FLAG_TC_WB_NOT_INVALIDATE (1 << 3)
+
+/* Set GDS_COMPUTE_MAX_WAVE_ID = DEFAULT before PACKET3_INDIRECT_BUFFER.
+ * This will reset wave ID counters for the IB.
+ */
+#define AMDGPU_IB_FLAG_RESET_GDS_MAX_WAVE_ID (1 << 4)
+
+/* Flag the IB as secure (TMZ)
+ */
+#define AMDGPU_IB_FLAGS_SECURE (1 << 5)
+
+/* Tell KMD to flush and invalidate caches
+ */
+#define AMDGPU_IB_FLAG_EMIT_MEM_SYNC (1 << 6)
+
+struct drm_amdgpu_cs_chunk_ib {
+  __u32 _pad;
+  /** AMDGPU_IB_FLAG_* */
+  __u32 flags;
+  /** Virtual address to begin IB execution */
+  __u64 va_start;
+  /** Size of submission */
+  __u32 ib_bytes;
+  /** HW IP to submit to */
+  __u32 ip_type;
+  /** HW IP index of the same type to submit to  */
+  __u32 ip_instance;
+  /** Ring index to submit to */
+  __u32 ring;
+};
+
+struct drm_amdgpu_cs_chunk_dep {
+  __u32 ip_type;
+  __u32 ip_instance;
+  __u32 ring;
+  __u32 ctx_id;
+  __u64 handle;
+};
+
+struct drm_amdgpu_cs_chunk_fence {
+  __u32 handle;
+  __u32 offset;
+};
+
+struct drm_amdgpu_cs_chunk_sem {
+  __u32 handle;
+};
+
+struct drm_amdgpu_cs_chunk_syncobj {
+  __u32 handle;
+  __u32 flags;
+  __u64 point;
+};
+
+#define AMDGPU_FENCE_TO_HANDLE_GET_SYNCOBJ 0
+#define AMDGPU_FENCE_TO_HANDLE_GET_SYNCOBJ_FD 1
+#define AMDGPU_FENCE_TO_HANDLE_GET_SYNC_FILE_FD 2
+
+union drm_amdgpu_fence_to_handle {
+  struct {
+    struct drm_amdgpu_fence fence;
+    __u32 what;
+    __u32 pad;
+  } in;
+  struct {
+    __u32 handle;
+  } out;
+};
+
+struct drm_amdgpu_cs_chunk_data {
+  union {
+    struct drm_amdgpu_cs_chunk_ib ib_data;
+    struct drm_amdgpu_cs_chunk_fence fence_data;
+  };
+};
+
+#define AMDGPU_CS_CHUNK_CP_GFX_SHADOW_FLAGS_INIT_SHADOW 0x1
+
+struct drm_amdgpu_cs_chunk_cp_gfx_shadow {
+  __u64 shadow_va;
+  __u64 csa_va;
+  __u64 gds_va;
+  __u64 flags;
+};
+
+/*
+ *  Query h/w info: Flag that this is integrated (a.h.a. fusion) GPU
+ *
+ */
+#define AMDGPU_IDS_FLAGS_FUSION 0x1
+#define AMDGPU_IDS_FLAGS_PREEMPTION 0x2
+#define AMDGPU_IDS_FLAGS_TMZ 0x4
+#define AMDGPU_IDS_FLAGS_CONFORMANT_TRUNC_COORD 0x8
+
+/*
+ *  Query h/w info: Flag identifying VF/PF/PT mode
+ *
+ */
+#define AMDGPU_IDS_FLAGS_MODE_MASK 0x300
+#define AMDGPU_IDS_FLAGS_MODE_SHIFT 0x8
+#define AMDGPU_IDS_FLAGS_MODE_PF 0x0
+#define AMDGPU_IDS_FLAGS_MODE_VF 0x1
+#define AMDGPU_IDS_FLAGS_MODE_PT 0x2
+
+/* indicate if acceleration can be working */
+#define AMDGPU_INFO_ACCEL_WORKING 0x00
+/* get the crtc_id from the mode object id? */
+#define AMDGPU_INFO_CRTC_FROM_ID 0x01
+/* query hw IP info */
+#define AMDGPU_INFO_HW_IP_INFO 0x02
+/* query hw IP instance count for the specified type */
+#define AMDGPU_INFO_HW_IP_COUNT 0x03
+/* timestamp for GL_ARB_timer_query */
+#define AMDGPU_INFO_TIMESTAMP 0x05
+/* Query the firmware version */
+#define AMDGPU_INFO_FW_VERSION 0x0e
+/* Subquery id: Query VCE firmware version */
+#define AMDGPU_INFO_FW_VCE 0x1
+/* Subquery id: Query UVD firmware version */
+#define AMDGPU_INFO_FW_UVD 0x2
+/* Subquery id: Query GMC firmware version */
+#define AMDGPU_INFO_FW_GMC 0x03
+/* Subquery id: Query GFX ME firmware version */
+#define AMDGPU_INFO_FW_GFX_ME 0x04
+/* Subquery id: Query GFX PFP firmware version */
+#define AMDGPU_INFO_FW_GFX_PFP 0x05
+/* Subquery id: Query GFX CE firmware version */
+#define AMDGPU_INFO_FW_GFX_CE 0x06
+/* Subquery id: Query GFX RLC firmware version */
+#define AMDGPU_INFO_FW_GFX_RLC 0x07
+/* Subquery id: Query GFX MEC firmware version */
+#define AMDGPU_INFO_FW_GFX_MEC 0x08
+/* Subquery id: Query SMC firmware version */
+#define AMDGPU_INFO_FW_SMC 0x0a
+/* Subquery id: Query SDMA firmware version */
+#define AMDGPU_INFO_FW_SDMA 0x0b
+/* Subquery id: Query PSP SOS firmware version */
+#define AMDGPU_INFO_FW_SOS 0x0c
+/* Subquery id: Query PSP ASD firmware version */
+#define AMDGPU_INFO_FW_ASD 0x0d
+/* Subquery id: Query VCN firmware version */
+#define AMDGPU_INFO_FW_VCN 0x0e
+/* Subquery id: Query GFX RLC SRLC firmware version */
+#define AMDGPU_INFO_FW_GFX_RLC_RESTORE_LIST_CNTL 0x0f
+/* Subquery id: Query GFX RLC SRLG firmware version */
+#define AMDGPU_INFO_FW_GFX_RLC_RESTORE_LIST_GPM_MEM 0x10
+/* Subquery id: Query GFX RLC SRLS firmware version */
+#define AMDGPU_INFO_FW_GFX_RLC_RESTORE_LIST_SRM_MEM 0x11
+/* Subquery id: Query DMCU firmware version */
+#define AMDGPU_INFO_FW_DMCU 0x12
+#define AMDGPU_INFO_FW_TA 0x13
+/* Subquery id: Query DMCUB firmware version */
+#define AMDGPU_INFO_FW_DMCUB 0x14
+/* Subquery id: Query TOC firmware version */
+#define AMDGPU_INFO_FW_TOC 0x15
+/* Subquery id: Query CAP firmware version */
+#define AMDGPU_INFO_FW_CAP 0x16
+/* Subquery id: Query GFX RLCP firmware version */
+#define AMDGPU_INFO_FW_GFX_RLCP 0x17
+/* Subquery id: Query GFX RLCV firmware version */
+#define AMDGPU_INFO_FW_GFX_RLCV 0x18
+/* Subquery id: Query MES_KIQ firmware version */
+#define AMDGPU_INFO_FW_MES_KIQ 0x19
+/* Subquery id: Query MES firmware version */
+#define AMDGPU_INFO_FW_MES 0x1a
+/* Subquery id: Query IMU firmware version */
+#define AMDGPU_INFO_FW_IMU 0x1b
+/* Subquery id: Query VPE firmware version */
+#define AMDGPU_INFO_FW_VPE 0x1c
+
+/* number of bytes moved for TTM migration */
+#define AMDGPU_INFO_NUM_BYTES_MOVED 0x0f
+/* the used VRAM size */
+#define AMDGPU_INFO_VRAM_USAGE 0x10
+/* the used GTT size */
+#define AMDGPU_INFO_GTT_USAGE 0x11
+/* Information about GDS, etc. resource configuration */
+#define AMDGPU_INFO_GDS_CONFIG 0x13
+/* Query information about VRAM and GTT domains */
+#define AMDGPU_INFO_VRAM_GTT 0x14
+/* Query information about register in MMR address space*/
+#define AMDGPU_INFO_READ_MMR_REG 0x15
+/* Query information about device: rev id, family, etc. */
+#define AMDGPU_INFO_DEV_INFO 0x16
+/* visible vram usage */
+#define AMDGPU_INFO_VIS_VRAM_USAGE 0x17
+/* number of TTM buffer evictions */
+#define AMDGPU_INFO_NUM_EVICTIONS 0x18
+/* Query memory about VRAM and GTT domains */
+#define AMDGPU_INFO_MEMORY 0x19
+/* Query vce clock table */
+#define AMDGPU_INFO_VCE_CLOCK_TABLE 0x1A
+/* Query vbios related information */
+#define AMDGPU_INFO_VBIOS 0x1B
+/* Subquery id: Query vbios size */
+#define AMDGPU_INFO_VBIOS_SIZE 0x1
+/* Subquery id: Query vbios image */
+#define AMDGPU_INFO_VBIOS_IMAGE 0x2
+/* Subquery id: Query vbios info */
+#define AMDGPU_INFO_VBIOS_INFO 0x3
+/* Query UVD handles */
+#define AMDGPU_INFO_NUM_HANDLES 0x1C
+/* Query sensor related information */
+#define AMDGPU_INFO_SENSOR 0x1D
+/* Subquery id: Query GPU shader clock */
+#define AMDGPU_INFO_SENSOR_GFX_SCLK 0x1
+/* Subquery id: Query GPU memory clock */
+#define AMDGPU_INFO_SENSOR_GFX_MCLK 0x2
+/* Subquery id: Query GPU temperature */
+#define AMDGPU_INFO_SENSOR_GPU_TEMP 0x3
+/* Subquery id: Query GPU load */
+#define AMDGPU_INFO_SENSOR_GPU_LOAD 0x4
+/* Subquery id: Query average GPU power	*/
+#define AMDGPU_INFO_SENSOR_GPU_AVG_POWER 0x5
+/* Subquery id: Query northbridge voltage */
+#define AMDGPU_INFO_SENSOR_VDDNB 0x6
+/* Subquery id: Query graphics voltage */
+#define AMDGPU_INFO_SENSOR_VDDGFX 0x7
+/* Subquery id: Query GPU stable pstate shader clock */
+#define AMDGPU_INFO_SENSOR_STABLE_PSTATE_GFX_SCLK 0x8
+/* Subquery id: Query GPU stable pstate memory clock */
+#define AMDGPU_INFO_SENSOR_STABLE_PSTATE_GFX_MCLK 0x9
+/* Subquery id: Query GPU peak pstate shader clock */
+#define AMDGPU_INFO_SENSOR_PEAK_PSTATE_GFX_SCLK 0xa
+/* Subquery id: Query GPU peak pstate memory clock */
+#define AMDGPU_INFO_SENSOR_PEAK_PSTATE_GFX_MCLK 0xb
+/* Subquery id: Query input GPU power	*/
+#define AMDGPU_INFO_SENSOR_GPU_INPUT_POWER 0xc
+/* Number of VRAM page faults on CPU access. */
+#define AMDGPU_INFO_NUM_VRAM_CPU_PAGE_FAULTS 0x1E
+#define AMDGPU_INFO_VRAM_LOST_COUNTER 0x1F
+/* query ras mask of enabled features*/
+#define AMDGPU_INFO_RAS_ENABLED_FEATURES 0x20
+/* RAS MASK: UMC (VRAM) */
+#define AMDGPU_INFO_RAS_ENABLED_UMC (1 << 0)
+/* RAS MASK: SDMA */
+#define AMDGPU_INFO_RAS_ENABLED_SDMA (1 << 1)
+/* RAS MASK: GFX */
+#define AMDGPU_INFO_RAS_ENABLED_GFX (1 << 2)
+/* RAS MASK: MMHUB */
+#define AMDGPU_INFO_RAS_ENABLED_MMHUB (1 << 3)
+/* RAS MASK: ATHUB */
+#define AMDGPU_INFO_RAS_ENABLED_ATHUB (1 << 4)
+/* RAS MASK: PCIE */
+#define AMDGPU_INFO_RAS_ENABLED_PCIE (1 << 5)
+/* RAS MASK: HDP */
+#define AMDGPU_INFO_RAS_ENABLED_HDP (1 << 6)
+/* RAS MASK: XGMI */
+#define AMDGPU_INFO_RAS_ENABLED_XGMI (1 << 7)
+/* RAS MASK: DF */
+#define AMDGPU_INFO_RAS_ENABLED_DF (1 << 8)
+/* RAS MASK: SMN */
+#define AMDGPU_INFO_RAS_ENABLED_SMN (1 << 9)
+/* RAS MASK: SEM */
+#define AMDGPU_INFO_RAS_ENABLED_SEM (1 << 10)
+/* RAS MASK: MP0 */
+#define AMDGPU_INFO_RAS_ENABLED_MP0 (1 << 11)
+/* RAS MASK: MP1 */
+#define AMDGPU_INFO_RAS_ENABLED_MP1 (1 << 12)
+/* RAS MASK: FUSE */
+#define AMDGPU_INFO_RAS_ENABLED_FUSE (1 << 13)
+/* query video encode/decode caps */
+#define AMDGPU_INFO_VIDEO_CAPS 0x21
+/* Subquery id: Decode */
+#define AMDGPU_INFO_VIDEO_CAPS_DECODE 0
+/* Subquery id: Encode */
+#define AMDGPU_INFO_VIDEO_CAPS_ENCODE 1
+/* Query the max number of IBs per gang per submission */
+#define AMDGPU_INFO_MAX_IBS 0x22
+/* query last page fault info */
+#define AMDGPU_INFO_GPUVM_FAULT 0x23
+/* query FW object size and alignment */
+#define AMDGPU_INFO_UQ_FW_AREAS 0x24
+
+#define AMDGPU_INFO_MMR_SE_INDEX_SHIFT 0
+#define AMDGPU_INFO_MMR_SE_INDEX_MASK 0xff
+#define AMDGPU_INFO_MMR_SH_INDEX_SHIFT 8
+#define AMDGPU_INFO_MMR_SH_INDEX_MASK 0xff
+
+struct drm_amdgpu_query_fw {
+  /** AMDGPU_INFO_FW_* */
+  __u32 fw_type;
+  /**
+   * Index of the IP if there are more IPs of
+   * the same type.
+   */
+  __u32 ip_instance;
+  /**
+   * Index of the engine. Whether this is used depends
+   * on the firmware type. (e.g. MEC, SDMA)
+   */
+  __u32 index;
+  __u32 _pad;
+};
+
+/* Input structure for the INFO ioctl */
+struct drm_amdgpu_info {
+  /* Where the return value will be stored */
+  __u64 return_pointer;
+  /* The size of the return value. Just like "size" in "snprintf",
+   * it limits how many bytes the kernel can write. */
+  __u32 return_size;
+  /* The query request id. */
+  __u32 query;
+
+  union {
+    struct {
+      __u32 id;
+      __u32 _pad;
+    } mode_crtc;
+
+    struct {
+      /** AMDGPU_HW_IP_* */
+      __u32 type;
+      /**
+       * Index of the IP if there are more IPs of the same
+       * type. Ignored by AMDGPU_INFO_HW_IP_COUNT.
+       */
+      __u32 ip_instance;
+    } query_hw_ip;
+
+    struct {
+      __u32 dword_offset;
+      /** number of registers to read */
+      __u32 count;
+      __u32 instance;
+      /** For future use, no flags defined so far */
+      __u32 flags;
+    } read_mmr_reg;
+
+    struct drm_amdgpu_query_fw query_fw;
+
+    struct {
+      __u32 type;
+      __u32 offset;
+    } vbios_info;
+
+    struct {
+      __u32 type;
+    } sensor_info;
+
+    struct {
+      __u32 type;
+    } video_cap;
+  };
+};
+
+struct drm_amdgpu_info_gds {
+  /** GDS GFX partition size */
+  __u32 gds_gfx_partition_size;
+  /** GDS compute partition size */
+  __u32 compute_partition_size;
+  /** total GDS memory size */
+  __u32 gds_total_size;
+  /** GWS size per GFX partition */
+  __u32 gws_per_gfx_partition;
+  /** GSW size per compute partition */
+  __u32 gws_per_compute_partition;
+  /** OA size per GFX partition */
+  __u32 oa_per_gfx_partition;
+  /** OA size per compute partition */
+  __u32 oa_per_compute_partition;
+  __u32 _pad;
+};
+
+struct drm_amdgpu_info_vram_gtt {
+  __u64 vram_size;
+  __u64 vram_cpu_accessible_size;
+  __u64 gtt_size;
+};
+
+struct drm_amdgpu_heap_info {
+  /** max. physical memory */
+  __u64 total_heap_size;
+
+  /** Theoretical max. available memory in the given heap */
+  __u64 usable_heap_size;
+
+  /**
+   * Number of bytes allocated in the heap. This includes all processes
+   * and private allocations in the kernel. It changes when new buffers
+   * are allocated, freed, and moved. It cannot be larger than
+   * heap_size.
+   */
+  __u64 heap_usage;
+
+  /**
+   * Theoretical possible max. size of buffer which
+   * could be allocated in the given heap
+   */
+  __u64 max_allocation;
+};
+
+struct drm_amdgpu_memory_info {
+  struct drm_amdgpu_heap_info vram;
+  struct drm_amdgpu_heap_info cpu_accessible_vram;
+  struct drm_amdgpu_heap_info gtt;
+};
+
+struct drm_amdgpu_info_firmware {
+  __u32 ver;
+  __u32 feature;
+};
+
+struct drm_amdgpu_info_vbios {
+  __u8 name[64];
+  __u8 vbios_pn[64];
+  __u32 version;
+  __u32 pad;
+  __u8 vbios_ver_str[32];
+  __u8 date[32];
+};
+
+#define AMDGPU_VRAM_TYPE_UNKNOWN 0
+#define AMDGPU_VRAM_TYPE_GDDR1 1
+#define AMDGPU_VRAM_TYPE_DDR2 2
+#define AMDGPU_VRAM_TYPE_GDDR3 3
+#define AMDGPU_VRAM_TYPE_GDDR4 4
+#define AMDGPU_VRAM_TYPE_GDDR5 5
+#define AMDGPU_VRAM_TYPE_HBM 6
+#define AMDGPU_VRAM_TYPE_DDR3 7
+#define AMDGPU_VRAM_TYPE_DDR4 8
+#define AMDGPU_VRAM_TYPE_GDDR6 9
+#define AMDGPU_VRAM_TYPE_DDR5 10
+#define AMDGPU_VRAM_TYPE_LPDDR4 11
+#define AMDGPU_VRAM_TYPE_LPDDR5 12
+
+struct drm_amdgpu_info_device {
+  /** PCI Device ID */
+  __u32 device_id;
+  /** Internal chip revision: A0, A1, etc.) */
+  __u32 chip_rev;
+  __u32 external_rev;
+  /** Revision id in PCI Config space */
+  __u32 pci_rev;
+  __u32 family;
+  __u32 num_shader_engines;
+  __u32 num_shader_arrays_per_engine;
+  /* in KHz */
+  __u32 gpu_counter_freq;
+  __u64 max_engine_clock;
+  __u64 max_memory_clock;
+  /* cu information */
+  __u32 cu_active_number;
+  /* NOTE: cu_ao_mask is INVALID, DON'T use it */
+  __u32 cu_ao_mask;
+  __u32 cu_bitmap[4][4];
+  /** Render backend pipe mask. One render backend is CB+DB. */
+  __u32 enabled_rb_pipes_mask;
+  __u32 num_rb_pipes;
+  __u32 num_hw_gfx_contexts;
+  /* PCIe version (the smaller of the GPU and the CPU/motherboard) */
+  __u32 pcie_gen;
+  __u64 ids_flags;
+  /** Starting virtual address for UMDs. */
+  __u64 virtual_address_offset;
+  /** The maximum virtual address */
+  __u64 virtual_address_max;
+  /** Required alignment of virtual addresses. */
+  __u32 virtual_address_alignment;
+  /** Page table entry - fragment size */
+  __u32 pte_fragment_size;
+  __u32 gart_page_size;
+  /** constant engine ram size*/
+  __u32 ce_ram_size;
+  /** video memory type info*/
+  __u32 vram_type;
+  /** video memory bit width*/
+  __u32 vram_bit_width;
+  /* vce harvesting instance */
+  __u32 vce_harvest_config;
+  /* gfx double offchip LDS buffers */
+  __u32 gc_double_offchip_lds_buf;
+  /* NGG Primitive Buffer */
+  __u64 prim_buf_gpu_addr;
+  /* NGG Position Buffer */
+  __u64 pos_buf_gpu_addr;
+  /* NGG Control Sideband */
+  __u64 cntl_sb_buf_gpu_addr;
+  /* NGG Parameter Cache */
+  __u64 param_buf_gpu_addr;
+  __u32 prim_buf_size;
+  __u32 pos_buf_size;
+  __u32 cntl_sb_buf_size;
+  __u32 param_buf_size;
+  /* wavefront size*/
+  __u32 wave_front_size;
+  /* shader visible vgprs*/
+  __u32 num_shader_visible_vgprs;
+  /* CU per shader array*/
+  __u32 num_cu_per_sh;
+  /* number of tcc blocks*/
+  __u32 num_tcc_blocks;
+  /* gs vgt table depth*/
+  __u32 gs_vgt_table_depth;
+  /* gs primitive buffer depth*/
+  __u32 gs_prim_buffer_depth;
+  /* max gs wavefront per vgt*/
+  __u32 max_gs_waves_per_vgt;
+  /* PCIe number of lanes (the smaller of the GPU and the CPU/motherboard) */
+  __u32 pcie_num_lanes;
+  /* always on cu bitmap */
+  __u32 cu_ao_bitmap[4][4];
+  /** Starting high virtual address for UMDs. */
+  __u64 high_va_offset;
+  /** The maximum high virtual address */
+  __u64 high_va_max;
+  /* gfx10 pa_sc_tile_steering_override */
+  __u32 pa_sc_tile_steering_override;
+  /* disabled TCCs */
+  __u64 tcc_disabled_mask;
+  __u64 min_engine_clock;
+  __u64 min_memory_clock;
+  /* The following fields are only set on gfx11+, older chips set 0. */
+  __u32 tcp_cache_size; /* AKA GL0, VMEM cache */
+  __u32 num_sqc_per_wgp;
+  __u32 sqc_data_cache_size; /* AKA SMEM cache */
+  __u32 sqc_inst_cache_size;
+  __u32 gl1c_cache_size;
+  __u32 gl2c_cache_size;
+  __u64 mall_size; /* AKA infinity cache */
+  /* high 32 bits of the rb pipes mask */
+  __u32 enabled_rb_pipes_mask_hi;
+  /* shadow area size for gfx11 */
+  __u32 shadow_size;
+  /* shadow area base virtual alignment for gfx11 */
+  __u32 shadow_alignment;
+  /* context save area size for gfx11 */
+  __u32 csa_size;
+  /* context save area base virtual alignment for gfx11 */
+  __u32 csa_alignment;
+  /* Userq IP mask (1 << AMDGPU_HW_IP_*) */
+  __u32 userq_ip_mask;
+  __u32 pad;
+};
+
+struct drm_amdgpu_info_hw_ip {
+  /** Version of h/w IP */
+  __u32 hw_ip_version_major;
+  __u32 hw_ip_version_minor;
+  /** Capabilities */
+  __u64 capabilities_flags;
+  /** command buffer address start alignment*/
+  __u32 ib_start_alignment;
+  /** command buffer size alignment*/
+  __u32 ib_size_alignment;
+  /** Bitmask of available rings. Bit 0 means ring 0, etc. */
+  __u32 available_rings;
+  /** version info: bits 23:16 major, 15:8 minor, 7:0 revision */
+  __u32 ip_discovery_version;
+};
+
+/* GFX metadata BO sizes and alignment info (in bytes) */
+struct drm_amdgpu_info_uq_fw_areas_gfx {
+  /* shadow area size */
+  __u32 shadow_size;
+  /* shadow area base virtual mem alignment */
+  __u32 shadow_alignment;
+  /* context save area size */
+  __u32 csa_size;
+  /* context save area base virtual mem alignment */
+  __u32 csa_alignment;
+};
+
+/* IP specific metadata related information used in the
+ * subquery AMDGPU_INFO_UQ_FW_AREAS
+ */
+struct drm_amdgpu_info_uq_fw_areas {
+  union {
+    struct drm_amdgpu_info_uq_fw_areas_gfx gfx;
+  };
+};
+
+struct drm_amdgpu_info_num_handles {
+  /** Max handles as supported by firmware for UVD */
+  __u32 uvd_max_handles;
+  /** Handles currently in use for UVD */
+  __u32 uvd_used_handles;
+};
+
+#define AMDGPU_VCE_CLOCK_TABLE_ENTRIES 6
+
+struct drm_amdgpu_info_vce_clock_table_entry {
+  /** System clock */
+  __u32 sclk;
+  /** Memory clock */
+  __u32 mclk;
+  /** VCE clock */
+  __u32 eclk;
+  __u32 pad;
+};
+
+struct drm_amdgpu_info_vce_clock_table {
+  struct drm_amdgpu_info_vce_clock_table_entry entries[AMDGPU_VCE_CLOCK_TABLE_ENTRIES];
+  __u32 num_valid_entries;
+  __u32 pad;
+};
+
+/* query video encode/decode caps */
+#define AMDGPU_INFO_VIDEO_CAPS_CODEC_IDX_MPEG2 0
+#define AMDGPU_INFO_VIDEO_CAPS_CODEC_IDX_MPEG4 1
+#define AMDGPU_INFO_VIDEO_CAPS_CODEC_IDX_VC1 2
+#define AMDGPU_INFO_VIDEO_CAPS_CODEC_IDX_MPEG4_AVC 3
+#define AMDGPU_INFO_VIDEO_CAPS_CODEC_IDX_HEVC 4
+#define AMDGPU_INFO_VIDEO_CAPS_CODEC_IDX_JPEG 5
+#define AMDGPU_INFO_VIDEO_CAPS_CODEC_IDX_VP9 6
+#define AMDGPU_INFO_VIDEO_CAPS_CODEC_IDX_AV1 7
+#define AMDGPU_INFO_VIDEO_CAPS_CODEC_IDX_COUNT 8
+
+struct drm_amdgpu_info_video_codec_info {
+  __u32 valid;
+  __u32 max_width;
+  __u32 max_height;
+  __u32 max_pixels_per_frame;
+  __u32 max_level;
+  __u32 pad;
+};
+
+struct drm_amdgpu_info_video_caps {
+  struct drm_amdgpu_info_video_codec_info codec_info[AMDGPU_INFO_VIDEO_CAPS_CODEC_IDX_COUNT];
+};
+
+#define AMDGPU_VMHUB_TYPE_MASK 0xff
+#define AMDGPU_VMHUB_TYPE_SHIFT 0
+#define AMDGPU_VMHUB_TYPE_GFX 0
+#define AMDGPU_VMHUB_TYPE_MM0 1
+#define AMDGPU_VMHUB_TYPE_MM1 2
+#define AMDGPU_VMHUB_IDX_MASK 0xff00
+#define AMDGPU_VMHUB_IDX_SHIFT 8
+
+struct drm_amdgpu_info_gpuvm_fault {
+  __u64 addr;
+  __u32 status;
+  __u32 vmhub;
+};
+
+/*
+ * Supported GPU families
+ */
+#define AMDGPU_FAMILY_UNKNOWN 0
+#define AMDGPU_FAMILY_SI 110        /* Hainan, Oland, Verde, Pitcairn, Tahiti */
+#define AMDGPU_FAMILY_CI 120        /* Bonaire, Hawaii */
+#define AMDGPU_FAMILY_KV 125        /* Kaveri, Kabini, Mullins */
+#define AMDGPU_FAMILY_VI 130        /* Iceland, Tonga */
+#define AMDGPU_FAMILY_CZ 135        /* Carrizo, Stoney */
+#define AMDGPU_FAMILY_AI 141        /* Vega10 */
+#define AMDGPU_FAMILY_RV 142        /* Raven */
+#define AMDGPU_FAMILY_NV 143        /* Navi10 */
+#define AMDGPU_FAMILY_VGH 144       /* Van Gogh */
+#define AMDGPU_FAMILY_GC_11_0_0 145 /* GC 11.0.0 */
+#define AMDGPU_FAMILY_YC 146        /* Yellow Carp */
+#define AMDGPU_FAMILY_GC_11_0_1 148 /* GC 11.0.1 */
+#define AMDGPU_FAMILY_GC_10_3_6 149 /* GC 10.3.6 */
+#define AMDGPU_FAMILY_GC_10_3_7 151 /* GC 10.3.7 */
+#define AMDGPU_FAMILY_GC_11_5_0 150 /* GC 11.5.0 */
+#define AMDGPU_FAMILY_GC_12_0_0 152 /* GC 12.0.0 */
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/emulation/rocjitsu/lib/rocjitsu/external_headers/drm_headers/linux/uapi/drm/drm.h
+++ b/emulation/rocjitsu/lib/rocjitsu/external_headers/drm_headers/linux/uapi/drm/drm.h
@@ -1,0 +1,1421 @@
+/*
+ * Header for the Direct Rendering Manager
+ *
+ * Author: Rickard E. (Rik) Faith <faith@valinux.com>
+ *
+ * Acknowledgments:
+ * Dec 1999, Richard Henderson <rth@twiddle.net>, move to generic cmpxchg.
+ */
+
+/*
+ * Copyright 1999 Precision Insight, Inc., Cedar Park, Texas.
+ * Copyright 2000 VA Linux Systems, Inc., Sunnyvale, California.
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * VA LINUX SYSTEMS AND/OR ITS SUPPLIERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef _DRM_H_
+#define _DRM_H_
+
+#if defined(__linux__)
+
+#include <asm/ioctl.h>
+#include <linux/types.h>
+typedef unsigned int drm_handle_t;
+
+#else /* One of the BSDs */
+
+#include <stdint.h>
+#include <sys/ioccom.h>
+#include <sys/types.h>
+typedef int8_t __s8;
+typedef uint8_t __u8;
+typedef int16_t __s16;
+typedef uint16_t __u16;
+typedef int32_t __s32;
+typedef uint32_t __u32;
+typedef int64_t __s64;
+typedef uint64_t __u64;
+typedef size_t __kernel_size_t;
+typedef unsigned long drm_handle_t;
+
+#endif
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#define DRM_NAME "drm"     /**< Name in kernel, /dev, and /proc */
+#define DRM_MIN_ORDER 5    /**< At least 2^5 bytes = 32 bytes */
+#define DRM_MAX_ORDER 22   /**< Up to 2^22 bytes = 4MB */
+#define DRM_RAM_PERCENT 10 /**< How much system ram can we lock? */
+
+#define _DRM_LOCK_HELD 0x80000000U /**< Hardware lock is held */
+#define _DRM_LOCK_CONT 0x40000000U /**< Hardware lock is contended */
+#define _DRM_LOCK_IS_HELD(lock) ((lock) & _DRM_LOCK_HELD)
+#define _DRM_LOCK_IS_CONT(lock) ((lock) & _DRM_LOCK_CONT)
+#define _DRM_LOCKING_CONTEXT(lock) ((lock) & ~(_DRM_LOCK_HELD | _DRM_LOCK_CONT))
+
+typedef unsigned int drm_context_t;
+typedef unsigned int drm_drawable_t;
+typedef unsigned int drm_magic_t;
+
+/*
+ * Cliprect.
+ *
+ * \warning: If you change this structure, make sure you change
+ * XF86DRIClipRectRec in the server as well
+ *
+ * \note KW: Actually it's illegal to change either for
+ * backwards-compatibility reasons.
+ */
+struct drm_clip_rect {
+  unsigned short x1;
+  unsigned short y1;
+  unsigned short x2;
+  unsigned short y2;
+};
+
+/*
+ * Drawable information.
+ */
+struct drm_drawable_info {
+  unsigned int num_rects;
+  struct drm_clip_rect *rects;
+};
+
+/*
+ * Texture region,
+ */
+struct drm_tex_region {
+  unsigned char next;
+  unsigned char prev;
+  unsigned char in_use;
+  unsigned char padding;
+  unsigned int age;
+};
+
+/*
+ * Hardware lock.
+ *
+ * The lock structure is a simple cache-line aligned integer.  To avoid
+ * processor bus contention on a multiprocessor system, there should not be any
+ * other data stored in the same cache line.
+ */
+struct drm_hw_lock {
+  __volatile__ unsigned int lock; /**< lock variable */
+  char padding[60];               /**< Pad to cache line */
+};
+
+/*
+ * DRM_IOCTL_VERSION ioctl argument type.
+ *
+ * \sa drmGetVersion().
+ */
+struct drm_version {
+  int version_major;        /**< Major version */
+  int version_minor;        /**< Minor version */
+  int version_patchlevel;   /**< Patch level */
+  __kernel_size_t name_len; /**< Length of name buffer */
+  char *name;               /**< Name of driver */
+  __kernel_size_t date_len; /**< Length of date buffer */
+  char *date;               /**< User-space buffer to hold date */
+  __kernel_size_t desc_len; /**< Length of desc buffer */
+  char *desc;               /**< User-space buffer to hold desc */
+};
+
+/*
+ * DRM_IOCTL_GET_UNIQUE ioctl argument type.
+ *
+ * \sa drmGetBusid() and drmSetBusId().
+ */
+struct drm_unique {
+  __kernel_size_t unique_len; /**< Length of unique */
+  char *unique;               /**< Unique name for driver instantiation */
+};
+
+struct drm_list {
+  int count; /**< Length of user-space structures */
+  struct drm_version *version;
+};
+
+struct drm_block {
+  int unused;
+};
+
+/*
+ * DRM_IOCTL_CONTROL ioctl argument type.
+ *
+ * \sa drmCtlInstHandler() and drmCtlUninstHandler().
+ */
+struct drm_control {
+  enum { DRM_ADD_COMMAND, DRM_RM_COMMAND, DRM_INST_HANDLER, DRM_UNINST_HANDLER } func;
+  int irq;
+};
+
+/*
+ * Type of memory to map.
+ */
+enum drm_map_type {
+  _DRM_FRAME_BUFFER = 0,   /**< WC (no caching), no core dump */
+  _DRM_REGISTERS = 1,      /**< no caching, no core dump */
+  _DRM_SHM = 2,            /**< shared, cached */
+  _DRM_AGP = 3,            /**< AGP/GART */
+  _DRM_SCATTER_GATHER = 4, /**< Scatter/gather memory for PCI DMA */
+  _DRM_CONSISTENT = 5      /**< Consistent memory for PCI DMA */
+};
+
+/*
+ * Memory mapping flags.
+ */
+enum drm_map_flags {
+  _DRM_RESTRICTED = 0x01, /**< Cannot be mapped to user-virtual */
+  _DRM_READ_ONLY = 0x02,
+  _DRM_LOCKED = 0x04,          /**< shared, cached, locked */
+  _DRM_KERNEL = 0x08,          /**< kernel requires access */
+  _DRM_WRITE_COMBINING = 0x10, /**< use write-combining if available */
+  _DRM_CONTAINS_LOCK = 0x20,   /**< SHM page that contains lock */
+  _DRM_REMOVABLE = 0x40,       /**< Removable mapping */
+  _DRM_DRIVER = 0x80           /**< Managed by driver */
+};
+
+struct drm_ctx_priv_map {
+  unsigned int ctx_id; /**< Context requesting private mapping */
+  void *handle;        /**< Handle of map */
+};
+
+/*
+ * DRM_IOCTL_GET_MAP, DRM_IOCTL_ADD_MAP and DRM_IOCTL_RM_MAP ioctls
+ * argument type.
+ *
+ * \sa drmAddMap().
+ */
+struct drm_map {
+  unsigned long offset;     /**< Requested physical address (0 for SAREA)*/
+  unsigned long size;       /**< Requested physical size (bytes) */
+  enum drm_map_type type;   /**< Type of memory to map */
+  enum drm_map_flags flags; /**< Flags */
+  void *handle;             /**< User-space: "Handle" to pass to mmap() */
+                            /**< Kernel-space: kernel-virtual address */
+  int mtrr;                 /**< MTRR slot used */
+                            /*   Private data */
+};
+
+/*
+ * DRM_IOCTL_GET_CLIENT ioctl argument type.
+ */
+struct drm_client {
+  int idx;             /**< Which client desired? */
+  int auth;            /**< Is client authenticated? */
+  unsigned long pid;   /**< Process ID */
+  unsigned long uid;   /**< User ID */
+  unsigned long magic; /**< Magic */
+  unsigned long iocs;  /**< Ioctl count */
+};
+
+enum drm_stat_type {
+  _DRM_STAT_LOCK,
+  _DRM_STAT_OPENS,
+  _DRM_STAT_CLOSES,
+  _DRM_STAT_IOCTLS,
+  _DRM_STAT_LOCKS,
+  _DRM_STAT_UNLOCKS,
+  _DRM_STAT_VALUE, /**< Generic value */
+  _DRM_STAT_BYTE,  /**< Generic byte counter (1024bytes/K) */
+  _DRM_STAT_COUNT, /**< Generic non-byte counter (1000/k) */
+
+  _DRM_STAT_IRQ,       /**< IRQ */
+  _DRM_STAT_PRIMARY,   /**< Primary DMA bytes */
+  _DRM_STAT_SECONDARY, /**< Secondary DMA bytes */
+  _DRM_STAT_DMA,       /**< DMA */
+  _DRM_STAT_SPECIAL,   /**< Special DMA (e.g., priority or polled) */
+  _DRM_STAT_MISSED     /**< Missed DMA opportunity */
+                       /* Add to the *END* of the list */
+};
+
+/*
+ * DRM_IOCTL_GET_STATS ioctl argument type.
+ */
+struct drm_stats {
+  unsigned long count;
+  struct {
+    unsigned long value;
+    enum drm_stat_type type;
+  } data[15];
+};
+
+/*
+ * Hardware locking flags.
+ */
+enum drm_lock_flags {
+  _DRM_LOCK_READY = 0x01,     /**< Wait until hardware is ready for DMA */
+  _DRM_LOCK_QUIESCENT = 0x02, /**< Wait until hardware quiescent */
+  _DRM_LOCK_FLUSH = 0x04,     /**< Flush this context's DMA queue first */
+  _DRM_LOCK_FLUSH_ALL = 0x08, /**< Flush all DMA queues first */
+  /* These *HALT* flags aren't supported yet
+     -- they will be used to support the
+     full-screen DGA-like mode. */
+  _DRM_HALT_ALL_QUEUES = 0x10, /**< Halt all current and future queues */
+  _DRM_HALT_CUR_QUEUES = 0x20  /**< Halt all current queues */
+};
+
+/*
+ * DRM_IOCTL_LOCK, DRM_IOCTL_UNLOCK and DRM_IOCTL_FINISH ioctl argument type.
+ *
+ * \sa drmGetLock() and drmUnlock().
+ */
+struct drm_lock {
+  int context;
+  enum drm_lock_flags flags;
+};
+
+/*
+ * DMA flags
+ *
+ * \warning
+ * These values \e must match xf86drm.h.
+ *
+ * \sa drm_dma.
+ */
+enum drm_dma_flags {
+  /* Flags for DMA buffer dispatch */
+  _DRM_DMA_BLOCK = 0x01,        /**<
+                                 * Block until buffer dispatched.
+                                 *
+                                 * \note The buffer may not yet have
+                                 * been processed by the hardware --
+                                 * getting a hardware lock with the
+                                 * hardware quiescent will ensure
+                                 * that the buffer has been
+                                 * processed.
+                                 */
+  _DRM_DMA_WHILE_LOCKED = 0x02, /**< Dispatch while lock held */
+  _DRM_DMA_PRIORITY = 0x04,     /**< High priority dispatch */
+
+  /* Flags for DMA buffer request */
+  _DRM_DMA_WAIT = 0x10,       /**< Wait for free buffers */
+  _DRM_DMA_SMALLER_OK = 0x20, /**< Smaller-than-requested buffers OK */
+  _DRM_DMA_LARGER_OK = 0x40   /**< Larger-than-requested buffers OK */
+};
+
+/*
+ * DRM_IOCTL_ADD_BUFS and DRM_IOCTL_MARK_BUFS ioctl argument type.
+ *
+ * \sa drmAddBufs().
+ */
+struct drm_buf_desc {
+  int count;     /**< Number of buffers of this size */
+  int size;      /**< Size in bytes */
+  int low_mark;  /**< Low water mark */
+  int high_mark; /**< High water mark */
+  enum {
+    _DRM_PAGE_ALIGN = 0x01,   /**< Align on page boundaries for DMA */
+    _DRM_AGP_BUFFER = 0x02,   /**< Buffer is in AGP space */
+    _DRM_SG_BUFFER = 0x04,    /**< Scatter/gather memory buffer */
+    _DRM_FB_BUFFER = 0x08,    /**< Buffer is in frame buffer */
+    _DRM_PCI_BUFFER_RO = 0x10 /**< Map PCI DMA buffer read-only */
+  } flags;
+  unsigned long agp_start; /**<
+                            * Start address of where the AGP buffers are
+                            * in the AGP aperture
+                            */
+};
+
+/*
+ * DRM_IOCTL_INFO_BUFS ioctl argument type.
+ */
+struct drm_buf_info {
+  int count; /**< Entries in list */
+  struct drm_buf_desc *list;
+};
+
+/*
+ * DRM_IOCTL_FREE_BUFS ioctl argument type.
+ */
+struct drm_buf_free {
+  int count;
+  int *list;
+};
+
+/*
+ * Buffer information
+ *
+ * \sa drm_buf_map.
+ */
+struct drm_buf_pub {
+  int idx;       /**< Index into the master buffer list */
+  int total;     /**< Buffer size */
+  int used;      /**< Amount of buffer in use (for DMA) */
+  void *address; /**< Address of buffer */
+};
+
+/*
+ * DRM_IOCTL_MAP_BUFS ioctl argument type.
+ */
+struct drm_buf_map {
+  int count; /**< Length of the buffer list */
+#ifdef __cplusplus
+  void *virt;
+#else
+  void *virtual; /**< Mmap'd area in user-virtual */
+#endif
+  struct drm_buf_pub *list; /**< Buffer information */
+};
+
+/*
+ * DRM_IOCTL_DMA ioctl argument type.
+ *
+ * Indices here refer to the offset into the buffer list in drm_buf_get.
+ *
+ * \sa drmDMA().
+ */
+struct drm_dma {
+  int context;              /**< Context handle */
+  int send_count;           /**< Number of buffers to send */
+  int *send_indices;        /**< List of handles to buffers */
+  int *send_sizes;          /**< Lengths of data to send */
+  enum drm_dma_flags flags; /**< Flags */
+  int request_count;        /**< Number of buffers requested */
+  int request_size;         /**< Desired size for buffers */
+  int *request_indices;     /**< Buffer information */
+  int *request_sizes;
+  int granted_count; /**< Number of buffers granted */
+};
+
+enum drm_ctx_flags { _DRM_CONTEXT_PRESERVED = 0x01, _DRM_CONTEXT_2DONLY = 0x02 };
+
+/*
+ * DRM_IOCTL_ADD_CTX ioctl argument type.
+ *
+ * \sa drmCreateContext() and drmDestroyContext().
+ */
+struct drm_ctx {
+  drm_context_t handle;
+  enum drm_ctx_flags flags;
+};
+
+/*
+ * DRM_IOCTL_RES_CTX ioctl argument type.
+ */
+struct drm_ctx_res {
+  int count;
+  struct drm_ctx *contexts;
+};
+
+/*
+ * DRM_IOCTL_ADD_DRAW and DRM_IOCTL_RM_DRAW ioctl argument type.
+ */
+struct drm_draw {
+  drm_drawable_t handle;
+};
+
+/*
+ * DRM_IOCTL_UPDATE_DRAW ioctl argument type.
+ */
+typedef enum { DRM_DRAWABLE_CLIPRECTS } drm_drawable_info_type_t;
+
+struct drm_update_draw {
+  drm_drawable_t handle;
+  unsigned int type;
+  unsigned int num;
+  unsigned long long data;
+};
+
+/*
+ * DRM_IOCTL_GET_MAGIC and DRM_IOCTL_AUTH_MAGIC ioctl argument type.
+ */
+struct drm_auth {
+  drm_magic_t magic;
+};
+
+/*
+ * DRM_IOCTL_IRQ_BUSID ioctl argument type.
+ *
+ * \sa drmGetInterruptFromBusID().
+ */
+struct drm_irq_busid {
+  int irq;     /**< IRQ number */
+  int busnum;  /**< bus number */
+  int devnum;  /**< device number */
+  int funcnum; /**< function number */
+};
+
+enum drm_vblank_seq_type {
+  _DRM_VBLANK_ABSOLUTE = 0x0, /**< Wait for specific vblank sequence number */
+  _DRM_VBLANK_RELATIVE = 0x1, /**< Wait for given number of vblanks */
+  /* bits 1-6 are reserved for high crtcs */
+  _DRM_VBLANK_HIGH_CRTC_MASK = 0x0000003e,
+  _DRM_VBLANK_EVENT = 0x4000000,       /**< Send event instead of blocking */
+  _DRM_VBLANK_FLIP = 0x8000000,        /**< Scheduled buffer swap should flip */
+  _DRM_VBLANK_NEXTONMISS = 0x10000000, /**< If missed, wait for next vblank */
+  _DRM_VBLANK_SECONDARY = 0x20000000,  /**< Secondary display controller */
+  _DRM_VBLANK_SIGNAL = 0x40000000      /**< Send signal instead of blocking, unsupported */
+};
+#define _DRM_VBLANK_HIGH_CRTC_SHIFT 1
+
+#define _DRM_VBLANK_TYPES_MASK (_DRM_VBLANK_ABSOLUTE | _DRM_VBLANK_RELATIVE)
+#define _DRM_VBLANK_FLAGS_MASK                                                                     \
+  (_DRM_VBLANK_EVENT | _DRM_VBLANK_SIGNAL | _DRM_VBLANK_SECONDARY | _DRM_VBLANK_NEXTONMISS)
+
+struct drm_wait_vblank_request {
+  enum drm_vblank_seq_type type;
+  unsigned int sequence;
+  unsigned long signal;
+};
+
+struct drm_wait_vblank_reply {
+  enum drm_vblank_seq_type type;
+  unsigned int sequence;
+  long tval_sec;
+  long tval_usec;
+};
+
+/*
+ * DRM_IOCTL_WAIT_VBLANK ioctl argument type.
+ *
+ * \sa drmWaitVBlank().
+ */
+union drm_wait_vblank {
+  struct drm_wait_vblank_request request;
+  struct drm_wait_vblank_reply reply;
+};
+
+#define _DRM_PRE_MODESET 1
+#define _DRM_POST_MODESET 2
+
+/*
+ * DRM_IOCTL_MODESET_CTL ioctl argument type
+ *
+ * \sa drmModesetCtl().
+ */
+struct drm_modeset_ctl {
+  __u32 crtc;
+  __u32 cmd;
+};
+
+/*
+ * DRM_IOCTL_AGP_ENABLE ioctl argument type.
+ *
+ * \sa drmAgpEnable().
+ */
+struct drm_agp_mode {
+  unsigned long mode; /**< AGP mode */
+};
+
+/*
+ * DRM_IOCTL_AGP_ALLOC and DRM_IOCTL_AGP_FREE ioctls argument type.
+ *
+ * \sa drmAgpAlloc() and drmAgpFree().
+ */
+struct drm_agp_buffer {
+  unsigned long size;     /**< In bytes -- will round to page boundary */
+  unsigned long handle;   /**< Used for binding / unbinding */
+  unsigned long type;     /**< Type of memory to allocate */
+  unsigned long physical; /**< Physical used by i810 */
+};
+
+/*
+ * DRM_IOCTL_AGP_BIND and DRM_IOCTL_AGP_UNBIND ioctls argument type.
+ *
+ * \sa drmAgpBind() and drmAgpUnbind().
+ */
+struct drm_agp_binding {
+  unsigned long handle; /**< From drm_agp_buffer */
+  unsigned long offset; /**< In bytes -- will round to page boundary */
+};
+
+/*
+ * DRM_IOCTL_AGP_INFO ioctl argument type.
+ *
+ * \sa drmAgpVersionMajor(), drmAgpVersionMinor(), drmAgpGetMode(),
+ * drmAgpBase(), drmAgpSize(), drmAgpMemoryUsed(), drmAgpMemoryAvail(),
+ * drmAgpVendorId() and drmAgpDeviceId().
+ */
+struct drm_agp_info {
+  int agp_version_major;
+  int agp_version_minor;
+  unsigned long mode;
+  unsigned long aperture_base;  /* physical address */
+  unsigned long aperture_size;  /* bytes */
+  unsigned long memory_allowed; /* bytes */
+  unsigned long memory_used;
+
+  /* PCI information */
+  unsigned short id_vendor;
+  unsigned short id_device;
+};
+
+/*
+ * DRM_IOCTL_SG_ALLOC ioctl argument type.
+ */
+struct drm_scatter_gather {
+  unsigned long size;   /**< In bytes -- will round to page boundary */
+  unsigned long handle; /**< Used for mapping / unmapping */
+};
+
+/*
+ * DRM_IOCTL_SET_VERSION ioctl argument type.
+ */
+struct drm_set_version {
+  int drm_di_major;
+  int drm_di_minor;
+  int drm_dd_major;
+  int drm_dd_minor;
+};
+
+/* DRM_IOCTL_GEM_CLOSE ioctl argument type */
+struct drm_gem_close {
+  /** Handle of the object to be closed. */
+  __u32 handle;
+  __u32 pad;
+};
+
+/* DRM_IOCTL_GEM_FLINK ioctl argument type */
+struct drm_gem_flink {
+  /** Handle for the object being named */
+  __u32 handle;
+
+  /** Returned global name */
+  __u32 name;
+};
+
+/* DRM_IOCTL_GEM_OPEN ioctl argument type */
+struct drm_gem_open {
+  /** Name of object being opened */
+  __u32 name;
+
+  /** Returned handle for the object */
+  __u32 handle;
+
+  /** Returned size of the object */
+  __u64 size;
+};
+
+/**
+ * DRM_CAP_DUMB_BUFFER
+ *
+ * If set to 1, the driver supports creating dumb buffers via the
+ * &DRM_IOCTL_MODE_CREATE_DUMB ioctl.
+ */
+#define DRM_CAP_DUMB_BUFFER 0x1
+/**
+ * DRM_CAP_VBLANK_HIGH_CRTC
+ *
+ * If set to 1, the kernel supports specifying a :ref:`CRTC index<crtc_index>`
+ * in the high bits of &drm_wait_vblank_request.type.
+ *
+ * Starting kernel version 2.6.39, this capability is always set to 1.
+ */
+#define DRM_CAP_VBLANK_HIGH_CRTC 0x2
+/**
+ * DRM_CAP_DUMB_PREFERRED_DEPTH
+ *
+ * The preferred bit depth for dumb buffers.
+ *
+ * The bit depth is the number of bits used to indicate the color of a single
+ * pixel excluding any padding. This is different from the number of bits per
+ * pixel. For instance, XRGB8888 has a bit depth of 24 but has 32 bits per
+ * pixel.
+ *
+ * Note that this preference only applies to dumb buffers, it's irrelevant for
+ * other types of buffers.
+ */
+#define DRM_CAP_DUMB_PREFERRED_DEPTH 0x3
+/**
+ * DRM_CAP_DUMB_PREFER_SHADOW
+ *
+ * If set to 1, the driver prefers userspace to render to a shadow buffer
+ * instead of directly rendering to a dumb buffer. For best speed, userspace
+ * should do streaming ordered memory copies into the dumb buffer and never
+ * read from it.
+ *
+ * Note that this preference only applies to dumb buffers, it's irrelevant for
+ * other types of buffers.
+ */
+#define DRM_CAP_DUMB_PREFER_SHADOW 0x4
+/**
+ * DRM_CAP_PRIME
+ *
+ * Bitfield of supported PRIME sharing capabilities. See &DRM_PRIME_CAP_IMPORT
+ * and &DRM_PRIME_CAP_EXPORT.
+ *
+ * Starting from kernel version 6.6, both &DRM_PRIME_CAP_IMPORT and
+ * &DRM_PRIME_CAP_EXPORT are always advertised.
+ *
+ * PRIME buffers are exposed as dma-buf file descriptors.
+ * See :ref:`prime_buffer_sharing`.
+ */
+#define DRM_CAP_PRIME 0x5
+/**
+ * DRM_PRIME_CAP_IMPORT
+ *
+ * If this bit is set in &DRM_CAP_PRIME, the driver supports importing PRIME
+ * buffers via the &DRM_IOCTL_PRIME_FD_TO_HANDLE ioctl.
+ *
+ * Starting from kernel version 6.6, this bit is always set in &DRM_CAP_PRIME.
+ */
+#define DRM_PRIME_CAP_IMPORT 0x1
+/**
+ * DRM_PRIME_CAP_EXPORT
+ *
+ * If this bit is set in &DRM_CAP_PRIME, the driver supports exporting PRIME
+ * buffers via the &DRM_IOCTL_PRIME_HANDLE_TO_FD ioctl.
+ *
+ * Starting from kernel version 6.6, this bit is always set in &DRM_CAP_PRIME.
+ */
+#define DRM_PRIME_CAP_EXPORT 0x2
+/**
+ * DRM_CAP_TIMESTAMP_MONOTONIC
+ *
+ * If set to 0, the kernel will report timestamps with ``CLOCK_REALTIME`` in
+ * struct drm_event_vblank. If set to 1, the kernel will report timestamps with
+ * ``CLOCK_MONOTONIC``. See ``clock_gettime(2)`` for the definition of these
+ * clocks.
+ *
+ * Starting from kernel version 2.6.39, the default value for this capability
+ * is 1. Starting kernel version 4.15, this capability is always set to 1.
+ */
+#define DRM_CAP_TIMESTAMP_MONOTONIC 0x6
+/**
+ * DRM_CAP_ASYNC_PAGE_FLIP
+ *
+ * If set to 1, the driver supports &DRM_MODE_PAGE_FLIP_ASYNC for legacy
+ * page-flips.
+ */
+#define DRM_CAP_ASYNC_PAGE_FLIP 0x7
+/**
+ * DRM_CAP_CURSOR_WIDTH
+ *
+ * The ``CURSOR_WIDTH`` and ``CURSOR_HEIGHT`` capabilities return a valid
+ * width x height combination for the hardware cursor. The intention is that a
+ * hardware agnostic userspace can query a cursor plane size to use.
+ *
+ * Note that the cross-driver contract is to merely return a valid size;
+ * drivers are free to attach another meaning on top, eg. i915 returns the
+ * maximum plane size.
+ */
+#define DRM_CAP_CURSOR_WIDTH 0x8
+/**
+ * DRM_CAP_CURSOR_HEIGHT
+ *
+ * See &DRM_CAP_CURSOR_WIDTH.
+ */
+#define DRM_CAP_CURSOR_HEIGHT 0x9
+/**
+ * DRM_CAP_ADDFB2_MODIFIERS
+ *
+ * If set to 1, the driver supports supplying modifiers in the
+ * &DRM_IOCTL_MODE_ADDFB2 ioctl.
+ */
+#define DRM_CAP_ADDFB2_MODIFIERS 0x10
+/**
+ * DRM_CAP_PAGE_FLIP_TARGET
+ *
+ * If set to 1, the driver supports the &DRM_MODE_PAGE_FLIP_TARGET_ABSOLUTE and
+ * &DRM_MODE_PAGE_FLIP_TARGET_RELATIVE flags in
+ * &drm_mode_crtc_page_flip_target.flags for the &DRM_IOCTL_MODE_PAGE_FLIP
+ * ioctl.
+ */
+#define DRM_CAP_PAGE_FLIP_TARGET 0x11
+/**
+ * DRM_CAP_CRTC_IN_VBLANK_EVENT
+ *
+ * If set to 1, the kernel supports reporting the CRTC ID in
+ * &drm_event_vblank.crtc_id for the &DRM_EVENT_VBLANK and
+ * &DRM_EVENT_FLIP_COMPLETE events.
+ *
+ * Starting kernel version 4.12, this capability is always set to 1.
+ */
+#define DRM_CAP_CRTC_IN_VBLANK_EVENT 0x12
+/**
+ * DRM_CAP_SYNCOBJ
+ *
+ * If set to 1, the driver supports sync objects. See :ref:`drm_sync_objects`.
+ */
+#define DRM_CAP_SYNCOBJ 0x13
+/**
+ * DRM_CAP_SYNCOBJ_TIMELINE
+ *
+ * If set to 1, the driver supports timeline operations on sync objects. See
+ * :ref:`drm_sync_objects`.
+ */
+#define DRM_CAP_SYNCOBJ_TIMELINE 0x14
+/**
+ * DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP
+ *
+ * If set to 1, the driver supports &DRM_MODE_PAGE_FLIP_ASYNC for atomic
+ * commits.
+ */
+#define DRM_CAP_ATOMIC_ASYNC_PAGE_FLIP 0x15
+
+/* DRM_IOCTL_GET_CAP ioctl argument type */
+struct drm_get_cap {
+  __u64 capability;
+  __u64 value;
+};
+
+/**
+ * DRM_CLIENT_CAP_STEREO_3D
+ *
+ * If set to 1, the DRM core will expose the stereo 3D capabilities of the
+ * monitor by advertising the supported 3D layouts in the flags of struct
+ * drm_mode_modeinfo. See ``DRM_MODE_FLAG_3D_*``.
+ *
+ * This capability is always supported for all drivers starting from kernel
+ * version 3.13.
+ */
+#define DRM_CLIENT_CAP_STEREO_3D 1
+
+/**
+ * DRM_CLIENT_CAP_UNIVERSAL_PLANES
+ *
+ * If set to 1, the DRM core will expose all planes (overlay, primary, and
+ * cursor) to userspace.
+ *
+ * This capability has been introduced in kernel version 3.15. Starting from
+ * kernel version 3.17, this capability is always supported for all drivers.
+ */
+#define DRM_CLIENT_CAP_UNIVERSAL_PLANES 2
+
+/**
+ * DRM_CLIENT_CAP_ATOMIC
+ *
+ * If set to 1, the DRM core will expose atomic properties to userspace. This
+ * implicitly enables &DRM_CLIENT_CAP_UNIVERSAL_PLANES and
+ * &DRM_CLIENT_CAP_ASPECT_RATIO.
+ *
+ * If the driver doesn't support atomic mode-setting, enabling this capability
+ * will fail with -EOPNOTSUPP.
+ *
+ * This capability has been introduced in kernel version 4.0. Starting from
+ * kernel version 4.2, this capability is always supported for atomic-capable
+ * drivers.
+ */
+#define DRM_CLIENT_CAP_ATOMIC 3
+
+/**
+ * DRM_CLIENT_CAP_ASPECT_RATIO
+ *
+ * If set to 1, the DRM core will provide aspect ratio information in modes.
+ * See ``DRM_MODE_FLAG_PIC_AR_*``.
+ *
+ * This capability is always supported for all drivers starting from kernel
+ * version 4.18.
+ */
+#define DRM_CLIENT_CAP_ASPECT_RATIO 4
+
+/**
+ * DRM_CLIENT_CAP_WRITEBACK_CONNECTORS
+ *
+ * If set to 1, the DRM core will expose special connectors to be used for
+ * writing back to memory the scene setup in the commit. The client must enable
+ * &DRM_CLIENT_CAP_ATOMIC first.
+ *
+ * This capability is always supported for atomic-capable drivers starting from
+ * kernel version 4.19.
+ */
+#define DRM_CLIENT_CAP_WRITEBACK_CONNECTORS 5
+
+/**
+ * DRM_CLIENT_CAP_CURSOR_PLANE_HOTSPOT
+ *
+ * Drivers for para-virtualized hardware (e.g. vmwgfx, qxl, virtio and
+ * virtualbox) have additional restrictions for cursor planes (thus
+ * making cursor planes on those drivers not truly universal,) e.g.
+ * they need cursor planes to act like one would expect from a mouse
+ * cursor and have correctly set hotspot properties.
+ * If this client cap is not set the DRM core will hide cursor plane on
+ * those virtualized drivers because not setting it implies that the
+ * client is not capable of dealing with those extra restictions.
+ * Clients which do set cursor hotspot and treat the cursor plane
+ * like a mouse cursor should set this property.
+ * The client must enable &DRM_CLIENT_CAP_ATOMIC first.
+ *
+ * Setting this property on drivers which do not special case
+ * cursor planes (i.e. non-virtualized drivers) will return
+ * EOPNOTSUPP, which can be used by userspace to gauge
+ * requirements of the hardware/drivers they're running on.
+ *
+ * This capability is always supported for atomic-capable virtualized
+ * drivers starting from kernel version 6.6.
+ */
+#define DRM_CLIENT_CAP_CURSOR_PLANE_HOTSPOT 6
+
+/* DRM_IOCTL_SET_CLIENT_CAP ioctl argument type */
+struct drm_set_client_cap {
+  __u64 capability;
+  __u64 value;
+};
+
+#define DRM_RDWR O_RDWR
+#define DRM_CLOEXEC O_CLOEXEC
+struct drm_prime_handle {
+  __u32 handle;
+
+  /** Flags.. only applicable for handle->fd */
+  __u32 flags;
+
+  /** Returned dmabuf file descriptor */
+  __s32 fd;
+};
+
+struct drm_syncobj_create {
+  __u32 handle;
+#define DRM_SYNCOBJ_CREATE_SIGNALED (1 << 0)
+  __u32 flags;
+};
+
+struct drm_syncobj_destroy {
+  __u32 handle;
+  __u32 pad;
+};
+
+#define DRM_SYNCOBJ_FD_TO_HANDLE_FLAGS_IMPORT_SYNC_FILE (1 << 0)
+#define DRM_SYNCOBJ_FD_TO_HANDLE_FLAGS_TIMELINE (1 << 1)
+#define DRM_SYNCOBJ_HANDLE_TO_FD_FLAGS_EXPORT_SYNC_FILE (1 << 0)
+#define DRM_SYNCOBJ_HANDLE_TO_FD_FLAGS_TIMELINE (1 << 1)
+struct drm_syncobj_handle {
+  __u32 handle;
+  __u32 flags;
+
+  __s32 fd;
+  __u32 pad;
+
+  __u64 point;
+};
+
+struct drm_syncobj_transfer {
+  __u32 src_handle;
+  __u32 dst_handle;
+  __u64 src_point;
+  __u64 dst_point;
+  __u32 flags;
+  __u32 pad;
+};
+
+#define DRM_SYNCOBJ_WAIT_FLAGS_WAIT_ALL (1 << 0)
+#define DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT (1 << 1)
+#define DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE                                                      \
+  (1 << 2)                                            /* wait for time point to become available   \
+                                                       */
+#define DRM_SYNCOBJ_WAIT_FLAGS_WAIT_DEADLINE (1 << 3) /* set fence deadline to deadline_nsec */
+struct drm_syncobj_wait {
+  __u64 handles;
+  /* absolute timeout */
+  __s64 timeout_nsec;
+  __u32 count_handles;
+  __u32 flags;
+  __u32 first_signaled; /* only valid when not waiting all */
+  __u32 pad;
+  /**
+   * @deadline_nsec - fence deadline hint
+   *
+   * Deadline hint, in absolute CLOCK_MONOTONIC, to set on backing
+   * fence(s) if the DRM_SYNCOBJ_WAIT_FLAGS_WAIT_DEADLINE flag is
+   * set.
+   */
+  __u64 deadline_nsec;
+};
+
+struct drm_syncobj_timeline_wait {
+  __u64 handles;
+  /* wait on specific timeline point for every handles*/
+  __u64 points;
+  /* absolute timeout */
+  __s64 timeout_nsec;
+  __u32 count_handles;
+  __u32 flags;
+  __u32 first_signaled; /* only valid when not waiting all */
+  __u32 pad;
+  /**
+   * @deadline_nsec - fence deadline hint
+   *
+   * Deadline hint, in absolute CLOCK_MONOTONIC, to set on backing
+   * fence(s) if the DRM_SYNCOBJ_WAIT_FLAGS_WAIT_DEADLINE flag is
+   * set.
+   */
+  __u64 deadline_nsec;
+};
+
+/**
+ * struct drm_syncobj_eventfd
+ * @handle: syncobj handle.
+ * @flags: Zero to wait for the point to be signalled, or
+ *         &DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE to wait for a fence to be
+ *         available for the point.
+ * @point: syncobj timeline point (set to zero for binary syncobjs).
+ * @fd: Existing eventfd to sent events to.
+ * @pad: Must be zero.
+ *
+ * Register an eventfd to be signalled by a syncobj. The eventfd counter will
+ * be incremented by one.
+ */
+struct drm_syncobj_eventfd {
+  __u32 handle;
+  __u32 flags;
+  __u64 point;
+  __s32 fd;
+  __u32 pad;
+};
+
+struct drm_syncobj_array {
+  __u64 handles;
+  __u32 count_handles;
+  __u32 pad;
+};
+
+#define DRM_SYNCOBJ_QUERY_FLAGS_LAST_SUBMITTED                                                     \
+  (1 << 0) /* last available point on timeline syncobj */
+struct drm_syncobj_timeline_array {
+  __u64 handles;
+  __u64 points;
+  __u32 count_handles;
+  __u32 flags;
+};
+
+/* Query current scanout sequence number */
+struct drm_crtc_get_sequence {
+  __u32 crtc_id;     /* requested crtc_id */
+  __u32 active;      /* return: crtc output is active */
+  __u64 sequence;    /* return: most recent vblank sequence */
+  __s64 sequence_ns; /* return: most recent time of first pixel out */
+};
+
+/* Queue event to be delivered at specified sequence. Time stamp marks
+ * when the first pixel of the refresh cycle leaves the display engine
+ * for the display
+ */
+#define DRM_CRTC_SEQUENCE_RELATIVE 0x00000001     /* sequence is relative to current */
+#define DRM_CRTC_SEQUENCE_NEXT_ON_MISS 0x00000002 /* Use next sequence if we've missed */
+
+struct drm_crtc_queue_sequence {
+  __u32 crtc_id;
+  __u32 flags;
+  __u64 sequence;  /* on input, target sequence. on output, actual sequence */
+  __u64 user_data; /* user data passed to event */
+};
+
+#define DRM_CLIENT_NAME_MAX_LEN 64
+struct drm_set_client_name {
+  __u64 name_len;
+  __u64 name;
+};
+
+#if defined(__cplusplus)
+}
+#endif
+
+#include "drm_mode.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#define DRM_IOCTL_BASE 'd'
+#define DRM_IO(nr) _IO(DRM_IOCTL_BASE, nr)
+#define DRM_IOR(nr, type) _IOR(DRM_IOCTL_BASE, nr, type)
+#define DRM_IOW(nr, type) _IOW(DRM_IOCTL_BASE, nr, type)
+#define DRM_IOWR(nr, type) _IOWR(DRM_IOCTL_BASE, nr, type)
+
+#define DRM_IOCTL_VERSION DRM_IOWR(0x00, struct drm_version)
+#define DRM_IOCTL_GET_UNIQUE DRM_IOWR(0x01, struct drm_unique)
+#define DRM_IOCTL_GET_MAGIC DRM_IOR(0x02, struct drm_auth)
+#define DRM_IOCTL_IRQ_BUSID DRM_IOWR(0x03, struct drm_irq_busid)
+#define DRM_IOCTL_GET_MAP DRM_IOWR(0x04, struct drm_map)
+#define DRM_IOCTL_GET_CLIENT DRM_IOWR(0x05, struct drm_client)
+#define DRM_IOCTL_GET_STATS DRM_IOR(0x06, struct drm_stats)
+#define DRM_IOCTL_SET_VERSION DRM_IOWR(0x07, struct drm_set_version)
+#define DRM_IOCTL_MODESET_CTL DRM_IOW(0x08, struct drm_modeset_ctl)
+/**
+ * DRM_IOCTL_GEM_CLOSE - Close a GEM handle.
+ *
+ * GEM handles are not reference-counted by the kernel. User-space is
+ * responsible for managing their lifetime. For example, if user-space imports
+ * the same memory object twice on the same DRM file description, the same GEM
+ * handle is returned by both imports, and user-space needs to ensure
+ * &DRM_IOCTL_GEM_CLOSE is performed once only. The same situation can happen
+ * when a memory object is allocated, then exported and imported again on the
+ * same DRM file description. The &DRM_IOCTL_MODE_GETFB2 IOCTL is an exception
+ * and always returns fresh new GEM handles even if an existing GEM handle
+ * already refers to the same memory object before the IOCTL is performed.
+ */
+#define DRM_IOCTL_GEM_CLOSE DRM_IOW(0x09, struct drm_gem_close)
+#define DRM_IOCTL_GEM_FLINK DRM_IOWR(0x0a, struct drm_gem_flink)
+#define DRM_IOCTL_GEM_OPEN DRM_IOWR(0x0b, struct drm_gem_open)
+#define DRM_IOCTL_GET_CAP DRM_IOWR(0x0c, struct drm_get_cap)
+#define DRM_IOCTL_SET_CLIENT_CAP DRM_IOW(0x0d, struct drm_set_client_cap)
+
+#define DRM_IOCTL_SET_UNIQUE DRM_IOW(0x10, struct drm_unique)
+#define DRM_IOCTL_AUTH_MAGIC DRM_IOW(0x11, struct drm_auth)
+#define DRM_IOCTL_BLOCK DRM_IOWR(0x12, struct drm_block)
+#define DRM_IOCTL_UNBLOCK DRM_IOWR(0x13, struct drm_block)
+#define DRM_IOCTL_CONTROL DRM_IOW(0x14, struct drm_control)
+#define DRM_IOCTL_ADD_MAP DRM_IOWR(0x15, struct drm_map)
+#define DRM_IOCTL_ADD_BUFS DRM_IOWR(0x16, struct drm_buf_desc)
+#define DRM_IOCTL_MARK_BUFS DRM_IOW(0x17, struct drm_buf_desc)
+#define DRM_IOCTL_INFO_BUFS DRM_IOWR(0x18, struct drm_buf_info)
+#define DRM_IOCTL_MAP_BUFS DRM_IOWR(0x19, struct drm_buf_map)
+#define DRM_IOCTL_FREE_BUFS DRM_IOW(0x1a, struct drm_buf_free)
+
+#define DRM_IOCTL_RM_MAP DRM_IOW(0x1b, struct drm_map)
+
+#define DRM_IOCTL_SET_SAREA_CTX DRM_IOW(0x1c, struct drm_ctx_priv_map)
+#define DRM_IOCTL_GET_SAREA_CTX DRM_IOWR(0x1d, struct drm_ctx_priv_map)
+
+#define DRM_IOCTL_SET_MASTER DRM_IO(0x1e)
+#define DRM_IOCTL_DROP_MASTER DRM_IO(0x1f)
+
+#define DRM_IOCTL_ADD_CTX DRM_IOWR(0x20, struct drm_ctx)
+#define DRM_IOCTL_RM_CTX DRM_IOWR(0x21, struct drm_ctx)
+#define DRM_IOCTL_MOD_CTX DRM_IOW(0x22, struct drm_ctx)
+#define DRM_IOCTL_GET_CTX DRM_IOWR(0x23, struct drm_ctx)
+#define DRM_IOCTL_SWITCH_CTX DRM_IOW(0x24, struct drm_ctx)
+#define DRM_IOCTL_NEW_CTX DRM_IOW(0x25, struct drm_ctx)
+#define DRM_IOCTL_RES_CTX DRM_IOWR(0x26, struct drm_ctx_res)
+#define DRM_IOCTL_ADD_DRAW DRM_IOWR(0x27, struct drm_draw)
+#define DRM_IOCTL_RM_DRAW DRM_IOWR(0x28, struct drm_draw)
+#define DRM_IOCTL_DMA DRM_IOWR(0x29, struct drm_dma)
+#define DRM_IOCTL_LOCK DRM_IOW(0x2a, struct drm_lock)
+#define DRM_IOCTL_UNLOCK DRM_IOW(0x2b, struct drm_lock)
+#define DRM_IOCTL_FINISH DRM_IOW(0x2c, struct drm_lock)
+
+/**
+ * DRM_IOCTL_PRIME_HANDLE_TO_FD - Convert a GEM handle to a DMA-BUF FD.
+ *
+ * User-space sets &drm_prime_handle.handle with the GEM handle to export and
+ * &drm_prime_handle.flags, and gets back a DMA-BUF file descriptor in
+ * &drm_prime_handle.fd.
+ *
+ * The export can fail for any driver-specific reason, e.g. because export is
+ * not supported for this specific GEM handle (but might be for others).
+ *
+ * Support for exporting DMA-BUFs is advertised via &DRM_PRIME_CAP_EXPORT.
+ */
+#define DRM_IOCTL_PRIME_HANDLE_TO_FD DRM_IOWR(0x2d, struct drm_prime_handle)
+/**
+ * DRM_IOCTL_PRIME_FD_TO_HANDLE - Convert a DMA-BUF FD to a GEM handle.
+ *
+ * User-space sets &drm_prime_handle.fd with a DMA-BUF file descriptor to
+ * import, and gets back a GEM handle in &drm_prime_handle.handle.
+ * &drm_prime_handle.flags is unused.
+ *
+ * If an existing GEM handle refers to the memory object backing the DMA-BUF,
+ * that GEM handle is returned. Therefore user-space which needs to handle
+ * arbitrary DMA-BUFs must have a user-space lookup data structure to manually
+ * reference-count duplicated GEM handles. For more information see
+ * &DRM_IOCTL_GEM_CLOSE.
+ *
+ * The import can fail for any driver-specific reason, e.g. because import is
+ * only supported for DMA-BUFs allocated on this DRM device.
+ *
+ * Support for importing DMA-BUFs is advertised via &DRM_PRIME_CAP_IMPORT.
+ */
+#define DRM_IOCTL_PRIME_FD_TO_HANDLE DRM_IOWR(0x2e, struct drm_prime_handle)
+
+#define DRM_IOCTL_AGP_ACQUIRE DRM_IO(0x30)
+#define DRM_IOCTL_AGP_RELEASE DRM_IO(0x31)
+#define DRM_IOCTL_AGP_ENABLE DRM_IOW(0x32, struct drm_agp_mode)
+#define DRM_IOCTL_AGP_INFO DRM_IOR(0x33, struct drm_agp_info)
+#define DRM_IOCTL_AGP_ALLOC DRM_IOWR(0x34, struct drm_agp_buffer)
+#define DRM_IOCTL_AGP_FREE DRM_IOW(0x35, struct drm_agp_buffer)
+#define DRM_IOCTL_AGP_BIND DRM_IOW(0x36, struct drm_agp_binding)
+#define DRM_IOCTL_AGP_UNBIND DRM_IOW(0x37, struct drm_agp_binding)
+
+#define DRM_IOCTL_SG_ALLOC DRM_IOWR(0x38, struct drm_scatter_gather)
+#define DRM_IOCTL_SG_FREE DRM_IOW(0x39, struct drm_scatter_gather)
+
+#define DRM_IOCTL_WAIT_VBLANK DRM_IOWR(0x3a, union drm_wait_vblank)
+
+#define DRM_IOCTL_CRTC_GET_SEQUENCE DRM_IOWR(0x3b, struct drm_crtc_get_sequence)
+#define DRM_IOCTL_CRTC_QUEUE_SEQUENCE DRM_IOWR(0x3c, struct drm_crtc_queue_sequence)
+
+#define DRM_IOCTL_UPDATE_DRAW DRM_IOW(0x3f, struct drm_update_draw)
+
+#define DRM_IOCTL_MODE_GETRESOURCES DRM_IOWR(0xA0, struct drm_mode_card_res)
+#define DRM_IOCTL_MODE_GETCRTC DRM_IOWR(0xA1, struct drm_mode_crtc)
+#define DRM_IOCTL_MODE_SETCRTC DRM_IOWR(0xA2, struct drm_mode_crtc)
+#define DRM_IOCTL_MODE_CURSOR DRM_IOWR(0xA3, struct drm_mode_cursor)
+#define DRM_IOCTL_MODE_GETGAMMA DRM_IOWR(0xA4, struct drm_mode_crtc_lut)
+#define DRM_IOCTL_MODE_SETGAMMA DRM_IOWR(0xA5, struct drm_mode_crtc_lut)
+#define DRM_IOCTL_MODE_GETENCODER DRM_IOWR(0xA6, struct drm_mode_get_encoder)
+#define DRM_IOCTL_MODE_GETCONNECTOR DRM_IOWR(0xA7, struct drm_mode_get_connector)
+#define DRM_IOCTL_MODE_ATTACHMODE                                                                  \
+  DRM_IOWR(0xA8, struct drm_mode_mode_cmd) /* deprecated (never worked) */
+#define DRM_IOCTL_MODE_DETACHMODE                                                                  \
+  DRM_IOWR(0xA9, struct drm_mode_mode_cmd) /* deprecated (never worked) */
+
+#define DRM_IOCTL_MODE_GETPROPERTY DRM_IOWR(0xAA, struct drm_mode_get_property)
+#define DRM_IOCTL_MODE_SETPROPERTY DRM_IOWR(0xAB, struct drm_mode_connector_set_property)
+#define DRM_IOCTL_MODE_GETPROPBLOB DRM_IOWR(0xAC, struct drm_mode_get_blob)
+#define DRM_IOCTL_MODE_GETFB DRM_IOWR(0xAD, struct drm_mode_fb_cmd)
+#define DRM_IOCTL_MODE_ADDFB DRM_IOWR(0xAE, struct drm_mode_fb_cmd)
+/**
+ * DRM_IOCTL_MODE_RMFB - Remove a framebuffer.
+ *
+ * This removes a framebuffer previously added via ADDFB/ADDFB2. The IOCTL
+ * argument is a framebuffer object ID.
+ *
+ * Warning: removing a framebuffer currently in-use on an enabled plane will
+ * disable that plane. The CRTC the plane is linked to may also be disabled
+ * (depending on driver capabilities).
+ */
+#define DRM_IOCTL_MODE_RMFB DRM_IOWR(0xAF, unsigned int)
+#define DRM_IOCTL_MODE_PAGE_FLIP DRM_IOWR(0xB0, struct drm_mode_crtc_page_flip)
+#define DRM_IOCTL_MODE_DIRTYFB DRM_IOWR(0xB1, struct drm_mode_fb_dirty_cmd)
+
+/**
+ * DRM_IOCTL_MODE_CREATE_DUMB - Create a new dumb buffer object.
+ *
+ * KMS dumb buffers provide a very primitive way to allocate a buffer object
+ * suitable for scanout and map it for software rendering. KMS dumb buffers are
+ * not suitable for hardware-accelerated rendering nor video decoding. KMS dumb
+ * buffers are not suitable to be displayed on any other device than the KMS
+ * device where they were allocated from. Also see
+ * :ref:`kms_dumb_buffer_objects`.
+ *
+ * The IOCTL argument is a struct drm_mode_create_dumb.
+ *
+ * User-space is expected to create a KMS dumb buffer via this IOCTL, then add
+ * it as a KMS framebuffer via &DRM_IOCTL_MODE_ADDFB and map it via
+ * &DRM_IOCTL_MODE_MAP_DUMB.
+ *
+ * &DRM_CAP_DUMB_BUFFER indicates whether this IOCTL is supported.
+ * &DRM_CAP_DUMB_PREFERRED_DEPTH and &DRM_CAP_DUMB_PREFER_SHADOW indicate
+ * driver preferences for dumb buffers.
+ */
+#define DRM_IOCTL_MODE_CREATE_DUMB DRM_IOWR(0xB2, struct drm_mode_create_dumb)
+#define DRM_IOCTL_MODE_MAP_DUMB DRM_IOWR(0xB3, struct drm_mode_map_dumb)
+#define DRM_IOCTL_MODE_DESTROY_DUMB DRM_IOWR(0xB4, struct drm_mode_destroy_dumb)
+#define DRM_IOCTL_MODE_GETPLANERESOURCES DRM_IOWR(0xB5, struct drm_mode_get_plane_res)
+#define DRM_IOCTL_MODE_GETPLANE DRM_IOWR(0xB6, struct drm_mode_get_plane)
+#define DRM_IOCTL_MODE_SETPLANE DRM_IOWR(0xB7, struct drm_mode_set_plane)
+#define DRM_IOCTL_MODE_ADDFB2 DRM_IOWR(0xB8, struct drm_mode_fb_cmd2)
+#define DRM_IOCTL_MODE_OBJ_GETPROPERTIES DRM_IOWR(0xB9, struct drm_mode_obj_get_properties)
+#define DRM_IOCTL_MODE_OBJ_SETPROPERTY DRM_IOWR(0xBA, struct drm_mode_obj_set_property)
+#define DRM_IOCTL_MODE_CURSOR2 DRM_IOWR(0xBB, struct drm_mode_cursor2)
+#define DRM_IOCTL_MODE_ATOMIC DRM_IOWR(0xBC, struct drm_mode_atomic)
+#define DRM_IOCTL_MODE_CREATEPROPBLOB DRM_IOWR(0xBD, struct drm_mode_create_blob)
+#define DRM_IOCTL_MODE_DESTROYPROPBLOB DRM_IOWR(0xBE, struct drm_mode_destroy_blob)
+
+#define DRM_IOCTL_SYNCOBJ_CREATE DRM_IOWR(0xBF, struct drm_syncobj_create)
+#define DRM_IOCTL_SYNCOBJ_DESTROY DRM_IOWR(0xC0, struct drm_syncobj_destroy)
+#define DRM_IOCTL_SYNCOBJ_HANDLE_TO_FD DRM_IOWR(0xC1, struct drm_syncobj_handle)
+#define DRM_IOCTL_SYNCOBJ_FD_TO_HANDLE DRM_IOWR(0xC2, struct drm_syncobj_handle)
+#define DRM_IOCTL_SYNCOBJ_WAIT DRM_IOWR(0xC3, struct drm_syncobj_wait)
+#define DRM_IOCTL_SYNCOBJ_RESET DRM_IOWR(0xC4, struct drm_syncobj_array)
+#define DRM_IOCTL_SYNCOBJ_SIGNAL DRM_IOWR(0xC5, struct drm_syncobj_array)
+
+#define DRM_IOCTL_MODE_CREATE_LEASE DRM_IOWR(0xC6, struct drm_mode_create_lease)
+#define DRM_IOCTL_MODE_LIST_LESSEES DRM_IOWR(0xC7, struct drm_mode_list_lessees)
+#define DRM_IOCTL_MODE_GET_LEASE DRM_IOWR(0xC8, struct drm_mode_get_lease)
+#define DRM_IOCTL_MODE_REVOKE_LEASE DRM_IOWR(0xC9, struct drm_mode_revoke_lease)
+
+#define DRM_IOCTL_SYNCOBJ_TIMELINE_WAIT DRM_IOWR(0xCA, struct drm_syncobj_timeline_wait)
+#define DRM_IOCTL_SYNCOBJ_QUERY DRM_IOWR(0xCB, struct drm_syncobj_timeline_array)
+#define DRM_IOCTL_SYNCOBJ_TRANSFER DRM_IOWR(0xCC, struct drm_syncobj_transfer)
+#define DRM_IOCTL_SYNCOBJ_TIMELINE_SIGNAL DRM_IOWR(0xCD, struct drm_syncobj_timeline_array)
+
+/**
+ * DRM_IOCTL_MODE_GETFB2 - Get framebuffer metadata.
+ *
+ * This queries metadata about a framebuffer. User-space fills
+ * &drm_mode_fb_cmd2.fb_id as the input, and the kernels fills the rest of the
+ * struct as the output.
+ *
+ * If the client is DRM master or has &CAP_SYS_ADMIN, &drm_mode_fb_cmd2.handles
+ * will be filled with GEM buffer handles. Fresh new GEM handles are always
+ * returned, even if another GEM handle referring to the same memory object
+ * already exists on the DRM file description. The caller is responsible for
+ * removing the new handles, e.g. via the &DRM_IOCTL_GEM_CLOSE IOCTL. The same
+ * new handle will be returned for multiple planes in case they use the same
+ * memory object. Planes are valid until one has a zero handle -- this can be
+ * used to compute the number of planes.
+ *
+ * Otherwise, &drm_mode_fb_cmd2.handles will be zeroed and planes are valid
+ * until one has a zero &drm_mode_fb_cmd2.pitches.
+ *
+ * If the framebuffer has a format modifier, &DRM_MODE_FB_MODIFIERS will be set
+ * in &drm_mode_fb_cmd2.flags and &drm_mode_fb_cmd2.modifier will contain the
+ * modifier. Otherwise, user-space must ignore &drm_mode_fb_cmd2.modifier.
+ *
+ * To obtain DMA-BUF FDs for each plane without leaking GEM handles, user-space
+ * can export each handle via &DRM_IOCTL_PRIME_HANDLE_TO_FD, then immediately
+ * close each unique handle via &DRM_IOCTL_GEM_CLOSE, making sure to not
+ * double-close handles which are specified multiple times in the array.
+ */
+#define DRM_IOCTL_MODE_GETFB2 DRM_IOWR(0xCE, struct drm_mode_fb_cmd2)
+
+#define DRM_IOCTL_SYNCOBJ_EVENTFD DRM_IOWR(0xCF, struct drm_syncobj_eventfd)
+
+/**
+ * DRM_IOCTL_MODE_CLOSEFB - Close a framebuffer.
+ *
+ * This closes a framebuffer previously added via ADDFB/ADDFB2. The IOCTL
+ * argument is a framebuffer object ID.
+ *
+ * This IOCTL is similar to &DRM_IOCTL_MODE_RMFB, except it doesn't disable
+ * planes and CRTCs. As long as the framebuffer is used by a plane, it's kept
+ * alive. When the plane no longer uses the framebuffer (because the
+ * framebuffer is replaced with another one, or the plane is disabled), the
+ * framebuffer is cleaned up.
+ *
+ * This is useful to implement flicker-free transitions between two processes.
+ *
+ * Depending on the threat model, user-space may want to ensure that the
+ * framebuffer doesn't expose any sensitive user information: closed
+ * framebuffers attached to a plane can be read back by the next DRM master.
+ */
+#define DRM_IOCTL_MODE_CLOSEFB DRM_IOWR(0xD0, struct drm_mode_closefb)
+
+/**
+ * DRM_IOCTL_SET_CLIENT_NAME - Attach a name to a drm_file
+ *
+ * Having a name allows for easier tracking and debugging.
+ * The length of the name (without null ending char) must be
+ * <= DRM_CLIENT_NAME_MAX_LEN.
+ * The call will fail if the name contains whitespaces or non-printable chars.
+ */
+#define DRM_IOCTL_SET_CLIENT_NAME DRM_IOWR(0xD1, struct drm_set_client_name)
+
+/*
+ * Device specific ioctls should only be in their respective headers
+ * The device specific ioctl range is from 0x40 to 0x9f.
+ * Generic IOCTLS restart at 0xA0.
+ *
+ * \sa drmCommandNone(), drmCommandRead(), drmCommandWrite(), and
+ * drmCommandReadWrite().
+ */
+#define DRM_COMMAND_BASE 0x40
+#define DRM_COMMAND_END 0xA0
+
+/**
+ * struct drm_event - Header for DRM events
+ * @type: event type.
+ * @length: total number of payload bytes (including header).
+ *
+ * This struct is a header for events written back to user-space on the DRM FD.
+ * A read on the DRM FD will always only return complete events: e.g. if the
+ * read buffer is 100 bytes large and there are two 64 byte events pending,
+ * only one will be returned.
+ *
+ * Event types 0 - 0x7fffffff are generic DRM events, 0x80000000 and
+ * up are chipset specific. Generic DRM events include &DRM_EVENT_VBLANK,
+ * &DRM_EVENT_FLIP_COMPLETE and &DRM_EVENT_CRTC_SEQUENCE.
+ */
+struct drm_event {
+  __u32 type;
+  __u32 length;
+};
+
+/**
+ * DRM_EVENT_VBLANK - vertical blanking event
+ *
+ * This event is sent in response to &DRM_IOCTL_WAIT_VBLANK with the
+ * &_DRM_VBLANK_EVENT flag set.
+ *
+ * The event payload is a struct drm_event_vblank.
+ */
+#define DRM_EVENT_VBLANK 0x01
+/**
+ * DRM_EVENT_FLIP_COMPLETE - page-flip completion event
+ *
+ * This event is sent in response to an atomic commit or legacy page-flip with
+ * the &DRM_MODE_PAGE_FLIP_EVENT flag set.
+ *
+ * The event payload is a struct drm_event_vblank.
+ */
+#define DRM_EVENT_FLIP_COMPLETE 0x02
+/**
+ * DRM_EVENT_CRTC_SEQUENCE - CRTC sequence event
+ *
+ * This event is sent in response to &DRM_IOCTL_CRTC_QUEUE_SEQUENCE.
+ *
+ * The event payload is a struct drm_event_crtc_sequence.
+ */
+#define DRM_EVENT_CRTC_SEQUENCE 0x03
+
+struct drm_event_vblank {
+  struct drm_event base;
+  __u64 user_data;
+  __u32 tv_sec;
+  __u32 tv_usec;
+  __u32 sequence;
+  __u32 crtc_id; /* 0 on older kernels that do not support this */
+};
+
+/* Event delivered at sequence. Time stamp marks when the first pixel
+ * of the refresh cycle leaves the display engine for the display
+ */
+struct drm_event_crtc_sequence {
+  struct drm_event base;
+  __u64 user_data;
+  __s64 time_ns;
+  __u64 sequence;
+};
+
+/* typedef area */
+typedef struct drm_clip_rect drm_clip_rect_t;
+typedef struct drm_drawable_info drm_drawable_info_t;
+typedef struct drm_tex_region drm_tex_region_t;
+typedef struct drm_hw_lock drm_hw_lock_t;
+typedef struct drm_version drm_version_t;
+typedef struct drm_unique drm_unique_t;
+typedef struct drm_list drm_list_t;
+typedef struct drm_block drm_block_t;
+typedef struct drm_control drm_control_t;
+typedef enum drm_map_type drm_map_type_t;
+typedef enum drm_map_flags drm_map_flags_t;
+typedef struct drm_ctx_priv_map drm_ctx_priv_map_t;
+typedef struct drm_map drm_map_t;
+typedef struct drm_client drm_client_t;
+typedef enum drm_stat_type drm_stat_type_t;
+typedef struct drm_stats drm_stats_t;
+typedef enum drm_lock_flags drm_lock_flags_t;
+typedef struct drm_lock drm_lock_t;
+typedef enum drm_dma_flags drm_dma_flags_t;
+typedef struct drm_buf_desc drm_buf_desc_t;
+typedef struct drm_buf_info drm_buf_info_t;
+typedef struct drm_buf_free drm_buf_free_t;
+typedef struct drm_buf_pub drm_buf_pub_t;
+typedef struct drm_buf_map drm_buf_map_t;
+typedef struct drm_dma drm_dma_t;
+typedef union drm_wait_vblank drm_wait_vblank_t;
+typedef struct drm_agp_mode drm_agp_mode_t;
+typedef enum drm_ctx_flags drm_ctx_flags_t;
+typedef struct drm_ctx drm_ctx_t;
+typedef struct drm_ctx_res drm_ctx_res_t;
+typedef struct drm_draw drm_draw_t;
+typedef struct drm_update_draw drm_update_draw_t;
+typedef struct drm_auth drm_auth_t;
+typedef struct drm_irq_busid drm_irq_busid_t;
+typedef enum drm_vblank_seq_type drm_vblank_seq_type_t;
+
+typedef struct drm_agp_buffer drm_agp_buffer_t;
+typedef struct drm_agp_binding drm_agp_binding_t;
+typedef struct drm_agp_info drm_agp_info_t;
+typedef struct drm_scatter_gather drm_scatter_gather_t;
+typedef struct drm_set_version drm_set_version_t;
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/emulation/rocjitsu/lib/rocjitsu/external_headers/drm_headers/linux/uapi/drm/drm_mode.h
+++ b/emulation/rocjitsu/lib/rocjitsu/external_headers/drm_headers/linux/uapi/drm/drm_mode.h
@@ -1,0 +1,1336 @@
+/*
+ * Copyright (c) 2007 Dave Airlie <airlied@linux.ie>
+ * Copyright (c) 2007 Jakob Bornecrantz <wallbraker@gmail.com>
+ * Copyright (c) 2008 Red Hat Inc.
+ * Copyright (c) 2007-2008 Tungsten Graphics, Inc., Cedar Park, TX., USA
+ * Copyright (c) 2007-2008 Intel Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#ifndef _DRM_MODE_H
+#define _DRM_MODE_H
+
+#include "drm.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * DOC: overview
+ *
+ * DRM exposes many UAPI and structure definitions to have a consistent
+ * and standardized interface with users.
+ * Userspace can refer to these structure definitions and UAPI formats
+ * to communicate to drivers.
+ */
+
+#define DRM_CONNECTOR_NAME_LEN 32
+#define DRM_DISPLAY_MODE_LEN 32
+#define DRM_PROP_NAME_LEN 32
+
+#define DRM_MODE_TYPE_BUILTIN (1 << 0)                           /* deprecated */
+#define DRM_MODE_TYPE_CLOCK_C ((1 << 1) | DRM_MODE_TYPE_BUILTIN) /* deprecated */
+#define DRM_MODE_TYPE_CRTC_C ((1 << 2) | DRM_MODE_TYPE_BUILTIN)  /* deprecated */
+#define DRM_MODE_TYPE_PREFERRED (1 << 3)
+#define DRM_MODE_TYPE_DEFAULT (1 << 4) /* deprecated */
+#define DRM_MODE_TYPE_USERDEF (1 << 5)
+#define DRM_MODE_TYPE_DRIVER (1 << 6)
+
+#define DRM_MODE_TYPE_ALL (DRM_MODE_TYPE_PREFERRED | DRM_MODE_TYPE_USERDEF | DRM_MODE_TYPE_DRIVER)
+
+/* Video mode flags */
+/* bit compatible with the xrandr RR_ definitions (bits 0-13)
+ *
+ * ABI warning: Existing userspace really expects
+ * the mode flags to match the xrandr definitions. Any
+ * changes that don't match the xrandr definitions will
+ * likely need a new client cap or some other mechanism
+ * to avoid breaking existing userspace. This includes
+ * allocating new flags in the previously unused bits!
+ */
+#define DRM_MODE_FLAG_PHSYNC (1 << 0)
+#define DRM_MODE_FLAG_NHSYNC (1 << 1)
+#define DRM_MODE_FLAG_PVSYNC (1 << 2)
+#define DRM_MODE_FLAG_NVSYNC (1 << 3)
+#define DRM_MODE_FLAG_INTERLACE (1 << 4)
+#define DRM_MODE_FLAG_DBLSCAN (1 << 5)
+#define DRM_MODE_FLAG_CSYNC (1 << 6)
+#define DRM_MODE_FLAG_PCSYNC (1 << 7)
+#define DRM_MODE_FLAG_NCSYNC (1 << 8)
+#define DRM_MODE_FLAG_HSKEW (1 << 9)   /* hskew provided */
+#define DRM_MODE_FLAG_BCAST (1 << 10)  /* deprecated */
+#define DRM_MODE_FLAG_PIXMUX (1 << 11) /* deprecated */
+#define DRM_MODE_FLAG_DBLCLK (1 << 12)
+#define DRM_MODE_FLAG_CLKDIV2 (1 << 13)
+/*
+ * When adding a new stereo mode don't forget to adjust DRM_MODE_FLAGS_3D_MAX
+ * (define not exposed to user space).
+ */
+#define DRM_MODE_FLAG_3D_MASK (0x1f << 14)
+#define DRM_MODE_FLAG_3D_NONE (0 << 14)
+#define DRM_MODE_FLAG_3D_FRAME_PACKING (1 << 14)
+#define DRM_MODE_FLAG_3D_FIELD_ALTERNATIVE (2 << 14)
+#define DRM_MODE_FLAG_3D_LINE_ALTERNATIVE (3 << 14)
+#define DRM_MODE_FLAG_3D_SIDE_BY_SIDE_FULL (4 << 14)
+#define DRM_MODE_FLAG_3D_L_DEPTH (5 << 14)
+#define DRM_MODE_FLAG_3D_L_DEPTH_GFX_GFX_DEPTH (6 << 14)
+#define DRM_MODE_FLAG_3D_TOP_AND_BOTTOM (7 << 14)
+#define DRM_MODE_FLAG_3D_SIDE_BY_SIDE_HALF (8 << 14)
+
+/* Picture aspect ratio options */
+#define DRM_MODE_PICTURE_ASPECT_NONE 0
+#define DRM_MODE_PICTURE_ASPECT_4_3 1
+#define DRM_MODE_PICTURE_ASPECT_16_9 2
+#define DRM_MODE_PICTURE_ASPECT_64_27 3
+#define DRM_MODE_PICTURE_ASPECT_256_135 4
+
+/* Content type options */
+#define DRM_MODE_CONTENT_TYPE_NO_DATA 0
+#define DRM_MODE_CONTENT_TYPE_GRAPHICS 1
+#define DRM_MODE_CONTENT_TYPE_PHOTO 2
+#define DRM_MODE_CONTENT_TYPE_CINEMA 3
+#define DRM_MODE_CONTENT_TYPE_GAME 4
+
+/* Aspect ratio flag bitmask (4 bits 22:19) */
+#define DRM_MODE_FLAG_PIC_AR_MASK (0x0F << 19)
+#define DRM_MODE_FLAG_PIC_AR_NONE (DRM_MODE_PICTURE_ASPECT_NONE << 19)
+#define DRM_MODE_FLAG_PIC_AR_4_3 (DRM_MODE_PICTURE_ASPECT_4_3 << 19)
+#define DRM_MODE_FLAG_PIC_AR_16_9 (DRM_MODE_PICTURE_ASPECT_16_9 << 19)
+#define DRM_MODE_FLAG_PIC_AR_64_27 (DRM_MODE_PICTURE_ASPECT_64_27 << 19)
+#define DRM_MODE_FLAG_PIC_AR_256_135 (DRM_MODE_PICTURE_ASPECT_256_135 << 19)
+
+#define DRM_MODE_FLAG_ALL                                                                          \
+  (DRM_MODE_FLAG_PHSYNC | DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_PVSYNC | DRM_MODE_FLAG_NVSYNC |     \
+   DRM_MODE_FLAG_INTERLACE | DRM_MODE_FLAG_DBLSCAN | DRM_MODE_FLAG_CSYNC | DRM_MODE_FLAG_PCSYNC |  \
+   DRM_MODE_FLAG_NCSYNC | DRM_MODE_FLAG_HSKEW | DRM_MODE_FLAG_DBLCLK | DRM_MODE_FLAG_CLKDIV2 |     \
+   DRM_MODE_FLAG_3D_MASK)
+
+/* DPMS flags */
+/* bit compatible with the xorg definitions. */
+#define DRM_MODE_DPMS_ON 0
+#define DRM_MODE_DPMS_STANDBY 1
+#define DRM_MODE_DPMS_SUSPEND 2
+#define DRM_MODE_DPMS_OFF 3
+
+/* Scaling mode options */
+#define DRM_MODE_SCALE_NONE                                                                        \
+  0                                 /* Unmodified timing (display or                               \
+                                       software can still scale) */
+#define DRM_MODE_SCALE_FULLSCREEN 1 /* Full screen, ignore aspect */
+#define DRM_MODE_SCALE_CENTER 2     /* Centered, no scaling */
+#define DRM_MODE_SCALE_ASPECT 3     /* Full screen, preserve aspect */
+
+/* Dithering mode options */
+#define DRM_MODE_DITHERING_OFF 0
+#define DRM_MODE_DITHERING_ON 1
+#define DRM_MODE_DITHERING_AUTO 2
+
+/* Dirty info options */
+#define DRM_MODE_DIRTY_OFF 0
+#define DRM_MODE_DIRTY_ON 1
+#define DRM_MODE_DIRTY_ANNOTATE 2
+
+/* Link Status options */
+#define DRM_MODE_LINK_STATUS_GOOD 0
+#define DRM_MODE_LINK_STATUS_BAD 1
+
+/*
+ * DRM_MODE_ROTATE_<degrees>
+ *
+ * Signals that a drm plane is been rotated <degrees> degrees in counter
+ * clockwise direction.
+ *
+ * This define is provided as a convenience, looking up the property id
+ * using the name->prop id lookup is the preferred method.
+ */
+#define DRM_MODE_ROTATE_0 (1 << 0)
+#define DRM_MODE_ROTATE_90 (1 << 1)
+#define DRM_MODE_ROTATE_180 (1 << 2)
+#define DRM_MODE_ROTATE_270 (1 << 3)
+
+/*
+ * DRM_MODE_ROTATE_MASK
+ *
+ * Bitmask used to look for drm plane rotations.
+ */
+#define DRM_MODE_ROTATE_MASK                                                                       \
+  (DRM_MODE_ROTATE_0 | DRM_MODE_ROTATE_90 | DRM_MODE_ROTATE_180 | DRM_MODE_ROTATE_270)
+
+/*
+ * DRM_MODE_REFLECT_<axis>
+ *
+ * Signals that the contents of a drm plane is reflected along the <axis> axis,
+ * in the same way as mirroring.
+ * See kerneldoc chapter "Plane Composition Properties" for more details.
+ *
+ * This define is provided as a convenience, looking up the property id
+ * using the name->prop id lookup is the preferred method.
+ */
+#define DRM_MODE_REFLECT_X (1 << 4)
+#define DRM_MODE_REFLECT_Y (1 << 5)
+
+/*
+ * DRM_MODE_REFLECT_MASK
+ *
+ * Bitmask used to look for drm plane reflections.
+ */
+#define DRM_MODE_REFLECT_MASK (DRM_MODE_REFLECT_X | DRM_MODE_REFLECT_Y)
+
+/* Content Protection Flags */
+#define DRM_MODE_CONTENT_PROTECTION_UNDESIRED 0
+#define DRM_MODE_CONTENT_PROTECTION_DESIRED 1
+#define DRM_MODE_CONTENT_PROTECTION_ENABLED 2
+
+/**
+ * struct drm_mode_modeinfo - Display mode information.
+ * @clock: pixel clock in kHz
+ * @hdisplay: horizontal display size
+ * @hsync_start: horizontal sync start
+ * @hsync_end: horizontal sync end
+ * @htotal: horizontal total size
+ * @hskew: horizontal skew
+ * @vdisplay: vertical display size
+ * @vsync_start: vertical sync start
+ * @vsync_end: vertical sync end
+ * @vtotal: vertical total size
+ * @vscan: vertical scan
+ * @vrefresh: approximate vertical refresh rate in Hz
+ * @flags: bitmask of misc. flags, see DRM_MODE_FLAG_* defines
+ * @type: bitmask of type flags, see DRM_MODE_TYPE_* defines
+ * @name: string describing the mode resolution
+ *
+ * This is the user-space API display mode information structure. For the
+ * kernel version see struct drm_display_mode.
+ */
+struct drm_mode_modeinfo {
+  __u32 clock;
+  __u16 hdisplay;
+  __u16 hsync_start;
+  __u16 hsync_end;
+  __u16 htotal;
+  __u16 hskew;
+  __u16 vdisplay;
+  __u16 vsync_start;
+  __u16 vsync_end;
+  __u16 vtotal;
+  __u16 vscan;
+
+  __u32 vrefresh;
+
+  __u32 flags;
+  __u32 type;
+  char name[DRM_DISPLAY_MODE_LEN];
+};
+
+struct drm_mode_card_res {
+  __u64 fb_id_ptr;
+  __u64 crtc_id_ptr;
+  __u64 connector_id_ptr;
+  __u64 encoder_id_ptr;
+  __u32 count_fbs;
+  __u32 count_crtcs;
+  __u32 count_connectors;
+  __u32 count_encoders;
+  __u32 min_width;
+  __u32 max_width;
+  __u32 min_height;
+  __u32 max_height;
+};
+
+struct drm_mode_crtc {
+  __u64 set_connectors_ptr;
+  __u32 count_connectors;
+
+  __u32 crtc_id; /**< Id */
+  __u32 fb_id;   /**< Id of framebuffer */
+
+  __u32 x; /**< x Position on the framebuffer */
+  __u32 y; /**< y Position on the framebuffer */
+
+  __u32 gamma_size;
+  __u32 mode_valid;
+  struct drm_mode_modeinfo mode;
+};
+
+#define DRM_MODE_PRESENT_TOP_FIELD (1 << 0)
+#define DRM_MODE_PRESENT_BOTTOM_FIELD (1 << 1)
+
+/* Planes blend with or override other bits on the CRTC */
+struct drm_mode_set_plane {
+  __u32 plane_id;
+  __u32 crtc_id;
+  __u32 fb_id; /* fb object contains surface format type */
+  __u32 flags; /* see above flags */
+
+  /* Signed dest location allows it to be partially off screen */
+  __s32 crtc_x;
+  __s32 crtc_y;
+  __u32 crtc_w;
+  __u32 crtc_h;
+
+  /* Source values are 16.16 fixed point */
+  __u32 src_x;
+  __u32 src_y;
+  __u32 src_h;
+  __u32 src_w;
+};
+
+/**
+ * struct drm_mode_get_plane - Get plane metadata.
+ *
+ * Userspace can perform a GETPLANE ioctl to retrieve information about a
+ * plane.
+ *
+ * To retrieve the number of formats supported, set @count_format_types to zero
+ * and call the ioctl. @count_format_types will be updated with the value.
+ *
+ * To retrieve these formats, allocate an array with the memory needed to store
+ * @count_format_types formats. Point @format_type_ptr to this array and call
+ * the ioctl again (with @count_format_types still set to the value returned in
+ * the first ioctl call).
+ */
+struct drm_mode_get_plane {
+  /**
+   * @plane_id: Object ID of the plane whose information should be
+   * retrieved. Set by caller.
+   */
+  __u32 plane_id;
+
+  /** @crtc_id: Object ID of the current CRTC. */
+  __u32 crtc_id;
+  /** @fb_id: Object ID of the current fb. */
+  __u32 fb_id;
+
+  /**
+   * @possible_crtcs: Bitmask of CRTC's compatible with the plane. CRTC's
+   * are created and they receive an index, which corresponds to their
+   * position in the bitmask. Bit N corresponds to
+   * :ref:`CRTC index<crtc_index>` N.
+   */
+  __u32 possible_crtcs;
+  /** @gamma_size: Never used. */
+  __u32 gamma_size;
+
+  /** @count_format_types: Number of formats. */
+  __u32 count_format_types;
+  /**
+   * @format_type_ptr: Pointer to ``__u32`` array of formats that are
+   * supported by the plane. These formats do not require modifiers.
+   */
+  __u64 format_type_ptr;
+};
+
+struct drm_mode_get_plane_res {
+  __u64 plane_id_ptr;
+  __u32 count_planes;
+};
+
+#define DRM_MODE_ENCODER_NONE 0
+#define DRM_MODE_ENCODER_DAC 1
+#define DRM_MODE_ENCODER_TMDS 2
+#define DRM_MODE_ENCODER_LVDS 3
+#define DRM_MODE_ENCODER_TVDAC 4
+#define DRM_MODE_ENCODER_VIRTUAL 5
+#define DRM_MODE_ENCODER_DSI 6
+#define DRM_MODE_ENCODER_DPMST 7
+#define DRM_MODE_ENCODER_DPI 8
+
+struct drm_mode_get_encoder {
+  __u32 encoder_id;
+  __u32 encoder_type;
+
+  __u32 crtc_id; /**< Id of crtc */
+
+  __u32 possible_crtcs;
+  __u32 possible_clones;
+};
+
+/* This is for connectors with multiple signal types. */
+/* Try to match DRM_MODE_CONNECTOR_X as closely as possible. */
+enum drm_mode_subconnector {
+  DRM_MODE_SUBCONNECTOR_Automatic = 0,    /* DVI-I, TV     */
+  DRM_MODE_SUBCONNECTOR_Unknown = 0,      /* DVI-I, TV, DP */
+  DRM_MODE_SUBCONNECTOR_VGA = 1,          /*            DP */
+  DRM_MODE_SUBCONNECTOR_DVID = 3,         /* DVI-I      DP */
+  DRM_MODE_SUBCONNECTOR_DVIA = 4,         /* DVI-I         */
+  DRM_MODE_SUBCONNECTOR_Composite = 5,    /*        TV     */
+  DRM_MODE_SUBCONNECTOR_SVIDEO = 6,       /*        TV     */
+  DRM_MODE_SUBCONNECTOR_Component = 8,    /*        TV     */
+  DRM_MODE_SUBCONNECTOR_SCART = 9,        /*        TV     */
+  DRM_MODE_SUBCONNECTOR_DisplayPort = 10, /*            DP */
+  DRM_MODE_SUBCONNECTOR_HDMIA = 11,       /*            DP */
+  DRM_MODE_SUBCONNECTOR_Native = 15,      /*            DP */
+  DRM_MODE_SUBCONNECTOR_Wireless = 18,    /*            DP */
+};
+
+#define DRM_MODE_CONNECTOR_Unknown 0
+#define DRM_MODE_CONNECTOR_VGA 1
+#define DRM_MODE_CONNECTOR_DVII 2
+#define DRM_MODE_CONNECTOR_DVID 3
+#define DRM_MODE_CONNECTOR_DVIA 4
+#define DRM_MODE_CONNECTOR_Composite 5
+#define DRM_MODE_CONNECTOR_SVIDEO 6
+#define DRM_MODE_CONNECTOR_LVDS 7
+#define DRM_MODE_CONNECTOR_Component 8
+#define DRM_MODE_CONNECTOR_9PinDIN 9
+#define DRM_MODE_CONNECTOR_DisplayPort 10
+#define DRM_MODE_CONNECTOR_HDMIA 11
+#define DRM_MODE_CONNECTOR_HDMIB 12
+#define DRM_MODE_CONNECTOR_TV 13
+#define DRM_MODE_CONNECTOR_eDP 14
+#define DRM_MODE_CONNECTOR_VIRTUAL 15
+#define DRM_MODE_CONNECTOR_DSI 16
+#define DRM_MODE_CONNECTOR_DPI 17
+#define DRM_MODE_CONNECTOR_WRITEBACK 18
+#define DRM_MODE_CONNECTOR_SPI 19
+#define DRM_MODE_CONNECTOR_USB 20
+
+/**
+ * struct drm_mode_get_connector - Get connector metadata.
+ *
+ * User-space can perform a GETCONNECTOR ioctl to retrieve information about a
+ * connector. User-space is expected to retrieve encoders, modes and properties
+ * by performing this ioctl at least twice: the first time to retrieve the
+ * number of elements, the second time to retrieve the elements themselves.
+ *
+ * To retrieve the number of elements, set @count_props and @count_encoders to
+ * zero, set @count_modes to 1, and set @modes_ptr to a temporary struct
+ * drm_mode_modeinfo element.
+ *
+ * To retrieve the elements, allocate arrays for @encoders_ptr, @modes_ptr,
+ * @props_ptr and @prop_values_ptr, then set @count_modes, @count_props and
+ * @count_encoders to their capacity.
+ *
+ * Performing the ioctl only twice may be racy: the number of elements may have
+ * changed with a hotplug event in-between the two ioctls. User-space is
+ * expected to retry the last ioctl until the number of elements stabilizes.
+ * The kernel won't fill any array which doesn't have the expected length.
+ *
+ * **Force-probing a connector**
+ *
+ * If the @count_modes field is set to zero and the DRM client is the current
+ * DRM master, the kernel will perform a forced probe on the connector to
+ * refresh the connector status, modes and EDID. A forced-probe can be slow,
+ * might cause flickering and the ioctl will block.
+ *
+ * User-space needs to force-probe connectors to ensure their metadata is
+ * up-to-date at startup and after receiving a hot-plug event. User-space
+ * may perform a forced-probe when the user explicitly requests it. User-space
+ * shouldn't perform a forced-probe in other situations.
+ */
+struct drm_mode_get_connector {
+  /** @encoders_ptr: Pointer to ``__u32`` array of object IDs. */
+  __u64 encoders_ptr;
+  /** @modes_ptr: Pointer to struct drm_mode_modeinfo array. */
+  __u64 modes_ptr;
+  /** @props_ptr: Pointer to ``__u32`` array of property IDs. */
+  __u64 props_ptr;
+  /** @prop_values_ptr: Pointer to ``__u64`` array of property values. */
+  __u64 prop_values_ptr;
+
+  /** @count_modes: Number of modes. */
+  __u32 count_modes;
+  /** @count_props: Number of properties. */
+  __u32 count_props;
+  /** @count_encoders: Number of encoders. */
+  __u32 count_encoders;
+
+  /** @encoder_id: Object ID of the current encoder. */
+  __u32 encoder_id;
+  /** @connector_id: Object ID of the connector. */
+  __u32 connector_id;
+  /**
+   * @connector_type: Type of the connector.
+   *
+   * See DRM_MODE_CONNECTOR_* defines.
+   */
+  __u32 connector_type;
+  /**
+   * @connector_type_id: Type-specific connector number.
+   *
+   * This is not an object ID. This is a per-type connector number. Each
+   * (type, type_id) combination is unique across all connectors of a DRM
+   * device.
+   *
+   * The (type, type_id) combination is not a stable identifier: the
+   * type_id can change depending on the driver probe order.
+   */
+  __u32 connector_type_id;
+
+  /**
+   * @connection: Status of the connector.
+   *
+   * See enum drm_connector_status.
+   */
+  __u32 connection;
+  /** @mm_width: Width of the connected sink in millimeters. */
+  __u32 mm_width;
+  /** @mm_height: Height of the connected sink in millimeters. */
+  __u32 mm_height;
+  /**
+   * @subpixel: Subpixel order of the connected sink.
+   *
+   * See enum subpixel_order.
+   */
+  __u32 subpixel;
+
+  /** @pad: Padding, must be zero. */
+  __u32 pad;
+};
+
+#define DRM_MODE_PROP_PENDING (1 << 0) /* deprecated, do not use */
+#define DRM_MODE_PROP_RANGE (1 << 1)
+#define DRM_MODE_PROP_IMMUTABLE (1 << 2)
+#define DRM_MODE_PROP_ENUM (1 << 3) /* enumerated type with text strings */
+#define DRM_MODE_PROP_BLOB (1 << 4)
+#define DRM_MODE_PROP_BITMASK (1 << 5) /* bitmask of enumerated types */
+
+/* non-extended types: legacy bitmask, one bit per type: */
+#define DRM_MODE_PROP_LEGACY_TYPE                                                                  \
+  (DRM_MODE_PROP_RANGE | DRM_MODE_PROP_ENUM | DRM_MODE_PROP_BLOB | DRM_MODE_PROP_BITMASK)
+
+/* extended-types: rather than continue to consume a bit per type,
+ * grab a chunk of the bits to use as integer type id.
+ */
+#define DRM_MODE_PROP_EXTENDED_TYPE 0x0000ffc0
+#define DRM_MODE_PROP_TYPE(n) ((n) << 6)
+#define DRM_MODE_PROP_OBJECT DRM_MODE_PROP_TYPE(1)
+#define DRM_MODE_PROP_SIGNED_RANGE DRM_MODE_PROP_TYPE(2)
+
+/* the PROP_ATOMIC flag is used to hide properties from userspace that
+ * is not aware of atomic properties.  This is mostly to work around
+ * older userspace (DDX drivers) that read/write each prop they find,
+ * without being aware that this could be triggering a lengthy modeset.
+ */
+#define DRM_MODE_PROP_ATOMIC 0x80000000
+
+/**
+ * struct drm_mode_property_enum - Description for an enum/bitfield entry.
+ * @value: numeric value for this enum entry.
+ * @name: symbolic name for this enum entry.
+ *
+ * See struct drm_property_enum for details.
+ */
+struct drm_mode_property_enum {
+  __u64 value;
+  char name[DRM_PROP_NAME_LEN];
+};
+
+/**
+ * struct drm_mode_get_property - Get property metadata.
+ *
+ * User-space can perform a GETPROPERTY ioctl to retrieve information about a
+ * property. The same property may be attached to multiple objects, see
+ * "Modeset Base Object Abstraction".
+ *
+ * The meaning of the @values_ptr field changes depending on the property type.
+ * See &drm_property.flags for more details.
+ *
+ * The @enum_blob_ptr and @count_enum_blobs fields are only meaningful when the
+ * property has the type &DRM_MODE_PROP_ENUM or &DRM_MODE_PROP_BITMASK. For
+ * backwards compatibility, the kernel will always set @count_enum_blobs to
+ * zero when the property has the type &DRM_MODE_PROP_BLOB. User-space must
+ * ignore these two fields if the property has a different type.
+ *
+ * User-space is expected to retrieve values and enums by performing this ioctl
+ * at least twice: the first time to retrieve the number of elements, the
+ * second time to retrieve the elements themselves.
+ *
+ * To retrieve the number of elements, set @count_values and @count_enum_blobs
+ * to zero, then call the ioctl. @count_values will be updated with the number
+ * of elements. If the property has the type &DRM_MODE_PROP_ENUM or
+ * &DRM_MODE_PROP_BITMASK, @count_enum_blobs will be updated as well.
+ *
+ * To retrieve the elements themselves, allocate an array for @values_ptr and
+ * set @count_values to its capacity. If the property has the type
+ * &DRM_MODE_PROP_ENUM or &DRM_MODE_PROP_BITMASK, allocate an array for
+ * @enum_blob_ptr and set @count_enum_blobs to its capacity. Calling the ioctl
+ * again will fill the arrays.
+ */
+struct drm_mode_get_property {
+  /** @values_ptr: Pointer to a ``__u64`` array. */
+  __u64 values_ptr;
+  /** @enum_blob_ptr: Pointer to a struct drm_mode_property_enum array. */
+  __u64 enum_blob_ptr;
+
+  /**
+   * @prop_id: Object ID of the property which should be retrieved. Set
+   * by the caller.
+   */
+  __u32 prop_id;
+  /**
+   * @flags: ``DRM_MODE_PROP_*`` bitfield. See &drm_property.flags for
+   * a definition of the flags.
+   */
+  __u32 flags;
+  /**
+   * @name: Symbolic property name. User-space should use this field to
+   * recognize properties.
+   */
+  char name[DRM_PROP_NAME_LEN];
+
+  /** @count_values: Number of elements in @values_ptr. */
+  __u32 count_values;
+  /** @count_enum_blobs: Number of elements in @enum_blob_ptr. */
+  __u32 count_enum_blobs;
+};
+
+struct drm_mode_connector_set_property {
+  __u64 value;
+  __u32 prop_id;
+  __u32 connector_id;
+};
+
+#define DRM_MODE_OBJECT_CRTC 0xcccccccc
+#define DRM_MODE_OBJECT_CONNECTOR 0xc0c0c0c0
+#define DRM_MODE_OBJECT_ENCODER 0xe0e0e0e0
+#define DRM_MODE_OBJECT_MODE 0xdededede
+#define DRM_MODE_OBJECT_PROPERTY 0xb0b0b0b0
+#define DRM_MODE_OBJECT_FB 0xfbfbfbfb
+#define DRM_MODE_OBJECT_BLOB 0xbbbbbbbb
+#define DRM_MODE_OBJECT_PLANE 0xeeeeeeee
+#define DRM_MODE_OBJECT_ANY 0
+
+struct drm_mode_obj_get_properties {
+  __u64 props_ptr;
+  __u64 prop_values_ptr;
+  __u32 count_props;
+  __u32 obj_id;
+  __u32 obj_type;
+};
+
+struct drm_mode_obj_set_property {
+  __u64 value;
+  __u32 prop_id;
+  __u32 obj_id;
+  __u32 obj_type;
+};
+
+struct drm_mode_get_blob {
+  __u32 blob_id;
+  __u32 length;
+  __u64 data;
+};
+
+struct drm_mode_fb_cmd {
+  __u32 fb_id;
+  __u32 width;
+  __u32 height;
+  __u32 pitch;
+  __u32 bpp;
+  __u32 depth;
+  /* driver specific handle */
+  __u32 handle;
+};
+
+#define DRM_MODE_FB_INTERLACED (1 << 0) /* for interlaced framebuffers */
+#define DRM_MODE_FB_MODIFIERS (1 << 1)  /* enables ->modifier[] */
+
+/**
+ * struct drm_mode_fb_cmd2 - Frame-buffer metadata.
+ *
+ * This struct holds frame-buffer metadata. There are two ways to use it:
+ *
+ * - User-space can fill this struct and perform a &DRM_IOCTL_MODE_ADDFB2
+ *   ioctl to register a new frame-buffer. The new frame-buffer object ID will
+ *   be set by the kernel in @fb_id.
+ * - User-space can set @fb_id and perform a &DRM_IOCTL_MODE_GETFB2 ioctl to
+ *   fetch metadata about an existing frame-buffer.
+ *
+ * In case of planar formats, this struct allows up to 4 buffer objects with
+ * offsets and pitches per plane. The pitch and offset order are dictated by
+ * the format FourCC as defined by ``drm_fourcc.h``, e.g. NV12 is described as:
+ *
+ *     YUV 4:2:0 image with a plane of 8-bit Y samples followed by an
+ *     interleaved U/V plane containing 8-bit 2x2 subsampled colour difference
+ *     samples.
+ *
+ * So it would consist of a Y plane at ``offsets[0]`` and a UV plane at
+ * ``offsets[1]``.
+ *
+ * To accommodate tiled, compressed, etc formats, a modifier can be specified.
+ * For more information see the "Format Modifiers" section. Note that even
+ * though it looks like we have a modifier per-plane, we in fact do not. The
+ * modifier for each plane must be identical. Thus all combinations of
+ * different data layouts for multi-plane formats must be enumerated as
+ * separate modifiers.
+ *
+ * All of the entries in @handles, @pitches, @offsets and @modifier must be
+ * zero when unused. Warning, for @offsets and @modifier zero can't be used to
+ * figure out whether the entry is used or not since it's a valid value (a zero
+ * offset is common, and a zero modifier is &DRM_FORMAT_MOD_LINEAR).
+ */
+struct drm_mode_fb_cmd2 {
+  /** @fb_id: Object ID of the frame-buffer. */
+  __u32 fb_id;
+  /** @width: Width of the frame-buffer. */
+  __u32 width;
+  /** @height: Height of the frame-buffer. */
+  __u32 height;
+  /**
+   * @pixel_format: FourCC format code, see ``DRM_FORMAT_*`` constants in
+   * ``drm_fourcc.h``.
+   */
+  __u32 pixel_format;
+  /**
+   * @flags: Frame-buffer flags (see &DRM_MODE_FB_INTERLACED and
+   * &DRM_MODE_FB_MODIFIERS).
+   */
+  __u32 flags;
+
+  /**
+   * @handles: GEM buffer handle, one per plane. Set to 0 if the plane is
+   * unused. The same handle can be used for multiple planes.
+   */
+  __u32 handles[4];
+  /** @pitches: Pitch (aka. stride) in bytes, one per plane. */
+  __u32 pitches[4];
+  /** @offsets: Offset into the buffer in bytes, one per plane. */
+  __u32 offsets[4];
+  /**
+   * @modifier: Format modifier, one per plane. See ``DRM_FORMAT_MOD_*``
+   * constants in ``drm_fourcc.h``. All planes must use the same
+   * modifier. Ignored unless &DRM_MODE_FB_MODIFIERS is set in @flags.
+   */
+  __u64 modifier[4];
+};
+
+#define DRM_MODE_FB_DIRTY_ANNOTATE_COPY 0x01
+#define DRM_MODE_FB_DIRTY_ANNOTATE_FILL 0x02
+#define DRM_MODE_FB_DIRTY_FLAGS 0x03
+
+#define DRM_MODE_FB_DIRTY_MAX_CLIPS 256
+
+/*
+ * Mark a region of a framebuffer as dirty.
+ *
+ * Some hardware does not automatically update display contents
+ * as a hardware or software draw to a framebuffer. This ioctl
+ * allows userspace to tell the kernel and the hardware what
+ * regions of the framebuffer have changed.
+ *
+ * The kernel or hardware is free to update more then just the
+ * region specified by the clip rects. The kernel or hardware
+ * may also delay and/or coalesce several calls to dirty into a
+ * single update.
+ *
+ * Userspace may annotate the updates, the annotates are a
+ * promise made by the caller that the change is either a copy
+ * of pixels or a fill of a single color in the region specified.
+ *
+ * If the DRM_MODE_FB_DIRTY_ANNOTATE_COPY flag is given then
+ * the number of updated regions are half of num_clips given,
+ * where the clip rects are paired in src and dst. The width and
+ * height of each one of the pairs must match.
+ *
+ * If the DRM_MODE_FB_DIRTY_ANNOTATE_FILL flag is given the caller
+ * promises that the region specified of the clip rects is filled
+ * completely with a single color as given in the color argument.
+ */
+
+struct drm_mode_fb_dirty_cmd {
+  __u32 fb_id;
+  __u32 flags;
+  __u32 color;
+  __u32 num_clips;
+  __u64 clips_ptr;
+};
+
+struct drm_mode_mode_cmd {
+  __u32 connector_id;
+  struct drm_mode_modeinfo mode;
+};
+
+#define DRM_MODE_CURSOR_BO 0x01
+#define DRM_MODE_CURSOR_MOVE 0x02
+#define DRM_MODE_CURSOR_FLAGS 0x03
+
+/*
+ * depending on the value in flags different members are used.
+ *
+ * CURSOR_BO uses
+ *    crtc_id
+ *    width
+ *    height
+ *    handle - if 0 turns the cursor off
+ *
+ * CURSOR_MOVE uses
+ *    crtc_id
+ *    x
+ *    y
+ */
+struct drm_mode_cursor {
+  __u32 flags;
+  __u32 crtc_id;
+  __s32 x;
+  __s32 y;
+  __u32 width;
+  __u32 height;
+  /* driver specific handle */
+  __u32 handle;
+};
+
+struct drm_mode_cursor2 {
+  __u32 flags;
+  __u32 crtc_id;
+  __s32 x;
+  __s32 y;
+  __u32 width;
+  __u32 height;
+  /* driver specific handle */
+  __u32 handle;
+  __s32 hot_x;
+  __s32 hot_y;
+};
+
+struct drm_mode_crtc_lut {
+  __u32 crtc_id;
+  __u32 gamma_size;
+
+  /* pointers to arrays */
+  __u64 red;
+  __u64 green;
+  __u64 blue;
+};
+
+struct drm_color_ctm {
+  /*
+   * Conversion matrix in S31.32 sign-magnitude
+   * (not two's complement!) format.
+   *
+   * out   matrix    in
+   * |R|   |0 1 2|   |R|
+   * |G| = |3 4 5| x |G|
+   * |B|   |6 7 8|   |B|
+   */
+  __u64 matrix[9];
+};
+
+struct drm_color_lut {
+  /*
+   * Values are mapped linearly to 0.0 - 1.0 range, with 0x0 == 0.0 and
+   * 0xffff == 1.0.
+   */
+  __u16 red;
+  __u16 green;
+  __u16 blue;
+  __u16 reserved;
+};
+
+/**
+ * struct drm_plane_size_hint - Plane size hints
+ * @width: The width of the plane in pixel
+ * @height: The height of the plane in pixel
+ *
+ * The plane SIZE_HINTS property blob contains an
+ * array of struct drm_plane_size_hint.
+ */
+struct drm_plane_size_hint {
+  __u16 width;
+  __u16 height;
+};
+
+/**
+ * struct hdr_metadata_infoframe - HDR Metadata Infoframe Data.
+ *
+ * HDR Metadata Infoframe as per CTA 861.G spec. This is expected
+ * to match exactly with the spec.
+ *
+ * Userspace is expected to pass the metadata information as per
+ * the format described in this structure.
+ */
+struct hdr_metadata_infoframe {
+  /**
+   * @eotf: Electro-Optical Transfer Function (EOTF)
+   * used in the stream.
+   */
+  __u8 eotf;
+  /**
+   * @metadata_type: Static_Metadata_Descriptor_ID.
+   */
+  __u8 metadata_type;
+  /**
+   * @display_primaries: Color Primaries of the Data.
+   * These are coded as unsigned 16-bit values in units of
+   * 0.00002, where 0x0000 represents zero and 0xC350
+   * represents 1.0000.
+   * @display_primaries.x: X coordinate of color primary.
+   * @display_primaries.y: Y coordinate of color primary.
+   */
+  struct {
+    __u16 x, y;
+  } display_primaries[3];
+  /**
+   * @white_point: White Point of Colorspace Data.
+   * These are coded as unsigned 16-bit values in units of
+   * 0.00002, where 0x0000 represents zero and 0xC350
+   * represents 1.0000.
+   * @white_point.x: X coordinate of whitepoint of color primary.
+   * @white_point.y: Y coordinate of whitepoint of color primary.
+   */
+  struct {
+    __u16 x, y;
+  } white_point;
+  /**
+   * @max_display_mastering_luminance: Max Mastering Display Luminance.
+   * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+   * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+   */
+  __u16 max_display_mastering_luminance;
+  /**
+   * @min_display_mastering_luminance: Min Mastering Display Luminance.
+   * This value is coded as an unsigned 16-bit value in units of
+   * 0.0001 cd/m2, where 0x0001 represents 0.0001 cd/m2 and 0xFFFF
+   * represents 6.5535 cd/m2.
+   */
+  __u16 min_display_mastering_luminance;
+  /**
+   * @max_cll: Max Content Light Level.
+   * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+   * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+   */
+  __u16 max_cll;
+  /**
+   * @max_fall: Max Frame Average Light Level.
+   * This value is coded as an unsigned 16-bit value in units of 1 cd/m2,
+   * where 0x0001 represents 1 cd/m2 and 0xFFFF represents 65535 cd/m2.
+   */
+  __u16 max_fall;
+};
+
+/**
+ * struct hdr_output_metadata - HDR output metadata
+ *
+ * Metadata Information to be passed from userspace
+ */
+struct hdr_output_metadata {
+  /**
+   * @metadata_type: Static_Metadata_Descriptor_ID.
+   */
+  __u32 metadata_type;
+  /**
+   * @hdmi_metadata_type1: HDR Metadata Infoframe.
+   */
+  union {
+    struct hdr_metadata_infoframe hdmi_metadata_type1;
+  };
+};
+
+/**
+ * DRM_MODE_PAGE_FLIP_EVENT
+ *
+ * Request that the kernel sends back a vblank event (see
+ * struct drm_event_vblank) with the &DRM_EVENT_FLIP_COMPLETE type when the
+ * page-flip is done.
+ */
+#define DRM_MODE_PAGE_FLIP_EVENT 0x01
+/**
+ * DRM_MODE_PAGE_FLIP_ASYNC
+ *
+ * Request that the page-flip is performed as soon as possible, ie. with no
+ * delay due to waiting for vblank. This may cause tearing to be visible on
+ * the screen.
+ *
+ * When used with atomic uAPI, the driver will return an error if the hardware
+ * doesn't support performing an asynchronous page-flip for this update.
+ * User-space should handle this, e.g. by falling back to a regular page-flip.
+ *
+ * Note, some hardware might need to perform one last synchronous page-flip
+ * before being able to switch to asynchronous page-flips. As an exception,
+ * the driver will return success even though that first page-flip is not
+ * asynchronous.
+ */
+#define DRM_MODE_PAGE_FLIP_ASYNC 0x02
+#define DRM_MODE_PAGE_FLIP_TARGET_ABSOLUTE 0x4
+#define DRM_MODE_PAGE_FLIP_TARGET_RELATIVE 0x8
+#define DRM_MODE_PAGE_FLIP_TARGET                                                                  \
+  (DRM_MODE_PAGE_FLIP_TARGET_ABSOLUTE | DRM_MODE_PAGE_FLIP_TARGET_RELATIVE)
+/**
+ * DRM_MODE_PAGE_FLIP_FLAGS
+ *
+ * Bitmask of flags suitable for &drm_mode_crtc_page_flip_target.flags.
+ */
+#define DRM_MODE_PAGE_FLIP_FLAGS                                                                   \
+  (DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_PAGE_FLIP_ASYNC | DRM_MODE_PAGE_FLIP_TARGET)
+
+/*
+ * Request a page flip on the specified crtc.
+ *
+ * This ioctl will ask KMS to schedule a page flip for the specified
+ * crtc.  Once any pending rendering targeting the specified fb (as of
+ * ioctl time) has completed, the crtc will be reprogrammed to display
+ * that fb after the next vertical refresh.  The ioctl returns
+ * immediately, but subsequent rendering to the current fb will block
+ * in the execbuffer ioctl until the page flip happens.  If a page
+ * flip is already pending as the ioctl is called, EBUSY will be
+ * returned.
+ *
+ * Flag DRM_MODE_PAGE_FLIP_EVENT requests that drm sends back a vblank
+ * event (see drm.h: struct drm_event_vblank) when the page flip is
+ * done.  The user_data field passed in with this ioctl will be
+ * returned as the user_data field in the vblank event struct.
+ *
+ * Flag DRM_MODE_PAGE_FLIP_ASYNC requests that the flip happen
+ * 'as soon as possible', meaning that it not delay waiting for vblank.
+ * This may cause tearing on the screen.
+ *
+ * The reserved field must be zero.
+ */
+
+struct drm_mode_crtc_page_flip {
+  __u32 crtc_id;
+  __u32 fb_id;
+  __u32 flags;
+  __u32 reserved;
+  __u64 user_data;
+};
+
+/*
+ * Request a page flip on the specified crtc.
+ *
+ * Same as struct drm_mode_crtc_page_flip, but supports new flags and
+ * re-purposes the reserved field:
+ *
+ * The sequence field must be zero unless either of the
+ * DRM_MODE_PAGE_FLIP_TARGET_ABSOLUTE/RELATIVE flags is specified. When
+ * the ABSOLUTE flag is specified, the sequence field denotes the absolute
+ * vblank sequence when the flip should take effect. When the RELATIVE
+ * flag is specified, the sequence field denotes the relative (to the
+ * current one when the ioctl is called) vblank sequence when the flip
+ * should take effect. NOTE: DRM_IOCTL_WAIT_VBLANK must still be used to
+ * make sure the vblank sequence before the target one has passed before
+ * calling this ioctl. The purpose of the
+ * DRM_MODE_PAGE_FLIP_TARGET_ABSOLUTE/RELATIVE flags is merely to clarify
+ * the target for when code dealing with a page flip runs during a
+ * vertical blank period.
+ */
+
+struct drm_mode_crtc_page_flip_target {
+  __u32 crtc_id;
+  __u32 fb_id;
+  __u32 flags;
+  __u32 sequence;
+  __u64 user_data;
+};
+
+/**
+ * struct drm_mode_create_dumb - Create a KMS dumb buffer for scanout.
+ * @height: buffer height in pixels
+ * @width: buffer width in pixels
+ * @bpp: bits per pixel
+ * @flags: must be zero
+ * @handle: buffer object handle
+ * @pitch: number of bytes between two consecutive lines
+ * @size: size of the whole buffer in bytes
+ *
+ * User-space fills @height, @width, @bpp and @flags. If the IOCTL succeeds,
+ * the kernel fills @handle, @pitch and @size.
+ */
+struct drm_mode_create_dumb {
+  __u32 height;
+  __u32 width;
+  __u32 bpp;
+  __u32 flags;
+
+  __u32 handle;
+  __u32 pitch;
+  __u64 size;
+};
+
+/* set up for mmap of a dumb scanout buffer */
+struct drm_mode_map_dumb {
+  /** Handle for the object being mapped. */
+  __u32 handle;
+  __u32 pad;
+  /**
+   * Fake offset to use for subsequent mmap call
+   *
+   * This is a fixed-size type for 32/64 compatibility.
+   */
+  __u64 offset;
+};
+
+struct drm_mode_destroy_dumb {
+  __u32 handle;
+};
+
+/**
+ * DRM_MODE_ATOMIC_TEST_ONLY
+ *
+ * Do not apply the atomic commit, instead check whether the hardware supports
+ * this configuration.
+ *
+ * See &drm_mode_config_funcs.atomic_check for more details on test-only
+ * commits.
+ */
+#define DRM_MODE_ATOMIC_TEST_ONLY 0x0100
+/**
+ * DRM_MODE_ATOMIC_NONBLOCK
+ *
+ * Do not block while applying the atomic commit. The &DRM_IOCTL_MODE_ATOMIC
+ * IOCTL returns immediately instead of waiting for the changes to be applied
+ * in hardware. Note, the driver will still check that the update can be
+ * applied before retuning.
+ */
+#define DRM_MODE_ATOMIC_NONBLOCK 0x0200
+/**
+ * DRM_MODE_ATOMIC_ALLOW_MODESET
+ *
+ * Allow the update to result in temporary or transient visible artifacts while
+ * the update is being applied. Applying the update may also take significantly
+ * more time than a page flip. All visual artifacts will disappear by the time
+ * the update is completed, as signalled through the vblank event's timestamp
+ * (see struct drm_event_vblank).
+ *
+ * This flag must be set when the KMS update might cause visible artifacts.
+ * Without this flag such KMS update will return a EINVAL error. What kind of
+ * update may cause visible artifacts depends on the driver and the hardware.
+ * User-space that needs to know beforehand if an update might cause visible
+ * artifacts can use &DRM_MODE_ATOMIC_TEST_ONLY without
+ * &DRM_MODE_ATOMIC_ALLOW_MODESET to see if it fails.
+ *
+ * To the best of the driver's knowledge, visual artifacts are guaranteed to
+ * not appear when this flag is not set. Some sinks might display visual
+ * artifacts outside of the driver's control.
+ */
+#define DRM_MODE_ATOMIC_ALLOW_MODESET 0x0400
+
+/**
+ * DRM_MODE_ATOMIC_FLAGS
+ *
+ * Bitfield of flags accepted by the &DRM_IOCTL_MODE_ATOMIC IOCTL in
+ * &drm_mode_atomic.flags.
+ */
+#define DRM_MODE_ATOMIC_FLAGS                                                                      \
+  (DRM_MODE_PAGE_FLIP_EVENT | DRM_MODE_PAGE_FLIP_ASYNC | DRM_MODE_ATOMIC_TEST_ONLY |               \
+   DRM_MODE_ATOMIC_NONBLOCK | DRM_MODE_ATOMIC_ALLOW_MODESET)
+
+struct drm_mode_atomic {
+  __u32 flags;
+  __u32 count_objs;
+  __u64 objs_ptr;
+  __u64 count_props_ptr;
+  __u64 props_ptr;
+  __u64 prop_values_ptr;
+  __u64 reserved;
+  __u64 user_data;
+};
+
+struct drm_format_modifier_blob {
+#define FORMAT_BLOB_CURRENT 1
+  /* Version of this blob format */
+  __u32 version;
+
+  /* Flags */
+  __u32 flags;
+
+  /* Number of fourcc formats supported */
+  __u32 count_formats;
+
+  /* Where in this blob the formats exist (in bytes) */
+  __u32 formats_offset;
+
+  /* Number of drm_format_modifiers */
+  __u32 count_modifiers;
+
+  /* Where in this blob the modifiers exist (in bytes) */
+  __u32 modifiers_offset;
+
+  /* __u32 formats[] */
+  /* struct drm_format_modifier modifiers[] */
+};
+
+struct drm_format_modifier {
+  /* Bitmask of formats in get_plane format list this info applies to. The
+   * offset allows a sliding window of which 64 formats (bits).
+   *
+   * Some examples:
+   * In today's world with < 65 formats, and formats 0, and 2 are
+   * supported
+   * 0x0000000000000005
+   *		  ^-offset = 0, formats = 5
+   *
+   * If the number formats grew to 128, and formats 98-102 are
+   * supported with the modifier:
+   *
+   * 0x0000007c00000000 0000000000000000
+   *		  ^
+   *		  |__offset = 64, formats = 0x7c00000000
+   *
+   */
+  __u64 formats;
+  __u32 offset;
+  __u32 pad;
+
+  /* The modifier that applies to the >get_plane format list bitmask. */
+  __u64 modifier;
+};
+
+/**
+ * struct drm_mode_create_blob - Create New blob property
+ *
+ * Create a new 'blob' data property, copying length bytes from data pointer,
+ * and returning new blob ID.
+ */
+struct drm_mode_create_blob {
+  /** @data: Pointer to data to copy. */
+  __u64 data;
+  /** @length: Length of data to copy. */
+  __u32 length;
+  /** @blob_id: Return: new property ID. */
+  __u32 blob_id;
+};
+
+/**
+ * struct drm_mode_destroy_blob - Destroy user blob
+ * @blob_id: blob_id to destroy
+ *
+ * Destroy a user-created blob property.
+ *
+ * User-space can release blobs as soon as they do not need to refer to them by
+ * their blob object ID.  For instance, if you are using a MODE_ID blob in an
+ * atomic commit and you will not make another commit re-using the same ID, you
+ * can destroy the blob as soon as the commit has been issued, without waiting
+ * for it to complete.
+ */
+struct drm_mode_destroy_blob {
+  __u32 blob_id;
+};
+
+/**
+ * struct drm_mode_create_lease - Create lease
+ *
+ * Lease mode resources, creating another drm_master.
+ *
+ * The @object_ids array must reference at least one CRTC, one connector and
+ * one plane if &DRM_CLIENT_CAP_UNIVERSAL_PLANES is enabled. Alternatively,
+ * the lease can be completely empty.
+ */
+struct drm_mode_create_lease {
+  /** @object_ids: Pointer to array of object ids (__u32) */
+  __u64 object_ids;
+  /** @object_count: Number of object ids */
+  __u32 object_count;
+  /** @flags: flags for new FD (O_CLOEXEC, etc) */
+  __u32 flags;
+
+  /** @lessee_id: Return: unique identifier for lessee. */
+  __u32 lessee_id;
+  /** @fd: Return: file descriptor to new drm_master file */
+  __u32 fd;
+};
+
+/**
+ * struct drm_mode_list_lessees - List lessees
+ *
+ * List lesses from a drm_master.
+ */
+struct drm_mode_list_lessees {
+  /**
+   * @count_lessees: Number of lessees.
+   *
+   * On input, provides length of the array.
+   * On output, provides total number. No
+   * more than the input number will be written
+   * back, so two calls can be used to get
+   * the size and then the data.
+   */
+  __u32 count_lessees;
+  /** @pad: Padding. */
+  __u32 pad;
+
+  /**
+   * @lessees_ptr: Pointer to lessees.
+   *
+   * Pointer to __u64 array of lessee ids
+   */
+  __u64 lessees_ptr;
+};
+
+/**
+ * struct drm_mode_get_lease - Get Lease
+ *
+ * Get leased objects.
+ */
+struct drm_mode_get_lease {
+  /**
+   * @count_objects: Number of leased objects.
+   *
+   * On input, provides length of the array.
+   * On output, provides total number. No
+   * more than the input number will be written
+   * back, so two calls can be used to get
+   * the size and then the data.
+   */
+  __u32 count_objects;
+  /** @pad: Padding. */
+  __u32 pad;
+
+  /**
+   * @objects_ptr: Pointer to objects.
+   *
+   * Pointer to __u32 array of object ids.
+   */
+  __u64 objects_ptr;
+};
+
+/**
+ * struct drm_mode_revoke_lease - Revoke lease
+ */
+struct drm_mode_revoke_lease {
+  /** @lessee_id: Unique ID of lessee */
+  __u32 lessee_id;
+};
+
+/**
+ * struct drm_mode_rect - Two dimensional rectangle.
+ * @x1: Horizontal starting coordinate (inclusive).
+ * @y1: Vertical starting coordinate (inclusive).
+ * @x2: Horizontal ending coordinate (exclusive).
+ * @y2: Vertical ending coordinate (exclusive).
+ *
+ * With drm subsystem using struct drm_rect to manage rectangular area this
+ * export it to user-space.
+ *
+ * Currently used by drm_mode_atomic blob property FB_DAMAGE_CLIPS.
+ */
+struct drm_mode_rect {
+  __s32 x1;
+  __s32 y1;
+  __s32 x2;
+  __s32 y2;
+};
+
+/**
+ * struct drm_mode_closefb
+ * @fb_id: Framebuffer ID.
+ * @pad: Must be zero.
+ */
+struct drm_mode_closefb {
+  __u32 fb_id;
+  __u32 pad;
+};
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
@@ -12,6 +12,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -223,10 +224,14 @@ RJ_API_EXPORT rj_status_t rj_vm_execute(rj_vm_t *vm, rj_vm_cmd_t *cmd);
 /// @param[in,out] cmd Command descriptor.
 RJ_API_EXPORT rj_status_t rj_vm_execute_as(rj_vm_t *vm, uint32_t process_id, rj_vm_cmd_t *cmd);
 
-/// @brief Open the VM's simulated device and create a new KFD process.
+/// @brief Open the VM's simulated device and create (or reuse) a KFD process.
 /// @param[in] vm VM handle.
-/// @param[out] process_id The new process ID (may be NULL for legacy callers).
-RJ_API_EXPORT rj_status_t rj_vm_device_open(rj_vm_t *vm, uint32_t *process_id);
+/// @param[in] client_pid Connecting client's OS PID for daemon mode (enables
+///   cross-process memory access and process reuse); pass 0 in local mode where
+///   there is no separate client process. If a process already exists for a
+///   nonzero client_pid, it is reused.
+/// @param[out] process_id The simulator's process handle (may be NULL).
+RJ_API_EXPORT rj_status_t rj_vm_device_open(rj_vm_t *vm, pid_t client_pid, uint32_t *process_id);
 
 /// @brief Close a specific KFD process by ID.
 /// @param[in] vm VM handle.

--- a/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
+++ b/emulation/rocjitsu/lib/rocjitsu/include/rocjitsu/vm/rj_vm.h
@@ -12,7 +12,6 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,6 +29,11 @@ typedef struct rj_vm_t rj_vm_t;
 
 /// @brief Platform-specific handle type (fd on Linux, HANDLE on Windows).
 typedef int rj_handle_t;
+
+/// @brief Connecting client's process ID, in fixed-width form.
+/// @details Kept ABI-stable and OS agnostic so we don't depend on the
+/// platform width of a process ID.
+typedef int32_t rj_client_pid_t;
 
 /// @brief VM creation mode.
 typedef enum rj_vm_mode_t {
@@ -231,7 +235,8 @@ RJ_API_EXPORT rj_status_t rj_vm_execute_as(rj_vm_t *vm, uint32_t process_id, rj_
 ///   there is no separate client process. If a process already exists for a
 ///   nonzero client_pid, it is reused.
 /// @param[out] process_id The simulator's process handle (may be NULL).
-RJ_API_EXPORT rj_status_t rj_vm_device_open(rj_vm_t *vm, pid_t client_pid, uint32_t *process_id);
+RJ_API_EXPORT rj_status_t rj_vm_device_open(rj_vm_t *vm, rj_client_pid_t client_pid,
+                                            uint32_t *process_id);
 
 /// @brief Close a specific KFD process by ID.
 /// @param[in] vm VM handle.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -87,7 +87,7 @@ uint32_t config_u32(const std::unordered_map<std::string, std::string> &cfg, con
 uint32_t default_sgprs_per_wf(rj_code_arch_t arch) {
   if (arch == ROCJITSU_CODE_ARCH_RDNA4 || arch == ROCJITSU_CODE_ARCH_GFX1250)
     return 128;
-  return 104;
+  return 112;
 }
 
 uint32_t default_vgprs_per_wf(rj_code_arch_t arch) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/CMakeLists.txt
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(
         ${ROCJITSU_INCLUDE_DIR}
         ${ROCJITSU_SRC_DIR}
         ${HSA_INCLUDE_DIR}
+        ${DRM_INCLUDE_DIR}
         ${GENERATED_DIR}
 )
 target_link_libraries(

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -20,6 +20,18 @@
 #include "rocjitsu/vm/rj_vm.h"
 #include "rocjitsu/vm/rj_vm_impl.h"
 
+RJ_DIAGNOSTIC_PUSH
+RJ_DIAGNOSTIC_IGNORE_PEDANTIC
+#include "linux/uapi/kfd_ioctl.h"
+// Vendored kernel DRM/amdgpu UAPI (MIT). Provides the real drm_version,
+// drm_amdgpu_info, drm_amdgpu_info_device, drm_amdgpu_info_vram_gtt, and
+// drm_amdgpu_memory_info structs so the interposer services the amdgpu DRM
+// ioctl ABI directly. These are kernel ABI, not libdrm library types, so this
+// keeps the interposer independent of libdrm.
+#include "amdgpu_drm.h"
+#include "drm.h"
+RJ_DIAGNOSTIC_POP
+
 #include "util/dynamic_loader.h"
 #include "util/log.h"
 
@@ -168,11 +180,13 @@ public:
   void reset_after_fork() {
     rj_vm_ = nullptr;
     remote_ = nullptr;
-    remote_kfd_fd_ = -1;
+    remote_kfd_fd_.store(-1, std::memory_order_relaxed);
     new (&init_mutex_) std::mutex();
     new (&fd_mutex_) std::mutex();
+    new (&remote_mutex_) std::mutex();
     sysfs_fds_.clear();
     drm_fds_.clear();
+    handle_to_drm_fd_.clear();
     kfd_dup_fds_.clear();
     in_construction = false;
   }
@@ -184,40 +198,30 @@ public:
   }
   bool initialized() const { return rj_vm_ != nullptr || remote_ != nullptr; }
 
-  /// @brief Get the remote driver instance, or nullptr if not connected.
+  std::unique_lock<std::mutex> lock_remote() { return std::unique_lock(remote_mutex_); }
+
   RemoteDriver *remote() { return remote_; }
 
-  /// @brief Get the synthetic KFD fd for the remote driver.
-  /// @retval >=0 Valid fd when connected to a daemon.
-  /// @retval -1 Not connected.
-  int remote_kfd_fd() const { return remote_kfd_fd_; }
+  int remote_kfd_fd() const { return remote_kfd_fd_.load(std::memory_order_acquire); }
 
-  /// @brief Look up the remote driver by its KFD fd.
-  /// @retval non-null If fd matches the remote KFD fd.
-  /// @retval nullptr If fd doesn't match or no remote driver exists.
   RemoteDriver *remote_lookup(int fd) {
-    return (fd >= 0 && fd == remote_kfd_fd_ && remote_) ? remote_ : nullptr;
+    return (fd >= 0 && fd == remote_kfd_fd_.load(std::memory_order_acquire) && remote_) ? remote_
+                                                                                        : nullptr;
   }
 
-  /// @brief Get the daemon's sysfs topology directory path.
-  /// @returns The topology path string, or empty if not connected.
   std::string remote_topology_path() {
+    std::lock_guard lock(remote_mutex_);
     return remote_ ? std::string(remote_->topology_path()) : std::string{};
   }
 
-  /// @brief Get the daemon's DRM sysfs directory path.
-  /// @returns The DRM path string, or empty if not connected.
   std::string remote_drm_path() {
+    std::lock_guard lock(remote_mutex_);
     return remote_ ? std::string(remote_->drm_path()) : std::string{};
   }
 
-  /// @brief Connect to the daemon and perform the RPC handshake.
-  /// @details Tries to connect to the daemon socket. If successful, creates
-  /// a RemoteDriver, performs the handshake, and caches the instance.
-  /// @retval non-null Connected remote driver.
-  /// @retval nullptr No daemon running or handshake failed.
   RemoteDriver *get_or_create_remote() {
-    if (remote_ && remote_kfd_fd_ >= 0)
+    std::lock_guard lock(remote_mutex_);
+    if (remote_ && remote_kfd_fd_.load(std::memory_order_acquire) >= 0)
       return remote_;
     int sock = connect_to_daemon();
     if (sock < 0)
@@ -227,7 +231,7 @@ public:
     int fd = remote_->open();
     if (fd < 0)
       return nullptr;
-    remote_kfd_fd_ = fd;
+    remote_kfd_fd_.store(fd, std::memory_order_release);
     return remote_;
   }
 
@@ -246,7 +250,9 @@ public:
     return d ? d->redirect_sysfs_path(path) : std::string{};
   }
 
-  bool is_kfd_primary(int fd) { return fd == driver_fd() || fd == remote_kfd_fd_; }
+  bool is_kfd_primary(int fd) {
+    return fd == driver_fd() || fd == remote_kfd_fd_.load(std::memory_order_acquire);
+  }
 
   bool is_kfd_dup(int fd) {
     std::lock_guard lock(fd_mutex_);
@@ -272,6 +278,49 @@ public:
   void clear_dups() {
     std::lock_guard lock(fd_mutex_);
     kfd_dup_fds_.clear();
+  }
+
+  int close_remote() {
+    std::lock_guard lock(remote_mutex_);
+    if (!remote_)
+      return 0;
+    int rc = remote_->close();
+    delete remote_;
+    remote_ = nullptr;
+    int fd = remote_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
+    if (fd >= 0) {
+      int close_rc = static_cast<int>(InterposerContext::real.close(fd));
+      if (rc == 0)
+        rc = close_rc;
+    }
+    clear_dups();
+    return rc;
+  }
+
+  void try_close_remote() {
+    std::unique_lock lock(remote_mutex_, std::try_to_lock);
+    if (!lock.owns_lock() || !remote_)
+      return;
+    remote_->close();
+    delete remote_;
+    remote_ = nullptr;
+    int fd = remote_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
+    if (fd >= 0)
+      InterposerContext::real.close(fd);
+    clear_dups();
+  }
+
+  int close_remote_fd_only() {
+    // Closes only the primary remote KFD fd. Dup-tracked fds may still be open
+    // in the process, so dup tracking is left intact here and cleared only when
+    // the remote connection is actually torn down (close_remote/
+    // try_close_remote). Wiping it here would drop tracking for live fds and
+    // misroute their subsequent ioctl/close calls.
+    int fd = remote_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
+    int rc = 0;
+    if (fd >= 0)
+      rc = static_cast<int>(InterposerContext::real.close(fd));
+    return rc;
   }
 
   void track_sysfs(int fd, const std::string &path) {
@@ -320,6 +369,16 @@ public:
   void track_drm_handle(void *handle, int fd) {
     std::lock_guard lock(fd_mutex_);
     handle_to_drm_fd_[handle] = fd;
+  }
+
+  int untrack_drm_handle(void *handle) {
+    std::lock_guard lock(fd_mutex_);
+    auto it = handle_to_drm_fd_.find(handle);
+    if (it == handle_to_drm_fd_.end())
+      return -1;
+    int fd = it->second;
+    handle_to_drm_fd_.erase(it);
+    return fd;
   }
 
   SimulatedDriver *get_or_create() {
@@ -408,10 +467,11 @@ public:
 private:
   rj_vm_t *rj_vm_ = nullptr;
   RemoteDriver *remote_ = nullptr;
-  int remote_kfd_fd_ = -1;
+  std::atomic<int> remote_kfd_fd_{-1};
 
   std::mutex init_mutex_;
   std::mutex fd_mutex_;
+  std::mutex remote_mutex_;
   std::unordered_map<int, std::string> sysfs_fds_;
   std::unordered_map<int, uint32_t> drm_fds_;
   std::unordered_map<void *, int> handle_to_drm_fd_;
@@ -427,169 +487,7 @@ alignas(16) uint8_t InterposerContext::storage_[sizeof(InterposerContext)];
 InterposerContext &InterposerContext::ctx =
     *reinterpret_cast<InterposerContext *>(InterposerContext::storage_);
 
-static void *(*real_dlsym_fn)(void *, const char *) = nullptr;
-
-__attribute__((constructor(101))) static void resolve_real_dlsym() {
-  real_dlsym_fn =
-      reinterpret_cast<decltype(real_dlsym_fn)>(dlvsym(RTLD_NEXT, "dlsym", "GLIBC_2.34"));
-  if (!real_dlsym_fn)
-    real_dlsym_fn =
-        reinterpret_cast<decltype(real_dlsym_fn)>(dlvsym(RTLD_NEXT, "dlsym", "GLIBC_2.2.5"));
-  if (!real_dlsym_fn) {
-    fprintf(stderr, "rocjitsu: failed to resolve real dlsym\n");
-    abort();
-  }
-}
-
 __attribute__((constructor)) static void init_interposer() { InterposerContext::init(); }
-
-constexpr int DRM_NODE_PRIMARY = 0;
-constexpr int DRM_NODE_RENDER = 2;
-constexpr int DRM_BUS_PCI = 0;
-constexpr unsigned kDrmCommandBase = 0x40;
-constexpr unsigned kDrmAmdgpuInfo = 0x05;
-constexpr unsigned kAmdgpuInfoDevInfo = 0x16;
-
-// Local ABI mirrors for the libdrm calls we interpose. The source of truth is
-// the Linux UAPI DRM headers for drm_version, drm_amdgpu_info, and
-// drm_amdgpu_info_device, plus libdrm's amdgpu.h for amdgpu_device_handle and
-// amdgpu_gpu_info. Keep this target independent of libdrm headers; the layout
-// test covers the drm_amdgpu_info_device prefix where that dependency already
-// existed.
-struct RjAmdgpuDevice;
-using RjAmdgpuDeviceHandle = RjAmdgpuDevice *;
-
-struct RjDrmVersion {
-  int version_major;
-  int version_minor;
-  int version_patchlevel;
-  size_t name_len;
-  char *name;
-  size_t date_len;
-  char *date;
-  size_t desc_len;
-  char *desc;
-};
-
-struct RjDrmAmdgpuInfo {
-  uint64_t return_pointer;
-  uint32_t return_size;
-  uint32_t query;
-  uint64_t pad;
-};
-
-struct RjAmdgpuGpuInfo {
-  uint32_t asic_id;
-  uint32_t chip_rev;
-  uint32_t chip_external_rev;
-  uint32_t family_id;
-  uint64_t ids_flags;
-  uint64_t max_engine_clk;
-  uint64_t max_memory_clk;
-  uint32_t num_shader_engines;
-  uint32_t num_shader_arrays_per_engine;
-  uint32_t avail_quad_shader_pipes;
-  uint32_t max_quad_shader_pipes;
-  uint32_t cache_entries_per_quad_pipe;
-  uint32_t num_hw_gfx_contexts;
-  uint32_t rb_pipes;
-  uint32_t enabled_rb_pipes_mask;
-  uint32_t gpu_counter_freq;
-  uint32_t backend_disable[4];
-  uint32_t mc_arb_ramcfg;
-  uint32_t gb_addr_cfg;
-  uint32_t gb_tile_mode[32];
-  uint32_t gb_macro_tile_mode[16];
-  uint32_t pa_sc_raster_cfg[4];
-  uint32_t pa_sc_raster_cfg1[4];
-  uint32_t cu_active_number;
-  uint32_t cu_ao_mask;
-  uint32_t cu_bitmap[4][4];
-  uint32_t vram_type;
-  uint32_t vram_bit_width;
-  uint32_t ce_ram_size;
-  uint32_t vce_harvest_config;
-  uint32_t pci_rev_id;
-};
-
-struct RjDrmAmdgpuInfoDevice {
-  uint32_t device_id;
-  uint32_t chip_rev;
-  uint32_t external_rev;
-  uint32_t pci_rev;
-  uint32_t family;
-  uint32_t num_shader_engines;
-  uint32_t num_shader_arrays_per_engine;
-  uint32_t gpu_counter_freq;
-  uint64_t max_engine_clock;
-  uint64_t max_memory_clock;
-  uint32_t cu_active_number;
-  uint32_t cu_ao_mask;
-  uint32_t cu_bitmap[4][4];
-  uint32_t enabled_rb_pipes_mask;
-  uint32_t num_rb_pipes;
-  uint32_t num_hw_gfx_contexts;
-  uint32_t pcie_gen;
-  uint64_t ids_flags;
-  uint64_t virtual_address_offset;
-  uint64_t virtual_address_max;
-  uint32_t virtual_address_alignment;
-  uint32_t pte_fragment_size;
-  uint32_t gart_page_size;
-  uint32_t ce_ram_size;
-  uint32_t vram_type;
-  uint32_t vram_bit_width;
-  uint32_t vce_harvest_config;
-  uint32_t gc_double_offchip_lds_buf;
-  uint64_t prim_buf_gpu_addr;
-  uint64_t pos_buf_gpu_addr;
-  uint64_t cntl_sb_buf_gpu_addr;
-  uint64_t param_buf_gpu_addr;
-  uint32_t prim_buf_size;
-  uint32_t pos_buf_size;
-  uint32_t cntl_sb_buf_size;
-  uint32_t param_buf_size;
-  uint32_t wave_front_size;
-  uint32_t num_shader_visible_vgprs;
-  uint32_t num_cu_per_sh;
-  uint32_t num_tcc_blocks;
-  uint32_t gs_vgt_table_depth;
-  uint32_t gs_prim_buffer_depth;
-  uint32_t max_gs_waves_per_vgt;
-  uint32_t pcie_num_lanes;
-  uint32_t cu_ao_bitmap[4][4];
-  uint64_t high_va_offset;
-  uint64_t high_va_max;
-  uint32_t pa_sc_tile_steering_override;
-  uint64_t tcc_disabled_mask;
-};
-
-struct drmPciBusInfo {
-  uint16_t domain;
-  uint8_t bus;
-  uint8_t dev;
-  uint8_t func;
-};
-
-struct drmPciDeviceInfo {
-  uint16_t vendor_id;
-  uint16_t device_id;
-  uint16_t subvendor_id;
-  uint16_t subdevice_id;
-  uint8_t revision_id;
-};
-
-struct drmDevice {
-  char **nodes;
-  int available_nodes;
-  int bustype;
-  union {
-    drmPciBusInfo *pci;
-  } businfo;
-  union {
-    drmPciDeviceInfo *pci;
-  } deviceinfo;
-};
 
 } // namespace
 
@@ -811,8 +709,8 @@ int openat64(int dirfd, const char *path, int flags, ...) {
 
 int close(int fd) {
   assert(InterposerContext::real.ready());
-  if (auto *remote = InterposerContext::ctx.remote_lookup(fd))
-    return remote->close();
+  if (InterposerContext::ctx.remote_lookup(fd))
+    return InterposerContext::ctx.close_remote_fd_only();
   InterposerContext::ctx.untrack_sysfs(fd);
   if (InterposerContext::ctx.untrack_drm(fd)) {
     InterposerContext::real.close(fd);
@@ -832,6 +730,8 @@ int close(int fd) {
   return static_cast<int>(InterposerContext::real.close(fd));
 }
 
+__attribute__((destructor(101))) void rj_interposer_shutdown() {}
+
 int ioctl(int fd, unsigned long request, ...) {
   assert(InterposerContext::real.ready());
   va_list ap;
@@ -841,13 +741,14 @@ int ioctl(int fd, unsigned long request, ...) {
 
   constexpr unsigned kDrmIoctlType = 'd';
   constexpr unsigned kDrmIoctlNrVersion = 0x00;
-  constexpr unsigned kDrmIoctlNrAmdgpuInfo = kDrmCommandBase + kDrmAmdgpuInfo;
+  constexpr unsigned kDrmIoctlNrAmdgpuInfo = DRM_COMMAND_BASE + DRM_AMDGPU_INFO;
+  constexpr unsigned kDrmIoctlNrPrimeFdToHandle = 0x2e;
 
   if (InterposerContext::ctx.is_drm(fd)) {
     unsigned nr = _IOC_NR(request);
     unsigned type = _IOC_TYPE(request);
     if (type == kDrmIoctlType && nr == kDrmIoctlNrVersion && arg) {
-      auto *ver = static_cast<RjDrmVersion *>(arg);
+      auto *ver = static_cast<drm_version *>(arg);
       ver->version_major = 3;
       ver->version_minor = 57;
       ver->version_patchlevel = 0;
@@ -863,45 +764,111 @@ int ioctl(int fd, unsigned long request, ...) {
       ver->desc_len = 1;
       return 0;
     }
+    if (type == kDrmIoctlType && nr == kDrmIoctlNrPrimeFdToHandle && arg) {
+      struct drm_prime_handle {
+        uint32_t handle;
+        uint32_t flags;
+        int32_t fd;
+      };
+      auto *prime = static_cast<drm_prime_handle *>(arg);
+      if (prime->fd < 0) {
+        errno = EINVAL;
+        return -1;
+      }
+      prime->handle = static_cast<uint32_t>(prime->fd) + 1u;
+      return 0;
+    }
     if (type == kDrmIoctlType && nr == kDrmIoctlNrAmdgpuInfo && arg) {
-      auto *info = static_cast<RjDrmAmdgpuInfo *>(arg);
-      if (info->query == kAmdgpuInfoDevInfo && !interposer_gpu_info()) {
+      // Service the AMDGPU_INFO queries that real libdrm_amdgpu issues during
+      // amdgpu_device_initialize / amdgpu_query_gpu_info_init. Answering these
+      // at the ioctl layer lets real libdrm run unmodified (no library shim).
+      // The init cascade (amdgpu_gpu_info.c) requires, in order:
+      //   ACCEL_WORKING (must be nonzero or init aborts), DEV_INFO,
+      //   READ_MMR_REG (gb_addr_cfg is mandatory for all families),
+      //   VRAM_GTT, MEMORY. Failures (-1) abort device init.
+      auto *info = static_cast<drm_amdgpu_info *>(arg);
+      auto *gpu = interposer_gpu_info();
+      if (!gpu) {
         errno = ENODEV;
         return -1;
       }
-      if (info->return_pointer && info->return_size > 0) {
-        auto *out = reinterpret_cast<void *>(info->return_pointer);
-        std::memset(out, 0, info->return_size);
-        if (info->query == kAmdgpuInfoDevInfo) {
-          if (info->return_size >= sizeof(RjDrmAmdgpuInfoDevice)) {
-            auto *dev = static_cast<RjDrmAmdgpuInfoDevice *>(out);
-            auto *gpu = interposer_gpu_info();
-            if (gpu) {
-              dev->device_id = gpu->device_id;
-              dev->chip_rev = gpu->revision_id;
-              dev->external_rev = rocjitsu::kmd::external_rev_id_for_gfx_target_version(
-                  gpu->gfx_target_version, gpu->revision_id);
-              dev->pci_rev = gpu->pci_revision_id;
-              dev->family = gpu->family_id;
-              dev->num_shader_engines = rocjitsu::kmd::drm_shader_engine_count(
-                  gpu->num_shader_engines, gpu->num_shader_arrays_per_engine);
-              dev->num_shader_arrays_per_engine = gpu->num_shader_arrays_per_engine;
-              dev->gpu_counter_freq = 100000;
-              dev->max_engine_clock = gpu->max_engine_clk_fcompute;
-              dev->max_memory_clock = gpu->mem_clk_max;
-              dev->wave_front_size = gpu->wave_front_size;
-              dev->num_cu_per_sh = gpu->num_cu_per_sh;
-              dev->num_hw_gfx_contexts = rocjitsu::kmd::num_hw_gfx_contexts_for_gfx_target_version(
-                  gpu->gfx_target_version);
-              dev->vram_type = gpu->vram_type;
-              dev->vram_bit_width = gpu->mem_width;
-              dev->cu_active_number =
-                  rocjitsu::kmd::drm_cu_active_number(gpu->num_shader_engines, gpu->num_cu_per_sh);
-            }
-          }
-        }
+      auto *out = info->return_pointer ? reinterpret_cast<void *>(info->return_pointer) : nullptr;
+      if (!out || info->return_size == 0)
+        return 0;
+      std::memset(out, 0, info->return_size);
+
+      switch (info->query) {
+      case AMDGPU_INFO_ACCEL_WORKING: {
+        if (info->return_size >= sizeof(uint32_t))
+          *static_cast<uint32_t *>(out) = 1u;
+        return 0;
       }
-      return 0;
+      case AMDGPU_INFO_READ_MMR_REG: {
+        // rocjitsu does not model raster/tiling MMRs. libdrm only stores the
+        // returned words (never validates them), so zero-fill `count` u32s is
+        // sufficient for both the AI short path and the pre-AI cascade.
+        return 0; // buffer already zeroed
+      }
+      case AMDGPU_INFO_VRAM_GTT: {
+        if (info->return_size >= sizeof(drm_amdgpu_info_vram_gtt)) {
+          auto *vg = static_cast<drm_amdgpu_info_vram_gtt *>(out);
+          vg->vram_size = gpu->local_mem_size;
+          vg->vram_cpu_accessible_size = gpu->local_mem_size;
+          vg->gtt_size = gpu->local_mem_size;
+        }
+        return 0;
+      }
+      case AMDGPU_INFO_MEMORY: {
+        if (info->return_size >= sizeof(drm_amdgpu_memory_info)) {
+          auto *m = static_cast<drm_amdgpu_memory_info *>(out);
+          m->vram.total_heap_size = gpu->local_mem_size;
+          m->vram.usable_heap_size = gpu->local_mem_size;
+          m->vram.max_allocation = gpu->local_mem_size;
+          m->cpu_accessible_vram = m->vram;
+          m->gtt = m->vram;
+        }
+        return 0;
+      }
+      case AMDGPU_INFO_DEV_INFO: {
+        if (info->return_size >= sizeof(drm_amdgpu_info_device)) {
+          auto *dev = static_cast<drm_amdgpu_info_device *>(out);
+          dev->device_id = gpu->device_id;
+          dev->chip_rev = gpu->revision_id;
+          dev->external_rev = rocjitsu::kmd::external_rev_id_for_gfx_target_version(
+              gpu->gfx_target_version, gpu->revision_id);
+          dev->pci_rev = gpu->pci_revision_id;
+          dev->family = gpu->family_id;
+          dev->num_shader_engines = rocjitsu::kmd::drm_shader_engine_count(
+              gpu->num_shader_engines, gpu->num_shader_arrays_per_engine);
+          dev->num_shader_arrays_per_engine = gpu->num_shader_arrays_per_engine;
+          dev->gpu_counter_freq = 100000;
+          dev->max_engine_clock = gpu->max_engine_clk_fcompute;
+          dev->max_memory_clock = gpu->mem_clk_max;
+          dev->wave_front_size = gpu->wave_front_size;
+          dev->num_cu_per_sh = gpu->num_cu_per_sh;
+          dev->num_hw_gfx_contexts =
+              rocjitsu::kmd::num_hw_gfx_contexts_for_gfx_target_version(gpu->gfx_target_version);
+          dev->vram_type = gpu->vram_type;
+          dev->vram_bit_width = gpu->mem_width;
+          dev->cu_active_number =
+              rocjitsu::kmd::drm_cu_active_number(gpu->num_shader_engines, gpu->num_cu_per_sh);
+          // VA aperture — libdrm's VA manager (amdgpu_vamgr_init) needs a sane
+          // range. Mirror the KFD GPUVM aperture used elsewhere.
+          dev->virtual_address_offset = 0x200000;       // 2 MiB
+          dev->virtual_address_max = 0x800000000000ULL; // 47-bit canonical
+          dev->virtual_address_alignment = 0x1000;      // 4 KiB
+          dev->pte_fragment_size = 0x200000;            // 2 MiB
+          dev->gart_page_size = 0x1000;                 // 4 KiB
+          dev->high_va_offset = 0xffff800000000000ULL;
+          dev->high_va_max = 0xffffffffffffffffULL;
+        }
+        return 0;
+      }
+      default:
+        // Unhandled query: succeed with zero-filled buffer. libdrm tolerates
+        // zeros for the optional queries (FW_VERSION, sensors, etc.).
+        return 0;
+      }
     }
     errno = EINVAL;
     return -1;
@@ -911,6 +878,14 @@ int ioctl(int fd, unsigned long request, ...) {
     return remote->ioctl(request, arg);
   if (InterposerContext::ctx.is_kfd_dup(fd)) {
     if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()))
+      return remote->ioctl(request, arg);
+  }
+  // Late-ioctl safety net: a KFD fd may receive AMDKFD ioctls after it has lost
+  // tracking (e.g. a close/dup race in daemon mode). Forward only AMDKFD-typed
+  // ('K') ioctls, and only on fds not already classified as DRM, so unrelated
+  // DRM fds are never misrouted to the remote KFD driver.
+  if (_IOC_TYPE(request) == AMDKFD_IOCTL_BASE && !InterposerContext::ctx.is_drm(fd)) {
+    if (auto *remote = InterposerContext::ctx.remote())
       return remote->ioctl(request, arg);
   }
 
@@ -1025,37 +1000,75 @@ FcntlArgKind fcntl_arg_kind(int cmd) {
 }
 } // namespace
 
-int fcntl(int fd, int cmd, ...) {
-  assert(InterposerContext::real.ready());
-  va_list ap;
-  va_start(ap, cmd);
+namespace {
+// Shared implementation for fcntl / fcntl64. The variadic third argument is
+// extracted by the public entry points (which can't forward a va_list) and
+// passed here already resolved. Both fcntl and fcntl64 share the same kernel
+// ABI, so InterposerContext::real.fcntl services both.
+int fcntl_impl(int fd, int cmd, void *ptr_arg, int int_arg) {
   FcntlArgKind kind = fcntl_arg_kind(cmd);
   long rc = 0;
   switch (kind) {
-  case FcntlArgKind::Int: {
-    int arg = va_arg(ap, int);
-    rc = InterposerContext::real.fcntl(fd, cmd, arg);
+  case FcntlArgKind::Int:
+    rc = InterposerContext::real.fcntl(fd, cmd, int_arg);
     break;
-  }
-  case FcntlArgKind::Ptr: {
-    void *arg = va_arg(ap, void *);
-    rc = InterposerContext::real.fcntl(fd, cmd, arg);
+  case FcntlArgKind::Ptr:
+    rc = InterposerContext::real.fcntl(fd, cmd, ptr_arg);
     break;
-  }
   case FcntlArgKind::None:
   default:
     rc = InterposerContext::real.fcntl(fd, cmd, 0L);
     break;
   }
-  va_end(ap);
 
   if (rc >= 0 && (cmd == F_DUPFD || cmd == F_DUPFD_CLOEXEC)) {
     if (InterposerContext::ctx.is_kfd_tracked(fd))
       InterposerContext::ctx.track_dup(static_cast<int>(rc));
     else
       InterposerContext::ctx.untrack_dup(static_cast<int>(rc));
+    // Propagate DRM render-node tracking across dup so ioctls on the duped fd
+    // are still recognized. libdrm's amdgpu_device_initialize duplicates the
+    // render fd (via fcntl64 F_DUPFD_CLOEXEC) and issues all AMDGPU_INFO ioctls
+    // on the copy.
+    if (InterposerContext::ctx.is_drm(fd))
+      InterposerContext::ctx.track_drm(static_cast<int>(rc),
+                                       InterposerContext::ctx.drm_render_minor(fd));
   }
   return static_cast<int>(rc);
+}
+} // namespace
+
+int fcntl(int fd, int cmd, ...) {
+  assert(InterposerContext::real.ready());
+  va_list ap;
+  va_start(ap, cmd);
+  FcntlArgKind kind = fcntl_arg_kind(cmd);
+  void *ptr_arg = nullptr;
+  int int_arg = 0;
+  if (kind == FcntlArgKind::Ptr)
+    ptr_arg = va_arg(ap, void *);
+  else if (kind == FcntlArgKind::Int)
+    int_arg = va_arg(ap, int);
+  va_end(ap);
+  return fcntl_impl(fd, cmd, ptr_arg, int_arg);
+}
+
+// libdrm_amdgpu imports fcntl64@GLIBC_2.28 (not fcntl), so it must be
+// interposed separately or libdrm's F_DUPFD_CLOEXEC on the render fd bypasses
+// our dup tracking and subsequent ioctls land on an untracked fd.
+int fcntl64(int fd, int cmd, ...) {
+  assert(InterposerContext::real.ready());
+  va_list ap;
+  va_start(ap, cmd);
+  FcntlArgKind kind = fcntl_arg_kind(cmd);
+  void *ptr_arg = nullptr;
+  int int_arg = 0;
+  if (kind == FcntlArgKind::Ptr)
+    ptr_arg = va_arg(ap, void *);
+  else if (kind == FcntlArgKind::Int)
+    int_arg = va_arg(ap, int);
+  va_end(ap);
+  return fcntl_impl(fd, cmd, ptr_arg, int_arg);
 }
 
 void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
@@ -1128,78 +1141,9 @@ int munmap(void *addr, size_t length) {
   return InterposerContext::real.munmap(addr, length);
 }
 
-// -- libdrm interposition --
+} // extern "C"
 
-int amdgpu_device_initialize(int /*fd*/, uint32_t *major_version, uint32_t *minor_version,
-                             RjAmdgpuDeviceHandle *device_handle) {
-  if (InterposerContext::ctx.driver_fd() < 0 && InterposerContext::ctx.remote_kfd_fd() < 0)
-    return -1;
-  *major_version = 3;
-  *minor_version = 57;
-  static int dummy_handle = 1;
-  *device_handle = reinterpret_cast<RjAmdgpuDeviceHandle>(&dummy_handle);
-  return 0;
-}
-
-int amdgpu_device_initialize2(int fd, bool /*deduplicate_device*/, uint32_t *major_version,
-                              uint32_t *minor_version, RjAmdgpuDeviceHandle *device_handle) {
-  return amdgpu_device_initialize(fd, major_version, minor_version, device_handle);
-}
-
-int amdgpu_device_deinitialize(RjAmdgpuDeviceHandle /*device_handle*/) { return 0; }
-
-int amdgpu_device_get_fd(RjAmdgpuDeviceHandle /*device_handle*/) {
-  int fd = InterposerContext::ctx.remote_kfd_fd();
-  return fd >= 0 ? fd : InterposerContext::ctx.driver_fd();
-}
-
-const char *amdgpu_get_marketing_name(RjAmdgpuDeviceHandle /*device_handle*/) {
-  auto *gpu = interposer_gpu_info();
-  if (!gpu)
-    return nullptr;
-
-  static thread_local std::string name;
-  if (!gpu->marketing_name.empty()) {
-    name = gpu->marketing_name;
-  } else {
-    name = rocjitsu::kmd::gfx_target_name(gpu->gfx_target_version);
-  }
-  return name.c_str();
-}
-
-int amdgpu_query_gpu_info(RjAmdgpuDeviceHandle /*device_handle*/, RjAmdgpuGpuInfo *info) {
-  if (!info)
-    return -EINVAL;
-
-  auto *gpu = interposer_gpu_info();
-  if (!gpu)
-    return -ENODEV;
-
-  std::memset(info, 0, sizeof(*info));
-  info->asic_id = gpu->device_id;
-  info->chip_rev = gpu->revision_id;
-  info->chip_external_rev = rocjitsu::kmd::external_rev_id_for_gfx_target_version(
-      gpu->gfx_target_version, gpu->revision_id);
-  info->family_id = gpu->family_id;
-  info->max_engine_clk = gpu->max_engine_clk_fcompute;
-  info->max_memory_clk = gpu->mem_clk_max;
-  info->num_shader_engines = rocjitsu::kmd::drm_shader_engine_count(
-      gpu->num_shader_engines, gpu->num_shader_arrays_per_engine);
-  info->num_shader_arrays_per_engine = gpu->num_shader_arrays_per_engine;
-  info->avail_quad_shader_pipes =
-      rocjitsu::kmd::drm_quad_shader_pipe_count(gpu->num_shader_engines);
-  info->max_quad_shader_pipes = info->avail_quad_shader_pipes;
-  info->num_hw_gfx_contexts =
-      rocjitsu::kmd::num_hw_gfx_contexts_for_gfx_target_version(gpu->gfx_target_version);
-  info->gpu_counter_freq = 100000;
-  info->gb_addr_cfg = rocjitsu::kmd::gb_addr_config_for_gfx_target_version(gpu->gfx_target_version);
-  info->cu_active_number =
-      rocjitsu::kmd::drm_cu_active_number(gpu->num_shader_engines, gpu->num_cu_per_sh);
-  info->vram_type = gpu->vram_type;
-  info->vram_bit_width = gpu->mem_width;
-  info->pci_rev_id = gpu->pci_revision_id;
-  return 0;
-}
+extern "C" {
 
 // -- fopen / freopen interposition (sysfs redirect) --
 
@@ -1356,7 +1300,17 @@ static std::string redirect_dev_dri(const char *path) {
   if (!path || !InterposerContext::real.ready() || InterposerContext::in_construction)
     return {};
   std::string_view sv(path);
-  if (sv != "/dev/dri" && sv != "/dev/dri/")
+  // Redirect both the /dev/dri directory and individual node files
+  // (/dev/dri/renderD<minor>, /dev/dri/card<n>) into our synthetic dev_dri
+  // tree. libdrm's drmGetMinorType probes node existence with access() on these
+  // exact paths to classify an fd as a render node; without per-node redirect
+  // the probe hits the real host (where extra GPUs don't exist) and fails,
+  // breaking amdgpu_device_initialize's amdgpu_get_auth on multi-GPU configs.
+  constexpr std::string_view kDevDri = "/dev/dri/";
+  bool is_dir = (sv == "/dev/dri" || sv == "/dev/dri/");
+  bool is_node = sv.starts_with(kDevDri) && (sv.substr(kDevDri.size()).starts_with("renderD") ||
+                                             sv.substr(kDevDri.size()).starts_with("card"));
+  if (!is_dir && !is_node)
     return {};
   std::string drm_base;
   auto *drv = InterposerContext::ctx.driver();
@@ -1366,7 +1320,9 @@ static std::string redirect_dev_dri(const char *path) {
     drm_base = InterposerContext::ctx.remote_drm_path();
   if (drm_base.empty())
     return {};
-  return drm_base + "/dev_dri";
+  if (is_dir)
+    return drm_base + "/dev_dri";
+  return drm_base + "/dev_dri/" + std::string(sv.substr(kDevDri.size()));
 }
 
 int stat(const char *path, struct stat *buf) {
@@ -1607,157 +1563,6 @@ int __lxstat64(int ver, const char *path, struct stat64 *buf) {
     redirected = redirect_sys_dev_char(path);
   const char *actual = redirected.empty() ? path : redirected.c_str();
   return real_lxstat64(ver, actual, buf);
-}
-
-// -- DRM device enumeration (direct PLT linkage consumers) --
-
-static std::unordered_set<void *> our_drm_allocs;
-static std::mutex drm_alloc_mutex;
-
-static drmDevice *alloc_drm_device(const Sysfs::GpuInfo &gpu, uint32_t card_idx) {
-  uint32_t render_minor = gpu.drm_render_minor;
-  char primary_path[64], render_path[64];
-  snprintf(primary_path, sizeof(primary_path), "/dev/dri/card%u", card_idx);
-  snprintf(render_path, sizeof(render_path), "/dev/dri/renderD%u", render_minor);
-
-  size_t primary_len = strlen(primary_path) + 1;
-  size_t render_len = strlen(render_path) + 1;
-  constexpr int kMaxNodeTypes = 3;
-
-  size_t alloc_size = sizeof(drmDevice) + kMaxNodeTypes * sizeof(char *) + primary_len +
-                      render_len + sizeof(drmPciBusInfo) + sizeof(drmPciDeviceInfo);
-  auto *mem = static_cast<uint8_t *>(calloc(1, alloc_size));
-  if (!mem)
-    return nullptr;
-
-  auto *dev = reinterpret_cast<drmDevice *>(mem);
-  auto *nodes = reinterpret_cast<char **>(mem + sizeof(drmDevice));
-  auto *str_buf = reinterpret_cast<char *>(nodes + kMaxNodeTypes);
-  auto *bus = reinterpret_cast<drmPciBusInfo *>(str_buf + primary_len + render_len);
-  auto *pci_dev = reinterpret_cast<drmPciDeviceInfo *>(bus + 1);
-
-  memcpy(str_buf, primary_path, primary_len);
-  memcpy(str_buf + primary_len, render_path, render_len);
-
-  nodes[DRM_NODE_PRIMARY] = str_buf;
-  nodes[DRM_NODE_RENDER] = str_buf + primary_len;
-  nodes[1] = nullptr;
-
-  uint32_t bus_num = (gpu.location_id >> 8) & 0xFF;
-  uint32_t dev_num = (gpu.location_id >> 3) & 0x1F;
-  uint32_t func_num = gpu.location_id & 0x7;
-
-  bus->domain = static_cast<uint16_t>(gpu.domain);
-  bus->bus = static_cast<uint8_t>(bus_num);
-  bus->dev = static_cast<uint8_t>(dev_num);
-  bus->func = static_cast<uint8_t>(func_num);
-
-  pci_dev->vendor_id = static_cast<uint16_t>(gpu.vendor_id);
-  pci_dev->device_id = static_cast<uint16_t>(gpu.device_id);
-  pci_dev->subvendor_id = static_cast<uint16_t>(gpu.vendor_id);
-  pci_dev->subdevice_id = static_cast<uint16_t>(gpu.device_id);
-  pci_dev->revision_id = static_cast<uint8_t>(gpu.pci_revision_id);
-
-  dev->nodes = nodes;
-  dev->available_nodes = (1 << DRM_NODE_PRIMARY) | (1 << DRM_NODE_RENDER);
-  dev->bustype = DRM_BUS_PCI;
-  dev->businfo.pci = bus;
-  dev->deviceinfo.pci = pci_dev;
-
-  {
-    std::lock_guard lock(drm_alloc_mutex);
-    our_drm_allocs.insert(mem);
-  }
-
-  return dev;
-}
-
-void drmFreeDevice(drmDevice **device) {
-  if (!device || !*device)
-    return;
-  bool ours;
-  {
-    std::lock_guard lock(drm_alloc_mutex);
-    ours = our_drm_allocs.erase(*device) != 0;
-  }
-  if (ours) {
-    free(*device);
-    *device = nullptr;
-    return;
-  }
-  using fn_t = void (*)(drmDevice **);
-  static fn_t real_fn = util::lookup_symbol<fn_t>(RTLD_NEXT, "drmFreeDevice");
-  if (real_fn)
-    real_fn(device);
-}
-
-void drmFreeDevices(drmDevice **devices, int count) {
-  for (int i = 0; i < count; ++i) {
-    if (devices[i])
-      drmFreeDevice(&devices[i]);
-  }
-}
-
-int drmGetDevice(int fd, drmDevice **device) {
-  if (!device)
-    return -EINVAL;
-  *device = nullptr;
-  if (!InterposerContext::real.ready() || !InterposerContext::ctx.is_drm(fd))
-    return -ENODEV;
-  auto *gpu = interposer_gpu_info();
-  if (!gpu)
-    return -ENODEV;
-  *device = alloc_drm_device(*gpu, 0);
-  return *device ? 0 : -ENOMEM;
-}
-
-int drmGetDevice2(int fd, uint32_t /*flags*/, drmDevice **device) {
-  return drmGetDevice(fd, device);
-}
-
-int drmGetDevices(drmDevice **devices, int max_devices) {
-  if (!devices || max_devices <= 0)
-    return 0;
-  auto *gpu = interposer_gpu_info();
-  if (!gpu)
-    return 0;
-  devices[0] = alloc_drm_device(*gpu, 0);
-  return devices[0] ? 1 : 0;
-}
-
-int drmGetDevices2(uint32_t /*flags*/, drmDevice **devices, int max_devices) {
-  return drmGetDevices(devices, max_devices);
-}
-
-// Intercept dlsym so that dlsym-based consumers (amdsmi) get our DRM
-// device query implementations instead of libdrm's.  Without this,
-// libdrm's internal drmGetDeviceFromDevId runs on our synthetic memfds
-// and produces a corrupted drmDevice that crashes in drmFreeDevice.
-// drmFreeDevice/drmFreeDevices are intentionally excluded: our own
-// drmFreeDevice fallback calls dlsym(RTLD_NEXT, "drmFreeDevice") and
-// including it here would cause infinite recursion.
-void *dlsym(void *handle, const char *symbol) {
-  auto symbol_addr = reinterpret_cast<uintptr_t>(symbol);
-  if (symbol_addr != 0 && InterposerContext::real.ready()) {
-    static const std::unordered_map<std::string_view, void *> overrides = {
-        {"drmGetDevice", reinterpret_cast<void *>(&drmGetDevice)},
-        {"drmGetDevice2", reinterpret_cast<void *>(&drmGetDevice2)},
-        {"drmGetDevices", reinterpret_cast<void *>(&drmGetDevices)},
-        {"drmGetDevices2", reinterpret_cast<void *>(&drmGetDevices2)},
-        {"amdgpu_get_marketing_name", reinterpret_cast<void *>(&amdgpu_get_marketing_name)},
-        {"amdgpu_query_gpu_info", reinterpret_cast<void *>(&amdgpu_query_gpu_info)},
-    };
-    auto it = overrides.find(symbol);
-    if (it != overrides.end())
-      return it->second;
-  }
-  if (real_dlsym_fn)
-    return real_dlsym_fn(handle, symbol);
-  // Called before resolve_real_dlsym constructor runs (e.g., during
-  // dynamic linker symbol resolution at library load time).  Resolve
-  // the real dlsym now and forward.
-  resolve_real_dlsym();
-  return real_dlsym_fn(handle, symbol);
 }
 
 pid_t fork() {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -264,20 +264,46 @@ public:
   void track_dup(int fd) {
     if (fd < 0 || is_kfd_primary(fd))
       return;
-    std::lock_guard lock(fd_mutex_);
-    kfd_dup_fds_.insert(fd);
+    bool newly_tracked = false;
+    {
+      std::lock_guard lock(fd_mutex_);
+      newly_tracked = kfd_dup_fds_.insert(fd).second;
+    }
+    // Each live KFD fd (primary + every dup) holds one local-mode open
+    // reference, so the process is torn down only when the last fd closes.
+    // No-op in remote mode (no local process to retain).
+    if (newly_tracked)
+      if (auto *d = driver())
+        d->retain_local_open();
   }
 
   void untrack_dup(int fd) {
     if (fd < 0)
       return;
-    std::lock_guard lock(fd_mutex_);
-    kfd_dup_fds_.erase(fd);
+    bool was_tracked = false;
+    {
+      std::lock_guard lock(fd_mutex_);
+      was_tracked = kfd_dup_fds_.erase(fd) != 0;
+    }
+    if (was_tracked)
+      if (auto *d = driver())
+        d->close();
   }
 
   void clear_dups() {
-    std::lock_guard lock(fd_mutex_);
-    kfd_dup_fds_.clear();
+    size_t released = 0;
+    {
+      std::lock_guard lock(fd_mutex_);
+      released = kfd_dup_fds_.size();
+      kfd_dup_fds_.clear();
+    }
+    // Drop the references the cleared dups were holding. Used on remote
+    // teardown (driver() is null → no-op) and when a fresh open() rebinds the
+    // local process; in the latter case the just-opened reference is preserved
+    // because clear_dups runs before any new dups are tracked.
+    if (auto *d = driver())
+      for (size_t i = 0; i < released; ++i)
+        d->close();
   }
 
   int close_remote() {
@@ -721,9 +747,8 @@ int close(int fd) {
     return static_cast<int>(InterposerContext::real.close(fd));
   }
   if (auto *drv = InterposerContext::ctx.lookup(fd)) {
-    int rc = drv->close();
-    InterposerContext::ctx.clear_dups();
-    return rc;
+    drv->close();
+    return 0;
   }
   if (InterposerContext::ctx.owns_fd(fd))
     return 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -179,7 +179,7 @@ public:
   /// the next open("/dev/kfd") creates a fresh connection.
   void reset_after_fork() {
     rj_vm_ = nullptr;
-    remote_ = nullptr;
+    remote_.store(nullptr, std::memory_order_relaxed);
     remote_kfd_fd_.store(-1, std::memory_order_relaxed);
     remote_open_refs_.store(0, std::memory_order_relaxed);
     new (&init_mutex_) std::mutex();
@@ -197,27 +197,33 @@ public:
     auto *d = driver();
     return d ? d->fd() : -1;
   }
-  bool initialized() const { return rj_vm_ != nullptr || remote_ != nullptr; }
+  bool initialized() const {
+    return rj_vm_ != nullptr || remote_.load(std::memory_order_acquire) != nullptr;
+  }
 
   std::unique_lock<std::mutex> lock_remote() { return std::unique_lock(remote_mutex_); }
 
-  RemoteDriver *remote() { return remote_; }
+  RemoteDriver *remote() { return remote_.load(std::memory_order_acquire); }
 
   int remote_kfd_fd() const { return remote_kfd_fd_.load(std::memory_order_acquire); }
 
   RemoteDriver *remote_lookup(int fd) {
-    return (fd >= 0 && fd == remote_kfd_fd_.load(std::memory_order_acquire) && remote_) ? remote_
-                                                                                        : nullptr;
+    RemoteDriver *active_remote = remote_.load(std::memory_order_acquire);
+    return (fd >= 0 && fd == remote_kfd_fd_.load(std::memory_order_acquire) && active_remote)
+               ? active_remote
+               : nullptr;
   }
 
   std::string remote_topology_path() {
     std::lock_guard lock(remote_mutex_);
-    return remote_ ? std::string(remote_->topology_path()) : std::string{};
+    RemoteDriver *active_remote = remote_.load(std::memory_order_acquire);
+    return active_remote ? std::string(active_remote->topology_path()) : std::string{};
   }
 
   std::string remote_drm_path() {
     std::lock_guard lock(remote_mutex_);
-    return remote_ ? std::string(remote_->drm_path()) : std::string{};
+    RemoteDriver *active_remote = remote_.load(std::memory_order_acquire);
+    return active_remote ? std::string(active_remote->drm_path()) : std::string{};
   }
 
   /// @brief True when a daemon-mode (remote) KFD connection is open.
@@ -243,24 +249,27 @@ public:
 
   RemoteDriver *get_or_create_remote() {
     std::lock_guard lock(remote_mutex_);
-    if (remote_ && remote_kfd_fd_.load(std::memory_order_acquire) >= 0) {
+    RemoteDriver *active_remote = remote_.load(std::memory_order_acquire);
+    if (active_remote && remote_kfd_fd_.load(std::memory_order_acquire) >= 0) {
       // Re-open of an already-connected daemon: each open holds one reference,
       // mirroring SimulatedDriver::open() retaining the local process.
       retain_remote_open();
-      return remote_;
+      return active_remote;
     }
     int sock = connect_to_daemon();
     if (sock < 0)
       return nullptr;
-    if (!remote_)
-      remote_ = new RemoteDriver(sock);
-    int fd = remote_->open();
+    if (!active_remote) {
+      active_remote = new RemoteDriver(sock);
+      remote_.store(active_remote, std::memory_order_release);
+    }
+    int fd = active_remote->open();
     if (fd < 0)
       return nullptr;
     remote_kfd_fd_.store(fd, std::memory_order_release);
     // The primary remote KFD fd holds the first open reference.
     remote_open_refs_.store(1, std::memory_order_release);
-    return remote_;
+    return active_remote;
   }
 
   SimulatedDriver *lookup(int fd) {
@@ -348,11 +357,12 @@ public:
   /// instead of being misrouted to a dead RPC connection.
   void teardown_remote() {
     std::lock_guard lock(remote_mutex_);
-    if (!remote_)
+    RemoteDriver *active_remote = remote_.load(std::memory_order_acquire);
+    if (!active_remote)
       return;
-    remote_->close();
-    delete remote_;
-    remote_ = nullptr;
+    active_remote->close();
+    remote_.store(nullptr, std::memory_order_release);
+    delete active_remote;
     int fd = remote_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
     if (fd >= 0)
       InterposerContext::real.close(fd);
@@ -503,7 +513,14 @@ public:
 
 private:
   rj_vm_t *rj_vm_ = nullptr;
-  RemoteDriver *remote_ = nullptr;
+  /// @brief Active daemon-mode remote driver, or nullptr in local mode.
+  /// @details Stored atomically so lock-free readers (`remote()`,
+  /// `remote_lookup()`, `initialized()`, the AMDKFD ioctl fallback, the mmap
+  /// path) never race the writer that swaps it under `remote_mutex_` in
+  /// `get_or_create_remote()`/`teardown_remote()`. The mutex still serializes the
+  /// compound new+open and delete+clear sequences; the atomic only makes the
+  /// bare pointer read/write data-race-free.
+  std::atomic<RemoteDriver *> remote_{nullptr};
   std::atomic<int> remote_kfd_fd_{-1};
   /// @brief Open-reference count for the remote (daemon-mode) KFD connection.
   /// @details The primary remote fd and every dup of it each hold one
@@ -800,9 +817,18 @@ int ioctl(int fd, unsigned long request, ...) {
       ver->version_minor = 57;
       ver->version_patchlevel = 0;
       static constexpr const char drv_name[] = "amdgpu";
-      if (ver->name && ver->name_len >= sizeof(drv_name) - 1)
-        std::memcpy(ver->name, drv_name, sizeof(drv_name));
-      ver->name_len = sizeof(drv_name) - 1;
+      constexpr size_t kNameStrLen = sizeof(drv_name) - 1;
+      // Mirror the kernel's drm_version contract: copy at most the caller's
+      // advertised buffer length, and only write the NUL terminator when the
+      // buffer has room for it. A caller that sized name to exactly the queried
+      // length must not get a terminator written one byte past the end.
+      if (ver->name && ver->name_len > 0) {
+        size_t copy = ver->name_len < kNameStrLen ? ver->name_len : kNameStrLen;
+        std::memcpy(ver->name, drv_name, copy);
+        if (ver->name_len > kNameStrLen)
+          ver->name[kNameStrLen] = '\0';
+      }
+      ver->name_len = kNameStrLen;
       if (ver->date && ver->date_len > 0)
         ver->date[0] = '\0';
       ver->date_len = 1;
@@ -960,32 +986,37 @@ int dup(int oldfd) {
 
 int dup2(int oldfd, int newfd) {
   assert(InterposerContext::real.ready());
+  // dup2(fd, fd) is a POSIX no-op that leaves the descriptor live; mutating
+  // tracking would drop a still-open ref. Forward without touching tracking.
+  if (oldfd == newfd)
+    return InterposerContext::real.dup2(oldfd, newfd);
+  int rc = InterposerContext::real.dup2(oldfd, newfd);
+  if (rc < 0)
+    return rc;
+  // newfd was atomically closed and replaced; reconcile its tracking only now.
   InterposerContext::ctx.untrack_sysfs(newfd);
   InterposerContext::ctx.untrack_drm(newfd);
-  InterposerContext::ctx.untrack_dup(newfd);
-  int rc = InterposerContext::real.dup2(oldfd, newfd);
-  if (rc >= 0) {
-    if (InterposerContext::ctx.is_kfd_tracked(oldfd))
-      InterposerContext::ctx.track_dup(rc);
-    else
-      InterposerContext::ctx.untrack_dup(rc);
-  }
+  if (InterposerContext::ctx.is_kfd_tracked(oldfd))
+    InterposerContext::ctx.track_dup(rc);
+  else
+    InterposerContext::ctx.untrack_dup(rc);
   return rc;
 }
 
 #ifdef SYS_dup3
 int dup3(int oldfd, int newfd, int flags) {
   assert(InterposerContext::real.ready());
+  // dup3(fd, fd, ...) is required to fail with EINVAL without altering the
+  // descriptor; do not mutate tracking before the syscall confirms that.
+  int rc = InterposerContext::real.dup3(oldfd, newfd, flags);
+  if (rc < 0)
+    return rc;
   InterposerContext::ctx.untrack_sysfs(newfd);
   InterposerContext::ctx.untrack_drm(newfd);
-  InterposerContext::ctx.untrack_dup(newfd);
-  int rc = InterposerContext::real.dup3(oldfd, newfd, flags);
-  if (rc >= 0) {
-    if (InterposerContext::ctx.is_kfd_tracked(oldfd))
-      InterposerContext::ctx.track_dup(rc);
-    else
-      InterposerContext::ctx.untrack_dup(rc);
-  }
+  if (InterposerContext::ctx.is_kfd_tracked(oldfd))
+    InterposerContext::ctx.track_dup(rc);
+  else
+    InterposerContext::ctx.untrack_dup(rc);
   return rc;
 }
 #endif
@@ -1549,6 +1580,8 @@ int stat64(const char *path, struct stat64 *buf) {
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
+  if (redirected.empty())
+    redirected = redirect_dev_dri(path);
   const char *actual = redirected.empty() ? path : redirected.c_str();
   return real_stat64(actual, buf);
 }
@@ -1561,6 +1594,8 @@ int lstat64(const char *path, struct stat64 *buf) {
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
+  if (redirected.empty())
+    redirected = redirect_dev_dri(path);
   const char *actual = redirected.empty() ? path : redirected.c_str();
   return real_lstat64(actual, buf);
 }
@@ -1573,6 +1608,8 @@ int __xstat(int ver, const char *path, struct stat *buf) {
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
+  if (redirected.empty())
+    redirected = redirect_dev_dri(path);
   const char *actual = redirected.empty() ? path : redirected.c_str();
   return real_xstat(ver, actual, buf);
 }
@@ -1585,6 +1622,8 @@ int __xstat64(int ver, const char *path, struct stat64 *buf) {
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
+  if (redirected.empty())
+    redirected = redirect_dev_dri(path);
   const char *actual = redirected.empty() ? path : redirected.c_str();
   return real_xstat64(ver, actual, buf);
 }
@@ -1597,6 +1636,8 @@ int __lxstat(int ver, const char *path, struct stat *buf) {
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
+  if (redirected.empty())
+    redirected = redirect_dev_dri(path);
   const char *actual = redirected.empty() ? path : redirected.c_str();
   return real_lxstat(ver, actual, buf);
 }
@@ -1609,6 +1650,8 @@ int __lxstat64(int ver, const char *path, struct stat64 *buf) {
   auto redirected = redirect_sysfs_path(path);
   if (redirected.empty())
     redirected = redirect_sys_dev_char(path);
+  if (redirected.empty())
+    redirected = redirect_dev_dri(path);
   const char *actual = redirected.empty() ? path : redirected.c_str();
   return real_lxstat64(ver, actual, buf);
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -181,6 +181,7 @@ public:
     rj_vm_ = nullptr;
     remote_ = nullptr;
     remote_kfd_fd_.store(-1, std::memory_order_relaxed);
+    remote_open_refs_.store(0, std::memory_order_relaxed);
     new (&init_mutex_) std::mutex();
     new (&fd_mutex_) std::mutex();
     new (&remote_mutex_) std::mutex();
@@ -219,10 +220,35 @@ public:
     return remote_ ? std::string(remote_->drm_path()) : std::string{};
   }
 
+  /// @brief True when a daemon-mode (remote) KFD connection is open.
+  bool is_remote_mode() const { return remote_open_refs_.load(std::memory_order_acquire) > 0; }
+
+  /// @brief Add one open reference for a remote (daemon-mode) KFD fd.
+  /// @details Each live remote KFD fd (the primary plus every dup) holds one
+  /// reference; the RPC connection is torn down only when the last reference is
+  /// dropped. Mirrors SimulatedDriver's local open refcount for the daemon path.
+  void retain_remote_open() { remote_open_refs_.fetch_add(1, std::memory_order_acq_rel); }
+
+  /// @brief Drop one remote open reference, tearing down the connection on the
+  /// last release.
+  /// @details On the final release this sends RPC_CLOSE to the daemon (via
+  /// RemoteDriver::close()) so the daemon frees this client's process state,
+  /// rather than leaking it until socket disconnect at process exit.
+  void release_remote_open() {
+    int prev = remote_open_refs_.fetch_sub(1, std::memory_order_acq_rel);
+    assert(prev > 0 && "remote open refcount underflow");
+    if (prev == 1)
+      teardown_remote();
+  }
+
   RemoteDriver *get_or_create_remote() {
     std::lock_guard lock(remote_mutex_);
-    if (remote_ && remote_kfd_fd_.load(std::memory_order_acquire) >= 0)
+    if (remote_ && remote_kfd_fd_.load(std::memory_order_acquire) >= 0) {
+      // Re-open of an already-connected daemon: each open holds one reference,
+      // mirroring SimulatedDriver::open() retaining the local process.
+      retain_remote_open();
       return remote_;
+    }
     int sock = connect_to_daemon();
     if (sock < 0)
       return nullptr;
@@ -232,6 +258,8 @@ public:
     if (fd < 0)
       return nullptr;
     remote_kfd_fd_.store(fd, std::memory_order_release);
+    // The primary remote KFD fd holds the first open reference.
+    remote_open_refs_.store(1, std::memory_order_release);
     return remote_;
   }
 
@@ -269,12 +297,15 @@ public:
       std::lock_guard lock(fd_mutex_);
       newly_tracked = kfd_dup_fds_.insert(fd).second;
     }
-    // Each live KFD fd (primary + every dup) holds one local-mode open
-    // reference, so the process is torn down only when the last fd closes.
-    // No-op in remote mode (no local process to retain).
-    if (newly_tracked)
-      if (auto *d = driver())
-        d->retain_local_open();
+    if (!newly_tracked)
+      return;
+    // Each live KFD fd (primary + every dup) holds one open reference, so the
+    // process/connection is torn down only when the last fd closes. Retain on
+    // whichever backend is active (local SimulatedDriver or remote daemon RPC).
+    if (auto *d = driver())
+      d->retain_local_open();
+    else if (is_remote_mode())
+      retain_remote_open();
   }
 
   void untrack_dup(int fd) {
@@ -285,9 +316,12 @@ public:
       std::lock_guard lock(fd_mutex_);
       was_tracked = kfd_dup_fds_.erase(fd) != 0;
     }
-    if (was_tracked)
-      if (auto *d = driver())
-        d->close();
+    if (!was_tracked)
+      return;
+    if (auto *d = driver())
+      d->close();
+    else if (is_remote_mode())
+      release_remote_open();
   }
 
   void clear_dups() {
@@ -297,35 +331,24 @@ public:
       released = kfd_dup_fds_.size();
       kfd_dup_fds_.clear();
     }
-    // Drop the references the cleared dups were holding. Used on remote
-    // teardown (driver() is null → no-op) and when a fresh open() rebinds the
-    // local process; in the latter case the just-opened reference is preserved
-    // because clear_dups runs before any new dups are tracked.
+    // Drop the references the cleared dups were holding. Used when a fresh
+    // open() rebinds the local process; the just-opened reference is preserved
+    // because clear_dups runs before any new dups are tracked. Remote teardown
+    // releases its own references explicitly and never routes through here.
     if (auto *d = driver())
       for (size_t i = 0; i < released; ++i)
         d->close();
   }
 
-  int close_remote() {
+  /// @brief Tear down the remote (daemon) connection: send RPC_CLOSE, close the
+  /// synthetic primary fd, and drop daemon-redirect topology paths.
+  /// @details Invoked on the last remote open reference release. Any remaining
+  /// dup-tracked fds refer to the now-closed synthetic fd; clear the set so
+  /// their subsequent close()/ioctl calls fall through to the real syscall
+  /// instead of being misrouted to a dead RPC connection.
+  void teardown_remote() {
     std::lock_guard lock(remote_mutex_);
     if (!remote_)
-      return 0;
-    int rc = remote_->close();
-    delete remote_;
-    remote_ = nullptr;
-    int fd = remote_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
-    if (fd >= 0) {
-      int close_rc = static_cast<int>(InterposerContext::real.close(fd));
-      if (rc == 0)
-        rc = close_rc;
-    }
-    clear_dups();
-    return rc;
-  }
-
-  void try_close_remote() {
-    std::unique_lock lock(remote_mutex_, std::try_to_lock);
-    if (!lock.owns_lock() || !remote_)
       return;
     remote_->close();
     delete remote_;
@@ -333,20 +356,8 @@ public:
     int fd = remote_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
     if (fd >= 0)
       InterposerContext::real.close(fd);
-    clear_dups();
-  }
-
-  int close_remote_fd_only() {
-    // Closes only the primary remote KFD fd. Dup-tracked fds may still be open
-    // in the process, so dup tracking is left intact here and cleared only when
-    // the remote connection is actually torn down (close_remote/
-    // try_close_remote). Wiping it here would drop tracking for live fds and
-    // misroute their subsequent ioctl/close calls.
-    int fd = remote_kfd_fd_.exchange(-1, std::memory_order_acq_rel);
-    int rc = 0;
-    if (fd >= 0)
-      rc = static_cast<int>(InterposerContext::real.close(fd));
-    return rc;
+    std::lock_guard fd_lock(fd_mutex_);
+    kfd_dup_fds_.clear();
   }
 
   void track_sysfs(int fd, const std::string &path) {
@@ -494,6 +505,11 @@ private:
   rj_vm_t *rj_vm_ = nullptr;
   RemoteDriver *remote_ = nullptr;
   std::atomic<int> remote_kfd_fd_{-1};
+  /// @brief Open-reference count for the remote (daemon-mode) KFD connection.
+  /// @details The primary remote fd and every dup of it each hold one
+  /// reference; the RPC connection is torn down only when the last reference is
+  /// released. Mirrors SimulatedDriver's local open refcount for daemon mode.
+  std::atomic<int> remote_open_refs_{0};
 
   std::mutex init_mutex_;
   std::mutex fd_mutex_;
@@ -735,8 +751,14 @@ int openat64(int dirfd, const char *path, int flags, ...) {
 
 int close(int fd) {
   assert(InterposerContext::real.ready());
-  if (InterposerContext::ctx.remote_lookup(fd))
-    return InterposerContext::ctx.close_remote_fd_only();
+  if (InterposerContext::ctx.remote_lookup(fd)) {
+    // Closing the primary remote KFD fd drops one open reference; the synthetic
+    // fd and RPC connection are torn down only when the last reference is
+    // released (teardown_remote), mirroring local-mode primary close which also
+    // defers teardown to the last reference.
+    InterposerContext::ctx.release_remote_open();
+    return 0;
+  }
   InterposerContext::ctx.untrack_sysfs(fd);
   if (InterposerContext::ctx.untrack_drm(fd)) {
     InterposerContext::real.close(fd);
@@ -905,11 +927,12 @@ int ioctl(int fd, unsigned long request, ...) {
     if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd()))
       return remote->ioctl(request, arg);
   }
-  // Late-ioctl safety net: a KFD fd may receive AMDKFD ioctls after it has lost
-  // tracking (e.g. a close/dup race in daemon mode). Forward only AMDKFD-typed
-  // ('K') ioctls, and only on fds not already classified as DRM, so unrelated
-  // DRM fds are never misrouted to the remote KFD driver.
-  if (_IOC_TYPE(request) == AMDKFD_IOCTL_BASE && !InterposerContext::ctx.is_drm(fd)) {
+  // Late-ioctl safety net: an AMDKFD ('K') ioctl may arrive on a tracked KFD fd
+  // whose primary remote handle changed underneath it (e.g. a close/dup race in
+  // daemon mode). Forward only AMDKFD-typed ioctls, and only on fds we already
+  // track as KFD (primary or dup), so an arbitrary unrelated fd carrying a
+  // type-'K' ioctl is never misrouted to the remote KFD driver.
+  if (_IOC_TYPE(request) == AMDKFD_IOCTL_BASE && InterposerContext::ctx.is_kfd_tracked(fd)) {
     if (auto *remote = InterposerContext::ctx.remote())
       return remote->ioctl(request, arg);
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -15,6 +15,7 @@
 #include "rocjitsu/kmd/linux/events.h"
 #include "rocjitsu/vm/amdgpu/mtype.h"
 
+#include <atomic>
 #include <cstdint>
 #include <mutex>
 #include <shared_mutex>
@@ -52,6 +53,13 @@ public:
 
   /// @brief Get the process ID (PASID analog).
   uint32_t process_id() const { return process_id_; }
+
+  pid_t client_pid() const { return client_pid_; }
+  void set_client_pid(pid_t pid) { client_pid_ = pid; }
+
+  uint32_t open_ref_count() const { return open_ref_count_.load(std::memory_order_relaxed); }
+  void retain_open() { open_ref_count_.fetch_add(1, std::memory_order_relaxed); }
+  bool release_open() { return open_ref_count_.fetch_sub(1, std::memory_order_acq_rel) == 1; }
 
   /// @brief GPU memory allocation descriptor.
   struct GpuAllocation {
@@ -140,6 +148,8 @@ public:
   // -- Per-process state --
 
   uint32_t process_id_;
+  pid_t client_pid_ = 0;
+  std::atomic<uint32_t> open_ref_count_{1};
 
   mutable std::mutex alloc_mutex_;
   std::unordered_map<uint64_t, GpuAllocation> allocations_;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/kfd_process.h
@@ -16,6 +16,7 @@
 #include "rocjitsu/vm/amdgpu/mtype.h"
 
 #include <atomic>
+#include <cassert>
 #include <cstdint>
 #include <mutex>
 #include <shared_mutex>
@@ -59,7 +60,17 @@ public:
 
   uint32_t open_ref_count() const { return open_ref_count_.load(std::memory_order_relaxed); }
   void retain_open() { open_ref_count_.fetch_add(1, std::memory_order_relaxed); }
-  bool release_open() { return open_ref_count_.fetch_sub(1, std::memory_order_acq_rel) == 1; }
+
+  /// @brief Drop one open reference; returns true when the last one is released.
+  /// @details Asserts on underflow: every release must pair with a prior open or
+  /// retain. An unbalanced release means an fd reference (primary or dup) was
+  /// tracked without retaining, which would otherwise wrap the count and leak
+  /// the process forever.
+  bool release_open() {
+    uint32_t prev = open_ref_count_.fetch_sub(1, std::memory_order_acq_rel);
+    assert(prev > 0 && "KfdProcess open refcount underflow");
+    return prev == 1;
+  }
 
   /// @brief GPU memory allocation descriptor.
   struct GpuAllocation {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/remote_driver.cpp
@@ -529,6 +529,12 @@ int RemoteDriver::send_ioctl(unsigned long request, void *arg) {
     }
   }
 
+  if (request == AMDKFD_IOC_EXPORT_DMABUF && resp->result == 0) {
+    auto *export_args = static_cast<kfd_ioctl_export_dmabuf_args *>(arg);
+    if (num_fds > 0 && received_fds[0] >= 0)
+      export_args->dmabuf_fd = received_fds[0];
+  }
+
   if (request == AMDKFD_IOC_FREE_MEMORY_OF_GPU && resp->result == 0) {
     auto *free_args = static_cast<kfd_ioctl_free_memory_of_gpu_args *>(arg);
     if (auto it = handle_memfds_.find(free_args->handle); it != handle_memfds_.end()) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
@@ -354,7 +354,19 @@ int SimulatedDriver::open() {
   return fd_;
 }
 
-uint32_t SimulatedDriver::open_process() {
+void SimulatedDriver::set_process_client_pid(uint32_t process_id, pid_t client_pid) {
+  std::lock_guard<std::mutex> lk(process_mutex_);
+  auto it = processes_.find(process_id);
+  if (it != processes_.end()) {
+    it->second->set_client_pid(client_pid);
+    for (auto &g : gpus_) {
+      if (auto *mem = g.soc ? g.soc->memory() : nullptr)
+        mem->set_process_client_pid(process_id, client_pid);
+    }
+  }
+}
+
+uint32_t SimulatedDriver::open_process(pid_t client_pid) {
   if (fd_ < 0) {
     fd_ = static_cast<int>(syscall(SYS_memfd_create, "rocjitsu_kfd", 0));
     if (fd_ < 0)
@@ -364,12 +376,25 @@ uint32_t SimulatedDriver::open_process() {
   uint32_t pid;
   {
     std::lock_guard<std::mutex> lk(process_mutex_);
+    if (client_pid > 0) {
+      for (auto &[id, proc] : processes_) {
+        if (proc->client_pid() == client_pid) {
+          proc->retain_open();
+          return id;
+        }
+      }
+    }
     pid = next_process_id_++;
     auto proc = std::make_shared<KfdProcess>(pid, static_cast<uint32_t>(gpus_.size()));
+    if (client_pid > 0)
+      proc->set_client_pid(client_pid);
     proc->event_state_.reset();
     for (auto &g : gpus_) {
-      if (auto *mem = g.soc ? g.soc->memory() : nullptr)
+      if (auto *mem = g.soc ? g.soc->memory() : nullptr) {
         mem->register_process(pid, &proc->page_table_, &proc->page_table_mutex_);
+        if (client_pid > 0)
+          mem->set_process_client_pid(pid, client_pid);
+      }
     }
     processes_[pid] = proc;
 
@@ -435,6 +460,8 @@ int SimulatedDriver::close(uint32_t process_id) {
     std::lock_guard<std::mutex> lk(process_mutex_);
     auto it = processes_.find(process_id);
     if (it == processes_.end())
+      return 0;
+    if (daemon_mode_ && it->second->client_pid() > 0 && !it->second->release_open())
       return 0;
     extracted = std::move(it->second);
     processes_.erase(it);
@@ -1270,7 +1297,8 @@ int SimulatedDriver::unmap_memory_ioctl(KfdProcess &proc, void *arg) {
     // releases it. Erasing here would leak those fds and make a later FREE a
     // no-op for this handle.
     auto &alloc = it->second;
-    unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
+    if (alloc.host_ptr)
+      unmap_from_gpu(proc, alloc.gpu_va, alloc.size);
   }
   args->n_success = args->n_devices;
   return 0;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
@@ -376,7 +376,13 @@ uint32_t SimulatedDriver::open_process(pid_t client_pid) {
   uint32_t pid;
   {
     std::lock_guard<std::mutex> lk(process_mutex_);
-    if (client_pid > 0) {
+    // Client-PID process reuse (and its matching retain) is a daemon-mode
+    // feature: multiple client opens of the same PID share one process and
+    // balance against multiple close()/release_open() calls. Gating reuse on
+    // daemon_mode_ keeps it symmetric with close() — outside daemon mode every
+    // open creates a fresh process so the first close cannot tear down a
+    // still-referenced one.
+    if (daemon_mode_ && client_pid > 0) {
       for (auto &[id, proc] : processes_) {
         if (proc->client_pid() == client_pid) {
           proc->retain_open();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.cpp
@@ -287,7 +287,7 @@ int SimulatedDriver::open() {
 
   std::lock_guard<std::mutex> lk(process_mutex_);
   if (!daemon_mode_ && local_process_id_ != 0 && processes_.contains(local_process_id_)) {
-    processes_[local_process_id_]->event_state_.reset();
+    processes_[local_process_id_]->retain_open();
     return fd_;
   }
   uint32_t pid = next_process_id_++;
@@ -450,6 +450,23 @@ uint32_t SimulatedDriver::open_process(pid_t client_pid) {
   return pid;
 }
 
+void SimulatedDriver::retain_local_open() {
+  std::lock_guard<std::mutex> lk(process_mutex_);
+  if (local_process_id_ == 0)
+    return;
+  auto it = processes_.find(local_process_id_);
+  if (it != processes_.end())
+    it->second->retain_open();
+}
+
+uint32_t SimulatedDriver::local_open_ref_count() const {
+  std::lock_guard<std::mutex> lk(process_mutex_);
+  if (local_process_id_ == 0)
+    return 0;
+  auto it = processes_.find(local_process_id_);
+  return it != processes_.end() ? it->second->open_ref_count() : 0;
+}
+
 int SimulatedDriver::close() { return close(local_process_id_); }
 
 int SimulatedDriver::close(uint32_t process_id) {
@@ -461,7 +478,7 @@ int SimulatedDriver::close(uint32_t process_id) {
     auto it = processes_.find(process_id);
     if (it == processes_.end())
       return 0;
-    if (daemon_mode_ && it->second->client_pid() > 0 && !it->second->release_open())
+    if (!it->second->release_open())
       return 0;
     extracted = std::move(it->second);
     processes_.erase(it);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.h
@@ -100,7 +100,8 @@ public:
   /// @details Unlike open(), which sets local_process_id_ (not thread-safe for
   /// concurrent daemon clients), this method returns the ID directly so the
   /// caller can associate it with a specific client connection.
-  uint32_t open_process();
+  uint32_t open_process(pid_t client_pid = 0);
+  void set_process_client_pid(uint32_t process_id, pid_t client_pid);
 
   int ioctl(uint32_t process_id, unsigned long request, void *arg);
   void *mmap(uint32_t process_id, void *addr, size_t length, int prot, int flags, off_t offset);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/simulated_driver.h
@@ -88,6 +88,13 @@ public:
   /// @{
   int open() override;
   int close() override;
+
+  /// @brief Add one open reference to the local process without re-opening.
+  /// @details Used by the interposer when an existing KFD fd is duplicated
+  /// (dup/dup2/dup3/fcntl F_DUPFD). Each live fd holds one reference so the
+  /// process is torn down only when the last fd is closed, not the first.
+  /// No-op when there is no local process (e.g. daemon/remote mode).
+  void retain_local_open();
   int ioctl(unsigned long request, void *arg) override;
   void *mmap(void *addr, size_t length, int prot, int flags, off_t offset) override;
   int munmap(void *addr, size_t length) override;
@@ -123,6 +130,12 @@ public:
   std::string topology_path() const { return topology_.path(); }
   [[nodiscard]] int fd() const { return fd_; }
   [[nodiscard]] uint32_t local_process_id() const { return local_process_id_; }
+
+  /// @brief Open-reference count of the local process, or 0 if none is alive.
+  /// @details Introspection for tests/diagnostics. Each live KFD fd (the primary
+  /// plus every dup) holds one reference; the process is destroyed at zero.
+  [[nodiscard]] uint32_t local_open_ref_count() const;
+
   [[nodiscard]] bool owns_fd(int fd) const;
   std::string redirect_sysfs_path(const char *path) const;
   [[nodiscard]] int claim_fd(int real_fd);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -936,8 +936,10 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   dp.dispatched_wgs = 0;
   dp.completed_wgs = 0;
   dp.wfs_per_workgroup = wfs_per_wg;
-  dp.sgprs_per_wf = sgprs > 0 ? sgprs : 104;
-  dp.vgprs_per_wf = vgprs > 0 ? vgprs : 256;
+  uint32_t sgpr_limit = cus_.empty() ? 112 : cus_[0]->config().sgprs_per_wf;
+  uint32_t vgpr_limit = cus_.empty() ? 256 : cus_[0]->vgpr_allocation_block_size();
+  dp.sgprs_per_wf = std::min(sgprs > 0 ? sgprs : sgpr_limit, sgpr_limit);
+  dp.vgprs_per_wf = std::min(vgprs > 0 ? vgprs : vgpr_limit, vgpr_limit);
   dp.kernarg_addr = reinterpret_cast<uint64_t>(pkt.kernarg_address);
   dp.kernarg_size = kd.kernarg_size;
   dp.num_user_sgprs = user_sgprs;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -18,6 +18,7 @@
 #include <mutex>
 #include <shared_mutex>
 #include <string>
+#include <sys/uio.h>
 #include <unordered_map>
 #include <utility>
 
@@ -66,6 +67,13 @@ public:
                      std::dec);
     std::unique_lock lk(vmid_mutex_);
     vmid_table_.erase(pid);
+  }
+
+  void set_process_client_pid(uint32_t pid, pid_t client_pid) {
+    std::unique_lock lk(vmid_mutex_);
+    auto it = vmid_table_.find(pid);
+    if (it != vmid_table_.end())
+      it->second.client_pid = client_pid;
   }
 
   /// @brief Enable passthrough for unmapped addresses (local/user-mode only).
@@ -126,6 +134,9 @@ public:
   uint8_t read8(uint64_t addr, uint32_t vmid = 0) const {
     if (auto *p = translate(addr, vmid))
       return p[addr & PAGE_MASK];
+    uint8_t val = 0;
+    if (vmid > 0 && read_client_memory(addr, &val, 1, vmid))
+      return val;
     return SparseMemory::read8(addr);
   }
 
@@ -135,6 +146,9 @@ public:
       std::memcpy(&val, p + (addr & PAGE_MASK), 2);
       return val;
     }
+    uint16_t val = 0;
+    if (vmid > 0 && read_client_memory(addr, &val, 2, vmid))
+      return val;
     return SparseMemory::read16(addr);
   }
 
@@ -144,6 +158,9 @@ public:
       std::memcpy(&val, p + (addr & PAGE_MASK), 4);
       return val;
     }
+    uint32_t val = 0;
+    if (vmid > 0 && read_client_memory(addr, &val, 4, vmid))
+      return val;
     return SparseMemory::read32(addr);
   }
 
@@ -153,6 +170,9 @@ public:
       std::memcpy(&val, p + (addr & PAGE_MASK), 8);
       return val;
     }
+    uint64_t val = 0;
+    if (vmid > 0 && read_client_memory(addr, &val, 8, vmid))
+      return val;
     return SparseMemory::read64(addr);
   }
 
@@ -161,6 +181,8 @@ public:
       p[addr & PAGE_MASK] = val;
       return;
     }
+    if (vmid > 0 && write_client_memory(addr, &val, 1, vmid))
+      return;
     SparseMemory::write8(addr, val);
   }
 
@@ -169,6 +191,8 @@ public:
       std::memcpy(p + (addr & PAGE_MASK), &val, 2);
       return;
     }
+    if (vmid > 0 && write_client_memory(addr, &val, 2, vmid))
+      return;
     SparseMemory::write16(addr, val);
   }
 
@@ -177,6 +201,8 @@ public:
       std::memcpy(p + (addr & PAGE_MASK), &val, 4);
       return;
     }
+    if (vmid > 0 && write_client_memory(addr, &val, 4, vmid))
+      return;
     SparseMemory::write32(addr, val);
   }
 
@@ -185,6 +211,8 @@ public:
       std::memcpy(p + (addr & PAGE_MASK), &val, 8);
       return;
     }
+    if (vmid > 0 && write_client_memory(addr, &val, 8, vmid))
+      return;
     SparseMemory::write64(addr, val);
   }
 
@@ -192,6 +220,7 @@ private:
   struct VmidEntry {
     KfdProcess::PageTable *page_table = nullptr;
     std::shared_mutex *mutex = nullptr;
+    pid_t client_pid = 0;
   };
 
   uint8_t *translate(uint64_t addr, uint32_t vmid) const {
@@ -212,6 +241,42 @@ private:
     if (passthrough_ && addr < kUserSpaceLimit)
       return reinterpret_cast<uint8_t *>(addr & ~PAGE_MASK);
     return nullptr;
+  }
+
+  pid_t client_pid_for_vmid(uint32_t vmid) const {
+    std::shared_lock lk(vmid_mutex_);
+    auto it = vmid_table_.find(vmid);
+    return (it != vmid_table_.end()) ? it->second.client_pid : 0;
+  }
+
+  bool read_client_memory(uint64_t addr, void *dst, size_t len, uint32_t vmid) const {
+    pid_t pid = client_pid_for_vmid(vmid);
+    if (pid <= 0)
+      return false;
+    iovec local{dst, len};
+    iovec remote{reinterpret_cast<void *>(addr), len};
+    ssize_t rc = process_vm_readv(pid, &local, 1, &remote, 1, 0);
+    if (rc != static_cast<ssize_t>(len)) {
+      util::Logger::warn("process_vm_readv failed: addr=0x", std::hex, addr, " pid=", std::dec, pid,
+                         " rc=", rc, " errno=", errno);
+      return false;
+    }
+    return true;
+  }
+
+  bool write_client_memory(uint64_t addr, const void *src, size_t len, uint32_t vmid) {
+    pid_t pid = client_pid_for_vmid(vmid);
+    if (pid <= 0)
+      return false;
+    iovec local{const_cast<void *>(src), len};
+    iovec remote{reinterpret_cast<void *>(addr), len};
+    ssize_t rc = process_vm_writev(pid, &local, 1, &remote, 1, 0);
+    if (rc != static_cast<ssize_t>(len)) {
+      util::Logger::warn("process_vm_writev failed: addr=0x", std::hex, addr, " pid=", std::dec,
+                         pid, " rc=", rc, " errno=", errno);
+      return false;
+    }
+    return true;
   }
 
   simdojo::Port *cpl_ = nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -260,7 +260,7 @@ rj_status_t rj_vm_execute_as(rj_vm_t *vm, uint32_t process_id, rj_vm_cmd_t *cmd)
   return execute_impl(vm->vm->driver(), process_id, cmd);
 }
 
-rj_status_t rj_vm_device_open(rj_vm_t *vm, pid_t client_pid, uint32_t *process_id) {
+rj_status_t rj_vm_device_open(rj_vm_t *vm, rj_client_pid_t client_pid, uint32_t *process_id) {
   if (!vm || !vm->vm || !vm->vm->driver())
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
   auto *drv = dynamic_cast<SimulatedDriver *>(vm->vm->driver());
@@ -268,8 +268,9 @@ rj_status_t rj_vm_device_open(rj_vm_t *vm, pid_t client_pid, uint32_t *process_i
     return ROCJITSU_STATUS_ERROR;
   // client_pid == 0 (local mode) maps to SimulatedDriver::open_process()'s
   // default; a nonzero client_pid enables daemon-mode process reuse and
-  // cross-process memory access.
-  uint32_t pid = drv->open_process(client_pid);
+  // cross-process memory access. Narrow the fixed-width public type to the
+  // platform pid_t at the Linux daemon boundary.
+  uint32_t pid = drv->open_process(static_cast<pid_t>(client_pid));
   if (pid == 0)
     return ROCJITSU_STATUS_ERROR;
   if (process_id)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/rj_vm.cpp
@@ -260,13 +260,16 @@ rj_status_t rj_vm_execute_as(rj_vm_t *vm, uint32_t process_id, rj_vm_cmd_t *cmd)
   return execute_impl(vm->vm->driver(), process_id, cmd);
 }
 
-rj_status_t rj_vm_device_open(rj_vm_t *vm, uint32_t *process_id) {
+rj_status_t rj_vm_device_open(rj_vm_t *vm, pid_t client_pid, uint32_t *process_id) {
   if (!vm || !vm->vm || !vm->vm->driver())
     return ROCJITSU_STATUS_INVALID_ARGUMENT;
   auto *drv = dynamic_cast<SimulatedDriver *>(vm->vm->driver());
   if (!drv)
     return ROCJITSU_STATUS_ERROR;
-  uint32_t pid = drv->open_process();
+  // client_pid == 0 (local mode) maps to SimulatedDriver::open_process()'s
+  // default; a nonzero client_pid enables daemon-mode process reuse and
+  // cross-process memory access.
+  uint32_t pid = drv->open_process(client_pid);
   if (pid == 0)
     return ROCJITSU_STATUS_ERROR;
   if (process_id)

--- a/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
+++ b/emulation/rocjitsu/tests/kfd_ioctl_test.cpp
@@ -309,4 +309,33 @@ TEST_F(KfdIoctlTest, RuntimeEnableAndDisable) {
   EXPECT_EQ(args.capabilities_mask, 0u);
 }
 
+// Models the interposer's fd lifecycle: the primary KFD fd plus every dup each
+// hold one open reference, so the process must survive until the LAST fd is
+// closed, not the first. retain_local_open() is what the interposer calls when
+// it tracks a dup; close() is what it calls per fd close.
+TEST_F(KfdIoctlTest, OpenRefcountSurvivesDupThenPrimaryClose) {
+  // SetUp() already performed the primary open().
+  EXPECT_EQ(driver_->local_open_ref_count(), 1u);
+
+  // Two dups of the KFD fd.
+  driver_->retain_local_open();
+  driver_->retain_local_open();
+  EXPECT_EQ(driver_->local_open_ref_count(), 3u);
+
+  // Closing the primary fd first must NOT tear the process down.
+  driver_->close();
+  EXPECT_EQ(driver_->local_open_ref_count(), 2u);
+
+  // Closing the first dup: still alive.
+  driver_->close();
+  EXPECT_EQ(driver_->local_open_ref_count(), 1u);
+
+  // Closing the last dup: now the process is destroyed.
+  driver_->close();
+  EXPECT_EQ(driver_->local_open_ref_count(), 0u);
+
+  // Re-open so the fixture's TearDown close() is balanced.
+  ASSERT_GE(driver_->open(), 0);
+}
+
 } // namespace

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -34,7 +34,15 @@
 
 using namespace rocjitsu;
 
-static void handle_client(int client_fd, rj_vm_t *vm, std::stop_token stop) {
+static pid_t peer_pid_for_socket(int fd) {
+  struct ucred cred {};
+  socklen_t len = sizeof(cred);
+  if (getsockopt(fd, SOL_SOCKET, SO_PEERCRED, &cred, &len) == 0 && cred.pid > 0)
+    return cred.pid;
+  return 0;
+}
+
+static void handle_client(int client_fd, rj_vm_t *vm, pid_t client_pid, std::stop_token stop) {
   uint32_t process_id = 0;
   bool connected = true;
 
@@ -45,7 +53,7 @@ static void handle_client(int client_fd, rj_vm_t *vm, std::stop_token stop) {
 
     switch (hdr.opcode) {
     case RPC_HANDSHAKE: {
-      auto open_rc = rj_vm_device_open(vm, &process_id);
+      auto open_rc = rj_vm_device_open(vm, client_pid, &process_id);
       if (open_rc != ROCJITSU_STATUS_SUCCESS) {
         RpcHeader resp{};
         resp.request_id = hdr.request_id;
@@ -252,9 +260,10 @@ static int run_daemon_server(const char *config_path) {
     if (client < 0)
       break;
 
+    pid_t peer_pid = peer_pid_for_socket(client);
     std::lock_guard<std::mutex> lock(client_threads_mutex);
     active_client_fds.push_back(client);
-    client_threads.emplace_back(handle_client, client, vm, stop_source.get_token());
+    client_threads.emplace_back(handle_client, client, vm, peer_pid, stop_source.get_token());
   }
 
   stop_source.request_stop();


### PR DESCRIPTION
## Motivation

The rocjitsu interposer layer intercepts at the system call level (to be precise, the C lib's syscall wrappers) and it doesn't intercept any user-mode driver API explicitly. As a temporary workaround we intercepted some libdrm amdgpu calls for expediency. This PR removes those cases in favor of native support for amdgpu DRM ioctls, etc.

## Technical Details

Replace the libdrm library-symbol shims with native handling of the amdgpu/DRM ioctl ABI so real libdrm_amdgpu runs unmodified over the simulator, and harden the existing daemon mode for multi-process clients with cross-process memory access, client-PID tracking, and process reuse.

Serve the amdgpu/DRM driver natively (interposer.cpp):
  - Remove all libdrm symbol interceptions (amdgpu_device_initialize/2, amdgpu_device_deinitialize/get_fd, amdgpu_query_gpu_info, amdgpu_get_marketing_name, amdgpu_bo_import/export/free/cpu_map/ cpu_unmap/va_op/query_info/set_metadata, drmCommandWriteRead, drmGetDevice(s)/drmFreeDevice(s)) and the dlsym override; real libdrm_amdgpu now runs and its calls are caught at the syscall layer
  - Handle DRM_IOCTL_AMDGPU_INFO for the queries libdrm issues during amdgpu_device_initialize: ACCEL_WORKING, DEV_INFO (with VA aperture), VRAM_GTT, MEMORY, and READ_MMR_REG; VERSION and PRIME_FD_TO_HANDLE remain handled
  - Interpose fcntl64 (libdrm imports fcntl64@GLIBC_2.28, not fcntl) so F_DUPFD_CLOEXEC on the render fd propagates DRM tracking; ioctls on the duped fd are otherwise unrecognized
  - Redirect individual /dev/dri/renderD*,card* node paths (not just the /dev/dri directory) into the synthetic dev_dri tree so libdrm's drmGetMinorType access() probe classifies every GPU's render node on multi-GPU configs
  - Drop the RjFakeBo/dmabuf bridge, Rj* libdrm mirror types, and the dlsym passthrough machinery left dead by the removals

Vendor kernel DRM UAPI headers (MIT):
  - Add external_headers/drm_headers/linux/uapi/drm/{drm.h,amdgpu_drm.h} (libdrm 2.4.125) and a DRM_INCLUDE_DIR include path, so the ioctl handlers use the real kernel structs (drm_amdgpu_info, drm_amdgpu_info_device, drm_amdgpu_info_vram_gtt, drm_amdgpu_memory_info, drm_version) rather than hand-mirrored copies

Harden daemon-mode KFD lifecycle, memory bridging, and process reuse (daemon mode and its RemoteDriver/RPC transport already exist; this adds the multi-process client support on top):
  - Interposer: remote_mutex_ guards RemoteDriver create/destroy, remote_kfd_fd_ made atomic, close_remote()/close_remote_fd_only() for clean shutdown, AMDKFD_IOCTL_BASE fallback for late ioctls, reset_after_fork() clears all containers and reinits remote_mutex_
  - SimulatedDriver: client_pid parameter on open_process() with process reuse, open_process() TOCTOU fix (pid search + create under one lock), unmap_memory_ioctl unmaps GPU pages without erasing the allocation record, set_process_client_pid() for post-hoc pid attachment
  - KfdProcess: client_pid_ plus retain_open()/release_open() refcount
  - gpu_memory.h: process_vm_readv/writev fallback for cross-process access, per-VMID client_pid tracking, warnings on access failure
  - remote_driver.cpp: extract dmabuf fd from EXPORT_DMABUF RPC response
  - rj_vm.h/cpp: rj_vm_device_open_for_client_pid() and rj_vm_device_set_client_pid() APIs
  - main.cpp: extract client PID via SO_PEERCRED, pass to rj_vm_device_open_for_client_pid()

## JIRA ID

N/A

## Test Plan

Run all CI tests, run OPT125, run hrx-systems tests.

## Test Result

CI tests: PASSED
OPT125: PASSED with 100% accurate tokens/logits compared to CPU reference run.
hrs-systems tests: 61/107 PASSED (known failures, no regressions)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
