### PR TITLE
[hipfile] Add license comment to python/CMakeLists.txt

### DIFF
--- a/projects/hipfile/python/CMakeLists.txt
+++ b/projects/hipfile/python/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+
 cmake_minimum_required(VERSION 3.21)
 project(hipfile-python LANGUAGES C)
 


### PR DESCRIPTION
## Motivation

All source files need license comments

## Technical Details

Add standard license comment block to python/CMakeLists.txt

## JIRA ID

AIHIPFILE-176

## Test Plan

CI Passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
