### PR TITLE
[rocprofiler-systems]: Align perf_event_paranoid gating with runtime in tests

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -772,10 +772,9 @@ def pytest_sessionfinish(session, exitstatus):
 
 
 def overflow_unavailable_reason(rocprof_config: RocprofsysConfig) -> Optional[str]:
-    caps = rocprof_config.capabilities
-    if caps.perf_event_paranoid <= 3 or caps.cap_sys_admin or caps.cap_perfmon:
+    if rocprof_config.capabilities.perf_events_usable:
         return None
-    return "Requires either perf_event_paranoid <= 3, CAP_SYS_ADMIN, or CAP_PERFMON to be available"
+    return "Requires either perf_event_paranoid <= 2 or CAP_SYS_ADMIN to be available"
 
 
 def gpu_unavailable_reason() -> Optional[str]:
@@ -805,9 +804,9 @@ def attach_unavailable_reason(rocprof_config: RocprofsysConfig) -> Optional[str]
 
 def nic_unavailable_reason(rocprof_config: RocprofsysConfig) -> Optional[str]:
     caps = rocprof_config.capabilities
-    if caps.papi_nic_events is not None and caps.perf_event_paranoid <= 2:
+    if caps.papi_nic_events is not None and caps.perf_events_usable:
         return None
-    return "Requires PAPI network events and perf_event_paranoid <= 2 to be available"
+    return "Requires PAPI network events and perf_event_paranoid <= 2 (or CAP_SYS_ADMIN) to be available"
 
 
 def ainic_unavailable_reason(rocprof_config: RocprofsysConfig) -> Optional[str]:

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -1524,6 +1524,7 @@ def _generate_rocprofsys_config_header() -> list[str]:
         _row("Perf event paranoid:", cap.perf_event_paranoid),
         _row("CAP_SYS_ADMIN:", cap.cap_sys_admin),
         _row("CAP_PERFMON:", cap.cap_perfmon),
+        _row("Perf events usable:", cap.perf_events_usable),
         _row("Ptrace scope:", cap.ptrace_scope),
         _row("Is inside docker:", rocprof_config.capabilities.is_inside_docker),
         _row("PAPI available:", cap.papi_availability),

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -283,6 +283,19 @@ class SystemCapabilities:
             return False
 
     @cached_property
