### PR TITLE
[rocprofiler-compute] Add per-CI test exclude labels

### DIFF
--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -118,15 +118,12 @@ jobs:
         run: |
           if [ '${{ github.event_name }}' = 'schedule' ] || [ '${{ inputs.mode }}' = 'nightly' ]; then
             MODE=Nightly
-            EXCLUDED_TESTS=""
             ADD_COVERAGE="--coverage"
           else
             MODE=Continuous
-            EXCLUDED_TESTS="test_profile_live_attach_detach"
             ADD_COVERAGE=""
           fi
           echo "mode=${MODE}" >> $GITHUB_OUTPUT
-          echo "excluded_tests=${EXCLUDED_TESTS}" >> $GITHUB_OUTPUT
           echo "add_coverage=${ADD_COVERAGE}" >> $GITHUB_OUTPUT
 
           if [ '${{ matrix.system.os-release }}' = '24.04' ]; then
@@ -202,7 +199,8 @@ jobs:
             -DINSTALL_TESTS=ON \
             -DPYTEST_NUMPROCS=8 \
             -- \
-            -E "${{ steps.setup_env.outputs.excluded_tests }}"
+            -L full \
+            -LE rocprofiler_compute_ci_exclude
 
       - name: Output Logs
         if: steps.test.outcome == 'failure'

--- a/.github/workflows/rocprofiler-compute-continuous-integration.yml
+++ b/.github/workflows/rocprofiler-compute-continuous-integration.yml
@@ -200,7 +200,7 @@ jobs:
             -DPYTEST_NUMPROCS=8 \
             -- \
             -L full \
-            -LE rocprofiler_compute_ci_exclude
+            -LE full_rocprofiler_compute_ci_exclude
 
       - name: Output Logs
         if: steps.test.outcome == 'failure'

--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -30,6 +30,10 @@ test_categories:
       - test_mem_chart
       - test_native_tool_finder
       - test-rocprofiler-compute-tool
+    # Remove once ROCm/TheRock#6087 lands and the rocm-systems hash is bumped in TheRock; therock_ci_exclude replaces this.
+    exclude:
+      - test_profile_live_attach_detach
+      - test_metric_validation
     therock_ci_exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
@@ -82,6 +86,10 @@ test_categories:
       - test_mem_chart
       - test_native_tool_finder
       - test-rocprofiler-compute-tool
+    # Remove once ROCm/TheRock#6087 lands and the rocm-systems hash is bumped in TheRock; therock_ci_exclude replaces this.
+    exclude:
+      - test_profile_live_attach_detach
+      - test_metric_validation
     therock_ci_exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
@@ -133,6 +141,10 @@ test_categories:
       - test_mem_chart
       - test_native_tool_finder
       - test-rocprofiler-compute-tool
+    # Remove once ROCm/TheRock#6087 lands and the rocm-systems hash is bumped in TheRock; therock_ci_exclude replaces this.
+    exclude:
+      - test_profile_live_attach_detach
+      - test_metric_validation
     therock_ci_exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
@@ -184,6 +196,10 @@ test_categories:
       - test_mem_chart
       - test_native_tool_finder
       - test-rocprofiler-compute-tool
+    # Remove once ROCm/TheRock#6087 lands and the rocm-systems hash is bumped in TheRock; therock_ci_exclude replaces this.
+    exclude:
+      - test_profile_live_attach_detach
+      - test_metric_validation
     therock_ci_exclude:
       - test_profile_live_attach_detach
       - test_metric_validation

--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -30,9 +30,11 @@ test_categories:
       - test_mem_chart
       - test_native_tool_finder
       - test-rocprofiler-compute-tool
-    exclude:
+    therock_ci_exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
+    rocprofiler_compute_ci_exclude:
+      - test_profile_live_attach_detach
     labels:
       - "quick"
       - "pre-commit"
@@ -80,9 +82,11 @@ test_categories:
       - test_mem_chart
       - test_native_tool_finder
       - test-rocprofiler-compute-tool
-    exclude:
+    therock_ci_exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
+    rocprofiler_compute_ci_exclude:
+      - test_profile_live_attach_detach
     labels:
       - "standard"
       - "pr"
@@ -129,9 +133,11 @@ test_categories:
       - test_mem_chart
       - test_native_tool_finder
       - test-rocprofiler-compute-tool
-    exclude:
+    therock_ci_exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
+    rocprofiler_compute_ci_exclude:
+      - test_profile_live_attach_detach
     labels:
       - "comprehensive"
       - "nightly"
@@ -178,9 +184,11 @@ test_categories:
       - test_mem_chart
       - test_native_tool_finder
       - test-rocprofiler-compute-tool
-    exclude:
+    therock_ci_exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
+    rocprofiler_compute_ci_exclude:
+      - test_profile_live_attach_detach
     labels:
       - "full"
       - "weekly"

--- a/shared/ctest/parse_ctest_categories.py
+++ b/shared/ctest/parse_ctest_categories.py
@@ -151,7 +151,6 @@ def generate_cmake(categories):
     for category, config in categories.items():
         test_patterns = config.get("test_patterns") or []
         test_labels = config.get("test_labels") or []
-        excludes = config.get("exclude") or []
         custom_labels = config.get("labels") or []
 
         # Combine the tier labels and custom labels, and remove duplicates
@@ -167,16 +166,9 @@ def generate_cmake(categories):
                 lines, test_labels, labels_str, f"Category: {category} - test_labels"
             )
 
