### PR TITLE
[ROCM-26333] Guard self-hosted amdsmi CI against fork PRs

### DIFF
--- a/.github/workflows/amdsmi-build.yml
+++ b/.github/workflows/amdsmi-build.yml
@@ -44,6 +44,9 @@ jobs:
   # artifact format used for upload.
   build-and-test:
     name: ${{ matrix.os }}
+    # Privileged self-hosted runner (SYS_MODULE + host /lib/modules): never
+    # auto-run untrusted fork-PR code on it. Mirrors the guard other CI jobs use.
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
     runs-on:
       - self-hosted
       - ${{ vars.RUNNER_TYPE }}


### PR DESCRIPTION
## Motivation

`amdsmi-build.yml` runs on a `--privileged` self-hosted GPU runner with `--cap-add=SYS_MODULE` and a host `/lib/modules` mount — the only workflow in the repo with that combination — and triggers on `pull_request` to `develop` with no fork guard. A fork PR's code can therefore execute on the host runner (kernel-module load → host compromise), gated only by a GitHub UI setting with no defense-in-depth in the YAML.

## Technical Details

**CI** (`.github/workflows/amdsmi-build.yml`):
- Gate the `build-and-test` job with `if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork`, so fork PRs never run on the privileged self-hosted runner.
- Mirrors the existing guard already used by `rocprofiler-sdk-continuous_integration.yml` and `aqlprofile-continuous_integration.yml`.

## JIRA ID

Resolves ROCM-26333

## Test Plan

- Validated the workflow still parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/amdsmi-build.yml'))"`.
- Reviewed the condition: evaluates true for `push` / `workflow_dispatch` and same-repo PRs, false for fork PRs.

## Test Result

- YAML parses; guard attached to `build-and-test`. Same-repo push/PR behavior unchanged; fork PRs are skipped.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
