### PR TITLE
[rocprofiler-sdk] fix HIP stream lifetime ID reuse

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/stream.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/stream.cpp
@@ -80,35 +80,44 @@ add_stream(hipStream_t stream, bool reindex_existing = true)
 {
     return get_stream_map()->wlock(
         [](stream_map_t& _data, hipStream_t _stream, const bool _reindex_existing) {
-            static uint64_t idx_offset = 0;
+            static uint64_t next_stream_idx = 1;
 
-            auto idx = _data.size() + idx_offset;
-            ROCP_INFO << fmt::format(
-                "hipStream_t={} :: id={{.handle={}}}", static_cast<void*>(_stream), idx);
+            auto make_stream_id = [&_stream]() {
+                return rocprofiler_stream_id_t{
+                    .handle = (_stream == nullptr) ? 0 : next_stream_idx++};
+            };
 
-            ROCP_CI_LOG_IF(WARNING, idx == 0 && _stream != nullptr)
-                << "null hip stream does not have index 0";
-
-            if(!_data.emplace(_stream, rocprofiler_stream_id_t{.handle = idx}).second)
+            auto itr = _data.find(_stream);
+            if(itr == _data.end())
             {
-                // Do not change the index if attachment mode is currently active
-                if(!_reindex_existing) return _data.at(_stream);
-                idx_offset += 1;
-                // Handle special hipStreamPerThread case where each thread has it's own implicit
-                // stream ID. No need to update map since hipStreamPerThread is defined as 0x02
-                if(_stream == hipStreamPerThread)
-                {
-                    return rocprofiler_stream_id_t{.handle = idx};
-                }
-                idx            = _data.size() + idx_offset;
-                auto _existing = _data.at(_stream);
-                ROCP_INFO << "existing hipStream_t ("
-                          << sdk::utility::as_hex(static_cast<void*>(_stream))
-                          << ") reallocated. rocprofiler_stream_id_t{.handle = " << _existing.handle
-                          << "} -> rocprofiler_stream_id_t{.handle = " << idx << "}";
-                _data.at(_stream) = rocprofiler_stream_id_t{.handle = idx};
+                auto stream_id = make_stream_id();
+                ROCP_INFO << fmt::format("hipStream_t={} :: id={{.handle={}}}",
+                                         static_cast<void*>(_stream),
+                                         stream_id.handle);
+
+                ROCP_CI_LOG_IF(WARNING, stream_id.handle == 0 && _stream != nullptr)
+                    << "null hip stream does not have index 0";
+
+                return _data.emplace(_stream, stream_id).first->second;
             }
-            return _data.at(_stream);
+
+            // Do not change the index if attachment mode is currently active. The null stream is
+            // also permanently reserved as stream ID 0.
+            if(!_reindex_existing || _stream == nullptr) return itr->second;
+
+            auto stream_id = make_stream_id();
+
+            // Handle special hipStreamPerThread case where each thread has its own implicit stream
+            // ID. No need to update map since hipStreamPerThread is defined as 0x02.
+            if(_stream == hipStreamPerThread) return stream_id;
+
+            auto _existing = itr->second;
+            ROCP_INFO << "existing hipStream_t ("
+                      << sdk::utility::as_hex(static_cast<void*>(_stream))
+                      << ") reallocated. rocprofiler_stream_id_t{.handle = " << _existing.handle
+                      << "} -> rocprofiler_stream_id_t{.handle = " << stream_id.handle << "}";
+            itr->second = stream_id;
+            return itr->second;
         },
         stream,
         reindex_existing);

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/stream.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hip/stream.cpp
@@ -83,8 +83,8 @@ add_stream(hipStream_t stream, bool reindex_existing = true)
             static uint64_t next_stream_idx = 1;
 
             auto make_stream_id = [&_stream]() {
-                return rocprofiler_stream_id_t{
-                    .handle = (_stream == nullptr) ? 0 : next_stream_idx++};
+                return rocprofiler_stream_id_t{.handle =
+                                                   (_stream == nullptr) ? 0 : next_stream_idx++};
             };
 
             auto itr = _data.find(_stream);

--- a/projects/rocprofiler-sdk/tests/bin/hip-stream-reuse/hip-stream-reuse.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/hip-stream-reuse/hip-stream-reuse.cpp
@@ -21,8 +21,10 @@
 // THE SOFTWARE.
 
 #include <hip/hip_runtime.h>
+#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <vector>
 
 #define HIP_ASSERT(call)                                                                           \
@@ -141,12 +143,15 @@ main(int argc, char** argv)
     const char* ptr_file = argc > 1 ? argv[1] : "stream_pointers.txt";
 
     FILE* fp = fopen(ptr_file, "w");
-    if(fp)
+    if(!fp)
     {
-        for(auto* ptr : g_stream_ptrs)
-            fprintf(fp, "%p\n", ptr);
-        fclose(fp);
+        fprintf(stderr, "Failed to open '%s' for writing: %s\n", ptr_file, strerror(errno));
+        return 1;
     }
+
+    for(auto* ptr : g_stream_ptrs)
+        fprintf(fp, "%p\n", ptr);
+    fclose(fp);
 
     return 0;
 }

