### PR TITLE
dbgapi: flags refactor/cleanups

### DIFF
--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -1365,11 +1365,8 @@ amdgcn_architecture_t::set_exceptions (wave_t &wave, exception_mask_t mask,
 
   uint32_t trapsts;
   wave.read_register (amdgpu_regnum_t::trapsts, &trapsts);
-  while (mask != 0)
+  utils::for_each_flag (mask, [&] (exception_mask_t single_exception)
     {
-      /* Get the lowest bit that is set.  */
-      auto single_exception = mask ^ (mask & (mask - 1));
-
       /* For each exception, set or clear the corresponding bit in TRAPSTS.  */
       auto trapsts_bit = convert_exception (single_exception);
       if (trapsts_bit != 0)
@@ -1381,9 +1378,7 @@ amdgcn_architecture_t::set_exceptions (wave_t &wave, exception_mask_t mask,
         }
       else
         unhandled_exceptions |= single_exception;
-
-      mask ^= single_exception;
-    }
+    });
   wave.write_register (amdgpu_regnum_t::trapsts, trapsts);
 
   return unhandled_exceptions;
@@ -3940,11 +3935,8 @@ gfx9_4_architecture_t::set_exceptions (wave_t &wave, exception_mask_t mask,
 
   uint32_t trapsts;
   wave.read_register (amdgpu_regnum_t::trapsts, &trapsts);
-  while (mask != 0)
+  utils::for_each_flag (mask, [&] (exception_mask_t single_exception)
     {
-      /* Get the lowest bit that is set.  */
-      auto single_exception = mask ^ (mask & (mask - 1));
-
       /* For each exception, set or clear the corresponding bit in TRAPSTS.  */
       auto trapsts_bit = convert_exception (single_exception);
       if (trapsts_bit != 0)
@@ -3956,9 +3948,7 @@ gfx9_4_architecture_t::set_exceptions (wave_t &wave, exception_mask_t mask,
         }
       else
         unhandled_exceptions |= single_exception;
-
-      mask ^= single_exception;
-    }
+    });
   wave.write_register (amdgpu_regnum_t::trapsts, trapsts);
 
   return unhandled_exceptions;
@@ -5639,11 +5629,8 @@ gfx11_architecture_t::set_exceptions (wave_t &wave, exception_mask_t mask,
 
   uint32_t trapsts;
   wave.read_register (amdgpu_regnum_t::trapsts, &trapsts);
-  while (mask != 0)
+  utils::for_each_flag (mask, [&] (exception_mask_t single_exception)
     {
-      /* Get the lowest bit that is set.  */
-      auto single_exception = mask ^ (mask & (mask - 1));
-
       /* For each exception, set or clear the corresponding bit in TRAPSTS.  */
       auto trapsts_bit = convert_exception (single_exception);
       if (trapsts_bit != 0)
@@ -5655,9 +5642,7 @@ gfx11_architecture_t::set_exceptions (wave_t &wave, exception_mask_t mask,
         }
       else
         unhandled_exceptions |= single_exception;
-
-      mask ^= single_exception;
-    }
+    });
   wave.write_register (amdgpu_regnum_t::trapsts, trapsts);
 
   return unhandled_exceptions;
@@ -6597,11 +6582,8 @@ gfx12_architecture_t::set_exceptions (wave_t &wave, exception_mask_t mask,
   uint32_t excp_flag_priv_reg, excp_flag_user_reg;
   wave.read_register (amdgpu_regnum_t::excp_flag_priv, &excp_flag_priv_reg);
   wave.read_register (amdgpu_regnum_t::excp_flag_user, &excp_flag_user_reg);
-  while (mask != 0)
+  utils::for_each_flag (mask, [&] (exception_mask_t single_exception)
     {
-      /* Get the lowest bit that is set.  */
-      auto single_exception = mask ^ (mask & (mask - 1));
-
       /* For each exception, set or clear the corresponding bit.  */
       auto excp_flag_priv_bit = convert_priv_exception (single_exception);
       auto excp_flag_user_bit = convert_user_exception (single_exception);
@@ -6623,9 +6605,7 @@ gfx12_architecture_t::set_exceptions (wave_t &wave, exception_mask_t mask,
         }
       else
         unhandled_exceptions |= single_exception;
-
-      mask ^= single_exception;
-    }
+    });
   wave.write_register (amdgpu_regnum_t::excp_flag_priv, excp_flag_priv_reg);
   wave.write_register (amdgpu_regnum_t::excp_flag_user, excp_flag_user_reg);
 

