### PR TITLE
kfdtest: fix bit shift formula

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/src/KFDMemoryTest.cpp
@@ -201,7 +201,7 @@ void KFDMemoryTest::MapUnmapToNodes(int gpuNode) {
     memFlags.ui32.HostAccess = 1;
 
     for (unsigned i = 0; i < 1<<14; i ++) {
-        HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, srcBuffer.As<void*>(), PAGE_SIZE, NULL, memFlags, (i>>5)&1+1, mapNodes);
+        HSAKMT_CALL(hsaKmtMapMemoryToGPUNodes, m_hsakmt_current_ctx, srcBuffer.As<void*>(), PAGE_SIZE, NULL, memFlags, ((i>>5)&1)+1, mapNodes);
     }
 
     /* Fill src buffer so shader quits */


### PR DESCRIPTION
Fixes assert assert(NumberOfNodes > 0) in hsaKmtMapMemoryToGPUNodesCtx