### PR TITLE
[ROCM-9123] amdsmitst: add missing non-privileged guards to ComputePartitionMemAllocMode and Memory ReadWrite tests

### DIFF
--- a/projects/amdsmi/tests/amd_smi_test/main.cc
+++ b/projects/amdsmi/tests/amd_smi_test/main.cc
@@ -328,6 +328,7 @@ TEST(amdsmitstReadWrite, TestComputePartitionReadWrite) {
 }
 
 TEST(amdsmitstReadWrite, TestComputePartitionMemAllocModeReadWrite) {
+  if (std::getenv("AMDSMI_NON_PRIVILEGED")) GTEST_SKIP_("Skipped in non-privileged mode");
   if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
   TestComputePartitionMemAllocModeReadWrite tst;
   RunGenericTest(&tst);
@@ -354,6 +355,7 @@ TEST(amdsmitstReadOnly, TestGPUCacheRead) {
 
 TEST(amdsmitstReadWrite, TestMemoryReadWrite) {
   if (std::getenv("AMDSMI_NON_PRIVILEGED")) GTEST_SKIP_("Skipped in non-privileged mode");
+  if (!amd::smi::is_sudo_user()) GTEST_SKIP_("Invalid permission - Must run as super user");
   TestMemoryReadWrite tst;
   RunGenericTest(&tst);
 }


### PR DESCRIPTION
## Motivation

PR #7274 added `AMDSMI_NON_PRIVILEGED` skips so amdsmitst can run in
non-privileged containers (e.g. GFX 110X CI), but two privileged ReadWrite
tests were left with inconsistent guards. This follow-up closes those gaps so
every privileged write test gates the same way.

## Technical Details

Both fixes are in `projects/amdsmi/tests/amd_smi_test/main.cc`:

- `TestComputePartitionMemAllocModeReadWrite` was the only privilege-gated
  (`is_sudo_user()`) ReadWrite test that did not receive the
  `AMDSMI_NON_PRIVILEGED` skip. Without it, the test passes the `is_sudo_user()`
  check in a root-in-container environment and then fails on the privileged
  `amdsmi_set_gpu_compute_partition_mem_alloc_mode` write — the exact failure
  #7274 set out to prevent. Added the skip.
- `TestMemoryReadWrite` had the `AMDSMI_NON_PRIVILEGED` skip but was missing the
  `is_sudo_user()` guard, even though it issues privileged
  `amdsmi_set_gpu_uma_carveout` / `amdsmi_set_ttm_pages_limit` writes. On a
  non-root host (env unset) it would run and fail instead of skipping. Added the
  missing `is_sudo_user()` guard to match every other privileged write test.

Net change: +2 lines, test-only, no library/ABI impact.

## JIRA ID

Resolves ROCM-9123

## Test Plan

- `pre-commit run --config projects/amdsmi/.pre-commit-config.yaml --from-ref develop --to-ref HEAD` (clang-format + codespell + hooks).
- Built amdsmitst and ran with `AMDSMI_NON_PRIVILEGED=1`, confirming both tests now report SKIPPED.
- Ran without the env var as non-root, confirming `TestMemoryReadWrite` skips on the permission guard instead of failing.

## Test Result

All pre-commit hooks pass. With `AMDSMI_NON_PRIVILEGED=1`, all privileged
ReadWrite tests (including the two fixed here) report SKIPPED; as a non-root user
with the env var unset, the tests skip on the permission guard rather than
failing.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.