### PR TITLE
fix(rocjitsu): Propagate VMID through mem hierarchy, fix coherency/SDMA

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/config_loader.cpp
@@ -462,11 +462,13 @@ std::unordered_map<std::string, FactoryFn> &factories() {
       bool packed = (arch == ROCJITSU_CODE_ARCH_CDNA3 || arch == ROCJITSU_CODE_ARCH_CDNA4 ||
                      arch == ROCJITSU_CODE_ARCH_GFX1250);
       cp->set_packed_tid(packed);
-      const bool gfx11_plus_sdma =
-          arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ||
-          arch == ROCJITSU_CODE_ARCH_RDNA4 || arch == ROCJITSU_CODE_ARCH_GFX1250;
-      cp->set_sdma_packet_dialect(gfx11_plus_sdma ? amdgpu::SdmaPacketDialect::Gfx11Plus
-                                                  : amdgpu::SdmaPacketDialect::Legacy);
+      amdgpu::SdmaPacketDialect sdma_dialect = amdgpu::SdmaPacketDialect::Legacy;
+      if (arch == ROCJITSU_CODE_ARCH_GFX1250)
+        sdma_dialect = amdgpu::SdmaPacketDialect::Gfx1250;
+      else if (arch == ROCJITSU_CODE_ARCH_RDNA3 || arch == ROCJITSU_CODE_ARCH_RDNA3_5 ||
+               arch == ROCJITSU_CODE_ARCH_RDNA4)
+        sdma_dialect = amdgpu::SdmaPacketDialect::Gfx11Plus;
+      cp->set_sdma_packet_dialect(sdma_dialect);
       return cp;
     };
 
