### PR TITLE
[RCCL] rccl_ptr: enable global dwordx4 builtins on gfx1250

### DIFF
--- a/projects/rccl/src/include/nccl_device/rccl_ptr.h
+++ b/projects/rccl/src/include/nccl_device/rccl_ptr.h
@@ -36,12 +36,12 @@ using u16_gptr = __attribute__((address_space(1))) uint16_t*;
 using u8_gptr = __attribute__((address_space(1))) uint8_t*;
 
 #ifdef __HIP_DEVICE_COMPILE__
-#if (defined(__gfx942__) || defined(__gfx950__)) && __has_builtin(__builtin_amdgcn_global_load_b128) && __has_builtin(__builtin_amdgcn_global_store_b128) && !defined(DWORDX4_INTRINSICS_FORCE_OFF)
+#if (defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)) && __has_builtin(__builtin_amdgcn_global_load_b128) && __has_builtin(__builtin_amdgcn_global_store_b128) && !defined(DWORDX4_INTRINSICS_FORCE_OFF)
 #define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 1
-//#pragma message "RCCL DWORDX4 Builtins Enabled on GFX942/GFX950"
+//#pragma message "RCCL DWORDX4 Builtins Enabled on GFX942/GFX950/GFX1250"
 #else
 #define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 0
-//#pragma message "RCCL DWORDX4 Builtins Disabled on GFX942/GFX950"
+//#pragma message "RCCL DWORDX4 Builtins Disabled on GFX942/GFX950/GFX1250"
 #endif
 #else
 #define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 0


### PR DESCRIPTION
## Motivation
On gfx1250, 128-bit global load/store used the faulting fallback path instead of the builtin.

## Technical Details
Add gfx1250 to the RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS gate so dwordx4 global access uses the builtin path.

## JIRA ID
Resolves AICOMRCCL-1389.

## Test Plan
Built and exercised 128-bit global load/store paths on gfx1250.

## Test Result
gfx1250 now uses the dwordx4 builtin path with no fault; other arches unchanged.