### PR TITLE
hip-tests: disable StreamCapture_ClusterDim test on NVIDIA

### DIFF
--- a/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
+++ b/projects/hip-tests/catch/unit/module/hipDrvLaunchKernelEx.cc
@@ -435,7 +435,7 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_With_MaxBlockDims) {
   HIP_CHECK(hipModuleUnload(module));
   CTX_DESTROY();
 }
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !HT_NVIDIA
 /**
  * Test Description
  * ------------------------
@@ -601,7 +601,7 @@ HIP_TEST_CASE(Unit_hipDrvLaunchKernelEx_StreamCapture_ClusterDim) {
   HIP_CHECK(hipFree(d_out));
   HIP_CHECK(hipModuleUnload(mod));
 }
-#endif  // !defined(_WIN32)
+#endif  // !defined(_WIN32) && !HT_NVIDIA
 
 /**
  * End doxygen group ModuleTest.


### PR DESCRIPTION
## Summary
- `hipLaunchAttributeClusterDimension` is AMD-only and undefined in CUDA headers
- The `Unit_hipDrvLaunchKernelEx_StreamCapture_ClusterDim` test was causing a build failure on the NVIDIA CI job
- Guard the test with `!HT_NVIDIA` (in addition to the existing `!defined(_WIN32)`)

## Test plan
- [ ] NVIDIA CI build should now pass (test excluded from compilation)
- [ ] AMD CI unaffected — test still compiled and run on AMD

🤖 Generated with [Claude Code](https://claude.com/claude-code)