### PR TITLE
refactor(rocr): Have DmaBufClose take int* and invalidate the fd after close

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -573,7 +573,7 @@ hsa_status_t KfdDriver::ImportMemoryHandle(const core::Agent& agent, core::Drive
     if (status != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
 
     handle->handle = reinterpret_cast<uint64_t>(res.buf_handle);
-    rocr::os::DmaBufClose(res.dmabuf_fd);
+    rocr::os::DmaBufClose(&res.dmabuf_fd);
     handle->size = res.alloc_size;
     return HSA_STATUS_SUCCESS;
   }
@@ -637,7 +637,7 @@ hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
   hsa_status_t ret = ImportMemoryHandle(agent, &targetHandle, core::ShareType::DMABUF_FD,
                                         &source_handle, mem);
 #if defined(__linux__)
-  rocr::os::DmaBufClose(source_fd);
+  rocr::os::DmaBufClose(&source_fd);
 #endif
   if (ret != HSA_STATUS_SUCCESS)
     return ret;
@@ -672,11 +672,7 @@ hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
 }
 
 hsa_status_t KfdDriver::DestroyMemoryHandle(core::DriverMemoryHandle* handle) {
-  if (handle->dmabuf_fd >= 0) {
-    hsa_status_t status = rocr::os::DmaBufClose(handle->dmabuf_fd);
-    handle->dmabuf_fd = -1;
-    if (status != HSA_STATUS_SUCCESS) return status;
-  }
+  rocr::os::DmaBufClose(&handle->dmabuf_fd);
 
   auto memhandle = reinterpret_cast<HsaMemoryObjectHandle>(handle->handle);
   if (memhandle != nullptr) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -573,7 +573,7 @@ hsa_status_t KfdDriver::ImportMemoryHandle(const core::Agent& agent, core::Drive
     if (status != HSAKMT_STATUS_SUCCESS) return HSA_STATUS_ERROR;
 
     handle->handle = reinterpret_cast<uint64_t>(res.buf_handle);
-    rocr::os::DmaBufClose(&res.dmabuf_fd);
+    if (rocr::os::DmaBufClose(&res.dmabuf_fd) != HSA_STATUS_SUCCESS) return HSA_STATUS_ERROR;
     handle->size = res.alloc_size;
     return HSA_STATUS_SUCCESS;
   }
@@ -672,7 +672,7 @@ hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
 }
 
 hsa_status_t KfdDriver::DestroyMemoryHandle(core::DriverMemoryHandle* handle) {
-  rocr::os::DmaBufClose(&handle->dmabuf_fd);
+  hsa_status_t ret = rocr::os::DmaBufClose(&handle->dmabuf_fd);
 
   auto memhandle = reinterpret_cast<HsaMemoryObjectHandle>(handle->handle);
   if (memhandle != nullptr) {
@@ -682,7 +682,7 @@ hsa_status_t KfdDriver::DestroyMemoryHandle(core::DriverMemoryHandle* handle) {
     }
   }
   *handle = {};
-  return HSA_STATUS_SUCCESS;
+  return ret;
 }
 
 hsa_status_t KfdDriver::SPMAcquire(uint32_t preferred_node_id) const {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -1844,6 +1844,7 @@ hsa_status_t hsa_amd_portable_export_dmabuf_v2(const void* ptr, size_t size,
 }
 
 hsa_status_t hsa_amd_portable_close_dmabuf(int dmabuf) {
+  /* dmabuf is passed by value; caller's copy is not zeroed — ABI constraint */
   TRY;
   return rocr::os::DmaBufClose(&dmabuf);
   CATCH;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_ext_amd.cpp
@@ -1845,7 +1845,7 @@ hsa_status_t hsa_amd_portable_export_dmabuf_v2(const void* ptr, size_t size,
 
 hsa_status_t hsa_amd_portable_close_dmabuf(int dmabuf) {
   TRY;
-  return rocr::os::DmaBufClose(dmabuf);
+  return rocr::os::DmaBufClose(&dmabuf);
   CATCH;
 }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -1351,7 +1351,7 @@ void Runtime::AsyncIPCSockServerConnLoop(void*) {
       uint64_t fragOffset;
       void *ptr = NULL;
       size_t len = 0;
-      MAKE_SCOPE_GUARD([&]() { os::DmaBufClose(dmabuf_fd); })
+      MAKE_SCOPE_GUARD([&]() { os::DmaBufClose(&dmabuf_fd); })
       std::lock_guard<std::mutex> lock(ipc_sock_server_lock_);
       for (auto& conns : ipc_sock_server_conns_) {
         if (conn_handle == conns.first) {
@@ -1470,7 +1470,7 @@ hsa_status_t Runtime::IPCCreate(void* ptr, size_t len, hsa_amd_ipc_memory_t* han
     HsaHandleImportResult res = {};
     HSAKMT_STATUS status = HSAKMT_CALL(hsaKmtHandleImport(&desc, &res, &hflags));
     if (status != HSAKMT_STATUS_SUCCESS) {
-      os::DmaBufClose(dmabuf_fd);
+      os::DmaBufClose(&dmabuf_fd);
       return HSA_STATUS_ERROR;
     }
     // Reuse token already stored on the BO
@@ -1481,7 +1481,7 @@ hsa_status_t Runtime::IPCCreate(void* ptr, size_t len, hsa_amd_ipc_memory_t* han
     HSAKMT_CALL(hsaKmtMemHandleFreePreserveMetadata(res.buf_handle));
   }
 
-  os::DmaBufClose(dmabuf_fd);
+  os::DmaBufClose(&dmabuf_fd);
 
   std::unique_lock<std::mutex> lock(ipc_sock_server_lock_);
 
@@ -1572,7 +1572,7 @@ int Runtime::IPCClientImport(uint32_t conn_handle, uint64_t dmabuf_fd_handle,
 
     if (dmabuf_fd_handle == IPC_SOCK_SERVER_CONN_CLOSE_HANDLE) return 0;
 
-    intptr_t dmabuf_fd = os::IPCRecvHandle(socket_fd);
+    int dmabuf_fd = static_cast<int>(os::IPCRecvHandle(socket_fd));
     if (dmabuf_fd == -1) return -1;
 
     HsaGraphicsResourceInfo info;
@@ -1603,7 +1603,7 @@ int Runtime::IPCClientImport(uint32_t conn_handle, uint64_t dmabuf_fd_handle,
       if (status != HSAKMT_STATUS_SUCCESS) {
         fprintf(stderr, "IPC Client Import: Invalid IPC handle! expected %u, got %u\n",
                 shared_handle, res.metadata);
-        os::DmaBufClose(static_cast<int>(dmabuf_fd));
+        os::DmaBufClose(&dmabuf_fd);
         return -1;
       }
 
@@ -1624,7 +1624,7 @@ int Runtime::IPCClientImport(uint32_t conn_handle, uint64_t dmabuf_fd_handle,
       } else {
         HSAKMT_CALL(hsaKmtMemHandleFreePreserveMetadata(res.buf_handle));
       }
-      os::DmaBufClose(static_cast<int>(dmabuf_fd));
+      os::DmaBufClose(&dmabuf_fd);
     }
 
     // Ping socket server to close exporter
@@ -4215,10 +4215,9 @@ Runtime::MemoryHandle::~MemoryHandle() {
     destroy_agent->driver().DestroyMemoryHandle(&driver_handle);
   }
 
-  if (driver_handle.dmabuf_fd >= 0) {
-    os::DmaBufClose(driver_handle.dmabuf_fd);
-    driver_handle.dmabuf_fd = -1;
-  }
+  /* FIXME: the Driver class should close the dmabuf_fd, but in case of imported handles,
+   * we do not have a region so we do not have an agentOwner() to call the driver.*/
+  os::DmaBufClose(&driver_handle.dmabuf_fd);
 }
 
 // Note: VMemorySetAccessPerHandle should be called with &memory_lock_ held
@@ -4249,8 +4248,7 @@ Runtime::VMemorySetAccessPerHandle(void *va, MappedHandle &mappedHandle,
 
   MAKE_SCOPE_GUARD([&]() {
     if (created_dmabuf_fd) {
-      os::DmaBufClose(memHandle->driver_handle.dmabuf_fd);
-      memHandle->driver_handle.dmabuf_fd = -1;
+      os::DmaBufClose(&memHandle->driver_handle.dmabuf_fd);
     }
   });
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -1574,6 +1574,7 @@ int Runtime::IPCClientImport(uint32_t conn_handle, uint64_t dmabuf_fd_handle,
 
     int dmabuf_fd = static_cast<int>(os::IPCRecvHandle(socket_fd));
     if (dmabuf_fd == -1) return -1;
+    MAKE_SCOPE_GUARD([&]() { os::DmaBufClose(&dmabuf_fd); });
 
     HsaGraphicsResourceInfo info;
     HSA_REGISTER_MEM_FLAGS regFlags{0};
@@ -1603,7 +1604,6 @@ int Runtime::IPCClientImport(uint32_t conn_handle, uint64_t dmabuf_fd_handle,
       if (status != HSAKMT_STATUS_SUCCESS) {
         fprintf(stderr, "IPC Client Import: Invalid IPC handle! expected %u, got %u\n",
                 shared_handle, res.metadata);
-        os::DmaBufClose(&dmabuf_fd);
         return -1;
       }
 
@@ -1624,7 +1624,6 @@ int Runtime::IPCClientImport(uint32_t conn_handle, uint64_t dmabuf_fd_handle,
       } else {
         HSAKMT_CALL(hsaKmtMemHandleFreePreserveMetadata(res.buf_handle));
       }
-      os::DmaBufClose(&dmabuf_fd);
     }
 
     // Ping socket server to close exporter
@@ -4213,11 +4212,11 @@ Runtime::MemoryHandle::~MemoryHandle() {
     dispatched through drm_owner */
     core::Agent* destroy_agent = drmAgent();
     destroy_agent->driver().DestroyMemoryHandle(&driver_handle);
+  } else {
+    /* FIXME: the Driver class should close the dmabuf_fd, but in case of imported handles,
+    * we do not have a region so we do not have an agentOwner() to call the driver.*/
+    os::DmaBufClose(&driver_handle.dmabuf_fd);
   }
-
-  /* FIXME: the Driver class should close the dmabuf_fd, but in case of imported handles,
-   * we do not have a region so we do not have an agentOwner() to call the driver.*/
-  os::DmaBufClose(&driver_handle.dmabuf_fd);
 }
 
 // Note: VMemorySetAccessPerHandle should be called with &memory_lock_ held

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -883,10 +883,14 @@ bool MapMemory(void* va, size_t size, MemProt perms, int fd, uint64_t cpu_addr) 
 hsa_status_t DmaBufClose(int* dmabuf) {
   if (dmabuf == nullptr) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   if (*dmabuf < 0) return HSA_STATUS_SUCCESS;
-  hsa_status_t status =
-      ::close(*dmabuf) == 0 ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR_RESOURCE_FREE;
+  if (::close(*dmabuf) != 0) {
+    LogPrint(HSA_AMD_LOG_FLAG_ERROR, "close dmabuf failed: %s", strerror(errno));
+    *dmabuf = -1;
+    return HSA_STATUS_ERROR_RESOURCE_FREE;
+  }
+  /* Set to -1 even on close failure: the fd is no longer valid regardless of errno. */
   *dmabuf = -1;
-  return status;
+  return HSA_STATUS_SUCCESS;
 }
 
 void* ReserveMemory(void* start, size_t size, size_t alignment, MemProt prot) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -880,9 +880,13 @@ bool MapMemory(void* va, size_t size, MemProt perms, int fd, uint64_t cpu_addr) 
   return true;
 }
 
-hsa_status_t DmaBufClose(int dmabuf) {
-  if (dmabuf < 0) return HSA_STATUS_SUCCESS;
-  return ::close(dmabuf) == 0 ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR_RESOURCE_FREE;
+hsa_status_t DmaBufClose(int* dmabuf) {
+  if (dmabuf == nullptr) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  if (*dmabuf < 0) return HSA_STATUS_SUCCESS;
+  hsa_status_t status =
+      ::close(*dmabuf) == 0 ? HSA_STATUS_SUCCESS : HSA_STATUS_ERROR_RESOURCE_FREE;
+  *dmabuf = -1;
+  return status;
 }
 
 void* ReserveMemory(void* start, size_t size, size_t alignment, MemProt prot) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/lnx/os_linux.cpp
@@ -884,7 +884,7 @@ hsa_status_t DmaBufClose(int* dmabuf) {
   if (dmabuf == nullptr) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
   if (*dmabuf < 0) return HSA_STATUS_SUCCESS;
   if (::close(*dmabuf) != 0) {
-    LogPrint(HSA_AMD_LOG_FLAG_ERROR, "close dmabuf failed: %s", strerror(errno));
+    LogPrint(HSA_AMD_LOG_FLAG_INFO, "close dmabuf failed: %s", strerror(errno));
     *dmabuf = -1;
     return HSA_STATUS_ERROR_RESOURCE_FREE;
   }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/os.h
@@ -361,8 +361,8 @@ bool UncommitMemory(void* addr, size_t size);
 bool UnmapMemory(void* addr, size_t size);
 bool MapMemory(void* addr, size_t size, MemProt prot, int fd, uint64_t cpu_addr);
 
-/// Close a dmabuf file descriptor.
-hsa_status_t DmaBufClose(int dmabuf);
+/// Close a dmabuf file descriptor and set *dmabuf to -1.
+hsa_status_t DmaBufClose(int* dmabuf);
 
 bool ProtectMemory(void* va, size_t size, MemProt perms);
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/win/os_win.cpp
@@ -481,8 +481,8 @@ bool MapMemory(void* addr, size_t size, MemProt perms, int fd [[maybe_unused]],
   return VirtualProtect(addr, size, memProtToOsProt(perms), &OldProtect) != 0;
 }
 
-hsa_status_t DmaBufClose(int dmabuf) {
-  (void)dmabuf;
+hsa_status_t DmaBufClose(int* dmabuf) {
+  if (dmabuf) *dmabuf = -1;
   return HSA_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
## Summary

- Change `os::DmaBufClose` to accept `int*`, close the fd when valid, and set `*dmabuf` to `-1` so callers cannot reuse a stale handle.
- Update all call sites and simplify `DestroyMemoryHandle` accordingly.

Stacks on #7786 (`users/dayatsin/close-dmabuf-handles`).

## JIRA ID

JIRA ID : ROCM-26177

## Test plan

- [ ] Build `libhsa-runtime64` on Linux
- [ ] Re-run VMM shareable-handle / IPC tests from #7786 to confirm no regressions