### PR TITLE
feat(clr): Use device-resident queue ring buffers

### DIFF
--- a/projects/clr/hipamd/src/hip_code_object.cpp
+++ b/projects/clr/hipamd/src/hip_code_object.cpp
@@ -268,10 +268,12 @@ hipError_t DynCO::populateDynGlobalFuncs() {
     // if symbols are init/fini, we trim them out
     // These are ASAN specific symbols and we do not bubble them up to the user
     // This means something like count of kernels in code object remains the same.
-#if defined(__clang__) && __has_feature(address_sanitizer)
+#if defined(__clang__)
+#if __has_feature(address_sanitizer)
     if (elem == "amdgcn.device.init" || elem == "amdgcn.device.fini") {
       continue;
     }
+#endif
 #endif
     functions_.insert(std::make_pair(elem, new Function(elem)));
   }

--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -1825,6 +1825,7 @@ void GraphExecSegmented::PacketBatch::rebuildFilteredLists(
   enabledKernelNames.reserve(dispatchPackets.size());
   filteredFlatPacketData.reserve(dispatchPackets.size() * kAqlPktSize);
   filteredValidPacketFullHeaders.reserve(dispatchPackets.size());
+  filteredFlatMetadataData.reserve(dispatchPackets.size() * kMetadataPktSize);
 
   const bool hasMetadata = !dispatchMetadataPackets.empty();
 
@@ -1837,20 +1838,21 @@ void GraphExecSegmented::PacketBatch::rebuildFilteredLists(
       size_t filteredIdx = enabledPackets.size();
       enabledPackets.push_back(dispatchPackets[i]);
       enabledKernelNames.push_back(dispatchKernelNames[i]);
-      appendPacketToFlatBuffer(dispatchPackets[i], filteredFlatPacketData,
-                               filteredValidPacketFullHeaders);
-      // Append corresponding metadata slot. Slots without captured metadata are
-      // published as HSA_PACKET_TYPE_INVALID so the CP prefetch engine skips them.
-      if (hasMetadata) {
-        size_t metaOff = filteredFlatMetadataData.size();
-        filteredFlatMetadataData.resize(metaOff + kMetadataPktSize, 0);
-        uint8_t* slot = filteredFlatMetadataData.data() + metaOff;
-        if (i < dispatchMetadataPackets.size() && dispatchMetadataPackets[i] != nullptr) {
-          std::memcpy(slot, dispatchMetadataPackets[i], kMetadataPktSize);
-        } else {
-          invalidateMetadataSlot(slot);
-        }
+      // appendPacketToFlatBuffer also appends the index-aligned metadata slot
+      // (zero-filled when this index has no metadata packet). Empty slots
+      // (barriers / uncaptured dispatches) are then stamped
+      // HSA_PACKET_TYPE_INVALID so the CP prefetch engine skips them — a zeroed
+      // slot would be type 0 (VENDOR_SPECIFIC), which the CP could process.
+      const uint8_t* metadata_raw =
+          (hasMetadata && i < dispatchMetadataPackets.size()) ? dispatchMetadataPackets[i]
+                                                              : nullptr;
+      appendPacketToFlatBuffer(dispatchPackets[i], metadata_raw, filteredFlatPacketData,
+                               filteredValidPacketFullHeaders, filteredFlatMetadataData);
+      if (hasMetadata && metadata_raw == nullptr) {
+        invalidateMetadataSlot(filteredFlatMetadataData.data() +
+                               filteredFlatMetadataData.size() - kMetadataPktSize);
       }
+
       packetToFilteredIndex[dispatchPackets[i]] = filteredIdx;
     }
   }
@@ -2268,8 +2270,10 @@ hipError_t GraphExecSegmented::UpdateAQLPacket(hip::GraphNode* node) {
 // Append one 64-byte AQL packet to a flat buffer: copies the body, saves the original full_header
 // and invalidates the header.
 void GraphExecSegmented::PacketBatch::appendPacketToFlatBuffer(const uint8_t* pkt_raw,
-                                                      std::vector<uint8_t>& flatData,
-                                                      std::vector<uint32_t>& fullHeaders) {
+                                                      const uint8_t* metadata_raw,
+                                                      amd::AlignedVector64<uint8_t>& flatData,
+                                                      std::vector<uint32_t>& fullHeaders,
+                                                      std::vector<uint8_t>& flatMetadata) {
   static constexpr size_t kSigOff = 56;
   const size_t baseOff = flatData.size();
   flatData.insert(flatData.end(), pkt_raw, pkt_raw + kAqlPktSize);
@@ -2286,6 +2290,14 @@ void GraphExecSegmented::PacketBatch::appendPacketToFlatBuffer(const uint8_t* pk
   memcpy(dst, &kInvalidAqlHeader, sizeof(kInvalidAqlHeader));
   // Zero completion signal; ApplyHwEventPatches re-patches it directly via flat_packet pointers.
   memset(dst + kSigOff, 0, sizeof(uint64_t));
+
+  // Append the matching metadata-prefetch packet so flatMetadata stays index-
+  // aligned with flatData. A nullptr |metadata_raw| yields a zeroed slot.
+  const size_t metaOff = flatMetadata.size();
+  flatMetadata.insert(flatMetadata.end(), kMetadataPktSize, 0);
+  if (metadata_raw != nullptr) {
+    memcpy(flatMetadata.data() + metaOff, metadata_raw, kMetadataPktSize);
+  }
 }
 
 // ================================================================================================
@@ -2310,8 +2322,12 @@ void GraphExecSegmented::PacketBatch::rebuildFlatBuffer() {
   filteredCacheValid = false;
   flatPacketData.reserve(n * kAqlPktSize);
   validPacketFullHeaders.reserve(n);
-  for (const uint8_t* pkt_raw : dispatchPackets) {
-    appendPacketToFlatBuffer(pkt_raw, flatPacketData, validPacketFullHeaders);
+  flatMetadataData.reserve(n * kMetadataPktSize);
+  for (size_t i = 0; i < n; ++i) {
+    const uint8_t* metadata_raw =
+        (i < dispatchMetadataPackets.size()) ? dispatchMetadataPackets[i] : nullptr;
+    appendPacketToFlatBuffer(dispatchPackets[i], metadata_raw, flatPacketData,
+                             validPacketFullHeaders, flatMetadataData);
   }
   // Build flat metadata buffer (kMetadataPktSize per slot).
   // Slots without captured metadata (barriers, uncaptured dispatches) are published as
@@ -2560,7 +2576,7 @@ hipError_t GraphExecSegmented::EnqueueSegment(const Segment& segment, hip::Strea
       return hipSuccess;
     }
 
-    const std::vector<uint8_t>* flatData;
+    const amd::AlignedVector64<uint8_t>* flatData;
     const std::vector<uint32_t>* flatHdrs;
     const std::vector<uint8_t>* metaData = nullptr;
 
@@ -3255,13 +3271,7 @@ void GraphKernelArgManager::ReadBackOrFlush() {
   for (const auto& kernarg : kernarg_graph_) {
     const auto kernArgImpl = kernarg.first->settings().kernel_arg_impl_;
 
-    if (kernArgImpl == KernelArgImpl::DeviceKernelArgsHDP) {
-      // Trigger HDP flush
-      *kernarg.first->info().hdpMemFlushCntl = 1u;
-      // Read back to ensure flush completion
-      volatile int kSentinel = *reinterpret_cast<volatile int*>(kernarg.first->info().hdpMemFlushCntl);
-      (void)kSentinel; // Suppress unused variable warning
-    } else if (kernArgImpl == KernelArgImpl::DeviceKernelArgsReadback) {
+    if (kernArgImpl == KernelArgImpl::DeviceKernelArgsReadback) {
       const auto& pool = kernarg.second.back();
       if (pool.kernarg_pool_addr_ == 0) {
         continue;

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -22,6 +22,7 @@
 #include "hip_platform.hpp"
 #include "hip_mempool_impl.hpp"
 #include "hip_vm.hpp"
+#include "utils/nontemporal.hpp"
 
 typedef struct ihipExtKernelEvents {
   hipEvent_t startEvent_;
@@ -258,13 +259,19 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   }
   // Return gpu packet address to update with actual packet under capture.
   std::vector<uint8_t*>& GetAqlPackets() { return gpuPackets_; }
+  // Return captured metadata-prefetch packets (parallel to gpuPackets_).
+  std::vector<uint8_t*>& GetMetadataPackets() { return gpuMetadataPackets_; }
   void SetKernelName(const std::string* kernelName) { capturedKernelName_ = kernelName; }
   const std::string* GetKernelName() const { return capturedKernelName_; }
   size_t GetKerArgSize() const { return alignedKernArgSize_; }
   size_t GetKernargSegmentByteSize() const { return kernargSegmentByteSize_; }
   size_t GetKernargSegmentAlignment() const { return kernargSegmentAlignment_; }
 
-  //! Capture packets and accumulate them into a batch if provided
+  //! Capture packets and accumulate them into a batch if provided.
+  //! |batchMetadataPackets|, when provided, receives the captured metadata-prefetch
+  //! packet for each AQL packet (pointer-parallel to |batchPackets|). Entries are
+  //! nullptr for packets that produced no metadata (e.g. device has no metadata
+  //! ring buffer), so the batch's flat metadata buffer stays index-aligned.
   hipError_t CaptureAndFormPacket(GraphKernelArgManager* kernArgMgr,
                                   std::vector<uint8_t*>* batchPackets = nullptr,
                                   std::vector<const std::string*>* batchKernelNames = nullptr,
@@ -290,6 +297,13 @@ class GraphNode : public hipGraphNodeDOTAttribute {
       // The packet is stored in gpuPacket_ and submitted during graph launch.
       command->submit(*(command->queue())->vdev());
       command->release();
+    }
+
+    // The metadata capture path appends one metadata packet per AQL packet, but
+    // only on devices with a metadata ring buffer. Normalize to be pointer-parallel
+    // with gpuPackets_ so downstream flattening can rely on a 1:1 index mapping.
+    if (gpuMetadataPackets_.empty()) {
+      gpuMetadataPackets_.resize(gpuPackets_.size(), nullptr);
     }
 
     // Accumulate packets directly into the batch (only if batch vectors are provided)
@@ -1189,14 +1203,16 @@ class GraphExecSegmented : public GraphExecBase {
     std::vector<const std::string*> enabledKernelNames;
 
     // Pre-built flat packet buffer for fast bulk dispatch (all nodes enabled).
-    std::vector<uint8_t> flatPacketData;
+    // 64-byte aligned so NT copies from this buffer can use aligned SIMD loads.
+    amd::AlignedVector64<uint8_t> flatPacketData;
     std::vector<uint32_t> validPacketFullHeaders;
+
     // Pre-built flat metadata buffer (kMetadataPktSize per AQL packet).
     std::vector<uint8_t> flatMetadataData;
 
     // Filtered flat buffer - built alongside enabledPackets when some nodes are disabled.
     // Allows the fast flat-dispatch path even in the partially-disabled case.
-    std::vector<uint8_t> filteredFlatPacketData;
+    amd::AlignedVector64<uint8_t> filteredFlatPacketData;
     std::vector<uint32_t> filteredValidPacketFullHeaders;
     std::vector<uint8_t> filteredFlatMetadataData;
     bool filteredCacheValid = false;
@@ -1225,9 +1241,14 @@ class GraphExecSegmented : public GraphExecBase {
     // Append one 64-byte AQL packet to a flat buffer: copies the body, saves the
     // full_header dword, and invalidates the header. Zeroes completion_signal
     // (ApplyHwEventPatches re-patches it directly via flat_packet pointers at launch).
+    // Also appends the matching kMetadataPktSize metadata packet to flatMetadata,
+    // keeping it index-aligned with flatData. |metadata_raw| may be nullptr, in
+    // which case a zeroed metadata slot is appended.
     static void appendPacketToFlatBuffer(const uint8_t* pkt_raw,
-                                         std::vector<uint8_t>& flatData,
-                                         std::vector<uint32_t>& fullHeaders);
+                                         const uint8_t* metadata_raw,
+                                         amd::AlignedVector64<uint8_t>& flatData,
+                                         std::vector<uint32_t>& fullHeaders,
+                                         std::vector<uint8_t>& flatMetadata);
     // Stamp the four packet headers of a 256-byte metadata slot with
     // HSA_PACKET_TYPE_INVALID (type=1) so the CP metadata-prefetch engine skips it.
     static void invalidateMetadataSlot(uint8_t* slot);

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -22,6 +22,7 @@
 #include "devkernel.hpp"
 #include "amdocl/cl_profile_amd.h"
 #include "devsignal.hpp"
+#include "utils/nontemporal.hpp"
 
 #if defined(__clang__)
 #if __has_feature(address_sanitizer)
@@ -654,6 +655,9 @@ struct Info : public amd::EmbeddedObject {
   //! large bar support.
   bool largeBar_;
 
+  //! CPU supports MOVDIR64B (atomic 64-byte write with WC buffer close).
+  bool movdir64b_;
+
   uint32_t hmmSupported_;            //!< ROCr supports HMM interfaces
   uint32_t hmmCpuMemoryAccessible_;  //!< CPU memory is accessible by GPU without pinning/register
   uint32_t hmmDirectHostAccess_;     //!< HMM memory is accessible from the host without migration
@@ -700,10 +704,8 @@ class Settings {
     HostKernelArgs = 0,        //!< Kernel Arguments are put into host memory
     DeviceKernelArgs,          //!< Device memory kernel arguments with no memory
                                //!< ordering workaround (e.g. XGMI)
-    DeviceKernelArgsReadback,  //!< Device memory kernel arguments with kernel
+    DeviceKernelArgsReadback   //!< Device memory kernel arguments with kernel
                                //!< argument readback workaround
-    DeviceKernelArgsHDP        //!< Device memory kernel arguments with kernel
-                               //!< argument readback plus HDP flush workaround.
   };
 
   uint64_t extensions_;  //!< Supported OCL extensions
@@ -730,7 +732,8 @@ class Settings {
       uint sdma_swap_supported_ : 1;         //!< SDMA linear swap copy (gfx94x/gfx95x)
       uint groupMemCarveout_ : 1;             //!< Group memory carveout functionality
       uint sdma_indirect_supported_ : 1;     //!< SDMA linear indirect copy (gfx1250+)
-      uint reserved_ : 9;
+      uint aql_device_ring_buf_ : 1;          //!< Place the AQL queue ring buffer in device memory
+      uint reserved_ : 8;
     };
     uint value_;
   };
@@ -1375,7 +1378,7 @@ class VirtualDevice : public amd::ReferenceCountedObject {
   virtual void HiddenHeapInit() = 0;
 
   //! Fast-path dispatch using a pre-built contiguous flat packet buffer.
-  virtual bool dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPacketData,
+  virtual bool dispatchAqlPacketBatchFlat(const amd::AlignedVector64<uint8_t>& flatPacketData,
                                           const std::vector<uint32_t>& validFullHeaders,
                                           amd::AccumulateCommand* vcmd = nullptr,
                                           bool attach_signal = false,

--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -638,7 +638,6 @@ bool Device::create() {
 
   info_.hdpMemFlushCntl = hdpInfo.HDP_MEM_FLUSH_CNTL;
   info_.hdpRegFlushCntl = hdpInfo.HDP_REG_FLUSH_CNTL;
-  bool hasValidHDPFlush = (info_.hdpMemFlushCntl != nullptr) && (info_.hdpRegFlushCntl != nullptr);
 
   // Create HSA settings
   assert(!settings_);
@@ -646,7 +645,7 @@ bool Device::create() {
   settings_ = hsaSettings;
   if (!hsaSettings || !hsaSettings->create((agent_profile_ == HSA_PROFILE_FULL), *isa,
                                            isa->xnack() == amd::Isa::Feature::Enabled, coop_groups,
-                                           isXgmi_, hasValidHDPFlush)) {
+                                           isXgmi_)) {
     LogPrintfError("Unable to create settings for HSA device %s (PCI ID %x)", agent_name,
                    pciDeviceId_);
     return false;
@@ -1652,6 +1651,7 @@ bool Device::populateOCLDeviceConstants() {
     info_.cooperativeMultiDeviceGroups_ = settings().enableCoopMultiDeviceGroups_;
     // Enable StreamWrite and StreamWait for all devices
     info_.aqlBarrierValue_ = true;
+    info_.movdir64b_ = amd::hasMovdir64b() && (DEBUG_CLR_USE_MOVDIR64B != 0);
   }
 
   info_.maxPipePacketSize_ = info_.maxMemAllocSize_;
@@ -3161,10 +3161,8 @@ VirtualGPU* Device::xferQueue() const {
       return;
     }
     if (thisDevice->xferQueue_->gpu_queue() == nullptr) {
-      void* md_rb = nullptr;
-      auto* queue = thisDevice->AcquireActiveQueue(amd::CommandQueue::Priority::Normal,
-                                                   nullptr, nullptr, &md_rb);
-      thisDevice->xferQueue_->SetGpuQueue(queue, md_rb);
+      thisDevice->xferQueue_->SetGpuQueue(
+          thisDevice->AcquireActiveQueue(amd::CommandQueue::Priority::Normal));
     }
   });
   if (!xferQueue_) {
@@ -3222,8 +3220,7 @@ void Device::getHwEventTime(const amd::Event& event, uint64_t* start, uint64_t* 
 // ================================================================================================
 hsa_queue_t* Device::getQueueFromPool(const uint qIndex, bool force_reuse,
                                       hsa_queue_t* preferred,
-                                      const std::unordered_set<uint64_t>* excluded_ids,
-                                      void** metadata_ring_buffer) {
+                                      const std::unordered_set<uint64_t>* excluded_ids) {
   // Only reuse queues when we've reached the maximum limit, unless forced
   // Below the limit, return nullptr to allow creating new queues
   if (!force_reuse && queuePool_[qIndex].size() < settings().max_hw_queues_) {
@@ -3240,9 +3237,6 @@ hsa_queue_t* Device::getQueueFromPool(const uint qIndex, bool force_reuse,
         auto it = queuePool_[qIndex].find(preferred);
         if (it != queuePool_[qIndex].end()) {
           it->second.refCount++;
-          if (metadata_ring_buffer) {
-            *metadata_ring_buffer = it->second.metadataRingBuffer_;
-          }
           ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
                   "Reusing preferred queue: %p refCount: %d",
                   it->first->base_address, it->second.refCount);
@@ -3289,9 +3283,6 @@ hsa_queue_t* Device::getQueueFromPool(const uint qIndex, bool force_reuse,
         });
 
     lowest->second.refCount++;
-    if (metadata_ring_buffer) {
-      *metadata_ring_buffer = lowest->second.metadataRingBuffer_;
-    }
     ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
             "Selected queue (mode=%u): %p refCount: %d, depth: %lu, metric: %lu, pipe: %d%s%s",
             mode, lowest->first->base_address, lowest->second.refCount,
@@ -3309,12 +3300,10 @@ hsa_queue_t* Device::getQueueFromPool(const uint qIndex, bool force_reuse,
 // ================================================================================================
 hsa_queue_t* Device::AcquireActiveQueue(amd::CommandQueue::Priority priority,
                                         hsa_queue_t* preferred,
-                                        const std::unordered_set<uint64_t>* excluded_ids,
-                                        void** metadata_ring_buffer) {
+                                        const std::unordered_set<uint64_t>* excluded_ids) {
   uint32_t queue_size = ROC_AQL_QUEUE_SIZE;
   auto queue = acquireQueue(queue_size, false, std::vector<uint32_t>{},
-                            priority, true, false, preferred, excluded_ids,
-                            metadata_ring_buffer);
+                            priority, true, false, preferred, excluded_ids);
   return queue;
 }
 
@@ -3382,8 +3371,7 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
     // decide when to start reclaiming queues.
     if (!coop_queue && (cuMask.size() == 0) &&
         (queuePool_[qIndex].size() >= settings().max_hw_queues_)) {
-      hsa_queue_t* queue = getQueueFromPool(qIndex, false, preferred, excluded_ids,
-                                            metadata_ring_buffer);
+      hsa_queue_t* queue = getQueueFromPool(qIndex, false, preferred, excluded_ids);
       if (queue != nullptr) {
         if (!managed) {
           num_queues_[qIndex]++;
@@ -3402,84 +3390,22 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
   }
   auto queue_size = (queue_max_packets < queue_size_hint) ? queue_max_packets : queue_size_hint;
 
-  hsa_queue_t* queue;
   auto queue_type = HSA_QUEUE_TYPE_MULTI;
 
-  // Enable cooperative queue for the device queue
   if (coop_queue) {
     queue_type = HSA_QUEUE_TYPE_COOPERATIVE;
   }
 
-  while (Hsa::queue_create(bkendDevice_, queue_size, queue_type, callbackQueue, this,
-                           std::numeric_limits<uint>::max(), std::numeric_limits<uint>::max(),
-                           &queue) != HSA_STATUS_SUCCESS) {
-    queue_size >>= 1;
-    if (queue_size < 64) {
-      LogError("Device::acquireQueue: hsa_queue_create failed!");
-      // If we can't create even a small queue, try to reuse any existing queue
-      if (!coop_queue && (cuMask.size() == 0)) {
-        amd::ScopedLock l(active_queue_access_);
-        if (queuePool_[qIndex].size() > 0) {
-          bool kForceReuse = true;
-          return getQueueFromPool(qIndex, kForceReuse, nullptr, nullptr,
-                                  metadata_ring_buffer);
-        }
-      }
-      ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE,
-              "Device::acquireQueue: hsa_queue_create failed!");
-      return nullptr;
-    }
-  }
-
-  // default priority is normal so no need to set it again
-  if (queue_priority != HSA_AMD_QUEUE_PRIORITY_NORMAL) {
-    hsa_status_t st = Hsa::queue_set_priority(queue, queue_priority);
-    if (st != HSA_STATUS_SUCCESS) {
-      ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE,
-              "Device::acquireQueue: hsa_amd_queue_set_priority failed!");
-      Hsa::queue_destroy(queue);
-      return nullptr;
-    }
-  }
-
-  ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
-          "Created SWq=%p to map on HWq=%p with "
-          "size %d with priority %d, cooperative: %i",
-          queue, queue->base_address, queue_size, queue_priority, coop_queue);
-
-  Hsa::profiling_set_profiler_enabled(queue, 1);
-
-  // Query metadata prefetch version once from the first queue created on this device.
-  // The version is identical for all queues.
-  if (!metadata_version_queried_) {
-    uint8_t major = 0, minor = 0;
-    hsa_amd_queue_get_info(queue,
-        HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_DISPATCH_PKT_VERSION_MAJOR, &major);
-    hsa_amd_queue_get_info(queue,
-        HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_DISPATCH_PKT_VERSION_MINOR, &minor);
-    if (major < (1 << 3) && minor < (1 << 5)) {
-      metadata_version_header_ =
-          (static_cast<uint32_t>(major) << HSA_AMD_METADATA_PACKET_HEADER_VERSION_MAJOR) |
-          (static_cast<uint32_t>(minor) << HSA_AMD_METADATA_PACKET_HEADER_VERSION_MINOR);
-    }
-    metadata_version_queried_ = true;
-  }
-
+  // Resolve the final CU mask (merge custom + global, expand for WGP mode)
+  std::vector<uint32_t> final_mask;
   if (cuMask.size() != 0 || info_.globalCUMask_.size() != 0) {
-    std::stringstream ss;
-    ss << std::hex;
-    std::vector<uint32_t> mask = {};
-
-    // handle scenarios where cuMask (custom-defined), globalCUMask_ or both are valid and
-    // fill the final mask which will be appiled to the current queue
+    std::vector<uint32_t> mask;
     if (cuMask.size() != 0 && info_.globalCUMask_.size() == 0) {
       mask = cuMask;
     } else if (cuMask.size() != 0 && info_.globalCUMask_.size() != 0) {
       for (unsigned int i = 0; i < std::min(cuMask.size(), info_.globalCUMask_.size()); i++) {
         mask.push_back(cuMask[i] & info_.globalCUMask_[i]);
       }
-      // check to make sure after ANDing cuMask (custom-defined) with global
-      // CU mask, we have non-zero mask, oterwise just apply global CU mask
       bool zeroCUMask = true;
       for (auto m : mask) {
         if (m != 0) {
@@ -3494,28 +3420,13 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
       mask = info_.globalCUMask_;
     }
 
-
-    for (int i = mask.size() - 1; i >= 0; i--) {
-      ss << std::setfill('0') << std::setw(8) << mask[i];
-    }
-    ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Setting CU mask 0x%s for hardware queue %p",
-            ss.str().c_str(), queue->base_address);
-
-    std::vector<uint32_t> final_mask = {};
-    // hsa_amd_queue_cu_set_mask expects each bit in cuMask to represent each CU
-    // For wgp mode: Each wgp consists of 2 CUs and CUs must be adjacent pairwise enabled
-    // Convert each bit in the cuMask from wgp to cu by duplicating it
     if (settings().enableWgpMode_) {
       final_mask.resize(mask.size() * 2, 0);
-
-      for (int i = 0; i < mask.size(); i++) {
+      for (size_t i = 0; i < mask.size(); i++) {
         for (int j = 0; j < 16; j++) {
-          // Convert least significant 16 bits
           if (((mask[i] >> j) & 0x1) == 0x1) {
             final_mask[2 * i] |= (0x3 << (2 * j));
           }
-
-          // Convert most significant 16 bits
           if (((mask[i] >> (16 + j)) & 0x1) == 0x1) {
             final_mask[2 * i + 1] |= (0x3 << (2 * j));
           }
@@ -3524,29 +3435,115 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
     } else {
       final_mask = mask;
     }
+  }
 
-    hsa_status_t status = Hsa::queue_cu_set_mask(queue, final_mask.size() * 32, final_mask.data());
-    if (status != HSA_STATUS_SUCCESS) {
+  // Build the queue creation descriptor with priority, CU mask, and flags.
+  // settings().aql_device_ring_buf_ controls queue ring buffer placement (enabled
+  // by default on gfx94x/gfx125x, overridable via DEBUG_CLR_AQL_DEV_QUEUE):
+  //   false - system memory
+  //   true  - ring buffer in device memory if Large BAR is available.
+  const bool device_mem_ring_buf =
+      settings().aql_device_ring_buf_ && info_.largeBar_ && Hsa::amd_queue_create_available();
+  hsa_amd_queue_create_desc_t desc = {};
+  desc.version = HSA_AMD_QUEUE_CREATE_DESC_VERSION;
+  desc.engine_type = HSA_AMD_QUEUE_ENGINE_COMPUTE;
+  desc.queue_size_bytes = queue_size * sizeof(hsa_kernel_dispatch_packet_t);
+  desc.priority = queue_priority;
+  desc.callback = callbackQueue;
+  desc.callback_data = this;
+  desc.engine.compute.type = queue_type;
+  desc.engine.compute.private_segment_size = HSA_AMD_PRIVATE_SEGMENT_SIZE_DEFAULT;
+  if (device_mem_ring_buf) {
+    desc.flags = static_cast<hsa_amd_queue_create_flag_t>(
+        desc.flags | HSA_AMD_QUEUE_CREATE_DEVICE_MEM_RING_BUF);
+  }
+  if (!final_mask.empty()) {
+    desc.engine.compute.cu_mask_count = static_cast<uint32_t>(final_mask.size() * 32);
+    desc.engine.compute.cu_mask = final_mask.data();
+  }
+
+  while (Hsa::amd_queue_create(bkendDevice_, &desc, 1) != HSA_STATUS_SUCCESS) {
+    queue_size >>= 1;
+    desc.queue_size_bytes = queue_size * sizeof(hsa_kernel_dispatch_packet_t);
+    if (queue_size < 64) {
+      LogError("Device::acquireQueue: hsa_amd_queue_create failed!");
+      if (!coop_queue && (cuMask.size() == 0)) {
+        amd::ScopedLock l(active_queue_access_);
+        if (queuePool_[qIndex].size() > 0) {
+          bool kForceReuse = true;
+          return getQueueFromPool(qIndex, kForceReuse);
+        }
+      }
       ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_QUEUE,
-              "Device::acquireQueue: hsa_amd_queue_cu_set_mask failed!");
-      Hsa::queue_destroy(queue);
+              "Device::acquireQueue: hsa_amd_queue_create failed!");
       return nullptr;
     }
+  }
 
-    if (metadata_ring_buffer) {
-      hsa_amd_queue_get_info(queue, HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER,
-                             metadata_ring_buffer);
+  hsa_queue_t* queue = desc.queue;
+  if (IsLogEnabled(amd::LOG_INFO, amd::LOG_QUEUE)) {
+    if (!final_mask.empty()) {
+      std::stringstream ss;
+      ss << std::hex;
+      for (int i = final_mask.size() - 1; i >= 0; i--) {
+        ss << std::setfill('0') << std::setw(8) << final_mask[i];
+      }
+      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+              "Created SWq=%p HWq=%p size %d priority %d cooperative %i flags 0x%x "
+              "device_mem_ring_buf %i CU mask 0x%s",
+              queue, queue->base_address, queue_size, queue_priority, coop_queue, desc.flags,
+              device_mem_ring_buf, ss.str().c_str());
+    } else {
+      ClPrint(amd::LOG_INFO, amd::LOG_QUEUE,
+              "Created SWq=%p HWq=%p size %d priority %d cooperative %i flags 0x%x "
+              "device_mem_ring_buf %i",
+              queue, queue->base_address, queue_size, queue_priority, coop_queue, desc.flags,
+              device_mem_ring_buf);
     }
+  }
+
+  Hsa::profiling_set_profiler_enabled(queue, 1);
+
+  if (!metadata_version_queried_) {
+    uint8_t major = 0, minor = 0;
+    hsa_amd_queue_get_info(queue,
+        HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_DISPATCH_PKT_VERSION_MAJOR, &major);
+    hsa_amd_queue_get_info(queue,
+        HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_DISPATCH_PKT_VERSION_MINOR, &minor);
+    if (major < (1 << 3) && minor < (1 << 5)) {
+      metadata_version_header_ =
+          (static_cast<uint32_t>(major) << HSA_AMD_METADATA_PACKET_HEADER_VERSION_MAJOR) |
+          (static_cast<uint32_t>(minor) << HSA_AMD_METADATA_PACKET_HEADER_VERSION_MINOR);
+    }
+    metadata_version_queried_ = true;
+  }
+
+  // Query extras for the newly-created queue and insert into the lookup map
+  auto populateExtras = [&]() {
+    QueueExtras extras;
+    extras.deviceMemRingBuf = (desc.flags & HSA_AMD_QUEUE_CREATE_DEVICE_MEM_RING_BUF) != 0;
+    hsa_amd_queue_get_info(queue, HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER,
+                           &extras.metadataRingBuffer);
+    if (DEBUG_CLR_DIRECT_DOORBELL) {
+      uint64_t db_id = 0;
+      if (hsa_amd_queue_get_info(queue, HSA_AMD_QUEUE_INFO_DOORBELL_ID, &db_id) ==
+              HSA_STATUS_SUCCESS &&
+          db_id != 0) {
+        extras.doorbellPtr = reinterpret_cast<volatile uint64_t*>(db_id);
+      }
+    }
+    queue_extras_[queue] = extras;
+  };
+
+  if (!final_mask.empty()) {
+    amd::ScopedLock l(active_queue_access_);
+    populateExtras();
     return queue;
   }
 
   if (coop_queue) {
-    // Skip queue recycling for cooperative queues, since it should be just one
-    // per device.
-    if (metadata_ring_buffer) {
-      hsa_amd_queue_get_info(queue, HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER,
-                             metadata_ring_buffer);
-    }
+    amd::ScopedLock l(active_queue_access_);
+    populateExtras();
     return queue;
   }
 
@@ -3557,11 +3554,7 @@ hsa_queue_t* Device::acquireQueue(uint32_t queue_size_hint, bool coop_queue,
   auto& qInfo = result.first->second;
   qInfo.refCount = 1;
   qInfo.hasDedicatedQueue_ = dedicated_queue;
-  hsa_amd_queue_get_info(queue, HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER,
-                         &qInfo.metadataRingBuffer_);
-  if (metadata_ring_buffer) {
-    *metadata_ring_buffer = qInfo.metadataRingBuffer_;
-  }
+  populateExtras();
   ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "acquireQueue refCount: %p (%d) %s",
           result.first->first->base_address, result.first->second.refCount,
           dedicated_queue ? "(dedicated)" : "");
@@ -3654,6 +3647,13 @@ void Device::DrainDeferredQueueDestroys() {
     ClPrint(amd::LOG_INFO, amd::LOG_QUEUE, "Deleting deferred hardware queue %p", queue->base_address);
     Hsa::queue_destroy(queue);
   }
+}
+
+// ================================================================================================
+Device::QueueExtras Device::GetQueueExtras(hsa_queue_t* queue) {
+  amd::ScopedLock l(active_queue_access_);
+  auto it = queue_extras_.find(queue);
+  return (it != queue_extras_.end()) ? it->second : QueueExtras{};
 }
 
 bool Device::findLinkInfo(const amd::Device& other_device, std::vector<LinkAttrType>* link_attrs) {

--- a/projects/clr/rocclr/device/rocm/rocdevice.hpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.hpp
@@ -595,6 +595,13 @@ class Device : public NullDevice {
 
   VirtualGPU* xferQueue() const;
 
+  struct QueueExtras {
+    void* metadataRingBuffer = nullptr;
+    //! Cached hardware doorbell (UC MMIO), only set when DEBUG_CLR_DIRECT_DOORBELL is enabled.
+    volatile uint64_t* doorbellPtr = nullptr;
+    bool deviceMemRingBuf = false;
+  };
+
   //! Acquire HSA queue. This method can create a new HSA queue or
   hsa_queue_t* acquireQueue(
       uint32_t queue_size_hint, bool coop_queue = false, const std::vector<uint32_t>& cuMask = {},
@@ -610,9 +617,11 @@ class Device : public NullDevice {
 
   hsa_queue_t* AcquireActiveQueue(amd::CommandQueue::Priority priority,
                                    hsa_queue_t* preferred = nullptr,
-                                   const std::unordered_set<uint64_t>* excluded_ids = nullptr,
-                                   void** metadata_ring_buffer = nullptr);
+                                   const std::unordered_set<uint64_t>* excluded_ids = nullptr);
   bool ReleaseActiveQueue(hsa_queue_t* queue, amd::CommandQueue::Priority priority);
+
+  //! Look up per-queue extras (metadata ring buffer and placement).
+  QueueExtras GetQueueExtras(hsa_queue_t* queue);
 
   //! Return the pre-computed metadata packet version header bits
   uint32_t MetadataVersionHeader() const { return metadata_version_header_; }
@@ -761,10 +770,9 @@ class Device : public NullDevice {
   struct QueueInfo {
     int refCount;             //! Reference counter. Shows how many time the queue was shared
     bool hasDedicatedQueue_;  //! True if this queue is a dedicated queue (e.g., null stream)
-    void* metadataRingBuffer_; //! Metadata prefetch ring buffer base
 
     // Constructor
-    QueueInfo() : refCount(0), hasDedicatedQueue_(false), metadataRingBuffer_(nullptr) {}
+    QueueInfo() : refCount(0), hasDedicatedQueue_(false) {}
 
     //! Get the current hardware queue depth (wptr - rptr)
     static uint64_t GetHwQueueDepth(hsa_queue_t* queue) {
@@ -799,8 +807,11 @@ class Device : public NullDevice {
   //! Use dynamic queues mode to get a queue from pool
   hsa_queue_t* getQueueFromPool(const uint qIndex, bool force_reuse = false,
                                 hsa_queue_t* preferred = nullptr,
-                                const std::unordered_set<uint64_t>* excluded_ids = nullptr,
-                                void** metadata_ring_buffer = nullptr);
+                                const std::unordered_set<uint64_t>* excluded_ids = nullptr);
+
+  //! Per-queue extras (metadata ring buffer and placement), keyed by queue pointer.
+  //! Populated at queue creation, erased when non-pooled queues are destroyed.
+  std::unordered_map<hsa_queue_t*, QueueExtras> queue_extras_;
 
   //! returns value for corresponding LinkAttrbutes in a vector given Memory pool.
   virtual bool findLinkInfo(const hsa_amd_memory_pool_t& pool,

--- a/projects/clr/rocclr/device/rocm/rocrctx.cpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.cpp
@@ -95,6 +95,7 @@ bool Hsa::LoadLib() {
   GET_ROCR_SYMBOL(hsa_amd_signal_create)
   GET_ROCR_SYMBOL(hsa_amd_register_system_event_handler)
   GET_ROCR_SYMBOL(hsa_amd_queue_set_priority)
+  GET_ROCR_OPTIONAL_SYMBOL(hsa_amd_queue_create)
   GET_ROCR_SYMBOL(hsa_amd_memory_async_copy_rect)
   GET_ROCR_SYMBOL(hsa_amd_memory_lock_to_pool)
   GET_ROCR_SYMBOL(hsa_amd_signal_value_pointer)

--- a/projects/clr/rocclr/device/rocm/rocrctx.hpp
+++ b/projects/clr/rocclr/device/rocm/rocrctx.hpp
@@ -25,6 +25,9 @@
 #include "hsa/hsa_ven_amd_aqlprofile.h"
 #endif
 
+typedef hsa_status_t HSA_API hsa_amd_queue_create_fn(
+    hsa_agent_t agent, hsa_amd_queue_create_desc_t* descs, uint32_t num_descs);
+
 namespace amd {
 namespace roc {
 
@@ -104,6 +107,7 @@ struct RocrEntryPoints {
   decltype(hsa_amd_signal_create)* hsa_amd_signal_create_;
   decltype(hsa_amd_register_system_event_handler)* hsa_amd_register_system_event_handler_;
   decltype(hsa_amd_queue_set_priority)* hsa_amd_queue_set_priority_;
+  hsa_amd_queue_create_fn* hsa_amd_queue_create_;
   decltype(hsa_amd_memory_async_copy_rect)* hsa_amd_memory_async_copy_rect_;
   decltype(hsa_amd_memory_lock_to_pool)* hsa_amd_memory_lock_to_pool_;
   decltype(hsa_amd_signal_value_pointer)* hsa_amd_signal_value_pointer_;
@@ -153,7 +157,7 @@ struct RocrEntryPoints {
     return false;                                                                                 \
   }
 #define GET_ROCR_OPTIONAL_SYMBOL(NAME)                                                            \
-  cep_.NAME = reinterpret_cast<t_##NAME>(Os::getSymbol(cep_.handle, #NAME));
+  cep_.NAME##_ = reinterpret_cast<NAME##_fn*>(Os::getSymbol(cep_.handle, #NAME));
 #else
 #define ROCR_DYN(NAME) NAME
 #define GET_ROCR_SYMBOL(NAME)
@@ -441,6 +445,26 @@ class Hsa : public amd::AllStatic {
   }
   static hsa_status_t queue_set_priority(hsa_queue_t* queue, hsa_amd_queue_priority_t priority) {
     return ROCR_DYN(hsa_amd_queue_set_priority)(queue, priority);
+  }
+  static bool amd_queue_create_available() {
+#ifdef ROCR_DYN_DLL
+    return ROCR_DYN(hsa_amd_queue_create) != nullptr;
+#else
+    return true;
+#endif
+  }
+  static hsa_status_t amd_queue_create(hsa_agent_t agent,
+                                       hsa_amd_queue_create_desc_t* descs,
+                                       uint32_t num_descs) {
+#ifdef ROCR_DYN_DLL
+    auto fn = ROCR_DYN(hsa_amd_queue_create);
+    if (fn == nullptr) {
+      return HSA_STATUS_ERROR;
+    }
+    return fn(agent, descs, num_descs);
+#else
+    return hsa_amd_queue_create(agent, descs, num_descs);
+#endif
   }
   static hsa_status_t memory_async_copy_rect(
     const hsa_pitched_ptr_t* dst, const hsa_dim3_t* dst_offset, const hsa_pitched_ptr_t* src,

--- a/projects/clr/rocclr/device/rocm/rocsettings.cpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.cpp
@@ -73,6 +73,7 @@ Settings::Settings() {
   barrier_value_packet_ = false;
   ext_dispatch_packet_ = false;
   kernel_arg_impl_ = KernelArgImpl::HostKernelArgs;
+  aql_device_ring_buf_ = false;
   gwsInitSupported_ = true;
   limit_blit_wg_ = 16;
 
@@ -87,7 +88,7 @@ Settings::Settings() {
 
 // ================================================================================================
 bool Settings::create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, bool coop_groups,
-                      bool isXgmi, bool hasValidHDPFlush) {
+                      bool isXgmi) {
   uint32_t gfxipMajor = isa.versionMajor();
   uint32_t gfxipMinor = isa.versionMinor();
   uint32_t gfxStepping = isa.versionStepping();
@@ -150,7 +151,7 @@ bool Settings::create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, b
     sdma_swap_supported_ = true;
   }
 
-  setKernelArgImpl(isa, isXgmi, hasValidHDPFlush);
+  setKernelArgImpl(isa, isXgmi);
 
   if (gfxipMajor >= 10) {
      enableWave32Mode_ = true;
@@ -249,7 +250,7 @@ void Settings::override() {
 }
 
 // ================================================================================================
-void Settings::setKernelArgImpl(const amd::Isa& isa, bool isXgmi, bool hasValidHDPFlush) {
+void Settings::setKernelArgImpl(const amd::Isa& isa, bool isXgmi) {
   const uint32_t gfxipMajor = isa.versionMajor();
   const uint32_t gfxipMinor = isa.versionMinor();
   const uint32_t gfxStepping = isa.versionStepping();
@@ -257,40 +258,33 @@ void Settings::setKernelArgImpl(const amd::Isa& isa, bool isXgmi, bool hasValidH
   const bool isGfx94x = gfxipMajor == 9 && gfxipMinor >= 4 &&
                         (gfxStepping == 0 || gfxStepping == 1 || gfxStepping == 2);
   const bool isGfx90a = (gfxipMajor == 9 && gfxipMinor == 0 && gfxStepping == 10);
-  const bool isPreGfx908 =
-      (gfxipMajor < 9) || ((gfxipMajor == 9) && (gfxipMinor == 0) && (gfxStepping < 8));
-  const bool isGfx101x = (gfxipMajor == 10) && ((gfxipMinor == 0) || (gfxipMinor == 1));
-  const bool isGfx125x =
-      (gfxipMajor == 12) && ((gfxipMinor >= 5));
+  const bool isGfx125x = (gfxipMajor == 12) && ((gfxipMinor >= 5));
 
   auto kernelArgImpl = KernelArgImpl::HostKernelArgs;
-
-  hasValidHDPFlush &= DEBUG_CLR_KERNARG_HDP_FLUSH_WA;
 
   if (isXgmi) {
     // The XGMI-connected path does not require the manual memory ordering
     // workarounds that the PCIe connected path requires
     kernelArgImpl = KernelArgImpl::DeviceKernelArgs;
-  } else if (hasValidHDPFlush) {
-    // If the HDP flush register is valid implement the HDP flush to MMIO
-    // workaround.
-    if (!(isPreGfx908 || isGfx101x)) {
-      kernelArgImpl = KernelArgImpl::DeviceKernelArgsHDP;
-    }
   } else if (isGfx94x || isGfx90a || isGfx125x) {
     // Implement the kernel argument readback workaround
     // (write all args -> sfence -> write last byte -> mfence -> read last byte)
     kernelArgImpl = KernelArgImpl::DeviceKernelArgsReadback;
   }
 
-  // Enable device kernel args for gfx94x for now
+  // Enable device kernel args and device-memory AQL queue ring buffers by
+  // default on gfx94x/gfx125x.
   if (isGfx94x || isGfx125x) {
     kernel_arg_impl_ = kernelArgImpl;
     kernel_arg_opt_ = true;
+    aql_device_ring_buf_ = true;
   }
 
   if (!flagIsDefault(HIP_FORCE_DEV_KERNARG)) {
     kernel_arg_impl_ = kernelArgImpl & (HIP_FORCE_DEV_KERNARG ? 0xF : 0x0);
+  }
+  if (!flagIsDefault(DEBUG_CLR_AQL_DEV_QUEUE)) {
+    aql_device_ring_buf_ = (DEBUG_CLR_AQL_DEV_QUEUE > 0);
   }
 }
 }  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocsettings.hpp
+++ b/projects/clr/rocclr/device/rocm/rocsettings.hpp
@@ -69,7 +69,7 @@ class Settings : public device::Settings {
 
   //! Creates settings
   bool create(bool fullProfile, const amd::Isa& isa, bool enableXNACK, bool coop_groups = false,
-              bool isXgmi = false, bool hasValidHDPFlush = true);
+              bool isXgmi = false);
 
  private:
   //! Disable copy constructor
@@ -83,7 +83,7 @@ class Settings : public device::Settings {
 
   //! Determine how kernel arguments should be implemented given ASIC (host
   //! memory, device memory, device memory with memory ordering workaround)
-  void setKernelArgImpl(const amd::Isa& isa, bool isXgmi, bool hasValidHDPFlush);
+  void setKernelArgImpl(const amd::Isa& isa, bool isXgmi);
 };
 
 /*@}*/  // namespace amd::roc

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -8,6 +8,7 @@
 #include "device/rocm/rocdevice.hpp"
 #include "device/rocm/rocvirtual.hpp"
 #include "device/rocm/rockernel.hpp"
+#include "utils/nontemporal.hpp"
 #include "device/rocm/rocmemory.hpp"
 #include "device/rocm/rocblit.hpp"
 #include "device/rocm/roccounters.hpp"
@@ -39,13 +40,6 @@
 #include <cstdarg>
 #include <mutex>
 
-#if defined(__AVX__)
-#if defined(__MINGW64__)
-#include <intrin.h>
-#else
-#include <immintrin.h>
-#endif
-#endif
 
 /**
  * HSA image object size in bytes (see HSA spec)
@@ -1231,8 +1225,9 @@ bool VirtualGPU::processMemObjects(const amd::Kernel& kernel, const_address para
 }
 
 // ================================================================================================
-void VirtualGPU::SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer) {
+void VirtualGPU::SetGpuQueue(hsa_queue_t* queue) {
   gpu_queue_ = queue;
+
   cached_read_dispatch_id_ = 0;
   // The cached queue-progress state belongs to the previously assigned HW queue. When the HW
   // queue changes (released back to / reacquired from the shared dynamic-queue pool), that state
@@ -1240,17 +1235,27 @@ void VirtualGPU::SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer) {
   // so IsQueueIdle() reports idle for the freshly assigned queue.
   last_write_index_ = kInvalidQueueIndex;
   last_packet_with_signal_index_ = kInvalidQueueIndex;
-  metadata_preloader_.SetQueueBase(metadata_ring_buffer,
-                                   roc_device_.MetadataVersionHeader());
+
+  if (queue) {
+    auto extras = roc_device_.GetQueueExtras(queue);
+    device_mem_ring_buf_ = extras.deviceMemRingBuf;
+    use_movdir64b_ = roc_device_.info().movdir64b_ && device_mem_ring_buf_;
+    doorbell_ptr_ = extras.doorbellPtr;
+    metadata_preloader_.SetQueueBase(extras.metadataRingBuffer,
+                                     roc_device_.MetadataVersionHeader());
+  } else {
+    device_mem_ring_buf_ = false;
+    use_movdir64b_ = false;
+    doorbell_ptr_ = nullptr;
+    metadata_preloader_.SetQueueBase(nullptr, roc_device_.MetadataVersionHeader());
+  }
 }
 
 // ================================================================================================
 void VirtualGPU::AcquireQueueWithPreference() {
   std::scoped_lock lock(execution());
   if (!dedicated_queue_ && gpu_queue_ == nullptr && last_hwq_ != nullptr) {
-    void* md_rb = nullptr;
-    auto* queue = roc_device_.AcquireActiveQueue(priority_, last_hwq_, nullptr, &md_rb);
-    SetGpuQueue(queue, md_rb);
+    SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, last_hwq_));
     last_hwq_ = nullptr;
   }
 }
@@ -1266,9 +1271,7 @@ bool VirtualGPU::ReacquireQueueExcluding(const std::unordered_set<uint64_t>& exc
     roc_device_.releaseQueue(gpu_queue_, std::vector<uint32_t>{}, false, true);
     gpu_queue_ = nullptr;
   }
-  void* md_rb = nullptr;
-  auto* queue = roc_device_.AcquireActiveQueue(priority_, nullptr, &excluded_ids, &md_rb);
-  SetGpuQueue(queue, md_rb);
+  SetGpuQueue(roc_device_.AcquireActiveQueue(priority_, nullptr, &excluded_ids));
   return gpu_queue_ != nullptr;
 }
 
@@ -1277,9 +1280,7 @@ uint64_t VirtualGPU::getQueueID() {
   std::scoped_lock lock(execution());
   // Dedicated queues keep their HW queue, never acquire from pool
   if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-    void* md_rb = nullptr;
-    auto* queue = roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb);
-    SetGpuQueue(queue, md_rb);
+    SetGpuQueue(roc_device_.AcquireActiveQueue(priority_));
   }
   return gpu_queue_->id;
 }
@@ -1370,6 +1371,43 @@ std::string VirtualGPU::AnalyzeAqlQueue() const {
 }
 
 // ================================================================================================
+// Write an AQL packet to the ring buffer with metadata prefetch.
+//
+// MOVDIR64B + device memory path (2 sfences):
+//   metadata MOVDIR64B → sfence → AQL MOVDIR64B → ROCr doorbell sfence → doorbell
+//
+// Legacy + device memory (2 sfences):
+//   AQL body NT → metadata 4x64B NT (staged) → sfence → AQL header → sfence → doorbell
+//   (body+header within each 64B NT copy share one WC buffer fill — no internal sfence)
+//
+// Legacy + system memory (3 sfences):
+//   AQL body NT → metadata direct writes → sfence(body→hdr) → metadata headers →
+//   sfence → AQL header → sfence → doorbell
+template <typename AqlPacket>
+void VirtualGPU::writePacketToRingBuffer(AqlPacket* aql_loc, AqlPacket* packet,
+                                         uint16_t header, uint16_t rest, uint64_t slot_index) {
+  if (use_movdir64b_) {
+    metadata_preloader_.SetMetadata(packet, header, slot_index, true, device_mem_ring_buf_);
+    amd::nontemporalStoreFence();
+    amd::nontemporalWriteAQL(aql_loc, packet, header, rest);
+  } else {
+    amd::nontemporalCopyAQL(aql_loc, packet);
+    metadata_preloader_.SetMetadata(packet, header, slot_index, false, device_mem_ring_buf_);
+    amd::nontemporalStoreFence();
+    packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), header, rest);
+  }
+}
+
+// ================================================================================================
+void VirtualGPU::ringQueueDoorbell(uint64_t index) {
+  if (doorbell_ptr_) {
+    amd::ringDoorbell(doorbell_ptr_, index, use_movdir64b_);
+  } else {
+    Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
+  }
+}
+
+// ================================================================================================
 template <typename AqlPacket>
 bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, uint16_t rest,
                                           bool blocking, bool attach_signal, bool cluster_launch) {
@@ -1417,12 +1455,8 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
   TrackQueueProgress(*packet, index);
 
   AqlPacket* aql_loc = &((AqlPacket*)(gpu_queue_->base_address))[index & queueMask];
-  *aql_loc = *packet;
+  writePacketToRingBuffer(aql_loc, packet, header, rest, index & queueMask);
 
-  metadata_preloader_.Set(packet, header, index & queueMask);
-  if (header != 0) {
-    packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), header, rest);
-  }
   if (IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
     if (dev().settings().ext_dispatch_packet_) {
       logAqlDispatchPacketExtended(
@@ -1442,7 +1476,7 @@ bool VirtualGPU::dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header, ui
   bool ring_doorbell = IS_LINUX || dev().IsPm4Emulation() || blocking ||
                        (skippedDispatches_ >= skip_limit) || ring_for_non_profiler_signal;
   if (ring_doorbell) {
-    Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
+    ringQueueDoorbell(index);
     skippedDispatches_ = 0;
   } else {
     ++skippedDispatches_;
@@ -1550,13 +1584,41 @@ bool VirtualGPU::dispatchAqlPacket(hsa_barrier_and_packet_t* packet, uint16_t he
 }
 
 // ================================================================================================
+// Publish one metadata-prefetch packet (256B = 4 x 64B segments) to the metadata ring at |dst|.
+// |src| is the captured metadata packet with valid headers already baked into each segment
+// (INVALID for barrier/empty slots).  Each 64B segment carries its own header dword together
+// with its body, so the header/body ordering within a segment is guaranteed by the single 64B
+// store and no intra-packet fence is needed.  This mirrors the single-dispatch staged path
+// (MetaDataPreloader::SetPacket): MOVDIR64B when available, otherwise non-temporal stores.
+static inline void writeMetadataPacketToRing(uint8_t* dst, const uint8_t* src,
+                                             bool use_movdir64b) {
+  static constexpr size_t kMetaSize = 256;
+  for (size_t off = 0; off < kMetaSize; off += 64) {
+    if (use_movdir64b) {
+      amd::movdir64b_copy64(dst + off, src + off);
+    } else {
+      amd::nontemporalMemcpy(dst + off, src + off, 64);
+    }
+  }
+}
+
+// ================================================================================================
 // Unified flat-buffer graph dispatch.  Reserves all N queue slots with a single wptr bump,
 // then processes them in kPeriod-sized chunks: yield-until-free → memcpy → per-packet fixups
 // (profiling signals, correlation IDs, kernel-name printing) → valid-header writes → doorbell.
 // For graphs that fit in the queue the yield never fires.  For oversized graphs the GPU drains
 // earlier chunks while the CPU copies later ones, avoiding a deadlock.  Packet-0's header is
 // committed last in the first chunk per the AQL protocol.
-bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPacketData,
+//
+// Two ring-write paths, selected by |use_movdir64b| (device-memory ring + HW support +
+// DEBUG_CLR_USE_MOVDIR64B):
+//   * Non-temporal (default/baseline): bulk NT copy of packet bodies (headers held INVALID in
+//     the flat data), one sfence, then scattered 4-byte valid-header release stores.
+//   * MOVDIR64B: one sfence, then publish each packet as a single atomic 64B write (body +
+//     signal + valid header).  Reserved slots already carry INVALID headers from the CP's
+//     previous consumption, so publish order is irrelevant and no packet-0-last dance is
+//     needed.  The metadata ring uses the same NT-vs-MOVDIR64B split.
+bool VirtualGPU::dispatchAqlPacketBatchFlat(const amd::AlignedVector64<uint8_t>& flatPacketData,
                                             const std::vector<uint32_t>& validFullHeaders,
                                             amd::AccumulateCommand* vcmd, bool attach_signal,
                                             bool pre_patched, bool blocking,
@@ -1573,6 +1635,15 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
   if (flatPacketData.size() != numPackets * 64) {
     return false;
   }
+
+  static constexpr size_t kMetaPktSize =
+      sizeof(hsa_amd_metadata_kernel_dispatch_packet_t);
+  if (flatMetadataData != nullptr && !flatMetadataData->empty()) {
+    if (flatMetadataData->size() != numPackets * kMetaPktSize) {
+      return false;
+    }
+  }
+
   std::scoped_lock lock(execution());
   profilingBegin(*vcmd);
   dispatchBlockingWait(nullptr);
@@ -1604,6 +1675,7 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
 
   uint8_t* queueBase = static_cast<uint8_t*>(gpu_queue_->base_address);
 
+  const bool use_movdir64b = use_movdir64b_;
   // Reserve ALL slots with a single wptr bump, then submit in kPeriod-sized chunks.
   // Per-chunk: yield if the queue is full (handles graphs larger than the queue), then
   // memcpy + per-packet fixups + headers + doorbell.  For graphs that fit in the queue
@@ -1633,6 +1705,114 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
   auto* first_loc = reinterpret_cast<uint32_t*>(
       queueBase + (startIndex & queueMask) * kPacketSize);
 
+  // Attach profiling / completion signals to one packet.  Used by the MOVDIR64B path,
+  // which assembles the full packet (body + signal + valid header) in a host staging
+  // buffer before the atomic 64B store, so signals must be written into |pkt| (staging)
+  // rather than patched into the ring slot after the body copy (the NT path does the
+  // latter inline below).  |isLast| marks the final packet of the whole batch.
+  auto attachPacketSignal = [&](hsa_kernel_dispatch_packet_t* pkt, size_t i, bool isLast) {
+    const uint16_t hdr = static_cast<uint16_t>(validFullHeaders[i]);
+    const uint8_t pktType =
+        extractAqlBits(hdr, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE);
+    const uint8_t amdFormat = static_cast<uint8_t>((validFullHeaders[i] >> 16) & 0xFF);
+    const bool isBaseKernelDispatch = (pktType == HSA_PACKET_TYPE_KERNEL_DISPATCH);
+    const bool isKernelDispatch =
+        isBaseKernelDispatch ||
+        (pktType == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
+         amdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH);
+    if (timestamp_ != nullptr) {
+      // When pre_patched, keep any completion_signal already written by
+      // ApplyHwEventPatches (carried into staging via the flat-buffer copy).
+      bool has_prepatched_signal = pre_patched && (pkt->completion_signal.handle != 0);
+      if (!has_prepatched_signal) {
+        pkt->completion_signal =
+            Barriers().ActiveSignal(kInitSignalValueOne, timestamp_, true);
+        if (isKernelDispatch) {
+          if (isBaseKernelDispatch && amd::activity_prof::IsEnabled(OP_ID_DISPATCH)) {
+            pkt->reserved2 = timestamp_->command().profilingInfo().correlation_id_;
+          }
+          Barriers().GetLastSignal()->flags_.isPacketDispatch_ = true;
+        }
+      } else if (has_prepatched_signal && isBaseKernelDispatch &&
+                 amd::activity_prof::IsEnabled(OP_ID_DISPATCH)) {
+        pkt->reserved2 = timestamp_->command().profilingInfo().correlation_id_;
+      }
+    } else if (isLast && (attach_signal || blocking)) {
+      pkt->completion_signal = Barriers().ActiveSignal();
+    }
+  };
+
+  // Kernel-name collection is required when dispatch activity tracing is on; detailed
+  // packet logging when LOG_KERN2 / LOG_AQL is on.  Both are handled by logBatchPacket.
+  const bool needKernelNamesReported = amd::activity_prof::IsEnabled(OP_ID_DISPATCH);
+  const bool kLogBatch = IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2) ||
+                         IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL);
+
+  // All packet fields are read from the host-side flat buffer (|flatPacketData|), never
+  // from the ring slot: the device-resident ring is write-combining, so reading
+  // kernel_object back from it is unreliable.  Kernel names are resolved from the device
+  // KernelMap by kernel_object and, when activity tracing is on, recorded into the command
+  // via addKernelName().  getDemangledName() returns a reference to a name cached for the
+  // device's lifetime, so the borrowed pointer stays valid.
+  auto logBatchPacket = [&](size_t i, uint64_t slotIdx) {
+    const auto* hostPkt = reinterpret_cast<const hsa_kernel_dispatch_packet_t*>(
+        flatPacketData.data() + i * kPacketSize);
+    const uint16_t hdr = static_cast<uint16_t>(validFullHeaders[i]);
+    const uint8_t pktType =
+        extractAqlBits(hdr, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE);
+    const uint8_t amdFormat = static_cast<uint8_t>((validFullHeaders[i] >> 16) & 0xFF);
+    const bool isBaseKernelDispatch = (pktType == HSA_PACKET_TYPE_KERNEL_DISPATCH);
+    const bool isKernelDispatch =
+        isBaseKernelDispatch ||
+        (pktType == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
+         amdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH);
+    if (isKernelDispatch) {
+      auto kit = dev().KernelMap().find(hostPkt->kernel_object);
+      const char* kname = kit != dev().KernelMap().end()
+                              ? kit->second.getDemangledName().c_str()
+                              : "<unknown>";
+      if (needKernelNamesReported) {
+        vcmd->addKernelName(kname);
+      }
+      if (kLogBatch) {
+        ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2,
+                "Graph ShaderName : %s, device id : %u", kname, dev().index());
+        if (isBaseKernelDispatch) {
+          logAqlDispatchPacket(roc_device_, gpu_queue_, hdr, hostPkt, slotIdx, priority_);
+        } else {
+          logAqlDispatchPacketExtended(
+              roc_device_, gpu_queue_, hdr,
+              reinterpret_cast<const hsa_amd_ext_kernel_dispatch_packet_t*>(hostPkt), slotIdx,
+              priority_);
+        }
+      }
+    } else if (kLogBatch && pktType == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
+               amdFormat == HSA_AMD_PACKET_TYPE_BARRIER_VALUE) {
+      ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2,
+              "Graph ShaderName : [Graph vendor barrier value], device id : %u", dev().index());
+      logAqlBarrierValuePacket(
+          roc_device_, gpu_queue_, hdr,
+          reinterpret_cast<const hsa_amd_barrier_value_packet_t*>(hostPkt), slotIdx, priority_);
+    } else if (kLogBatch &&
+               (pktType == HSA_PACKET_TYPE_BARRIER_AND || pktType == HSA_PACKET_TYPE_BARRIER_OR)) {
+      // Inline barriers placed in the batch by BuildSyncPlan never go through
+      // dispatchBarrierPacket, so log them here. Classify by patched fields:
+      // dep_signal set -> cross-dep barrier, else completion_signal -> per-segment barrier.
+      const auto* bpkt = reinterpret_cast<const hsa_barrier_and_packet_t*>(hostPkt);
+      bool has_dep = false;
+      for (int k = 0; k < 5 && !has_dep; ++k) {
+        if (bpkt->dep_signal[k].handle != 0) has_dep = true;
+      }
+      const char* tag = has_dep
+          ? " [Graph cross dep barrier]"
+          : (bpkt->completion_signal.handle != 0 ? " [Graph completion barrier]"
+                                                 : " [Graph batch barrier]");
+      ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2, "Graph ShaderName :%s, device id : %u", tag,
+              dev().index());
+      logAqlBarrierPacket(roc_device_, gpu_queue_, hdr, bpkt, slotIdx, priority_);
+    }
+  };
+
   for (size_t chunkStart = 0; chunkStart < numPackets; ) {
     const size_t period = (chunkStart == 0) ? kLead : kPeriod;
     const size_t chunkEnd  = std::min(chunkStart + period, numPackets);
@@ -1643,171 +1823,114 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
     // Yield until this chunk's physical slots are free.
     WaitForQueueSlot(startIndex + chunkEnd - 1, sw_queue_size);
 
-    // Copy this chunk's packet bodies to the queue. Handles RB wrap-around.
     const size_t chunkSlot = (startIndex + chunkStart) & queueMask;
-    const uint8_t* srcData = flatPacketData.data() + chunkStart * kPacketSize;
-    if (chunkSlot + thisChunk <= queueSize) {
-      memcpy(queueBase + chunkSlot * kPacketSize, srcData, thisChunk * kPacketSize);
-    } else {
-      const size_t firstCount = queueSize - chunkSlot;
-      memcpy(queueBase + chunkSlot * kPacketSize, srcData, firstCount * kPacketSize);
-      memcpy(queueBase, srcData + firstCount * kPacketSize,
-             (thisChunk - firstCount) * kPacketSize);
+
+    // Publish Bodies with invalid headers for NT store only. MOVDIR64B may not need this
+    if (!use_movdir64b) {
+      // Non-temporal path: copy this chunk's packet bodies to the ring using NT stores.
+      // Headers within the flat data are invalid; real headers are armed via
+      // packet_store_release below, after the sfence.
+      const uint8_t* srcData = flatPacketData.data() + chunkStart * kPacketSize;
+      if (chunkSlot + thisChunk <= queueSize) {
+        amd::nontemporalMemcpy(queueBase + chunkSlot * kPacketSize, srcData,
+                               thisChunk * kPacketSize);
+      } else {
+        const size_t firstCount = queueSize - chunkSlot;
+        amd::nontemporalMemcpy(queueBase + chunkSlot * kPacketSize, srcData,
+                               firstCount * kPacketSize);
+        amd::nontemporalMemcpy(queueBase, srcData + firstCount * kPacketSize,
+                               (thisChunk - firstCount) * kPacketSize);
+      }
     }
 
-    // Copy this chunk's metadata packets to the metadata ring buffer, following the
-    // same publish protocol as the live single-dispatch path (MetaDataPreloader::Set):
-    // write each packet body first with the headers held at HSA_PACKET_TYPE_INVALID,
-    // then arm the four packet headers last. This guarantees the CP prefetch engine
-    // never observes an armed header over a partially-written body. The captured
-    // buffer already carries the armed header value for real slots and INVALID for
-    // slots without metadata (barriers), so re-arming from it preserves both cases.
+    // Publish this chunk's metadata-prefetch packets. The captured flat buffer already
+    // carries the armed header value for real slots and INVALID for barrier/empty slots;
+    // each 64B segment is written with its header and body together (NT or MOVDIR64B).
     if (flatMetadataData != nullptr && metadata_preloader_.HasMetadataQueue()) {
-      static constexpr size_t kMetaSize = 256;
-      // Header dword offsets within a 256B AqlMetadataPrefetchPacket.
-      static constexpr size_t kHdrOff[4] = {0, 64, 128, 192};
-      static constexpr uint32_t kInvalidMetaHeader = HSA_PACKET_TYPE_INVALID;
       auto* metaBase = static_cast<uint8_t*>(metadata_preloader_.GetQueueBase());
       for (size_t j = 0; j < thisChunk; ++j) {
         const uint64_t slot = (startIndex + chunkStart + j) & queueMask;
-        uint8_t* dst = metaBase + slot * kMetaSize;
-        const uint8_t* src = flatMetadataData->data() + (chunkStart + j) * kMetaSize;
-        for (size_t h = 0; h < 4; ++h) {
-          // Hold the header INVALID while the body region after it is copied.
-          std::memcpy(dst + kHdrOff[h], &kInvalidMetaHeader, sizeof(kInvalidMetaHeader));
-          const size_t bodyStart = kHdrOff[h] + sizeof(uint32_t);
-          const size_t bodyEnd = (h + 1 < 4) ? kHdrOff[h + 1] : kMetaSize;
-          std::memcpy(dst + bodyStart, src + bodyStart, bodyEnd - bodyStart);
-        }
-        // Arm the headers last, in reverse order (header3 -> header0)
-        for (size_t h = 4; h-- > 0;) {
-          std::memcpy(dst + kHdrOff[h], src + kHdrOff[h], sizeof(uint32_t));
-        }
+        writeMetadataPacketToRing(metaBase + slot * kMetaPktSize,
+                                  flatMetadataData->data() + (chunkStart + j) * kMetaPktSize,
+                                  use_movdir64b);
       }
     }
 
-    // Attach signal to the last packet when requested (before per-packet logging).
-    auto* lastSlotPtr = reinterpret_cast<hsa_kernel_dispatch_packet_t*>(
-        queueBase + ((startIndex + chunkEnd - 1) & queueMask) * kPacketSize);
-    if (isLastChunk && (attach_signal || blocking) && timestamp_ == nullptr) {
-      lastSlotPtr->completion_signal = Barriers().ActiveSignal();
-    }
+    // Core path to publish headers
+    if (!use_movdir64b) {
+      // Non-temporal publish: signals patched in place, then armed headers
+      // Attach signal to the last packet when requested (before per-packet logging).
+      auto* lastSlotPtr = reinterpret_cast<hsa_kernel_dispatch_packet_t*>(
+          queueBase + ((startIndex + chunkEnd - 1) & queueMask) * kPacketSize);
+      if (isLastChunk && (attach_signal || blocking) && timestamp_ == nullptr) {
+        lastSlotPtr->completion_signal = Barriers().ActiveSignal();
+      }
 
-    // Per-packet fixups: profiling signals, kernel-name collection, kernel-name
-    // printing, and inline barrier logging.
-    const bool needKernelNames = amd::activity_prof::IsEnabled(OP_ID_DISPATCH);
-    if (timestamp_ != nullptr || needKernelNames ||
-        IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2) ||
-        IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
+      // Per-packet fixups: profiling signals, kernel-name printing, inline barrier logging.
+      if (timestamp_ != nullptr || needKernelNamesReported || kLogBatch) {
+        for (size_t i = chunkStart; i < chunkEnd; ++i) {
+          const uint64_t slotIdx = (startIndex + i) & queueMask;
+          auto* slot = reinterpret_cast<hsa_kernel_dispatch_packet_t*>(
+              queueBase + slotIdx * kPacketSize);
+          if (timestamp_ != nullptr) {
+            attachPacketSignal(slot, i, i == numPackets - 1);
+          }
+          if (needKernelNamesReported || kLogBatch) {
+            logBatchPacket(i, slotIdx);
+          }
+        }
+      }
+
+      // Ordering point: drain all preceding NT body writes from the WC buffer
+      // before writing any valid headers (diagram steps #6a, #7, #9).
+      amd::nontemporalStoreFence();
+
+      // Write valid headers. Hold global packet-0's header back in the first chunk so the
+      // GPU sees a fully-committed batch before starting (AQL protocol). Subsequent chunks
+      // write in forward order — packet 0 is already committed.
+      for (size_t i = (isFirstChunk ? 1 : chunkStart); i < chunkEnd; ++i) {
+        const uint64_t idx = startIndex + i;
+        auto* aql_loc =
+            reinterpret_cast<uint32_t*>(queueBase + (idx & queueMask) * kPacketSize);
+        const uint32_t dword = validFullHeaders[i];
+        const uint16_t hdr = (i == numPackets - 1) ? lastHeader : static_cast<uint16_t>(dword);
+        packet_store_release(aql_loc, hdr, static_cast<uint16_t>(dword >> 16));
+      }
+      if (isFirstChunk) {
+        packet_store_release(first_loc, firstHeader, firstSetup);
+      }
+    } else {
+      // MOVDIR64B publish: full 64B atomic writes (body + signal + valid header).
+      // sfence orders the preceding metadata MOVDIR64B writes (WC-ordered) so they
+      // are globally visible before any dispatch packet becomes visible to the CP.
+      // Every reserved slot already carries an INVALID header from the CP's previous
+      // consumption (guaranteed by WaitForQueueSlot), so publish order is irrelevant —
+      // the CP stalls on any not-yet-written slot — and no packet-0-last dance is needed.
+      amd::nontemporalStoreFence();
       for (size_t i = chunkStart; i < chunkEnd; ++i) {
         const uint64_t slotIdx = (startIndex + i) & queueMask;
-        auto* slot = reinterpret_cast<hsa_kernel_dispatch_packet_t*>(
-            queueBase + slotIdx * kPacketSize);
-        const uint16_t hdr = static_cast<uint16_t>(validFullHeaders[i]);
-        const uint8_t pktType =
-            extractAqlBits(hdr, HSA_PACKET_HEADER_TYPE, HSA_PACKET_HEADER_WIDTH_TYPE);
-        const uint8_t amdFormat = static_cast<uint8_t>((validFullHeaders[i] >> 16) & 0xFF);
-        // Classify purely from the packet header/type fields: ext-kernel-dispatch
-        // packets can be emitted opportunistically (e.g. cluster-dimension launches)
-        // regardless of the global ext_dispatch_packet_ setting.
-        const bool isBaseKernelDispatch = (pktType == HSA_PACKET_TYPE_KERNEL_DISPATCH);
-        const bool isKernelDispatch =
-            isBaseKernelDispatch ||
-            (pktType == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
-             amdFormat == HSA_AMD_PACKET_TYPE_EXT_KERNEL_DISPATCH);
-        if (timestamp_ != nullptr) {
-          // When pre_patched, skip any slot whose completion_signal was already
-          // written by ApplyHwEventPatches (non-zero means pre-patched).
-          bool has_prepatched_signal = pre_patched && (slot->completion_signal.handle != 0);
-          if (!has_prepatched_signal) {
-            slot->completion_signal =
-                Barriers().ActiveSignal(kInitSignalValueOne, timestamp_, true);
-            if (isKernelDispatch) {
-              // reserved2 correlation-id stamping is only valid for the base
-              // hsa_kernel_dispatch_packet_t layout; the ext packet has a
-              // different field at that offset.
-              if (isBaseKernelDispatch && amd::activity_prof::IsEnabled(OP_ID_DISPATCH)) {
-                slot->reserved2 = timestamp_->command().profilingInfo().correlation_id_;
-              }
-              Barriers().GetLastSignal()->flags_.isPacketDispatch_ = true;
-            }
-          } else if (has_prepatched_signal && isBaseKernelDispatch &&
-                     amd::activity_prof::IsEnabled(OP_ID_DISPATCH)) {
-            slot->reserved2 = timestamp_->command().profilingInfo().correlation_id_;
-          }
-        }
-        if (isKernelDispatch && (needKernelNames ||
-            IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2) ||
-            IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL))) {
-          auto kit = dev().KernelMap().find(slot->kernel_object);
-          const char* kname = kit != dev().KernelMap().end()
-                                  ? kit->second.getDemangledName().c_str()
-                                  : "<unknown>";
-          if (needKernelNames) {
-            vcmd->addKernelName(kname);
-          }
-          ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2, "Graph ShaderName : %s, device id : %u",
-                  kname, dev().index());
-          if (isBaseKernelDispatch) {
-            logAqlDispatchPacket(roc_device_, gpu_queue_, hdr, slot, slotIdx, priority_);
-          } else {
-            logAqlDispatchPacketExtended(
-                roc_device_, gpu_queue_, hdr,
-                reinterpret_cast<const hsa_amd_ext_kernel_dispatch_packet_t*>(slot), slotIdx,
-                priority_);
-          }
-        } else if ((IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2) ||
-                    IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) &&
-                   pktType == HSA_PACKET_TYPE_VENDOR_SPECIFIC &&
-                   amdFormat == HSA_AMD_PACKET_TYPE_BARRIER_VALUE) {
-          ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2,
-                  "Graph ShaderName : [Graph vendor barrier value], device id : %u",
-                  dev().index());
-          logAqlBarrierValuePacket(
-              roc_device_, gpu_queue_, hdr,
-              reinterpret_cast<const hsa_amd_barrier_value_packet_t*>(slot), slotIdx, priority_);
-        } else if ((IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2) ||
-                    IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) &&
-                   (pktType == HSA_PACKET_TYPE_BARRIER_AND ||
-                    pktType == HSA_PACKET_TYPE_BARRIER_OR)) {
-          // Inline barriers placed in the batch by BuildSyncPlan never go
-          // through dispatchBarrierPacket, so log them here. Classify by
-          // patched fields: dep_signal set -> cross-dep barrier, else
-          // completion_signal set -> per-segment completion barrier.
-          const auto* bpkt = reinterpret_cast<const hsa_barrier_and_packet_t*>(slot);
-          bool has_dep = false;
-          for (int k = 0; k < 5 && !has_dep; ++k) {
-            if (bpkt->dep_signal[k].handle != 0) has_dep = true;
-          }
-          const char* tag = has_dep
-              ? " [Graph cross dep barrier]"
-              : (bpkt->completion_signal.handle != 0 ? " [Graph completion barrier]"
-                                                     : " [Graph batch barrier]");
-          ClPrint(amd::LOG_DETAIL_DEBUG, amd::LOG_KERN2,
-                  "Graph ShaderName :%s, device id : %u", tag, dev().index());
-          // Tag is shown in the "Graph ShaderName" line above; don't repeat it as
-          // the packet prefix.
-          logAqlBarrierPacket(roc_device_, gpu_queue_, hdr, bpkt, slotIdx, priority_);
+        alignas(64) hsa_kernel_dispatch_packet_t stg;
+        std::memcpy(&stg, flatPacketData.data() + i * kPacketSize, kPacketSize);
+        attachPacketSignal(&stg, i, i == numPackets - 1);
+        const uint32_t dword = validFullHeaders[i];
+        const uint16_t hdr = (i == 0)                 ? firstHeader
+                             : (i == numPackets - 1)  ? lastHeader
+                                                      : static_cast<uint16_t>(dword);
+        const uint16_t setup = (i == 0) ? firstSetup : static_cast<uint16_t>(dword >> 16);
+        *reinterpret_cast<uint32_t*>(&stg) = hdr | (static_cast<uint32_t>(setup) << 16);
+        auto* dst = queueBase + slotIdx * kPacketSize;
+        amd::movdir64b_copy64(dst, &stg);
+        if (needKernelNamesReported || kLogBatch) {
+          logBatchPacket(i, slotIdx);
         }
       }
     }
 
-    // Write valid headers and ring the doorbell for this chunk.
-    // Hold global packet-0's header back in the first chunk so the GPU sees a
-    // fully-committed batch before starting (AQL protocol).  Subsequent chunks
-    // write in forward order — packet 0 is already committed.
-    for (size_t i = (isFirstChunk ? 1 : chunkStart); i < chunkEnd; ++i) {
-      const uint64_t idx = startIndex + i;
-      auto* aql_loc =
-          reinterpret_cast<uint32_t*>(queueBase + (idx & queueMask) * kPacketSize);
-      const uint32_t dword = validFullHeaders[i];
-      const uint16_t hdr = (i == numPackets - 1) ? lastHeader : static_cast<uint16_t>(dword);
-      packet_store_release(aql_loc, hdr, static_cast<uint16_t>(dword >> 16));
+    if (doorbell_ptr_) {
+      amd::ringDoorbell(doorbell_ptr_, startIndex + chunkEnd - 1);
+    } else {
+      Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, startIndex + chunkEnd - 1);
     }
-    if (isFirstChunk) {
-      packet_store_release(first_loc, firstHeader, firstSetup);
-    }
-    Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, startIndex + chunkEnd - 1);
 
     chunkStart = chunkEnd;
   }
@@ -1849,8 +1972,8 @@ bool VirtualGPU::dispatchCounterAqlPacket(hsa_ext_amd_aql_pm4_packet_t* packet,
   switch (gfxVersion) {
     case PerfCounter::ROC_GFX9:
     case PerfCounter::ROC_GFX10: {
-      packet->header = HSA_PACKET_TYPE_VENDOR_SPECIFIC << HSA_PACKET_HEADER_TYPE;
-      return dispatchGenericAqlPacket(packet, 0, 0, blocking);
+      uint16_t hdr = HSA_PACKET_TYPE_VENDOR_SPECIFIC << HSA_PACKET_HEADER_TYPE;
+      return dispatchGenericAqlPacket(packet, hdr, 0, blocking);
     } break;
   }
 
@@ -1912,11 +2035,9 @@ void VirtualGPU::dispatchBarrierPacket(uint16_t packetHeader, bool skipSignal,
   WaitForQueueSlot(index, queueMask);
   hsa_barrier_and_packet_t* aql_loc =
       &(reinterpret_cast<hsa_barrier_and_packet_t*>(gpu_queue_->base_address))[index & queueMask];
-  *aql_loc = barrier_packet_;
-  metadata_preloader_.Set(&barrier_packet_, packetHeader, index & queueMask);
-  packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), packetHeader, 0);
 
-  Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
+  writePacketToRingBuffer(aql_loc, &barrier_packet_, packetHeader, uint16_t{0}, index & queueMask);
+  ringQueueDoorbell(index);
   if (IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
     logAqlBarrierPacket(roc_device_, gpu_queue_, packetHeader, &barrier_packet_, index, priority_);
   }
@@ -1993,10 +2114,8 @@ void VirtualGPU::dispatchBarrierValuePacket(uint16_t packetHeader, bool resolveD
   WaitForQueueSlot(index, queueMask);
   hsa_amd_barrier_value_packet_t* aql_loc = &(reinterpret_cast<hsa_amd_barrier_value_packet_t*>(
       gpu_queue_->base_address))[index & queueMask];
-  *aql_loc = barrier_value_packet_;
-  metadata_preloader_.Set(&barrier_value_packet_, packetHeader, index & queueMask);
-  packet_store_release(reinterpret_cast<uint32_t*>(aql_loc), packetHeader, rest);
-  Hsa::signal_store_screlease(gpu_queue_->doorbell_signal, index);
+  writePacketToRingBuffer(aql_loc, &barrier_value_packet_, packetHeader, rest, index & queueMask);
+  ringQueueDoorbell(index);
 
   if (IsLogEnabled(amd::LOG_DETAIL_DEBUG, amd::LOG_AQL)) {
     logAqlBarrierValuePacket(roc_device_, gpu_queue_, packetHeader, &barrier_value_packet_, index,
@@ -2155,9 +2274,7 @@ VirtualGPU::~VirtualGPU() {
     std::scoped_lock l(execution());
     // Dedicated queues keep their HW queue, never acquire from pool
     if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-      void* md_rb = nullptr;
-      auto* queue = roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb);
-      SetGpuQueue(queue, md_rb);
+      SetGpuQueue(roc_device_.AcquireActiveQueue(priority_));
     }
     // Windows requires an interrupt in more cases than Linux for OS fence updates
     force_irq_ = IS_WINDOWS;
@@ -2193,6 +2310,7 @@ VirtualGPU::~VirtualGPU() {
 #endif  // _WIN32
     Hsa::queue_destroy(schedulerQueue_);
     schedulerQueue_ = nullptr;
+    schedulerDoorbell_ = nullptr;
   }
 
   if (nullptr != virtualQueue_) {
@@ -2225,10 +2343,8 @@ VirtualGPU::~VirtualGPU() {
 bool VirtualGPU::create() {
   // Pick a reasonable queue size
   uint32_t queue_size = ROC_AQL_QUEUE_SIZE;
-  void* md_rb = nullptr;
-  auto* queue = roc_device_.acquireQueue(queue_size, cooperative_, cuMask_, priority_, false,
-                                         dedicated_queue_, nullptr, nullptr, &md_rb);
-  SetGpuQueue(queue, md_rb);
+  SetGpuQueue(roc_device_.acquireQueue(queue_size, cooperative_, cuMask_, priority_, false,
+                                       dedicated_queue_));
   if (!gpu_queue_) return false;
 
   if (dev().isa().versionMajor() == 12 && dev().isa().versionMinor() >= 5) {
@@ -2484,9 +2600,7 @@ void releaseSdmaProfiling() {
 void VirtualGPU::profilingBegin(amd::Command& command, bool sdmaProfiling) {
   // Dedicated queues keep their HW queue, never acquire from pool
   if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-    void* md_rb = nullptr;
-    auto* queue = roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb);
-    SetGpuQueue(queue, md_rb);
+    SetGpuQueue(roc_device_.AcquireActiveQueue(priority_));
   }
   // Track the current command
   command_ = &command;
@@ -4182,6 +4296,16 @@ bool VirtualGPU::createSchedulerParam() {
       break;
     }
 
+    schedulerDoorbell_ = nullptr;
+    if (DEBUG_CLR_DIRECT_DOORBELL) {
+      uint64_t db_id = 0;
+      if (hsa_amd_queue_get_info(schedulerQueue_, HSA_AMD_QUEUE_INFO_DOORBELL_ID, &db_id) ==
+              HSA_STATUS_SUCCESS &&
+          db_id != 0) {
+        schedulerDoorbell_ = reinterpret_cast<volatile uint64_t*>(db_id);
+      }
+    }
+
 #if defined(_WIN32)
   if (!isSchedulerQueueThreadRunning()) {
     std::call_once(scheduler_thread_init_, [this]() { startSchedulerQueueThread(); });
@@ -4221,7 +4345,11 @@ void VirtualGPU::startSchedulerQueueThread() {
 
         if (write_index > updated_write_index) {
           // New packets in the scheduler queue, ringing the doorbell
-          Hsa::signal_store_screlease(schedulerQueue_->doorbell_signal, write_index - 1);
+          if (schedulerDoorbell_) {
+            amd::ringDoorbell(schedulerDoorbell_, write_index - 1);
+          } else {
+            Hsa::signal_store_screlease(schedulerQueue_->doorbell_signal, write_index - 1);
+          }
           updated_write_index = write_index;
         } else {
           // Yield briefly before re-checking.
@@ -4365,60 +4493,6 @@ bool VirtualGPU::createVirtualQueue(uint deviceQueueSize) {
   return true;
 }
 
-// ================================================================================================
-#if IS_LINUX
-__attribute__((optimize("unroll-all-loops"), always_inline)) static inline void nontemporalMemcpy(
-    void* __restrict dst, const void* __restrict src, size_t size) {
-#if defined(ATI_ARCH_X86)
-#if defined(__AVX512F__)
-  for (auto i = 0u; i != size / sizeof(__m512i); ++i) {
-    _mm512_stream_si512(reinterpret_cast<__m512i* __restrict&>(dst)++,
-                        *reinterpret_cast<const __m512i* __restrict&>(src)++);
-  }
-  size = size % sizeof(__m512i);
-#endif
-
-#if defined(__AVX__)
-  for (auto i = 0u; i != size / sizeof(__m256i); ++i) {
-    _mm256_stream_si256(reinterpret_cast<__m256i* __restrict&>(dst)++,
-                        *reinterpret_cast<const __m256i* __restrict&>(src)++);
-  }
-  size = size % sizeof(__m256i);
-#endif
-
-  for (auto i = 0u; i != size / sizeof(__m128i); ++i) {
-    _mm_stream_si128(reinterpret_cast<__m128i* __restrict&>(dst)++,
-                     *(reinterpret_cast<const __m128i* __restrict&>(src)++));
-  }
-  size = size % sizeof(__m128i);
-
-  for (auto i = 0u; i != size / sizeof(long long); ++i) {
-    _mm_stream_si64(reinterpret_cast<long long* __restrict&>(dst)++,
-                    *reinterpret_cast<const long long* __restrict&>(src)++);
-  }
-  size = size % sizeof(long long);
-
-  for (auto i = 0u; i != size / sizeof(int); ++i) {
-    _mm_stream_si32(reinterpret_cast<int* __restrict&>(dst)++,
-                    *reinterpret_cast<const int* __restrict&>(src)++);
-  }
-
-  size = size % sizeof(int);
-  // Copy remaining bytes for unaligned size
-  std::memcpy(dst, src, size);
-
-  // Add memory fence
-  _mm_sfence();
-#else
-  std::memcpy(dst, src, size);
-#endif
-}
-#else
-static inline void nontemporalMemcpy(void* __restrict dst, const void* __restrict src,
-                                     size_t size) {
-  std::memcpy(dst, src, size);
-}
-#endif
 
 void VirtualGPU::HiddenHeapInit() {
   // We don't really need its id, just want to ensure the queue is created.
@@ -4665,13 +4739,15 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
           allocKernArg(gpuKernel.KernargSegmentByteSize(), gpuKernel.KernargSegmentAlignment()));
     }
 
-    nontemporalMemcpy(argBuffer, parameters, argSize);
-    if (roc_device_.info().largeBar_ && !isGraphCapture) {
+    amd::nontemporalMemcpy(argBuffer, parameters, argSize);
+    // When the queue ring buffer is in device memory, kernarg NT stores and
+    // the dispatch packet all travel to the same PCIe endpoint.  PCIe posted
+    // write ordering guarantees the kernargs arrive before the dispatch
+    // header, so no HDP flush or readback workaround is needed — the sfence
+    // before packet_store_release is sufficient.
+    if (roc_device_.info().largeBar_ && !isGraphCapture && !device_mem_ring_buf_) {
       const auto kernArgImpl = dev().settings().kernel_arg_impl_;
-      if (kernArgImpl == KernelArgImpl::DeviceKernelArgsHDP) {
-        *dev().info().hdpMemFlushCntl = 1u;
-        auto kSentinel = *reinterpret_cast<volatile int*>(dev().info().hdpMemFlushCntl);
-      } else if (kernArgImpl == KernelArgImpl::DeviceKernelArgsReadback && argSize != 0) {
+      if (kernArgImpl == KernelArgImpl::DeviceKernelArgsReadback && argSize != 0) {
 #if defined(ATI_ARCH_X86)
         _mm_sfence();
 #else
@@ -4699,7 +4775,7 @@ bool VirtualGPU::submitKernelInternal(const amd::NDRangeContainer& sizes, const 
     static_assert(sizeof(hsa_kernel_dispatch_packet_t)
                   == sizeof(hsa_amd_ext_kernel_dispatch_packet_t));
 
-    union {
+    alignas(64) union {
       hsa_kernel_dispatch_packet_t kernelDispatch;
       hsa_amd_ext_kernel_dispatch_packet_t extKernelDispatch;
     } dispatchPacketUnion;
@@ -4963,9 +5039,7 @@ void VirtualGPU::submitMarker(amd::Marker& vcmd) {
     // It should be safe to call flush directly if there are not pending dispatches without
     // HSA signal callback
     if (!dedicated_queue_ && gpu_queue_ == nullptr) {
-      void* md_rb = nullptr;
-      auto* queue = roc_device_.AcquireActiveQueue(priority_, nullptr, nullptr, &md_rb);
-      SetGpuQueue(queue, md_rb);
+      SetGpuQueue(roc_device_.AcquireActiveQueue(priority_));
     }
     flush(vcmd.GetBatchHead());
     SetCoalesceWindow(0, nullptr);
@@ -5305,104 +5379,177 @@ static void convertDynDataPrefetchToHsa(const amd::DynDataPrefetchRegion* region
   }
 }
 
-void VirtualGPU::MetaDataPreloader::SetPacket(
-    hsa_kernel_dispatch_packet_t* aql,  uint16_t header,
-    hsa_amd_metadata_kernel_dispatch_packet_t* metadata) {
+// ================================================================================================
+// Fill the body (all fields except the 4 header dwords) of a kernel-dispatch
+// metadata packet from |aql| and the staged descriptor/preload state, returning
+// the header dword the caller must publish into header0..header3.  Pure field
+// assembly with no ring-buffer transfer or fences — callers (SetPacket for the
+// queue write, CaptureMetadata for graph capture) handle the destination.
+uint32_t VirtualGPU::MetaDataPreloader::FillKernelDispatchMetadata(
+    hsa_kernel_dispatch_packet_t* aql, uint16_t header,
+    hsa_amd_metadata_kernel_dispatch_packet_t* m, bool target_is_zeroed) {
   assert(pending_descriptor_ != nullptr);
-
-  // Headers must remain HSA_PACKET_TYPE_INVALID until we publish valid metadata headers
-  // at the end. Only clear fields that could otherwise contain stale required-zero data.
-  std::memset(metadata->reserved0, 0, sizeof(metadata->reserved0));
-  std::memset(&metadata->launch_descriptor, 0, sizeof(metadata->launch_descriptor));
-
-  if (dyn_data_prefetch_enabled_ && dyn_data_prefetch_num_regions_ > 0) {
-    metadata->launch_descriptor.version = launch_descriptor_version_;
-    convertDynDataPrefetchToHsa(
-        dyn_data_prefetch_regions_,
-        dyn_data_prefetch_hints_,
-        metadata->launch_descriptor.prefetch,
-        dyn_data_prefetch_num_regions_);
-  }
-
-  // Write event_id from amd_signal_t directly (non-interrupt signals have event_id == 0).
-  if (aql->completion_signal.handle) {
-    auto* signal = reinterpret_cast<amd_signal_t*>(aql->completion_signal.handle);
-    metadata->event_id = signal->event_id;
-  } else {
-    metadata->event_id = 0;
-  }
-
-  // Fill hsa_amd_metadata_kernel_dispatch_packet->kernel_descriptor fields.
-  // The metadata packet kernel descriptor fields are a subset of
-  // kernel_descriptor_t (Code Object V3 Kernel Descriptor) from the AQL packet, from bytes
-  // llvm::amdhsa::KERNEL_CODE_ENTRY_BYTE_OFFSET_OFFSET(16) to sizeof(kernel_descriptor_t).
-  // See include/llvm/Support/AMDHSAKernelDescriptor.h.
-  std::memcpy(&metadata->kernel_descriptor, pending_descriptor_,
-              sizeof(metadata->kernel_descriptor));
-
-  // Fill hsa_amd_metadata_kernel_dispatch_packet->kernarg_preload_* fields
-  constexpr uint16_t kPreload_limit =
-      (sizeof(metadata->kernarg_preload_0_14) +
-       sizeof(metadata->kernarg_preload_15_29) +
-       sizeof(metadata->kernarg_preload_30_31)) / sizeof(uint32_t);
-
-  uint16_t preload_length = pending_preload_length_;
-  if (preload_length > kPreload_limit) {
-    metadata->kernel_descriptor.kernarg_preload.length = kPreload_limit;
-    preload_length = kPreload_limit;
-  }
-  ClPrint(amd::LOG_DEBUG, amd::LOG_AQL,
-          "metadata prefetch: preload_length=%u, preload_offset=%u, preload_limit=%u",
-          preload_length, pending_preload_offset_, kPreload_limit);
-
-  if (preload_length > 0) {
-    const uint8_t* kernargs = reinterpret_cast<const uint8_t*>(aql->kernarg_address);
-    assert(kernargs);
-    const uint8_t* src = kernargs + pending_preload_offset_ * sizeof(uint32_t);
-    uint16_t remain = preload_length;
-
-    constexpr uint16_t kSec0 = sizeof(metadata->kernarg_preload_0_14) / sizeof(uint32_t);
-    constexpr uint16_t kSec1 = sizeof(metadata->kernarg_preload_15_29) / sizeof(uint32_t);
-    constexpr uint16_t kSec2 = sizeof(metadata->kernarg_preload_30_31) / sizeof(uint32_t);
-
-    // Copy data first, zero only the tail — avoids double-writing the prefix
-    // that the old memset+memcpy pattern caused.
-    uint16_t n = std::min<uint16_t>(remain, kSec0);
-    std::memcpy(metadata->kernarg_preload_0_14, src, n * sizeof(uint32_t));
-    if (n < kSec0) {
-      std::memset(&metadata->kernarg_preload_0_14[n], 0, (kSec0 - n) * sizeof(uint32_t));
+  {
+    // Headers must remain HSA_PACKET_TYPE_INVALID until we publish valid metadata headers
+    // at the end. Only clear fields that could otherwise contain stale required-zero data.
+    // When staging, the stack-local is already zero-initialized so these are unnecessary.
+    if (!target_is_zeroed) {
+      std::memset(m->reserved0, 0, sizeof(m->reserved0));
+      std::memset(&m->launch_descriptor, 0, sizeof(m->launch_descriptor));
     }
-    remain -= n;
 
-    if (remain > 0) {
-      src += n * sizeof(uint32_t);
-      n = std::min<uint16_t>(remain, kSec1);
-      std::memcpy(metadata->kernarg_preload_15_29, src, n * sizeof(uint32_t));
-      if (n < kSec1) {
-        std::memset(&metadata->kernarg_preload_15_29[n], 0, (kSec1 - n) * sizeof(uint32_t));
+    if (dyn_data_prefetch_enabled_ && dyn_data_prefetch_num_regions_ > 0) {
+      m->launch_descriptor.version = launch_descriptor_version_;
+      convertDynDataPrefetchToHsa(
+          dyn_data_prefetch_regions_,
+          dyn_data_prefetch_hints_,
+          m->launch_descriptor.prefetch,
+          dyn_data_prefetch_num_regions_);
+    }
+
+    // Write event_id from amd_signal_t directly (non-interrupt signals have event_id == 0).
+    if (aql->completion_signal.handle) {
+      auto* signal = reinterpret_cast<amd_signal_t*>(aql->completion_signal.handle);
+      m->event_id = signal->event_id;
+    } else {
+      m->event_id = 0;
+    }
+
+    // Fill hsa_amd_metadata_kernel_dispatch_packet->kernel_descriptor fields.
+    // The metadata packet kernel descriptor fields are a subset of
+    // kernel_descriptor_t (Code Object V3 Kernel Descriptor) from the AQL packet, from bytes
+    // llvm::amdhsa::KERNEL_CODE_ENTRY_BYTE_OFFSET_OFFSET(16) to sizeof(kernel_descriptor_t).
+    // See include/llvm/Support/AMDHSAKernelDescriptor.h.
+    std::memcpy(&m->kernel_descriptor, pending_descriptor_,
+                sizeof(m->kernel_descriptor));
+
+    // Fill hsa_amd_metadata_kernel_dispatch_packet->kernarg_preload_* fields
+    constexpr uint16_t kPreload_limit =
+        (sizeof(m->kernarg_preload_0_14) +
+         sizeof(m->kernarg_preload_15_29) +
+         sizeof(m->kernarg_preload_30_31)) / sizeof(uint32_t);
+
+    uint16_t preload_length = pending_preload_length_;
+    if (preload_length > kPreload_limit) {
+      m->kernel_descriptor.kernarg_preload.length = kPreload_limit;
+      preload_length = kPreload_limit;
+    }
+    ClPrint(amd::LOG_DEBUG, amd::LOG_AQL,
+            "metadata prefetch: preload_length=%u, preload_offset=%u, preload_limit=%u",
+            preload_length, pending_preload_offset_, kPreload_limit);
+
+    if (preload_length > 0) {
+      const uint8_t* kernargs = reinterpret_cast<const uint8_t*>(aql->kernarg_address);
+      assert(kernargs);
+      // Kernarg preload offset is in DWORDs
+      const uint8_t* src = kernargs + pending_preload_offset_ * sizeof(uint32_t);
+      uint16_t remain = preload_length;
+
+      constexpr uint16_t kSec0 = sizeof(m->kernarg_preload_0_14) / sizeof(uint32_t);
+      constexpr uint16_t kSec1 = sizeof(m->kernarg_preload_15_29) / sizeof(uint32_t);
+      constexpr uint16_t kSec2 = sizeof(m->kernarg_preload_30_31) / sizeof(uint32_t);
+
+      // Copy the prefix first, then zero only the tail — avoids double-writing
+      // the prefix that a memset(whole)+memcpy(prefix) pattern caused. When
+      // target_is_zeroed (staging buffer is already zero-initialized), skip the
+      // tail zeroing entirely.
+      uint16_t n = std::min<uint16_t>(remain, kSec0);
+      std::memcpy(m->kernarg_preload_0_14, src, n * sizeof(uint32_t));
+      if (!target_is_zeroed && n < kSec0) {
+        std::memset(&m->kernarg_preload_0_14[n], 0, (kSec0 - n) * sizeof(uint32_t));
       }
       remain -= n;
 
       if (remain > 0) {
         src += n * sizeof(uint32_t);
-        n = std::min<uint16_t>(remain, kSec2);
-        std::memcpy(metadata->kernarg_preload_30_31, src, n * sizeof(uint32_t));
-        if (n < kSec2) {
-          std::memset(&metadata->kernarg_preload_30_31[n], 0, (kSec2 - n) * sizeof(uint32_t));
+        n = std::min<uint16_t>(remain, kSec1);
+        std::memcpy(m->kernarg_preload_15_29, src, n * sizeof(uint32_t));
+        if (!target_is_zeroed && n < kSec1) {
+          std::memset(&m->kernarg_preload_15_29[n], 0, (kSec1 - n) * sizeof(uint32_t));
+        }
+        remain -= n;
+
+        if (remain > 0) {
+          src += n * sizeof(uint32_t);
+          n = std::min<uint16_t>(remain, kSec2);
+          std::memcpy(m->kernarg_preload_30_31, src, n * sizeof(uint32_t));
+          if (!target_is_zeroed && n < kSec2) {
+            std::memset(&m->kernarg_preload_30_31[n], 0, (kSec2 - n) * sizeof(uint32_t));
+          }
         }
       }
     }
+
+    return GetType(header) | metadata_version_header_;
   }
+}
 
-  // Write headers last — arms the metadata packet for the CP.
-  // Plain stores are sufficient here: the subsequent packet_store_release on the main
-  // AQL dispatch header provides a release fence that orders all metadata writes (body
-  // and headers) before the CP sees the valid dispatch packet.
+// ================================================================================================
+// Unified metadata write for kernel dispatch packets.  Body assembly is shared
+// via FillKernelDispatchMetadata; only the final transfer to the ring buffer
+// differs:
+//
+// (A) Device memory (WC over PCIe BAR): stage locally, then copy 4 x 64B
+//     segments via MOVDIR64B (if available) or NT stores.  Each segment's
+//     body + header are in the same atomic/NT copy — no sfence between them.
+//     Avoids dozens of scattered WC stores over the bus.
+//
+// (B) System memory (WB): write fields directly into the ring buffer (all
+//     stores hit L1 cache).  SFENCE between body and headers because the
+//     CP's prefetcher may observe WB memory via a non-cached path.
+//
+// The ROCR allocator guarantees the metadata ring buffer is 4KiB-aligned with
+// 256B packets, so every slot is naturally 64B-aligned.
+void VirtualGPU::MetaDataPreloader::SetPacket(
+    hsa_kernel_dispatch_packet_t* aql,  uint16_t header,
+    hsa_amd_metadata_kernel_dispatch_packet_t* metadata,
+    bool use_movdir64b, bool device_mem_ring_buf) {
+  assert(pending_descriptor_ != nullptr);
 
-  uint32_t metadata_header = GetType(header) | metadata_version_header_;
-  metadata->header3 = metadata_header;
-  metadata->header2 = metadata_header;
-  metadata->header1 = metadata_header;
-  metadata->header0 = metadata_header;
+  // Staging is only needed for device-memory (WC) ring buffers to avoid
+  // scattered WC stores over PCIe.  For system-memory (WB) queues, direct
+  // writes hit L1 cache and are fast — no staging overhead needed.
+  const bool use_staging = device_mem_ring_buf;
+
+  if (use_staging) {
+    alignas(64) hsa_amd_metadata_kernel_dispatch_packet_t stg = {};
+    uint32_t metadata_header = FillKernelDispatchMetadata(aql, header, &stg, true);
+
+    // Write headers into the staging buffer before copying out.
+    stg.header0 = metadata_header;
+    stg.header1 = metadata_header;
+    stg.header2 = metadata_header;
+    stg.header3 = metadata_header;
+
+    assert(reinterpret_cast<uintptr_t>(metadata) % 64 == 0 &&
+           "metadata ring buffer slot must be 64-byte aligned");
+    static_assert(sizeof(stg) % 64 == 0);
+    auto* s = reinterpret_cast<const char*>(&stg);
+    auto* d = reinterpret_cast<char*>(metadata);
+
+    if (use_movdir64b) {
+      for (size_t off = 0; off < sizeof(stg); off += 64) {
+        amd::movdir64b_copy64(d + off, s + off);
+      }
+    } else {
+      for (size_t off = 0; off < sizeof(stg); off += 64) {
+        amd::nontemporalMemcpy(d + off, s + off, 64);
+      }
+    }
+  } else {
+    uint32_t metadata_header = FillKernelDispatchMetadata(aql, header, metadata, false);
+
+    // Write headers last — arms the metadata packet for the CP.
+    // SFENCE between body and headers: the metadata ring buffer may be WC-mapped
+    // (device memory) and the CP's prefetcher reads it independently. Without a
+    // fence, WC reordering could make valid headers visible before the body is
+    // flushed, causing the prefetcher to read garbage. This fence ensures all
+    // body writes are ordered before the header writes (ordering point #7).
+    amd::nontemporalStoreFence();
+    metadata->header3 = metadata_header;
+    metadata->header2 = metadata_header;
+    metadata->header1 = metadata_header;
+    metadata->header0 = metadata_header;
+  }
 }
 }  // End of roc namespace

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -10,6 +10,7 @@
 #include "rocdefs.hpp"
 #include "rocdevice.hpp"
 #include "utils/flags.hpp"
+#include "utils/nontemporal.hpp"
 #include "utils/util.hpp"
 #include "rocprintf.hpp"
 #include "rocsched.hpp"
@@ -327,7 +328,7 @@ class VirtualGPU : public device::VirtualDevice {
     public:
       //! Set the metadata ring buffer base for the current queue.
       void SetQueueBase(void* ring_buffer, uint32_t version_header = 0) {
-        queue_base_ = (DEBUG_CLR_ENABLE_PREFETCH_METADATA) ? ring_buffer : nullptr;
+        queue_base_ = ring_buffer;
         if (queue_base_ != nullptr) {
           metadata_version_header_ = version_header;
         }
@@ -345,14 +346,32 @@ class VirtualGPU : public device::VirtualDevice {
         pending_preload_offset_ = preload_offset;
       }
 
-      //! Set metadata prefetching packet associated with regular aql packet
+      //! Write the metadata prefetch packet for the AQL slot at |index|.
+      //! |use_movdir64b|: use atomic 64B writes (no sfence between body/header).
+      //! |device_mem_ring_buf|: ring buffer is WC over PCIe — when MOVDIR64B is
+      //!   unavailable, stages locally then NT-copies to avoid scattered WC stores.
       template <class AqlPacket>
-      inline void Set(AqlPacket* packet, uint16_t header, uint64_t index) {
-        if (!IsAttached()) {
+      inline void SetMetadata(AqlPacket* packet, uint16_t header,
+                              uint64_t index, bool use_movdir64b,
+                              bool device_mem_ring_buf) {
+        if (!HasMetadataQueue()) {
           return;
         }
-        FillMetadata(packet, header,
-                     static_cast<uint8_t*>(queue_base_) + index * kMetadataPacketSize);
+        auto* dst = static_cast<uint8_t*>(queue_base_) + index * kMetadataPacketSize;
+        FillMetadata(packet, header, dst, use_movdir64b, device_mem_ring_buf);
+      }
+
+      //! Build the metadata-prefetch packet for a captured (graph) dispatch into a
+      //! caller-provided, zero-initialized host buffer.  Mirrors SetMetadata but
+      //! targets plain host memory — no NT/MOVDIR64B stores or fences needed.
+      //! The buffer is flattened and later bulk-copied to the metadata ring at
+      //! graph-launch time.
+      template <class AqlPacket>
+      inline void CaptureMetadata(AqlPacket* packet, uint16_t header, uint8_t* dst) {
+        if (!HasMetadataQueue() || dst == nullptr) {
+          return;
+        }
+        FillMetadata(packet, header, dst, false, false);
       }
 
       //! Set the launch descriptor version (called once from VirtualGPU::create)
@@ -375,10 +394,13 @@ class VirtualGPU : public device::VirtualDevice {
         dyn_data_prefetch_enabled_ = false;
       }
 
-      //! Whether the preloader has a metadata queue attached
-      bool HasMetadataQueue() const { return IsAttached(); }
+      //! Whether the current queue has a valid metadata ring buffer. This is the
+      //! single gate for all metadata work: the ring base is an optional resource
+      //! provided by ROCr/firmware (HSA_AMD_QUEUE_INFO_PREFETCH_METADATA_RING_BUFFER)
+      //! and is null when no queue is assigned or the queue lacks prefetch support.
+      bool HasMetadataQueue() const { return queue_base_ != nullptr; }
 
-      //! Returns the metadata ring buffer base (nullptr if not attached)
+      //! Returns the metadata ring buffer base (nullptr if no metadata queue)
       void* GetQueueBase() const { return queue_base_; }
 
       //! Returns the metadata packet slot for the given (masked) queue index,
@@ -389,17 +411,6 @@ class VirtualGPU : public device::VirtualDevice {
         }
         return reinterpret_cast<const hsa_amd_metadata_kernel_dispatch_packet_t*>(
             static_cast<uint8_t*>(queue_base_) + index * kMetadataPacketSize);
-      }
-
-      //! Capture a metadata packet into a host buffer (for graph capture).
-      //! Fills the 256-byte buffer with the same content that Set() would write
-      //! to the queue metadata ring, but targets an arbitrary host pointer instead.
-      template <class AqlPacket>
-      void CaptureMetadata(AqlPacket* packet, uint16_t header, uint8_t* host_metadata) {
-        if (host_metadata == nullptr || !IsAttached()) {
-          return;
-        }
-        FillMetadata(packet, header, host_metadata);
       }
 
     private:
@@ -414,10 +425,12 @@ class VirtualGPU : public device::VirtualDevice {
       //! Return whether the loader is attached to a gpu queue
       bool IsAttached() const { return queue_base_ != nullptr; }
 
-      //! Populate the metadata packet at `dst` from the given aql packet. Shared by
-      //! Set() (ring destination) and CaptureMetadata() (host buffer destination).
+      //! Populate the metadata packet at |dst| from the given AQL packet.
+      //! Shared by SetMetadata() (ring-buffer destination with NT/MOVDIR64B
+      //! writes) and CaptureMetadata() (host-buffer destination with plain stores).
       template <class AqlPacket>
-      void FillMetadata(AqlPacket* packet, uint16_t header, uint8_t* dst) {
+      void FillMetadata(AqlPacket* packet, uint16_t header, uint8_t* dst,
+                        bool use_movdir64b, bool device_mem_ring_buf) {
         if constexpr (std::is_same_v<AqlPacket, hsa_kernel_dispatch_packet_t> ||
                      std::is_same_v<AqlPacket, hsa_amd_ext_kernel_dispatch_packet_t>) {
           if (pending_descriptor_ == nullptr) {
@@ -425,12 +438,12 @@ class VirtualGPU : public device::VirtualDevice {
           }
           auto* metadata = reinterpret_cast<hsa_amd_metadata_kernel_dispatch_packet_t*>(dst);
           auto* dispatch_packet = reinterpret_cast<hsa_kernel_dispatch_packet_t*>(packet);
-          SetPacket(dispatch_packet, header, metadata);
+          SetPacket(dispatch_packet, header, metadata, use_movdir64b, device_mem_ring_buf);
         } else if constexpr (std::is_same_v<AqlPacket, hsa_barrier_and_packet_t> ||
                              std::is_same_v<AqlPacket, hsa_barrier_or_packet_t> ||
                              std::is_same_v<AqlPacket, hsa_amd_barrier_value_packet_t>) {
           auto* metadata = reinterpret_cast<hsa_amd_metadata_barrier_packet_t*>(dst);
-          SetPacket(packet, header, metadata);
+          SetPacket(packet, header, metadata, use_movdir64b, device_mem_ring_buf);
         }
       }
 
@@ -439,28 +452,50 @@ class VirtualGPU : public device::VirtualDevice {
         return (header >> HSA_PACKET_HEADER_TYPE) & ((1 << HSA_PACKET_HEADER_WIDTH_TYPE) - 1);
       }
 
-      //! Set the metadata prefetch aql packet for kernel dispatch
+      //! Write the metadata prefetch packet for kernel dispatch.
+      //! Unified function covering MOVDIR64B, legacy+device-mem (staged NT),
+      //! and legacy+system-mem (direct write) paths.  The assembly logic is
+      //! shared; only the final write to the ring buffer differs.
       void SetPacket(hsa_kernel_dispatch_packet_t* aql, uint16_t header,
-                     hsa_amd_metadata_kernel_dispatch_packet_t* metadata);
+                     hsa_amd_metadata_kernel_dispatch_packet_t* metadata,
+                     bool use_movdir64b, bool device_mem_ring_buf);
 
-      //! Set the metadata prefetch aql packet for barrier.
-      //! The CP invalidates headers after completion, so only header0
-      //! and event_id need to be written.
-      //! Read event_id directly from amd_signal_t to avoid the hsa_amd_signal_get_event_id
-      //! API overhead. Only interrupt signals carry a valid event_id.
+      //! Fill the body (everything except the 4 header dwords) of a kernel-dispatch
+      //! metadata packet from |aql| and the staged descriptor/preload state. Returns
+      //! the header dword value the caller should write into header0..header3.
+      //! |target_is_zeroed| signals that |metadata| is already zero-initialized so
+      //! redundant memsets of required-zero fields can be skipped. Shared by the
+      //! queue-write path (SetPacket) and the graph-capture path (CaptureMetadata).
+      uint32_t FillKernelDispatchMetadata(hsa_kernel_dispatch_packet_t* aql, uint16_t header,
+                                          hsa_amd_metadata_kernel_dispatch_packet_t* metadata,
+                                          bool target_is_zeroed);
+
+      //! Write the metadata prefetch packet for barrier.
+      //! Unified function covering MOVDIR64B, legacy+device-mem (staged NT),
+      //! and legacy+system-mem (direct write) paths — analogous to the
+      //! kernel-dispatch SetPacket.
       template <class AqlBarrierPacket>
       void SetPacket(AqlBarrierPacket* aql, uint16_t header,
-                     hsa_amd_metadata_barrier_packet_t* metadata) const {
+                     hsa_amd_metadata_barrier_packet_t* metadata,
+                     bool use_movdir64b, bool device_mem_ring_buf) const {
+        const uint32_t metadata_header = GetType(header) | metadata_version_header_;
+        uint32_t event_id = 0;
         if (aql->completion_signal.handle) {
           auto* signal = reinterpret_cast<amd_signal_t*>(aql->completion_signal.handle);
-          metadata->event_id = signal->event_id;
-        } else {
-          metadata->event_id = 0;
+          event_id = signal->event_id;
         }
-        // Plain store is sufficient: the subsequent packet_store_release on the main
-        // AQL barrier header provides a release fence that orders all metadata writes
-        // (event_id and header) before the CP sees the valid barrier packet.
-        metadata->header0 = GetType(header);
+        if (use_movdir64b) {
+          alignas(64) uint8_t seg0[64] = {};
+          *reinterpret_cast<uint32_t*>(seg0) = metadata_header;
+          *reinterpret_cast<uint32_t*>(seg0 + 4) = event_id;
+          amd::movdir64b_copy64(metadata, seg0);
+        } else {
+          metadata->event_id = event_id;
+          if (device_mem_ring_buf) {
+            amd::nontemporalStoreFence();
+          }
+          metadata->header0 = metadata_header;
+        }
       }
 
       void* queue_base_ = nullptr;        //!< The buffer base of prefetching queue
@@ -556,7 +591,7 @@ class VirtualGPU : public device::VirtualDevice {
   hsa_queue_t* gpu_queue() { return gpu_queue_; }
 
   //! Set the active HW queue and keep the metadata preloader in sync.
-  void SetGpuQueue(hsa_queue_t* queue, void* metadata_ring_buffer = nullptr);
+  void SetGpuQueue(hsa_queue_t* queue);
 
   //! Snapshot the current HW queue as preferred for future re-acquisition (used by graph launch).
   //! Only updates if the queue is still valid — avoids clobbering a hint saved by ReleaseHwQueue.
@@ -679,7 +714,7 @@ class VirtualGPU : public device::VirtualDevice {
                          bool blocking = true, bool attach_signal = false);
 
   //! Fast-path dispatch: pre-built flat contiguous buffer
-  bool dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPacketData,
+  bool dispatchAqlPacketBatchFlat(const amd::AlignedVector64<uint8_t>& flatPacketData,
                                   const std::vector<uint32_t>& validFullHeaders,
                                   amd::AccumulateCommand* vcmd = nullptr,
                                   bool attach_signal = false,
@@ -703,6 +738,16 @@ class VirtualGPU : public device::VirtualDevice {
                                   bool skipTs = false,
                                   hsa_signal_t completionSignal = hsa_signal_t{0});
   void initializeDispatchPacket(hsa_kernel_dispatch_packet_t* packet, amd::NDRangeContainer& sizes);
+
+  //! Write an AQL packet to the ring buffer with metadata prefetch.
+  //! Selects MOVDIR64B only for device-memory queues with CPU support;
+  //! otherwise uses the legacy NT-store path.
+  template <typename AqlPacket>
+  void writePacketToRingBuffer(AqlPacket* aql_loc, AqlPacket* packet,
+                               uint16_t header, uint16_t rest, uint64_t slot_index);
+
+  //! Ring the queue doorbell via direct UC store or ROCr signal.
+  void ringQueueDoorbell(uint64_t index);
 
   void resetKernArgPool() { managed_kernarg_buffer_.ResetPool(); }
 
@@ -824,9 +869,14 @@ class VirtualGPU : public device::VirtualDevice {
   //! as its HwEvent so query/sync observe correct readiness. Released on reset.
   void* last_barrier_hw_event_ = nullptr;
   hsa_agent_t gpu_device_;  //!< Physical device
-  hsa_queue_t* gpu_queue_;  //!< Active queue associated with a vgpu
-  hsa_barrier_and_packet_t barrier_packet_ {};
-  hsa_amd_barrier_value_packet_t barrier_value_packet_ {};
+  hsa_queue_t* gpu_queue_;                //!< Active queue associated with a vgpu
+  bool device_mem_ring_buf_ = false;           //!< Queue ring buffer is in device memory
+  bool use_movdir64b_ = false;                 //!< Use MOVDIR64B for AQL packet writes
+  //! Cached hardware doorbell for the active queue (UC MMIO). Non-null only when
+  //! DEBUG_CLR_DIRECT_DOORBELL is enabled and the doorbell id query succeeded.
+  volatile uint64_t* doorbell_ptr_ = nullptr;
+  alignas(64) hsa_barrier_and_packet_t barrier_packet_ {};
+  alignas(64) hsa_amd_barrier_value_packet_t barrier_value_packet_ {};
 
   uint64_t cached_read_dispatch_id_ = 0;  //!< Cached read_dispatch_id to avoid DRAM reads
                                           //!< when queue is not full. GPU updates to
@@ -846,6 +896,9 @@ class VirtualGPU : public device::VirtualDevice {
   uint schedulerThreads_;      //!< The number of scheduler threads
 
   hsa_queue_t* schedulerQueue_;
+  //! Cached hardware doorbell for the scheduler queue (UC MMIO). Non-null only when
+  //! DEBUG_CLR_DIRECT_DOORBELL is enabled and the doorbell id query succeeded.
+  volatile uint64_t* schedulerDoorbell_ = nullptr;
 
   std::thread schedulerQueueThread_;                  //!< Host thread that monitors the scheduler queue
   std::atomic<bool> schedulerQueueThreadRunning_;     //!< Flag to indicate if the thread is running

--- a/projects/clr/rocclr/os/os.hpp
+++ b/projects/clr/rocclr/os/os.hpp
@@ -106,6 +106,9 @@ class Os : AllStatic {
   static void cpuid(int regs[4], int info);
   //! Get value of extended control register
   static uint64_t xgetbv(uint32_t which);
+  //! CPU supports MOVDIR64B (atomic 64-byte store with WC buffer close).
+  //! Result is cached on first call.
+  static bool hasMovdir64b();
 #endif  // ATI_ARCH_X86
 
   // Stack helper routines:

--- a/projects/clr/rocclr/os/os_posix.cpp
+++ b/projects/clr/rocclr/os/os_posix.cpp
@@ -735,6 +735,30 @@ uint64_t Os::xgetbv(uint32_t ecx) {
 
   return ((uint64_t)edx << 32) | (uint64_t)eax;
 }
+
+bool Os::hasMovdir64b() {
+  // CPUID leaf 7, sub-leaf 0: ECX bit 28 = MOVDIR64B.
+  static const bool supported = [] {
+    int regs[4];
+#ifdef _LP64
+    __asm__ __volatile__(
+        "movq %%rbx, %%rsi;"
+        "cpuid;"
+        "xchgq %%rbx, %%rsi;"
+        : "=a"(regs[0]), "=S"(regs[1]), "=c"(regs[2]), "=d"(regs[3])
+        : "a"(7), "c"(0));
+#else
+    __asm__ __volatile__(
+        "movl %%ebx, %%esi;"
+        "cpuid;"
+        "xchgl %%ebx, %%esi;"
+        : "=a"(regs[0]), "=S"(regs[1]), "=c"(regs[2]), "=d"(regs[3])
+        : "a"(7), "c"(0));
+#endif
+    return static_cast<bool>((regs[2] >> 28) & 1);
+  }();
+  return supported;
+}
 #endif  // ATI_ARCH_X86
 
 uint64_t Os::offsetToEpochNanos() {

--- a/projects/clr/rocclr/os/os_win32.cpp
+++ b/projects/clr/rocclr/os/os_win32.cpp
@@ -497,6 +497,16 @@ void Os::cpuid(int regs[4], int info) { return __cpuid(regs, info); }
 
 uint64_t Os::xgetbv(uint32_t ecx) { return (uint64_t)_xgetbv(ecx); }
 
+bool Os::hasMovdir64b() {
+  // CPUID leaf 7, sub-leaf 0: ECX bit 28 = MOVDIR64B.
+  static const bool supported = [] {
+    int regs[4];
+    __cpuidex(regs, 7, 0);
+    return static_cast<bool>((regs[2] >> 28) & 1);
+  }();
+  return supported;
+}
+
 uint64_t Os::offsetToEpochNanos() {
   static uint64_t offset = 0;
 

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -375,7 +375,9 @@ class Command : public Event {
   }
   bool getPktCapturingState() const { return packetCapturing_; }
 
-  //! Sets AQL capture state, aql packet to capture and where to copy kernArgs
+  //! Sets AQL capture state, aql packet to capture and where to copy kernArgs.
+  //! |metadataPacket|, when non-null, also enables capturing the metadata-prefetch
+  //! packet that parallels each captured AQL packet.
   void setPktCapturingState(bool state, std::vector<uint8_t*>* packet,
                             amd::GraphKernelArgManager* graphKernArgMgr,
                             const std::string** capturedKernelName,

--- a/projects/clr/rocclr/utils/flags.hpp
+++ b/projects/clr/rocclr/utils/flags.hpp
@@ -264,8 +264,6 @@ release(uint, DEBUG_CLR_MAX_BATCH_SIZE, 1000,                                 \
         "Forces the callback to clean-up CPU submission queue")               \
 release(bool, DEBUG_CLR_SYSMEM_POOL, false,                                   \
         "Use sysmem pool implementation in runtime for amd commands")         \
-release(bool, DEBUG_CLR_KERNARG_HDP_FLUSH_WA, false,                          \
-        "Toggle kernel arg copy workaround")                                  \
 release(uint, DEBUG_HIP_DYNAMIC_QUEUES, 1,                                    \
         "Dynamic queue management: 0=off, 1=Depth heuristic,"                 \
         " 2=1 + dedicated null-stream queue")                                 \
@@ -275,12 +273,10 @@ release(uint, HIP_SKIP_ABORT_ON_GPU_ERROR, true,                              \
         "Set this to true, to avoid host side abort for GPU errors")          \
 release(bool, HIP_FORCE_SPIRV_CODEOBJECT, false,                              \
         "Force use of SPIRV instead of device specific code object.")         \
-release(uint, DEBUG_CLR_BATCH_CPU_SYNC_SIZE, 16,                               \
+release(uint, DEBUG_CLR_BATCH_CPU_SYNC_SIZE, 16,                              \
         "Forces the minimum batch size for CPU sync")                         \
 release(bool, DEBUG_CLR_DISABLE_IMAGE, false,                                 \
         "1 = Disable Image support for ROC path")                             \
-release(bool, DEBUG_CLR_ENABLE_PREFETCH_METADATA, true,                       \
-        "Enable metadata prefetch for some Aql packets")                      \
 release(cstring, HIP_HRR_CAPTURE_OUTPUT, "",                                  \
         "Set to a directory path to enable HRR capture; archive written there") \
 release(bool, HIP_HRR_DEBUG_ARGS, false,                                      \
@@ -289,8 +285,15 @@ release(bool, HIP_HRR_DEBUG_ARGS, false,                                      \
 release(uint, DEBUG_CLR_DOORBELL_SKIP, 16,                                    \
         "Number of consecutive dispatches that may skip the doorbell flush.") \
 release(bool, DEBUG_CLR_DISABLE_FALLBACK, false,                              \
-        "Disables certain fallback paths")
-
+        "Disables certain fallback paths")                                    \
+release(bool, DEBUG_CLR_DIRECT_DOORBELL, false,                               \
+        "Write the hardware doorbell directly from CLR")                      \
+release(uint, DEBUG_CLR_AQL_DEV_QUEUE, 0,                                     \
+        "Device-memory AQL ring buffer for supported asics "                  \
+        "(1=enabled, 0=force system mem (default))")                          \
+release(uint, DEBUG_CLR_USE_MOVDIR64B, 1,                                     \
+        "Use MOVDIR64B full-packet writes for AQL + metadata rings"           \
+        "(1=enabled (default), 0=non-temporal store path)")                   \
 
 namespace amd {
 

--- a/projects/clr/rocclr/utils/nontemporal.hpp
+++ b/projects/clr/rocclr/utils/nontemporal.hpp
@@ -1,0 +1,468 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc., or its affiliates.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef CLR_ROCCLR_UTILS_NONTEMPORAL_HPP_
+#define CLR_ROCCLR_UTILS_NONTEMPORAL_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <new>
+#include <vector>
+#include "os/os.hpp"
+
+#if defined(ATI_ARCH_X86)
+#if defined(__MINGW64__)
+#include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
+#endif
+
+namespace amd {
+
+// Non-temporal store utilities for AQL packet submission.
+//
+// The ordering analysis below (WC buffers, SFENCE semantics, UC MMIO
+// flushes) is specific to x86/x86-64.  On ARM or other CPU ISAs the memory
+// model, cache attributes, and barrier instructions are different.  The
+// non-x86 fallback paths in this file use plain memcpy / atomic fences
+// which are correct but the performance rationale does not directly apply.
+//
+// --- CPU memory-mapping of device memory (x86) ---
+//
+// On discrete GPUs connected via PCIe, device memory mapped into the CPU
+// address space is marked Write Combining (WC).  WC has weaker ordering
+// than normal Write Back (WB) cached DRAM:
+//
+//   * Regular stores enter a write-combining buffer and may be coalesced
+//     or reordered.  An explicit SFENCE is required to guarantee ordering
+//     between groups of WC writes.
+//   * Each SFENCE flushes the WC buffer and the CPU stalls until WriteACK
+//     returns from the PCIe posted write (one bus round-trip).
+//   * A write to UC (uncacheable) memory (e.g. the MMIO doorbell region)
+//     also implicitly flushes the WC buffer, so no SFENCE is needed
+//     between the last WC write and the doorbell.
+//
+// On A+A / XGMI topologies the GPU memory can also be mapped WB, giving
+// the CPU the same strong ordering as host DRAM.
+// In that case:
+//
+//   * Write ordering is guaranteed by x86 TSO — no SFENCE needed between
+//     regular stores.
+//   * CPU writes stay in the cache hierarchy; GPU reads may have to
+//     probe-read them out of CPU caches (higher latency than reading from
+//     local GPU memory).
+//   * Non-temporal stores bypass the cache and go directly to the
+//     destination, avoiding the probe-read penalty.  They still require
+//     SFENCE for ordering relative to subsequent stores.
+//
+// On x86, certain instructions follow the WC memory model even when
+// targeting WB memory:
+//
+//   * Streaming / non-temporal stores (MOVNTQ, MOVNTI, MOVNTPS, etc.)
+//     do not necessarily close/flush the write-combining buffer
+//     immediately; later stores may still coalesce in the WC buffer.
+//     An SFENCE is required to guarantee the buffer is flushed and
+//     the store begins its trek to the destination.
+//
+//   * MOVDIR64B / MOVDIRI close the WC buffer after execution but
+//     still follow the weak WC memory ordering model (i.e. they can
+//     be reordered with respect to other WC and NT stores).
+//
+// This is why SFENCE is necessary even on A+A / WB-mapped topologies:
+// the NT stores used here always behave as WC regardless of the
+// underlying memory type.
+//
+// These utilities use non-temporal stores so they are correct (and
+// performant) regardless of whether the target is WC or WB mapped.
+//
+// --- Ordering points in the AQL submission flow ---
+//
+// When queues / kernargs are in device memory, the NT store sequence is:
+//
+//   1.  nontemporalMemcpy  — kernel args CPU → GPU (step #1)
+//   2.  nontemporalCopyAQL — packet body (w/ invalid header) → ring buffer (step 6)
+//       metadata_preloader writes metadata packet (steps 5/7/8)
+//   3.  nontemporalStoreFence — ONE sfence that subsumes ordering points
+//       1(a), 6(a), 7, and 9 from the AQL submission diagram:
+//         * kernel-arg NT stores are visible          (#1a)
+//         * dispatch-packet body is ordered before its header write (#6a)
+//         * metadata body is ordered before header writes          (#7)
+//         * metadata is valid before dispatch header is released   (#9)
+//   4.  packet_store_release — atomic 32-bit write of valid header (step #10)
+//   5.  doorbell ring — see note below                             (step #12)
+//
+//  +------------------+  +------------------+  +------------------+  +------------------+
+//  | 1. Copy N bytes   |  | 2. Atomically    |  | 3. Create kernel |  | 4. Create kernel |
+//  | of kernel args    |  | increment        |  | meta-data packet |  | dispatch packet  |
+//  | from CPU -> GPU   |  | write_dispatch_id|  | in CPU w/invalid |  | in CPU w/invalid |
+//  +--------+---------+  +--------+---------+  | header           |  | header           |
+//           |                      |            +--------+---------+  +--------+---------+
+//           |                      |                     |                     |
+//           |                      |                     v                     v
+//           |                      |            +------------------+  +------------------+
+//           |                      |            | 5. Copy meta-data|  | 6. Copy dispatch |
+//           |                      |            | packets w/invalid|  | packet w/invalid |
+//           |                      |            | hdrs to GPU ring |  | hdr to GPU ring  |
+//           |                      |            | buffer           |  | buffer           |
+//           |                      |            +--------+---------+  +--------+---------+
+//           |                      |                     |                     |
+//           |                      |                     v                     v
+//           |                      |       *============================*  *=============*
+//           |                      |       H 7. Ensure meta-data packet H  H 6(a). Ensur-H
+//           |                      |       H body write is ordered      H  H e dispatch  H
+//           |                      |       H before header writes       H  H pkt body is H
+//           |                      |       *=============+==============*  H ordered be- H
+//           |                      |                     |                 H fore header H
+//           |                      |                     v                 H write       H
+//           |                      |            +------------------+       *======+======*
+//           |                      |            | 8. Write valid   |              |
+//           |                      |            | headers into     |              |
+//           |                      |            | meta-data packet |              |
+//           |                      |            | segments         |              |
+//           |                      |            +--------+---------+              |
+//           |                      |                     |                        |
+//           |                      |                     |                        |
+//           |                      |                     |                        |
+//           |                      |                     |                        |
+//           |                      |                     |                        |
+//           |                      |                     |                        |
+//           |                      |                     |                        v
+//  *========+========*             |                     v                 *=============*
+//  H 1(a). Ensure    H             |       *============================*  H 6(a). Ensur-H
+//  H kernel args are H             |       H 9. Ensure meta-data packet H  H e dispatch  H
+//  H visible before  H             |       H is valid before dispatch   H  H pkt body is H
+//  H dispatch is     H             |       H pkt is released to HW      H  H ordered be- H
+//  H legal           H             |       *=============+==============*  H fore header H
+//  *========+========*             |                     |                 H write       H
+//           |                      |                     |                 *======+======*
+//           |                      |                     |                        |
+//           +----------------------+---------------------+------------------------+
+//                                  |
+//                                  v
+//                         +------------------+
+//                         | 10. Write valid  |
+//                         | header into      |
+//                         | kernel dispatch  |
+//                         | packet           |
+//                         +--------+---------+
+//                                  |
+//                                  v
+//                         *==================*
+//                         H 11. Ensure valid H
+//                         H packets visible  H
+//                         H to the hardware  H
+//                         *========+=========*
+//                                  |
+//                                  v
+//                         +------------------+
+//                         | 12. Ring the     |
+//                         | queue's MMIO     |
+//                         | doorbell         |
+//                         +------------------+
+//
+//  Legend:  +--..--+  data operation    *==..==*  ordering / fence point
+//                                      H      H
+//
+ //  CLR uses THREE sfences in the legacy (non-MOVDIR64B) submission path:
+ //  (1) Inside metadata_preloader::SetPacket, between the metadata body
+ //      writes and the metadata header writes (ordering point #7).  This
+ //      ensures the CP's prefetcher never sees valid metadata headers
+ //      before the body is flushed — required because the metadata ring
+ //      buffer may be WC-mapped and the prefetcher reads it independently.
+ //  (2) nontemporalStoreFence() before step #10 (packet_store_release),
+ //      satisfying ordering points #1(a), #6(a), and #9.
+ //  (3) sfence before the doorbell ring (step #11).  This is inside
+ //      ROCr's AqlQueue::StoreRelease and ensures the valid dispatch
+ //      header is flushed from the WC buffer before the UC doorbell write.
+ //
+ // SFENCE orders ALL preceding NT/WC stores, not just the most recent.
+ // On PCIe each SFENCE causes the CPU to stall until WriteACK returns
+ // from the PCIe posted write / XGMI coherence station.
+ //
+ // --- MOVDIR64B optimisation (runtime-detected) ---
+ //
+// When MOVDIR64B is available (hasMovdir64b()), the submission path
+// switches to an optimised flow that reduces 3 sfences to 2:
+ //
+ // MOVDIR64B atomically writes 64 bytes and closes the WC buffer after
+ // execution.  If used for both the metadata packet and the dispatch
+ // packet, the body-to-header ordering within each 64-byte write is
+// guaranteed atomically, eliminating sfences #1 and #2.  The explicit
+// sfence before the dispatch MOVDIR64B ensures kernarg NT stores and
+// metadata MOVDIR64B writes are globally ordered before the dispatch
+// packet becomes visible (#1a / #9). ROCr still performs the final
+// doorbell sfence in hsa_signal_store_screlease:
+ //
+ //   1. MOVDIR64B metadata segments (body + headers atomic per 64B, WC closed)
+//   2. nontemporalStoreFence — explicit sfence (#1a / #7 / #9)
+ //   3. MOVDIR64B dispatch packet   (body + header atomic, WC closed)
+//   4. doorbell ring               (ROCr sfence + UC write)
+ //
+// This reduces the dispatch hot path from 3 sfences to 2.
+ //
+ // Note: the sfence between steps 1 and 3 also guarantees that
+ // metadata MOVDIR64B writes (which follow WC ordering) are globally
+ // visible before the dispatch MOVDIR64B.  This satisfies ordering
+ // point #9 (metadata valid before dispatch is released to HW).
+//
+// --- Doorbell ring (step #11 / #12) — two paths ---
+//
+// CLR supports two doorbell paths, selected by DEBUG_CLR_DIRECT_DOORBELL:
+//
+// (A) Default path (DEBUG_CLR_DIRECT_DOORBELL=0):
+//     CLR calls hsa_signal_store_screlease(doorbell_signal, index).
+//     ROCr's AqlQueue::StoreRelease (amd_aql_queue.cpp) does:
+//
+//         std::atomic_thread_fence(memory_order_release);   // (redundant)
+//         _mm_sfence();
+//         *(signal_.hardware_doorbell_ptr) = uint64_t(value);
+//
+//     That SFENCE ensures the valid header written by packet_store_release
+//     (step #10) is flushed from the WC buffer before the UC doorbell store.
+//     CLR does NOT need its own SFENCE between step #10 and the doorbell.
+//
+// (B) Direct path (DEBUG_CLR_DIRECT_DOORBELL=1):
+//     CLR calls ringDoorbell(doorbell_ptr_, index) which does:
+//
+//         nontemporalStoreFence();   // sfence — flushes header from WC buffer
+//         *doorbell = index;         // UC store — also implicitly flushes WC
+//
+//     The doorbell pointer is cached at queue creation via
+//     HSA_AMD_QUEUE_INFO_DOORBELL_ID.  This eliminates the levels of
+//     indirection in the ROCr signal store on the dispatch hot path.
+//
+// In both paths the UC (uncacheable) MMIO doorbell write implicitly flushes
+// any remaining WC data, so no additional SFENCE is needed after the store.
+
+// ================================================================================================
+#if IS_LINUX
+__attribute__((optimize("unroll-all-loops"), always_inline)) static inline void nontemporalMemcpy(
+    void* __restrict dst, const void* __restrict src, size_t size) {
+#if defined(ATI_ARCH_X86)
+  // Drain unaligned head with scalar NT stores to reach 4-byte then 16-byte
+  // dst alignment.  The streaming store intrinsics require aligned destinations;
+  // source is always loaded with unaligned intrinsics since the caller may pass
+  // an arbitrary struct pointer (e.g. AQL packet body at +4 offset).
+  auto dst_addr = reinterpret_cast<uintptr_t>(dst);
+  if ((dst_addr & 0x3) && size) {
+    auto lead = std::min(size, static_cast<size_t>(4 - (dst_addr & 0x3)));
+    std::memcpy(dst, src, lead);
+    dst = static_cast<char*>(dst) + lead;
+    src = static_cast<const char*>(src) + lead;
+    size -= lead;
+    dst_addr = reinterpret_cast<uintptr_t>(dst);
+  }
+  while ((dst_addr & 0xF) && size >= sizeof(int)) {
+    int scalar;
+    std::memcpy(&scalar, src, sizeof(int));
+    _mm_stream_si32(static_cast<int*>(dst), scalar);
+    dst = static_cast<char*>(dst) + sizeof(int);
+    src = static_cast<const char*>(src) + sizeof(int);
+    size -= sizeof(int);
+    dst_addr += sizeof(int);
+  }
+
+#if defined(__AVX512F__)
+  if ((reinterpret_cast<uintptr_t>(dst) & (sizeof(__m512i) - 1)) == 0) {
+    for (auto idx = 0u; idx != size / sizeof(__m512i); ++idx) {
+      _mm512_stream_si512(reinterpret_cast<__m512i*>(dst),
+                          _mm512_loadu_si512(src));
+      dst = static_cast<char*>(dst) + sizeof(__m512i);
+      src = static_cast<const char*>(src) + sizeof(__m512i);
+    }
+    size = size % sizeof(__m512i);
+  }
+#endif
+
+#if defined(__AVX__)
+  if ((reinterpret_cast<uintptr_t>(dst) & (sizeof(__m256i) - 1)) == 0) {
+    for (auto idx = 0u; idx != size / sizeof(__m256i); ++idx) {
+      _mm256_stream_si256(reinterpret_cast<__m256i*>(dst),
+                          _mm256_loadu_si256(reinterpret_cast<const __m256i*>(src)));
+      dst = static_cast<char*>(dst) + sizeof(__m256i);
+      src = static_cast<const char*>(src) + sizeof(__m256i);
+    }
+    size = size % sizeof(__m256i);
+  }
+#endif
+
+  for (auto idx = 0u; idx != size / sizeof(__m128i); ++idx) {
+    _mm_stream_si128(reinterpret_cast<__m128i*>(dst),
+                     _mm_loadu_si128(reinterpret_cast<const __m128i*>(src)));
+    dst = static_cast<char*>(dst) + sizeof(__m128i);
+    src = static_cast<const char*>(src) + sizeof(__m128i);
+  }
+  size = size % sizeof(__m128i);
+
+  for (auto idx = 0u; idx != size / sizeof(long long); ++idx) {
+    long long scalar;
+    std::memcpy(&scalar, src, sizeof(long long));
+    _mm_stream_si64(static_cast<long long*>(dst), scalar);
+    dst = static_cast<char*>(dst) + sizeof(long long);
+    src = static_cast<const char*>(src) + sizeof(long long);
+  }
+  size = size % sizeof(long long);
+
+  for (auto idx = 0u; idx != size / sizeof(int); ++idx) {
+    int scalar;
+    std::memcpy(&scalar, src, sizeof(int));
+    _mm_stream_si32(static_cast<int*>(dst), scalar);
+    dst = static_cast<char*>(dst) + sizeof(int);
+    src = static_cast<const char*>(src) + sizeof(int);
+  }
+
+  size = size % sizeof(int);
+  std::memcpy(dst, src, size);
+#else
+  std::memcpy(dst, src, size);
+#endif
+}
+#else
+static inline void nontemporalMemcpy(void* __restrict dst, const void* __restrict src,
+                                     size_t size) {
+  std::memcpy(dst, src, size);
+}
+#endif
+
+// Copy the body of an AQL packet (64 bytes) using non-temporal stores.
+// The first 4 bytes (header + setup) are NOT written — they retain the
+// HSA_PACKET_TYPE_INVALID value left by the GPU after consuming the previous
+// packet in this slot.  The caller publishes the valid header later via
+// packet_store_release.  Caller MUST issue nontemporalStoreFence() between
+// this call and the header write (ordering point #6a / #9 in the diagram).
+template <typename AqlPacket>
+static inline void nontemporalCopyAQL(AqlPacket* __restrict dst,
+                                      const AqlPacket* __restrict src) {
+  static_assert(sizeof(AqlPacket) == 64, "AQL packets must be 64 bytes");
+  auto* dst_bytes = reinterpret_cast<uint8_t*>(dst);
+  auto* src_bytes = reinterpret_cast<const uint8_t*>(src);
+  nontemporalMemcpy(dst_bytes + 4, src_bytes + 4, sizeof(AqlPacket) - 4);
+}
+
+// Drain the write-combining buffer and wait for all preceding NT stores to
+// reach the destination coherence point.  On PCIe this stalls the CPU until
+// WriteACK returns, so minimise the number of fences per submission.
+static inline void nontemporalStoreFence() {
+#if IS_LINUX && defined(ATI_ARCH_X86)
+  _mm_sfence();
+#else
+  std::atomic_thread_fence(std::memory_order_release);
+#endif
+}
+
+// Write the hardware doorbell directly, bypassing hsa_signal_store_screlease.
+// Ordering: the sfence flushes the WC buffer so that the packet header written
+// by packet_store_release (step #10) is visible before the UC doorbell write
+// reaches the GPU (steps #11 / #12).  The UC write itself also implicitly
+// flushes any remaining WC data.
+//
+// When skip_fence is true (MOVDIR64B path), the sfence is omitted: MOVDIR64B
+// already closed the WC buffer, so the dispatch packet is posted before the
+// UC doorbell store reaches the GPU.
+static inline void ringDoorbell(volatile uint64_t* doorbell, uint64_t index,
+                                bool skip_fence = false) {
+  if (!skip_fence) {
+    nontemporalStoreFence();
+  }
+  *doorbell = index;
+}
+
+// ---- MOVDIR64B support ----------------------------------------------------------
+//
+// MOVDIR64B atomically writes 64 bytes and closes the WC buffer after
+// execution.  When used for AQL packet submission it eliminates multiple
+// sfences — see the "MOVDIR64B optimisation" section in the long comment
+// above for the full ordering analysis.
+//
+// Detection lives in Os::hasMovdir64b() (CPUID leaf 7, sub-leaf 0, ECX
+// bit 28).  The result is cached on first call.
+
+static inline bool hasMovdir64b() {
+#if IS_LINUX && defined(ATI_ARCH_X86) && defined(_LP64)
+  return Os::hasMovdir64b();
+#else
+  return false;
+#endif
+}
+
+// Atomically write 64 bytes from src to dst using MOVDIR64B.
+//
+// dst MUST be 64-byte aligned (hardware requirement; #GP otherwise).
+// src has no alignment requirement but 64-byte alignment is optimal.
+//
+// The instruction reads 64 bytes from [src] (normal load, can be WB/WC/UC)
+// and writes them as a single atomic 64-byte store to [dst].  The WC buffer
+// is closed after execution, which guarantees the write is posted before
+// any subsequent store begins filling a new WC buffer entry.
+//
+// Caller must ensure hasMovdir64b() == true before calling.
+static inline void movdir64b_copy64(void* __restrict dst, const void* __restrict src) {
+#if IS_LINUX && defined(ATI_ARCH_X86) && defined(_LP64)
+  assert((reinterpret_cast<uintptr_t>(dst) & 63) == 0 && "MOVDIR64B dst must be 64-byte aligned");
+  // AT&T syntax: movdir64b (%src_reg), %dst_reg
+  __asm__ __volatile__("movdir64b %1, %0"
+                       : : "r"(dst), "m"(*(const char(*)[64])src) : "memory");
+#else
+  (void)dst; (void)src;
+#endif
+}
+
+// Write a full 64-byte AQL packet (body + valid header) atomically using
+// MOVDIR64B.  Unlike the split nontemporalCopyAQL + sfence +
+// packet_store_release sequence, this writes all 64 bytes including the
+// valid header in a single atomic store.  The WC buffer is closed after
+// execution, so no sfence is needed between this write and a subsequent
+// UC doorbell store.
+//
+// src is the caller's CPU-side staging packet (e.g. dispatchPacket on the
+// stack).  The valid header/rest are merged into a local aligned copy
+// before the MOVDIR64B.
+template <typename AqlPacket>
+static inline void nontemporalWriteAQL(AqlPacket* __restrict dst,
+                                       const AqlPacket* __restrict src,
+                                       uint16_t header, uint16_t rest) {
+  static_assert(sizeof(AqlPacket) == 64, "AQL packets must be 64 bytes");
+  alignas(64) AqlPacket staging;
+  std::memcpy(&staging, src, sizeof(AqlPacket));
+  *reinterpret_cast<uint32_t*>(&staging) = header | (static_cast<uint32_t>(rest) << 16);
+  movdir64b_copy64(dst, &staging);
+}
+
+// STL-compatible allocator that guarantees N-byte alignment.
+// Use with std::vector to ensure the backing store is aligned for SIMD NT stores.
+template <typename T, std::size_t Align>
+struct AlignedAllocator {
+  using value_type = T;
+
+  AlignedAllocator() noexcept = default;
+  template <typename U>
+  AlignedAllocator(const AlignedAllocator<U, Align>&) noexcept {}
+
+  T* allocate(std::size_t count) {
+    void* ptr = ::operator new(count * sizeof(T), std::align_val_t{Align});
+    return static_cast<T*>(ptr);
+  }
+  void deallocate(T* ptr, std::size_t) noexcept {
+    ::operator delete(ptr, std::align_val_t{Align});
+  }
+
+  template <typename U>
+  struct rebind { using other = AlignedAllocator<U, Align>; };
+
+  bool operator==(const AlignedAllocator&) const noexcept { return true; }
+  bool operator!=(const AlignedAllocator&) const noexcept { return false; }
+};
+
+template <typename T>
+using AlignedVector64 = std::vector<T, AlignedAllocator<T, 64>>;
+
+}  // namespace amd
+
+#endif  // CLR_ROCCLR_UTILS_NONTEMPORAL_HPP_

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-attach/queue_registration.cpp
@@ -60,6 +60,11 @@ struct queue_registration_t
         hsa_amd_profiling_set_profiler_enabled_fn = nullptr;
     decltype(AmdExtTable::hsa_amd_queue_intercept_register_fn) hsa_amd_queue_intercept_register_fn =
         nullptr;
+#if defined(HSA_AMD_EXT_API_TABLE_STEP_VERSION) && HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x10
+    // Real ROCr hsa_amd_queue_create, used to forward non-compute (e.g. SDMA) queue requests that
+    // cannot be wrapped in an InterceptQueue.
+    decltype(AmdExtTable::hsa_amd_queue_create_fn) hsa_amd_queue_create_fn = nullptr;
+#endif
     decltype(CoreApiTable::hsa_status_string_fn) hsa_status_string_fn = nullptr;
 };
 
@@ -126,6 +131,53 @@ write_interceptor(const void*                             packets,
     }
 }
 
+// Shared finalization for a freshly created InterceptQueue: enable profiling, register the write
+// interceptor shim, record the queue, and notify queue-created callbacks. Used by both the classic
+// (hsa_queue_create) and descriptor-based (hsa_amd_queue_create) intercept paths.
+hsa_status_t
+finalize_intercept_queue(hsa_agent_t agent, hsa_queue_t* new_queue)
+{
+    auto* registration = CHECK_NOTNULL(get_queue_registration());
+
+    ROCP_ATTACH_HSA_TABLE_CALL(
+        FATAL, registration->hsa_amd_profiling_set_profiler_enabled_fn(new_queue, true))
+        << "Could not setup intercept profiler";
+
+    // Create and insert our queue's data entry now, as we need to provide a reference to it for the
+    // write_interceptor
+    queue_entry_t entry{};
+    entry.agent = agent;
+
+    queue_entry_t* write_interceptor_data = nullptr;
+    auto           snapshot               = std::vector<queue_cb_entry_t>{};
+    {
+        std::lock_guard lg(registration->mutex);
+        ROCP_FATAL_IF(registration->queues.count(new_queue) > 0)
+            << "Queue registration already contains an entry for new queue handle " << new_queue;
+        registration->queues.insert({new_queue, entry});
+        write_interceptor_data = &(registration->queues.at(new_queue));
+        snapshot               = std::vector<queue_cb_entry_t>{registration->cb_list};
+    }
+
+    // Pass queue_entry_t* as user data, used to directly call the user's write interceptor
+    ROCP_ATTACH_HSA_TABLE_CALL(FATAL,
+                               registration->hsa_amd_queue_intercept_register_fn(
+                                   new_queue, write_interceptor, write_interceptor_data))
+        << "Could not register interceptor";
+
+    ROCP_INFO << "created attach queue for HSA agent handle " << agent.handle;
+
+    for(auto& cb_entry : snapshot)
+    {
+        if(cb_entry.cb)
+        {
+            cb_entry.cb(new_queue, agent, ROCPROFILER_ATTACH_QUEUE_CREATED, cb_entry.data);
+        }
+    }
+
+    return HSA_STATUS_SUCCESS;
+}
+
 // HSA Intercept Functions (create_queue/destroy_queue)
 hsa_status_t
 create_queue(hsa_agent_t        agent,
@@ -158,46 +210,75 @@ create_queue(hsa_agent_t        agent,
                                                                                &new_queue))
         << "Could not create intercept queue";
 
-    ROCP_ATTACH_HSA_TABLE_CALL(
-        FATAL, registration->hsa_amd_profiling_set_profiler_enabled_fn(new_queue, true))
-        << "Could not setup intercept profiler";
-
-    // Create and insert our queue's data entry now, as we need to provide a reference to it for the
-    // write_interceptor
-    queue_entry_t entry{};
-    entry.agent = agent;
-
-    queue_entry_t* write_interceptor_data = nullptr;
-    auto           snapshot               = std::vector<queue_cb_entry_t>{};
-    {
-        std::lock_guard lg(registration->mutex);
-        ROCP_FATAL_IF(registration->queues.count(new_queue) > 0)
-            << "Queue registration already contains an entry for new queue handle " << new_queue;
-        registration->queues.insert({new_queue, entry});
-        write_interceptor_data = &(registration->queues.at(new_queue));
-        snapshot               = std::vector<queue_cb_entry_t>{registration->cb_list};
-    }
-
-    // Pass queue_entry_t* as user data, used to directly call the user's write interceptor
-    ROCP_ATTACH_HSA_TABLE_CALL(FATAL,
-                               registration->hsa_amd_queue_intercept_register_fn(
-                                   new_queue, write_interceptor, write_interceptor_data))
-        << "Could not register interceptor";
+    auto status = finalize_intercept_queue(agent, new_queue);
+    if(status != HSA_STATUS_SUCCESS) return status;
 
     *queue = new_queue;
+    return HSA_STATUS_SUCCESS;
+}
 
-    ROCP_INFO << "created attach queue for HSA agent handle " << agent.handle;
+#if defined(HSA_AMD_EXT_API_TABLE_STEP_VERSION) && HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x10
+// Descriptor-based queue creation (hsa_amd_queue_create). A queue created by this API is a plain
+// queue that cannot carry a ROCr packet interceptor, so for compute queues we build an
+// InterceptQueue that mirrors the descriptor's compute parameters instead (the InterceptQueue is
+// what allows kernel-dispatch tracing under attachment). Non-compute queues (e.g. SDMA) do not
+// dispatch kernels and are forwarded to the real implementation unchanged.
+//
+// NOTE: the InterceptQueue is created via the classic hsa_queue_create path, so the descriptor's
+// device-memory ring-buffer flag is not honored while the queue is being profiled; the queue falls
+// back to a system-memory ring.
+hsa_status_t
+create_amd_queue(hsa_agent_t agent, hsa_amd_queue_create_desc_t* descs, uint32_t num_descs)
+{
+    auto* registration = CHECK_NOTNULL(get_queue_registration());
 
-    for(auto& cb_entry : snapshot)
+    ROCP_FATAL_IF(!registration->hsa_amd_queue_intercept_create_fn ||
+                  !registration->hsa_amd_profiling_set_profiler_enabled_fn ||
+                  !registration->hsa_amd_queue_intercept_register_fn ||
+                  !registration->hsa_amd_queue_create_fn || !registration->hsa_status_string_fn)
+        << "Queue registration was not initialized before create queue was called!";
+
+    for(uint32_t desc_idx = 0; desc_idx < num_descs; ++desc_idx)
     {
-        if(cb_entry.cb)
+        if(descs[desc_idx].engine_type != HSA_AMD_QUEUE_ENGINE_COMPUTE)
         {
-            cb_entry.cb(new_queue, agent, ROCPROFILER_ATTACH_QUEUE_CREATED, cb_entry.data);
+            // Non-compute queues cannot dispatch kernels; forward to the real implementation so the
+            // queue is still created (just not intercepted).
+            ROCP_ATTACH_HSA_TABLE_CALL(
+                FATAL, registration->hsa_amd_queue_create_fn(agent, &descs[desc_idx], 1))
+                << "Could not create non-compute amd queue";
+            continue;
         }
+
+        const auto&    compute_params = descs[desc_idx].engine.compute;
+        const uint32_t ring_packets   = static_cast<uint32_t>(
+            descs[desc_idx].queue_size_bytes / sizeof(hsa_kernel_dispatch_packet_t));
+
+        hsa_queue_t* new_queue = nullptr;
+        ROCP_ATTACH_HSA_TABLE_CALL(
+            FATAL,
+            registration->hsa_amd_queue_intercept_create_fn(
+                agent,
+                ring_packets,
+                compute_params.type,
+                descs[desc_idx].callback,
+                descs[desc_idx].callback_data,
+                compute_params.private_segment_size,
+                // Descriptor v1 does not expose group_segment_size; UINT32_MAX requests the runtime
+                // default, matching the classic hsa_queue_create behavior.
+                UINT32_MAX,
+                &new_queue))
+            << "Could not create intercept queue";
+
+        auto status = finalize_intercept_queue(agent, new_queue);
+        if(status != HSA_STATUS_SUCCESS) return status;
+
+        descs[desc_idx].queue = new_queue;
     }
 
     return HSA_STATUS_SUCCESS;
 }
+#endif
 
 hsa_status_t
 destroy_queue(hsa_queue_t* hsa_queue)
@@ -326,6 +407,13 @@ queue_registration_init(HsaApiTable* table)
 
     core_table.hsa_queue_create_fn  = create_queue;
     core_table.hsa_queue_destroy_fn = destroy_queue;
+
+#if defined(HSA_AMD_EXT_API_TABLE_STEP_VERSION) && HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x10
+    // Save the real hsa_amd_queue_create before overwriting it, so non-compute queue requests can
+    // be forwarded, then intercept descriptor-based queue creation.
+    registration->hsa_amd_queue_create_fn      = *table->amd_ext_->hsa_amd_queue_create_fn;
+    table->amd_ext_->hsa_amd_queue_create_fn   = create_amd_queue;
+#endif
 
     registration->hsa_amd_queue_intercept_create_fn =
         *table->amd_ext_->hsa_amd_queue_intercept_create_fn;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue_controller.cpp
@@ -112,6 +112,112 @@ destroy_queue(hsa_queue_t* hsa_queue)
     return HSA_STATUS_SUCCESS;
 }
 
+#if defined(HSA_AMD_EXT_API_TABLE_STEP_VERSION) && HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x10
+hsa_status_t
+create_amd_queue(hsa_agent_t                  agent,
+                 hsa_amd_queue_create_desc_t* descs,
+                 uint32_t                     num_descs)
+{
+    auto* controller = CHECK_NOTNULL(get_queue_controller());
+    auto  status     = controller->get_ext_table().hsa_amd_queue_create_fn(agent, descs, num_descs);
+    if(status != HSA_STATUS_SUCCESS) return status;
+
+    const bool inline_intercept = queue_interposition::supports_queue_interposition();
+
+    for(uint32_t desc_idx = 0; desc_idx < num_descs; ++desc_idx)
+    {
+        hsa_queue_t* queue = descs[desc_idx].queue;
+        if(!queue) continue;
+
+        for(const auto& [_, agent_info] : controller->get_supported_agents())
+        {
+            if(agent_info.get_hsa_agent().handle != agent.handle) continue;
+
+            std::unique_ptr<Queue> new_queue;
+            if(inline_intercept)
+            {
+                // Inline write-index wrappers intercept this plain queue directly (via the
+                // per-queue state registered in add_queue), so no ROCr-level packet
+                // interceptor needs to be attached here.
+                ROCP_INFO << "[queue-intercept] registering hsa_amd_queue_create queue via "
+                             "INLINE path for agent "
+                          << agent.handle;
+                new_queue = std::make_unique<Queue>(agent_info,
+                                                    controller->get_core_table(),
+                                                    controller->get_ext_table(),
+                                                    queue,
+                                                    [](write_interceptor_t, void*) {});
+            }
+            else if(descs[desc_idx].engine_type == HSA_AMD_QUEUE_ENGINE_COMPUTE)
+            {
+                // A queue created by hsa_amd_queue_create is a plain queue that cannot carry a
+                // ROCr packet interceptor (hsa_amd_queue_intercept_register only accepts an
+                // InterceptQueue). In non-inline mode we therefore discard the plain queue and
+                // build a ROCr InterceptQueue that mirrors the descriptor's compute parameters,
+                // then hand that back to the caller in place of the original queue.
+                //
+                // NOTE: the InterceptQueue is created via the classic hsa_queue_create path, so
+                // the descriptor's device-memory ring-buffer flag is not honored while a
+                // non-inline profiling context (e.g. --sys-trace / HIP graph tracing) is active;
+                // the queue falls back to a system-memory ring.
+                ROCP_INFO << "[queue-intercept] registering hsa_amd_queue_create queue via "
+                             "LEGACY path (InterceptQueue) for agent "
+                          << agent.handle;
+
+                const auto&    compute_params = descs[desc_idx].engine.compute;
+                const uint32_t ring_packets   = static_cast<uint32_t>(
+                    descs[desc_idx].queue_size_bytes / sizeof(hsa_kernel_dispatch_packet_t));
+
+                // Release the plain queue that hsa_amd_queue_create just handed us; the
+                // InterceptQueue built below replaces it. get_core_table() holds the real ROCr
+                // functions (saved before the interception wrappers were installed).
+                controller->get_core_table().hsa_queue_destroy_fn(queue);
+
+                hsa_queue_t* intercept_queue = nullptr;
+                new_queue                    = std::make_unique<Queue>(
+                    agent_info,
+                    ring_packets,
+                    compute_params.type,
+                    descs[desc_idx].callback,
+                    descs[desc_idx].callback_data,
+                    compute_params.private_segment_size,
+                    // Descriptor v1 does not expose group_segment_size; UINT32_MAX requests the
+                    // runtime default, matching the classic hsa_queue_create behavior.
+                    UINT32_MAX,
+                    controller->get_core_table(),
+                    controller->get_ext_table(),
+                    &intercept_queue);
+
+                queue                 = intercept_queue;
+                descs[desc_idx].queue = intercept_queue;
+            }
+            else
+            {
+                // Non-compute engines (e.g. SDMA) do not dispatch kernels; keep the plain queue
+                // and register it without a packet interceptor.
+                ROCP_INFO << "[queue-intercept] registering non-compute hsa_amd_queue_create "
+                             "queue (no packet interception) for agent "
+                          << agent.handle;
+                new_queue = std::make_unique<Queue>(agent_info,
+                                                    controller->get_core_table(),
+                                                    controller->get_ext_table(),
+                                                    queue,
+                                                    [](write_interceptor_t, void*) {});
+            }
+
+            controller->serializer(new_queue.get()).wlock([&](auto& serializer) {
+                serializer.add_queue(&queue, *new_queue);
+            });
+            controller->add_queue(queue, std::move(new_queue));
+            ROCP_INFO << "created queue (hsa_amd_queue_create) for HSA agent handle "
+                      << agent.handle;
+            break;
+        }
+    }
+    return HSA_STATUS_SUCCESS;
+}
+#endif
+
 constexpr rocprofiler_agent_t default_agent =
     rocprofiler_agent_t{.size                       = sizeof(rocprofiler_agent_t),
                         .id                         = rocprofiler_agent_id_t{.handle = 0},
@@ -369,6 +475,9 @@ QueueController::init(CoreApiTable& core_table, AmdExtTable& ext_table)
         {
             core_table.hsa_queue_create_fn  = hsa::create_queue;
             core_table.hsa_queue_destroy_fn = hsa::destroy_queue;
+#if defined(HSA_AMD_EXT_API_TABLE_STEP_VERSION) && HSA_AMD_EXT_API_TABLE_STEP_VERSION >= 0x10
+            ext_table.hsa_amd_queue_create_fn = hsa::create_amd_queue;
+#endif
         }
     }
 }

--- a/projects/rocprofiler-sdk/tests/async-copy-tracing/validate.py
+++ b/projects/rocprofiler-sdk/tests/async-copy-tracing/validate.py
@@ -113,7 +113,7 @@ def test_data_structure(input_data):
     node_exists("names", sdk_data["callback_records"])
     node_exists("code_objects", sdk_data["callback_records"])
     node_exists("kernel_symbols", sdk_data["callback_records"])
-    node_exists("host_functions", sdk_data["callback_records"])
+    node_exists("host_functions", sdk_data["callback_records"], 0)
     node_exists("hsa_api_traces", sdk_data["callback_records"])
     node_exists("hip_api_traces", sdk_data["callback_records"], 0)
     node_exists("marker_api_traces", sdk_data["callback_records"])

--- a/projects/rocprofiler-sdk/tests/hip-graph-tracing/validate.py
+++ b/projects/rocprofiler-sdk/tests/hip-graph-tracing/validate.py
@@ -56,7 +56,7 @@ def test_data_structure(input_data):
     node_exists("names", sdk_data["callback_records"])
     node_exists("code_objects", sdk_data["callback_records"])
     node_exists("kernel_symbols", sdk_data["callback_records"])
-    node_exists("host_functions", sdk_data["callback_records"])
+    node_exists("host_functions", sdk_data["callback_records"], 0)
     node_exists("hip_api_traces", sdk_data["callback_records"])
     node_exists("kernel_dispatch", sdk_data["callback_records"])
 

--- a/projects/rocprofiler-sdk/tests/kernel-tracing/validate.py
+++ b/projects/rocprofiler-sdk/tests/kernel-tracing/validate.py
@@ -64,7 +64,7 @@ def test_data_structure(input_data):
     node_exists("names", sdk_data["callback_records"])
     node_exists("code_objects", sdk_data["callback_records"])
     node_exists("kernel_symbols", sdk_data["callback_records"])
-    node_exists("host_functions", sdk_data["callback_records"])
+    node_exists("host_functions", sdk_data["callback_records"], 0)
     node_exists("hsa_api_traces", sdk_data["callback_records"])
     node_exists("hip_api_traces", sdk_data["callback_records"], 0)
     node_exists("marker_api_traces", sdk_data["callback_records"])

--- a/projects/rocprofiler-sdk/tests/scratch-memory-tracing/validate.py
+++ b/projects/rocprofiler-sdk/tests/scratch-memory-tracing/validate.py
@@ -60,7 +60,7 @@ def test_data_structure(input_data):
     node_exists("names", sdk_data["callback_records"])
     node_exists("code_objects", sdk_data["callback_records"])
     node_exists("kernel_symbols", sdk_data["callback_records"])
-    node_exists("host_functions", sdk_data["callback_records"])
+    node_exists("host_functions", sdk_data["callback_records"], 0)
     node_exists("hsa_api_traces", sdk_data["callback_records"])
     node_exists("hip_api_traces", sdk_data["callback_records"], 0)
     # Each scratch allocation produces a phase-enter and phase-exit callback record.

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -606,11 +606,19 @@ void AqlQueue::AllocRegisteredRingBuffer(uint32_t queue_size_pkts) {
                                 "Trying to allocate an AQL ring buffer in device memory without "
                                 "large BAR PCIe enabled.");
     }
-    // Device-memory ring buffers use the region's default CPU mapping; callers
-    // that select this path are responsible for the required packet-store ordering.
+    // AllocateExecutable: the CP hardware requests execute permissions for
+    // packet buffer accesses — it treats AQL packets as an execution language
+    // and will fault on ring buffers without the execute attribute.
+    //
+    // AllocateUncached: propagates through KFD (KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED)
+    // → AMDGPU (AMDGPU_GEM_CREATE_UNCACHED) and sets the page MTYPE to UC in the
+    // GPU page tables.  This is a GPU-side attribute, not CPU-side.
+    //
+    // Callers are responsible for the required CPU-side packet-store ordering
+    // (non-temporal stores + sfence / MOVDIR64B).
     ring_buf_ = agent_->coarsegrain_allocator()(
         ring_buf_alloc_bytes_ + ring_buf_metadata_alloc_bytes_,
-        core::MemoryRegion::AllocateExecutable);
+        core::MemoryRegion::AllocateExecutable | core::MemoryRegion::AllocateUncached);
   } else {
     ring_buf_ = agent_->system_allocator()(
         ring_buf_alloc_bytes_ + ring_buf_metadata_alloc_bytes_, 0x1000,


### PR DESCRIPTION
- Switch CLR queue acquisition to the descriptor-based hsa_amd_queue_create API (nested hsa_amd_queue_create_desc_t). Ring-buffer placement is selected purely via the descriptor flags: HSA_AMD_QUEUE_CREATE_DEVICE_MEM_RING_BUF for device memory, no flag for system memory. Cache the per-queue metadata ring buffer and hardware doorbell in QueueExtras.
- Allocate the device-memory ring buffer (and appended metadata ring) with AllocateExecutable | AllocateUncached. AllocateExecutable is required because the CP hardware requests execute permissions for packet buffer accesses (the hardware treats AQL packets as an execution language). AllocateUncached propagates through ROCr → KFD (KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED) → AMDGPU (AMDGPU_GEM_CREATE_UNCACHED) and sets the page MTYPE to UC in the *GPU* page tables, not the CPU side. Without this the coarse-grain VRAM default is MTYPE_NC; removing the uncached attribute causes GPU hangs on gfx1250 with older MEC firmware.
- Add DEBUG_CLR_AQL_DEV_QUEUE release flag (default 0): device-memory AQL ring buffers are auto-enabled on gfx94x/gfx125x when Large BAR is available; set the flag to 1 to force device-memory rings on other architectures, or to 0 to force a system-memory ring everywhere. Other architectures always use system memory unless overridden. Queue descriptors remain host-resident.
- Add DEBUG_CLR_DIRECT_DOORBELL release flag (default off): write the hardware doorbell directly from CLR through a cached uncacheable doorbell pointer, bypassing hsa_signal_store_screlease. On the MOVDIR64B path the write-combining buffer is already closed, so the pre-doorbell fence is skipped; falls back to the ROCr signal store when the doorbell pointer is unavailable.
- Cache MOVDIR64B CPU capability at device initialization (via Os::hasMovdir64b / CPUID) and use it only for Large BAR-backed device-memory ring buffers to publish full 64-byte AQL packets with a single atomic store. Add DEBUG_CLR_USE_MOVDIR64B release flag (default 1) to force the non-temporal store path even on MOVDIR64B-capable CPUs.
- Add nontemporal.hpp: non-temporal store helpers, MOVDIR64B 64-byte copy support, the direct-doorbell helper, and 64-byte aligned flat packet buffers, plus unified packet write helpers for AQL submission (writePacketToRingBuffer, ringQueueDoorbell).
- Align barrier_packet_ and barrier_value_packet_ to 64 bytes for MOVDIR64B source alignment.
- Stage metadata-prefetch packets for device-memory ring buffers on the single-dispatch path: MetaDataPreloader::SetPacket publishes full 64-byte segments to reduce scattered write-combining stores. Unify SetMetadata and CaptureMetadata through a shared FillMetadata helper that handles MOVDIR64B, legacy+device-mem (staged NT), and legacy+system-mem (direct write) paths for both kernel-dispatch and barrier metadata packets.
- Capture metadata-prefetch packets during graph build: each captured AQL dispatch also captures its corresponding metadata packet into a host buffer (Command::getMetadataPacket / MetaDataPreloader::CaptureMetadata), kept pointer-parallel with the AQL packet vector. Flatten captured metadata into a contiguous 64-byte-aligned buffer (flatMetadataData / filteredFlatMetadataData) index-aligned with the flat AQL packet buffer.
- Publish metadata to the metadata ring on graph batch-flat dispatch: dispatchAqlPacketBatchFlat accepts the pre-built flat metadata buffer and NT-copies it to the per-queue metadata ring at the corresponding slot indices, handling ring-buffer wrap, before the store fence — ensuring metadata is visible when AQL headers go valid.
- Propagate 64-byte aligned graph flat-packet buffers through the HIP graph dispatch paths.
- Remove the legacy DeviceKernelArgsHDP kernel-argument workaround and its DEBUG_CLR_KERNARG_HDP_FLUSH_WA flag. Also remove the DEBUG_CLR_ENABLE_PREFETCH_METADATA flag (metadata is now gated on whether the metadata ring buffer base is non-null).
- Add support for new qeueu create API in rocprof-sdk so that interception can work

## Motivation

## Technical Details

## JIRA ID

JIRA ID : AIRUNTIME-2368

## Test Plan

## Test Result

## Submission Checklist

- Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.