### PR TITLE
[rocprofiler-compute] Update strix halo runner labels

### DIFF
--- a/projects/rocprofiler-compute/.github/ci-matrix.yml
+++ b/projects/rocprofiler-compute/.github/ci-matrix.yml
@@ -11,10 +11,10 @@ matrix-ubuntu-nightly:
   - { os-release: '22.04', gpu: 'mi200', arch: 'gfx90a', runner: 'linux-gfx90a-gpu-rocm' }
   - { os-release: '24.04', gpu: 'mi200', arch: 'gfx90a', runner: 'linux-gfx90a-gpu-rocm' }
   # Strix Halo
-  - { os-release: '22.04', gpu: 'strix-halo', arch: 'gfx1151', runner: 'linux-strix-halo-gpu-rocm' }
-  - { os-release: '24.04', gpu: 'strix-halo', arch: 'gfx1151', runner: 'linux-strix-halo-gpu-rocm' }
+  - { os-release: '22.04', gpu: 'strix-halo', arch: 'gfx1151', runner: 'linux-gfx1151-gpu-rocm' }
+  - { os-release: '24.04', gpu: 'strix-halo', arch: 'gfx1151', runner: 'linux-gfx1151-gpu-rocm' }
 matrix-ubuntu-ci:
   # MI355
   - { os-release: '24.04', gpu: 'mi355', arch: 'gfx950', runner: 'linux-mi355-1gpu-ossci-rocm' }
   # Strix Halo
-  - { os-release: '24.04', gpu: 'strix-halo', arch: 'gfx1151', runner: 'linux-strix-halo-gpu-rocm' }
+  - { os-release: '24.04', gpu: 'strix-halo', arch: 'gfx1151', runner: 'linux-gfx1151-gpu-rocm' }


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The strix halo runners referenced were having issues and failing, moving to new gfx1151 runners that are more stable.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
- Update `ci-matrix.yml` to replace `linux-strix-halo-gpu-rocm` labels with `linux-gfx1151-gpu-rocm`

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->
Ensure gfx1151 workflows pass

## Test Result

<!-- Briefly summarize test outcomes. -->
gfx1151 workflows pass

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
