### PR TITLE
[hipFile][examples] Standardize CMake scheme across example dirs

### DIFF
--- a/projects/hipfile/cmake/AISInstall.cmake
+++ b/projects/hipfile/cmake/AISInstall.cmake
@@ -44,28 +44,24 @@ if(AIS_INSTALL_EXAMPLES)
     # The CMakeLists.txt files in the examples tree use our build
     # flags and infrastructure so we can ensure they are well-vetted
     # and these can't be installed.
-
-    # aiscp
-    configure_file(
-        "${CMAKE_CURRENT_SOURCE_DIR}/examples/aiscp/CMakeLists.install.cmake"
-        "examples/aiscp/CMakeLists.txt"
-        @ONLY
+    set(AIS_EXAMPLE_DIRS
+        aiscp
+        api
+        common
+        basics
+        async
     )
-    install(FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/examples/aiscp/CMakeLists.txt"
-        DESTINATION "share/doc/${CMAKE_PROJECT_NAME}/examples/aiscp/"
-    )
-
-    # API examples
-    configure_file(
-        "${CMAKE_CURRENT_SOURCE_DIR}/examples/api/CMakeLists.install.in"
-        "examples/api/CMakeLists.txt"
-        @ONLY
-    )
-    install(FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/examples/api/CMakeLists.txt"
-        DESTINATION "share/doc/${CMAKE_PROJECT_NAME}/examples/api/"
-    )
+    foreach(example_dir ${AIS_EXAMPLE_DIRS})
+        configure_file(
+            "${CMAKE_CURRENT_SOURCE_DIR}/examples/${example_dir}/CMakeLists.install.cmake"
+            "examples/${example_dir}/CMakeLists.txt"
+            @ONLY
+        )
+        install(FILES
+            "${CMAKE_CURRENT_BINARY_DIR}/examples/${example_dir}/CMakeLists.txt"
+            DESTINATION "share/doc/${CMAKE_PROJECT_NAME}/examples/${example_dir}/"
+        )
+    endforeach()
 endif()
 
 # When we have RELEASE/DEV builds set up, we can split

--- a/projects/hipfile/examples/README.md
+++ b/projects/hipfile/examples/README.md
@@ -1,9 +1,8 @@
 # hipFile examples
 
-This directory contains working examples of the hipFile API, grouped by what they demonstrate. The
-programs verify their results with an FNV-1a hash and print `OK …` on success.
-This top-level README consolidates the full program lists, build, and run
-instructions for every example directory.
+This directory contains working examples of the hipFile API, grouped by what
+they demonstrate. The `basics` and `async` programs verify their results with
+an FNV-1a hash and print `OK …` on success.
 
 Most examples move data through the GPU on hipFile's fast path, which opens
 files with `O_DIRECT`; running them as written therefore requires an AMD GPU
@@ -26,36 +25,49 @@ query the library and need neither a GPU nor an `O_DIRECT` filesystem.
 
 ## Building
 
-Most examples are built in-tree by the parent hipFile project when
-`AIS_INSTALL_EXAMPLES=ON` (the default):
+Each example directory contains a ready-to-use `CMakeLists.txt` that finds the
+installed hipFile via `find_package`. To build a directory, configure and build
+it in place:
 
 ```bash
-cd rocm-systems/projects/hipfile
-cmake -DCMAKE_CXX_COMPILER=amdclang++ -DCMAKE_HIP_PLATFORM=amd \
-      -DAIS_INSTALL_EXAMPLES=ON -B build
+cd basics
+cmake -B build -DCMAKE_PREFIX_PATH="/opt/rocm;/path/to/hipfile"
 cmake --build build --parallel
 ```
 
-The binaries land under `build/examples/<directory>/`. The `api` and `aiscp`
-directories can also be built standalone against an installed hipFile — see
-those sections below.
+This is an out-of-source build, so the example binaries land in `build/`. The
+run snippets below assume you have `cd build`'d into that directory first.
 
-### Building a single example
+Drop the `-DCMAKE_PREFIX_PATH` argument if ROCm and hipFile are installed in
+standard locations. If the install tree is read-only, copy the directory (and,
+for `basics`/`async`, the sibling [`common`](common) directory) somewhere
+writable first.
 
-Each example program is its own CMake target, named exactly after the program
-(the `basics`/`async` directories create one target per program in a `foreach`
-loop; `api`/`aiscp` do the same via `ais_add_executable(NAME …)`). After
-configuring, build just one with `--target`:
+`basics` and `async` link the shared helpers in [`common`](common) and pull it
+in via `add_subdirectory(../common …)`, so keep the `common` directory alongside
+them when you build.
+
+### Finding the library at runtime
+
+When you build an example, CMake records the location of `libhipfile.so` (taken
+from the same `find_package` result used above) in the example binary, so it
+runs in place even when hipFile is installed outside the default library search
+path — no `LD_LIBRARY_PATH` needed.
+
+That recorded path is fixed at build time. If you later move the hipFile
+installation, the binaries can no longer find the library and fail to start with
+`error while loading shared libraries: libhipfile.so.0`. Point the loader at the
+new location to recover (or rebuild the examples):
 
 ```bash
-cmake --build build --target bufregister-write
-cmake --build build --target roundtrip-async-multi-stream
+cd build
+LD_LIBRARY_PATH=/new/path/to/hipfile/lib ./bufregister-write out.bin
 ```
 
 Per-example payload and chunk sizes are compile-time `#define`s (e.g.
-`-DBRW_SIZE=…`, `-DIR_CHUNK_SIZE=…`, documented at the top of each `.cpp`); to
-build an example with different sizes, re-run the configure step with the
-corresponding `-D` flag.
+`-DBRW_SIZE=…`, `-DIR_CHUNK_SIZE=…`, documented at the top of each `.cpp`). To
+build an example with different sizes, pass the corresponding `-D` flag at
+configure time.
 
 ---
 
@@ -65,32 +77,14 @@ Minimal examples of the non-I/O parts of the hipFile API — calls that query or
 configure the library rather than move data through the GPU. These do **not**
 require an `O_DIRECT`-capable filesystem or even file arguments.
 
-
 | Program | What it shows | Args |
 | --- | --- | --- |
 | `get-version` | Read the hipFile version both ways: the `HIPFILE_VERSION_*` header macros (compile-time) and `hipFileGetVersion()` (runtime). | none |
 