--- a/projects/rocdbgapi/src/logging.cpp
+++ b/projects/rocdbgapi/src/logging.cpp
@@ -452,25 +452,8 @@ template <>
 std::string
 to_string (amd_dbgapi_instruction_properties_t instruction_properties)
 {
-  std::string str;
-
-  if (!instruction_properties)
-    return one_instruction_property_to_string (instruction_properties);
-
-  while (instruction_properties)
-    {
-      amd_dbgapi_instruction_properties_t one_bit
-        = instruction_properties
-          ^ (instruction_properties & (instruction_properties - 1));
-
-      if (!str.empty ())
-        str += " | ";
-      str += one_instruction_property_to_string (one_bit);
-
-      instruction_properties ^= one_bit;
-    }
-
-  return str;
+  return utils::flags_to_string (instruction_properties,
+                                 one_instruction_property_to_string);
 }
 
 namespace
@@ -496,25 +479,8 @@ template <>
 std::string
 to_string (amd_dbgapi_register_properties_t register_properties)
 {
-  std::string str;
-
-  if (!register_properties)
-    return one_register_property_to_string (register_properties);
-
-  while (register_properties)
-    {
-      amd_dbgapi_register_properties_t one_bit
-        = register_properties
-          ^ (register_properties & (register_properties - 1));
-
-      if (!str.empty ())
-        str += " | ";
-      str += one_register_property_to_string (one_bit);
-
-      register_properties ^= one_bit;
-    }
-
-  return str;
+  return utils::flags_to_string (register_properties,
+                                 one_register_property_to_string);
 }
 
 template <>
@@ -985,24 +951,8 @@ template <>
 std::string
 to_string (amd_dbgapi_exceptions_t queue_error_reason)
 {
-  std::string str;
-
-  if (!queue_error_reason)
-    return one_queue_error_reason_to_string (queue_error_reason);
-
-  while (queue_error_reason)
-    {
-      amd_dbgapi_exceptions_t one_bit
-        = queue_error_reason ^ (queue_error_reason & (queue_error_reason - 1));
-
-      if (!str.empty ())
-        str += " | ";
-      str += one_queue_error_reason_to_string (one_bit);
-
-      queue_error_reason ^= one_bit;
-    }
-
-  return str;
+  return utils::flags_to_string (queue_error_reason,
+                                 one_queue_error_reason_to_string);
 }
 
 template <>
@@ -1240,24 +1190,7 @@ template <>
 std::string
 to_string (amd_dbgapi_wave_stop_reasons_t stop_reason)
 {
-  std::string str;
-
-  if (!stop_reason)
-    return one_stop_reason_to_string (stop_reason);
-
-  while (stop_reason)
-    {
-      amd_dbgapi_wave_stop_reasons_t one_bit
-        = stop_reason ^ (stop_reason & (stop_reason - 1));
-
-      if (!str.empty ())
-        str += " | ";
-      str += one_stop_reason_to_string (one_bit);
-
-      stop_reason ^= one_bit;
-    }
-
-  return str;
+  return utils::flags_to_string (stop_reason, one_stop_reason_to_string);
 }
 
 template <>
@@ -1689,23 +1622,7 @@ template <>
 std::string
 to_string (os_wave_launch_trap_mask_t value)
 {
-  std::string str;
-
-  if (!value)
-    return one_launch_trap_mask_to_string (value);
-
-  while (value != os_wave_launch_trap_mask_t::none)
-    {
-      os_wave_launch_trap_mask_t one_bit = value ^ (value & (value - 1));
-
-      if (!str.empty ())
-        str += " | ";
-      str += one_launch_trap_mask_to_string (one_bit);
-
-      value ^= one_bit;
-    }
-
-  return str;
+  return utils::flags_to_string (value, one_launch_trap_mask_to_string);
 }
 
 template <>

--- a/projects/rocdbgapi/src/os_driver.cpp
+++ b/projects/rocdbgapi/src/os_driver.cpp
@@ -137,24 +137,7 @@ template <>
 std::string
 to_string (os_exception_mask_t exception_mask)
 {
-  std::string str;
-
-  if (exception_mask == os_exception_mask_t::none)
-    return one_os_exception_to_string (exception_mask);
-
-  while (exception_mask != os_exception_mask_t::none)
-    {
-      os_exception_mask_t one_bit
-        = exception_mask ^ (exception_mask & (exception_mask - 1));
-
-      if (!str.empty ())
-        str += " | ";
-      str += one_os_exception_to_string (one_bit);
-
-      exception_mask ^= one_bit;
-    }
-
-  return str;
+  return utils::flags_to_string (exception_mask, one_os_exception_to_string);
 }
 
 template <>
@@ -279,24 +262,7 @@ template <>
 std::string
 to_string (os_queue_state_t queue_state)
 {
-  std::string str;
-
-  if (!queue_state)
-    return one_queue_state_t_to_string (queue_state);
-
-  while (!!queue_state)
-    {
-      os_queue_state_t one_flag
-        = queue_state ^ (queue_state & (queue_state - 1));
-
-      if (!str.empty ())
-        str += " | ";
-      str += one_queue_state_t_to_string (one_flag);
-
-      queue_state ^= one_flag;
-    }
-
-  return str;
+  return utils::flags_to_string (queue_state, one_queue_state_t_to_string);
 }
 
 template <>
