### PR TITLE
Fix amdsmiFabricMaxDevices limit (ROCM-26920)

### DIFF
--- a/projects/rccl/src/include/amdsmi_wrap.h
+++ b/projects/rccl/src/include/amdsmi_wrap.h
@@ -7,6 +7,7 @@
 #include <ctime>
 
 #include "nccl.h"
+#include "device.h"
 
 /*************************************************************************
  * UALoE Fabric Support
@@ -500,7 +501,8 @@ struct amdsmiFabricDeviceInfo {
     uint32_t vpodSize;                              //!< Virtual POD size
 };
 
-constexpr int amdsmiFabricMaxDevices = 32;
+// Sized to match NCCL_MAX_LOCAL_RANKS so every local GPU can cache fabric info.
+constexpr int amdsmiFabricMaxDevices = NCCL_MAX_LOCAL_RANKS;
 extern int amdsmiFabricDeviceCount;
 extern struct amdsmiFabricDeviceInfo amdsmiFabricDevices[amdsmiFabricMaxDevices];
 

--- a/projects/rccl/src/misc/amdsmi_wrap.cc
+++ b/projects/rccl/src/misc/amdsmi_wrap.cc
@@ -563,11 +563,12 @@ ncclResult_t amd_smi_ensureFabricInitialized() {
     return fabricInitResult;
   }
   if (numDevs > (uint32_t)amdsmiFabricMaxDevices) {
-    WARN("%s fabric: device count %u exceeds max %d, truncating",
+    WARN("%s fabric: device count %u exceeds internal maximum (amdsmiFabricMaxDevices=%d)",
          useSysfs ? "ARSMI" : "AMD SMI", numDevs, amdsmiFabricMaxDevices);
-    numDevs = amdsmiFabricMaxDevices;
+    fabricInitResult = ncclInternalError;
+    return fabricInitResult;
   }
-  amdsmiFabricDeviceCount = numDevs;
+  amdsmiFabricDeviceCount = (int)numDevs;
 
   for (uint32_t d = 0; d < numDevs; d++) {
     struct amdsmiFabricDeviceInfo* devInfo = &amdsmiFabricDevices[d];


### PR DESCRIPTION
**Motivation**
Raise fabric device cache to NCCL_MAX_LOCAL_RANKS and fail on overflow instead of truncating.

**Technical Details**
Errors: 
Observing ncclOsSocketProgressOpt reported bad address when running pyt_huggingface bert, pyt_huggingface_xbloom, vllm.

Fix: 
- Increase amdsmiFabricMaxDevices from a fixed 32 to NCCL_MAX_LOCAL_RANKS (via device.h) so all local GPUs can be cached.
- Change fabric initialization behavior to return ncclInternalError (instead of truncating) when the detected device count exceeds amdsmiFabricMaxDevices, and update the warning message accordingly.
- Make the assignment to amdsmiFabricDeviceCount an explicit cast to int.

**JIRA ID**
ROCM-26920

**Test Plan**
Follow the detailed reproducing steps documented in the original ticket (JIRA ROCM-26920).

**Test Result**
Each of the applications listed in the original JIRA ticket completes its run successfully.

