### PR TITLE
rocdbgapi: allow attaching with no forward progress requirement

### DIFF
--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -62,7 +62,7 @@
 
 cmake_minimum_required(VERSION 3.8)
 
-project(amd-dbgapi VERSION 0.80.0)
+project(amd-dbgapi VERSION 0.81.0)
 
 include(CheckIncludeFile)
 include(CheckIncludeFiles)

--- a/projects/rocdbgapi/include/amd-dbgapi.h.in
+++ b/projects/rocdbgapi/include/amd-dbgapi.h.in
@@ -665,6 +665,12 @@ typedef unsigned long amd_dbgapi_DWORD;
  */
 #define AMD_DBGAPI_VERSION_0_80
 
+/**
+ * The function was introduced in version 0.81 of the interface and has the
+ * symbol version string of ``"@AMD_DBGAPI_NAME@_0.81"``.
+ */
+#define AMD_DBGAPI_VERSION_0_81
+
 /** @} */
 
 /** \ingroup callbacks_group
@@ -1944,6 +1950,17 @@ amd_dbgapi_status_t AMD_DBGAPI amd_dbgapi_process_get_info (
     amd_dbgapi_process_id_t process_id, amd_dbgapi_process_info_t query,
     size_t value_size, void *value) AMD_DBGAPI_VERSION_0_80;
 
+/** Flags influencing the how the library attaches to a process.
+  */
+typedef enum {
+  AMD_DBGAPI_PROCESS_ATTACH_FLAGS_NONE = 0,
+  /**
+   * When attaching to a process, set forward progress requirement to
+   * ::AMD_DBGAPI_PROGRESS_NO_FORWARD.
+   */
+  AMD_DBGAPI_PROCESS_ATTACH_FLAGS_NO_FORWARD_PROGRESS = 1,
+} amd_dbgapi_process_attach_flags;
+
 /**
  * Attach to a process in order to provide debug control of the AMD GPUs it
  * uses.
@@ -2042,7 +2059,8 @@ amd_dbgapi_status_t AMD_DBGAPI amd_dbgapi_process_get_info (
  */
 amd_dbgapi_status_t AMD_DBGAPI amd_dbgapi_process_attach (
     amd_dbgapi_client_process_id_t client_process_id,
-    amd_dbgapi_process_id_t *process_id) AMD_DBGAPI_VERSION_0_56;
+    amd_dbgapi_process_id_t *process_id,
+    amd_dbgapi_process_attach_flags attach_flags) AMD_DBGAPI_VERSION_0_81;
 
 /**
  * Detach from a process and no longer have debug control of the AMD GPU

--- a/projects/rocdbgapi/src/exportmap.in
+++ b/projects/rocdbgapi/src/exportmap.in
@@ -38,13 +38,9 @@ global: amd_dbgapi_address_is_in_address_class;
 local:  *;
 };
 
-@AMD_DBGAPI_NAME@_0.56 {
-global: amd_dbgapi_process_attach;
-} @AMD_DBGAPI_NAME@_0.54;
-
 @AMD_DBGAPI_NAME@_0.58 {
 global: amd_dbgapi_classify_instruction;
-} @AMD_DBGAPI_NAME@_0.56;
+} @AMD_DBGAPI_NAME@_0.54;
 
 @AMD_DBGAPI_NAME@_0.62 {
 global: amd_dbgapi_address_class_get_info;
@@ -105,3 +101,7 @@ global:	amd_dbgapi_address_dependency;
 @AMD_DBGAPI_NAME@_0.80 {
 global: amd_dbgapi_process_get_info;
 } @AMD_DBGAPI_NAME@_0.79;
+
+@AMD_DBGAPI_NAME@_0.81 {
+global: amd_dbgapi_process_attach;
+} @AMD_DBGAPI_NAME@_0.80;

--- a/projects/rocdbgapi/src/logging.cpp
+++ b/projects/rocdbgapi/src/logging.cpp
@@ -91,6 +91,49 @@ to_string (amd_dbgapi_architecture_id_t architecture_id)
   return str;
 }
 
+#define CASE(x)                                                               \
+  case AMD_DBGAPI_##x:                                                        \
+    return #x
+
+namespace
+{
+
+inline std::string
+one_process_attach_flag_to_string (amd_dbgapi_process_attach_flags flag)
+{
+  switch (flag)
+    {
+      CASE (PROCESS_ATTACH_FLAGS_NONE);
+      CASE (PROCESS_ATTACH_FLAGS_NO_FORWARD_PROGRESS);
+    }
+  return to_string (make_hex (flag));
+}
+
+} /* (anonymous) namespace.  */
+
+template <>
+std::string
+to_string (amd_dbgapi_process_attach_flags flags)
+{
+  std::string str;
+
+  if (!flags)
+    return one_process_attach_flag_to_string (flags);
+
+  while (flags != AMD_DBGAPI_PROCESS_ATTACH_FLAGS_NONE)
+    {
+      amd_dbgapi_process_attach_flags one_flag = flags ^ (flags & (flags - 1));
+
+      if (!str.empty ())
+        str += " | ";
+
+      str += one_process_attach_flag_to_string (one_flag);
+      flags ^= one_flag;
+    }
+
+  return str;
+}
+
 template <>
 std::string
 to_string (amd_dbgapi_process_id_t process_id)
