### PR TITLE
[rocprofiler-sdk] Fix gfx1151/gfx1152 APU support in HSA test apps

### DIFF
--- a/projects/rocprofiler-sdk/samples/openmp_target/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/samples/openmp_target/CMakeLists.txt
@@ -30,8 +30,17 @@ target_link_libraries(
     PRIVATE rocprofiler-sdk::rocprofiler-sdk rocprofiler-sdk::samples-build-flags
             rocprofiler-sdk::samples-common-library)
 
-set(DEFAULT_GPU_TARGETS "gfx906" "gfx908" "gfx90a" "gfx942" "gfx950" "gfx1100" "gfx1101"
-                        "gfx1102")
+set(DEFAULT_GPU_TARGETS
+    "gfx906"
+    "gfx908"
+    "gfx90a"
+    "gfx942"
+    "gfx950"
+    "gfx1100"
+    "gfx1101"
+    "gfx1102"
+    "gfx1151"
+    "gfx1152")
 
 set(OPENMP_GPU_TARGETS
     "${DEFAULT_GPU_TARGETS}"

--- a/projects/rocprofiler-sdk/tests/bin/hsa-code-object/hsa_code_object_app.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/hsa-code-object/hsa_code_object_app.cpp
@@ -41,7 +41,11 @@ code_object_load(MQDependencyTest&             obj,
                  MQDependencyTest::CodeObject& code_object)
 {
     hsa_status_t status;
-    obj.device_discovery();
+    if(!obj.device_discovery() || obj.gpu.empty())
+    {
+        fprintf(stderr, "No GPU agent found; cannot run test.\n");
+        exit(EXIT_FAILURE);
+    }
     char agent_name[64];
     status = hsa_agent_get_info(obj.gpu[0].agent, HSA_AGENT_INFO_NAME, agent_name);
     RET_IF_HSA_ERR(status)

--- a/projects/rocprofiler-sdk/tests/bin/hsa-code-object/hsa_code_object_app.h
+++ b/projects/rocprofiler-sdk/tests/bin/hsa-code-object/hsa_code_object_app.h
@@ -276,7 +276,11 @@ public:
         hsa_status_t err = hsa_amd_memory_pool_allocate(mem.pool, size, 0, &ret);
         RET_IF_HSA_ERR(err);
 
-        err = hsa_amd_agents_allow_access(all_devices.size(), all_devices.data(), nullptr, ret);
+        // Grant access to the GPU agent only. On APUs (for example, gfx1151) the CPU
+        // agent is rejected by hsa_amd_agents_allow_access with
+        // HSA_STATUS_ERROR_INVALID_AGENT, so passing the full agent list fails.
+        hsa_agent_t ag_list[1] = {gpu[0].agent};
+        err                    = hsa_amd_agents_allow_access(1, ag_list, nullptr, ret);
         RET_IF_HSA_ERR(err);
         return ret;
     }

--- a/projects/rocprofiler-sdk/tests/bin/hsa-code-object/hsa_code_object_app.h
+++ b/projects/rocprofiler-sdk/tests/bin/hsa-code-object/hsa_code_object_app.h
@@ -276,12 +276,29 @@ public:
         hsa_status_t err = hsa_amd_memory_pool_allocate(mem.pool, size, 0, &ret);
         RET_IF_HSA_ERR(err);
 
-        // Grant access to the GPU agent only. On APUs (for example, gfx1151) the CPU
-        // agent is rejected by hsa_amd_agents_allow_access with
-        // HSA_STATUS_ERROR_INVALID_AGENT, so passing the full agent list fails.
-        hsa_agent_t ag_list[1] = {gpu[0].agent};
-        err                    = hsa_amd_agents_allow_access(1, ag_list, nullptr, ret);
-        RET_IF_HSA_ERR(err);
+        // Grant access only to the GPU agents that can actually access this pool.
+        // The CPU agent is excluded: the host already owns the kernarg pool and on
+        // APUs (for example, gfx1151) it is rejected with
+        // HSA_STATUS_ERROR_INVALID_AGENT. Agents for which the pool is never
+        // accessible are filtered out as well, so multi-GPU systems (where some
+        // agents cannot reach the pool) and systems with no GPU both work.
+        std::vector<hsa_agent_t> agents;
+        agents.reserve(gpu.size());
+        for(const auto& dev : gpu)
+        {
+            hsa_amd_memory_pool_access_t access = HSA_AMD_MEMORY_POOL_ACCESS_NEVER_ALLOWED;
+            if(hsa_amd_agent_memory_pool_get_info(
+                   dev.agent, mem.pool, HSA_AMD_AGENT_MEMORY_POOL_INFO_ACCESS, &access) ==
+                   HSA_STATUS_SUCCESS &&
+               access != HSA_AMD_MEMORY_POOL_ACCESS_NEVER_ALLOWED)
+                agents.push_back(dev.agent);
+        }
+
+        if(!agents.empty())
+        {
+            err = hsa_amd_agents_allow_access(agents.size(), agents.data(), nullptr, ret);
+            RET_IF_HSA_ERR(err);
+        }
         return ret;
     }
 

--- a/projects/rocprofiler-sdk/tests/bin/hsa-queue-dependency/multiqueue_app.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/hsa-queue-dependency/multiqueue_app.cpp
@@ -41,7 +41,11 @@ main()
     MQDependencyTest obj;
 
     // Get Agent info
