### PR TITLE
[rocprofv3][docs] Document async output generation in attach mode

### DIFF
--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-process-attachment.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-process-attachment.rst
@@ -25,6 +25,10 @@ Here are the options used in the preceding example:
 
 - ``--output-format``: The desired output format such as rocpd, csv, or json.
 
+.. note::
+
+   In process-attachment mode, ``rocprofv3`` may generate output files asynchronously during detach. As a result, output files might not be fully written immediately when ``rocprofv3`` returns. If your workflow needs output files to be complete before continuing, for example, if a script processes or removes the output directory right after detach, use ``--attach-sync-output``. This makes detach wait for output generation to finish, which can increase detach time.
+
 **Basic attachment syntax:**
 
 .. code-block:: bash
@@ -118,6 +122,35 @@ There are some restrictions on what the options are allowed to change when reatt
 By default, the output file generation runs asynchronously after detachment, allowing for faster tool detachment. This implies that the output files might not be immediately available when ``rocprofv3`` exits. If the output file generation from the previous attachment is still in progress, ``rocprofv3`` blocks reattachment until the ongoing output generation completes.
 
 For use cases requiring output files to be fully written before detachment completes, such as scripts that process or delete output directories immediately after detachment, you can enable synchronous output generation using the ``--attach-sync-output`` flag. This causes ``tool_detach`` to wait for all output files to be written before returning, ensuring output files are complete when the ``rocprofv3`` process exits.
+
+For example, consider a script that attaches for a fixed duration and then terminates the workload as soon as ``rocprofv3`` returns:
+
+.. code-block:: bash
+
+   # Start the workload in the background
+   ./myapp &
+   WL_PID=$!
+
+   # Attach for 5 seconds, then detach
+   rocprofv3 --pid "$WL_PID" --attach-duration-msec 5000 \
+       --output-format csv -o profile -d "$PWD"
+
+   # Workload is killed immediately after rocprofv3 returns
+   kill "$WL_PID"
+
+With the default asynchronous output generation, the output thread runs inside the target process. Killing the workload right after ``rocprofv3`` returns can terminate that thread before it finishes writing, producing truncated or incomplete output files. Add ``--attach-sync-output`` so that detach waits for output generation to finish before returning:
+
+.. code-block:: bash
+
+   ./myapp &
+   WL_PID=$!
+
+   rocprofv3 --pid "$WL_PID" --attach-duration-msec 5000 \
+       --attach-sync-output \
+       --output-format csv -o profile -d "$PWD"
+
+   # Safe: output files are fully written before rocprofv3 returns
+   kill "$WL_PID"
 
 .. class:: details
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-process-attachment.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-rocprofv3-process-attachment.rst
@@ -27,7 +27,7 @@ Here are the options used in the preceding example:
 
 .. note::
 
-   In process-attachment mode, ``rocprofv3`` may generate output files asynchronously during detach. As a result, output files might not be fully written immediately when ``rocprofv3`` returns. If your workflow needs output files to be complete before continuing, for example, if a script processes or removes the output directory right after detach, use ``--attach-sync-output``. This makes detach wait for output generation to finish, which can increase detach time.
+   In process-attachment mode, ``rocprofv3`` may generate output files asynchronously during detachment. As a result, output files might not be fully written immediately when ``rocprofv3`` returns. If your workflow needs output files to be complete before continuing, for example, if a script processes or removes the output directory right after detach, use ``--attach-sync-output``. This makes detach wait for output generation to finish, which can increase detach time.
 
 **Basic attachment syntax:**
 
@@ -121,6 +121,24 @@ There are some restrictions on what the options are allowed to change when reatt
 
 By default, the output file generation runs asynchronously after detachment, allowing for faster tool detachment. This implies that the output files might not be immediately available when ``rocprofv3`` exits. If the output file generation from the previous attachment is still in progress, ``rocprofv3`` blocks reattachment until the ongoing output generation completes.
 
+.. class:: details
+
+   Full list of options that mustn't change:
+
+   - ALL options ending with ``trace``
+   - ALL options starting with ``pc_sampling``
+   - ALL options starting with ``att``
+   - ``pmc``
+   - ``pmc_groups``
+   - ``output_config``
+   - ``extra_counters``
+   - ``kernel_include_regex``
+   - ``kernel_exclude_regex``
+   - ``kernel_iteration_range``
+
+Synchronous output generation for scripts
+------------------------------------------
+
 For use cases requiring output files to be fully written before detachment completes, such as scripts that process or delete output directories immediately after detachment, you can enable synchronous output generation using the ``--attach-sync-output`` flag. This causes ``tool_detach`` to wait for all output files to be written before returning, ensuring output files are complete when the ``rocprofv3`` process exits.
 
 For example, consider a script that attaches for a fixed duration and then terminates the workload as soon as ``rocprofv3`` returns:
@@ -138,7 +156,7 @@ For example, consider a script that attaches for a fixed duration and then termi
    # Workload is killed immediately after rocprofv3 returns
    kill "$WL_PID"
 
-With the default asynchronous output generation, the output thread runs inside the target process. Killing the workload right after ``rocprofv3`` returns can terminate that thread before it finishes writing, producing truncated or incomplete output files. Add ``--attach-sync-output`` so that detach waits for output generation to finish before returning:
+With the default asynchronous output generation, the output thread runs inside the target process. Killing the workload right after ``rocprofv3`` returns can terminate that thread before it finishes writing, producing truncated or incomplete output files. Add ``--attach-sync-output`` so that detachment waits for output generation to finish before returning:
 
 .. code-block:: bash
 
@@ -151,21 +169,6 @@ With the default asynchronous output generation, the output thread runs inside t
 
    # Safe: output files are fully written before rocprofv3 returns
    kill "$WL_PID"
-
-.. class:: details
-
-   Full list of options that mustn't change:
-
-   - ALL options ending with ``trace``
-   - ALL options starting with ``pc_sampling``
-   - ALL options starting with ``att``
-   - ``pmc``
-   - ``pmc_groups``
-   - ``output_config``
-   - ``extra_counters``
-   - ``kernel_include_regex``
-   - ``kernel_exclude_regex``
-   - ``kernel_iteration_range``
 
 Attaching to a process tree
 ----------------------------


### PR DESCRIPTION
Add a prominent note and a worked example to the process attachment guide explaining that output files are generated asynchronously during detach by default, so killing or cleaning up the target immediately after rocprofv3 returns can truncate output. Recommend --attach-sync-output for scripts that need complete output before continuing (ROCM-24849).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Addresses the documentation request on ROCM-24849 (stochastic PC sampling in attach mode producing mostly uncorrelated samples when the workload is killed right after `rocprofv3` returns). This PR is docs-only and does not change runtime behavior.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
 ROCM-24849
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
