### PR TITLE
fix(CUID) : AILITOOLS-239 Corrected temp cuid errors

### DIFF
--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -475,7 +475,7 @@ amdcuid_status_t amdcuid_refresh() {
 amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
                                                amdcuid_query_t query,
                                                void *data, uint32_t *length) {
-  if (!length || data == nullptr) {
+  if (!length) {
     return AMDCUID_STATUS_INVALID_ARGUMENT;
   }
   auto device = mgr.lookup_by_handle(handle);
@@ -493,7 +493,9 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     }
     amdcuid_primary_id id = {};
     status = device->get_primary_cuid(id);
-    *(amdcuid_id_t *)data = id.UUIDv8_representation;
+    if (data != nullptr) {
+      std::memcpy(data, &id.UUIDv8_representation, sizeof(amdcuid_id_t));
+    }
     *length = sizeof(amdcuid_id_t);
   } break;
   case AMDCUID_QUERY_DERIVED_CUID: {
@@ -508,7 +510,9 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
       // if not elevated, only get existing derived cuid
       status = device->get_derived_cuid(sec_id);
     }
-    *(amdcuid_id_t *)data = sec_id.UUIDv8_representation;
+    if (data != nullptr) {
+      std::memcpy(data, &sec_id.UUIDv8_representation, sizeof(amdcuid_id_t));
+    }
     *length = sizeof(amdcuid_id_t);
   } break;
   case AMDCUID_QUERY_HARDWARE_FINGERPRINT: {
@@ -518,7 +522,10 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     if (*length < sizeof(uint64_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    status = device->get_hardware_fingerprint(*(uint64_t *)data);
+    if (data != nullptr) {
+      std::memset(data, 0, sizeof(uint64_t));
+      status = device->get_hardware_fingerprint(*(uint64_t *)data);
+    }
     *length = sizeof(uint64_t);
   } break;
   case AMDCUID_QUERY_DEVICE_PATH: {
@@ -533,14 +540,19 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
       *length = required_length;
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    std::memcpy(data, path.c_str(), required_length);
+    if (data != nullptr) {
+      std::memcpy(data, path.c_str(), required_length);
+    }
     *length = required_length;
   } break;
   case AMDCUID_QUERY_DEVICE_TYPE: {
     if (*length < sizeof(amdcuid_device_type_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    *(amdcuid_device_type_t *)data = device->type();
+    if (data != nullptr) {
+      amdcuid_device_type_t device_type = device->type();
+      std::memcpy(data, &device_type, sizeof(amdcuid_device_type_t));
+    }
     *length = sizeof(amdcuid_device_type_t);
     status = AMDCUID_STATUS_SUCCESS;
   } break;
@@ -548,28 +560,40 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    status = device->get_vendor_id(*(uint16_t *)data);
+    if (data != nullptr) {
+      uint16_t vendor_id = 0;
+      std::memcpy(data, &vendor_id, sizeof(uint16_t));
+    }
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_DEVICE_ID: {
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    status = device->get_device_id(*(uint16_t *)data);
+    if (data != nullptr) {
+      uint16_t device_id = 0;
+      std::memcpy(data, &device_id, sizeof(uint16_t));
+    }
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_REVISION_ID: {
     if (*length < sizeof(uint8_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    status = device->get_revision_id(*(uint8_t *)data);
+    if (data != nullptr) {
+      uint8_t revision_id = 0;
+      std::memcpy(data, &revision_id, sizeof(uint8_t));
+    }
     *length = sizeof(uint8_t);
   } break;
   case AMDCUID_QUERY_UNIT_ID: {
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    status = device->get_unit_id(*(uint16_t *)data);
+    if (data != nullptr) {
+      uint16_t unit_id = 0;
+      std::memcpy(data, &unit_id, sizeof(uint16_t));
+    }
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_FAMILY: {
@@ -577,7 +601,10 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    status = device->get_family(*(uint16_t *)data);
+    if (data != nullptr) {
+      uint16_t family = 0;
+      std::memcpy(data, &family, sizeof(uint16_t));
+    }
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_MODEL: {
@@ -585,7 +612,10 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    status = device->get_model(*(uint16_t *)data);
+    if (data != nullptr) {
+      uint16_t model = 0;
+      std::memcpy(data, &model, sizeof(uint16_t));
+    }
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_CORE_ID: {
@@ -593,7 +623,10 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    status = device->get_core(*(uint16_t *)data);
+    if (data != nullptr) {
+      uint16_t core = 0;
+      std::memcpy(data, &core, sizeof(uint16_t));
+    }
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_PHYSICAL_ID: {
@@ -601,7 +634,10 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    status = device->get_physical_id(*(uint16_t *)data);
+    if (data != nullptr) {
+      uint16_t physical_id = 0;
+      std::memcpy(data, &physical_id, sizeof(uint16_t));
+    }
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_PCI_CLASS: {
@@ -609,7 +645,10 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    status = device->get_pci_class(*(uint16_t *)data);
+    if (data != nullptr) {
+      uint16_t pci_class = 0;
+      std::memcpy(data, &pci_class, sizeof(uint16_t));
+    }
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_BDF: {
@@ -625,16 +664,20 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
       *length = required_length;
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    std::memcpy(data, bdf.c_str(), required_length);
+    if (data != nullptr) {
+      std::memcpy(data, bdf.c_str(), required_length);
+    }
     *length = required_length;
   } break;
   case AMDCUID_QUERY_TEMPORARY_CUID: {
     if (*length < sizeof(bool)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    bool is_temporary = false;
-    status = device->is_temporary_cuid(&is_temporary);
-    *(bool *)data = is_temporary;
+    if (data != nullptr) {
+      bool is_temporary = false;
+      status = device->is_temporary_cuid(&is_temporary);
+      *(bool *)data = is_temporary;
+    }
     *length = sizeof(bool);
   } break;
   default:

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -562,6 +562,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     }
     if (data != nullptr) {
       uint16_t vendor_id = 0;
+      status = device->get_vendor_id(vendor_id);
       std::memcpy(data, &vendor_id, sizeof(uint16_t));
     }
     *length = sizeof(uint16_t);
@@ -572,6 +573,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     }
     if (data != nullptr) {
       uint16_t device_id = 0;
+      status = device->get_device_id(device_id);
       std::memcpy(data, &device_id, sizeof(uint16_t));
     }
     *length = sizeof(uint16_t);
@@ -582,6 +584,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     }
     if (data != nullptr) {
       uint8_t revision_id = 0;
+      status = device->get_revision_id(revision_id);
       std::memcpy(data, &revision_id, sizeof(uint8_t));
     }
     *length = sizeof(uint8_t);
@@ -592,6 +595,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     }
     if (data != nullptr) {
       uint16_t unit_id = 0;
+      status = device->get_unit_id(unit_id);
       std::memcpy(data, &unit_id, sizeof(uint16_t));
     }
     *length = sizeof(uint16_t);
@@ -603,6 +607,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     }
     if (data != nullptr) {
       uint16_t family = 0;
+      status = device->get_family(family);
       std::memcpy(data, &family, sizeof(uint16_t));
     }
     *length = sizeof(uint16_t);
@@ -614,6 +619,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     }
     if (data != nullptr) {
       uint16_t model = 0;
+      status = device->get_model(model);
       std::memcpy(data, &model, sizeof(uint16_t));
     }
     *length = sizeof(uint16_t);
@@ -625,6 +631,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     }
     if (data != nullptr) {
       uint16_t core = 0;
+      status = device->get_core(core);
       std::memcpy(data, &core, sizeof(uint16_t));
     }
     *length = sizeof(uint16_t);
@@ -636,6 +643,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     }
     if (data != nullptr) {
       uint16_t physical_id = 0;
+      status = device->get_physical_id(physical_id);
       std::memcpy(data, &physical_id, sizeof(uint16_t));
     }
     *length = sizeof(uint16_t);
@@ -647,6 +655,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     }
     if (data != nullptr) {
       uint16_t pci_class = 0;
+      status = device->get_pci_class(pci_class);
       std::memcpy(data, &pci_class, sizeof(uint16_t));
     }
     *length = sizeof(uint16_t);
@@ -684,11 +693,8 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     status = AMDCUID_STATUS_INVALID_ARGUMENT;
     break;
   }
-  if (status != AMDCUID_STATUS_SUCCESS) {
-    return status;
-  }
 
-  return AMDCUID_STATUS_SUCCESS;
+  return status;
 }
 
 amdcuid_status_t amdcuid_set_hash_key(const uint8_t key[32]) {

--- a/projects/cuid/lib/src/cuid.cc
+++ b/projects/cuid/lib/src/cuid.cc
@@ -475,6 +475,9 @@ amdcuid_status_t amdcuid_refresh() {
 amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
                                                amdcuid_query_t query,
                                                void *data, uint32_t *length) {
+  if (!length || data == nullptr) {
+    return AMDCUID_STATUS_INVALID_ARGUMENT;
+  }
   auto device = mgr.lookup_by_handle(handle);
   if (!device) {
     return AMDCUID_STATUS_DEVICE_NOT_FOUND;
@@ -490,8 +493,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     }
     amdcuid_primary_id id = {};
     status = device->get_primary_cuid(id);
-    if (data != nullptr)
-      *(amdcuid_id_t *)data = id.UUIDv8_representation;
+    *(amdcuid_id_t *)data = id.UUIDv8_representation;
     *length = sizeof(amdcuid_id_t);
   } break;
   case AMDCUID_QUERY_DERIVED_CUID: {
@@ -506,8 +508,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
       // if not elevated, only get existing derived cuid
       status = device->get_derived_cuid(sec_id);
     }
-    if (data != nullptr)
-      *(amdcuid_id_t *)data = sec_id.UUIDv8_representation;
+    *(amdcuid_id_t *)data = sec_id.UUIDv8_representation;
     *length = sizeof(amdcuid_id_t);
   } break;
   case AMDCUID_QUERY_HARDWARE_FINGERPRINT: {
@@ -517,12 +518,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     if (*length < sizeof(uint64_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    if (data != nullptr) {
-      status = device->get_hardware_fingerprint(*(uint64_t *)data);
-    } else {
-      uint64_t dummy;
-      status = device->get_hardware_fingerprint(dummy);
-    }
+    status = device->get_hardware_fingerprint(*(uint64_t *)data);
     *length = sizeof(uint64_t);
   } break;
   case AMDCUID_QUERY_DEVICE_PATH: {
@@ -537,16 +533,14 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
       *length = required_length;
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    if (data != nullptr)
-      std::memcpy(data, path.c_str(), required_length);
+    std::memcpy(data, path.c_str(), required_length);
     *length = required_length;
   } break;
   case AMDCUID_QUERY_DEVICE_TYPE: {
     if (*length < sizeof(amdcuid_device_type_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    if (data != nullptr)
-      *(amdcuid_device_type_t *)data = device->type();
+    *(amdcuid_device_type_t *)data = device->type();
     *length = sizeof(amdcuid_device_type_t);
     status = AMDCUID_STATUS_SUCCESS;
   } break;
@@ -554,48 +548,28 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    if (data != nullptr) {
-      status = device->get_vendor_id(*(uint16_t *)data);
-    } else {
-      uint16_t dummy;
-      status = device->get_vendor_id(dummy);
-    }
+    status = device->get_vendor_id(*(uint16_t *)data);
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_DEVICE_ID: {
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    if (data != nullptr) {
-      status = device->get_device_id(*(uint16_t *)data);
-    } else {
-      uint16_t dummy;
-      status = device->get_device_id(dummy);
-    }
+    status = device->get_device_id(*(uint16_t *)data);
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_REVISION_ID: {
     if (*length < sizeof(uint8_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    if (data != nullptr) {
-      status = device->get_revision_id(*(uint8_t *)data);
-    } else {
-      uint8_t dummy;
-      status = device->get_revision_id(dummy);
-    }
+    status = device->get_revision_id(*(uint8_t *)data);
     *length = sizeof(uint8_t);
   } break;
   case AMDCUID_QUERY_UNIT_ID: {
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    if (data != nullptr) {
-      status = device->get_unit_id(*(uint16_t *)data);
-    } else {
-      uint16_t dummy;
-      status = device->get_unit_id(dummy);
-    }
+    status = device->get_unit_id(*(uint16_t *)data);
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_FAMILY: {
@@ -603,12 +577,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    if (data != nullptr) {
-      status = device->get_family(*(uint16_t *)data);
-    } else {
-      uint16_t dummy;
-      status = device->get_family(dummy);
-    }
+    status = device->get_family(*(uint16_t *)data);
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_MODEL: {
@@ -616,12 +585,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    if (data != nullptr) {
-      status = device->get_model(*(uint16_t *)data);
-    } else {
-      uint16_t dummy;
-      status = device->get_model(dummy);
-    }
+    status = device->get_model(*(uint16_t *)data);
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_CORE_ID: {
@@ -629,12 +593,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    if (data != nullptr) {
-      status = device->get_core(*(uint16_t *)data);
-    } else {
-      uint16_t dummy;
-      status = device->get_core(dummy);
-    }
+    status = device->get_core(*(uint16_t *)data);
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_PHYSICAL_ID: {
@@ -642,12 +601,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    if (data != nullptr) {
-      status = device->get_physical_id(*(uint16_t *)data);
-    } else {
-      uint16_t dummy;
-      status = device->get_physical_id(dummy);
-    }
+    status = device->get_physical_id(*(uint16_t *)data);
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_PCI_CLASS: {
@@ -655,12 +609,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     if (*length < sizeof(uint16_t)) {
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    if (data != nullptr) {
-      status = device->get_pci_class(*(uint16_t *)data);
-    } else {
-      uint16_t dummy;
-      status = device->get_pci_class(dummy);
-    }
+    status = device->get_pci_class(*(uint16_t *)data);
     *length = sizeof(uint16_t);
   } break;
   case AMDCUID_QUERY_BDF: {
@@ -676,8 +625,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
       *length = required_length;
       return AMDCUID_STATUS_INSUFFICIENT_SIZE;
     }
-    if (data != nullptr)
-      std::memcpy(data, bdf.c_str(), required_length);
+    std::memcpy(data, bdf.c_str(), required_length);
     *length = required_length;
   } break;
   case AMDCUID_QUERY_TEMPORARY_CUID: {
@@ -686,8 +634,7 @@ amdcuid_status_t amdcuid_query_device_property(amdcuid_id_t handle,
     }
     bool is_temporary = false;
     status = device->is_temporary_cuid(&is_temporary);
-    if (data != nullptr)
-      *(bool *)data = is_temporary;
+    *(bool *)data = is_temporary;
     *length = sizeof(bool);
   } break;
   default:

--- a/projects/cuid/lib/src/cuid_cpu.cc
+++ b/projects/cuid/lib/src/cuid_cpu.cc
@@ -423,7 +423,7 @@ amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id &id) const {
     // share the same physical_id:core_id)
     if (!m_info.device_node.empty()) {
       status = primary_file.find_by_device_node(m_info.device_node, entry);
-      if (status == AMDCUID_STATUS_SUCCESS) {
+      if (status == AMDCUID_STATUS_SUCCESS && entry.is_temporary == false) {
         id.UUIDv8_representation = entry.primary_cuid;
         CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation,
                                           id.raw_bits);
@@ -436,9 +436,8 @@ amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id &id) const {
     std::string package_core_id =
         std::to_string(m_info.header.fields.cpu.physical_id) + ":" +
         std::to_string(m_info.header.fields.cpu.core);
-    amdcuid_status_t status =
-        primary_file.find_by_package_core_id(package_core_id, entry);
-    if (status == AMDCUID_STATUS_SUCCESS) {
+    status = primary_file.find_by_package_core_id(package_core_id, entry);
+    if (status == AMDCUID_STATUS_SUCCESS && entry.is_temporary == false) {
       id.UUIDv8_representation = entry.primary_cuid;
       CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
       return AMDCUID_STATUS_SUCCESS;

--- a/projects/cuid/lib/src/cuid_cpu.cc
+++ b/projects/cuid/lib/src/cuid_cpu.cc
@@ -406,48 +406,48 @@ CuidCpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
 
 amdcuid_status_t CuidCpu::get_primary_cuid(amdcuid_primary_id &id) const {
   bool temp = false;
-  if (geteuid() != 0) {
-    temp = true;
-  }
+  uint64_t fingerprint = 0;
+  amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
 
-  // Attempt to read the CUID from the file first
-  std::string cuid_file_path = CuidUtilities::priv_cuid_file();
-  CuidFile primary_file(cuid_file_path, false);
-  primary_file.load();
-  std::vector<CuidFileEntry> entries = primary_file.get_entries();
+  if (geteuid() == 0) {
+    // Attempt to read the CUID from the file first
+    std::string cuid_file_path = CuidUtilities::priv_cuid_file();
+    CuidFile primary_file(cuid_file_path, false);
+    primary_file.load();
+    std::vector<CuidFileEntry> entries = primary_file.get_entries();
 
-  CuidFileEntry entry;
+    CuidFileEntry entry;
 
-  // First, try lookup by device_node which is unique per logical CPU
-  // (package_core_id is not unique on SMT systems where sibling threads
-  // share the same physical_id:core_id)
-  if (!m_info.device_node.empty()) {
+    // First, try lookup by device_node which is unique per logical CPU
+    // (package_core_id is not unique on SMT systems where sibling threads
+    // share the same physical_id:core_id)
+    if (!m_info.device_node.empty()) {
+      status = primary_file.find_by_device_node(m_info.device_node, entry);
+      if (status == AMDCUID_STATUS_SUCCESS) {
+        id.UUIDv8_representation = entry.primary_cuid;
+        CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation,
+                                          id.raw_bits);
+        return AMDCUID_STATUS_SUCCESS;
+      }
+    }
+
+    // Fallback: try lookup by package_core_id for backward compatibility
+    // with files that don't have device_node for CPU entries
+    std::string package_core_id =
+        std::to_string(m_info.header.fields.cpu.physical_id) + ":" +
+        std::to_string(m_info.header.fields.cpu.core);
     amdcuid_status_t status =
-        primary_file.find_by_device_node(m_info.device_node, entry);
+        primary_file.find_by_package_core_id(package_core_id, entry);
     if (status == AMDCUID_STATUS_SUCCESS) {
       id.UUIDv8_representation = entry.primary_cuid;
       CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
       return AMDCUID_STATUS_SUCCESS;
     }
-  }
 
-  // Fallback: try lookup by package_core_id for backward compatibility
-  // with files that don't have device_node for CPU entries
-  std::string package_core_id =
-      std::to_string(m_info.header.fields.cpu.physical_id) + ":" +
-      std::to_string(m_info.header.fields.cpu.core);
-  amdcuid_status_t status =
-      primary_file.find_by_package_core_id(package_core_id, entry);
-  if (status == AMDCUID_STATUS_SUCCESS) {
-    id.UUIDv8_representation = entry.primary_cuid;
-    CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
-    return AMDCUID_STATUS_SUCCESS;
+    // Get hardware fingerprint (PPIN, ACPI UID, or fallback)
+    status = get_hardware_fingerprint(fingerprint);
   }
-
-  // Get hardware fingerprint (PPIN, ACPI UID, or fallback)
-  uint64_t fingerprint = 0;
-  status = get_hardware_fingerprint(fingerprint);
-  if (status != AMDCUID_STATUS_SUCCESS) {
+  if (geteuid() != 0 || status != AMDCUID_STATUS_SUCCESS) {
     // if hardware fingerprint is not available, use physical_id + core +
     // machine_id as fallback, but set a flag bit to indicate it's not a true
     // hardware fingerprint

--- a/projects/cuid/lib/src/cuid_device.cc
+++ b/projects/cuid/lib/src/cuid_device.cc
@@ -222,7 +222,7 @@ amdcuid_status_t CuidDevice::is_temporary_cuid(bool *is_temp) const {
     return status;
   }
   *is_temp = primary.raw_bits[14] &
-             0x04; // check the temp indicator bit in the reserved bits
+             0x20; // check the temp indicator bit in the reserved bits
 
   return AMDCUID_STATUS_SUCCESS;
 }

--- a/projects/cuid/lib/src/cuid_file.cc
+++ b/projects/cuid/lib/src/cuid_file.cc
@@ -21,6 +21,7 @@
  */
 
 #include "src/cuid_file.h"
+#include "smbios_util.h"
 #include "src/cuid_cpu.h"
 #include "src/cuid_device.h"
 #include "src/cuid_gpu.h"
@@ -773,6 +774,16 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
     entry.last_update = now;
 
     amdcuid_status_t status;
+    // Check if the CUID is temporary
+    bool is_temporary = false;
+    status = device->is_temporary_cuid(&is_temporary);
+    if (status != AMDCUID_STATUS_SUCCESS) {
+      std::cerr
+          << "Warning: Failed to get temporary CUID status for device type "
+          << entry.device_type << " status: " << status << std::endl;
+    }
+    entry.is_temporary = is_temporary;
+
     if (is_privileged) {
       // Get primary CUID
       amdcuid_primary_id primary_id = {};
@@ -786,11 +797,10 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
       // get hardware fingerprint
       uint64_t fingerprint = 0;
       status = device->get_hardware_fingerprint(fingerprint);
-      if (status != AMDCUID_STATUS_SUCCESS) {
+      if (status != AMDCUID_STATUS_SUCCESS && !is_temporary) {
         std::cerr
             << "Warning: Failed to get hardware fingerprint for device type "
             << entry.device_type << " status: " << status << std::endl;
-        entry.hardware_fingerprint = 0;
       } else {
         entry.hardware_fingerprint = fingerprint;
       }
@@ -803,16 +813,6 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
                 << entry.device_type << " status: " << status << std::endl;
     }
     entry.derived_cuid = derived_id.UUIDv8_representation;
-
-    // Check if the CUID is temporary
-    bool is_temporary = false;
-    status = device->is_temporary_cuid(&is_temporary);
-    if (status != AMDCUID_STATUS_SUCCESS) {
-      std::cerr
-          << "Warning: Failed to get temporary CUID status for device type "
-          << entry.device_type << " status: " << status << std::endl;
-    }
-    entry.is_temporary = is_temporary;
 
     // Fill in device-specific information
     switch (entry.device_type) {
@@ -827,6 +827,13 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
         entry.unit_id = info.header.fields.gpu.unit_id;
         entry.device_node = info.render_node;
         entry.bdf = info.bdf;
+
+        // if temp CUID, make the fallback fingerprint based on the GPU's PCIe
+        // BDF
+        if (is_temporary) {
+          CuidUtilities::make_fallback_fingerprint(info.bdf,
+                                                   entry.hardware_fingerprint);
+        }
       }
       break;
     }
@@ -849,6 +856,12 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
         if (cpu->get_device_path(cpu_device_path) == AMDCUID_STATUS_SUCCESS) {
           entry.device_node = cpu_device_path;
         }
+        // if temp CUID, make the fallback fingerprint based on the CPU's
+        // package:core
+        if (is_temporary) {
+          CuidUtilities::make_fallback_fingerprint(entry.package_core_id,
+                                                   entry.hardware_fingerprint);
+        }
       }
       break;
     }
@@ -866,6 +879,13 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
           entry.mac_address = mac_address;
         }
         entry.bdf = info.bdf;
+
+        // if temp CUID, make the fallback fingerprint based on the NIC's PCIe
+        // BDF
+        if (is_temporary) {
+          CuidUtilities::make_fallback_fingerprint(info.bdf,
+                                                   entry.hardware_fingerprint);
+        }
       }
       break;
     }
@@ -879,6 +899,12 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
         entry.pci_class = info.header.fields.npu.pci_class;
         entry.device_node = info.accel_node;
         entry.bdf = info.bdf;
+        // if temp CUID, make the fallback fingerprint based on the NPU's PCIe
+        // BDF
+        if (is_temporary) {
+          CuidUtilities::make_fallback_fingerprint(info.bdf,
+                                                   entry.hardware_fingerprint);
+        }
       }
       break;
     }
@@ -888,6 +914,16 @@ generate_from_devices(const std::vector<std::shared_ptr<CuidDevice>> &devices,
       if (platform) {
         const auto &info = platform->get_info();
         entry.vendor_id = info.header.fields.platform.vendor_id;
+
+        // if temp CUID, make the fallback fingerprint based on the platform
+        // product name
+        if (is_temporary) {
+          std::string name = "";
+          std::string family_dummy = "";
+          SmbiosUtil::get_product_info(name, family_dummy);
+          CuidUtilities::make_fallback_fingerprint(name,
+                                                   entry.hardware_fingerprint);
+        }
       }
       break;
     }

--- a/projects/cuid/lib/src/cuid_file.cc
+++ b/projects/cuid/lib/src/cuid_file.cc
@@ -449,6 +449,8 @@ amdcuid_status_t CuidFile::load() {
 
         if (key == "primary_cuid") {
           current_entry.primary_cuid = string_to_cuid(value);
+        } else if (key == "is_temporary") {
+          current_entry.is_temporary = (value == "true");
         } else if (key == "derived_cuid") {
           current_entry.derived_cuid = string_to_cuid(value);
         } else if (key == "device_node") {

--- a/projects/cuid/lib/src/cuid_file.h
+++ b/projects/cuid/lib/src/cuid_file.h
@@ -154,8 +154,8 @@ struct CuidFileEntry {
   std::string bdf;             // PCIe Bus:Device.Function
   std::string mac_address;     // For NIC
 
-  bool is_temporary; // Indicates if the CUID is temporary (not derived from a
-                     // true hardware fingerprint)
+  bool is_temporary = true; // Indicates if the CUID is temporary (not derived
+                            // from a true hardware fingerprint)
 
   time_t last_update; // Unix timestamp
 

--- a/projects/cuid/lib/src/cuid_file.h
+++ b/projects/cuid/lib/src/cuid_file.h
@@ -154,8 +154,8 @@ struct CuidFileEntry {
   std::string bdf;             // PCIe Bus:Device.Function
   std::string mac_address;     // For NIC
 
-  bool is_temporary = true; // Indicates if the CUID is temporary (not derived
-                            // from a true hardware fingerprint)
+  bool is_temporary = false; // Indicates if the CUID is temporary (not derived
+                             // from a true hardware fingerprint)
 
   time_t last_update; // Unix timestamp
 

--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -109,7 +109,9 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
   // Falls back to 0 if VF detection is unavailable.
   info.header.fields.gpu.unit_id = CuidUtilities::get_gpu_vf_id(device_path);
 
-  // check for XCP partitioning and skip if so
+  // check for XCP partitioning by looking for pci config space file on devices
+  // where unit_id is 0 (bare metal or passthrough). If config file is missing,
+  // that indicates partition which is unsupported for CUID generation.
   std::string config_file = device_path + "/config";
   if (access(config_file.c_str(), F_OK) == -1 &&
       info.header.fields.gpu.unit_id == 0) {

--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -110,7 +110,8 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
   info.header.fields.gpu.unit_id = CuidUtilities::get_gpu_vf_id(device_path);
 
   // check for XCP partitioning and skip if so
-  if (CuidUtilities::read_sysfs_file(device_path + "/unique_id").empty() &&
+  std::string config_file = device_path + "/config";
+  if (access(config_file.c_str(), F_OK) == -1 &&
       info.header.fields.gpu.unit_id == 0) {
     return AMDCUID_STATUS_UNSUPPORTED;
   }

--- a/projects/cuid/lib/src/cuid_gpu.cc
+++ b/projects/cuid/lib/src/cuid_gpu.cc
@@ -85,7 +85,10 @@ amdcuid_status_t CuidGpu::discover(std::vector<DevicePtr> &gpus) {
       std::string device_path =
           std::string(drm_path) + "/" + card_name + "/device";
       amdcuid_gpu_info info = {};
-      discover_single(&info, device_path);
+      amdcuid_status_t status = CuidGpu::discover_single(&info, device_path);
+      if (status == AMDCUID_STATUS_UNSUPPORTED) {
+        continue;
+      }
 
       gpus.emplace_back(std::make_shared<CuidGpu>(info));
     }
@@ -105,6 +108,12 @@ amdcuid_status_t CuidGpu::discover_single(amdcuid_gpu_info *gpu_info,
   // For VFs, unit_id is the 1-based VF index.
   // Falls back to 0 if VF detection is unavailable.
   info.header.fields.gpu.unit_id = CuidUtilities::get_gpu_vf_id(device_path);
+
+  // check for XCP partitioning and skip if so
+  if (CuidUtilities::read_sysfs_file(device_path + "/unique_id").empty() &&
+      info.header.fields.gpu.unit_id == 0) {
+    return AMDCUID_STATUS_UNSUPPORTED;
+  }
 
   std::string vendor = CuidUtilities::read_sysfs_file(device_path + "/vendor");
   if (vendor.empty() && !bdf.empty()) {
@@ -280,7 +289,7 @@ amdcuid_status_t CuidGpu::get_primary_cuid(amdcuid_primary_id &id) const {
 
     CuidFileEntry entry;
     status = primary_file.find_by_device_node(m_info.render_node, entry);
-    if (status == AMDCUID_STATUS_SUCCESS) {
+    if (status == AMDCUID_STATUS_SUCCESS && entry.is_temporary == false) {
       id.UUIDv8_representation = entry.primary_cuid;
       CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
       return AMDCUID_STATUS_SUCCESS;

--- a/projects/cuid/lib/src/cuid_nic.cc
+++ b/projects/cuid/lib/src/cuid_nic.cc
@@ -203,28 +203,28 @@ CuidNic::get_hardware_fingerprint(uint64_t &fingerprint) const {
 
 amdcuid_status_t CuidNic::get_primary_cuid(amdcuid_primary_id &id) const {
   bool temp = false;
-  if (geteuid() != 0) {
-    temp = true;
-  }
-
-  // attempt to read the CUID from the file first
-  std::string cuid_file_path = CuidUtilities::priv_cuid_file();
-  CuidFile primary_file(cuid_file_path, false);
-  primary_file.load();
-  std::vector<CuidFileEntry> entries = primary_file.get_entries();
-
-  CuidFileEntry entry;
-  amdcuid_status_t status =
-      primary_file.find_by_device_node(m_info.network_interface, entry);
-  if (status == AMDCUID_STATUS_SUCCESS) {
-    id.UUIDv8_representation = entry.primary_cuid;
-    CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
-    return AMDCUID_STATUS_SUCCESS;
-  }
-
   uint64_t fingerprint = 0;
-  status = get_hardware_fingerprint(fingerprint);
-  if (status != AMDCUID_STATUS_SUCCESS) {
+  amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
+
+  if (geteuid() == 0) {
+    // attempt to read the CUID from the file first
+    std::string cuid_file_path = CuidUtilities::priv_cuid_file();
+    CuidFile primary_file(cuid_file_path, false);
+    primary_file.load();
+    std::vector<CuidFileEntry> entries = primary_file.get_entries();
+
+    CuidFileEntry entry;
+    status = primary_file.find_by_device_node(m_info.network_interface, entry);
+    if (status == AMDCUID_STATUS_SUCCESS) {
+      id.UUIDv8_representation = entry.primary_cuid;
+      CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
+      return AMDCUID_STATUS_SUCCESS;
+    }
+
+    status = get_hardware_fingerprint(fingerprint);
+  }
+
+  if (geteuid() != 0 || status != AMDCUID_STATUS_SUCCESS) {
     std::string bdf;
     status = this->get_bdf(bdf);
     if (status != AMDCUID_STATUS_SUCCESS) {

--- a/projects/cuid/lib/src/cuid_nic.cc
+++ b/projects/cuid/lib/src/cuid_nic.cc
@@ -52,6 +52,10 @@ amdcuid_status_t CuidNic::discover(std::vector<DevicePtr> &nics) {
       amdcuid_nic_info info = {};
       std::string device_path =
           std::string(nic_base_path) + "/" + entry->d_name + "/device";
+      // filter out virtual devices by checking device symlink
+      if (CuidUtilities::readlink_bdf(device_path).empty()) {
+        continue;
+      }
       discover_single(&info, device_path);
 
       nics.emplace_back(std::make_shared<CuidNic>(info));
@@ -215,7 +219,7 @@ amdcuid_status_t CuidNic::get_primary_cuid(amdcuid_primary_id &id) const {
 
     CuidFileEntry entry;
     status = primary_file.find_by_device_node(m_info.network_interface, entry);
-    if (status == AMDCUID_STATUS_SUCCESS) {
+    if (status == AMDCUID_STATUS_SUCCESS && entry.is_temporary == false) {
       id.UUIDv8_representation = entry.primary_cuid;
       CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
       return AMDCUID_STATUS_SUCCESS;

--- a/projects/cuid/lib/src/cuid_npu.cc
+++ b/projects/cuid/lib/src/cuid_npu.cc
@@ -309,7 +309,7 @@ amdcuid_status_t CuidNpu::get_primary_cuid(amdcuid_primary_id &id) const {
 
     CuidFileEntry entry;
     status = primary_file.find_by_device_node(m_info.accel_node, entry);
-    if (status == AMDCUID_STATUS_SUCCESS) {
+    if (status == AMDCUID_STATUS_SUCCESS && entry.is_temporary == false) {
       id.UUIDv8_representation = entry.primary_cuid;
       CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
       return AMDCUID_STATUS_SUCCESS;

--- a/projects/cuid/lib/src/cuid_npu.cc
+++ b/projects/cuid/lib/src/cuid_npu.cc
@@ -298,28 +298,27 @@ CuidNpu::get_hardware_fingerprint(uint64_t &fingerprint) const {
 
 amdcuid_status_t CuidNpu::get_primary_cuid(amdcuid_primary_id &id) const {
   bool temp = false;
-  if (geteuid() != 0) {
-    temp = true;
-  }
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
   uint64_t fingerprint = 0;
 
-  // Attempt to read the CUID from the file first
-  std::string cuid_file_path = CuidUtilities::priv_cuid_file();
-  CuidFile primary_file(cuid_file_path, false);
-  primary_file.load();
+  if (geteuid() == 0) {
+    // Attempt to read the CUID from the file first
+    std::string cuid_file_path = CuidUtilities::priv_cuid_file();
+    CuidFile primary_file(cuid_file_path, false);
+    primary_file.load();
 
-  CuidFileEntry entry;
-  status = primary_file.find_by_device_node(m_info.accel_node, entry);
-  if (status == AMDCUID_STATUS_SUCCESS) {
-    id.UUIDv8_representation = entry.primary_cuid;
-    CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
-    return AMDCUID_STATUS_SUCCESS;
+    CuidFileEntry entry;
+    status = primary_file.find_by_device_node(m_info.accel_node, entry);
+    if (status == AMDCUID_STATUS_SUCCESS) {
+      id.UUIDv8_representation = entry.primary_cuid;
+      CuidUtilities::remove_UUIDv8_bits(&id.UUIDv8_representation, id.raw_bits);
+      return AMDCUID_STATUS_SUCCESS;
+    }
+
+    // Primary CUID not found in file, so generate it
+    status = get_hardware_fingerprint(fingerprint);
   }
-
-  // Primary CUID not found in file, so generate it
-  status = get_hardware_fingerprint(fingerprint);
-  if (status != AMDCUID_STATUS_SUCCESS) {
+  if (geteuid() != 0 || status != AMDCUID_STATUS_SUCCESS) {
     std::string bdf;
     status = this->get_bdf(bdf);
     if (status != AMDCUID_STATUS_SUCCESS) {

--- a/projects/cuid/lib/src/cuid_platform.cc
+++ b/projects/cuid/lib/src/cuid_platform.cc
@@ -53,19 +53,44 @@ amdcuid_status_t CuidPlatform::discover(std::vector<DevicePtr> &platforms) {
 
 amdcuid_status_t
 CuidPlatform::get_hardware_fingerprint(uint64_t &fingerprint) const {
-  std::string serial;
-  amdcuid_status_t status = SmbiosUtil::get_system_serial(serial);
-  if (status != AMDCUID_STATUS_SUCCESS) {
+  amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
+  // Get system UUID from SMBIOS
+  uint8_t uuid[16] = {0};
+  status = SmbiosUtil::get_system_uuid(uuid);
+  // After getting uuid, check it's not a sentinel "not set" value
+  bool uuid_valid = false;
+  for (int i = 0; i < 16; ++i) {
+    if (uuid[i] != 0x00 && uuid[i] != 0xFF) {
+      uuid_valid = true;
+      break;
+    }
+  }
+  if (status == AMDCUID_STATUS_SUCCESS && uuid_valid) {
+    // use UUID as basis for CUID
+    fingerprint = (static_cast<uint64_t>(uuid[0]) << 56) |
+                  (static_cast<uint64_t>(uuid[1]) << 48) |
+                  (static_cast<uint64_t>(uuid[2]) << 40) |
+                  (static_cast<uint64_t>(uuid[3]) << 32) |
+                  (static_cast<uint64_t>(uuid[4]) << 24) |
+                  (static_cast<uint64_t>(uuid[5]) << 16) |
+                  (static_cast<uint64_t>(uuid[6]) << 8) |
+                  static_cast<uint64_t>(uuid[7]);
+  } else {
+    std::string serial;
+    amdcuid_status_t status = SmbiosUtil::get_system_serial(serial);
+    if (status != AMDCUID_STATUS_SUCCESS) {
+      fingerprint = 0;
+      return AMDCUID_STATUS_UNSUPPORTED;
+    }
+
+    // Generate fingerprint from serial number
     fingerprint = 0;
-    return AMDCUID_STATUS_UNSUPPORTED;
+    for (size_t i = 0; i < serial.length() && i < 8; ++i) {
+      fingerprint |= (static_cast<uint64_t>(serial[i]) << (i * 8));
+    }
   }
 
-  // Generate fingerprint from serial number
-  fingerprint = 0;
-  for (size_t i = 0; i < serial.length() && i < 8; ++i) {
-    fingerprint |= (static_cast<uint64_t>(serial[i]) << (i * 8));
-  }
-  return AMDCUID_STATUS_SUCCESS;
+  return status;
 }
 
 amdcuid_status_t CuidPlatform::get_primary_cuid(amdcuid_primary_id &id) const {
@@ -87,33 +112,15 @@ amdcuid_status_t CuidPlatform::get_primary_cuid(amdcuid_primary_id &id) const {
   }
 
   uint64_t fingerprint = 0;
+  status = get_hardware_fingerprint(fingerprint);
 
-  // Get system UUID from SMBIOS
-  uint8_t uuid[16] = {0};
-  status = SmbiosUtil::get_system_uuid(uuid);
-  if (status == AMDCUID_STATUS_SUCCESS) {
-    // use UUID as basis for CUID
-    fingerprint = (static_cast<uint64_t>(uuid[0]) << 56) |
-                  (static_cast<uint64_t>(uuid[1]) << 48) |
-                  (static_cast<uint64_t>(uuid[2]) << 40) |
-                  (static_cast<uint64_t>(uuid[3]) << 32) |
-                  (static_cast<uint64_t>(uuid[4]) << 24) |
-                  (static_cast<uint64_t>(uuid[5]) << 16) |
-                  (static_cast<uint64_t>(uuid[6]) << 8) |
-                  static_cast<uint64_t>(uuid[7]);
-  } else {
-    // Fallback: get fingerprint from other sources
-    status = get_hardware_fingerprint(fingerprint);
-
-    if (status != AMDCUID_STATUS_SUCCESS) {
-      std::string name = "";
-      // family here not used
-      std::string family = "";
-      status = SmbiosUtil::get_product_info(name, family);
-
-      CuidUtilities::make_fallback_fingerprint(name, fingerprint);
-      temp = true;
-    }
+  if (status != AMDCUID_STATUS_SUCCESS) {
+    std::string name = "";
+    // family here not used
+    std::string family = "";
+    status = SmbiosUtil::get_product_info(name, family);
+    CuidUtilities::make_fallback_fingerprint(name, fingerprint);
+    temp = true;
   }
 
   status = CuidUtilities::generate_primary_cuid(

--- a/projects/cuid/lib/src/cuid_platform.cc
+++ b/projects/cuid/lib/src/cuid_platform.cc
@@ -117,8 +117,8 @@ amdcuid_status_t CuidPlatform::get_primary_cuid(amdcuid_primary_id &id) const {
   if (status != AMDCUID_STATUS_SUCCESS) {
     std::string name = "";
     // family here not used
-    std::string family = "";
-    status = SmbiosUtil::get_product_info(name, family);
+    std::string family_dummy = "";
+    status = SmbiosUtil::get_product_info(name, family_dummy);
     CuidUtilities::make_fallback_fingerprint(name, fingerprint);
     temp = true;
   }

--- a/projects/cuid/lib/src/cuid_platform.cc
+++ b/projects/cuid/lib/src/cuid_platform.cc
@@ -77,7 +77,7 @@ CuidPlatform::get_hardware_fingerprint(uint64_t &fingerprint) const {
                   static_cast<uint64_t>(uuid[7]);
   } else {
     std::string serial;
-    amdcuid_status_t status = SmbiosUtil::get_system_serial(serial);
+    status = SmbiosUtil::get_system_serial(serial);
     if (status != AMDCUID_STATUS_SUCCESS) {
       fingerprint = 0;
       return AMDCUID_STATUS_UNSUPPORTED;

--- a/projects/cuid/lib/src/cuid_util.cc
+++ b/projects/cuid/lib/src/cuid_util.cc
@@ -458,10 +458,13 @@ CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
   // insert reserved bits part 1 at bits 64-71
   id_bits[8] = reserved_1;
 
-  // copy next 6 bytes (46 bits) from hash and mask off last 2 bits for bits
-  // 72-117
+  // copy next 6 bytes (45 bits) from hash and mask off last 3 bits for bits
+  // 72-116
   memcpy(id_bits + 9, derived_id->hash + 8, 6);
-  id_bits[14] &= 0xFC;
+  id_bits[14] &= 0xF8;
+
+  // bit 117: temp bit carried over from primary ID
+  id_bits[14] |= (primary_id->raw_bits[14] & 0x04) >> 2;
 
   // bits 118-121: reserved bits part 2 (4 bits)
   id_bits[14] |= (reserved_2 >> 2); // upper 2 bits of reserved bits part 2

--- a/projects/cuid/lib/src/cuid_util.cc
+++ b/projects/cuid/lib/src/cuid_util.cc
@@ -388,7 +388,11 @@ CuidUtilities::make_fallback_fingerprint(const std::string &id,
   std::string system_id;
   amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
 
-  if (geteuid() != 0) {
+  if (geteuid() == 0) {
+    // If running as root, get platform serial number
+    status = SmbiosUtil::get_system_serial(system_id);
+  }
+  if (getuid() != 0 || system_id.empty() || status != AMDCUID_STATUS_SUCCESS) {
     std::ifstream machine_id_file("/etc/machine-id");
     if (machine_id_file.is_open())
       std::getline(machine_id_file, system_id);
@@ -398,11 +402,6 @@ CuidUtilities::make_fallback_fingerprint(const std::string &id,
       if (hostname_file.is_open())
         std::getline(hostname_file, system_id);
     }
-  } else {
-    // If running as root, get platform serial number
-    status = SmbiosUtil::get_system_serial(system_id);
-    if (status != AMDCUID_STATUS_SUCCESS)
-      return status;
   }
 
   std::string id_hex;
@@ -464,7 +463,7 @@ CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
   id_bits[14] &= 0xF8;
 
   // bit 117: temp bit carried over from primary ID
-  id_bits[14] |= (primary_id->raw_bits[14] & 0x04) >> 2;
+  id_bits[14] |= (primary_id->raw_bits[14] & 0x04);
 
   // bits 118-121: reserved bits part 2 (4 bits)
   id_bits[14] |= (reserved_2 >> 2); // upper 2 bits of reserved bits part 2

--- a/projects/cuid/lib/src/cuid_util.cc
+++ b/projects/cuid/lib/src/cuid_util.cc
@@ -392,7 +392,7 @@ CuidUtilities::make_fallback_fingerprint(const std::string &id,
     // If running as root, get platform serial number
     status = SmbiosUtil::get_system_serial(system_id);
   }
-  if (getuid() != 0 || system_id.empty() || status != AMDCUID_STATUS_SUCCESS) {
+  if (geteuid() != 0 || system_id.empty() || status != AMDCUID_STATUS_SUCCESS) {
     std::ifstream machine_id_file("/etc/machine-id");
     if (machine_id_file.is_open())
       std::getline(machine_id_file, system_id);
@@ -443,7 +443,7 @@ CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
   // copy 110 LSB bits of hash to derived_id->hash
   // Using only first 14 bytes (112 bits) of hash, then will mask last 2 bits
   memcpy(derived_id->hash, hash, 14);
-  derived_id->hash[13] &= 0xFC; // 11111100
+  derived_id->hash[13] &= 0x3F; // 00111111
 
   // Get the unit id parts from the primary ID
   uint8_t reserved_2 = 0;
@@ -460,14 +460,15 @@ CuidUtilities::generate_derived_cuid(const amdcuid_primary_id *primary_id,
   // copy next 6 bytes (45 bits) from hash and mask off last 3 bits for bits
   // 72-116
   memcpy(id_bits + 9, derived_id->hash + 8, 6);
-  id_bits[14] &= 0xF8;
+  id_bits[14] &= 0x1F;
 
   // bit 117: temp bit carried over from primary ID
-  id_bits[14] |= (primary_id->raw_bits[14] & 0x04);
+  id_bits[14] |= (primary_id->raw_bits[14] & 0x20);
 
   // bits 118-121: reserved bits part 2 (4 bits)
-  id_bits[14] |= (reserved_2 >> 2); // upper 2 bits of reserved bits part 2
-  id_bits[15] |= (reserved_2 & 0x03)
+  id_bits[14] |= (reserved_2 & 0xC)
+                 << 4; // upper 2 bits of reserved bits part 2
+  id_bits[15] |= (reserved_2 & 0x3)
                  << 6; // lower 2 bits of reserved bits part 2
   // last 6 bits are padding (bits 122-127)
   id_bits[15] &= 0xC0;
@@ -492,7 +493,8 @@ amdcuid_status_t CuidUtilities::generate_primary_cuid(
   uint8_t unit_id_part2 = (unit_id >> 8) & 0x1F;
 
   // Bits 0-63: Serial number (8 bytes)
-  memcpy(id_bits, &serial_number, 8);
+  for (int i = 0; i < 8; i++)
+    id_bits[i] = (serial_number >> (8 * i)) & 0xFF;
 
   // Bits 64-71: UnitID part 1 (1 byte)
   id_bits[8] = unit_id_part1;
@@ -509,12 +511,11 @@ amdcuid_status_t CuidUtilities::generate_primary_cuid(
   id_bits[12] = vendor_id & 0xFF;
   id_bits[13] = (vendor_id >> 8) & 0xFF;
 
-  // Bits 112-116: UnitID part 2 (5 bits) + Bits 118-121: Component Type (4
-  // bits)
+  // Bits 112-116: UnitID part 2 (5 bits) + Bit 117: temp indicator (1 bit) +
+  // Bits 118-121: Component Type (4 bits)
   uint8_t temp_bit = temp ? 1 : 0;
-  id_bits[14] =
-      (unit_id_part2 << 3) | (temp_bit << 2) | ((device_type & 0xC) >> 2);
-  id_bits[15] = (device_type & 0x3) << 6; // Last 6 bits are padding
+  id_bits[14] = (unit_id_part2) | (temp_bit << 5) | ((device_type & 0x3) << 6);
+  id_bits[15] = (device_type & 0xC) << 4; // Last 6 bits are padding
 
   memcpy(primary_id->raw_bits, id_bits, 16);
 

--- a/projects/cuid/lib/src/cuid_util.cc
+++ b/projects/cuid/lib/src/cuid_util.cc
@@ -21,6 +21,7 @@
  */
 
 #include "cuid_util.h"
+#include "smbios_util.h"
 #include <algorithm>
 #include <cctype>
 #include <cstring>
@@ -385,15 +386,23 @@ amdcuid_status_t
 CuidUtilities::make_fallback_fingerprint(const std::string &id,
                                          uint64_t &fingerprint) {
   std::string system_id;
+  amdcuid_status_t status = AMDCUID_STATUS_SUCCESS;
 
-  std::ifstream machine_id_file("/etc/machine-id");
-  if (machine_id_file.is_open())
-    std::getline(machine_id_file, system_id);
+  if (geteuid() != 0) {
+    std::ifstream machine_id_file("/etc/machine-id");
+    if (machine_id_file.is_open())
+      std::getline(machine_id_file, system_id);
 
-  if (system_id.empty()) {
-    std::ifstream hostname_file("/etc/hostname");
-    if (hostname_file.is_open())
-      std::getline(hostname_file, system_id);
+    if (system_id.empty()) {
+      std::ifstream hostname_file("/etc/hostname");
+      if (hostname_file.is_open())
+        std::getline(hostname_file, system_id);
+    }
+  } else {
+    // If running as root, get platform serial number
+    status = SmbiosUtil::get_system_serial(system_id);
+    if (status != AMDCUID_STATUS_SUCCESS)
+      return status;
   }
 
   std::string id_hex;
@@ -402,9 +411,8 @@ CuidUtilities::make_fallback_fingerprint(const std::string &id,
 
   std::string combined = id_hex + system_id;
   uint8_t digest[32];
-  amdcuid_status_t status =
-      sha256_unkeyed(reinterpret_cast<const uint8_t *>(combined.data()),
-                     combined.size(), digest);
+  status = sha256_unkeyed(reinterpret_cast<const uint8_t *>(combined.data()),
+                          combined.size(), digest);
   if (status != AMDCUID_STATUS_SUCCESS)
     return status;
 

--- a/projects/cuid/tests/CMakeLists.txt
+++ b/projects/cuid/tests/CMakeLists.txt
@@ -35,6 +35,10 @@ if(NOT GTest_FOUND)
         GIT_TAG v1.14.0
     )
     FetchContent_MakeAvailable(googletest)
+elseif(TARGET GTest::GTest AND NOT TARGET GTest::gtest)
+    # MODULE mode found GTest::GTest — create the canonical aliases expected below.
+    add_library(GTest::gtest ALIAS GTest::GTest)
+    add_library(GTest::gtest_main ALIAS GTest::Main)
 endif()
 
 set(AMDCUID_TST_EXECUTABLE amdcuid_test)
@@ -55,8 +59,8 @@ target_include_directories(amdcuid_test PRIVATE ${CMAKE_SOURCE_DIR}/lib)
 target_link_libraries(
     ${AMDCUID_TST_EXECUTABLE}
     amdcuid_static
-    GTest::GTest
-    GTest::Main
+    GTest::gtest
+    GTest::gtest_main
 )
 
 # Register tests with CTest

--- a/projects/cuid/tests/functional/cuid_reverse_lookup_test.cc
+++ b/projects/cuid/tests/functional/cuid_reverse_lookup_test.cc
@@ -235,7 +235,7 @@ void test_cuid_reverse_unit_id() {
     extract_primary_raw_bits(primary_id, raw_bits);
     // unit_id is 14 bits split across two bytes:
     //   lower 8 bits: raw_bits[8]
-    //   upper 6 bits: bits [7:2] of raw_bits[14]
+    //   upper 5 bits: bits [7:3] of raw_bits[14]
     uint16_t extracted_unit_id =
         static_cast<uint16_t>(raw_bits[8]) |
         (static_cast<uint16_t>((raw_bits[14] >> 3) & 0x1F) << 8);

--- a/projects/cuid/tests/functional/cuid_reverse_lookup_test.cc
+++ b/projects/cuid/tests/functional/cuid_reverse_lookup_test.cc
@@ -23,6 +23,7 @@
 #include "include/amd_cuid.h"
 #include "src/cuid_util.h"
 #include "src/pci_util.h"
+#include "src/smbios_util.h"
 #include <cstring>
 #include <gtest/gtest.h>
 #include <unistd.h>
@@ -34,13 +35,14 @@
 
 // Helper: strip UUIDv8 overhead from a primary CUID to recover the 122 raw data
 // bits. Raw bit layout (after stripping):
-//   [0..7]  serial number (uint64_t, little-endian)
-//   [8]     unit_id lower 8 bits
-//   [9]     revision_id (uint8_t)
-//   [10..11] device_id (uint16_t, little-endian)
-//   [12..13] vendor_id (uint16_t, little-endian)
-//   [14]    (unit_id upper 6 bits << 2) | (device_type upper 2 bits)
-//   [15]    (device_type lower 2 bits << 6) | padding
+//   [0..7]   serial number (uint64_t, little-endian)
+//   [8]      unit_id lower 8 bits (raw bits 64:71)
+//   [9]      revision_id (uint8_t) (raw bits 72:79)
+//   [10..11] device_id (uint16_t, little-endian) (raw bits 80:95)
+//   [12..13] vendor_id (uint16_t, little-endian) (raw bits 96:111)
+//   [14]     bits[4:0]=unit_id upper 5 bits | bit[5]=aux_indicator |
+//   bits[7:6]=device_type[1:0] [15]     bits[7:6]=device_type[3:2] |
+//   bits[5:0]=padding
 static void extract_primary_raw_bits(const amdcuid_id_t &uuid,
                                      uint8_t raw_bits[16]) {
   amdcuid_id_t mutable_uuid = uuid;
@@ -70,8 +72,62 @@ void test_cuid_reverse_serial_number() {
     status = amdcuid_query_device_property(handles[i],
                                            AMDCUID_QUERY_HARDWARE_FINGERPRINT,
                                            &serial_number, &length);
-    EXPECT_EQ(status, AMDCUID_STATUS_SUCCESS);
-    EXPECT_NE(serial_number, 0); // Assuming valid serial numbers are non-zero
+    if (status == AMDCUID_STATUS_HW_FINGERPRINT_NOT_FOUND) {
+      // expect temporary fingerprint and create fallback fingerprint to check
+      // against primary CUID
+      bool is_temporary = false;
+      length = sizeof(is_temporary);
+      status = amdcuid_query_device_property(
+          handles[i], AMDCUID_QUERY_TEMPORARY_CUID, &is_temporary, &length);
+      EXPECT_EQ(status, AMDCUID_STATUS_SUCCESS);
+      EXPECT_TRUE(is_temporary);
+
+      amdcuid_device_type_t device_type;
+      length = sizeof(device_type);
+      status = amdcuid_query_device_property(
+          handles[i], AMDCUID_QUERY_DEVICE_TYPE, &device_type, &length);
+
+      switch (device_type) {
+      case AMDCUID_DEVICE_TYPE_PLATFORM: {
+        std::string name = "";
+        std::string family_dummy = "";
+        status = SmbiosUtil::get_product_info(name, family_dummy);
+        EXPECT_EQ(status, AMDCUID_STATUS_SUCCESS);
+        CuidUtilities::make_fallback_fingerprint(name, serial_number);
+      } break;
+      case AMDCUID_DEVICE_TYPE_CPU: {
+        uint16_t physical_id = 0;
+        uint16_t core_id = 0;
+        length = sizeof(physical_id);
+        status = amdcuid_query_device_property(
+            handles[i], AMDCUID_QUERY_PHYSICAL_ID, &physical_id, &length);
+        EXPECT_EQ(status, AMDCUID_STATUS_SUCCESS);
+        length = sizeof(core_id);
+        status = amdcuid_query_device_property(
+            handles[i], AMDCUID_QUERY_CORE_ID, &core_id, &length);
+        EXPECT_EQ(status, AMDCUID_STATUS_SUCCESS);
+        std::string physical_core_id =
+            std::to_string(physical_id) + ":" + std::to_string(core_id);
+        CuidUtilities::make_fallback_fingerprint(physical_core_id,
+                                                 serial_number);
+      } break;
+      case AMDCUID_DEVICE_TYPE_GPU:
+      case AMDCUID_DEVICE_TYPE_NIC:
+      case AMDCUID_DEVICE_TYPE_NPU: {
+        char bdf[32] = {0};
+        length = sizeof(bdf);
+        status = amdcuid_query_device_property(handles[i], AMDCUID_QUERY_BDF,
+                                               bdf, &length);
+        EXPECT_EQ(status, AMDCUID_STATUS_SUCCESS);
+        CuidUtilities::make_fallback_fingerprint(bdf, serial_number);
+      } break;
+      default:
+        FAIL() << "Unsupported device type for fallback fingerprint";
+      }
+    } else {
+      EXPECT_EQ(status, AMDCUID_STATUS_SUCCESS);
+      EXPECT_NE(serial_number, 0); // Assuming valid serial numbers are non-zero
+    }
 
     // get the primary CUID to reverse it
     amdcuid_id_t primary_id = {};
@@ -233,12 +289,12 @@ void test_cuid_reverse_unit_id() {
 
     uint8_t raw_bits[16] = {0};
     extract_primary_raw_bits(primary_id, raw_bits);
-    // unit_id is 14 bits split across two bytes:
-    //   lower 8 bits: raw_bits[8]
-    //   upper 5 bits: bits [7:3] of raw_bits[14]
+    // unit_id is 13 bits split across two bytes:
+    //   lower 8 bits: raw_bits[8] (raw bits 64:71)
+    //   upper 5 bits: bits [4:0] of raw_bits[14] (raw bits 112:116)
     uint16_t extracted_unit_id =
         static_cast<uint16_t>(raw_bits[8]) |
-        (static_cast<uint16_t>((raw_bits[14] >> 3) & 0x1F) << 8);
+        (static_cast<uint16_t>(raw_bits[14] & 0x1F) << 8);
 
     uint16_t queried_unit_id = 0;
     length = sizeof(queried_unit_id);
@@ -278,10 +334,11 @@ void test_cuid_reverse_device_type() {
     uint8_t raw_bits[16] = {0};
     extract_primary_raw_bits(primary_id, raw_bits);
     // device_type is 4 bits split across two bytes:
-    //   upper 2 bits: bits [1:0] of raw_bits[14]
-    //   lower 2 bits: bits [7:6] of raw_bits[15]
-    uint8_t extracted_type = static_cast<uint8_t>(((raw_bits[14] & 0x3) << 2) |
-                                                  ((raw_bits[15] >> 6) & 0x3));
+    //   bits [1:0] of device_type (MSB pair): bits [7:6] of raw_bits[14] (raw
+    //   bits 119:118) bits [3:2] of device_type (LSB pair): bits [7:6] of
+    //   raw_bits[15] (raw bits 121:120)
+    uint8_t extracted_type = static_cast<uint8_t>(((raw_bits[14] >> 6) & 0x3) |
+                                                  ((raw_bits[15] >> 4) & 0xC));
 
     amdcuid_device_type_t queried_type = AMDCUID_DEVICE_TYPE_NONE;
     length = sizeof(queried_type);

--- a/projects/cuid/tests/functional/cuid_reverse_lookup_test.cc
+++ b/projects/cuid/tests/functional/cuid_reverse_lookup_test.cc
@@ -238,7 +238,7 @@ void test_cuid_reverse_unit_id() {
     //   upper 6 bits: bits [7:2] of raw_bits[14]
     uint16_t extracted_unit_id =
         static_cast<uint16_t>(raw_bits[8]) |
-        (static_cast<uint16_t>((raw_bits[14] >> 2) & 0x3F) << 8);
+        (static_cast<uint16_t>((raw_bits[14] >> 3) & 0x1F) << 8);
 
     uint16_t queried_unit_id = 0;
     length = sizeof(queried_unit_id);


### PR DESCRIPTION
## Motivation
Temporary CUIDs were being generated in some cases where full CUIDs should have been generated instead and vice versa. Temporary CUIDs should also address creation of CUIDs for APU devices.

## Technical Details
Adjusted temp CUID generation logic to ensure that they were generated correctly and only under the correct circumstances.

## JIRA ID
AILITOOLS-239