### PR TITLE
ci(rocjitsu): Install tests as a build artifact

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -122,8 +122,7 @@ jobs:
           ROCBLAS_GEMMS=RocblasGemmTest
           ROCBLAS_GEMM_FUZZ=RocblasGemmFuzz
           ROCBLAS_GEMM_CDNA3=RocblasGemmCdna3
-          RACE_CONDITIONS=RaceTest
-          EXCLUDED_TESTS="${ROCMINFO}|${ROCBLAS_GEMM}|${RCCL_DAEMON}|${ROCBLAS_GEMMS}|${ROCBLAS_GEMM_FUZZ}|${ROCBLAS_GEMM_CDNA3}|${RACE_CONDITIONS}"
+          EXCLUDED_TESTS="${ROCMINFO}|${ROCBLAS_GEMM}|${RCCL_DAEMON}|${ROCBLAS_GEMMS}|${ROCBLAS_GEMM_FUZZ}|${ROCBLAS_GEMM_CDNA3}"
           ASAN_UBSAN_EXCLUDED_TESTS=(
             "HsaTest\.InitSucceeded"
             "HsaTest\.GpuAgentFound"
@@ -140,6 +139,36 @@ jobs:
             "LoggingTest\.dispatch_logged"
             "ProfiledPluginTest\.hook_profile_output"
             "CvtNarrow\.AllTests"
+            "RaceTest\.vgpr_waitcnt"
+            "RaceTest\.vgpr_waitcnt_race"
+            "RaceTest\.sgpr_waitcnt"
+            "RaceTest\.sgpr_waitcnt_race"
+            "RaceTest\.lds_cross_wave"
+            "RaceTest\.lds_cross_wave_race"
+            "RaceTest\.global_to_lds_buffer"
+            "RaceTest\.global_to_lds_buffer_race"
+            "RaceTest\.partial_vmcnt_race"
+            "RaceTest\.multiple_race"
+            "RaceTest\.multi_kernel"
+            "RaceTest\.multi_kernel_race"
+            "RaceTest\.multi_workgroup"
+            "RaceTest\.multi_workgroup_race"
+            "RaceTest\.mixed_counters_race"
+            "RaceTest\.stress_wavefront_reuse"
+            "RaceTest\.stress_wavefront_reuse_race"
+            "RaceTest\.exec_mask"
+            "RaceTest\.exec_mask_race"
+            "RaceTest\.exec_mask_same_wave"
+            "RaceTest\.exec_mask_cross_wave_race"
+            "RaceTest\.exec_mask_cross_wave"
+            "RaceTest\.lds_transpose"
+            "RaceTest\.lds_transpose_race"
+            "RaceTest\.dual_offset_lds"
+            "RaceTest\.dual_offset_lds_race"
+            "RaceTest\.scratch_vmcnt"
+            "RaceTest\.scratch_vmcnt_race"
+            "RaceTest\.f64_vgpr_safe"
+            "RaceTest\.f64_vgpr_race"
           )
 
           CMAKE_CONFIG_FLAGS=()

--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -122,7 +122,8 @@ jobs:
           ROCBLAS_GEMMS=RocblasGemmTest
           ROCBLAS_GEMM_FUZZ=RocblasGemmFuzz
           ROCBLAS_GEMM_CDNA3=RocblasGemmCdna3
