### PR TITLE
[hipFile] Correct inaccuracies in the documentation

### DIFF
--- a/projects/hipfile/INSTALL.md
+++ b/projects/hipfile/INSTALL.md
@@ -2,7 +2,7 @@
 
 ## Quick Install Guide
 
-hipFile depends on ROCm 7.2.x or greater. TheRock technology preview releases (e.g. 7.9) may not be based on the 7.2 release and may not support hipFile. Install ROCm and amdgpu-dkms, as described in the [ROCm quick start installation guide](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html).
+hipFile depends on ROCm 7.2.x or greater. TheRock technology preview release 7.13 and newer also supports hipFile. Please note that these steps are based on ROCm 7.2. Install ROCm and amdgpu-dkms, as described in the [ROCm quick start installation guide](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html).
 
 On Ubuntu 24.04, the installation process is as follows. First, install a couple of needed packages.
 
@@ -10,13 +10,7 @@ On Ubuntu 24.04, the installation process is as follows. First, install a couple
 sudo apt install libmount-dev wget
 ```
 
-Then, install the nightly hipFile packages.
-
-```
-wget https://github.com/ROCm/hipFile/releases/download/nightly/hipfile_0.2.0.70200-nightly.9999.24.04_amd64.deb
-wget https://github.com/ROCm/hipFile/releases/download/nightly/hipfile-dev_0.2.0.70200-nightly.9999.24.04_amd64.deb
-sudo dpkg -i hipfile-dev_0.2.0.70200-nightly.9999.24.04_amd64.deb hipfile_0.2.0.70200-nightly.9999.24.04_amd64.deb
-```
+Then, download & install the nightly hipFile packages from the [nightly ROCm package repository](https://rocm.nightlies.amd.com/deb/).
 
 We can verify that the HIP libraries and kernel support AIS by running ais-check.
 
@@ -51,7 +45,7 @@ sudo chown "$USER": /mnt/ext4/"$USER"
 Now, we can download and compile the aiscp test program.
 
 ```
-wget https://raw.githubusercontent.com/ROCm/hipFile/refs/heads/develop/examples/aiscp/aiscp.cpp
+wget https://raw.githubusercontent.com/ROCm/rocm-systems/refs/heads/develop/projects/hipfile/examples/aiscp/aiscp.cpp
 amdclang++ -D__HIP_PLATFORM_AMD__ -L/opt/rocm/lib -I/opt/rocm/include -lamdhip64 -lhipfile aiscp.cpp -o aiscp
 ```
 
@@ -99,7 +93,7 @@ sudo systemctl reboot
 
 #### Build Tools
 * CMake >= 3.21
-* C++ >= 17 (tested w/ clang++ & g++, we don't use GNU extensions)
+* C++ >= 20 (tested w/ clang++ & g++, we don't use GNU extensions)
 * The `ais-check` tool requires Python >= 3.6
 * The hipFile Python bindings require Python >= 3.10
 

--- a/projects/hipfile/docs/install/build-from-source.rst
+++ b/projects/hipfile/docs/install/build-from-source.rst
@@ -115,7 +115,7 @@ exist for sanitizers, clang-tidy, and documentation generation. Inspect
      - Adds LLVM coverage instrumentation for Clang builds.
    * - ``BUILD_TESTING``
      - ``ON`` unless you pass ``-DBUILD_TESTING=OFF``
-     - Controls whether CTest registers the hipFile unit and system tests.
+     - Controls whether the hipFile test binaries are built.
    * - ``CMAKE_BUILD_TYPE``
      - ``RelWithDebInfo``
      - CMake build flavor. Other common values are ``Debug``, ``Release``,

--- a/projects/hipfile/docs/install/install.rst
+++ b/projects/hipfile/docs/install/install.rst
@@ -96,5 +96,3 @@ The `TheRock <https://github.com/ROCm/TheRock>`__ build system publishes nightly
 builds for the ROCm Core SDK and its components. See `Nightly release status
 <https://github.com/ROCm/TheRock#nightly-release-status>`__ for download links and
 support notes.
-
-Some hipFile preview packages also appear on the `ROCm hipFile releases page <https://github.com/ROCm/hipFile/releases>`__. Treat those artifacts as previews unless your release notes state otherwise. Match the ``.deb`` or RPM file names to your distribution and ROCm version before you install them.

--- a/projects/hipfile/docs/install/python-bindings.rst
+++ b/projects/hipfile/docs/install/python-bindings.rst
@@ -75,9 +75,9 @@ searches:
 
 - The sibling ``../include`` directory (relative to the ``python/`` directory)
   is searched for ``hipfile.h``, with ``/opt/rocm/include`` as a fallback
-  location.
+  location
 - The sibling ``../build/src/amd_detail`` directory is searched for
