### PR TITLE
[RCCL] Fix oneRankReduce dropping tail elements on non-block-multiple counts

### DIFF
--- a/projects/rccl/src/device/onerank.cu
+++ b/projects/rccl/src/device/onerank.cu
@@ -30,8 +30,8 @@ namespace {
 
     // each block/channel gets a roughly equal segment of 16 byte packs
     constexpr int EltPerPack = 16/sizeof(T);
-    intptr_t i0 = (bid+0)*alignUp(nElts/bn, EltPerPack);
-    intptr_t i1 = (bid+1)*alignUp(nElts/bn, EltPerPack);
+    intptr_t i0 = (bid+0)*alignUp(divUp(nElts, bn), EltPerPack);
+    intptr_t i1 = (bid+1)*alignUp(divUp(nElts, bn), EltPerPack);
     i0 = min(i0, nElts);
     i1 = min(i1, nElts);
 

--- a/projects/rccl/test/AllReduceTests.cpp
+++ b/projects/rccl/test/AllReduceTests.cpp
@@ -710,4 +710,66 @@ namespace RcclUnitTesting
       return;
   }
 #endif
+
+  // Regression test for "one-rank avg reduction missing elements"
+  // (NVIDIA/nccl GitHub issue #1950, fixed upstream in NCCL v2.29.7-1; AICOMRCCL-1110).
+  //
+  // On a single-rank communicator, ncclAvg on floating-point types lowers to a
+  // PreMulSum reduction (scalar 1/nRanks), which is the only out-of-place path
+  // that is serviced by the oneRankReduce kernel (src/device/onerank.cu) rather
+  // than a plain memcpy. The kernel divided work across blocks using floor
+  // division (nElts/bn) instead of divUp(nElts, bn); when the element count was
+  // not a multiple of the launched block count, the trailing (nElts % bn)
+  // elements were never written, silently corrupting the tail of the output.
+  //
+  // Each count below is constructed so that floor(count/numBlocks) is already
+  // pack-aligned and the buffer is large enough to launch the maximum of 32
+  // blocks. This guarantees the pre-fix kernel under-covers the output by a
+  // fixed, non-zero remainder, so ValidateResults observes the corrupted tail.
+  // The test fails on the pre-fix kernel and passes once divUp is used.
+  TEST(AllReduce, OneRankAvgTailElements)
+  {
+    TestBed testBed;
+
+    if (testBed.numDevicesAvailable < 1)
+      GTEST_SKIP() << "Requires at least 1 GPU";
+
+    ncclFunc_t                  const funcType      = ncclCollAllReduce;
+    std::vector<ncclDataType_t> const dataTypes     = {ncclFloat32, ncclFloat64, ncclBfloat16};
+    bool                        const inPlace       = false; // out-of-place: tail of separate output buffer must be written
+    bool                        const useManagedMem = false;
+
+    // oneRankReduce only executes for a single-rank communicator.
+    testBed.InitComms(1);
+
+    OptionalColArgs options;
+    options.redOp = ncclAvg;
+
+    bool isCorrect = true;
+    for (int dataIdx = 0; dataIdx < dataTypes.size() && isCorrect; ++dataIdx)
+    {
+      ncclDataType_t const dataType  = dataTypes[dataIdx];
+      size_t         const eltSize   = DataTypeToBytes(dataType);
+      // Mirror the kernel: EltPerPack = 16 / sizeof(T), grid.x capped at 32 blocks.
+      size_t         const eltPerPack = 16 / eltSize;
+      size_t         const numBlocks  = 32;
+      // Pack-aligned per-block segment, then add a remainder that is not a
+      // multiple of numBlocks so the pre-fix floor division drops the tail.
+      size_t         const perBlock   = eltPerPack * 4096;
+      size_t         const numElems   = numBlocks * perBlock + 17;
+
+      if (testBed.ev.showNames)
+        TEST_INFO("SP 1-rank AllReduce (avg) %s count %zu",
+                  ncclDataTypeNames[dataType], numElems);
+
+      testBed.SetCollectiveArgs(funcType, dataType, numElems, numElems, options);
+      testBed.AllocateMem(inPlace, useManagedMem);
+      testBed.PrepareData();
+      testBed.ExecuteCollectives();
+      testBed.ValidateResults(isCorrect);
+      testBed.DeallocateMem();
+    }
+    testBed.DestroyComms();
+    testBed.Finalize();
+  }
 }


### PR DESCRIPTION
## Motivation

Port the upstream NVIDIA/nccl fix for GitHub issue #1950 ("One-rank avg reduction missing elements"), fixed in NCCL v2.29.7-1, which had not yet been brought into RCCL. The bug causes silent data corruption in the output of single-rank reductions and was observed in the field via PyTorch (pytorch/pytorch#168092). This PR applies the fix and adds a regression test so the support cannot degrade on future NCCL syncs.

## Technical Details

The `oneRankReduce` kernel in `src/device/onerank.cu` divides the element range across blocks using floor division:

```c
intptr_t i0 = (bid+0)*alignUp(nElts/bn, EltPerPack);
intptr_t i1 = (bid+1)*alignUp(nElts/bn, EltPerPack);
```

When `nElts` is not a multiple of the launched block count `bn` (`gridDim.x`, capped at 32), `floor(nElts/bn)` rounds down, so the total covered range `bn * alignUp(floor(nElts/bn), EltPerPack)` is less than `nElts`. The final block is clamped by `min(i1, nElts)` but nothing extends coverage to the end, leaving the trailing `nElts % bn` elements unwritten.

The fix uses ceiling division so blocks slightly over-cover and the existing `min(..., nElts)` clamp closes the gap:

```c
intptr_t i0 = (bid+0)*alignUp(divUp(nElts, bn), EltPerPack);
intptr_t i1 = (bid+1)*alignUp(divUp(nElts, bn), EltPerPack);
```

This matches the upstream change exactly. Note this kernel only runs for a single-rank communicator and only on the out-of-place path that goes through `oneRankReduce` rather than the `cudaMemcpyAsync` fast-path, i.e. when `acc != nullptr` or `redOp.op == ncclDevPreMulSum`. For floating-point types, `ncclAvg` lowers to `PreMulSum`, which is precisely the reported scenario.

- Upstream issue: https://github.com/NVIDIA/nccl/issues/1950
- Upstream fix released in: https://github.com/NVIDIA/nccl/releases/tag/v2.29.7-1

## JIRA ID

Resolves AICOMRCCL-1110

## Test Plan

Added a regression test `AllReduce.OneRankAvgTailElements` (`test/AllReduceTests.cpp`):

- Forces a single-rank communicator (`InitComms(1)`), the only configuration that reaches `oneRankReduce`.
- Runs out-of-place `ncclAvg` (which lowers to `PreMulSum` and so exercises the kernel rather than the memcpy fast-path) over `ncclFloat32`, `ncclFloat64`, and `ncclBfloat16`.
- Uses element counts engineered to deterministically trigger the bug: per dtype, `count = 32 * (eltPerPack * 4096) + 17`, so the buffer is large enough to launch the full 32 blocks, `floor(count/32)` is already pack-aligned, and the