### PR TITLE
[rocjitsu] Use composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,20 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    exclude-paths:
+      - "emulation/rocjitsu/actions/**"
     groups:
       github-actions:
+        patterns:
+          - "*"
+
+  # Check for updates to RocJitsu GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/emulation/rocjitsu/actions"
+    schedule:
+      interval: "weekly"
+    groups:
+      rocjitsu-github-actions:
         patterns:
           - "*"
 

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -68,185 +68,21 @@ jobs:
             enable_msan: 0
 
     steps:
-      - name: Install base dependencies
-        run: |
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            build-essential \
-            ca-certificates \
-            cmake \
-            git \
-            libdrm-dev \
-            ninja-build \
-            clang
-
-      - name: Checkout rocm-systems
+      - name: Checkout rocjitsu actions
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          path: rocm-systems
           sparse-checkout: |
-            emulation/rocjitsu
-            .github
+            emulation/rocjitsu/actions
 
-      - name: Checkout rocjitsu corpus
-        if: matrix.name == 'release'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Run rocjitsu corpus tests
+        uses: ./emulation/rocjitsu/actions/rocjitsu-corpus-tests
         with:
-          repository: ${{ github.event.inputs.corpus_repository || 'ROCm/rocjitsu-test-corpus' }}
+          matrix-name: ${{ matrix.name }}
+          build-type: ${{ matrix.build_type }}
+          enable-asan: ${{ matrix.enable_asan }}
+          enable-ubsan: ${{ matrix.enable_ubsan }}
+          enable-tsan: ${{ matrix.enable_tsan }}
+          enable-msan: ${{ matrix.enable_msan }}
+          corpus-repository: ${{ github.event.inputs.corpus_repository || 'ROCm/rocjitsu-test-corpus' }}
           # Last updated on 2026/06/23.
