### PR TITLE
[rocdecode] added info about setting env vars for running samples

### DIFF
--- a/projects/rocdecode/docs/how-to/using-rocDecode-bitstream.rst
+++ b/projects/rocdecode/docs/how-to/using-rocDecode-bitstream.rst
@@ -50,11 +50,17 @@ The ``videodecoderaw.cpp`` example also demonstrates how to use the bitstream re
             return 1;
         }
 
+``rocDecDestroyBitstreamReader`` must always be called to destroy the bitstream reader once processing is complete.
 
 .. note:: 
-    
-    ``rocDecDestroyBitstreamReader`` must always be called to destroy the bitstream reader once processing is complete.
 
+    To run the sample, you'll need to set the ``ROCM_PATH`` environment variable to point to the location of your ROCm installation, then set ``LD_PRELOAD`` and ``LIBVA_DRIVERS_PATH`` to point to the ROCm systems libraries and drivers:
+
+    .. code:: shell
+
+        export LD_PRELOAD=$ROCM_PATH/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:$ROCM_PATH/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
+
+        export LIBVA_DRIVERS_PATH=$ROCM_PATH/lib/rocm_sysdeps/lib/
 
 .. |videodecode| replace:: ``videodecode.cpp``
 .. _videodecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/videoDecode/videodecode.cpp

--- a/projects/rocdecode/docs/how-to/using-rocDecode-ffmpeg.rst
+++ b/projects/rocdecode/docs/how-to/using-rocDecode-ffmpeg.rst
@@ -75,6 +75,16 @@ Delete the demuxer once demultiplexing is complete.
 
   delete demuxer;
 
+.. note:: 
+
+  To run the sample, you'll need to set the ``ROCM_PATH`` environment variable to point to the location of your ROCm installation, then set ``LD_PRELOAD`` and ``LIBVA_DRIVERS_PATH`` to point to the ROCm systems libraries and drivers:
+
+  .. code:: shell
+
+    export LD_PRELOAD=$ROCM_PATH/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:$ROCM_PATH/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
+
+    export LIBVA_DRIVERS_PATH=$ROCM_PATH/lib/rocm_sysdeps/lib/
+
 .. |videodecode| replace:: ``videodecode.cpp``
 .. _videodecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/videoDecode/videodecode.cpp
 

--- a/projects/rocdecode/docs/how-to/using-rocDecode-rocdecdecoder.rst
+++ b/projects/rocdecode/docs/how-to/using-rocDecode-rocdecdecoder.rst
@@ -243,6 +243,16 @@ From the ``rocdecdecode.cpp`` sample:
 
 Once decoding is complete, ``rocDecDestroyVideoParser()`` needs to be called to destroy the parser, and either ``rocDecDestroyDecoderHost()`` or ``rocDecDestroyDecoder()`` needs to be called to destroy the decoder.
 
+.. note:: 
+
+  To run the sample, you'll need to set the ``ROCM_PATH`` environment variable to point to the location of your ROCm installation, then set ``LD_PRELOAD`` and ``LIBVA_DRIVERS_PATH`` to point to the ROCm systems libraries and drivers:
+
+  .. code:: shell
+
+    export LD_PRELOAD=$ROCM_PATH/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:$ROCM_PATH/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
+
+    export LIBVA_DRIVERS_PATH=$ROCM_PATH/lib/rocm_sysdeps/lib/
+
 .. |rocdecdecode| replace:: ``rocdecdecode``
 .. _rocdecdecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/rocdecDecode/README.md
 

--- a/projects/rocdecode/docs/how-to/using-rocDecode-video-decoder.rst
+++ b/projects/rocdecode/docs/how-to/using-rocDecode-video-decoder.rst
@@ -118,6 +118,16 @@ The reconfiguration parameters need to be defined prior to entering the decoding
 
 In the decode loop, the demultiplexed coded picture is passed to ``DecodeFrame``. Once the frame is decoded and processed, it is released with ``ReleaseFrame``. 
 
+.. note:: 
+
+    To run the sample, you'll need to set the ``ROCM_PATH`` environment variable to point to the location of your ROCm installation, then set ``LD_PRELOAD`` and ``LIBVA_DRIVERS_PATH`` to point to the ROCm systems libraries and drivers:
+
+    .. code:: shell
+
+        export LD_PRELOAD=$ROCM_PATH/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:$ROCM_PATH/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
+
+        export LIBVA_DRIVERS_PATH=$ROCM_PATH/lib/rocm_sysdeps/lib/
+
 .. |videodecode| replace:: ``videodecode.cpp``
 .. _videodecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/videoDecode/videodecode.cpp
 

--- a/projects/rocdecode/docs/how-to/using-rocDecode-videodecode-sample.rst
+++ b/projects/rocdecode/docs/how-to/using-rocDecode-videodecode-sample.rst
@@ -231,6 +231,16 @@ The demuxer is deleted once decoding is done.
 
   delete demuxer;
 
+.. note:: 
+
+  To run the sample, you'll need to set the ``ROCM_PATH`` environment variable to point to the location of your ROCm installation, then set ``LD_PRELOAD`` and ``LIBVA_DRIVERS_PATH`` to point to the ROCm systems libraries and drivers:
+
+  .. code:: shell
+
+    export LD_PRELOAD=$ROCM_PATH/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:$ROCM_PATH/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
+
+    export LIBVA_DRIVERS_PATH=$ROCM_PATH/lib/rocm_sysdeps/lib/
+
 .. |videodecode| replace:: ``videodecode.cpp``
 .. _videodecode: https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples/videoDecode/videodecode.cpp
 

--- a/projects/rocdecode/docs/tutorials/rocDecode-samples.rst
+++ b/projects/rocdecode/docs/tutorials/rocDecode-samples.rst
@@ -8,13 +8,23 @@ rocDecode samples
 
 rocDecode samples are available in the `rocDecode GitHub repository <https://github.com/ROCm/rocm-systems/tree/develop/projects/rocdecode/samples>`_.
 
-You can find a walkthrough of the ``videodecode.cpp`` sample at :doc:`Understanding the videodecode.cpp sample <../how-to/using-rocDecode-videodecode-sample>`.
+To run the samples, you'll need to set the ``ROCM_PATH`` to point to the location of your ROCm installation, and set ``LD_PRELOAD`` and ``LIBVA_DRIVERS_PATH`` to point to the ROCm systems libraries and drivers:
+
+.. code:: shell
+
+  export LD_PRELOAD=$ROCM_PATH/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:$ROCM_PATH/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
+
+  export LIBVA_DRIVERS_PATH=$ROCM_PATH/lib/rocm_sysdeps/lib/
+ 
 
 FFmpeg development libraries must be installed to build and run samples that use FFmpeg for either demultiplexing or decoding:
 
 .. code:: 
 
   sudo apt install libavcodec-dev libavformat-dev libavutil-dev
+
+
+You can find a walkthrough of the ``videodecode.cpp`` sample at :doc:`Understanding the videodecode.cpp sample <../how-to/using-rocDecode-videodecode-sample>`.
 
 
 


### PR DESCRIPTION
## Motivation

Need to set env vars to point to the rocm systems libraries and drivers before running the samples. 