-    obj.device_discovery();
+    if(!obj.device_discovery() || obj.gpu.empty())
+    {
+        fprintf(stderr, "No GPU agent found; cannot run test.\n");
+        return EXIT_FAILURE;
+    }
 
     char agent_name[64];
     status = hsa_agent_get_info(obj.gpu[0].agent, HSA_AGENT_INFO_NAME, agent_name);

--- a/projects/rocprofiler-sdk/tests/bin/hsa-queue-dependency/multiqueue_app.h
+++ b/projects/rocprofiler-sdk/tests/bin/hsa-queue-dependency/multiqueue_app.h
@@ -250,12 +250,29 @@ public:
             hsa_amd_memory_pool_allocate(mem.pool, size, hsa_amd_memory_pool_executable_flag, &ret);
         RET_IF_HSA_ERR(err);
 
-        // Grant access to the GPU agent only. On APUs (for example, gfx1151) the CPU
-        // agent is rejected by hsa_amd_agents_allow_access with
-        // HSA_STATUS_ERROR_INVALID_AGENT, so passing the full agent list fails.
-        hsa_agent_t ag_list[1] = {gpu[0].agent};
-        err                    = hsa_amd_agents_allow_access(1, ag_list, nullptr, ret);
-        RET_IF_HSA_ERR(err);
+        // Grant access only to the GPU agents that can actually access this pool.
+        // The CPU agent is excluded: the host already owns the kernarg pool and on
+        // APUs (for example, gfx1151) it is rejected with
+        // HSA_STATUS_ERROR_INVALID_AGENT. Agents for which the pool is never
+        // accessible are filtered out as well, so multi-GPU systems (where some
+        // agents cannot reach the pool) and systems with no GPU both work.
+        std::vector<hsa_agent_t> agents;
+        agents.reserve(gpu.size());
+        for(const auto& dev : gpu)
+        {
+            hsa_amd_memory_pool_access_t access = HSA_AMD_MEMORY_POOL_ACCESS_NEVER_ALLOWED;
+            if(hsa_amd_agent_memory_pool_get_info(
+                   dev.agent, mem.pool, HSA_AMD_AGENT_MEMORY_POOL_INFO_ACCESS, &access) ==
+                   HSA_STATUS_SUCCESS &&
+               access != HSA_AMD_MEMORY_POOL_ACCESS_NEVER_ALLOWED)
+                agents.push_back(dev.agent);
+        }
+
+        if(!agents.empty())
+        {
+            err = hsa_amd_agents_allow_access(agents.size(), agents.data(), nullptr, ret);
+            RET_IF_HSA_ERR(err);
+        }
         return ret;
     }
 

--- a/projects/rocprofiler-sdk/tests/bin/hsa-queue-dependency/multiqueue_app.h
+++ b/projects/rocprofiler-sdk/tests/bin/hsa-queue-dependency/multiqueue_app.h
@@ -250,8 +250,11 @@ public:
             hsa_amd_memory_pool_allocate(mem.pool, size, hsa_amd_memory_pool_executable_flag, &ret);
         RET_IF_HSA_ERR(err);
 
-        err = hsa_amd_agents_allow_access(
-            Device::all_devices.size(), Device::all_devices.data(), nullptr, ret);
+        // Grant access to the GPU agent only. On APUs (for example, gfx1151) the CPU
+        // agent is rejected by hsa_amd_agents_allow_access with
+        // HSA_STATUS_ERROR_INVALID_AGENT, so passing the full agent list fails.
+        hsa_agent_t ag_list[1] = {gpu[0].agent};
+        err                    = hsa_amd_agents_allow_access(1, ag_list, nullptr, ret);
         RET_IF_HSA_ERR(err);
         return ret;
     }

--- a/projects/rocprofiler-sdk/tests/bin/openmp/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/bin/openmp/CMakeLists.txt
@@ -23,8 +23,17 @@ project(rocprofiler-sdk-tests-bin-openmp LANGUAGES CXX)
 
 find_package(rocprofiler-sdk REQUIRED)
 
-set(DEFAULT_GPU_TARGETS "gfx906" "gfx908" "gfx90a" "gfx942" "gfx950" "gfx1100" "gfx1101"
-                        "gfx1102")
+set(DEFAULT_GPU_TARGETS
+    "gfx906"
+    "gfx908"
+    "gfx90a"
+    "gfx942"
+    "gfx950"
+    "gfx1100"
+    "gfx1101"
+    "gfx1102"
+    "gfx1151"
+    "gfx1152")
 
 set(OPENMP_GPU_TARGETS
     "${DEFAULT_GPU_TARGETS}"

--- a/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/common/CMakeLists.txt
@@ -23,7 +23,9 @@ set(DEFAULT_GPU_TARGETS
     "gfx1010"
     "gfx1100"
     "gfx1101"
-    "gfx1102")
+    "gfx1102"
+    "gfx1151"
+    "gfx1152")
 
 set(GPU_TARGETS
     "${DEFAULT_GPU_TARGETS}"


### PR DESCRIPTION
Grant memory access to the GPU agent only in the test apps' hsa_malloc helpers instead of passing the full agent list (CPU + GPU). On APUs such as gfx1151, hsa_amd_agents_allow_access rejects the CPU agent with HSA_STATUS_ERROR_INVALID_AGENT, causing the test apps to abort. This matches the production pattern in hsa_rsrc_factory.cpp.

Also add gfx1151 and gfx1152 to DEFAULT_GPU_TARGETS so the test HSACO kernels are generated for these architectures.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
