### PR TITLE
[rocr-debug-agent] Support % format tokens in -o and --save-code-objects

### DIFF
--- a/projects/rocr-debug-agent/CHANGELOG.md
+++ b/projects/rocr-debug-agent/CHANGELOG.md
@@ -3,6 +3,12 @@
 Full documentation for the ROCR Debug Agent library is available at
 [rocm.docs.amd.com/rocr_debug_agent](https://rocm.docs.amd.com/projects/rocr_debug_agent/en/latest/).
 
+## ROCR Debug Agent 2.2.0  for ROCm 10.1
+
+- The `--output` and `--save-code-objects` options now support '%' format
+  tokens to produce the output file names.  The `%p`, `%h`, `%t`, `%e`, `%u`,
+  `%g` and `%%` tokens are supported.
+
 ## ROCR Debug Agent 2.1.0 for ROCm 7.0
 
 ### Added

--- a/projects/rocr-debug-agent/CMakeLists.txt
+++ b/projects/rocr-debug-agent/CMakeLists.txt
@@ -54,7 +54,7 @@
 
 cmake_minimum_required(VERSION 3.21)
 
-project(rocm-debug-agent VERSION 2.1.0 LANGUAGES CXX)
+project(rocm-debug-agent VERSION 2.2.0 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/projects/rocr-debug-agent/README.md
+++ b/projects/rocr-debug-agent/README.md
@@ -202,6 +202,9 @@ The supported options are:
   Saves all loaded code objects.  If the directory is not specified, the code
   objects are saved in the current directory.
 
+  The `%` foramt tokens in the DIR name are expanded according to the supported
+  tokens list below.
+
   The file name in which the code object is saved is the same as the code
   object URI with special characters replaced by ``'_'``, prefixed with a
   unique code object ID.  For example, the code object URI:
@@ -230,6 +233,11 @@ The supported options are:
 
   Saves the output produced by the ROCdebug-agent in the specified file.
 
+  The file-path can contain '%' format tockens which will be expanded to
+  according to the specification below.
+
+  Unrecognised `%` tokens are left unchanged, including the `%` character.
+
   By default, the output is redirected to ``stderr``.
 
 - __``-d``, ``--disable-linux-signals``__
@@ -250,6 +258,16 @@ The supported options are:
 - __``-h``, ``--help``__
 
   Displays a usage message and aborts the process.
+
+For options supporting `%` format tokens expansions, the following tokens are
+supported:
+- `%p`: process ID of the application being debuggged
+- `%h`: host name
+- `%t`: timestanp (seconds since the Epoch) when the patch is expanded
+- `%e`: abbreviated name of the application being debugged
+- `%u`: real user ID (UID) of the process
+- `%g`: real group ID (GID) of the process
+- `%%`: the literal `%` character
 
 Build the ROCdebug-agent library
 ---------------------------------

--- a/projects/rocr-debug-agent/docs/how-to/user-guide.rst
+++ b/projects/rocr-debug-agent/docs/how-to/user-guide.rst
@@ -164,8 +164,10 @@ The following table lists the supported options:
 
   * - ``-s [DIR]``, ``--save-code-objects[=DIR]``
     - Saves all loaded code objects. If the directory is not specified, the
-      code objects are saved in the current directory. The file name in which
-      the code object is saved is the same as the code object URI with special
+      code objects are saved in the current directory. Directory name can
+      contain ``%`` format tokens which will be expanded as specified in
+      `supported % format tokens`_.  The file name in which the code
+      object is saved is the same as the code object URI with special
       characters replaced by '_', prefixed with a unique code object ID. For
       example, the code object URI
       ``file:///rocm-debug-agent/rocm-debug-agent-test#offset=14309&size=31336``
@@ -182,8 +184,12 @@ The following table lists the supported options:
       compatible with ``-c``.
 
   * - ``-o <file-path>``, ``--output=<file-path>``
-    - Saves the output produced by the ROCdebug-agent in the specified file. By
-      default, the output is redirected to ``stderr``.
+    - Saves the output produced by the ROCdebug-agent in the specified file.
+
+      The file path can contain '%' format tokens, which will be expanded
+      according to the specification in `supported % format tokens`_.
+
+      By default, the output is redirected to ``stderr``.
 
   * - ``-d``, ``--disable-linux-signals``
     - Disables installation of ``SIGQUIT`` signal handler, so that the default
@@ -197,6 +203,23 @@ The following table lists the supported options:
 
   * - ``-h``, ``--help``
     - Displays a usage message and aborts the process.
+
+.. _supported % format tokens:
+
+Supported ``%`` format tokens
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following ``%`` format token are supported:
+
+  - ``%p``: process ID of the application being debuggged
+  - ``%h``: host name
+  - ``%t``: timestanp (seconds since the Epoch) when the patch is expanded
+  - ``%e``: abbreviated name of the application being debugged
+  - ``%u``: real user ID (UID) of the process
+  - ``%g``: real group ID (GID) of the process
+  - ``%%``: the literal `%` character
+
+Unrecognised ``%`` tokens are left unchanged, including the ``%`` character.
 
 Known limitations
 ------------------

--- a/projects/rocr-debug-agent/src/debug_agent.cpp
+++ b/projects/rocr-debug-agent/src/debug_agent.cpp
@@ -50,6 +50,7 @@
 #include <atomic>
 #include <cstdint>
 #include <cstdlib>
+#include <ctime>
 #include <future>
 #include <iomanip>
 #include <iostream>
@@ -880,6 +881,84 @@ print_wavefronts (amd_dbgapi_process_id_t process_id, bool all_wavefronts,
   return code_objects_reported;
 }
 
+/* Expand `%' format tokens in a user-specified output path (the --output
+   file name or the --save-code-objects directory).
+
+   Supported tokens:
+     %p   process ID of the application being debugged
+     %h   host name
+     %t   timestamp (seconds since the Epoch) of when the path is expanded
+     %e   short name of the application being debugged
+     %u   real user ID (UID) of the process
+     %g   real group ID (GID) of the process
+     %%   a literal `%' character
+
+   An unrecognized token is left unchanged, including the leading `%'.  */
+std::string
+expand_format_tokens (const std::string &format)
+{
+  std::string result;
+  result.reserve (format.size ());
+
+  for (size_t i = 0; i < format.size (); ++i)
+    {
+      if (format[i] != '%' || i + 1 == format.size ())
+        {
+          result += format[i];
+          continue;
+        }
+
+      switch (format[++i])
+        {
+        case 'p':
+          result += std::to_string (::getpid ());
+          break;
+
+        case 'h':
+          {
+            char hostname[256] = {};
+            if (::gethostname (hostname, sizeof (hostname) - 1) == 0)
+              result += hostname;
+          }
+          break;
+
+        case 't':
+          result
+              += std::to_string (static_cast<long long> (std::time (nullptr)));
+          break;
+
+        case 'e':
+          {
+            std::ifstream comm ("/proc/self/comm");
+            std::string name;
+            if (comm && std::getline (comm, name))
+              result += name;
+          }
+          break;
+
+        case 'u':
+          result += std::to_string (::getuid ());
+          break;
+
+        case 'g':
+          result += std::to_string (::getgid ());
+          break;
+
+        case '%':
+          result += '%';
+          break;
+
+        default:
+          /* Leave unrecognized tokens unchanged.  */
+          result += '%';
+          result += format[i];
+          break;
+        }
+    }
+
+  return result;
+}
+
 void
 print_usage ()
 {
@@ -894,13 +973,16 @@ print_usage ()
                "is not specified, the code objects are saved in"
             << std::endl
             << "                              "
-               "the current directory."
+               "the current directory. DIR may contain the same"
+            << std::endl
+            << "                              "
+               "format tokens as --output (see below)."
             << std::endl;
   std::cerr << "  -c, --load-all-code-objects "
                "Load all code objects as soon as they are loaded"
             << std::endl
-            << "                              "
-            << "by the runtime.";
+            << "                              " << "by the runtime."
+            << std::endl;
   std::cerr << "  -z, --lazy                  "
                "Delay inspecting the content of all loaded code "
             << std::endl
@@ -932,6 +1014,33 @@ print_usage ()
             << std::endl
             << "                              "
                "is redirected to stderr."
+            << std::endl
+            << "                              "
+               "FILE may contain the following format tokens,"
+            << std::endl
+            << "                              "
+               "which are expanded when the file is created:"
+            << std::endl
+            << "                              "
+               "  %p  process ID of the application"
+            << std::endl
+            << "                              "
+               "  %h  host name"
+            << std::endl
+            << "                              "
+               "  %t  timestamp (seconds since the Epoch)"
+            << std::endl
+            << "                              "
+               "  %e  short name of the application"
+            << std::endl
+            << "                              "
+               "  %u  real user ID (UID) of the process"
+            << std::endl
+            << "                              "
+               "  %g  real group ID (GID) of the process"
+            << std::endl
+            << "                              "
+               "  %%  a literal '%' character"
             << std::endl;
   std::cerr << "  -d, --disable-linux-signals "
                "Disable installing a SIGQUIT signal handler, so"
@@ -1755,17 +1864,19 @@ OnLoad (void *table, uint64_t runtime_version, uint64_t failed_tool_count,
         case 's': /* -s or --save-code-objects  */
           if (argument)
             {
+              std::string dir = expand_format_tokens (*argument);
+
               struct stat path_stat;
-              if (stat (argument->c_str (), &path_stat) == -1
+              if (stat (dir.c_str (), &path_stat) == -1
                   || !S_ISDIR (path_stat.st_mode))
                 {
                   std::cerr
                       << "error: Cannot access code object save directory `"
-                      << *argument << "'" << std::endl;
+                      << dir << "'" << std::endl;
                   print_usage ();
                 }
 
-              g_code_objects_dir = *argument;
+              g_code_objects_dir = std::move (dir);
             }
           else
             {
@@ -1777,12 +1888,16 @@ OnLoad (void *table, uint64_t runtime_version, uint64_t failed_tool_count,
           if (!argument)
             print_usage ();
 
-          agent_out.open (*argument);
-          if (!agent_out.is_open ())
-            {
-              std::cerr << "could not open `" << *argument << "'" << std::endl;
-              abort ();
-            }
+          {
+            std::string file_name = expand_format_tokens (*argument);
+            agent_out.open (file_name);
+            if (!agent_out.is_open ())
+              {
+                std::cerr << "could not open `" << file_name << "'"
+                          << std::endl;
+                abort ();
+              }
+          }
           break;
 
         case '?': /* Unrecognized option  */

--- a/projects/rocr-debug-agent/test/run-test.py
+++ b/projects/rocr-debug-agent/test/run-test.py
@@ -1,6 +1,7 @@
 import os
 import re
 import select
+import socket
 import sys
 import tempfile
 import unittest.mock
@@ -299,6 +300,55 @@ def test_save_code_objects(*, name, args, **_):
         return True
 
 
+def test_save_code_objects_dir_tokens(*, name, args, **_):
+    """--save-code-objects honors %-format tokens in the directory path.
+
+    Only tokens whose expansion the test process shares with the debugged
+    child (%u, %g, %h) plus the literal %% are used here: the agent validates
+    the directory with stat(), so it must already exist, which means the test
+    has to be able to predict the expanded path.
+    """
+    if not shutil.which("readelf"):
+        logger().info("Tool readelf not found, skipping %s", name)
+        unsupported_tests.add(test_save_code_objects_dir_tokens)
+        return True
+
+    _log = logger()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        template = "co-u%u-g%g-h%h-%%"
+        expanded = f"co-u{os.getuid()}-g{os.getgid()}-h{socket.gethostname()}-%"
+
+        save_dir = os.path.join(tmpdir, expanded)
+        os.mkdir(save_dir)
+
+        run_and_communicate(
+            test_name=name,
+            args=args,
+            debug_agent_options=(
+                f"--save-code-objects={tmpdir}/{template} --load-all-code-objects"
+            ),
+        )
+
+        produced = [
+            p
+            for p in (os.path.join(save_dir, f) for f in os.listdir(save_dir))
+            if os.path.isfile(p)
+        ]
+        with_symbol = [
+            p for p in produced if _has_symbol_with_readelf(p, "saved_test_kernel")
+        ]
+        if len(with_symbol) != 2:
+            _log.info(
+                "Expected 2 code objects with symbol in expanded dir %s, found %d",
+                save_dir,
+                len(with_symbol),
+            )
+            _log.info("Directory contents:\n\t%s", "\n\t".join(produced))
+            return False
+
+        return True
+
+
 def test_output_redirection(*, name, args, patterns=(), **_):
     check_list = [re.compile(s) for s in patterns]
 
@@ -330,6 +380,57 @@ def test_output_redirection(*, name, args, patterns=(), **_):
                 _log.info("Full output log contents:\n%s", log_contents)
 
             return all_output_string_found
+
+
+def test_output_filename_tokens(*, name, args, patterns=(), **_):
+    """Verify that %-format tokens in the -o filename are expanded.
+
+    Exercises every supported token at once.  The numeric tokens (%p, %t, %u,
+    %g) must expand to digits, %e to the (possibly truncated) executable comm
+    name, and %% to a single literal '%'.  No raw token may survive, and the
+    expanded file must contain the wave dump.
+    """
+    check_list = [re.compile(s) for s in patterns]
+    _log = logger()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        name_template = "dump-%e-pid%p-t%t-u%u-g%g-%%.txt"
+        options = f"-o {tmpdir}/{name_template}"
+
+        run_and_communicate(
+            test_name=name,
+            args=args,
+            debug_agent_options=options,
+        )
+
+        produced = os.listdir(tmpdir)
+        if len(produced) != 1:
+            _log.info("expected exactly one output file, found: %s", produced)
+            return False
+
+        produced_name = produced[0]
+
+        # The numeric tokens become digits and %% becomes a literal '%'.
+        name_re = re.compile(r"^dump-.+-pid\d+-t\d+-u\d+-g\d+-%\.txt$")
+        if not name_re.match(produced_name):
+            _log.info("filename not expanded as expected: %s", produced_name)
+            return False
+
+        for raw in ("%e", "%p", "%t", "%u", "%g"):
+            if raw in produced_name:
+                _log.info("unexpanded token %s left in name: %s", raw, produced_name)
+                return False
+
+        with open(os.path.join(tmpdir, produced_name), "r") as f:
+            log_contents = f.read()
+
+        for check_str in check_list:
+            if not check_str.search(log_contents):
+                _log.info('"%s" not found in %s', check_str.pattern, produced_name)
+                _log.info("Full output log contents:\n%s", log_contents)
+                return False
+
+        return True
 
 
 def test_sigquit(*, args, patterns=(), **_):
@@ -604,10 +705,28 @@ TEST_DEFINITIONS = [
         'function': test_save_code_objects,
     },
     {
+        'name': 'test_save_code_objects_dir_tokens',
+        'description': '--save-code-objects expands %-format tokens in the directory path',
+        'args': '4',
+        'function': test_save_code_objects_dir_tokens,
+    },
+    {
         'name': 'test_output_redirection',
         'description': '-o redirects the wave dump to a file instead of stderr',
         'args': '1',
         'function': test_output_redirection,
+        'patterns': [
+            r"s0:",
+            r"v0:",
+            r"0x0000: 22222222 11111111",
+            r"Disassembly for function vector_add_assert_trap\(int\*, int\*, int\*\)",
+        ],
+    },
+    {
+        'name': 'test_output_filename_tokens',
+        'description': '-o expands %-format tokens (%e %p %t %u %g %%) in the filename',
+        'args': '1',
+        'function': test_output_filename_tokens,
         'patterns': [
             r"s0:",
             r"v0:",


### PR DESCRIPTION
Expand a set of % format tokens in the user-specified --output file name and --save-code-objects directory path, so dump and code-object outputs can be named per process/host/time/user. Tokens are expanded once when the path is used:

  %p  process ID of the application
  %h  host name
  %t  timestamp (seconds since the Epoch)
  %e  short name of the application
  %u  real user ID (UID) of the process
  %g  real group ID (GID) of the process
  %%  a literal '%' character

Unrecognized tokens are left unchanged. A shared expand_format_tokens helper serves both options. Documented in the usage banner and covered by new test_output_filename_tokens and test_save_code_objects_dir_tokens tests.