### PR TITLE
[rocprofiler-compute] Fix inconsistent claimed Python version support

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -18,6 +18,8 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Changed
 
+* Split Python version requirements by mode. Profile mode now runs on Python 3.8+ (standard library only). Analyze mode requires Python 3.9+ and exits with a clear message on older interpreters instead of failing with an import error.
+
 * `--pc-sampling-sorting-type` now defaults to `count` (was `offset`), so the PC sampling table shows the most-sampled instructions first.
 
 * Renamed the `Pct of Peak` / `PoP` analysis column to `Percent of Peak` in analysis output.

--- a/projects/rocprofiler-compute/docs/how-to/analyze/mode.rst
+++ b/projects/rocprofiler-compute/docs/how-to/analyze/mode.rst
@@ -14,6 +14,12 @@ choose.
 
 .. note::
 
+   Analyze mode requires Python 3.9 or newer; its dependencies (numpy, pandas,
+   dash, textual) drop support for older versions. Profile mode runs on Python
+   3.8+. See the Python version support table in :doc:`/install/quickstart`.
+
+.. note::
+
    Analyze mode merges separate counter collection files (pmc_perf_*.csv or results_*.csv) into a unified pmc_perf.csv for analysis.
 
 .. note::

--- a/projects/rocprofiler-compute/docs/install/quickstart.rst
+++ b/projects/rocprofiler-compute/docs/install/quickstart.rst
@@ -63,7 +63,28 @@ Ensure ROCm is installed and follow the steps:
 
    .. code-block:: shell-session
 
-      python3 --version   # Requires Python 3.8+
+      python3 --version
+
+   The required Python version depends on which mode you use:
+
+   .. list-table:: Python version support
+      :header-rows: 1
+      :widths: 40 60
+
+      * - Component
+        - Python requirement
+      * - Profile mode (standard library only)
+        - 3.8 or newer
+      * - Analyze mode (numpy, pandas, dash, textual)
+        - 3.9 or newer
+      * - Torch-trace profiling
+        - Profile mode floor, plus ROCm roctx bindings built for the
+          active interpreter
+      * - Standalone binary build
+        - exactly 3.11.x (build time only)
+
+   Analyze mode aborts with a clear message if launched on Python older
+   than 3.9.
 
 3. Check the installation dependencies.
 

--- a/projects/rocprofiler-compute/docs/install/quickstart.rst
+++ b/projects/rocprofiler-compute/docs/install/quickstart.rst
@@ -81,7 +81,8 @@ Ensure ROCm is installed and follow the steps:
    Analyze mode aborts with a clear message if launched on Python older
    than 3.9.
 
-3. Check the installation dependencies.
+3. Check the installation dependencies. These are required for analyze mode
+   only; profile mode uses the standard library and needs no extra packages.
 
    .. code-block:: shell-session
 

--- a/projects/rocprofiler-compute/docs/install/quickstart.rst
+++ b/projects/rocprofiler-compute/docs/install/quickstart.rst
@@ -77,11 +77,6 @@ Ensure ROCm is installed and follow the steps:
         - 3.8 or newer
       * - Analyze mode (numpy, pandas, dash, textual)
         - 3.9 or newer
-      * - Torch-trace profiling
-        - Profile mode floor, plus ROCm roctx bindings built for the
-          active interpreter
-      * - Standalone binary build
-        - exactly 3.11.x (build time only)
 
    Analyze mode aborts with a clear message if launched on Python older
    than 3.9.

--- a/projects/rocprofiler-compute/pyproject.toml
+++ b/projects/rocprofiler-compute/pyproject.toml
@@ -1,6 +1,8 @@
 [project]
 name = "rocprof_compute"
-requires-python = ">=3.9"
+# Baseline floor for the project (profile mode). Analyze mode requires >=3.9,
+# enforced at runtime in src/rocprof-compute.
+requires-python = ">=3.8"
 
 [tool.ruff]
 line-length = 88

