### PR TITLE
[rocDecode] Multiarch ASAN - unit test fixes

### DIFF
--- a/projects/rocdecode/test/CMakeLists.txt
+++ b/projects/rocdecode/test/CMakeLists.txt
@@ -93,14 +93,74 @@ else()
 endif(BUILD_FROM_SOURCE)
 find_package(FFmpeg QUIET)
 
+# Check if ASAN is enabled via environment variables or compiler flags
+set(ASAN_ENABLED OFF)
+# Check common ASAN environment variables
+if(DEFINED ENV{ASAN_OPTIONS} OR DEFINED ENV{ASAN_SYMBOLIZER_PATH} OR DEFINED ENV{LSAN_OPTIONS})
+  set(ASAN_ENABLED ON)
+endif()
+# Check if -fsanitize=address is in the compiler flags
+if(CMAKE_CXX_FLAGS MATCHES "-fsanitize=address" OR
+   CMAKE_C_FLAGS MATCHES "-fsanitize=address" OR
+   CMAKE_EXE_LINKER_FLAGS MATCHES "-fsanitize=address")
+  set(ASAN_ENABLED ON)
+endif()
+
+# Locate the ASAN runtime library if ASAN is enabled
+set(ASAN_PRELOAD "")
+if(ASAN_ENABLED)
+  set(ASAN_LIB_PATH "${ROCM_PATH}/lib/llvm/lib/clang")
+  # Try to get the clang version from the compiler
+  execute_process(
+    COMMAND ${CMAKE_CXX_COMPILER} --version
+    OUTPUT_VARIABLE CLANG_VERSION_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  # Extract major version (e.g., "19" from "clang version 19.0.0")
+  if(CLANG_VERSION_OUTPUT MATCHES "clang version ([0-9]+)")
+    set(CLANG_MAJOR_VERSION "${CMAKE_MATCH_1}")
+    set(ASAN_LIB_CANDIDATE "${ASAN_LIB_PATH}/${CLANG_MAJOR_VERSION}/lib/linux/libclang_rt.asan-x86_64.so")
+    if(EXISTS "${ASAN_LIB_CANDIDATE}")
+      set(ASAN_PRELOAD "${ASAN_LIB_CANDIDATE}")
+      message("-- ${White}${PROJECT_NAME}: ASAN enabled, runtime library found -- ${ASAN_PRELOAD}${ColourReset}")
+    endif()
+  endif()
+  # Fallback: search available versions (sorted descending) if compiler detection failed
+  if(NOT ASAN_PRELOAD)
+    file(GLOB CLANG_VERSION_DIRS "${ASAN_LIB_PATH}/*")
+    list(SORT CLANG_VERSION_DIRS ORDER DESCENDING)
+    foreach(CLANG_DIR ${CLANG_VERSION_DIRS})
+      if(IS_DIRECTORY ${CLANG_DIR})
+        set(ASAN_LIB_CANDIDATE "${CLANG_DIR}/lib/linux/libclang_rt.asan-x86_64.so")
+        if(EXISTS "${ASAN_LIB_CANDIDATE}")
+          set(ASAN_PRELOAD "${ASAN_LIB_CANDIDATE}")
+          message("-- ${White}${PROJECT_NAME}: ASAN enabled, runtime library found (fallback) -- ${ASAN_PRELOAD}${ColourReset}")
+          break()
+        endif()
+      endif()
+    endforeach()
+  endif()
+  if(NOT ASAN_PRELOAD)
+    message(WARNING "${PROJECT_NAME}: ASAN detected but libclang_rt.asan-x86_64.so not found in ${ASAN_LIB_PATH}")
+  endif()
+endif()
+
 # Check if lib/rocm_sysdeps/lib exists in the ROCm path which indicates ROCm installation via TheRock
 set(USING_THE_ROCK OFF)
 if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
   set(USING_THE_ROCK ON)
   set(THEROCK_SYSDEPS_LIB "${ROCM_PATH}/lib/rocm_sysdeps/lib")
-  set(THEROCK_ENV
-    "LD_PRELOAD=${THEROCK_SYSDEPS_LIB}/librocm_sysdeps_va.so.2:${THEROCK_SYSDEPS_LIB}/librocm_sysdeps_va-drm.so.2;LIBVA_DRIVERS_PATH=${THEROCK_SYSDEPS_LIB}"
-  )
+  set(VA_LIBS "${THEROCK_SYSDEPS_LIB}/librocm_sysdeps_va.so.2:${THEROCK_SYSDEPS_LIB}/librocm_sysdeps_va-drm.so.2")
+  if(ASAN_PRELOAD)
+    set(THEROCK_ENV
+      "LD_PRELOAD=${ASAN_PRELOAD}:${VA_LIBS};LIBVA_DRIVERS_PATH=${THEROCK_SYSDEPS_LIB}"
+    )
+  else()
+    set(THEROCK_ENV
+      "LD_PRELOAD=${VA_LIBS};LIBVA_DRIVERS_PATH=${THEROCK_SYSDEPS_LIB}"
+    )
+  endif()
 endif()
 
 # Helper macro: apply TheRock VA environment to a test when building via TheRock

--- a/projects/rocdecode/test/CMakeLists.txt
+++ b/projects/rocdecode/test/CMakeLists.txt
@@ -163,11 +163,18 @@ if(EXISTS "${ROCM_PATH}/lib/rocm_sysdeps/lib")
   endif()
 endif()
 
-# Helper macro: apply TheRock VA environment to a test when building via TheRock
-macro(set_therock_env TEST_NAME)
+# Helper macro: apply test environment (ASAN preload and/or TheRock VA libs)
+macro(set_test_env TEST_NAME)
   if(USING_THE_ROCK)
     set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "${THEROCK_ENV}")