-### Building
-
-In-tree, the `api` examples are built by the parent hipFile project when
-`AIS_INSTALL_EXAMPLES=ON` (the default). Unlike `basics/` and `async/`, these
-use the `ais_add_executable` macro and link the `hipfile` target directly.
-
-To build standalone against an installed hipFile, copy `CMakeLists.install.in`
-to `CMakeLists.txt` in a scratch copy of the directory — it uses
-`find_package(hipfile)` instead of the in-tree macro:
-
-```bash
-mkdir -p /tmp/api-example
-cp CMakeLists.install.in /tmp/api-example/CMakeLists.txt
-cp get-version.cpp /tmp/api-example/
-cmake -DCMAKE_PREFIX_PATH="/opt/rocm;/path/to/hipfile" -S /tmp/api-example -B /tmp/api-example/build
-cmake --build /tmp/api-example/build
-```
-
 ### Running
 
 ```bash
+cd build
 ./get-version
 ```
 
@@ -109,7 +103,6 @@ helpers in [`common`](common) (`open_file`, `hash_file_range`, `align_up`,
 `fill_pattern`, …). Every example verifies its result with an FNV-1a hash and
 prints `OK …` on success.
 
-
 | Program | What it shows | Args |
 | --- | --- | --- |
 | `bufregister-write` | Write a GPU buffer registered with `hipFileBufRegister` straight to disk (the fast path). | `OUTPUT [GPUID]` |
@@ -125,23 +118,18 @@ prints `OK …` on success.
 `#define`s (e.g. `-DBRW_SIZE=…`, `-DIR_CHUNK_SIZE=…`) documented at the top of
 each `.cpp`.
 