--- a/projects/rocprofiler-compute/requirements.txt
+++ b/projects/rocprofiler-compute/requirements.txt
@@ -1,3 +1,4 @@
+# Analyze mode only. These dependencies require Python >=3.9.
 astunparse==1.6.2
 dash-bootstrap-components==2.0.4
 dash-svg==0.0.12

--- a/projects/rocprofiler-compute/src/rocprof-compute
+++ b/projects/rocprofiler-compute/src/rocprof-compute
@@ -67,26 +67,24 @@ def check_python_version() -> None:
     min_python = (3, 8)
     # Check which version of python is being used
     if sys.version_info < min_python:  # noqa: UP036
-        print(
-            f"[ERROR] Python {min_python[0]}.{min_python[1]} or higher "
-            f"is required for rocprofiler-compute. "
-            f"The current version is "
+        console_error(
+            f"Python {min_python[0]}.{min_python[1]} or higher "
+            "is required for rocprofiler-compute. "
+            "The current version is "
             f"{sys.version_info[0]}.{sys.version_info[1]}."
         )
-        sys.exit(1)
 
 
 def check_analyze_python_version() -> None:
     """Enforce the analyze-mode Python floor (its dependencies require 3.9+)."""
     min_python = (3, 9)
     if sys.version_info < min_python:
-        print(
-            f"[ERROR] analyze mode requires Python {min_python[0]}.{min_python[1]} "
-            f"or higher. The current version is "
+        console_error(
+            f"analyze mode requires Python {min_python[0]}.{min_python[1]} "
+            "or higher. The current version is "
             f"{sys.version_info[0]}.{sys.version_info[1]}. "
-            f"Profile mode supports Python 3.8+."
+            "Profile mode supports Python 3.8+."
         )
-        sys.exit(1)
 
 
 def verify_deps() -> None:
@@ -108,6 +106,9 @@ def verify_deps() -> None:
             version_pattern = re.compile(r"^([^=<>]+)([=<>]+)(.*)$")
 
             for dependency in dependencies:
+                dependency = dependency.strip()
+                if not dependency or dependency.startswith("#"):
+                    continue
                 match = version_pattern.match(dependency)
                 if match:
                     package, operator, desired_version = match.groups()
@@ -118,9 +119,10 @@ def verify_deps() -> None:
                     local_version = metadata.distribution(package).version
                 except metadata.PackageNotFoundError:
                     error = True
-                    print(
-                        f"[ERROR] The '{dependency}' package was not found "
-                        "in the current execution environment."
+                    console_error(
+                        f"The '{dependency}' package was not found "
+                        "in the current execution environment.",
+                        exit=False,
                     )
                     continue
 
@@ -128,21 +130,22 @@ def verify_deps() -> None:
                 if desired_version and not check_version(
                     local_version, desired_version, operator
                 ):
-                    print(
-                        f"[ERROR] the '{dependency}' distribution does not meet "
+                    console_error(
+                        f"the '{dependency}' distribution does not meet "
                         "version requirements to use rocprofiler-compute."
+                        f"\n  --> version installed : {local_version}",
+                        exit=False,
                     )
-                    print(f"  --> version installed : {local_version}")
                     error = True
 
             if error:
-                print(
+                console_error(
                     "\nPlease verify all of the python dependencies called out "
                     "in the requirements file"
+                    "\nare installed locally prior to running "
+                    "rocprofiler-compute."
+                    f"\n\nSee: {check_file}"
                 )
-                print("are installed locally prior to running rocprofiler-compute.")
-                print(f"\nSee: {check_file}")
-                sys.exit(1)
             return
 
 

--- a/projects/rocprofiler-compute/src/rocprof-compute
+++ b/projects/rocprofiler-compute/src/rocprof-compute
@@ -77,11 +77,7 @@ def check_python_version() -> None:
 
 
 def check_analyze_python_version() -> None:
-    """Enforce the analyze-mode Python floor.
-
-    Analyze mode depends on numpy, pandas, dash, and textual, whose current
-    pinned versions require Python 3.9+. Profile mode is unaffected.
-    """
+    """Enforce the analyze-mode Python floor (its dependencies require 3.9+)."""
     min_python = (3, 9)
     if sys.version_info < min_python:
         print(

--- a/projects/rocprofiler-compute/src/rocprof-compute
+++ b/projects/rocprofiler-compute/src/rocprof-compute
@@ -59,9 +59,10 @@ def check_version(local_ver: str, desired_ver: str, operator: str) -> bool:
 
 
 def check_python_version() -> None:
-    """Check that Python version meets minimum requirement for rocprofiler-compute.
+    """Check the baseline Python version required to launch rocprofiler-compute.
 
-    Both profile and analyze modes require Python 3.8+.
+    Profile mode runs on Python 3.8+ (standard library only). Analyze mode has a
+    higher floor enforced separately in check_analyze_python_version().
     """
     min_python = (3, 8)
     # Check which version of python is being used
@@ -71,6 +72,23 @@ def check_python_version() -> None:
             f"is required for rocprofiler-compute. "
             f"The current version is "
             f"{sys.version_info[0]}.{sys.version_info[1]}."
+        )
+        sys.exit(1)
+
+
+def check_analyze_python_version() -> None:
+    """Enforce the analyze-mode Python floor.
+
+    Analyze mode depends on numpy, pandas, dash, and textual, whose current
+    pinned versions require Python 3.9+. Profile mode is unaffected.
+    """
+    min_python = (3, 9)
+    if sys.version_info < min_python:
+        print(
+            f"[ERROR] analyze mode requires Python {min_python[0]}.{min_python[1]} "
+            f"or higher. The current version is "
+            f"{sys.version_info[0]}.{sys.version_info[1]}. "
+            f"Profile mode supports Python 3.8+."
         )
         sys.exit(1)
 
@@ -135,7 +153,7 @@ def verify_deps() -> None:
 def main() -> None:
     """Main function for rocprofiler-compute"""
 
-    # Check Python version requirement applies to both profile and analyze modes
+    # Baseline Python floor for any mode (profile is 3.8+); analyze adds its own
     check_python_version()
 
     rocprof_compute = RocProfCompute()
@@ -145,7 +163,8 @@ def main() -> None:
     if mode == "profile":
         rocprof_compute.run_profiler()
     elif mode == "analyze":
-        # Analyze mode requires external dependencies - verify them
+        # Analyze mode needs a higher Python floor and external dependencies
+        check_analyze_python_version()
         verify_deps()
         rocprof_compute.run_analysis()
     else:


### PR DESCRIPTION
## Motivation

The project stated conflicting Python version requirements across components, so a single Python environment could appear valid yet fail at runtime. Most notably, the launcher claimed both modes ran on 3.8 while analyze mode's dependencies (numpy, pandas, dash, textual) require 3.9+, and `pyproject.toml` declared 3.9 even though profile mode runs fine on 3.8. This PR makes the real contract explicit and consistent: profile mode is 3.8+, analyze mode is 3.9+.

## Technical Details

- Enforce the analyze floor at runtime: `check_analyze_python_version()` aborts with a clear message when analyze is launched on Python older than 3.9, instead of failing later on a dependency import (`src/rocprof-compute`). Profile mode keeps the 3.8 baseline.
- Lower `requires-python` to `>=3.8` so the declared floor matches profile mode and ruff's UP target aligns with it (`pyproject.toml`).
- Mark `requirements.txt` as analyze-only and note the `>=3.9` requirement.
- Document a single Python version support matrix for profile and analyze modes in the quickstart, and add an analyze-mode note pointing to it.

## JIRA ID

AIPROFCOMP-498

## Test Plan

- `ruff check` and `ruff format --check` on changed `src/` files.
- `python3 -m py_compile src/rocprof-compute`.
- Manual: launch analyze on Python 3.8 and confirm the new error; confirm profile mode still runs on 3.8.

## Test Result

- ruff check / format: passed.
- py_compile: passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.