### PR TITLE
[rocjitsu] Fix build portability

### DIFF
--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/event_queue.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/event_queue.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 namespace simdojo {

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -612,7 +612,8 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
                 ${HIPCC_EXECUTABLE} --offload-arch=${ARG_ARCH} -std=c++20
                 -isystem ${GTEST_INC} -I${CMAKE_CURRENT_SOURCE_DIR}
                 -L${GTEST_LIB_DIR} -lgtest -lpthread ${ARG_EXTRA_LIBS}
-                -Wl,-rpath,${GTEST_LIB_DIR} -o ${HIP_TEST_BIN} ${HIP_TEST_SRC}
+                -Wl,-rpath,${GTEST_LIB_DIR} -Wl,-rpath,${RJ_HSA_LIBRARY_DIR} -o
+                ${HIP_TEST_BIN} ${HIP_TEST_SRC}
             DEPENDS ${HIP_TEST_SRC} GTest::gtest GTest::gtest_main
             COMMENT "Building ${TEST_NAME} with hipcc (${ARG_ARCH})"
             VERBATIM

--- a/emulation/rocjitsu/tools/rocjitsu/main.cpp
+++ b/emulation/rocjitsu/tools/rocjitsu/main.cpp
@@ -281,9 +281,12 @@ static std::string find_interposer_lib() {
   self[n] = '\0';
   auto bin_dir = std::filesystem::path(self).parent_path();
   // Installed layout: <prefix>/bin/rocjitsu → <prefix>/lib/librocjitsu_kmd.so
+  //                   or <prefix>/bin/rocjitsu → <prefix>/lib64/librocjitsu_kmd.so
   // Build layout: build/tools/rocjitsu/rocjitsu → build/lib/.../librocjitsu_kmd.so
+  //               or build/tools/rocjitsu/rocjitsu → build/lib64/.../librocjitsu_kmd.so
   for (auto &candidate : {
            bin_dir / ".." / "lib" / "librocjitsu_kmd.so",
+           bin_dir / ".." / "lib64" / "librocjitsu_kmd.so",
            bin_dir / ".." / ".." / "lib" / "rocjitsu" / "src" / "rocjitsu" / "kmd" / "linux" /
                "librocjitsu_kmd.so",
        }) {


### PR DESCRIPTION
## Motivation

There were some missing includes, missing lib64 path, and HIP test rpaths that caused build failures in some environments.

## Technical Details

Add #include <mutex> to event_queue.h for std::lock_guard portability (some toolchains don't transitively include it via other headers).

Search lib64/ in addition to lib/ for the interposer shared library, covering RHEL/Fedora distros that use lib64 for 64-bit libraries.

Add -Wl,-rpath,${RJ_HSA_LIBRARY_DIR} to HIP test link flags so hipcc-built test binaries can find libhsa-runtime64.so at runtime without LD_LIBRARY_PATH.

## JIRA ID

N/A

## Test Plan

Run all CI tests

## Test Result

CI tests: PASSED

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.