-          ref: 34a1241bb374307d24c5aee93c9fbd2279c1b04b
-          path: rocjitsu-test-corpus
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.12"
-
-      - name: Install ROCm SDK
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --pre \
-            --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
-            "rocm[devel,libraries]==7.14.0a20260619"
-          ROCM_LIB="$(rocm-sdk path --root)"/lib
-          echo "LD_LIBRARY_PATH=${ROCM_LIB}:${LD_LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
-
-      - name: Build rocjitsu
-        working-directory: ${{ env.ROCJITSU_SOURCE_DIR }}
-        shell: bash
-        run: |
-          ROCMINFO=RocminfoTest
-          ROCBLAS_GEMM=RocblasGemmTest
-          RCCL_DAEMON=RcclDaemonTest
-          ROCBLAS_GEMMS=RocblasGemmTest
-          ROCBLAS_GEMM_FUZZ=RocblasGemmFuzz
-          ROCBLAS_GEMM_CDNA3=RocblasGemmCdna3
-          EXCLUDED_TESTS="${ROCMINFO}|${ROCBLAS_GEMM}|${RCCL_DAEMON}|${ROCBLAS_GEMMS}|${ROCBLAS_GEMM_FUZZ}|${ROCBLAS_GEMM_CDNA3}"
-          ASAN_UBSAN_EXCLUDED_TESTS=(
-            "HsaTest\.InitSucceeded"
-            "HsaTest\.GpuAgentFound"
-            "HipMemcpyTest\.RoundTripFloat"
-            "HipMemcpyTest\.RoundTripInt"
-            "HipMemcpyTest\.DeviceToDevice"
-            "HipVectorAddTest\.CorrectResult"
-            "DaemonTest\.HipVectorAdd"
-            "DaemonTest\.HipMemcpyRoundTripFloat"
-            "DaemonTest\.HipMemcpyRoundTripInt"
-            "DaemonTest\.HipMemcpyDeviceToDevice"
-            "DaemonTest\.TwoIndependentClients"
-            "BfeRegressionTest\.ThreadIdxY"
-            "LoggingTest\.dispatch_logged"
-            "ProfiledPluginTest\.hook_profile_output"
-            "CvtNarrow\.AllTests"
-            "RaceTest\.vgpr_waitcnt"
-            "RaceTest\.vgpr_waitcnt_race"
-            "RaceTest\.sgpr_waitcnt"
-            "RaceTest\.sgpr_waitcnt_race"
-            "RaceTest\.lds_cross_wave"
-            "RaceTest\.lds_cross_wave_race"
-            "RaceTest\.global_to_lds_buffer"
-            "RaceTest\.global_to_lds_buffer_race"
-            "RaceTest\.partial_vmcnt_race"
-            "RaceTest\.multiple_race"
-            "RaceTest\.multi_kernel"
-            "RaceTest\.multi_kernel_race"
-            "RaceTest\.multi_workgroup"
-            "RaceTest\.multi_workgroup_race"
-            "RaceTest\.mixed_counters_race"
-            "RaceTest\.stress_wavefront_reuse"
-            "RaceTest\.stress_wavefront_reuse_race"
-            "RaceTest\.exec_mask"
-            "RaceTest\.exec_mask_race"
-            "RaceTest\.exec_mask_same_wave"
-            "RaceTest\.exec_mask_cross_wave_race"
-            "RaceTest\.exec_mask_cross_wave"
-            "RaceTest\.lds_transpose"
-            "RaceTest\.lds_transpose_race"
-            "RaceTest\.dual_offset_lds"
-            "RaceTest\.dual_offset_lds_race"
-            "RaceTest\.scratch_vmcnt"
-            "RaceTest\.scratch_vmcnt_race"
-            "RaceTest\.f64_vgpr_safe"
-            "RaceTest\.f64_vgpr_race"
-          )
-
-          CMAKE_CONFIG_FLAGS=()
-          if [[ "${{ matrix.name }}" == "asan-ubsan" ]]; then
-            EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${ASAN_UBSAN_EXCLUDED_TESTS[*]}")"
-            CMAKE_CONFIG_FLAGS+=(
-              -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -g"
-              -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -g"
-            )
-          fi
-
-          CXXFLAGS="-Wno-error=unknown-warning-option -Wno-error=nested-anon-types"
-          ROCM_PATH=`rocm-sdk path --root` \
-            cmake -B "${ROCJITSU_BUILD_DIR}" -G Ninja \
-            -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}" \
-            -DCMAKE_C_FLAGS="${CFLAGS:-}" \
-            -DCMAKE_CXX_FLAGS="${CXXFLAGS:-}" \
-            "${CMAKE_CONFIG_FLAGS[@]}" \
-            -DRJ_ENABLE_ASAN=${{ matrix.enable_asan }} \
-            -DRJ_ENABLE_UBSAN=${{ matrix.enable_ubsan }} \
-            -DRJ_ENABLE_TSAN=${{ matrix.enable_tsan }} \
-            -DRJ_ENABLE_MSAN=${{ matrix.enable_msan }}
-
-          cmake --build "${ROCJITSU_BUILD_DIR}"
-
-          ctest --test-dir "${ROCJITSU_BUILD_DIR}" \
-            -E "${EXCLUDED_TESTS}" \
-            --output-on-failure
-
-          echo "${ROCJITSU_BUILD_DIR}/tools/rocjitsu" >> "${GITHUB_PATH}"
-          echo "CXXFLAGS=" >> "${GITHUB_ENV}"
-
-      - name: Install corpus test dependencies
-        if: matrix.name == 'release'
-        working-directory: ${{ env.ROCJITSU_CORPUS_DIR }}
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-
-      - name: Run corpus tests
-        if: matrix.name == 'release'
-        working-directory: ${{ env.ROCJITSU_CORPUS_DIR }}
-        shell: bash
-        env:
-          ROCJITSU_ROOT: ${{ env.ROCJITSU_SOURCE_DIR }}
-          ROCJITSU_BUILD: ${{ env.ROCJITSU_BUILD_DIR }}
-        run: |
-          targets=(
-            "gfx942 amdgpu_cdna3.json iree_gfx942_hip.json"
-            "gfx950 amdgpu_cdna4.json iree_gfx950_hip.json"
-            "gfx1100 amdgpu_rdna3_gfx1100_w7900_kmd.json iree_gfx1100_hip.json"
-            "gfx1201 amdgpu_rdna4_gfx1201_r9700_kmd.json iree_gfx1201_hip.json"
-            "gfx1250 amdgpu_gfx1250.json iree_gfx1250_hip.json"
-          )
-
-          for target in "${targets[@]}"; do
-            read -r name rocjitsu_config corpus_config <<< "${target}"
-            echo "::group::pytest (${name})"
-            rocjitsu \
-              --config "${ROCJITSU_SOURCE_DIR}/configs/${rocjitsu_config}" \
-              -- pytest \
-              --config-files="${ROCJITSU_SOURCE_DIR}/tests/corpus/${corpus_config}" \
-              --timeout 15 \
-              corpus/iree/
-            echo "::endgroup::"
-          done
-
-          targets=(
-            "gfx1201 amdgpu_rdna4_gfx1201_r9700_kmd.json fuzz_gfx1201.json"
-          )
-          for target in "${targets[@]}"; do
-            read -r name rocjitsu_config corpus_config <<< "${target}"
-            echo "::group::pytest (${name})"
-            ROCM_PATH=`rocm-sdk path --root` \
-              rocjitsu \
-              --config "${ROCJITSU_SOURCE_DIR}/configs/${rocjitsu_config}" \
-              -- pytest \
-              --fuzz-target-config-files="${ROCJITSU_SOURCE_DIR}/tests/corpus/${corpus_config}" \
-              --timeout 60 \
-              tests/test_fuzz_targets.py
-            echo "::endgroup::"
-          done
+          corpus-ref: ${{ github.event.inputs.corpus_ref || '34a1241bb374307d24c5aee93c9fbd2279c1b04b' }}

