### PR TITLE
[rocprofiler-compute] Default PC sampling sort to count, add --pc-sampling-rows

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -7,7 +7,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Added
 
-* Added ``--pc-sampling-rows`` analyze option to cap the PC sampling table at the top N rows (default 10); set ``0`` to show all.
+* Added ``--pc-sampling-rows`` analyze option to cap the PC sampling table at the top N rows (default 10); set ``0`` to show all. Must be non-negative.
 
 * Added ``--bench-only`` profile mode option to run the roofline microbenchmark standalone (without profiling an application or collecting performance counters). No application run is required. Useful for regenerating ``roofline.csv`` in an existing workload directory or running the microbenchmark on systems where only HIP is available but rocprofiler-sdk is not.
 

--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -7,6 +7,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Added
 
+* Added ``--pc-sampling-rows`` analyze option to cap the PC sampling table at the top N rows (default 10); set ``0`` to show all.
+
 * Added ``--bench-only`` profile mode option to run the roofline microbenchmark standalone (without profiling an application or collecting performance counters). No application run is required. Useful for regenerating ``roofline.csv`` in an existing workload directory or running the microbenchmark on systems where only HIP is available but rocprofiler-sdk is not.
 
 * Added ``--overwrite`` profile mode option to explicitly allow replacing existing workload output.
@@ -21,6 +23,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
   * gfx11 supports Wave Matrix Multiply Accumulate (WMMA), replacing MFMA operations.
 
 ### Changed
+
+* `--pc-sampling-sorting-type` now defaults to `count` (was `offset`), so the PC sampling table shows the most-sampled instructions first.
 
 * Renamed the `Pct of Peak` / `PoP` analysis column to `Percent of Peak` in analysis output.
 

--- a/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
+++ b/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
@@ -40,7 +40,8 @@ Analysis options
 ================
 For using analysis options for PC sampling the configuration needed are:
 
-* ``--pc-sampling-sorting-type``: ``offset`` or ``count``. The default option is ``offset``. ``offset`` is an assembly instruction offset in the code object.
+* ``--pc-sampling-sorting-type``: ``offset`` or ``count``. The default option is ``count``, which surfaces the most-sampled instructions (hotspots) first. ``offset`` is an assembly instruction offset in the code object.
+* ``--pc-sampling-rows``: Maximum number of rows shown in the PC sampling table (DEFAULT: 10). Use ``0`` or a negative value to show all rows.
 
 **Sample command:**
 

--- a/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
+++ b/projects/rocprofiler-compute/docs/how-to/pc_sampling.rst
@@ -41,7 +41,7 @@ Analysis options
 For using analysis options for PC sampling the configuration needed are:
 
 * ``--pc-sampling-sorting-type``: ``offset`` or ``count``. The default option is ``count``, which surfaces the most-sampled instructions (hotspots) first. ``offset`` is an assembly instruction offset in the code object.
-* ``--pc-sampling-rows``: Maximum number of rows shown in the PC sampling table (DEFAULT: 10). Use ``0`` or a negative value to show all rows.
+* ``--pc-sampling-rows``: Maximum number of rows shown in the PC sampling table (DEFAULT: 10). Must be a non-negative integer; use ``0`` to show all rows.
 
 **Sample command:**
 

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -104,6 +104,18 @@ def block_token_or_alias(s: str) -> str:
         return s
 
 
+def non_negative_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected an integer, got {value!r}")
+    if parsed < 0:
+        raise argparse.ArgumentTypeError(
+            f"must be a non-negative integer (0 means all), got {parsed}"
+        )
+    return parsed
+
+
 def print_avail_arch(avail_arch: list[str], args: str) -> str:
     ret_str = f"List all available {args} for analysis on specified arch:"
     for arch in avail_arch:
@@ -797,10 +809,9 @@ Examples:
         metavar="",
         dest="pc_sampling_rows",
         default=10,
-        type=int,
+        type=non_negative_int,
         help="\t\tSpecify the maximum number of rows shown in the PC "
-        "sampling table; use 0 or a negative value to show all rows "
-        "(DEFAULT: 10).",
+        "sampling table; use 0 to show all rows (DEFAULT: 10).",
     )
 
     ## Roofline Command Line Options (analyze: visualization)

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -786,10 +786,21 @@ Examples:
         required=False,
         metavar="",
         dest="pc_sampling_sorting_type",
-        default="offset",
+        default="count",
         type=str,
         help="\t\tSet the sorting type of pc sampling: "
