### PR TITLE
amdsmi: link libamd_smi with -Bsymbolic-functions to stop rsmi_init 

### DIFF
--- a/projects/amdsmi/src/CMakeLists.txt
+++ b/projects/amdsmi/src/CMakeLists.txt
@@ -192,6 +192,12 @@ if(BUILD_BOTH_LIBS OR BUILD_SHARED_LIBS)
     )
     target_link_options(${AMD_SMI} PRIVATE "LINKER:--version-script=${VERSION_SCRIPT}")
     set_property(TARGET ${AMD_SMI} APPEND PROPERTY LINK_DEPENDS "${VERSION_SCRIPT}")
+    # Bind amd_smi's internal calls to its own embedded rsmi_init /
+    # rsmi_is_P2P_accessible at link time. Without this, dlopen'ing
+    # librocm_smi64.so.1 with RTLD_GLOBAL first (as rocm_sdk/TheRock does on
+    # `import torch`) interposes those calls and breaks device discovery
+    # (rocm-systems#7643). Symbols stay exported for external use.
+    target_link_options(${AMD_SMI} PRIVATE "LINKER:-Bsymbolic-functions")
 endif()
 
 # Add UALOE compile flags for netlink dependencies (e.g. -I.../libnl3 for


### PR DESCRIPTION
libamd_smi.so statically embeds rocm_smi and internally PLT-calls rsmi_init()/rsmi_is_P2P_accessible() (amd_smi_system.cc, amd_smi.cc) while also exporting those symbols at default visibility for external consumers. When librocm_smi64.so.1 (which also exports rsmi_init) is dlopen'd with RTLD_GLOBAL before libamd_smi.so loads -- exactly what rocm_sdk/TheRock does during 'import torch' -- ELF global-scope interposition redirects amd_smi's internal 'call rsmi_init@plt' to librocm_smi64's rsmi_init. The wrong rsmi_init initializes a different global state, so device discovery enumerates 0 devices and amdsmi_get_processor_handles() returns 0.

Add -Bsymbolic-functions so amd_smi's own references to globally-defined functions bind to its own definitions at link time; internal rsmi calls can no longer be interposed, while the symbols stay exported for external use.

Fixes: ROCm/rocm-systems#7643