### PR TITLE
[RCCL] graph: guard kvConvertToStr against null dictionary and result pointer

### DIFF
--- a/projects/rccl/src/graph/xml.h
+++ b/projects/rccl/src/graph/xml.h
@@ -423,6 +423,10 @@ static ncclResult_t kvConvertToInt(const char* str, int* value, struct kvDict* d
   return ncclSuccess;
 }
 static ncclResult_t kvConvertToStr(int value, const char** str, struct kvDict* dict) {
+  if (dict == nullptr) {
+    WARN("KV Convert to str : null dictionary");
+    return ncclInternalError;
+  }
   struct kvDict* d = dict;
   while (d->str) {
     if (value == d->value) {

--- a/projects/rccl/src/graph/xml.h
+++ b/projects/rccl/src/graph/xml.h
@@ -423,11 +423,11 @@ static ncclResult_t kvConvertToInt(const char* str, int* value, struct kvDict* d
   return ncclSuccess;
 }
 static ncclResult_t kvConvertToStr(int value, const char** str, struct kvDict* dict) {
-  if (dict == nullptr) {
+  if (dict == NULL) {
     WARN("KV Convert to str : null dictionary");
     return ncclInternalError;
   }
-  if (str == nullptr) {
+  if (str == NULL) {
     WARN("KV Convert to str : null result pointer");
     return ncclInternalError;
   }

--- a/projects/rccl/src/graph/xml.h
+++ b/projects/rccl/src/graph/xml.h
@@ -427,6 +427,10 @@ static ncclResult_t kvConvertToStr(int value, const char** str, struct kvDict* d
     WARN("KV Convert to str : null dictionary");
     return ncclInternalError;
   }
+  if (str == nullptr) {
+    WARN("KV Convert to str : null result pointer");
+    return ncclInternalError;
+  }
   struct kvDict* d = dict;
   while (d->str) {
     if (value == d->value) {


### PR DESCRIPTION
## Motivation
kvConvertToStr segfaulted on a null dictionary and wrote through a null result pointer (caught by XmlTest.kvConvertToStr_NullResultPointer in Debug).

## Technical Details
Add null checks for both the dict and the output str pointer, returning ncclInternalError before any dereference.

```
[ RUN      ] XmlTest.kvConvertToStr_NullDict
[mc2-18:3323389:0:3323389] Caught signal 11 (Segmentation fault: address not mapped to object at address (nil))
==== backtrace (tid:3323389) ====
 0  /home/user/ucx-1.16.0/lib/libucs.so.0(ucs_handle_error+0x294) [0x7f77aaee8a04]
 1  /home/user/ucx-1.16.0/lib/libucs.so.0(+0x33bbf) [0x7f77aaee8bbf]
 2  /home/user/ucx-1.16.0/lib/libucs.so.0(+0x33e86) [0x7f77aaee8e86]
 3  /lib64/libc.so.6(+0x3fc30) [0x7f77aa83fc30]
 4  ./rccl-UnitTestsFixturesDebug(+0x20d1cf) [0x55aade6d21cf]
 5  ./rccl-UnitTestsFixturesDebug(+0x20db10) [0x55aade6d2b10]
 6  ./rccl-UnitTestsFixturesDebug(+0x2a9f44) [0x55aade76ef44]
 7  ./rccl-UnitTestsFixturesDebug(+0x290b76) [0x55aade755b76]
 8  ./rccl-UnitTestsFixturesDebug(+0x2747f7) [0x55aade7397f7]
 9  ./rccl-UnitTestsFixturesDebug(+0x27529c) [0x55aade73a29c]
10  ./rccl-UnitTestsFixturesDebug(+0x275a12) [0x55aade73aa12]
11  ./rccl-UnitTestsFixturesDebug(+0x285087) [0x55aade74a087]
12  ./rccl-UnitTestsFixturesDebug(+0x2ac234) [0x55aade771234]
13  ./rccl-UnitTestsFixturesDebug(+0x292ab6) [0x55aade757ab6]
14  ./rccl-UnitTestsFixturesDebug(+0x284c28) [0x55aade749c28]
15  ./rccl-UnitTestsFixturesDebug(+0x23c031) [0x55aade701031]
16  ./rccl-UnitTestsFixturesDebug(main+0x4c) [0x55aade700b8c]
17  /lib64/libc.so.6(+0x2a610) [0x7f77aa82a610]
18  /lib64/libc.so.6(__libc_start_main+0x80) [0x7f77aa82a6c0]
19  ./rccl-UnitTestsFixturesDebug(+0x11e3a5) [0x55aade5e33a5]
=================================

  Result: FAILED (0.664 seconds)
```

## JIRA ID
Resolves AICOMRCCL-1386.

## Test Plan
Ran XmlTest.kvConvertToStr_NullResultPointer (Debug) plus the null-dictionary path.

## Test Result
Previously crashing cases now return ncclInternalError and the test passes; normal lookups unchanged.