### PR TITLE
[hip-tests] Use host-side delay callback in hipMemsetSync instead of relaying on wall clock

### DIFF
--- a/projects/hip-tests/catch/include/utils.hh
+++ b/projects/hip-tests/catch/include/utils.hh
@@ -167,6 +167,22 @@ inline void LaunchDelayKernel(const std::chrono::milliseconds interval, const hi
   Delay<<<1, 1, 0, stream>>>(interval.count(), ticks_per_ms);
 }
 
+// Keeps a stream busy for at least `interval` by enqueuing a host callback that
+// sleeps on the host. The duration is measured with the host clock, so it does
+// not depend on hipDeviceAttributeWallClockRate being accurate the way the
+// GPU-side Delay kernel does. Prefer this in synchronization tests that only
+// need the stream to stay un-drained for a controlled time.
+inline void DelayHostCallback(void* user_data) {
+  const auto ms = reinterpret_cast<intptr_t>(user_data);
+  std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
+
+inline void LaunchDelayHostFunc(const std::chrono::milliseconds interval,
+                                const hipStream_t stream = nullptr) {
+  HIPCHECK(hipLaunchHostFunc(stream, DelayHostCallback,
+                             reinterpret_cast<void*>(static_cast<intptr_t>(interval.count()))));
+}
+
 template <typename... Attributes>
 inline bool DeviceAttributesSupport(const int device, Attributes... attributes) {
   constexpr auto DeviceAttributeSupport = [](const int device,

--- a/projects/hip-tests/catch/include/utils.hh
+++ b/projects/hip-tests/catch/include/utils.hh
@@ -173,14 +173,14 @@ inline void LaunchDelayKernel(const std::chrono::milliseconds interval, const hi
 // GPU-side Delay kernel does. Prefer this in synchronization tests that only
 // need the stream to stay un-drained for a controlled time.
 inline void DelayHostCallback(void* user_data) {
-  const auto ms = reinterpret_cast<intptr_t>(user_data);
+  const auto ms = reinterpret_cast<int64_t>(user_data);
   std::this_thread::sleep_for(std::chrono::milliseconds(ms));
 }
 
 inline void LaunchDelayHostFunc(const std::chrono::milliseconds interval,
                                 const hipStream_t stream = nullptr) {
   HIPCHECK(hipLaunchHostFunc(stream, DelayHostCallback,
-                             reinterpret_cast<void*>(static_cast<intptr_t>(interval.count()))));
+                             reinterpret_cast<void*>(interval.count())));
 }
 
 template <typename... Attributes>

--- a/projects/hip-tests/catch/unit/memory/hipMemsetSync.cc
+++ b/projects/hip-tests/catch/unit/memory/hipMemsetSync.cc
@@ -390,7 +390,10 @@ void runTests(allocType type, memSetType memsetType, MultiDData data, hipStream_
   CAPTURE(type, memsetType, data.width, data.height, data.depth, stream, async);
   std::pair<T*, T*> aPtr = initMemory<T>(type, memsetType, data);
   const auto delay = std::chrono::milliseconds(isQuickLevel() ? 10 : 100);
-  LaunchDelayKernel(delay, stream);
+  // Keep the stream busy with a host-side delay rather than the GPU Delay
+  // kernel: the host timer is deterministic and doesn't depend on the device
+  // wall-clock-rate attribute, which makes this synchronization check robust.
+  LaunchDelayHostFunc(delay, stream);
   memsetCheck(aPtr.first, testValue, memsetType, data, async, stream);
 
   if (async || type == allocType::deviceMalloc) {


### PR DESCRIPTION
 ## Motivation

  The synchronous memset tests in `hipMemsetSync.cc` (`Unit_hipMemsetSync`,
  `Unit_hipMemsetDSync`, `Unit_hipMemset2DSync`, `Unit_hipMemset3DSync`) verify that
  the synchronous `hipMemset*` APIs are asynchronous with respect to the host, except
  when the target is pinned host memory or a Unified Memory region. To prove this, the
  test keeps the stream busy, issues the memset, and immediately calls `hipStreamQuery`
  expecting `hipErrorNotReady` (async cases) or `hipSuccess` (sync host-memory cases).

  The stream was kept busy with the GPU `Delay` kernel (`LaunchDelayKernel`), whose
  duration is derived from `hipDeviceAttributeWallClockRate`. When that attribute is
  inaccurate (or reports 0 and falls back to a guessed rate), the kernel finishes early,
  the stream drains before `hipStreamQuery` runs, and the async-vs-host check fails
  spuriously. This makes the test fragile across GPUs/drivers even though the runtime
  behavior under test is correct.

  ## Technical Details

  - Added `LaunchDelayHostFunc` (and its `DelayHostCallback`) in `catch/include/utils.hh`.
    It keeps a stream busy by enqueuing a host callback via `hipLaunchHostFunc` that sleeps
    for a host-measured interval (`std::this_thread::sleep_for`). Because the wait is timed
    on the host, it no longer depends on the device wall-clock rate.
  - Switched `runTests` in `catch/unit/memory/hipMemsetSync.cc` to use `LaunchDelayHostFunc`
    instead of `LaunchDelayKernel`. Stream ordering is unchanged (the memset is still queued
    behind the delay), so the `hipErrorNotReady` / `hipSuccess` semantics the test checks are
    identical.
  - `LaunchDelayKernel` is left intact, since other tests still rely on the GPU-side delay.

  ## JIRA ID

ROCM-9281/AIRUNTIME-2357

  ## Test Plan

  - Build `MemoryTest2` (which contains `hipMemsetSync.cc`) on gfx950, ROCm 7.14.
  - Run each synchronous memset test and confirm it passes:
    - `./MemoryTest2 Unit_hipMemsetSync`
    - `./MemoryTest2 "Unit_hipMemsetDSync*"`
    - `./MemoryTest2 Unit_hipMemset2DSync`
    - `./MemoryTest2 Unit_hipMemset3DSync`

  ## Test Result

  All four synchronous memset tests pass on gfx950 (ROCm 7.14):

  - `Unit_hipMemsetSync` — All tests passed (20 assertions in 1 test case)
  - `Unit_hipMemsetDSync` — All tests passed (60 assertions in 3 test cases)
  - `Unit_hipMemset2DSync` — All tests passed (40 assertions in 1 test case)
  - `Unit_hipMemset3DSync` — All tests passed (80 assertions in 1 test case)