### PR TITLE
[RCCL] Add offline C2C GDR/CX8 path regression test

### DIFF
--- a/projects/rccl/src/graph/xml.cc
+++ b/projects/rccl/src/graph/xml.cc
@@ -350,7 +350,11 @@ ncclResult_t ncclTopoXmlLoadC2c(FILE* file, struct ncclXml* xml, struct ncclXmlN
 }
 ncclResult_t ncclTopoXmlLoadGpu(FILE* file, struct ncclXml* xml, struct ncclXmlNode* head) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
-  struct xmlHandler handlers[] = { { "xgmi", ncclTopoXmlLoadNvlink } };
+  // Accept <c2c> on AMD too: coherent GPU<->CPU links (e.g. MI300A-class APUs, or
+  // when ingesting NCCL-format topology files) must be parsed so the C2C+PHB path
+  // logic in ncclTopoComputePaths()/ncclTopoCheckGdr() is exercised. This also fixes
+  // the handler-count mismatch below (nHandlers was 2 with a single entry).
+  struct xmlHandler handlers[] = { { "xgmi", ncclTopoXmlLoadNvlink }, { "c2c", ncclTopoXmlLoadC2c } };
 #else
   struct xmlHandler handlers[] = { { "nvlink", ncclTopoXmlLoadNvlink }, { "c2c", ncclTopoXmlLoadC2c } };
 #endif

--- a/projects/rccl/tools/topo_expl/include/model_descs.h
+++ b/projects/rccl/tools/topo_expl/include/model_descs.h
@@ -94,6 +94,9 @@ inline NodeModelDesc model_descs[] = {
   {"topo_16p_gio-3s-1rp-split-flat.xml", "16gfx942 2H7XGMI  1NIC 2AMD   B"},
   // GFX 950
   {"topo_8p_950.xml",                    " 8gfx950 1H7XGMI  8NIC 2AMD   A"},
+  // C2C (coherent GPU<->CPU link) regression model for the GB200/300 + CX8
+  // "hang when GDR is disabled" fix (see topo_expl_tests.cpp / topo_2p_c2c_2nic.xml).
+  {"topo_2p_c2c_2nic.xml",               " 2gfx942 1HC2C    2NIC 1Intel A"},
 };
 
 inline const int num_models = sizeof(model_descs) / sizeof(*model_descs);

--- a/projects/rccl/tools/topo_expl/include/topo_expl_api.h
+++ b/projects/rccl/tools/topo_expl/include/topo_expl_api.h
@@ -137,6 +137,27 @@ TopoExplResult topoExplGetAlgoTime(
     uint64_t count,
     float* time);
 
