### PR TITLE
[ci] Adding test dependency to rocm-systems multi-arch CI 

### DIFF
--- a/.github/scripts/ci_utils.py
+++ b/.github/scripts/ci_utils.py
@@ -1,0 +1,76 @@
+"""Shared CI utilities for GitHub Actions workflow scripts."""
+
+import fnmatch
+import logging
+import os
+import subprocess
+import time
+from typing import Callable, Iterable, Mapping, Tuple, Type, TypeVar
+
+F = TypeVar("F", bound=Callable[..., object])
+
+logging.basicConfig(level=logging.INFO)
+
+
+def retry(
+    max_attempts: int,
+    delay_seconds: float,
+    exceptions: Tuple[Type[BaseException], ...],
+) -> Callable[[F], F]:
+    """Retry decorator with exponential backoff."""
+
+    def decorator(func: F) -> F:
+        def wrapper(*args, **kwargs):
+            attempt = 0
+            while attempt < max_attempts:
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as e:
+                    print(
+                        f"Exception {str(e)} thrown when attempting to run, "
+                        f"attempt {attempt} of {max_attempts}"
+                    )
+                    attempt += 1
+                    if attempt < max_attempts:
+                        backoff = delay_seconds * (2 ** (attempt - 1))
+                        time.sleep(backoff)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+@retry(max_attempts=3, delay_seconds=2, exceptions=(TimeoutError,))
+def get_modified_paths(base_ref: str) -> set[str]:
+    """Returns paths of files changed relative to the base reference."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", base_ref],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=60,
+    )
+    return set(result.stdout.splitlines())
+
+
+def matches_paths(changed_files: Iterable[str], patterns: Iterable[str]) -> bool:
+    """Returns True if any changed file matches any of the fnmatch patterns."""
+    for f in changed_files:
+        for pattern in patterns:
+            if fnmatch.fnmatch(f, pattern):
+                return True
+    return False
+
+
+def set_github_output(outputs: Mapping[str, str]):
+    """Writes key=value pairs to GITHUB_OUTPUT (or prints if not in CI)."""
+    logging.info(f"Setting github output:\n{dict(outputs)}")
+    output_file = os.environ.get("GITHUB_OUTPUT", "")
+    if not output_file:
+        for k, v in outputs.items():
+            print(f"{k}={v}")
+        return
+    with open(output_file, "a") as f:
+        for k, v in outputs.items():
+            f.write(f"{k}={v}\n")

--- a/.github/scripts/ci_utils.py
+++ b/.github/scripts/ci_utils.py
@@ -20,28 +20,28 @@ def retry(
     """Retry decorator with exponential backoff."""
 
     def decorator(func: F) -> F:
-        def wrapper(*args, **kwargs):
-            attempt = 0
-            while attempt < max_attempts:
+        def wrapper(*args: object, **kwargs: object) -> object:
+            last_exception: BaseException | None = None
+            for attempt in range(max_attempts):
                 try:
                     return func(*args, **kwargs)
                 except exceptions as e:
-                    print(
+                    last_exception = e
+                    logging.warning(
                         f"Exception {str(e)} thrown when attempting to run, "
-                        f"attempt {attempt} of {max_attempts}"
+                        f"attempt {attempt + 1} of {max_attempts}"
                     )
-                    attempt += 1
-                    if attempt < max_attempts:
-                        backoff = delay_seconds * (2 ** (attempt - 1))
+                    if attempt < max_attempts - 1:
+                        backoff = delay_seconds * (2**attempt)
                         time.sleep(backoff)
-            return func(*args, **kwargs)
+            raise last_exception  # type: ignore[misc]
 
         return wrapper
 
     return decorator
 
 
-@retry(max_attempts=3, delay_seconds=2, exceptions=(TimeoutError,))
+@retry(max_attempts=3, delay_seconds=2, exceptions=(subprocess.TimeoutExpired,))
 def get_modified_paths(base_ref: str) -> set[str]:
     """Returns paths of files changed relative to the base reference."""
     result = subprocess.run(

--- a/.github/scripts/get_changed_projects.py
+++ b/.github/scripts/get_changed_projects.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Get changed project paths based on git diff, validated against repos-config.json."""
+
+import fnmatch
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+from ci_utils import get_modified_paths, matches_paths, set_github_output
+from config_loader import load_repo_config
+from pr_detect_changed_subtrees import get_valid_prefixes, find_matched_subtrees
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+SKIPPABLE_PATH_PATTERNS = [
+    "*.md",
+    "*.rst",
+    "docs/*",
+    "projects/*/docs/*",
+    "shared/*/docs/*",
+]
+
+# Patterns that trigger a full test run when changed.
+# This includes CI workflows and the scripts that determine project selection logic.
+FULL_TEST_TRIGGER_PATTERNS = [
+    ".github/workflows/therock*",
+    ".github/scripts/therock*",
+    ".github/scripts/get_changed_projects.py",
+    ".github/scripts/ci_utils.py",
+    ".github/scripts/config_loader.py",
+    ".github/scripts/repo_config_model.py",
+    ".github/scripts/pr_detect_changed_subtrees.py",
+    ".github/repos-config.json",
+]
+
+
+@dataclass
+class ChangedProjectsResult:
+    """Result of analyzing changed projects."""
+
+    changed_projects: str  # Comma-separated list of changed project paths
+    run_all_tests: bool  # Whether to run all tests (e.g., CI files changed)
+    skip_tests: bool  # Whether to skip tests entirely (e.g., docs-only changes)
+
+
+def is_path_skippable(path: str) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in SKIPPABLE_PATH_PATTERNS)
+
+
+def check_for_non_skippable_path(paths: Optional[Iterable[str]]) -> bool:
+    if paths is None:
+        return False
+    return any(not is_path_skippable(p) for p in paths)
+
+
+def should_run_all_tests(paths: Optional[Iterable[str]]) -> bool:
+    """Check if any changed files should trigger a full test run."""
+    if paths is None:
+        return False
+    return matches_paths(paths, FULL_TEST_TRIGGER_PATTERNS)
+
+
+def get_changed_projects(base_ref: str) -> ChangedProjectsResult:
+    """Get changed project paths validated against repos-config.json.
+
+    Returns a ChangedProjectsResult with:
+    - changed_projects: comma-separated list of changed project paths
+    - run_all_tests: True if CI-related files changed (run full test suite)
+    - skip_tests: True if only skippable files changed (skip tests entirely)
+    """
+    modified_paths = get_modified_paths(base_ref)
+    if not modified_paths:
+        return ChangedProjectsResult(
+            changed_projects="", run_all_tests=False, skip_tests=True
+        )
+
+    # If CI workflow/script files changed, run all tests
+    if should_run_all_tests(modified_paths):
+        return ChangedProjectsResult(
+            changed_projects="", run_all_tests=True, skip_tests=False
+        )
+
+    # If only skippable files changed, skip tests
+    if not check_for_non_skippable_path(modified_paths):
+        return ChangedProjectsResult(
+            changed_projects="", run_all_tests=False, skip_tests=True
+        )
+
+    repo_config_path = SCRIPT_DIR / ".." / "repos-config.json"
+    config = load_repo_config(str(repo_config_path))
+    valid_prefixes = get_valid_prefixes(config)
+    matched_subtrees = find_matched_subtrees(list(modified_paths), valid_prefixes)
+
+    return ChangedProjectsResult(
+        changed_projects=",".join(matched_subtrees),
+        run_all_tests=False,
+        skip_tests=False,
+    )
+
+
+if __name__ == "__main__":
+    base_ref = os.environ.get("BASE_REF", "HEAD^")
+    result = get_changed_projects(base_ref)
+    set_github_output(
+        {
+            "changed_projects": result.changed_projects,
+            "run_all_tests": str(result.run_all_tests).lower(),
+            "skip_tests": str(result.skip_tests).lower(),
+        }
+    )

