### PR TITLE
Remove default 48-channel cap for gfx950 multi-node

### DIFF
--- a/projects/rccl/src/graph/connect.cc
+++ b/projects/rccl/src/graph/connect.cc
@@ -1182,9 +1182,6 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
     if (userMax != -2) {
       maxChannels = std::max(std::min(userMax, 64), 1);
       INFO(NCCL_TUNING, "RCCL MaxChannels is capped to: %d", maxChannels);
-    } else {
-      maxChannels = 48;
-      INFO(NCCL_TUNING, "RCCL MaxChannels: default capping to 48");
     }
   }
 


### PR DESCRIPTION
Drop the unconditional maxChannels = 48 default applied to gfx950 multi-node comms when RCCL_MAX_NCHANNELS is unset. The user override path is unchanged; with the env var unset, maxChannels now falls through to the previously computed min(gpu.cu, MAXCHANNELS) value (still bounded downstream by the existing non-MNNVL 64-channel cap).