### PR TITLE
[rocprofiler-compute] Fix test_categories.yaml test inventory

### DIFF
--- a/projects/rocprofiler-compute/tests/test_categories.yaml
+++ b/projects/rocprofiler-compute/tests/test_categories.yaml
@@ -37,7 +37,6 @@ test_categories:
       - test_metrics_common
       - test_tty
       - test-rocprofiler-compute-tool
-      - test_inject_roctx_loader
       - test_soc_base
       - test-pc-sampling-collector
     exclude:
@@ -97,9 +96,11 @@ test_categories:
       - test_metrics_common
       - test_tty
       - test-rocprofiler-compute-tool
-      - test_inject_roctx_loader
       - test_soc_base
       - test-pc-sampling-collector
+      - test_profile_torch_trace
+      - test_profile_live_attach_detach
+      - test_metric_validation
     exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
@@ -156,9 +157,11 @@ test_categories:
       - test_metrics_common
       - test_tty
       - test-rocprofiler-compute-tool
-      - test_inject_roctx_loader
       - test_soc_base
       - test-pc-sampling-collector
+      - test_profile_torch_trace
+      - test_profile_live_attach_detach
+      - test_metric_validation
     exclude:
       - test_profile_live_attach_detach
       - test_metric_validation
@@ -215,9 +218,11 @@ test_categories:
       - test_metrics_common
       - test_tty
       - test-rocprofiler-compute-tool
-      - test_inject_roctx_loader
       - test_soc_base
       - test-pc-sampling-collector
+      - test_profile_torch_trace
+      - test_profile_live_attach_detach
+      - test_metric_validation
     exclude:
       - test_profile_live_attach_detach
       - test_metric_validation


### PR DESCRIPTION
## Motivation

Align tests/test_categories.yaml with the tests actually registered via ctest. test_profile_torch_trace was registered but listed in no category, and a stale name (test_inject_roctx_loader) referenced a test that does not exist in any build config.

## Technical Details

- Add `test_profile_torch_trace` to standard/comprehensive/full test_patterns (GPU profile+analyze torch-trace flow; not added to quick).
- Add `test_profile_live_attach_detach` and `test_metric_validation` to the same tiers for inventory completeness; their existing `exclude` entries still suppress them via the `{tier}_exclude` labels.
- Remove `test_inject_roctx_loader` (no `add_test` in any build config).

## JIRA ID



## Test Plan

- Build with `-D ENABLE_TESTS=ON -D INSTALL_TESTS=ON` and confirm `ctest -N` registers the expected tests.
- Run the category parser and verify torch_trace gets standard/comprehensive/full labels while the excluded tests carry matching `{tier}_exclude` labels.

## Test Result



## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.