### PR TITLE
[rocprofiler-sdk] Update SPM docs - minimum required driver version

### DIFF
--- a/projects/rocprofiler-sdk/source/docs/how-to/using-spm.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-spm.rst
@@ -58,7 +58,7 @@ To check the driver version, use:
   # Example output:
   # 6.19.14.31400000
 
-The value is also reported by ``amd-smi version`` on DKMS-built systems.
+You can also check this driver version using ``amd-smi version`` command on DKMS-built systems.
 
 Use the following command to use SPM:
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-spm.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-spm.rst
@@ -46,7 +46,7 @@ The output lists if ``rocprofv3`` supports SPM
 The preceding output shows that the TCC_MISS counter can be sampled.
 
 .. note::
-   SPM requires AMD GPU Driver version **6.19.14.31400000** or newer to work correctly.
+   For proper functioning, SPM requires AMD GPU Driver version **6.19.14.31400000** or later.
    Verify the loaded ``amdgpu`` kernel module version before using SPM.
 
 To check the driver version, use:

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-spm.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-spm.rst
@@ -47,7 +47,7 @@ The preceding output shows that the TCC_MISS counter can be sampled.
 
 .. note::
    For proper functioning, SPM requires AMD GPU Driver version **6.19.14.31400000** or later.
-   Verify the loaded ``amdgpu`` kernel module version before using SPM.
+   Before using SPM, verify the loaded ``amdgpu`` kernel module version.
 
 To check the driver version, use:
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-spm.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-spm.rst
@@ -46,7 +46,7 @@ The output lists if ``rocprofv3`` supports SPM
 The preceding output shows that the TCC_MISS counter can be sampled.
 
 .. note::
-   SPM requires AMD GPU Driver version **6.19.0.3140xxxx** or newer to work correctly.
+   SPM requires AMD GPU Driver version **6.19.14.31400000** or newer to work correctly.
    Verify the loaded ``amdgpu`` kernel module version before using SPM.
 
 To check the driver version, use:
@@ -56,7 +56,7 @@ To check the driver version, use:
   cat /sys/module/amdgpu/version
 
   # Example output:
-  # 6.19.0.31300009
+  # 6.19.14.31400000
 
 The value is also reported by ``amd-smi version`` on DKMS-built systems.
 

--- a/projects/rocprofiler-sdk/source/docs/how-to/using-spm.rst
+++ b/projects/rocprofiler-sdk/source/docs/how-to/using-spm.rst
@@ -43,7 +43,22 @@ The output lists if ``rocprofv3`` supports SPM
       SPM                 :   Supported
       Dimensions          :   DIMENSION_INSTANCE[0:15] DIMENSION_XCC[0:7]
 
-The preceding output shows that the TCC_MISS counter can be sampled. 
+The preceding output shows that the TCC_MISS counter can be sampled.
+
+.. note::
+   SPM requires AMD GPU Driver version **6.19.0.3140xxxx** or newer to work correctly.
+   Verify the loaded ``amdgpu`` kernel module version before using SPM.
+
+To check the driver version, use:
+
+.. code-block:: bash
+
+  cat /sys/module/amdgpu/version
+
+  # Example output:
+  # 6.19.0.31300009
+
+The value is also reported by ``amd-smi version`` on DKMS-built systems.
 
 Use the following command to use SPM:
 


### PR DESCRIPTION
## Motivation

This PR documents the minimum required amdgpu driver version for SPM in using-spm.rst. It adds a note in the SPM availability section that states the required driver version and how to verify it with cat /sys/module/amdgpu/version, with an example output and a reference to amd-smi version on DKMS-built systems. This gives users a clear prerequisite before enabling SPM with rocprofv3.

## Technical Details

Updated projects/rocprofiler-sdk/source/docs/how-to/using-spm.rst in the 
SPM availability and configuration section:

- Added a .. note:: stating that SPM requires AMD GPU Driver version 6.19.14.31400000 or newer.
- Added instructions to check the loaded driver version with:
cat /sys/module/amdgpu/version

- Included example output (6.19.14.31400000) from a DKMS-built system.
- Noted that the same value is reported by amd-smi version on DKMS-built systems.
- No code or API changes; documentation only.

## JIRA ID
ROCM-21674

## Test Plan

No testing needed, this is a documentation PR