+// Number of NET (NIC) nodes in the topology visible to a given rank's GPU.
+TopoExplResult topoExplGetNetCount(
+    TopoExplContext* context,
+    int rank,
+    int* netCount);
+
+// For a given rank's GPU, query the computed topology path to NET node `netIndex`:
+//   *pathType -> RCCL PATH_* value (PATH_LOC=0 .. PATH_DIS=11). See
+//                topoExplGetPathTypeP2C() for the P2C sentinel.
+//   *isLocal  -> 1 if `netIndex` is one of the GPU's "local" (highest-bandwidth)
+//                NICs as selected by ncclTopoGetLocal(), else 0.
+TopoExplResult topoExplGetNetPathInfo(
+    TopoExplContext* context,
+    int rank,
+    int netIndex,
+    int* pathType,
+    int* isLocal);
+
+// Returns RCCL's PATH_P2C constant so tests stay bound to the library enum.
+int topoExplGetPathTypeP2C(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/projects/rccl/tools/topo_expl/models/topo_2p_c2c_2nic.xml
+++ b/projects/rccl/tools/topo_expl/models/topo_2p_c2c_2nic.xml
@@ -1,0 +1,53 @@
+<!--
+ - Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ - See LICENSE.txt for license information
+ -
+ - Synthetic C2C (GPU<->CPU coherent link) topology used to regression-test the
+ - NCCL 2.29.2 "hang on GB200/300 + CX8 when GDR is disabled" fix.
+ -
+ - Two GPUs are attached to a single CPU/NUMA node through a coherent C2C link
+ - (mimicking a Grace/MI300A-style superchip). Two NICs hang off the same CPU
+ - root complex (both PHB to the CPU) but at different bandwidths:
+ -   * mlx5_0 (fast, 400 Gb/s) -> highest-bandwidth NIC => "local" to the GPUs
+ -   * mlx5_1 (slow, 100 Gb/s) -> NOT the closest NIC => must be reached via PXN
+ -
+ - The fix restricts the C2C+PHB "P2C" path promotion in ncclTopoComputePaths()
+ - to a GPU's local NIC(s). Before the fix, every NIC whose merged GPU/NIC->CPU
+ - path was P2C (including the slow, non-local mlx5_1) was promoted to PATH_P2C,
+ - which broke PXN preference / GDR routing and caused the hang. This model makes
+ - that divergence observable offline.
+ -->
+<system version="2">
+  <cpu numaid="0" affinity="ffffffff,ffffffff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="143">
+    <!-- Fast NIC: 400 Gb/s, directly under the CPU root complex (PHB) -->
+    <pci busid="0000:03:00.0" class="0x020000" vendor="0x15b3" device="0x1023" link_speed="32.0 GT/s PCIe" link_width="16">
+      <nic>
+        <net name="mlx5_0" dev="0" latency="0" speed="400000" port="1" guid="0x0000000000000001" maxconn="131072" gdr="1"/>
+      </nic>
+    </pci>
+    <!-- Slow NIC: 100 Gb/s, directly under the CPU root complex (PHB) -->
+    <pci busid="0000:04:00.0" class="0x020000" vendor="0x15b3" device="0x1023" link_speed="8.0 GT/s PCIe" link_width="16">
+      <nic>
+        <net name="mlx5_1" dev="1" latency="0" speed="100000" port="1" guid="0x0000000000000002" maxconn="131072" gdr="1"/>
+      </nic>
+    </pci>
+    <!-- GPU 0: attached to the CPU via a coherent C2C link -->
+    <pci busid="0000:08:00.0" class="0x060400" link_speed="32.0 GT/s PCIe" link_width="16">
+      <pci busid="0000:09:00.0" class="0x120000" vendor="0x1002" device="0x74a0" link_speed="32.0 GT/s PCIe" link_width="16">
+        <gpu dev="0" sm="304" gcn="gfx942" arch="38911" rank="0" gdr="1">
+          <c2c count="8" bw="50000"/>
+          <xgmi target="0000:0b:00.0" count="8" tclass="0x120000"/>
+        </gpu>
+      </pci>
+    </pci>
+    <!-- GPU 1: attached to the CPU via a coherent C2C link -->
+    <pci busid="0000:0a:00.0" class="0x060400" link_speed="32.0 GT/s PCIe" link_width="16">
+      <pci busid="0000:0b:00.0" class="0x120000" vendor="0x1002" device="0x74a0" link_speed="32.0 GT/s PCIe" link_width="16">
+        <gpu dev="1" sm="304" gcn="gfx942" arch="38911" rank="1" gdr="1">
+          <c2c count="8" bw="50000"/>
+          <xgmi target="0000:09:00.0" count="8" tclass="0x120000"/>
+        </gpu>
+      </pci>
+    </pci>
+  </cpu>
+</system>

--- a/projects/rccl/tools/topo_expl/src/topo_expl_api.cpp
+++ b/projects/rccl/tools/topo_expl/src/topo_expl_api.cpp
@@ -389,3 +389,72 @@ TopoExplResult topoExplGetAlgoTime(
   
   return TOPO_EXPL_SUCCESS;
 }
+
+TopoExplResult topoExplGetNetCount(
+    TopoExplContext* context,
+    int rank,
+    int* netCount) {
+
+  if (!context || !netCount) {
+    return TOPO_EXPL_INVALID_ARG;
+  }
+  if (rank < 0 || rank >= context->nRanks) {
+    return TOPO_EXPL_INVALID_ARG;
+  }
+
+  struct ncclTopoSystem* system = context->comms[rank].topo;
+  if (!system) {
+    return TOPO_EXPL_INTERNAL_ERROR;
+  }
+
+  *netCount = system->nodes[NET].count;
+  return TOPO_EXPL_SUCCESS;
+}
+
+TopoExplResult topoExplGetNetPathInfo(
+    TopoExplContext* context,
+    int rank,
+    int netIndex,
+    int* pathType,
+    int* isLocal) {
+
+  if (!context || !pathType || !isLocal) {
+    return TOPO_EXPL_INVALID_ARG;
+  }
+  if (rank < 0 || rank >= context->nRanks) {
+    return TOPO_EXPL_INVALID_ARG;
+  }
+
+  struct ncclTopoSystem* system = context->comms[rank].topo;
+  if (!system) {
+    return TOPO_EXPL_INTERNAL_ERROR;
+  }
+  if (netIndex < 0 || netIndex >= system->nodes[NET].count) {
+    return TOPO_EXPL_INVALID_ARG;
+  }
+
+  int g = -1;
+  TOPO_NCCLCHECK(ncclTopoRankToIndex(system, rank, &g, /*showWarn=*/true));
+
+  struct ncclTopoLinkList* netPaths = system->nodes[GPU].nodes[g].paths[NET];
+  if (netPaths == NULL) {
+    // No physical NIC path from this GPU (e.g. MNNVL remote GPU).
+    return TOPO_EXPL_INTERNAL_ERROR;
+  }
+  *pathType = netPaths[netIndex].type;
+
+  // Determine whether netIndex is one of the GPU's local (highest-bandwidth) NICs.
+  int locals[NCCL_TOPO_MAX_NODES];
+  int localCount = 0;
+  TOPO_NCCLCHECK(ncclTopoGetLocal(system, GPU, g, NET, locals, &localCount, NULL));
+  *isLocal = 0;
+  for (int i = 0; i < localCount; i++) {
+    if (locals[i] == netIndex) { *isLocal = 1; break; }
+  }
+
+  return TOPO_EXPL_SUCCESS;
+}
+
+int topoExplGetPathTypeP2C(void) {
+  return PATH_P2C;
+}

--- a/projects/rccl/tools/topo_expl/test/topo_expl_tests.cpp
+++ b/projects/rccl/tools/topo_expl/test/topo_expl_tests.cpp
@@ -102,7 +102,37 @@ static bool run_single_test(int model_id, int num_nodes) {
     bool algo_time_ok = (agTimeResult == TOPO_EXPL_SUCCESS && agTime >= 0.0f &&
                          arTimeResult == TOPO_EXPL_SUCCESS && arTime >= 0.0f);
 
-    test_result.success = rank_info_ok && algo_info_ok && algo_time_ok;
+    // Regression check for the NCCL 2.29.2 "hang on GB200/300 + CX8 when the user
+    // disables GDR" fix.
+    //
+    // On C2C platforms (coherent GPU<->CPU link), ncclTopoComputePaths() promotes a
+    // GPU->NIC path to PATH_P2C when the merged GPU/NIC->CPU path is P2C (the GPU is
+    // C2C to the CPU and the NIC is PHB on that CPU). The original code applied this
+    // promotion to EVERY NIC, including non-local ones that should instead be reached
+    // via PXN. That false "P2C closeness" broke PXN preference / GDR routing and caused
+    // a hang when GDR was disabled. The fix (ncclTopoGetLocal()-gated loop) only
+    // promotes a GPU's local (highest-bandwidth) NIC(s) to P2C.
+    //
+    // Invariant locked in here: a NIC may only carry PATH_P2C to a GPU if it is one of
+    // that GPU's local NICs. For non-C2C models no path is ever P2C, so this is vacuous;
+    // for the topo_2p_c2c_2nic model the pre-fix code promotes the slow, non-local NIC
+    // to P2C and trips this check.
+    bool p2c_locality_ok = true;
+    const int p2cType = topoExplGetPathTypeP2C();
+    for (int r = 0; r < expected_nranks && p2c_locality_ok; r++) {
+        int netCount = 0;
+        if (topoExplGetNetCount(context, r, &netCount) != TOPO_EXPL_SUCCESS) continue;
+        for (int n = 0; n < netCount && p2c_locality_ok; n++) {
+            int pathType = -1, isLocal = 0;
+            if (topoExplGetNetPathInfo(context, r, n, &pathType, &isLocal) != TOPO_EXPL_SUCCESS)
+                continue;
+            if (pathType == p2cType && !isLocal) {
+                p2c_locality_ok = false;
+            }
+        }
+    }
+
+    test_result.success = rank_info_ok && algo_info_ok && algo_time_ok && p2c_locality_ok;
     test_result.nranks = expected_nranks;
     test_result.nnodes = expected_nnodes;
 
@@ -111,8 +141,10 @@ static bool run_single_test(int model_id, int num_nodes) {
             test_result.error_msg = "Failed to get rank info";
         } else if (!algo_info_ok) {
             test_result.error_msg = "Failed to get algorithm info";
-        } else {
+        } else if (!algo_time_ok) {
             test_result.error_msg = "No valid algo/proto time (tuning may be broken)";
+        } else {
+            test_result.error_msg = "Non-local NIC promoted to PATH_P2C on C2C platform - see NCCL 2.29.2 GDR/CX8 hang fix";
         }
     }
     


### PR DESCRIPTION
## Summary

Locks in the NCCL 2.29.2 fix for the **"hang on GB200/300 + CX8 when the user disables GDR"** defect with a deterministic, GPU-free regression test in `topo_expl`.

### Root cause (already fixed in RCCL's `develop`)
The hang originates in `ncclTopoComputePaths()`. On C2C platforms (coherent GPU↔CPU link), the "C2C + PHB" step promotes a `GPU→NIC` path to `PATH_P2C` when the merged `GPU/NIC→CPU` path is P2C. The pre-2.29.2 code applied this promotion to **every** NIC — including non-local ones that should be reached via PXN — so a remote NIC was falsely advertised as P2C-close. That broke PXN preference / GDR routing and deadlocked when GDR was disabled. The fix gates the promotion on `ncclTopoGetLocal()` so only a GPU's local (highest-bandwidth) NIC(s) become P2C. RCCL (2.30.4 base) already carries the fixed form; this PR only adds coverage.

### What's here
- **`models/topo_2p_c2c_2nic.xml`** — an MI300A-style C2C node (GPU↔CPU coherent link) with a fast (local) and a slow (non-local) NIC on the same CPU, which makes the pre/post-fix divergence observable offline.
- **New `topo_expl` API** — `topoExplGetNetCount`, `topoExplGetNetPathInfo`, `topoExplGetPathTypeP2C` to inspect computed `GPU→NET` path types and NIC locality.
- **Suite assertion** — a NIC may only carry `PATH_P2C` to a GPU if it is one of that GPU's local NICs (vacuous for non-C2C models).
- **`xml.cc`** — enables `<c2c>` parsing in the AMD/HIP topology loader (was NVIDIA-only). Required to ingest C2C topologies on RCCL builds, and also fixes a latent handler-count mismatch (`nHandlers=2` with a single entry → out-of-bounds read).

### Before/after proof
- On `develop` (post-fix): the local NIC is `P2C` (6), the non-local NIC stays `PHB` (8) → **test PASSES**.
- Temporarily reverting the fix to the pre-2.29.2 all-NIC promotion: the slow non-local NIC becomes `P2C` (6) → **test FAILS** with `Non-local NIC promoted to PATH_P2C on C2C platform`.

## Test plan
- [x] `cd projects/rccl/tools/topo_expl && make`
- [x] `./topo_expl -t --include-models=60` → all node counts (1,2,4,8,16) PASS
- [x] Reproduced the bug by reverting the fix → new test FAILS, then restored → PASSES
- [x] Full `./topo_expl -t` suite: 296/305 PASS; the 9 failures are pre-existing `host_hash` issues on models 57/59 (confirmed identical on a clean tree, unrelated to this change)

Made with [Cursor](https://cursor.com)