### PR TITLE
[rocprofiler-compute] Add changelog notes for --overwrite profiling behavior

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -9,6 +9,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * Added ``--bench-only`` profile mode option to run the roofline microbenchmark standalone (without profiling an application or collecting performance counters). No application run is required. Useful for regenerating ``roofline.csv`` in an existing workload directory or running the microbenchmark on systems where only HIP is available but rocprofiler-sdk is not.
 
+* Added ``--overwrite`` profile mode option to explicitly allow replacing existing workload output.
+
 * Added LDS arithmetic intensity as a roofline plot point and analysis database field.
 
 * Added backward compatibility for live attach mode to work with older ROCm 7.x.x releases.
@@ -52,6 +54,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 * PC sampling analysis without `-k` now shows the full per-instruction table across all kernels (with a `Kernel_Name` column), identical in schema to the single-kernel view, instead of a collapsed source-line summary.
 
 * `--pc-sampling-interval` now defaults to a method-appropriate value (512 microseconds for `host_trap`, 1048576 cycles for `stochastic`). Stochastic intervals are validated to be a power of 2 and at least 65536; previously invalid values were passed through silently.
+
+* Profile mode now errors when the target workload directory is non-empty unless `--overwrite` is passed. `--bench-only` likewise requires `--overwrite` before replacing an existing `roofline.csv`.
 
 ### Removed
 


### PR DESCRIPTION
## Motivation

Document the user facing behavior change introduced by `--overwrite` in profile mode. Re profiling into an already existing workload dir now need explicit authorization so the changelog should call out both the new option and the changed overwrite policy.

## Technical Details

Added changelog entries for:
- The new `--overwrite` profile mode option.
- The new requirement to pass `--overwrite` when writing to a non-empty workload directory.
- The matching `--bench-only` behavior requiring `--overwrite` before replacing an existing `roofline.csv`.

## JIRA ID

AIPROFCOMP-253 (follow up)

## Test Plan

No functional changes, N/A

## Test Result

No functional changes, N/A

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.