--- a/.github/workflows/rocjitsu-formatting.yml
+++ b/.github/workflows/rocjitsu-formatting.yml
@@ -16,39 +16,11 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout rocjitsu actions
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-          # Sparse checkout controls which files are on disk, and therefore
-          # which files pre-commit can check. To add a new project to this
-          # CI job, add its path here. That's the only change needed.
           sparse-checkout: |
-            emulation/rocjitsu
-            .github
+            emulation/rocjitsu/actions
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - run: pip install pre-commit
-
-      - name: Run pre-commit on changed files
-        run: |
-          # Find the common ancestor between the PR base and head.
-          MERGE_BASE=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
-
-          # List files that were added, copied, modified, or renamed in
-          # the PR, then keep only those present on disk. The sparse
-          # checkout determines which files are on disk, so this is how
-          # we scope the check to the projects listed above.
-          FILES=$(git diff --name-only --diff-filter=ACMR "$MERGE_BASE" HEAD \
-            | while IFS= read -r f; do if [ -f "$f" ]; then echo "$f"; fi; done)
-
-          if [ -z "$FILES" ]; then
-            echo "No checked-in files changed in sparse checkout, skipping."
-            exit 0
-          fi
-
-          echo "Checking files:"
-          echo "$FILES"
-          pre-commit run --files $FILES
+      - name: Run rocjitsu formatting checks
+        uses: ./emulation/rocjitsu/actions/rocjitsu-formatting