-### Building
-
-Built in-tree by the parent hipFile project when `AIS_INSTALL_EXAMPLES=ON`
-(the default; see the top-level [Building](#building) section). The binaries
-land under `build/examples/basics/`.
-
 ### Running
 
 Reads need an existing input file; create one with `dd`:
 
 ```bash
+cd build
 dd if=/dev/urandom of=input.bin bs=1M count=1
 ```
 
 The input and output paths must live on an `O_DIRECT`-capable local
 filesystem (ext4 mounted `data=ordered`, or xfs); verify with
-`/opt/rocm/bin/ais-check`. Then, from `build/examples/basics/`:
+`/opt/rocm/bin/ais-check`:
 
 ```bash
 ./bufregister-write            out_bufregister.bin
@@ -153,21 +141,6 @@ filesystem (ext4 mounted `data=ordered`, or xfs); verify with
 ./various-mem-rw               input.bin out_vmrw.bin 1     # 1=device 2=managed 3=pinned
 ./roundtrip-verify             rtv_created.bin rtv_copied.bin
 ```
-
-### Via ctest
-
-When configured with `-DBUILD_TESTING=ON`, each example is wrapped as a system
-test (labels `basics;hipfile;system`). The wrappers seed a scratch input and
-run under `AIS_CAPABLE_DIR` (defaults to `/tmp` — point it at an
-`O_DIRECT`-capable path):
-
-```bash
-ctest --test-dir build -L basics --output-on-failure
-```
-
-Note: `various-mem-rw`'s `managed` and `pinned` modes are marked `DISABLED` in
-the ctest setup, so only the `device` mode runs under ctest. Run the other two
-modes by hand.
 
 ---
 
@@ -193,7 +166,7 @@ share the helpers in [`common`](common) and print `OK …` on success.
 
 All four take the same arguments:
 
-```
+```text
 PROGRAM READ_FILE WRITE_FILE [GPUID]
 ```
 
@@ -202,34 +175,17 @@ PROGRAM READ_FILE WRITE_FILE [GPUID]
 payload. `GPUID` is optional (default `0`). Sizes and stream counts are
 compile-time `#define`s documented at the top of each `.cpp`.
 
-### Building
-
-Built in-tree by the parent hipFile project when `AIS_INSTALL_EXAMPLES=ON`
-(the default; see the top-level [Building](#building) section). The binaries
-land under `build/examples/async/`.
-
 ### Running
 
 Both paths must live on an `O_DIRECT`-capable local filesystem (ext4 mounted
-`data=ordered`, or xfs); verify with `/opt/rocm/bin/ais-check`. From
-`build/examples/async/`:
+`data=ordered`, or xfs); verify with `/opt/rocm/bin/ais-check`:
 
 ```bash
+cd build
 ./roundtrip-async                        in.bin out.bin
 ./roundtrip-async-nonblocking-stream     in.bin out.bin
 ./roundtrip-async-multi-stream           in.bin out.bin
 ./roundtrip-async-multi-stream-registered in.bin out.bin
-```
-
-### Via ctest
-
-When configured with `-DBUILD_TESTING=ON`, each example is wrapped as a system
-test (labels `async;hipfile;system`), with each test getting its own seeded
-input path under `AIS_CAPABLE_DIR` (defaults to `/tmp` — point it at an
-`O_DIRECT`-capable path):
-
-```bash
-ctest --test-dir build -L async --output-on-failure
 ```
 
 ---
@@ -239,26 +195,8 @@ ctest --test-dir build -L async --output-on-failure
 `aiscp` is a simple test program that uses hipFile to copy a file. It works
 like the Linux `cp` command:
 
-```
+```text
 aiscp SOURCE DEST
-```
-
-### Building
-
-In-tree, `aiscp` is built by the parent hipFile project when
-`AIS_INSTALL_EXAMPLES=ON` (the default; see the top-level
-[Building](#building) section). Its default `CMakeLists.txt` uses the in-tree
-`ais_add_executable` macro, so it builds alongside the other examples and the
-binary lands under `build/examples/aiscp/`.
-
-To build it standalone against an installed hipFile, use the
-`find_package`-based `CMakeLists.install.cmake` (copy it to `CMakeLists.txt` in
-a scratch copy of the directory). You may need to add the path(s) to ROCm
-and/or hipFile if they are installed in non-standard locations:
-
-```bash
-cmake -DCMAKE_PREFIX_PATH="/path/to/rocm;/path/to/hipfile" /path/to/aiscp/dir
-cmake --build .
 ```
 
 ---
@@ -270,8 +208,10 @@ by the [`basics`](basics) and [`async`](async) examples. It was pulled out to
 remove verbatim duplication; each example still drives the hipFile API directly
 in its own `main()` so the example flow stays readable top-to-bottom.
 
-There is nothing to run here. The library is built automatically as a
-dependency whenever the examples are built (`AIS_INSTALL_EXAMPLES=ON`).
+There is nothing to run or build here on its own. The `basics`/`async`
+directories pull it in via `add_subdirectory(../common …)`, so the helper code
+is compiled once and shared rather than duplicated into each example. Keep this
+directory alongside `basics`/`async` when building them.
 
 ### What's in it
 

--- a/projects/hipfile/examples/aiscp/CMakeLists.install.cmake
+++ b/projects/hipfile/examples/aiscp/CMakeLists.install.cmake
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: MIT
 
 # You may need to add -DCMAKE_PREFIX_PATH=/path/to/hipfile
-# if hipFile has been installed to a non-standard location
+# if hipFile has been installed to a non-standard location. That same path is
+# recorded in the example binaries (via CMake's default RPATH handling), so they
+# find libhipfile.so at runtime without LD_LIBRARY_PATH even from a non-standard
+# install location.
 
 cmake_minimum_required(VERSION 3.21)
 

--- a/projects/hipfile/examples/api/CMakeLists.install.cmake
+++ b/projects/hipfile/examples/api/CMakeLists.install.cmake
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: MIT
 
 # You may need to add -DCMAKE_PREFIX_PATH=/path/to/hipfile
-# if hipFile has been installed to a non-standard location
+# if hipFile has been installed to a non-standard location. That same path is
+# recorded in the example binaries (via CMake's default RPATH handling), so they
+# find libhipfile.so at runtime without LD_LIBRARY_PATH even from a non-standard
+# install location.
 
 cmake_minimum_required(VERSION 3.21)
 

--- a/projects/hipfile/examples/async/CMakeLists.install.cmake
+++ b/projects/hipfile/examples/async/CMakeLists.install.cmake
@@ -1,0 +1,35 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# You may need to add -DCMAKE_PREFIX_PATH=/path/to/hipfile
+# if hipFile has been installed to a non-standard location. That same path is
+# recorded in the example binaries (via CMake's default RPATH handling), so they
+# find libhipfile.so at runtime without LD_LIBRARY_PATH even from a non-standard
+# install location.
+
+cmake_minimum_required(VERSION 3.21)
+
+project(async_examples LANGUAGES CXX)
+
+find_package(hip REQUIRED CONFIG)
+find_package(hipfile REQUIRED CONFIG)
+
+# The async examples share helpers from the common/ directory. Build that
+# static library here so the examples can link it without duplicating the code.
+add_subdirectory(../common "${CMAKE_CURRENT_BINARY_DIR}/common")
+
+set(ASYNC_EXAMPLES
+    roundtrip-async
+    roundtrip-async-nonblocking-stream
+    roundtrip-async-multi-stream
+    roundtrip-async-multi-stream-registered
+)
+
+foreach(example ${ASYNC_EXAMPLES})
+    add_executable(${example} "${example}.cpp")
+    target_compile_features(${example} PRIVATE cxx_std_17)
+    set_target_properties(${example} PROPERTIES CXX_EXTENSIONS OFF)
+    target_compile_options(${example} PRIVATE -Wall -Wextra)
+    target_link_libraries(${example} PRIVATE examples_common)
+endforeach()

--- a/projects/hipfile/examples/async/CMakeLists.txt
+++ b/projects/hipfile/examples/async/CMakeLists.txt
@@ -2,11 +2,14 @@
 #
 # SPDX-License-Identifier: MIT
 
-# Async examples for the hipFile C API. Same style as examples/basics:
-# bypass ais_add_executable and wire dependencies in by hand. Shared helpers
-# come from the examples_common target defined in examples/common; the parent
-# CMakeLists adds examples/common before examples/async, so the target is in
-# scope by the time we reach this file.
+# Async examples for the hipFile C API. They build with the AIS infrastructure
+# (ais_add_executable) and link the shared helpers from the examples_common
+# target defined in examples/common; the parent CMakeLists adds examples/common
+# before examples/async, so the target is in scope here. examples_common is
+# PUBLIC-linked against hipfile and exports its own include dir, so
+# DEPS examples_common transitively supplies the library and headers.
+
+include(AISAddExecutable)
 
 set(ASYNC_EXAMPLES
     roundtrip-async
@@ -16,33 +19,12 @@ set(ASYNC_EXAMPLES
 )
 
 foreach(example ${ASYNC_EXAMPLES})
-    add_executable(${example} "${example}.cpp")
-    target_compile_features(${example} PRIVATE cxx_std_${AIS_CXX_STANDARD})
-    set_target_properties(${example} PROPERTIES CXX_EXTENSIONS OFF)
-    target_compile_options(${example} PRIVATE -Wall -Wextra)
-    # hipfile is instrumented when the sanitizers are on; an uninstrumented
-    # executable linked against it dies at load with undefined __asan_*/__tsan_*
-    # symbols. Instrument the example too so it pulls in the sanitizer runtime.
-    if(AIS_USE_SANITIZERS OR AIS_USE_THREAD_SANITIZER)
-        ais_add_sanitizers(${example})
-    endif()
-
-    if(CMAKE_HIP_PLATFORM STREQUAL "amd")
-        target_compile_definitions(${example} PRIVATE __HIP_PLATFORM_AMD__)
-    elseif(CMAKE_HIP_PLATFORM STREQUAL "nvidia")
-        target_compile_definitions(${example} PRIVATE __HIP_PLATFORM_NVIDIA__)
-        target_include_directories(${example} SYSTEM PRIVATE ${HIP_INCLUDE_DIRS})
-        target_include_directories(
-            ${example}
-            SYSTEM
-            BEFORE
-            PRIVATE ${CUDAToolkit_INCLUDE_DIRS}
-        )
-        target_link_libraries(${example} PRIVATE CUDA::cuda_driver CUDA::cudart)
-    endif()
-
-    target_include_directories(${example} SYSTEM PRIVATE ${HIPFILE_INCLUDE_PATH})
-    target_link_libraries(${example} PRIVATE examples_common)
+    ais_add_executable(
+        NAME ${example}
+        DEPS examples_common
+        SRCS "${example}.cpp"
+        SYSINCLS ${HIPFILE_INCLUDE_PATH}
+    )
 endforeach()
 
 # CTest wrappers: run each async example as a hipFile system test.

--- a/projects/hipfile/examples/async/roundtrip-async-multi-stream-registered.cpp
+++ b/projects/hipfile/examples/async/roundtrip-async-multi-stream-registered.cpp
@@ -64,7 +64,7 @@
 #define SLICE_SIZE (1UL * 1024UL * 1024UL)
 #endif
 
-#define TOTAL_SIZE ((size_t)NUM_STREAMS * (size_t)SLICE_SIZE)
+#define TOTAL_SIZE (static_cast<size_t>(NUM_STREAMS) * SLICE_SIZE)
 
 static_assert((SLICE_SIZE % BLOCK_ALIGN) == 0, "SLICE_SIZE must be a multiple of BLOCK_ALIGN");
 
@@ -130,13 +130,13 @@ main(int argc, char *argv[])
     for (int i = 0; i < NUM_STREAMS; ++i) {
         slice_state &s = slices[i];
         s.io_size      = SLICE_SIZE;
-        s.file_offset  = (hoff_t)i * (hoff_t)SLICE_SIZE;
+        s.file_offset  = static_cast<hoff_t>(i) * static_cast<hoff_t>(SLICE_SIZE);
         s.buf_offset   = 0;
 
         hip_err = hipMalloc(&s.devbuf, SLICE_SIZE);
         if (hipSuccess != hip_err) {
-            fprintf(stderr, "Could not allocate %zu bytes on GPU %d for slice %d (%d)\n", (size_t)SLICE_SIZE,
-                    gpu_id, i, hip_err);
+            fprintf(stderr, "Could not allocate %zu bytes on GPU %d for slice %d (%d)\n", SLICE_SIZE, gpu_id,
+                    i, hip_err);
             goto cleanup_slices;
         }
 
@@ -217,14 +217,12 @@ main(int argc, char *argv[])
             goto close_wfile;
         }
 
-        if (s.bytes_read != (ssize_t)SLICE_SIZE) {
-            fprintf(stderr, "Async read short on slice %d: %zd of %zu\n", i, s.bytes_read,
-                    (size_t)SLICE_SIZE);
+        if (s.bytes_read != static_cast<ssize_t>(SLICE_SIZE)) {
+            fprintf(stderr, "Async read short on slice %d: %zd of %zu\n", i, s.bytes_read, SLICE_SIZE);
             goto close_wfile;
         }
-        if (s.bytes_written != (ssize_t)SLICE_SIZE) {
-            fprintf(stderr, "Async write short on slice %d: %zd of %zu\n", i, s.bytes_written,
-                    (size_t)SLICE_SIZE);
+        if (s.bytes_written != static_cast<ssize_t>(SLICE_SIZE)) {
+            fprintf(stderr, "Async write short on slice %d: %zd of %zu\n", i, s.bytes_written, SLICE_SIZE);
             goto close_wfile;
         }
     }
@@ -256,7 +254,7 @@ main(int argc, char *argv[])
             goto cleanup_slices;
 
         printf("OK  %s == %s  (%zu bytes across %d registered streams, hash 0x%016" PRIx64 ")\n", read_path,
-               write_path, (size_t)TOTAL_SIZE, NUM_STREAMS, hash);
+               write_path, TOTAL_SIZE, NUM_STREAMS, hash);
     }
 
     exit_status = EXIT_SUCCESS;

--- a/projects/hipfile/examples/async/roundtrip-async-multi-stream.cpp
+++ b/projects/hipfile/examples/async/roundtrip-async-multi-stream.cpp
@@ -61,7 +61,7 @@
 #define SLICE_SIZE (1UL * 1024UL * 1024UL)
 #endif
 
-#define TOTAL_SIZE ((size_t)NUM_STREAMS * (size_t)SLICE_SIZE)
+#define TOTAL_SIZE (static_cast<size_t>(NUM_STREAMS) * SLICE_SIZE)
 
 static_assert((SLICE_SIZE % BLOCK_ALIGN) == 0, "SLICE_SIZE must be a multiple of BLOCK_ALIGN");
 
@@ -118,13 +118,13 @@ main(int argc, char *argv[])
     for (int i = 0; i < NUM_STREAMS; ++i) {
         slice_state &s = slices[i];
         s.io_size      = SLICE_SIZE;
-        s.file_offset  = (hoff_t)i * (hoff_t)SLICE_SIZE;
+        s.file_offset  = static_cast<hoff_t>(i) * static_cast<hoff_t>(SLICE_SIZE);
         s.buf_offset   = 0;
 
         hip_err = hipMalloc(&s.devbuf, SLICE_SIZE);
         if (hipSuccess != hip_err) {
-            fprintf(stderr, "Could not allocate %zu bytes on GPU %d for slice %d (%d)\n", (size_t)SLICE_SIZE,
-                    gpu_id, i, hip_err);
+            fprintf(stderr, "Could not allocate %zu bytes on GPU %d for slice %d (%d)\n", SLICE_SIZE, gpu_id,
+                    i, hip_err);
             goto cleanup_slices;
         }
 
@@ -197,14 +197,12 @@ main(int argc, char *argv[])
             goto close_wfile;
         }
 
-        if (s.bytes_read != (ssize_t)SLICE_SIZE) {
-            fprintf(stderr, "Async read short on slice %d: %zd of %zu\n", i, s.bytes_read,
-                    (size_t)SLICE_SIZE);
+        if (s.bytes_read != static_cast<ssize_t>(SLICE_SIZE)) {
+            fprintf(stderr, "Async read short on slice %d: %zd of %zu\n", i, s.bytes_read, SLICE_SIZE);
             goto close_wfile;
         }
-        if (s.bytes_written != (ssize_t)SLICE_SIZE) {
-            fprintf(stderr, "Async write short on slice %d: %zd of %zu\n", i, s.bytes_written,
-                    (size_t)SLICE_SIZE);
+        if (s.bytes_written != SLICE_SIZE) {
+            fprintf(stderr, "Async write short on slice %d: %zd of %zu\n", i, s.bytes_written, SLICE_SIZE);
             goto close_wfile;
         }
     }
@@ -236,7 +234,7 @@ main(int argc, char *argv[])
             goto cleanup_slices;
 
         printf("OK  %s == %s  (%zu bytes across %d streams, hash 0x%016" PRIx64 ")\n", read_path, write_path,
-               (size_t)TOTAL_SIZE, NUM_STREAMS, hash);
+               TOTAL_SIZE, NUM_STREAMS, hash);
     }
 
     exit_status = EXIT_SUCCESS;

--- a/projects/hipfile/examples/async/roundtrip-async-nonblocking-stream.cpp
+++ b/projects/hipfile/examples/async/roundtrip-async-nonblocking-stream.cpp
@@ -171,18 +171,18 @@ main(int argc, char *argv[])
             goto destroy_stream;
         }
 
-        if (bytes_read != (ssize_t)alloc_size) {
+        if (bytes_read != static_cast<ssize_t>(alloc_size)) {
             fprintf(stderr, "Async read short: %zd of %zu\n", bytes_read, alloc_size);
             goto destroy_stream;
         }
-        if (bytes_written != (ssize_t)alloc_size) {
+        if (bytes_written != static_cast<ssize_t>(alloc_size)) {
             fprintf(stderr, "Async write short: %zd of %zu\n", bytes_written, alloc_size);
             goto destroy_stream;
         }
     }
 
     /* 8. Trim WRITE_FILE down to the true payload size (we wrote padded). */
-    if (-1 == ftruncate(wfd, (off_t)payload_size)) {
+    if (-1 == ftruncate(wfd, static_cast<off_t>(payload_size))) {
         fprintf(stderr, "Could not truncate %s (%s)\n", write_path, strerror(errno));
         goto destroy_stream;
     }

--- a/projects/hipfile/examples/async/roundtrip-async.cpp
+++ b/projects/hipfile/examples/async/roundtrip-async.cpp
@@ -99,7 +99,7 @@ main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    hip_err = hipMemsetAsync(devbuf, 0, alloc_size, /*stream=*/0);
+    hip_err = hipMemsetAsync(devbuf, 0, alloc_size, /*stream=*/nullptr);
     if (hipSuccess != hip_err) {
         fprintf(stderr, "hipMemsetAsync failed (%d)\n", hip_err);
         goto free_devbuf;
@@ -136,8 +136,8 @@ main(int argc, char *argv[])
         hoff_t  wbuf_offset   = 0;
         ssize_t bytes_written = 0;
 
-        hipfile_err =
-            hipFileReadAsync(rhandle, devbuf, &rsize, &rfile_offset, &rbuf_offset, &bytes_read, /*stream=*/0);
+        hipfile_err = hipFileReadAsync(rhandle, devbuf, &rsize, &rfile_offset, &rbuf_offset, &bytes_read,
+                                       /*stream=*/nullptr);
         if (hipFileSuccess != hipfile_err.err) {
             fprintf(stderr, "hipFileReadAsync submit failed (%s)\n",
                     hipFileGetOpErrorString(hipfile_err.err));
@@ -145,31 +145,31 @@ main(int argc, char *argv[])
         }
 
         hipfile_err = hipFileWriteAsync(whandle, devbuf, &wsize, &wfile_offset, &wbuf_offset, &bytes_written,
-                                        /*stream=*/0);
+                                        /*stream=*/nullptr);
         if (hipFileSuccess != hipfile_err.err) {
             fprintf(stderr, "hipFileWriteAsync submit failed (%s)\n",
                     hipFileGetOpErrorString(hipfile_err.err));
             goto close_wfile;
         }
 
-        hip_err = hipStreamSynchronize(0);
+        hip_err = hipStreamSynchronize(nullptr);
         if (hipSuccess != hip_err) {
             fprintf(stderr, "hipStreamSynchronize failed (%d)\n", hip_err);
             goto close_wfile;
         }
 
-        if (bytes_read != (ssize_t)alloc_size) {
+        if (bytes_read != static_cast<ssize_t>(alloc_size)) {
             fprintf(stderr, "Async read short: %zd of %zu\n", bytes_read, alloc_size);
             goto close_wfile;
         }
-        if (bytes_written != (ssize_t)alloc_size) {
+        if (bytes_written != static_cast<ssize_t>(alloc_size)) {
             fprintf(stderr, "Async write short: %zd of %zu\n", bytes_written, alloc_size);
             goto close_wfile;
         }
     }
 
     /* 8. Trim WRITE_FILE down to the true payload size (we wrote padded). */
-    if (-1 == ftruncate(wfd, (off_t)payload_size)) {
+    if (-1 == ftruncate(wfd, static_cast<off_t>(payload_size))) {
         fprintf(stderr, "Could not truncate %s (%s)\n", write_path, strerror(errno));
         goto close_wfile;
     }

--- a/projects/hipfile/examples/basics/CMakeLists.install.cmake
+++ b/projects/hipfile/examples/basics/CMakeLists.install.cmake
@@ -1,0 +1,39 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# You may need to add -DCMAKE_PREFIX_PATH=/path/to/hipfile
+# if hipFile has been installed to a non-standard location. That same path is
+# recorded in the example binaries (via CMake's default RPATH handling), so they
+# find libhipfile.so at runtime without LD_LIBRARY_PATH even from a non-standard
+# install location.
+
+cmake_minimum_required(VERSION 3.21)
+
+project(basics_examples LANGUAGES CXX)
+
+find_package(hip REQUIRED CONFIG)
+find_package(hipfile REQUIRED CONFIG)
+
+# The basics examples share helpers from the common/ directory. Build that
+# static library here so the examples can link it without duplicating the code.
+add_subdirectory(../common "${CMAKE_CURRENT_BINARY_DIR}/common")
+
+set(BASICS_EXAMPLES
+    bufregister-write
+    no-bufregister-write
+    no-odirect-write
+    iterative-read
+    iterative-devmem-offset-read
+    various-mem-rw
+    subregion-write
+    roundtrip-verify
+)
+
+foreach(example ${BASICS_EXAMPLES})
+    add_executable(${example} "${example}.cpp")
+    target_compile_features(${example} PRIVATE cxx_std_17)
+    set_target_properties(${example} PROPERTIES CXX_EXTENSIONS OFF)
+    target_compile_options(${example} PRIVATE -Wall -Wextra)
+    target_link_libraries(${example} PRIVATE examples_common)
+endforeach()

--- a/projects/hipfile/examples/basics/CMakeLists.txt
+++ b/projects/hipfile/examples/basics/CMakeLists.txt
@@ -2,10 +2,14 @@
 #
 # SPDX-License-Identifier: MIT
 
-# These examples use the hipFile C API directly from C++ (matching the
-# style of the standalone aiscp/offsetcp/read-write-check programs).
-# They deliberately bypass ais_add_executable and wire the dependencies
-# in by hand.
+# These examples use the hipFile C API directly from C++. They build with the
+# AIS infrastructure (ais_add_executable) and link the shared helpers from the
+# examples_common target defined in examples/common; the parent CMakeLists adds
+# examples/common before examples/basics, so the target is in scope here.
+# examples_common is PUBLIC-linked against hipfile and exports its own include
+# dir, so DEPS examples_common transitively supplies the library and headers.
+
+include(AISAddExecutable)
 
 set(BASICS_EXAMPLES
     bufregister-write
@@ -19,33 +23,12 @@ set(BASICS_EXAMPLES
 )
 
 foreach(example ${BASICS_EXAMPLES})
-    add_executable(${example} "${example}.cpp")
-    target_compile_features(${example} PRIVATE cxx_std_17)
-    set_target_properties(${example} PROPERTIES CXX_EXTENSIONS OFF)
-    target_compile_options(${example} PRIVATE -Wall -Wextra)
-    # hipfile is instrumented when the sanitizers are on; an uninstrumented
-    # executable linked against it dies at load with undefined __asan_*/__tsan_*
-    # symbols. Instrument the example too so it pulls in the sanitizer runtime.
-    if(AIS_USE_SANITIZERS OR AIS_USE_THREAD_SANITIZER)
-        ais_add_sanitizers(${example})
-    endif()
-
-    if(CMAKE_HIP_PLATFORM STREQUAL "amd")
-        target_compile_definitions(${example} PRIVATE __HIP_PLATFORM_AMD__)
-    elseif(CMAKE_HIP_PLATFORM STREQUAL "nvidia")
-        target_compile_definitions(${example} PRIVATE __HIP_PLATFORM_NVIDIA__)
-        target_include_directories(${example} SYSTEM PRIVATE ${HIP_INCLUDE_DIRS})
-        target_include_directories(
-            ${example}
-            SYSTEM
-            BEFORE
-            PRIVATE ${CUDAToolkit_INCLUDE_DIRS}
-        )
-        target_link_libraries(${example} PRIVATE CUDA::cuda_driver CUDA::cudart)
-    endif()
-
-    target_include_directories(${example} SYSTEM PRIVATE ${HIPFILE_INCLUDE_PATH})
-    target_link_libraries(${example} PRIVATE examples_common)
+    ais_add_executable(
+        NAME ${example}
+        DEPS examples_common
+        SRCS "${example}.cpp"
+        SYSINCLS ${HIPFILE_INCLUDE_PATH}
+    )
 endforeach()
 
 # CTest wrappers: run each example as a hipFile system test.

--- a/projects/hipfile/examples/basics/bufregister-write.cpp
+++ b/projects/hipfile/examples/basics/bufregister-write.cpp
@@ -74,7 +74,7 @@ main(int argc, char *argv[])
     }
 
     /* 2. Build CPU pattern + copy to GPU */
-    cpu_pattern = (uint8_t *)malloc(payload_size);
+    cpu_pattern = static_cast<uint8_t *>(malloc(payload_size));
     if (!cpu_pattern) {
         fprintf(stderr, "Could not allocate CPU pattern buffer\n");
         return EXIT_FAILURE;
@@ -117,7 +117,7 @@ main(int argc, char *argv[])
     }
 
     /* 6. ftruncate to exact size */
-    if (-1 == ftruncate(out_fd, (off_t)payload_size)) {
+    if (-1 == ftruncate(out_fd, static_cast<off_t>(payload_size))) {
         fprintf(stderr, "Could not truncate %s (%s)\n", out_path, strerror(errno));
         goto close_out;
     }

--- a/projects/hipfile/examples/basics/iterative-devmem-offset-read.cpp
+++ b/projects/hipfile/examples/basics/iterative-devmem-offset-read.cpp
@@ -78,8 +78,8 @@ main(int argc, char *argv[])
             fprintf(stderr, "Could not stat %s (%s)\n", in_path, strerror(errno));
             return EXIT_FAILURE;
         }
-        file_size  = (size_t)statbuf.st_size;
-        block_size = (size_t)statbuf.st_blksize;
+        file_size  = static_cast<size_t>(statbuf.st_size);
+        block_size = static_cast<size_t>(statbuf.st_blksize);
         if (!is_power_of_two(block_size)) {
             fprintf(stderr, "Block size is not a power of two (%zu)\n", block_size);
             return EXIT_FAILURE;
@@ -158,8 +158,8 @@ main(int argc, char *argv[])
             const size_t this_chunk = (chunk_size < remaining) ? chunk_size : remaining;
 
             nbytes = hipFileRead(in_handle, devbuf, this_chunk,
-                                 /*file_offset=*/(hoff_t)bytes_read,
-                                 /*buf_offset=*/(hoff_t)bytes_read);
+                                 /*file_offset=*/static_cast<hoff_t>(bytes_read),
+                                 /*buf_offset=*/static_cast<hoff_t>(bytes_read));
             if (nbytes < 0) {
                 fprintf(stderr, "Could not read from %s (%zd) (%s)\n", in_path, nbytes,
                         IS_HIPFILE_ERR(nbytes) ? HIPFILE_ERRSTR(nbytes) : strerror(errno));
@@ -167,7 +167,7 @@ main(int argc, char *argv[])
             }
             if (nbytes == 0)
                 break; /* EOF — file ended before alloc_size; OK */
-            bytes_read += (size_t)nbytes;
+            bytes_read += static_cast<size_t>(nbytes);
         }
 
         if (bytes_read < payload_size) {
@@ -192,7 +192,7 @@ main(int argc, char *argv[])
     }
 
     /* 6. ftruncate to exact size + hash verify */
-    if (-1 == ftruncate(out_fd, (off_t)payload_size)) {
+    if (-1 == ftruncate(out_fd, static_cast<off_t>(payload_size))) {
         fprintf(stderr, "Could not truncate %s (%s)\n", out_path, strerror(errno));
         goto close_out;
     }

--- a/projects/hipfile/examples/basics/iterative-read.cpp
+++ b/projects/hipfile/examples/basics/iterative-read.cpp
@@ -74,8 +74,8 @@ main(int argc, char *argv[])
             fprintf(stderr, "Could not stat %s (%s)\n", in_path, strerror(errno));
             return EXIT_FAILURE;
         }
-        file_size  = (size_t)statbuf.st_size;
-        block_size = (size_t)statbuf.st_blksize;
+        file_size  = static_cast<size_t>(statbuf.st_size);
+        block_size = static_cast<size_t>(statbuf.st_blksize);
         if (!is_power_of_two(block_size)) {
             fprintf(stderr, "Block size is not a power of two (%zu)\n", block_size);
             return EXIT_FAILURE;
@@ -148,9 +148,9 @@ main(int argc, char *argv[])
         while (bytes_read < alloc_size) {
             const size_t remaining  = alloc_size - bytes_read;
             const size_t this_chunk = (chunk_size < remaining) ? chunk_size : remaining;
-            void        *dst        = (char *)devbuf + bytes_read;
+            void        *dst        = static_cast<char *>(devbuf) + bytes_read;
 
-            nbytes = hipFileRead(in_handle, dst, this_chunk, (hoff_t)bytes_read, 0);
+            nbytes = hipFileRead(in_handle, dst, this_chunk, static_cast<hoff_t>(bytes_read), 0);
             if (nbytes < 0) {
                 fprintf(stderr, "Could not read from %s (%zd) (%s)\n", in_path, nbytes,
                         IS_HIPFILE_ERR(nbytes) ? HIPFILE_ERRSTR(nbytes) : strerror(errno));
@@ -158,7 +158,7 @@ main(int argc, char *argv[])
             }
             if (nbytes == 0)
                 break; /* EOF — file ended before alloc_size; OK */
-            bytes_read += (size_t)nbytes;
+            bytes_read += static_cast<size_t>(nbytes);
         }
 
         if (bytes_read < payload_size) {
@@ -183,7 +183,7 @@ main(int argc, char *argv[])
     }
 
     /* 6. ftruncate to exact size + hash verify */
-    if (-1 == ftruncate(out_fd, (off_t)payload_size)) {
+    if (-1 == ftruncate(out_fd, static_cast<off_t>(payload_size))) {
         fprintf(stderr, "Could not truncate %s (%s)\n", out_path, strerror(errno));
         goto close_out;
     }

--- a/projects/hipfile/examples/basics/no-bufregister-write.cpp
+++ b/projects/hipfile/examples/basics/no-bufregister-write.cpp
@@ -73,7 +73,7 @@ main(int argc, char *argv[])
     }
 
     /* 2. Build CPU pattern + copy to GPU */
-    cpu_pattern = (uint8_t *)malloc(payload_size);
+    cpu_pattern = static_cast<uint8_t *>(malloc(payload_size));
     if (!cpu_pattern) {
         fprintf(stderr, "Could not allocate CPU pattern buffer\n");
         return EXIT_FAILURE;
@@ -108,7 +108,7 @@ main(int argc, char *argv[])
     }
 
     /* 5. ftruncate to exact size */
-    if (-1 == ftruncate(out_fd, (off_t)payload_size)) {
+    if (-1 == ftruncate(out_fd, static_cast<off_t>(payload_size))) {
         fprintf(stderr, "Could not truncate %s (%s)\n", out_path, strerror(errno));
         goto close_out;
     }

--- a/projects/hipfile/examples/basics/no-odirect-write.cpp
+++ b/projects/hipfile/examples/basics/no-odirect-write.cpp
@@ -85,7 +85,7 @@ main(int argc, char *argv[])
     }
 
     /* 2. Build CPU pattern + copy to GPU */
-    cpu_pattern = (uint8_t *)malloc(payload_size);
+    cpu_pattern = static_cast<uint8_t *>(malloc(payload_size));
     if (!cpu_pattern) {
         fprintf(stderr, "Could not allocate CPU pattern buffer\n");
         return EXIT_FAILURE;
@@ -130,7 +130,7 @@ main(int argc, char *argv[])
     }
 
     /* 6. ftruncate to exact size (defensive; no-op when we wrote payload_size exactly) */
-    if (-1 == ftruncate(out_fd, (off_t)payload_size)) {
+    if (-1 == ftruncate(out_fd, static_cast<off_t>(payload_size))) {
         fprintf(stderr, "Could not truncate %s (%s)\n", out_path, strerror(errno));
         goto close_out;
     }

--- a/projects/hipfile/examples/basics/roundtrip-verify.cpp
+++ b/projects/hipfile/examples/basics/roundtrip-verify.cpp
@@ -80,7 +80,7 @@ main(int argc, char *argv[])
     }
 
     /* 2. Build CPU pattern + copy to GPU + hipFileBufRegister */
-    cpu_pattern = (uint8_t *)malloc(payload_size);
+    cpu_pattern = static_cast<uint8_t *>(malloc(payload_size));
     if (!cpu_pattern) {
         fprintf(stderr, "Could not allocate CPU pattern buffer\n");
         return EXIT_FAILURE;
@@ -121,7 +121,7 @@ main(int argc, char *argv[])
         goto deregister_buf;
     }
 
-    if (-1 == ftruncate(fd, (off_t)payload_size)) {
+    if (-1 == ftruncate(fd, static_cast<off_t>(payload_size))) {
         fprintf(stderr, "Could not truncate %s (%s)\n", created_path, strerror(errno));
         close_file(created_path, fd, handle);
         fd = -1;
@@ -171,7 +171,7 @@ main(int argc, char *argv[])
         goto deregister_buf;
     }
 
-    if (-1 == ftruncate(fd, (off_t)payload_size)) {
+    if (-1 == ftruncate(fd, static_cast<off_t>(payload_size))) {
         fprintf(stderr, "Could not truncate %s (%s)\n", copied_path, strerror(errno));
         close_file(copied_path, fd, handle);
         fd = -1;

--- a/projects/hipfile/examples/basics/subregion-write.cpp
+++ b/projects/hipfile/examples/basics/subregion-write.cpp
@@ -73,8 +73,8 @@ main(int argc, char *argv[])
             fprintf(stderr, "Could not stat %s (%s)\n", in_path, strerror(errno));
             return EXIT_FAILURE;
         }
-        file_size  = (size_t)statbuf.st_size;
-        block_size = (size_t)statbuf.st_blksize;
+        file_size  = static_cast<size_t>(statbuf.st_size);
+        block_size = static_cast<size_t>(statbuf.st_blksize);
         if (!is_power_of_two(block_size)) {
             fprintf(stderr, "Block size is not a power of two (%zu)\n", block_size);
             return EXIT_FAILURE;
@@ -161,7 +161,7 @@ main(int argc, char *argv[])
                 IS_HIPFILE_ERR(nbytes) ? HIPFILE_ERRSTR(nbytes) : strerror(errno));
         goto deregister_buf;
     }
-    if ((size_t)nbytes < payload_size) {
+    if (static_cast<size_t>(nbytes) < payload_size) {
         fprintf(stderr, "Short read on %s: got %zd bytes, expected at least %zu\n", in_path, nbytes,
                 payload_size);
         goto deregister_buf;
@@ -178,7 +178,7 @@ main(int argc, char *argv[])
      * lands at OUTPUT[0 .. write_xfer). The trailing bytes past write_size
      * (alignment padding read past payload_size) are removed by ftruncate. */
     nbytes = hipFileWrite(out_handle, devbuf, write_xfer, /*file_offset=*/0,
-                          /*buf_offset=*/(hoff_t)sub_offset);
+                          /*buf_offset=*/static_cast<hoff_t>(sub_offset));
     if (nbytes < 0) {
         fprintf(stderr, "Could not write to %s (%zd) (%s)\n", out_path, nbytes,
                 IS_HIPFILE_ERR(nbytes) ? HIPFILE_ERRSTR(nbytes) : strerror(errno));
@@ -186,7 +186,7 @@ main(int argc, char *argv[])
     }
 
     /* 6. ftruncate to logical sub-region size + hash verify */
-    if (-1 == ftruncate(out_fd, (off_t)write_size)) {
+    if (-1 == ftruncate(out_fd, static_cast<off_t>(write_size))) {
         fprintf(stderr, "Could not truncate %s (%s)\n", out_path, strerror(errno));
         goto close_out;
     }
@@ -201,7 +201,7 @@ main(int argc, char *argv[])
         uint64_t hash_in_tail, hash_out;
 
         /* Hash bytes [sub_offset, payload_size) of INPUT vs all of OUTPUT. */
-        if (hash_file_range(in_path, (off_t)sub_offset, write_size, &hash_in_tail))
+        if (hash_file_range(in_path, static_cast<off_t>(sub_offset), write_size, &hash_in_tail))
             goto deregister_buf;
         if (hash_file_range(out_path, 0, write_size, &hash_out))
             goto deregister_buf;

--- a/projects/hipfile/examples/basics/various-mem-rw.cpp
+++ b/projects/hipfile/examples/basics/various-mem-rw.cpp
@@ -88,7 +88,7 @@ alloc_buf(mem_mode_t mode, size_t size, void **out_buf)
             hip_err = hipHostMalloc(out_buf, size, hipHostMallocDefault);
             break;
         default:
-            fprintf(stderr, "alloc_buf: invalid mode %d\n", (int)mode);
+            fprintf(stderr, "alloc_buf: invalid mode %d\n", static_cast<int>(mode));
             return 1;
     }
     if (hipSuccess != hip_err) {
@@ -112,7 +112,7 @@ free_buf(mem_mode_t mode, void *buf)
             hip_err = hipHostFree(buf);
             break;
         default:
-            fprintf(stderr, "free_buf: invalid mode %d\n", (int)mode);
+            fprintf(stderr, "free_buf: invalid mode %d\n", static_cast<int>(mode));
             return 1;
     }
     if (hipSuccess != hip_err) {
@@ -162,7 +162,7 @@ main(int argc, char *argv[])
         fprintf(stderr, "MODE must be 1 (device), 2 (managed), or 3 (pinned-host)\n");
         return EXIT_FAILURE;
     }
-    const mem_mode_t mode = (mem_mode_t)mode_raw;
+    const mem_mode_t mode = static_cast<mem_mode_t>(mode_raw);
 
     /* Stat the input file to get its size and the filesystem block size. */
     size_t file_size, block_size;
@@ -172,8 +172,8 @@ main(int argc, char *argv[])
             fprintf(stderr, "Could not stat %s (%s)\n", in_path, strerror(errno));
             return EXIT_FAILURE;
         }
-        file_size  = (size_t)statbuf.st_size;
-        block_size = (size_t)statbuf.st_blksize;
+        file_size  = static_cast<size_t>(statbuf.st_size);
+        block_size = static_cast<size_t>(statbuf.st_blksize);
         if (!is_power_of_two(block_size)) {
             fprintf(stderr, "Block size is not a power of two (%zu)\n", block_size);
             return EXIT_FAILURE;
@@ -221,7 +221,7 @@ main(int argc, char *argv[])
                 IS_HIPFILE_ERR(nbytes) ? HIPFILE_ERRSTR(nbytes) : strerror(errno));
         goto release_buf;
     }
-    if ((size_t)nbytes < payload_size) {
+    if (static_cast<size_t>(nbytes) < payload_size) {
         fprintf(stderr, "Short read on %s: got %zd bytes, expected at least %zu\n", in_path, nbytes,
                 payload_size);
         goto release_buf;
@@ -240,7 +240,7 @@ main(int argc, char *argv[])
         goto close_out;
     }
 
-    if (-1 == ftruncate(out_fd, (off_t)payload_size)) {
+    if (-1 == ftruncate(out_fd, static_cast<off_t>(payload_size))) {
         fprintf(stderr, "Could not truncate %s (%s)\n", out_path, strerror(errno));
         goto close_out;
     }

--- a/projects/hipfile/examples/common/CMakeLists.install.cmake
+++ b/projects/hipfile/examples/common/CMakeLists.install.cmake
@@ -1,0 +1,23 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
+# You may need to add -DCMAKE_PREFIX_PATH=/path/to/hipfile
+# if hipFile has been installed to a non-standard location
+
+cmake_minimum_required(VERSION 3.21)
+
+project(examples_common LANGUAGES CXX)
+
+find_package(hip REQUIRED CONFIG)
+find_package(hipfile REQUIRED CONFIG)
+
+# Shared helpers used by the basics/ and async/ examples. The dependent example
+# directories pull this in via add_subdirectory(), so the include dir and the
+# hipFile link are PUBLIC to propagate to them.
+add_library(examples_common STATIC examples_common.cpp)
+target_compile_features(examples_common PRIVATE cxx_std_17)
+set_target_properties(examples_common PROPERTIES CXX_EXTENSIONS OFF)
+target_compile_options(examples_common PRIVATE -Wall -Wextra)
+target_include_directories(examples_common PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(examples_common PUBLIC hip::host hip::hipfile)

--- a/projects/hipfile/examples/common/CMakeLists.txt
+++ b/projects/hipfile/examples/common/CMakeLists.txt
@@ -10,12 +10,6 @@ add_library(examples_common STATIC examples_common.cpp)
 target_compile_features(examples_common PRIVATE cxx_std_${AIS_CXX_STANDARD})
 set_target_properties(examples_common PROPERTIES CXX_EXTENSIONS OFF)
 target_compile_options(examples_common PRIVATE -Wall -Wextra)
-# hipfile is instrumented when the sanitizers are on; this static lib is linked
-# into the example executables, so instrument it to match and avoid an
-# instrumentation mismatch.
-if(AIS_USE_SANITIZERS OR AIS_USE_THREAD_SANITIZER)
-    ais_add_sanitizers(examples_common)
-endif()
 target_include_directories(examples_common PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
 if(CMAKE_HIP_PLATFORM STREQUAL "amd")

--- a/projects/hipfile/examples/common/examples_common.h
+++ b/projects/hipfile/examples/common/examples_common.h
@@ -30,7 +30,7 @@ is_power_of_two(size_t value)
 /// @brief Alignment used for O_DIRECT transfers. Must be a power of two and a
 /// multiple of the underlying filesystem's logical block size; 4 KiB satisfies
 /// both for the ext4/xfs setups hipFile supports today.
-#define BLOCK_ALIGN ((size_t)4096)
+#define BLOCK_ALIGN (static_cast<size_t>(4096))
 static_assert(is_power_of_two(BLOCK_ALIGN), "BLOCK_ALIGN must be a power of two");
 
 /// @brief Round value up to the next multiple of align. Align _must_ be a power of 2.


### PR DESCRIPTION
## Motivation

The CMake code in the examples diverges among the example directories. They should be brought in line with the standard way of making sure the examples build and install.

## Technical Details

Every example directory now follows the same two-file pattern: a CMakeLists.txt that builds in-tree with the AIS infrastructure, and a CMakeLists.install.cmake that builds standalone against an installed hipFile via find_package(). Previously basics/ and async/ hand-rolled add_executable() with manual sanitizer wiring, api/ used a .install.in template (invisible to cmakelint), and basics/async/common had no install-side CMake at all.

Changes:
- basics/ and async/ now build via ais_add_executable(DEPS examples_common), dropping the bespoke add_executable loops and the manual ais_add_sanitizers() blocks. Examples are not instrumented (ais_add_executable adds -fno-sanitize=all while still linking the sanitizer runtime), matching the convention from the test programs. The BUILD_TESTING ctest wiring (scratch-dir fixtures, per-test inputs, the various-mem-rw mode matrix) is unchanged.
- common/ stays a static library but drops its sanitizer block.
- Renamed api/CMakeLists.install.in to .install.cmake so cmakelint processes it; added new CMakeLists.install.cmake files for common, basics, and async. basics/async pull in common via add_subdirectory so the shared helpers are built once, never duplicated.
- AISInstall.cmake configures and installs the new install-side files.
- Converting basics/async to the stricter AIS warning set surfaced C-style casts and zero-as-null-pointer uses; converted them to static_cast/nullptr so the examples build warning-free.
- Rewrote examples/README.md for the installed audience: removed all in-tree/repo-build instructions, documented the find_package build, and noted that the hipFile library path is baked into the example binaries via CMake's default RPATH (with LD_LIBRARY_PATH as the fallback if the install is later relocated).

## JIRA ID

AIHIPFILE-120

## Test Plan

CI passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
