### PR TITLE
[AMD-SMI] Export and document new fabric and process query APIs

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -24,14 +24,15 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - When `--partition` is set with `--clock`: sources GFX/VCLK/DCLK/SOCCLK from partition metrics and adds per-AID and per-XCP clock entries with their limits.
   - When `--partition` is set with `--usage`: reports per-XCP GFX/JPEG/VCN activity.
 
-- **Added `--folder` support to `amd-smi ras --afid`**.
+- **Added `--folder` support to `amd-smi ras --afid`**.  
   - `amd-smi ras --afid --folder <DIR>` decodes every `*.cper` in a directory and prints a `file_name | list of afids` table (or a JSON array under `--json`).
   - Records with no AFIDs show `-`; files that cannot be parsed show `decode failed`.
 
 - **Added IFoE/UALoE fabric telemetry and topology support**.  
-  - New `amd-smi fabric` CLI subcommand with `--topology` / `-t` and `--info` / `-i` flags for querying fabric (UALoE) information.
-  - New C APIs: `amdsmi_get_fabric_telemetry_data()` and `amdsmi_get_gpu_fabric_info()`.
-  - Fabric telemetry category masks and size constants converted from preprocessor defines to enums so they are picked up by the Python wrapper generator and exposed to Python callers.
+  - New `amd-smi fabric` CLI subcommand with `--topology`/`-t` and `--info`/`-i` flags for querying fabric (UALoE) information.
+  - New C APIs: `amdsmi_alloc_fabric_telemetry()`, `amdsmi_get_fabric_telemetry_data()`, `amdsmi_free_fabric_telemetry()`, `amdsmi_fabric_telem_id_to_string()`, and `amdsmi_get_gpu_fabric_info()`.
+  - New Python APIs: `amdsmi_get_fabric_telemetry_data()` and `amdsmi_get_gpu_fabric_info()`.
+  - Fabric telemetry category masks and size constants converted from preprocessor `#define`s to enums so they are exposed through the Python wrapper.
 
 - **Wrapped ESMI functions in `amdsmi_go_shim`**.  
   - Go callers can now access ESMI CPU functionality through the existing `amdsmi_go_shim` interface.
@@ -49,13 +50,14 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Added new alias for `amd-smi set -C/--compute-partition` as `amd-smi set --accelerator-partition`**.  
   - Compute and accelerator partitions are fundamentally the same, so users can now use `--accelerator-partition` to set the compute/accelerator partition.
 
-- **Added input validation for CPU `set` commands**.
+- **Added input validation for CPU `set` commands**.  
   - Out-of-range values are now rejected with a clear error showing the valid range:
     - `--cpu-xgmi-link-width` (0-1)
     - `--cpu-gmi3-link-width` (0-2)
     - `--cpu-lclk-dpm-level` (0-3)
     - `--cpu-disable-apb` (0-3)
   - `--cpu-pwr-limit` values above the socket maximum are now reduced to the maximum and applied, with a warning.
+
 - **Added compute partition memory allocation mode API**.  
   - New `amd-smi static --partition` output includes `COMPUTE_PARTITION_MEM_ALLOC_MODE` field.
   - New `amd-smi set --compute-partition-mem-alloc-mode [CAPPING|ALL]` to control memory allocation mode (requires sudo).
@@ -63,21 +65,24 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - New enum: `amdsmi_compute_partition_mem_alloc_mode_t` (`AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_CAPPING`, `AMDSMI_COMPUTE_PARTITION_MEM_ALLOC_ALL`).
   - Reads/writes sysfs: `/sys/class/drm/cardN/device/compute_partition_mem_alloc_mode`.
 
-- **Added `AMDSMI_LINK_TYPE_NUMA` and `AMDSMI_LINK_TYPE_XNUMA` to `amdsmi_link_type_t` enum**.  
-  - Added the new types to `amdsmi_link_types` as part of support for NICs
+- **Added `AMDSMI_LINK_TYPE_NUMA` and `AMDSMI_LINK_TYPE_XNUMA` to `amdsmi_link_type_t`**.  
+  - Represent NIC-to-GPU links that cross different PCIe switches on the same CPU (NUMA) or across CPUs (XNUMA).
+
+- **Added PID-grouped process listing across GPUs**.  
+  - `amd-smi process --sort-by-pid` and `amd-smi monitor --sort-by-pid` group output by PID, merging each PID's per-GPU usage into one row.
+  - New C and Python API `amdsmi_get_gpu_process_list_by_pid()`.
 
 ### Changed
 
