### PR TITLE
[RCCL] dda: validate datatype in allgather/alltoall IPC dispatch

### DIFF
--- a/projects/rccl/src/dda_all_gather_ipc.cu
+++ b/projects/rccl/src/dda_all_gather_ipc.cu
@@ -125,6 +125,10 @@ ncclResult_t ncclAllGatherDdaIpc(
     ncclDataType_t datatype,
     ncclComm* comm,
     cudaStream_t stream) {
+  if (datatype != ncclFloat32 && datatype != ncclFloat16 &&
+      datatype != ncclBfloat16) {
+    return ncclInvalidArgument;
+  }
   int typeSize = ncclTypeSize(datatype);
   return ncclAllGatherDdaIpcTyped<int8_t>(
       sendbuff, recvbuff, sendcount * typeSize, comm, stream);

--- a/projects/rccl/src/dda_alltoall_ipc.cu
+++ b/projects/rccl/src/dda_alltoall_ipc.cu
@@ -125,7 +125,11 @@ ncclResult_t ncclAllToAllDdaIpc(
     ncclDataType_t datatype,
     ncclComm* comm,
     cudaStream_t stream) {
-  
+
+  if (datatype != ncclFloat32 && datatype != ncclFloat16 &&
+      datatype != ncclBfloat16) {
+    return ncclInvalidArgument;
+  }
   int typeSize = ncclTypeSize(datatype);
   return ncclAllToAllDdaIpcTyped<int8_t>(
         sendbuff, recvbuff, count * typeSize, comm, stream);


### PR DESCRIPTION
## Motivation
ncclAllGatherDdaIpc/ncclAllToAllDdaIpc crashed on unsupported datatypes by flattening to bytes and dereferencing the comm.

## Technical Details
Reject datatypes other than Float32/Float16/Bfloat16 with ncclInvalidArgument, matching the eligibility check and reduce-scatter dispatch.

```
[ RUN      ] DdaIpcEligibilityTest.AllGather_InvalidDatatypeDispatch
[mc2-18:3323422:0:3323422] Caught signal 11 (Segmentation fault: address not mapped to object at address 0xc)
==== backtrace (tid:3323422) ====
 0  /home/user/ucx-1.16.0/lib/libucs.so.0(ucs_handle_error+0x294) [0x7f1ab8e74a04]
 1  /home/user/ucx-1.16.0/lib/libucs.so.0(+0x33bbf) [0x7f1ab8e74bbf]
 2  /home/user/ucx-1.16.0/lib/libucs.so.0(+0x33e86) [0x7f1ab8e74e86]
 3  /lib64/libc.so.6(+0x3fc30) [0x7f1ab8c3fc30]
 4  /lib64/libc.so.6(+0x19144d) [0x7f1ab8d9144d]
 5  /home/user/code/rocm-sparse/projects/rccl/build/debug/librccl.so.1(_Z19ncclAllGatherDdaIpcPKvPvm14ncclDataType_tP8ncclCommP12ihipStream_t+0x17f) [0x7f1abd08d25f]
 6  ./rccl-UnitTestsFixturesDebug(+0x15239e) [0x55810e56839e]
 7  ./rccl-UnitTestsFixturesDebug(+0x2a9f44) [0x55810e6bff44]
 8  ./rccl-UnitTestsFixturesDebug(+0x290b76) [0x55810e6a6b76]
 9  ./rccl-UnitTestsFixturesDebug(+0x2747f7) [0x55810e68a7f7]
10  ./rccl-UnitTestsFixturesDebug(+0x27529c) [0x55810e68b29c]
11  ./rccl-UnitTestsFixturesDebug(+0x275a12) [0x55810e68ba12]
12  ./rccl-UnitTestsFixturesDebug(+0x285087) [0x55810e69b087]
13  ./rccl-UnitTestsFixturesDebug(+0x2ac234) [0x55810e6c2234]
14  ./rccl-UnitTestsFixturesDebug(+0x292ab6) [0x55810e6a8ab6]
15  ./rccl-UnitTestsFixturesDebug(+0x284c28) [0x55810e69ac28]
16  ./rccl-UnitTestsFixturesDebug(+0x23c031) [0x55810e652031]
17  ./rccl-UnitTestsFixturesDebug(main+0x4c) [0x55810e651b8c]
18  /lib64/libc.so.6(+0x2a610) [0x7f1ab8c2a610]
19  /lib64/libc.so.6(__libc_start_main+0x80) [0x7f1ab8c2a6c0]
20  ./rccl-UnitTestsFixturesDebug(+0x11e3a5) [0x55810e5343a5]
=================================

  Result: FAILED (0.549 seconds)
```

## JIRA ID
Resolves AICOMRCCL-1385.

## Test Plan
Exercised AllGather/AllToAll DDA-IPC dispatch with an unsupported datatype.

## Test Result
Unsupported types now return ncclInvalidArgument instead of crashing; supported types unaffected.