### PR TITLE
[hipfile] Bump hipFile version from 0.2.0 to 0.3.0

### DIFF
--- a/projects/hipfile/CMakeLists.txt
+++ b/projects/hipfile/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 # Set the library version in a variable so we can use
 # it in *.in files and avoid version mismatch.
 set(AIS_LIBRARY_MAJOR 0)
-set(AIS_LIBRARY_MINOR 2)
+set(AIS_LIBRARY_MINOR 3)
 set(AIS_LIBRARY_PATCH 0)
 set(AIS_LIBRARY_VERSION "${AIS_LIBRARY_MAJOR}.${AIS_LIBRARY_MINOR}.${AIS_LIBRARY_PATCH}")
 

--- a/projects/hipfile/include/hipfile.h
+++ b/projects/hipfile/include/hipfile.h
@@ -84,7 +84,7 @@ extern "C" {
  * @brief hipFile minor version number
  * @ingroup core
  */
-#define HIPFILE_VERSION_MINOR 2
+#define HIPFILE_VERSION_MINOR 3
 /*!
  * @brief hipFile patch version number
  * @ingroup core

--- a/projects/hipfile/python/CHANGELOG.md
+++ b/projects/hipfile/python/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the hipFile Python bindings will be documented in this fi
 
 ## [Unreleased]
 
+## [0.3.0dev0]
+
 ### Added
 
 - Docstrings for the public Python API.

--- a/projects/hipfile/python/pyproject.toml
+++ b/projects/hipfile/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "hipfile"
-version = "0.2.0.dev1"
+version = "0.3.0.dev0"
 classifiers = [
     "Development Status :: 3 - Alpha",
 ]


### PR DESCRIPTION
## Motivation

We need to bump the hipFile version number for the 7.14 release

## Technical Details

Updates:
* Root CMakeLists.txt
* Public header file include/hipfile.h
* Python wrapper version and its CHANGELOG.md

NOTE: Does not update the main library's CHANGELOG.md

## JIRA ID

AIHIPFILE-27
ROCM-1261

## Test Plan

CI Passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
