### PR TITLE
CLR: set imagePitchAlignment unconditionally so pitched allocs work w…

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1521,14 +1521,16 @@ bool Device::populateOCLDeviceConstants() {
     }
     info_.imageMaxBufferSize_ = (amd::IS_HIP) ? image_max_dim[0] : (1 << 27);
 
-    info_.imagePitchAlignment_ = 256;
-
-    info_.imageBaseAddressAlignment_ = 256;
-
-    info_.bufferFromImageSupport_ = false;
-
     info_.imageSupport_ = (info_.maxReadWriteImageArgs_ > 0) ? true : false;
   }
+
+  // These are properties of the device's linear memory layout, not the image
+  // extension.  They must be set unconditionally so that hipMallocPitch /
+  // hipMalloc3D produce correct pitch alignment even when IMAGE_SUPPORT is
+  // off.  The PAL backend already sets them unconditionally.
+  info_.imagePitchAlignment_ = 256;
+  info_.imageBaseAddressAlignment_ = 256;
+  info_.bufferFromImageSupport_ = false;
 
   // Enable SVM Capabilities of Hsa device. Ensure
   // user has not setup memory to be non-coherent


### PR DESCRIPTION
…ithout IMAGE_SUPPORT

Move imagePitchAlignment_, imageBaseAddressAlignment_, and bufferFromImageSupport_ out of the `if (image_is_supported)` block in Device::populateOCLDeviceConstants().

These are properties of the device's linear memory layout, not the HSA image extension. When CLR is built with -DIMAGE_SUPPORT=OFF, the HSA agent does not advertise HSA_EXTENSION_IMAGES, the entire block is skipped, and imagePitchAlignment_ stays at its memset-zero default. ihipMallocPitch then computes:

    *pitch    = alignUp(width, 0)   → 0
    sizeBytes = 0 * height * depth  → 0

and returns hipErrorOutOfMemory for every pitched allocation. The PAL backend (paldevice.cpp:451) already sets imagePitchAlignment_ unconditionally. This change aligns the ROCm backend to match.