### PR TITLE
rocr: gfx1250 SDMA fused WaitSignal path - chunking, single-reservati…

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
@@ -81,6 +81,21 @@ class BlitSdmaBase : public core::Blit {
       std::vector<core::Signal*>& dep_signals,
       core::Signal& out_signal) = 0;
 
+  /// @brief Multicast (one source, N destinations) linear copy.  Only valid
+  /// when MulticastSupported() is true.  When @p profiling_enabled, the plain
+  /// multicast packet is submitted through the classic prologue/copy/epilogue
+  /// path so start/end timestamps are collected.  Otherwise it fuses the GCR
+  /// invalidate prologue, poll+copy+signal, and the GCR writeback + mailbox
+  /// epilogue into a single ring reservation: dep_signals[0] folds into each
+  /// chunk's packet WAIT and out_signal is decremented by every chunk's SIGNAL
+  /// (the count is pre-loaded accordingly); any remaining dep_signals are
+  /// emitted as poll commands.
+  virtual hsa_status_t SubmitLinearCopyMulticastCommand(
+      const std::vector<void*>& dsts, const void* src, size_t size,
+      std::vector<core::Signal*>& dep_signals,
+      core::Signal& out_signal,
+      bool profiling_enabled) = 0;
+
   /// @brief Pack N linear copy packets back-to-back in a single SDMA ring
   /// submission (linearB2BCopy path).  Each entry i copies srcs[i] -> dsts[i]
   /// of sizes[i] bytes.  For the broadcast case (same src/size for all dsts),
@@ -91,8 +106,17 @@ class BlitSdmaBase : public core::Blit {
       core::Signal& out_signal) = 0;
 
   virtual bool BroadcastSupported() const = 0;
+  virtual bool MulticastSupported() const = 0;
   virtual bool PlatformAtomicSupport() const = 0;
   virtual bool IsGfx1250() const = 0;