-        if excludes:
-            _emit_label_block(
-                lines,
-                excludes,
-                f"{category}_exclude",
-                f"Category: {category} - exclude",
-            )
-
+        # Emit a per-category label for exclude and any *_exclude list.
         for key, value in config.items():
-            if key.endswith("_exclude") and isinstance(value, list) and value:
+            if key.endswith("exclude") and isinstance(value, list) and value:
                 _emit_label_block(
                     lines,
                     value,

--- a/shared/ctest/parse_ctest_categories.py
+++ b/shared/ctest/parse_ctest_categories.py
@@ -166,7 +166,7 @@ def generate_cmake(categories):
                 lines, test_labels, labels_str, f"Category: {category} - test_labels"
             )
 
-        # Emit a per-category label for exclude and any *_exclude list.
+        # Emit a per-category label for any *exclude list.
         for key, value in config.items():
             if key.endswith("exclude") and isinstance(value, list) and value:
                 _emit_label_block(

--- a/shared/ctest/parse_ctest_categories.py
+++ b/shared/ctest/parse_ctest_categories.py
@@ -175,10 +175,17 @@ def generate_cmake(categories):
                 f"Category: {category} - exclude",
             )
 
+        # Scope each *_exclude list to its category, mirroring {category}_exclude.
+        # A bare label would union the lists across categories (labels attach to
+        # test names, which recur in every category), so a per-category edit
+        # could not narrow the exclusion.
         for key, value in config.items():
             if key.endswith("_exclude") and isinstance(value, list) and value:
                 _emit_label_block(
-                    lines, value, key, f"Category: {category} - {key}"
+                    lines,
+                    value,
+                    f"{category}_{key}",
+                    f"Category: {category} - {key}",
                 )
 
     # Deduplicate labels across all tests, since APPEND_PROPERTY doesn't deduplicate.

--- a/shared/ctest/parse_ctest_categories.py
+++ b/shared/ctest/parse_ctest_categories.py
@@ -175,10 +175,6 @@ def generate_cmake(categories):
                 f"Category: {category} - exclude",
             )
 
-        # Scope each *_exclude list to its category, mirroring {category}_exclude.
-        # A bare label would union the lists across categories (labels attach to
-        # test names, which recur in every category), so a per-category edit
-        # could not narrow the exclusion.
         for key, value in config.items():
             if key.endswith("_exclude") and isinstance(value, list) and value:
                 _emit_label_block(

--- a/shared/ctest/parse_ctest_categories.py
+++ b/shared/ctest/parse_ctest_categories.py
@@ -175,6 +175,12 @@ def generate_cmake(categories):
                 f"Category: {category} - exclude",
             )
 
+        for key, value in config.items():
+            if key.endswith("_exclude") and isinstance(value, list) and value:
+                _emit_label_block(
+                    lines, value, key, f"Category: {category} - {key}"
+                )
+
     # Deduplicate labels across all tests, since APPEND_PROPERTY doesn't deduplicate.
     lines.append("# Deduplicate labels across all tests")
     lines.append(


### PR DESCRIPTION
## Motivation

Make `tests/test_categories.yaml` the single source of truth for CI test exclusions, with separate exclude lists per consuming CI. TheRock CI and the rocprofiler-compute CI need to skip different sets (TheRock skips 2 tests, rocprofiler-compute skips 1), so each category carries one exclude list per CI and each CI honors its own.

## Technical Details

- `tests/test_categories.yaml`: replace each category's single `exclude:` block with two named lists: `therock_ci_exclude` (`test_profile_live_attach_detach`, `test_metric_validation`) and `rocprofiler_compute_ci_exclude` (`test_profile_live_attach_detach`).
- `shared/ctest/parse_ctest_categories.py`: any category key ending in `_exclude` emits a per-category ctest label `{category}_{key}` (e.g. `full_therock_ci_exclude`), mirroring the existing `{category}_exclude`. Per-category scoping is deliberate: a bare label would union the lists across categories (labels attach to test names, which recur in every category), so a per-category edit could not narrow the exclusion. The built-in `exclude:` path used by other components is unchanged, so their generated output is byte-identical.
- `.github/workflows/rocprofiler-compute-continuous-integration.yml`: drop the hardcoded `EXCLUDED_TESTS` name regex. The job runs the `full` category and excludes via `-L full -LE full_rocprofiler_compute_ci_exclude`, in both continuous and nightly modes.
- TheRock CI consumes the matching `<category>_therock_ci_exclude` label via its own test script (TheRock PR ROCm/TheRock#6087); that PR depends on this one landing and the rocm-systems submodule being re-pinned.

## JIRA ID

N/A

## Test Plan

- Configure a build with `-DENABLE_TESTS=ON -DINSTALL_TESTS=ON` and run `ctest --print-labels`; confirm `{category}_therock_ci_exclude` and `{category}_rocprofiler_compute_ci_exclude` labels exist for each category.
- `ctest -L full -LE full_rocprofiler_compute_ci_exclude -N` lists the full suite minus `test_profile_live_attach_detach`.
- `ctest -L full -LE full_therock_ci_exclude -N` additionally drops `test_metric_validation`.

## Test Result

- Parser run on the updated YAML emits `{category}_therock_ci_exclude` (on both tests) and `{category}_rocprofiler_compute_ci_exclude` (on one test) for every category.
- Diff of old vs new parser on an `exclude:`-style YAML (other components): identical.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.