### PR TITLE
[AMD-SMI] Make BDF lookups accept string or struct, align fabric telemetry name

### DIFF
--- a/projects/amdsmi/amdsmi_cli/subcommands/fabric.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/fabric.py
@@ -215,7 +215,7 @@ class FabricCommands:
                     | amdsmi_interface.amdsmi_wrapper.AMDSMI_FABRIC_TELEMETRY_CATEGORY_MASK_DERIVED_UALOE
                     | amdsmi_interface.amdsmi_wrapper.AMDSMI_FABRIC_TELEMETRY_CATEGORY_MASK_DERIVED_NETPORT
                 )
-                fabric_telemetry = amdsmi_interface.amdsmi_get_fabric_telemetry(
+                fabric_telemetry = amdsmi_interface.amdsmi_get_fabric_telemetry_data(
                     gpu_handle, category_mask
                 )
             except amdsmi_exception.AmdSmiLibraryException as e:

--- a/projects/amdsmi/amdsmi_cli/subcommands/topology.py
+++ b/projects/amdsmi/amdsmi_cli/subcommands/topology.py
@@ -247,9 +247,7 @@ class TopologyCommands:
                     gpu_bdf = amdsmi_interface.amdsmi_get_gpu_device_bdf(gpu_dest)
                     CPU_Affinity = amdsmi_interface.amdsmi_get_gpu_topo_cpu_affinity(gpu_dest)
                     numa_node = amdsmi_interface.amdsmi_get_gpu_topo_numa_affinity(gpu_dest)
-                    switch_bdf = amdsmi_interface.amdsmi_get_root_switch(
-                        amdsmi_interface.amdsmi_get_gpu_device_bdf_bdf(gpu_dest)
-                    )
+                    switch_bdf = amdsmi_interface.amdsmi_get_root_switch(gpu_bdf)
 
                     # Add GPU row to the table
                     if self.logger.is_human_readable_format():
@@ -280,9 +278,7 @@ class TopologyCommands:
                         nic_bdf = nic_info["bdf"]
                     CPU_Affinity = amdsmi_interface.amdsmi_get_nic_topo_cpu_affinity(nic_dest)
                     numa_node = amdsmi_interface.amdsmi_get_nic_topo_numa_affinity(nic_dest)
-                    switch_bdf = amdsmi_interface.amdsmi_get_root_switch(
-                        amdsmi_interface.amdsmi_get_nic_device_bdf_bdf(nic_dest)
-                    )
+                    switch_bdf = amdsmi_interface.amdsmi_get_root_switch(nic_bdf)
 
                     # Add NIC row to the table
                     if self.logger.is_human_readable_format():

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -2171,6 +2171,19 @@ def amdsmi_get_gpu_device_bdf(processor_handle: processor_handle_t) -> str:
 def amdsmi_get_gpu_device_bdf_bdf(
     processor_handle: amdsmi_wrapper.amdsmi_processor_handle,
 ) -> amdsmi_wrapper.amdsmi_bdf_t:
+    """Deprecated: use amdsmi_get_gpu_device_bdf() and format the returned BDF string instead.
+
+    Returns the raw amdsmi_bdf_t struct for a GPU. The same data is available as a
+    formatted string from amdsmi_get_gpu_device_bdf().
+    """
+    import warnings
+
+    warnings.warn(
+        "amdsmi_get_gpu_device_bdf_bdf() is deprecated, use amdsmi_get_gpu_device_bdf() "
+        "and format the returned BDF string instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):
         raise AmdSmiParameterException(processor_handle, amdsmi_wrapper.amdsmi_processor_handle)
 
@@ -2423,8 +2436,17 @@ def amdsmi_get_switch_link_info(
     return link_info_dict
 
 
-def amdsmi_get_root_switch(amdsmi_bdf: amdsmi_wrapper.amdsmi_bdf_t) -> str:
-    if not isinstance(amdsmi_bdf, amdsmi_wrapper.amdsmi_bdf_t):
+def amdsmi_get_root_switch(amdsmi_bdf: Union[str, amdsmi_wrapper.amdsmi_bdf_t]) -> str:
+    # An empty BDF means the caller has no device to resolve (e.g. NIC info
+    # unavailable); report it as N/A instead of forcing callers to guard.
+    if isinstance(amdsmi_bdf, str):
+        if not amdsmi_bdf:
+            return "N/A"
+        parsed_bdf = _parse_bdf(amdsmi_bdf)
+        if parsed_bdf is None:
+            raise AmdSmiBdfFormatException(amdsmi_bdf)
+        amdsmi_bdf = _make_amdsmi_bdf_from_list(parsed_bdf)
+    elif not isinstance(amdsmi_bdf, amdsmi_wrapper.amdsmi_bdf_t):
         raise AmdSmiParameterException(amdsmi_bdf, amdsmi_wrapper.amdsmi_bdf_t)
 
     switch_bdf_info = amdsmi_wrapper.amdsmi_bdf_t()
@@ -3730,11 +3752,14 @@ def amdsmi_get_gpu_xcd_counter(processor_handle: processor_handle_t) -> int:
     return xcd_counter.value
 
 
-def amdsmi_get_processor_handle_from_bdf(bdf):
-    bdf = _parse_bdf(bdf)
-    if bdf is None:
-        raise AmdSmiBdfFormatException(bdf)
-    amdsmi_bdf = _make_amdsmi_bdf_from_list(bdf)
+def amdsmi_get_processor_handle_from_bdf(bdf: Union[str, amdsmi_wrapper.amdsmi_bdf_t]):
+    if isinstance(bdf, amdsmi_wrapper.amdsmi_bdf_t):
+        amdsmi_bdf = bdf
+    else:
+        parsed_bdf = _parse_bdf(bdf)
+        if parsed_bdf is None:
+            raise AmdSmiBdfFormatException(bdf)
+        amdsmi_bdf = _make_amdsmi_bdf_from_list(parsed_bdf)
     processor_handle = amdsmi_wrapper.amdsmi_processor_handle()
     _check_res(
         amdsmi_wrapper.amdsmi_get_processor_handle_from_bdf(

--- a/projects/amdsmi/py-interface/amdsmi_interface.py
+++ b/projects/amdsmi/py-interface/amdsmi_interface.py
@@ -6616,7 +6616,7 @@ _FABRIC_ACCEL_STATE_NAMES = {
 }
 
 
-def amdsmi_get_fabric_telemetry(
+def amdsmi_get_fabric_telemetry_data(
     processor_handle: processor_handle_t, category_mask: int
 ) -> List[Dict[str, Any]]:
     if not isinstance(processor_handle, amdsmi_wrapper.amdsmi_processor_handle):


### PR DESCRIPTION
## Motivation

The Python interface had a fabric-telemetry binding whose name dropped the `_data` suffix present in the C header, and the BDF-consuming lookups forced callers to pre-convert handles to `amdsmi_bdf_t` structs and guard empty BDFs themselves. The topology CLI also called a never-defined `amdsmi_get_nic_device_bdf_bdf`.

## Technical Details

**Python interface** (`py-interface/amdsmi_interface.py`):
- Rename `amdsmi_get_fabric_telemetry` to `amdsmi_get_fabric_telemetry_data` to match the C declaration in `include/amd_smi/amdsmi.h`
- `amdsmi_get_root_switch` and `amdsmi_get_processor_handle_from_bdf` now accept either a formatted BDF string or an `amdsmi_bdf_t` struct
- `amdsmi_get_root_switch` returns `N/A` for an empty BDF so callers no longer need to guard the empty case
- Deprecate `amdsmi_get_gpu_device_bdf_bdf` with a `DeprecationWarning` in favor of formatting the string from `amdsmi_get_gpu_device_bdf`

**CLI** (`amdsmi_cli/subcommands/fabric.py`, `amdsmi_cli/subcommands/topology.py`):
- Update fabric subcommand to call the renamed function
- Topology now passes formatted BDF strings, removing a call to the never-defined `amdsmi_get_nic_device_bdf_bdf`

## JIRA ID

N/A

## Test Plan

- `python3 -c 'import ast; ast.parse(...)'` syntax check on edited files
- pre-commit (ruff format / mixed-line-ending) passed on both commits
- GPU topology path exercised on lsttserver2 (3x MI210); NIC/switch root-switch path requires Broadcom hardware (b20-31, currently without reservation)

## Test Result

- Syntax + pre-commit pass; GPU topology renders unchanged

## Submission Checklist

- [x] Changes target `develop`
- [x] pre-commit passes
- [ ] Hardware validation on Broadcom NIC pending