-          EXCLUDED_TESTS="${ROCMINFO}|${ROCBLAS_GEMM}|${RCCL_DAEMON}|${ROCBLAS_GEMMS}|${ROCBLAS_GEMM_FUZZ}|${ROCBLAS_GEMM_CDNA3}"
+          RACE_CONDITIONS=RaceTest
+          EXCLUDED_TESTS="${ROCMINFO}|${ROCBLAS_GEMM}|${RCCL_DAEMON}|${ROCBLAS_GEMMS}|${ROCBLAS_GEMM_FUZZ}|${ROCBLAS_GEMM_CDNA3}|${RACE_CONDITIONS}"
           ASAN_UBSAN_EXCLUDED_TESTS=(
             "HsaTest\.InitSucceeded"
             "HsaTest\.GpuAgentFound"
@@ -139,36 +140,6 @@ jobs:
             "LoggingTest\.dispatch_logged"
             "ProfiledPluginTest\.hook_profile_output"
             "CvtNarrow\.AllTests"
-            "RaceTest\.vgpr_waitcnt"
-            "RaceTest\.vgpr_waitcnt_race"
-            "RaceTest\.sgpr_waitcnt"
-            "RaceTest\.sgpr_waitcnt_race"
-            "RaceTest\.lds_cross_wave"
-            "RaceTest\.lds_cross_wave_race"
-            "RaceTest\.global_to_lds_buffer"
-            "RaceTest\.global_to_lds_buffer_race"
-            "RaceTest\.partial_vmcnt_race"
-            "RaceTest\.multiple_race"
-            "RaceTest\.multi_kernel"
-            "RaceTest\.multi_kernel_race"
-            "RaceTest\.multi_workgroup"
-            "RaceTest\.multi_workgroup_race"
-            "RaceTest\.mixed_counters_race"
-            "RaceTest\.stress_wavefront_reuse"
-            "RaceTest\.stress_wavefront_reuse_race"
-            "RaceTest\.exec_mask"
-            "RaceTest\.exec_mask_race"
-            "RaceTest\.exec_mask_same_wave"
-            "RaceTest\.exec_mask_cross_wave_race"
-            "RaceTest\.exec_mask_cross_wave"
-            "RaceTest\.lds_transpose"
-            "RaceTest\.lds_transpose_race"
-            "RaceTest\.dual_offset_lds"
-            "RaceTest\.dual_offset_lds_race"
-            "RaceTest\.scratch_vmcnt"
-            "RaceTest\.scratch_vmcnt_race"
-            "RaceTest\.f64_vgpr_safe"
-            "RaceTest\.f64_vgpr_race"
           )
 
           CMAKE_CONFIG_FLAGS=()

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -66,6 +66,9 @@ set(DRM_INCLUDE_DIR
 
 include(rj_log)
 
+# Install directory variables are used by subdirectories that add install rules.
+include(GNUInstallDirs)
+
 # Sanitizer and static analysis options.
 option(RJ_ENABLE_ASAN "Enable AddressSanitizer" OFF)
 option(RJ_ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer" OFF)
@@ -77,6 +80,7 @@ option(
     "Enable expensive exhaustive test suites (MFMA/WMMA SIMD bit-exactness)"
     OFF
 )
+option(RJ_INSTALL_TESTS "Install rocjitsu test binaries" OFF)
 option(
     LTO
     "Enable link-time optimization (IPO) for Release / RelWithDebInfo"
@@ -299,8 +303,6 @@ endif()
 # ---------------------------------------------------------------------------
 # Install rules.
 # ---------------------------------------------------------------------------
-
-include(GNUInstallDirs)
 
 # Public headers: include/rocjitsu/
 install(

--- a/emulation/rocjitsu/cmake/rj_find_amdcxx.cmake
+++ b/emulation/rocjitsu/cmake/rj_find_amdcxx.cmake
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Locate the ROCm amdclang++ compiler selected by ROCM_PATH.
+#
+# Some systems expose /usr/bin/amdclang++ through alternatives; using that
+# wrapper can derive --rocm-path as /usr and mix headers/device libraries from
+# different installs. Keep this lookup constrained to ROCM_PATH.
+function(rj_find_amdcxx out_var)
+    find_program(
+        _rj_amdcxx
+        NAMES amdclang++
+        PATHS "${ROCM_PATH}"
+        PATH_SUFFIXES lib/llvm/bin bin
+        NO_DEFAULT_PATH
+        NO_CACHE
+    )
+    set(${out_var} "${_rj_amdcxx}" PARENT_SCOPE)
+endfunction()

--- a/emulation/rocjitsu/cmake/rj_generate_installed_gtest_ctest.cmake
+++ b/emulation/rocjitsu/cmake/rj_generate_installed_gtest_ctest.cmake
@@ -1,0 +1,97 @@
+# Copyright (c) 2025-2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Build-time helper for installed GoogleTest discovery.
+#
+# This script is run with `cmake -P` after TEST_EXECUTABLE has been built. It
+# asks GoogleTest for the concrete test list, including parameterized TEST_P
+# expansions, then writes a CTest fragment that runs the installed executable
+# once per discovered test case.
+#
+# Required variables:
+#   TEST_EXECUTABLE      Build-tree executable used for --gtest_list_tests.
+#   INSTALLED_EXECUTABLE Path CTest should run from the installed test dir.
+#   OUTPUT_FILE          Generated CTest fragment path.
+function(rj_generate_installed_gtest_ctest)
+    set(oneValueArgs TEST_EXECUTABLE INSTALLED_EXECUTABLE OUTPUT_FILE)
+    cmake_parse_arguments(ARG "" "${oneValueArgs}" "" ${ARGN})
+
+    if(NOT ARG_TEST_EXECUTABLE)
+        message(FATAL_ERROR "TEST_EXECUTABLE is required")
+    endif()
+    if(NOT ARG_INSTALLED_EXECUTABLE)
+        message(FATAL_ERROR "INSTALLED_EXECUTABLE is required")
+    endif()
+    if(NOT ARG_OUTPUT_FILE)
+        message(FATAL_ERROR "OUTPUT_FILE is required")
+    endif()
+
+    execute_process(
+        COMMAND
+            "${ARG_TEST_EXECUTABLE}" --gtest_list_tests
+            "--gtest_filter=-*Benchmark*"
+        RESULT_VARIABLE _result
+        OUTPUT_VARIABLE _tests
+        ERROR_VARIABLE _errors
+    )
+    if(NOT _result EQUAL 0)
+        message(
+            FATAL_ERROR
+            "Failed to list tests from ${ARG_TEST_EXECUTABLE}: ${_errors}"
+        )
+    endif()
+
+    file(WRITE "${ARG_OUTPUT_FILE}" "# Installed GoogleTest CTest tests\n")
+    set(_suite)
+    string(REPLACE "\n" ";" _lines "${_tests}")
+    foreach(_line IN LISTS _lines)
+        string(STRIP "${_line}" _stripped_line)
+        if(_line MATCHES "^([^# \t]+)\\.[ \t]*(#.*)?$")
+            set(_suite "${CMAKE_MATCH_1}")
+        elseif(_line MATCHES "^  ([^# \t]+)")
+            if(NOT _suite)
+                message(FATAL_ERROR "Found gtest case without suite: ${_line}")
+            endif()
+            set(_case_name "${CMAKE_MATCH_1}")
+            set(_pretty_case_name "${_case_name}")
+            if(
+                _case_name MATCHES "/[0-9]+$"
+                AND _line MATCHES "# GetParam\\(\\) = \"?([A-Za-z0-9_]+)\"?$"
+            )
+                string(
+                    REGEX REPLACE
+                    "/[0-9]+$"
+                    "/${CMAKE_MATCH_1}"
+                    _pretty_case_name
+                    "${_case_name}"
+                )
+            endif()
+            set(_test_name "${_suite}.${_pretty_case_name}")
+            set(_test_filter "${_suite}.${_case_name}")
+            string(REPLACE "\\" "\\\\" _escaped_name "${_test_name}")
+            string(REPLACE "\"" "\\\"" _escaped_name "${_escaped_name}")
+            string(REPLACE "\\" "\\\\" _escaped_filter "${_test_filter}")
+            string(REPLACE "\"" "\\\"" _escaped_filter "${_escaped_filter}")
+            file(
+                APPEND "${ARG_OUTPUT_FILE}"
+                "add_test(\"${_escaped_name}\" \"${ARG_INSTALLED_EXECUTABLE}\" \"--gtest_filter=${_escaped_filter}\")\n"
+                "set_tests_properties(\"${_escaped_name}\" PROPERTIES\n"
+                "  SKIP_REGULAR_EXPRESSION [=[\\[  SKIPPED \\]]=]\n"
+                "  ENVIRONMENT \"ROCJITSU_CONFIG_DIR=\${RJ_INSTALLED_CONFIG_DIR};ROCJITSU_KERNEL_DIR=\${RJ_INSTALLED_KERNEL_DIR}\")\n\n"
+            )
+        elseif(_line MATCHES "^Running main\\(\\) from .*/gtest_main\\.cc$")
+            # GoogleTest's gtest_main emits this banner before the test list.
+        elseif(_stripped_line)
+            message(
+                FATAL_ERROR
+                "Unrecognized --gtest_list_tests line from ${ARG_TEST_EXECUTABLE}: ${_line}"
+            )
+        endif()
+    endforeach()
+endfunction()
+
+rj_generate_installed_gtest_ctest(
+    TEST_EXECUTABLE "${TEST_EXECUTABLE}"
+    INSTALLED_EXECUTABLE "${INSTALLED_EXECUTABLE}"
+    OUTPUT_FILE "${OUTPUT_FILE}"
+)

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -914,11 +914,12 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
             OUTPUT ${HIP_TEST_BIN}
             COMMAND
                 ${AMDCXX} -x hip --offload-arch=${ARG_ARCH}
-                --rocm-path=${ROCM_PATH} -std=c++20 ${RJ_HIP_SANITIZER_FLAGS}
-                -isystem ${GTEST_INC} -I${CMAKE_CURRENT_SOURCE_DIR} -o
-                ${HIP_TEST_BIN} ${HIP_TEST_SRC} ${HIP_EXTRA_LIBS}
-                -L${GTEST_LIB_DIR} -lgtest -lpthread -Wl,-rpath,${GTEST_LIB_DIR}
-                -Wl,-rpath,${RJ_HSA_LIBRARY_DIR} ${RJ_HIP_SANITIZER_LINK_FLAGS}
+                --rocm-path=${ROCM_PATH} -std=c++20 -O2
+                ${RJ_HIP_SANITIZER_FLAGS} -isystem ${GTEST_INC}
+                -I${CMAKE_CURRENT_SOURCE_DIR} -o ${HIP_TEST_BIN} ${HIP_TEST_SRC}
+                ${HIP_EXTRA_LIBS} -L${GTEST_LIB_DIR} -lgtest -lpthread
+                -Wl,-rpath,${GTEST_LIB_DIR} -Wl,-rpath,${RJ_HSA_LIBRARY_DIR}
+                ${RJ_HIP_SANITIZER_LINK_FLAGS}
             DEPENDS ${HIP_TEST_SRC} GTest::gtest GTest::gtest_main
             COMMENT "Building ${TEST_NAME} with hipcc (${ARG_ARCH})"
             VERBATIM

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -32,6 +32,241 @@ set(RJ_OBJECT_LIBS
     rocjitsu_config
 )
 
+if(RJ_INSTALL_TESTS)
+    set(RJ_INSTALL_TEST_DIR "${CMAKE_INSTALL_DATADIR}/rocjitsu/tests")
+    set(RJ_INSTALL_TEST_BIN_DIR "${RJ_INSTALL_TEST_DIR}/bin")
+    set(RJ_INSTALL_CTEST_FILE
+        "${CMAKE_CURRENT_BINARY_DIR}/install/CTestTestfile.cmake"
+    )
+    set(RJ_INSTALL_GTEST_GENERATOR
+        "${PROJECT_SOURCE_DIR}/cmake/rj_generate_installed_gtest_ctest.cmake"
+    )
+    if(IS_ABSOLUTE "${CMAKE_INSTALL_BINDIR}")
+        set(_rj_installed_bindir "${CMAKE_INSTALL_BINDIR}")
+    else()
+        set(_rj_installed_bindir "../../../${CMAKE_INSTALL_BINDIR}")
+    endif()
+    if(IS_ABSOLUTE "${CMAKE_INSTALL_DATADIR}")
+        set(_rj_installed_datadir "${CMAKE_INSTALL_DATADIR}")
+    else()
+        set(_rj_installed_datadir "../..")
+    endif()
+    if(IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+        set(_rj_installed_libdir "${CMAKE_INSTALL_LIBDIR}")
+    else()
+        set(_rj_installed_libdir "../../../${CMAKE_INSTALL_LIBDIR}")
+    endif()
+    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/install")
+    file(WRITE "${RJ_INSTALL_CTEST_FILE}" "# Installed rocjitsu CTest tests\n")
+    file(
+        APPEND "${RJ_INSTALL_CTEST_FILE}"
+        "set(RJ_INSTALLED_BINDIR \"${_rj_installed_bindir}\")\n"
+        "set(RJ_INSTALLED_CONFIG_DIR \"${_rj_installed_datadir}/rocjitsu/configs\")\n\n"
+        "set(RJ_INSTALLED_KERNEL_DIR \"kernels\")\n\n"
+        "set(RJ_INSTALLED_LIBDIR \"${_rj_installed_libdir}\")\n\n"
+        "include(\"rocjitsu_tests.cmake\")\n\n"
+    )
+
+    # Install a compiled test/tool target into the installed CTest bin directory.
+    # The installed CTest file references these binaries with paths relative to
+    # ${RJ_INSTALL_TEST_DIR}, e.g. bin/rocjitsu_tests.
+    function(rj_install_test_target target)
+        install(
+            TARGETS ${target}
+            RUNTIME DESTINATION ${RJ_INSTALL_TEST_BIN_DIR}
+        )
+    endfunction()
+
+    # Install a non-CMake executable produced by a custom command, such as a HIP
+    # test binary compiled directly with hipcc.
+    function(rj_install_test_program path)
+        install(PROGRAMS ${path} DESTINATION ${RJ_INSTALL_TEST_BIN_DIR})
+    endfunction()
+
+    # Append one installed CTest entry to ${RJ_INSTALL_CTEST_FILE}. This mirrors
+    # the subset of add_test()/set_tests_properties() used by rj_add_test, but
+    # writes plain CMake code because the file is consumed later by
+    # `ctest --test-dir <installed tests dir>`.
+    function(rj_install_ctest name)
+        set(oneValueArgs TIMEOUT SKIP_REGULAR_EXPRESSION)
+        set(multiValueArgs COMMAND ENVIRONMENT LABELS)
+        cmake_parse_arguments(
+            ARG
+            ""
+            "${oneValueArgs}"
+            "${multiValueArgs}"
+            ${ARGN}
+        )
+        if(NOT ARG_COMMAND)
+            message(FATAL_ERROR "rj_install_ctest(${name}) requires COMMAND")
+        endif()
+
+        set(_content "add_test(\"${name}\"")
+        foreach(_arg IN LISTS ARG_COMMAND)
+            string(APPEND _content " \"${_arg}\"")
+        endforeach()
+        string(APPEND _content ")\n")
+
+        set(_props)
+        if(ARG_TIMEOUT)
+            string(APPEND _props " \"TIMEOUT\" \"${ARG_TIMEOUT}\"")
+        endif()
+        if(ARG_SKIP_REGULAR_EXPRESSION)
+            string(
+                APPEND _props
+                " \"SKIP_REGULAR_EXPRESSION\" [=[${ARG_SKIP_REGULAR_EXPRESSION}]=]"
+            )
+        endif()
+        if(ARG_LABELS)
+            list(JOIN ARG_LABELS ";" _labels)
+            string(APPEND _props " \"LABELS\" \"${_labels}\"")
+        endif()
+        if(ARG_ENVIRONMENT)
+            list(JOIN ARG_ENVIRONMENT ";" _env)
+            string(APPEND _props " \"ENVIRONMENT\" \"${_env}\"")
+        endif()
+        if(_props)
+            string(
+                APPEND _content
+                "set_tests_properties(\"${name}\" PROPERTIES"
+            )
+            string(APPEND _content "${_props})\n")
+        endif()
+
+        file(APPEND "${RJ_INSTALL_CTEST_FILE}" "${_content}\n")
+    endfunction()
+
+    # Generate and install fine-grained CTest entries for every concrete
+    # GoogleTest case in a target. The target executable must already exist, so
+    # this is a build-time custom command that runs --gtest_list_tests and writes
+    # an installed CTest fragment like rocjitsu_tests.cmake.
+    function(rj_install_gtest_cases target)
+        set(_fragment "${CMAKE_CURRENT_BINARY_DIR}/install/${target}.cmake")
+        add_custom_command(
+            OUTPUT "${_fragment}"
+            COMMAND
+                ${CMAKE_COMMAND} "-DTEST_EXECUTABLE=$<TARGET_FILE:${target}>"
+                "-DINSTALLED_EXECUTABLE=bin/${target}"
+                "-DOUTPUT_FILE=${_fragment}" -P "${RJ_INSTALL_GTEST_GENERATOR}"
+            DEPENDS ${target} "${RJ_INSTALL_GTEST_GENERATOR}"
+            COMMENT "Generating installed CTest entries for ${target}"
+            VERBATIM
+        )
+        add_custom_target(${target}_installed_ctest ALL DEPENDS "${_fragment}")
+        install(FILES "${_fragment}" DESTINATION ${RJ_INSTALL_TEST_DIR})
+    endfunction()
+
+    install(FILES "${RJ_INSTALL_CTEST_FILE}" DESTINATION ${RJ_INSTALL_TEST_DIR})
+endif()
+
+include(GoogleTest)
+
+set(_rj_installed_test_bin_dir "${CMAKE_INSTALL_DATADIR}/rocjitsu/tests/bin")
+function(_rj_path_from_installed_test_bin out install_dir file_name)
+    if(IS_ABSOLUTE "${install_dir}")
+        set(_path "${install_dir}/${file_name}")
+    elseif(IS_ABSOLUTE "${_rj_installed_test_bin_dir}")
+        set(_path "${CMAKE_INSTALL_PREFIX}/${install_dir}/${file_name}")
+    else()
+        file(
+            RELATIVE_PATH
+            _rel_dir
+            "/${_rj_installed_test_bin_dir}"
+            "/${install_dir}"
+        )
+        set(_path "${_rel_dir}/${file_name}")
+    endif()
+    set(${out} "${_path}" PARENT_SCOPE)
+endfunction()
+
+# Register a test for both the build tree and, when RJ_INSTALL_TESTS is ON, the
+# installed CTest tree. COMMAND is the normal build-tree command passed to
+# add_test(). INSTALL_COMMAND is optional and should use paths relative to the
+# installed test directory, e.g. bin/my_test or ${RJ_INSTALLED_BINDIR}/rocjitsu.
+# Shared properties TIMEOUT, SKIP_REGULAR_EXPRESSION, and LABELS are applied to
+# both registrations. ENVIRONMENT applies only to the build-tree test;
+# INSTALL_ENVIRONMENT adds to the default installed test environment, which
+# points installed tests at packaged configs, kernels, binaries, and runtimes.
+function(rj_add_test)
+    set(oneValueArgs NAME WORKING_DIRECTORY TIMEOUT SKIP_REGULAR_EXPRESSION)
+    set(multiValueArgs
+        COMMAND
+        ENVIRONMENT
+        INSTALL_COMMAND
+        INSTALL_ENVIRONMENT
+        LABELS
+    )
+    cmake_parse_arguments(ARG "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+    if(NOT ARG_NAME)
+        message(FATAL_ERROR "rj_add_test requires NAME")
+    endif()
+    if(NOT ARG_COMMAND)
+        message(FATAL_ERROR "rj_add_test(${ARG_NAME}) requires COMMAND")
+    endif()
+
+    add_test(NAME "${ARG_NAME}" COMMAND ${ARG_COMMAND})
+
+    if(ARG_WORKING_DIRECTORY)
+        set_tests_properties(
+            "${ARG_NAME}"
+            PROPERTIES WORKING_DIRECTORY "${ARG_WORKING_DIRECTORY}"
+        )
+    endif()
+    if(ARG_TIMEOUT)
+        set_tests_properties("${ARG_NAME}" PROPERTIES TIMEOUT "${ARG_TIMEOUT}")
+    endif()
+    if(ARG_SKIP_REGULAR_EXPRESSION)
+        set_tests_properties(
+            "${ARG_NAME}"
+            PROPERTIES SKIP_REGULAR_EXPRESSION "${ARG_SKIP_REGULAR_EXPRESSION}"
+        )
+    endif()
+    if(ARG_LABELS)
+        list(JOIN ARG_LABELS ";" _labels)
+        set_tests_properties("${ARG_NAME}" PROPERTIES LABELS "${_labels}")
+    endif()
+    if(ARG_ENVIRONMENT)
+        list(JOIN ARG_ENVIRONMENT ";" _env)
+        set_tests_properties("${ARG_NAME}" PROPERTIES ENVIRONMENT "${_env}")
+    endif()
+
+    if(RJ_INSTALL_TESTS AND ARG_INSTALL_COMMAND)
+        set(_install_args COMMAND ${ARG_INSTALL_COMMAND})
+        if(ARG_TIMEOUT)
+            list(APPEND _install_args TIMEOUT "${ARG_TIMEOUT}")
+        endif()
+        if(ARG_SKIP_REGULAR_EXPRESSION)
+            list(
+                APPEND _install_args
+                SKIP_REGULAR_EXPRESSION
+                "${ARG_SKIP_REGULAR_EXPRESSION}"
+            )
+        endif()
+        if(ARG_LABELS)
+            list(APPEND _install_args LABELS ${ARG_LABELS})
+        endif()
+        set(_install_env
+            "ROCJITSU_CONFIG_DIR=\${RJ_INSTALLED_CONFIG_DIR}"
+            "ROCJITSU_KERNEL_DIR=\${RJ_INSTALLED_KERNEL_DIR}"
+        )
+        list(APPEND _install_env ${ARG_INSTALL_ENVIRONMENT})
+        list(APPEND _install_args ENVIRONMENT ${_install_env})
+        rj_install_ctest("${ARG_NAME}" ${_install_args})
+    endif()
+endfunction()
+
+# Register a GoogleTest target with fine-grained tests in both the build tree
+# and installed CTest tree. Build-tree discovery delegates to
+# gtest_discover_tests(); installed discovery delegates to rj_install_gtest_cases
+# so parameterized TEST_P cases are expanded from the built executable.
+function(rj_add_gtest_tests target)
+    gtest_discover_tests(${target} ${ARGN})
+    if(RJ_INSTALL_TESTS)
+        rj_install_test_target(${target})
+        rj_install_gtest_cases(${target})
+    endif()
+endfunction()
+
 # --- Unit / integration test suite ---
 
 add_executable(
@@ -134,12 +369,10 @@ target_link_libraries(
         GTest::gtest_main
 )
 rj_configure_target(rocjitsu_tests TEST)
-
-include(GoogleTest)
 # Benchmarks are timing tools, not correctness tests; keep them out of the
 # default ctest run (invoke them directly via
 # ./rocjitsu_tests --gtest_filter='*Benchmark*').
-gtest_discover_tests(rocjitsu_tests TEST_FILTER -*Benchmark*)
+rj_add_gtest_tests(rocjitsu_tests TEST_FILTER -*Benchmark*)
 
 add_executable(
     rj_dbt_translate_smoke_test
@@ -154,10 +387,17 @@ target_include_directories(
 target_link_libraries(rj_dbt_translate_smoke_test PRIVATE GTest::gtest)
 rj_configure_target(rj_dbt_translate_smoke_test TEST)
 add_dependencies(rj_dbt_translate_smoke_test rj_dbt_translate)
-add_test(
+if(RJ_INSTALL_TESTS)
+    rj_install_test_target(rj_dbt_translate_smoke_test)
+    rj_install_test_target(rj_dbt_translate)
+endif()
+rj_add_test(
     NAME "RjDbtTranslate.Smoke"
     COMMAND rj_dbt_translate_smoke_test $<TARGET_FILE:rj_dbt_translate>
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    INSTALL_COMMAND
+        "bin/rj_dbt_translate_smoke_test"
+        "bin/rj_dbt_translate"
 )
 
 # --- Scaling test (standalone executable) ---
@@ -176,7 +416,16 @@ rj_configure_target(scaling_test TEST)
 # The CLI handles LD_PRELOAD and config discovery. No RESOURCE_LOCK needed.
 
 set(RJ_CDNA4_KMD_CONFIG "${CMAKE_SOURCE_DIR}/configs/gfx950_cdna4_kmd.json")
+set(RJ_CDNA4_KMD_2GPU_CONFIG
+    "${CMAKE_SOURCE_DIR}/configs/gfx950_cdna4_kmd_2gpu.json"
+)
 set(RJ_CDNA3_KMD_CONFIG "${CMAKE_SOURCE_DIR}/configs/gfx942_cdna3_kmd.json")
+get_filename_component(RJ_CDNA4_KMD_CONFIG_NAME "${RJ_CDNA4_KMD_CONFIG}" NAME)
+get_filename_component(
+    RJ_CDNA4_KMD_2GPU_CONFIG_NAME
+    "${RJ_CDNA4_KMD_2GPU_CONFIG}"
+    NAME
+)
 set(RJ_CLI "$<TARGET_FILE:rocjitsu_bin>")
 
 set(RJ_KMD_PRELOAD_ENV
@@ -186,6 +435,17 @@ set(RJ_KMD_PRELOAD_ENV
 
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---
 # Spawns rocminfo via the rocjitsu CLI and validates output.
+
+_rj_path_from_installed_test_bin(
+    _rj_installed_rocjitsu_bin
+    "${CMAKE_INSTALL_BINDIR}"
+    "rocjitsu"
+)
+_rj_path_from_installed_test_bin(
+    _rj_installed_cdna4_kmd_config
+    "${CMAKE_INSTALL_DATADIR}/rocjitsu/configs"
+    "${RJ_CDNA4_KMD_CONFIG_NAME}"
+)
 
 find_program(
     ROCMINFO_EXECUTABLE
@@ -202,49 +462,47 @@ if(ROCMINFO_EXECUTABLE)
             ROCMINFO_PATH="${ROCMINFO_EXECUTABLE}"
             ROCJITSU_BIN="$<TARGET_FILE:rocjitsu_bin>"
             RJ_CONFIG_PATH="${RJ_CDNA4_KMD_CONFIG}"
+            RJ_INSTALLED_ROCJITSU_BIN="${_rj_installed_rocjitsu_bin}"
+            RJ_INSTALLED_CONFIG_PATH="${_rj_installed_cdna4_kmd_config}"
     )
     target_link_libraries(rocminfo_test PRIVATE GTest::gtest_main)
     add_dependencies(rocminfo_test rocjitsu_bin rocjitsu_kmd_shim)
 
-    add_test(
-        NAME "RocminfoTest.ExitsSuccessfully"
-        COMMAND rocminfo_test --gtest_filter=RocminfoTest.ExitsSuccessfully
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    if(RJ_INSTALL_TESTS)
+        rj_install_test_target(rocminfo_test)
+    endif()
+    set(_rocminfo_install_environment_arg)
+    if(ROCM_PATH AND EXISTS "${ROCM_PATH}/bin/rocminfo")
+        list(
+            APPEND _rocminfo_install_environment_arg
+            INSTALL_ENVIRONMENT
+            "ROCMINFO_PATH=${ROCM_PATH}/bin/rocminfo"
+        )
+    endif()
+    foreach(
+        _rocminfo_test
+        IN
+        ITEMS
+            ExitsSuccessfully
+            InterposerActive
+            HsaSystemAttributes
+            DetectsGpuAgent
+            ReportsGfx950
+            ReportsWavefrontSize
     )
-    add_test(
-        NAME "RocminfoTest.InterposerActive"
-        COMMAND rocminfo_test --gtest_filter=RocminfoTest.InterposerActive
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-    add_test(
-        NAME "RocminfoTest.HsaSystemAttributes"
-        COMMAND rocminfo_test --gtest_filter=RocminfoTest.HsaSystemAttributes
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-    add_test(
-        NAME "RocminfoTest.DetectsGpuAgent"
-        COMMAND rocminfo_test --gtest_filter=RocminfoTest.DetectsGpuAgent
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-    add_test(
-        NAME "RocminfoTest.ReportsGfx950"
-        COMMAND rocminfo_test --gtest_filter=RocminfoTest.ReportsGfx950
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-    add_test(
-        NAME "RocminfoTest.ReportsWavefrontSize"
-        COMMAND rocminfo_test --gtest_filter=RocminfoTest.ReportsWavefrontSize
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-    set_tests_properties(
-        "RocminfoTest.ExitsSuccessfully"
-        "RocminfoTest.InterposerActive"
-        "RocminfoTest.HsaSystemAttributes"
-        "RocminfoTest.DetectsGpuAgent"
-        "RocminfoTest.ReportsGfx950"
-        "RocminfoTest.ReportsWavefrontSize"
-        PROPERTIES ENVIRONMENT "${RJ_KMD_PRELOAD_ENV}"
-    )
+        rj_add_test(
+            NAME "RocminfoTest.${_rocminfo_test}"
+            COMMAND
+                rocminfo_test
+                "--gtest_filter=RocminfoTest.${_rocminfo_test}"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            ENVIRONMENT ${RJ_KMD_PRELOAD_ENV}
+            INSTALL_COMMAND
+                "bin/rocminfo_test"
+                "--gtest_filter=RocminfoTest.${_rocminfo_test}"
+            ${_rocminfo_install_environment_arg}
+        )
+    endforeach()
     message(STATUS "rocminfo test enabled (found ${ROCMINFO_EXECUTABLE})")
 else()
     message(STATUS "rocminfo test disabled (rocminfo not found)")
@@ -266,25 +524,30 @@ if(HSA_RUNTIME64)
     target_link_libraries(hsa_init_test PRIVATE ${HSA_RUNTIME64} GTest::gtest)
     target_link_options(hsa_init_test PRIVATE -Wl,-rpath,${RJ_HSA_LIBRARY_DIR})
     add_dependencies(hsa_init_test rocjitsu_bin rocjitsu_kmd_shim)
-    add_test(
-        NAME "HsaTest.InitSucceeded"
-        COMMAND
-            ${RJ_CLI} --config ${RJ_CDNA4_KMD_CONFIG} --
-            $<TARGET_FILE:hsa_init_test> --gtest_filter=HsaTest.InitSucceeded
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-    add_test(
-        NAME "HsaTest.GpuAgentFound"
-        COMMAND
-            ${RJ_CLI} --config ${RJ_CDNA4_KMD_CONFIG} --
-            $<TARGET_FILE:hsa_init_test> --gtest_filter=HsaTest.GpuAgentFound
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    )
-    set_tests_properties(
-        "HsaTest.InitSucceeded"
-        "HsaTest.GpuAgentFound"
-        PROPERTIES SKIP_REGULAR_EXPRESSION "\\[  SKIPPED \\]"
-    )
+    if(RJ_INSTALL_TESTS)
+        rj_install_test_target(hsa_init_test)
+    endif()
+    foreach(_hsa_test IN ITEMS InitSucceeded GpuAgentFound)
+        rj_add_test(
+            NAME "HsaTest.${_hsa_test}"
+            COMMAND
+                ${RJ_CLI}
+                --config
+                ${RJ_CDNA4_KMD_CONFIG}
+                --
+                $<TARGET_FILE:hsa_init_test>
+                "--gtest_filter=HsaTest.${_hsa_test}"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            SKIP_REGULAR_EXPRESSION "\\[  SKIPPED \\]"
+            INSTALL_COMMAND
+                "\${RJ_INSTALLED_BINDIR}/rocjitsu"
+                "--config"
+                "\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA4_KMD_CONFIG_NAME}"
+                "--"
+                "bin/hsa_init_test"
+                "--gtest_filter=HsaTest.${_hsa_test}"
+        )
+    endforeach()
     message(STATUS "HSA init test enabled (found ${HSA_RUNTIME64})")
 
     # --- HSA translate test: CDNA4→RDNA4 on-device verification ---
@@ -358,6 +621,9 @@ if(HSA_RUNTIME64)
         )
         add_dependencies(hsa_translate_test device_kernels)
         rj_configure_target(hsa_translate_test TEST)
+        if(RJ_INSTALL_TESTS)
+            rj_install_test_target(hsa_translate_test)
+        endif()
 
         add_executable(hsa_hooks_test dbt/hsa_hooks_test.cpp)
         target_include_directories(
@@ -386,37 +652,51 @@ if(HSA_RUNTIME64)
         )
         add_dependencies(hsa_hooks_test device_kernels rocjitsu_hooks)
         rj_configure_target(hsa_hooks_test TEST)
+        if(RJ_INSTALL_TESTS)
+            rj_install_test_target(hsa_hooks_test)
+        endif()
 
         if(HAS_RDNA4_GPU)
-            add_test(
+            rj_add_test(
                 NAME "HsaTranslateTest.TranslateAndDispatchVectorAdd"
                 COMMAND hsa_translate_test --gtest_filter=*VectorAdd*
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                INSTALL_COMMAND
+                    "bin/hsa_translate_test"
+                    "--gtest_filter=*VectorAdd*"
             )
         endif()
 
         if(HAS_GFX1201_GPU)
-            add_test(
+            rj_add_test(
                 NAME "HsaHooksTest.TranslateGfx950Mfma16x16ThroughToolsLib"
                 COMMAND
                     hsa_hooks_test
                     --gtest_filter=HsaHooksTest.TranslateGfx950Mfma16x16ThroughToolsLib
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            )
-            set_tests_properties(
-                "HsaHooksTest.TranslateGfx950Mfma16x16ThroughToolsLib"
-                PROPERTIES
-                    TIMEOUT 60
-                    ENVIRONMENT
-                        "HSA_TOOLS_LIB=$<TARGET_FILE:rocjitsu_hooks>;RJ_DBT_TARGET_ISA=gfx1201;RJ_DBT_LOG=1"
+                TIMEOUT 60
+                ENVIRONMENT
+                    "HSA_TOOLS_LIB=$<TARGET_FILE:rocjitsu_hooks>"
+                    "RJ_DBT_TARGET_ISA=gfx1201"
+                    "RJ_DBT_LOG=1"
+                INSTALL_COMMAND
+                    "bin/hsa_hooks_test"
+                    "--gtest_filter=HsaHooksTest.TranslateGfx950Mfma16x16ThroughToolsLib"
+                INSTALL_ENVIRONMENT
+                    "HSA_TOOLS_LIB=\${RJ_INSTALLED_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}rocjitsu_hooks${CMAKE_SHARED_LIBRARY_SUFFIX}"
+                    "RJ_DBT_TARGET_ISA=gfx1201"
+                    "RJ_DBT_LOG=1"
             )
         endif()
 
         if(HAS_RDNA4_GPU)
-            add_test(
+            rj_add_test(
                 NAME "HsaTranslateTest.TranslateAndDispatchMfma16x16"
                 COMMAND hsa_translate_test --gtest_filter=*Mfma16x16*
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                INSTALL_COMMAND
+                    "bin/hsa_translate_test"
+                    "--gtest_filter=*Mfma16x16*"
             )
             message(STATUS "HSA translate test enabled (RDNA4 GPU detected)")
         else()
@@ -458,6 +738,9 @@ if(HSA_RUNTIME64)
         )
         add_dependencies(${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE} device_kernels)
         rj_configure_target(${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE} TEST)
+        if(RJ_INSTALL_TESTS)
+            rj_install_test_target(${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE})
+        endif()
 
         set(RJ_CDNA4_TO_CDNA3_TRANSLATE_TESTS
             DynamicCopyLoopTranslates
@@ -467,16 +750,16 @@ if(HSA_RUNTIME64)
             TritonFlashAttentionBufferAsyncTranslates
         )
         foreach(_test_name IN LISTS RJ_CDNA4_TO_CDNA3_TRANSLATE_TESTS)
-            add_test(
+            rj_add_test(
                 NAME "Cdna4ToCdna3DispatchTest.${_test_name}"
                 COMMAND
                     ${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}
                     --gtest_filter=Cdna4ToCdna3DispatchTest.${_test_name}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-            )
-            set_tests_properties(
-                "Cdna4ToCdna3DispatchTest.${_test_name}"
-                PROPERTIES TIMEOUT 120
+                TIMEOUT 120
+                INSTALL_COMMAND
+                    "bin/${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}"
+                    "--gtest_filter=Cdna4ToCdna3DispatchTest.${_test_name}"
             )
         endforeach()
 
@@ -490,16 +773,16 @@ if(HSA_RUNTIME64)
                 TritonFlashAttentionBufferAsyncDispatchAndRun
             )
             foreach(_test_name IN LISTS RJ_CDNA4_TO_CDNA3_DISPATCH_RUN_TESTS)
-                add_test(
+                rj_add_test(
                     NAME "Cdna4ToCdna3DispatchTest.${_test_name}"
                     COMMAND
                         ${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}
                         --gtest_filter=Cdna4ToCdna3DispatchTest.${_test_name}
                     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-                )
-                set_tests_properties(
-                    "Cdna4ToCdna3DispatchTest.${_test_name}"
-                    PROPERTIES TIMEOUT 120
+                    TIMEOUT 120
+                    INSTALL_COMMAND
+                        "bin/${RJ_CDNA4_TO_CDNA3_DISPATCH_TEST_EXE}"
+                        "--gtest_filter=Cdna4ToCdna3DispatchTest.${_test_name}"
                 )
             endforeach()
             message(
@@ -543,6 +826,9 @@ if(HSA_RUNTIME64)
         )
         add_dependencies(hsa_dbi_smoke_test device_kernels)
         rj_configure_target(hsa_dbi_smoke_test TEST)
+        if(RJ_INSTALL_TESTS)
+            rj_install_test_target(hsa_dbi_smoke_test)
+        endif()
 
         # Local helper: register one TEST_F case from hsa_dbi_smoke_test as a
         # CTest entry. <group> is the part of the fixture name after
@@ -552,17 +838,15 @@ if(HSA_RUNTIME64)
             set(oneValueArgs TIMEOUT)
             cmake_parse_arguments(RJ_DBI "" "${oneValueArgs}" "" ${ARGN})
             set(name "HsaDbiSmoke${group}.${case}")
-            add_test(
+            rj_add_test(
                 NAME "${name}"
                 COMMAND hsa_dbi_smoke_test --gtest_filter=${name}
                 WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                INSTALL_COMMAND
+                    "bin/hsa_dbi_smoke_test"
+                    "--gtest_filter=${name}"
+                ${ARGN}
             )
-            if(RJ_DBI_TIMEOUT)
-                set_tests_properties(
-                    "${name}"
-                    PROPERTIES TIMEOUT ${RJ_DBI_TIMEOUT}
-                )
-            endif()
         endfunction()
 
         # Static-only test: no GPU needed, runs anywhere the binary is built.
@@ -594,7 +878,21 @@ find_program(HIPCC_EXECUTABLE hipcc PATHS "${ROCM_PATH}" PATH_SUFFIXES bin)
 if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
     set(GTEST_INC ${googletest_SOURCE_DIR}/googletest/include)
     set(GTEST_LIB_DIR ${CMAKE_BINARY_DIR}/lib)
-    set(RJ_HIP_SANITIZER_FLAGS ${RJ_SANITIZER_COMPILE_OPTIONS})
+    set(RJ_HIP_SANITIZER_FLAGS)
+    foreach(_rj_sanitizer_flag IN LISTS RJ_SANITIZER_COMPILE_OPTIONS)
+        list(APPEND RJ_HIP_SANITIZER_FLAGS -Xarch_host ${_rj_sanitizer_flag})
+    endforeach()
+    set(RJ_HIP_SANITIZER_LINK_FLAGS)
+    foreach(_rj_sanitizer_flag IN LISTS RJ_SANITIZER_LINK_OPTIONS)
+        list(
+            APPEND RJ_HIP_SANITIZER_LINK_FLAGS
+            -Xarch_host
+            ${_rj_sanitizer_flag}
+        )
+    endforeach()
+    if(RJ_HIP_SANITIZER_FLAGS OR RJ_HIP_SANITIZER_LINK_FLAGS)
+        list(APPEND RJ_HIP_SANITIZER_FLAGS -Xarch_device -fno-sanitize=all)
+    endif()
 
     # Helper: build a HIP test binary with hipcc + gtest.
     function(rj_add_hip_test TEST_NAME)
@@ -608,21 +906,28 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
             set(HIP_TEST_SRC ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_NAME}.cpp)
         endif()
         set(HIP_TEST_BIN ${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME})
+        set(HIP_EXTRA_LIBS)
+        if(ARG_EXTRA_LIBS)
+            set(HIP_EXTRA_LIBS -x none ${ARG_EXTRA_LIBS})
+        endif()
         add_custom_command(
             OUTPUT ${HIP_TEST_BIN}
             COMMAND
-                ${HIPCC_EXECUTABLE} --offload-arch=${ARG_ARCH} -std=c++20
-                ${RJ_HIP_SANITIZER_FLAGS} -isystem ${GTEST_INC}
-                -I${CMAKE_CURRENT_SOURCE_DIR} -L${GTEST_LIB_DIR} -lgtest
-                -lpthread ${ARG_EXTRA_LIBS} -Wl,-rpath,${GTEST_LIB_DIR}
-                -Wl,-rpath,${RJ_HSA_LIBRARY_DIR} -o ${HIP_TEST_BIN}
-                ${HIP_TEST_SRC}
+                ${AMDCXX} -x hip --offload-arch=${ARG_ARCH}
+                --rocm-path=${ROCM_PATH} -std=c++20 ${RJ_HIP_SANITIZER_FLAGS}
+                -isystem ${GTEST_INC} -I${CMAKE_CURRENT_SOURCE_DIR} -o
+                ${HIP_TEST_BIN} ${HIP_TEST_SRC} ${HIP_EXTRA_LIBS}
+                -L${GTEST_LIB_DIR} -lgtest -lpthread -Wl,-rpath,${GTEST_LIB_DIR}
+                -Wl,-rpath,${RJ_HSA_LIBRARY_DIR} ${RJ_HIP_SANITIZER_LINK_FLAGS}
             DEPENDS ${HIP_TEST_SRC} GTest::gtest GTest::gtest_main
             COMMENT "Building ${TEST_NAME} with hipcc (${ARG_ARCH})"
             VERBATIM
         )
         add_custom_target(${TEST_NAME}_target ALL DEPENDS ${HIP_TEST_BIN})
         add_dependencies(${TEST_NAME}_target rocjitsu_bin rocjitsu_kmd_shim)
+        if(RJ_INSTALL_TESTS)
+            rj_install_test_program(${HIP_TEST_BIN})
+        endif()
     endfunction()
 
     # Helper: register a HIP test case run through the CLI launcher.
@@ -640,23 +945,65 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
         if(NOT ARG_NAME)
             set(ARG_NAME ${TEST_CASE})
         endif()
-        add_test(
-            NAME ${ARG_NAME}
+        get_filename_component(_install_config_name "${ARG_CONFIG}" NAME)
+        set(_install_env)
+        foreach(_env_entry IN LISTS ARG_ENVIRONMENT)
+            if(_env_entry MATCHES "^(ROCJITSU_RUNTIME_DIR|RJ_SINK_DIR)=(.*)$")
+                set(_env_name "${CMAKE_MATCH_1}")
+                set(_env_value "${CMAKE_MATCH_2}")
+                if(IS_ABSOLUTE "${_env_value}")
+                    file(
+                        RELATIVE_PATH
+                        _env_relpath
+                        "${CMAKE_CURRENT_BINARY_DIR}"
+                        "${_env_value}"
+                    )
+                    if(_env_relpath MATCHES "^\\.\\.")
+                        get_filename_component(
+                            _env_relpath
+                            "${_env_value}"
+                            NAME
+                        )
+                    endif()
+                    list(
+                        APPEND _install_env
+                        "${_env_name}=runtime/${_env_relpath}"
+                    )
+                else()
+                    list(APPEND _install_env "${_env_entry}")
+                endif()
+            else()
+                list(APPEND _install_env "${_env_entry}")
+            endif()
+        endforeach()
+        set(_test_args
+            NAME
+            ${ARG_NAME}
             COMMAND
-                ${RJ_CLI} --config ${ARG_CONFIG} --
-                ${CMAKE_CURRENT_BINARY_DIR}/${TEST_BIN}
-                --gtest_filter=${TEST_CASE}
+            ${RJ_CLI}
+            --config
+            ${ARG_CONFIG}
+            --
+            ${CMAKE_CURRENT_BINARY_DIR}/${TEST_BIN}
+            --gtest_filter=${TEST_CASE}
+            INSTALL_COMMAND
+            "\${RJ_INSTALLED_BINDIR}/rocjitsu"
+            "--config"
+            "\${RJ_INSTALLED_CONFIG_DIR}/${_install_config_name}"
+            "--"
+            "bin/${TEST_BIN}"
+            "--gtest_filter=${TEST_CASE}"
         )
+        if(RJ_INSTALL_TESTS AND _install_env)
+            list(APPEND _test_args INSTALL_ENVIRONMENT ${_install_env})
+        endif()
         if(ARG_ENVIRONMENT)
-            list(JOIN ARG_ENVIRONMENT ";" _ENV_STR)
-            set_tests_properties(
-                ${ARG_NAME}
-                PROPERTIES ENVIRONMENT "${_ENV_STR}"
-            )
+            list(APPEND _test_args ENVIRONMENT ${ARG_ENVIRONMENT})
         endif()
         if(ARG_TIMEOUT)
-            set_tests_properties(${ARG_NAME} PROPERTIES TIMEOUT ${ARG_TIMEOUT})
+            list(APPEND _test_args TIMEOUT ${ARG_TIMEOUT})
         endif()
+        rj_add_test(${_test_args})
     endfunction()
 
     rj_add_hip_test(hip_memcpy_test)
@@ -679,17 +1026,40 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
     # --- Daemon RPC tests (gtest-driven) ---
     # A gtest fixture manages the daemon lifecycle: fork+exec the daemon in
     # SetUp, run the HIP test binary as a subprocess, tear down in TearDown.
+    _rj_path_from_installed_test_bin(
+        _rj_installed_daemon_config
+        "${CMAKE_INSTALL_DATADIR}/rocjitsu/configs"
+        "${RJ_CDNA4_KMD_CONFIG_NAME}"
+    )
+    _rj_path_from_installed_test_bin(
+        _rj_installed_daemon_config_2gpu
+        "${CMAKE_INSTALL_DATADIR}/rocjitsu/configs"
+        "${RJ_CDNA4_KMD_2GPU_CONFIG_NAME}"
+    )
+    _rj_path_from_installed_test_bin(
+        _rj_installed_preload_lib
+        "${CMAKE_INSTALL_LIBDIR}"
+        "${CMAKE_SHARED_LIBRARY_PREFIX}rocjitsu_kmd${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    )
+
     add_executable(daemon_test daemon_test.cpp)
     target_compile_definitions(
         daemon_test
         PRIVATE
             RJ_DAEMON_BIN="$<TARGET_FILE:rocjitsu_bin>"
-            RJ_DAEMON_CONFIG="${CMAKE_SOURCE_DIR}/configs/gfx950_cdna4_kmd.json"
-            RJ_DAEMON_CONFIG_2GPU="${CMAKE_SOURCE_DIR}/configs/gfx950_cdna4_kmd_2gpu.json"
+            RJ_DAEMON_CONFIG="${RJ_CDNA4_KMD_CONFIG}"
+            RJ_DAEMON_CONFIG_2GPU="${RJ_CDNA4_KMD_2GPU_CONFIG}"
             RJ_PRELOAD_LIB="$<TARGET_FILE:rocjitsu_kmd_shim>"
             RJ_HIP_VECTOR_ADD_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_vector_add_test"
             RJ_HIP_MEMCPY_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_memcpy_test"
             RJ_HIP_RCCL_BIN="${CMAKE_CURRENT_BINARY_DIR}/hip_rccl_test"
+            RJ_INSTALLED_DAEMON_BIN="${_rj_installed_rocjitsu_bin}"
+            RJ_INSTALLED_DAEMON_CONFIG="${_rj_installed_daemon_config}"
+            RJ_INSTALLED_DAEMON_CONFIG_2GPU="${_rj_installed_daemon_config_2gpu}"
+            RJ_INSTALLED_PRELOAD_LIB="${_rj_installed_preload_lib}"
+            RJ_INSTALLED_HIP_VECTOR_ADD_BIN="hip_vector_add_test"
+            RJ_INSTALLED_HIP_MEMCPY_BIN="hip_memcpy_test"
+            RJ_INSTALLED_HIP_RCCL_BIN="hip_rccl_test"
     )
     target_link_libraries(daemon_test PRIVATE GTest::gtest_main)
     add_dependencies(
@@ -701,7 +1071,9 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
     if(RCCL_LIB)
         add_dependencies(daemon_test hip_rccl_test_target)
     endif()
-
+    if(RJ_INSTALL_TESTS)
+        rj_install_test_target(daemon_test)
+    endif()
     set(RJ_DAEMON_TESTS
         DaemonTest.HipVectorAdd
         DaemonTest.HipMemcpyRoundTripFloat
@@ -710,8 +1082,15 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
         DaemonTest.TwoIndependentClients
     )
     foreach(TC IN LISTS RJ_DAEMON_TESTS)
-        add_test(NAME ${TC} COMMAND daemon_test --gtest_filter=${TC})
-        set_tests_properties(${TC} PROPERTIES TIMEOUT 120 LABELS "daemon")
+        rj_add_test(
+            NAME ${TC}
+            COMMAND daemon_test --gtest_filter=${TC}
+            TIMEOUT 120
+            LABELS daemon
+            INSTALL_COMMAND
+                "bin/daemon_test"
+                "--gtest_filter=${TC}"
+        )
     endforeach()
 
     if(RCCL_LIB)
@@ -723,10 +1102,14 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
             RcclDaemonTest.SendRecv
         )
         foreach(TC IN LISTS RJ_RCCL_TESTS)
-            add_test(NAME ${TC} COMMAND daemon_test --gtest_filter=${TC})
-            set_tests_properties(
-                ${TC}
-                PROPERTIES TIMEOUT 180 LABELS "daemon;rccl"
+            rj_add_test(
+                NAME ${TC}
+                COMMAND daemon_test --gtest_filter=${TC}
+                TIMEOUT 180
+                LABELS daemon rccl
+                INSTALL_COMMAND
+                    "bin/daemon_test"
+                    "--gtest_filter=${TC}"
             )
         endforeach()
     endif()
@@ -755,12 +1138,16 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
                 BetaZero
                 Large_2048x2048
         )
-            rj_add_hip_test_case(hip_gemm_test "RocblasGemmTest.${TC}")
+            if(TC STREQUAL "Large_2048x2048")
+                rj_add_hip_test_case(
+                    hip_gemm_test
+                    "RocblasGemmTest.${TC}"
+                    TIMEOUT 300
+                )
+            else()
+                rj_add_hip_test_case(hip_gemm_test "RocblasGemmTest.${TC}")
+            endif()
         endforeach()
-        set_tests_properties(
-            RocblasGemmTest.Large_2048x2048
-            PROPERTIES TIMEOUT 300
-        )
         foreach(I RANGE 0 4)
             rj_add_hip_test_case(hip_gemm_test "RocblasGemmFuzz.Iter${I}")
         endforeach()
@@ -836,16 +1223,26 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
             ${RJ_HIP_SANITIZER_FLAGS} -I${CMAKE_SOURCE_DIR}/lib/util/include -o
             ${CVT_NARROW_BIN}
             ${CMAKE_CURRENT_SOURCE_DIR}/hip_cvt_narrow_test.cpp
+            ${RJ_HIP_SANITIZER_LINK_FLAGS}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hip_cvt_narrow_test.cpp
         COMMENT "Building hip_cvt_narrow_test with hipcc (gfx950)"
         VERBATIM
     )
     add_custom_target(hip_cvt_narrow_test_target ALL DEPENDS ${CVT_NARROW_BIN})
     add_dependencies(hip_cvt_narrow_test_target rocjitsu_bin rocjitsu_kmd_shim)
+    if(RJ_INSTALL_TESTS)
+        rj_install_test_program(${CVT_NARROW_BIN})
+    endif()
 
-    add_test(
+    rj_add_test(
         NAME "CvtNarrow.AllTests"
         COMMAND ${RJ_CLI} --config ${RJ_CDNA4_KMD_CONFIG} -- ${CVT_NARROW_BIN}
+        TIMEOUT 300
+        INSTALL_COMMAND
+            "\${RJ_INSTALLED_BINDIR}/rocjitsu"
+            "--config"
+            "\${RJ_INSTALLED_CONFIG_DIR}/${RJ_CDNA4_KMD_CONFIG_NAME}"
+            "--"
+            "bin/hip_cvt_narrow_test"
     )
-    set_tests_properties("CvtNarrow.AllTests" PROPERTIES TIMEOUT 300)
 endif()

--- a/emulation/rocjitsu/tests/daemon_test.cpp
+++ b/emulation/rocjitsu/tests/daemon_test.cpp
@@ -23,6 +23,7 @@
 #include <sys/stat.h>
 #include <sys/un.h>
 #include <sys/wait.h>
+#include <system_error>
 #include <thread>
 #include <unistd.h>
 #include <vector>
@@ -46,6 +47,80 @@ bool daemon_ready(const std::string &path) {
   return ok;
 }
 
+struct TestPaths {
+  std::string daemon_bin = RJ_DAEMON_BIN;
+  std::string daemon_config = RJ_DAEMON_CONFIG;
+  std::string daemon_config_2gpu = RJ_DAEMON_CONFIG_2GPU;
+  std::string preload_lib = RJ_PRELOAD_LIB;
+  std::string hip_vector_add_bin = RJ_HIP_VECTOR_ADD_BIN;
+  std::string hip_memcpy_bin = RJ_HIP_MEMCPY_BIN;
+  std::string hip_rccl_bin = RJ_HIP_RCCL_BIN;
+};
+
+std::filesystem::path resolve_relative_to_exe(const std::filesystem::path &exe_dir,
+                                              const char *path) {
+  std::filesystem::path candidate(path);
+  if (!candidate.is_absolute())
+    candidate = exe_dir / candidate;
+  return candidate.lexically_normal();
+}
+
+std::filesystem::path current_exe_dir() {
+  std::error_code ec;
+  std::filesystem::path exe = std::filesystem::read_symlink("/proc/self/exe", ec);
+  if (ec)
+    return {};
+  return exe.parent_path();
+}
+
+bool installed_paths_exist(const TestPaths &paths) {
+  return std::filesystem::exists(paths.daemon_bin) &&
+         std::filesystem::exists(paths.daemon_config) &&
+         std::filesystem::exists(paths.daemon_config_2gpu) &&
+         std::filesystem::exists(paths.preload_lib) &&
+         std::filesystem::exists(paths.hip_vector_add_bin) &&
+         std::filesystem::exists(paths.hip_memcpy_bin);
+}
+
+TestPaths installed_paths(const std::filesystem::path &exe_dir) {
+  return {
+      resolve_relative_to_exe(exe_dir, RJ_INSTALLED_DAEMON_BIN).string(),
+      resolve_relative_to_exe(exe_dir, RJ_INSTALLED_DAEMON_CONFIG).string(),
+      resolve_relative_to_exe(exe_dir, RJ_INSTALLED_DAEMON_CONFIG_2GPU).string(),
+      resolve_relative_to_exe(exe_dir, RJ_INSTALLED_PRELOAD_LIB).string(),
+      resolve_relative_to_exe(exe_dir, RJ_INSTALLED_HIP_VECTOR_ADD_BIN).string(),
+      resolve_relative_to_exe(exe_dir, RJ_INSTALLED_HIP_MEMCPY_BIN).string(),
+      resolve_relative_to_exe(exe_dir, RJ_INSTALLED_HIP_RCCL_BIN).string(),
+  };
+}
+
+TestPaths &test_paths() {
+  static TestPaths paths = [] {
+    std::filesystem::path exe_dir = current_exe_dir();
+    if (!exe_dir.empty()) {
+      TestPaths installed = installed_paths(exe_dir);
+      if (installed_paths_exist(installed))
+        return installed;
+    }
+    return TestPaths{};
+  }();
+  return paths;
+}
+
+const char *daemon_bin() { return test_paths().daemon_bin.c_str(); }
+
+const char *daemon_config() { return test_paths().daemon_config.c_str(); }
+
+const char *daemon_config_2gpu() { return test_paths().daemon_config_2gpu.c_str(); }
+
+const char *preload_lib() { return test_paths().preload_lib.c_str(); }
+
+const char *hip_vector_add_bin() { return test_paths().hip_vector_add_bin.c_str(); }
+
+const char *hip_memcpy_bin() { return test_paths().hip_memcpy_bin.c_str(); }
+
+const char *hip_rccl_bin() { return test_paths().hip_rccl_bin.c_str(); }
+
 class DaemonTest : public ::testing::Test {
 protected:
   void SetUp() override {
@@ -63,7 +138,7 @@ protected:
 
     if (daemon_pid_ == 0) {
       setenv("XDG_RUNTIME_DIR", tmp_dir_.c_str(), 1);
-      execl(RJ_DAEMON_BIN, RJ_DAEMON_BIN, "--daemon", "--config", RJ_DAEMON_CONFIG, nullptr);
+      execl(daemon_bin(), daemon_bin(), "--daemon", "--config", daemon_config(), nullptr);
       _exit(127);
     }
 
@@ -95,7 +170,7 @@ protected:
     std::string cmd = "XDG_RUNTIME_DIR=";
     cmd += tmp_dir_;
     cmd += " LD_PRELOAD=";
-    cmd += RJ_PRELOAD_LIB;
+    cmd += preload_lib();
     cmd += " HSA_ENABLE_SDMA=1 ";
     cmd += binary;
     if (gtest_filter && gtest_filter[0]) {
@@ -123,11 +198,11 @@ protected:
     std::string cmd = "XDG_RUNTIME_DIR=";
     cmd += tmp_dir_;
     cmd += " ";
-    cmd += RJ_DAEMON_BIN;
+    cmd += daemon_bin();
     cmd += " --attach --config ";
-    cmd += RJ_DAEMON_CONFIG;
+    cmd += daemon_config();
     cmd += " -- ";
-    cmd += RJ_HIP_RCCL_BIN;
+    cmd += hip_rccl_bin();
     cmd += " --rank=";
     cmd += std::to_string(rank);
     cmd += " --world-size=";
@@ -182,24 +257,24 @@ protected:
 // --- hip_vector_add_test ---
 
 TEST_F(DaemonTest, HipVectorAdd) {
-  auto r = run_hip_test(RJ_HIP_VECTOR_ADD_BIN, "HipVectorAddTest.CorrectResult");
+  auto r = run_hip_test(hip_vector_add_bin(), "HipVectorAddTest.CorrectResult");
   EXPECT_EQ(r.exit_code, 0) << r.output;
 }
 
 // --- hip_memcpy_test ---
 
 TEST_F(DaemonTest, HipMemcpyRoundTripFloat) {
-  auto r = run_hip_test(RJ_HIP_MEMCPY_BIN, "HipMemcpyTest.RoundTripFloat");
+  auto r = run_hip_test(hip_memcpy_bin(), "HipMemcpyTest.RoundTripFloat");
   EXPECT_EQ(r.exit_code, 0) << r.output;
 }
 
 TEST_F(DaemonTest, HipMemcpyRoundTripInt) {
-  auto r = run_hip_test(RJ_HIP_MEMCPY_BIN, "HipMemcpyTest.RoundTripInt");
+  auto r = run_hip_test(hip_memcpy_bin(), "HipMemcpyTest.RoundTripInt");
   EXPECT_EQ(r.exit_code, 0) << r.output;
 }
 
 TEST_F(DaemonTest, HipMemcpyDeviceToDevice) {
-  auto r = run_hip_test(RJ_HIP_MEMCPY_BIN, "HipMemcpyTest.DeviceToDevice");
+  auto r = run_hip_test(hip_memcpy_bin(), "HipMemcpyTest.DeviceToDevice");
   EXPECT_EQ(r.exit_code, 0) << r.output;
 }
 
@@ -210,8 +285,8 @@ TEST_F(DaemonTest, TwoIndependentClients) {
   ProcessResult r1, r2;
 
   t1 = std::thread(
-      [&] { r1 = run_hip_test(RJ_HIP_VECTOR_ADD_BIN, "HipVectorAddTest.CorrectResult"); });
-  t2 = std::thread([&] { r2 = run_hip_test(RJ_HIP_MEMCPY_BIN, "HipMemcpyTest.RoundTripFloat"); });
+      [&] { r1 = run_hip_test(hip_vector_add_bin(), "HipVectorAddTest.CorrectResult"); });
+  t2 = std::thread([&] { r2 = run_hip_test(hip_memcpy_bin(), "HipMemcpyTest.RoundTripFloat"); });
 
   t1.join();
   t2.join();
@@ -237,7 +312,7 @@ protected:
 
     if (daemon_pid_ == 0) {
       setenv("XDG_RUNTIME_DIR", tmp_dir_.c_str(), 1);
-      execl(RJ_DAEMON_BIN, RJ_DAEMON_BIN, "--daemon", "--config", RJ_DAEMON_CONFIG_2GPU, nullptr);
+      execl(daemon_bin(), daemon_bin(), "--daemon", "--config", daemon_config_2gpu(), nullptr);
       _exit(127);
     }
 
@@ -275,11 +350,11 @@ protected:
     cmd += " NCCL_P2P_DISABLE=1 NCCL_SHM_DISABLE=1 HSA_NO_SCRATCH_RECLAIM=1"
            " NCCL_SOCKET_NTHREADS=1 NCCL_NSOCKS_PERTHREAD=1"
            " NCCL_SOCKET_IFNAME=lo ";
-    cmd += RJ_DAEMON_BIN;
+    cmd += daemon_bin();
     cmd += " --attach --config ";
-    cmd += RJ_DAEMON_CONFIG_2GPU;
+    cmd += daemon_config_2gpu();
     cmd += " -- ";
-    cmd += RJ_HIP_RCCL_BIN;
+    cmd += hip_rccl_bin();
     cmd += " --rank=";
     cmd += std::to_string(rank);
     cmd += " --world-size=";

--- a/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
+++ b/emulation/rocjitsu/tests/dbi/hsa_dbi_smoke_test.cpp
@@ -13,6 +13,7 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include <hsa/hsa_ext_amd.h>
 RJ_DIAGNOSTIC_POP
 
+#include "../test_paths.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/basic_block.h"
 #include "rocjitsu/code/executable.h"
@@ -39,7 +40,7 @@ using namespace rocjitsu;
 
 namespace {
 
-std::string kernel_path(const char *name) { return std::string(KERNEL_DIR) + "/" + name + ".o"; }
+using test::kernel_path;
 
 // Find a GPU agent whose ISA name contains "gfx90a". Returns {handle=0} if
 // no such agent is present.

--- a/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/cdna4_to_cdna3_dispatch_test.cpp
@@ -11,6 +11,7 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include <hsa/hsa_ext_amd.h>
 RJ_DIAGNOSTIC_POP
 
+#include "../test_paths.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/dbt/binary_translator.h"
 #include "rocjitsu/code/executable.h"
@@ -34,10 +35,8 @@ using namespace rocjitsu;
 
 namespace {
 
-std::string kernel_path(const char *name) { return std::string(KERNEL_DIR) + "/" + name + ".o"; }
-std::string kernel_hsaco_path(const char *name) {
-  return std::string(KERNEL_DIR) + "/" + name + ".hsaco";
-}
+using test::kernel_hsaco_path;
+using test::kernel_path;
 
 std::vector<uint8_t> load_kernel_hsaco_bytes(const char *name) {
   std::ifstream file(kernel_hsaco_path(name), std::ios::binary);

--- a/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
+++ b/emulation/rocjitsu/tests/dbt/device_kernels_translate_tests.cpp
@@ -8,6 +8,7 @@
 #error "device_kernels_translate_tests.cpp requires HAS_DEVICE_KERNELS"
 #endif
 
+#include "../test_paths.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/dbt/binary_translator.h"
@@ -40,7 +41,7 @@ RJ_DIAGNOSTIC_POP
 
 namespace {
 
-std::string kernel_path(const char *name) { return std::string(KERNEL_DIR) + "/" + name + ".o"; }
+using rocjitsu::test::kernel_path;
 
 const rocjitsu::Section *find_section(const rocjitsu::CodeObject &co, std::string_view name) {
   for (const auto &section : co.all_sections()) {

--- a/emulation/rocjitsu/tests/dbt/hsa_hooks_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_hooks_test.cpp
@@ -20,6 +20,7 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include <hsa/hsa_ext_amd.h>
 RJ_DIAGNOSTIC_POP
 
+#include "../test_paths.h"
 #include "rocjitsu/code/executable.h"
 #include "rocjitsu/code/rj_code.h"
 
@@ -39,7 +40,7 @@ using namespace rocjitsu;
 
 namespace {
 
-std::string kernel_path(const char *name) { return std::string(KERNEL_DIR) + "/" + name + ".o"; }
+using test::kernel_path;
 
 struct GpuTarget {
   hsa_agent_t agent{};

--- a/emulation/rocjitsu/tests/dbt/hsa_translate_test.cpp
+++ b/emulation/rocjitsu/tests/dbt/hsa_translate_test.cpp
@@ -12,6 +12,7 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include <hsa/hsa_ext_amd.h>
 RJ_DIAGNOSTIC_POP
 
+#include "../test_paths.h"
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/dbt/binary_translator.h"
@@ -31,7 +32,7 @@ using namespace rocjitsu;
 
 namespace {
 
-std::string kernel_path(const char *name) { return std::string(KERNEL_DIR) + "/" + name + ".o"; }
+using test::kernel_path;
 
 hsa_agent_t find_gpu_agent() {
   hsa_agent_t gpu{};

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -96,6 +96,30 @@ rj_add_triton_asm_fixture(triton_cdna3_flash_attention_buffer_async_1024 gfx942)
 # single-bundle assumption — see executable.cpp::load_hip_fatbin.)
 rj_add_device_kernel(vector_add gfx90a OUTPUT_NAME vector_add_gfx90a)
 
+if(RJ_INSTALL_TESTS)
+    set(RJ_DEVICE_KERNEL_FIXTURES
+        ${KERNEL_OUTPUT_DIR}/matmul_naive.o
+        ${KERNEL_OUTPUT_DIR}/matmul_mfma.o
+        ${KERNEL_OUTPUT_DIR}/matmul_mfma_16x16.o
+        ${KERNEL_OUTPUT_DIR}/matmul_tiled.o
+        ${KERNEL_OUTPUT_DIR}/vector_add.o
+        ${KERNEL_OUTPUT_DIR}/vector_add_gfx90a.o
+        ${KERNEL_OUTPUT_DIR}/dynamic_copy_loop.o
+        ${KERNEL_OUTPUT_DIR}/triton_cdna4_matmul_dynamic_32x32x64.hsaco
+        ${KERNEL_OUTPUT_DIR}/triton_cdna4_matmul_buffer_async_1024.hsaco
+        ${KERNEL_OUTPUT_DIR}/triton_cdna4_flash_attention_no_async_1024.hsaco
+        ${KERNEL_OUTPUT_DIR}/triton_cdna4_flash_attention_buffer_async_1024.hsaco
+        ${KERNEL_OUTPUT_DIR}/triton_cdna3_matmul_dynamic_32x32x64.hsaco
+        ${KERNEL_OUTPUT_DIR}/triton_cdna3_matmul_buffer_async_1024.hsaco
+        ${KERNEL_OUTPUT_DIR}/triton_cdna3_flash_attention_no_async_1024.hsaco
+        ${KERNEL_OUTPUT_DIR}/triton_cdna3_flash_attention_buffer_async_1024.hsaco
+    )
+    install(
+        FILES ${RJ_DEVICE_KERNEL_FIXTURES}
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/rocjitsu/tests/kernels
+    )
+endif()
+
 # Umbrella target for all device kernels.
 add_custom_target(
     device_kernels

--- a/emulation/rocjitsu/tests/matmul_test.cpp
+++ b/emulation/rocjitsu/tests/matmul_test.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "aql_queue.h"
+#include "test_paths.h"
 
 #include "embedded_schema.h"
 #include "rocjitsu/code/executable.h"
@@ -38,10 +39,9 @@ RJ_DIAGNOSTIC_POP
 namespace {
 
 using namespace rocjitsu;
+using test::kernel_path;
 
-const std::string CONFIG_PATH = std::string(CONFIG_DIR) + "/gfx950_cdna4.json";
-
-std::string kernel_path(const char *name) { return std::string(KERNEL_DIR) + "/" + name + ".o"; }
+const std::string CONFIG_PATH = test::config_path("gfx950_cdna4.json");
 
 constexpr uint32_t TOTAL_XCDS = 8;
 constexpr uint32_t CUS_PER_XCD = 32; // 4 SEs × 8 CUs

--- a/emulation/rocjitsu/tests/race-detector/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/race-detector/CMakeLists.txt
@@ -10,6 +10,12 @@
 # cross-workgroup synchronization checking.
 rj_add_hip_test(hip_race_tests SOURCE hip_race_tests.hip)
 set(RJ_RACE_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/race_test_config.json)
+if(RJ_INSTALL_TESTS)
+    install(
+        FILES ${RJ_RACE_CONFIG}
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/rocjitsu/configs
+    )
+endif()
 
 function(rj_add_race_test_case TEST_CASE)
     set(SINK_DIR ${CMAKE_CURRENT_BINARY_DIR}/racetest_${TEST_CASE})

--- a/emulation/rocjitsu/tests/rocminfo_test.cpp
+++ b/emulation/rocjitsu/tests/rocminfo_test.cpp
@@ -10,7 +10,9 @@
 #include <array>
 #include <cstdio>
 #include <cstdlib>
+#include <filesystem>
 #include <string>
+#include <system_error>
 
 namespace {
 
@@ -18,6 +20,51 @@ struct ProcessResult {
   std::string output;
   int exit_code;
 };
+
+struct TestPaths {
+  std::string rocjitsu_bin = ROCJITSU_BIN;
+  std::string config_path = RJ_CONFIG_PATH;
+};
+
+std::filesystem::path resolve_relative_to_exe(const std::filesystem::path &exe_dir,
+                                              const char *path) {
+  std::filesystem::path candidate(path);
+  if (!candidate.is_absolute())
+    candidate = exe_dir / candidate;
+  return candidate.lexically_normal();
+}
+
+std::filesystem::path current_exe_dir() {
+  std::error_code ec;
+  std::filesystem::path exe = std::filesystem::read_symlink("/proc/self/exe", ec);
+  if (ec)
+    return {};
+  return exe.parent_path();
+}
+
+bool installed_paths_exist(const TestPaths &paths) {
+  return std::filesystem::exists(paths.rocjitsu_bin) && std::filesystem::exists(paths.config_path);
+}
+
+TestPaths installed_paths(const std::filesystem::path &exe_dir) {
+  return {
+      resolve_relative_to_exe(exe_dir, RJ_INSTALLED_ROCJITSU_BIN).string(),
+      resolve_relative_to_exe(exe_dir, RJ_INSTALLED_CONFIG_PATH).string(),
+  };
+}
+
+const TestPaths &test_paths() {
+  static TestPaths paths = [] {
+    std::filesystem::path exe_dir = current_exe_dir();
+    if (!exe_dir.empty()) {
+      TestPaths installed = installed_paths(exe_dir);
+      if (installed_paths_exist(installed))
+        return installed;
+    }
+    return TestPaths{};
+  }();
+  return paths;
+}
 
 ProcessResult run_command(const std::string &cmd) {
   ProcessResult result;
@@ -39,8 +86,11 @@ ProcessResult run_command(const std::string &cmd) {
 }
 
 const ProcessResult &rocminfo_output() {
-  static const ProcessResult result = run_command(std::string(ROCJITSU_BIN) + " --config " +
-                                                  RJ_CONFIG_PATH + " -- " + ROCMINFO_PATH);
+  const TestPaths &paths = test_paths();
+  const char *rocminfo_path = std::getenv("ROCMINFO_PATH");
+  static const ProcessResult result =
+      run_command(paths.rocjitsu_bin + " --config " + paths.config_path + " -- " +
+                  (rocminfo_path ? rocminfo_path : ROCMINFO_PATH));
   return result;
 }
 

--- a/emulation/rocjitsu/tests/scaling_test.cpp
+++ b/emulation/rocjitsu/tests/scaling_test.cpp
@@ -5,6 +5,7 @@
 // and matmul_mfma across 1..8 threads (one per XCD). Outputs CSV to stdout.
 
 #include "aql_queue.h"
+#include "test_paths.h"
 
 #include "embedded_schema.h"
 #include "rocjitsu/code/executable.h"
@@ -35,10 +36,8 @@ RJ_DIAGNOSTIC_POP
 
 using namespace rocjitsu;
 
-static const std::string CONFIG_PATH = std::string(CONFIG_DIR) + "/gfx950_cdna4.json";
-static std::string kernel_path(const char *name) {
-  return std::string(KERNEL_DIR) + "/" + name + ".o";
-}
+static const std::string CONFIG_PATH = test::config_path("gfx950_cdna4.json");
+using test::kernel_path;
 
 static constexpr uint32_t TOTAL_XCDS = 8;
 static constexpr uint32_t CUS_PER_XCD = 32;

--- a/emulation/rocjitsu/tests/test_paths.h
+++ b/emulation/rocjitsu/tests/test_paths.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdlib>
+#include <string>
+
+namespace rocjitsu::test {
+
+inline std::string config_path(const char *name) {
+  if (const char *dir = std::getenv("ROCJITSU_CONFIG_DIR"))
+    return std::string(dir) + "/" + name;
+#ifdef CONFIG_DIR
+  return std::string(CONFIG_DIR) + "/" + name;
+#else
+  return name;
+#endif
+}
+
+inline std::string kernel_path(const char *name) {
+  if (const char *dir = std::getenv("ROCJITSU_KERNEL_DIR"))
+    return std::string(dir) + "/" + name + ".o";
+#ifdef KERNEL_DIR
+  return std::string(KERNEL_DIR) + "/" + name + ".o";
+#else
+  return std::string(name) + ".o";
+#endif
+}
+
+inline std::string kernel_hsaco_path(const char *name) {
+  if (const char *dir = std::getenv("ROCJITSU_KERNEL_DIR"))
+    return std::string(dir) + "/" + name + ".hsaco";
+#ifdef KERNEL_DIR
+  return std::string(KERNEL_DIR) + "/" + name + ".hsaco";
+#else
+  return std::string(name) + ".hsaco";
+#endif
+}
+
+} // namespace rocjitsu::test

--- a/emulation/rocjitsu/tests/vector_add_test.cpp
+++ b/emulation/rocjitsu/tests/vector_add_test.cpp
@@ -9,6 +9,7 @@
 /// CPU golden reference.
 
 #include "aql_queue.h"
+#include "test_paths.h"
 
 #include "embedded_schema.h"
 #include "rocjitsu/code/executable.h"
@@ -44,9 +45,8 @@ namespace {
 
 using namespace rocjitsu;
 
-const std::string CONFIG_PATH = std::string(CONFIG_DIR) + "/gfx950_cdna4.json";
-
-std::string kernel_path(const char *name) { return std::string(KERNEL_DIR) + "/" + name + ".o"; }
+const std::string CONFIG_PATH = test::config_path("gfx950_cdna4.json");
+using test::kernel_path;
 
 constexpr uint32_t TOTAL_XCDS = 8;
 constexpr uint32_t CUS_PER_XCD = 32; // 4 SEs x 8 CUs


### PR DESCRIPTION
## Motivation

Adds the possibility to install tests as a build artifact. This is necessary to separate rocjitsu's testing from TheRock's build and test phases.

## Technical Details

We have a CMake function rj_add_test that is used instead of add_test to register tests. When RJ_INSTALL_TESTS=OFF, it is just add_test. When RJ_INSTALL_TESTS=ON, these tests are also installed under /share/rocjitsu/tests and binaries under /share/rocjitsu/tests/bin. Some tests are updated to take into account this.

## JIRA ID

#7891

## Test Plan

Locally built with RJ_INSTALL_TESTS=OFF and RJ_INSTALL_TESTS=ON, making sure to preserve the original behaviour and installing in a new directory

## Test Result

Test build artifacts are installed.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
