### PR TITLE
fix(ci): Fix ASAN workflow concurrency to allow parallel post-submit runs

### DIFF
--- a/.github/workflows/therock_multi_arch_ci_asan.yml
+++ b/.github/workflows/therock_multi_arch_ci_asan.yml
@@ -35,7 +35,13 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  # Only allow one run at a time for 'pull_request' events.
+  # Allow multiple runs for 'push' and 'workflow_dispatch'.
+  #
+  # `github.workflow`: each workflow gets its own concurrency group
+  # `github.head_ref`: the branch name (only defined for pull_request events)
+  # `github.run_id`  : fallback, unique for each run
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Use github.run_id instead of github.ref as fallback in concurrency group. This gives each push to develop its own unique group, preventing newer commits from cancelling in-progress ASAN builds.

It keeps cancelling itself: https://github.com/ROCm/rocm-systems/actions/workflows/therock_multi_arch_ci_asan.yml