### PR TITLE
security audit: harden sprintf->snprintf

### DIFF
--- a/projects/rocshmem/src/gda/topology.cpp
+++ b/projects/rocshmem/src/gda/topology.cpp
@@ -257,8 +257,9 @@ namespace rocshmem
     char const* deviceName = ibv.get_device_name(context->device);
     char gidRoceVerStr[16]      = {};
     char roceTypePath[PATH_MAX] = {};
-    sprintf(roceTypePath, "/sys/class/infiniband/%s/ports/%d/gid_attrs/types/%d",
-            deviceName, portNum, gidIndex);
+    snprintf(roceTypePath, sizeof(roceTypePath),
+             "/sys/class/infiniband/%s/ports/%d/gid_attrs/types/%d",
+             deviceName, portNum, gidIndex);
 
     int fd = open(roceTypePath, O_RDONLY);
     if (fd == -1) {


### PR DESCRIPTION
## Motivation

Use of raw sprintf with variadic length strings is fragile. 

## Technical Details

substitute sprintf with snprintf

## JIRA ID

ROCM-26549

## Test Plan

CI 

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
