### PR TITLE
[RocR]ROCM-21690 Update hsa_signal_silent_store_relaxed implementation

### DIFF
--- a/projects/rocr-runtime/rocrtst/suites/stress/queue_write_index_concurrent_tests.cc
+++ b/projects/rocr-runtime/rocrtst/suites/stress/queue_write_index_concurrent_tests.cc
@@ -50,6 +50,13 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include <thread>
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <pthread.h>
+#include <sys/resource.h>
+#include <iomanip>
 
 #include "suites/stress/queue_write_index_concurrent_tests.h"
 #include "common/base_rocr_utils.h"
@@ -572,6 +579,156 @@ void QueueWriteIndexConcurrentTest::QueueLoadStoreWriteIndexAtomic(void) {
   for (unsigned int i = 0 ; i< gpus.size(); ++i) {
     QueueLoadStoreWriteIndexAtomic(cpus[0], gpus[i]);
   }
+
+  if (verbosity() > 0) {
+    std::cout << "subtest Passed" << std::endl;
+    std::cout << kSubTestSeparator << std::endl;
+  }
+}
+// Helper function to run a signal operation test with a waiter thread
+// Returns the total number of context switches observed by the waiter
+static long RunSignalOperationTest(
+    hsa_agent_t* cpu_agent,
+    int num_operations,
+    std::function<void(hsa_signal_t)> operation_func,
+    hsa_signal_value_t target_value) {
+
+  hsa_status_t err;
+  hsa_signal_t signal;
+  err = hsa_signal_create(0, 1, cpu_agent, &signal);
+  if (err != HSA_STATUS_SUCCESS) {
+    std::cout << "  [ERROR] Failed to create signal" << std::endl;
+    return -1;
+  }
+
+  std::atomic<bool> waiter_ready{false};
+  long total_ctx_switches = 0;
+
+  // Waiter thread that blocks waiting for target value
+  std::thread waiter_thread([&]() {
+    pthread_t waiter_tid = pthread_self();
+    std::cout << "  [WAITER TID: " << waiter_tid << "] Started" << std::endl;
+
+    waiter_ready.store(true, std::memory_order_release);
+
+    struct rusage usage_start, usage_end;
+    getrusage(RUSAGE_THREAD, &usage_start);
+
+    auto start = std::chrono::steady_clock::now();
+    hsa_signal_value_t observed = hsa_signal_wait_relaxed(
+        signal, HSA_SIGNAL_CONDITION_EQ, target_value,
+        5000000000, HSA_WAIT_STATE_BLOCKED);  // 5 second timeout
+    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - start).count();
+
+    getrusage(RUSAGE_THREAD, &usage_end);
+
+    long voluntary = usage_end.ru_nvcsw - usage_start.ru_nvcsw;
+    long involuntary = usage_end.ru_nivcsw - usage_start.ru_nivcsw;
+    total_ctx_switches = voluntary + involuntary;
+
+    std::cout << "  [WAITER TID: " << waiter_tid << "] Completed after " << elapsed_ms << "ms" << std::endl;
+    std::cout << "    Context switches: " << total_ctx_switches
+              << " (voluntary=" << voluntary << ", involuntary=" << involuntary << ")" << std::endl;
+  });
+
+  // Wait for waiter to be ready
+  while (!waiter_ready.load(std::memory_order_acquire)) {
+    std::this_thread::yield();
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // Perform the signal operations from main thread
+  std::cout << "  [MAIN] Starting " << num_operations << " operations..." << std::endl;
+  auto op_start = std::chrono::steady_clock::now();
+
+  for (int i = 0; i < num_operations; ++i) {
+    operation_func(signal);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+  }
+
+  auto op_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - op_start).count();
+  std::cout << "  [MAIN] Completed " << num_operations << " operations in " << op_elapsed << "ms" << std::endl;
+
+  // Wake up waiter with final store to target value
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  hsa_signal_store_screlease(signal, target_value);
+
+  waiter_thread.join();
+  hsa_signal_destroy(signal);
+
+  return total_ctx_switches;
+}
+
+void QueueWriteIndexConcurrentTest::TestSilentStoreSemantics(void) {
+  if (verbosity() > 0) {
+    PrintDebugSubtestHeader("Signal Silent Store Test & Performance Comparison");
+  }
+
+  pthread_t main_tid = pthread_self();
+  std::cout << "  [MAIN THREAD TID: " << main_tid << "]" << std::endl;
+
+  // Get CPU agent to use as consumer (forces InterruptSignal creation)
+  hsa_agent_t* cpu_agent_ptr = cpu_device();
+  ASSERT_NE(cpu_agent_ptr, nullptr);
+
+  const int NUM_STORES = 100;
+  const hsa_signal_value_t target_value = 1000;
+
+  std::cout << "\n  ===== TEST 1: Silent Stores (No SetEvent) =====" << std::endl;
+  std::cout << "  Expected: Minimal context switches" << std::endl;
+
+  // Test 1: Silent stores (no SetEvent calls)
+  long silent_ctx_switches = RunSignalOperationTest(
+      cpu_agent_ptr,
+      NUM_STORES,
+      [](hsa_signal_t signal) {
+        static int i = 1;
+        hsa_signal_silent_store_screlease(signal, i++);
+      },
+      target_value);
+
+  std::cout << "\n  TEST 1 RESULTS:" << std::endl;
+  std::cout << "    Total context switches: " << silent_ctx_switches << std::endl;
+
+  // Verify minimal context switches with silent stores
+  EXPECT_LT(silent_ctx_switches, 5)
+      << "Silent stores should have minimal context switches";
+
+  std::cout << "\n  ===== TEST 2: Regular Stores (Always SetEvent) =====" << std::endl;
+  std::cout << "  Expected: High context switches" << std::endl;
+
+  // Test 2: Regular stores (always call SetEvent)
+  long regular_ctx_switches = RunSignalOperationTest(
+      cpu_agent_ptr,
+      NUM_STORES,
+      [](hsa_signal_t signal) {
+        static int i = 1;
+        hsa_signal_store_screlease(signal, i++);
+      },
+      target_value);
+
+  std::cout << "\n  TEST 2 RESULTS:" << std::endl;
+  std::cout << "    Total context switches: " << regular_ctx_switches << std::endl;
+
+  // Verify high context switches with regular stores
+  EXPECT_GT(regular_ctx_switches, 5)
+      << "Regular stores should have many context switches (> 5)";
+
+  // Calculate and print efficiency comparison
+  double efficiency_ratio = (silent_ctx_switches > 0)
+      ? (double)regular_ctx_switches / (double)silent_ctx_switches
+      : 0.0;
+
+  std::cout << "\n  ===== EFFICIENCY COMPARISON =====" << std::endl;
+  std::cout << "  Test 1 (Silent Stores - No SetEvent):   " << silent_ctx_switches
+            << " context switches" << std::endl;
+  std::cout << "  Test 2 (Regular Stores - SetEvent):     " << regular_ctx_switches
+            << " context switches" << std::endl;
+  std::cout << "  Efficiency improvement: " << std::fixed << std::setprecision(1)
+            << efficiency_ratio << "x fewer context switches with silent stores" << std::endl;
+  std::cout << "  ==================================" << std::endl;
 
   if (verbosity() > 0) {
     std::cout << "subtest Passed" << std::endl;

--- a/projects/rocr-runtime/rocrtst/suites/stress/queue_write_index_concurrent_tests.h
+++ b/projects/rocr-runtime/rocrtst/suites/stress/queue_write_index_concurrent_tests.h
@@ -90,6 +90,10 @@ class QueueWriteIndexConcurrentTest : public TestBase {
   // concurrently.
   void QueueLoadStoreWriteIndexAtomic(void);
 
+  // @Brief: Verifies that silent signal stores don't wake waiting threads,
+  // while regular stores do wake them.
+  void TestSilentStoreSemantics(void);
+
  private:
   void QueueAddWriteIndexAtomic(hsa_agent_t cpuAgent, hsa_agent_t gpuAgent);
   void QueueCasWriteIndexAtomic(hsa_agent_t cpuAgent, hsa_agent_t gpuAgent);

--- a/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
+++ b/projects/rocr-runtime/rocrtst/suites/test_common/main.cc
@@ -780,6 +780,13 @@ TEST(rocrtstStress, Queue_LoadStore_Write_Index_ConcurrentTest) {
     RunCustomTestEpilog(&Qw);
 }
 
+TEST(rocrtstStress, Signal_Silent_Store_Semantics) {
+    QueueWriteIndexConcurrentTest Qw(false, false, false);
+    if (!RunCustomTestProlog(&Qw)) return;
+    Qw.TestSilentStoreSemantics();
+    RunCustomTestEpilog(&Qw);
+}
+
 TEST(rocrtstPerf, Memory_Async_Copy) {
   MemoryAsyncCopy mac;
   // To do full test, uncomment this:

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aie_aql_queue.h
@@ -91,6 +91,8 @@ class AieAqlQueue : public core::Queue,
   uint64_t AddWriteIndexAcqRel(uint64_t value) override;
   void StoreRelaxed(hsa_signal_value_t value) override;
   void StoreRelease(hsa_signal_value_t value) override;
+  void SilentStoreRelaxed(hsa_signal_value_t value) override;
+  void SilentStoreRelease(hsa_signal_value_t value) override;
   hsa_status_t GetInfo(hsa_queue_info_attribute_t attribute,
                        void *value) override;
   hsa_status_t GetCUMasking(uint32_t num_cu_mask_count, uint32_t* cu_mask) override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_aql_queue.h
@@ -237,6 +237,12 @@ class AqlQueue : public core::Queue, private core::LocalSignal, public core::Doo
   /// @brief Update signal value using Release semantics
   void StoreRelease(hsa_signal_value_t value) override;
 
+  /// @brief Update signal value using Relaxed semantics without waking waiters
+  void SilentStoreRelaxed(hsa_signal_value_t value) override;
+
+  /// @brief Update signal value using Release semantics without waking waiters
+  void SilentStoreRelease(hsa_signal_value_t value) override;
+
   /// @brief Provide information about the queue
   hsa_status_t GetInfo(hsa_queue_info_attribute_t attribute, void* value) override;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_sdma_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_sdma_queue.h
@@ -125,6 +125,10 @@ class SdmaQueue : public core::Queue, private core::LocalSignal, public core::Do
   void StoreRelaxed(hsa_signal_value_t value) override;
   void StoreRelease(hsa_signal_value_t value) override;
 
+  /// @brief Silent doorbell signal store entry points.
+  void SilentStoreRelaxed(hsa_signal_value_t value) override;
+  void SilentStoreRelease(hsa_signal_value_t value) override;
+
  private:
   static __forceinline int& rtti_id() {
     static int rtti_id_ = 0;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/default_signal.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/default_signal.h
@@ -77,6 +77,10 @@ class BusyWaitSignal : public Signal {
 
   void StoreRelease(hsa_signal_value_t value);
 
+  void SilentStoreRelaxed(hsa_signal_value_t value);
+
+  void SilentStoreRelease(hsa_signal_value_t value);
+
   hsa_signal_value_t WaitRelaxed(hsa_signal_condition_t condition,
                                  hsa_signal_value_t compare_value,
                                  uint64_t timeout, hsa_wait_state_t wait_hint);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/intercept_queue.h
@@ -278,6 +278,22 @@ class InterceptQueue : public QueueProxy, private LocalSignal, public DoorbellSi
     StoreRelaxed(value);
   }
 
+  /// @brief Update signal value using Relaxed semantics without waking waiters
+  ///
+  /// @param value Value of signal to update with
+  void SilentStoreRelaxed(hsa_signal_value_t value) override {
+    // InterceptQueue doorbell stores are inherently "silent" - they don't use SetEvent
+    StoreRelaxed(value);
+  }
+
+  /// @brief Update signal value using Release semantics without waking waiters
+  ///
+  /// @param value Value of signal to update with
+  void SilentStoreRelease(hsa_signal_value_t value) override {
+    // InterceptQueue doorbell stores are inherently "silent" - they don't use SetEvent
+    StoreRelease(value);
+  }
+
   /// @brief Provide information about the queue
   hsa_status_t GetInfo(hsa_queue_info_attribute_t attribute, void* value) override;
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/interrupt_signal.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/interrupt_signal.h
@@ -114,6 +114,10 @@ class InterruptSignal : private LocalSignal, public Signal {
 
   void StoreRelease(hsa_signal_value_t value);
 
+  void SilentStoreRelaxed(hsa_signal_value_t value);
+
+  void SilentStoreRelease(hsa_signal_value_t value);
+
   hsa_signal_value_t WaitRelaxed(hsa_signal_condition_t condition,
                                  hsa_signal_value_t compare_value,
                                  uint64_t timeout, hsa_wait_state_t wait_hint);

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/signal.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/signal.h
@@ -127,13 +127,13 @@ inline bool CheckSignalCondition(int64_t value, hsa_signal_condition_t condition
                                hsa_signal_value_t compare_value) {
   switch (condition) {
     case HSA_SIGNAL_CONDITION_EQ:
-      return value == compare_value;
+      return (value == compare_value);
     case HSA_SIGNAL_CONDITION_NE:
-      return value != compare_value;
+      return (value != compare_value);
     case HSA_SIGNAL_CONDITION_GTE:
-      return value >= compare_value;
+      return (value >= compare_value);
     case HSA_SIGNAL_CONDITION_LT:
-      return value < compare_value;
+      return (value < compare_value);
     default:
       return false;
   }
@@ -353,6 +353,9 @@ class Signal {
 
   virtual void StoreRelaxed(hsa_signal_value_t value) = 0;
   virtual void StoreRelease(hsa_signal_value_t value) = 0;
+
+  virtual void SilentStoreRelaxed(hsa_signal_value_t value) = 0;
+  virtual void SilentStoreRelease(hsa_signal_value_t value) = 0;
 
   virtual hsa_signal_value_t WaitRelaxed(hsa_signal_condition_t condition,
                                          hsa_signal_value_t compare_value,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aie_aql_queue.cpp
@@ -235,6 +235,16 @@ void AieAqlQueue::StoreRelease(hsa_signal_value_t value) {
   StoreRelaxed(value);
 }
 
+void AieAqlQueue::SilentStoreRelaxed(hsa_signal_value_t value) {
+  // AIE queue doorbell stores are inherently "silent" - they don't use SetEvent
+  StoreRelaxed(value);
+}
+
+void AieAqlQueue::SilentStoreRelease(hsa_signal_value_t value) {
+  // AIE queue doorbell stores are inherently "silent" - they don't use SetEvent
+  StoreRelease(value);
+}
+
 hsa_status_t AieAqlQueue::GetInfo(hsa_queue_info_attribute_t attribute, void* value) {
   switch (attribute) {
     case HSA_AMD_QUEUE_INFO_AGENT:

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_aql_queue.cpp
@@ -497,6 +497,16 @@ void AqlQueue::StoreRelease(hsa_signal_value_t value) {
   StoreRelaxed(value);
 }
 
+void AqlQueue::SilentStoreRelaxed(hsa_signal_value_t value) {
+  // AqlQueue doorbell stores are inherently "silent" - they don't use SetEvent
+  StoreRelaxed(value);
+}
+
+void AqlQueue::SilentStoreRelease(hsa_signal_value_t value) {
+  // AqlQueue doorbell stores are inherently "silent" - they don't use SetEvent
+  StoreRelease(value);
+}
+
 void AqlQueue::GetInfoProperties(uint8_t value[8]) const {
   auto setFlag = [&](uint32_t bit) {
     assert(bit < 8 * 8 && "Flag value exceeds input parameter size");

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_sdma_queue.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_sdma_queue.cpp
@@ -315,5 +315,15 @@ void SdmaQueue::StoreRelease(hsa_signal_value_t value) {
   RingDoorbell(static_cast<uint64_t>(value));
 }
 
+void SdmaQueue::SilentStoreRelaxed(hsa_signal_value_t value) {
+  // SDMA queue doorbell stores are inherently "silent" - they don't use SetEvent
+  StoreRelaxed(value);
+}
+
+void SdmaQueue::SilentStoreRelease(hsa_signal_value_t value) {
+  // SDMA queue doorbell stores are inherently "silent" - they don't use SetEvent
+  StoreRelease(value);
+}
+
 }  // namespace AMD
 }  // namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/default_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/default_signal.cpp
@@ -74,6 +74,16 @@ void BusyWaitSignal::StoreRelease(hsa_signal_value_t value) {
   atomic::Store(&signal_.value, int64_t(value), std::memory_order_release);
 }
 
+void BusyWaitSignal::SilentStoreRelaxed(hsa_signal_value_t value) {
+  atomic::Store(&signal_.value, int64_t(value), std::memory_order_relaxed);
+  // BusyWaitSignal has no event, so silent and regular stores are identical
+}
+
+void BusyWaitSignal::SilentStoreRelease(hsa_signal_value_t value) {
+  atomic::Store(&signal_.value, int64_t(value), std::memory_order_release);
+  // BusyWaitSignal has no event, so silent and regular stores are identical
+}
+
 hsa_signal_value_t BusyWaitSignal::WaitRelaxed(hsa_signal_condition_t condition,
                                                hsa_signal_value_t compare_value, uint64_t timeout,
                                                hsa_wait_state_t wait_hint) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa.cpp
@@ -1238,6 +1238,22 @@ void hsa_signal_store_screlease(hsa_signal_t hsa_signal, hsa_signal_value_t valu
   CATCHRET(void);
 }
 
+void hsa_signal_silent_store_relaxed(hsa_signal_t hsa_signal, hsa_signal_value_t value) {
+  TRY;
+  core::Signal* signal = core::Signal::Convert(hsa_signal);
+  assert(IsValid(signal));
+  signal->SilentStoreRelaxed(value);
+  CATCHRET(void);
+}
+
+void hsa_signal_silent_store_screlease(hsa_signal_t hsa_signal, hsa_signal_value_t value) {
+  TRY;
+  core::Signal* signal = core::Signal::Convert(hsa_signal);
+  assert(IsValid(signal));
+  signal->SilentStoreRelease(value);
+  CATCHRET(void);
+}
+
 hsa_signal_value_t
     hsa_signal_wait_relaxed(hsa_signal_t hsa_signal,
                             hsa_signal_condition_t condition,

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/hsa_api_trace.cpp
@@ -345,9 +345,9 @@ void HsaApiTable::UpdateCore() {
   core_api.hsa_agent_major_extension_supported_fn = HSA::hsa_agent_major_extension_supported;
   core_api.hsa_cache_get_info_fn = HSA::hsa_cache_get_info;
   core_api.hsa_agent_iterate_caches_fn = HSA::hsa_agent_iterate_caches;
-  // Silent store optimization is present in all signal ops when no agents are sleeping.
-  core_api.hsa_signal_silent_store_relaxed_fn = HSA::hsa_signal_store_relaxed;
-  core_api.hsa_signal_silent_store_screlease_fn = HSA::hsa_signal_store_screlease;
+  // Silent stores skip SetEvent() to avoid syscalls when there are no waiters
+  core_api.hsa_signal_silent_store_relaxed_fn = HSA::hsa_signal_silent_store_relaxed;
+  core_api.hsa_signal_silent_store_screlease_fn = HSA::hsa_signal_silent_store_screlease;
   core_api.hsa_signal_group_create_fn = HSA::hsa_signal_group_create;
   core_api.hsa_signal_group_destroy_fn = HSA::hsa_signal_group_destroy;
   core_api.hsa_signal_group_wait_any_scacquire_fn = HSA::hsa_signal_group_wait_any_scacquire;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/interrupt_signal.cpp
@@ -135,6 +135,16 @@ void InterruptSignal::StoreRelease(hsa_signal_value_t value) {
   SetEvent();
 }
 
+void InterruptSignal::SilentStoreRelaxed(hsa_signal_value_t value) {
+  atomic::Store(&signal_.value, int64_t(value), std::memory_order_relaxed);
+  // Intentionally skip SetEvent() - silent stores don't wake waiters
+}
+
+void InterruptSignal::SilentStoreRelease(hsa_signal_value_t value) {
+  atomic::Store(&signal_.value, int64_t(value), std::memory_order_release);
+  // Intentionally skip SetEvent() - silent stores don't wake waiters
+}
+
 hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition,
                                                hsa_signal_value_t compare_value,
                                                uint64_t timeout,
@@ -155,7 +165,9 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
     core::Runtime::runtime_singleton_->flag().signal_abort_timeout();
 
   while (true) {
-    if (!IsValid()) return 0;
+    if (!IsValid()) {
+      return 0;
+    }
 
     int64_t value = atomic::Load(&signal_.value, std::memory_order_relaxed);
 
@@ -172,7 +184,6 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
 
     if (wait_hint == HSA_WAIT_STATE_ACTIVE) {
       if (g_use_mwaitx) {
-        // Short timeout for active waiting
         timer::DoMwaitx(const_cast<int64_t*>(&signal_.value), value, 1000, true);
       }
       continue;
@@ -180,7 +191,6 @@ hsa_signal_value_t InterruptSignal::WaitRelaxed(hsa_signal_condition_t condition
 
     if (now - start_time < kMaxElapsed) {
       if (g_use_mwaitx) {
-        // Longer timeout with timer for passive waiting
         timer::DoMwaitx(const_cast<int64_t*>(&signal_.value), value, 60000, true);
       }
       continue;


### PR DESCRIPTION
## Motivation

  hsa_signal_silent_store_relaxed says that it should not wake waiting
  agents.Atomically set the value of a signal without necessarily
  notifying the the agents waiting on it.

## Technical Details

  Updated the implementation of hsa_signal_silent_store_relaxed so 
  it doesnt reroute to hsa_signal_store_relaxed which calls SetEvent()

## JIRA ID
 ROCM-21690

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