@@ -651,18 +653,28 @@ TopologyBuildResult build_topology(const fb::TopologyDef *topology_def, simdojo:
         if (soc)
           soc->add_xcd(xcd);
 
+        amdgpu::CommandProcessor *xcd_cp = nullptr;
+        amdgpu::L2Cache *xcd_l2 = nullptr;
         for (auto &ch : xcd->children()) {
-          if (auto *cp = dynamic_cast<amdgpu::CommandProcessor *>(ch.get()))
+          if (auto *cp = dynamic_cast<amdgpu::CommandProcessor *>(ch.get())) {
             xcd->set_command_processor(cp);
-          else if (auto *l2 = dynamic_cast<amdgpu::L2Cache *>(ch.get()))
+            xcd_cp = cp;
+          } else if (auto *l2 = dynamic_cast<amdgpu::L2Cache *>(ch.get())) {
             xcd->set_l2_cache(l2);
-          else if (auto *se = dynamic_cast<amdgpu::ShaderEngine *>(ch.get())) {
+            xcd_l2 = l2;
+          } else if (auto *se = dynamic_cast<amdgpu::ShaderEngine *>(ch.get())) {
             xcd->add_shader_engine(se);
             for (auto &sch : se->children())
               if (auto *cu = dynamic_cast<amdgpu::ComputeUnitCore *>(sch.get()))
                 se->add_compute_unit(cu);
           }
         }
+        // Register the XCD's L2 with its CP so SDMA cache maintenance
+        // (flush_gpu_caches/invalidate_gpu_caches) operates on it. The Xcd full
+        // constructor wires this, but the config-driven path builds children
+        // from the topology and must wire it here.
+        if (xcd_cp && xcd_l2)
+          xcd_cp->add_l2_cache(xcd_l2);
       } else if (auto *iod = dynamic_cast<amdgpu::Iod *>(c)) {
         if (soc)
           soc->add_iod(iod);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -14,6 +14,7 @@ RJ_DIAGNOSTIC_POP
 
 #include "simdojo/sim/message.h"
 #include "simdojo/sim/simulation.h"
+#include "util/bit.h"
 #include "util/log.h"
 
 #include <algorithm>
@@ -84,10 +85,10 @@ void validate_cluster_shape(const DispatchEntry &dp) {
   }
 }
 
-uint32_t read_memory_u32(GpuMemory *memory, uint64_t addr) {
+uint32_t read_memory_u32(GpuMemory *memory, uint64_t addr, uint32_t vmid = 0) {
   uint32_t value = 0;
   for (uint32_t i = 0; i < sizeof(value); ++i)
-    value |= static_cast<uint32_t>(memory->read8(addr + i)) << (i * 8);
+    value |= static_cast<uint32_t>(memory->read8(addr + i, vmid)) << (i * 8);
   return value;
 }
 
@@ -239,7 +240,8 @@ void CommandProcessor::init_wavefront_regs(ComputeUnitCore *cu, Wavefront *wf,
 
       uint64_t preload_addr = pkt.kernarg_addr + static_cast<uint64_t>(preload_offset) * 4;
       for (uint32_t i = 0; i < preload_length; ++i)
-        cu->write_sgpr(sbase + idx + i, read_memory_u32(memory_, preload_addr + i * 4));
+        cu->write_sgpr(sbase + idx + i,
+                       read_memory_u32(memory_, preload_addr + i * 4, pkt.process_id));
       util::Logger::vm("CP: init_wf kernarg preload s[", idx, ":", idx + preload_length - 1,
                        "] length=", preload_length, " offset=", preload_offset, " sbase=", sbase);
       idx += preload_length;
@@ -922,9 +924,12 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   uint32_t wfs_per_wg = (wg_size + wave_size - 1) / wave_size;
 
   uint32_t num_dims = pkt.setup & 0x3;
-  uint32_t grid_wgs_x = pkt.workgroup_size_x > 0 ? pkt.grid_size_x / pkt.workgroup_size_x : 1;
-  uint32_t grid_wgs_y = pkt.workgroup_size_y > 0 ? pkt.grid_size_y / pkt.workgroup_size_y : 1;
-  uint32_t grid_wgs_z = pkt.workgroup_size_z > 0 ? pkt.grid_size_z / pkt.workgroup_size_z : 1;
+  uint32_t grid_wgs_x =
+      util::ceil_div_or_one(pkt.grid_size_x, static_cast<uint32_t>(pkt.workgroup_size_x));
+  uint32_t grid_wgs_y =
+      util::ceil_div_or_one(pkt.grid_size_y, static_cast<uint32_t>(pkt.workgroup_size_y));
+  uint32_t grid_wgs_z =
+      util::ceil_div_or_one(pkt.grid_size_z, static_cast<uint32_t>(pkt.workgroup_size_z));
   uint32_t total_wgs = grid_wgs_x * grid_wgs_y * grid_wgs_z;
 
   DispatchEntry dp{};
@@ -1478,7 +1483,7 @@ static void *resolve_sdma_ptr(GpuMemory *memory, uint64_t va, uint32_t vmid) {
   return page_base + (va & 0xFFF);
 }
 
-// SDMA opcodes (from sdma_registers.h).
+// SDMA opcodes.
 namespace sdma {
 constexpr uint8_t OP_NOP = 0;
 constexpr uint8_t OP_COPY = 1;
@@ -1506,7 +1511,26 @@ constexpr uint32_t ATOMIC_SIZE = 8;
 constexpr uint32_t CONST_FILL_SIZE = 5;
 constexpr uint32_t TIMESTAMP_SIZE = 3;
 constexpr uint32_t GCR_SIZE = 5;
-constexpr uint32_t GCR_GFX11_PLUS_SIZE = 6;
+constexpr uint32_t GCR_GFX1250_SIZE = 6;
+
+// GCR GL2 cache-op control bits. The control dword and bit positions genuinely
+// differ by dialect (the gfx1250 GCR packet is a distinct layout, not a resized
+// legacy packet). Legacy/gfx9-12 pack gcr_control[15:0] into DW2 starting at
+// bit 16 (DW2 low 16 bits hold BaseVA_HI); gfx1250 makes DW2 a full 25-bit base
+// VA and relocates the control field to DW3 starting at bit 0. Only the GL2
+// writeback/invalidate/discard bits matter for the functional GL2 model.
+//   Legacy DW2:  GL2_DISCARD=29, GL2_INV=30, GL2_WB=31  (= gcr_control 13/14/15 + 16)
+//   gfx1250 DW3: GL2_DISCARD=13, GL2_INV=14, GL2_WB=15
+// Layouts and sizes (legacy 5 dwords, gfx1250 6 dwords) match the vendored
+// runtime SDMA GCR packet definitions for each dialect.
+constexpr uint32_t GCR_LEGACY_CONTROL_DW = 2;
+constexpr uint32_t GCR_LEGACY_GL2_DISCARD_BIT = 1u << 29;
+constexpr uint32_t GCR_LEGACY_GL2_INV_BIT = 1u << 30;
+constexpr uint32_t GCR_LEGACY_GL2_WB_BIT = 1u << 31;
+constexpr uint32_t GCR_GFX1250_CONTROL_DW = 3;
+constexpr uint32_t GCR_GFX1250_GL2_DISCARD_BIT = 1u << 13;
+constexpr uint32_t GCR_GFX1250_GL2_INV_BIT = 1u << 14;
+constexpr uint32_t GCR_GFX1250_GL2_WB_BIT = 1u << 15;
 constexpr uint32_t COPY_LINEAR_WAITSIGNAL_GFX11_PLUS_SIZE = 19;
 constexpr uint32_t FENCE_64B_GFX11_PLUS_SIZE = 5;
 constexpr uint32_t POLL_MEM_64B_GFX11_PLUS_SIZE = 8;
@@ -1538,6 +1562,30 @@ bool sdma_compare_u64(uint32_t func, uint64_t value, uint64_t reference) {
 }
 
 } // namespace
+
+void CommandProcessor::flush_gpu_caches() {
+  // Write back dirty scalar L1 (K$) lines into L2 first, then flush L2 to
+  // backing, so a dirty K$ line overlapping an SDMA destination is published
+  // before the direct write (which happens after this helper returns) rather
+  // than being written out over it by a later K$ flush. Each line is written
+  // back under its own owning vmid. Vector L1 (V$) is write-through, so it only
+  // needs invalidation. Ordering: K$ -> L2 -> backing, then invalidate V$.
+  for (auto *cu : cus_) {
+    cu->l1_scalar().writeback_all();
+    cu->l1_scalar().invalidate_all();
+  }
+  for (auto *l2 : l2_caches_)
+    l2->flush_all();
+  for (auto *cu : cus_)
+    cu->l1_vector().invalidate_all();
+}
+
+void CommandProcessor::invalidate_gpu_caches() {
+  for (auto *l2 : l2_caches_)
+    l2->invalidate_all();
+  for (auto *cu : cus_)
+    cu->l1_vector().invalidate_all();
+}
 
 void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint64_t write_idx) {
   uint32_t ring_mask = (queue.ring_size / sizeof(uint32_t)) - 1;
@@ -1660,18 +1708,21 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
           return stop_and_retry_current_packet();
         }
 
+        // Emulated SDMA writes straight to the backing store, bypassing the GPU
+        // caches. Real SDMA does not snoop GL2; coherence is re-established by
+        // the consuming kernel's acquire fence at dispatch. We model that with a
+        // coarse writeback+invalidate that runs BEFORE the direct write: the
+        // writeback publishes any dirty L2 lines (e.g. from K$ writeback) so
+        // they are not lost, and — critically — a dirty line overlapping the
+        // destination is written back first, so the subsequent SDMA write
+        // supersedes it instead of being clobbered by a later flush. After the
+        // flush the caches are empty, so the destination re-reads fresh backing.
+        flush_gpu_caches();
         std::memcpy(dst_ptr, src_ptr, count);
-
-        for (auto *l2 : l2_caches_)
-          l2->invalidate_range(dst_va, count);
-        for (auto *cu : cus_)
-          cu->l1_vector().invalidate_all();
 
         if (signal_decrement) {
           std::atomic_ref<int64_t>(*signal_ptr)
               .fetch_sub(static_cast<int64_t>(signal_data), std::memory_order_release);
-          for (auto *l2 : l2_caches_)
-            l2->invalidate_range(signal_addr, sizeof(int64_t));
         }
 
         pkt_dwords = sdma::COPY_LINEAR_WAITSIGNAL_GFX11_PLUS_SIZE;
@@ -1703,17 +1754,16 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         if (!dst2_ptr) {
           return stop_and_retry_current_packet();
         }
+        // Flush before the direct write (see COPY_LINEAR_WAITSIGNAL above): a
+        // destination-overlapping dirty L2 line must be written back first so
+        // the SDMA write supersedes it rather than being clobbered afterward.
+        flush_gpu_caches();
         std::memcpy(dst_ptr, src_ptr, count);
-        for (auto *l2 : l2_caches_)
-          l2->invalidate_range(dst_va, count);
         std::memcpy(dst2_ptr, src_ptr, count);
-        for (auto *l2 : l2_caches_)
-          l2->invalidate_range(dst2_va, count);
         pkt_dwords = sdma::COPY_LINEAR_BROADCAST_SIZE;
       } else {
+        flush_gpu_caches();
         std::memcpy(dst_ptr, src_ptr, count);
-        for (auto *l2 : l2_caches_)
-          l2->invalidate_range(dst_va, count);
         pkt_dwords = sdma::COPY_LINEAR_SIZE;
       }
       break;
@@ -1730,9 +1780,10 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         uint64_t data = static_cast<uint64_t>(dw(3)) | (static_cast<uint64_t>(dw(4)) << 32);
         auto *ptr = static_cast<uint64_t *>(resolve(addr_va));
         if (ptr) {
+          // Flush before the store so a destination-overlapping dirty line is
+          // published first and the fence write supersedes it.
+          flush_gpu_caches();
           std::atomic_ref<uint64_t>(*ptr).store(data, std::memory_order_release);
-          for (auto *l2 : l2_caches_)
-            l2->invalidate_range(addr_va, sizeof(uint64_t));
         }
         pkt_dwords = sdma::FENCE_64B_GFX11_PLUS_SIZE;
         break;
@@ -1742,9 +1793,8 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       uint32_t data = dw(3);
       auto *ptr = static_cast<uint32_t *>(resolve(addr_va));
       if (ptr) {
+        flush_gpu_caches();
         std::atomic_ref<uint32_t>(*ptr).store(data, std::memory_order_release);
-        for (auto *l2 : l2_caches_)
-          l2->invalidate_range(addr_va, sizeof(uint32_t));
       }
       pkt_dwords = sdma::FENCE_SIZE;
       break;
@@ -1831,10 +1881,13 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       if (atomic_op == 47 && addr_va > 0x1000) {
         auto *ptr = static_cast<int64_t *>(resolve(addr_va));
         if (ptr) {
+          // Flush before the RMW: the fetch_add reads the backing value, so a
+          // dirty overlapping L2 line must be written back first or the atomic
+          // would operate on stale data. The flush also leaves caches empty so
+          // the new value re-reads fresh.
+          flush_gpu_caches();
           std::atomic_ref<int64_t>(*ptr).fetch_add(static_cast<int64_t>(src_data),
                                                    std::memory_order_release);
-          for (auto *l2 : l2_caches_)
-            l2->invalidate_range(addr_va, sizeof(int64_t));
           if (static_cast<int64_t>(src_data) < 0 && interrupt_cb_) {
             // Signal layout: addr is at offset 8 (value field) from sig base.
             uint64_t sig_base = addr_va - 8;
@@ -1845,10 +1898,9 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
             if (mailbox_ptr != 0) {
               auto *mb_dst = static_cast<uint64_t *>(resolve(mailbox_ptr));
               if (mb_dst) {
+                flush_gpu_caches();
                 std::atomic_ref<uint64_t>(*mb_dst).store(uint64_t(event_id),
                                                          std::memory_order_release);
-                for (auto *l2 : l2_caches_)
-                  l2->invalidate_range(mailbox_ptr, sizeof(uint64_t));
               }
             }
             interrupt_cb_(queue.process_id, event_id);
@@ -1865,14 +1917,15 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       uint32_t fillsize = (header >> 30) & 0x3;
       auto *dst = static_cast<uint8_t *>(resolve(addr_va));
       if (dst) {
+        // Flush before the fill so a destination-overlapping dirty line is
+        // published first and the fill supersedes it.
+        flush_gpu_caches();
         if (fillsize == 2) {
           for (uint32_t i = 0; i < count; i += 4)
             std::memcpy(dst + i, &data, 4);
         } else {
           std::memset(dst, static_cast<int>(data & 0xFF), count);
         }
-        for (auto *l2 : l2_caches_)
-          l2->invalidate_range(addr_va, count);
       }
       pkt_dwords = sdma::CONST_FILL_SIZE;
       break;
@@ -1884,26 +1937,47 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
         uint64_t ts = static_cast<uint64_t>(
             std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
         auto *ptr = static_cast<uint64_t *>(resolve(addr_va));
-        if (ptr)
+        if (ptr) {
+          // Flush before the direct store so a dirty cached line overlapping the
+          // timestamp address is published first and the timestamp supersedes it
+          // rather than being clobbered by a later flush (see other direct-write
+          // SDMA ops).
+          flush_gpu_caches();
           std::atomic_ref<uint64_t>(*ptr).store(ts, std::memory_order_release);
+        }
       }
       pkt_dwords = sdma::TIMESTAMP_SIZE;
       break;
     }
     case sdma::OP_GCR: {
-      uint64_t base_va =
-          (static_cast<uint64_t>(dw(1)) | (static_cast<uint64_t>(dw(2)) << 32)) & ~0xFULL;
-      uint64_t size_field =
-          (static_cast<uint64_t>(dw(3)) | (static_cast<uint64_t>(dw(4)) << 32)) & ~0xFULL;
-      uint32_t range =
-          size_field > 0 ? static_cast<uint32_t>(std::min(size_field, uint64_t(UINT32_MAX))) : 0;
-      for (auto *l2 : l2_caches_) {
-        if (range > 0)
-          l2->invalidate_range(base_va, range);
-        else
-          l2->invalidate_all();
+      // GCR is the real SDMA cache-maintenance packet. It carries a base/size
+      // range plus separate GL2 writeback / invalidate / discard control bits.
+      // GFX9+ HW services the range at coarse (whole-cache) granularity, so we
+      // ignore the range but honor the control bits: a writeback must publish
+      // dirty L2 lines to backing (flush), while invalidate/discard drop them.
+      // Treating every GCR as an invalidate would silently lose simulator data
+      // that a writeback-only packet was meant to publish.
+      const bool gfx1250 = uses_gfx1250_gcr_packet();
+      const uint32_t control =
+          gfx1250 ? dw(sdma::GCR_GFX1250_CONTROL_DW) : dw(sdma::GCR_LEGACY_CONTROL_DW);
+      const uint32_t wb_bit = gfx1250 ? sdma::GCR_GFX1250_GL2_WB_BIT : sdma::GCR_LEGACY_GL2_WB_BIT;
+      const uint32_t inv_bit =
+          gfx1250 ? sdma::GCR_GFX1250_GL2_INV_BIT : sdma::GCR_LEGACY_GL2_INV_BIT;
+      const uint32_t discard_bit =
+          gfx1250 ? sdma::GCR_GFX1250_GL2_DISCARD_BIT : sdma::GCR_LEGACY_GL2_DISCARD_BIT;
+      const bool gl2_wb = (control & wb_bit) != 0;
+      const bool gl2_inv = (control & (inv_bit | discard_bit)) != 0;
+      if (gl2_wb) {
+        // Any writeback must publish dirty L2 data before it can be dropped. In
+        // the functional model a subsequent re-fetch from backing returns the
+        // same bytes, so the (harmless) invalidate inside flush is kept even for
+        // writeback-without-invalidate requests.
+        flush_gpu_caches();
+      } else if (gl2_inv) {
+        // Invalidate/discard only: drop without writeback.
+        invalidate_gpu_caches();
       }
-      pkt_dwords = uses_gfx11_plus_sdma_packets() ? sdma::GCR_GFX11_PLUS_SIZE : sdma::GCR_SIZE;
+      pkt_dwords = gfx1250 ? sdma::GCR_GFX1250_SIZE : sdma::GCR_SIZE;
       break;
     }
     case sdma::OP_HDP_FLUSH:
@@ -1919,10 +1993,11 @@ void CommandProcessor::process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint
       if (addr_va > 0x1000 && rpos + 4 + count <= wpos) {
         auto *dst = static_cast<uint32_t *>(resolve(addr_va));
         if (dst) {
+          // Flush before the write so a destination-overlapping dirty line is
+          // published first and the SDMA write supersedes it.
+          flush_gpu_caches();
           for (uint32_t i = 0; i < count; ++i)
             dst[i] = dw(4 + i);
-          for (auto *l2 : l2_caches_)
-            l2->invalidate_range(addr_va, count * sizeof(uint32_t));
         }
       }
       pkt_dwords = 4 + count;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.h
@@ -31,6 +31,7 @@
 
 #include "simdojo/sim/component.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -74,6 +75,7 @@ struct HwQueue {
 enum class SdmaPacketDialect {
   Legacy,
   Gfx11Plus,
+  Gfx1250,
 };
 
 /// @brief AMDGPU command processor that dispatches wavefronts to compute units.
@@ -93,7 +95,13 @@ public:
   ~CommandProcessor() override { stop_doorbell_monitor(); }
 
   void set_memory(GpuMemory *mem) { memory_ = mem; }
-  void add_l2_cache(L2Cache *l2) { l2_caches_.push_back(l2); }
+  void add_l2_cache(L2Cache *l2) {
+    // Idempotent: the config-driven builder and the Xcd full constructor may
+    // both attempt to register the same L2. Avoid duplicate entries so cache
+    // maintenance does not flush the same L2 twice.
+    if (std::find(l2_caches_.begin(), l2_caches_.end(), l2) == l2_caches_.end())
+      l2_caches_.push_back(l2);
+  }
   void set_vgpr_granularity(uint32_t g) { vgpr_granularity_ = g; }
   uint32_t vgpr_granularity() const { return vgpr_granularity_; }
   void set_packed_tid(bool v) { packed_tid_ = v; }
@@ -180,6 +188,29 @@ private:
   /// @brief Process SDMA packets from an SDMA queue's ring buffer.
   void process_sdma_ring(HwQueue &queue, uint64_t read_idx, uint64_t write_idx);
 
+  /// @brief Coarse invalidate of the GPU data caches (L1 V$ + L2/GL2).
+  /// @details Emulated SDMA and CP writes land directly in the backing store,
+  /// bypassing the cache hierarchy. Real SDMA does not snoop GL2, so stale
+  /// cached copies are knocked out the way HW cache-maintenance does it: coarse
+  /// and indiscriminate, not per-range. This is the simulator's stand-in for a
+  /// GL2 invalidate; the consuming kernel's acquire fence at dispatch flushes
+  /// the remaining per-CU caches (including the scalar K$).
+  ///
+  /// @warning Drops dirty L2 lines without writeback. Only use after a direct
+  /// backing write whose destination is the only stale region; otherwise use
+  /// flush_gpu_caches() so K$-writeback dirty lines are published, not lost.
+  void invalidate_gpu_caches();
+
+  /// @brief Coarse writeback+invalidate of the GPU data caches (L1 K$/V$ + L2).
+  /// @details Like invalidate_gpu_caches(), but publishes dirty data instead of
+  /// dropping it. Ordering is load-bearing: dirty scalar L1 (K$) lines are
+  /// written back into L2 first, then L2 is flushed to backing, so a dirty K$ or
+  /// L2 line overlapping an SDMA destination reaches backing before the direct
+  /// SDMA write (which runs after this returns) rather than being written out
+  /// over it by a later K$/L2 flush. Each line is written back under its own
+  /// owning vmid. Vector L1 (V$) is write-through, so it only needs invalidation.
+  void flush_gpu_caches();
+
   /// @brief Parse an AQL dispatch packet, read its kernel descriptor, and create a DispatchEntry.
   void process_aql_packet(const hsa_kernel_dispatch_packet_t &pkt, const HwQueue &queue,
                           uint64_t pkt_addr, HwQueueState &qs,
@@ -228,7 +259,13 @@ private:
   }
 
   bool uses_gfx11_plus_sdma_packets() const {
-    return sdma_packet_dialect_ == SdmaPacketDialect::Gfx11Plus;
+    return sdma_packet_dialect_ == SdmaPacketDialect::Gfx11Plus ||
+           sdma_packet_dialect_ == SdmaPacketDialect::Gfx1250;
+  }
+
+  // gfx1250 widens the GCR packet to 6 dwords; gfx11/12 keep the 5-dword layout.
+  bool uses_gfx1250_gcr_packet() const {
+    return sdma_packet_dialect_ == SdmaPacketDialect::Gfx1250;
   }
 
   GpuMemory *memory_ = nullptr;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -42,10 +42,10 @@ public:
       auto *data = reinterpret_cast<uint8_t *>(msg->payload());
       if (hdr.op == simdojo::MessageOp::READ) {
         for (uint32_t i = 0; i < hdr.size_bytes; ++i)
-          data[i] = read8(hdr.addr + i);
+          data[i] = read8(hdr.addr + i, hdr.vmid);
       } else if (hdr.op == simdojo::MessageOp::WRITE) {
         for (uint32_t i = 0; i < hdr.size_bytes; ++i)
-          write8(hdr.addr + i, data[i]);
+          write8(hdr.addr + i, data[i], hdr.vmid);
       }
       hdr.op = simdojo::MessageOp::RESPONSE;
     });

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/hbm_controller.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/hbm_controller.h
@@ -89,9 +89,9 @@ private:
       auto &hdr = msg->header();
       auto *data = reinterpret_cast<uint8_t *>(msg->payload());
       if (hdr.op == simdojo::MessageOp::READ)
-        read(hdr.addr, data, hdr.size_bytes);
+        read(hdr.addr, data, hdr.size_bytes, hdr.vmid);
       else if (hdr.op == simdojo::MessageOp::WRITE) {
-        write(hdr.addr, data, hdr.size_bytes);
+        write(hdr.addr, data, hdr.size_bytes, hdr.vmid);
       }
       hdr.op = simdojo::MessageOp::RESPONSE;
     });

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.cpp
@@ -13,25 +13,25 @@ namespace rocjitsu {
 namespace amdgpu {
 
 void L1ScalarCache::ensure_line(uint64_t addr, uint32_t vmid) {
-  if (cache_.lookup(addr))
+  if (cache_.lookup(addr, nullptr, vmid))
     return;
 
   uint64_t line_addr = CacheStore::line_address(addr);
   simdojo::CacheTag evicted;
   uint8_t evicted_data[CacheStore::LINE_SIZE];
-  cache_.allocate(addr, &evicted, evicted_data);
+  cache_.allocate(addr, vmid, &evicted, evicted_data);
 
   if (evicted.valid && evicted.dirty) {
     constexpr uint32_t set_bits = 6; // log2(NUM_SETS=64)
     uint64_t evicted_line_addr =
         (evicted.tag << (LINE_SIZE_BITS + set_bits)) |
         (static_cast<uint64_t>(CacheStore::set_index(addr)) << LINE_SIZE_BITS);
-    l2_->writeback_line(evicted_line_addr, evicted_data, Mtype::RW, vmid);
+    l2_->writeback_line(evicted_line_addr, evicted_data, Mtype::RW, evicted.vmid);
   }
 
   uint8_t line_buf[CacheStore::LINE_SIZE];
   l2_->read(line_addr, line_buf, CacheStore::LINE_SIZE, Mtype::RW, vmid);
-  cache_.fill_line(addr, line_buf);
+  cache_.fill_line(addr, line_buf, vmid);
 }
 
 void L1ScalarCache::store(uint64_t addr, uint32_t num_dwords, const uint32_t *src, uint32_t vmid) {
@@ -57,7 +57,7 @@ void L1ScalarCache::store(uint64_t addr, uint32_t num_dwords, const uint32_t *sr
       }
 
       if (mtype == Mtype::CC) {
-        cache_.invalidate(chunk_addr);
+        cache_.invalidate(chunk_addr, vmid);
         l2_->write(chunk_addr, buf + copied, chunk, Mtype::CC, vmid);
         copied += chunk;
         continue;
@@ -66,10 +66,10 @@ void L1ScalarCache::store(uint64_t addr, uint32_t num_dwords, const uint32_t *sr
       ensure_line(chunk_addr, vmid); // read-allocate on miss
 
       simdojo::CacheTag *tag = nullptr;
-      cache_.lookup(chunk_addr, &tag);
+      cache_.lookup(chunk_addr, &tag, vmid);
       assert(tag != nullptr && "ensure_line must guarantee hit");
 
-      cache_.write_line(chunk_addr, buf + copied, line_offset, chunk);
+      cache_.write_line(chunk_addr, buf + copied, line_offset, chunk, vmid);
       tag->dirty = true;
       copied += chunk;
     }
@@ -77,8 +77,14 @@ void L1ScalarCache::store(uint64_t addr, uint32_t num_dwords, const uint32_t *sr
 }
 
 void L1ScalarCache::writeback_all(uint32_t vmid) {
-  cache_.for_each_dirty([this, vmid](simdojo::CacheTag &tag, uint64_t line_addr, uint8_t *data) {
-    l2_->writeback_line(line_addr, data, Mtype::RW, vmid);
+  // Each dirty line is written back under its own owning vmid (recorded in the
+  // tag), not the caller's vmid. A CU can retain dirty K$ lines from process A
+  // and then be flushed while processing process B; using the caller vmid would
+  // install A's line into L2 under B's page table and corrupt another process's
+  // VA. The eviction path in ensure_line() uses evicted.vmid for the same reason.
+  (void)vmid;
+  cache_.for_each_dirty([this](simdojo::CacheTag &tag, uint64_t line_addr, uint8_t *data) {
+    l2_->writeback_line(line_addr, data, Mtype::RW, tag.vmid);
     tag.dirty = false;
   });
 }
@@ -101,11 +107,11 @@ void L1ScalarCache::load(uint64_t addr, uint32_t num_dwords, uint32_t *dst, uint
       if (mtype == Mtype::UC) {
         l2_->read(chunk_addr, buf + copied, chunk, Mtype::UC, vmid);
       } else if (mtype == Mtype::CC) {
-        cache_.invalidate(chunk_addr);
+        cache_.invalidate(chunk_addr, vmid);
         l2_->read(chunk_addr, buf + copied, chunk, Mtype::CC, vmid);
       } else {
         ensure_line(chunk_addr, vmid);
-        cache_.read_line(chunk_addr, buf + copied, line_offset, chunk);
+        cache_.read_line(chunk_addr, buf + copied, line_offset, chunk, vmid);
       }
       copied += chunk;
     }
@@ -127,11 +133,11 @@ void L1ScalarCache::load_bytes(uint64_t addr, uint32_t num_bytes, uint8_t *dst, 
     if (mtype == Mtype::UC) {
       l2_->read(ea, dst + copied, chunk, Mtype::UC, vmid);
     } else if (mtype == Mtype::CC) {
-      cache_.invalidate(ea);
+      cache_.invalidate(ea, vmid);
       l2_->read(ea, dst + copied, chunk, Mtype::CC, vmid);
     } else {
       ensure_line(ea, vmid);
-      cache_.read_line(ea, dst + copied, line_offset, chunk);
+      cache_.read_line(ea, dst + copied, line_offset, chunk, vmid);
     }
     copied += chunk;
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_scalar_cache.h
@@ -55,6 +55,9 @@ public:
   void store(uint64_t addr, uint32_t num_dwords, const uint32_t *src, uint32_t vmid = 0);
 
   /// @brief Write back all dirty K$ lines to L2 (s_dcache_wb).
+  /// @param vmid Ignored. Each dirty line is written back under its own owning
+  /// vmid (recorded in the line tag), so a caller-supplied vmid cannot be
+  /// correct for a bulk writeback. Retained only for call-site signature symmetry.
   void writeback_all(uint32_t vmid = 0);
 
   /// @brief Invalidate all K$ lines without writeback (s_dcache_inv).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.cpp
@@ -17,19 +17,19 @@ namespace rocjitsu {
 namespace amdgpu {
 
 void L1VectorCache::ensure_line(uint64_t addr, uint32_t vmid) {
-  if (cache_.lookup(addr))
+  if (cache_.lookup(addr, nullptr, vmid))
     return;
 
   uint64_t line_addr = CacheStore::line_address(addr);
   simdojo::CacheTag evicted;
   uint8_t evicted_data[LINE_SIZE];
-  cache_.allocate(addr, &evicted, evicted_data);
+  cache_.allocate(addr, vmid, &evicted, evicted_data);
 
   assert(!evicted.dirty && "L1 V$ is write-through; lines should never be dirty");
 
   uint8_t line_buf[LINE_SIZE];
   l2_->fetch_line(line_addr, line_buf, vmid);
-  cache_.fill_line(addr, line_buf);
+  cache_.fill_line(addr, line_buf, vmid);
 }
 
 // Per-line CC invalidation is sufficient: the CP serializes dispatch N's cache
@@ -72,14 +72,14 @@ void L1VectorCache::read_bytes(uint64_t addr, uint8_t *dst, uint32_t size, Mtype
     }
 
     if (chunk_mtype == Mtype::CC) {
-      cache_.invalidate(ea);
+      cache_.invalidate(ea, vmid);
       l2_->read(ea, dst + copied, chunk, chunk_mtype, vmid);
       copied += chunk;
       continue;
     }
 
     ensure_line(ea, vmid);
-    cache_.read_line(ea, dst + copied, line_offset, chunk);
+    cache_.read_line(ea, dst + copied, line_offset, chunk, vmid);
     copied += chunk;
   }
 }
@@ -123,7 +123,7 @@ void L1VectorCache::write_bytes(uint64_t addr, const uint8_t *src, uint32_t size
     }
 
     ensure_line(ea, vmid);
-    cache_.write_line(ea, src + copied, line_offset, chunk);
+    cache_.write_line(ea, src + copied, line_offset, chunk, vmid);
 
     // Write through to L2 for all cacheable stores. This ensures partial writes
     // from different CUs sharing the same L2 are properly merged at byte
@@ -132,7 +132,7 @@ void L1VectorCache::write_bytes(uint64_t addr, const uint8_t *src, uint32_t size
     l2_->write(ea, src + copied, chunk, chunk_mtype, vmid);
 
     simdojo::CacheTag *tag = nullptr;
-    cache_.lookup(ea, &tag);
+    cache_.lookup(ea, &tag, vmid);
     assert(tag != nullptr && "ensure_line must guarantee hit");
 
     // L1 line stays clean since L2 has the authoritative copy.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l1_vector_cache.h
@@ -42,7 +42,7 @@ public:
   void store(const uint64_t *addrs, uint64_t lane_mask, uint32_t elem_size, uint32_t num_elems,
              const uint8_t *src, Mtype mtype, bool non_temporal, uint32_t vmid = 0);
 
-  void invalidate(uint64_t addr) { cache_.invalidate(addr); }
+  void invalidate(uint64_t addr, uint32_t vmid = 0) { cache_.invalidate(addr, vmid); }
   void invalidate_all() { cache_.invalidate_all(); }
   void flush_all();
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
@@ -38,18 +38,19 @@ void L2Cache::send_backing(uint64_t addr, uint8_t *data, uint32_t size, simdojo:
   hdr.addr = addr;
   hdr.size_bytes = size;
   hdr.op = op;
+  hdr.vmid = vmid;
   msg->set_payload(reinterpret_cast<uintptr_t>(data));
   req_port_->send(std::move(msg));
 }
 
 void L2Cache::ensure_line(uint64_t addr, uint32_t vmid) {
-  if (cache_.lookup(addr))
+  if (cache_.lookup(addr, nullptr, vmid))
     return;
 
   uint64_t line_addr = CacheStore::line_address(addr);
   simdojo::CacheTag evicted;
   uint8_t evicted_data[LINE_SIZE];
-  cache_.allocate(addr, &evicted, evicted_data);
+  cache_.allocate(addr, vmid, &evicted, evicted_data);
 
   if (evicted.valid && evicted.dirty) {
     static constexpr uint32_t SET_INDEX_BITS = std::bit_width(NUM_SETS - 1);
@@ -60,15 +61,15 @@ void L2Cache::ensure_line(uint64_t addr, uint32_t vmid) {
       if (++evict_count <= 5 || (evict_count % 10000) == 0)
         os << std::format("L2 evict #{} addr={:#x} new={:#x}", evict_count, evicted_addr, addr);
     });
-    // Evicted dirty line uses the current request's vmid. This is correct
-    // because the only source of dirty L2 lines is K$ writeback, and K$
-    // lines belong to the same process whose wavefront is currently active.
-    send_backing(evicted_addr, evicted_data, LINE_SIZE, simdojo::MessageOp::WRITE, vmid);
+    // The evicted line is written back under its own owning vmid, which may
+    // differ from the current request's vmid when two processes alias the
+    // same GPU VA in different ways of the same set.
+    send_backing(evicted_addr, evicted_data, LINE_SIZE, simdojo::MessageOp::WRITE, evicted.vmid);
   }
 
   uint8_t line_buf[LINE_SIZE];
   send_backing(line_addr, line_buf, LINE_SIZE, simdojo::MessageOp::READ, vmid);
-  cache_.fill_line(addr, line_buf);
+  cache_.fill_line(addr, line_buf, vmid);
 }
 
 void L2Cache::read(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype, uint32_t vmid) {
@@ -100,7 +101,7 @@ void L2Cache::read(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype, uint
     }
 
     ensure_line(ea, vmid);
-    cache_.read_line(ea, dst + copied, line_offset, chunk);
+    cache_.read_line(ea, dst + copied, line_offset, chunk, vmid);
     copied += chunk;
   }
 }
@@ -127,10 +128,10 @@ void L2Cache::write(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtyp
     const uint32_t chunk = std::min(size - copied, LINE_SIZE - line_offset);
 
     ensure_line(ea, vmid);
-    cache_.write_line(ea, src + copied, line_offset, chunk);
+    cache_.write_line(ea, src + copied, line_offset, chunk, vmid);
 
     simdojo::CacheTag *tag = nullptr;
-    cache_.lookup(ea, &tag);
+    cache_.lookup(ea, &tag, vmid);
     assert(tag != nullptr && "ensure_line must guarantee hit");
 
     // Write through to backing store for all mtypes. In the simulator, GPU
@@ -151,28 +152,28 @@ void L2Cache::write(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtyp
 void L2Cache::fetch_line(uint64_t addr, uint8_t *line_buf, uint32_t vmid) {
   uint64_t line_addr = CacheStore::line_address(addr);
   ensure_line(line_addr, vmid);
-  cache_.read_line(line_addr, line_buf, 0, LINE_SIZE);
+  cache_.read_line(line_addr, line_buf, 0, LINE_SIZE, vmid);
 }
 
 void L2Cache::writeback_line(uint64_t line_addr, const uint8_t *data, Mtype mtype, uint32_t vmid) {
   simdojo::CacheTag *tag = nullptr;
-  if (cache_.lookup(line_addr, &tag)) {
-    cache_.write_line(line_addr, data, 0, LINE_SIZE);
+  if (cache_.lookup(line_addr, &tag, vmid)) {
+    cache_.write_line(line_addr, data, 0, LINE_SIZE, vmid);
   } else {
     simdojo::CacheTag evicted;
     uint8_t evicted_data[LINE_SIZE];
-    cache_.allocate(line_addr, &evicted, evicted_data);
+    cache_.allocate(line_addr, vmid, &evicted, evicted_data);
 
     if (evicted.valid && evicted.dirty) {
       static constexpr uint32_t SET_INDEX_BITS = std::bit_width(NUM_SETS - 1);
       uint64_t evicted_addr =
           (evicted.tag << (LINE_SIZE_BITS + SET_INDEX_BITS)) |
           (static_cast<uint64_t>(CacheStore::set_index(line_addr)) << LINE_SIZE_BITS);
-      send_backing(evicted_addr, evicted_data, LINE_SIZE, simdojo::MessageOp::WRITE, vmid);
+      send_backing(evicted_addr, evicted_data, LINE_SIZE, simdojo::MessageOp::WRITE, evicted.vmid);
     }
 
-    cache_.fill_line(line_addr, data);
-    cache_.lookup(line_addr, &tag);
+    cache_.fill_line(line_addr, data, vmid);
+    cache_.lookup(line_addr, &tag, vmid);
   }
 
   if (mtype == Mtype::CC) {
@@ -187,24 +188,26 @@ void L2Cache::writeback_line(uint64_t line_addr, const uint8_t *data, Mtype mtyp
 
 void L2Cache::flush_line(uint64_t addr, uint32_t vmid) {
   simdojo::CacheTag *tag = nullptr;
-  if (!cache_.lookup(addr, &tag))
+  if (!cache_.lookup(addr, &tag, vmid))
     return;
 
   if (tag->dirty) {
     uint8_t line_buf[LINE_SIZE];
-    cache_.read_line(addr, line_buf, 0, LINE_SIZE);
+    cache_.read_line(addr, line_buf, 0, LINE_SIZE, vmid);
     uint64_t line_addr = CacheStore::line_address(addr);
     send_backing(line_addr, line_buf, LINE_SIZE, simdojo::MessageOp::WRITE, vmid);
   }
-  cache_.invalidate(addr);
+  cache_.invalidate(addr, vmid);
 }
 
 void L2Cache::flush_all(uint32_t vmid) {
+  (void)vmid;
   uint32_t dirty_count = 0;
   uint64_t min_addr = UINT64_MAX, max_addr = 0;
-  cache_.for_each_dirty([this, vmid, &dirty_count, &min_addr,
+  cache_.for_each_dirty([this, &dirty_count, &min_addr,
                          &max_addr](simdojo::CacheTag &tag, uint64_t line_addr, uint8_t *data) {
-    send_backing(line_addr, data, LINE_SIZE, simdojo::MessageOp::WRITE, vmid);
+    // Each dirty line is written back under its own owning vmid.
+    send_backing(line_addr, data, LINE_SIZE, simdojo::MessageOp::WRITE, tag.vmid);
     tag.dirty = false;
     ++dirty_count;
     if (line_addr < min_addr)
@@ -215,15 +218,6 @@ void L2Cache::flush_all(uint32_t vmid) {
   util::Logger::vm("L2 flush: ", dirty_count, " dirty lines [0x", std::hex, min_addr, "-0x",
                    max_addr, "]", std::dec, " total_writes=", write_count_);
   cache_.invalidate_all();
-}
-
-void L2Cache::invalidate_range(uint64_t addr, uint32_t size) {
-  if (size == 0)
-    return;
-  uint64_t line_start = CacheStore::line_address(addr);
-  uint64_t end = addr + size;
-  for (uint64_t la = line_start; la < end; la += LINE_SIZE)
-    cache_.invalidate(la);
 }
 
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
@@ -134,7 +134,7 @@ public:
     ensure_line(addr, vmid);
 
     uint32_t offset = CacheStore::line_offset(addr);
-    uint8_t *line = cache_.line_data_for_write(addr);
+    uint8_t *line = cache_.line_data_for_write(addr, vmid);
     assert(line != nullptr && "ensure_line must guarantee hit");
 
     fn(line, offset);
@@ -142,7 +142,7 @@ public:
     send_backing(addr, line + offset, size, simdojo::MessageOp::WRITE, vmid);
 
     simdojo::CacheTag *ctag = nullptr;
-    cache_.lookup(addr, &ctag);
+    cache_.lookup(addr, &ctag, vmid);
     if (ctag) {
       ctag->coherence = simdojo::CoherenceState::MODIFIED;
       ctag->dirty = false;
@@ -160,12 +160,10 @@ public:
   /// @brief Invalidate all L2 lines.
   void invalidate_all() { cache_.invalidate_all(); }
 
-  /// @brief Invalidate L2 lines covering an address range.
-  /// @details Used after host/SDMA writes to ensure GPU reads reload from
-  /// backing store. No writeback — the backing store already has latest data.
-  void invalidate_range(uint64_t addr, uint32_t size);
-
   /// @brief Flush all dirty L2 lines to HBM and invalidate.
+  /// @param vmid Ignored. Each dirty line is written back under its own owning
+  /// vmid (recorded in the line tag), so a caller-supplied vmid cannot be
+  /// correct for a global flush. Retained only for call-site signature symmetry.
   void flush_all(uint32_t vmid = 0);
 
   /// @brief Create a completer port for a CU connection (one per CU).

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_pipeline.cpp
@@ -378,7 +378,7 @@ void execute_atomic_rmw(VectorMemState &d, L2Cache *l2, L1VectorCache *l1, uint3
         vmid);
 
     // Invalidate stale L1 line.
-    l1->invalidate(ea);
+    l1->invalidate(ea, vmid);
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.cpp
@@ -12,39 +12,40 @@ namespace rocjitsu {
 namespace amdgpu {
 
 void MemorySideCache::send_backing(uint64_t addr, uint8_t *data, uint32_t size,
-                                   simdojo::MessageOp op) {
+                                   simdojo::MessageOp op, uint32_t vmid) {
   assert(req_ != nullptr && "MemorySideCache: req_ not set");
   auto msg = std::make_unique<simdojo::Message>();
   auto &hdr = msg->header();
   hdr.addr = addr;
   hdr.size_bytes = size;
   hdr.op = op;
+  hdr.vmid = vmid;
   msg->set_payload(reinterpret_cast<uintptr_t>(data));
   req_->send(std::move(msg));
 }
 
-void MemorySideCache::ensure_line(uint64_t addr) {
-  if (cache_.lookup(addr))
+void MemorySideCache::ensure_line(uint64_t addr, uint32_t vmid) {
+  if (cache_.lookup(addr, nullptr, vmid))
     return;
 
   uint64_t line_addr = CacheStore::line_address(addr);
   simdojo::CacheTag evicted;
   uint8_t evicted_data[LINE_SIZE];
-  cache_.allocate(addr, &evicted, evicted_data);
+  cache_.allocate(addr, vmid, &evicted, evicted_data);
 
   if (evicted.valid && evicted.dirty) {
     static constexpr uint32_t SET_INDEX_BITS = std::bit_width(NUM_SETS - 1);
     uint64_t evicted_addr = (evicted.tag << (LINE_SIZE_BITS + SET_INDEX_BITS)) |
                             (static_cast<uint64_t>(CacheStore::set_index(addr)) << LINE_SIZE_BITS);
-    send_backing(evicted_addr, evicted_data, LINE_SIZE, simdojo::MessageOp::WRITE);
+    send_backing(evicted_addr, evicted_data, LINE_SIZE, simdojo::MessageOp::WRITE, evicted.vmid);
   }
 
   uint8_t line_buf[LINE_SIZE];
-  send_backing(line_addr, line_buf, LINE_SIZE, simdojo::MessageOp::READ);
-  cache_.fill_line(addr, line_buf);
+  send_backing(line_addr, line_buf, LINE_SIZE, simdojo::MessageOp::READ, vmid);
+  cache_.fill_line(addr, line_buf, vmid);
 }
 
-void MemorySideCache::read(uint64_t addr, uint8_t *dst, uint32_t size) {
+void MemorySideCache::read(uint64_t addr, uint8_t *dst, uint32_t size, uint32_t vmid) {
   uint32_t copied = 0;
   while (copied < size) {
     const uint64_t ea = addr + copied;
@@ -52,13 +53,13 @@ void MemorySideCache::read(uint64_t addr, uint8_t *dst, uint32_t size) {
     const uint32_t chunk = std::min(size - copied, LINE_SIZE - line_offset);
 
     std::lock_guard<std::mutex> lock(stripes_[stripe_index(ea)]);
-    ensure_line(ea);
-    cache_.read_line(ea, dst + copied, line_offset, chunk);
+    ensure_line(ea, vmid);
+    cache_.read_line(ea, dst + copied, line_offset, chunk, vmid);
     copied += chunk;
   }
 }
 
-void MemorySideCache::write(uint64_t addr, const uint8_t *src, uint32_t size) {
+void MemorySideCache::write(uint64_t addr, const uint8_t *src, uint32_t size, uint32_t vmid) {
   uint32_t copied = 0;
   while (copied < size) {
     const uint64_t ea = addr + copied;
@@ -66,14 +67,15 @@ void MemorySideCache::write(uint64_t addr, const uint8_t *src, uint32_t size) {
     const uint32_t chunk = std::min(size - copied, LINE_SIZE - line_offset);
 
     std::lock_guard<std::mutex> lock(stripes_[stripe_index(ea)]);
-    ensure_line(ea);
-    cache_.write_line(ea, src + copied, line_offset, chunk);
+    ensure_line(ea, vmid);
+    cache_.write_line(ea, src + copied, line_offset, chunk, vmid);
 
     simdojo::CacheTag *tag = nullptr;
-    cache_.lookup(ea, &tag);
+    cache_.lookup(ea, &tag, vmid);
     assert(tag != nullptr && "ensure_line must guarantee hit");
-    tag->dirty = true;
-    tag->coherence = simdojo::CoherenceState::MODIFIED;
+    send_backing(ea, const_cast<uint8_t *>(src + copied), chunk, simdojo::MessageOp::WRITE, vmid);
+    tag->dirty = false;
+    tag->coherence = simdojo::CoherenceState::EXCLUSIVE;
     copied += chunk;
   }
 }
@@ -85,7 +87,7 @@ void MemorySideCache::flush_all() {
   for (auto &s : stripes_)
     s.lock();
   cache_.for_each_dirty([this](simdojo::CacheTag &tag, uint64_t line_addr, uint8_t *data) {
-    send_backing(line_addr, data, LINE_SIZE, simdojo::MessageOp::WRITE);
+    send_backing(line_addr, data, LINE_SIZE, simdojo::MessageOp::WRITE, tag.vmid);
     tag.dirty = false;
   });
   cache_.invalidate_all();

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/memory_side_cache.h
@@ -20,10 +20,12 @@ namespace amdgpu {
 
 /// @brief Memory-side cache component sitting between L2 and HBM on each IOD.
 ///
-/// @details Write-back, write-allocate cache, and no mtype awareness. All traffic from
+/// @details Write-through, write-allocate cache, and no mtype awareness. All traffic from
 /// L2 is already filtered (UC bypasses L2, so it never reaches the MSC).
 /// On miss, fetches from the backing store via the requester port (typically HbmController).
-/// On eviction, dirty lines are written back to the backing store.
+/// Stores are pushed straight to the backing store and the line is left clean
+/// (EXCLUSIVE), so the daemon's process_vm_readv bridge sees writes immediately;
+/// the for_each_dirty writeback in flush_all() is retained as a safety net.
 ///
 /// Provides structural ports for the topology graph. The backing store is reached
 /// through the requester port (req), which is connected to the HBM controller via a link.
@@ -51,8 +53,8 @@ public:
                                                     simdojo::PortProtocol::MEMORY));
   }
 
-  void read(uint64_t addr, uint8_t *dst, uint32_t size);
-  void write(uint64_t addr, const uint8_t *src, uint32_t size);
+  void read(uint64_t addr, uint8_t *dst, uint32_t size, uint32_t vmid = 0);
+  void write(uint64_t addr, const uint8_t *src, uint32_t size, uint32_t vmid = 0);
 
   /// @brief Flush all dirty lines to the backing store and invalidate.
   void flush_all();
@@ -64,9 +66,9 @@ public:
           auto &hdr = msg->header();
           auto *data = reinterpret_cast<uint8_t *>(msg->payload());
           if (hdr.op == simdojo::MessageOp::READ)
-            read(hdr.addr, data, hdr.size_bytes);
+            read(hdr.addr, data, hdr.size_bytes, hdr.vmid);
           else if (hdr.op == simdojo::MessageOp::WRITE)
-            write(hdr.addr, data, hdr.size_bytes);
+            write(hdr.addr, data, hdr.size_bytes, hdr.vmid);
           hdr.op = simdojo::MessageOp::RESPONSE;
         });
       }
@@ -85,9 +87,9 @@ public:
       auto &hdr = msg->header();
       auto *data = reinterpret_cast<uint8_t *>(msg->payload());
       if (hdr.op == simdojo::MessageOp::READ)
-        read(hdr.addr, data, hdr.size_bytes);
+        read(hdr.addr, data, hdr.size_bytes, hdr.vmid);
       else if (hdr.op == simdojo::MessageOp::WRITE)
-        write(hdr.addr, data, hdr.size_bytes);
+        write(hdr.addr, data, hdr.size_bytes, hdr.vmid);
       hdr.op = simdojo::MessageOp::RESPONSE;
     });
     cpl_ports_.push_back(raw);
@@ -95,10 +97,11 @@ public:
   }
 
 private:
-  void ensure_line(uint64_t addr);
+  void ensure_line(uint64_t addr, uint32_t vmid);
 
   /// @brief Send a read or write request to the backing store via the req port.
-  void send_backing(uint64_t addr, uint8_t *data, uint32_t size, simdojo::MessageOp op);
+  void send_backing(uint64_t addr, uint8_t *data, uint32_t size, simdojo::MessageOp op,
+                    uint32_t vmid);
 
   /// @brief Return the stripe index for a given address.
   uint32_t stripe_index(uint64_t addr) const {

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/components/cache.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/components/cache.h
@@ -67,8 +67,13 @@ enum class CoherenceState : uint8_t {
 };
 
 /// @brief Tag and metadata for a single cache line.
+///
+/// @details @c vmid identifies the owning process address space. Lines with the
+/// same line address but different vmids are distinct entries, because guest VAs
+/// are per-process and may alias across processes.
 struct CacheTag {
   uint64_t tag = 0;
+  uint32_t vmid = 0;
   bool valid = false;
   bool dirty = false;
   CoherenceState coherence = CoherenceState::INVALID;
@@ -104,14 +109,15 @@ public:
   ///
   /// @param addr The memory address to look up.
   /// @param tag_out If non-null and hit, set to point at the matching tag.
+  /// @param vmid Owning process address space (lines are tagged by (vmid, addr)).
   /// @retval true Cache hit.
   /// @retval false Cache miss.
-  bool lookup(uint64_t addr, CacheTag **tag_out = nullptr) {
+  bool lookup(uint64_t addr, CacheTag **tag_out = nullptr, uint32_t vmid = 0) {
     uint32_t set = set_index(addr);
     uint64_t tag = tag_bits(addr);
     for (uint32_t w = 0; w < Associativity; ++w) {
       auto &t = tag_at(set, w);
-      if (t.valid && t.tag == tag) {
+      if (t.valid && t.tag == tag && t.vmid == vmid) {
         policy_.access(set, w);
         if (tag_out)
           *tag_out = &t;
@@ -124,10 +130,12 @@ public:
   /// @brief Allocate a cache line for an address, evicting the LRU victim if needed.
   ///
   /// @param addr The memory address to allocate for.
-  /// @param evicted_tag If non-null, filled with the evicted tag (caller checks dirty).
+  /// @param vmid Owning process address space recorded in the new line's tag.
+  /// @param evicted_tag If non-null, filled with the evicted tag (caller checks dirty,
+  ///        and uses @c evicted_tag->vmid for the writeback address space).
   /// @param evicted_data If non-null, the evicted line data is copied here.
   /// @returns Pointer to the allocated tag entry.
-  CacheTag *allocate(uint64_t addr, CacheTag *evicted_tag = nullptr,
+  CacheTag *allocate(uint64_t addr, uint32_t vmid = 0, CacheTag *evicted_tag = nullptr,
                      uint8_t *evicted_data = nullptr) {
     uint32_t set = set_index(addr);
     uint64_t tag = tag_bits(addr);
@@ -137,6 +145,7 @@ public:
       auto &t = tag_at(set, w);
       if (!t.valid) {
         t.tag = tag;
+        t.vmid = vmid;
         t.valid = true;
         t.dirty = false;
         t.coherence = CoherenceState::INVALID;
@@ -154,6 +163,7 @@ public:
       std::memcpy(evicted_data, line_data(set, victim_way), LINE_SIZE);
 
     vt.tag = tag;
+    vt.vmid = vmid;
     vt.valid = true;
     vt.dirty = false;
     vt.coherence = CoherenceState::INVALID;
@@ -163,12 +173,13 @@ public:
 
   /// @brief Invalidate the cache line for an address (if present).
   /// @param addr The memory address whose cache line to invalidate.
-  void invalidate(uint64_t addr) {
+  /// @param vmid Owning process address space.
+  void invalidate(uint64_t addr, uint32_t vmid = 0) {
     uint32_t set = set_index(addr);
     uint64_t tag = tag_bits(addr);
     for (uint32_t w = 0; w < Associativity; ++w) {
       auto &t = tag_at(set, w);
-      if (t.valid && t.tag == tag) {
+      if (t.valid && t.tag == tag && t.vmid == vmid) {
         t.valid = false;
         t.dirty = false;
         t.coherence = CoherenceState::INVALID;
@@ -191,12 +202,13 @@ public:
   /// @param dst Destination buffer for the read data.
   /// @param offset Byte offset within the cache line.
   /// @param size Number of bytes to read.
-  void read_line(uint64_t addr, uint8_t *dst, uint32_t offset, uint32_t size) const {
+  void read_line(uint64_t addr, uint8_t *dst, uint32_t offset, uint32_t size,
+                 uint32_t vmid = 0) const {
     uint32_t set = set_index(addr);
     uint64_t tag = tag_bits(addr);
     for (uint32_t w = 0; w < Associativity; ++w) {
       const auto &t = tag_at(set, w);
-      if (t.valid && t.tag == tag) {
+      if (t.valid && t.tag == tag && t.vmid == vmid) {
         assert(offset + size <= LINE_SIZE);
         std::memcpy(dst, line_data(set, w) + offset, size);
         return;
@@ -210,12 +222,13 @@ public:
   /// @param src Source buffer containing data to write.
   /// @param offset Byte offset within the cache line.
   /// @param size Number of bytes to write.
-  void write_line(uint64_t addr, const uint8_t *src, uint32_t offset, uint32_t size) {
+  void write_line(uint64_t addr, const uint8_t *src, uint32_t offset, uint32_t size,
+                  uint32_t vmid = 0) {
     uint32_t set = set_index(addr);
     uint64_t tag = tag_bits(addr);
     for (uint32_t w = 0; w < Associativity; ++w) {
       auto &t = tag_at(set, w);
-      if (t.valid && t.tag == tag) {
+      if (t.valid && t.tag == tag && t.vmid == vmid) {
         assert(offset + size <= LINE_SIZE);
         std::memcpy(line_data(set, w) + offset, src, size);
         return;
@@ -227,12 +240,12 @@ public:
   /// @brief Fill an entire cache line with data (used after allocate on a miss).
   /// @param addr The memory address identifying the cache line.
   /// @param data Source buffer containing a full cache line of data.
-  void fill_line(uint64_t addr, const uint8_t *data) {
+  void fill_line(uint64_t addr, const uint8_t *data, uint32_t vmid = 0) {
     uint32_t set = set_index(addr);
     uint64_t tag = tag_bits(addr);
     for (uint32_t w = 0; w < Associativity; ++w) {
       auto &t = tag_at(set, w);
-      if (t.valid && t.tag == tag) {
+      if (t.valid && t.tag == tag && t.vmid == vmid) {
         std::memcpy(line_data(set, w), data, LINE_SIZE);
         return;
       }
@@ -245,12 +258,12 @@ public:
   /// Used by atomic RMW operations that need to read-modify-write in place.
   /// @param addr The memory address identifying the cache line.
   /// @returns Pointer to the line data, or nullptr if not found.
-  uint8_t *line_data_for_write(uint64_t addr) {
+  uint8_t *line_data_for_write(uint64_t addr, uint32_t vmid = 0) {
     uint32_t set = set_index(addr);
     uint64_t tag = tag_bits(addr);
     for (uint32_t w = 0; w < Associativity; ++w) {
       auto &t = tag_at(set, w);
-      if (t.valid && t.tag == tag) {
+      if (t.valid && t.tag == tag && t.vmid == vmid) {
         policy_.access(set, w);
         return line_data(set, w);
       }

--- a/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/message.h
+++ b/emulation/rocjitsu/lib/simdojo/include/simdojo/sim/message.h
@@ -38,6 +38,7 @@ struct MessageHeader {
   uint64_t addr = 0;              ///< Memory address (unused for non-memory ops).
   MessageOp op = MessageOp::NONE; ///< Operation type.
   uint8_t mtype = 0;              ///< Memory type (Mtype enum, unused for non-memory ops).
+  uint32_t vmid = 0;              ///< VMID for address translation in daemon mode.
 };
 
 /// @brief Simulation message sent over links between components.

--- a/emulation/rocjitsu/lib/util/include/util/bit.h
+++ b/emulation/rocjitsu/lib/util/include/util/bit.h
@@ -249,12 +249,26 @@ constexpr inline T align_up(T val, T alignment) {
   return (val + alignment - 1) & ~(alignment - 1);
 }
 
-/// @brief Divide @p numerator by @p denominator, rounding up.
+/// @brief Divide @p numerator by @p divisor, rounding up.
+/// @details Asserts that @p divisor is non-zero; this is the strict,
+/// general-purpose form. Call sites that must tolerate a zero divisor from
+/// untrusted guest input should use ceil_div_or_one() instead.
 template <typename T>
   requires metaprogramming::IsUnsignedInt<T>
-constexpr T ceil_div(T numerator, T denominator) {
-  assert(denominator != 0);
-  return numerator / denominator + (numerator % denominator != 0 ? T{1} : T{0});
+constexpr inline T ceil_div(T numerator, T divisor) {
+  assert(divisor != 0);
+  return numerator / divisor + (numerator % divisor != 0 ? T{1} : T{0});
+}
+
+/// @brief Divide @p numerator by @p divisor, rounding up, returning 1 when
+/// @p divisor is 0.
+/// @details Tolerant variant for paths that parse malformed guest input (e.g.
+/// a dispatch packet with a zero workgroup dimension): the emulator must not
+/// abort on bad guest data, so a zero divisor yields 1 rather than asserting.
+template <typename T>
+  requires metaprogramming::IsUnsignedInt<T>
+constexpr inline T ceil_div_or_one(T numerator, T divisor) {
+  return divisor == 0 ? T{1} : ceil_div(numerator, divisor);
 }
 
 /// @brief Return true when @p val is aligned to @p alignment.

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -7,6 +7,10 @@
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
+#include "rocjitsu/kmd/linux/kfd_process.h"
+#include "rocjitsu/vm/amdgpu/gpu_memory.h"
+#include "rocjitsu/vm/amdgpu/l1_scalar_cache.h"
+#include "rocjitsu/vm/amdgpu/l2_cache.h"
 #include "rocjitsu/vm/rj_vm.h"
 #include "rocjitsu/vm/soc.h"
 
@@ -1490,6 +1494,55 @@ TEST(DsTransposeTest, ReadB64TrB16_AccBit) {
   EXPECT_NE(acc_val, 0u) << "AccVGPR a" << VDST << " should have been written by ds_read";
   EXPECT_NE(acc_val, 42u) << "AccVGPR a" << VDST
                           << " should contain LDS data, not the VGPR sentinel";
+}
+
+// L1ScalarCache::writeback_all() must write each dirty K$ line back under its
+// own owning vmid (from the line tag), not the caller-supplied vmid. A CU can
+// retain dirty K$ lines from process A and then be flushed while processing
+// process B (e.g. from an acquire fence or SDMA path). If the bulk writeback
+// used the caller vmid, A's dirty line would be published through B's page
+// table and corrupt B's address space. Two page tables map the same GPU VA to
+// different host pages; a store under VMID 7 followed by writeback_all(8) must
+// land in VMID 7's backing, not VMID 8's.
+TEST(L1ScalarCacheVmidTest, WritebackAllUsesLineOwnerVmidNotCaller) {
+  constexpr uint32_t kVmidA = 7;
+  constexpr uint32_t kVmidB = 8;
+  constexpr uint64_t kSharedVa = 0x40000; // page-aligned, aliased across procs.
+  constexpr uint32_t kStoreWord = 0xA5A5A5A5u;
+
+  amdgpu::GpuMemory mem("test.vram");
+
+  // Two processes whose page tables map the same VA to different host buffers.
+  KfdProcess proc_a(kVmidA);
+  KfdProcess proc_b(kVmidB);
+  alignas(4096) std::array<uint8_t, 4096> backing_a{};
+  alignas(4096) std::array<uint8_t, 4096> backing_b{};
+  proc_a.map_pages(kSharedVa, backing_a.data(), backing_a.size());
+  proc_b.map_pages(kSharedVa, backing_b.data(), backing_b.size());
+  mem.register_process(kVmidA, &proc_a.page_table_, &proc_a.page_table_mutex_);
+  mem.register_process(kVmidB, &proc_b.page_table_, &proc_b.page_table_mutex_);
+
+  amdgpu::L2Cache l2("test.l2");
+  l2.set_backing_memory(&mem);
+
+  amdgpu::L1ScalarCache k_cache(&l2);
+  k_cache.set_memory(&mem);
+
+  // Store a dword under VMID A, leaving a dirty K$ line owned by VMID A.
+  k_cache.store(kSharedVa, /*num_dwords=*/1, &kStoreWord, kVmidA);
+
+  // Flush the K$ as if servicing VMID B, then flush L2 to backing. The line
+  // must be published through VMID A's page table (its owner), not B's.
+  k_cache.writeback_all(kVmidB);
+  l2.flush_all();
+
+  EXPECT_EQ(mem.read32(kSharedVa, kVmidA), kStoreWord)
+      << "dirty K$ line must be written back under its owner VMID A";
+  EXPECT_NE(mem.read32(kSharedVa, kVmidB), kStoreWord)
+      << "line must NOT leak into VMID B's address space";
+
+  mem.unregister_process(kVmidA);
+  mem.unregister_process(kVmidB);
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -51,6 +51,7 @@ RJ_DIAGNOSTIC_POP
 #include <fstream>
 #include <memory>
 #include <optional>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -91,6 +92,9 @@ constexpr uint32_t kGfx1250LdsSizeKb = 160;
 constexpr uint32_t kSdmaOpCopy = 1;
 constexpr uint32_t kSdmaOpFence = 5;
 constexpr uint32_t kSdmaOpPollRegmem = 8;
+constexpr uint32_t kSdmaOpConstFill = 11;
+constexpr uint32_t kSdmaOpTimestamp = 13;
+constexpr uint32_t kSdmaOpGcr = 17;
 constexpr uint32_t kSdmaSubopCopyLinear = 0;
 constexpr uint32_t kSdmaSubopFence64 = 2;
 constexpr uint32_t kSdmaSubopPollMem64 = 5;
@@ -644,7 +648,7 @@ TEST(Gfx1250ConfigTest, ConfigLoadsTopology) {
   EXPECT_EQ(cu->config().lds_size_kb, kGfx1250LdsSizeKb);
   EXPECT_EQ(soc->xcd(0)->command_processor()->vgpr_granularity(), kGfx1250VgprEncodingGranule);
   EXPECT_EQ(soc->xcd(0)->command_processor()->sdma_packet_dialect(),
-            amdgpu::SdmaPacketDialect::Gfx11Plus);
+            amdgpu::SdmaPacketDialect::Gfx1250);
 }
 
 TEST(Gfx1250SdmaTest, PollMem64WaitsForFull64BitCondition) {
@@ -687,6 +691,244 @@ TEST(Gfx1250SdmaTest, Fence64WritesFull64BitValue) {
   ASSERT_TRUE(sim.engine->step());
   EXPECT_EQ(queue.read_idx(), 5u * sizeof(uint32_t));
   EXPECT_EQ(std::atomic_ref<uint64_t>(value).load(std::memory_order_acquire), kFenceValue);
+}
+
+// A wrong GCR packet size silently desyncs the SDMA ring read pointer and
+// corrupts the following packet. Emit OP_GCR followed by a 32-bit FENCE and
+// assert both the read pointer advance and that the FENCE decoded at the right
+// boundary (its sentinel lands). gfx11/12 GCR is 5 dwords; gfx1250 is 6.
+TEST(Gfx1250SdmaTest, GcrPacketSizeMatchesDialectAndKeepsRingInSync) {
+  constexpr uint32_t kGcrLegacySize = 5;
+  constexpr uint32_t kGcrGfx1250Size = 6;
+  constexpr uint32_t kFenceSize = 4;
+  constexpr uint32_t kFenceSentinel = 0xC0FFEE11u;
+  // GL2 invalidate control bit position differs by dialect; setting it exercises
+  // a realistic invalidate GCR but does not affect the decoded packet size.
+  constexpr uint32_t kLegacyGl2InvControlDw = 2;
+  constexpr uint32_t kLegacyGl2InvBit = 1u << 30;
+  constexpr uint32_t kGfx1250Gl2InvControlDw = 3;
+  constexpr uint32_t kGfx1250Gl2InvBit = 1u << 14;
+
+  auto run_dialect = [kFenceSentinel](amdgpu::SdmaPacketDialect dialect, uint32_t gcr_size,
+                                      uint32_t control_dw, uint32_t control_bit) {
+    Gfx1250Sim sim;
+    sim.cp()->set_sdma_packet_dialect(dialect);
+    HostSdmaQueueForTest queue(sim);
+    alignas(8) uint32_t fence_value = 0;
+
+    auto *packet = queue.ring();
+    packet[0] = kSdmaOpGcr;
+    packet[control_dw] = control_bit;
+
+    uint32_t *fence = packet + gcr_size;
+    fence[0] = kSdmaOpFence; // 32-bit fence (sub_op 0).
+    write_sdma_qword_address(fence, 1, 2, &fence_value);
+    fence[3] = kFenceSentinel;
+
+    queue.submit(gcr_size + kFenceSize);
+    ASSERT_TRUE(sim.engine->step());
+    EXPECT_EQ(queue.read_idx(), (gcr_size + kFenceSize) * sizeof(uint32_t));
+    EXPECT_EQ(std::atomic_ref<uint32_t>(fence_value).load(std::memory_order_acquire),
+              kFenceSentinel);
+  };
+
+  run_dialect(amdgpu::SdmaPacketDialect::Gfx11Plus, kGcrLegacySize, kLegacyGl2InvControlDw,
+              kLegacyGl2InvBit);
+  run_dialect(amdgpu::SdmaPacketDialect::Gfx1250, kGcrGfx1250Size, kGfx1250Gl2InvControlDw,
+              kGfx1250Gl2InvBit);
+}
+
+// SDMA writes go straight to backing while L2 may still hold a dirty line that
+// overlaps the destination (e.g. left by a prior K$ writeback). The post-write
+// cache maintenance must not write that stale line back over the SDMA result.
+// The fix flushes the caches before the direct write, so the dirty line is
+// published first and the SDMA data supersedes it. Regression for that ordering.
+TEST(Gfx1250SdmaTest, ConstFillSupersedesOverlappingDirtyL2Line) {
+  Gfx1250Sim sim;
+  // The config-driven topology build wires the XCD's L2 into the CP, so the SDMA
+  // cache maintenance operates on the same L2 instance we dirty below.
+  auto *l2 = sim.xcd()->l2_cache();
+  ASSERT_NE(l2, nullptr);
+
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kProcessId = 1251; // matches TranslatedSdmaQueueForTest.
+  constexpr uint32_t kStaleWord = 0x11111111u;
+  constexpr uint32_t kFillWord = 0x22222222u;
+
+  // Seed a dirty L2 line overlapping the destination, without touching backing.
+  uint8_t stale_line[amdgpu::L2Cache::LINE_SIZE];
+  std::memset(stale_line, static_cast<int>(kStaleWord & 0xFF), sizeof(stale_line));
+  l2->writeback_line(queue.dst_va(), stale_line, amdgpu::Mtype::RW, kProcessId);
+
+  // CONST_FILL the destination line with a different byte pattern.
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpConstFill | (0x2u << 30); // fillsize=2 (dword granularity).
+  write_sdma_qword_va(packet, 1, 2, queue.dst_va());
+  packet[3] = kFillWord;
+  packet[4] = amdgpu::L2Cache::LINE_SIZE - 1; // count-1 bytes.
+
+  queue.submit(5);
+  ASSERT_TRUE(sim.engine->step());
+
+  // Backing must reflect the SDMA fill, not the stale cached line.
+  EXPECT_EQ(sim.memory->read32(queue.dst_va(), kProcessId), kFillWord);
+  EXPECT_NE(sim.memory->read32(queue.dst_va(), kProcessId), kStaleWord);
+}
+
+// Same ordering hazard as above, but for a dirty scalar L1 (K$) line rather than
+// an L2 line. A CU can hold a dirty K$ line overlapping an SDMA destination. The
+// pre-write maintenance must write the K$ line back (through L2 to backing)
+// before the direct SDMA write, so the SDMA result is not later clobbered when
+// the stale scalar line is flushed. Regression for K$ inclusion in the flush.
+TEST(Gfx1250SdmaTest, ConstFillSupersedesOverlappingDirtyScalarL1Line) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  ASSERT_NE(cu, nullptr);
+
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kProcessId = 1251; // matches TranslatedSdmaQueueForTest.
+  constexpr uint32_t kStaleWord = 0x11111111u;
+  constexpr uint32_t kFillWord = 0x22222222u;
+
+  // Dirty a K$ line overlapping the SDMA destination via a scalar store. This
+  // leaves the line dirty in K$ (write-back), not yet in L2 or backing.
+  cu->l1_scalar().store(queue.dst_va(), /*num_dwords=*/1, &kStaleWord, kProcessId);
+
+  // CONST_FILL the destination line with a different pattern.
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpConstFill | (0x2u << 30); // fillsize=2 (dword granularity).
+  write_sdma_qword_va(packet, 1, 2, queue.dst_va());
+  packet[3] = kFillWord;
+  packet[4] = amdgpu::L2Cache::LINE_SIZE - 1; // count-1 bytes.
+
+  queue.submit(5);
+  ASSERT_TRUE(sim.engine->step());
+
+  // Force any still-resident dirty K$ line out to backing, mimicking a later
+  // acquire/release flush. With the fix the K$ line was already published and
+  // invalidated before the SDMA write, so this does not resurrect stale data.
+  cu->flush_l1(kProcessId);
+  if (auto *l2 = sim.xcd()->l2_cache())
+    l2->flush_all();
+
+  // Backing must reflect the SDMA fill, not the stale scalar line.
+  EXPECT_EQ(sim.memory->read32(queue.dst_va(), kProcessId), kFillWord);
+  EXPECT_NE(sim.memory->read32(queue.dst_va(), kProcessId), kStaleWord);
+}
+
+// OP_TIMESTAMP is a direct backing-store write like COPY/FENCE/CONST_FILL, so it
+// has the same clobber hazard: a dirty cached line overlapping the timestamp
+// address must be published before the store, not written out over it by a later
+// flush. Seed a dirty L2 line at the timestamp address, issue OP_TIMESTAMP, then
+// force a flush; the stored timestamp must survive (stale word gone, value set).
+TEST(Gfx1250SdmaTest, TimestampSupersedesOverlappingDirtyL2Line) {
+  Gfx1250Sim sim;
+  auto *l2 = sim.xcd()->l2_cache();
+  ASSERT_NE(l2, nullptr);
+
+  TranslatedSdmaQueueForTest queue(sim);
+  constexpr uint32_t kProcessId = 1251; // matches TranslatedSdmaQueueForTest.
+  constexpr uint64_t kStaleQword = 0x1111111111111111ULL;
+
+  // Seed a dirty L2 line overlapping the timestamp destination, without touching
+  // backing.
+  uint8_t stale_line[amdgpu::L2Cache::LINE_SIZE];
+  std::memset(stale_line, 0x11, sizeof(stale_line));
+  l2->writeback_line(queue.dst_va(), stale_line, amdgpu::Mtype::RW, kProcessId);
+
+  auto *packet = queue.ring();
+  packet[0] = kSdmaOpTimestamp;
+  write_sdma_qword_va(packet, 1, 2, queue.dst_va());
+
+  queue.submit(3); // TIMESTAMP is 3 dwords.
+  ASSERT_TRUE(sim.engine->step());
+
+  // Force any still-resident dirty line out, mimicking a later flush.
+  if (auto *xl2 = sim.xcd()->l2_cache())
+    xl2->flush_all();
+
+  // The timestamp value is nondeterministic, but it must not be the stale word
+  // and must be a plausible nonzero nanosecond count.
+  const uint64_t stored = sim.memory->read64(queue.dst_va(), kProcessId);
+  EXPECT_NE(stored, kStaleQword);
+  EXPECT_NE(stored, 0u);
+}
+
+// The GCR decoder now distinguishes GL2 writeback (publish dirty lines),
+// invalidate/discard (drop without writeback), and no-op (no GL2 bits). This is
+// the data-loss distinction the PR protects. Dirty an L2 line, then issue each
+// GCR flavor and observe whether the dirty data reaches backing.
+TEST(Gfx1250SdmaTest, GcrWritebackPublishesInvalidateDropsNoopKeeps) {
+  constexpr uint32_t kProcessId = 1251; // matches TranslatedSdmaQueueForTest.
+  constexpr uint32_t kDirtyWord = 0x33333333u;
+  constexpr uint32_t kBackingWord = 0x44444444u;
+  // gfx1250 GCR control dword (DW3) bit positions.
+  constexpr uint32_t kControlDw = 3;
+  constexpr uint32_t kGl2InvBit = 1u << 14;
+  constexpr uint32_t kGl2WbBit = 1u << 15;
+
+  // Outcome of a GCR flavor: the value in backing (read directly through the
+  // page table) and the value seen through L2 (which returns the resident dirty
+  // line if still present, or re-fetches backing if the line was dropped).
+  struct GcrOutcome {
+    uint32_t backing = 0;
+    uint32_t via_l2 = 0;
+  };
+
+  enum class GcrKind { WritebackOnly, InvalidateOnly, Noop };
+  // Void return so a missing L2 is a fatal guard (ASSERT_*) before we deref it.
+  auto run = [&](GcrKind kind, GcrOutcome &out) {
+    Gfx1250Sim sim;
+    auto *l2 = sim.xcd()->l2_cache();
+    ASSERT_NE(l2, nullptr);
+    TranslatedSdmaQueueForTest queue(sim);
+
+    // Put a known value in backing, then a different dirty value in L2 on top.
+    for (uint32_t i = 0; i < sizeof(uint32_t); ++i)
+      sim.memory->write8(queue.dst_va() + i, static_cast<uint8_t>((kBackingWord >> (i * 8)) & 0xFF),
+                         kProcessId);
+    uint8_t dirty_line[amdgpu::L2Cache::LINE_SIZE];
+    std::memset(dirty_line, static_cast<int>(kDirtyWord & 0xFF), sizeof(dirty_line));
+    l2->writeback_line(queue.dst_va(), dirty_line, amdgpu::Mtype::RW, kProcessId);
+
+    auto *packet = queue.ring();
+    packet[0] = kSdmaOpGcr;
+    if (kind == GcrKind::WritebackOnly)
+      packet[kControlDw] = kGl2WbBit;
+    else if (kind == GcrKind::InvalidateOnly)
+      packet[kControlDw] = kGl2InvBit;
+    else
+      packet[kControlDw] = 0; // no GL2 bits: no-op.
+
+    queue.submit(6); // gfx1250 GCR is 6 dwords.
+    EXPECT_TRUE(sim.engine->step());
+
+    out.backing = sim.memory->read32(queue.dst_va(), kProcessId);
+    // Read back through L2: a still-resident dirty line returns kDirtyWord; a
+    // dropped line re-fetches from backing on the miss.
+    uint32_t l2_word = 0;
+    l2->read(queue.dst_va(), reinterpret_cast<uint8_t *>(&l2_word), sizeof(l2_word),
+             amdgpu::Mtype::RW, kProcessId);
+    out.via_l2 = l2_word;
+  };
+
+  // Writeback publishes the dirty line to backing.
+  GcrOutcome wb;
+  run(GcrKind::WritebackOnly, wb);
+  EXPECT_EQ(wb.backing, kDirtyWord);
+  // Invalidate/discard drops the dirty line without writeback; backing keeps its
+  // original value and the line is no longer resident.
+  GcrOutcome inv;
+  run(GcrKind::InvalidateOnly, inv);
+  EXPECT_EQ(inv.backing, kBackingWord);
+  EXPECT_EQ(inv.via_l2, kBackingWord); // line dropped → L2 re-fetches backing.
+  // No GL2 bits: no cache maintenance at all. Backing is untouched and the dirty
+  // line stays resident in L2 (this is what distinguishes no-op from
+  // invalidate-only: an incorrect invalidate would drop the line here too).
+  GcrOutcome noop;
+  run(GcrKind::Noop, noop);
+  EXPECT_EQ(noop.backing, kBackingWord);
+  EXPECT_EQ(noop.via_l2, kDirtyWord); // dirty line still resident in L2.
 }
 
 TEST(Gfx1250SdmaTest, CopyWaitSignalResolvesTranslatedAddresses) {
@@ -3299,6 +3541,64 @@ TEST(Gfx1250SimulationTest, PartialWorkgroupMasksTailWaveExec) {
   std::sort(exec_masks.begin(), exec_masks.end());
   const std::vector<uint64_t> expected{1ULL, 0xFFFFFFFFULL};
   EXPECT_EQ(exec_masks, expected);
+}
+
+// Count the distinct workgroup ids across all wavefronts activated for the
+// (single) dispatch. dispatched_count() counts dispatch packets, not
+// workgroups, so it cannot observe the rounding; wavefront wg_ids can.
+uint32_t count_dispatched_workgroups(Gfx1250Sim &sim) {
+  std::set<uint32_t> wg_ids;
+  for (uint32_t se_idx = 0; se_idx < sim.xcd()->num_shader_engines(); ++se_idx) {
+    auto *se = sim.xcd()->shader_engine(se_idx);
+    for (uint32_t cu_idx = 0; cu_idx < se->num_compute_units(); ++cu_idx) {
+      auto *cu = se->compute_unit(cu_idx);
+      for (uint32_t wf_idx = 0; wf_idx < cu->num_wf_slots(); ++wf_idx) {
+        auto *wf = cu->wf(wf_idx);
+        if (wf && wf->sgpr_alloc().count > 0)
+          wg_ids.insert(wf->wg_id());
+      }
+    }
+  }
+  return static_cast<uint32_t>(wg_ids.size());
+}
+
+// The grid-to-workgroup count must round up: a partial final workgroup still
+// counts. With grid_size_x=65 and workgroup_size_x=32, HW dispatches 3 WGs
+// (ceil(65/32)); the old floor division dropped the tail WG and dispatched 2.
+TEST(Gfx1250SimulationTest, PartialFinalWorkgroupRoundsUpDispatchCount) {
+  Gfx1250Sim sim;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code));
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  queue.dispatch(kernel_object, /*grid_size_x=*/65, /*workgroup_size_x=*/32);
+  step_until_xcd_halted(sim);
+
+  EXPECT_EQ(count_dispatched_workgroups(sim), 3u);
+}
+
+// Same rounding rule in 2D: grid 65x33 with workgroups 32x16 dispatches
+// ceil(65/32) * ceil(33/16) = 3 * 3 = 9 workgroups, not floor's 2 * 2 = 4.
+TEST(Gfx1250SimulationTest, PartialFinalWorkgroupRoundsUpDispatchCount2D) {
+  Gfx1250Sim sim;
+  const uint32_t code[] = {S_ENDPGM_GFX12};
+  uint64_t kernel_object = sim.write_kernel(0x10000, code, std::size(code));
+
+  test::AqlQueue queue(sim.memory, sim.cp());
+  hsa_kernel_dispatch_packet_t pkt{};
+  pkt.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  pkt.setup = 2; // 2D grid.
+  pkt.workgroup_size_x = 32;
+  pkt.workgroup_size_y = 16;
+  pkt.workgroup_size_z = 1;
+  pkt.grid_size_x = 65;
+  pkt.grid_size_y = 33;
+  pkt.grid_size_z = 1;
+  pkt.kernel_object = kernel_object;
+  queue.submit(pkt);
+  step_until_xcd_halted(sim);
+
+  EXPECT_EQ(count_dispatched_workgroups(sim), 9u);
 }
 
 TEST(Gfx1250SimulationTest, DispatchPreloadsKernargDwordsIntoUserSgprs) {

--- a/emulation/rocjitsu/tests/simdojo_sim_test.cpp
+++ b/emulation/rocjitsu/tests/simdojo_sim_test.cpp
@@ -5,6 +5,7 @@
 /// @brief Tests for simdojo simulation engine: LBTS correctness, cross-partition
 /// communication, async causality, termination, pacing, spinlock, and stress.
 
+#include "simdojo/components/cache.h"
 #include "simdojo/sim/pacing_controller.h"
 #include "simdojo/sim/simulation.h"
 #include "util/spinlock.h"
@@ -719,4 +720,87 @@ TEST(StressTest, AsyncInjectionDuringActiveSimulation) {
   auto exit = engine.run();
 
   EXPECT_GT(async_processed.load(), 0u);
+}
+
+// ============================================================================
+// Cache VMID-tagging invariants
+// ============================================================================
+//
+// The memory hierarchy tags every line by (vmid, addr) so two processes that
+// alias the same guest VA do not share a cached line. These tests exercise that
+// invariant directly on the header-only Cache: distinct data per VMID at the
+// same address, eviction reporting the evicted line's owner VMID, and per-VMID
+// invalidation.
+
+namespace {
+// 64B lines, 4 sets, 2-way. Small associativity makes eviction easy to force.
+using TestCache = Cache<6, 4, 2>;
+
+// Fill the whole line for @p addr/@p vmid with a repeating 32-bit pattern.
+void fill_line_word(TestCache &cache, uint64_t addr, uint32_t vmid, uint32_t word) {
+  uint8_t line[TestCache::LINE_SIZE];
+  for (uint32_t i = 0; i < TestCache::LINE_SIZE; i += sizeof(word))
+    std::memcpy(line + i, &word, sizeof(word));
+  cache.allocate(addr, vmid);
+  cache.fill_line(addr, line, vmid);
+}
+
+uint32_t read_line_word(TestCache &cache, uint64_t addr, uint32_t vmid) {
+  uint32_t word = 0;
+  cache.read_line(addr, reinterpret_cast<uint8_t *>(&word), 0, sizeof(word), vmid);
+  return word;
+}
+} // namespace
+
+TEST(CacheVmidTest, SameAddressUnderTwoVmidsStoresDistinctData) {
+  TestCache cache;
+  constexpr uint64_t kAddr = 0x4000;
+
+  fill_line_word(cache, kAddr, /*vmid=*/1, 0xAAAAAAAAu);
+  fill_line_word(cache, kAddr, /*vmid=*/2, 0xBBBBBBBBu);
+
+  // Two distinct lines coexist in the same set; each VMID sees its own data.
+  CacheTag *tag1 = nullptr;
+  CacheTag *tag2 = nullptr;
+  EXPECT_TRUE(cache.lookup(kAddr, &tag1, /*vmid=*/1));
+  EXPECT_TRUE(cache.lookup(kAddr, &tag2, /*vmid=*/2));
+  EXPECT_EQ(read_line_word(cache, kAddr, /*vmid=*/1), 0xAAAAAAAAu);
+  EXPECT_EQ(read_line_word(cache, kAddr, /*vmid=*/2), 0xBBBBBBBBu);
+}
+
+TEST(CacheVmidTest, EvictionReportsEvictedLineOwnerVmid) {
+  TestCache cache;
+  // Three addresses that map to the same set (set index = (addr >> 6) & 3).
+  // With 2 ways, allocating a third forces eviction of the LRU (first) line.
+  constexpr uint64_t kSetStride = static_cast<uint64_t>(TestCache::LINE_SIZE) * 4;
+  const uint64_t addr_a = 0x1000;
+  const uint64_t addr_b = addr_a + kSetStride;
+  const uint64_t addr_c = addr_b + kSetStride;
+
+  // First line is owned by vmid 7 and marked dirty so a real cache would write
+  // it back under that vmid.
+  CacheTag *ta = cache.allocate(addr_a, /*vmid=*/7);
+  ta->dirty = true;
+  cache.allocate(addr_b, /*vmid=*/8);
+
+  CacheTag evicted;
+  cache.allocate(addr_c, /*vmid=*/9, &evicted);
+
+  EXPECT_TRUE(evicted.valid);
+  EXPECT_TRUE(evicted.dirty);
+  EXPECT_EQ(evicted.vmid, 7u); // writeback must use the evicted line's owner.
+}
+
+TEST(CacheVmidTest, InvalidatePerVmidLeavesOtherVmidIntact) {
+  TestCache cache;
+  constexpr uint64_t kAddr = 0x8000;
+
+  fill_line_word(cache, kAddr, /*vmid=*/1, 0x11111111u);
+  fill_line_word(cache, kAddr, /*vmid=*/2, 0x22222222u);
+
+  cache.invalidate(kAddr, /*vmid=*/1);
+
+  EXPECT_FALSE(cache.lookup(kAddr, nullptr, /*vmid=*/1));
+  EXPECT_TRUE(cache.lookup(kAddr, nullptr, /*vmid=*/2));
+  EXPECT_EQ(read_line_word(cache, kAddr, /*vmid=*/2), 0x22222222u);
 }


### PR DESCRIPTION
## Motivation

This PR tags every cache line by (vmid, addr) and threads the VMID end-to-end from L1 down to HBM,
eliminating cross-process data aliasing in daemon mode. It also replaces the simulator-only
per-range SDMA invalidates with the coarse cache maintenance real hardware performs, relying on the
dispatch-time acquire fence for coherence, and fixes the GCR packet sizing that desynced the SDMA
ring pointer on RDNA3/4.

## Technical Details

VMID tagging and propagation:
    - Tag every cache line by (vmid, addr), not addr alone. Guest VAs are
        per-process and can alias across processes, so two VMIDs sharing a GPU
        VA must occupy distinct cache entries. Add a vmid field to simdojo
        CacheTag and match it in lookup/allocate/invalidate/read_line/
        write_line/fill_line/line_data_for_write.
    - Carry vmid in the simdojo message header so it survives across links
        (L2 -> MSC -> HBM).
    - Thread vmid through L1 vector, L1 scalar, L2, and memory-side caches,
        the HBM controller, and GpuMemory's request handler.
    - Write back evicted/flushed dirty lines under the evicted line's own
        vmid rather than the current request's vmid, so cross-process aliased
        lines flush to the correct address space.
    - Pass vmid to kernarg preload reads and the atomic-RMW L1 invalidate
        so daemon mode resolves client-process memory.
    
MSC write-through:
  - Change the memory-side cache from write-back to write-through: stores
    are pushed straight to the backing store and the line is left clean
    (EXCLUSIVE) instead of dirty (MODIFIED), so the daemon's
    process_vm_readv bridge observes writes immediately.
    
HW-faithful SDMA coherence:
  - Replace the surgical per-range L2 invalidates after SDMA copy/fill/
    write/fence/atomic/GCR with a single coarse invalidate_gpu_caches()
    (whole L2 + L1 V$). Real SDMA does not snoop GL2 and HW cache
    maintenance is indiscriminate, not per-range; the consuming kernel's
    acquire fence at dispatch re-establishes coherence. Remove the
    simulator-only L2Cache::invalidate_range API.
    
AQL grid workgroup count:
  - Compute grid workgroup counts with ceiling division instead of
    truncating division, which undercounted workgroups when grid_size is
    not a multiple of workgroup_size. Make util::ceil_div strict
    (asserts on zero divisor) and add util::ceil_div_or_one for the
    guest-packet path, which must tolerate a malformed zero dimension
    without aborting.

 SDMA GCR packet size by dialect:
  - Split the SDMA GCR packet size: gfx1250 uses the 6-dword
    SDMA_PKT_GCR_GFX1250 layout while gfx11/gfx12 use the 5-dword layout.
    Previously all gfx11+ arches used 6 dwords, desyncing the SDMA ring
    read pointer on RDNA3/RDNA4. Add a Gfx1250 SdmaPacketDialect and
    select it for gfx1250 in the config loader.

## JIRA ID

JIRA ID N/A
PR #7835

## Test Plan

Run CI tests

## Test Result

CI tests: PASSED

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
