### PR TITLE
[rocjitsu] Install the rocjitsu CLI

### DIFF
--- a/emulation/rocjitsu/tools/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/tools/rocjitsu/CMakeLists.txt
@@ -42,3 +42,8 @@ target_link_libraries(
 set_target_properties(rocjitsu_bin PROPERTIES OUTPUT_NAME rocjitsu)
 
 rj_configure_target(rocjitsu_bin TOOL)
+
+# Install the rocjitsu CLI so it is usable from a packaged dist (the default
+# entrypoint for driving emulation when mirage is not present).
+include(GNUInstallDirs)
+install(TARGETS rocjitsu_bin RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
## Motivation

The rocjitsu CLI (`rocjitsu_bin`, output name `rocjitsu`) is built but never installed. As a result, a packaged ROCm dist has no entrypoint to drive emulation from an installed tree — `librocjitsu.so` and `rocjitsu_kmd_shim` are installed, but not the CLI that wires them together (`rocjitsu --config <cfg> -- <app>`). mirage is a separate component and not always present.

## Change

Add `install(TARGETS rocjitsu_bin RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})` in `emulation/rocjitsu/tools/rocjitsu/CMakeLists.txt` so the CLI installs to `bin/rocjitsu`, matching the already-installed library/configs/schemas.

## Test Plan

- Configure + build rocjitsu, `cmake --install`, and confirm `bin/rocjitsu` is present in the install prefix.
- `bin/rocjitsu --help` runs from the installed tree.
