### PR TITLE
[AMD-SMI] Fixed #7583 for RX 9060 XT

### DIFF
--- a/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/set_value.py
@@ -1608,7 +1608,7 @@ class SetValueCommands:
 
                 if lim_type == "min":
                     amdsmi_lim_type = amdsmi_interface.AmdSmiClkLimitType.MIN
-                    if val > clk_tuple["max_clk"]:
+                    if isinstance(clk_tuple["max_clk"], int) and val > clk_tuple["max_clk"]:
                         self.logger.store_output(
                             args.gpu,
                             "clk_limit",
@@ -1622,7 +1622,7 @@ class SetValueCommands:
                         val_changed = False  # Clock limit value did not changed
                 elif lim_type == "max":
                     amdsmi_lim_type = amdsmi_interface.AmdSmiClkLimitType.MAX
-                    if val < clk_tuple["min_clk"]:
+                    if isinstance(clk_tuple["min_clk"], int) and val < clk_tuple["min_clk"]:
                         self.logger.store_output(
                             args.gpu,
                             "clk_limit",


### PR DESCRIPTION
## Motivation

Fixes #7583. RX 9060 XT can return 'N/A' and a tuple for min/max clock may not be available. So comparing a number with a string will fail.

## Technical Details

We have no reason to do a comparison when we know that it will fail. We can ignore validation if the target tuple value is unknown.

## Test Plan

Run `sudo amd-smi set --gpu 0 --clk-limit sclk max 2100` on RX 9060 XT.

## Submission Checklist

- [*] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
