### PR TITLE
fix(libhsakmt): fix gpuvm base/limit returning 0 on GPUVM64 dGPUs

### DIFF
--- a/projects/rocr-runtime/libhsakmt/src/fmm.c
+++ b/projects/rocr-runtime/libhsakmt/src/fmm.c
@@ -207,7 +207,8 @@ typedef struct {
 						 * dgpu_aperture. When requested by RT, each
 						 * GPU will get a differnt range
 						 */
-	manageable_aperture_t gpuvm_aperture;   /* used for GPUVM on APU, outsidethe canonical address range */
+	manageable_aperture_t gpuvm_aperture;   /* used for GPUVM on APU, outside the canonical address range */
+	aperture_t gpuvm_range;                 /* raw gpuvm base/limit from kernel, always valid */
 	int drm_render_fd;
 	uint32_t usable_peer_id_num;
 	uint32_t *usable_peer_id_array;
@@ -3074,6 +3075,11 @@ HSAKMT_STATUS hsakmt_fmm_init_process_apertures(HsaKFDContext *ctx,
 		gpu_mem[gpu_mem_id].scratch_aperture.limit =
 			PORT_UINT64_TO_VPTR(process_apertures[i].scratch_limit);
 
+		gpu_mem[gpu_mem_id].gpuvm_range.base =
+			PORT_UINT64_TO_VPTR(process_apertures[i].gpuvm_base);
+		gpu_mem[gpu_mem_id].gpuvm_range.limit =
+			PORT_UINT64_TO_VPTR(process_apertures[i].gpuvm_limit);
+
 		if (IS_CANONICAL_ADDR(process_apertures[i].gpuvm_limit)) {
 			uint64_t vm_alignment = get_vm_alignment(
 				gpu_mem[gpu_mem_id].device_id);
@@ -3263,10 +3269,10 @@ HSAKMT_STATUS hsakmt_fmm_get_aperture_base_and_limit(HsaKFDContext *ctx,
 
 	switch (aperture_type) {
 	case FMM_GPUVM:
-		if (aperture_is_valid(fmm_ctx->gpu_mem[slot].gpuvm_aperture.base,
-			fmm_ctx->gpu_mem[slot].gpuvm_aperture.limit)) {
-			*aperture_base = PORT_VPTR_TO_UINT64(fmm_ctx->gpu_mem[slot].gpuvm_aperture.base);
-			*aperture_limit = PORT_VPTR_TO_UINT64(fmm_ctx->gpu_mem[slot].gpuvm_aperture.limit);
+		if (aperture_is_valid(fmm_ctx->gpu_mem[slot].gpuvm_range.base,
+			fmm_ctx->gpu_mem[slot].gpuvm_range.limit)) {
+			*aperture_base = PORT_VPTR_TO_UINT64(fmm_ctx->gpu_mem[slot].gpuvm_range.base);
+			*aperture_limit = PORT_VPTR_TO_UINT64(fmm_ctx->gpu_mem[slot].gpuvm_range.limit);
 			err = HSAKMT_STATUS_SUCCESS;
 		}
 		break;


### PR DESCRIPTION
## Motivation

On GPUVM64 dGPUs (canonical address space mode), querying FMM_GPUVM via hsakmt_fmm_get_apert_base_and_limit() returns 0 for both gpuvm_base and gpuvm_limit. This breaks any consumer that needs the actual GPU virtual memory address range, including [core dump](https://github.com/ROCm/rocm-systems/pull/6811) device info collection.

## Technical Details

In GPUVM64 mode, `gpuvm_aperture` (a manageable_aperture_t) is intentionally left unpopulated to avoid conflicts with the SVM aperture's allocation management (rbtree, mutex, vm_find_object() lookups). However, the kernel reports valid gpuvm base/limit values in process_apertures — they were simply being discarded.

This fix adds a lightweight `aperture_t gpuvm_range` field to gpu_mem_t that unconditionally caches the kernel-returned gpuvm base/limit during topology init. The `FMM_GPUVM` query path now reads directly from gpuvm_range instead of gpuvm_aperture, providing correct boundaries without interfering with SVM aperture's allocation management.

## JIRA ID

JIRA ID :  NO_EXISTED-000

## Test Plan

kfdtest

## Test Result

- gpuvm_base/gpuvm_limit correctly return the kernel-reported range on GPUVM64 dGPU
- Core dump collection succeeds with valid gpuvm boundaries
- kfdtest passed with no regressions observed

