### PR TITLE
rocr: Fix tempnam TOCTOU race in code-object writer (ROCM-26868)

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_elf_image.cpp
@@ -60,7 +60,6 @@
 #ifndef _WIN32
 #define _open open
 #define _close close
-#define _tempnam tempnam
 #include <fcntl.h>
 #include <unistd.h>
 #endif

--- a/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_hsa_code_util.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/libamdhsacode/amd_hsa_code_util.cpp
@@ -48,6 +48,7 @@
 #include <cassert>
 #include <algorithm>
 #include <sstream>
+#include <vector>
 #ifdef _WIN32
 #include <Windows.h>
 #include <io.h>
@@ -940,7 +941,6 @@ bool ReadFileIntoBuffer(const std::string& filename, std::vector<char>& buffer)
 }
 
 #ifndef _WIN32
-#define _tempnam tempnam
 #define _close close
 #define _getpid getpid
 #define _open open
@@ -949,32 +949,41 @@ bool ReadFileIntoBuffer(const std::string& filename, std::vector<char>& buffer)
 int OpenTempFile(const char* prefix)
 {
   unsigned c = 0;
-  std::string tname = prefix;
-  tname += "_";
-  tname += std::to_string(_getpid());
-  tname += "_";
   while (c++ < 20) { // Loop because several threads can generate same filename.
 #ifdef _WIN32
-    char dir[MAX_PATH+1];
+    char dir[MAX_PATH + 1];
+    char name[MAX_PATH + 1];
     if (!GetTempPath(sizeof(dir), dir)) { return -1; }
-    char *name = _tempnam(dir, tname.c_str());
-    if (!name) { return -1; }
+    char short_prefix[4] = {0};
+    strncpy(short_prefix, prefix, 3);
+    if (GetTempFileName(dir, short_prefix, 0, name) == 0) { continue; }
     HANDLE h = CreateFile(
       name,
       GENERIC_READ | GENERIC_WRITE,
       0, // No sharing
       NULL,
-      CREATE_NEW,
+      OPEN_EXISTING,
       FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE,
       NULL);
-    free(name);
-    if (h == INVALID_HANDLE_VALUE) { continue; }
+    if (h == INVALID_HANDLE_VALUE) {
+      DeleteFile(name);
+      continue;
+    }
     return _open_osfhandle((intptr_t)h, 0);
 #else // _WIN32
-    tname += "XXXXXX";
-    int d = mkstemp((char*)tname.c_str());
+    const char* tmpdir = getenv("TMPDIR");
+    if (tmpdir == nullptr || tmpdir[0] == '\0') { tmpdir = "/tmp"; }
+    std::string tname = tmpdir;
+    tname += '/';
+    tname += prefix;
+    tname += '_';
+    tname += std::to_string(_getpid());
+    tname += "_XXXXXX";
+    std::vector<char> path(tname.begin(), tname.end());
+    path.push_back('\0');
+    int d = mkstemp(path.data());
     if (d < 0) { continue; }
-    if (unlink(tname.c_str()) < 0) { _close(d); return -1; }
+    if (unlink(path.data()) < 0) { _close(d); return -1; }
     return d;
 #endif // _WIN32
   }


### PR DESCRIPTION
## Summary

- Fixes SEC-00603 / [ROCM-26868](https://amd-hub.atlassian.net/browse/ROCM-26868): `tempnam()` in ROCr's code-object writer created a TOCTOU window between name generation and file open, enabling symlink attacks on predictable `/tmp` paths.
- **Unix**: `OpenTempFile()` now atomically creates temp files via `mkstemp()` under `$TMPDIR` (or `/tmp`), then unlinks the path while keeping the fd open — same anonymous-temp pattern as before, without the race.
- **Windows**: Replaced `tempnam()` with `GetTempFileName()` + `OPEN_EXISTING` / `FILE_FLAG_DELETE_ON_CLOSE`.
- Removed stale `_tempnam` macro from `amd_elf_image.cpp` (unused).

## Context

A partial Unix fix landed in 2023 (`bd8c4079da`) but still had issues: `XXXXXX` was appended inside the retry loop, files were created in CWD instead of the temp directory, and Windows continued using `tempnam()`.

## Test plan

- [ ] Build `libhsa-runtime64` on Linux
- [ ] Verify code-object load/compile paths that use `FileImage::create()` / `OpenTempFile()` still work (e.g. HIP module load, HSA finalizer)
- [ ] Build on Windows if applicable


Made with [Cursor](https://cursor.com)

[ROCM-26868]: https://amd-hub.atlassian.net/browse/ROCM-26868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