### PR TITLE
[hipfile] Fix broken shebang in ais-check

### DIFF
--- a/projects/hipfile/tools/ais-check/ais-check
+++ b/projects/hipfile/tools/ais-check/ais-check
@@ -1,8 +1,8 @@
+#!/usr/bin/env python3
 # Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
 #
 # SPDX-License-Identifier: MIT
 
-#! /usr/bin/env python3
 # pylint: disable=invalid-name
 
 """


### PR DESCRIPTION
This got moved below a comment block in a recent change (https://github.com/ROCm/rocm-systems/pull/7653)

## Motivation

Adding license comment blocks moved a shebang out of the first row

## Technical Details

Move the shebang to row 1

## JIRA ID

N/A

## Test Plan

CI passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