+  elseif(ASAN_PRELOAD)
+    set_property(TEST ${TEST_NAME} PROPERTY ENVIRONMENT "LD_PRELOAD=${ASAN_PRELOAD}")
   endif()
+endmacro()
+
+# Keep old name for compatibility
+macro(set_therock_env TEST_NAME)
+  set_test_env(${TEST_NAME})
 endmacro()
 
 # Option to enable extended tests
@@ -185,6 +192,7 @@ add_test(
             --test-command "videodecoderaw"
             -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.265
 )
+set_test_env(video_decodeRaw-HEVC)
 
 # 2 - videoDecodeRaw AVC
 add_test(
@@ -198,6 +206,7 @@ add_test(
             --test-command "videodecoderaw"
             -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H264.264
 )
+set_test_env(video_decodeRaw-AVC)
 
 # 3 - videoDecodeRaw AV1
 add_test(
@@ -211,6 +220,7 @@ add_test(
             --test-command "videodecoderaw"
             -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-AV1.ivf
 )
+set_test_env(video_decodeRaw-AV1)
 
 # 4 - videoDecodeRaw VP9
 add_test(
@@ -224,6 +234,7 @@ add_test(
             --test-command "videodecoderaw"
             -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf
 )
+set_test_env(video_decodeRaw-VP9)
 
 # 5 - rocdecDecode
 add_test(
@@ -237,6 +248,7 @@ add_test(
             --test-command "rocdecdecode"
             -i ${ROCM_PATH}/share/rocdecode/frames
 )
+set_test_env(rocdec_Decode-HEVC)
 
 # 6 - rocDecodeNegativeApiTests
 add_test(
@@ -249,6 +261,7 @@ add_test(
             --build-generator "${CMAKE_GENERATOR}"
             --test-command "rocdecodenegativetest"
 )
+set_test_env(rocDecode_Negative_API_Tests)
 
 if(FFMPEG_FOUND AND ENABLE_EXTENDED_TESTS)
   # 7 - videoDecode HEVC

--- a/projects/rocdecode/test/CMakeLists.txt
+++ b/projects/rocdecode/test/CMakeLists.txt
@@ -172,11 +172,6 @@ macro(set_test_env TEST_NAME)
   endif()
 endmacro()
 
-# Keep old name for compatibility
-macro(set_therock_env TEST_NAME)
-  set_test_env(${TEST_NAME})
-endmacro()
-
 # Option to enable extended tests
 option(ENABLE_EXTENDED_TESTS "Enable extended FFmpeg-based tests" OFF)
 
@@ -276,7 +271,7 @@ if(FFMPEG_FOUND AND ENABLE_EXTENDED_TESTS)
             --test-command "videodecode"
             -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4
   )
-  set_therock_env(video_decode-HEVC)
+  set_test_env(video_decode-HEVC)
 
   # 8 - videoDecode AVC
   add_test(
@@ -290,7 +285,7 @@ if(FFMPEG_FOUND AND ENABLE_EXTENDED_TESTS)
             --test-command "videodecode"
             -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H264.mp4
   )
-  set_therock_env(video_decode-AVC)
+  set_test_env(video_decode-AVC)
 
   # 9 - videoDecode AV1
   add_test(
@@ -304,7 +299,7 @@ if(FFMPEG_FOUND AND ENABLE_EXTENDED_TESTS)
             --test-command "videodecode"
             -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-AV1.mp4
   )
-  set_therock_env(video_decode-AV1)
+  set_test_env(video_decode-AV1)
 
   # 10 - videoDecode VP9
   add_test(
@@ -318,7 +313,7 @@ if(FFMPEG_FOUND AND ENABLE_EXTENDED_TESTS)
             --test-command "videodecode"
             -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf
   )
-  set_therock_env(video_decode-VP9)
+  set_test_env(video_decode-VP9)
 
   # 11 - videoDecodePerf
   add_test(
@@ -332,7 +327,7 @@ if(FFMPEG_FOUND AND ENABLE_EXTENDED_TESTS)
             --test-command "videodecodeperf"
             -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4
   )
-  set_therock_env(video_decodePerf-HEVC)
+  set_test_env(video_decodePerf-HEVC)
 
   # 12 - videoDecodeBatch
   add_test(
@@ -346,7 +341,7 @@ if(FFMPEG_FOUND AND ENABLE_EXTENDED_TESTS)
             --test-command "videodecodebatch"
             -i ${ROCM_PATH}/share/rocdecode/video/ -t 2
   )
-  set_therock_env(video_decodeBatch)
+  set_test_env(video_decodeBatch)
 
   # 13 - videoDecodeRGB
   add_test(
@@ -360,7 +355,7 @@ if(FFMPEG_FOUND AND ENABLE_EXTENDED_TESTS)
             --test-command "videodecodergb"
             -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4 -of rgb
   )
-  set_therock_env(video_decodeRGB-HEVC)
+  set_test_env(video_decodeRGB-HEVC)
 
   # 14 - videoDecodeMem
   add_test(
@@ -374,7 +369,7 @@ if(FFMPEG_FOUND AND ENABLE_EXTENDED_TESTS)
             --test-command "videodecodemem"
             -i ${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4
   )
-  set_therock_env(video_decodeMem-HEVC)
+  set_test_env(video_decodeMem-HEVC)
 
   # 15 - videoDecodeRGBResize
   add_test(
@@ -388,7 +383,7 @@ if(FFMPEG_FOUND AND ENABLE_EXTENDED_TESTS)
             --test-command "videodecodergb"
             -i "${ROCM_PATH}/share/rocdecode/video/AMD_driving_virtual_20-H265.mp4" -resize 640x360 -of rgb
   )
-  set_therock_env(video_decodeRGB-Resize)
+  set_test_env(video_decodeRGB-Resize)
 
   if(rocdecode-host_FOUND AND NOT USING_THE_ROCK)
     # 16 - videoDecode Host backend


### PR DESCRIPTION
## Motivation

The unit tests fails in an asan build currently, since `asan.so` is not set in the LD_PRELOAD. This PR fixes that issue.

## Technical Details

Check for an ASAN environment first, and if enabled,  finds the `asan.so` in the environment and adds it to the LD_PRELOAD path

## JIRA ID

ROCM-26593

## Test Plan

Run ctests on regular build and ASAN

## Test Result

On a non ASAN build.
```
 lakshmi@kapu:~/work/rocdecode-test$ cmake $ROCM_PATH/share/rocdecode/test
-- The C compiler identification is Clang 23.0.0
-- The CXX compiler identification is Clang 23.0.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- rocdecode-test: rocdecode found with find_package(rocdecode QUIET)
--      rocdecode_INCLUDE_DIR -- /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/include
--      rocdecode_LIB_DIR -- /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib
--      rocdecode_LIBRARY -- /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/librocdecode.so
--      rocdecode_FOUND -- 1
--      rocdecode_VERSION -- 1.8.0
--      rocdecode_VERSION_MAJOR -- 1
--      rocdecode_VERSION_MINOR -- 8
--      rocdecode_VERSION_PATCH -- 0
-- rocdecode-test: rocdecode-host found with find_package(rocdecode-host QUIET)
--      rocdecode-host_INCLUDE_DIR -- /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/include
--      rocdecode-host_LIB_DIR -- /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib
--      rocdecode-host_LIBRARY -- /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/librocdecode-host.so
--      rocdecode-host_FOUND -- 1
--      rocdecode-host_VERSION -- 1.0.0
--      rocdecode-host_VERSION_MAJOR -- 1
--      rocdecode-host_VERSION_MINOR -- 0
--      rocdecode-host_VERSION_PATCH -- 0
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2")
-- Checking for module 'libavcodec'
--   Found libavcodec, version 58.134.100
-- Checking for module 'libavformat'
--   Found libavformat, version 58.76.100
-- Checking for module 'libavutil'
--   Found libavutil, version 56.70.100
-- Using FFMPEG --
        Libraries:/usr/lib/x86_64-linux-gnu/libavcodec.so;/usr/lib/x86_64-linux-gnu/libavformat.so;/usr/lib/x86_64-linux-gnu/libavutil.so
        Includes:/usr/include/x86_64-linux-gnu
-- Configuring done
-- Generating done
-- Build files have been written to: /home/lakshmi/work/rocdecode-test
(rock_0408) lakshmi@kapu:~/work/rocdecode-test$ ctest -VV
UpdateCTestConfiguration  from :/home/lakshmi/work/rocdecode-test/DartConfiguration.tcl
Parse Config file:/home/lakshmi/work/rocdecode-test/DartConfiguration.tcl
UpdateCTestConfiguration  from :/home/lakshmi/work/rocdecode-test/DartConfiguration.tcl
Parse Config file:/home/lakshmi/work/rocdecode-test/DartConfiguration.tcl
Test project /home/lakshmi/work/rocdecode-test
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 1
    Start 1: video_decodeRaw-HEVC

1: Test command: /usr/local/bin/ctest "--build-and-test" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/samples/videoDecodeRaw" "/home/lakshmi/work/rocdecode-test/videoDecodeRaw-HEVC" "--build-generator" "Unix Makefiles" "--test-command" "videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-H265.265"
1: Working Directory: /home/lakshmi/work/rocdecode-test
1: Environment variables:
1:  LD_PRELOAD=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
1:  LIBVA_DRIVERS_PATH=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib
1: Test timeout computed to be: 1500
1: Internal cmake changing into directory: /home/lakshmi/work/rocdecode-test/videoDecodeRaw-HEVC
1: ======== CMake output     ======
1: The C compiler identification is Clang 23.0.0
1: The CXX compiler identification is Clang 23.0.0
1: Detecting C compiler ABI info
1: Detecting C compiler ABI info - done
1: Check for working C compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang - skipped
1: Detecting C compile features
1: Detecting C compile features - done
1: Detecting CXX compiler ABI info
1: Detecting CXX compiler ABI info - done
1: Check for working CXX compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang++ - skipped
1: Detecting CXX compile features
1: Detecting CXX compile features - done
1: HIP: Using hipcc from relative path: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/bin/hipcc
1: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
1: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
1: Configuring done
1: Generating done
1: Build files have been written to: /home/lakshmi/work/rocdecode-test/videoDecodeRaw-HEVC
1: ======== End CMake output ======
1: Change Dir: /home/lakshmi/work/rocdecode-test/videoDecodeRaw-HEVC
1:
1: Run Clean Command:/usr/bin/gmake -f Makefile clean
1:
1: Run Build Command(s):/usr/bin/gmake -f Makefile && [ 33%] Building CXX object CMakeFiles/videodecoderaw.dir/videodecoderaw.cpp.o
1: [ 66%] Building CXX object CMakeFiles/videodecoderaw.dir/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
1: [100%] Linking CXX executable videodecoderaw
1: [100%] Built target videodecoderaw
1:
1: Running test command: "/home/lakshmi/work/rocdecode-test/videoDecodeRaw-HEVC/videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-H265.265"
1: info: Input file: AMD_driving_virtual_20-H265.265
1: info: Using built-in bitstream reader
1: info: Using GPU device 0 - AMD Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
1: info: decoding started, please wait!
1: Input Video Information
1:      Codec        : H.265/HEVC
1:      Frame rate   : 30000/1001 = 29.97 fps
1:      Sequence     : Progressive
1:      Coded size   : [2048, 1024]
1:      Display area : [0, 0, 2048, 1024]
1:      Chroma       : YUV 420
1:      Bit depth    : 8
1: Video Decoding Params:
1:      Num Surfaces : 7
1:      Crop         : [0, 0, 2048, 1024]
1:      Resize       : 2048x1024
1:
1: info: Total pictures decoded: 601
1: info: Total frames output/displayed: 601
1: info: avg decoding time per picture: 1.02047 ms
1: info: avg decode FPS: 979.937
1: info: avg output/display time per frame: 1.02047 ms
1: info: avg output/display FPS: 979.937
1:
1/6 Test #1: video_decodeRaw-HEVC .............   Passed    3.91 sec
test 2
    Start 2: video_decodeRaw-AVC

2: Test command: /usr/local/bin/ctest "--build-and-test" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/samples/videoDecodeRaw" "/home/lakshmi/work/rocdecode-test/videoDecodeRaw-AVC" "--build-generator" "Unix Makefiles" "--test-command" "videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-H264.264"
2: Working Directory: /home/lakshmi/work/rocdecode-test
2: Environment variables:
2:  LD_PRELOAD=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
2:  LIBVA_DRIVERS_PATH=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib
2: Test timeout computed to be: 1500
2: Internal cmake changing into directory: /home/lakshmi/work/rocdecode-test/videoDecodeRaw-AVC
2: ======== CMake output     ======
2: The C compiler identification is Clang 23.0.0
2: The CXX compiler identification is Clang 23.0.0
2: Detecting C compiler ABI info
2: Detecting C compiler ABI info - done
2: Check for working C compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang - skipped
2: Detecting C compile features
2: Detecting C compile features - done
2: Detecting CXX compiler ABI info
2: Detecting CXX compiler ABI info - done
2: Check for working CXX compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang++ - skipped
2: Detecting CXX compile features
2: Detecting CXX compile features - done
2: HIP: Using hipcc from relative path: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/bin/hipcc
2: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
2: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
2: Configuring done
2: Generating done
2: Build files have been written to: /home/lakshmi/work/rocdecode-test/videoDecodeRaw-AVC
2: ======== End CMake output ======
2: Change Dir: /home/lakshmi/work/rocdecode-test/videoDecodeRaw-AVC
2:
2: Run Clean Command:/usr/bin/gmake -f Makefile clean
2:
2: Run Build Command(s):/usr/bin/gmake -f Makefile && [ 33%] Building CXX object CMakeFiles/videodecoderaw.dir/videodecoderaw.cpp.o
2: [ 66%] Building CXX object CMakeFiles/videodecoderaw.dir/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
2: [100%] Linking CXX executable videodecoderaw
2: [100%] Built target videodecoderaw
2:
2: Running test command: "/home/lakshmi/work/rocdecode-test/videoDecodeRaw-AVC/videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-H264.264"
2: info: Input file: AMD_driving_virtual_20-H264.264
2: info: Using built-in bitstream reader
2: info: Using GPU device 0 - AMD Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
2: info: decoding started, please wait!
2: Input Video Information
2:      Codec        : AVC/H.264
2:      Frame rate   : 60000/2002 = 29.97 fps
2:      Sequence     : Progressive
2:      Coded size   : [2048, 1024]
2:      Display area : [0, 0, 2048, 1024]
2:      Chroma       : YUV 420
2:      Bit depth    : 8
2: Video Decoding Params:
2:      Num Surfaces : 7
2:      Crop         : [0, 0, 2048, 1024]
2:      Resize       : 2048x1024
2:
2: info: Total pictures decoded: 601
2: info: Total frames output/displayed: 601
2: info: avg decoding time per picture: 0.990579 ms
2: info: avg decode FPS: 1009.51
2: info: avg output/display time per frame: 0.990579 ms
2: info: avg output/display FPS: 1009.51
2:
2/6 Test #2: video_decodeRaw-AVC ..............   Passed    3.86 sec
test 3
    Start 3: video_decodeRaw-AV1

3: Test command: /usr/local/bin/ctest "--build-and-test" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/samples/videoDecodeRaw" "/home/lakshmi/work/rocdecode-test/videoDecodeRaw-AV1" "--build-generator" "Unix Makefiles" "--test-command" "videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-AV1.ivf"
3: Working Directory: /home/lakshmi/work/rocdecode-test
3: Environment variables:
3:  LD_PRELOAD=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
3:  LIBVA_DRIVERS_PATH=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib
3: Test timeout computed to be: 1500
3: Internal cmake changing into directory: /home/lakshmi/work/rocdecode-test/videoDecodeRaw-AV1
3: ======== CMake output     ======
3: The C compiler identification is Clang 23.0.0
3: The CXX compiler identification is Clang 23.0.0
3: Detecting C compiler ABI info
3: Detecting C compiler ABI info - done
3: Check for working C compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang - skipped
3: Detecting C compile features
3: Detecting C compile features - done
3: Detecting CXX compiler ABI info
3: Detecting CXX compiler ABI info - done
3: Check for working CXX compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang++ - skipped
3: Detecting CXX compile features
3: Detecting CXX compile features - done
3: HIP: Using hipcc from relative path: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/bin/hipcc
3: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
3: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
3: Configuring done
3: Generating done
3: Build files have been written to: /home/lakshmi/work/rocdecode-test/videoDecodeRaw-AV1
3: ======== End CMake output ======
3: Change Dir: /home/lakshmi/work/rocdecode-test/videoDecodeRaw-AV1
3:
3: Run Clean Command:/usr/bin/gmake -f Makefile clean
3:
3: Run Build Command(s):/usr/bin/gmake -f Makefile && [ 33%] Building CXX object CMakeFiles/videodecoderaw.dir/videodecoderaw.cpp.o
3: [ 66%] Building CXX object CMakeFiles/videodecoderaw.dir/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
3: [100%] Linking CXX executable videodecoderaw
3: [100%] Built target videodecoderaw
3:
3: Running test command: "/home/lakshmi/work/rocdecode-test/videoDecodeRaw-AV1/videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-AV1.ivf"
3: info: Input file: AMD_driving_virtual_20-AV1.ivf
3: info: Using built-in bitstream reader
3: info: Using GPU device 0 - AMD Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
3: info: decoding started, please wait!
3: Input Video Information
3:      Codec        : AV1
3:      Sequence     : Progressive
3:      Coded size   : [2048, 1024]
3:      Display area : [0, 0, 2048, 1024]
3:      Chroma       : YUV 420
3:      Bit depth    : 8
3: Video Decoding Params:
3:      Num Surfaces : 12
3:      Crop         : [0, 0, 2048, 1024]
3:      Resize       : 2048x1024
3:
3: info: Total pictures decoded: 602
3: info: Total frames output/displayed: 601
3: info: avg decoding time per picture: 1.02181 ms
3: info: avg decode FPS: 978.654
3: info: avg output/display time per frame: 1.02351 ms
3: info: avg output/display FPS: 977.028
3:
3/6 Test #3: video_decodeRaw-AV1 ..............   Passed    3.87 sec
test 4
    Start 4: video_decodeRaw-VP9

4: Test command: /usr/local/bin/ctest "--build-and-test" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/samples/videoDecodeRaw" "/home/lakshmi/work/rocdecode-test/videoDecodeRaw-VP9" "--build-generator" "Unix Makefiles" "--test-command" "videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf"
4: Working Directory: /home/lakshmi/work/rocdecode-test
4: Environment variables:
4:  LD_PRELOAD=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
4:  LIBVA_DRIVERS_PATH=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib
4: Test timeout computed to be: 1500
4: Internal cmake changing into directory: /home/lakshmi/work/rocdecode-test/videoDecodeRaw-VP9
4: ======== CMake output     ======
4: The C compiler identification is Clang 23.0.0
4: The CXX compiler identification is Clang 23.0.0
4: Detecting C compiler ABI info
4: Detecting C compiler ABI info - done
4: Check for working C compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang - skipped
4: Detecting C compile features
4: Detecting C compile features - done
4: Detecting CXX compiler ABI info
4: Detecting CXX compiler ABI info - done
4: Check for working CXX compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang++ - skipped
4: Detecting CXX compile features
4: Detecting CXX compile features - done
4: HIP: Using hipcc from relative path: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/bin/hipcc
4: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
4: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
4: Configuring done
4: Generating done
4: Build files have been written to: /home/lakshmi/work/rocdecode-test/videoDecodeRaw-VP9
4: ======== End CMake output ======
4: Change Dir: /home/lakshmi/work/rocdecode-test/videoDecodeRaw-VP9
4:
4: Run Clean Command:/usr/bin/gmake -f Makefile clean
4:
4: Run Build Command(s):/usr/bin/gmake -f Makefile && [ 33%] Building CXX object CMakeFiles/videodecoderaw.dir/videodecoderaw.cpp.o
4: [ 66%] Building CXX object CMakeFiles/videodecoderaw.dir/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/utils/rocvideodecode/roc_video_dec.cpp.o
4: [100%] Linking CXX executable videodecoderaw
4: [100%] Built target videodecoderaw
4:
4: Running test command: "/home/lakshmi/work/rocdecode-test/videoDecodeRaw-VP9/videodecoderaw" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/video/AMD_driving_virtual_20-VP9.ivf"
4: info: Input file: AMD_driving_virtual_20-VP9.ivf
4: info: Using built-in bitstream reader
4: info: Using GPU device 0 - AMD Radeon RX 7900 XT[gfx1100] on PCI bus 03:00.0
4: info: decoding started, please wait!
4: Input Video Information
4:      Codec        : VP9
4:      Sequence     : Progressive
4:      Coded size   : [2048, 1024]
4:      Display area : [0, 0, 2048, 1024]
4:      Chroma       : YUV 420
4:      Bit depth    : 8
4: Video Decoding Params:
4:      Num Surfaces : 12
4:      Crop         : [0, 0, 2048, 1024]
4:      Resize       : 2048x1024
4:
4: info: Total pictures decoded: 601
4: info: Total frames output/displayed: 601
4: info: avg decoding time per picture: 1.11495 ms
4: info: avg decode FPS: 896.899
4: info: avg output/display time per frame: 1.11495 ms
4: info: avg output/display FPS: 896.899
4:
4/6 Test #4: video_decodeRaw-VP9 ..............   Passed    3.91 sec
test 5
    Start 5: rocdec_Decode-HEVC

5: Test command: /usr/local/bin/ctest "--build-and-test" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/samples/rocdecDecode" "/home/lakshmi/work/rocdecode-test/rocdecDecode" "--build-generator" "Unix Makefiles" "--test-command" "rocdecdecode" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/frames"
5: Working Directory: /home/lakshmi/work/rocdecode-test
5: Environment variables:
5:  LD_PRELOAD=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
5:  LIBVA_DRIVERS_PATH=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib
5: Test timeout computed to be: 1500
5: Internal cmake changing into directory: /home/lakshmi/work/rocdecode-test/rocdecDecode
5: ======== CMake output     ======
5: The C compiler identification is Clang 23.0.0
5: The CXX compiler identification is Clang 23.0.0
5: Detecting C compiler ABI info
5: Detecting C compiler ABI info - done
5: Check for working C compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang - skipped
5: Detecting C compile features
5: Detecting C compile features - done
5: Detecting CXX compiler ABI info
5: Detecting CXX compiler ABI info - done
5: Check for working CXX compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang++ - skipped
5: Detecting CXX compile features
5: Detecting CXX compile features - done
5: HIP: Using hipcc from relative path: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/bin/hipcc
5: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
5: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
5: Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2")
5: Checking for module 'libavcodec'
5:   Found libavcodec, version 58.134.100
5: Checking for module 'libavformat'
5:   Found libavformat, version 58.76.100
5: Checking for module 'libavutil'
5:   Found libavutil, version 56.70.100
5: -- Using FFMPEG --
5:      Libraries:/usr/lib/x86_64-linux-gnu/libavcodec.so;/usr/lib/x86_64-linux-gnu/libavformat.so;/usr/lib/x86_64-linux-gnu/libavutil.so
5:      Includes:/usr/include/x86_64-linux-gnu
5: Configuring done
5: Generating done
5: Build files have been written to: /home/lakshmi/work/rocdecode-test/rocdecDecode
5: ======== End CMake output ======
5: Change Dir: /home/lakshmi/work/rocdecode-test/rocdecDecode
5:
5: Run Clean Command:/usr/bin/gmake -f Makefile clean
5:
5: Run Build Command(s):/usr/bin/gmake -f Makefile && [ 50%] Building CXX object CMakeFiles/rocdecdecode.dir/rocdecdecode.cpp.o
5: [100%] Linking CXX executable rocdecdecode
5: [100%] Built target rocdecdecode
5:
5: Running test command: "/home/lakshmi/work/rocdecode-test/rocdecDecode/rocdecdecode" "-i" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/frames"
5: Read 53 frames from disk.
5: Input Video Information
5:      Codec        : 4
5:      Frame rate   : 30000/1001 = 29.97 fps
5:      Sequence     : Progressive
5:      Coded size   : [2048, 1024]
5:      Display area : [0, 0, 2048, 1024]
5:      Bit depth    : 8
5: Total decoded frames in iteration 0: 53
5: Decoding time: 58858 microseconds
5: Success.
5:
5:
5:
5/6 Test #5: rocdec_Decode-HEVC ...............   Passed    2.32 sec
test 6
    Start 6: rocDecode_Negative_API_Tests

6: Test command: /usr/local/bin/ctest "--build-and-test" "/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/share/rocdecode/test/rocDecodeNegativeApiTests" "/home/lakshmi/work/rocdecode-test/rocdecodenegativetest" "--build-generator" "Unix Makefiles" "--test-command" "rocdecodenegativetest"
6: Working Directory: /home/lakshmi/work/rocdecode-test
6: Environment variables:
6:  LD_PRELOAD=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va.so.2:/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib/librocm_sysdeps_va-drm.so.2
6:  LIBVA_DRIVERS_PATH=/home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/rocm_sysdeps/lib
6: Test timeout computed to be: 1500
6: Internal cmake changing into directory: /home/lakshmi/work/rocdecode-test/rocdecodenegativetest
6: ======== CMake output     ======
6: The C compiler identification is Clang 23.0.0
6: The CXX compiler identification is Clang 23.0.0
6: Detecting C compiler ABI info
6: Detecting C compiler ABI info - done
6: Check for working C compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang - skipped
6: Detecting C compile features
6: Detecting C compile features - done
6: Detecting CXX compiler ABI info
6: Detecting CXX compiler ABI info - done
6: Check for working CXX compiler: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/lib/llvm/bin/amdclang++ - skipped
6: Detecting CXX compile features
6: Detecting CXX compile features - done
6: HIP: Using hipcc from relative path: /home/lakshmi/rock_0408/lib/python3.10/site-packages/_rocm_sdk_devel/bin/hipcc
6: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS
6: Performing Test HIP_CLANG_SUPPORTS_PARALLEL_JOBS - Success
6: Configuring done
6: Generating done
6: Build files have been written to: /home/lakshmi/work/rocdecode-test/rocdecodenegativetest
6: ======== End CMake output ======
6: Change Dir: /home/lakshmi/work/rocdecode-test/rocdecodenegativetest
6:
6: Run Clean Command:/usr/bin/gmake -f Makefile clean
6:
6: Run Build Command(s):/usr/bin/gmake -f Makefile && [ 33%] Building CXX object CMakeFiles/rocdecodenegativetest.dir/rocdecodenegativetest.cpp.o
6: [ 66%] Building CXX object CMakeFiles/rocdecodenegativetest.dir/rocdecode_api_negative_tests.cpp.o
6: [100%] Linking CXX executable rocdecodenegativetest
6: [100%] Built target rocdecodenegativetest
6:
6: Running test command: "/home/lakshmi/work/rocdecode-test/rocdecodenegativetest/rocdecodenegativetest"
6: info: Executing negative test cases for the rocDecCreateDecoder API
6: [0, Critical] rocdecode_api.cpp:37: 849626476281 us: [pid:1526419 tid:1526419 hashid:0x91e74] rocDecCreateDecoder(): Null pointer
6: [0, Critical] roc_decoder.cpp:51: 849626476299 us: [pid:1526419 tid:1526419 hashid:0x91e74] InitializeDecoder(): Invalid number of decode surfaces.
6: [0, Critical] vaapi_videodecoder.cpp:1028: 849626508117 us: [pid:1526419 tid:1526419 hashid:0x91e74] InitHIP(): ERROR: the requested device_id is not found!
6: [0, Critical] vaapi_videodecoder.cpp:686: 849626508131 us: [pid:1526419 tid:1526419 hashid:0x91e74] GetVaContext(): Failed to initialize the HIP.
6: [0, Critical] vaapi_videodecoder.cpp:824: 849626508137 us: [pid:1526419 tid:1526419 hashid:0x91e74] CheckDecCapForCodecType(): Failed to initialize.
6: [0, Critical] rocdecode_api.cpp:90: 849626508143 us: [pid:1526419 tid:1526419 hashid:0x91e74] rocDecGetDecoderCaps(): Error: Failed to obtain decoder capabilities from driver.
6: [0, Critical] vaapi_videodecoder.cpp:130: 849626508148 us: [pid:1526419 tid:1526419 hashid:0x91e74] InitializeDecoder(): The codec config combination is not supported.
6: [0, Critical] roc_decoder.cpp:61: 849626508153 us: [pid:1526419 tid:1526419 hashid:0x91e74] InitializeDecoder(): Failed to initialize the VAAPI Video decoder.
6: [0, Critical] vaapi_videodecoder.cpp:130: 849626509822 us: [pid:1526419 tid:1526419 hashid:0x91e74] InitializeDecoder(): The codec config combination is not supported.
6: [0, Critical] roc_decoder.cpp:61: 849626509829 us: [pid:1526419 tid:1526419 hashid:0x91e74] InitializeDecoder(): Failed to initialize the VAAPI Video decoder.
6: [0, Critical] vaapi_videodecoder.cpp:130: 849626509835 us: [pid:1526419 tid:1526419 hashid:0x91e74] InitializeDecoder(): The codec config combination is not supported.
6: [0, Critical] roc_decoder.cpp:61: 849626509838 us: [pid:1526419 tid:1526419 hashid:0x91e74] InitializeDecoder(): Failed to initialize the VAAPI Video decoder.
6: [0, Critical] vaapi_videodecoder.cpp:130: 849626509849 us: [pid:1526419 tid:1526419 hashid:0x91e74] InitializeDecoder(): The codec config combination is not supported.
6: [0, Critical] roc_decoder.cpp:61: 849626509852 us: [pid:1526419 tid:1526419 hashid:0x91e74] InitializeDecoder(): Failed to initialize the VAAPI Video decoder.
6: [0, Critical] vaapi_videodecoder.cpp:894: 849626509858 us: [pid:1526419 tid:1526419 hashid:0x91e74] CheckDecCapForCodecType(): VAAPI failure: vaCreateConfig(va_contexts_[va_ctx_id].va_display, va_contexts_[va_ctx_id].va_profile, VAEntrypointVLD, &va_config_attrib, 1, &va_contexts_[va_ctx_id].va_config_id) failed with 'status: 13: the requested VAEntryPoint is not supported' at /home/lakshmi/work/rocm-systems/projects/rocdecode/src/rocdecode/vaapi/vaapi_videodecoder.cpp:894
6: [0, Critical] rocdecode_api.cpp:90: 849626509865 us: [pid:1526419 tid:1526419 hashid:0x91e74] rocDecGetDecoderCaps(): Error: Failed to obtain decoder capabilities from driver.
6: [0, Critical] vaapi_videodecoder.cpp:130: 849626509868 us: [pid:1526419 tid:1526419 hashid:0x91e74] InitializeDecoder(): The codec config combination is not supported.
6: [0, Critical] roc_decoder.cpp:61: 849626509870 us: [pid:1526419 tid:1526419 hashid:0x91e74] InitializeDecoder(): Failed to initialize the VAAPI Video decoder.
6: info: Executing negative test cases for the rocDecDestroyDecoder API
6: info: Executing negative test cases for the rocDecGetDecoderCaps API
6: info: Executing negative test cases for the rocDecDecodeFrame API
6: info: Executing negative test cases for the rocDecGetDecodeStatus API
6: info: Executing negative test cases for the rocDecReconfigureDecoder API
6: info: Executing negative test cases for the rocDecGetVideoFrame API
6: info: Executing negative test cases for the rocDecGetErrorName API
6: info: Executing negative test cases for the rocDecCreateVideoParser API
6: [0, Critical] roc_decoder.cpp:124: 849626510695 us: [pid:1526419 tid:1526419 hashid:0x91e74] GetVideoFrame(): Invalid parameters.
6: [0, Critical] rocparser_api.cpp:44: 849626510705 us: [pid:1526419 tid:1526419 hashid:0x91e74] rocDecCreateVideoParser(): Error: The current version of rocDecode officially supports only the H.265 (HEVC), H.264 (AVC), AV1 and VP9 codecs.
6: info: Executing negative test cases for the rocDecParseVideoData API
6: info: Executing negative test cases for the rocDecDestroyVideoParser API
6: info: Executing negative test cases for the rocDecCreateBitstreamReader API
6: info: Executing negative test cases for the rocDecGetBitstreamCodecType API
6: info: Executing negative test cases for the rocDecGetBitstreamBitDepth API
6: [0, Critical] roc_bs_reader_api.cpp:31: 849626511165 us: [pid:1526419 tid:1526419 hashid:0x91e74] rocDecCreateBitstreamReader(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpp:31: 849626511169 us: [pid:1526419 tid:1526419 hashid:0x91e74] rocDecCreateBitstreamReader(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpp:52: 849626511174 us: [pid:1526419 tid:1526419 hashid:0x91e74] rocDecGetBitstreamCodecType(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpp:52: 849626511177 us: [pid:1526419 tid:1526419 hashid:0x91e74] rocDecGetBitstreamCodecType(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpp:74: 849626511182 us: [pid:1526419 tid:1526419 hashid:0x91e74] rocDecGetBitstreamBitDepth(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpp:74: 849626511185 us: [pid:1526419 tid:1526419 hashid:0x91e74] rocDecGetBitstreamBitDepth(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpp:96: 849626511189 us: [pid:1526419 tid:1526419 hashid:0x91e74] rocDecGetBitstreamPicData(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpinfo: Executing negative test cases for the rocDecGetBitstreamPicData API
6: info: Executing negative test cases for the rocDecDestroyBitstreamReader API
6: Test Passed!
6: p:96: 849626511193 us: [pid:1526419 tid:1526419 hashid:0x91e74] rocDecGetBitstreamPicData(): Null pointer
6: [0, Critical] roc_bs_reader_api.cpp:118: 849626511197 us: [pid:1526419 tid:1526419 hashid:0x91e74] rocDecDestroyBitstreamReader(): Null pointer
6:
6/6 Test #6: rocDecode_Negative_API_Tests .....   Passed    1.99 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) =  19.86 sec
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
