### PR TITLE
[RCCL] test: restrict code coverage instrumentation to host pass to fix gfx1250 device link

### DIFF
--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -17,8 +17,8 @@ if(BUILD_TESTS)
   endif()
 
   if (ENABLE_CODE_COVERAGE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
-    set(HIPCC_COMPILE_FLAGS "${HIPCC_COMPILE_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xarch_host -fprofile-instr-generate -Xarch_host -fcoverage-mapping")
+    set(HIPCC_COMPILE_FLAGS "${HIPCC_COMPILE_FLAGS} -Xarch_host -fprofile-instr-generate -Xarch_host -fcoverage-mapping")
     # Allow ProcessIsolatedTestRunner.cpp to call __llvm_profile_write_file()
     # explicitly before _exit() so child-process coverage data is flushed.
     add_compile_definitions(RCCL_TEST_CODE_COVERAGE=1)

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -17,8 +17,8 @@ if(BUILD_TESTS)
   endif()
 
   if (ENABLE_CODE_COVERAGE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xarch_host -fprofile-instr-generate -Xarch_host -fcoverage-mapping")
-    set(HIPCC_COMPILE_FLAGS "${HIPCC_COMPILE_FLAGS} -Xarch_host -fprofile-instr-generate -Xarch_host -fcoverage-mapping")
+    add_compile_options("SHELL:-Xarch_host -fprofile-instr-generate" "SHELL:-Xarch_host -fcoverage-mapping")
+    add_link_options("SHELL:-Xarch_host -fprofile-instr-generate" "SHELL:-Xarch_host -fcoverage-mapping")
     # Allow ProcessIsolatedTestRunner.cpp to call __llvm_profile_write_file()
     # explicitly before _exit() so child-process coverage data is flushed.
     add_compile_definitions(RCCL_TEST_CODE_COVERAGE=1)


### PR DESCRIPTION
## Motivation
Code coverage instrumentation applied to the device pass broke gfx1250 device linking.

## Technical Details
Limit the coverage instrumentation flags in test/CMakeLists.txt to the host compilation pass only.

## JIRA ID
Resolves AICOMRCCL-1390.

## Test Plan
Built the unit tests with code coverage enabled targeting gfx1250.

## Test Result
Device link succeeds with coverage enabled; host-side coverage still collected.