### PR TITLE
[RCCL] test: fix GinDeviceTests amdgcn-link undefined symbol

### DIFF
--- a/projects/rccl/test/device/GinDeviceTests.cpp
+++ b/projects/rccl/test/device/GinDeviceTests.cpp
@@ -17,6 +17,7 @@
 #include "nccl_device/gin/gin_device_common.h"
 #include "nccl_device/gin/proxy/gin_proxy.h"
 #include "nccl_device/gin/proxy/gin_proxy_device_host_common.h"
+#include "nccl_device/impl/core__funcs.h"
 
 #include <iomanip>
 


### PR DESCRIPTION
## Motivation
GinDeviceTests failed at device link time with an undefined hidden symbol for ncclGetLocalPointer().

## Technical Details
gin_proxy.h only declares ncclGetLocalPointer(); include impl/core__funcs.h (where the HIP `__device__` definition lives) in GinDeviceTests.cpp.

```
lld: error: undefined hidden symbol: ncclGetLocalPointer(ncclWindow_vidmem*, unsigned long)
>>> referenced by gin_proxy.h:361 (/home/user/code/rocm-sparse/projects/rccl/build/debug/include/nccl_device/gin/proxy/gin_proxy.h:361)
>>>               /tmp/GinDeviceTests-gfx950-0966c0.o:(RcclUnitTesting::kernelResetSignal(ncclGinCtx, unsigned int))
>>> referenced by gin_proxy.h:361 (/home/user/code/rocm-sparse/projects/rccl/build/debug/include/nccl_device/gin/proxy/gin_proxy.h:361)
>>>               /tmp/GinDeviceTests-gfx950-0966c0.o:(RcclUnitTesting::kernelResetSignal(ncclGinCtx, unsigned int))
clang++: error: amdgcn-link command failed with exit code 1 (use -v to see invocation)
```

## JIRA ID
Resolves AICOMRCCL-1384.

## Test Plan
Built and linked the GinDeviceTests device target for gfx950(+gfx1250).

## Test Result
Device link now succeeds with no undefined-symbol error; the test builds and runs.