### PR TITLE
[ci] Update thread limit env vars to 14

### DIFF
--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -112,8 +112,8 @@ jobs:
           # components leave it empty. See: https://github.com/ROCm/TheRock/issues/3587
           GPU_ENABLE_PAL: ${{ fromJSON(inputs.component).gpu_enable_pal }}
           # Limit thread count to prevent CPU over-subscription during tests
-          OPENBLAS_NUM_THREADS: "4"
-          OMP_NUM_THREADS: "4"
+          OPENBLAS_NUM_THREADS: "14"
+          OMP_NUM_THREADS: "14"
         run: |
           ${{ fromJSON(inputs.component).test_script }}
 


### PR DESCRIPTION
Increase OPENBLAS_NUM_THREADS and OMP_NUM_THREADS from 4 to 14 to better utilize available CPU cores during tests.