--- a/emulation/rocjitsu/actions/rocjitsu-corpus-tests/action.yml
+++ b/emulation/rocjitsu/actions/rocjitsu-corpus-tests/action.yml
@@ -1,0 +1,214 @@
+name: "rocjitsu-test-corpus"
+description: "Build rocjitsu and run the pytest corpus checks."
+inputs:
+  matrix-name:
+    description: "Name of the current workflow matrix entry."
+    required: true
+  build-type:
+    description: "CMake build type."
+    required: true
+  enable-asan:
+    description: "Whether to enable AddressSanitizer."
+    required: true
+  enable-ubsan:
+    description: "Whether to enable UndefinedBehaviorSanitizer."
+    required: true
+  enable-tsan:
+    description: "Whether to enable ThreadSanitizer."
+    required: true
+  enable-msan:
+    description: "Whether to enable MemorySanitizer."
+    required: true
+  corpus-repository:
+    description: "Repository containing the rocjitsu pytest corpus."
+    required: true
+  corpus-ref:
+    description: "Branch, tag, or SHA to check out from the corpus repository."
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Install base dependencies
+      shell: bash
+      run: |
+        apt-get update
+        apt-get install -y --no-install-recommends \
+          build-essential \
+          ca-certificates \
+          cmake \
+          git \
+          libdrm-dev \
+          ninja-build \
+          clang
+
+    - name: Checkout rocm-systems
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        path: rocm-systems
+        sparse-checkout: |
+          emulation/rocjitsu
+          .github
+
+    - name: Checkout rocjitsu corpus
+      if: ${{ inputs['matrix-name'] == 'release' }}
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        repository: ${{ inputs['corpus-repository'] }}
+        ref: ${{ inputs['corpus-ref'] }}
+        path: rocjitsu-test-corpus
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.12"
+
+    - name: Install ROCm SDK
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --pre \
+          --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
+          "rocm[devel,libraries]==7.14.0a20260619"
+        ROCM_LIB="$(rocm-sdk path --root)"/lib
+        echo "LD_LIBRARY_PATH=${ROCM_LIB}:${LD_LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
+
+    - name: Build rocjitsu
+      working-directory: ${{ env.ROCJITSU_SOURCE_DIR }}
+      shell: bash
+      run: |
+        ROCMINFO=RocminfoTest
+        ROCBLAS_GEMM=RocblasGemmTest
+        RCCL_DAEMON=RcclDaemonTest
+        ROCBLAS_GEMMS=RocblasGemmTest
+        ROCBLAS_GEMM_FUZZ=RocblasGemmFuzz
+        ROCBLAS_GEMM_CDNA3=RocblasGemmCdna3
+        EXCLUDED_TESTS="${ROCMINFO}|${ROCBLAS_GEMM}|${RCCL_DAEMON}|${ROCBLAS_GEMMS}|${ROCBLAS_GEMM_FUZZ}|${ROCBLAS_GEMM_CDNA3}"
+        ASAN_UBSAN_EXCLUDED_TESTS=(
+          "HsaTest\.InitSucceeded"
+          "HsaTest\.GpuAgentFound"
+          "HipMemcpyTest\.RoundTripFloat"
+          "HipMemcpyTest\.RoundTripInt"
+          "HipMemcpyTest\.DeviceToDevice"
+          "HipVectorAddTest\.CorrectResult"
+          "DaemonTest\.HipVectorAdd"
+          "DaemonTest\.HipMemcpyRoundTripFloat"
+          "DaemonTest\.HipMemcpyRoundTripInt"
+          "DaemonTest\.HipMemcpyDeviceToDevice"
+          "DaemonTest\.TwoIndependentClients"
+          "BfeRegressionTest\.ThreadIdxY"
+          "LoggingTest\.dispatch_logged"
+          "ProfiledPluginTest\.hook_profile_output"
+          "CvtNarrow\.AllTests"
+          "RaceTest\.vgpr_waitcnt"
+          "RaceTest\.vgpr_waitcnt_race"
+          "RaceTest\.sgpr_waitcnt"
+          "RaceTest\.sgpr_waitcnt_race"
+          "RaceTest\.lds_cross_wave"
+          "RaceTest\.lds_cross_wave_race"
+          "RaceTest\.global_to_lds_buffer"
+          "RaceTest\.global_to_lds_buffer_race"
+          "RaceTest\.partial_vmcnt_race"
+          "RaceTest\.multiple_race"
+          "RaceTest\.multi_kernel"
+          "RaceTest\.multi_kernel_race"
+          "RaceTest\.multi_workgroup"
+          "RaceTest\.multi_workgroup_race"
+          "RaceTest\.mixed_counters_race"
+          "RaceTest\.stress_wavefront_reuse"
+          "RaceTest\.stress_wavefront_reuse_race"
+          "RaceTest\.exec_mask"
+          "RaceTest\.exec_mask_race"
+          "RaceTest\.exec_mask_same_wave"
+          "RaceTest\.exec_mask_cross_wave_race"
+          "RaceTest\.exec_mask_cross_wave"
+          "RaceTest\.lds_transpose"
+          "RaceTest\.lds_transpose_race"
+          "RaceTest\.dual_offset_lds"
+          "RaceTest\.dual_offset_lds_race"
+          "RaceTest\.scratch_vmcnt"
+          "RaceTest\.scratch_vmcnt_race"
+          "RaceTest\.f64_vgpr_safe"
+          "RaceTest\.f64_vgpr_race"
+        )
+
+        CMAKE_CONFIG_FLAGS=()
+        if [[ "${{ inputs['matrix-name'] }}" == "asan-ubsan" ]]; then
+          EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${ASAN_UBSAN_EXCLUDED_TESTS[*]}")"
+          CMAKE_CONFIG_FLAGS+=(
+            -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -g"
+            -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -g"
+          )
+        fi
+
+        CXXFLAGS="-Wno-error=unknown-warning-option -Wno-error=nested-anon-types"
+        ROCM_PATH=`rocm-sdk path --root` \
+          cmake -B "${ROCJITSU_BUILD_DIR}" -G Ninja \
+          -DCMAKE_BUILD_TYPE="${{ inputs['build-type'] }}" \
+          -DCMAKE_C_FLAGS="${CFLAGS:-}" \
+          -DCMAKE_CXX_FLAGS="${CXXFLAGS:-}" \
+          "${CMAKE_CONFIG_FLAGS[@]}" \
+          -DRJ_ENABLE_ASAN=${{ inputs['enable-asan'] }} \
+          -DRJ_ENABLE_UBSAN=${{ inputs['enable-ubsan'] }} \
+          -DRJ_ENABLE_TSAN=${{ inputs['enable-tsan'] }} \
+          -DRJ_ENABLE_MSAN=${{ inputs['enable-msan'] }}
+
+        cmake --build "${ROCJITSU_BUILD_DIR}"
+
+        ctest --test-dir "${ROCJITSU_BUILD_DIR}" \
+          -E "${EXCLUDED_TESTS}" \
+          --output-on-failure
+
+        echo "${ROCJITSU_BUILD_DIR}/tools/rocjitsu" >> "${GITHUB_PATH}"
+        echo "CXXFLAGS=" >> "${GITHUB_ENV}"
+
+    - name: Install corpus test dependencies
+      if: ${{ inputs['matrix-name'] == 'release' }}
+      working-directory: ${{ env.ROCJITSU_CORPUS_DIR }}
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt
+
+    - name: Run corpus tests
+      if: ${{ inputs['matrix-name'] == 'release' }}
+      working-directory: ${{ env.ROCJITSU_CORPUS_DIR }}
+      shell: bash
+      env:
+        ROCJITSU_ROOT: ${{ env.ROCJITSU_SOURCE_DIR }}
+        ROCJITSU_BUILD: ${{ env.ROCJITSU_BUILD_DIR }}
+      run: |
+        targets=(
+          "gfx942 amdgpu_cdna3.json iree_gfx942_hip.json"
+          "gfx950 amdgpu_cdna4.json iree_gfx950_hip.json"
+          "gfx1100 amdgpu_rdna3_gfx1100_w7900_kmd.json iree_gfx1100_hip.json"
+          "gfx1201 amdgpu_rdna4_gfx1201_r9700_kmd.json iree_gfx1201_hip.json"
+          "gfx1250 amdgpu_gfx1250.json iree_gfx1250_hip.json"
+        )
+
+        for target in "${targets[@]}"; do
+          read -r name rocjitsu_config corpus_config <<< "${target}"
+          echo "::group::pytest (${name})"
+          rocjitsu \
+            --config "${ROCJITSU_SOURCE_DIR}/configs/${rocjitsu_config}" \
+            -- pytest \
+            --config-files="${ROCJITSU_SOURCE_DIR}/tests/corpus/${corpus_config}" \
+            --timeout 15 \
+            corpus/iree/
+          echo "::endgroup::"
+        done
+
+        targets=(
+          "gfx1201 amdgpu_rdna4_gfx1201_r9700_kmd.json fuzz_gfx1201.json"
+        )
+        for target in "${targets[@]}"; do
+          read -r name rocjitsu_config corpus_config <<< "${target}"
+          echo "::group::pytest (${name})"
+          ROCM_PATH=`rocm-sdk path --root` \
+            rocjitsu \
+            --config "${ROCJITSU_SOURCE_DIR}/configs/${rocjitsu_config}" \
+            -- pytest \
+            --fuzz-target-config-files="${ROCJITSU_SOURCE_DIR}/tests/corpus/${corpus_config}" \
+            --timeout 60 \
+            tests/test_fuzz_targets.py
+          echo "::endgroup::"
+        done

