### PR TITLE
[ci] Using external GitHub repo for runner data retrieval

### DIFF
--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -26,7 +26,7 @@ import os
 # Add TheRock's github_actions to path for shared utilities
 THEROCK_ACTIONS_PATH = Path("TheRock") / "build_tools" / "github_actions"
 sys.path.insert(0, str(THEROCK_ACTIONS_PATH))
-from amdgpu_family_matrix import BUILD_RUNNER_LABELS, select_weighted_label
+from amdgpu_family_matrix import get_build_runner_labels, select_weighted_label
 
 logging.basicConfig(level=logging.INFO)
 
@@ -363,12 +363,13 @@ def retrieve_projects(args):
 
 def select_build_runner(platform: str) -> str:
     """Select a build runner label based on platform and build variant."""
-    if platform not in BUILD_RUNNER_LABELS:
+    build_runner_labels = get_build_runner_labels()
+    if platform not in build_runner_labels:
         # Platform not configured for weighted selection, return default
         print(f"  No build runner config for platform {platform}, using default")
         return ""
 
-    platform_config = BUILD_RUNNER_LABELS[platform]
+    platform_config = build_runner_labels[platform]
 
     labels_config = platform_config["default"]
     context_name = f"build-runner ({platform})"

--- a/.github/scripts/therock_configure_ci.py
+++ b/.github/scripts/therock_configure_ci.py
@@ -10,7 +10,9 @@ and some workflow_dispatch invocations do not require SUBTREES.
 import fnmatch
 import json
 import logging
+from pathlib import Path
 import subprocess
