### PR TITLE
ROCM-26407 - use wall clock to spin over kernel.

### DIFF
--- a/projects/hip-tests/catch/unit/graph/hipLaunchHostFuncWithGraph.cc
+++ b/projects/hip-tests/catch/unit/graph/hipLaunchHostFuncWithGraph.cc
@@ -250,8 +250,8 @@ __global__ void spin_then_set(int* flag, long long spin_ticks) {
   long long start = clock64();
   while ((clock64() - start) < spin_ticks) { /* spin */ }
 #else
-  long long start = wall_clock64();
-  while ((wall_clock64() - start) < spin_ticks) {
+  unsigned long long start = wall_clock64();
+  while ((wall_clock64() - start) < static_cast<unsigned long long>(spin_ticks)) {
     __builtin_amdgcn_s_sleep(10);
   }
 #endif

--- a/projects/hip-tests/catch/unit/graph/hipLaunchHostFuncWithGraph.cc
+++ b/projects/hip-tests/catch/unit/graph/hipLaunchHostFuncWithGraph.cc
@@ -245,9 +245,16 @@ HIP_TEST_CASE(Unit_hipLaunchHostFunc_H2D_Kernel_D2H_Capture) {
 
 
 namespace {
-__global__ void spin_then_set(int* flag, long long spin_cycles) {
+__global__ void spin_then_set(int* flag, long long spin_ticks) {
+#if HT_NVIDIA
   long long start = clock64();
-  while ((clock64() - start) < spin_cycles) { /* spin */ }
+  while ((clock64() - start) < spin_ticks) { /* spin */ }
+#else
+  long long start = wall_clock64();
+  while ((wall_clock64() - start) < spin_ticks) {
+    __builtin_amdgcn_s_sleep(10);
+  }
+#endif
   *flag = 1;
 }
 __global__ void noop() {}
@@ -288,8 +295,19 @@ __global__ void noop() {}
  */
 HIP_TEST_CASE(Unit_hipLaunchHostFunc_CrossStreamDep_UncapturedFirstNode) {
   // ~500ms spin ensures K_prod is still running when HW queue 0 hits the
-  // host_node markers (microseconds) if the barrier is missing.
-  constexpr long long kSpin = 1000000000LL;
+  // host_node markers (microseconds) if the barrier is missing. The budget is
+  // scaled by the device's wall-clock rate so the duration is identical across
+  // architectures and clock states (see catch/include/utils.hh).
+  int ticks_per_ms = 0;
+#if HT_NVIDIA
+  HIP_CHECK(hipDeviceGetAttribute(&ticks_per_ms, hipDeviceAttributeClockRate, 0));
+#else
+  HIP_CHECK(hipDeviceGetAttribute(&ticks_per_ms, hipDeviceAttributeWallClockRate, 0));
+#endif
+  if (ticks_per_ms == 0) {
+    ticks_per_ms = 1000;  // 1000 kHz fallback when the attribute is unavailable
+  }
+  const long long kSpin = static_cast<long long>(ticks_per_ms) * 500;  // ~500 ms
   constexpr int kExpected = 1;
 
   int* h_flag{};   // written by K_prod's captured DtoH on HW queue 1


### PR DESCRIPTION
## Motivation

Unit_hipLaunchHostFunc_CrossStreamDep_UncapturedFirstNode hangs on gfx11
(e.g. gfx1153 / Radeon 820M APU) and any part whose engine clock is gated
low for a single-wave kernel.

The regression test's producer kernel spin_then_set() busy-waited on
clock64() for a hardcoded 1e9-cycle budget, tuned to ~500 ms on gfx942
(MI300). clock64() counts engine-clock (SCLK) cycles, whose rate varies
with DVFS and differs across architectures. On gfx1153 the wall-clock rate
is ~100 MHz while SCLK nominally reaches 2.8 GHz, but a single-wave spin
keeps the engine clock gated near idle, so clock64() advances
pathologically slowly: a 1e7-cycle spin did not complete in 60 s and the
1e9 budget never finished. The producer therefore never reaches its
captured DtoH, the graph's host node never fires, and hipStreamSynchronize
appears to hang.

## Technical Details

- Replace clock64() with the fixed-rate wall_clock64() on AMD, matching the
  LaunchDelayKernel/Delay pattern in catch/include/utils.hh. wall_clock64()
  runs at hipDeviceAttributeWallClockRate independent of SCLK/DVFS, so the
  delay duration is identical across architectures and clock states.
- Express the spin budget in wall-clock ticks: kSpin = ticks_per_ms * 500,
  where ticks_per_ms is queried from hipDeviceAttributeWallClockRate (AMD)
  or hipDeviceAttributeClockRate (NVIDIA, which retains clock64()).
- Add __builtin_amdgcn_s_sleep(10) inside the AMD spin as a yield/power hint
  (same as Delay()).
- Keep the NVIDIA path on clock64()/ClockRate; no behavior change there.
The test's intent is preserved: the producer still reliably outlives the
consumer segment's host-node markers, so h_cb_saw == 1 continues to verify
the leading-barrier ordering fix from <hash of 9da53f4>.

## JIRA ID

ROCM-26407

## Test Plan

- gfx1153: Unit_hipLaunchHostFunc_CrossStreamDep_UncapturedFirstNode test is passed (20 assertions in 1 test case), previously hung indefinitely.

## Test Result

- gfx1153: Unit_hipLaunchHostFunc_CrossStreamDep_UncapturedFirstNode test is passed (20 assertions in 1 test case), previously hung indefinitely.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
