### PR TITLE
rocdbgapi: add .gitignore and .gitattribute files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .cline_storage
 /projects/hip/_build
 
+# Emacs backup files.
+*~
+
 # Visual Studio project files
 *.suo
 *.user

--- a/projects/rocdbgapi/.gitattributes
+++ b/projects/rocdbgapi/.gitattributes
@@ -1,0 +1,4 @@
+# Use cpp-style diffs.
+*.h     diff=cpp
+*.h.in  diff=cpp
+*.cpp   diff=cpp

--- a/projects/rocr-debug-agent/.gitattributes
+++ b/projects/rocr-debug-agent/.gitattributes
@@ -1,0 +1,4 @@
+# Use cpp-style diffs.
+*.h     diff=cpp
+*.h.in  diff=cpp
+*.cpp   diff=cpp


### PR DESCRIPTION
Add git files for developer convenience.

## Motivation

Avoid seeing `...~` files in git status and display `git diff` better using C++ context.