+    def perf_events_usable(self) -> bool:
+        """Whether perf_event_open-based features can actually be used.
+
+        This gates anything that opens Linux perf events, including PAPI
+        hardware/software counters and overflow sampling. It mirrors the
+        runtime gate in ``source/lib/core/config.cpp``, which disables PAPI
+        when ``/proc/sys/kernel/perf_event_paranoid`` is greater than 2 unless
+        ``CAP_SYS_ADMIN`` is held. Note the runtime does not consult
+        ``CAP_PERFMON``, so it is intentionally not checked here.
+        """
+        return self.perf_event_paranoid <= 2 or self.cap_sys_admin
+
+    @cached_property
     def papi_availability(self) -> bool:
         """Check if PAPI is built into rocprofiler-systems.
 

--- a/projects/rocprofiler-systems/tests/pytest/test_annotate.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_annotate.py
@@ -19,11 +19,8 @@ pytestmark = [pytest.mark.annotate]
 @pytest.fixture
 def annotate_papi_condition(rocprof_config) -> bool:
     """Check if PAPI is available and usable."""
-    return rocprof_config.capabilities.papi_availability and (
-        rocprof_config.capabilities.perf_event_paranoid <= 3
-        or rocprof_config.capabilities.cap_sys_admin
-        or rocprof_config.capabilities.cap_perfmon
-    )
+    caps = rocprof_config.capabilities
+    return caps.papi_availability and caps.perf_events_usable
 
 
 @pytest.fixture


### PR DESCRIPTION
## Motivation

The pytest availability checks allowed `perf_event_paranoid <= 3`, which is more permissive than the actual runtime, which disables PAPI/perf-event collection when the value is `> 2`. This caused PAPI/overflow tests to be enabled (and then fail or produce no counter data) on systems sitting at `paranoid = 3`.

## Technical Details

- Added a centralized `perf_events_usable` property in `SystemCapabilities` (`capabilities.py`) that returns `perf_event_paranoid <= 2` or `cap_sys_admin`, exactly mirroring the runtime gate in https://github.com/ROCm/rocm-systems/blob/705ceb4b0dd819ccb734b9653cfcac85fff3ceae/projects/rocprofiler-systems/source/lib/core/config.cpp#L1054
- Dropped `CAP_PERFMON` from the test gating, since the `rocprof-sys` runtime only honors `CAP_SYS_ADMIN` (not `CAP_PERFMON`) as the escape hatch above `paranoid = 2`; including it would make tests more permissive than the binding runtime constraint.
- Refactored `overflow_unavailable_reason` and `nic_unavailable_reason` in `conftest.py` to delegate to `perf_events_usable` (also fixes `annotate_unavailable_reason`, which routes through `overflow_unavailable_reason`), and updated the skip-reason messages accordingly.
- Replaced the duplicated, too-permissive `<= 3` inline check in the `annotate_papi_condition` fixture (`test_annotate.py`) with `caps.papi_availability` and` caps.perf_events_usable`.
- Net effect: test enablement now agrees with runtime behavior; the only behavioral change is correctly skipping PAPI/overflow/annotate tests at `paranoid = 3` without `CAP_SYS_ADMIN`.

## JIRA ID

AIPROFSYST-553

## Test Plan

Manual Testing on `gfx1151` and `gfx942`.

## Test Result

Relevant segments from the test logs:

```
1: System Capabilities:
1:   Detected num procs:   16
1:   UCX available:        True
1:   Perf event paranoid:  4
1:   CAP_SYS_ADMIN:        False
1:   CAP_PERFMON:          False
1:   Perf events usable:   False

[15:14:26.832][P:201578 T:201578][config.cpp:1056 configure_settings][warning] /proc/sys/kernel/perf_event_paranoid has a value of 4. Disabling PAPI (requires a value <= 2)
[15:14:26.832][P:201578 T:201578][config.cpp:1059 configure_settings][warning] In order to enable PAPI support, run 'echo N | sudo tee /proc/sys/kernel/perf_event_paranoid' where N is <= 2

The following tests did not run:
2 - ainic-performance-tracks (Skipped)
207 - nic-performance (Skipped)
3 - annotate-parallel-overhead-sampling (Skipped)
4 - annotate-parallel-overhead-binary-rewrite (Skipped)
5 - annotate-parallel-overhead-sys-run (Skipped)
229 - overflow-parallel-overhead-sampling (Skipped)
230 - overflow-parallel-overhead-binary-rewrite (Skipped)
231 - overflow-parallel-overhead-runtime-instrument (Skipped)
232 - overflow-parallel-overhead-sys-run (Skipped)

=========================== short test summary info ============================
SKIPPED [1] ../share/rocprofiler-systems/tests/pytest/test_ainic_perf.py:99: No AI NIC devices found (amd-smi static reports no NETDEV entries)
============================== 1 skipped in 0.10s ==============================
=========================== short test summary info ============================
SKIPPED [1] ../share/rocprofiler-systems/tests/pytest/test_nic_perf.py: Requires PAPI network events and perf_event_paranoid <= 2 (or CAP_SYS_ADMIN) to be available
============================== 1 skipped in 0.02s ==============================
=========================== short test summary info ============================
SKIPPED [1] ../share/rocprofiler-systems/tests/pytest/test_annotate.py: Requires either perf_event_paranoid <= 2 or CAP_SYS_ADMIN to be available
============================== 1 skipped in 0.02s ==============================
=========================== short test summary info ============================
SKIPPED [1] ../share/rocprofiler-systems/tests/pytest/test_overflow.py: Requires either perf_event_paranoid <= 2 or CAP_SYS_ADMIN to be available
============================== 1 skipped in 0.02s ==============================
```

The above tests will pass if the settings are modified with:

`echo 2 | sudo tee /proc/sys/kernel/perf_event_paranoid`

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
