### PR TITLE
Revert "[rocprofiler-compute] add known issue about multi rank analysis using --nodes (#7695)"

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -82,8 +82,6 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * On gfx1151, `$max_mclk` is not automatically populated in sysinfo, so the related bandwidth metrics may be incorrect. Use `amd-smi` to obtain the maximum memory clock and provide it via `--specs-correction`.
 
-* For analysis of multi-rank profiles, use `--path` with the rank-specific path (e.g., `--path workload/1`) instead of `--path workload --nodes 1`, which might not work as expected.
-
 ## ROCm Compute Profiler 3.6.0 for ROCm 7.13.0
 
 ### Added


### PR DESCRIPTION
## Motivation

Revert #7695.

## Technical Details

Reverts the CHANGELOG.md known-issue note about `--nodes` in multi-rank analysis.

## JIRA ID

AIPROFCOMP-679

## Test Plan

N/A

## Test Result

N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.