### PR TITLE
fix(rocSHMEM): Drop LLC dependency in HSACO object compilation

### DIFF
--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -192,20 +192,30 @@ endif()
 set(DEFAULT_GPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING
     "Target default GPUs if GPU_TARGETS is not defined.")
 
-# Preserve the user-supplied GPU_TARGETS before rocm_check_target_ids strips
-# feature suffixes (e.g. gfx942:sramecc+:xnack-). GPU_TARGETS_FULL is consumed
-# by DeviceBitcode.cmake to embed correct amdhsa.target metadata in HSACOs.
+# Preserve the raw user-supplied GPU_TARGETS in GPU_TARGETS_FULL before
+# rocm_check_target_ids strips feature suffixes (e.g. gfx942:sramecc+:xnack-).
+# GPU_TARGETS_FULL is consumed by DeviceBitcode.cmake to embed correct
+# amdhsa.target metadata in HSACOs.
 if(GPU_TARGETS)
   set(GPU_TARGETS_FULL "${GPU_TARGETS}" CACHE STRING
     "GPU arch strings with feature suffixes as supplied by the user (before validation strips them)")
 endif()
 
 if (COMMAND rocm_check_target_ids)
-  message(STATUS "Checking for ROCm support for GPU targets: " "${DEFAULT_GPU_TARGETS}")
-  rocm_check_target_ids(SUPPORTED_GPUS TARGETS ${DEFAULT_GPU_TARGETS})
+  if(GPU_TARGETS)
+    message(STATUS "Checking for ROCm support for GPU targets: " "${GPU_TARGETS}")
+    rocm_check_target_ids(SUPPORTED_GPUS TARGETS ${GPU_TARGETS})
+  else()
+    message(STATUS "Checking for ROCm support for GPU targets: " "${DEFAULT_GPU_TARGETS}")
+    rocm_check_target_ids(SUPPORTED_GPUS TARGETS ${DEFAULT_GPU_TARGETS})
+  endif()
 else()
   message(WARNING "Unable to check for supported GPU targets.")
-  set(SUPPORTED_GPUS ${DEFAULT_GPU_TARGETS})
+  if(GPU_TARGETS)
+    set(SUPPORTED_GPUS ${GPU_TARGETS})
+  else()
+    set(SUPPORTED_GPUS ${DEFAULT_GPU_TARGETS})
+  endif()
 endif()
 
 set(GPU_TARGETS "${SUPPORTED_GPUS}" CACHE STRING "GPU architectures to compile for")

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -192,6 +192,14 @@ endif()
 set(DEFAULT_GPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING
     "Target default GPUs if GPU_TARGETS is not defined.")
 
+# Preserve the user-supplied GPU_TARGETS before rocm_check_target_ids strips
+# feature suffixes (e.g. gfx942:sramecc+:xnack-). GPU_TARGETS_FULL is consumed
+# by DeviceBitcode.cmake to embed correct amdhsa.target metadata in HSACOs.
+if(GPU_TARGETS)
+  set(GPU_TARGETS_FULL "${GPU_TARGETS}" CACHE STRING
+    "GPU arch strings with feature suffixes as supplied by the user (before validation strips them)")
+endif()
+
 if (COMMAND rocm_check_target_ids)
   message(STATUS "Checking for ROCm support for GPU targets: " "${DEFAULT_GPU_TARGETS}")
   rocm_check_target_ids(SUPPORTED_GPUS TARGETS ${DEFAULT_GPU_TARGETS})

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -219,8 +219,9 @@ if(COMMAND rocm_check_target_ids)
   endif()
 else()
   message(WARNING "Unable to check for supported GPU targets.")
-  set(SUPPORTED_GPUS ${GPU_TARGETS})
-  if(NOT SUPPORTED_GPUS)
+  if(GPU_TARGETS)
+    set(SUPPORTED_GPUS ${_bare_targets})
+  else()
     set(SUPPORTED_GPUS ${DEFAULT_GPU_TARGETS})
   endif()
 endif()
@@ -229,6 +230,8 @@ endif()
 # Consumed by DeviceBitcode.cmake to embed correct amdhsa.target metadata in
 # HSACOs — HIP error 209 occurs if the suffix in the HSACO metadata does not
 # match the active feature configuration of the GPU.
+# Explicitly cleared when GPU_TARGETS is not set so a stale cached value from a
+# previous -DGPU_TARGETS=... configure run cannot persist into the defaults path.
 if(GPU_TARGETS)
   set(_full_validated "")
   foreach(_base ${SUPPORTED_GPUS})
@@ -240,6 +243,8 @@ if(GPU_TARGETS)
   endforeach()
   set(GPU_TARGETS_FULL "${_full_validated}" CACHE STRING
     "Validated GPU arch strings with feature suffixes (consumed by DeviceBitcode.cmake)" FORCE)
+else()
+  unset(GPU_TARGETS_FULL CACHE)
 endif()
 
 set(GPU_TARGETS "${SUPPORTED_GPUS}" CACHE STRING "GPU architectures to compile for" FORCE)

--- a/projects/rocshmem/CMakeLists.txt
+++ b/projects/rocshmem/CMakeLists.txt
@@ -192,33 +192,57 @@ endif()
 set(DEFAULT_GPU_TARGETS "${DEFAULT_GPUS}" CACHE STRING
     "Target default GPUs if GPU_TARGETS is not defined.")
 
-# Preserve the raw user-supplied GPU_TARGETS in GPU_TARGETS_FULL before
-# rocm_check_target_ids strips feature suffixes (e.g. gfx942:sramecc+:xnack-).
-# GPU_TARGETS_FULL is consumed by DeviceBitcode.cmake to embed correct
-# amdhsa.target metadata in HSACOs.
+# When the user supplies GPU_TARGETS:
+#   - Normalise comma/semicolon separators
+#   - Build a base→full map so feature suffixes (e.g. gfx950:sramecc+:xnack-)
+#     can be restored after validation
+#   - Produce a bare-arch list for rocm_check_target_ids and HIP compilation,
+#     which both reject feature-suffixed entries in --offload-arch
 if(GPU_TARGETS)
