### PR TITLE
[rocprofiler-sdk] keep ATT completion callback active after marker pause

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/profile_serializer.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/profile_serializer.cpp
@@ -92,14 +92,17 @@ profiler_serializer::add_queue(hsa_queue_t** hsa_queues, const Queue& queue)
 }
 
 void
-profiler_serializer::kernel_completion_signal(const Queue& completed)
+profiler_serializer::kernel_completion_signal(const Queue& completed, bool is_serialized)
 {
     const auto qid          = completed.get_id().handle;
     uint64_t   completed_id = 0;
-    if(auto it = _serial.find(qid); it != _serial.end())
-        completed_id = it->second.completed.fetch_add(1, std::memory_order_relaxed) + 1;
+    if(is_serialized)
+    {
+        if(auto it = _serial.find(qid); it != _serial.end())
+            completed_id = it->second.completed.fetch_add(1, std::memory_order_relaxed) + 1;
 
-    drain_barriers(_barrier, qid, completed_id);
+        drain_barriers(_barrier, qid, completed_id);
+    }
 
     // We do not want to track kernel completion signals before we have reached the barrier
     clear_complete_barriers(_barrier);
@@ -122,7 +125,9 @@ profiler_serializer::kernel_completion_signal(const Queue& completed)
         }
     }
 
-    if(state == Status::DISABLED) return;
+    // Transition barriers count every active intercepted dispatch. Dispatches that did not request
+    // serialization must decrement those barriers without releasing or transferring a queue token.
+    if(!is_serialized || state == Status::DISABLED) return;
 
     CHECK(_dispatch_queue);
     _dispatch_queue = nullptr;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/profile_serializer.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/profile_serializer.hpp
@@ -71,7 +71,9 @@ public:
         std::unique_ptr<hsa_barrier> barrier;
     };
 
-    void kernel_completion_signal(const Queue&);
+    // Notify the serializer that an intercepted dispatch completed. Non-serialized dispatches
+    // still advance transition barriers but do not participate in queue token handoff.
+    void kernel_completion_signal(const Queue&, bool is_serialized);
     // Signal a kernel dispatch is taking place, generates packets needed to be
     // inserted to support kernel dispatch
     common::container::small_vector<hsa::rocprofiler_packet, 3> kernel_dispatch(const Queue&) const;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/hsa/queue.cpp
@@ -168,14 +168,11 @@ AsyncSignalHandler(hsa_signal_value_t /*signal_v*/, void* data)
             }
         });
 