@@ -271,10 +314,6 @@ to_string (amd_dbgapi_breakpoint_id_t breakpoint_id)
 
   return string_printf ("breakpoint_%" PRId64, breakpoint_id.handle);
 }
-
-#define CASE(x)                                                               \
-  case AMD_DBGAPI_##x:                                                        \
-    return #x
 
 template <>
 std::string

--- a/projects/rocdbgapi/src/logging.h
+++ b/projects/rocdbgapi/src/logging.h
@@ -529,6 +529,7 @@ to_string (detail::parameter_t<detail::query_ref<T>, name, kind> param)
   F (amd_dbgapi_memory_precision_t)                                           \
   F (amd_dbgapi_alu_exceptions_precision_t)                                   \
   F (amd_dbgapi_os_queue_type_t)                                              \
+  F (amd_dbgapi_process_attach_flags)                                         \
   F (amd_dbgapi_process_id_t)                                                 \
   F (amd_dbgapi_process_info_t)                                               \
   F (amd_dbgapi_progress_t)                                                   \

--- a/projects/rocdbgapi/src/process.cpp
+++ b/projects/rocdbgapi/src/process.cpp
@@ -2569,9 +2569,11 @@ amd_dbgapi_process_unfreeze (amd_dbgapi_process_id_t process_id)
 
 amd_dbgapi_status_t AMD_DBGAPI
 amd_dbgapi_process_attach (amd_dbgapi_client_process_id_t client_process_id,
-                           amd_dbgapi_process_id_t *process_id)
+                           amd_dbgapi_process_id_t *process_id,
+                           amd_dbgapi_process_attach_flags attach_flags)
 {
-  TRACE_BEGIN (param_in (client_process_id), param_in (process_id));
+  TRACE_BEGIN (param_in (client_process_id), param_in (process_id),
+               param_in (attach_flags));
   TRY
   {
     if (!detail::is_initialized)
@@ -2601,6 +2603,8 @@ amd_dbgapi_process_attach (amd_dbgapi_client_process_id_t client_process_id,
 
     try
       {
+        if (attach_flags & AMD_DBGAPI_PROCESS_ATTACH_FLAGS_NO_FORWARD_PROGRESS)
+          process->set_forward_progress_needed (false);
         process->attach ();
       }
     catch (const process_exited_exception_t &)

--- a/projects/rocdbgapi/src/utils.h
+++ b/projects/rocdbgapi/src/utils.h
@@ -1174,6 +1174,11 @@ template <> struct is_flag<amd_dbgapi_wave_stop_reasons_t> : std::true_type
 {
 };
 
+/* Enable bitwise operations for amd_dbgapi_process_attach_flags.  */
+template <> struct is_flag<amd_dbgapi_process_attach_flags> : std::true_type
+{
+};
+
 /* A monotonic counter with wrap-around detection. Type must be an integral
    unsigned type. The WrapAroundCheck functor returns true if the counter has
    wrapped around. The default functor is (new_value > old_value).  */

--- a/projects/rocr-debug-agent/src/debug_agent.cpp
+++ b/projects/rocr-debug-agent/src/debug_agent.cpp
@@ -1187,7 +1187,7 @@ process_dbgapi_events (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
   /* TODO, we  should have a RAII object to handle forward progress wave
      creation mode override.  */
   DBGAPI_CHECK (amd_dbgapi_process_set_progress (
-      process_id, AMD_DBGAPI_PROGRESS_NO_FORWARD));
+      process_id, AMD_DBGAPI_PROCESS_ATTACH_FLAGS_NO_FORWARD_PROGRESS));
 
   DBGAPI_CHECK (amd_dbgapi_process_set_wave_creation (
       process_id, AMD_DBGAPI_WAVE_CREATION_STOP));
@@ -1362,7 +1362,7 @@ dbgapi_worker (int listen_fd, bool all_wavefronts, bool precise_memory,
 
   DBGAPI_CHECK (amd_dbgapi_process_attach (
       reinterpret_cast<amd_dbgapi_client_process_id_t> (&self_mem_fd),
-      &process_id));
+      &process_id, PROCESS_ATTACH_FLAGS_NONE));
 
   /* Runtime has been activated just before tools are loaded.  We do expect
      a runtime loaded event to be ready to be consumed.  */


### PR DESCRIPTION


We could have made this the new default, but to maintain compatibility with existing debuggers, we make this behavior an opt-in and not a new default.

Suggested-by: Laurent Morichetti <laurent.morichetti@amd.com>

## Motivation

When attaching to a process, we currently implicitly have forward progress requirement disabled.  As a consequence, during the attach sequence, we have a few suspend-restore cycles, which are not necessary.
## Technical Details

To fix this inefficiency, allow the client to attach with process requirement disabled.

## Test Plan

Tested using https://github.com/ROCm/ROCgdb/pull/182, as well as debug agent tests.

## Test Result

Pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