--- a/projects/rocprofiler-sdk/tests/rocprofv3/hip-stream-reuse/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/hip-stream-reuse/CMakeLists.txt
@@ -34,14 +34,14 @@ string(REPLACE "LD_PRELOAD=" "ROCPROF_PRELOAD=" PRELOAD_ENV
                "${ROCPROFILER_MEMCHECK_PRELOAD_ENV}")
 
 set(hip-stream-reuse-env "${PRELOAD_ENV}")
+set(hip-stream-reuse-pointer-file "${CMAKE_CURRENT_BINARY_DIR}/stream_pointers.txt")
 
 rocprofiler_add_integration_execute_test(
     rocprofv3-test-hip-stream-reuse
     COMMAND
         $<TARGET_FILE:rocprofiler-sdk::rocprofv3> -s -d
         ${CMAKE_CURRENT_BINARY_DIR}/%tag%-trace -o out --output-format json --log-level
-        env -- $<TARGET_FILE:hip-stream-reuse>
-        ${CMAKE_CURRENT_BINARY_DIR}/hip-stream-reuse-trace/stream_pointers.txt
+        env -- $<TARGET_FILE:hip-stream-reuse> ${hip-stream-reuse-pointer-file}
     DEPENDS hip-stream-reuse
     TIMEOUT 60
     LABELS "integration-tests"
@@ -55,8 +55,7 @@ rocprofiler_add_integration_validate_test(
     COPY conftest.py
     CONFIG pytest.ini
     ARGS --json-input ${CMAKE_CURRENT_BINARY_DIR}/hip-stream-reuse-trace/out_results.json
-         --pointer-file
-         ${CMAKE_CURRENT_BINARY_DIR}/hip-stream-reuse-trace/stream_pointers.txt
+         --pointer-file ${hip-stream-reuse-pointer-file}
     TIMEOUT 60
     LABELS "integration-tests"
     FIXTURES_REQUIRED rocprofv3-test-hip-stream-reuse

--- a/projects/rocprofiler-sdk/tests/rocprofv3/hip-stream-reuse/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/hip-stream-reuse/conftest.py
@@ -49,7 +49,7 @@ def pytest_addoption(parser):
 def json_data(request):
     filename = request.config.getoption("--json-input")
     if not os.path.isfile(filename):
-        return pytest.skip("stream tracing unavailable")
+        pytest.fail(f"stream tracing output unavailable: {filename}")
     with open(filename, "r") as inp:
         return dotdict(collapse_dict_list(json.load(inp)))
 
@@ -59,6 +59,6 @@ def pointer_data(request):
     """Read the raw hipStream_t pointer values written by the test binary."""
     filename = request.config.getoption("--pointer-file")
     if not os.path.isfile(filename):
-        return pytest.skip("pointer file unavailable")
+        pytest.fail(f"stream pointer file unavailable: {filename}")
     with open(filename, "r") as inp:
         return [line.strip() for line in inp if line.strip()]


### PR DESCRIPTION
## Motivation

- rocprofiler-sdk is reusing `Stream_Id` for different HIP stream lifetimes.
- https://github.com/ROCm/rocm-systems/actions/runs/28015566480/job/82918889423#step:17:2313
  
## Technical Details

Use a monotonic stream lifetime counter when assigning `rocprofiler_stream_id_t` values instead of deriving IDs from the current stream map size. The stream map now shrinks on `hipStreamDestroy`, so using `_data.size()` caused new stream lifetimes to reuse old IDs whenever HIP recycled `hipStream_t` handle values.

Keep stream ID 0 reserved for the null stream and preserve the existing `hipStreamPerThread` handling.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Tighten the hip-stream-reuse regression test:
- write the pointer file into the `CMAKE_CURRENT_BINARY_DIR` instead of the rocprofv3 output dir, which is created later
- fail if the pointer sidecar or JSON trace is missing instead of skipping validation

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
