### PR TITLE
[RCCL] Validate NCCL 2.29.7 defect - memory init in P2P transport

### DIFF
--- a/projects/rccl/test/AllocTests.cpp
+++ b/projects/rccl/test/AllocTests.cpp
@@ -8,6 +8,9 @@
 #include <gtest/gtest.h>
 #include <rccl/rccl.h>
 
+#include <cstdint>
+#include <vector>
+
 #include "TestBed.hpp"
 #include "common/ErrCode.hpp"
 #include "common/ProcessIsolatedTestRunner.hpp"
@@ -138,6 +141,73 @@ TEST(Alloc, ncclCuMemFreeAddr)
     );
 }
 #endif // ROCM_VERSION < 70000
+
+#if ROCM_VERSION >= 70000
+// Regression test for NCCL GitHub issue #1962 ("Fix memory initialization in the
+// P2P transport"), fixed upstream in NCCL 2.29.7. The cuMem (VMM) allocation path
+// must hand back zero-initialized memory: it backs the P2P shareable buffers whose
+// control structures (ncclSendMem/ncclRecvMem head, tail, ptrExchange,
+// redOpArgExchange) must start at zero. RCCL satisfies this by zeroing inside
+// ncclCuMemAlloc (the ROCM-20370 workaround, where hsa_amd_vmem_map leaves
+// non-zero residue after the driver's SDMA clear). Pre-fix, the freshly mapped
+// buffer carried residue at specific offsets; this test fails in that case.
+TEST(Alloc, ncclCuMemAllocZeroInitialized)
+{
+    RUN_ISOLATED_TEST(
+        "ncclCuMemAllocZeroInitialized",
+        []()
+        {
+            int devCount = 0;
+            if(hipGetDeviceCount(&devCount) != hipSuccess || devCount < 1)
+            {
+                GTEST_SKIP() << "No HIP-visible GPU; skipping";
+            }
+            ASSERT_EQ(hipSetDevice(0), hipSuccess);
+
+            // Note: we call ncclCuMemAlloc directly rather than gating on
+            // ncclCuMemEnable(). The zero-init fix lives inside ncclCuMemAlloc and
+            // is independent of NCCL's runtime decision to *use* cuMem (which is
+            // version-gated and may be off, e.g. on ROCm releases in the
+            // HIP-version gap below the 7.12 native cutoff). If the VMM driver API
+            // is genuinely unavailable, the allocation fails and we skip.
+
+            // Use a multi-MB size (larger than the VMM allocation granularity) to
+            // span the offsets where the ROCM-20370 residue was observed.
+            constexpr size_t size = 4 * 1024 * 1024;
+
+            void*                           ptr    = nullptr;
+            hipMemGenericAllocationHandle_t handle = {};
+            ncclResult_t                    result
+                = ncclCuMemAlloc(&ptr, &handle, ncclCuMemHandleType, size, /*manager=*/nullptr);
+            if(result != ncclSuccess)
+            {
+                // VMM requested but not actually usable on this device/driver.
+                GTEST_SKIP() << "ncclCuMemAlloc unsupported here (result=" << result << ")";
+            }
+            ASSERT_NE(ptr, nullptr);
+
+            // Pre-fill the host buffer with a poison pattern so a successful copy of
+            // genuinely-zeroed device memory is what clears it.
+            std::vector<uint8_t> host(size, 0xFF);
+            ASSERT_EQ(hipMemcpy(host.data(), ptr, size, hipMemcpyDeviceToHost), hipSuccess);
+
+            size_t firstNonZero = size;
+            for(size_t i = 0; i < size; ++i)
+            {
+                if(host[i] != 0)
+                {
+                    firstNonZero = i;
+                    break;
+                }
+            }
+            EXPECT_EQ(firstNonZero, size)
+                << "ncclCuMemAlloc returned non-zero byte at offset " << firstNonZero
+                << " (NCCL issue #1962 / ROCM-20370 regression)";
+
+            EXPECT_EQ(ncclCuMemFree(ptr, /*manager=*/nullptr), ncclSuccess);
+        });
+}
+#endif // ROCM_VERSION >= 70000
 
 TEST(Alloc, NcclCudaMemcpy)
 {


### PR DESCRIPTION
Add `Alloc.ncclCuMemAllocZeroInitialized` unit test that asserts the cuMem (VMM) allocation path returns zero-initialized memory, locking in the fix for NCCL GitHub issue [#1962](https://github.com/NVIDIA/nccl/issues/1962) ("Fix memory initialization in the P2P transport") and the RCCL ROCM-20370 workaround in `ncclCuMemAlloc`.

The test allocates via `ncclCuMemAlloc` and verifies every byte is zero. Verified it FAILS when the zeroing is removed/poisoned and PASSES with the fix in place. Gated on `ROCM_VERSION >= 70000` and skips gracefully when no GPU is present or the VMM driver API is unavailable.

## Motivation

NCCL 2.29.7 fixed issue [#1962](https://github.com/NVIDIA/nccl/issues/1962): the cuMem (VMM) allocation path in the P2P transport returned uninitialized memory (no `memset` after `cuMemAlloc`), whereas the legacy `cudaMalloc` path zeroed via `ncclCudaCalloc`. These shareable buffers back the P2P FIFO control structures (`ncclSendMem`/`ncclRecvMem` — `head`, `tail`, `ptrExchange`, `redOpArgExchange`), which must start at zero; otherwise a receiver can observe stale/garbage flags before the producer writes them, leading to data corruption or stalls.

RCCL already satisfies this requirement — but it does so centrally inside `ncclCuMemAlloc` (the ROCM-20370 workaround, where `hsa_amd_vmem_map` writes bookkeeping metadata into the user-visible buffer after the kernel driver's SDMA clear, leaving non-zero residue). This is an AMD-relevant correctness behavior with no automated coverage. This PR adds a deterministic regression guard so the zeroing can't be silently dropped (e.g. removed for perf) in the future.


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

AICOMRCCL-1111

## Test Plan

- Run: `./build/debug/test/rccl-UnitTestsFixturesDebug --gtest_filter='Alloc.ncclCuMemAllocZeroInitialized'`.
- Validate fail-before / pass-after by temporarily neutralizing the zeroing in `ncclCuMemAlloc` (`alloc.h`) and re-running.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
