### PR TITLE
[hipfile] Add license comment blocks to Python

### DIFF
--- a/projects/hipfile/docs/conf.py
+++ b/projects/hipfile/docs/conf.py
@@ -1,6 +1,16 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 # Configuration file for the Sphinx documentation builder.
 #
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# pylint: disable=invalid-name
+
+"""
+Configuration for hipFile documentation
+"""
 
 import re
 
@@ -24,7 +34,9 @@ version_number = (
 
 project = "hipFile"
 author = "Advanced Micro Devices, Inc."
+# pylint: disable=redefined-builtin
 copyright = "2024-2026, Advanced Micro Devices, Inc."
+# pylint: enable=redefined-builtin
 version = version_number
 release = version_number
 html_title = f"hipFile {version_number} documentation"

--- a/projects/hipfile/python/hipfile/__init__.py
+++ b/projects/hipfile/python/hipfile/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """Python bindings for the hipFile GPU-accelerated file I/O library."""
 
 from hipfile._hipfile import (  # pylint: disable=E0401,E0611

--- a/projects/hipfile/python/hipfile/buffer.py
+++ b/projects/hipfile/python/hipfile/buffer.py
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """GPU memory buffer registration for hipFile I/O."""
 
 from __future__ import annotations

--- a/projects/hipfile/python/hipfile/driver.py
+++ b/projects/hipfile/python/hipfile/driver.py
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """hipFile driver lifecycle management."""
 
 from __future__ import annotations

--- a/projects/hipfile/python/hipfile/enums.py
+++ b/projects/hipfile/python/hipfile/enums.py
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """Enumerations mirroring hipFile C types."""
 
 from enum import IntEnum

--- a/projects/hipfile/python/hipfile/error.py
+++ b/projects/hipfile/python/hipfile/error.py
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """Exception type for hipFile operations."""
 
 from __future__ import annotations

--- a/projects/hipfile/python/hipfile/file.py
+++ b/projects/hipfile/python/hipfile/file.py
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """GPU-accelerated file I/O through hipFile."""
 
 from __future__ import annotations

--- a/projects/hipfile/python/hipfile/hipMalloc.py
+++ b/projects/hipfile/python/hipfile/hipMalloc.py
@@ -1,4 +1,9 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 # pylint: disable=all
+
 """
 This is a hack to have some semblance of GPU memory management
 without introducing a dependency at this early stage of

--- a/projects/hipfile/python/hipfile/properties.py
+++ b/projects/hipfile/python/hipfile/properties.py
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """Query hipFile driver properties and version information."""
 
 from __future__ import annotations

--- a/projects/hipfile/python/main.py
+++ b/projects/hipfile/python/main.py
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """
 A quick & rough script for testing the Cython bindings to the
 hipFile C library. Reads a given file and copies it to an

--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -1,5 +1,10 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 #! /usr/bin/env python3
 # pylint: disable=invalid-name
+
 """
 Check if the necessary AMD Infinity Storage (AIS) components are installed
 

--- a/projects/hipfile/tools/ais-check/tests/conftest.py
+++ b/projects/hipfile/tools/ais-check/tests/conftest.py
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """
 Shared test fixtures for the ais-check suite.
 

--- a/projects/hipfile/tools/ais-check/tests/test_amdgpu.py
+++ b/projects/hipfile/tools/ais-check/tests/test_amdgpu.py
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """Tests for amdgpu_supports_ais()."""
 
 # pylint: disable=missing-function-docstring

--- a/projects/hipfile/tools/ais-check/tests/test_find_hip_runtimes.py
+++ b/projects/hipfile/tools/ais-check/tests/test_find_hip_runtimes.py
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """Tests for find_hip_runtimes()."""
 
 # The isolated_env fixture is requested by name (pytest's dependency-injection

--- a/projects/hipfile/tools/ais-check/tests/test_hip_runtime_ais.py
+++ b/projects/hipfile/tools/ais-check/tests/test_hip_runtime_ais.py
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """Tests for hip_runtime_supports_ais()."""
 
 # The FakeHip double mirrors the HIP C API: its method names must match the

--- a/projects/hipfile/tools/ais-check/tests/test_main.py
+++ b/projects/hipfile/tools/ais-check/tests/test_main.py
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """Tests for main(): the argument parsing, output, and exit-code contract."""
 
 # The stub_checks fixture is requested by name (pytest dependency injection),

--- a/projects/hipfile/tools/ais-check/tests/test_p2pdma.py
+++ b/projects/hipfile/tools/ais-check/tests/test_p2pdma.py
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 """Tests for kernel_supports_p2pdma()."""
 
 # Test functions are self-documenting by name; docstrings add noise.


### PR DESCRIPTION
## Motivation

The hipFile Python files lack license comment blocks

## Technical Details

Adds a license comment block to all hipFile Python files. Also suppresses some pylint warnings in docs/conf.py that snuck in.

## JIRA ID

AIHIPFILE-176

## Test Plan

CI passes (especially pylint)

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
