### PR TITLE
[rocprofiler-systems] sdma-test review fixes: working version gates + amdgpu gate

### DIFF
--- a/projects/rocprofiler-systems/examples/sdma-test/README.md
+++ b/projects/rocprofiler-systems/examples/sdma-test/README.md
@@ -63,6 +63,7 @@ rocprof-sys-run -- ./sdma-test -s 256 -n 5
 | ---------- | ------- | --------- |
 | `ROCPROFSYS_ROCM_DOMAINS` | `hip_runtime_api,kernel_dispatch,memory_copy` | Trace HIP API and memory copy operations |
 | `ROCPROFSYS_ROCM_EVENTS` | `SQ_WAVES,GRBM_COUNT` | Sample GPU hardware counters |
+| `ROCPROFSYS_AMD_SMI_METRICS` | `sdma_usage` | Collect SDMA engine usage via AMD-SMI |
 | `ROCPROFSYS_TRACE` | `true` | Generate Perfetto trace for timeline analysis |
 
 To capture SDMA-specific metrics:
@@ -70,6 +71,7 @@ To capture SDMA-specific metrics:
 ```bash
 rocprof-sys-run \
     -e ROCPROFSYS_ROCM_DOMAINS=hip_runtime_api,memory_copy \
+    -e ROCPROFSYS_AMD_SMI_METRICS=sdma_usage \
     -e ROCPROFSYS_TRACE=true \
     -- ./sdma-test -s 512 -n 5
 ```

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -232,6 +232,10 @@ def pytest_configure(config: pytest.Config) -> None:
     )
     config.addinivalue_line(
         "markers",
+        "amdgpu_min_version(version): mark test as requiring minimum amdgpu driver version",
+    )
+    config.addinivalue_line(
+        "markers",
         "rocpd(env): mark test as using ROCpd and inject ROCpd env into given env",
     )
     # TODO: Deprecate once TheRock switches to CTest and CTest based filtering
@@ -617,6 +621,20 @@ def pytest_collection_modifyitems(config, items) -> None:
                     item.add_marker(
                         pytest.mark.skip(
                             reason=f"AMD-SMI {'.'.join(map(str, system_version))} < required {req_version}"
+                        )
+                    )
+        if "amdgpu_min_version" in item.keywords:
+            req_version = item.get_closest_marker("amdgpu_min_version").args[0]
+            system_version = rocprof_config.capabilities.amdgpu_version
+            if system_version is None:
+                item.add_marker(pytest.mark.skip(reason="amdgpu version not found"))
+            else:
+                min_parts = req_version.split(".")
+                min_tuple = tuple(int(p) for p in (min_parts + ["0", "0", "0"])[:3])
+                if system_version < min_tuple:
+                    item.add_marker(
+                        pytest.mark.skip(
+                            reason=f"amdgpu {'.'.join(map(str, system_version))} < required {req_version}"
                         )
                     )
         if "run_if_gpu_category" in item.keywords:
