### PR TITLE
chore(profilers): Update GitHub Actions workflows to use actions/cache@v6 for caching

### DIFF
--- a/.github/workflows/profiler-hub-sanitizers.yml
+++ b/.github/workflows/profiler-hub-sanitizers.yml
@@ -73,7 +73,7 @@ jobs:
           sudo apt-get install -y libgtest-dev libgmock-dev libbenchmark-dev
 
       - name: Cache ccache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ccache
           key: ccache-${{ matrix.sanitizer.name }}-${{ github.sha }}

--- a/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
+++ b/.github/workflows/rocprof-trace-decoder-continuous_integration.yml
@@ -170,7 +170,7 @@ jobs:
           { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
       - name: Restore submodule cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ${{ steps.submods.outputs.paths }}

--- a/.github/workflows/rocprofiler-sdk-code_coverage.yml
+++ b/.github/workflows/rocprofiler-sdk-code_coverage.yml
@@ -131,7 +131,7 @@ jobs:
         { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
     - name: Restore submodule cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: |
           ${{ steps.submods.outputs.paths }}
@@ -161,7 +161,7 @@ jobs:
     - name: Load Existing XML Code Coverage
       if: github.event_name == 'pull_request'
       id: load-coverage
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         key: ${{ github.event.pull_request.base.sha }}-codecov
         path: .codecov/**

--- a/.github/workflows/rocprofiler-sdk-continuous_integration.yml
+++ b/.github/workflows/rocprofiler-sdk-continuous_integration.yml
@@ -148,7 +148,7 @@ jobs:
           { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
       - name: Restore submodule cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ${{ steps.submods.outputs.paths }}
@@ -373,7 +373,7 @@ jobs:
           { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
       - name: Restore submodule cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ${{ steps.submods.outputs.paths }}
@@ -515,7 +515,7 @@ jobs:
         { echo "paths<<EOF"; cat .git-submodule-paths; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
     - name: Restore submodule cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: |
           ${{ steps.submods.outputs.paths }}

--- a/.github/workflows/rocprofiler-systems-debian.yml
+++ b/.github/workflows/rocprofiler-systems-debian.yml
@@ -75,7 +75,7 @@ jobs:
           .gitmodules
 
     - name: Restore ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ github.workspace }}/.ccache
         key: ccache-debian-${{ github.job }}-${{ matrix.os-release }}-${{ matrix.compiler }}-${{ matrix.rocm-version }}-${{ matrix.build-type }}-${{ github.sha }}

--- a/.github/workflows/rocprofiler-systems-redhat.yml
+++ b/.github/workflows/rocprofiler-systems-redhat.yml
@@ -112,7 +112,7 @@ jobs:
           fi
 
     - name: Restore ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ github.workspace }}/.ccache
         key: ccache-redhat-${{ github.job }}-${{ matrix.os-release }}-${{ matrix.compiler }}-${{ matrix.rocm-version }}-${{ matrix.build-type }}-${{ github.sha }}
@@ -311,7 +311,7 @@ jobs:
           dnf clean all
 
     - name: Restore ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ github.workspace }}/.ccache
         key: ccache-redhat-system-deps-${{ github.job }}-${{ matrix.os-release }}-${{ matrix.compiler }}-${{ github.sha }}

--- a/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-jammy.yml
@@ -100,7 +100,7 @@ jobs:
           apt-get autoclean
 
     - name: Restore ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ github.workspace }}/.ccache
         key: ccache-ubuntu-jammy-${{ github.job }}-${{ matrix.compiler }}-${{ matrix.rocm-version }}-${{ matrix.build-type }}-${{ github.sha }}
@@ -324,7 +324,7 @@ jobs:
           apt-get autoclean
 
     - name: Restore ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ github.workspace }}/.ccache
         key: ccache-ubuntu-jammy-system-deps-${{ github.job }}-${{ matrix.compiler }}-${{ github.sha }}

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble-sanitizers.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble-sanitizers.yml
@@ -100,7 +100,7 @@ jobs:
             apt-get autoclean
 
       - name: Restore ccache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ${{ github.workspace }}/.ccache
           key: ccache-ubuntu-noble-sanitizers-${{ github.job }}-${{ matrix.compiler }}-${{ matrix.sanitizer-type }}-${{ github.sha }}

--- a/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
+++ b/.github/workflows/rocprofiler-systems-ubuntu-noble.yml
@@ -75,7 +75,7 @@ jobs:
           .gitmodules
 
     - name: Restore ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ github.workspace }}/.ccache
         key: ccache-ubuntu-noble-${{ github.job }}-${{ matrix.compiler }}-${{ matrix.rocm-version }}-${{ matrix.build-type }}-${{ github.sha }}
@@ -279,7 +279,7 @@ jobs:
           apt-get autoclean
 
     - name: Restore ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ github.workspace }}/.ccache
         key: ccache-ubuntu-noble-system-deps-${{ github.job }}-${{ matrix.compiler }}-${{ github.sha }}


### PR DESCRIPTION
## Motivation

Resolves runner warning:

> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` environment variable. For more information see: <https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners>

## Technical Details

- Bumped `actions/cache` usage from `@v4` to `@v6` in rocprofiler-systems CI workflows (Ubuntu Noble/Jammy, Debian, Red Hat, sanitizers).
- Bumped `actions/cache` usage from `@v4` to `@v6` in rocprofiler SDK workflows (CI + code coverage).
- Bumped `actions/cache` usage from `@v4` to `@v6` in profiler hub sanitizers and rocprof trace decoder CI.

## JIRA ID

- AIPROFSYST-581

## Test Plan

- Execute workflows

## Test Result

- Passing

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