--- a/emulation/rocjitsu/actions/rocjitsu-formatting/action.yml
+++ b/emulation/rocjitsu/actions/rocjitsu-formatting/action.yml
@@ -1,0 +1,43 @@
+name: "rocjitsu-formatting"
+description: "Run formatting checks for emulation/rocjitsu."
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        # Sparse checkout controls which files are on disk, and therefore
+        # which files pre-commit can check. To add a new project to this
+        # CI job, add its path here. That's the only change needed.
+        sparse-checkout: |
+          emulation/rocjitsu
+          .github
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - run: pip install pre-commit
+      shell: bash
+
+    - name: Run pre-commit on changed files
+      shell: bash
+      run: |
+        # Find the common ancestor between the PR base and head.
+        MERGE_BASE=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+
+        # List files that were added, copied, modified, or renamed in
+        # the PR, then keep only those present on disk. The sparse
+        # checkout determines which files are on disk, so this is how
+        # we scope the check to the projects listed above.
+        FILES=$(git diff --name-only --diff-filter=ACMR "$MERGE_BASE" HEAD \
+          | while IFS= read -r f; do if [ -f "$f" ]; then echo "$f"; fi; done)
+
+        if [ -z "$FILES" ]; then
+          echo "No checked-in files changed in sparse checkout, skipping."
+          exit 0
+        fi
+
+        echo "Checking files:"
+        echo "$FILES"
+        pre-commit run --files $FILES


### PR DESCRIPTION
## Motivation

With GitHub's composite action we can place GitHub action files in different directories other than .github/workflow. This allows dependabot updates to target specific directories that can be taken care by specific teams. Right now, there is this dependabot PR https://github.com/ROCm/rocm-systems/pull/7771 which has many different files owned by many different teams. By using composite actions dependabot can update in a single PR those which fall under the rocjistu/actions/ path. And can be updated by any member of the rocjitsu-core-team.

## Technical Details

Unfortunately, composite actions require that minimal .github/workflow/rocjitsu-*.yml files exist and these still use the checkout action. So dependabot, will still target these along with all the other ones.

## JIRA ID

None

## Test Plan

Test on CI

## Test Result

Ci passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