@@ -355,23 +321,7 @@ template <>
 std::string
 to_string (os_process_flags_t flags)
 {
-  std::string str;
-
-  if (!flags)
-    return one_os_process_flag_to_string (flags);
-
-  while (!!flags)
-    {
-      os_process_flags_t one_flag = flags ^ (flags & (flags - 1));
-
-      if (!str.empty ())
-        str += " | ";
-      str += one_os_process_flag_to_string (one_flag);
-
-      flags ^= one_flag;
-    }
-
-  return str;
+  return utils::flags_to_string (flags, one_os_process_flag_to_string);
 }
 
 template <>

--- a/projects/rocdbgapi/src/os_driver_kfd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kfd.cpp
@@ -234,13 +234,8 @@ kfd_to_os_exception_mask (__u64 kfd_mask)
 {
   os_exception_mask_t mask{};
 
-  if (kfd_mask == 0)
-    return mask;
-
-  while (kfd_mask != 0)
+  utils::for_each_flag (kfd_mask, [&] (__u64 one_bit)
     {
-      __u64 one_bit = kfd_mask ^ (kfd_mask & (kfd_mask - 1));
-
       auto code = os_exception_code (
         excp_mask_to_excp_code<kfd_dbg_trap_exception_code> (one_bit));
 
@@ -249,9 +244,7 @@ kfd_to_os_exception_mask (__u64 kfd_mask)
       else
         warning ("Unknown KFD exception code %" PRIx64,
                  static_cast<uint64_t> (one_bit));
-
-      kfd_mask ^= one_bit;
-    }
+    });
 
   return mask;
 }
@@ -262,18 +255,13 @@ static constexpr __u64
 kfd_exception_mask (os_exception_mask_t mask)
 {
   __u64 kfd_mask = 0;
-  if (mask == os_exception_mask_t::none)
-    return kfd_mask;
 
-  while (mask != os_exception_mask_t::none)
+  utils::for_each_flag (mask, [&] (os_exception_mask_t one_bit)
     {
-      os_exception_mask_t one_bit = mask ^ (mask & (mask - 1));
-
       kfd_mask |= KFD_EC_MASK (kfd_exception_code (
         excp_mask_to_excp_code<os_exception_code_t, os_exception_mask_t> (
           one_bit)));
-      mask ^= one_bit;
-    }
+    });
 
   return kfd_mask;
 }
@@ -350,14 +338,11 @@ kfd_wave_launch_trap_mask (os_wave_launch_trap_mask_t wave_launch_trap)
     dbgapi_assert_not_reached ();
   };
 
-  while (wave_launch_trap != os_wave_launch_trap_mask_t::none)
+  utils::for_each_flag (wave_launch_trap,
+                        [&] (os_wave_launch_trap_mask_t one_bit)
     {
-      os_wave_launch_trap_mask_t one_bit
-        = wave_launch_trap ^ (wave_launch_trap & (wave_launch_trap - 1));
-
       kfd_wave_launch_trap |= convert_one (one_bit);
-      wave_launch_trap ^= one_bit;
-    }
+    });
 
   return kfd_wave_launch_trap;
 }

--- a/projects/rocdbgapi/src/os_driver_kmd.cpp
+++ b/projects/rocdbgapi/src/os_driver_kmd.cpp
@@ -307,13 +307,8 @@ os_exception_mask (ULONG64 kmd_mask)
 {
   os_exception_mask_t mask{};
 
-  if (kmd_mask == 0)
-    return mask;
-
-  while (kmd_mask != 0)
+  utils::for_each_flag (kmd_mask, [&] (ULONG64 one_bit)
     {
-      ULONG64 one_bit = kmd_mask ^ (kmd_mask & (kmd_mask - 1));
-
       auto code = os_exception_code (
         excp_mask_to_excp_code<KMD_DBGR_EXCEPTIONS> (one_bit));
 
@@ -322,9 +317,7 @@ os_exception_mask (ULONG64 kmd_mask)
       else
         warning ("Unknown KMD exception code %" PRIx64,
                  static_cast<uint64_t> (one_bit));
-
-      kmd_mask ^= one_bit;
-    }
+    });
 
   return mask;
 }
@@ -336,20 +329,11 @@ kmd_exception_mask (os_exception_mask_t mask)
 {
   ULONG64 kmd_mask = 0;
 
-  if (mask == os_exception_mask_t::none)
-    return kmd_mask;
-
-  while (mask != os_exception_mask_t::none)
+  utils::for_each_flag (mask, [&] (os_exception_mask_t one_bit)
     {
-      os_exception_mask_t one_bit = mask ^ (mask & (mask - 1));
-
       kmd_mask |= kmd_code_to_mask (
         kmd_exception (excp_mask_to_excp_code<os_exception_code_t> (one_bit)));
-
-      mask ^= one_bit;
-    }
-
-  dbgapi_assert (mask == 0);
+    });
 
   return kmd_mask;
 }