-- **Normalized JSON/CSV key casing in `amd-smi metric` clock and temperature sections**.
+- **Normalized JSON/CSV key casing in `amd-smi metric` clock and temperature sections**.  
   - The `uclk_aid`, `socclks_mid`, and temperature `xcd` keys are now lowercase (`aid_<N>`, `mid_<N>`, `xcp_<N>`) in JSON and CSV output, matching the existing `xcp_<N>` usage keys; they were previously uppercase (`AID_<N>`, `MID_<N>`, `XCP_<N>`).
   - Human-readable output is unchanged, since it uppercases all keys.
 
-- **Normalized JSON/CSV key casing in the `amd-smi topology` NIC-GPU access table**.
+- **Normalized JSON/CSV key casing in the `amd-smi topology` NIC-GPU access table**.  
   - The per-GPU columns are now lowercase (`gpu_<N>` for the BDF header row, `gpu_<N>_topo` for each NIC's status row) in JSON and CSV output, matching the existing `gpu_<N>` keys in the GPU-to-GPU access matrix; they were previously uppercase (`GPU<N>`, `GPU<N>_Topo`).
   - Human-readable output is unchanged, since it uppercases all keys.
 
-- **Fixed `amd-smi static --clock` csv and human_readable formatting to output frequency 
-levels as strings instead of dictionary objects**.  
+- **Fixed `amd-smi static --clock` CSV and human-readable formatting to output frequency levels as strings instead of dictionary objects**.  
 
 - **Deprecated `amdsmi_get_gpu_vram_vendor()` in favor of `amdsmi_get_gpu_vram_info()`**.  
   - `amdsmi_get_gpu_vram_vendor` is slated for removal in a future ROCm release. It now emits a `DeprecationWarning` from the Python interface and functions as a wrapper of `amdsmi_get_gpu_vram_info()`.
@@ -88,6 +93,8 @@ levels as strings instead of dictionary objects**.
 ### Removed
 
 - **Removed the non-functional `--decode` flag from `amd-smi ras`**. Out-of-band CPER decoding is available via `amd-smi ras --afid --cper-file <path>` or `--afid --folder <DIR>`.
+
+- **Removed the unused `amdsmi_nic_link_type_t` enum from the public header**. No API or struct referenced it; NIC link types are reported through `amdsmi_link_type_t`, which gains `AMDSMI_LINK_TYPE_NUMA` and `AMDSMI_LINK_TYPE_XNUMA` in this release.
 
 ### Resolved Issues
 

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -638,7 +638,8 @@ Set Arguments:
   -P, --profile PROFILE_LEVEL                 Set power profile level (#) or choose one of available profiles:
                                                 CUSTOM_MASK, VIDEO_MASK, POWER_SAVING_MASK, COMPUTE_MASK, VR_MASK, THREE_D_FULL_SCR_MASK, BOOTUP_DEFAULT
   -d, --perf-determinism SCLKMAX              Enable performance determinism mode and set GFXCLK softmax limit (in MHz)
-  -C, --compute-partition TYPE/INDEX          Set one of the following the accelerator TYPE or profile INDEX:
+  -C, --compute-partition, --accelerator-partition TYPE/INDEX
+                                              Set one of the following the accelerator TYPE or profile INDEX:
                                                 N/A.
                                                 Use `sudo amd-smi partition --accelerator` to find acceptable values.
   -M, --memory-partition PARTITION            Set one of the following the memory partition modes:
@@ -974,6 +975,45 @@ Command Modifiers:
   --file FILE                 Saves output into a file on the provided path (stdout by default).
   --loglevel LEVEL            Set the logging level from the possible choices:
                                 DEBUG, INFO, WARNING, ERROR, CRITICAL
+```
+
+### amd-smi fabric
+
+Displays fabric (UALoE/UALink over Ethernet) information of the devices.
+
+```{note}
+The `fabric` subcommand is registered only when the amdgpu driver is initialized.
+On systems without IFoE/UALoE fabric hardware the fabric queries report `N/A` /
+not supported.
+```
+
+```shell-session
+~$ amd-smi fabric --help
+usage: amd-smi fabric [-h] [-t] [-i] [-g GPU [GPU ...]] [--json | --csv]
+                      [--file FILE] [--loglevel LEVEL]
+
+If no GPU is specified, returns information for all GPUs on the system.
+If no fabric argument is provided, all fabric information will be displayed.
+
+Fabric arguments:
+  -h, --help               show this help message and exit
+  -t, --topology           Display fabric topology data (counters per category, instance, and item)
+  -i, --info               Display fabric device configuration (BDF, bandwidth, latency, vPoD/pPoD, accelerator state)
+
+Device Arguments:
+  -g, --gpu GPU [GPU ...]  Select a GPU ID, BDF, or UUID from the possible choices:
+                           ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+                           ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+                           ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+                           ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+                             all | Selects all devices
+
+Command Modifiers:
+  --json                   Displays output in JSON format (human readable by default).
+  --csv                    Displays output in CSV format (human readable by default).
+  --file FILE              Saves output into a file on the provided path (stdout by default).
+  --loglevel LEVEL         Set the logging level from the possible choices:
+                             DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 ## Interpreting the output

--- a/projects/amdsmi/docs/reference/amdsmi-py-api.md
+++ b/projects/amdsmi/docs/reference/amdsmi-py-api.md
@@ -1665,6 +1665,50 @@ finally:
     amdsmi.amdsmi_shut_down()
 ```
 
+### amdsmi_get_gpu_process_list_by_pid
+
+Description: Returns the list of processes running across one or more GPUs, grouped by PID. Each entry aggregates the per-GPU usage for every GPU the process is active on; the calling process is omitted. Requires root level access to display root process names; otherwise the name is reported as "N/A".
+
+Input parameters:
+
+* `processor_handles` list of device handles to query
+
+Output: List of Dictionaries with the corresponding fields; empty list if no running process are detected
+
+Field | Description
+---|---
+`pid` | Process ID
+`name` | Name of process. If user does not have permission this will be "N/A"
+`container_name` | Container name, when the process runs inside a container
+`gpus` | <table><thead><tr><th>Subfield</th><th>Description</th></tr></thead><tbody><tr><td>`gpu_index`</td><td>GPU index the entry refers to</td></tr><tr><td>`mem`</td><td>Total memory usage on this GPU in Bytes</td></tr><tr><td>`engine_usage`</td><td>`gfx` and `enc` engine usage in ns</td></tr><tr><td>`memory_usage`</td><td>`gtt_mem`, `cpu_mem`, and `vram_mem` usage in Bytes</td></tr><tr><td>`cu_occupancy`</td><td>Number of Compute Units utilized</td></tr><tr><td>`sdma_usage`</td><td>SDMA usage in microseconds</td></tr><tr><td>`evicted_time`</td><td>Time queues are evicted on this GPU in milliseconds</td></tr></tbody></table>
+
+Exceptions that can be thrown by `amdsmi_get_gpu_process_list_by_pid` function:
+
+* `AmdSmiLibraryException`
+* `AmdSmiParameterException`
+
+Example:
+
+```python
+import amdsmi
+try:
+    amdsmi.amdsmi_init()
+    devices = amdsmi.amdsmi_get_processor_handles()
+    if len(devices) == 0:
+        print("No GPUs on machine")
+    else:
+        processes = amdsmi.amdsmi_get_gpu_process_list_by_pid(devices)
+        if len(processes) == 0:
+            print("No processes running on these GPUs")
+        else:
+            for process in processes:
+                print(process)
+except amdsmi.AmdSmiException as e:
+    print(e)
+finally:
+    amdsmi.amdsmi_shut_down()
+```
+
 ### amdsmi_get_gpu_total_ecc_count
 
 Description: Returns the ECC error count for the given GPU.
@@ -6533,6 +6577,97 @@ try:
         for device in devices:
             bitmask = amdsmi.amdsmi_get_cpu_affinity_with_scope(device, scope)
             print(bitmask['size'])
+except amdsmi.AmdSmiException as e:
+    print(e)
+finally:
+    amdsmi.amdsmi_shut_down()
+```
+
+### amdsmi_get_gpu_fabric_info
+
+Description: Returns IFoE/UALoE fabric device configuration for the target GPU, read from sysfs. Fields whose sysfs source is unavailable keep their sentinel/default values. Available only on platforms with IFoE/UALoE fabric hardware; other devices return not supported.
+
+Input parameters:
+
+* `processor_handle` device which to query
+
+Output: Dictionary with the corresponding fields
+
+Field | Description
+---|---
+`bdf` | BDF of the fabric device
+`version` | Fabric info structure version
+`accelerator_id` | Accelerator identifier (range 0 to 1023)
+`fabric_type` | Fabric type: `UALOE`, `UALLINK`, or `UNKNOWN`
+`bandwidth` | Station bandwidth share in Mb/s
+`latency` | Latency in nanoseconds
+`ppod_id` | Physical PoD identifier as a list of 16 bytes
+`ppod_size` | Physical PoD size
+`vpod_id` | Virtual PoD identifier
+`vpod_size` | Virtual PoD size
+`local_accelerators` | List of local accelerator IDs
+`vpod_active_accelerators` | Active-accelerator bitmap as a list of 32-bit words (bit N set = accelerator ID N is active)
+`addr_mode` | NPA address mode: `SOURCE_ALIASING`, `SOURCE_IDENTIFICATION`, or `UNKNOWN`
+`accel_state` | Accelerator vPoD state: `UNCONFIGURED`, `CONFIGURED`, `READY`, `ACTIVE`, `ERROR`, or `UNKNOWN`
+
+Exceptions that can be thrown by `amdsmi_get_gpu_fabric_info` function:
+
+* `AmdSmiLibraryException`
+* `AmdSmiParameterException`
+* `AmdSmiRetryException`
+* `AmdSmiTimeoutException`
+
+Example:
+
+```python
+import amdsmi
+try:
+    amdsmi.amdsmi_init()
+    devices = amdsmi.amdsmi_get_processor_handles()
+    for device in devices:
+        info = amdsmi.amdsmi_get_gpu_fabric_info(device)
+        print(info)
+except amdsmi.AmdSmiException as e:
+    print(e)
+finally:
+    amdsmi.amdsmi_shut_down()
+```
+
+### amdsmi_get_fabric_telemetry_data
+
+Description: Returns IFoE/UALoE fabric telemetry for the target GPU. The `category_mask` selects which telemetry categories to retrieve and is built from the `AMDSMI_FABRIC_TELEMETRY_CATEGORY_MASK_*` bit values. Available only on platforms with IFoE/UALoE fabric hardware; other devices return not supported.
+
+Input parameters:
+
+* `processor_handle` device which to query
+* `category_mask` integer bitmask of the telemetry categories to retrieve
+
+Output: List of Dictionaries, one per populated category
+
+Field | Description
+---|---
+`category` | Category name: `UALOE`, `SWITCH`, `CRYPTO`, `PFC`, `NETPORT`, `DERIVED_UALOE`, or `DERIVED_NETPORT`
+`generation_count` | Sequence number incremented each time the telemetry is written
+`timestamp` | Dictionary with `tv_sec` and `tv_nsec`
+`instances` | <table><thead><tr><th>Subfield</th><th>Description</th></tr></thead><tbody><tr><td>`name`</td><td>Instance name</td></tr><tr><td>`logical_idx`</td><td>Logical index of the instance</td></tr><tr><td>`items`</td><td>List of `{id, name, value}` telemetry items</td></tr></tbody></table>
+
+Exceptions that can be thrown by `amdsmi_get_fabric_telemetry_data` function:
+
+* `AmdSmiLibraryException`
+* `AmdSmiParameterException`
+
+Example:
+
+```python
+import amdsmi
+from amdsmi import amdsmi_interface
+try:
+    amdsmi.amdsmi_init()
+    category_mask = amdsmi_interface.amdsmi_wrapper.AMDSMI_FABRIC_TELEMETRY_CATEGORY_MASK_ALL_KNOWN
+    devices = amdsmi.amdsmi_get_processor_handles()
+    for device in devices:
+        for category in amdsmi.amdsmi_get_fabric_telemetry_data(device, category_mask):
+            print(category)
 except amdsmi.AmdSmiException as e:
     print(e)
 finally:

--- a/projects/amdsmi/py-interface/__init__.py
+++ b/projects/amdsmi/py-interface/__init__.py
@@ -161,6 +161,7 @@ from .amdsmi_interface import amdsmi_stop_gpu_event_notification
 
 # # Process Information
 from .amdsmi_interface import amdsmi_get_gpu_process_list
+from .amdsmi_interface import amdsmi_get_gpu_process_list_by_pid
 
 # # ECC Error Information
 from .amdsmi_interface import amdsmi_get_gpu_total_ecc_count
@@ -353,6 +354,10 @@ from .amdsmi_interface import amdsmi_set_gpu_uma_carveout
 from .amdsmi_interface import amdsmi_get_ttm_info
 from .amdsmi_interface import amdsmi_set_ttm_pages_limit
 from .amdsmi_interface import amdsmi_reset_ttm_pages_limit
+
+# # Fabric (IFoE/UALoE) Information
+from .amdsmi_interface import amdsmi_get_fabric_telemetry_data
+from .amdsmi_interface import amdsmi_get_gpu_fabric_info
 
 # Exceptions
 from .amdsmi_exception import AmdSmiLibraryException


### PR DESCRIPTION
## Motivation

The 7.14 fabric (IFoE/UALoE) and PID-grouped process APIs already shipped on
`develop`, but they were not reachable from the `amdsmi` package root and were
missing from the CLI guide, the Python API reference, and parts of the
changelog. This PR closes those gaps so the new APIs are usable via
`from amdsmi import ...` and fully documented for the release.

## Technical Details

**Python package** (`py-interface/__init__.py`):
- Re-export `amdsmi_get_gpu_process_list_by_pid`, `amdsmi_get_fabric_telemetry`,
  and `amdsmi_get_gpu_fabric_info`; they were defined in `amdsmi_interface` but
  raised `ImportError` from the package root

**CLI guide** (`docs/how-to/amdsmi-cli-tool.md`):
- Add an `amd-smi fabric` subcommand section
- Show the `--accelerator-partition` alias in the `amd-smi set` help block

**Python API reference** (`docs/reference/amdsmi-py-api.md`):
- Add entries for `amdsmi_get_gpu_process_list_by_pid`,
  `amdsmi_get_gpu_fabric_info`, and `amdsmi_get_fabric_telemetry`

**Changelog** (`CHANGELOG.md`):
- Add the `amdsmi_get_gpu_process_list_by_pid` / `--sort-by-pid` addition and
  the `amdsmi_nic_link_type_t` removal
- List all five fabric C APIs and the two Python fabric APIs under the
  IFoE/UALoE entry
- Fix Sphinx hard breaks, collapse the wrapped `static --clock` headline, and
  tighten redundant wording

The literal `amd-smi --help` capture is intentionally left untouched: `fabric`
(like `node`/`profile`) is registered only when the amdgpu driver is
initialized, so it is documented as its own section rather than added to the
verbatim snapshot.

## JIRA ID

N/A

## Test Plan

- `pre-commit run --config projects/amdsmi/.pre-commit-config.yaml --files projects/amdsmi/py-interface/__init__.py`
- `python3 -c "import ast; ast.parse(open('py-interface/__init__.py').read())"`
- Reproduced the `develop` defect (`ImportError: cannot import name 'amdsmi_get_fabric_telemetry'`) and confirmed the export change resolves it
- Verified balanced markdown code fences in both edited docs and zero remaining Sphinx hard-break violations in the 7.14 changelog section

## Test Result

- pre-commit: all hooks passed (codespell, ruff-format, trailing-whitespace)
- `__init__.py` parses; the three names are now importable from `amdsmi`
- Docs fences balanced; changelog 7.14 section clean

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
