### PR TITLE
clr: Use device-resident queue ring buffers

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1759,7 +1759,7 @@ hipError_t GraphExec::UpdateAQLPacket(hip::GraphNode* node) {
 // Append one 64-byte AQL packet to a flat buffer: copies the body, saves the original full_header
 // and invalidates the header.
 void GraphExec::PacketBatch::appendPacketToFlatBuffer(const uint8_t* pkt_raw,
-                                                      std::vector<uint8_t>& flatData,
+                                                      amd::AlignedVector64<uint8_t>& flatData,
                                                       std::vector<uint32_t>& fullHeaders) {
   static constexpr size_t kSigOff = 56;
   const size_t baseOff = flatData.size();
@@ -2031,7 +2031,7 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
     }
 
     const std::vector<const std::string*>* kernelNamesToDispatch;
-    const std::vector<uint8_t>* flatData;
+    const amd::AlignedVector64<uint8_t>* flatData;
     const std::vector<uint32_t>* flatHdrs;
 
     if (packetBatch.disabledNodeCount == 0) {
@@ -2727,13 +2727,7 @@ void GraphKernelArgManager::ReadBackOrFlush() {
   for (const auto& kernarg : kernarg_graph_) {
     const auto kernArgImpl = kernarg.first->settings().kernel_arg_impl_;
 
-    if (kernArgImpl == KernelArgImpl::DeviceKernelArgsHDP) {
-      // Trigger HDP flush
-      *kernarg.first->info().hdpMemFlushCntl = 1u;
-      // Read back to ensure flush completion
-      volatile int kSentinel = *reinterpret_cast<volatile int*>(kernarg.first->info().hdpMemFlushCntl);
-      (void)kSentinel; // Suppress unused variable warning
-    } else if (kernArgImpl == KernelArgImpl::DeviceKernelArgsReadback) {
+    if (kernArgImpl == KernelArgImpl::DeviceKernelArgsReadback) {
       const auto& pool = kernarg.second.back();
       if (pool.kernarg_pool_addr_ == 0) {
         continue;

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -22,6 +22,7 @@
 #include "hip_platform.hpp"
 #include "hip_mempool_impl.hpp"
 #include "hip_vm.hpp"
+#include "utils/nontemporal.hpp"
 
 typedef struct ihipExtKernelEvents {
   hipEvent_t startEvent_;
@@ -1131,12 +1132,13 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
     std::vector<const std::string*> enabledKernelNames;
 
     // Pre-built flat packet buffer for fast bulk dispatch (all nodes enabled).
-    std::vector<uint8_t> flatPacketData;
+    // 64-byte aligned so NT copies from this buffer can use aligned SIMD loads.
+    amd::AlignedVector64<uint8_t> flatPacketData;
     std::vector<uint32_t> validPacketFullHeaders;
 
     // Filtered flat buffer - built alongside enabledPackets when some nodes are disabled.
     // Allows the fast flat-dispatch path even in the partially-disabled case.
-    std::vector<uint8_t> filteredFlatPacketData;
+    amd::AlignedVector64<uint8_t> filteredFlatPacketData;
     std::vector<uint32_t> filteredValidPacketFullHeaders;
     bool filteredCacheValid = false;
 
@@ -1165,7 +1167,7 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
     // full_header dword, and invalidates the header. Zeroes completion_signal
     // (ApplyHwEventPatches re-patches it directly via flat_packet pointers at launch).
     static void appendPacketToFlatBuffer(const uint8_t* pkt_raw,
-                                         std::vector<uint8_t>& flatData,
+                                         amd::AlignedVector64<uint8_t>& flatData,
                                          std::vector<uint32_t>& fullHeaders);
   };
 

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -21,6 +21,7 @@
 #include "devkernel.hpp"
 #include "amdocl/cl_profile_amd.h"
 #include "devsignal.hpp"
+#include "utils/nontemporal.hpp"
 
 #if defined(__clang__)
 #if __has_feature(address_sanitizer)
@@ -651,6 +652,9 @@ struct Info : public amd::EmbeddedObject {
   //! large bar support.
   bool largeBar_;
 
+  //! CPU supports MOVDIR64B (atomic 64-byte write with WC buffer close).
+  bool movdir64b_;
+
   uint32_t hmmSupported_;            //!< ROCr supports HMM interfaces
   uint32_t hmmCpuMemoryAccessible_;  //!< CPU memory is accessible by GPU without pinning/register
   uint32_t hmmDirectHostAccess_;     //!< HMM memory is accessible from the host without migration
@@ -697,10 +701,8 @@ class Settings {
     HostKernelArgs = 0,        //!< Kernel Arguments are put into host memory
     DeviceKernelArgs,          //!< Device memory kernel arguments with no memory
                                //!< ordering workaround (e.g. XGMI)
-    DeviceKernelArgsReadback,  //!< Device memory kernel arguments with kernel
+    DeviceKernelArgsReadback   //!< Device memory kernel arguments with kernel
                                //!< argument readback workaround
-    DeviceKernelArgsHDP        //!< Device memory kernel arguments with kernel
-                               //!< argument readback plus HDP flush workaround.
   };
 
   uint64_t extensions_;  //!< Supported OCL extensions
@@ -727,7 +729,8 @@ class Settings {
       uint sdma_swap_supported_ : 1;         //!< SDMA linear swap copy (gfx94x/gfx95x)
       uint groupMemCarveout_ : 1;             //!< Group memory carveout functionality
       uint sdma_indirect_supported_ : 1;     //!< SDMA linear indirect copy (gfx1250+)
-      uint reserved_ : 9;
+      uint aql_device_ring_buf_ : 1;          //!< Place the AQL queue ring buffer in device memory
+      uint reserved_ : 8;
     };
     uint value_;
   };
@@ -1370,7 +1373,7 @@ class VirtualDevice : public amd::ReferenceCountedObject {
   virtual void HiddenHeapInit() = 0;
 
   //! Fast-path dispatch using a pre-built contiguous flat packet buffer.
-  virtual bool dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPacketData,
+  virtual bool dispatchAqlPacketBatchFlat(const amd::AlignedVector64<uint8_t>& flatPacketData,
                                           const std::vector<uint32_t>& validFullHeaders,
                                           amd::AccumulateCommand* vcmd = nullptr,
                                           bool attach_signal = false,

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -625,7 +625,6 @@ bool Device::create() {
 
   info_.hdpMemFlushCntl = hdpInfo.HDP_MEM_FLUSH_CNTL;
   info_.hdpRegFlushCntl = hdpInfo.HDP_REG_FLUSH_CNTL;
-  bool hasValidHDPFlush = (info_.hdpMemFlushCntl != nullptr) && (info_.hdpRegFlushCntl != nullptr);
 
   // Create HSA settings
   assert(!settings_);
@@ -633,7 +632,7 @@ bool Device::create() {
   settings_ = hsaSettings;
   if (!hsaSettings || !hsaSettings->create((agent_profile_ == HSA_PROFILE_FULL), *isa,
                                            isa->xnack() == amd::Isa::Feature::Enabled, coop_groups,
-                                           isXgmi_, hasValidHDPFlush)) {
+                                           isXgmi_)) {
     LogPrintfError("Unable to create settings for HSA device %s (PCI ID %x)", agent_name,
                    pciDeviceId_);
     return false;
@@ -1626,6 +1625,7 @@ bool Device::populateOCLDeviceConstants() {
     info_.cooperativeMultiDeviceGroups_ = settings().enableCoopMultiDeviceGroups_;
     // Enable StreamWrite and StreamWait for all devices
     info_.aqlBarrierValue_ = true;
+    info_.movdir64b_ = amd::hasMovdir64b();
   }
 
   info_.maxPipePacketSize_ = info_.maxMemAllocSize_;
@@ -3011,10 +3011,8 @@ VirtualGPU* Device::xferQueue() const {
       return nullptr;
     }
     if (xferQueue_->gpu_queue() == nullptr) {
-      void* md_rb = nullptr;
       xferQueue_->SetGpuQueue(
-          thisDevice->AcquireActiveQueue(amd::CommandQueue::Priority::Normal,
-                                         nullptr, nullptr, &md_rb), md_rb);
+          thisDevice->AcquireActiveQueue(amd::CommandQueue::Priority::Normal));
     }
   }
   xferQueue_->enableSyncBlit();
@@ -3068,8 +3066,7 @@ void Device::getHwEventTime(const amd::Event& event, uint64_t* start, uint64_t* 
 // ================================================================================================
 hsa_queue_t* Device::getQueueFromPool(const uint qIndex, bool force_reuse,
                                       hsa_queue_t* preferred,
-                                      const std::unordered_set<uint64_t>* excluded_ids,
-                                      void** metadata_ring_buffer) {
+                                      const std::unordered_set<uint64_t>* excluded_ids) {
   // Only reuse queues when we've reached the maximum limit, unless forced
   // Below the limit, return nullptr to allow creating new queues
   if (!force_reuse && queuePool_[qIndex].size() < settings().max_hw_queues_) {
@@ -3086,9 +3083,6 @@ hsa_queue_t* Device::getQueueFromPool(const uint qIndex, bool force_reuse,
         auto it = queuePool_[qIndex].find(preferred);
         if (it != queuePool_[qIndex].end()) {
           it->second.refCount++;
-          if (metadata_ring_buffer) {
-            *metadata_ring_buffer = it->second.metadataRingBuffer_;
-          }
           ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
                   "Reusing preferred queue: %p refCount: %d",
                   it->first->base_address, it->second.refCount);
@@ -3135,9 +3129,6 @@ hsa_queue_t* Device::getQueueFromPool(const uint qIndex, bool force_reuse,
         });
 
     lowest->second.refCount++;
-    if (metadata_ring_buffer) {
-      *metadata_ring_buffer = lowest->second.metadataRingBuffer_;
-    }
     ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
             "Selected queue (mode=%u): %p refCount: %d, depth: %lu, metric: %lu, pipe: %d%s%s",
             mode, lowest->first->base_address, lowest->second.refCount,
@@ -3155,12 +3146,10 @@ hsa_queue_t* Device::getQueueFromPool(const uint qIndex, bool force_reuse,
 // ================================================================================================
 hsa_queue_t* Device::AcquireActiveQueue(amd::CommandQueue::Priority priority,
                                         hsa_queue_t* preferred,
-                                        const std::unordered_set<uint64_t>* excluded_ids,
-                                        void** metadata_ring_buffer) {
+                                        const std::unordered_set<uint64_t>* excluded_ids) {
   uint32_t queue_size = ROC_AQL_QUEUE_SIZE;
   auto queue = acquireQueue(queue_size, false, std::vector<uint32_t>{},
-                            priority, true, false, preferred, excluded_ids,
-                            metadata_ring_buffer);
+                            priority, true, false, preferred, excluded_ids);
   return queue;
 }
 
@@ -3169,8 +3158,7 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
                                   const std::vector<uint32_t>& cuMask,
                                   amd::CommandQueue::Priority priority, bool managed,
                                   bool dedicated_queue, hsa_queue_t* preferred,
-                                  const std::unordered_set<uint64_t>* excluded_ids,
-                                  void** metadata_ring_buffer) {
+                                  const std::unordered_set<uint64_t>* excluded_ids) {
   hsa_amd_queue_priority_t queue_priority;
   uint qIndex;
   switch (priority) {
@@ -3222,8 +3210,7 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
     // decide when to start reclaiming queues.
     if (!coop_queue && (cuMask.size() == 0) &&
         (queuePool_[qIndex].size() >= settings().max_hw_queues_)) {
-      hsa_queue_t* queue = getQueueFromPool(qIndex, false, preferred, excluded_ids,
-                                            metadata_ring_buffer);
+      hsa_queue_t* queue = getQueueFromPool(qIndex, false, preferred, excluded_ids);
       if (queue != nullptr) {
         if (!managed) {
           num_queues_[qIndex]++;
@@ -3242,84 +3229,22 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
   }
   auto queue_size = (queue_max_packets < queue_size_hint) ? queue_max_packets : queue_size_hint;
 
-  hsa_queue_t* queue;
   auto queue_type = HSA_QUEUE_TYPE_MULTI;
 
-  // Enable cooperative queue for the device queue
   if (coop_queue) {
     queue_type = HSA_QUEUE_TYPE_COOPERATIVE;
   }
 
-  while (Hsa::queue_create(bkendDevice_, queue_size, queue_type, callbackQueue, this,
-                           std::numeric_limits<uint>::max(), std::numeric_limits<uint>::max(),
-                           &queue) != HSA_STATUS_SUCCESS) {
-    queue_size >>= 1;
-    if (queue_size < 64) {
-      LogError("Device::acquireQueue: hsa_queue_create failed!");
-      // If we can't create even a small queue, try to reuse any existing queue
-      if (!coop_queue && (cuMask.size() == 0)) {
-        amd::ScopedLock l(active_queue_access_);
-        if (queuePool_[qIndex].size() > 0) {
-          bool kForceReuse = true;
-          return getQueueFromPool(qIndex, kForceReuse, nullptr, nullptr,
-                                  metadata_ring_buffer);
-        }
-      }
-      ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE,
-              "Device::acquireQueue: hsa_queue_create failed!");
-      return nullptr;
-    }
-  }
-
-  // default priority is normal so no need to set it again
-  if (queue_priority != HSA_AMD_QUEUE_PRIORITY_NORMAL) {
-    hsa_status_t st = Hsa::queue_set_priority(queue, queue_priority);
-    if (st != HSA_STATUS_SUCCESS) {
-      ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE,
-              "Device::acquireQueue: hsa_amd_queue_set_priority failed!");
-      Hsa::queue_destroy(queue);
-      return nullptr;
-    }
-  }
-
-  ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
-          "Created SWq=%p to map on HWq=%p with "
-          "size %d with priority %d, cooperative: %i",
-          queue, queue->base_address, queue_size, queue_priority, coop_queue);
-
-  Hsa::profiling_set_profiler_enabled(queue, 1);
-
-  // Query metadata prefetch version once from the first queue created on this device.
-  // The version is identical for all queues.
-  if (!metadata_version_queried_) {
-    uint8_t major = 0, minor = 0;
-    hsa_amd_queue_get_info(queue,
-        HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_DISPATCH_PKT_VERSION_MAJOR, &major);
-    hsa_amd_queue_get_info(queue,
-        HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_DISPATCH_PKT_VERSION_MINOR, &minor);
-    if (major < (1 << 3) && minor < (1 << 5)) {
-      metadata_version_header_ =
-          (static_cast<uint32_t>(major) << HSA_AMD_METADATA_PACKET_HEADER_VERSION_MAJOR) |
-          (static_cast<uint32_t>(minor) << HSA_AMD_METADATA_PACKET_HEADER_VERSION_MINOR);
-    }
-    metadata_version_queried_ = true;
-  }
-
+  // Resolve the final CU mask (merge custom + global, expand for WGP mode)
+  std::vector<uint32_t> final_mask;
   if (cuMask.size() != 0 || info_.globalCUMask_.size() != 0) {
-    std::stringstream ss;
-    ss << std::hex;
-    std::vector<uint32_t> mask = {};
-
-    // handle scenarios where cuMask (custom-defined), globalCUMask_ or both are valid and
-    // fill the final mask which will be appiled to the current queue
+    std::vector<uint32_t> mask;
     if (cuMask.size() != 0 && info_.globalCUMask_.size() == 0) {
       mask = cuMask;
     } else if (cuMask.size() != 0 && info_.globalCUMask_.size() != 0) {
       for (unsigned int i = 0; i < std::min(cuMask.size(), info_.globalCUMask_.size()); i++) {
         mask.push_back(cuMask[i] & info_.globalCUMask_[i]);
       }
-      // check to make sure after ANDing cuMask (custom-defined) with global
-      // CU mask, we have non-zero mask, oterwise just apply global CU mask
       bool zeroCUMask = true;
       for (auto m : mask) {
         if (m != 0) {
@@ -3334,28 +3259,13 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
       mask = info_.globalCUMask_;
     }
 
-
-    for (int i = mask.size() - 1; i >= 0; i--) {
-      ss << std::setfill('0') << std::setw(8) << mask[i];
-    }
-    ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Setting CU mask 0x%s for hardware queue %p",
-            ss.str().c_str(), queue->base_address);
-
-    std::vector<uint32_t> final_mask = {};
-    // hsa_amd_queue_cu_set_mask expects each bit in cuMask to represent each CU
-    // For wgp mode: Each wgp consists of 2 CUs and CUs must be adjacent pairwise enabled
-    // Convert each bit in the cuMask from wgp to cu by duplicating it
     if (settings().enableWgpMode_) {
       final_mask.resize(mask.size() * 2, 0);
-
-      for (int i = 0; i < mask.size(); i++) {
+      for (size_t i = 0; i < mask.size(); i++) {
         for (int j = 0; j < 16; j++) {
-          // Convert least significant 16 bits
           if (((mask[i] >> j) & 0x1) == 0x1) {
             final_mask[2 * i] |= (0x3 << (2 * j));
           }
-
-          // Convert most significant 16 bits
           if (((mask[i] >> (16 + j)) & 0x1) == 0x1) {
             final_mask[2 * i + 1] |= (0x3 << (2 * j));
           }
@@ -3364,29 +3274,115 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
     } else {
       final_mask = mask;
     }
+  }
 
-    hsa_status_t status = Hsa::queue_cu_set_mask(queue, final_mask.size() * 32, final_mask.data());
-    if (status != HSA_STATUS_SUCCESS) {
+  // Build the queue creation descriptor with priority, CU mask, and flags.
+  // settings().aql_device_ring_buf_ controls queue ring buffer placement (enabled
+  // by default on gfx94x/gfx125x, overridable via DEBUG_CLR_AQL_DEV_QUEUE):
+  //   false - system memory
+  //   true  - ring buffer in device memory if Large BAR is available.
+  const bool device_mem_ring_buf =
+      settings().aql_device_ring_buf_ && info_.largeBar_ && Hsa::amd_queue_create_available();
+  hsa_amd_queue_create_desc_t desc = {};
+  desc.version = HSA_AMD_QUEUE_CREATE_DESC_VERSION;
+  desc.engine_type = HSA_AMD_QUEUE_ENGINE_COMPUTE;
+  desc.queue_size_bytes = queue_size * sizeof(hsa_kernel_dispatch_packet_t);
+  desc.priority = queue_priority;
+  desc.callback = callbackQueue;
+  desc.callback_data = this;
+  desc.engine.compute.type = queue_type;
+  desc.engine.compute.private_segment_size = HSA_AMD_PRIVATE_SEGMENT_SIZE_DEFAULT;
+  if (device_mem_ring_buf) {
+    desc.flags = static_cast<hsa_amd_queue_create_flag_t>(
+        desc.flags | HSA_AMD_QUEUE_CREATE_DEVICE_MEM_RING_BUF);
+  }
+  if (!final_mask.empty()) {
+    desc.engine.compute.cu_mask_count = static_cast<uint32_t>(final_mask.size() * 32);
+    desc.engine.compute.cu_mask = final_mask.data();
+  }
+
+  while (Hsa::amd_queue_create(bkendDevice_, &desc, 1) != HSA_STATUS_SUCCESS) {
+    queue_size >>= 1;
+    desc.queue_size_bytes = queue_size * sizeof(hsa_kernel_dispatch_packet_t);
+    if (queue_size < 64) {
+      LogError("Device::acquireQueue: hsa_amd_queue_create failed!");
+      if (!coop_queue && (cuMask.size() == 0)) {
+        amd::ScopedLock l(active_queue_access_);
+        if (queuePool_[qIndex].size() > 0) {
+          bool kForceReuse = true;
+          return getQueueFromPool(qIndex, kForceReuse);
+        }
+      }
       ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE,
-              "Device::acquireQueue: hsa_amd_queue_cu_set_mask failed!");
-      Hsa::queue_destroy(queue);
+              "Device::acquireQueue: hsa_amd_queue_create failed!");
       return nullptr;
     }
+  }
 
-    if (metadata_ring_buffer) {
-      hsa_amd_queue_get_info(queue, HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER,
-                             metadata_ring_buffer);
+  hsa_queue_t* queue = desc.queue;
+  if (IsLogEnabled(amd::LOG_INFO, amd::LOG_QUEUE)) {
+    if (!final_mask.empty()) {
+      std::stringstream ss;
+      ss << std::hex;
+      for (int i = final_mask.size() - 1; i >= 0; i--) {
+        ss << std::setfill('0') << std::setw(8) << final_mask[i];
+      }
+      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+              "Created SWq=%p HWq=%p size %d priority %d cooperative %i flags 0x%x "
+              "device_mem_ring_buf %i CU mask 0x%s",
+              queue, queue->base_address, queue_size, queue_priority, coop_queue, desc.flags,
+              device_mem_ring_buf, ss.str().c_str());
+    } else {
+      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+              "Created SWq=%p HWq=%p size %d priority %d cooperative %i flags 0x%x "
+              "device_mem_ring_buf %i",
+              queue, queue->base_address, queue_size, queue_priority, coop_queue, desc.flags,
+              device_mem_ring_buf);
     }
+  }
+
+  Hsa::profiling_set_profiler_enabled(queue, 1);
+
+  if (!metadata_version_queried_) {
+    uint8_t major = 0, minor = 0;
+    hsa_amd_queue_get_info(queue,
+        HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_DISPATCH_PKT_VERSION_MAJOR, &major);
+    hsa_amd_queue_get_info(queue,
+        HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_DISPATCH_PKT_VERSION_MINOR, &minor);
+    if (major < (1 << 3) && minor < (1 << 5)) {
+      metadata_version_header_ =
+          (static_cast<uint32_t>(major) << HSA_AMD_METADATA_PACKET_HEADER_VERSION_MAJOR) |
+          (static_cast<uint32_t>(minor) << HSA_AMD_METADATA_PACKET_HEADER_VERSION_MINOR);
+    }
+    metadata_version_queried_ = true;
+  }
+
+  // Query extras for the newly-created queue and insert into the lookup map
+  auto populateExtras = [&]() {
+    QueueExtras extras;
+    extras.deviceMemRingBuf = (desc.flags & HSA_AMD_QUEUE_CREATE_DEVICE_MEM_RING_BUF) != 0;
+    hsa_amd_queue_get_info(queue, HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER,
+                           &extras.metadataRingBuffer);
+    if (DEBUG_CLR_DIRECT_DOORBELL) {
+      uint64_t db_id = 0;
+      if (hsa_amd_queue_get_info(queue, HSA_AMD_QUEUE_INFO_DOORBELL_ID, &db_id) ==
+              HSA_STATUS_SUCCESS &&
+          db_id != 0) {
+        extras.doorbellPtr = reinterpret_cast<volatile uint64_t*>(db_id);
+      }
+    }
+    queue_extras_[queue] = extras;
+  };
+
+  if (!final_mask.empty()) {
+    amd::ScopedLock l(active_queue_access_);
+    populateExtras();
     return queue;
   }
 
   if (coop_queue) {
-    // Skip queue recycling for cooperative queues, since it should be just one
-    // per device.
-    if (metadata_ring_buffer) {
-      hsa_amd_queue_get_info(queue, HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER,
-                             metadata_ring_buffer);
-    }
+    amd::ScopedLock l(active_queue_access_);
+    populateExtras();
     return queue;
   }
 
@@ -3397,11 +3393,7 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
   auto& qInfo = result.first->second;
   qInfo.refCount = 1;
   qInfo.hasDedicatedQueue_ = dedicated_queue;
-  hsa_amd_queue_get_info(queue, HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER,
-                         &qInfo.metadataRingBuffer_);
-  if (metadata_ring_buffer) {
-    *metadata_ring_buffer = qInfo.metadataRingBuffer_;
-  }
+  populateExtras();
   ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "acquireQueue refCount: %p (%d) %s",
           result.first->first->base_address, result.first->second.refCount,
           dedicated_queue ? "(dedicated)" : "");
@@ -3464,8 +3456,19 @@ void Device::releaseQueue(hsa_queue_t* queue, const std::vector<uint32_t>& cuMas
   if (!cuMask.empty() || coop_queue) {
     ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting CG enabled hardware queue %p ",
             queue->base_address);
+    {
+      amd::ScopedLock l(active_queue_access_);
+      queue_extras_.erase(queue);
+    }
     Hsa::queue_destroy(queue);
   }
+}
+
+// ================================================================================================
+Device::QueueExtras Device::GetQueueExtras(hsa_queue_t* queue) {
+  amd::ScopedLock l(active_queue_access_);
+  auto it = queue_extras_.find(queue);
+  return (it != queue_extras_.end()) ? it->second : QueueExtras{};
 }
 
 bool Device::findLinkInfo(const amd::Device& other_device, std::vector<LinkAttrType>* link_attrs) {

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -567,14 +567,20 @@ class Device : public NullDevice {
 
   VirtualGPU* xferQueue() const;
 
+  struct QueueExtras {
+    void* metadataRingBuffer = nullptr;
+    //! Cached hardware doorbell (UC MMIO), only set when DEBUG_CLR_DIRECT_DOORBELL is enabled.
+    volatile uint64_t* doorbellPtr = nullptr;
+    bool deviceMemRingBuf = false;
+  };
+
   //! Acquire HSA queue. This method can create a new HSA queue or
   hsa_queue_t* acquireQueue(
       uint32_t queue_size_hint, bool coop_queue = false, const std::vector<uint32_t>& cuMask = {},
       amd::CommandQueue::Priority priority = amd::CommandQueue::Priority::Normal,
       bool managed = false, bool dedicated_queue = false,
       hsa_queue_t* preferred = nullptr,
-      const std::unordered_set<uint64_t>* excluded_ids = nullptr,
-      void** metadata_ring_buffer = nullptr);
+      const std::unordered_set<uint64_t>* excluded_ids = nullptr);
 
   //! Release HSA queue
   void releaseQueue(hsa_queue_t*, const std::vector<uint32_t>& cuMask = {}, bool coop_queue = false,
@@ -582,9 +588,11 @@ class Device : public NullDevice {
 
   hsa_queue_t* AcquireActiveQueue(amd::CommandQueue::Priority priority,
                                    hsa_queue_t* preferred = nullptr,
-                                   const std::unordered_set<uint64_t>* excluded_ids = nullptr,
-                                   void** metadata_ring_buffer = nullptr);
+                                   const std::unordered_set<uint64_t>* excluded_ids = nullptr);
   bool ReleaseActiveQueue(hsa_queue_t* queue, amd::CommandQueue::Priority priority);
+
+  //! Look up per-queue extras (metadata ring buffer and placement).
+  QueueExtras GetQueueExtras(hsa_queue_t* queue);
 
   //! Return the pre-computed metadata packet version header bits
   uint32_t MetadataVersionHeader() const { return metadata_version_header_; }
@@ -710,10 +718,9 @@ class Device : public NullDevice {
   struct QueueInfo {
     int refCount;             //! Reference counter. Shows how many time the queue was shared
     bool hasDedicatedQueue_;  //! True if this queue is a dedicated queue (e.g., null stream)
-    void* metadataRingBuffer_; //! Metadata prefetch ring buffer base
 
     // Constructor
-    QueueInfo() : refCount(0), hasDedicatedQueue_(false), metadataRingBuffer_(nullptr) {}
+    QueueInfo() : refCount(0), hasDedicatedQueue_(false) {}
 
     //! Get the current hardware queue depth (wptr - rptr)
     static uint64_t GetHwQueueDepth(hsa_queue_t* queue) {
@@ -748,8 +755,11 @@ class Device : public NullDevice {
   //! Use dynamic queues mode to get a queue from pool
   hsa_queue_t* getQueueFromPool(const uint qIndex, bool force_reuse = false,
                                 hsa_queue_t* preferred = nullptr,
-                                const std::unordered_set<uint64_t>* excluded_ids = nullptr,
-                                void** metadata_ring_buffer = nullptr);
+                                const std::unordered_set<uint64_t>* excluded_ids = nullptr);
+
+  //! Per-queue extras (metadata ring buffer and placement), keyed by queue pointer.
+  //! Populated at queue creation, erased when non-pooled queues are destroyed.
+  std::unordered_map<hsa_queue_t*, QueueExtras> queue_extras_;
 
   //! returns value for corresponding LinkAttrbutes in a vector given Memory pool.
   virtual bool findLinkInfo(const hsa_amd_memory_pool_t& pool,

--- a/projects/clr/rocclr/device/rocm/rocrctx.cpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.cpp
@@ -93,6 +93,7 @@ bool Hsa::LoadLib() {
   GET_ROCR_SYMBOL(hsa_amd_signal_create)
   GET_ROCR_SYMBOL(hsa_amd_register_system_event_handler)
   GET_ROCR_SYMBOL(hsa_amd_queue_set_priority)
+  GET_ROCR_OPTIONAL_SYMBOL(hsa_amd_queue_create)
   GET_ROCR_SYMBOL(hsa_amd_memory_async_copy_rect)
   GET_ROCR_SYMBOL(hsa_amd_memory_lock_to_pool)
   GET_ROCR_SYMBOL(hsa_amd_signal_value_pointer)

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -25,6 +25,9 @@
 #include "hsa/hsa_ven_amd_aqlprofile.h"
 #endif
 
+typedef hsa_status_t HSA_API hsa_amd_queue_create_fn(
+    hsa_agent_t agent, hsa_amd_queue_create_desc_t* descs, uint32_t num_descs);
+
 namespace amd {
 namespace roc {
 
@@ -102,6 +105,7 @@ struct RocrEntryPoints {
   decltype(hsa_amd_signal_create)* hsa_amd_signal_create_;
   decltype(hsa_amd_register_system_event_handler)* hsa_amd_register_system_event_handler_;
   decltype(hsa_amd_queue_set_priority)* hsa_amd_queue_set_priority_;
+  hsa_amd_queue_create_fn* hsa_amd_queue_create_;
   decltype(hsa_amd_memory_async_copy_rect)* hsa_amd_memory_async_copy_rect_;
   decltype(hsa_amd_memory_lock_to_pool)* hsa_amd_memory_lock_to_pool_;
   decltype(hsa_amd_signal_value_pointer)* hsa_amd_signal_value_pointer_;
@@ -151,7 +155,7 @@ struct RocrEntryPoints {
     return false;                                                                                 \
   }
 #define GET_ROCR_OPTIONAL_SYMBOL(NAME)                                                            \
-  cep_.NAME = reinterpret_cast<t_##NAME>(Os::getSymbol(cep_.handle, #NAME));
+  cep_.NAME##_ = reinterpret_cast<NAME##_fn*>(Os::getSymbol(cep_.handle, #NAME));
 #else
 #define ROCR_DYN(NAME) NAME
 #define GET_ROCR_SYMBOL(NAME)
@@ -431,6 +435,22 @@ class Hsa : public amd::AllStatic {
   }
   static hsa_status_t queue_set_priority(hsa_queue_t* queue, hsa_amd_queue_priority_t priority) {
     return ROCR_DYN(hsa_amd_queue_set_priority)(queue, priority);
+  }
+  static bool amd_queue_create_available() {
+#ifdef ROCR_DYN_DLL
+    return ROCR_DYN(hsa_amd_queue_create) != nullptr;
+#else
+    return true;
+#endif
+  }
+  static hsa_status_t amd_queue_create(hsa_agent_t agent,
+                                       hsa_amd_queue_create_desc_t* descs,
+                                       uint32_t num_descs) {
+#ifdef ROCR_DYN_DLL
+    return ROCR_DYN(hsa_amd_queue_create)(agent, descs, num_descs);
+#else
+    return hsa_amd_queue_create(agent, descs, num_descs);
+#endif
   }
   static hsa_status_t memory_async_copy_rect(
     const hsa_pitched_ptr_t* dst, const hsa_dim3_t* dst_offset, const hsa_pitched_ptr_t* src,

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -73,6 +73,7 @@ Settings::Settings() {
   barrier_value_packet_ = false;
   ext_dispatch_packet_ = false;
   kernel_arg_impl_ = KernelArgImpl::HostKernelArgs;
+  aql_device_ring_buf_ = false;
   gwsInitSupported_ = true;
   limit_blit_wg_ = 16;
 
@@ -87,7 +88,7 @@ Settings::Settings() {
 
 // ================================================================================================
 bool Settings::create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, bool coop_groups,
-                      bool isXgmi, bool hasValidHDPFlush) {
+                      bool isXgmi) {
   uint32_t gfxipMajor = isa.versionMajor();
   uint32_t gfxipMinor = isa.versionMinor();
   uint32_t gfxStepping = isa.versionStepping();
@@ -150,7 +151,7 @@ bool Settings::create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, b
     sdma_swap_supported_ = true;
   }
 
-  setKernelArgImpl(isa, isXgmi, hasValidHDPFlush);
+  setKernelArgImpl(isa, isXgmi);
 
   if (gfxipMajor >= 10) {
      enableWave32Mode_ = true;
@@ -238,7 +239,7 @@ void Settings::override() {
 }
 
 // ================================================================================================
-void Settings::setKernelArgImpl(const amd::Isa& isa, bool isXgmi, bool hasValidHDPFlush) {
+void Settings::setKernelArgImpl(const amd::Isa& isa, bool isXgmi) {
   const uint32_t gfxipMajor = isa.versionMajor();
   const uint32_t gfxipMinor = isa.versionMinor();
   const uint32_t gfxStepping = isa.versionStepping();
@@ -246,40 +247,33 @@ void Settings::setKernelArgImpl(const amd::Isa& isa, bool isXgmi, bool hasValidH
   const bool isGfx94x = gfxipMajor == 9 && gfxipMinor >= 4 &&
                         (gfxStepping == 0 || gfxStepping == 1 || gfxStepping == 2);
   const bool isGfx90a = (gfxipMajor == 9 && gfxipMinor == 0 && gfxStepping == 10);
-  const bool isPreGfx908 =
-      (gfxipMajor < 9) || ((gfxipMajor == 9) && (gfxipMinor == 0) && (gfxStepping < 8));
-  const bool isGfx101x = (gfxipMajor == 10) && ((gfxipMinor == 0) || (gfxipMinor == 1));
-  const bool isGfx125x =
-      (gfxipMajor == 12) && ((gfxipMinor >= 5));
+  const bool isGfx125x = (gfxipMajor == 12) && ((gfxipMinor >= 5));
 
   auto kernelArgImpl = KernelArgImpl::HostKernelArgs;
-
-  hasValidHDPFlush &= DEBUG_CLR_KERNARG_HDP_FLUSH_WA;
 
   if (isXgmi) {
     // The XGMI-connected path does not require the manual memory ordering
     // workarounds that the PCIe connected path requires
     kernelArgImpl = KernelArgImpl::DeviceKernelArgs;
-  } else if (hasValidHDPFlush) {
-    // If the HDP flush register is valid implement the HDP flush to MMIO
-    // workaround.
-    if (!(isPreGfx908 || isGfx101x)) {
-      kernelArgImpl = KernelArgImpl::DeviceKernelArgsHDP;
-    }
   } else if (isGfx94x || isGfx90a || isGfx125x) {
     // Implement the kernel argument readback workaround
     // (write all args -> sfence -> write last byte -> mfence -> read last byte)
     kernelArgImpl = KernelArgImpl::DeviceKernelArgsReadback;
   }
 
-  // Enable device kernel args for gfx94x for now
+  // Enable device kernel args and device-memory AQL queue ring buffers by
+  // default on gfx94x/gfx125x.
   if (isGfx94x || isGfx125x) {
     kernel_arg_impl_ = kernelArgImpl;
     kernel_arg_opt_ = true;
+    aql_device_ring_buf_ = true;
   }
 
   if (!flagIsDefault(HIP_FORCE_DEV_KERNARG)) {
     kernel_arg_impl_ = kernelArgImpl & (HIP_FORCE_DEV_KERNARG ? 0xF : 0x0);
+  }
+  if (!flagIsDefault(DEBUG_CLR_AQL_DEV_QUEUE)) {
+    aql_device_ring_buf_ = (DEBUG_CLR_AQL_DEV_QUEUE > 0);
   }
 }
 }  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocsettings.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.hpp
@@ -69,7 +69,7 @@ class Settings : public device::Settings {
 
   //! Creates settings
   bool create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, bool coop_groups = false,
-              bool isXgmi = false, bool hasValidHDPFlush = true);
+              bool isXgmi = false);
 
  private:
   //! Disable copy constructor
@@ -83,7 +83,7 @@ class Settings : public device::Settings {
 
   //! Determine how kernel arguments should be implemented given ASIC (host
   //! memory, device memory, device memory with memory ordering workaround)
-  void setKernelArgImpl(const amd::Isa& isa, bool isXgmi, bool hasValidHDPFlush);
+  void setKernelArgImpl(const amd::Isa& isa, bool isXgmi);
 };
 
 /*@}*/  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -8,6 +8,7 @@
 #include "device/rocm/rocdevice.hpp"
 #include "device/rocm/rocvirtual.hpp"
 #include "device/rocm/rockernel.hpp"
+#include "utils/nontemporal.hpp"
 #include "device/rocm/rocmemory.hpp"
 #include "device/rocm/rocblit.hpp"
 #include "device/rocm/roccounters.hpp"
@@ -30,13 +31,6 @@
 #include <atomic>
 #include <cinttypes>
 
-#if defined(__AVX__)
-#if defined(__MINGW64__)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
-#endif
 
 /**
  * HSA image object size in bytes (see HSA spec)
@@ -1094,8 +1088,9 @@ bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address para
 }
 
 // ================================================================================================
-void VirtualGPU::SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer) {
+void VirtualGPU::SetGpuQueue(hsa_queue_t* queue) {
   gpu_queue_ = queue;
+
   cached_read_dispatch_id_ = 0;
   // The cached queue-progress state belongs to the previously assigned HW queue. When the HW
   // queue changes (released back to / reacquired from the shared dynamic-queue pool), that state
@@ -1105,16 +1100,25 @@ void VirtualGPU::SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer) {
   last_write_index_ = kInvalidQueueIndex;
   last_packet_with_signal_index_ = kInvalidQueueIndex;
   last_completion_signal_.handle = 0;
-  metadata_preloader_.SetQueueBase(metadata_ring_buffer,
-                                   roc_device_.MetadataVersionHeader());
+
+  if (queue) {
+    auto extras = roc_device_.GetQueueExtras(queue);
+    device_mem_ring_buf_ = extras.deviceMemRingBuf;
+    doorbell_ptr_ = extras.doorbellPtr;
+    metadata_preloader_.SetQueueBase(extras.metadataRingBuffer,
+                                     roc_device_.MetadataVersionHeader());
+  } else {
+    device_mem_ring_buf_ = false;
+    doorbell_ptr_ = nullptr;
+    metadata_preloader_.SetQueueBase(nullptr, roc_device_.MetadataVersionHeader());
+  }
 }
 
 // ================================================================================================
 void VirtualGPU::AcquireQueueWithPreference() {
   std::scoped_lock lock(execution());
   if (!dedicated_queue_ && gpu_queue_ == nullptr && last_hwq_ != nullptr) {
-    void* md_rb = nullptr;
-    SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, last_hwq_, nullptr, &md_rb), md_rb);
+    SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, last_hwq_));
     last_hwq_ = nullptr;
   }
 }
@@ -1130,8 +1134,7 @@ bool VirtualGPU::ReacquireQueueExcluding(const std::unordered_set<uint64_t>& exc
     roc_device_.releaseQueue(gpu_queue_, std::vector<uint32_t>{}, false, true);
     gpu_queue_ = nullptr;
   }
-  void* md_rb = nullptr;
-  SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, nullptr, &excluded_ids, &md_rb), md_rb);
+  SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, nullptr, &excluded_ids));
   return gpu_queue_ != nullptr;
 }
 
@@ -1140,8 +1143,7 @@ uint64_t VirtualGPU::getQueueID() {
   std::scoped_lock lock(execution());
   // Dedicated queues keep their HW queue, never acquire from pool
   if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-    void* md_rb = nullptr;
-    SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb), md_rb);
+    SetGpuQueue(roc_device_.AcquireActiveQueue(priority_));
   }
   return gpu_queue_->id;
 }
@@ -1260,6 +1262,58 @@ std::string VirtualGPU::AnalyzeAqlQueue() const {
 }
 
 // ================================================================================================
+// Write an AQL packet to the ring buffer with metadata prefetch.
+//
+// MOVDIR64B + device memory path (2 sfences):
+//   metadata MOVDIR64B → sfence → AQL MOVDIR64B → ROCr doorbell sfence → doorbell
+//
+// Legacy + device memory (2 sfences):
+//   AQL body NT → metadata 4x64B NT (staged) → sfence → AQL header → sfence → doorbell
+//   (body+header within each 64B NT copy share one WC buffer fill — no internal sfence)
+//
+// Legacy + system memory (3 sfences):
+//   AQL body NT → metadata direct writes → sfence(body→hdr) → metadata headers →
+//   sfence → AQL header → sfence → doorbell
+template <typename AqlPacket>
+void VirtualGPU::writePacketToRingBuffer(AqlPacket* aql_loc, AqlPacket* packet,
+                                         uint16_t header, uint16_t rest, uint64_t slot_index) {
+  bool use_movdir64b = roc_device_.info().movdir64b_ && device_mem_ring_buf_;
+  if (header == 0) {
+    // Some vendor-specific packets are already fully formed by the caller.
+    // Preserve the first dword instead of using nontemporalCopyAQL(), which
+    // intentionally clears it for the split body/header publication path.
+    static_assert(sizeof(AqlPacket) == 64, "AQL packets must be 64 bytes");
+    if (use_movdir64b) {
+      amd::movdir64b_copy64(aql_loc, packet);
+    } else {
+      amd::nontemporalMemcpy(aql_loc, packet, sizeof(AqlPacket));
+    }
+    return;
+  }
+
+  if (use_movdir64b) {
+    metadata_preloader_.SetMetadata(packet, header, slot_index, true, device_mem_ring_buf_);
+    amd::nontemporalStoreFence();
+    amd::nontemporalWriteAQL(aql_loc, packet, header, rest);
+  } else {
+    amd::nontemporalCopyAQL(aql_loc, packet);
+    metadata_preloader_.SetMetadata(packet, header, slot_index, false, device_mem_ring_buf_);
+    amd::nontemporalStoreFence();
+    packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), header, rest);
+  }
+}
+
+// ================================================================================================
+void VirtualGPU::ringQueueDoorbell(uint64_t index) {
+  if (doorbell_ptr_) {
+    amd::ringDoorbell(doorbell_ptr_, index,
+                      roc_device_.info().movdir64b_ && device_mem_ring_buf_);
+  } else {
+    Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
+  }
+}
+
+// ================================================================================================
 template <typename AqlPacket>
 bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, uint16_t rest,
                                           bool blocking, bool attach_signal, bool cluster_launch) {
@@ -1330,31 +1384,27 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
   TrackQueueProgress(*packet, index);
 
   AqlPacket* aql_loc = &((AqlPacket*)(gpu_queue_->base_address))[index & queueMask];
-  *aql_loc = *packet;
+  writePacketToRingBuffer(aql_loc, packet, header, rest, index & queueMask);
 
-  metadata_preloader_.Set(packet, header, index & queueMask);
-  if (header != 0) {
-    packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), header, rest);
-  }
-  // Gate the entire dispatch-packet logging path on the log level.
-  if (IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
-    char buf[32];
-    const char* virtual_pipe_prefix = "";
-    if (roc_device_.settings().queue_pipe_dist_) {
-      snprintf(buf, sizeof(buf), " virtual_pipe_id=%zu,",
-               gpu_queue_->id % roc_device_.NumHwPipes());
-      virtual_pipe_prefix = buf;
-    }
-    const uint64_t rptr = Hsa::queue_load_read_index_scacquire(gpu_queue_);
-    if (dev().settings().ext_dispatch_packet_) {
-      logAqlDispatchPacketExtended(
-          gpu_queue_, header, reinterpret_cast<hsa_amd_ext_kernel_dispatch_packet_t*>(packet),
-          rptr, index, virtual_pipe_prefix);
-    } else {
-      logAqlDispatchPacket(gpu_queue_, header,
-                           reinterpret_cast<hsa_kernel_dispatch_packet_t*>(packet),
-                           rptr, index, virtual_pipe_prefix);
-    }
+
+  const auto virtual_pipe_prefix = IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)
+                                     ? [this]() -> const char* {
+                                         if (!roc_device_.settings().queue_pipe_dist_) return "";
+                                         static thread_local char buf[32];
+                                         snprintf(buf, sizeof(buf), " virtual_pipe_id=%zu,",
+                                                  gpu_queue_->id % roc_device_.NumHwPipes());
+                                         return buf;
+                                       }()
+                                     : "";
+  if (dev().settings().ext_dispatch_packet_) {
+    logAqlDispatchPacketExtended(
+        gpu_queue_, header, reinterpret_cast<hsa_amd_ext_kernel_dispatch_packet_t*>(packet),
+        Hsa::queue_load_read_index_scacquire(gpu_queue_), index, virtual_pipe_prefix);
+  } else {
+    logAqlDispatchPacket(gpu_queue_, header,
+                         reinterpret_cast<hsa_kernel_dispatch_packet_t*>(packet),
+                         Hsa::queue_load_read_index_scacquire(gpu_queue_), index,
+                         virtual_pipe_prefix);
   }
   // Optimization for native AQL path in Windows has problems with PM4 emulation,
   // skipping the doorbell will not wake up the AQL worker thread
@@ -1363,7 +1413,7 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
   bool ring_doorbell = IS_LINUX || dev().IsPm4Emulation() || blocking ||
                        (skippedDispatches_ >= skip_limit) || ring_for_non_profiler_signal;
   if (ring_doorbell) {
-    Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
+    ringQueueDoorbell(index);
     skippedDispatches_ = 0;
   } else {
     ++skippedDispatches_;
@@ -1444,7 +1494,7 @@ bool VirtualGPU::dispatchAqlPacket(hsa_barrier_and_packet_t* packet, uint16_t he
 // For graphs that fit in the queue the yield never fires.  For oversized graphs the GPU drains
 // earlier chunks while the CPU copies later ones, avoiding a deadlock.  Packet-0's header is
 // committed last in the first chunk per the AQL protocol.
-bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPacketData,
+bool VirtualGPU::dispatchAqlPacketBatchFlat(const amd::AlignedVector64<uint8_t>& flatPacketData,
                                             const std::vector<uint32_t>& validFullHeaders,
                                             amd::AccumulateCommand* vcmd, bool attach_signal,
                                             const std::vector<const std::string*>* kernelNames,
@@ -1518,16 +1568,20 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
     // Yield until this chunk's physical slots are free.
     WaitForQueueSlot(startIndex + chunkEnd - 1, sw_queue_size);
 
-    // Copy this chunk's packet bodies to the queue. Handles RB wrap-around.
+    // Copy this chunk's packet bodies to the ring buffer using NT stores.
+    // Headers within the flat data are invalid; real headers are written via
+    // packet_store_release below, after the sfence.
     const size_t chunkSlot = (startIndex + chunkStart) & queueMask;
     const uint8_t* srcData = flatPacketData.data() + chunkStart * kPacketSize;
     if (chunkSlot + thisChunk <= queueSize) {
-      memcpy(queueBase + chunkSlot * kPacketSize, srcData, thisChunk * kPacketSize);
+      amd::nontemporalMemcpy(queueBase + chunkSlot * kPacketSize, srcData,
+                             thisChunk * kPacketSize);
     } else {
       const size_t firstCount = queueSize - chunkSlot;
-      memcpy(queueBase + chunkSlot * kPacketSize, srcData, firstCount * kPacketSize);
-      memcpy(queueBase, srcData + firstCount * kPacketSize,
-             (thisChunk - firstCount) * kPacketSize);
+      amd::nontemporalMemcpy(queueBase + chunkSlot * kPacketSize, srcData,
+                             firstCount * kPacketSize);
+      amd::nontemporalMemcpy(queueBase, srcData + firstCount * kPacketSize,
+                             (thisChunk - firstCount) * kPacketSize);
     }
 
     // Attach signal to the last packet when requested (before per-packet logging).
@@ -1628,6 +1682,10 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
       }
     }
 
+    // Ordering point: drain all preceding NT body writes from the WC buffer
+    // before writing any valid headers (diagram steps #6a, #7, #9).
+    amd::nontemporalStoreFence();
+
     // Write valid headers and ring the doorbell for this chunk.
     // Hold global packet-0's header back in the first chunk so the GPU sees a
     // fully-committed batch before starting (AQL protocol).  Subsequent chunks
@@ -1643,7 +1701,11 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
     if (isFirstChunk) {
       packet_store_release(first_loc, firstHeader, firstSetup);
     }
-    Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, startIndex + chunkEnd - 1);
+    if (doorbell_ptr_) {
+      amd::ringDoorbell(doorbell_ptr_, startIndex + chunkEnd - 1);
+    } else {
+      Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, startIndex + chunkEnd - 1);
+    }
 
     chunkStart = chunkEnd;
   }
@@ -1744,22 +1806,20 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
   WaitForQueueSlot(index, queueMask);
   hsa_barrier_and_packet_t* aql_loc =
       &(reinterpret_cast<hsa_barrier_and_packet_t*>(gpu_queue_->base_address))[index & queueMask];
-  *aql_loc = barrier_packet_;
-  metadata_preloader_.Set(&barrier_packet_, packetHeader, index & queueMask);
-  packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), packetHeader, 0);
 
-  Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
-  if (IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
-    char buf[32];
-    const char* virtual_pipe_prefix = "";
-    if (roc_device_.settings().queue_pipe_dist_) {
-      snprintf(buf, sizeof(buf), " virtual_pipe_id=%zu,",
-               gpu_queue_->id % roc_device_.NumHwPipes());
-      virtual_pipe_prefix = buf;
-    }
-    logAqlBarrierPacket(gpu_queue_, packetHeader, &barrier_packet_,
-                        Hsa::queue_load_read_index_relaxed(gpu_queue_), index, virtual_pipe_prefix);
-  }
+  writePacketToRingBuffer(aql_loc, &barrier_packet_, packetHeader, uint16_t{0}, index & queueMask);
+  ringQueueDoorbell(index);
+  logAqlBarrierPacket(gpu_queue_, packetHeader, &barrier_packet_,
+                      Hsa::queue_load_read_index_scacquire(gpu_queue_), index,
+                      IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)
+                        ? [this]() -> const char* {
+                            if (!roc_device_.settings().queue_pipe_dist_) return "";
+                            static thread_local char buf[32];
+                            snprintf(buf, sizeof(buf), " virtual_pipe_id=%zu,",
+                                     gpu_queue_->id % roc_device_.NumHwPipes());
+                            return buf;
+                          }()
+                        : "");
 
   // Clear dependent signals for the next packet
   barrier_packet_.dep_signal[0] = hsa_signal_t{};
@@ -1829,10 +1889,8 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
   WaitForQueueSlot(index, queueMask);
   hsa_amd_barrier_value_packet_t* aql_loc = &(reinterpret_cast<hsa_amd_barrier_value_packet_t*>(
       gpu_queue_->base_address))[index & queueMask];
-  *aql_loc = barrier_value_packet_;
-  metadata_preloader_.Set(&barrier_value_packet_, packetHeader, index & queueMask);
-  packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), packetHeader, rest);
-  Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
+  writePacketToRingBuffer(aql_loc, &barrier_value_packet_, packetHeader, rest, index & queueMask);
+  ringQueueDoorbell(index);
 
   if (IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
     char buf[32];
@@ -1975,8 +2033,7 @@ VirtualGPU::~VirtualGPU() {
     std::scoped_lock l(execution());
     // Dedicated queues keep their HW queue, never acquire from pool
     if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-      void* md_rb = nullptr;
-      SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb), md_rb);
+      SetGpuQueue(roc_device_.AcquireActiveQueue(priority_));
     }
     // Windows requires an interrupt in more cases than Linux for OS fence updates
     force_irq_ = IS_WINDOWS;
@@ -2012,6 +2069,7 @@ VirtualGPU::~VirtualGPU() {
 #endif  // _WIN32
     Hsa::queue_destroy(schedulerQueue_);
     schedulerQueue_ = nullptr;
+    schedulerDoorbell_ = nullptr;
   }
 
   if (nullptr != virtualQueue_) {
@@ -2044,9 +2102,8 @@ VirtualGPU::~VirtualGPU() {
 bool VirtualGPU::create() {
   // Pick a reasonable queue size
   uint32_t queue_size = ROC_AQL_QUEUE_SIZE;
-  void* md_rb = nullptr;
   SetGpuQueue(roc_device_.acquireQueue(queue_size, cooperative_, cuMask_, priority_, false,
-                                       dedicated_queue_, nullptr, nullptr, &md_rb), md_rb);
+                                       dedicated_queue_));
   if (!gpu_queue_) return false;
 
   if (dev().isa().versionMajor() == 12 && dev().isa().versionMinor() >= 5) {
@@ -2273,8 +2330,7 @@ void VirtualGPU::ReleaseHwQueue() {
 void VirtualGPU::profilingBegin(amd::Command& command, bool sdmaProfiling) {
   // Dedicated queues keep their HW queue, never acquire from pool
   if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-    void* md_rb = nullptr;
-    SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb), md_rb);
+    SetGpuQueue(roc_device_.AcquireActiveQueue(priority_));
   }
   // Track the current command
   command_ = &command;
@@ -3864,6 +3920,16 @@ bool VirtualGPU::createSchedulerParam() {
       break;
     }
 
+    schedulerDoorbell_ = nullptr;
+    if (DEBUG_CLR_DIRECT_DOORBELL) {
+      uint64_t db_id = 0;
+      if (hsa_amd_queue_get_info(schedulerQueue_, HSA_AMD_QUEUE_INFO_DOORBELL_ID, &db_id) ==
+              HSA_STATUS_SUCCESS &&
+          db_id != 0) {
+        schedulerDoorbell_ = reinterpret_cast<volatile uint64_t*>(db_id);
+      }
+    }
+
 #if defined(_WIN32)
   if (!isSchedulerQueueThreadRunning()) {
     std::call_once(scheduler_thread_init_, [this]() { startSchedulerQueueThread(); });
@@ -3903,7 +3969,11 @@ void VirtualGPU::startSchedulerQueueThread() {
 
         if (write_index > updated_write_index) {
           // New packets in the scheduler queue, ringing the doorbell
-          Hsa::signal_store_screlease(schedulerQueue_->doorbell_signal, write_index - 1);
+          if (schedulerDoorbell_) {
+            amd::ringDoorbell(schedulerDoorbell_, write_index - 1);
+          } else {
+            Hsa::signal_store_screlease(schedulerQueue_->doorbell_signal, write_index - 1);
+          }
           updated_write_index = write_index;
         } else {
           // Yield briefly before re-checking.
@@ -4047,60 +4117,6 @@ bool VirtualGPU::createVirtualQueue(uint deviceQueueSize) {
   return true;
 }
 
-// ================================================================================================
-#if IS_LINUX
-__attribute__((optimize("unroll-all-loops"), always_inline)) static inline void nontemporalMemcpy(
-    void* __restrict dst, const void* __restrict src, size_t size) {
-#if defined(ATI_ARCH_X86)
-#if defined(__AVX512F__)
-  for (auto i = 0u; i != size / sizeof(__m512i); ++i) {
-    _mm512_stream_si512(reinterpret_cast<__m512i* __restrict&>(dst)++,
-                        *reinterpret_cast<const __m512i* __restrict&>(src)++);
-  }
-  size = size % sizeof(__m512i);
-#endif
-
-#if defined(__AVX__)
-  for (auto i = 0u; i != size / sizeof(__m256i); ++i) {
-    _mm256_stream_si256(reinterpret_cast<__m256i* __restrict&>(dst)++,
-                        *reinterpret_cast<const __m256i* __restrict&>(src)++);
-  }
-  size = size % sizeof(__m256i);
-#endif
-
-  for (auto i = 0u; i != size / sizeof(__m128i); ++i) {
-    _mm_stream_si128(reinterpret_cast<__m128i* __restrict&>(dst)++,
-                     *(reinterpret_cast<const __m128i* __restrict&>(src)++));
-  }
-  size = size % sizeof(__m128i);
-
-  for (auto i = 0u; i != size / sizeof(long long); ++i) {
-    _mm_stream_si64(reinterpret_cast<long long* __restrict&>(dst)++,
-                    *reinterpret_cast<const long long* __restrict&>(src)++);
-  }
-  size = size % sizeof(long long);
-
-  for (auto i = 0u; i != size / sizeof(int); ++i) {
-    _mm_stream_si32(reinterpret_cast<int* __restrict&>(dst)++,
-                    *reinterpret_cast<const int* __restrict&>(src)++);
-  }
-
-  size = size % sizeof(int);
-  // Copy remaining bytes for unaligned size
-  std::memcpy(dst, src, size);
-
-  // Add memory fence
-  _mm_sfence();
-#else
-  std::memcpy(dst, src, size);
-#endif
-}
-#else
-static inline void nontemporalMemcpy(void* __restrict dst, const void* __restrict src,
-                                     size_t size) {
-  std::memcpy(dst, src, size);
-}
-#endif
 
 void VirtualGPU::HiddenHeapInit() {
   // We don't really need its id, just want to ensure the queue is created.
@@ -4347,13 +4363,15 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
           allocKernArg(gpuKernel.KernargSegmentByteSize(), gpuKernel.KernargSegmentAlignment()));
     }
 
-    nontemporalMemcpy(argBuffer, parameters, argSize);
-    if (roc_device_.info().largeBar_ && !isGraphCapture) {
+    amd::nontemporalMemcpy(argBuffer, parameters, argSize);
+    // When the queue ring buffer is in device memory, kernarg NT stores and
+    // the dispatch packet all travel to the same PCIe endpoint.  PCIe posted
+    // write ordering guarantees the kernargs arrive before the dispatch
+    // header, so no HDP flush or readback workaround is needed — the sfence
+    // before packet_store_release is sufficient.
+    if (roc_device_.info().largeBar_ && !isGraphCapture && !device_mem_ring_buf_) {
       const auto kernArgImpl = dev().settings().kernel_arg_impl_;
-      if (kernArgImpl == KernelArgImpl::DeviceKernelArgsHDP) {
-        *dev().info().hdpMemFlushCntl = 1u;
-        auto kSentinel = *reinterpret_cast<volatile int*>(dev().info().hdpMemFlushCntl);
-      } else if (kernArgImpl == KernelArgImpl::DeviceKernelArgsReadback && argSize != 0) {
+      if (kernArgImpl == KernelArgImpl::DeviceKernelArgsReadback && argSize != 0) {
 #if defined(ATI_ARCH_X86)
         _mm_sfence();
 #else
@@ -4381,7 +4399,7 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
     static_assert(sizeof(hsa_kernel_dispatch_packet_t)
                   == sizeof(hsa_amd_ext_kernel_dispatch_packet_t));
 
-    union {
+    alignas(64) union {
       hsa_kernel_dispatch_packet_t kernelDispatch;
       hsa_amd_ext_kernel_dispatch_packet_t extKernelDispatch;
     } dispatchPacketUnion;
@@ -4647,8 +4665,7 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
     // It should be safe to call flush directly if there are not pending dispatches without
     // HSA signal callback
     if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-      void* md_rb = nullptr;
-      SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb), md_rb);
+      SetGpuQueue(roc_device_.AcquireActiveQueue(priority_));
     }
     flush(vcmd.GetBatchHead());
     SetCoalesceWindow(0, nullptr);
@@ -4932,106 +4949,165 @@ static void convertDynDataPrefetchToHsa(const amd::DynDataPrefetchRegion* region
   }
 }
 
+// ================================================================================================
+// Unified metadata write for kernel dispatch packets.  Two write-out paths
+// share the same assembly logic — only the final transfer to the ring buffer
+// differs:
+//
+// (A) Device memory (WC over PCIe BAR): stage locally, then copy 4 x 64B
+//     segments via MOVDIR64B (if available) or NT stores.  Each segment's
+//     body + header are in the same atomic/NT copy — no sfence between them.
+//     Avoids dozens of scattered WC stores over the bus.
+//
+// (B) System memory (WB): write fields directly into the ring buffer (all
+//     stores hit L1 cache).  SFENCE between body and headers because the
+//     CP's prefetcher may observe WB memory via a non-cached path.
+//
+// The ROCR allocator guarantees the metadata ring buffer is 4KiB-aligned with
+// 256B packets, so every slot is naturally 64B-aligned.
 void VirtualGPU::MetaDataPreloader::SetPacket(
     hsa_kernel_dispatch_packet_t* aql,  uint16_t header,
-    hsa_amd_metadata_kernel_dispatch_packet_t* metadata) {
+    hsa_amd_metadata_kernel_dispatch_packet_t* metadata,
+    bool use_movdir64b, bool device_mem_ring_buf) {
   assert(pending_descriptor_ != nullptr);
 
-  // Headers must remain HSA_PACKET_TYPE_INVALID until we publish valid metadata headers
-  // at the end. Only clear fields that could otherwise contain stale required-zero data.
-  std::memset(metadata->reserved0, 0, sizeof(metadata->reserved0));
-  std::memset(&metadata->launch_descriptor, 0, sizeof(metadata->launch_descriptor));
+  // Staging is only needed for device-memory (WC) ring buffers to avoid
+  // scattered WC stores over PCIe.  For system-memory (WB) queues, direct
+  // writes hit L1 cache and are fast — no staging overhead needed.
+  const bool use_staging = device_mem_ring_buf;
 
-  if (dyn_data_prefetch_enabled_ && dyn_data_prefetch_num_regions_ > 0) {
-    metadata->launch_descriptor.version = launch_descriptor_version_;
-    convertDynDataPrefetchToHsa(
-        dyn_data_prefetch_regions_,
-        dyn_data_prefetch_hints_,
-        metadata->launch_descriptor.prefetch,
-        dyn_data_prefetch_num_regions_);
-  }
-
-  // Write event_id from amd_signal_t directly (non-interrupt signals have event_id == 0).
-  if (aql->completion_signal.handle) {
-    auto* signal = reinterpret_cast<amd_signal_t*>(aql->completion_signal.handle);
-    metadata->event_id = signal->event_id;
-  } else {
-    metadata->event_id = 0;
-  }
-
-  // Fill hsa_amd_metadata_kernel_dispatch_packet->kernel_descriptor fields.
-  // The metadata packet kernel descriptor fields are a subset of
-  // kernel_descriptor_t (Code Object V3 Kernel Descriptor) from the AQL packet, from bytes
-  // llvm::amdhsa::KERNEL_CODE_ENTRY_BYTE_OFFSET_OFFSET(16) to sizeof(kernel_descriptor_t).
-  // See include/llvm/Support/AMDHSAKernelDescriptor.h.
-  std::memcpy(&metadata->kernel_descriptor, pending_descriptor_,
-              sizeof(metadata->kernel_descriptor));
-
-  // Fill hsa_amd_metadata_kernel_dispatch_packet->kernarg_preload_* fields
-  constexpr uint16_t kPreload_limit =
-      (sizeof(metadata->kernarg_preload_0_14) +
-       sizeof(metadata->kernarg_preload_15_29) +
-       sizeof(metadata->kernarg_preload_30_31)) / sizeof(uint32_t);
-
-  uint16_t preload_length = pending_preload_length_;
-  if (preload_length > kPreload_limit) {
-    metadata->kernel_descriptor.kernarg_preload.length = kPreload_limit;
-    preload_length = kPreload_limit;
-  }
-  ClPrint(amd::LOG_DEBUG, amd::LOG_AQL,
-          "metadata prefetch: preload_length=%u, preload_offset=%u, preload_limit=%u",
-          preload_length, pending_preload_offset_, kPreload_limit);
-
-  if (preload_length > 0) {
-    const uint8_t* kernargs = reinterpret_cast<const uint8_t*>(aql->kernarg_address);
-    assert(kernargs);
-    // Kernarg preload offset is in DWORDs
-    const uint8_t* src = kernargs + pending_preload_offset_ * sizeof(uint32_t);
-    uint16_t remain = preload_length;
-
-    // Copy kernarg_preload 0-14
-    uint16_t n = std::min<uint16_t>(
-        remain, sizeof(metadata->kernarg_preload_0_14) / sizeof(uint32_t));
-    if (n < (sizeof(metadata->kernarg_preload_0_14) / sizeof(uint32_t))) {
-      std::memset(metadata->kernarg_preload_0_14, 0, sizeof(metadata->kernarg_preload_0_14));
+  auto fill_metadata = [&](hsa_amd_metadata_kernel_dispatch_packet_t* m,
+                           bool target_is_zeroed) -> uint32_t {
+    // Headers must remain HSA_PACKET_TYPE_INVALID until we publish valid metadata headers
+    // at the end. Only clear fields that could otherwise contain stale required-zero data.
+    // When staging, the stack-local is already zero-initialized so these are unnecessary.
+    if (!target_is_zeroed) {
+      std::memset(m->reserved0, 0, sizeof(m->reserved0));
+      std::memset(&m->launch_descriptor, 0, sizeof(m->launch_descriptor));
     }
-    std::memcpy(metadata->kernarg_preload_0_14, src, n * sizeof(uint32_t));
-    remain -= n;
 
-    // Copy kernarg_preload 15-29
-    if (remain > 0) {
-      src += n * sizeof(uint32_t);
-      n = std::min<uint16_t>(
-          remain, sizeof(metadata->kernarg_preload_15_29) / sizeof(uint32_t));
-      if (n < (sizeof(metadata->kernarg_preload_15_29) / sizeof(uint32_t))) {
-        std::memset(metadata->kernarg_preload_15_29, 0,
-                    sizeof(metadata->kernarg_preload_15_29));
+    if (dyn_data_prefetch_enabled_ && dyn_data_prefetch_num_regions_ > 0) {
+      m->launch_descriptor.version = launch_descriptor_version_;
+      convertDynDataPrefetchToHsa(
+          dyn_data_prefetch_regions_,
+          dyn_data_prefetch_hints_,
+          m->launch_descriptor.prefetch,
+          dyn_data_prefetch_num_regions_);
+    }
+
+    // Write event_id from amd_signal_t directly (non-interrupt signals have event_id == 0).
+    if (aql->completion_signal.handle) {
+      auto* signal = reinterpret_cast<amd_signal_t*>(aql->completion_signal.handle);
+      m->event_id = signal->event_id;
+    } else {
+      m->event_id = 0;
+    }
+
+    // Fill hsa_amd_metadata_kernel_dispatch_packet->kernel_descriptor fields.
+    // The metadata packet kernel descriptor fields are a subset of
+    // kernel_descriptor_t (Code Object V3 Kernel Descriptor) from the AQL packet, from bytes
+    // llvm::amdhsa::KERNEL_CODE_ENTRY_BYTE_OFFSET_OFFSET(16) to sizeof(kernel_descriptor_t).
+    // See include/llvm/Support/AMDHSAKernelDescriptor.h.
+    std::memcpy(&m->kernel_descriptor, pending_descriptor_,
+                sizeof(m->kernel_descriptor));
+
+    // Fill hsa_amd_metadata_kernel_dispatch_packet->kernarg_preload_* fields
+    constexpr uint16_t kPreload_limit =
+        (sizeof(m->kernarg_preload_0_14) +
+         sizeof(m->kernarg_preload_15_29) +
+         sizeof(m->kernarg_preload_30_31)) / sizeof(uint32_t);
+
+    uint16_t preload_length = pending_preload_length_;
+    if (preload_length > kPreload_limit) {
+      m->kernel_descriptor.kernarg_preload.length = kPreload_limit;
+      preload_length = kPreload_limit;
+    }
+    ClPrint(amd::LOG_DEBUG, amd::LOG_AQL,
+            "metadata prefetch: preload_length=%u, preload_offset=%u, preload_limit=%u",
+            preload_length, pending_preload_offset_, kPreload_limit);
+
+    if (preload_length > 0) {
+      const uint8_t* kernargs = reinterpret_cast<const uint8_t*>(aql->kernarg_address);
+      assert(kernargs);
+      // Kernarg preload offset is in DWORDs
+      const uint8_t* src = kernargs + pending_preload_offset_ * sizeof(uint32_t);
+      uint16_t remain = preload_length;
+
+      // Copy kernarg_preload 0-14
+      uint16_t n = std::min<uint16_t>(
+          remain, sizeof(m->kernarg_preload_0_14) / sizeof(uint32_t));
+      if (!target_is_zeroed && n < (sizeof(m->kernarg_preload_0_14) / sizeof(uint32_t))) {
+        std::memset(m->kernarg_preload_0_14, 0, sizeof(m->kernarg_preload_0_14));
       }
-      std::memcpy(metadata->kernarg_preload_15_29, src, n * sizeof(uint32_t));
+      std::memcpy(m->kernarg_preload_0_14, src, n * sizeof(uint32_t));
       remain -= n;
 
-      // Copy kernarg_preload 30-31
+      // Copy kernarg_preload 15-29
       if (remain > 0) {
         src += n * sizeof(uint32_t);
         n = std::min<uint16_t>(
-            remain, sizeof(metadata->kernarg_preload_30_31) / sizeof(uint32_t));
-        if (n < (sizeof(metadata->kernarg_preload_30_31) / sizeof(uint32_t))) {
-          std::memset(metadata->kernarg_preload_30_31, 0,
-                      sizeof(metadata->kernarg_preload_30_31));
+            remain, sizeof(m->kernarg_preload_15_29) / sizeof(uint32_t));
+        if (!target_is_zeroed && n < (sizeof(m->kernarg_preload_15_29) / sizeof(uint32_t))) {
+          std::memset(m->kernarg_preload_15_29, 0, sizeof(m->kernarg_preload_15_29));
         }
-        std::memcpy(metadata->kernarg_preload_30_31, src, n * sizeof(uint32_t));
+        std::memcpy(m->kernarg_preload_15_29, src, n * sizeof(uint32_t));
+        remain -= n;
+
+        // Copy kernarg_preload 30-31
+        if (remain > 0) {
+          src += n * sizeof(uint32_t);
+          n = std::min<uint16_t>(
+              remain, sizeof(m->kernarg_preload_30_31) / sizeof(uint32_t));
+          if (!target_is_zeroed && n < (sizeof(m->kernarg_preload_30_31) / sizeof(uint32_t))) {
+            std::memset(m->kernarg_preload_30_31, 0, sizeof(m->kernarg_preload_30_31));
+          }
+          std::memcpy(m->kernarg_preload_30_31, src, n * sizeof(uint32_t));
+        }
       }
     }
-  }
 
-  // Write headers last — arms the metadata packet for the CP.
-  // Plain stores are sufficient here: the subsequent packet_store_release on the main
-  // AQL dispatch header provides a release fence that orders all metadata writes (body
-  // and headers) before the CP sees the valid dispatch packet.
-  uint32_t metadata_header = GetType(header) | metadata_version_header_;
-  metadata->header3 = metadata_header;
-  metadata->header2 = metadata_header;
-  metadata->header1 = metadata_header;
-  metadata->header0 = metadata_header;
+    return GetType(header) | metadata_version_header_;
+  };
+
+  if (use_staging) {
+    alignas(64) hsa_amd_metadata_kernel_dispatch_packet_t stg = {};
+    uint32_t metadata_header = fill_metadata(&stg, true);
+
+    // Write headers into the staging buffer before copying out.
+    stg.header0 = metadata_header;
+    stg.header1 = metadata_header;
+    stg.header2 = metadata_header;
+    stg.header3 = metadata_header;
+
+    assert(reinterpret_cast<uintptr_t>(metadata) % 64 == 0 &&
+           "metadata ring buffer slot must be 64-byte aligned");
+    static_assert(sizeof(stg) % 64 == 0);
+    auto* s = reinterpret_cast<const char*>(&stg);
+    auto* d = reinterpret_cast<char*>(metadata);
+
+    if (use_movdir64b) {
+      for (size_t off = 0; off < sizeof(stg); off += 64) {
+        amd::movdir64b_copy64(d + off, s + off);
+      }
+    } else {
+      for (size_t off = 0; off < sizeof(stg); off += 64) {
+        amd::nontemporalMemcpy(d + off, s + off, 64);
+      }
+    }
+  } else {
+    uint32_t metadata_header = fill_metadata(metadata, false);
+
+    // Write headers last — arms the metadata packet for the CP.
+    // SFENCE between body and headers: the metadata ring buffer may be WC-mapped
+    // (device memory) and the CP's prefetcher reads it independently. Without a
+    // fence, WC reordering could make valid headers visible before the body is
+    // flushed, causing the prefetcher to read garbage. This fence ensures all
+    // body writes are ordered before the header writes (ordering point #7).
+    amd::nontemporalStoreFence();
+    metadata->header3 = metadata_header;
+    metadata->header2 = metadata_header;
+    metadata->header1 = metadata_header;
+    metadata->header0 = metadata_header;
+  }
 }
 }  // End of roc namespace

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -10,6 +10,7 @@
 #include "rocdefs.hpp"
 #include "rocdevice.hpp"
 #include "utils/flags.hpp"
+#include "utils/nontemporal.hpp"
 #include "utils/util.hpp"
 #include "rocprintf.hpp"
 #include "rocsched.hpp"
@@ -349,9 +350,16 @@ class VirtualGPU : public device::VirtualDevice {
         pending_preload_offset_ = preload_offset;
       }
 
-      //! Set metadata prefetching packet associated with regular aql packet
+      //! Write the metadata prefetch packet for the AQL slot at |index|.
+      //! |use_movdir64b|: use atomic 64B writes (no sfence between body/header).
+      //! |device_mem_ring_buf|: ring buffer is WC over PCIe — when MOVDIR64B is
+      //!   unavailable, stages locally then NT-copies to avoid scattered WC stores.
+      //! pending_descriptor_ is kernel-dispatch-only — barrier packets
+      //! never set it, so only the barrier branch runs for them.
       template <class AqlPacket>
-      inline void Set(AqlPacket* packet, uint16_t header, uint64_t index) {
+      inline void SetMetadata(AqlPacket* packet, uint16_t header,
+                              uint64_t index, bool use_movdir64b,
+                              bool device_mem_ring_buf) {
         if (!IsAttached()) {
           return;
         }
@@ -359,16 +367,21 @@ class VirtualGPU : public device::VirtualDevice {
           if (pending_descriptor_ == nullptr) {
             return;
           }
-          hsa_amd_metadata_kernel_dispatch_packet_t* queue_metadata_packet =
+          auto* queue_metadata_packet =
                &(reinterpret_cast<hsa_amd_metadata_kernel_dispatch_packet_t*>(
                    queue_base_))[index];
-          SetPacket(packet, header, queue_metadata_packet);
+          SetPacket(packet, header, queue_metadata_packet,
+                    use_movdir64b, device_mem_ring_buf);
         } else if constexpr (std::is_same_v<AqlPacket, hsa_barrier_and_packet_t> ||
                              std::is_same_v<AqlPacket, hsa_amd_barrier_value_packet_t>) {
-          hsa_amd_metadata_barrier_packet_t* queue_metadata_packet =
+          auto* queue_metadata_packet =
                &(reinterpret_cast<hsa_amd_metadata_barrier_packet_t*>(
                    queue_base_))[index];
-          SetPacket(packet, header, queue_metadata_packet);
+          if (use_movdir64b) {
+            SetMetadataPacketMovdir64b(packet, header, queue_metadata_packet);
+          } else {
+            SetPacket(packet, header, queue_metadata_packet, device_mem_ring_buf);
+          }
         }
       }
 
@@ -401,28 +414,47 @@ class VirtualGPU : public device::VirtualDevice {
         return (header >> HSA_PACKET_HEADER_TYPE) & ((1 << HSA_PACKET_HEADER_WIDTH_TYPE) - 1);
       }
 
-      //! Set the metadata prefetch aql packet for kernel dispatch
+      //! Write the metadata prefetch packet for kernel dispatch.
+      //! Unified function covering MOVDIR64B, legacy+device-mem (staged NT),
+      //! and legacy+system-mem (direct write) paths.  The assembly logic is
+      //! shared; only the final write to the ring buffer differs.
       void SetPacket(hsa_kernel_dispatch_packet_t* aql, uint16_t header,
-                     hsa_amd_metadata_kernel_dispatch_packet_t* metadata);
+                     hsa_amd_metadata_kernel_dispatch_packet_t* metadata,
+                     bool use_movdir64b, bool device_mem_ring_buf);
 
-      //! Set the metadata prefetch aql packet for barrier.
+      //! Set the metadata prefetch aql packet for barrier (legacy NT store path).
       //! The CP invalidates headers after completion, so only header0
       //! and event_id need to be written.
-      //! Read event_id directly from amd_signal_t to avoid the hsa_amd_signal_get_event_id
-      //! API overhead. Only interrupt signals carry a valid event_id.
       template <class AqlBarrierPacket>
       void SetPacket(AqlBarrierPacket* aql, uint16_t header,
-                     hsa_amd_metadata_barrier_packet_t* metadata) const {
+                     hsa_amd_metadata_barrier_packet_t* metadata,
+                     bool device_mem_ring_buf) const {
         if (aql->completion_signal.handle) {
           auto* signal = reinterpret_cast<amd_signal_t*>(aql->completion_signal.handle);
           metadata->event_id = signal->event_id;
         } else {
           metadata->event_id = 0;
         }
-        // Plain store is sufficient: the subsequent packet_store_release on the main
-        // AQL barrier header provides a release fence that orders all metadata writes
-        // (event_id and header) before the CP sees the valid barrier packet.
-        metadata->header0 = GetType(header);
+        if (device_mem_ring_buf) {
+          amd::nontemporalStoreFence();
+        }
+        metadata->header0 = GetType(header) | metadata_version_header_;
+      }
+
+      //! Set the metadata prefetch aql packet for barrier (MOVDIR64B path).
+      //! Only header0 + event_id are meaningful; they live in the first
+      //! 64-byte segment.  One MOVDIR64B writes both atomically (no sfence).
+      template <class AqlBarrierPacket>
+      void SetMetadataPacketMovdir64b(AqlBarrierPacket* aql, uint16_t header,
+                              hsa_amd_metadata_barrier_packet_t* metadata) {
+        alignas(64) uint8_t seg0[64] = {};
+        *reinterpret_cast<uint32_t*>(seg0) = GetType(header) | metadata_version_header_;
+        auto& event_id = *reinterpret_cast<uint32_t*>(seg0 + 4);
+        if (aql->completion_signal.handle) {
+          auto* signal = reinterpret_cast<amd_signal_t*>(aql->completion_signal.handle);
+          event_id = signal->event_id;
+        }
+        amd::movdir64b_copy64(metadata, seg0);
       }
 
       void* queue_base_ = nullptr;        //!< The buffer base of prefetching queue
@@ -516,7 +548,7 @@ class VirtualGPU : public device::VirtualDevice {
   hsa_queue_t* gpu_queue() { return gpu_queue_; }
 
   //! Set the active HW queue and keep the metadata preloader in sync.
-  void SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer = nullptr);
+  void SetGpuQueue(hsa_queue_t* queue);
 
   //! Snapshot the current HW queue as preferred for future re-acquisition (used by graph launch).
   //! Only updates if the queue is still valid — avoids clobbering a hint saved by ReleaseHwQueue.
@@ -630,7 +662,7 @@ class VirtualGPU : public device::VirtualDevice {
                          bool blocking = true, bool attach_signal = false);
 
   //! Fast-path dispatch: pre-built flat contiguous buffer
-  bool dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPacketData,
+  bool dispatchAqlPacketBatchFlat(const amd::AlignedVector64<uint8_t>& flatPacketData,
                                   const std::vector<uint32_t>& validFullHeaders,
                                   amd::AccumulateCommand* vcmd = nullptr,
                                   bool attach_signal = false,
@@ -654,6 +686,16 @@ class VirtualGPU : public device::VirtualDevice {
                                   bool skipTs = false,
                                   hsa_signal_t completionSignal = hsa_signal_t{0});
   void initializeDispatchPacket(hsa_kernel_dispatch_packet_t* packet, amd::NDRangeContainer& sizes);
+
+  //! Write an AQL packet to the ring buffer with metadata prefetch.
+  //! Selects MOVDIR64B only for device-memory queues with CPU support;
+  //! otherwise uses the legacy NT-store path.
+  template <typename AqlPacket>
+  void writePacketToRingBuffer(AqlPacket* aql_loc, AqlPacket* packet,
+                               uint16_t header, uint16_t rest, uint64_t slot_index);
+
+  //! Ring the queue doorbell via direct UC store or ROCr signal.
+  void ringQueueDoorbell(uint64_t index);
 
   void resetKernArgPool() { managed_kernarg_buffer_.ResetPool(); }
 
@@ -793,9 +835,13 @@ class VirtualGPU : public device::VirtualDevice {
   //! as its HwEvent so query/sync observe correct readiness. Released on reset.
   void* last_barrier_hw_event_ = nullptr;
   hsa_agent_t gpu_device_;  //!< Physical device
-  hsa_queue_t* gpu_queue_;  //!< Active queue associated with a vgpu
-  hsa_barrier_and_packet_t barrier_packet_ {};
-  hsa_amd_barrier_value_packet_t barrier_value_packet_ {};
+  hsa_queue_t* gpu_queue_;                //!< Active queue associated with a vgpu
+  bool device_mem_ring_buf_ = false;           //!< Queue ring buffer is in device memory
+  //! Cached hardware doorbell for the active queue (UC MMIO). Non-null only when
+  //! DEBUG_CLR_DIRECT_DOORBELL is enabled and the doorbell id query succeeded.
+  volatile uint64_t* doorbell_ptr_ = nullptr;
+  alignas(64) hsa_barrier_and_packet_t barrier_packet_ {};
+  alignas(64) hsa_amd_barrier_value_packet_t barrier_value_packet_ {};
 
   uint64_t cached_read_dispatch_id_ = 0;  //!< Cached read_dispatch_id to avoid DRAM reads
                                           //!< when queue is not full. GPU updates to
@@ -815,6 +861,9 @@ class VirtualGPU : public device::VirtualDevice {
   uint schedulerThreads_;      //!< The number of scheduler threads
 
   hsa_queue_t* schedulerQueue_;
+  //! Cached hardware doorbell for the scheduler queue (UC MMIO). Non-null only when
+  //! DEBUG_CLR_DIRECT_DOORBELL is enabled and the doorbell id query succeeded.
+  volatile uint64_t* schedulerDoorbell_ = nullptr;
 
   std::thread schedulerQueueThread_;                  //!< Host thread that monitors the scheduler queue
   std::atomic<bool> schedulerQueueThreadRunning_;     //!< Flag to indicate if the thread is running

--- a/projects/clr/rocclr/os/os.hpp
+++ b/projects/clr/rocclr/os/os.hpp
@@ -106,6 +106,9 @@ class Os : AllStatic {
   static void cpuid(int regs[4], int info);
   //! Get value of extended control register
   static uint64_t xgetbv(uint32_t which);
+  //! CPU supports MOVDIR64B (atomic 64-byte store with WC buffer close).
+  //! Result is cached on first call.
+  static bool hasMovdir64b();
 #endif  // ATI_ARCH_X86
 
   // Stack helper routines:

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -735,6 +735,30 @@ uint64_t Os::xgetbv(uint32_t ecx) {
 
   return ((uint64_t)edx << 32) | (uint64_t)eax;
 }
+
+bool Os::hasMovdir64b() {
+  // CPUID leaf 7, sub-leaf 0: ECX bit 28 = MOVDIR64B.
+  static const bool supported = [] {
+    int regs[4];
+#ifdef _LP64
+    __asm__ __volatile__(
+        "movq %%rbx, %%rsi;"
+        "cpuid;"
+        "xchgq %%rbx, %%rsi;"
+        : "=a"(regs[0]), "=S"(regs[1]), "=c"(regs[2]), "=d"(regs[3])
+        : "a"(7), "c"(0));
+#else
+    __asm__ __volatile__(
+        "movl %%ebx, %%esi;"
+        "cpuid;"
+        "xchgl %%ebx, %%esi;"
+        : "=a"(regs[0]), "=S"(regs[1]), "=c"(regs[2]), "=d"(regs[3])
+        : "a"(7), "c"(0));
+#endif
+    return static_cast<bool>((regs[2] >> 28) & 1);
+  }();
+  return supported;
+}
 #endif  // ATI_ARCH_X86
 
 uint64_t Os::offsetToEpochNanos() {

--- a/projects/clr/rocclr/os/os_win32.cpp
+++ b/projects/clr/rocclr/os/os_win32.cpp
@@ -497,6 +497,16 @@ void Os::cpuid(int regs[4], int info) { return __cpuid(regs, info); }
 
 uint64_t Os::xgetbv(uint32_t ecx) { return (uint64_t)_xgetbv(ecx); }
 
+bool Os::hasMovdir64b() {
+  // CPUID leaf 7, sub-leaf 0: ECX bit 28 = MOVDIR64B.
+  static const bool supported = [] {
+    int regs[4];
+    __cpuidex(regs, 7, 0);
+    return static_cast<bool>((regs[2] >> 28) & 1);
+  }();
+  return supported;
+}
+
 uint64_t Os::offsetToEpochNanos() {
   static uint64_t offset = 0;
 

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -253,8 +253,6 @@ release(uint, DEBUG_CLR_MAX_BATCH_SIZE, 1000,                                 \
         "Forces the callback to clean-up CPU submission queue")               \
 release(bool, DEBUG_CLR_SYSMEM_POOL, false,                                   \
         "Use sysmem pool implementation in runtime for amd commands")         \
-release(bool, DEBUG_CLR_KERNARG_HDP_FLUSH_WA, false,                          \
-        "Toggle kernel arg copy workaround")                                  \
 release(uint, DEBUG_HIP_DYNAMIC_QUEUES, 1,                                    \
         "Dynamic queue management: 0=off, 1=Depth heuristic,"                 \
         " 2=1 + dedicated null-stream queue")                                 \
@@ -264,7 +262,7 @@ release(uint, HIP_SKIP_ABORT_ON_GPU_ERROR, true,                              \
         "Set this to true, to avoid host side abort for GPU errors")          \
 release(bool, HIP_FORCE_SPIRV_CODEOBJECT, false,                              \
         "Force use of SPIRV instead of device specific code object.")         \
-release(uint, DEBUG_CLR_BATCH_CPU_SYNC_SIZE, 16,                               \
+release(uint, DEBUG_CLR_BATCH_CPU_SYNC_SIZE, 16,                              \
         "Forces the minimum batch size for CPU sync")                         \
 release(bool, DEBUG_CLR_DISABLE_IMAGE, false,                                 \
         "1 = Disable Image support for ROC path")                             \
@@ -275,8 +273,12 @@ release(cstring, HIP_HRR_CAPTURE_OUTPUT, "",                                  \
 release(uint, DEBUG_CLR_DOORBELL_SKIP, 16,                                    \
         "Number of consecutive dispatches that may skip the doorbell flush.") \
 release(bool, DEBUG_CLR_DISABLE_FALLBACK, false,                              \
-        "Disables certain fallback paths")
-
+        "Disables certain fallback paths")                                    \
+release(bool, DEBUG_CLR_DIRECT_DOORBELL, false,                               \
+        "Write the hardware doorbell directly from CLR")                      \
+release(uint, DEBUG_CLR_AQL_DEV_QUEUE, 1,                                     \
+        "Devuce memory AQL ring buffer for supported asics"                   \                     \
+        "1=enabled (default), 0=force system mem")                            \
 
 namespace amd {
 

--- a/projects/clr/rocclr/utils/nontemporal.hpp
+++ b/projects/clr/rocclr/utils/nontemporal.hpp
@@ -1,0 +1,470 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef CLR_ROCCLR_UTILS_NONTEMPORAL_HPP_
+#define CLR_ROCCLR_UTILS_NONTEMPORAL_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <new>
+#include <vector>
+#include "os/os.hpp"
+
+#if defined(ATI_ARCH_X86)
+#if defined(__MINGW64__)
+#include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
+#endif
+
+namespace amd {
+
+// Non-temporal store utilities for AQL packet submission.
+//
+// The ordering analysis below (WC buffers, SFENCE semantics, UC MMIO
+// flushes) is specific to x86/x86-64.  On ARM or other CPU ISAs the memory
+// model, cache attributes, and barrier instructions are different.  The
+// non-x86 fallback paths in this file use plain memcpy / atomic fences
+// which are correct but the performance rationale does not directly apply.
+//
+// --- CPU memory-mapping of device memory (x86) ---
+//
+// On discrete GPUs connected via PCIe, device memory mapped into the CPU
+// address space is marked Write Combining (WC).  WC has weaker ordering
+// than normal Write Back (WB) cached DRAM:
+//
+//   * Regular stores enter a write-combining buffer and may be coalesced
+//     or reordered.  An explicit SFENCE is required to guarantee ordering
+//     between groups of WC writes.
+//   * Each SFENCE flushes the WC buffer and the CPU stalls until WriteACK
+//     returns from the PCIe posted write (one bus round-trip).
+//   * A write to UC (uncacheable) memory (e.g. the MMIO doorbell region)
+//     also implicitly flushes the WC buffer, so no SFENCE is needed
+//     between the last WC write and the doorbell.
+//
+// On A+A / XGMI topologies the GPU memory can also be mapped WB, giving
+// the CPU the same strong ordering as host DRAM.
+// In that case:
+//
+//   * Write ordering is guaranteed by x86 TSO — no SFENCE needed between
+//     regular stores.
+//   * CPU writes stay in the cache hierarchy; GPU reads may have to
+//     probe-read them out of CPU caches (higher latency than reading from
+//     local GPU memory).
+//   * Non-temporal stores bypass the cache and go directly to the
+//     destination, avoiding the probe-read penalty.  They still require
+//     SFENCE for ordering relative to subsequent stores.
+//
+// On x86, certain instructions follow the WC memory model even when
+// targeting WB memory:
+//
+//   * Streaming / non-temporal stores (MOVNTQ, MOVNTI, MOVNTPS, etc.)
+//     do not necessarily close/flush the write-combining buffer
+//     immediately; later stores may still coalesce in the WC buffer.
+//     An SFENCE is required to guarantee the buffer is flushed and
+//     the store begins its trek to the destination.
+//
+//   * MOVDIR64B / MOVDIRI close the WC buffer after execution but
+//     still follow the weak WC memory ordering model (i.e. they can
+//     be reordered with respect to other WC and NT stores).
+//
+// This is why SFENCE is necessary even on A+A / WB-mapped topologies:
+// the NT stores used here always behave as WC regardless of the
+// underlying memory type.
+//
+// These utilities use non-temporal stores so they are correct (and
+// performant) regardless of whether the target is WC or WB mapped.
+//
+// --- Ordering points in the AQL submission flow ---
+//
+// When queues / kernargs are in device memory, the NT store sequence is:
+//
+//   1.  nontemporalMemcpy  — kernel args CPU → GPU (step #1)
+//   2.  nontemporalCopyAQL — packet body (w/ invalid header) → ring buffer (step 6)
+//       metadata_preloader writes metadata packet (steps 5/7/8)
+//   3.  nontemporalStoreFence — ONE sfence that subsumes ordering points
+//       1(a), 6(a), 7, and 9 from the AQL submission diagram:
+//         * kernel-arg NT stores are visible          (#1a)
+//         * dispatch-packet body is ordered before its header write (#6a)
+//         * metadata body is ordered before header writes          (#7)
+//         * metadata is valid before dispatch header is released   (#9)
+//   4.  packet_store_release — atomic 32-bit write of valid header (step #10)
+//   5.  doorbell ring — see note below                             (step #12)
+//
+//  +------------------+  +------------------+  +------------------+  +------------------+
+//  | 1. Copy N bytes   |  | 2. Atomically    |  | 3. Create kernel |  | 4. Create kernel |
+//  | of kernel args    |  | increment        |  | meta-data packet |  | dispatch packet  |
+//  | from CPU -> GPU   |  | write_dispatch_id|  | in CPU w/invalid |  | in CPU w/invalid |
+//  +--------+---------+  +--------+---------+  | header           |  | header           |
+//           |                      |            +--------+---------+  +--------+---------+
+//           |                      |                     |                     |
+//           |                      |                     v                     v
+//           |                      |            +------------------+  +------------------+
+//           |                      |            | 5. Copy meta-data|  | 6. Copy dispatch |
+//           |                      |            | packets w/invalid|  | packet w/invalid |
+//           |                      |            | hdrs to GPU ring |  | hdr to GPU ring  |
+//           |                      |            | buffer           |  | buffer           |
+//           |                      |            +--------+---------+  +--------+---------+
+//           |                      |                     |                     |
+//           |                      |                     v                     v
+//           |                      |       *============================*  *=============*
+//           |                      |       H 7. Ensure meta-data packet H  H 6(a). Ensur-H
+//           |                      |       H body write is ordered      H  H e dispatch  H
+//           |                      |       H before header writes       H  H pkt body is H
+//           |                      |       *=============+==============*  H ordered be- H
+//           |                      |                     |                 H fore header H
+//           |                      |                     v                 H write       H
+//           |                      |            +------------------+       *======+======*
+//           |                      |            | 8. Write valid   |              |
+//           |                      |            | headers into     |              |
+//           |                      |            | meta-data packet |              |
+//           |                      |            | segments         |              |
+//           |                      |            +--------+---------+              |
+//           |                      |                     |                        |
+//           |                      |                     |                        |
+//           |                      |                     |                        |
+//           |                      |                     |                        |
+//           |                      |                     |                        |
+//           |                      |                     |                        |
+//           |                      |                     |                        v
+//  *========+========*             |                     v                 *=============*
+//  H 1(a). Ensure    H             |       *============================*  H 6(a). Ensur-H
+//  H kernel args are H             |       H 9. Ensure meta-data packet H  H e dispatch  H
+//  H visible before  H             |       H is valid before dispatch   H  H pkt body is H
+//  H dispatch is     H             |       H pkt is released to HW      H  H ordered be- H
+//  H legal           H             |       *=============+==============*  H fore header H
+//  *========+========*             |                     |                 H write       H
+//           |                      |                     |                 *======+======*
+//           |                      |                     |                        |
+//           +----------------------+---------------------+------------------------+
+//                                  |
+//                                  v
+//                         +------------------+
+//                         | 10. Write valid  |
+//                         | header into      |
+//                         | kernel dispatch  |
+//                         | packet           |
+//                         +--------+---------+
+//                                  |
+//                                  v
+//                         *==================*
+//                         H 11. Ensure valid H
+//                         H packets visible  H
+//                         H to the hardware  H
+//                         *========+=========*
+//                                  |
+//                                  v
+//                         +------------------+
+//                         | 12. Ring the     |
+//                         | queue's MMIO     |
+//                         | doorbell         |
+//                         +------------------+
+//
+//  Legend:  +--..--+  data operation    *==..==*  ordering / fence point
+//                                      H      H
+//
+ //  CLR uses THREE sfences in the legacy (non-MOVDIR64B) submission path:
+ //  (1) Inside metadata_preloader::SetPacket, between the metadata body
+ //      writes and the metadata header writes (ordering point #7).  This
+ //      ensures the CP's prefetcher never sees valid metadata headers
+ //      before the body is flushed — required because the metadata ring
+ //      buffer may be WC-mapped and the prefetcher reads it independently.
+ //  (2) nontemporalStoreFence() before step #10 (packet_store_release),
+ //      satisfying ordering points #1(a), #6(a), and #9.
+ //  (3) sfence before the doorbell ring (step #11).  This is inside
+ //      ROCr's AqlQueue::StoreRelease and ensures the valid dispatch
+ //      header is flushed from the WC buffer before the UC doorbell write.
+ //
+ // SFENCE orders ALL preceding NT/WC stores, not just the most recent.
+ // On PCIe each SFENCE causes the CPU to stall until WriteACK returns
+ // from the PCIe posted write / XGMI coherence station.
+ //
+ // --- MOVDIR64B optimisation (runtime-detected) ---
+ //
+// When MOVDIR64B is available (hasMovdir64b()), the submission path
+// switches to an optimised flow that reduces 3 sfences to 2:
+ //
+ // MOVDIR64B atomically writes 64 bytes and closes the WC buffer after
+ // execution.  If used for both the metadata packet and the dispatch
+ // packet, the body-to-header ordering within each 64-byte write is
+// guaranteed atomically, eliminating sfences #1 and #2.  The explicit
+// sfence before the dispatch MOVDIR64B ensures kernarg NT stores and
+// metadata MOVDIR64B writes are globally ordered before the dispatch
+// packet becomes visible (#1a / #9). ROCr still performs the final
+// doorbell sfence in hsa_signal_store_screlease:
+ //
+ //   1. MOVDIR64B metadata segments (body + headers atomic per 64B, WC closed)
+//   2. nontemporalStoreFence — explicit sfence (#1a / #7 / #9)
+ //   3. MOVDIR64B dispatch packet   (body + header atomic, WC closed)
+//   4. doorbell ring               (ROCr sfence + UC write)
+ //
+// This reduces the dispatch hot path from 3 sfences to 2.
+ //
+ // Note: the sfence between steps 1 and 3 also guarantees that
+ // metadata MOVDIR64B writes (which follow WC ordering) are globally
+ // visible before the dispatch MOVDIR64B.  This satisfies ordering
+ // point #9 (metadata valid before dispatch is released to HW).
+//
+// --- Doorbell ring (step #11 / #12) — two paths ---
+//
+// CLR supports two doorbell paths, selected by DEBUG_CLR_DIRECT_DOORBELL:
+//
+// (A) Default path (DEBUG_CLR_DIRECT_DOORBELL=0):
+//     CLR calls hsa_signal_store_screlease(doorbell_signal, index).
+//     ROCr's AqlQueue::StoreRelease (amd_aql_queue.cpp) does:
+//
+//         std::atomic_thread_fence(memory_order_release);   // (redundant)
+//         _mm_sfence();
+//         *(signal_.hardware_doorbell_ptr) = uint64_t(value);
+//
+//     That SFENCE ensures the valid header written by packet_store_release
+//     (step #10) is flushed from the WC buffer before the UC doorbell store.
+//     CLR does NOT need its own SFENCE between step #10 and the doorbell.
+//
+// (B) Direct path (DEBUG_CLR_DIRECT_DOORBELL=1):
+//     CLR calls ringDoorbell(doorbell_ptr_, index) which does:
+//
+//         nontemporalStoreFence();   // sfence — flushes header from WC buffer
+//         *doorbell = index;         // UC store — also implicitly flushes WC
+//
+//     The doorbell pointer is cached at queue creation via
+//     HSA_AMD_QUEUE_INFO_DOORBELL_ID.  This eliminates the levels of
+//     indirection in the ROCr signal store on the dispatch hot path.
+//
+// In both paths the UC (uncacheable) MMIO doorbell write implicitly flushes
+// any remaining WC data, so no additional SFENCE is needed after the store.
+
+// ================================================================================================
+#if IS_LINUX
+__attribute__((optimize("unroll-all-loops"), always_inline)) static inline void nontemporalMemcpy(
+    void* __restrict dst, const void* __restrict src, size_t size) {
+#if defined(ATI_ARCH_X86)
+  // Drain unaligned head with scalar NT stores to reach 4-byte then 16-byte
+  // dst alignment.  The streaming store intrinsics require aligned destinations;
+  // source is always loaded with unaligned intrinsics since the caller may pass
+  // an arbitrary struct pointer (e.g. AQL packet body at +4 offset).
+  auto addr = reinterpret_cast<uintptr_t>(dst);
+  if ((addr & 0x3) && size) {
+    auto lead = std::min(size, static_cast<size_t>(4 - (addr & 0x3)));
+    std::memcpy(dst, src, lead);
+    dst = static_cast<char*>(dst) + lead;
+    src = static_cast<const char*>(src) + lead;
+    size -= lead;
+    addr = reinterpret_cast<uintptr_t>(dst);
+  }
+  while ((addr & 0xF) && size >= sizeof(int)) {
+    int val;
+    std::memcpy(&val, src, sizeof(int));
+    _mm_stream_si32(static_cast<int*>(dst), val);
+    dst = static_cast<char*>(dst) + sizeof(int);
+    src = static_cast<const char*>(src) + sizeof(int);
+    size -= sizeof(int);
+    addr += sizeof(int);
+  }
+
+#if defined(__AVX512F__)
+  if ((reinterpret_cast<uintptr_t>(dst) & (sizeof(__m512i) - 1)) == 0) {
+    for (auto i = 0u; i != size / sizeof(__m512i); ++i) {
+      _mm512_stream_si512(reinterpret_cast<__m512i*>(dst),
+                          _mm512_loadu_si512(src));
+      dst = static_cast<char*>(dst) + sizeof(__m512i);
+      src = static_cast<const char*>(src) + sizeof(__m512i);
+    }
+    size = size % sizeof(__m512i);
+  }
+#endif
+
+#if defined(__AVX__)
+  if ((reinterpret_cast<uintptr_t>(dst) & (sizeof(__m256i) - 1)) == 0) {
+    for (auto i = 0u; i != size / sizeof(__m256i); ++i) {
+      _mm256_stream_si256(reinterpret_cast<__m256i*>(dst),
+                          _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src)));
+      dst = static_cast<char*>(dst) + sizeof(__m256i);
+      src = static_cast<const char*>(src) + sizeof(__m256i);
+    }
+    size = size % sizeof(__m256i);
+  }
+#endif
+
+  for (auto i = 0u; i != size / sizeof(__m128i); ++i) {
+    _mm_stream_si128(reinterpret_cast<__m128i*>(dst),
+                     _mm_loadu_si128(reinterpret_cast<const __m128i*>(src)));
+    dst = static_cast<char*>(dst) + sizeof(__m128i);
+    src = static_cast<const char*>(src) + sizeof(__m128i);
+  }
+  size = size % sizeof(__m128i);
+
+  for (auto i = 0u; i != size / sizeof(long long); ++i) {
+    long long val;
+    std::memcpy(&val, src, sizeof(long long));
+    _mm_stream_si64(static_cast<long long*>(dst), val);
+    dst = static_cast<char*>(dst) + sizeof(long long);
+    src = static_cast<const char*>(src) + sizeof(long long);
+  }
+  size = size % sizeof(long long);
+
+  for (auto i = 0u; i != size / sizeof(int); ++i) {
+    int val;
+    std::memcpy(&val, src, sizeof(int));
+    _mm_stream_si32(static_cast<int*>(dst), val);
+    dst = static_cast<char*>(dst) + sizeof(int);
+    src = static_cast<const char*>(src) + sizeof(int);
+  }
+
+  size = size % sizeof(int);
+  std::memcpy(dst, src, size);
+#else
+  std::memcpy(dst, src, size);
+#endif
+}
+#else
+static inline void nontemporalMemcpy(void* __restrict dst, const void* __restrict src,
+                                     size_t size) {
+  std::memcpy(dst, src, size);
+}
+#endif
+
+// Copy the body of an AQL packet (64 bytes) using non-temporal stores.
+// The header (first 4 bytes) is zeroed (HSA_PACKET_TYPE_INVALID) so that the
+// packet is invisible to the CP until the caller publishes the real header via
+// packet_store_release.  Caller MUST issue nontemporalStoreFence() between
+// this call and the header write (ordering point #6a / #9 in the diagram).
+template <typename AqlPacket>
+static inline void nontemporalCopyAQL(AqlPacket* __restrict dst,
+                                      const AqlPacket* __restrict src) {
+  static_assert(sizeof(AqlPacket) == 64, "AQL packets must be 64 bytes");
+  // Skip the first 4 bytes (header + rest) -- they are written atomically later.
+  // Zero the header in the destination to keep it HSA_PACKET_TYPE_INVALID.
+  auto* d = reinterpret_cast<uint8_t*>(dst);
+  auto* s = reinterpret_cast<const uint8_t*>(src);
+  std::memset(d, 0, 4);
+  nontemporalMemcpy(d + 4, s + 4, sizeof(AqlPacket) - 4);
+}
+
+// Drain the write-combining buffer and wait for all preceding NT stores to
+// reach the destination coherence point.  On PCIe this stalls the CPU until
+// WriteACK returns, so minimise the number of fences per submission.
+static inline void nontemporalStoreFence() {
+#if IS_LINUX && defined(ATI_ARCH_X86)
+  _mm_sfence();
+#else
+  std::atomic_thread_fence(std::memory_order_release);
+#endif
+}
+
+// Write the hardware doorbell directly, bypassing hsa_signal_store_screlease.
+// Ordering: the sfence flushes the WC buffer so that the packet header written
+// by packet_store_release (step #10) is visible before the UC doorbell write
+// reaches the GPU (steps #11 / #12).  The UC write itself also implicitly
+// flushes any remaining WC data.
+//
+// When skip_fence is true (MOVDIR64B path), the sfence is omitted: MOVDIR64B
+// already closed the WC buffer, so the dispatch packet is posted before the
+// UC doorbell store reaches the GPU.
+static inline void ringDoorbell(volatile uint64_t* doorbell, uint64_t index,
+                                bool skip_fence = false) {
+  if (!skip_fence) {
+    nontemporalStoreFence();
+  }
+  *doorbell = index;
+}
+
+// ---- MOVDIR64B support ----------------------------------------------------------
+//
+// MOVDIR64B atomically writes 64 bytes and closes the WC buffer after
+// execution.  When used for AQL packet submission it eliminates multiple
+// sfences — see the "MOVDIR64B optimisation" section in the long comment
+// above for the full ordering analysis.
+//
+// Detection lives in Os::hasMovdir64b() (CPUID leaf 7, sub-leaf 0, ECX
+// bit 28).  The result is cached on first call.
+
+static inline bool hasMovdir64b() {
+#if IS_LINUX && defined(ATI_ARCH_X86) && defined(_LP64)
+  return Os::hasMovdir64b();
+#else
+  return false;
+#endif
+}
+
+// Atomically write 64 bytes from src to dst using MOVDIR64B.
+//
+// dst MUST be 64-byte aligned (hardware requirement; #GP otherwise).
+// src has no alignment requirement but 64-byte alignment is optimal.
+//
+// The instruction reads 64 bytes from [src] (normal load, can be WB/WC/UC)
+// and writes them as a single atomic 64-byte store to [dst].  The WC buffer
+// is closed after execution, which guarantees the write is posted before
+// any subsequent store begins filling a new WC buffer entry.
+//
+// Caller must ensure hasMovdir64b() == true before calling.
+static inline void movdir64b_copy64(void* __restrict dst, const void* __restrict src) {
+#if IS_LINUX && defined(ATI_ARCH_X86) && defined(_LP64)
+  assert((reinterpret_cast<uintptr_t>(dst) & 63) == 0 && "MOVDIR64B dst must be 64-byte aligned");
+  // AT&T syntax: movdir64b (%src_reg), %dst_reg
+  __asm__ __volatile__("movdir64b %1, %0"
+                       : : "r"(dst), "m"(*(const char(*)[64])src) : "memory");
+#else
+  (void)dst; (void)src;
+#endif
+}
+
+// Write a full 64-byte AQL packet (body + valid header) atomically using
+// MOVDIR64B.  Unlike the split nontemporalCopyAQL + sfence +
+// packet_store_release sequence, this writes all 64 bytes including the
+// valid header in a single atomic store.  The WC buffer is closed after
+// execution, so no sfence is needed between this write and a subsequent
+// UC doorbell store.
+//
+// src is the caller's CPU-side staging packet (e.g. dispatchPacket on the
+// stack).  The valid header/rest are merged into a local aligned copy
+// before the MOVDIR64B.
+template <typename AqlPacket>
+static inline void nontemporalWriteAQL(AqlPacket* __restrict dst,
+                                       const AqlPacket* __restrict src,
+                                       uint16_t header, uint16_t rest) {
+  static_assert(sizeof(AqlPacket) == 64, "AQL packets must be 64 bytes");
+  alignas(64) AqlPacket staging;
+  std::memcpy(&staging, src, sizeof(AqlPacket));
+  *reinterpret_cast<uint32_t*>(&staging) = header | (static_cast<uint32_t>(rest) << 16);
+  movdir64b_copy64(dst, &staging);
+}
+
+// STL-compatible allocator that guarantees N-byte alignment.
+// Use with std::vector to ensure the backing store is aligned for SIMD NT stores.
+template <typename T, std::size_t Align>
+struct AlignedAllocator {
+  using value_type = T;
+
+  AlignedAllocator() noexcept = default;
+  template <typename U>
+  AlignedAllocator(const AlignedAllocator<U, Align>&) noexcept {}
+
+  T* allocate(std::size_t n) {
+    void* p = ::operator new(n * sizeof(T), std::align_val_t{Align});
+    return static_cast<T*>(p);
+  }
+  void deallocate(T* p, std::size_t) noexcept {
+    ::operator delete(p, std::align_val_t{Align});
+  }
+
+  template <typename U>
+  struct rebind { using other = AlignedAllocator<U, Align>; };
+
+  bool operator==(const AlignedAllocator&) const noexcept { return true; }
+  bool operator!=(const AlignedAllocator&) const noexcept { return false; }
+};
+
+template <typename T>
+using AlignedVector64 = std::vector<T, AlignedAllocator<T, 64>>;
+
+}  // namespace amd
+
+#endif  // CLR_ROCCLR_UTILS_NONTEMPORAL_HPP_


### PR DESCRIPTION
- Switch CLR queue acquisition to hsa_amd_queue_create and cache per-queue metadata ring buffer in QueueExtras.
- Add DEBUG_CLR_DEV_QUEUE release flag: 0 keeps system-memory ring buffers, while values greater than 0 request device-memory ring buffers when Large BAR is available; queue descriptors remain host-resident.
- Cache MOVDIR64B CPU capability at device initialization and use it only for Large BAR-backed device-memory queue ring buffers.
- Add non-temporal store helpers, MOVDIR64B 64-byte copy support, aligned flat packet buffers, and unified packet write helpers for AQL submission.
- Stage metadata packets for device-memory ring buffers and copy full 64-byte segments to reduce scattered write-combining stores.
- Propagate 64-byte aligned graph flat-packet buffers through HIP graph dispatch paths.
- Remove DEBUG_CLR_DIRECT_DOORBELL: direct hardware doorbell bypass showed no measurable latency improvement over the default ROCr signal_store_screlease path; all doorbell writes now go through ROCr.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