-        "offset or count (DEFAULT: offset).",
+        "offset or count (DEFAULT: count).",
+    )
+    analyze_group.add_argument(
+        "--pc-sampling-rows",
+        required=False,
+        metavar="",
+        dest="pc_sampling_rows",
+        default=10,
+        type=int,
+        help="\t\tSpecify the maximum number of rows shown in the PC "
+        "sampling table; use 0 or a negative value to show all rows "
+        "(DEFAULT: 10).",
     )
 
     ## Roofline Command Line Options (analyze: visualization)

--- a/projects/rocprofiler-compute/src/argparser.py
+++ b/projects/rocprofiler-compute/src/argparser.py
@@ -800,6 +800,7 @@ Examples:
         dest="pc_sampling_sorting_type",
         default="count",
         type=str,
+        choices=["offset", "count"],
         help="\t\tSet the sorting type of pc sampling: "
         "offset or count (DEFAULT: count).",
     )

--- a/projects/rocprofiler-compute/src/utils/parser.py
+++ b/projects/rocprofiler-compute/src/utils/parser.py
@@ -474,8 +474,8 @@ def load_pc_sampling_data_per_kernel(
         )
         return pd.DataFrame()
 
-    # num_rows of 0 (or None) means show all rows; argparse rejects negatives.
-    if num_rows:
+    # num_rows of 0 or None (or a negative passed programmatically) shows all.
+    if num_rows and num_rows > 0:
         df_sorted = df_sorted.head(num_rows)
 
     df_sorted["offset"] = df_sorted["offset"].apply(hex)