@@ -1091,6 +1109,7 @@ def _ctest_generate_tests(
         "oshrun_min_version",
         "rocm_min_version",
         "amdsmi_min_version",
+        "amdgpu_min_version",
         "run_if_gpu_category",
         "preserve",
         # For CTests
@@ -1326,6 +1345,13 @@ def _generate_rocprofsys_config_header() -> list[str]:
     else:
         amdsmi_version_str = "Not found"
 
+    if cap.amdgpu_version is not None:
+        amdgpu_version_str = (
+            f"{cap.amdgpu_version[0]}.{cap.amdgpu_version[1]}.{cap.amdgpu_version[2]}"
+        )
+    else:
+        amdgpu_version_str = "Not found"
+
     # Rocprofiler SDK version
     rocprofiler_sdk_version_str = (
         f"{cap.rocprofiler_sdk_version[0]}.{cap.rocprofiler_sdk_version[1]}.{cap.rocprofiler_sdk_version[2]}"
@@ -1349,6 +1375,7 @@ def _generate_rocprofsys_config_header() -> list[str]:
         _row("ROCm version:", rocm_version),
         _row("ROCprof-SDK version:", rocprofiler_sdk_version_str),
         _row("AMD-SMI version:", amdsmi_version_str),
+        _row("amdgpu version:", amdgpu_version_str),
         _row("ROCm path:", rocprof_config.rocm_path),
         _row("Is installed:", rocprof_config.is_installed),
         _row("Output dir:", rocprof_config.test_output_dir),

--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -1321,6 +1321,11 @@ def _generate_rocprofsys_config_header() -> list[str]:
     else:
         oshrun_version_str = "Not found"
 
+    if cap.amdsmi_version is not None:
+        amdsmi_version_str = f"{cap.amdsmi_version[0]}.{cap.amdsmi_version[1]}"
+    else:
+        amdsmi_version_str = "Not found"
+
     # Rocprofiler SDK version
     rocprofiler_sdk_version_str = (
         f"{cap.rocprofiler_sdk_version[0]}.{cap.rocprofiler_sdk_version[1]}.{cap.rocprofiler_sdk_version[2]}"
@@ -1343,6 +1348,7 @@ def _generate_rocprofsys_config_header() -> list[str]:
         "=" * 70,
         _row("ROCm version:", rocm_version),
         _row("ROCprof-SDK version:", rocprofiler_sdk_version_str),
+        _row("AMD-SMI version:", amdsmi_version_str),
         _row("ROCm path:", rocprof_config.rocm_path),
         _row("Is installed:", rocprof_config.is_installed),
         _row("Output dir:", rocprof_config.test_output_dir),

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/__init__.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/__init__.py
@@ -50,12 +50,6 @@ from .gpu import (
     get_xnack_support,
 )
 
-from .capabilities import (
-    SystemCapabilities,
-    get_amdsmi_version,
-    get_amdgpu_version,
-)
-
 __all__ = [
     # Config
     "RocprofsysConfig",
@@ -89,8 +83,4 @@ __all__ = [
     "get_target_gpu_arch",
     "get_offload_extractor",
     "get_xnack_support",
-    # Capabilities
-    "SystemCapabilities",
-    "get_amdsmi_version",
-    "get_amdgpu_version",
 ]

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/__init__.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/__init__.py
@@ -53,7 +53,6 @@ from .gpu import (
 from .capabilities import (
     SystemCapabilities,
     get_amdsmi_version,
-    amdsmi_sdma_supported,
 )
 
 __all__ = [
@@ -92,5 +91,4 @@ __all__ = [
     # Capabilities
     "SystemCapabilities",
     "get_amdsmi_version",
-    "amdsmi_sdma_supported",
 ]

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/__init__.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/__init__.py
@@ -53,6 +53,7 @@ from .gpu import (
 from .capabilities import (
     SystemCapabilities,
     get_amdsmi_version,
+    get_amdgpu_version,
 )
 
 __all__ = [
@@ -91,4 +92,5 @@ __all__ = [
     # Capabilities
     "SystemCapabilities",
     "get_amdsmi_version",
+    "get_amdgpu_version",
 ]

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -46,7 +46,7 @@ def get_amdsmi_version(rocm_path: Optional[Path] = None) -> Optional[tuple[int, 
     raw = _get_amdsmi_version_output(rocm_path)
     if raw is None:
         return None
-    # e.g. "AMDSMI Tool: 26.4.0+... | AMDSMI Library version: 26.4.0 | ROCm version: 7.13.0 ..."
+    # e.g. Output from `amd-smi version` = "AMDSMI Tool: 26.4.0+... | AMDSMI Library version: 26.4.0 | ROCm version: 7.13.0 ..."
     m = re.search(r"AMDSMI\s+(?:Tool|Library version):\s*(\d+)\.(\d+)", raw)
     if m:
         return (int(m.group(1)), int(m.group(2)))

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -60,7 +60,9 @@ def get_amdgpu_version(
     raw = _get_amdsmi_version_output(rocm_path)
     if raw is None:
         return None
-    # e.g. "... | amdgpu version: 6.19.14.31400000" (patch may be absent: "6.19.4")
+    # amdgpu version is "major.minor[.patch[.build]]"; e.g. "6.19.14.31400000"
+    # or "6.19.4". Compare on (major, minor, patch) only — the build suffix is
+    # ignored, and an absent patch is treated as .0.
     m = re.search(r"amdgpu version:\s*(\d+)\.(\d+)(?:\.(\d+))?", raw)
     if m:
         patch = int(m.group(3)) if m.group(3) is not None else 0

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -37,7 +37,8 @@ def get_amdsmi_version(rocm_path: Optional[Path] = None) -> Optional[tuple[int, 
             timeout=5,
         )
         raw = (result.stdout or "") + " " + (result.stderr or "")
-        m = re.search(r"Version:\s*(\d+)\.(\d+)", raw)
+        # e.g. "AMDSMI Tool: 26.4.0+... | AMDSMI Library version: 26.4.0 | ROCm version: 7.13.0 ..."
+        m = re.search(r"AMDSMI\s+(?:Tool|Library version):\s*(\d+)\.(\d+)", raw)
         if m:
             return (int(m.group(1)), int(m.group(2)))
     except (subprocess.SubprocessError, OSError, ValueError):

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -12,10 +12,6 @@ import shutil
 import subprocess
 import re
 
-# AMD-SMI >= 26.3 required for SDMA usage (see source/lib/core/sdma_feature.hpp)
-AMDSMI_SDMA_MIN_MAJOR = 26
-AMDSMI_SDMA_MIN_MINOR = 3
-
 
 def get_amdsmi_version(rocm_path: Optional[Path] = None) -> Optional[tuple[int, int]]:
     """Return (major, minor) of amd-smi if available, else None."""
@@ -47,19 +43,6 @@ def get_amdsmi_version(rocm_path: Optional[Path] = None) -> Optional[tuple[int, 
     except (subprocess.SubprocessError, OSError, ValueError):
         pass
     return None
-
-
-def amdsmi_sdma_supported(
-    rocm_path: Optional[Path] = None,
-    min_major: int = AMDSMI_SDMA_MIN_MAJOR,
-    min_minor: int = AMDSMI_SDMA_MIN_MINOR,
-) -> bool:
-    """Return True if AMD-SMI version supports SDMA usage (>= 26.3 by default)."""
-    ver = get_amdsmi_version(rocm_path)
-    if ver is None:
-        return False
-    major, minor = ver
-    return major > min_major or (major == min_major and minor >= min_minor)
 
 
 @dataclass
@@ -464,11 +447,6 @@ class SystemCapabilities:
     def amdsmi_version(self) -> Optional[tuple[int, int]]:
         """Get (major, minor) version of amd-smi, or None if not available."""
         return get_amdsmi_version(self.rocm_path)
-
-    @cached_property
-    def amdsmi_sdma_supported(self) -> bool:
-        """True if AMD-SMI supports SDMA usage (>= 26.3)."""
-        return amdsmi_sdma_supported(self.rocm_path)
 
 
 _ROCPROFILER_SDK_VERSION_H_RE = re.compile(

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -13,8 +13,8 @@ import subprocess
 import re
 
 
-def get_amdsmi_version(rocm_path: Optional[Path] = None) -> Optional[tuple[int, int]]:
-    """Return (major, minor) of amd-smi if available, else None."""
+def _get_amdsmi_version_output(rocm_path: Optional[Path] = None) -> Optional[str]:
+    """Return combined stdout/stderr of ``amd-smi version`` if available, else None."""
     amdsmi_exe = None
     if rocm_path is not None:
         candidate = Path(rocm_path) / "bin" / "amd-smi"
@@ -36,13 +36,35 @@ def get_amdsmi_version(rocm_path: Optional[Path] = None) -> Optional[tuple[int, 
             text=True,
             timeout=5,
         )
-        raw = (result.stdout or "") + " " + (result.stderr or "")
-        # e.g. "AMDSMI Tool: 26.4.0+... | AMDSMI Library version: 26.4.0 | ROCm version: 7.13.0 ..."
-        m = re.search(r"AMDSMI\s+(?:Tool|Library version):\s*(\d+)\.(\d+)", raw)
-        if m:
-            return (int(m.group(1)), int(m.group(2)))
-    except (subprocess.SubprocessError, OSError, ValueError):
-        pass
+        return (result.stdout or "") + " " + (result.stderr or "")
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+
+def get_amdsmi_version(rocm_path: Optional[Path] = None) -> Optional[tuple[int, int]]:
+    """Return (major, minor) of amd-smi if available, else None."""
+    raw = _get_amdsmi_version_output(rocm_path)
+    if raw is None:
+        return None
+    # e.g. "AMDSMI Tool: 26.4.0+... | AMDSMI Library version: 26.4.0 | ROCm version: 7.13.0 ..."
+    m = re.search(r"AMDSMI\s+(?:Tool|Library version):\s*(\d+)\.(\d+)", raw)
+    if m:
+        return (int(m.group(1)), int(m.group(2)))
+    return None
+
+
+def get_amdgpu_version(
+    rocm_path: Optional[Path] = None,
+) -> Optional[tuple[int, int, int]]:
+    """Return (major, minor, patch) of the amdgpu driver if available, else None."""
+    raw = _get_amdsmi_version_output(rocm_path)
+    if raw is None:
+        return None
+    # e.g. "... | amdgpu version: 6.19.14.31400000" (patch may be absent: "6.19.4")
+    m = re.search(r"amdgpu version:\s*(\d+)\.(\d+)(?:\.(\d+))?", raw)
+    if m:
+        patch = int(m.group(3)) if m.group(3) is not None else 0
+        return (int(m.group(1)), int(m.group(2)), patch)
     return None
 
 
@@ -448,6 +470,11 @@ class SystemCapabilities:
     def amdsmi_version(self) -> Optional[tuple[int, int]]:
         """Get (major, minor) version of amd-smi, or None if not available."""
         return get_amdsmi_version(self.rocm_path)
+
+    @cached_property
+    def amdgpu_version(self) -> Optional[tuple[int, int, int]]:
+        """Get (major, minor, patch) of the amdgpu driver, or None if not available."""
+        return get_amdgpu_version(self.rocm_path)
 
 
 _ROCPROFILER_SDK_VERSION_H_RE = re.compile(

--- a/projects/rocprofiler-systems/tests/pytest/test_sdma.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_sdma.py
@@ -8,8 +8,9 @@ Validates that running sdma-test with ROCPROFSYS_AMD_SMI_METRICS=sdma_usage
 produces expected SDMA usage tracks and values in Perfetto and ROCPD output,
 as implemented in the amd_smi component.
 
-SDMA usage requires AMD-SMI >= 26.3 (see source/lib/core/sdma_feature.hpp)
-and amdgpu driver >= 6.19.14; tests are skipped otherwise.
+SDMA usage requires an Instinct GPU, AMD-SMI >= 26.3
+(see source/lib/core/sdma_feature.hpp), and amdgpu driver >= 6.19.14;
+tests are skipped otherwise.
 """
 
 from __future__ import annotations
@@ -41,6 +42,7 @@ def sdma_rules(validation_rules_dir: Path) -> list[Path]:
     ]
 
 
+@pytest.mark.run_if_gpu_category("instinct")
 @pytest.mark.amdsmi_min_version("26.3")
 @pytest.mark.amdgpu_min_version("6.19.14")
 class TestSDMA(RocprofsysTest):

--- a/projects/rocprofiler-systems/tests/pytest/test_sdma.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_sdma.py
@@ -8,7 +8,8 @@ Validates that running sdma-test with ROCPROFSYS_AMD_SMI_METRICS=sdma_usage
 produces expected SDMA usage tracks and values in Perfetto and ROCPD output,
 as implemented in the amd_smi component.
 
-SDMA usage requires AMD-SMI >= 26.3 (see source/lib/core/sdma_feature.hpp).
+SDMA usage requires AMD-SMI >= 26.3 (see source/lib/core/sdma_feature.hpp)
+and amdgpu driver >= 6.19.14; tests are skipped otherwise.
 """
 
 from __future__ import annotations

--- a/projects/rocprofiler-systems/tests/pytest/test_sdma.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_sdma.py
@@ -41,6 +41,7 @@ def sdma_rules(validation_rules_dir: Path) -> list[Path]:
 
 
 @pytest.mark.amdsmi_min_version("26.3")
+@pytest.mark.amdgpu_min_version("6.19.14")
 class TestSDMA(RocprofsysTest):
     """Tests for SDMA usage metrics (Perfetto and ROCPD)."""
 

--- a/projects/rocprofiler-systems/tests/pytest/test_sdma.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_sdma.py
@@ -48,7 +48,7 @@ class TestSDMA(RocprofsysTest):
     @pytest.mark.parametrize(
         "mode", [pytest.param("sys_run", marks=pytest.mark.rocpd("sdma_env"))]
     )
-    def test_sdma_usage_tracks(self, mode, sdma_env, sdma_rules):
+    def test_usage(self, mode, sdma_env, sdma_rules):
         """Run sdma-test with sdma_usage and validate Perfetto + ROCPD for SDMA tracks/values."""
         result = self.run_test(
             mode,

--- a/projects/rocprofiler-systems/tests/pytest/test_sdma.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_sdma.py
@@ -50,11 +50,13 @@ class TestSDMA(RocprofsysTest):
     )
     def test_usage(self, mode, sdma_env, sdma_rules):
         """Run sdma-test with sdma_usage and validate Perfetto + ROCPD for SDMA tracks/values."""
+        # sdma-test is a host-side hipMemcpy benchmark with no device kernels,
+        # so the binary embeds no gfx offload bundle; skip the target-arch check
+        # (it would always report no supported architectures).
         result = self.run_test(
             mode,
             "sdma-test",
             env=sdma_env,
-            check_target_arch=True,
             run_args=["-n", "2", "-s", "64"],
         )
         self.assert_regex(result)


### PR DESCRIPTION
## Motivation

Follow-up fixes for PR #7655 (sdma-test pytest suite). During review, two bugs were found that prevented the test from ever running, plus several cleanups and a new amdgpu driver gate. Targeted at the PR branch so they can be folded into #7655.

**Tested:** `TestSDMA` passes on a system with amdgpu >= 6.19.14 (end-to-end: Perfetto `SDMA Usage` counter + ROCPD `device_sdma_usage`).

## Bug fixes (test never ran before these)

- **amd-smi version regex** (`b2344d8`): the case-sensitive `Version:` regex never matched real `amd-smi version` output (`AMDSMI Library version: ...`), so `get_amdsmi_version` always returned `None` and the gate skipped everywhere. Anchored to the AMDSMI Tool/Library fields.
- **check_target_arch** (`e3a113c`): `sdma-test` is a host-side `hipMemcpy` benchmark with no device kernels, so its binary embeds no gfx offload bundle; `check_target_arch=True` always produced an empty arch list and skipped on every system. Removed it (the `gpu` marker still requires a GPU).

## New gate

- **amdgpu driver >= 6.19.14** (`0d2a03e`): adds an `amdgpu_min_version` marker + `get_amdgpu_version`/`amdgpu_version` capability, mirroring the amdsmi pattern, and applies it to `TestSDMA`.

## Cleanups

- Remove dead `amdsmi_sdma_supported` helper + constants (`0d3326c`).
- Show AMD-SMI and amdgpu versions in the pytest config header (`73758a5`, `0d2a03e`).
- Rename `test_sdma_usage_tracks` -> `test_usage` to avoid the doubled `sdma-sdma-...` ctest name (`ae5d60b`).
- Add missing `ROCPROFSYS_AMD_SMI_METRICS=sdma_usage` to the example README (`f1e1db3`).
- Document both version requirements and amdgpu parsing assumptions (`af7325c`).

## Note

A version-skip-logic refactor (collapsing the four near-identical `*_min_version` blocks into one helper) was intentionally left out of this PR and parked for a separate refactor PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)