-  set(GPU_TARGETS_FULL "${GPU_TARGETS}" CACHE STRING
-    "GPU arch strings with feature suffixes as supplied by the user (before validation strips them)")
+  string(REPLACE "," ";" GPU_TARGETS "${GPU_TARGETS}")
+  set(_bare_targets "")
+  foreach(_t ${GPU_TARGETS})
+    string(REGEX REPLACE ":.*" "" _base "${_t}")
+    set(_USER_FULL_${_base} "${_t}")
+    list(APPEND _bare_targets "${_base}")
+  endforeach()
+  list(REMOVE_DUPLICATES _bare_targets)
 endif()
 
-if (COMMAND rocm_check_target_ids)
+if(COMMAND rocm_check_target_ids)
   if(GPU_TARGETS)
-    message(STATUS "Checking for ROCm support for GPU targets: " "${GPU_TARGETS}")
-    rocm_check_target_ids(SUPPORTED_GPUS TARGETS ${GPU_TARGETS})
+    message(STATUS "Checking for ROCm support for GPU targets: " "${_bare_targets}")
+    rocm_check_target_ids(SUPPORTED_GPUS TARGETS ${_bare_targets})
   else()
     message(STATUS "Checking for ROCm support for GPU targets: " "${DEFAULT_GPU_TARGETS}")
     rocm_check_target_ids(SUPPORTED_GPUS TARGETS ${DEFAULT_GPU_TARGETS})
   endif()
 else()
   message(WARNING "Unable to check for supported GPU targets.")
-  if(GPU_TARGETS)
-    set(SUPPORTED_GPUS ${GPU_TARGETS})
-  else()
+  set(SUPPORTED_GPUS ${GPU_TARGETS})
+  if(NOT SUPPORTED_GPUS)
     set(SUPPORTED_GPUS ${DEFAULT_GPU_TARGETS})
   endif()
 endif()
 
-set(GPU_TARGETS "${SUPPORTED_GPUS}" CACHE STRING "GPU architectures to compile for")
+# GPU_TARGETS_FULL: validated arch strings with feature suffixes restored.
+# Consumed by DeviceBitcode.cmake to embed correct amdhsa.target metadata in
+# HSACOs — HIP error 209 occurs if the suffix in the HSACO metadata does not
+# match the active feature configuration of the GPU.
+if(GPU_TARGETS)
+  set(_full_validated "")
+  foreach(_base ${SUPPORTED_GPUS})
+    if(DEFINED _USER_FULL_${_base})
+      list(APPEND _full_validated "${_USER_FULL_${_base}}")
+    else()
+      list(APPEND _full_validated "${_base}")
+    endif()
+  endforeach()
+  set(GPU_TARGETS_FULL "${_full_validated}" CACHE STRING
+    "Validated GPU arch strings with feature suffixes (consumed by DeviceBitcode.cmake)" FORCE)
+endif()
+
+set(GPU_TARGETS "${SUPPORTED_GPUS}" CACHE STRING "GPU architectures to compile for" FORCE)
 
 message(STATUS "Compiling for ${GPU_TARGETS}")
 

--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -61,7 +61,6 @@ if(GPU_TARGETS)
   # Convert comma-separated string to CMake list (semicolon-separated)
   # This handles both -DGPU_TARGETS=gfx942,gfx950 and -DGPU_TARGETS="gfx942;gfx950"
   string(REPLACE "," ";" _GPU_TARGETS_LIST "${GPU_TARGETS}")
-  set(_GPU_TARGETS_LIST ${_GPU_TARGETS_LIST})
   strip_arch_features("${_GPU_TARGETS_LIST}" _BITCODE_DEFAULT_ARCHS)
 elseif(COMMAND rocm_local_targets)
   rocm_local_targets(_LOCAL_GPUS)