+
+  /// @brief Maximum byte count a single linear copy packet can describe
+  /// (the 30-bit count field, ~1 GiB).  Larger copies are split into multiple
+  /// chunked packets; both the plain (BuildCopyCommand) and fused WaitSignal
+  /// builders chunk internally.  The indirect WaitSignal packet is the lone
+  /// exception - it has no offset field, so callers must reject indirect copies
+  /// larger than this limit.
+  virtual size_t MaxSingleLinearCopySize() const = 0;
 
   virtual hsa_status_t SubmitPrologue(const std::vector<core::Signal*>& dep_signals,
                                       core::Signal& out_signal,
@@ -118,10 +142,19 @@ class BlitSdmaBase : public core::Blit {
                                             core::Signal& prologue_signal,
                                             core::Signal& body_signal) = 0;
 
+  /// @brief Emit a fused wait/copy/signal linear copy.  @p dep_signals[0] folds
+  /// into the packet WAIT and @p out_signal is decremented by the packet SIGNAL
+  /// on the final chunk (large copies are chunked internally).  When
+  /// @p fused_notify is true the GCR invalidate (prologue) and GCR writeback +
+  /// mailbox notify (epilogue) are emitted in the same ring reservation, so a
+  /// standalone single-engine copy needs only one reserve/release instead of
+  /// three; the fan-out path leaves it false and drives notify separately across
+  /// engines.
   virtual hsa_status_t SubmitLinearCopyBodyWaitSignal(
       void* dst, const void* src, size_t size,
       const std::vector<core::Signal*>& dep_signals,
-      core::Signal& out_signal) = 0;
+      core::Signal& out_signal,
+      bool fused_notify = true) = 0;
 
   virtual hsa_status_t SubmitLinearSwapBodyWaitSignal(
       void* addr_a, void* addr_b, size_t size_a, size_t size_b,
@@ -219,6 +252,12 @@ template <bool useGCR, bool scopeFields> class BlitSdma : public BlitSdmaBase {
       std::vector<core::Signal*>& dep_signals,
       core::Signal& out_signal) override;
 
+  hsa_status_t SubmitLinearCopyMulticastCommand(
+      const std::vector<void*>& dsts, const void* src, size_t size,
+      std::vector<core::Signal*>& dep_signals,
+      core::Signal& out_signal,
+      bool profiling_enabled) override;
+
   hsa_status_t SubmitLinearCopyB2BCommand(
       const std::vector<void*>& dsts, const std::vector<const void*>& srcs,
       const std::vector<size_t>& sizes, std::vector<core::Signal*>& dep_signals,
@@ -238,8 +277,12 @@ template <bool useGCR, bool scopeFields> class BlitSdma : public BlitSdmaBase {
   virtual void GangLeader(bool gang_leader) override { gang_leader_ = gang_leader; }
   virtual bool GangLeader() const override { return gang_leader_; }
   bool BroadcastSupported() const override { return broadcast_supported_; }
+  bool MulticastSupported() const override { return multicast_supported_; }
   bool PlatformAtomicSupport() const override { return platform_atomic_support_; }
   bool IsGfx1250() const override { return is_gfx1250_; }
+  size_t MaxSingleLinearCopySize() const override {
+    return max_single_linear_copy_size_ ? max_single_linear_copy_size_ : kMaxSingleCopySize;
+  }
 
   hsa_status_t SubmitPrologue(const std::vector<core::Signal*>& dep_signals,
                               core::Signal& out_signal,
@@ -264,7 +307,8 @@ template <bool useGCR, bool scopeFields> class BlitSdma : public BlitSdmaBase {
   hsa_status_t SubmitLinearCopyBodyWaitSignal(
       void* dst, const void* src, size_t size,
       const std::vector<core::Signal*>& dep_signals,
-      core::Signal& out_signal) override;
+      core::Signal& out_signal,
+      bool fused_notify) override;
 
   hsa_status_t SubmitLinearSwapBodyWaitSignal(
       void* addr_a, void* addr_b, size_t size_a, size_t size_b,
@@ -341,6 +385,11 @@ template <bool useGCR, bool scopeFields> class BlitSdma : public BlitSdmaBase {
 
   void BuildMulticastCopyCommand(char* cmd_addr, uint32_t num_copy_command,
                                  const std::vector<void*>& dsts, const void* src, size_t size);
+
+  void BuildMulticastWaitSignalCopyCommand(
+      char* cmd_addr, uint32_t num_copy_command,
+      const std::vector<void*>& dsts, const void* src, size_t size,
+      const core::Signal* wait_signal, core::Signal* signal_signal);
 
   void BuildSwapCopyCommand(char* cmd_addr, uint32_t num_copy_command,
                             void* addr_a, void* addr_b, size_t size);
@@ -503,6 +552,9 @@ template <bool useGCR, bool scopeFields> class BlitSdma : public BlitSdmaBase {
   /// True if SDMA supports broadcast linear copy (one src -> two dst).
   bool broadcast_supported_;
 
+  /// True if SDMA supports multicast linear copy (one src -> N dst), gfx1250+.
+  bool multicast_supported_;
+
   /// True for gfx1250 (major=12 minor=5): multicast, wait/signal packets, 64b poll/fence.
   bool is_gfx1250_;
 
@@ -520,10 +572,12 @@ typedef BlitSdma<false, false> BlitSdmaV4;
 typedef BlitSdma<true, false> BlitSdmaV5;
 
 // SDMA ops are done by DACC Backend so LINEAR_COPY and CONSTANT_FILL ops are
-// not cached in GL2.
+// not cached in GL2, so GCR cache invalidate/writeback packets are not needed
+// (useGCR=false); the per-packet scope fields (scopeFields=true) handle
+// coherency instead.
 // SDMA ops support NPD field (no prior dependency)
 // SDMA OSS v7.1
-typedef BlitSdma<true, true> BlitSdmaV6;
+typedef BlitSdma<false, true> BlitSdmaV6;
 
 }  // namespace amd
 }  // namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -143,6 +143,7 @@ BlitSdma<useGCR, scopeFields>::BlitSdma()
       queue_rptr_(nullptr),
       queue_doorbell_(nullptr),
       broadcast_supported_(false),
+      multicast_supported_(false),
       is_gfx1250_(false),
       swap_supported_(false),
       indirect_copy_supported_(false) {
@@ -204,6 +205,9 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::Initialize(const core::Agent& agent,
 
   // The linear wait/signal-indirect copy packet is available on gfx1250.
   indirect_copy_supported_ = is_gfx1250_;
+
+  // Multicast (one src -> N dst) linear copy packet is gfx1250-specific.
+  multicast_supported_ = is_gfx1250_;
 
   // Broadcast linear copy supported on MI200+ and all SDMA 5.x/6.x+.
   if (major >= 10) {
@@ -1213,20 +1217,21 @@ template <bool useGCR, bool scopeFields>
 hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBodyWaitSignal(
     void* dst, const void* src, size_t size,
     const std::vector<core::Signal*>& dep_signals,
-    core::Signal& out_signal) {
+    core::Signal& out_signal,
+    bool fused_notify) {
 
   const size_t max_copy_size = max_single_linear_copy_size_ ? max_single_linear_copy_size_
                                                             : kMaxSingleCopySize;
   const uint32_t num_copy_command =
       static_cast<uint32_t>((size + max_copy_size - 1) / max_copy_size);
 
-  // Each packet: 1 header + up to 7 wait + 6 copy + up to 5 signal = 19 DWs max.
-  // First packet gets wait, last gets signal.
-  const uint32_t first_pkt_dws = 1 + 7 + 6 + (num_copy_command == 1 ? 5 : 0);
-  const uint32_t last_pkt_dws = (num_copy_command > 1) ? (1 + 6 + 5) : 0;
-  const uint32_t mid_pkt_dws = 1 + 6;  // no wait, no signal
-  const uint32_t total_copy_dws = first_pkt_dws + last_pkt_dws +
-      (num_copy_command > 2 ? (num_copy_command - 2) * mid_pkt_dws : 0);
+  // Option (b): every chunk carries wait (if there is a dep) + copy + signal.
+  // Per packet: 1 header + up to 7 wait + 6 copy + 5 signal.  The WAIT block is
+  // reserved only when there is a dep to fold in, matching the builder's
+  // compaction; the SIGNAL block is always present (out_signal is non-null).
+  const uint32_t wait_dws = dep_signals.empty() ? 0 : 7;
+  const uint32_t per_pkt_dws = 1 + wait_dws + 6 + 5;
+  const uint32_t total_copy_dws = num_copy_command * per_pkt_dws;
 
   // Extra 64b poll commands for dep_signals[1..N-1].
   const uint32_t extra_polls = (dep_signals.size() > 1)
@@ -1234,7 +1239,24 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBodyWaitSignal(
   const uint32_t extra_poll_bytes = extra_polls * poll_64b_command_size_;
 
   const uint32_t copy_bytes = total_copy_dws * sizeof(uint32_t);
-  const uint32_t total_command_size = extra_poll_bytes + copy_bytes;
+
+  // Standalone single-engine path folds the notify prologue (GCR invalidate)
+  // and epilogue (poll out_signal, GCR writeback, mailbox + trap) into the same
+  // ring reservation as the copy.  The ring is in-order, so no cross-engine
+  // signalling is required.  Mirrors SubmitNotifyPrologue/SubmitNotifyEpilogue.
+  const bool has_mailbox = (out_signal.signal_.event_mailbox_ptr != 0);
+  const bool emit_prologue = fused_notify && useGCR;
+  const bool emit_epilogue = fused_notify && (useGCR || has_mailbox);
+
+  const uint32_t prologue_bytes = emit_prologue ? gcr_command_size() : 0;
+  uint32_t epilogue_bytes = 0;
+  if (emit_epilogue) {
+    if (useGCR) epilogue_bytes += gcr_command_size();
+    if (has_mailbox) epilogue_bytes += fence_command_size_ + trap_command_size_;
+  }
+
+  const uint32_t total_command_size =
+      prologue_bytes + extra_poll_bytes + copy_bytes + epilogue_bytes;
 
   const uint32_t pad_size = total_command_size < min_submission_size_
       ? min_submission_size_ - total_command_size
@@ -1254,6 +1276,21 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBodyWaitSignal(
   }
   uint32_t wrapped_index = WrapIntoRing(curr_index);
 
+  // Each of the N chunks decrements out_signal, so pre-load it by
+  // N-1 (it starts at 1 here / is shared and pre-armed in the fan-out path).
+  // Must happen before the doorbell (ReleaseWriteAddress) so a waiter never sees
+  // a transient 0 between chunk signals.
+  if (num_copy_command > 1)
+    out_signal.AddRelaxed(num_copy_command - 1);
+
+  // Prologue: GCR invalidate before the copy.
+  if (emit_prologue) {
+    BuildGCRCommand(command_addr, true);
+    command_addr += gcr_command_size();
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += gcr_command_size();
+  }
+
   for (uint32_t i = 1; i < dep_signals.size(); ++i) {
     BuildPoll64bCommand(command_addr, dep_signals[i]->ValueLocation(), 0);
     command_addr += poll_64b_command_size_;
@@ -1270,6 +1307,33 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBodyWaitSignal(
   bytes_written_[wrapped_index + copy_bytes - sizeof(uint32_t)] = post_bytes;
   command_addr += copy_bytes;
   wrapped_index += copy_bytes;
+
+  // Epilogue: GCR writeback (if any), then notify KFD.  No self-poll on
+  // out_signal: the ring is in-order and the WaitSignal packet's inline SIGNAL
+  // already executes after its copy, so the copy is drained here.  (The poll was
+  // redundant for linear and outright deadlocks the multicast engine.)
+  if (emit_epilogue) {
+    if (useGCR) {
+      BuildGCRCommand(command_addr, false);
+      command_addr += gcr_command_size();
+      bytes_written_[wrapped_index] = post_bytes;
+      wrapped_index += gcr_command_size();
+    }
+
+    if (has_mailbox) {
+      BuildFenceCommand(command_addr,
+                        reinterpret_cast<uint32_t*>(out_signal.signal_.event_mailbox_ptr),
+                        static_cast<uint32_t>(out_signal.signal_.event_id));
+      command_addr += fence_command_size_;
+      bytes_written_[wrapped_index] = post_bytes;
+      wrapped_index += fence_command_size_;
+
+      BuildTrapCommand(command_addr, out_signal.signal_.event_id);
+      command_addr += trap_command_size_;
+      bytes_written_[wrapped_index] = post_bytes;
+      wrapped_index += trap_command_size_;
+    }
+  }
 
   if (pad_size) {
     memset(command_addr, 0, pad_size);
@@ -1383,12 +1447,13 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearSwapBodyWaitSignal(
   const uint32_t num_copy_command =
       static_cast<uint32_t>((size_max + max_copy_size - 1) / max_copy_size);
 
+  // Option (b): every chunk carries wait (if there is a dep) + copy + signal.
+  // The WAIT block is reserved only when there is a dep to fold in, matching the
+  // builder's compaction; the SIGNAL block is always present.
+  const uint32_t wait_dws = dep_signals.empty() ? 0 : 7;
   const uint32_t copy_body_dws = 6;
-  const uint32_t first_pkt_dws = 1 + 7 + copy_body_dws + (num_copy_command == 1 ? 5 : 0);
-  const uint32_t last_pkt_dws = (num_copy_command > 1) ? (1 + copy_body_dws + 5) : 0;
-  const uint32_t mid_pkt_dws = 1 + copy_body_dws;
-  const uint32_t total_copy_dws = first_pkt_dws + last_pkt_dws +
-      (num_copy_command > 2 ? (num_copy_command - 2) * mid_pkt_dws : 0);
+  const uint32_t per_pkt_dws = 1 + wait_dws + copy_body_dws + 5;
+  const uint32_t total_copy_dws = num_copy_command * per_pkt_dws;
 
   const uint32_t extra_polls = (dep_signals.size() > 1)
       ? static_cast<uint32_t>(dep_signals.size() - 1) : 0;
@@ -1414,6 +1479,11 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearSwapBodyWaitSignal(
     post_bytes = bytes_queued_;
   }
   uint32_t wrapped_index = WrapIntoRing(curr_index);
+
+  // Option (b): each of the N chunks decrements out_signal, so pre-load it by
+  // N-1 before the doorbell (the fan-out coordinator pre-arms the base count).
+  if (num_copy_command > 1)
+    out_signal.AddRelaxed(num_copy_command - 1);
 
   for (uint32_t i = 1; i < dep_signals.size(); ++i) {
     BuildPoll64bCommand(command_addr, dep_signals[i]->ValueLocation(), 0);
@@ -1501,22 +1571,6 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBroadcastCommand(
   const uint64_t total_bytes_moved = static_cast<uint64_t>(size) * dsts.size();
   std::vector<core::Signal*> no_gang;
 
-  if (is_gfx1250_) {
-    // Multicast handles each destination independently, so the broadcast
-    // pair-alignment check (kDstAlignMask_) does not apply here.
-    const uint32_t num_dsts = static_cast<uint32_t>(dsts.size());
-    // 5 fixed DWs (header, count, parameter, src_addr lo/hi) + 2 DWs per destination (lo/hi).
-    const size_t pkt_dwords = 5 + 2 * static_cast<size_t>(num_dsts);
-    const size_t pkt_bytes = pkt_dwords * sizeof(uint32_t);
-    const size_t total_cmd_size = num_chunks * pkt_bytes;
-
-    std::vector<char> cmd_buf(total_cmd_size, 0);
-    BuildMulticastCopyCommand(cmd_buf.data(), num_chunks, dsts, src, size);
-
-    return SubmitCommand(cmd_buf.data(), total_cmd_size, total_bytes_moved,
-                         dep_signals, out_signal, no_gang);
-  }
-
   constexpr size_t kMask = SDMA_PKT_COPY_LINEAR_BROADCAST::kDstAlignMask_;
   for (size_t i = 0; i + 1 < dsts.size(); i += 2) {
     if ((reinterpret_cast<uintptr_t>(dsts[i]) & kMask) !=
@@ -1555,6 +1609,167 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyBroadcastCommand(
 
   return SubmitCommand(cmd_buf.data(), total_cmd_size, total_bytes_moved,
                        dep_signals, out_signal, no_gang);
+}
+
+template <bool useGCR, bool scopeFields>
+hsa_status_t BlitSdma<useGCR, scopeFields>::SubmitLinearCopyMulticastCommand(
+    const std::vector<void*>& dsts, const void* src, size_t size,
+    std::vector<core::Signal*>& dep_signals,
+    core::Signal& out_signal,
+    bool profiling_enabled) {
+
+  if (!multicast_supported_)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  if (dsts.empty() || size == 0)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+  // The multicast packet's num_of_destination is a 10-bit field encoded as
+  // (count - 1), so at most 1024 destinations fit; reject more to avoid
+  // truncating the field and corrupting the packet.
+  constexpr size_t kMaxMulticastDsts = 1u << 10;  // 1024
+  if (dsts.size() > kMaxMulticastDsts)
+    return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+
+  const uint32_t num_dsts = static_cast<uint32_t>(dsts.size());
+  const size_t max_copy_size = max_single_linear_copy_size_ ? max_single_linear_copy_size_
+                                                            : kMaxSingleCopySize;
+  const uint32_t num_chunks =
+      static_cast<uint32_t>((size + max_copy_size - 1) / max_copy_size);
+  const uint64_t total_bytes_moved = static_cast<uint64_t>(size) * num_dsts;
+
+  // Profiling needs the classic prologue/copy/epilogue path to collect start/end
+  // timestamps, so it uses the plain multicast packet via SubmitCommand.  When
+  // profiling is off we fuse the GCR prologue, poll+copy+signal and the GCR
+  // writeback + mailbox epilogue into a single reservation: dep_signals[0] folds
+  // into the packet WAIT and out_signal is decremented by the packet SIGNAL on
+  // the final chunk.
+  if (profiling_enabled) {
+    std::vector<core::Signal*> no_gang;
+    // 5 fixed DWs (header, count, parameter, src_addr lo/hi) + 2 DWs per dst.
+    const size_t pkt_bytes = (5 + 2 * static_cast<size_t>(num_dsts)) * sizeof(uint32_t);
+    const size_t total_cmd_size = num_chunks * pkt_bytes;
+
+    std::vector<char> cmd_buf(total_cmd_size, 0);
+    BuildMulticastCopyCommand(cmd_buf.data(), num_chunks, dsts, src, size);
+
+    return SubmitCommand(cmd_buf.data(), total_cmd_size, total_bytes_moved,
+                         dep_signals, out_signal, no_gang);
+  }
+
+  const uint32_t num_copy_command = num_chunks;
+
+  // Per-chunk copy core: count (1) + parameter (1) + src lo/hi (2) + N dst
+  // lo/hi pairs (2N).  The 7-DW WAIT prefix is on the first chunk only and the
+  // 5-DW SIGNAL suffix on the last (variable-length packet, see
+  // BuildMulticastWaitSignalCopyCommand).
+  // Option (b): every chunk carries wait (if there is a dep) + copy + signal.
+  // The WAIT block is reserved only when there is a dep to fold in, matching the
+  // builder's compaction; the SIGNAL block is always present.
+  const uint32_t wait_dws = dep_signals.empty() ? 0 : 7;
+  const uint32_t core_dws = 4 + 2 * num_dsts;
+  const uint32_t per_pkt_dws = 1 + wait_dws + core_dws + 5;
+  const uint32_t total_copy_dws = num_copy_command * per_pkt_dws;
+
+  const uint32_t extra_polls = (dep_signals.size() > 1)
+      ? static_cast<uint32_t>(dep_signals.size() - 1) : 0;
+  const uint32_t extra_poll_bytes = extra_polls * poll_64b_command_size_;
+
+  const uint32_t copy_bytes = total_copy_dws * sizeof(uint32_t);
+
+  // Multicast is always issued standalone on a single engine, so the notify
+  // prologue (GCR invalidate) and epilogue (poll out_signal, GCR writeback,
+  // mailbox + trap) are folded into this same reservation.  Mirrors the linear
+  // SubmitLinearCopyBodyWaitSignal fused_notify path.
+  const bool has_mailbox = (out_signal.signal_.event_mailbox_ptr != 0);
+  const uint32_t prologue_bytes = useGCR ? gcr_command_size() : 0;
+  uint32_t epilogue_bytes = 0;
+  if (useGCR) epilogue_bytes += gcr_command_size();
+  if (has_mailbox) epilogue_bytes += fence_command_size_ + trap_command_size_;
+
+  const uint32_t total_command_size =
+      prologue_bytes + extra_poll_bytes + copy_bytes + epilogue_bytes;
+
+  const uint32_t pad_size = total_command_size < min_submission_size_
+      ? min_submission_size_ - total_command_size
+      : is_dxg_ ? AlignUp(total_command_size, 64) - total_command_size : 0;
+
+  uint64_t curr_index;
+  char* command_addr;
+  uint64_t prior_bytes, post_bytes;
+  {
+    std::lock_guard<std::mutex> lock(reservation_lock_);
+    command_addr = AcquireWriteAddress(total_command_size + pad_size, curr_index);
+    if (command_addr == nullptr)
+      return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
+    prior_bytes = bytes_queued_;
+    bytes_queued_ += total_bytes_moved;
+    post_bytes = bytes_queued_;
+  }
+  uint32_t wrapped_index = WrapIntoRing(curr_index);
+
+  // Each of the N chunks decrements out_signal once (one signal per
+  // multicast packet, independent of dst count), so pre-load it by N-1 before
+  // the doorbell.
+  if (num_copy_command > 1)
+    out_signal.AddRelaxed(num_copy_command - 1);
+
+  // Prologue: GCR invalidate before the copy.
+  if (useGCR) {
+    BuildGCRCommand(command_addr, true);
+    command_addr += gcr_command_size();
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += gcr_command_size();
+  }
+
+  for (uint32_t i = 1; i < dep_signals.size(); ++i) {
+    BuildPoll64bCommand(command_addr, dep_signals[i]->ValueLocation(), 0);
+    command_addr += poll_64b_command_size_;
+    bytes_written_[wrapped_index] = prior_bytes;
+    wrapped_index += poll_64b_command_size_;
+  }
+
+  const core::Signal* wait_sig = dep_signals.empty() ? nullptr : dep_signals[0];
+  BuildMulticastWaitSignalCopyCommand(command_addr, num_copy_command,
+                                      dsts, src, size, wait_sig, &out_signal);
+  bytes_written_.fill(wrapped_index, wrapped_index + copy_bytes, prior_bytes);
+  bytes_written_[wrapped_index + copy_bytes - sizeof(uint32_t)] = post_bytes;
+  command_addr += copy_bytes;
+  wrapped_index += copy_bytes;
+
+  // Epilogue: GCR writeback (if any), then notify KFD.  No self-poll on
+  // out_signal: the ring is in-order and the multicast packet's inline SIGNAL
+  // already executes after its copy, so the copy is drained by the time we get
+  // here.  Polling out_signal — the very address the packet itself signals —
+  // deadlocks the gfx1250 SDMA engine (the inline-signal write is not observed
+  // by the immediately-following POLL_REGMEM), wedging every later packet.
+  if (useGCR) {
+    BuildGCRCommand(command_addr, false);
+    command_addr += gcr_command_size();
+    bytes_written_[wrapped_index] = post_bytes;
+    wrapped_index += gcr_command_size();
+  }
+
+  if (has_mailbox) {
+    BuildFenceCommand(command_addr,
+                      reinterpret_cast<uint32_t*>(out_signal.signal_.event_mailbox_ptr),
+                      static_cast<uint32_t>(out_signal.signal_.event_id));
+    command_addr += fence_command_size_;
+    bytes_written_[wrapped_index] = post_bytes;
+    wrapped_index += fence_command_size_;
+
+    BuildTrapCommand(command_addr, out_signal.signal_.event_id);
+    command_addr += trap_command_size_;
+    bytes_written_[wrapped_index] = post_bytes;
+    wrapped_index += trap_command_size_;
+  }
+
+  if (pad_size) {
+    memset(command_addr, 0, pad_size);
+    uint32_t* dword_command_addr = reinterpret_cast<uint32_t*>(command_addr);
+    dword_command_addr[0] = (pad_size / 4 - 1) << 16;
+  }
+
+  ReleaseWriteAddress(curr_index, total_command_size + pad_size);
+  return HSA_STATUS_SUCCESS;
 }
 
 template <bool useGCR, bool scopeFields>
@@ -2010,14 +2225,118 @@ void BlitSdma<useGCR, scopeFields>::BuildMulticastCopyCommand(
 }
 
 template <bool useGCR, bool scopeFields>
+void BlitSdma<useGCR, scopeFields>::BuildMulticastWaitSignalCopyCommand(
+    char* cmd_addr, uint32_t num_copy_command,
+    const std::vector<void*>& dsts, const void* src, size_t size,
+    const core::Signal* wait_signal, core::Signal* signal_signal) {
+
+  const uint32_t num_dsts = static_cast<uint32_t>(dsts.size());
+  const size_t max_copy_size = max_single_linear_copy_size_ ? max_single_linear_copy_size_
+                                                            : kMaxSingleCopySize;
+  size_t cur_size = 0;
+
+  for (uint32_t i = 0; i < num_copy_command; ++i) {
+    const uint32_t copy_size =
+        static_cast<uint32_t>(std::min(size - cur_size, max_copy_size));
+
+    // Option (b) chunk synchronization: every chunk waits on the same input
+    // signal and decrements the same output signal, so completion is correct
+    // even if the HW overlaps chunk copies (caller pre-loads out_signal by N-1).
+    const bool do_wait = (wait_signal != nullptr);
+    const bool do_signal = (signal_signal != nullptr);
+
+    // Encode the fixed fields (header, optional wait, count, parameter, src and
+    // optional signal) into a full-layout scratch struct.  The N destination
+    // address pairs are written manually because the struct models only a
+    // single destination: per the MAS extra destinations cascade as 2-DW pairs
+    // and push the signal block out by 2*(N-1) DWs.  As with the other
+    // wait/signal packets the buffer is variable length, so a chunk without
+    // wait and/or signal omits those DW blocks entirely.
+    SDMA_PKT_COPY_LINEAR_MULTICAST_WAITSIGNAL_GFX1250 pkt;
+    memset(&pkt, 0, sizeof(pkt));
+
+    pkt.HEADER_UNION.op = SDMA_OP_COPY;
+    pkt.HEADER_UNION.sub_op = SDMA_SUBOP_COPY_MULTICAST;
+    pkt.HEADER_UNION.wait = do_wait ? 1 : 0;
+    pkt.HEADER_UNION.signal = do_signal ? 1 : 0;
+
+    if (do_wait) {
+      pkt.WAIT_FUNCTION_UNION.wait_function = 0x3;  // Equal
+      void* wait_addr = const_cast<core::Signal*>(wait_signal)->ValueLocation();
+      pkt.WAIT_ADDR_LO_UNION.wait_addr_31_3 = ptrlow32(wait_addr) >> 3;
+      pkt.WAIT_ADDR_HI_UNION.wait_addr_63_32 = ptrhigh32(wait_addr);
+      pkt.WAIT_REFERENCE_LO_UNION.wait_reference_31_0 = 0;
+      pkt.WAIT_REFERENCE_HI_UNION.wait_reference_63_32 = 0;
+      pkt.WAIT_MASK_LO_UNION.wait_mask_31_0 = 0xffffffff;
+      pkt.WAIT_MASK_HI_UNION.wait_mask_63_32 = 0xffffffff;
+    }
+
+    pkt.COUNT_UNION.count = copy_size - 1;
+    pkt.COPY_PARAMETER_UNION.num_of_destination = num_dsts - 1;
+    pkt.COPY_PARAMETER_UNION.dst_scope = SDMA_MEMORY_SCOPE_SYS;
+    pkt.COPY_PARAMETER_UNION.src_scope = SDMA_MEMORY_SCOPE_SYS;
+
+    const char* cur_src = reinterpret_cast<const char*>(src) + cur_size;
+    pkt.SRC_ADDR_LO_UNION.src_addr_31_0 = ptrlow32(cur_src);
+    pkt.SRC_ADDR_HI_UNION.src_addr_63_32 = ptrhigh32(cur_src);
+
+    if (do_signal) {
+      pkt.SIGNAL_OPERATION_UNION.signal_operation = 0x70;  // 64b sub
+      pkt.SIGNAL_OPERATION_UNION.signal_scope = SDMA_MEMORY_SCOPE_SYS;
+      void* sig_addr = signal_signal->ValueLocation();
+      pkt.SIGNAL_ADDR_LO_UNION.signal_addr_31_3 = ptrlow32(sig_addr) >> 3;
+      pkt.SIGNAL_ADDR_HI_UNION.signal_addr_63_32 = ptrhigh32(sig_addr);
+      pkt.SIGNAL_DATA_LO_UNION.signal_data_31_0 = 1;
+      pkt.SIGNAL_DATA_HI_UNION.signal_data_63_32 = 0;
+    }
+
+    // Emit compacted: header (DW0), optional wait (scratch DW1-7), then
+    // count+parameter+src (scratch DW8-11), then N dst pairs, then optional
+    // signal (scratch DW14-18).  cmd_addr advances by exactly the DWs emitted.
+    const uint32_t* s = reinterpret_cast<const uint32_t*>(&pkt);
+    uint32_t* out_dw = reinterpret_cast<uint32_t*>(cmd_addr);
+    uint32_t n = 0;
+    out_dw[n++] = s[0];
+    if (do_wait)
+      for (uint32_t d = 1; d <= 7; ++d) out_dw[n++] = s[d];
+    out_dw[n++] = s[8];   // count
+    out_dw[n++] = s[9];   // parameter (num_of_destination + scopes)
+    out_dw[n++] = s[10];  // src lo
+    out_dw[n++] = s[11];  // src hi
+    for (uint32_t j = 0; j < num_dsts; ++j) {
+      const char* cur_dst = reinterpret_cast<const char*>(dsts[j]) + cur_size;
+      out_dw[n++] = ptrlow32(cur_dst);
+      out_dw[n++] = ptrhigh32(cur_dst);
+    }
+    if (do_signal)
+      for (uint32_t d = 14; d <= 18; ++d) out_dw[n++] = s[d];
+
+    cmd_addr += n * sizeof(uint32_t);
+    cur_size += copy_size;
+  }
+
+  assert(cur_size == size);
+}
+
+template <bool useGCR, bool scopeFields>
 void BlitSdma<useGCR, scopeFields>::BuildSwapCopyCommand(char* cmd_addr, uint32_t num_copy_command,
                                             void* addr_a, void* addr_b, size_t size) {
-  [[maybe_unused]] constexpr size_t kAlign = SDMA_PKT_COPY_LINEAR_SWAP::kAlignment_;
+  // gfx1250 uses a dedicated swap packet that carries per-operand cache scope
+  // (the mechanism that replaces GCR cache invalidate/writeback); other archs
+  // use the legacy swap packet. The two are the same size, so they share the
+  // swap_copy_command_size_ stride and the SubmitLinearSwapBody buffer.
+  static_assert(sizeof(SDMA_PKT_COPY_LINEAR_SWAP_GFX1250) == sizeof(SDMA_PKT_COPY_LINEAR_SWAP),
+                "gfx1250 swap packet must match legacy swap packet size for shared stride");
+  const bool use_gfx1250 = scopeFields && is_gfx1250_;
+
+  const size_t kAlign = use_gfx1250 ? SDMA_PKT_COPY_LINEAR_SWAP_GFX1250::kAlignment_
+                                    : SDMA_PKT_COPY_LINEAR_SWAP::kAlignment_;
   assert((reinterpret_cast<uintptr_t>(addr_a) & (kAlign - 1)) == 0);
   assert((reinterpret_cast<uintptr_t>(addr_b) & (kAlign - 1)) == 0);
 
   size_t cur_size = 0;
-  const size_t max_copy_size = SDMA_PKT_COPY_LINEAR_SWAP::kMaxSize_;
+  const size_t max_copy_size = use_gfx1250 ? SDMA_PKT_COPY_LINEAR_SWAP_GFX1250::kMaxSize_
+                                           : SDMA_PKT_COPY_LINEAR_SWAP::kMaxSize_;
   for (uint32_t i = 0; i < num_copy_command; ++i) {
     const uint32_t copy_size =
         static_cast<uint32_t>(std::min((size - cur_size), max_copy_size));
@@ -2025,21 +2344,42 @@ void BlitSdma<useGCR, scopeFields>::BuildSwapCopyCommand(char* cmd_addr, uint32_
     void* cur_addr_a = static_cast<char*>(addr_a) + cur_size;
     void* cur_addr_b = static_cast<char*>(addr_b) + cur_size;
 
-    SDMA_PKT_COPY_LINEAR_SWAP* packet_addr =
-        reinterpret_cast<SDMA_PKT_COPY_LINEAR_SWAP*>(cmd_addr);
+    if (use_gfx1250) {
+      SDMA_PKT_COPY_LINEAR_SWAP_GFX1250* pkt =
+          reinterpret_cast<SDMA_PKT_COPY_LINEAR_SWAP_GFX1250*>(cmd_addr);
 
-    memset(packet_addr, 0, sizeof(SDMA_PKT_COPY_LINEAR_SWAP));
+      memset(pkt, 0, sizeof(SDMA_PKT_COPY_LINEAR_SWAP_GFX1250));
 
-    packet_addr->HEADER_UNION.op = SDMA_OP_COPY;
-    packet_addr->HEADER_UNION.sub_op = SDMA_SUBOP_COPY_SWAP;
+      pkt->HEADER_UNION.op = SDMA_OP_COPY;
+      pkt->HEADER_UNION.sub_op = SDMA_SUBOP_COPY_SWAP;
 
-    packet_addr->COUNT_UNION.count = copy_size - 1;
+      pkt->COUNT_UNION.count = copy_size - 1;
 
-    packet_addr->ADDR_A_LO_UNION.DW_3_DATA = ptrlow32(cur_addr_a);
-    packet_addr->ADDR_A_HI_UNION.addr_a_63_32 = ptrhigh32(cur_addr_a);
+      pkt->PARAMETER_UNION.scope_a = SDMA_MEMORY_SCOPE_SYS;
+      pkt->PARAMETER_UNION.scope_b = SDMA_MEMORY_SCOPE_SYS;
 
-    packet_addr->ADDR_B_LO_UNION.DW_5_DATA = ptrlow32(cur_addr_b);
-    packet_addr->ADDR_B_HI_UNION.addr_b_63_32 = ptrhigh32(cur_addr_b);
+      pkt->ADDR_A_LO_UNION.DW_3_DATA = ptrlow32(cur_addr_a);
+      pkt->ADDR_A_HI_UNION.addr_a_63_32 = ptrhigh32(cur_addr_a);
+
+      pkt->ADDR_B_LO_UNION.DW_5_DATA = ptrlow32(cur_addr_b);
+      pkt->ADDR_B_HI_UNION.addr_b_63_32 = ptrhigh32(cur_addr_b);
+    } else {
+      SDMA_PKT_COPY_LINEAR_SWAP* packet_addr =
+          reinterpret_cast<SDMA_PKT_COPY_LINEAR_SWAP*>(cmd_addr);
+
+      memset(packet_addr, 0, sizeof(SDMA_PKT_COPY_LINEAR_SWAP));
+
+      packet_addr->HEADER_UNION.op = SDMA_OP_COPY;
+      packet_addr->HEADER_UNION.sub_op = SDMA_SUBOP_COPY_SWAP;
+
+      packet_addr->COUNT_UNION.count = copy_size - 1;
+
+      packet_addr->ADDR_A_LO_UNION.DW_3_DATA = ptrlow32(cur_addr_a);
+      packet_addr->ADDR_A_HI_UNION.addr_a_63_32 = ptrhigh32(cur_addr_a);
+
+      packet_addr->ADDR_B_LO_UNION.DW_5_DATA = ptrlow32(cur_addr_b);
+      packet_addr->ADDR_B_HI_UNION.addr_b_63_32 = ptrhigh32(cur_addr_b);
+    }
 
     cmd_addr += swap_copy_command_size_;
     cur_size += copy_size;
@@ -2331,59 +2671,73 @@ void BlitSdma<useGCR, scopeFields>::BuildWaitSignalCopyCommand(
     const uint32_t copy_size =
         static_cast<uint32_t>(std::min(size - cur_size, max_copy_size));
 
-    const bool is_first = (i == 0);
-    const bool is_last = (i == num_copy_command - 1);
-    const bool do_wait = is_first && (wait_signal != nullptr);
-    const bool do_signal = is_last && (signal_signal != nullptr);
+    // Option (b) chunk synchronization: every chunk waits on the same input
+    // signal and decrements the same output signal.  This is correct even when
+    // the HW overlaps chunk copies (MI450+), since out_signal only reaches 0
+    // once all chunks have signalled (the caller pre-loads it by N-1).  A scheme
+    // that signals only on the last chunk could complete early under overlap.
+    const bool do_wait = (wait_signal != nullptr);
+    const bool do_signal = (signal_signal != nullptr);
 
-    SDMA_PKT_COPY_LINEAR_WAITSIGNAL_GFX1250* pkt =
-        reinterpret_cast<SDMA_PKT_COPY_LINEAR_WAITSIGNAL_GFX1250*>(cmd_addr);
-    memset(pkt, 0, sizeof(SDMA_PKT_COPY_LINEAR_WAITSIGNAL_GFX1250));
+    // The WaitSignal packet is variable length: per the MAS, the 7 WAIT DWs
+    // (DW1-7) and 5 SIGNAL DWs (DW14-18) are present in the buffer only when
+    // their header bit is set ("should not appear" otherwise).  We encode the
+    // packet into a full-layout scratch struct, then emit only the DW blocks
+    // that are present so a compacted chunk (no wait) places the copy block
+    // immediately after the header where the engine expects it.
+    SDMA_PKT_COPY_LINEAR_WAITSIGNAL_GFX1250 pkt;
+    memset(&pkt, 0, sizeof(pkt));
 
-    pkt->HEADER_UNION.op = SDMA_OP_COPY;
-    pkt->HEADER_UNION.sub_op = SDMA_SUBOP_COPY_LINEAR;
-    pkt->HEADER_UNION.wait = do_wait ? 1 : 0;
-    pkt->HEADER_UNION.signal = do_signal ? 1 : 0;
+    pkt.HEADER_UNION.op = SDMA_OP_COPY;
+    pkt.HEADER_UNION.sub_op = SDMA_SUBOP_COPY_LINEAR;
+    pkt.HEADER_UNION.wait = do_wait ? 1 : 0;
+    pkt.HEADER_UNION.signal = do_signal ? 1 : 0;
 
     if (do_wait) {
-      pkt->WAIT_FUNCTION_UNION.wait_function = 0x3;  // Equal
+      pkt.WAIT_FUNCTION_UNION.wait_function = 0x3;  // Equal
       void* wait_addr = const_cast<core::Signal*>(wait_signal)->ValueLocation();
-      pkt->WAIT_ADDR_LO_UNION.wait_addr_31_3 = ptrlow32(wait_addr) >> 3;
-      pkt->WAIT_ADDR_HI_UNION.wait_addr_63_32 = ptrhigh32(wait_addr);
-      pkt->WAIT_REFERENCE_LO_UNION.wait_reference_31_0 = 0;
-      pkt->WAIT_REFERENCE_HI_UNION.wait_reference_63_32 = 0;
-      pkt->WAIT_MASK_LO_UNION.wait_mask_31_0 = 0xffffffff;
-      pkt->WAIT_MASK_HI_UNION.wait_mask_63_32 = 0xffffffff;
+      pkt.WAIT_ADDR_LO_UNION.wait_addr_31_3 = ptrlow32(wait_addr) >> 3;
+      pkt.WAIT_ADDR_HI_UNION.wait_addr_63_32 = ptrhigh32(wait_addr);
+      pkt.WAIT_REFERENCE_LO_UNION.wait_reference_31_0 = 0;
+      pkt.WAIT_REFERENCE_HI_UNION.wait_reference_63_32 = 0;
+      pkt.WAIT_MASK_LO_UNION.wait_mask_31_0 = 0xffffffff;
+      pkt.WAIT_MASK_HI_UNION.wait_mask_63_32 = 0xffffffff;
     }
 
-    pkt->COPY_COUNT_UNION.copy_count = copy_size - 1;
-    pkt->COPY_PARAMETER_UNION.dst_scope = SDMA_MEMORY_SCOPE_SYS;
-    pkt->COPY_PARAMETER_UNION.src_scope = SDMA_MEMORY_SCOPE_SYS;
+    pkt.COPY_COUNT_UNION.copy_count = copy_size - 1;
+    pkt.COPY_PARAMETER_UNION.dst_scope = SDMA_MEMORY_SCOPE_SYS;
+    pkt.COPY_PARAMETER_UNION.src_scope = SDMA_MEMORY_SCOPE_SYS;
 
     const char* cur_src = reinterpret_cast<const char*>(src) + cur_size;
     char* cur_dst = reinterpret_cast<char*>(dst) + cur_size;
-    pkt->SRC_ADDR_LO_UNION.src_addr_31_0 = ptrlow32(cur_src);
-    pkt->SRC_ADDR_HI_UNION.src_addr_63_32 = ptrhigh32(cur_src);
-    pkt->DST_ADDR_LO_UNION.dst_addr_31_0 = ptrlow32(cur_dst);
-    pkt->DST_ADDR_HI_UNION.dst_addr_63_32 = ptrhigh32(cur_dst);
+    pkt.SRC_ADDR_LO_UNION.src_addr_31_0 = ptrlow32(cur_src);
+    pkt.SRC_ADDR_HI_UNION.src_addr_63_32 = ptrhigh32(cur_src);
+    pkt.DST_ADDR_LO_UNION.dst_addr_31_0 = ptrlow32(cur_dst);
+    pkt.DST_ADDR_HI_UNION.dst_addr_63_32 = ptrhigh32(cur_dst);
 
     if (do_signal) {
-      pkt->SIGNAL_OPERATION_UNION.signal_operation = 0x70;  // 64b sub
-      pkt->SIGNAL_OPERATION_UNION.signal_scope = SDMA_MEMORY_SCOPE_SYS;
+      pkt.SIGNAL_OPERATION_UNION.signal_operation = 0x70;  // 64b sub
+      pkt.SIGNAL_OPERATION_UNION.signal_scope = SDMA_MEMORY_SCOPE_SYS;
       void* sig_addr = signal_signal->ValueLocation();
-      pkt->SIGNAL_ADDR_LO_UNION.signal_addr_31_3 = ptrlow32(sig_addr) >> 3;
-      pkt->SIGNAL_ADDR_HI_UNION.signal_addr_63_32 = ptrhigh32(sig_addr);
-      pkt->SIGNAL_DATA_LO_UNION.signal_data_31_0 = 1;
-      pkt->SIGNAL_DATA_HI_UNION.signal_data_63_32 = 0;
+      pkt.SIGNAL_ADDR_LO_UNION.signal_addr_31_3 = ptrlow32(sig_addr) >> 3;
+      pkt.SIGNAL_ADDR_HI_UNION.signal_addr_63_32 = ptrhigh32(sig_addr);
+      pkt.SIGNAL_DATA_LO_UNION.signal_data_31_0 = 1;
+      pkt.SIGNAL_DATA_HI_UNION.signal_data_63_32 = 0;
     }
 
-    // Advance by the actual DW count used for this packet variant.
-    // Base copy is DW8-DW13 (6 DWs for count+param+src+dst), header is DW0.
-    // Total: 1 (header) + wait_dws + 6 (copy) + signal_dws
-    uint32_t pkt_dwords = 1 + 6;
-    if (do_wait) pkt_dwords += 7;   // DW1-DW7
-    if (do_signal) pkt_dwords += 5; // DW14-DW18
-    cmd_addr += pkt_dwords * sizeof(uint32_t);
+    // Emit compacted: header (DW0), optional wait (DW1-7), copy (DW8-13),
+    // optional signal (DW14-18).  cmd_addr advances by exactly the DWs emitted.
+    const uint32_t* pkt_dw = reinterpret_cast<const uint32_t*>(&pkt);
+    uint32_t* out_dw = reinterpret_cast<uint32_t*>(cmd_addr);
+    uint32_t n = 0;
+    out_dw[n++] = pkt_dw[0];
+    if (do_wait)
+      for (uint32_t d = 1; d <= 7; ++d) out_dw[n++] = pkt_dw[d];
+    for (uint32_t d = 8; d <= 13; ++d) out_dw[n++] = pkt_dw[d];
+    if (do_signal)
+      for (uint32_t d = 14; d <= 18; ++d) out_dw[n++] = pkt_dw[d];
+
+    cmd_addr += n * sizeof(uint32_t);
     cur_size += copy_size;
   }
 }
@@ -2453,10 +2807,11 @@ void BlitSdma<useGCR, scopeFields>::BuildWaitSignalSwapCommand(
   const size_t max_copy_size = SDMA_PKT_COPY_LINEAR_SWAP_WAITSIGNAL_GFX1250::kMaxSize_;
 
   for (uint32_t i = 0; i < num_copy_command; ++i) {
-    const bool is_first = (i == 0);
-    const bool is_last = (i == num_copy_command - 1);
-    const bool do_wait = is_first && (wait_signal != nullptr);
-    const bool do_signal = is_last && (signal_signal != nullptr);
+    // Option (b) chunk synchronization: every chunk waits on the same input
+    // signal and decrements the same output signal, so completion is correct
+    // even if the HW overlaps chunk copies (caller pre-loads out_signal by N-1).
+    const bool do_wait = (wait_signal != nullptr);
+    const bool do_signal = (signal_signal != nullptr);
 
     const uint32_t chunk_a = static_cast<uint32_t>(std::min(size_a - cur_a, max_copy_size));
     const uint32_t chunk_b = static_cast<uint32_t>(std::min(size_b - cur_b, max_copy_size));
@@ -2464,47 +2819,56 @@ void BlitSdma<useGCR, scopeFields>::BuildWaitSignalSwapCommand(
     const char* p_a = reinterpret_cast<const char*>(addr_a) + cur_a;
     const char* p_b = reinterpret_cast<const char*>(addr_b) + cur_b;
 
-    // gfx1250 packet — single COUNT, addr_b stored as full 32-bit pointer.
-    SDMA_PKT_COPY_LINEAR_SWAP_WAITSIGNAL_GFX1250* pkt =
-        reinterpret_cast<SDMA_PKT_COPY_LINEAR_SWAP_WAITSIGNAL_GFX1250*>(cmd_addr);
-    memset(pkt, 0, sizeof(SDMA_PKT_COPY_LINEAR_SWAP_WAITSIGNAL_GFX1250));
+    // Variable-length packet (see BuildWaitSignalCopyCommand): encode into a
+    // full-layout scratch struct, then emit only the DW blocks present so a
+    // compacted chunk places the copy block right after the header.
+    SDMA_PKT_COPY_LINEAR_SWAP_WAITSIGNAL_GFX1250 pkt;
+    memset(&pkt, 0, sizeof(pkt));
 
-    pkt->HEADER_UNION.op     = SDMA_OP_COPY;
-    pkt->HEADER_UNION.sub_op = SDMA_SUBOP_COPY_SWAP;
-    pkt->HEADER_UNION.wait   = do_wait   ? 1 : 0;
-    pkt->HEADER_UNION.signal = do_signal ? 1 : 0;
+    pkt.HEADER_UNION.op     = SDMA_OP_COPY;
+    pkt.HEADER_UNION.sub_op = SDMA_SUBOP_COPY_SWAP;
+    pkt.HEADER_UNION.wait   = do_wait   ? 1 : 0;
+    pkt.HEADER_UNION.signal = do_signal ? 1 : 0;
 
     if (do_wait) {
-      pkt->WAIT_FUNCTION_UNION.wait_function  = 0x3;  // Equal
+      pkt.WAIT_FUNCTION_UNION.wait_function  = 0x3;  // Equal
       void* wa = const_cast<core::Signal*>(wait_signal)->ValueLocation();
-      pkt->WAIT_ADDR_LO_UNION.wait_addr_31_3  = ptrlow32(wa) >> 3;
-      pkt->WAIT_ADDR_HI_UNION.wait_addr_63_32 = ptrhigh32(wa);
-      pkt->WAIT_MASK_LO_UNION.wait_mask_31_0  = 0xffffffff;
-      pkt->WAIT_MASK_HI_UNION.wait_mask_63_32 = 0xffffffff;
+      pkt.WAIT_ADDR_LO_UNION.wait_addr_31_3  = ptrlow32(wa) >> 3;
+      pkt.WAIT_ADDR_HI_UNION.wait_addr_63_32 = ptrhigh32(wa);
+      pkt.WAIT_MASK_LO_UNION.wait_mask_31_0  = 0xffffffff;
+      pkt.WAIT_MASK_HI_UNION.wait_mask_63_32 = 0xffffffff;
     }
 
-    pkt->COUNT_UNION.count                    = chunk_a - 1;
-    pkt->COPY_PARAMETER_UNION.scope_a         = SDMA_MEMORY_SCOPE_SYS;
-    pkt->COPY_PARAMETER_UNION.scope_b         = SDMA_MEMORY_SCOPE_SYS;
-    pkt->ADDR_A_LO_UNION.addr_a_31_0          = ptrlow32(p_a);
-    pkt->ADDR_A_HI_UNION.addr_a_63_32         = ptrhigh32(p_a);
-    pkt->ADDR_B_LO_UNION.addr_b_31_0          = ptrlow32(p_b);
-    pkt->ADDR_B_HI_UNION.addr_b_63_32         = ptrhigh32(p_b);
+    pkt.COUNT_UNION.count                    = chunk_a - 1;
+    pkt.COPY_PARAMETER_UNION.scope_a         = SDMA_MEMORY_SCOPE_SYS;
+    pkt.COPY_PARAMETER_UNION.scope_b         = SDMA_MEMORY_SCOPE_SYS;
+    pkt.ADDR_A_LO_UNION.addr_a_31_0          = ptrlow32(p_a);
+    pkt.ADDR_A_HI_UNION.addr_a_63_32         = ptrhigh32(p_a);
+    pkt.ADDR_B_LO_UNION.addr_b_31_0          = ptrlow32(p_b);
+    pkt.ADDR_B_HI_UNION.addr_b_63_32         = ptrhigh32(p_b);
 
     if (do_signal) {
-      pkt->SIGNAL_OPERATION_UNION.signal_operation = 0x70;  // 64b sub
-      pkt->SIGNAL_OPERATION_UNION.signal_scope     = SDMA_MEMORY_SCOPE_SYS;
+      pkt.SIGNAL_OPERATION_UNION.signal_operation = 0x70;  // 64b sub
+      pkt.SIGNAL_OPERATION_UNION.signal_scope     = SDMA_MEMORY_SCOPE_SYS;
       void* sa = signal_signal->ValueLocation();
-      pkt->SIGNAL_ADDR_LO_UNION.signal_addr_31_3   = ptrlow32(sa) >> 3;
-      pkt->SIGNAL_ADDR_HI_UNION.signal_addr_63_32  = ptrhigh32(sa);
-      pkt->SIGNAL_DATA_LO_UNION.signal_data_31_0   = 1;
+      pkt.SIGNAL_ADDR_LO_UNION.signal_addr_31_3   = ptrlow32(sa) >> 3;
+      pkt.SIGNAL_ADDR_HI_UNION.signal_addr_63_32  = ptrhigh32(sa);
+      pkt.SIGNAL_DATA_LO_UNION.signal_data_31_0   = 1;
     }
 
-    uint32_t pkt_dwords = 1 + 6;  // header + copy (6 DWs for gfx1250)
-    if (do_wait)   pkt_dwords += 7;
-    if (do_signal) pkt_dwords += 5;
-    cmd_addr += pkt_dwords * sizeof(uint32_t);
+    // Emit compacted: header (DW0), optional wait (DW1-7), copy (DW8-13),
+    // optional signal (DW14-18).
+    const uint32_t* pkt_dw = reinterpret_cast<const uint32_t*>(&pkt);
+    uint32_t* out_dw = reinterpret_cast<uint32_t*>(cmd_addr);
+    uint32_t n = 0;
+    out_dw[n++] = pkt_dw[0];
+    if (do_wait)
+      for (uint32_t d = 1; d <= 7; ++d) out_dw[n++] = pkt_dw[d];
+    for (uint32_t d = 8; d <= 13; ++d) out_dw[n++] = pkt_dw[d];
+    if (do_signal)
+      for (uint32_t d = 14; d <= 18; ++d) out_dw[n++] = pkt_dw[d];
 
+    cmd_addr += n * sizeof(uint32_t);
     cur_a += chunk_a;
     cur_b += chunk_b;
   }
@@ -2605,7 +2969,7 @@ template <bool useGCR, bool scopeFields> uint64_t BlitSdma<useGCR, scopeFields>:
 
 template class BlitSdma<false, false>;  // BlitSdmaV4
 template class BlitSdma<true, false>;   // BlitSdmaV5
-template class BlitSdma<true, true>;    // BlitSdmaV6
+template class BlitSdma<false, true>;   // BlitSdmaV6
 
 }  // namespace amd
 }  // namespace rocr

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_gpu_agent.cpp
@@ -1287,13 +1287,21 @@ hsa_status_t GpuAgent::DmaCopyOnEngine(void* dst, core::Agent& dst_agent,
     bool use_p2p_engines = is_p2p && dst_agent.HiveId() && src_agent.HiveId() == dst_agent.HiveId() &&
                          num_p2p_engines_;
 
+    // On platforms with dedicated xGMI SDMA engines, a P2P copy MUST target one of
+    // those engines: a host-facing SDMA engine physically cannot drive the xGMI link,
+    // so targeting an H2D/D2H engine for P2P is a hardware error. On platforms without
+    // dedicated xGMI engines (e.g. gfx1250) every SDMA engine is equivalent and
+    // P2P-capable, so the H2D/D2H-vs-P2P split is only a load-balancing preference
+    // (steered via DmaPreferredEngine) and must not be enforced as a hard rejection.
+    bool p2p_engine_is_mandatory = use_p2p_engines && properties_.NumSdmaXgmiEngines;
+
     // Due to a RAS issue, GFX90a can only support H2D copies on SDMA0
     bool is_h2d_blit = (src_agent.device_type() == core::Agent::kAmdCpuDevice &&
       dst_agent.device_type() == core::Agent::kAmdGpuDevice);
     bool limit_h2d_blit = supported_isas()[0]->GetVersion() == core::Isa::Version(9, 0, 10);
 
     // Ensure engine selection is within proper range based on transfer type
-    if ((use_p2p_engines && !rec_sdma_eng_override_ && engine_offset <= num_h2d_d2h_engines_) ||
+    if ((p2p_engine_is_mandatory && !rec_sdma_eng_override_ && engine_offset <= num_h2d_d2h_engines_) ||
           (!is_h2d_blit && !is_same_gpu && limit_h2d_blit &&
             engine_offset == BlitHostToDev)) {
       return HSA_STATUS_ERROR_INVALID_ARGUMENT;
@@ -1312,16 +1320,14 @@ hsa_status_t GpuAgent::DmaCopyOnEngine(void* dst, core::Agent& dst_agent,
     out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
   }
 
-  // gfx1250 fast path: fuse poll+copy+signal into a single WaitSignal packet.
-  if (core::Runtime::runtime_singleton_->flag().enable_sdma_fastpath_debug() && !profiling_enabled() && blit->isSDMA()) {
+  // gfx1250 fast path: fuse GCR invalidate, poll+copy+signal and the GCR
+  // writeback + mailbox notify into one ring submission (single reserve/release).
+  // The packet builder chunks large copies internally, so any size is eligible.
+  if (!profiling_enabled() && blit->isSDMA()) {
     BlitSdmaBase* sdma_blit = static_cast<BlitSdmaBase*>((*blit).get());
     if (sdma_blit->IsGfx1250()) {
-      hsa_status_t stat = sdma_blit->SubmitNotifyPrologue();
-      if (stat != HSA_STATUS_SUCCESS) return stat;
-      stat = sdma_blit->SubmitLinearCopyBodyWaitSignal(
+      return sdma_blit->SubmitLinearCopyBodyWaitSignal(
           dst, src, size, dep_signals, out_signal);
-      if (stat != HSA_STATUS_SUCCESS) return stat;
-      return sdma_blit->SubmitNotifyEpilogue(out_signal);
     }
   }
 
@@ -1356,7 +1362,11 @@ hsa_status_t GpuAgent::DmaCopyStatus(core::Agent& dst_agent, core::Agent& src_ag
                      dst_agent.HiveId() && src_agent.HiveId() == dst_agent.HiveId() &&
                        num_p2p_engines_ > 0) {
     //Find a free p2p SDMA engine
-    if (rec_sdma_eng_override_) {
+    // Without dedicated xGMI engines (e.g. gfx1250) every SDMA engine is P2P-capable,
+    // so advertise all free engines rather than only the preferred P2P band. The
+    // preference toward the P2P engines is still expressed via DmaPreferredEngine;
+    // here we report the full set of engines a P2P copy may legally run on.
+    if (rec_sdma_eng_override_ || !properties_.NumSdmaXgmiEngines) {
       for (int i = 0; i < (num_h2d_d2h_engines_ + num_p2p_engines_); i++) {
         if (DmaEngineIsFree(BlitHostToDev + i)) {
           *engine_ids_mask |= (HSA_AMD_SDMA_ENGINE_0 << i);
@@ -1497,6 +1507,22 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
   if (is_indirect && !coordinator->IndirectCopySupported())
     return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
+  // Only indirect copies cannot chunk a large entry: the indirect packet has no
+  // offset field into the resolved buffer, so a single >max entry must fall back
+  // (and is ultimately rejected, since the indirect body rejects size > max).
+  // Linear copy and swap fused WaitSignal builders chunk internally via
+  // num_copy_command, so large entries stay on the fused path.
+  bool requires_multi_packet = false;
+  if (is_indirect) {
+    const size_t max_single_copy = coordinator->MaxSingleLinearCopySize();
+    for (uint32_t d = 0; d < num_entries; ++d) {
+      if (size_list[d] > max_single_copy) {
+        requires_multi_packet = true;
+        break;
+      }
+    }
+  }
+
   struct EngineSlot { BlitSdmaBase* blit; uint32_t idx; };
   std::vector<EngineSlot> engines(num_entries, {coordinator, coord_idx});
 
@@ -1561,9 +1587,11 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
       is_indirect ? "Indirect" : "Copy";
 
   // GFX1250+ fast path: use wait/signal packets so bodies directly wait on
-  // dep_signals and signal out_signal. No prologue or epilogue needed when
-  // profiling is off (no timestamps to collect).
-  if ((coordinator->IsGfx1250()) && !profiling_enabled()) {
+  // dep_signals and signal out_signal, avoiding per-body prologue/epilogue
+  // timestamp collection. GCR/mailbox synchronization is still issued via the
+  // coordinator's SubmitNotifyPrologue/Epilogue below; only the profiling
+  // timestamp path is skipped.
+  if ((coordinator->IsGfx1250()) && !profiling_enabled() && !requires_multi_packet) {
     // N bodies each do a 64b-sub of 1 on out_signal. Initial value is 1,
     // so bump by (N-1) so the final value after all decrements is 0.
     out_signal.AddRelaxed(num_entries - 1);
@@ -1631,7 +1659,7 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
       default:
         stat = engines[d].blit->SubmitLinearCopyBodyWaitSignal(
             dst_list[d], src_list[d], size_list[d],
-            *body_deps_ptr, out_signal);
+            *body_deps_ptr, out_signal, /*fused_notify=*/false);
         break;
       }
       if (stat != HSA_STATUS_SUCCESS) return stat;
@@ -1659,9 +1687,11 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
   bool use_body_signals = !coordinator->PlatformAtomicSupport();
 
   // On gfx1250 with shared out_signal, use WaitSignal body to fuse
-  // poll+copy+signal into a single packet per body.
+  // poll+copy+signal per body; the builder chunks large entries internally.
+  // Only indirect bodies can't chunk (requires_multi_packet), so they fall back
+  // to the classic path here and are rejected just below.
   const bool waitsignal_body =
-      coordinator->IsGfx1250() && !use_body_signals;
+      coordinator->IsGfx1250() && !use_body_signals && !requires_multi_packet;
 
   // Indirect bodies only implement fused packets
   if (is_indirect && !waitsignal_body) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
@@ -1763,7 +1793,7 @@ hsa_status_t GpuAgent::DmaCopyFanOutOp(
       stat = waitsignal_body
           ? engines[d].blit->SubmitLinearCopyBodyWaitSignal(
                 dst_list[d], src_list[d], size_list[d],
-                body_deps, out_signal)
+                body_deps, out_signal, /*fused_notify=*/false)
           : engines[d].blit->SubmitLinearCopyBody(
                 dst_list[d], src_list[d], size_list[d],
                 *prologue_raw, body_sig);
@@ -1791,9 +1821,16 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
   core::Signal& out_signal = *out_signal_obj;
 
   const uint16_t num_entries = op.num_entries;
-  constexpr size_t kBroadcastMaxSize = 256 * 1024;
 
-  // Try HW broadcast/multicast.
+  // Size thresholds for multi-destination copy path selection.
+  // kMulticastMaxSize: HW multicast/broadcast packet reliable limit (256 KB).
+  //   gfx1250 multicast drops destinations above this.
+  // kB2BMinSize: minimum per-copy size for linearB2B on non-gfx1250.
+  //   Below this, the broadcast packet (2-dst) is used instead.
+  constexpr size_t kMulticastMaxSize = 256 * 1024;
+  constexpr size_t kB2BMinSize = 16 * 1024;
+
+  // Try HW broadcast/multicast or linearB2B on one engine.
   {
     SetCopyRequestRefCount(true);
     MAKE_SCOPE_GUARD([&]() { SetCopyRequestRefCount(false); });
@@ -1802,46 +1839,69 @@ hsa_status_t GpuAgent::DmaCopyBroadcast(
     if (blit->isSDMA()) {
       BlitSdmaBase* sdma_blit = static_cast<BlitSdmaBase*>((*blit).get());
 
-      // linearB2BCopy for per-copy sizes in [16KB, 256KB].
-      // Above 256KB the fan-out path parallelises across engines.
-      // HSA_SDMA_LINEAR_B2B: 1=force B2B, 0=force broadcast, unset=auto threshold.
-      constexpr size_t kLinearB2BMinSize = 16 * 1024;
-      const auto b2b_flag = core::Runtime::runtime_singleton_->flag().sdma_linear_b2b();
-      const bool use_linear_b2b = (b2b_flag == Flag::SDMA_ENABLE) ||
-          (b2b_flag == Flag::SDMA_DEFAULT && op.size >= kLinearB2BMinSize &&
-           op.size <= kBroadcastMaxSize);
+      // Common to every submission path below.
+      if (profiling_enabled())
+        out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
 
-      if (use_linear_b2b && !sdma_blit->IsGfx1250()) {
-        if (profiling_enabled())
-          out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
+      if (sdma_blit->IsGfx1250()) {
+        // gfx1250: multicast for small copies (<= 256 KB). The multicast engine
+        // silently drops destinations above that limit, so larger copies fall
+        // through to fan-out, which parallelises the per-destination copies
+        // across SDMA engines. Fan-out measured ~3-5% faster than packing all
+        // destinations into a single-engine linearB2B command at large sizes.
+        // HSA_SDMA_FORCE_MULTICAST=1 forces the multicast packet regardless of
+        // size (debug only; large copies will fail validation by design).
+        const bool force_multicast =
+            core::Runtime::runtime_singleton_->flag().sdma_force_multicast();
+        if (force_multicast || op.size <= kMulticastMaxSize) {
+          // SubmitLinearCopyMulticastCommand picks the fused wait/signal packet
+          // when profiling is off and the timestamp-capable plain packet when on.
+          std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
+          LogPrint(HSA_AMD_LOG_FLAG_SDMA,
+                   "SDMA Multicast engine %02u, src=%p, num_entries=%u, size=%zu, "
+                   "dep_signal=0x%zx, completion_signal=0x%zx",
+                   BlitHostToDev, op.src, num_entries, op.size,
+                   dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
+                   out_signal_obj->signal_);
+          return sdma_blit->SubmitLinearCopyMulticastCommand(
+              dsts, op.src, op.size, dep_signals, out_signal, profiling_enabled());
+        }
+        // Larger than the multicast limit: fall through to fan-out below.
+      } else {
+        // Non-gfx1250: linearB2B for [16KB, 256KB], broadcast for < 16KB,
+        // else fall through to fan-out which parallelises across engines.
+        // HSA_SDMA_LINEAR_B2B: 1=force B2B, 0=force broadcast, unset=auto
+        // (kept consistent with DmaCopyMulti, which honors the same override).
+        const auto b2b_flag = core::Runtime::runtime_singleton_->flag().sdma_linear_b2b();
+        const bool use_linear_b2b = (b2b_flag == Flag::SDMA_ENABLE) ||
+            (b2b_flag == Flag::SDMA_DEFAULT && op.size >= kB2BMinSize &&
+             op.size <= kMulticastMaxSize);
 
-        LogPrint(HSA_AMD_LOG_FLAG_SDMA,
-                 "SDMA linearB2BCopy using engine %02u, src=%p, num_entries=%u, size=%zu, "
-                 "dep_signal=0x%zx, completion_signal=0x%zx",
-                 BlitHostToDev, op.src, num_entries, op.size,
-                 dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
-                 out_signal_obj->signal_);
-        std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
-        std::vector<const void*> srcs(num_entries, op.src);
-        std::vector<size_t> sizes(num_entries, op.size);
-        return sdma_blit->SubmitLinearCopyB2BCommand(
-            dsts, srcs, sizes, dep_signals, out_signal);
-      }
+        if (use_linear_b2b) {
+          LogPrint(HSA_AMD_LOG_FLAG_SDMA,
+                   "SDMA linearB2B engine %02u, src=%p, num_entries=%u, size=%zu, "
+                   "dep_signal=0x%zx, completion_signal=0x%zx",
+                   BlitHostToDev, op.src, num_entries, op.size,
+                   dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
+                   out_signal_obj->signal_);
+          std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
+          std::vector<const void*> srcs(num_entries, op.src);
+          std::vector<size_t> sizes(num_entries, op.size);
+          return sdma_blit->SubmitLinearCopyB2BCommand(
+              dsts, srcs, sizes, dep_signals, out_signal);
+        }
 
-      if (sdma_blit->BroadcastSupported() && op.size < kLinearB2BMinSize) {
-        if (profiling_enabled())
-          out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
-
-        LogPrint(HSA_AMD_LOG_FLAG_SDMA,
-                 "SDMA %s using engine %02u, src=%p, num_entries=%u, size=%zu, "
-                 "dep_signal=0x%zx, completion_signal=0x%zx",
-                 (sdma_blit->IsGfx1250()) ? "Multicast" : "Broadcast",
-                 BlitHostToDev, op.src, num_entries, op.size,
-                 dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
-                 out_signal_obj->signal_);
-        std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
-        return sdma_blit->SubmitLinearCopyBroadcastCommand(
-            dsts, op.src, op.size, dep_signals, out_signal);
+        if (sdma_blit->BroadcastSupported() && op.size < kB2BMinSize) {
+          LogPrint(HSA_AMD_LOG_FLAG_SDMA,
+                   "SDMA Broadcast engine %02u, src=%p, num_entries=%u, size=%zu, "
+                   "dep_signal=0x%zx, completion_signal=0x%zx",
+                   BlitHostToDev, op.src, num_entries, op.size,
+                   dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
+                   out_signal_obj->signal_);
+          std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
+          return sdma_blit->SubmitLinearCopyBroadcastCommand(
+              dsts, op.src, op.size, dep_signals, out_signal);
+        }
       }
     }
   }
@@ -1863,14 +1923,13 @@ hsa_status_t GpuAgent::DmaCopyMulti(
   core::Signal& out_signal = *out_signal_obj;
 
   const uint16_t num_entries = op.num_entries;
-  constexpr size_t kLinearB2BMaxSize = 256 * 1024;
-  constexpr size_t kLinearB2BMinSize = 16 * 1024;
+  constexpr size_t kB2BMaxSize = 256 * 1024;
+  constexpr size_t kB2BMinSize = 16 * 1024;
 
-  // Try linearB2B: pack all entries as back-to-back SDMA linear copy packets in
-  // one ring submission to avoid fan-out signal overhead.  Use the same size
-  // thresholds as DmaCopyBroadcast: per-entry size in [16KB, 1MB) unless the
-  // flag forces B2B on.  For large entries the fan-out path parallelises across
-  // engines and is faster.
+  // LinearB2B: pack all entries as back-to-back SDMA linear copy packets in
+  // one ring submission to avoid fan-out signal overhead.  Per-entry size must
+  // be in [kB2BMinSize, kB2BMaxSize] unless the flag forces B2B on.
+  // For large entries the fan-out path parallelises across engines.
   {
     SetCopyRequestRefCount(true);
     MAKE_SCOPE_GUARD([&]() { SetCopyRequestRefCount(false); });
@@ -1878,18 +1937,14 @@ hsa_status_t GpuAgent::DmaCopyMulti(
     lazy_ptr<core::Blit>& blit = GetBlitObject(BlitHostToDev);
     if (blit->isSDMA()) {
       BlitSdmaBase* sdma_blit = static_cast<BlitSdmaBase*>((*blit).get());
-
       const auto b2b_flag = core::Runtime::runtime_singleton_->flag().sdma_linear_b2b();
 
-      // Check that every entry qualifies for B2B.
       bool all_qualify = true;
       for (uint16_t i = 0; i < num_entries; i++) {
         const size_t sz = op.size_list[i];
-        const bool qualifies =
-            (b2b_flag == Flag::SDMA_ENABLE) ||
-            (b2b_flag == Flag::SDMA_DEFAULT && sz >= kLinearB2BMinSize &&
-             sz <= kLinearB2BMaxSize);
-        if (!qualifies) {
+        if (b2b_flag != Flag::SDMA_ENABLE &&
+            !(b2b_flag == Flag::SDMA_DEFAULT &&
+              sz >= kB2BMinSize && sz <= kB2BMaxSize)) {
           all_qualify = false;
           break;
         }
@@ -1898,17 +1953,15 @@ hsa_status_t GpuAgent::DmaCopyMulti(
       if (all_qualify) {
         if (profiling_enabled())
           out_signal.async_copy_agent(core::Agent::Convert(this->public_handle()));
-
-        std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
-        std::vector<const void*> srcs(op.src_list, op.src_list + num_entries);
-        std::vector<size_t> sizes(op.size_list, op.size_list + num_entries);
-
         LogPrint(HSA_AMD_LOG_FLAG_SDMA,
-                 "SDMA multiB2BCopy using engine %02u, num_entries=%u, "
+                 "SDMA linearB2B engine %02u, num_entries=%u, "
                  "dep_signal=0x%zx, completion_signal=0x%zx",
                  BlitHostToDev, num_entries,
                  dep_signals.empty() ? 0 : core::Signal::Convert(dep_signals[0]).handle,
                  out_signal_obj->signal_);
+        std::vector<void*> dsts(op.dst_list, op.dst_list + num_entries);
+        std::vector<const void*> srcs(op.src_list, op.src_list + num_entries);
+        std::vector<size_t> sizes(op.size_list, op.size_list + num_entries);
         return sdma_blit->SubmitLinearCopyB2BCommand(dsts, srcs, sizes,
                                                      dep_signals, out_signal);
       }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -320,9 +320,6 @@ class Flag {
     var = os::GetEnvVar("HSA_CO_DMACOPY_SIZE");
     co_dmacopy_size_ = var.empty() ? 1024*1024 : atoi(var.c_str());
 
-    var = os::GetEnvVar("HSA_ENABLE_SDMA_FASTPATH_DEBUG");
-    enable_sdma_fastpath_debug_ = (var == "1") ? true : false;
-
     var = os::GetEnvVar("HSA_COREDUMP_SHOW_PROGRESS");
     enable_core_dump_progress_ = (var == "1");
 
@@ -335,12 +332,12 @@ class Flag {
     var = os::GetEnvVar("HSA_ENABLE_LIGHTWEIGHT_COREDUMP");
     lightweight_core_dump_enable_ = (var == "1");
 
-    // This limits the maximum number of hardware queues that can be created per 
+    // This limits the maximum number of hardware queues that can be created per
     // priority level for counted queues on every GPU agent. By default, the limit is set to 4.
     var = os::GetEnvVar("GPU_MAX_HW_QUEUES");
     cp_queues_limit_ = var.empty() ? DEFAULT_GPU_HW_QUEUES_MAX : atoi(var.c_str());
 
-    // This allows configuring the size of counted queues created through 
+    // This allows configuring the size of counted queues created through
     // hsa_amd_counted_queue_acquire API. If not set, default queue size is set to 16384.
     var = os::GetEnvVar("HSA_COUNTED_QUEUE_SIZE");
     counted_queue_size_ = var.empty() ? DEFAULT_COUNTED_QUEUE_SIZE : atoi(var.c_str());
@@ -348,6 +345,11 @@ class Flag {
     // HSA_SDMA_LINEAR_B2B: 1=force B2B, 0=force broadcast, unset=auto (size threshold)
     var = os::GetEnvVar("HSA_SDMA_LINEAR_B2B");
     sdma_linear_b2b_ = (var == "0") ? SDMA_DISABLE : ((var == "1") ? SDMA_ENABLE : SDMA_DEFAULT);
+
+    // HSA_SDMA_FORCE_MULTICAST: 1=force gfx1250 broadcast onto the multicast
+    // packet regardless of copy size (debug only; the multicast engine drops
+    // destinations above 256 KB, so large copies will produce wrong data).
+    sdma_force_multicast_ = (os::GetEnvVar("HSA_SDMA_FORCE_MULTICAST") == "1");
 
   }
 
@@ -485,13 +487,13 @@ class Flag {
 
   bool enable_3d_swizzle() const { return enable_3d_swizzle_; }
 
-  bool enable_sdma_fastpath_debug() const { return enable_sdma_fastpath_debug_; }
-
   bool enable_dtif() const { return enable_dtif_; }
 
   bool enable_dxg_detection() const { return enable_dxg_detection_; }
 
   SDMA_OVERRIDE sdma_linear_b2b() const { return sdma_linear_b2b_; }
+
+  bool sdma_force_multicast() const { return sdma_force_multicast_; }
 
   [[nodiscard]]
   bool core_dump_disable() const { return core_dump_disable_; }
@@ -505,9 +507,9 @@ class Flag {
                                          return core_dump_pattern_; }
 
   [[nodiscard]]
-  bool lightweight_core_dump_enable() const { 
-    return lightweight_core_dump_enable_; 
-  } 
+  bool lightweight_core_dump_enable() const {
+    return lightweight_core_dump_enable_;
+  }
 
   void set_sdma(bool peer_sdma, bool sdma_gang) {
     enable_peer_sdma_ = peer_sdma ? SDMA_ENABLE : SDMA_DISABLE;
@@ -574,6 +576,8 @@ class Flag {
   bool enable_dxg_detection_;
   SDMA_OVERRIDE sdma_linear_b2b_ = SDMA_DEFAULT;
 
+  bool sdma_force_multicast_ = false;
+
   SDMA_OVERRIDE enable_sdma_;
   SDMA_OVERRIDE enable_peer_sdma_;
   SDMA_OVERRIDE enable_sdma_gang_;
@@ -616,8 +620,6 @@ class Flag {
 
   // Map GPU index post RVD to its default cu mask.
   std::map<uint32_t, std::vector<uint32_t>> cu_mask_;
-
-  bool enable_sdma_fastpath_debug_;
 
   void parse_masks(std::string& args, uint32_t maxGpu, uint32_t maxCU);
 


### PR DESCRIPTION
## Summary

gfx1250 SDMA fused WaitSignal path: chunking, single-reservation notify, multicast consolidation, and broadcast routing tuning.

### Builders

* Fix `BuildWaitSignalCopyCommand` / `BuildWaitSignalSwapCommand` / multicast to emit **compacted variable-length packets** (only the WAIT/SIGNAL doubleword blocks actually present), matching the HW parser and fixing faults on multi-packet fused copies. Caller sizing reserves the WAIT block only when a dep is folded in, exactly matching the compacted emission.
* Fused linear-copy, swap, and multicast WaitSignal builders **chunk large transfers** via `num_copy_command`. Every chunk waits on the same input signal and signals the same output signal; the submit pre-loads `out_signal` by `N-1` so it only reaches 0 once all chunks complete — correct even when the HW overlaps chunk copies. Indirect packets still cannot chunk and reject `size > max`.

### Single-reservation notify

* `SubmitLinearCopyBodyWaitSignal` gains `fused_notify` (default true): it folds the GCR-invalidate prologue and the GCR-writeback/mailbox epilogue into the **same ring reservation**, so a standalone single-engine copy needs one reserve/release instead of three. The fan-out path passes `false` and keeps driving `SubmitNotifyPrologue/Epilogue` separately across engines.

### Multicast

* Consolidate multicast into a single `SubmitLinearCopyMulticastCommand` that branches on profiling: profiling uses the timestamp-capable plain packet via the classic submit path; non-profiling fuses GCR + copy/signal + GCR writeback/mailbox into one reservation using the multicast WaitSignal packet. Reject `> 1024` destinations (10-bit `num_of_destination` field).

### gfx1250 cache + epilogue

* **GCR off for gfx1250.** `BlitSdmaV6` now builds with `useGCR=false`: gfx1250 SDMA ops run on the DACC backend and are **not cached in GL2**, so the GCR invalidate/writeback packets are unnecessary; the per-packet system-scope fields handle coherency.
* **Drop the redundant epilogue self-poll on `out_signal`** from the fused linear and multicast WaitSignal paths. The ring is in-order and the packet's inline 64b-sub SIGNAL already executes after its copy, so the copy is drained before the epilogue. Worse than redundant on multicast: polling the very address the packet inline-signals **deadlocked the gfx1250 SDMA engine** (the inline-signal write was not observed by the immediately-following `POLL_REGMEM`), wedging every later packet. The cross-engine fan-out epilogue keeps its poll on the *other* engines' body signals, which is a legitimate cross-engine wait and is unchanged.

### Routing (`amd_gpu_agent`)

* gfx1250 single-copy fast path drops the `size <= MaxSingleLinearCopySize()` gate and the now-redundant prologue/epilogue calls; chunking is handled in the builder.
* `DmaCopyBroadcast` on gfx1250: multicast for copies `<= 256 KB`; larger copies now fall through to **fan-out** (was linearB2B). Fan-out parallelises the per-destination copies across SDMA engines and measured **~3–5% faster** than a single-engine linearB2B at large sizes. The non-gfx1250 path (linearB2B / broadcast / fan-out) is unchanged.
* `DmaCopyFanOutOp`: narrow the multi-packet fallback to indirect copies only, so large linear-copy and swap entries take the chunked fused WaitSignal path while oversized indirect copies still fall back and are rejected.

### CLR (`rocdevice` SdmaEngineAllocator)

* Enable the **simple round-robin** engine allocator on gfx1250+, whose SDMA engines have symmetric bandwidth, so broadcast fan-out actually spreads across engines. Older asics keep the preferred-engine heuristics.

### Debug

* `HSA_SDMA_FORCE_MULTICAST=1` forces the gfx1250 broadcast onto the multicast packet regardless of size. **Debug only**: the multicast engine drops destinations above 256 KB, so large copies fail validation by design.

## Motivation

gfx1250 multi-destination collectives (e.g. cuMem-fabric allgather) need a fused, chunked SDMA path that does not fault on large transfers, minimises ring reservations, and picks the fastest correct submission mode per size.

## Technical Details

See the per-area breakdown above. Key correctness fixes: (1) compacted variable-length packet emission now exactly matches caller-reserved sizes, eliminating uninitialized command-buffer regions that caused GPU faults on multi-packet fused copies; (2) the redundant epilogue self-poll that deadlocked the gfx1250 multicast engine is removed, and GCR cache packets are dropped on gfx1250 (uncached DACC backend + per-packet scopes). Key perf change: large broadcasts route through fan-out + round-robin engine allocation on gfx1250.

## Test Plan

* cuMem-fabric allgather (4 ranks, MI450), size sweep 512 B → 16 GiB.
* Pure-HSA `hsa_amd_memory_async_batch_copy` multicast sweep (512 B → 64 MiB), both GPU-only and interruptible completion signals.
* A/B of the three broadcast submission modes (multicast / linearB2B / fan-out) via a forced-path build to confirm correctness and relative throughput.

## Test Result

* Default routing: **Validation passed** across the full 512 B → 16 GiB sweep.
* Pure-HSA multicast sweep (MI450, gfx1250): **PASS** at every size for both GPU-only and interruptible signals — no hangs. (Previously the fused multicast epilogue self-poll wedged the SDMA engine; the poll removal fixes it.)
* Large-size throughput (4-rank allgather), fan-out vs previous linearB2B default:
| Size   | linearB2B | fan-out   | gain   |
| ------ | --------- | --------- | ------ |
| 1 GiB  | 630.3 µs  | 600.5 µs  | ~4.7% |
| 4 GiB  | 2454.7 µs | 2333.8 µs | ~4.9% |
| 8 GiB  | 4888.6 µs | 4645.0 µs | ~5.0% |
| 16 GiB | 9732.0 µs | 9278.1 µs | ~4.7% |
* `HSA_SDMA_FORCE_MULTICAST=1` reproduces the expected multicast > 256 KB destination-drop validation failures, confirming the debug knob (this is a HW limit, not a packet-encoding bug: the dumped packet carries all destinations and the correct count).

## JIRA ID

## Submission Checklist

* Look over the contributing guidelines at <https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests>.