-  ``libhipfile.so``, with ``/opt/rocm/lib`` as a fallback location.
+  ``libhipfile.so``, with ``/opt/rocm/lib`` as a fallback location
 
 If these default paths do not match your environment, use the override variables
 described in :ref:`python-cmake-overrides`.

--- a/projects/hipfile/docs/install/python-bindings.rst
+++ b/projects/hipfile/docs/install/python-bindings.rst
@@ -74,9 +74,10 @@ headers, the hipFile shared library, and the HIP runtime headers. By default, it
 searches:
 
 - The sibling ``../include`` directory (relative to the ``python/`` directory)
-  for ``hipfile.h``. ``/opt/rocm/include`` as a fallback location.
-- The sibling ``../build/src/amd_detail`` directory for ``libhipfile.so``.
-  ``/opt/rocm/lib`` as a fallback location.
+  is searched for ``hipfile.h``, with ``/opt/rocm/include`` as a fallback
+  location.
+- The sibling ``../build/src/amd_detail`` directory is searched for
+  ``libhipfile.so``, with ``/opt/rocm/lib`` as a fallback location.
 
 If these default paths do not match your environment, use the override variables
 described in :ref:`python-cmake-overrides`.

--- a/projects/hipfile/docs/install/python-bindings.rst
+++ b/projects/hipfile/docs/install/python-bindings.rst
@@ -16,13 +16,14 @@ Prerequisites
 
 The Python bindings require the following software:
 
-- Python 3 with the ``venv`` module
+- Python >= 3.10 with the ``venv`` module
 - Cython (installed into your virtual environment)
 - scikit-build-core (used as the build backend)
 - python-build (the ``build`` front-end, or ``pip`` for editable installs)
 - CMake (version 3.21 or later)
 - A C compiler (for building the Cython-generated C extension)
 - hipFile C library (``libhipfile.so``): built or installed before the Python bindings
+- hipFile C development header (``hipfile.h``)
 - HIP development headers (``hip/hip_runtime_api.h``)
 
 .. note::
@@ -73,9 +74,9 @@ headers, the hipFile shared library, and the HIP runtime headers. By default, it
 searches:
 
 - The sibling ``../include`` directory (relative to the ``python/`` directory)
-  for ``hipfile.h``
-- The sibling ``../build/src/amd_detail`` directory for ``libhipfile.so``
-- ``/opt/rocm/include`` and ``/opt/rocm/lib`` as fallback locations
+  for ``hipfile.h``. ``/opt/rocm/include`` as a fallback location.
+- The sibling ``../build/src/amd_detail`` directory for ``libhipfile.so``.
+  ``/opt/rocm/lib`` as a fallback location.
 
 If these default paths do not match your environment, use the override variables
 described in :ref:`python-cmake-overrides`.
@@ -86,7 +87,7 @@ Install an editable package
 For development, you can install the Python package in editable mode. An
 editable install lets you modify the Python source code and see changes
 immediately without rebuilding or reinstalling the package. Changes to the
-Cython source code (``_hipfile.pyx``) still require a rebuild.
+Cython source code still require a rebuild.
 
 .. code:: shell
 
@@ -115,7 +116,7 @@ front-end. Use the ``-Ccmake.define.<KEY>=<VALUE>`` syntax with
    * - ``HIPFILE_LIBRARY``
      - Path to ``libhipfile.so``. Defaults to ``../build/src/amd_detail`` or ``/opt/rocm/lib``.
    * - ``HIP_INCLUDE_DIR``
-     - Path to the directory containing ``hip/hip_runtime_api.h``. Defaults to ``/opt/rocm/include`` or ``/opt/rocm/hip/include``.
+     - Path to the directory containing ``hip/hip_runtime_api.h``. Defaults to ``/opt/rocm/include``.
 
 For example, to specify a custom hipFile install location when building the
 wheel:
@@ -124,7 +125,7 @@ wheel:
 
    python -m build --wheel \
      -Ccmake.define.HIPFILE_INCLUDE_DIR=/path/to/hipfile/include \
-     -Ccmake.define.HIPFILE_LIBRARY=/path/to/lib/libhipfile.so \
+     -Ccmake.define.HIPFILE_LIBRARY=/path/to/lib \
      -Ccmake.define.HIP_INCLUDE_DIR=/opt/rocm/include
 
 Or with ``pip install``:
@@ -133,7 +134,7 @@ Or with ``pip install``:
 
    pip install -e . \
      -Ccmake.define.HIPFILE_INCLUDE_DIR=/path/to/hipfile/include \
-     -Ccmake.define.HIPFILE_LIBRARY=/path/to/lib/libhipfile.so
+     -Ccmake.define.HIPFILE_LIBRARY=/path/to/lib
 
 .. warning::
 

