### PR TITLE
[rocprofiler-compute] Bump scipy test pin for Python 3.13 support

### DIFF
--- a/projects/rocprofiler-compute/requirements-test.txt
+++ b/projects/rocprofiler-compute/requirements-test.txt
@@ -1,4 +1,5 @@
 pytest==8.0.2
 pytest-cov==5.0.0
 pytest-xdist==3.5.0
-scipy==1.14.1
+scipy==1.11.4; python_version < "3.10"
+scipy==1.14.1; python_version >= "3.10"

--- a/projects/rocprofiler-compute/requirements-test.txt
+++ b/projects/rocprofiler-compute/requirements-test.txt
@@ -1,4 +1,4 @@
 pytest==8.0.2
 pytest-cov==5.0.0
 pytest-xdist==3.5.0
-scipy==1.11.4
+scipy==1.14.1


### PR DESCRIPTION
## Motivation

scipy 1.11.4 fails to install on Python 3.13: it pins legacy Cython <3.0, which cannot compile against the CPython 3.13 C-API. Bump the test pin to scipy 1.14.1, keeping numpy 1.26.4 unchanged.

## Technical Details

- requirements-test.txt: scipy 1.11.4 -> 1.14.1.
- 1.14.1 is the lowest scipy with a prebuilt cp313 wheel and runs against the existing numpy 1.26.4 pin.

## JIRA ID

ROCM-26919

## Test Plan

- Create a Python 3.13 venv, run pip install -r requirements-test.txt, then run the test suite.

## Test Result

Verified on Python 3.13: scipy 1.14.1 installs against the existing numpy 1.26.4 pin, with no change to test behavior.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.