### PR TITLE
clr: Defer IPC-event signal cleanup per-device

### DIFF
--- a/projects/clr/hipamd/src/hip_device.cpp
+++ b/projects/clr/hipamd/src/hip_device.cpp
@@ -135,6 +135,8 @@ void Device::AddSafeStream(Stream* event_stream, Stream* wait_stream) {
 
 // ================================================================================================
 void Device::Reset() {
+  // Free any deferred IPC-event signals before tearing the device down.
+  DrainDeferredIpcSignals();
   {
     std::scoped_lock lock(lock_);
     auto pools_to_delete = std::exchange(mem_pools_, {});
@@ -283,6 +285,57 @@ void Device::SyncAllStreams(bool cpu_wait, bool wait_blocking_streams_only) {
   }
   // Release freed memory for all memory pools on the device
   ReleaseFreedMemory();
+  // All of this device's work has been waited on, so the deferred IPC signals' barriers are
+  // complete; freeing them here won't block.
+  DrainDeferredIpcSignals();
+}
+
+// ================================================================================================
+void Device::CleanupDeferredIpcSignal(const DeferredIpcSignal& item) {
+  if (item.signal != nullptr) {
+    // Only armed signals (event != null) have an in-flight barrier to wait on; waiting on a
+    // never-recorded signal (still at its initial value) would hang forever.
+    if (item.event != nullptr) {
+      item.signal->Wait(1, amd::device::Signal::Condition::Lt, UINT64_MAX);
+    }
+    delete item.signal;
+  }
+  if (item.event != nullptr) {
+    item.event->release();
+  }
+}
+
+// ================================================================================================
+void Device::EnqueueDeferredIpcSignal(amd::device::Signal* signal, amd::Event* event) {
+  std::vector<DeferredIpcSignal> overflow;
+  {
+    std::scoped_lock lock(deferredIpcLock_);
+    // The queue is bounded by kDeferredIpcDrainThreshold; reserve up front (the buffer is
+    // moved out on each drain/overflow swap, so reserve again whenever it is empty) to avoid
+    // repeated reallocations as events are destroyed between drains.
+    if (deferredIpcSignals_.empty()) {
+      deferredIpcSignals_.reserve(kDeferredIpcDrainThreshold);
+    }
+    deferredIpcSignals_.push_back({signal, event});
+    if (deferredIpcSignals_.size() >= kDeferredIpcDrainThreshold) {
+      overflow.swap(deferredIpcSignals_);  // bounded: drain inline on overflow
+    }
+  }
+  for (const auto& item : overflow) {
+    CleanupDeferredIpcSignal(item);
+  }
+}
+
+// ================================================================================================
+void Device::DrainDeferredIpcSignals() {
+  std::vector<DeferredIpcSignal> pending;
+  {
+    std::scoped_lock lock(deferredIpcLock_);
+    pending.swap(deferredIpcSignals_);
+  }
+  for (const auto& item : pending) {
+    CleanupDeferredIpcSignal(item);
+  }
 }
 
 // ================================================================================================
@@ -346,6 +399,10 @@ const ResourceMeta* Device::lookupResource(uint32_t resId) {
 }
 
 Device::~Device() {
+  // Free any IPC signals still queued for deferred cleanup (e.g. events destroyed without a
+  // subsequent device sync) so they don't leak when the device goes away.
+  DrainDeferredIpcSignals();
+
   if ((IS_LINUX || !DEBUG_HIP_MEM_POOL_VMHEAP) && (default_mem_pool_ != nullptr)) {
     default_mem_pool_->release();
   }

--- a/projects/clr/hipamd/src/hip_event_ipc.cpp
+++ b/projects/clr/hipamd/src/hip_event_ipc.cpp
@@ -231,15 +231,14 @@ hipError_t IPCEvent::createIpcSignalIfNeeded() {
 
 IPCEvent::~IPCEvent() {
   if (ipc_signal_ != nullptr) {
-    // If the event was recorded (signal armed), wait for any in-flight barrier
-    // to finish before destroying the signal; otherwise the GPU could write to
-    // freed memory.  Skip the wait when the signal was never recorded (still at
-    // its initial value) — waiting would hang forever.
-    if (event_ != nullptr) {
-      ipc_signal_->Wait(1, amd::device::Signal::Condition::Lt, UINT64_MAX);
-    }
-    delete ipc_signal_;
+    // Transfer the signal (and the record marker's event) to the owning device's
+    // deferred-cleanup queue, which waits for the barrier and frees them at the next device
+    // sync/reset (or on overflow).
+    g_devices[deviceId()]->EnqueueDeferredIpcSignal(ipc_signal_, event_);
     ipc_signal_ = nullptr;
+    // Ownership of event_ is transferred to the deferred queue; clear it so the base ~Event()
+    // does not release it (the deferred cleanup will).
+    event_ = nullptr;
   }
 }
 

--- a/projects/clr/hipamd/src/hip_internal.hpp
+++ b/projects/clr/hipamd/src/hip_internal.hpp
@@ -37,6 +37,10 @@
 #define KCYN "\x1B[36m"
 #define KWHT "\x1B[37m"
 
+namespace amd::device {
+class Signal;
+}
+
 template <typename T> T ReturnPtrValue(T* ptr) { return (ptr != nullptr) ? *ptr : nullptr; }
 
 typedef struct hipArray {
@@ -598,6 +602,16 @@ namespace hip {
     /// doesn't stall the current thread.
     void WaitActiveStreams(hip::Stream* blocking_stream, bool wait_null_stream = false);
 
+    // Destroying a recorded IPC event must wait for the GPU barrier that decrements the
+    // event's IPC signal before the signal can be freed (otherwise the GPU could write to
+    // freed memory).
+
+    /// Transfer an IPC signal (and its record marker's event, may be null) to this device's
+    /// deferred-cleanup queue. Frees inline if the queue grows past its bound.
+    void EnqueueDeferredIpcSignal(amd::device::Signal* signal, amd::Event* event);
+    /// Wait for the pending barriers of all deferred IPC signals on this device and free them.
+    void DrainDeferredIpcSignals();
+
     // --- Device activity ---
 
     void SetActiveStatus() { isActive_.store(true, std::memory_order_release); }
@@ -672,6 +686,18 @@ namespace hip {
     std::unordered_map<uint32_t, ResourceMeta> resourceFamilyMap_;
     std::mutex resourceFamilyMapLock_;
 
+    struct DeferredIpcSignal {
+      amd::device::Signal* signal;  //!< IPC signal to free once its barrier completes
+      amd::Event* event;            //!< record marker's event (non-null => signal was armed)
+    };
+    /// Wait for an armed signal's in-flight barrier, then free the signal and release its event.
+    static void CleanupDeferredIpcSignal(const DeferredIpcSignal& item);
+
+    std::mutex deferredIpcLock_;                        //!< Guards deferredIpcSignals_
+    std::vector<DeferredIpcSignal> deferredIpcSignals_; //!< Signals awaiting deferred cleanup
+    /// Drain inline once the queue reaches this many entries, bounding memory if an app
+    /// destroys many IPC events without an intervening device sync.
+    static constexpr size_t kDeferredIpcDrainThreshold = 256;
   };
 
   /// Per-thread state aggregator for HIP runtime (one instance per thread via thread_local).

--- a/projects/hip-tests/catch/config/configs/unit/event.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/event.yaml
@@ -55,6 +55,9 @@ event:
     # (amd_wsl) Below tests fail in stress test on 24/07/23
     disabled: [amd_windows, amd_wsl]
     tags: [ipc]
+  Unit_hipEventIpc_DestroyNonBlocking:
+    <<: *level_2
+    tags: [ipc, lifecycle]
   Unit_hipEventDestroy_Unfinished:
     <<: *level_2
     # SWDEV-411303 fails in WSL. Profiling not support in WSL

--- a/projects/hip-tests/catch/unit/event/Unit_hipEventIpc.cc
+++ b/projects/hip-tests/catch/unit/event/Unit_hipEventIpc.cc
@@ -10,6 +10,10 @@
 #include <hip_test_kernels.hh>
 
 #include <hip_test_common.hh>
+#include <utils.hh>
+
+#include <chrono>
+#include <cstring>
 
 /**
  * @addtogroup hipEventCreateWithFlags hipEventCreateWithFlags
@@ -106,6 +110,83 @@ HIP_TEST_CASE(Unit_hipEventIpc) {
 
   HipTest::checkVectorADD(A_h, B_h, C_h, N, true);
   HipTest::freeArrays(A_d, B_d, C_d, A_h, B_h, C_h, false);
+}
+
+/**
+ * Test Description
+ * ------------------------
+ *  - Verify that hipEventDestroy() on an interprocess (IPC) event is non-blocking.
+ *    Destroying a still-pending IPC event must NOT wait for the event's own GPU work
+ *    to finish (matching CUDA's cudaEventDestroy() semantics). The IPC signal is handed
+ *    to a per-device deferred-cleanup queue and freed at the next device-wide sync,
+ *    so destroy returns in ~microseconds rather than ~the full kernel duration.
+ * Test source
+ * ------------------------
+ *  - unit/event/Unit_hipEventIpc.cc
+ * Test requirements
+ * ------------------------
+ *  - Device supports the true (ROCr) IPC-signal path; the emulated IPC path
+ *    (PAL/Windows) is skipped because its destroy is blocking by design.
+ *  - HIP_VERSION >= 7.0
+ */
+HIP_TEST_CASE(Unit_hipEventIpc_DestroyNonBlocking) {
+  hipDeviceProp_t props;
+  HIP_CHECK(hipGetDeviceProperties(&props, 0));
+  if (!props.ipcEventSupported) {
+    HIP_SKIP_TEST("Device does not support IPC events");
+  }
+
+  // Non-blocking destroy only applies to the true ROCr IPC-signal path. The emulated path
+  // (used when ROCr IPC signals are unavailable, e.g. PAL/Windows) intentionally waits for
+  // the event's GPU work in ~IPCEventEmulated(), so destroy is blocking there by design.
+  // Distinguish the two by the IPC handle's leading type word (0 == emulated, 1 == ROCr),
+  // which mirrors the runtime backend selection in hipEventCreateWithFlags().
+  {
+    hipEvent_t probe;
+    HIP_CHECK(hipEventCreateWithFlags(&probe, hipEventInterprocess | hipEventDisableTiming));
+    hipIpcEventHandle_t handle{};
+    HIP_CHECK(hipIpcGetEventHandle(&handle, probe));
+    uint32_t handleType = 0;
+    static_assert(sizeof(handleType) <= sizeof(handle), "IPC handle smaller than its type word");
+    std::memcpy(&handleType, &handle, sizeof(handleType));
+    HIP_CHECK(hipEventDestroy(probe));
+    constexpr uint32_t kEmulatedIpcEvent = 0;
+    if (handleType == kEmulatedIpcEvent) {
+      HIP_SKIP_TEST("Device uses emulated IPC events; destroy is blocking by design");
+    }
+  }
+
+  hipStream_t stream;
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  hipEvent_t event;
+  HIP_CHECK(hipEventCreateWithFlags(&event, hipEventInterprocess | hipEventDisableTiming));
+
+  // Keep the GPU busy so the event's recorded work is still in flight at destroy time. Use a
+  // long delay so a non-blocking destroy (microseconds) sits far below the threshold and a
+  // blocking destroy (~the full kernel) sits far above it, well clear of any timing jitter.
+  const std::chrono::milliseconds delay(isQuickLevel() ? 2000 : 5000);
+  LaunchDelayKernel(delay, stream);
+  HIP_CHECK(hipEventRecord(event, stream));
+
+  // The event completes only behind the long delay kernel, so it must read as pending.
+  HIP_CHECK_ERROR(hipEventQuery(event), hipErrorNotReady);
+
+  // The call under test: destroy must return immediately, not block for the kernel.
+  const auto t0 = std::chrono::steady_clock::now();
+  HIP_CHECK(hipEventDestroy(event));
+  const auto t1 = std::chrono::steady_clock::now();
+  const auto destroy_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+
+  INFO("hipEventDestroy took " << destroy_ms << " ms; delay kernel is " << delay.count() << " ms");
+  // A non-blocking destroy is sub-millisecond; the pre-fix blocking destroy took ~the full
+  // kernel duration. Half the kernel time cleanly separates the two while tolerating jitter.
+  REQUIRE(destroy_ms < delay.count() / 2);
+
+  // Drain the per-device deferred IPC-signal cleanup queue now that the work can complete.
+  HIP_CHECK(hipDeviceSynchronize());
+  HIP_CHECK(hipStreamDestroy(stream));
 }
 
 /**


### PR DESCRIPTION
~IPCEvent() no longer waits on the event's IPC signal barrier inside destroy. It transfers the signal (and the record marker's event) to a per-device deferred-cleanup queue on the owning hip::Device and returns immediately, matching CUDA's non-blocking cudaEventDestroy() semantics.

Each hip::Device drains its own queue where that device's work is already being waited on (SyncAllStreams / Reset / ~Device) or inline when the queue grows past 256 entries. Keeping the queue per-device (instead of a process-wide global) ensures synchronizing one device never blocks on another device's pending IPC work, and keeps the device::Signal/amd::Event lifetime managed by the device that owns them.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
