### PR TITLE
[RCCL] test: fix u32fpDecode test failure on gfx1250

### DIFF
--- a/projects/rccl/test/BitOpsTests.cpp
+++ b/projects/rccl/test/BitOpsTests.cpp
@@ -67,9 +67,9 @@ TEST(u32fpEncode, u32fpEncodeSuccess) {
 }
 
 TEST(u32fpDecode, u32fpDecodeSuccess) {
-    uint32_t u32Val{63};
-    uint32_t u32ExpectVal = 1073741824; // 0x40000000
     int bitsPerPow2 = 1;
+    uint32_t u32Val = u32fpEncode(0xFFFFFFFF, bitsPerPow2); // encoded value (== 63)
+    uint32_t u32ExpectVal = 0x40000000;
     EXPECT_EQ(u32fpDecode(u32Val, bitsPerPow2), u32ExpectVal);
 }
 

--- a/projects/rccl/test/BitOpsTests.cpp
+++ b/projects/rccl/test/BitOpsTests.cpp
@@ -67,9 +67,8 @@ TEST(u32fpEncode, u32fpEncodeSuccess) {
 }
 
 TEST(u32fpDecode, u32fpDecodeSuccess) {
-    // log2x is 1, use bitsPerPow2 = 1
-    uint32_t u32Val{0xFFFFFFFF}; // 32 bits set to 1
-    uint32_t u32ExpectVal = 63;
+    uint32_t u32Val{63};
+    uint32_t u32ExpectVal = 1073741824; // 0x40000000
     int bitsPerPow2 = 1;
     EXPECT_EQ(u32fpDecode(u32Val, bitsPerPow2), u32ExpectVal);
 }


### PR DESCRIPTION
## Motivation
The u32fpDecode test failed on gfx1250 due to an undefined shift producing arch-dependent results.

## Technical Details
Decode the value from u32fpEncode(0xFFFFFFFF, 1) (=63); a raw unencoded value pushed the exponent past 31 and triggered UB in `mantissa << exponent`.

## JIRA ID
Resolves AICOMRCCL-1388.

## Test Plan
Ran the BitOps u32fpDecode test on gfx1250.

## Test Result
The shift stays in range and the test passes deterministically on gfx1250.