### PR TITLE
[AMD-SMI] Catch ImportError when probing rocm_sdk in find_smi_library

### DIFF
--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -194,7 +194,7 @@ def find_smi_library():
         rocm_sdk_libamd_smi_path = rocm_sdk.find_libraries("amd_smi")
         if rocm_sdk_libamd_smi_path:
             possible_locations.append(rocm_sdk_libamd_smi_path[0])
-    except (ModuleNotFoundError, FileNotFoundError):  # If rocm_sdk is not installed or library is not found, skip
+    except (ImportError, FileNotFoundError):  # If rocm_sdk is not installed/importable or library is not found, skip (ImportError covers ModuleNotFoundError and import guards that forbid rocm_sdk)
         pass
     # 2.
     rocm_path = os.getenv("ROCM_HOME", os.getenv("ROCM_PATH"))

--- a/projects/amdsmi/tools/generator.py
+++ b/projects/amdsmi/tools/generator.py
@@ -211,7 +211,7 @@ def find_smi_library():
         rocm_sdk_libamd_smi_path = rocm_sdk.find_libraries("amd_smi")
         if rocm_sdk_libamd_smi_path:
             possible_locations.append(rocm_sdk_libamd_smi_path[0])
-    except (ModuleNotFoundError, FileNotFoundError):  # If rocm_sdk is not installed or library is not found, skip
+    except (ImportError, FileNotFoundError):  # If rocm_sdk is not installed/importable or library is not found, skip (ImportError covers ModuleNotFoundError and import guards that forbid rocm_sdk)
         pass
     # 2.
     rocm_path = os.getenv("ROCM_HOME", os.getenv("ROCM_PATH"))


### PR DESCRIPTION
find_smi_library() probes for libamd_smi.so via an optional `import rocm_sdk`, guarded by `except (ModuleNotFoundError, FileNotFoundError)`. Under rocprofiler-compute's profile-mode tests, the ProfileModeImportGuard intercepts `import rocm_sdk` (not in ALLOWED_ROCM_MODULES) and raises a plain ImportError. ModuleNotFoundError is a subclass of ImportError, not the reverse, so the guard's ImportError escapes, amdsmi fails to import, and all profile-mode tests exit 1 (PROFILE MODE DEPENDENCY VIOLATION: Forbidden package rocm_sdk).

Broaden the except to (ImportError, FileNotFoundError). ImportError subsumes ModuleNotFoundError (rocm_sdk not installed) and also catches import guards that forbid rocm_sdk, while FileNotFoundError still covers a missing library file. Applied to both the generated wrapper and the generator template so it survives regeneration.

Fixes ROCm/rocm-systems#7808