### PR TITLE
[rocprofiler-compute] Remove owners/reviewers comment from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,7 @@
 /projects/rocm-core/                                                  @nunnikri @frepaul @raramakr @ashutom @amd-isparry @arvindcheru
 /projects/rocm-smi-lib/                                               @ROCm/smi-reviewers
 /projects/rocminfo/                                                   @dayatsin-amd @shwetagkhatri
-/projects/rocprofiler-compute/                                        @ROCm/rocprof-compute-reviewer # Owners: @ROCm/rocprof-compute-owners, Reviewers: @ROCm/rocprof-compute-reviewer
+/projects/rocprofiler-compute/                                        @ROCm/rocprof-compute-reviewer
 /projects/rocprofiler-systems/                                        @ROCm/rocprof-sys @jrmadsen
 /projects/rocprofiler-sdk/                                            @ROCm/rocm-devtools-team @ROCm/rocprofiler-owners # First Review: @ROCm/rocm-devtools-team, Final Review: @ROCm/rocprofiler-owners
 /projects/rocr-runtime/                                               @kentrussell @dayatsin-amd @cfreeamd @atgutier


### PR DESCRIPTION
## Motivation

Clean up the rocprofiler-compute entry in `.github/CODEOWNERS` by removing the redundant trailing comment.

## Technical Details

- Drop the trailing comment on the `/projects/rocprofiler-compute/` line; the `@ROCm/rocprof-compute-reviewer` assignment is unchanged.

## JIRA ID

## Test Plan

- Confirm the CODEOWNERS entry still resolves `@ROCm/rocprof-compute-reviewer` as the owner for `/projects/rocprofiler-compute/`.

## Test Result

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.