--- a/projects/rocdbgapi/src/utils.h
+++ b/projects/rocdbgapi/src/utils.h
@@ -1103,6 +1103,43 @@ operator+= (T &lhs, int rhs)
   return lhs = lhs + rhs;
 }
 
+namespace utils
+{
+
+/* Build the "A | B | C" string representation of the flag set FLAGS,
+   converting each individual bit to string with ONE_FLAG_TO_STRING.
+   When FLAGS has no bit set, ONE_FLAG_TO_STRING is called once with
+   the zero value so that its "none" case is rendered.  */
+
+template <typename T, typename OneFlagToString>
+std::string
+flags_to_string (T flags, OneFlagToString one_flag_to_string)
+{
+  static_assert (is_flag_v<T>,
+                 "flags_to_string requires an is_flag-enabled type");
+
+  if (!flags)
+    return one_flag_to_string (flags);
+
+  std::string str;
+  /* The is_flag types provide operator! but no conversion to bool,
+     so test for "any bit set" with !!.  */
+  while (!!flags)
+    {
+      T one_flag = flags ^ (flags & (flags - 1));
+
+      if (!str.empty ())
+        str += " | ";
+      str += one_flag_to_string (one_flag);
+
+      flags ^= one_flag;
+    }
+
+  return str;
+}
+
+} /* namespace utils */
+
 /* Enable bitwise operations for amd_dbgapi_exceptions_t.  */
 template <> struct is_flag<amd_dbgapi_exceptions_t> : std::true_type
 {

--- a/projects/rocdbgapi/src/utils.h
+++ b/projects/rocdbgapi/src/utils.h
@@ -1106,6 +1106,25 @@ operator+= (T &lhs, int rhs)
 namespace utils
 {
 
+/* Call FUNC once for each bit (i.e., flag) set in FLAGS, lowest bit
+   first, passing it a value of type T with that single bit set.  T
+   may be an is_flag-enabled enum or a plain unsigned integer.  Does
+   nothing when FLAGS has no bit set.  */
+
+template <typename T, typename Func>
+constexpr void
+for_each_flag (T flags, Func func)
+{
+  /* The is_flag types provide operator! but no conversion to bool, so
+     test for "any bit set" with !!.  */
+  while (!!flags)
+    {
+      T one_flag = flags ^ (flags & (flags - 1));
+      func (one_flag);
+      flags ^= one_flag;
+    }
+}
+
 /* Build the "A | B | C" string representation of the flag set FLAGS,
    converting each individual bit to string with ONE_FLAG_TO_STRING.
    When FLAGS has no bit set, ONE_FLAG_TO_STRING is called once with
@@ -1122,18 +1141,12 @@ flags_to_string (T flags, OneFlagToString one_flag_to_string)
     return one_flag_to_string (flags);
 
   std::string str;
-  /* The is_flag types provide operator! but no conversion to bool,
-     so test for "any bit set" with !!.  */
-  while (!!flags)
+  for_each_flag (flags, [&] (T one_flag)
     {
-      T one_flag = flags ^ (flags & (flags - 1));
-
       if (!str.empty ())
         str += " | ";
       str += one_flag_to_string (one_flag);
-
-      flags ^= one_flag;
-    }
+    });
 
   return str;
 }

--- a/projects/rocdbgapi/src/wave.cpp
+++ b/projects/rocdbgapi/src/wave.cpp
@@ -588,12 +588,11 @@ wave_t::set_state (amd_dbgapi_wave_state_t state,
       /* Convert an amd_dbgapi_exception_t into an os_exception_mask_t.  */
       os_exception_mask_t os_exceptions = os_exception_mask_t::none;
 
-      while (exceptions)
+      utils::for_each_flag (exceptions,
+                            [&] (amd_dbgapi_exceptions_t one_exception)
         {
-          auto one_exception = exceptions ^ (exceptions & (exceptions - 1));
           os_exceptions |= convert_one_exception (one_exception);
-          exceptions ^= one_exception;
-        }
+        });
 
       /* A wave should only send queue exceptions, sometimes combined with a
          device_memory_exception.  */


### PR DESCRIPTION
## Motivation

This series removes the duplicated "walk the set bits of a flag value,
one at a time" loops scattered across the library, replacing them with
two small helpers in utils.h.  There is no functional change -- this is
cleanup only, the output and behavior are identical.

## Technical Details

See individual commits.

## Test Plan

Run ROCgdb gdb.rocm/ tests on gfx1030.

## Test Result

Pass.