--- a/projects/rocprofiler-compute/src/utils/parser.py
+++ b/projects/rocprofiler-compute/src/utils/parser.py
@@ -415,7 +415,7 @@ def load_pc_sampling_data_per_kernel(
     :param sorting_type: "offset" or "count".
     :param kernel_name: Kernel to filter to, or None for all kernels.
     :param num_rows: Keep only the first *num_rows* rows after sorting; None or
-        a non-positive value keeps every row.
+        0 keeps every row.
     """
     kernel_context = f"kernel '{kernel_name}'" if kernel_name else "all kernels"
     pc_samples = tool_data["buffer_records"][
@@ -474,7 +474,8 @@ def load_pc_sampling_data_per_kernel(
         )
         return pd.DataFrame()
 
-    if num_rows is not None and num_rows > 0:
+    # num_rows of 0 (or None) means show all rows; argparse rejects negatives.
+    if num_rows:
         df_sorted = df_sorted.head(num_rows)
 
     df_sorted["offset"] = df_sorted["offset"].apply(hex)

--- a/projects/rocprofiler-compute/src/utils/parser.py
+++ b/projects/rocprofiler-compute/src/utils/parser.py
@@ -404,6 +404,7 @@ def load_pc_sampling_data_per_kernel(
     tool_data: dict[str, Any],
     sorting_type: str,
     kernel_name: Optional[str] = None,
+    num_rows: Optional[int] = None,
 ) -> pd.DataFrame:
     """Build the detailed per-instruction PC sampling table from *tool_data*.
 
@@ -413,6 +414,8 @@ def load_pc_sampling_data_per_kernel(
     :param tool_data: The parsed ``rocprofiler-sdk-tool[0]`` dict.
     :param sorting_type: "offset" or "count".
     :param kernel_name: Kernel to filter to, or None for all kernels.
+    :param num_rows: Keep only the first *num_rows* rows after sorting; None or
+        a non-positive value keeps every row.
     """
     kernel_context = f"kernel '{kernel_name}'" if kernel_name else "all kernels"
     pc_samples = tool_data["buffer_records"][
@@ -471,6 +474,9 @@ def load_pc_sampling_data_per_kernel(
         )
         return pd.DataFrame()
 
+    if num_rows is not None and num_rows > 0:
+        df_sorted = df_sorted.head(num_rows)
+
     df_sorted["offset"] = df_sorted["offset"].apply(hex)
 
     # Stochastic adds issue/stall detail on top of the host_trap columns.
@@ -489,6 +495,7 @@ def load_pc_sampling_data(
     file_prefix: str,
     sorting_type: str,
     tool_data: Optional[dict[str, Any]],
+    num_rows: Optional[int] = None,
 ) -> pd.DataFrame:
     """Return the detailed per-instruction table for a single kernel or all.
 
@@ -513,6 +520,7 @@ def load_pc_sampling_data(
             pc_sampling_method,
             tool_data,
             sorting_type,
+            num_rows=num_rows,
         )
 
     if len(workload.filter_kernel_ids) > 1:
@@ -539,6 +547,7 @@ def load_pc_sampling_data(
         tool_data,
         sorting_type,
         kernel_name,
+        num_rows=num_rows,
     )
 
 
@@ -630,6 +639,7 @@ def load_non_mertrics_table(
                 df.loc[0, "from_pc_sampling"],
                 args.pc_sampling_sorting_type,
                 pc_sampling_tool_data,
+                num_rows=args.pc_sampling_rows,
             )
 
     workload.dfs.update(tmp)

--- a/projects/rocprofiler-compute/tests/test_argparser.py
+++ b/projects/rocprofiler-compute/tests/test_argparser.py
@@ -113,3 +113,28 @@ def test_config_dir_requires_value(capsys):
         build_args(["--config-dir"])
     assert exc.value.code == 2
     assert "--config-dir" in capsys.readouterr().err
+
+
+# =============================================================================
+# analyze: PC sampling options
+# =============================================================================
+
+
+def test_pc_sampling_sorting_type_defaults_to_count():
+    assert build_args(["analyze"]).pc_sampling_sorting_type == "count"
+
+
+def test_pc_sampling_rows_defaults_to_ten():
+    assert build_args(["analyze"]).pc_sampling_rows == 10
+
+
+def test_pc_sampling_options_accept_overrides():
+    args = build_args([
+        "analyze",
+        "--pc-sampling-sorting-type",
+        "offset",
+        "--pc-sampling-rows",
+        "25",
+    ])
+    assert args.pc_sampling_sorting_type == "offset"
+    assert args.pc_sampling_rows == 25

--- a/projects/rocprofiler-compute/tests/test_argparser.py
+++ b/projects/rocprofiler-compute/tests/test_argparser.py
@@ -6,7 +6,9 @@ Unit tests for rocprof-compute general CLI options.
 """
 
 import argparse
+from io import StringIO
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from common import SUPPORTED_ARCHS
@@ -115,37 +117,28 @@ def test_config_dir_requires_value(capsys):
     assert "--config-dir" in capsys.readouterr().err
 
 
-# =============================================================================
-# analyze: PC sampling options
-# =============================================================================
+def test_pc_sampling_analyze_options():
+    """Defaults, overrides, and validation for the analyze PC sampling options."""
+    defaults = build_args(["analyze"])
+    assert defaults.pc_sampling_sorting_type == "count"
+    assert defaults.pc_sampling_rows == 10
 
-
-def test_pc_sampling_sorting_type_defaults_to_count():
-    assert build_args(["analyze"]).pc_sampling_sorting_type == "count"
-
-
-def test_pc_sampling_rows_defaults_to_ten():
-    assert build_args(["analyze"]).pc_sampling_rows == 10
-
-
-def test_pc_sampling_rows_zero_allowed():
-    assert build_args(["analyze", "--pc-sampling-rows", "0"]).pc_sampling_rows == 0
-
-
-def test_pc_sampling_rows_rejects_negative(capsys):
-    with pytest.raises(SystemExit) as exc:
-        build_args(["analyze", "--pc-sampling-rows", "-1"])
-    assert exc.value.code == 2
-    assert "non-negative" in capsys.readouterr().err
-
-
-def test_pc_sampling_options_accept_overrides():
-    args = build_args([
+    overrides = build_args([
         "analyze",
         "--pc-sampling-sorting-type",
         "offset",
         "--pc-sampling-rows",
         "25",
     ])
-    assert args.pc_sampling_sorting_type == "offset"
-    assert args.pc_sampling_rows == 25
+    assert overrides.pc_sampling_sorting_type == "offset"
+    assert overrides.pc_sampling_rows == 25
+
+    # 0 is allowed and means "show all rows".
+    assert build_args(["analyze", "--pc-sampling-rows", "0"]).pc_sampling_rows == 0
+
+    # Negative row counts are rejected with a non-zero exit and a clear message.
+    with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+        with pytest.raises(SystemExit) as exc:
+            build_args(["analyze", "--pc-sampling-rows", "-1"])
+    assert exc.value.code == 2
+    assert "non-negative" in mock_stderr.getvalue()

--- a/projects/rocprofiler-compute/tests/test_argparser.py
+++ b/projects/rocprofiler-compute/tests/test_argparser.py
@@ -128,6 +128,17 @@ def test_pc_sampling_rows_defaults_to_ten():
     assert build_args(["analyze"]).pc_sampling_rows == 10
 
 
+def test_pc_sampling_rows_zero_allowed():
+    assert build_args(["analyze", "--pc-sampling-rows", "0"]).pc_sampling_rows == 0
+
+
+def test_pc_sampling_rows_rejects_negative(capsys):
+    with pytest.raises(SystemExit) as exc:
+        build_args(["analyze", "--pc-sampling-rows", "-1"])
+    assert exc.value.code == 2
+    assert "non-negative" in capsys.readouterr().err
+
+
 def test_pc_sampling_options_accept_overrides():
     args = build_args([
         "analyze",

--- a/projects/rocprofiler-compute/tests/test_argparser.py
+++ b/projects/rocprofiler-compute/tests/test_argparser.py
@@ -6,7 +6,6 @@ Unit tests for rocprof-compute general CLI options.
 """
 
 import argparse
-from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
@@ -136,9 +135,10 @@ def test_pc_sampling_analyze_options():
     # 0 is allowed and means "show all rows".
     assert build_args(["analyze", "--pc-sampling-rows", "0"]).pc_sampling_rows == 0
 
-    # Negative row counts are rejected with a non-zero exit and a clear message.
-    with patch("sys.stderr", new_callable=StringIO) as mock_stderr:
-        with pytest.raises(SystemExit) as exc:
+    # Negative row counts trigger an argparse error.
+    with patch.object(
+        argparse.ArgumentParser, "error", side_effect=SystemExit(2)
+    ) as mock_error:
+        with pytest.raises(SystemExit):
             build_args(["analyze", "--pc-sampling-rows", "-1"])
-    assert exc.value.code == 2
-    assert "non-negative" in mock_stderr.getvalue()
+    mock_error.assert_called_once()

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
@@ -614,6 +614,50 @@ def test_load_per_kernel_offset_sort_is_numeric() -> None:
     assert df["offset"].tolist() == ["0x20", "0x100"]
 
 
+def _three_hotspot_tool_data() -> dict:
+    """Three offsets with sample counts 3, 2, 1 for one kernel."""
+    host_trap = [
+        make_record(5, 0x10, 0, dispatch_id=0),
+        make_record(5, 0x10, 0, dispatch_id=0),
+        make_record(5, 0x10, 0, dispatch_id=0),
+        make_record(5, 0x20, 1, dispatch_id=0),
+        make_record(5, 0x20, 1, dispatch_id=0),
+        make_record(5, 0x30, 2, dispatch_id=0),
+    ]
+    return make_tool_data(
+        host_trap=host_trap,
+        instructions=["a", "b", "c"],
+        comments=["/src/f.cpp:1", "/src/f.cpp:2", "/src/f.cpp:3"],
+        kernel_symbols=[make_kernel_symbol(100, 5, "vecCopy")],
+        kernel_dispatch=[make_dispatch(0, 100)],
+    )
+
+
+def test_load_per_kernel_num_rows_keeps_top_hotspots() -> None:
+    """num_rows truncates after sorting, keeping the highest-count rows."""
+    df = load_pc_sampling_data_per_kernel(
+        method="host_trap",
+        tool_data=_three_hotspot_tool_data(),
+        kernel_name="vecCopy",
+        sorting_type="count",
+        num_rows=2,
+    )
+    assert df["count"].tolist() == [3, 2]
+
+
+@pytest.mark.parametrize("num_rows", [None, 0, -1])
+def test_load_per_kernel_num_rows_unset_keeps_all(num_rows: int | None) -> None:
+    """None or a non-positive num_rows keeps every row."""
+    df = load_pc_sampling_data_per_kernel(
+        method="host_trap",
+        tool_data=_three_hotspot_tool_data(),
+        kernel_name="vecCopy",
+        sorting_type="count",
+        num_rows=num_rows,
+    )
+    assert df["count"].tolist() == [3, 2, 1]
+
+
 def make_per_kernel_guard_data(
     instructions: list | None,
     comments: list | None,
@@ -1240,7 +1284,7 @@ def test_load_non_mertrics_table_populates_pc_sampling_from_tool_data(
     tmp_path: Path,
 ) -> None:
     """A ``from_pc_sampling`` table is populated when tool data is provided."""
-    args = argparse.Namespace(pc_sampling_sorting_type="count")
+    args = argparse.Namespace(pc_sampling_sorting_type="count", pc_sampling_rows=10)
     workload = schema.Workload()
     workload.dfs = {2101: pd.DataFrame({"from_pc_sampling": ["ps_file"]})}
     tool_data = make_tool_data(**sample_tool_data_kwargs())
@@ -1254,7 +1298,7 @@ def test_load_non_mertrics_table_pc_sampling_empty_without_tool_data(
     tmp_path: Path,
 ) -> None:
     """Without tool data the ``from_pc_sampling`` table stays empty (no crash)."""
-    args = argparse.Namespace(pc_sampling_sorting_type="count")
+    args = argparse.Namespace(pc_sampling_sorting_type="count", pc_sampling_rows=10)
     workload = schema.Workload()
     workload.dfs = {2101: pd.DataFrame({"from_pc_sampling": ["ps_file"]})}
     load_non_mertrics_table(workload, str(tmp_path), args)

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
@@ -614,48 +614,20 @@ def test_load_per_kernel_offset_sort_is_numeric() -> None:
     assert df["offset"].tolist() == ["0x20", "0x100"]
 
 
-def _three_hotspot_tool_data() -> dict:
-    """Three offsets with sample counts 3, 2, 1 for one kernel."""
-    host_trap = [
-        make_record(5, 0x10, 0, dispatch_id=0),
-        make_record(5, 0x10, 0, dispatch_id=0),
-        make_record(5, 0x10, 0, dispatch_id=0),
-        make_record(5, 0x20, 1, dispatch_id=0),
-        make_record(5, 0x20, 1, dispatch_id=0),
-        make_record(5, 0x30, 2, dispatch_id=0),
-    ]
-    return make_tool_data(
-        host_trap=host_trap,
-        instructions=["a", "b", "c"],
-        comments=["/src/f.cpp:1", "/src/f.cpp:2", "/src/f.cpp:3"],
-        kernel_symbols=[make_kernel_symbol(100, 5, "vecCopy")],
-        kernel_dispatch=[make_dispatch(0, 100)],
-    )
-
-
-def test_load_per_kernel_num_rows_keeps_top_hotspots() -> None:
-    """num_rows truncates after sorting, keeping the highest-count rows."""
+@pytest.mark.parametrize("num_rows, expected_rows", [(1, 1), (0, 2), (None, 2)])
+def test_load_per_kernel_num_rows_limit(
+    num_rows: int | None,
+    expected_rows: int,
+) -> None:
+    """num_rows caps the table after sorting; 0 or None keeps every row."""
     df = load_pc_sampling_data_per_kernel(
         method="host_trap",
-        tool_data=_three_hotspot_tool_data(),
-        kernel_name="vecCopy",
-        sorting_type="count",
-        num_rows=2,
-    )
-    assert df["count"].tolist() == [3, 2]
-
-
-@pytest.mark.parametrize("num_rows", [None, 0])
-def test_load_per_kernel_num_rows_unset_keeps_all(num_rows: int | None) -> None:
-    """None or 0 num_rows keeps every row."""
-    df = load_pc_sampling_data_per_kernel(
-        method="host_trap",
-        tool_data=_three_hotspot_tool_data(),
+        tool_data=setup_per_kernel_data(),
         kernel_name="vecCopy",
         sorting_type="count",
         num_rows=num_rows,
     )
-    assert df["count"].tolist() == [3, 2, 1]
+    assert len(df) == expected_rows
 
 
 def make_per_kernel_guard_data(

--- a/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
+++ b/projects/rocprofiler-compute/tests/test_pc_sampling_analysis.py
@@ -645,9 +645,9 @@ def test_load_per_kernel_num_rows_keeps_top_hotspots() -> None:
     assert df["count"].tolist() == [3, 2]
 
 
-@pytest.mark.parametrize("num_rows", [None, 0, -1])
+@pytest.mark.parametrize("num_rows", [None, 0])
 def test_load_per_kernel_num_rows_unset_keeps_all(num_rows: int | None) -> None:
-    """None or a non-positive num_rows keeps every row."""
+    """None or 0 num_rows keeps every row."""
     df = load_pc_sampling_data_per_kernel(
         method="host_trap",
         tool_data=_three_hotspot_tool_data(),


### PR DESCRIPTION
## Motivation

End users analyzing PC sampling mostly care about the top hotspots. Defaulting the sort to count surfaces the most-sampled instructions first, and a new --pc-sampling-rows option keeps the table from flooding the CLI by default while letting users widen it as needed.

## Technical Details

- Changed --pc-sampling-sorting-type default from offset to count, and restricted it to choices offset or count so invalid values fail fast at argparse.
- Added --pc-sampling-rows analyze option (default 10); 0 shows all rows. Negative values are rejected by the argparse validator.
- Row limit is applied in the shared loader after sorting, so both CLI and Web UI honor it.

## JIRA ID

AIPROFCOMP-681

## Test Plan

- Run unit tests: tests/test_argparser.py, tests/test_pc_sampling_analysis.py, tests/test_analyze_commands.py.
- Verify analyze output: default shows top 10 by count; --pc-sampling-rows 0 shows all; --pc-sampling-sorting-type offset still sorts by offset.

## Test Result

Unit tests pass locally (199 passed). Ruff clean.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.