### PR TITLE
[RCCL] [UT] Validate broadcast and scatter output on all ranks in unit tests

### DIFF
--- a/projects/rccl/test/common/CollectiveArgs.cpp
+++ b/projects/rccl/test/common/CollectiveArgs.cpp
@@ -120,9 +120,11 @@ namespace RcclUnitTesting
 
   ErrCode CollectiveArgs::ValidateResults()
   {
-    // Ignore non-root outputs for collectives with a root, except Broadcast where
-    // every rank receives the result and must be validated.
-    if (CollectiveArgs::UsesRoot(this->funcType) && this->funcType != ncclCollBroadcast && this->options.root != this->globalRank) return TEST_SUCCESS;
+    // Ignore non-root outputs for collectives with a root, except Broadcast/Scatter where
+    // every rank receives a defined result and must be validated.
+    if (CollectiveArgs::UsesRoot(this->funcType) &&
+        this->funcType != ncclCollBroadcast && this->funcType != ncclCollScatter &&
+        this->options.root != this->globalRank) return TEST_SUCCESS;
     if (this->funcType == ncclCollSend) return TEST_SUCCESS; // on the send receive pair only recv needs to be checked
     size_t const numOutputBytes = (this->numOutputElements * DataTypeToBytes(this->dataType));
 

--- a/projects/rccl/test/common/CollectiveArgs.cpp
+++ b/projects/rccl/test/common/CollectiveArgs.cpp
@@ -120,8 +120,9 @@ namespace RcclUnitTesting
 
   ErrCode CollectiveArgs::ValidateResults()
   {
-    // Ignore non-root outputs for collectives with a root
-    if (CollectiveArgs::UsesRoot(this->funcType) && this->options.root != this->globalRank) return TEST_SUCCESS;
+    // Ignore non-root outputs for collectives with a root, except Broadcast where
+    // every rank receives the result and must be validated.
+    if (CollectiveArgs::UsesRoot(this->funcType) && this->funcType != ncclCollBroadcast && this->options.root != this->globalRank) return TEST_SUCCESS;
     if (this->funcType == ncclCollSend) return TEST_SUCCESS; // on the send receive pair only recv needs to be checked
     size_t const numOutputBytes = (this->numOutputElements * DataTypeToBytes(this->dataType));
 


### PR DESCRIPTION
## Motivation

`CollectiveArgs::ValidateResults` skipped validation on all non-root ranks for any rooted collective. For Broadcast/Scatter that means the receivers — every rank's output, which is the entire result of the collective — were never checked, leaving the broadcast receive path effectively untested.

## Technical Details

Except `ncclCollBroadcast` and `ncclCollScatter` from the non-root skip so its output is validated on every rank. The `expected` buffer is already filled with the root's pattern for all ranks by the broadcast data-prep path. Reduce/Gather keep skipping non-root ranks since their non-root outputs are genuinely undefined.

## JIRA ID

## Test Plan

Run the broadcast/Scatter and group-call unit tests single- and multi-process across rank counts.

## Test Result

`Broadcast.*` and `GroupCall.*` pass single- and multi-process (1-8 ranks) on MI300x.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.