### PR TITLE
Revert rccl doxygen @param[in,out] recvbuff change (#6360)

### DIFF
--- a/projects/rccl/src/nccl.h.in
+++ b/projects/rccl/src/nccl.h.in
@@ -664,7 +664,7 @@ ncclResult_t pncclRedOpDestroy(ncclRedOp_t op, ncclComm_t comm);
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Local device data buffer to be reduced
-    @param[in,out] recvbuff      Data buffer where result is stored (only for *root* rank).  May be null for other ranks.
+    @param[out] recvbuff      Data buffer where result is stored (only for *root* rank).  May be null for other ranks.
     @param[in]  count         Number of elements in every send buffer
     @param[in]  datatype      Data buffer element datatype
     @param[in]  op            Reduction operator type
@@ -706,7 +706,7 @@ ncclResult_t pncclBcast(void* buff, size_t count, ncclDataType_t datatype, int r
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Data array to copy (if *root*).  May be NULL for other ranks
-    @param[in,out] recvbuff   Data array to store received array
+    @param[in]  recvbuff      Data array to store received array
     @param[in]  count         Number of elements in data buffer
     @param[in]  datatype      Data buffer element datatype
     @param[in]  root          Rank of broadcast root
@@ -726,7 +726,7 @@ ncclResult_t pncclBroadcast(const void* sendbuff, void* recvbuff, size_t count, 
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Input data array to reduce
-    @param[in,out] recvbuff      Data array to store reduced result array
+    @param[out] recvbuff      Data array to store reduced result array
     @param[in]  count         Number of elements in data buffer
     @param[in]  datatype      Data buffer element datatype
     @param[in]  op            Reduction operator
@@ -746,7 +746,7 @@ ncclResult_t pncclAllReduce(const void* sendbuff, void* recvbuff, size_t count,
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Input data array to reduce
-    @param[in,out] recvbuff      Data array to store reduced result array
+    @param[out] recvbuff      Data array to store reduced result array
     @param[in]  count         Number of elements in data buffer
     @param[in]  datatype      Data buffer element datatype
     @param[in]  op            Reduction operator
@@ -770,7 +770,7 @@ ncclResult_t pncclAllReduceWithBias(const void* sendbuff, void* recvbuff, size_t
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Input data array to reduce
-    @param[in,out] recvbuff      Data array to store reduced result subarray
+    @param[out] recvbuff      Data array to store reduced result subarray
     @param[in]  recvcount     Number of elements each rank receives
     @param[in]  datatype      Data buffer element datatype
     @param[in]  op            Reduction operator
@@ -794,7 +794,7 @@ ncclResult_t pncclReduceScatter(const void* sendbuff, void* recvbuff,
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Input data array to send
-    @param[in,out] recvbuff      Data array to store the gathered result
+    @param[out] recvbuff      Data array to store the gathered result
     @param[in]  sendcount     Number of elements each rank sends
     @param[in]  datatype      Data buffer element datatype
     @param[in]  comm          Communicator group object to execute on
@@ -814,7 +814,7 @@ ncclResult_t pncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcou
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Data array to send (contains blocks for each other rank)
-    @param[in,out] recvbuff      Data array to receive (contains blocks from each other rank)
+    @param[out] recvbuff      Data array to receive (contains blocks from each other rank)
     @param[in]  count         Number of elements to send between each pair of ranks
     @param[in]  datatype      Data buffer element datatype
     @param[in]  comm          Communicator group object to execute on
@@ -838,7 +838,7 @@ ncclResult_t pncclAlltoAll(const void* sendbuff, void* recvbuff, size_t count,
     @param[in]  sendbuff      Data array to send (contains blocks for each other rank)
     @param[in]  sendcounts    Array containing number of elements to send to each participating rank
     @param[in]  sdispls       Array of offsets into *sendbuff* for each participating rank
-    @param[in,out] recvbuff      Data array to receive (contains blocks from each other rank)
+    @param[out] recvbuff      Data array to receive (contains blocks from each other rank)
     @param[in]  recvcounts    Array containing number of elements to receive from each participating rank
     @param[in]  rdispls       Array of offsets into *recvbuff* for each participating rank
     @param[in]  datatype      Data buffer element datatype
@@ -863,7 +863,7 @@ ncclResult_t pncclAlltoAllv(const void *sendbuff, const size_t sendcounts[],
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Data array to send
-    @param[in,out] recvbuff   Data array to recv
+    @param[in]  recvbuff      Data array to recv
     @param[in]  count         Number of elements
     @param[in]  datatype      Data buffer element datatype
     @param[in]  root          Rank of gather root
@@ -886,7 +886,7 @@ ncclResult_t pncclGather(const void* sendbuff, void* recvbuff, size_t count,
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Data array to send
-    @param[in,out] recvbuff   Data array to recv
+    @param[in]  recvbuff      Data array to recv
     @param[in]  count         Number of elements
     @param[in]  datatype      Data buffer element datatype
     @param[in]  root          Rank of scatter root
@@ -909,7 +909,7 @@ ncclResult_t pncclScatter(const void* sendbuff, void* recvbuff, size_t count,
     @return     Result code. See @ref rccl_result_code for more details.
 
     @param[in]  sendbuff      Data array to send (contains blocks for each other rank)
-    @param[in,out] recvbuff      Data array to receive (contains blocks from each other rank)
+    @param[out] recvbuff      Data array to receive (contains blocks from each other rank)
     @param[in]  count         Number of elements to send between each pair of ranks
     @param[in]  datatype      Data buffer element datatype
     @param[in]  comm          Communicator group object to execute on
@@ -935,7 +935,7 @@ ncclResult_t pncclAllToAll(const void* sendbuff, void* recvbuff, size_t count,
     @param[in]  sendbuff      Data array to send (contains blocks for each other rank)
     @param[in]  sendcounts    Array containing number of elements to send to each participating rank
     @param[in]  sdispls       Array of offsets into *sendbuff* for each participating rank
-    @param[in,out] recvbuff      Data array to receive (contains blocks from each other rank)
+    @param[out] recvbuff      Data array to receive (contains blocks from each other rank)
     @param[in]  recvcounts    Array containing number of elements to receive from each participating rank
     @param[in]  rdispls       Array of offsets into *recvbuff* for each participating rank
     @param[in]  datatype      Data buffer element datatype
@@ -982,7 +982,7 @@ ncclResult_t pncclSend(const void* sendbuff, size_t count, ncclDataType_t dataty
                 ncclGroupEnd section.
     @return     Result code. See @ref rccl_result_code for more details.
 
-    @param[in,out] recvbuff      Data array to receive
+    @param[out] recvbuff      Data array to receive
     @param[in]  count         Number of elements to receive
     @param[in]  datatype      Data buffer element datatype
     @param[in]  peer          Peer rank to send to
@@ -1074,7 +1074,7 @@ ncclResult_t pmscclLoadAlgo(const char *mscclAlgoFilePath, mscclAlgoHandle_t *ms
     @param[in]  sendBuff         Data array to send
     @param[in]  sendCounts       Array containing number of elements to send to each participating rank
     @param[in]  sDisPls          Array of offsets into *sendbuff* for each participating rank
-    @param[in,out] recvBuff      Data array to receive
+    @param[out] recvBuff         Data array to receive
     @param[in]  recvCounts       Array containing number of elements to receive from each participating rank
     @param[in]  rDisPls          Array of offsets into *recvbuff* for each participating rank
     @param[in]  count            Number of elements


### PR DESCRIPTION
Reverts the recvbuff `@param` direction changes introduced in #6360 (commit 4b47b9681), restoring `projects/rccl/src/nccl.h.in` to its pre-PR state byte-for-byte (14 lines, comment-only).

### Why
#6360 retagged `recvbuff` as `@param[in,out]` on the premise that `@param[out]` implies the **callee** allocates the buffer. That premise is wrong:

- Per the [doxygen manual](https://www.doxygen.nl/manual/commands.html#cmdparam), `[in]`/`[out]`/`[in,out]` describe **data-flow direction only**, not allocation ownership. Doxygen's own canonical example tags `memcpy`'s caller-allocated `dest` as `@param[out]`.
- A collective writes its result into `recvbuff` without consuming the buffer's prior contents, so `[out]` is correct; `[in,out]` is misleading.
- Upstream NVIDIA NCCL carries **no** `@param` direction tags at all — there is no upstream convention being matched.

This matches the reviewer's conclusion on the tracking tickets, both now Discarded: AICOMRCCL-1017 and the identical HIP case AIRUNTIME-2171.

### Impact
Comment-only. Zero code / ABI / behavior impact.

### Intentionally out of scope
After this revert, 3 tags (`ncclBroadcast`, `ncclGather`, `ncclScatter` `recvbuff`) remain `@param[in]`. These were already mistagged read-only **before** #6360 and are left as-is here — correcting them to `[out]` is a separate change, not part of this revert.

Refs: AICOMRCCL-1017, AIRUNTIME-2171