--- a/.github/workflows/therock-multi-arch-ci.yml
+++ b/.github/workflows/therock-multi-arch-ci.yml
@@ -12,7 +12,8 @@
 # - Supports prebuilt stages to skip certain build stages
 # - Better parallelization across GPU architectures
 
-# We are keeping the branch main until this gets to post-submit. Then, we will use commit hashes
+# TheRock ref: using main until full migration, then switch to pinned SHA (TheRock#3343)
+# NOTE: update all `@<ref>` refs and `ref:` inputs together when switching
 
 name: TheRock Multi-Arch CI
 
@@ -56,7 +57,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  configure:
+    name: Configure Changed Projects
+    runs-on: ubuntu-24.04
+    outputs:
+      changed_projects: ${{ steps.configure.outputs.changed_projects }}
+      run_all_tests: ${{ steps.configure.outputs.run_all_tests }}
+      skip_tests: ${{ steps.configure.outputs.skip_tests }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: true
+
+      # pydantic is required by repo_config_model.py (used by config_loader.py)
+      - name: Install dependencies
+        run: pip install pydantic
+
+      - name: Determine changed projects from git diff
+        id: configure
+        run: |
+          if [ -n "${{ github.event.pull_request.base.sha }}" ]; then
+            # For PRs, compute the merge-base to match the actual PR diff
+            BASE_REF=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+            echo "Using merge-base for PR: $BASE_REF"
+          else
+            # For pushes, compare against the previous commit
+            BASE_REF="HEAD^"
+            echo "Using HEAD^ for push"
+          fi
+          export BASE_REF
+          python3 .github/scripts/get_changed_projects.py
+
   setup:
+    needs: configure
     uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@main
     with:
       build_variant: "release"
@@ -73,11 +109,12 @@ jobs:
 
   linux_build_and_test:
     name: Linux::${{ fromJSON(needs.setup.outputs.linux_build_config || '{}').build_variant_label || 'skip' }}
-    needs: setup
+    needs: [configure, setup]
     if: >-
       ${{
         needs.setup.outputs.linux_build_config != '' &&
-        needs.setup.outputs.enable_build_jobs == 'true'
+        needs.setup.outputs.enable_build_jobs == 'true' &&
+        needs.configure.outputs.skip_tests != 'true'
       }}
     uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@main
     secrets: inherit
@@ -87,6 +124,8 @@ jobs:
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
+      # Empty string when run_all_tests=true triggers full test run in downstream workflow
+      changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
       ref: main
     permissions:
@@ -95,11 +134,12 @@ jobs:
 
   windows_build_and_test:
     name: Windows::${{ fromJSON(needs.setup.outputs.windows_build_config || '{}').build_variant_label || 'skip' }}
-    needs: setup
+    needs: [configure, setup]
     if: >-
       ${{
         needs.setup.outputs.windows_build_config != '' &&
-        needs.setup.outputs.enable_build_jobs == 'true'
+        needs.setup.outputs.enable_build_jobs == 'true' &&
+        needs.configure.outputs.skip_tests != 'true'
       }}
     uses: ROCm/TheRock/.github/workflows/multi_arch_ci_windows.yml@main
     secrets: inherit
@@ -109,6 +149,8 @@ jobs:
       rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
+      # Empty string when run_all_tests=true triggers full test run in downstream workflow
+      changed_projects: ${{ needs.configure.outputs.run_all_tests == 'true' && '' || needs.configure.outputs.changed_projects }}
       repository: ROCm/TheRock
       ref: main
     permissions:


### PR DESCRIPTION
Changes:
- Adding test dependency selection to multi-arch CI
- adding new `.github/scripts/get_changed_projects.py` to provide a clean git diff script, instead of relying on `therock_configure_ci.py` (plan to delete this post migration, it's a messy script)

test ran here: https://github.com/ROCm/rocm-systems/actions/runs/28048813827/job/83033807636 (cancelled to save resources)