### PR TITLE
[rocprofiler-sdk] Fall back to cloning externals when submodule update is unavailable

### DIFF
--- a/projects/rocprofiler-sdk/cmake/rocprofiler_utilities.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_utilities.cmake
@@ -229,8 +229,16 @@ function(ROCPROFILER_CHECKOUT_GIT_SUBMODULE)
         if(RET GREATER 0)
             set(_CMD "${GIT_EXECUTABLE} submodule update --init ${_RECURSE}
                 ${CHECKOUT_ADDITIONAL_CMDS} ${CHECKOUT_RELATIVE_PATH}")
-            message(STATUS "function(rocprofiler_checkout_git_submodule) failed.")
-            message(FATAL_ERROR "Command: \"${_CMD}\"")
+            if(_HAS_REPO_URL)
+                message(
+                    WARNING
+                        "Command failed: \"${_CMD}\". Falling back to cloning ${CHECKOUT_REPO_URL}."
+                    )
+                set(_TEST_FILE_EXISTS OFF)
+            else()
+                message(STATUS "function(rocprofiler_checkout_git_submodule) failed.")
+                message(FATAL_ERROR "Command: \"${_CMD}\"")
+            endif()
         else()
             set(_TEST_FILE_EXISTS ON)
         endif()

--- a/projects/rocprofiler-sdk/cmake/rocprofiler_utilities.cmake
+++ b/projects/rocprofiler-sdk/cmake/rocprofiler_utilities.cmake
@@ -234,7 +234,6 @@ function(ROCPROFILER_CHECKOUT_GIT_SUBMODULE)
                     WARNING
                         "Command failed: \"${_CMD}\". Falling back to cloning ${CHECKOUT_REPO_URL}."
                     )
-                set(_TEST_FILE_EXISTS OFF)
             else()
                 message(STATUS "function(rocprofiler_checkout_git_submodule) failed.")
                 message(FATAL_ERROR "Command: \"${_CMD}\"")

--- a/projects/rocprofiler-sdk/external/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/external/CMakeLists.txt
@@ -107,7 +107,7 @@ if(ROCPROFILER_BUILD_FMT)
         RELATIVE_PATH external/fmt
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         REPO_URL https://github.com/fmtlib/fmt.git
-        REPO_BRANCH "master")
+        REPO_BRANCH "main")
 
     set(FMT_TEST OFF)
     set(FMT_DEBUG_POSTFIX "")


### PR DESCRIPTION
## Motivation

- Building rocprofiler-sdk from a source tarball can fail during CMake configure when the archive contains `.gitmodules` but has no `.git` metadata or populated submodules.
- In that case, `rocprofiler_checkout_git_submodule()` fails because the source tree is not a Git worktree. Previously this was treated as fatal, so CMake never reached the existing REPO_URL clone fallback.
- This change allows that fallback to run: if `git submodule update --init` fails and `REPO_URL` is available, CMake now warns and proceeds to clone. If no fallback URL exists, the fatal error behavior is unchanged.
- This also updates the `fmt` fallback ref from master to main, since upstream `fmt` no longer provides master.
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

JIRA ID : ROCM-25707

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