@@ -81,51 +80,19 @@ set(BITCODE_GPU_ARCHS "${_BITCODE_DEFAULT_ARCHS}" CACHE STRING "GPU architecture
 # -target-feature flags to clang. These are embedded in the HSACO amdhsa.target
 # metadata string, which HIP validates when loading the module — a mismatch causes error 209.
 #
-# The arch list always comes from GPU_TARGETS/auto-detect. ROCSHMEM_GPU_TARGETS
-# is an optional env var that supplies feature suffixes for individual arches —
-# it acts as an overlay, not a replacement. For any arch listed in
-# ROCSHMEM_GPU_TARGETS the full string (with suffixes) is used; arches not
-# mentioned fall back to bare arch names from GPU_TARGETS or auto-detect.
-#
-# Example — building for five arches, providing suffixes for two:
-#   -DGPU_TARGETS="gfx90a;gfx1100;gfx1201;gfx942;gfx950"
-#   ROCSHMEM_GPU_TARGETS="gfx942:sramecc+:xnack-;gfx950:sramecc+:xnack-"
-#
-# If GPU_TARGETS itself already carries feature suffixes they are used directly
-# and ROCSHMEM_GPU_TARGETS is not needed.
-if(GPU_TARGETS)
-  set(_FULL_BASE_LIST ${_GPU_TARGETS_LIST})
+# GPU_TARGETS_FULL is set by the main CMakeLists.txt from the user-supplied
+# GPU_TARGETS value before rocm_check_target_ids strips feature suffixes.
+# When available, use it as the source of truth for per-arch feature strings.
+# Fall back to bare arch names when building with auto-detected GPUs (where
+# no suffix information is available without querying the hardware directly).
+if(GPU_TARGETS_FULL)
+  string(REPLACE "," ";" _GPU_TARGETS_FULL_LIST "${GPU_TARGETS_FULL}")
+  set(_BITCODE_FULL_LIST ${_GPU_TARGETS_FULL_LIST})
 else()
-  set(_FULL_BASE_LIST ${_BITCODE_DEFAULT_ARCHS})
+  set(_BITCODE_FULL_LIST ${_BITCODE_DEFAULT_ARCHS})
 endif()
-
-# Build a base->full map from ROCSHMEM_GPU_TARGETS (feature suffix overlay).
-if(DEFINED ENV{ROCSHMEM_GPU_TARGETS})
-  string(REPLACE "," ";" _ROCSHMEM_GPU_TARGETS_LIST "$ENV{ROCSHMEM_GPU_TARGETS}")
-  foreach(_entry ${_ROCSHMEM_GPU_TARGETS_LIST})
-    string(REGEX REPLACE ":.*" "" _entry_base "${_entry}")
-    set(_ROCSHMEM_ARCH_${_entry_base} "${_entry}")
-  endforeach()
-  message(STATUS "Device bitcode: ROCSHMEM_GPU_TARGETS feature overlay: $ENV{ROCSHMEM_GPU_TARGETS}")
-endif()
-
-# For each arch in the build list, prefer the overlay entry if one exists,
-# then the full string from GPU_TARGETS, then the bare arch name.
-set(_BITCODE_FULL_LIST "")
-foreach(_entry ${_FULL_BASE_LIST})
-  string(REGEX REPLACE ":.*" "" _base "${_entry}")
-  if(DEFINED _ROCSHMEM_ARCH_${_base})
-    list(APPEND _BITCODE_FULL_LIST "${_ROCSHMEM_ARCH_${_base}}")
-  else()
-    list(APPEND _BITCODE_FULL_LIST "${_entry}")
-  endif()
-endforeach()
-
 set(BITCODE_GPU_ARCHS_FULL "${_BITCODE_FULL_LIST}" CACHE STRING
   "Full GPU arch strings with feature suffixes for device bitcode (e.g. gfx950:sramecc+:xnack-)")
-
-message(STATUS "Device bitcode GPU archs (base):  ${BITCODE_GPU_ARCHS}")
-message(STATUS "Device bitcode GPU archs (full):  ${BITCODE_GPU_ARCHS_FULL}")
 
 # -fvisibility=default ensures extern "C" device API symbols remain
 # externally visible after llvm-link and clang backend compilation.

--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -23,7 +23,7 @@ if(NOT LLVM_CLANG OR NOT LLVM_LINK)
   return()
 endif()
 
-# Strip feature suffixes (gfx942:sramecc+:xnack- → gfx942) and deduplicate.
+# Strip feature suffixes (gfx942:sramecc+:xnack- -> gfx942) and deduplicate.
 function(strip_arch_features targets_list out_var)
   set(_result "")
   foreach(_t ${targets_list})
@@ -34,14 +34,11 @@ function(strip_arch_features targets_list out_var)
   set(${out_var} "${_result}" PARENT_SCOPE)
 endfunction()
 
-# Convert arch feature suffix to a list of llc -mattr=<feature> flags.
-# gfx950:sramecc+:xnack-  →  CMake list: "-mattr=+sramecc;-mattr=-xnack"
-# Caller uses the list directly in add_custom_command COMMAND so each element
-# becomes a separate shell argument (avoiding comma-joining issues).
-function(arch_features_to_mattr_flags full_arch out_var)
-  # Split the full arch string on ":" into a list
+# Convert arch feature suffix to clang -Xclang -target-feature flags.
+# gfx950:sramecc+:xnack-  ->  "-Xclang;-target-feature;-Xclang;+sramecc;-Xclang;-target-feature;-Xclang;-xnack"
+# Caller passes the list directly to add_custom_command COMMAND.
+function(arch_features_to_target_feature_flags full_arch out_var)
   string(REPLACE ":" ";" _all_tokens "${full_arch}")
-  # Skip the first token (the base arch name) and process the rest as features
   list(LENGTH _all_tokens _ntokens)
   set(_flags "")
   if(_ntokens GREATER 1)
@@ -50,15 +47,15 @@ function(arch_features_to_mattr_flags full_arch out_var)
       if(_tok STREQUAL "")
         continue()
       endif()
-      # "sramecc+" → "+sramecc", "xnack-" → "-xnack"
-      string(REGEX REPLACE "([a-zA-Z0-9_]+)([+-])$" "\\2\\1" _part "${_tok}")
-      list(APPEND _flags "-mattr=${_part}")
+      # "sramecc+" -> "+sramecc", "xnack-" -> "-xnack"
+      string(REGEX REPLACE "([a-zA-Z0-9_]+)([+-])$" "\\2\\1" _feat "${_tok}")
+      list(APPEND _flags -Xclang -target-feature -Xclang ${_feat})
     endforeach()
   endif()
   set(${out_var} "${_flags}" PARENT_SCOPE)
 endfunction()
 
-# Resolve the target arch list: GPU_TARGETS CMake var → auto-detect local GPUs.
+# Resolve the target arch list: GPU_TARGETS CMake var -> auto-detect local GPUs.
 # Both accept comma- or semicolon-separated lists.
 if(GPU_TARGETS)
   # Convert comma-separated string to CMake list (semicolon-separated)
@@ -81,8 +78,8 @@ set(BITCODE_GPU_ARCHS "${_BITCODE_DEFAULT_ARCHS}" CACHE STRING "GPU architecture
 
 # BITCODE_GPU_ARCHS_FULL: full arch strings with feature suffixes (e.g.
 # gfx950:sramecc+:xnack-), used by CMakeDeviceBitcodeTester to pass the correct
-# -mattr flags to llc. llc embeds these in the HSACO amdhsa.target metadata
-# string, which HIP validates when loading the module — a mismatch causes error 209.
+# -target-feature flags to clang. These are embedded in the HSACO amdhsa.target
+# metadata string, which HIP validates when loading the module — a mismatch causes error 209.
 #
 # The arch list always comes from GPU_TARGETS/auto-detect. ROCSHMEM_GPU_TARGETS
 # is an optional env var that supplies feature suffixes for individual arches —
@@ -102,7 +99,7 @@ else()
   set(_FULL_BASE_LIST ${_BITCODE_DEFAULT_ARCHS})
 endif()
 
-# Build a base→full map from ROCSHMEM_GPU_TARGETS (feature suffix overlay).
+# Build a base->full map from ROCSHMEM_GPU_TARGETS (feature suffix overlay).
 if(DEFINED ENV{ROCSHMEM_GPU_TARGETS})
   string(REPLACE "," ";" _ROCSHMEM_GPU_TARGETS_LIST "$ENV{ROCSHMEM_GPU_TARGETS}")
   foreach(_entry ${_ROCSHMEM_GPU_TARGETS_LIST})
@@ -131,7 +128,7 @@ message(STATUS "Device bitcode GPU archs (base):  ${BITCODE_GPU_ARCHS}")
 message(STATUS "Device bitcode GPU archs (full):  ${BITCODE_GPU_ARCHS_FULL}")
 
 # -fvisibility=default ensures extern "C" device API symbols remain
-# externally visible after llvm-link and llc.
+# externally visible after llvm-link and clang backend compilation.
 set(BITCODE_COMPILE_FLAGS_BASE
     -Wall
     -Wextra

--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -23,7 +23,7 @@ if(NOT LLVM_CLANG OR NOT LLVM_LINK)
   return()
 endif()
 
-# Strip feature suffixes (gfx942:sramecc+:xnack- -> gfx942) and deduplicate.
+# Strip feature suffixes (gfx942:sramecc+:xnack- → gfx942) and deduplicate.
 function(strip_arch_features targets_list out_var)
   set(_result "")
   foreach(_t ${targets_list})

--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -79,6 +79,30 @@ endif()
 
 set(BITCODE_GPU_ARCHS "${_BITCODE_DEFAULT_ARCHS}" CACHE STRING "GPU architectures for device bitcode (semicolon-separated)")
 
+# BITCODE_GPU_ARCHS_FULL: full arch strings with feature suffixes (e.g.
+# gfx950:sramecc+:xnack-), used by CMakeDeviceBitcodeTester to pass the correct
+# -mattr flags to llc. llc embeds these in the HSACO amdhsa.target metadata
+# string, which HIP validates when loading the module — a mismatch causes error 209.
+#
+# When GPU_TARGETS is set, the user-supplied strings already carry any feature
+# suffixes, so we use them directly (no build-time GPU query needed). When
+# auto-detecting local GPUs, rocm_local_targets strips features, so the full
+# strings are unavailable without querying the hardware — in that case we fall
+# back to bare arch names. Users building for multiple architectures or for a
+# different machine than the build host should always set GPU_TARGETS explicitly
+# with the required feature suffixes, e.g.:
+#   -DGPU_TARGETS="gfx942:sramecc+:xnack-;gfx950:sramecc+:xnack-"
+if(GPU_TARGETS)
+  set(_BITCODE_FULL_LIST ${_GPU_TARGETS_LIST})
+else()
+  set(_BITCODE_FULL_LIST ${_BITCODE_DEFAULT_ARCHS})
+endif()
+set(BITCODE_GPU_ARCHS_FULL "${_BITCODE_FULL_LIST}" CACHE STRING
+  "Full GPU arch strings with feature suffixes for device bitcode (e.g. gfx950:sramecc+:xnack-)")
+
+message(STATUS "Device bitcode GPU archs (base):  ${BITCODE_GPU_ARCHS}")
+message(STATUS "Device bitcode GPU archs (full):  ${BITCODE_GPU_ARCHS_FULL}")
+
 # -fvisibility=default ensures extern "C" device API symbols remain
 # externally visible after llvm-link and llc.
 set(BITCODE_COMPILE_FLAGS_BASE

--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -58,12 +58,12 @@ function(arch_features_to_mattr_flags full_arch out_var)
   set(${out_var} "${_flags}" PARENT_SCOPE)
 endfunction()
 
-# Resolve the default arch list: GPU_TARGETS if set, otherwise auto-detect local GPUs.
+# Resolve the target arch list: GPU_TARGETS CMake var → auto-detect local GPUs.
+# Both accept comma- or semicolon-separated lists.
 if(GPU_TARGETS)
   # Convert comma-separated string to CMake list (semicolon-separated)
   # This handles both -DGPU_TARGETS=gfx942,gfx950 and -DGPU_TARGETS="gfx942;gfx950"
   string(REPLACE "," ";" _GPU_TARGETS_LIST "${GPU_TARGETS}")
-  # Ensure it's treated as a list even if already semicolon-separated
   set(_GPU_TARGETS_LIST ${_GPU_TARGETS_LIST})
   strip_arch_features("${_GPU_TARGETS_LIST}" _BITCODE_DEFAULT_ARCHS)
 elseif(COMMAND rocm_local_targets)
@@ -84,19 +84,46 @@ set(BITCODE_GPU_ARCHS "${_BITCODE_DEFAULT_ARCHS}" CACHE STRING "GPU architecture
 # -mattr flags to llc. llc embeds these in the HSACO amdhsa.target metadata
 # string, which HIP validates when loading the module — a mismatch causes error 209.
 #
-# When GPU_TARGETS is set, the user-supplied strings already carry any feature
-# suffixes, so we use them directly (no build-time GPU query needed). When
-# auto-detecting local GPUs, rocm_local_targets strips features, so the full
-# strings are unavailable without querying the hardware — in that case we fall
-# back to bare arch names. Users building for multiple architectures or for a
-# different machine than the build host should always set GPU_TARGETS explicitly
-# with the required feature suffixes, e.g.:
-#   -DGPU_TARGETS="gfx942:sramecc+:xnack-;gfx950:sramecc+:xnack-"
+# The arch list always comes from GPU_TARGETS/auto-detect. ROCSHMEM_GPU_TARGETS
+# is an optional env var that supplies feature suffixes for individual arches —
+# it acts as an overlay, not a replacement. For any arch listed in
+# ROCSHMEM_GPU_TARGETS the full string (with suffixes) is used; arches not
+# mentioned fall back to bare arch names from GPU_TARGETS or auto-detect.
+#
+# Example — building for five arches, providing suffixes for two:
+#   -DGPU_TARGETS="gfx90a;gfx1100;gfx1201;gfx942;gfx950"
+#   ROCSHMEM_GPU_TARGETS="gfx942:sramecc+:xnack-;gfx950:sramecc+:xnack-"
+#
+# If GPU_TARGETS itself already carries feature suffixes they are used directly
+# and ROCSHMEM_GPU_TARGETS is not needed.
 if(GPU_TARGETS)
-  set(_BITCODE_FULL_LIST ${_GPU_TARGETS_LIST})
+  set(_FULL_BASE_LIST ${_GPU_TARGETS_LIST})
 else()
-  set(_BITCODE_FULL_LIST ${_BITCODE_DEFAULT_ARCHS})
+  set(_FULL_BASE_LIST ${_BITCODE_DEFAULT_ARCHS})
 endif()
+
+# Build a base→full map from ROCSHMEM_GPU_TARGETS (feature suffix overlay).
+if(DEFINED ENV{ROCSHMEM_GPU_TARGETS})
+  string(REPLACE "," ";" _ROCSHMEM_GPU_TARGETS_LIST "$ENV{ROCSHMEM_GPU_TARGETS}")
+  foreach(_entry ${_ROCSHMEM_GPU_TARGETS_LIST})
+    string(REGEX REPLACE ":.*" "" _entry_base "${_entry}")
+    set(_ROCSHMEM_ARCH_${_entry_base} "${_entry}")
+  endforeach()
+  message(STATUS "Device bitcode: ROCSHMEM_GPU_TARGETS feature overlay: $ENV{ROCSHMEM_GPU_TARGETS}")
+endif()
+
+# For each arch in the build list, prefer the overlay entry if one exists,
+# then the full string from GPU_TARGETS, then the bare arch name.
+set(_BITCODE_FULL_LIST "")
+foreach(_entry ${_FULL_BASE_LIST})
+  string(REGEX REPLACE ":.*" "" _base "${_entry}")
+  if(DEFINED _ROCSHMEM_ARCH_${_base})
+    list(APPEND _BITCODE_FULL_LIST "${_ROCSHMEM_ARCH_${_base}}")
+  else()
+    list(APPEND _BITCODE_FULL_LIST "${_entry}")
+  endif()
+endforeach()
+
 set(BITCODE_GPU_ARCHS_FULL "${_BITCODE_FULL_LIST}" CACHE STRING
   "Full GPU arch strings with feature suffixes for device bitcode (e.g. gfx950:sramecc+:xnack-)")
 

--- a/projects/rocshmem/cmake/DeviceBitcode.cmake
+++ b/projects/rocshmem/cmake/DeviceBitcode.cmake
@@ -16,9 +16,14 @@ find_program(LLVM_LINK llvm-link
                ${ROCM_PATH}/llvm/bin
                ${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin
                NO_DEFAULT_PATH QUIET)
+find_program(LLVM_OPT opt
+             PATHS
+               ${ROCM_PATH}/llvm/bin
+               ${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin
+             NO_DEFAULT_PATH QUIET)
 
-if(NOT LLVM_CLANG OR NOT LLVM_LINK)
-  message(WARNING "ROCm LLVM tools (clang++, llvm-link) not found under "
+if(NOT LLVM_CLANG OR NOT LLVM_LINK OR NOT LLVM_OPT)
+  message(WARNING "ROCm LLVM tools (clang++, llvm-link, opt) not found under "
                   "${ROCM_PATH}/llvm/bin; skipping device bitcode targets.")
   return()
 endif()
@@ -194,9 +199,18 @@ if(USE_GDA)
 endif()
 
 # Build bitcode for each GPU architecture
+#
+# __device__ API functions (rocshmem_quiet, rocshmem_barrier_wg, etc.) are DCE'd
+# by LLVM's -O3 passes when compiled per-TU: no amdgpu_kernel in the same TU
+# calls them, so the optimizer treats them as dead.  Fix: compile each source
+# with -Xclang -disable-llvm-passes (frontend runs at -O3, LLVM DCE is skipped,
+# all __device__ bodies are retained), then run opt -O3 over the merged BC where
+# all callers exist.  This mirrors the approach in CMakeDeviceBitcodeTester.cmake.
 set(ALL_BITCODE_OUTPUTS)
 foreach(gpu_arch ${BITCODE_GPU_ARCHS})
-  set(BITCODE_COMPILE_FLAGS ${BITCODE_COMPILE_FLAGS_BASE} --offload-arch=${gpu_arch})
+  # Per-source flags: -Xclang -disable-llvm-passes suppresses DCE.
+  set(_COMPILE_FLAGS ${BITCODE_COMPILE_FLAGS_BASE} --offload-arch=${gpu_arch}
+                     -Xclang -disable-llvm-passes)
   set(BITCODE_OBJECTS_${gpu_arch})
   foreach(src_file ${BITCODE_SOURCES})
     get_filename_component(src_name ${src_file} NAME_WE)
@@ -206,21 +220,31 @@ foreach(gpu_arch ${BITCODE_GPU_ARCHS})
     add_custom_command(
       OUTPUT ${bc_file}
       COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/bitcode/${gpu_arch}
-      COMMAND ${LLVM_CLANG} ${BITCODE_COMPILE_FLAGS} -c ${src_file} -o ${bc_file}
+      COMMAND ${LLVM_CLANG} ${_COMPILE_FLAGS} -c ${src_file} -o ${bc_file}
       DEPENDS ${src_file}
       COMMENT "Compiling ${src_name} to bitcode for ${gpu_arch}"
       VERBATIM
     )
   endforeach()
 
+  set(_UNOPT_BC ${CMAKE_CURRENT_BINARY_DIR}/bitcode/${gpu_arch}/librocshmem_device_${gpu_arch}_unopt.bc)
   set(BITCODE_OUTPUT_${gpu_arch} ${CMAKE_CURRENT_BINARY_DIR}/librocshmem_device_${gpu_arch}.bc)
   list(APPEND ALL_BITCODE_OUTPUTS ${BITCODE_OUTPUT_${gpu_arch}})
 
   add_custom_command(
-    OUTPUT ${BITCODE_OUTPUT_${gpu_arch}}
-    COMMAND ${LLVM_LINK} ${BITCODE_OBJECTS_${gpu_arch}} -o ${BITCODE_OUTPUT_${gpu_arch}}
+    OUTPUT ${_UNOPT_BC}
+    COMMAND ${LLVM_LINK} ${BITCODE_OBJECTS_${gpu_arch}} -o ${_UNOPT_BC}
     DEPENDS ${BITCODE_OBJECTS_${gpu_arch}}
     COMMENT "Linking device bitcode for ${gpu_arch}"
+    VERBATIM
+  )
+
+  add_custom_command(
+    OUTPUT ${BITCODE_OUTPUT_${gpu_arch}}
+    COMMAND ${LLVM_OPT} -O3 -mtriple=amdgcn-amd-amdhsa -mcpu=${gpu_arch}
+            ${_UNOPT_BC} -o ${BITCODE_OUTPUT_${gpu_arch}}
+    DEPENDS ${_UNOPT_BC}
+    COMMENT "Optimizing device bitcode for ${gpu_arch}"
     VERBATIM
   )
 

--- a/projects/rocshmem/docs/build.rst
+++ b/projects/rocshmem/docs/build.rst
@@ -258,6 +258,41 @@ This is similar to the default build in ROCm 6.4.
   Other experimental configuration scripts are available in ``./scripts/build_configs``, but only ``all_backends``, ``ipc_single`` and ``ro_ipc``
   are officially supported.
 
+Targeting GPU architectures
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, rocSHMEM builds device bitcode for a predefined set of supported GPU architectures
+(``gfx90a``, ``gfx942``, ``gfx950``, ``gfx1100``, ``gfx1201``, and ``gfx1250`` on ROCm 7 or
+later). To restrict the build to a specific subset - for example to reduce build time or when
+targeting a known deployment environment - pass ``GPU_TARGETS`` to CMake:
+
+.. code-block:: bash
+
+  ../scripts/build_configs/all_backends -DGPU_TARGETS="gfx942;gfx950"
+
+Some GPU features, such as SRAM ECC and XNACK (hardware page-fault support), are encoded as
+feature suffixes in the architecture string (for example ``gfx950:sramecc+:xnack-``). These
+suffixes are embedded in the device bitcode metadata. If the suffixes in the bitcode do not
+match the active feature configuration of the GPU at runtime, the bitcode may fail to load.
+
+To embed the correct feature metadata, include the suffixes in ``GPU_TARGETS``:
+
+.. code-block:: bash
+
+  ../scripts/build_configs/all_backends \
+    -DGPU_TARGETS="gfx942:sramecc+:xnack-;gfx950:sramecc+:xnack-"
+
+The feature strings for your GPU can be obtained by running ``rocminfo`` on the target machine
+and looking for the ``Name:`` field under each agent, for example
+``amdgcn-amd-amdhsa--gfx950:sramecc+:xnack-``.
+
+.. note::
+
+  The ``xnack`` feature is runtime-configurable and can differ between machines. If a cluster
+  is configured with ``xnack+`` (unified memory), specifying ``xnack-`` in ``GPU_TARGETS``
+  may cause device bitcode load failures at runtime. Match the suffix to the actual
+  configuration of the target system.
+
 Installation prefix
 ^^^^^^^^^^^^^^^^^^^
 

--- a/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
+++ b/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
@@ -70,15 +70,11 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
   # bodies. After linking with the kernel (which provides callers), a final
   # opt -O3 pass over the merged BC optimizes everything together.
 
-  # Device sources: -O3 front-end IR, no LLVM DCE passes.
-  set(_TESTER_DEVICE_FLAGS "")
-  foreach(_f ${BITCODE_COMPILE_FLAGS_BASE})
-    list(APPEND _TESTER_DEVICE_FLAGS "${_f}")
-  endforeach()
+  # Device sources: suppress LLVM passes so DCE doesn't eliminate __device__
+  # functions that have no callers within the same TU. The kernel BC is compiled
+  # at plain -O3 (it has an amdgpu_kernel entry point, so nothing gets DCE'd).
+  set(_TESTER_DEVICE_FLAGS ${BITCODE_COMPILE_FLAGS_BASE})
   list(APPEND _TESTER_DEVICE_FLAGS -Xclang -disable-llvm-passes)
-
-  # Kernel: plain -O3 (only amdgpu_kernel entries, no library DCE concern).
-  set(_TESTER_KERNEL_FLAGS ${BITCODE_COMPILE_FLAGS_BASE})
 
   # Compile the kernel and each device source into tester-private BCs.
   set(_TESTER_BCS "")
@@ -86,7 +82,7 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
   add_custom_command(
     OUTPUT ${KERNEL_BC}
     COMMAND ${LLVM_CLANG}
-      ${_TESTER_KERNEL_FLAGS}
+      ${BITCODE_COMPILE_FLAGS_BASE}
       --offload-arch=${GPU_ARCH}
       -c ${CMAKE_CURRENT_SOURCE_DIR}/device_bitcode_tester_kernel.hip
       -o ${KERNEL_BC}

--- a/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
+++ b/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
@@ -25,12 +25,11 @@ endif()
 
 # LLVM_CLANG and LLVM_LINK are already set by DeviceBitcode.cmake.
 # Search for additional tools needed for HSACO generation.
-find_program(LLVM_LLC llc PATHS ${ROCM_PATH}/llvm/bin ${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin NO_DEFAULT_PATH QUIET)
 find_program(LLVM_LLD ld.lld PATHS ${ROCM_PATH}/llvm/bin ${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin NO_DEFAULT_PATH QUIET)
 find_program(LLVM_OPT opt PATHS ${ROCM_PATH}/llvm/bin ${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin NO_DEFAULT_PATH QUIET)
 
-if(NOT LLVM_LLC OR NOT LLVM_LLD OR NOT LLVM_OPT)
-  message(WARNING "device_bitcode_tester: llc/ld.lld/opt not found (ROCM_PATH=${ROCM_PATH}). "
+if(NOT LLVM_LLD OR NOT LLVM_OPT)
+  message(WARNING "device_bitcode_tester: ld.lld/opt not found (ROCM_PATH=${ROCM_PATH}). "
     "HSACOs will not be built; test will skip at runtime.")
   return()
 endif()
@@ -46,7 +45,7 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
   set(HSACO_FILE ${CMAKE_CURRENT_BINARY_DIR}/device_bitcode_tester_kernel_${GPU_ARCH}.hsaco)
 
   # Find the full arch string (with feature suffixes) for this base arch so we can
-  # pass -mattr to llc. Without features the amdhsa.target metadata in the HSACO
+  # pass -mattr flags. Without features the amdhsa.target metadata in the HSACO
   # omits the suffix, causing hipModuleLoadData error 209 on devices that report
   # e.g. gfx950:sramecc+:xnack-.
   set(_FULL_ARCH "${GPU_ARCH}")
@@ -57,9 +56,16 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
       break()
     endif()
   endforeach()
-  arch_features_to_mattr_flags("${_FULL_ARCH}" _LLC_MATTR_FLAGS)
+  arch_features_to_mattr_flags("${_FULL_ARCH}" _MATTR_FLAGS)
+  set(_CLANG_MATTR_FLAGS "")
+  foreach(_f ${_MATTR_FLAGS})
+    # _f is "-mattr=+sramecc" or "-mattr=-xnack"; extract the feature part
+    string(REGEX REPLACE "^-mattr=" "" _feat "${_f}")
+    list(APPEND _CLANG_MATTR_FLAGS -Xclang -target-feature -Xclang ${_feat})
+  endforeach()
 
-  message(status "_LLC_MATTR_FLAGS" ${_LLC_MATTR_FLAGS})
+  # message(status "_MATTR_FLAGS" ${_MATTR_FLAGS})
+  
   # The device API functions (rocshmem_my_pe, rocshmem_putmem, etc.) are plain
   # __device__ functions. When compiled at -O3 independently, LLVM DCEs them
   # because no amdgpu_kernel in the same TU calls them. Compiling at -O0
@@ -143,13 +149,13 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
 
   add_custom_command(
     OUTPUT ${OBJ_FILE}
-    COMMAND ${LLVM_LLC}
-      -mtriple=amdgcn-amd-amdhsa
+    COMMAND ${LLVM_CLANG}
+      -target amdgcn-amd-amdhsa
       -mcpu=${GPU_ARCH}
-      ${_LLC_MATTR_FLAGS}
-      --amdgpu-internalize-symbols=false
-      -filetype=obj
-      ${LINKED_BC}
+      ${_CLANG_MATTR_FLAGS}
+      -mllvm -amdgpu-internalize-symbols=false
+      -x ir
+      -c ${LINKED_BC}
       -o ${OBJ_FILE}
     DEPENDS ${LINKED_BC}
     COMMENT "device_bitcode_tester: compiling to object for ${GPU_ARCH}"

--- a/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
+++ b/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
@@ -51,15 +51,13 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
   set(_FULL_ARCH "${GPU_ARCH}")
   foreach(_candidate ${BITCODE_GPU_ARCHS_FULL})
     string(REGEX REPLACE ":.*" "" _candidate_base "${_candidate}")
-    if(_candidate_base STREQUAL GPU_ARCH)
+    if("${_candidate_base}" STREQUAL "${GPU_ARCH}")
       set(_FULL_ARCH "${_candidate}")
       break()
     endif()
   endforeach()
   arch_features_to_target_feature_flags("${_FULL_ARCH}" _CLANG_MATTR_FLAGS)
 
-  # message(status "_MATTR_FLAGS" ${_MATTR_FLAGS})
-  
   # The device API functions (rocshmem_my_pe, rocshmem_putmem, etc.) are plain
   # __device__ functions. When compiled at -O3 independently, LLVM DCEs them
   # because no amdgpu_kernel in the same TU calls them. Compiling at -O0

--- a/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
+++ b/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
@@ -145,6 +145,7 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
       -x ir
       -c ${LINKED_BC}
       -o ${OBJ_FILE}
+
     DEPENDS ${LINKED_BC}
     COMMENT "device_bitcode_tester: compiling to object for ${GPU_ARCH}"
     VERBATIM

--- a/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
+++ b/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
@@ -45,6 +45,21 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
   set(OBJ_FILE   ${CMAKE_CURRENT_BINARY_DIR}/device_bitcode_tester_kernel_${GPU_ARCH}.o)
   set(HSACO_FILE ${CMAKE_CURRENT_BINARY_DIR}/device_bitcode_tester_kernel_${GPU_ARCH}.hsaco)
 
+  # Find the full arch string (with feature suffixes) for this base arch so we can
+  # pass -mattr to llc. Without features the amdhsa.target metadata in the HSACO
+  # omits the suffix, causing hipModuleLoadData error 209 on devices that report
+  # e.g. gfx950:sramecc+:xnack-.
+  set(_FULL_ARCH "${GPU_ARCH}")
+  foreach(_candidate ${BITCODE_GPU_ARCHS_FULL})
+    string(REGEX REPLACE ":.*" "" _candidate_base "${_candidate}")
+    if(_candidate_base STREQUAL GPU_ARCH)
+      set(_FULL_ARCH "${_candidate}")
+      break()
+    endif()
+  endforeach()
+  arch_features_to_mattr_flags("${_FULL_ARCH}" _LLC_MATTR_FLAGS)
+
+  message(status "_LLC_MATTR_FLAGS" ${_LLC_MATTR_FLAGS})
   # The device API functions (rocshmem_my_pe, rocshmem_putmem, etc.) are plain
   # __device__ functions. When compiled at -O3 independently, LLVM DCEs them
   # because no amdgpu_kernel in the same TU calls them. Compiling at -O0

--- a/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
+++ b/projects/rocshmem/tests/functional_tests/CMakeDeviceBitcodeTester.cmake
@@ -45,9 +45,9 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
   set(HSACO_FILE ${CMAKE_CURRENT_BINARY_DIR}/device_bitcode_tester_kernel_${GPU_ARCH}.hsaco)
 
   # Find the full arch string (with feature suffixes) for this base arch so we can
-  # pass -mattr flags. Without features the amdhsa.target metadata in the HSACO
-  # omits the suffix, causing hipModuleLoadData error 209 on devices that report
-  # e.g. gfx950:sramecc+:xnack-.
+  # pass target-feature flags. Without features the amdhsa.target metadata in the
+  # HSACO omits the suffix, causing hipModuleLoadData error 209 on devices that
+  # report e.g. gfx950:sramecc+:xnack-.
   set(_FULL_ARCH "${GPU_ARCH}")
   foreach(_candidate ${BITCODE_GPU_ARCHS_FULL})
     string(REGEX REPLACE ":.*" "" _candidate_base "${_candidate}")
@@ -56,13 +56,7 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
       break()
     endif()
   endforeach()
-  arch_features_to_mattr_flags("${_FULL_ARCH}" _MATTR_FLAGS)
-  set(_CLANG_MATTR_FLAGS "")
-  foreach(_f ${_MATTR_FLAGS})
-    # _f is "-mattr=+sramecc" or "-mattr=-xnack"; extract the feature part
-    string(REGEX REPLACE "^-mattr=" "" _feat "${_f}")
-    list(APPEND _CLANG_MATTR_FLAGS -Xclang -target-feature -Xclang ${_feat})
-  endforeach()
+  arch_features_to_target_feature_flags("${_FULL_ARCH}" _CLANG_MATTR_FLAGS)
 
   # message(status "_MATTR_FLAGS" ${_MATTR_FLAGS})
   
@@ -70,7 +64,7 @@ foreach(GPU_ARCH ${BITCODE_GPU_ARCHS})
   # __device__ functions. When compiled at -O3 independently, LLVM DCEs them
   # because no amdgpu_kernel in the same TU calls them. Compiling at -O0
   # avoids DCE but produces unoptimized IR patterns that trigger an AMDGPU
-  # backend register-class bug (V_CMP_NE_U32 on $src_private_base) in llc.
+  # backend register-class bug (V_CMP_NE_U32 on $src_private_base).
   #
   # Solution: compile with -Xclang -disable-llvm-passes, which runs the
   # frontend at -O3 (generating valid, structured IR) but skips the LLVM


### PR DESCRIPTION
## Motivation

1. `llc` is not shipped by all ROCm/LLVM distributions (absent on LLVM 23+), causing the `device_bitcode_tester` build to be silently skipped at configure time on affected machines.
2. The HSACO `amdhsa.target` metadata should include GPU feature suffixes (e.g. `gfx950:sramecc+:xnack-`) to match what the runtime GPU reports. Previously there was no way to supply these suffixes without a build-time `rocminfo` call against the local GPU, which fails on GPU-less build hosts and on multi-arch builds where not all target GPUs are physically present. Now, we are letting the user pass those features through `GPU_TARGET` var to cmake scripts.

## Technical Details

### 1. Replace `llc` with `clang -x ir`

- Replace the `llc -filetype=obj` step in `CMakeDeviceBitcodeTester.cmake` with `clang -x ir -c -target amdgcn-amd-amdhsa`, which performs the same BC→object compilation using `clang`, which is always present.
- Arch feature flags (`sramecc`, `xnack`, etc.) previously passed as `-mattr=` flags to `llc` are now passed as `-Xclang -target-feature` flags to `clang`. The helper function `arch_features_to_mattr_flags` is renamed to `arch_features_to_target_feature_flags` and updated accordingly.
- Remove `find_program(LLVM_LLC ...)` and its guard. `llc` is no longer a build dependency.
- `llc`/`ld.lld`/`opt` search paths are extended to also look under `${THEROCK_TOOLCHAIN_ROOT}/lib/llvm/bin`, consistent with how `clang++` and `llvm-link` are already searched in `DeviceBitcode.cmake`.

### 2. Feature suffix support via `GPU_TARGETS`

- Users can now pass feature suffixes directly in the `GPU_TARGETS` CMake variable:

  ```bash
  ../scripts/build_configs/ipc_single -DGPU_TARGETS="gfx950:sramecc+:xnack-"
  ```

- The main `CMakeLists.txt` normalises `GPU_TARGETS` into bare arch names (required by HIP compilation and `rocm_check_target_ids`) while preserving the original suffixed strings in a new `GPU_TARGETS_FULL` cache variable. `DeviceBitcode.cmake` reads `GPU_TARGETS_FULL` to populate `BITCODE_GPU_ARCHS_FULL`, which drives the `-Xclang -target-feature` flags passed to `clang` when building the tester HSACOs.
- The `rocminfo` dependency for feature suffix resolution is removed entirely. Feature suffixes now come from the user-supplied `GPU_TARGETS` value.
- A bug in the original `CMakeLists.txt` is also fixed: `rocm_check_target_ids` was always called with `DEFAULT_GPU_TARGETS` regardless of whether the user supplied `GPU_TARGETS`, causing the user's value to be silently ignored.

## Test Result

- Functional tests pass on `gfx942` and `gfx950`.
- Regarding AIROCSHMEM-437, the device bitcode tester is fixed with this PR, but the all-to-all issue on `gfx942` should be further investigated (not related to this PR).

---
JIRA ID: AIROCSHMEM-439