### PR TITLE
fix race condition in rccl asan build

### DIFF
--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -242,7 +242,7 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
   target_compile_definitions(${_dev_target} PRIVATE RCCL_DEVICE_LINKER)
   target_link_libraries(${_dev_target} PRIVATE rccl_device_defs)
 
-  add_dependencies(${_dev_target} hipify_all)
+  add_dependencies(${_dev_target} hipify_all copy_nccl_device_headers)
   if(ENABLE_ROCSHMEM AND TARGET rocshmem_static)
     # rocSHMEM headers land in ext/rocshmem/include only after ExternalProject
     # completes; ensure they are installed before device kernels start compiling.
@@ -668,7 +668,7 @@ endif()
 add_custom_target(device_linker_build ALL
   DEPENDS ${COMMON_FAT_OBJ} ${ONERANK_FAT_OBJ} ${COLLECTIVES_FAT_OBJ} ${DDA_ALL_REDUCE_IPC_FAT_OBJ} ${DDA_REDUCE_SCATTER_IPC_FAT_OBJ} ${DDA_ALL_GATHER_IPC_FAT_OBJ} ${DDA_ALLTOALL_IPC_FAT_OBJ} ${SYM_FAT_OBJS}
 )
-add_dependencies(device_linker_build hipify_all)
+add_dependencies(device_linker_build hipify_all copy_nccl_device_headers)
 
 set(DEVICE_LINKER_OBJECTS
   ${COMMON_FAT_OBJ}
@@ -685,4 +685,4 @@ set(DEVICE_LINKER_OBJECTS
 # Optional: emit LLVM IR (ninja device_ir)
 # ===========================================================================
 add_custom_target(device_ir DEPENDS ${ALL_IR_FILES})
-add_dependencies(device_ir hipify_all)
+add_dependencies(device_ir hipify_all copy_nccl_device_headers)


### PR DESCRIPTION
## Motivation

RCCL build in TheRock ASAN CI pipeline is broken

## Technical Details

  Change: Add copy_nccl_device_headers as a build dependency to three targets in projects/rccl/cmake/DeviceLinker.cmake:
  - Per-arch device compile targets (rccl_device_<arch>)
  - device_linker_build
  - device_ir
  
  Problem: Intermittent ASAN CI build failures where build/include/nccl_device/utility.h was truncated (304 lines instead of 531), causing
   unterminated conditional directive errors across all GPU targets.

  Root cause: The device linker targets depended on hipify_all (which generates hipified headers into hipify/src/include/nccl_device/) but
   not on copy_nccl_device_headers (which copies them to build/include/nccl_device/). Since the device compiler reads from build/include/,
   a parallel build could start compiling device code before the copy finished, reading a partially-written header.
  
  Evidence: The failure was intermittent — the same commit (86af3706e7) both succeeded and failed on consecutive CI runs, confirming a
  race condition rather than a code defect.


## JIRA ID

ROCM-26932

## Test Plan

CI ASAN build

## Test Result

Builds succesfully

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