-        if(packet.is_serialized)
-        {
-            CHECK_NOTNULL(hsa::get_queue_controller())
-                ->serializer(&queue_info_session.queue)
-                .wlock([&](auto& serializer) {
-                    serializer.kernel_completion_signal(queue_info_session.queue);
-                });
-        }
+        CHECK_NOTNULL(hsa::get_queue_controller())
+            ->serializer(&queue_info_session.queue)
+            .wlock([&](auto& serializer) {
+                serializer.kernel_completion_signal(queue_info_session.queue, packet.is_serialized);
+            });
 
         auto _should_destroy_signal = [&packet](auto _hsa_signal) {
             // if there is a pooled signal, make sure we return value if the .handle matches.

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -411,6 +411,18 @@ DispatchThreadTracer::resource_init()
 void
 DispatchThreadTracer::resource_deinit()
 {
+    enabled.store(false, std::memory_order_release);
+
+    if(auto* controller = hsa::get_queue_controller())
+    {
+        client.wlock([&](auto& client_id) {
+            if(!client_id) return;
+            controller->remove_callback(*client_id);
+            client_id = std::nullopt;
+        });
+        controller->disable_serialization();
+    }
+
     ROCP_TRACE << "Clearing agents";
     auto lk = std::unique_lock{agents_map_mut};
     agents.clear();
@@ -435,6 +447,8 @@ DispatchThreadTracer::pre_kernel_call(const hsa::Queue&              queue,
         rocprof_corr_id.internal = corr_id->internal;
     }
     // TODO: Get external
+
+    if(!enabled.load(std::memory_order_acquire)) return {nullptr, false};
 
     std::shared_lock<std::shared_mutex> lk(agents_map_mut);
 
@@ -494,6 +508,7 @@ DispatchThreadTracer::start_context()
     // Only installs queue-controller callbacks (cached and applied to queues as
     // they are created), so this is safe to call before hsa_init.
     CHECK_NOTNULL(hsa::get_queue_controller())->enable_serialization();
+    enabled.store(true, std::memory_order_release);
 
     // Only one thread should be attempting to enable/disable this context
     client.wlock([&](auto& client_id) {
@@ -529,18 +544,10 @@ DispatchThreadTracer::start_context()
 void
 DispatchThreadTracer::stop_context()  // NOLINT(readability-convert-member-functions-to-static)
 {
-    auto* controller = hsa::get_queue_controller();
-    if(!controller) return;
-
-    client.wlock([&](auto& client_id) {
-        if(!client_id) return;
-
-        // Remove our callbacks from HSA's queue controller
-        controller->remove_callback(*client_id);
-        client_id = std::nullopt;
-    });
-
-    controller->disable_serialization();
+    // Stop injecting ATT packets for new dispatches. The completion callback and
+    // serializer must remain active until final teardown so ATT work submitted
+    // before the pause can finish and flush its data.
+    enabled.store(false, std::memory_order_release);
 }
 
 DeviceThreadTracer::DeviceThreadTracer()

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -544,10 +544,11 @@ DispatchThreadTracer::start_context()
 void
 DispatchThreadTracer::stop_context()  // NOLINT(readability-convert-member-functions-to-static)
 {
-    // Stop injecting ATT packets for new dispatches. The completion callback and
-    // serializer must remain active until final teardown so ATT work submitted
-    // before the pause can finish and flush its data.
-    enabled.store(false, std::memory_order_release);
+    // Stop injecting ATT packets before transitioning serialization. Completion callbacks remain
+    // registered so packets already in the queues can drain through the serializer transition.
+    if(!enabled.exchange(false, std::memory_order_acq_rel)) return;
+
+    if(auto* controller = hsa::get_queue_controller()) controller->disable_serialization();
 }
 
 DeviceThreadTracer::DeviceThreadTracer()

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.hpp
@@ -180,6 +180,7 @@ private:
 
     std::shared_mutex agents_map_mut{};
     std::atomic<int>  post_move_data{0};
+    std::atomic<bool> enabled{false};
 };
 
 class DeviceThreadTracer

--- a/projects/rocprofiler-sdk/tests/bin/roctx-pause-resume/roctx-pause-resume.cpp
+++ b/projects/rocprofiler-sdk/tests/bin/roctx-pause-resume/roctx-pause-resume.cpp
@@ -26,6 +26,7 @@
 #include <hip/hip_runtime.h>
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #define WIDTH 1024
 
@@ -122,7 +123,7 @@ pc_sampling_kernel(const int c)
 }
 
 int
-main()
+main(int argc, char** argv)
 {
     auto tid = roctx_thread_id_t{};
     // get the thread id recognized by rocprofiler-sdk from roctx
@@ -156,19 +157,22 @@ main()
         hipMemcpy(gpuTransposeMatrix, gpuMatrix, NUM * sizeof(float), hipMemcpyDeviceToDevice));
 
     // Set up simple kernels
-    constexpr auto   NUM_KERNELS              = 64;
-    constexpr size_t TARGET_KERNEL_ITERATIONS = NUM_KERNELS / 4;
-    float*           result                   = nullptr;
-    float            varA                     = 5.5;
-    float            varB                     = 11.7;
-    uint32_t         num_blocks               = BLOCK_SIZE;
+    constexpr auto NUM_KERNELS = size_t{64};
+    auto           num_kernels = NUM_KERNELS;
+    if(argc > 1) num_kernels = atoll(argv[1]);
+    const auto target_kernel_iterations = (num_kernels / 4 > 0) ? num_kernels / 4 : size_t{1};
+    float*     result                   = nullptr;
+    float      varA                     = 5.5;
+    float      varB                     = 11.7;
+    uint32_t   num_blocks               = BLOCK_SIZE;
+    if(argc > 2) num_blocks = static_cast<uint32_t>(atoi(argv[2]));
     checkHipErrors(hipMallocAsync(&result, sizeof(float), stream));
-    for(auto i = 0; i < NUM_KERNELS; ++i)
+    for(auto i = size_t{0}; i < num_kernels; ++i)
     {
         kernel_add<<<dim3(1), dim3(1), 0, stream>>>(varA++, varB++, result);
         kernel_mult<<<dim3(1), dim3(1), 0, stream>>>(varA++, varB++, result);
         // Run target kernel
-        if(i % TARGET_KERNEL_ITERATIONS == 0)
+        if(i % target_kernel_iterations == 0)
         {
             roctxProfilerResume(tid);
             hipLaunchKernelGGL(target_kernel,
@@ -180,7 +184,7 @@ main()
                                gpuMatrix,
                                WIDTH);
             // Use max(i, 1) to ensure at least 1 thread per block (i=0 would be invalid)
-            int threads_per_block = (i > 0 ? i : 1);
+            int threads_per_block = static_cast<int>(i > 0 ? i : 1);
             pc_sampling_kernel<<<num_blocks, threads_per_block>>>(threads_per_block);
             // Check for kernel launch errors
             checkHipErrors(hipGetLastError());

--- a/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/CMakeLists.txt
@@ -5,3 +5,4 @@
 add_subdirectory(nested-pause-resume)
 add_subdirectory(pc-sampling)
 add_subdirectory(tracing)
+add_subdirectory(att)

--- a/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/att/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/att/CMakeLists.txt
@@ -1,0 +1,85 @@
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+cmake_minimum_required(VERSION 3.21.0 FATAL_ERROR)
+
+include(FindPackageHandleStandardArgs)
+
+project(
+    rocprofiler-sdk-tests-rocprofv3-roctx-pause-resume-att
+    LANGUAGES CXX
+    VERSION 0.0.0)
+
+find_package(rocprofiler-sdk REQUIRED)
+
+rocprofiler_configure_pytest_files(CONFIG pytest.ini COPY validate.py conftest.py)
+
+string(REPLACE "LD_PRELOAD=" "ROCPROF_PRELOAD=" PRELOAD_ENV
+               "${ROCPROFILER_MEMCHECK_PRELOAD_ENV}")
+
+set(roctx-pause-resume-att-env "${PRELOAD_ENV}")
+
+find_library(
+    attdecoder_LIBRARY
+    NAMES rocprof-trace-decoder
+    HINTS ${ROCM_PATH}
+    PATHS ${ROCM_PATH}
+    PATH_SUFFIXES lib)
+
+if(attdecoder_LIBRARY)
+    cmake_path(GET attdecoder_LIBRARY PARENT_PATH attdecoder_LIB_DIR)
+endif()
+
+find_package_handle_standard_args(attdecoder REQUIRED_VARS attdecoder_LIB_DIR
+                                                           attdecoder_LIBRARY)
+
+set(IS_DISABLED ON)
+if(attdecoder_FOUND)
+    set(IS_DISABLED OFF)
+    set(ATT_LIB --att-library-path ${attdecoder_LIB_DIR})
+endif()
+
+rocprofiler_add_integration_execute_test(
+    rocprofv3-test-roctx-pause-resume-att
+    COMMAND
+        $<TARGET_FILE:rocprofiler-sdk::rocprofv3> ${ATT_LIB} --att --marker-trace -d
+        ${CMAKE_CURRENT_BINARY_DIR}/%tag%-att -o out --output-format json --log-level env
+        -- $<TARGET_FILE:roctx-pause-resume> 8 1
+    DEPENDS roctx-pause-resume
+    TIMEOUT 45
+    LABELS "integration-tests;thread-trace;pause-resume"
+    DISABLED ${IS_DISABLED}
+    ENVIRONMENT "${roctx-pause-resume-att-env}"
+    FIXTURES_SETUP rocprofv3-test-roctx-pause-resume-att)
+
+rocprofiler_add_integration_validate_test(
+    rocprofv3-test-roctx-pause-resume-att
+    TEST_PATHS validate.py
+    COPY conftest.py
+    CONFIG pytest.ini
+    ARGS --json-input ${CMAKE_CURRENT_BINARY_DIR}/roctx-pause-resume-att/out_results.json
+         --output-dir ${CMAKE_CURRENT_BINARY_DIR}/roctx-pause-resume-att
+    TIMEOUT 45
+    LABELS "integration-tests;thread-trace;pause-resume"
+    DISABLED ${IS_DISABLED}
+    FIXTURES_REQUIRED rocprofv3-test-roctx-pause-resume-att
+    FAIL_REGULAR_EXPRESSION "AssertionError")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/att/conftest.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/att/conftest.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import json
+import pytest
+
+from rocprofiler_sdk.pytest_utils.dotdict import dotdict
+from rocprofiler_sdk.pytest_utils import collapse_dict_list
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--json-input",
+        action="store",
+        default="roctx-pause-resume-att/out_results.json",
+        help="Input JSON",
+    )
+    parser.addoption(
+        "--output-dir",
+        action="store",
+        default="roctx-pause-resume-att",
+        help="Output directory",
+    )
+
+
+@pytest.fixture
+def json_data(request):
+    filename = request.config.getoption("--json-input")
+    with open(filename, "r") as inp:
+        return dotdict(collapse_dict_list(json.load(inp)))
+
+
+@pytest.fixture
+def output_dir(request):
+    return request.config.getoption("--output-dir")

--- a/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/att/pytest.ini
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/att/pytest.ini
@@ -1,0 +1,5 @@
+
+[pytest]
+addopts = --durations=20 -rA -s
+testpaths = validate.py
+pythonpath = @ROCPROFILER_SDK_TESTS_BINARY_DIR@/pytest-packages

--- a/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/att/validate.py
+++ b/projects/rocprofiler-sdk/tests/rocprofv3/roctx-pause-resume/att/validate.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# MIT License
+#
+# Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+from pathlib import Path
+import sys
+import pytest
+
+
+def test_att_data(json_data, output_dir):
+    data = json_data["rocprofiler-sdk-tool"]
+    strings = data["strings"]
+
+    assert "att_filenames" in strings.keys(), "No att_filenames in output"
+    att_files = [Path(output_dir) / filename for filename in strings["att_filenames"]]
+    assert len(att_files) >= 2, "Expected ATT data for resumed region"
+    assert all(path.is_file() for path in att_files), "Missing resumed-region .att files"
+
+    # Only target_kernel and pc_sampling_kernel run while profiling is resumed.
+    dispatch_ids = {path.stem.rsplit("_", 1)[-1] for path in att_files}
+    assert (
+        len(dispatch_ids) == 2
+    ), f"Expected 2 traced dispatch IDs, got {len(dispatch_ids)}"
+
+
+def test_marker_data(json_data):
+    data = json_data["rocprofiler-sdk-tool"]
+    marker_records = data["buffer_records"].get("marker_api", [])
+    assert len(marker_records) == 14, "Expected all marker API records"
+
+
+if __name__ == "__main__":
+    exit_code = pytest.main(["-x", __file__] + sys.argv[1:])
+    sys.exit(exit_code)


### PR DESCRIPTION
## Motivation

`rocprofv3 --att --marker-trace` failed when applications used `roctxProfilerPause` and `roctxProfilerResume`.
Stopping the profiling context immediately removed ATT queue callbacks and disabled serialization. ATT dispatches submitted before the pause could lose their completion callback, producing no `.att` output and leaving active traces during teardown.

## Technical Details

- Added an atomic `enabled` state to `DispatchThreadTracer`.
- `start_context()` enables ATT instrumentation.
- `pre_kernel_call()` skips ATT packet injection while paused.
- `stop_context()` disables only new ATT instrumentation.
- Queue completion callbacks and serialization remain active across pause/resume so in-flight ATT work can finish.
- Callback removal and serialization shutdown occur during `resource_deinit()`.
- Fix bug in profile_serializer

## JIRA ID

JIRA ID: AIPROFSDK-901

## Test Plan

- added tests with marker-trace and att

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