--- a/projects/hipfile/docs/reference/api-errors.rst
+++ b/projects/hipfile/docs/reference/api-errors.rst
@@ -19,7 +19,7 @@ For guidance on interpreting errors in practice, see
 ========================
 
 The ``hipFileError_t`` struct carries the ``[[nodiscard]]`` attribute when
-compiled with C++ 17 or newer, (``__cplusplus >= 201703L``) or C23 or newer
+compiled with C++ 17 or newer (``__cplusplus >= 201703L``) or C23 or newer
 (``__STDC_VERSION__ >= 202311L``). The compiler emits a warning if a caller
 discards the return value of any function that returns ``hipFileError_t``.
 

--- a/projects/hipfile/docs/reference/api-errors.rst
+++ b/projects/hipfile/docs/reference/api-errors.rst
@@ -19,7 +19,7 @@ For guidance on interpreting errors in practice, see
 ========================
 
 The ``hipFileError_t`` struct carries the ``[[nodiscard]]`` attribute when
-compiled with C++ 17 (``__cplusplus >= 201703L``) or C23
+compiled with C++ 17 or newer, (``__cplusplus >= 201703L``) or C23 or newer
 (``__STDC_VERSION__ >= 202311L``). The compiler emits a warning if a caller
 discards the return value of any function that returns ``hipFileError_t``.
 

--- a/projects/hipfile/docs/tutorials/copy-a-file.rst
+++ b/projects/hipfile/docs/tutorials/copy-a-file.rst
@@ -151,7 +151,7 @@ Allocate a GPU buffer
        goto close_src;
    }
 
-The ``align_up`` helper rounds up to the next multiple of a power-of-two alignment:
+``align_up`` is a helper in ``aiscp`` to round up to the next multiple of a power-of-two alignment:
 
 .. code-block:: cpp
 

--- a/projects/hipfile/docs/tutorials/python-gpu-io.rst
+++ b/projects/hipfile/docs/tutorials/python-gpu-io.rst
@@ -1,6 +1,6 @@
 .. meta::
    :description: Tutorial walking through direct-to-GPU I/O using the hipFile Python bindings, covering Driver, FileHandle, Buffer, read, write, and error handling.
-   :keywords: hipFile, Python, GPU I/O, tutorial, ROCm, direct I/O, hipMalloc, Buffer, Driver, FileHandle
+   :keywords: hipFile, Python, GPU I/O, tutorial, ROCm, direct I/O, Buffer, Driver, FileHandle
 
 *****************************************
 Perform GPU I/O with the Python bindings
@@ -12,7 +12,7 @@ a different file. You will learn how to:
 
 - Initialize the hipFile driver with the ``Driver`` context manager
 - Open and register files with ``FileHandle``
-- Allocate GPU memory with ``hipMalloc()`` and register it with ``Buffer``
+- Register GPU memory with ``Buffer``
 - Perform synchronous ``read()`` and ``write()`` operations
 - Handle errors with ``HipFileException``
 - Clean up resources automatically through context managers
@@ -49,7 +49,6 @@ with CLI arguments. Save it as ``gpu_copy.py``:
    import sys
 
    from hipfile import Buffer, Driver, FileHandle, HipFileException
-   from hipfile.hipMalloc import hipFree, hipMalloc
 
    CHUNK_SIZE = 64 * 1024  # 64 KiB per I/O operation
 
@@ -97,10 +96,8 @@ Import modules
 
    import os
    from hipfile import Buffer, Driver, FileHandle, HipFileException
-   from hipfile.hipMalloc import hipFree, hipMalloc
 
-The Python package name is ``hipfile``. ``hipMalloc()`` and ``hipFree()`` live in
-``hipfile.hipMalloc``, not the top-level package. For the full API, see
+The Python package name is ``hipfile``. For the full API, see
 :doc:`/reference/api-python`.
 
 Initialize the driver
@@ -171,8 +168,7 @@ Handle errors
 
 hipFile C API failures raise ``HipFileException``. ``FileHandle.read()`` and
 ``FileHandle.write()`` may also raise ``RuntimeError`` when the handle isn't open
-or ``OSError`` when the platform sets ``errno``. ``hipMalloc()`` and ``hipFree()``
-raise ``RuntimeError`` on HIP allocation failures.
+or ``OSError`` when the platform sets ``errno``.
 
 Clean up resources
 ------------------


### PR DESCRIPTION
## Motivation

#7630 was merged prior to me completing my review. There are several inaccuracies in the documentation that should not have been included, notably in the Python bindings.

More commits may be added here in a near future, but before EOD.

## Technical Details

hipFile.hipMalloc/hipFree are not part of the public API and we should not be using/mentioning/referencing them at all in official documentation.

## JIRA ID

AIHIPFILE-41

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
