### PR TITLE
[rdc] Fix non-partitionable gpu support

### DIFF
--- a/projects/rdc/rdc_libs/rdc/src/SmiUtils.cc
+++ b/projects/rdc/rdc_libs/rdc/src/SmiUtils.cc
@@ -240,6 +240,12 @@ amdsmi_status_t get_num_partition(uint32_t index, uint16_t* num_partition) {
   uint32_t partition_id{};
 
   ret = amdsmi_get_gpu_accelerator_partition_profile(proc_handle, &profile, &partition_id);
+  // Non-partitionable GPUs report this as unsupported; treat them as a single
+  // partition. All consumers handle a count of 1 correctly.
+  if (ret == AMDSMI_STATUS_NOT_SUPPORTED) {
+    *num_partition = 1;
+    return AMDSMI_STATUS_SUCCESS;
+  }
   if (ret != AMDSMI_STATUS_SUCCESS) {
     return ret;
   }


### PR DESCRIPTION
## Motivation

RDC broke support for unpartitioned GPUs in #4551. Think NV21. Because it lacks partitions - RDC would assume GPU is in a bad state and fail metric fetching.

## Technical Details

`amdsmi_get_gpu_accelerator_partition_profile` returned `AMDSMI_STATUS_NOT_SUPPORTED` and caused RDC to return early.
Forcing the number to 1 solves the issue.

## Test Plan

- Run `rdcd -u` and in another terminal `rdci dmon -u -e 2 -c 1` on different types of machines

## Test Result

- [x] NV21
- [ ] MI300A
- [ ] MI350X