+import sys
 from therock_matrix import (
     subtree_to_project_map,
     project_map,
@@ -20,6 +22,11 @@ from therock_matrix import (
 import time
 from typing import Mapping, Optional, Iterable
 import os
+
+# Add TheRock's github_actions to path for shared utilities
+THEROCK_ACTIONS_PATH = Path("TheRock") / "build_tools" / "github_actions"
+sys.path.insert(0, str(THEROCK_ACTIONS_PATH))
+from amdgpu_family_matrix import BUILD_RUNNER_LABELS, select_weighted_label
 
 logging.basicConfig(level=logging.INFO)
 
@@ -354,9 +361,26 @@ def retrieve_projects(args):
     ]
 
 
+def select_build_runner(platform: str) -> str:
+    """Select a build runner label based on platform and build variant."""
+    if platform not in BUILD_RUNNER_LABELS:
+        # Platform not configured for weighted selection, return default
+        print(f"  No build runner config for platform {platform}, using default")
+        return ""
+
+    platform_config = BUILD_RUNNER_LABELS[platform]
+
+    labels_config = platform_config["default"]
+    context_name = f"build-runner ({platform})"
+
+    return select_weighted_label(labels_config, context_name)
+
+
 def run(args):
+    platform = args.get("platform")
     project_to_run = retrieve_projects(args)
-    outputs = {"projects": json.dumps(project_to_run)}
+    build_runs_on = select_build_runner(platform)
+    outputs = {"projects": json.dumps(project_to_run), "build_runs_on": build_runs_on}
 
     # Determine if RCCL CI should run (only relevant for Linux platform)
     if args.get("platform") == "linux":

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -16,6 +16,9 @@ on:
       test_runs_on:
         type: string
         default: "linux-gfx942-1gpu-core42-ossci-rocm"
+      build_runs_on:
+        type: string
+        default: "azure-linux-scale-rocm"
 
 
 permissions:
@@ -24,7 +27,7 @@ permissions:
 jobs:
   therock-build-linux:
     name: Build Linux Packages
-    runs-on: azure-linux-scale-rocm
+    runs-on: ${{ inputs.build_runs_on }}
     permissions:
       id-token: write
     container:

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -134,6 +134,8 @@ jobs:
   therock-test-linux:
     name: "Test"
     needs: [therock-build-linux]
+    # TODO(TheRock#3288): Re-enable gfx950-dcgpu runners once we get more capacity
+    if: ${{ inputs.amdgpu_families != 'gfx950-dcgpu' }}
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       projects_to_test: ${{ inputs.projects_to_test }}

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 300c0928ffba5ceb555db6ef59f4948210fe5b78 # 2026-06-17
+          ref: f1e3fc2311fde45bf3e17b0e3349200be9caa4b4 # 2026-06-23
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -10,6 +10,9 @@ on:
       package_version:
         type: string
         required: true
+      amdgpu_families:
+        type: string
+        default: "gfx94X-dcgpu"
       test_runs_on:
         type: string
         default: "linux-gfx942-1gpu-core42-ossci-rocm"
@@ -32,7 +35,7 @@ jobs:
     env:
       CACHE_DIR: ${{ github.workspace }}/.container-cache
       CCACHE_CONFIGPATH: ${{ github.workspace }}/.ccache/ccache.conf
-      AMDGPU_FAMILIES: "gfx94X-dcgpu"
+      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       TEATIME_FORCE_INTERACTIVE: 0
       AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
     steps:
@@ -131,6 +134,6 @@ jobs:
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       projects_to_test: ${{ inputs.projects_to_test }}
-      amdgpu_families: "gfx94X-dcgpu"
+      amdgpu_families: ${{ inputs.amdgpu_families }}
       test_runs_on: ${{ inputs.test_runs_on }}
       platform: "linux"

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 300c0928ffba5ceb555db6ef59f4948210fe5b78 # 2026-06-17
+          ref: f1e3fc2311fde45bf3e17b0e3349200be9caa4b4 # 2026-06-23
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -8,6 +8,14 @@ on:
       projects:
         type: string
         description: "Insert space-separated list of projects to test or 'all' to test all projects. ex: 'projects/clr projects/rocminfo'"
+      linux_amdgpu_families:
+        type: string
+        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx950"
+        default: ""
+      windows_amdgpu_families:
+        type: string
+        description: "Insert comma-separated list of Windows GPU families to build and test. ex: gfx1151"
+        default: ""
 
 permissions:
   contents: read
@@ -33,6 +41,8 @@ jobs:
       windows_projects: ${{ steps.windows_projects.outputs.projects }}
       run_linux_rccl_ci: ${{ steps.linux_projects.outputs.run_linux_rccl_ci }}
       package_version: ${{ steps.rocm_package_version.outputs.rocm_package_version }}
+      linux_package_targets: ${{ steps.configure_linux.outputs.package_targets }}
+      windows_package_targets: ${{ steps.configure_windows.outputs.package_targets }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -47,6 +57,14 @@ jobs:
           repository: "ROCm/TheRock"
           path: TheRock
           ref: f1e3fc2311fde45bf3e17b0e3349200be9caa4b4 # 2026-06-23
+
+      - name: Checkout CI config
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/therock-ci-config
+          ref: main
+          path: ci-config
+        continue-on-error: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -79,8 +97,24 @@ jobs:
         run: |
           python TheRock/build_tools/compute_rocm_package_version.py --release-type=dev
 
+      - name: Fetch Linux targets for build and test
+        env:
+          THEROCK_PACKAGE_PLATFORM: "linux"
+          AMDGPU_FAMILIES: ${{ inputs.linux_amdgpu_families || 'gfx94X, gfx950' }}
+          CI_CONFIG_PATH: ci-config
+        id: configure_linux
+        run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py
+
+      - name: Fetch Windows targets for build and test
+        env:
+          THEROCK_PACKAGE_PLATFORM: "windows"
+          AMDGPU_FAMILIES: ${{ inputs.windows_amdgpu_families || 'gfx1151' }}
+          CI_CONFIG_PATH: ci-config
+        id: configure_windows
+        run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py
+
   therock-ci-linux:
-    name: Linux (${{ matrix.projects.projects_to_test }})
+    name: Linux (${{ matrix.projects.projects_to_test }} | ${{ matrix.target_bundle.amdgpu_family }})
     permissions:
       contents: read
       id-token: write
@@ -90,12 +124,15 @@ jobs:
       fail-fast: false
       matrix:
         projects: ${{ fromJSON(needs.setup.outputs.linux_projects) }}
+        target_bundle: ${{ fromJSON(needs.setup.outputs.linux_package_targets) }}
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
       package_version: ${{ needs.setup.outputs.package_version }}
+      amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
+      test_runs_on: ${{ matrix.target_bundle.test_machine }}
 
   therock-rccl-ci-linux:
     name: TheRock RCCL CI Linux
@@ -123,7 +160,7 @@ jobs:
         -DTHEROCK_ENABLE_MPI=ON
 
   therock-ci-windows:
-    name: Windows (${{ matrix.projects.projects_to_test }})
+    name: Windows (${{ matrix.projects.projects_to_test }} | ${{ matrix.target_bundle.amdgpu_family }})
     permissions:
       contents: read
       id-token: write
@@ -133,9 +170,12 @@ jobs:
       fail-fast: false
       matrix:
         projects: ${{ fromJSON(needs.setup.outputs.windows_projects) }}
+        target_bundle: ${{ fromJSON(needs.setup.outputs.windows_package_targets) }}
     uses: ./.github/workflows/therock-ci-windows.yml
     secrets: inherit
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
       package_version: ${{ needs.setup.outputs.package_version }}
+      amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
+      test_runs_on: ${{ matrix.target_bundle.test_machine }}

--- a/.github/workflows/therock-ci-nightly.yml
+++ b/.github/workflows/therock-ci-nightly.yml
@@ -43,6 +43,8 @@ jobs:
       package_version: ${{ steps.rocm_package_version.outputs.rocm_package_version }}
       linux_package_targets: ${{ steps.configure_linux.outputs.package_targets }}
       windows_package_targets: ${{ steps.configure_windows.outputs.package_targets }}
+      linux_build_runs_on: ${{ steps.linux_projects.outputs.build_runs_on }}
+      windows_build_runs_on: ${{ steps.windows_projects.outputs.build_runs_on }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -133,6 +135,7 @@ jobs:
       package_version: ${{ needs.setup.outputs.package_version }}
       amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
       test_runs_on: ${{ matrix.target_bundle.test_machine }}
+      build_runs_on: ${{ needs.setup.outputs.linux_build_runs_on }}
 
   therock-rccl-ci-linux:
     name: TheRock RCCL CI Linux
@@ -179,3 +182,4 @@ jobs:
       package_version: ${{ needs.setup.outputs.package_version }}
       amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
       test_runs_on: ${{ matrix.target_bundle.test_machine }}
+      build_runs_on: ${{ needs.setup.outputs.windows_build_runs_on }}

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -16,6 +16,9 @@ on:
       test_runs_on:
         type: string
         default: "windows-gfx1151-gpu-rocm"
+      build_runs_on:
+        type: string
+        default: "azure-windows-scale-rocm"
 
 permissions:
   contents: read
@@ -23,7 +26,7 @@ permissions:
 jobs:
   therock-build-windows:
     name: Build Windows Packages
-    runs-on: azure-windows-scale-rocm
+    runs-on: ${{ inputs.build_runs_on }}
     outputs:
       AMDGPU_FAMILIES: ${{ env.AMDGPU_FAMILIES }}
     permissions:

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 300c0928ffba5ceb555db6ef59f4948210fe5b78 # 2026-06-17
+          ref: f1e3fc2311fde45bf3e17b0e3349200be9caa4b4 # 2026-06-23
 
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0

--- a/.github/workflows/therock-ci-windows.yml
+++ b/.github/workflows/therock-ci-windows.yml
@@ -10,6 +10,12 @@ on:
       package_version:
         type: string
         required: true
+      amdgpu_families:
+        type: string
+        default: "gfx1151"
+      test_runs_on:
+        type: string
+        default: "windows-gfx1151-gpu-rocm"
 
 permissions:
   contents: read
@@ -30,9 +36,7 @@ jobs:
       BUILD_DIR: B:\build
       CCACHE_DIR: "${{ github.workspace }}/.container-cache/ccache"
       CCACHE_MAXSIZE: "700M"
-      # TODO(geomin12): Add matrix of families
-      # To get a fast signal of windows building for TheRock, adding gfx1151
-      AMDGPU_FAMILIES: "gfx1151"
+      AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
     steps:
       - name: "Checking out repository for rocm-systems"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -158,6 +162,6 @@ jobs:
     uses: ./.github/workflows/therock-test-packages.yml
     with:
       projects_to_test: ${{ inputs.projects_to_test }}
-      amdgpu_families: ${{ needs.therock-build-windows.outputs.AMDGPU_FAMILIES }}
-      test_runs_on: "windows-gfx1151-gpu-rocm"
+      amdgpu_families: ${{ inputs.amdgpu_families }}
+      test_runs_on: ${{ inputs.test_runs_on }}
       platform: "windows"

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -15,6 +15,14 @@ on:
       projects:
         type: string
         description: "Insert space-separated list of projects to test or 'all' to test all projects. ex: 'projects/clr projects/rocminfo'"
+      linux_amdgpu_families:
+        type: string
+        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx950"
+        default: ""
+      windows_amdgpu_families:
+        type: string
+        description: "Insert comma-separated list of Windows GPU families to build and test. ex: gfx1151"
+        default: ""
 
 permissions:
   contents: read
@@ -40,6 +48,8 @@ jobs:
       windows_projects: ${{ steps.windows_projects.outputs.projects }}
       run_linux_rccl_ci: ${{ steps.linux_projects.outputs.run_linux_rccl_ci }}
       package_version: ${{ steps.rocm_package_version.outputs.rocm_package_version }}
+      linux_package_targets: ${{ steps.configure_linux.outputs.package_targets }}
+      windows_package_targets: ${{ steps.configure_windows.outputs.package_targets }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -54,6 +64,14 @@ jobs:
           repository: "ROCm/TheRock"
           path: TheRock
           ref: f1e3fc2311fde45bf3e17b0e3349200be9caa4b4 # 2026-06-23
+
+      - name: Checkout CI config
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/therock-ci-config
+          ref: main
+          path: ci-config
+        continue-on-error: true
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -99,8 +117,24 @@ jobs:
         run: |
           python TheRock/build_tools/compute_rocm_package_version.py --release-type=dev
 
+      - name: Fetch Linux targets for build and test
+        env:
+          THEROCK_PACKAGE_PLATFORM: "linux"
+          AMDGPU_FAMILIES: ${{ inputs.linux_amdgpu_families || 'gfx94X, gfx950' }}
+          CI_CONFIG_PATH: ci-config
+        id: configure_linux
+        run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py
+
+      - name: Fetch Windows targets for build and test
+        env:
+          THEROCK_PACKAGE_PLATFORM: "windows"
+          AMDGPU_FAMILIES: ${{ inputs.windows_amdgpu_families || 'gfx1151' }}
+          CI_CONFIG_PATH: ci-config
+        id: configure_windows
+        run: python ./TheRock/build_tools/github_actions/fetch_package_targets.py
+
   therock-ci-linux:
-    name: Linux (${{ matrix.projects.projects_to_test }})
+    name: Linux (${{ matrix.projects.projects_to_test }} | ${{ matrix.target_bundle.amdgpu_family }})
     permissions:
       contents: read
       id-token: write
@@ -110,12 +144,15 @@ jobs:
       fail-fast: false
       matrix:
         projects: ${{ fromJSON(needs.setup.outputs.linux_projects) }}
+        target_bundle: ${{ fromJSON(needs.setup.outputs.linux_package_targets) }}
     uses: ./.github/workflows/therock-ci-linux.yml
     secrets: inherit
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
       package_version: ${{ needs.setup.outputs.package_version }}
+      amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
+      test_runs_on: ${{ matrix.target_bundle.test_machine }}
 
   therock-rccl-ci-linux:
     name: TheRock RCCL CI Linux
@@ -143,7 +180,7 @@ jobs:
         -DTHEROCK_ENABLE_MPI=ON
 
   therock-ci-windows:
-    name: Windows (${{ matrix.projects.projects_to_test }})
+    name: Windows (${{ matrix.projects.projects_to_test }} | ${{ matrix.target_bundle.amdgpu_family }})
     permissions:
       contents: read
       id-token: write
@@ -153,12 +190,15 @@ jobs:
       fail-fast: false
       matrix:
         projects: ${{ fromJSON(needs.setup.outputs.windows_projects) }}
+        target_bundle: ${{ fromJSON(needs.setup.outputs.windows_package_targets) }}
     uses: ./.github/workflows/therock-ci-windows.yml
     secrets: inherit
     with:
       cmake_options: ${{ matrix.projects.cmake_options }}
       projects_to_test: ${{ matrix.projects.projects_to_test }}
       package_version: ${{ needs.setup.outputs.package_version }}
+      amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
+      test_runs_on: ${{ matrix.target_bundle.test_machine }}
 
   therock_ci_summary:
     name: TheRock CI Summary

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: TheRock
-          ref: 300c0928ffba5ceb555db6ef59f4948210fe5b78 # 2026-06-17
+          ref: f1e3fc2311fde45bf3e17b0e3349200be9caa4b4 # 2026-06-23
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/therock-ci.yml
+++ b/.github/workflows/therock-ci.yml
@@ -50,6 +50,8 @@ jobs:
       package_version: ${{ steps.rocm_package_version.outputs.rocm_package_version }}
       linux_package_targets: ${{ steps.configure_linux.outputs.package_targets }}
       windows_package_targets: ${{ steps.configure_windows.outputs.package_targets }}
+      linux_build_runs_on: ${{ steps.linux_projects.outputs.build_runs_on }}
+      windows_build_runs_on: ${{ steps.windows_projects.outputs.build_runs_on }}
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -153,6 +155,7 @@ jobs:
       package_version: ${{ needs.setup.outputs.package_version }}
       amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
       test_runs_on: ${{ matrix.target_bundle.test_machine }}
+      build_runs_on: ${{ needs.setup.outputs.linux_build_runs_on }}
 
   therock-rccl-ci-linux:
     name: TheRock RCCL CI Linux
@@ -199,6 +202,7 @@ jobs:
       package_version: ${{ needs.setup.outputs.package_version }}
       amdgpu_families: ${{ matrix.target_bundle.amdgpu_family }}
       test_runs_on: ${{ matrix.target_bundle.test_machine }}
+      build_runs_on: ${{ needs.setup.outputs.windows_build_runs_on }}
 
   therock_ci_summary:
     name: TheRock CI Summary

--- a/.github/workflows/therock-rccl-ci-linux.yml
+++ b/.github/workflows/therock-rccl-ci-linux.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           path: "TheRock"
-          ref: 685f8c3b89006309b34a7c16de17e841400f0d76 # 2025-05-29 commit
+          ref: f1e3fc2311fde45bf3e17b0e3349200be9caa4b4 # 2026-06-23
 
       - name: Install python deps
         run: |

--- a/.github/workflows/therock-rccl-test-packages-multi-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-multi-node.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 685f8c3b89006309b34a7c16de17e841400f0d76 # 2025-05-29 commit
+          ref: f1e3fc2311fde45bf3e17b0e3349200be9caa4b4 # 2026-06-23
 
       # Centralized arch-specific configuration
       - name: Set arch-specific paths

--- a/.github/workflows/therock-rccl-test-packages-single-node.yml
+++ b/.github/workflows/therock-rccl-test-packages-single-node.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: "ROCm/TheRock"
-          ref: 685f8c3b89006309b34a7c16de17e841400f0d76 # 2025-05-29 commit
+          ref: f1e3fc2311fde45bf3e17b0e3349200be9caa4b4 # 2026-06-23
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 300c0928ffba5ceb555db6ef59f4948210fe5b78 # 2026-06-17
+          ref: f1e3fc2311fde45bf3e17b0e3349200be9caa4b4 # 2026-06-23
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -80,7 +80,8 @@ jobs:
     with:
       artifact_run_id: ${{ inputs.artifact_run_id }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      test_runs_on: ${{ inputs.test_runs_on }}
+      # Use the runner selected by fetch_test_configurations.py
+      test_runs_on: ${{ fromJSON(needs.configure_test_matrix.outputs.sanity_component).test_runner }}
       platform: ${{ needs.configure_test_matrix.outputs.platform }}
       component: ${{ needs.configure_test_matrix.outputs.sanity_component }}
 
@@ -97,13 +98,17 @@ jobs:
     with:
       artifact_run_id: ${{ inputs.artifact_run_id }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
-      # If the test requires a multi GPU, use the multi GPU test runner
-      # Otherwise, use the standard test runner
+      # Route to the appropriate runner:
+      #   1. Multi-GPU components use the multi-GPU runner
+      #   2. CPU-only components use standard GitHub runners (azure-linux-scale-rocm)
+      #   3. Per-component runner (set by fetch_test_configurations.py)
       test_runs_on: >-
         ${{
-          matrix.components.multi_gpu_runner != '' &&
-            matrix.components.multi_gpu_runner ||
-            inputs.test_runs_on
+          (matrix.components.multi_gpu_runner != '' &&
+            matrix.components.multi_gpu_runner) ||
+          (matrix.components.linux_cpu_runner == true &&
+            'azure-linux-scale-rocm') ||
+          matrix.components.test_runner
         }}
       platform: ${{ needs.configure_test_matrix.outputs.platform }}
       component: ${{ toJSON(matrix.components) }}

--- a/.github/workflows/therock-test-packages.yml
+++ b/.github/workflows/therock-test-packages.yml
@@ -49,7 +49,15 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: 300c0928ffba5ceb555db6ef59f4948210fe5b78 # 2026-06-17
+          ref: f1e3fc2311fde45bf3e17b0e3349200be9caa4b4 # 2026-06-23
+
+      - name: Checkout CI config
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/therock-ci-config
+          ref: main
+          path: ci-config
+        continue-on-error: true
 
       - name: Setting up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
@@ -61,6 +69,7 @@ jobs:
           PROJECTS_TO_TEST: ${{ inputs.projects_to_test }}
           AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
           WINDOWS_HIP_ROCR_TESTS: ${{ contains(inputs.projects_to_test, 'hip-tests') }}
+          CI_CONFIG_PATH: ci-config
         id: configure
         run: python ./build_tools/github_actions/fetch_test_configurations.py
 

--- a/.github/workflows/therock_multi_arch_ci_asan.yml
+++ b/.github/workflows/therock_multi_arch_ci_asan.yml
@@ -40,7 +40,7 @@ concurrency:
 
 jobs:
   setup:
-    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@685f8c3b89006309b34a7c16de17e841400f0d76 # 2026-05-29 commit
+    uses: ROCm/TheRock/.github/workflows/setup_multi_arch.yml@f1e3fc2311fde45bf3e17b0e3349200be9caa4b4 # 2026-06-23
     with:
       build_variant: "host-asan"
       # targets gfx94X and gfx950 are selected to replicate the ASAN coverage in TheRock
@@ -50,7 +50,7 @@ jobs:
       prebuilt_stages: ${{ inputs.prebuilt_stages || '' }}
       baseline_run_id: ${{ inputs.baseline_run_id || '' }}
       repository: ROCm/TheRock
-      ref: "685f8c3b89006309b34a7c16de17e841400f0d76" # 2026-05-29 commit
+      ref: "f1e3fc2311fde45bf3e17b0e3349200be9caa4b4" # 2026-06-23
       external_repo: '{"repository":"${{ github.repository }}","ref":"${{ github.sha }}"}'
 
   linux_build_and_test:
@@ -61,7 +61,7 @@ jobs:
         needs.setup.outputs.linux_build_config != '' &&
         needs.setup.outputs.enable_build_jobs == 'true'
       }}
-    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@685f8c3b89006309b34a7c16de17e841400f0d76 # 2026-05-29 commit
+    uses: ROCm/TheRock/.github/workflows/multi_arch_ci_linux.yml@f1e3fc2311fde45bf3e17b0e3349200be9caa4b4 # 2026-06-23
     secrets: inherit
     with:
       build_config: ${{ needs.setup.outputs.linux_build_config }}
@@ -70,7 +70,7 @@ jobs:
       test_type: ${{ needs.setup.outputs.test_type }}
       external_repo_config: ${{ needs.setup.outputs.external_repo_config }}
       repository: ROCm/TheRock
-      ref: "685f8c3b89006309b34a7c16de17e841400f0d76" # 2026-05-29 commit
+      ref: "f1e3fc2311fde45bf3e17b0e3349200be9caa4b4" # 2026-06-23
     permissions:
       contents: read
       id-token: write
@@ -88,7 +88,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: "685f8c3b89006309b34a7c16de17e841400f0d76" # 2026-05-29 commit
+          ref: "f1e3fc2311fde45bf3e17b0e3349200be9caa4b4" # 2026-06-23
           sparse-checkout: build_tools/github_actions
           sparse-checkout-cone-mode: true
 


### PR DESCRIPTION
As we have to update runner labels and weights for build and test often
(particularly weights as we add capacity), this requires a lot of PRs in
TheRock, rocm-libraries and rocm-systems. Especially if a label is
pulled, it takes a few hours to propogate changes, resulting in delays

Now, we will use https://github.com/ROCm/therock-ci-config to retrieve
runner data and have it retrieve dynamically while also keeping history.
The purpose of https://github.com/ROCm/therock-ci-config is for a public
accessible config repo (instead of TheRock-Infra). It is needed to be
public for:
- forked repo PRs to operate normally
- ROCm / open-source developers to see label availability 
- what gfx archs are covered / able to be tested
- when and where each gfx target is tested in our CI
- we're opensource! public when we can

For TheRock, rocm-libraries, rocm-systems, etc, those repos will use
https://github.com/ROCm/therock-ci-config off of main. For testing, we
will open a feature branch in therock-ci-config and open a feature
branch in TheRock and test. if all looks good, we can merge in
therock-ci-config branch and this change will propogate to other repos
automatically.

Changes:
- using https://github.com/ROCm/therock-ci-config as configuration and
API loader
- adding fallback in case it does not checkout
(https://github.com/ROCm/TheRock/actions/runs/27294577756/job/80623947810?pr=5257#step:4:16)