### PR TITLE
[rocjitsu] Track implicit operands, enable PC_OPERAND flag and remove DBI denylist

### DIFF
--- a/emulation/rocjitsu/docs/dbi-design.md
+++ b/emulation/rocjitsu/docs/dbi-design.md
@@ -120,9 +120,11 @@ Rules enforced:
 - `anchor.size()` is 4 or 8 and fits inside `text_bytes` (subtraction-based bounds check; resists overflow when `anchor_offset` is huge).
 - `anchor.raw_encoding()` is non-null.
 - `anchor` is not a branch / cond branch / indirect branch / indirect call / program terminator, and `branch_offset_bytes()` is `nullopt`.
-- `anchor.mnemonic()` is not on the small PC-relative denylist (`s_getpc_b64`, `s_call_b64`, `s_setpc_b64`, `s_swappc_b64`, `s_rfe_*`) — these may not surface as flag bits on every ISA.
+- `anchor.is_pc_operand()` is false — i.e. the instruction does not read or write the program counter (`s_getpc` / `s_setpc` / `s_swappc` / `s_call` / `s_addpc`, the `s_rfe` family, and `s_cbranch_g_fork`/`join`). Relocating such an instruction's bytes would change the PC value it reads or the target it computes.
 
-`arch` is accepted now so a future ISA-specific denylist can grow without an API change.
+The PC check uses the `PC_OPERAND` `InstFlag`, a structural property set in the ISA layer from the MR ISA spec's implicit `OPR_PC` operand (captured by the `amdisa` parser as `Instruction.has_pc_operand` and emitted into the generated per-ISA constructors). `s_call` / `s_setpc` / `s_swappc` are additionally caught by their `INDIRECT_BRANCH` / `INDIRECT_CALL` flags above. PC-relative *branches* are deliberately **not** `PC_OPERAND` — they carry a label operand, not `OPR_PC`, and are handled by the branch/`branch_offset_bytes()` rules instead.
+
+`arch` is accepted now so a future ISA-specific check can grow without an API change.
 
 ### `validate_anchor(anchor, anchor_offset, text_bytes, pt, arch, error_out)`
 

--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -5592,6 +5592,10 @@ class CodeGenerator:
                         'scalar_call',
                     ):
                         ctor_body_parts.append('flags_ |= INDIRECT_CALL;')
+                    # Instructions that read or write the program counter via an
+                    # implicit OPR_PC operand (e.g., s_getpc).
+                    if inst.has_implicit_operand('OPR_PC'):
+                        ctor_body_parts.append('flags_ |= PC_OPERAND;')
                     # Conditional scalar moves leave the destination unchanged
                     # when their predicate is false, so liveness cannot treat
                     # them as unconditional kills.

--- a/emulation/rocjitsu/lib/python/amdisa/gpuisa.py
+++ b/emulation/rocjitsu/lib/python/amdisa/gpuisa.py
@@ -183,7 +183,9 @@ class Instruction(InstBase):
     Attributes:
         name: Name of the instruction.
         opcode: Opcode of the instruction.
-        operands: The instruction's operands.
+        operands: The instruction's explicit (FieldName-bearing) operands.
+        implicit_operands: The instruction's implicit operands (e.g. EXEC and
+            PC) and are not included in `operands`.
     """
 
     def __init__(
@@ -193,11 +195,23 @@ class Instruction(InstBase):
         opcode: int,
         operands: list[Operand],
         is_implied_literal_enc: bool = False,
+        implicit_operands: list[Operand] | None = None,
     ) -> None:
         super().__init__(enc_name, is_implied_literal_enc)
         self.name = name
         self.opcode = opcode
         self.operands = operands
+        self.implicit_operands = (
+            implicit_operands if implicit_operands is not None else []
+        )
+
+    def has_implicit_operand(self, operand_type: str) -> bool:
+        """Whether any implicit operand has the given type (e.g. ``'OPR_PC'``).
+
+        Implicit operands are the field-less, side-effect operands the spec
+        declares (EXEC, SCC, VCC, M0, PC, memory).
+        """
+        return any(op.operand_type == operand_type for op in self.implicit_operands)
 
     @cached_property
     def fmt_name(self) -> str:

--- a/emulation/rocjitsu/lib/python/amdisa/parser.py
+++ b/emulation/rocjitsu/lib/python/amdisa/parser.py
@@ -864,6 +864,9 @@ class Parser:
                     continue
                 opcode = int(xs.get_node_text(opcode_node))
                 opnds = []
+                # Operands the spec declares implicit and are currently
+                # excluded from `opnds`.
+                implicit_opnds = []
                 for opnd in operands_node:
                     is_in = opnd.attrib[xs.OPERAND_ATTR_INPUT].lower() == 'true'
                     is_out = opnd.attrib[xs.OPERAND_ATTR_OUTPUT].lower() == 'true'
@@ -894,14 +897,33 @@ class Parser:
                                 order,
                             )
                         )
+                    else:
+                        implicit_opnds.append(
+                            Operand(
+                                '',
+                                opnd_size,
+                                opnd_type,
+                                is_in,
+                                is_out,
+                                is_implicit,
+                                is_bin_ucode_required,
+                                order,
+                            )
+                        )
                 opnds.sort(key=lambda x: x.order)
+                implicit_opnds.sort(key=lambda x: x.order)
 
                 enc = self.isa_spec.encoding_map[enc_name]
                 is_implied_literal = (
                     enc_name in self.isa_spec.alt_encs_with_implied_literal
                 )
                 inst = Instruction(
-                    inst_name, enc_name, opcode, opnds, is_implied_literal
+                    inst_name,
+                    enc_name,
+                    opcode,
+                    opnds,
+                    is_implied_literal,
+                    implicit_opnds,
                 )
 
                 # Implied-literal instructions go to the parent encoding's

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_implicit_operands.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_implicit_operands.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the ``Instruction.implicit_operands`` data model.
+
+The MR ISA XML declares some operands implicit: they have no ``<FieldName>`` and
+represent side-effect state (EXEC, SCC, VCC, M0, PC, memory). The parser adds
+them to ``Instruction.implicit_operands`` while explicit field-bearing operands
+go to ``Instruction.operands``.
+"""
+
+from __future__ import annotations
+
+from amdisa.gpuisa import Instruction, Operand
+
+
+def _operand(name: str, operand_type: str, *, implicit: bool) -> Operand:
+    # Operand(name, size, operand_type, is_input, is_output, is_implicit,
+    #         is_bin_ucode_required, order)
+    return Operand(name, 32, operand_type, False, True, implicit, implicit, 0)
+
+
+def test_stores_explicit_and_implicit_operands_independently():
+    # The MR ISA gives s_getpc an explicit destination (sdst) and an implicit
+    # PC source; the two land on separate lists and do not bleed into each other.
+    sdst = _operand('sdst', 'OPR_SDST', implicit=False)
+    pc = _operand('', 'OPR_PC', implicit=True)
+    inst = Instruction('S_GETPC_B64', 'ENC_SOP1', 0, [sdst], implicit_operands=[pc])
+
+    assert inst.operands == [sdst]
+    assert inst.implicit_operands == [pc]
+
+
+def test_has_implicit_operand_matches_by_type():
+    # The generic accessor matches on operand type and ignores the explicit
+    # operand list. Used by codegen as inst.has_implicit_operand('OPR_PC').
+    inst = Instruction(
+        'S_AND_SAVEEXEC_B32',
+        'ENC_SOP1',
+        0,
+        [_operand('sdst', 'OPR_SDST', implicit=False)],
+        implicit_operands=[
+            _operand('', 'OPR_SDST_EXEC', implicit=True),
+            _operand('', 'OPR_SSRC_SPECIAL_SCC', implicit=True),
+        ],
+    )
+
+    assert inst.has_implicit_operand('OPR_SDST_EXEC')
+    assert inst.has_implicit_operand('OPR_SSRC_SPECIAL_SCC')
+    assert not inst.has_implicit_operand('OPR_PC')
+    # An explicit operand's type does not count as an implicit operand.
+    assert not inst.has_implicit_operand('OPR_SDST')
+
+
+def test_has_implicit_operand_false_when_none():
+    assert not Instruction('S_NOP', 'ENC_SOPP', 0, []).has_implicit_operand('OPR_PC')
+
+
+def test_implicit_operands_default_to_empty_list():
+    inst = Instruction('S_MOV_B32', 'ENC_SOP1', 0, [])
+    assert inst.implicit_operands == []
+
+
+def test_implicit_operands_default_is_not_shared_between_instances():
+    # Guards against the classic mutable-default-argument bug: each instruction
+    # must get its own list.
+    a = Instruction('A', 'ENC_SOP1', 0, [])
+    b = Instruction('B', 'ENC_SOP1', 0, [])
+    a.implicit_operands.append(_operand('', 'OPR_PC', implicit=True))
+    assert b.implicit_operands == []
+
+
+def test_implicit_operand_preserves_type_and_direction():
+    # The list keeps the operand's type and is_input/is_output direction, so a
+    # future read-vs-write analysis (e.g. reads PC vs writes PC) can use them.
+    pc_read = Operand('', 64, 'OPR_PC', True, False, True, True, 1)
+    pc_write = Operand('', 64, 'OPR_PC', False, True, True, True, 1)
+
+    reader = Instruction('S_GETPC_B64', 'ENC_SOP1', 0, [], implicit_operands=[pc_read])
+    writer = Instruction('S_RFE_B64', 'ENC_SOP1', 0, [], implicit_operands=[pc_write])
+
+    assert (
+        reader.implicit_operands[0].is_input
+        and not reader.implicit_operands[0].is_output
+    )
+    assert (
+        writer.implicit_operands[0].is_output
+        and not writer.implicit_operands[0].is_input
+    )

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_pc_operand_flag.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_pc_operand_flag.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Tests for the PC_OPERAND flag.
+
+The code generator emits ``flags_ |= PC_OPERAND;`` into an instruction's
+constructor when the instruction has an implicit ``OPR_PC`` operand.
+The DBI anchor validator currently uses that flag to reject non-relocatable
+trampoline anchors.
+
+These tests:
+
+* exercise the production predicate directly on hand-built ``Instruction`` /
+  ``Operand`` fixtures
+* read the committed generated ``.cpp`` to confirm the real parser -> codegen
+  pipeline actually emits the flag for the MR ISA's PC families
+* check instructions that do not have the ``OPR_PC`` operand
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from amdisa.gpuisa import Instruction, Operand
+
+_GEN_ROOT = (
+    pathlib.Path(__file__).resolve().parents[4]
+    / 'lib'
+    / 'rocjitsu'
+    / 'src'
+    / 'rocjitsu'
+    / 'isa'
+    / 'arch'
+    / 'amdgpu'
+)
+
+
+def _implicit(
+    operand_type: str, *, reads: bool, writes: bool, size: int = 64
+) -> Operand:
+    """A field-less implicit operand, as the parser produces for OPR_* operands."""
+    return Operand('', size, operand_type, reads, writes, True, True, 1)
+
+
+# ---------------------------------------------------------------------------
+# Predicate: Instruction.has_implicit_operand('OPR_PC')
+# ---------------------------------------------------------------------------
+
+
+def test_pc_read_operand_is_detected():
+    # MR ISA: s_getpc_b64 has an implicit OPR_PC operand with Input=true.
+    getpc = Instruction(
+        'S_GETPC_B64',
+        'ENC_SOP1',
+        0,
+        [],
+        implicit_operands=[_implicit('OPR_PC', reads=True, writes=False)],
+    )
+    assert getpc.has_implicit_operand('OPR_PC')
+
+
+def test_pc_write_operand_is_detected():
+    # MR ISA: s_rfe_b64 has an implicit OPR_PC operand with Output=true. It is
+    # classified true_nop and carries no control-flow flag, so this operand is
+    # the only structural signal that it touches PC.
+    rfe = Instruction(
+        'S_RFE_B64',
+        'ENC_SOP1',
+        0,
+        [],
+        implicit_operands=[_implicit('OPR_PC', reads=False, writes=True)],
+    )
+    assert rfe.has_implicit_operand('OPR_PC')
+
+
+def test_non_pc_implicit_operand_is_not_detected():
+    # MR ISA: s_and_b32 has an implicit SCC operand (OPR_SSRC_SPECIAL_SCC) and no
+    # OPR_PC. The predicate must discriminate by operand type, not merely flag
+    # any instruction that has implicit operands.
+    s_and = Instruction(
+        'S_AND_B32',
+        'ENC_SOP2',
+        0,
+        [],
+        implicit_operands=[
+            _implicit('OPR_SSRC_SPECIAL_SCC', reads=False, writes=True, size=1)
+        ],
+    )
+    assert s_and.implicit_operands  # it does carry an implicit operand ...
+    assert not s_and.has_implicit_operand('OPR_PC')  # ... just not a PC one
+
+
+def test_instruction_without_pc_operand_is_not_detected():
+    # MR ISA: s_branch carries a label operand (not OPR_PC); s_mov_b32 has no
+    # implicit operands at all. Neither reads nor writes PC.
+    branch = Instruction('S_BRANCH', 'ENC_SOPP', 0, [])
+    mov = Instruction('S_MOV_B32', 'ENC_SOP1', 0, [])
+    assert not branch.has_implicit_operand('OPR_PC')
+    assert not mov.has_implicit_operand('OPR_PC')
+
+
+# ---------------------------------------------------------------------------
+# Generated-output: the real pipeline emits the flag for the MR ISA families
+# ---------------------------------------------------------------------------
+
+
+def _ctor_body(src: str, cls: str) -> str:
+    """Slice out the constructor body for class `cls` (ctor up to its execute_impl)."""
+    start = src.index(f'{cls}::{cls}(')
+    end = src.index(f'void {cls}::execute_impl', start)
+    return src[start:end]
+
+
+def test_generated_cdna_constructors_emit_pc_operand_flag():
+    src = (_GEN_ROOT / 'cdna2' / 'sop1.cpp').read_text()
+
+    assert 'flags_ |= PC_OPERAND;' in _ctor_body(src, 'SGetpcB64Sop1')
+    assert 'flags_ |= PC_OPERAND;' in _ctor_body(src, 'SRfeB64Sop1')
+    # Ordinary scalar move must NOT be flagged.
+    assert 'flags_ |= PC_OPERAND;' not in _ctor_body(src, 'SMovB32Sop1')
+
+
+def test_generated_gfx1250_renamed_constructors_emit_pc_operand_flag():
+    # gfx1250 renames the family (s_getpc_b64 -> s_get_pc_i64) but keeps the
+    # OPR_PC operand, so the flag must still be emitted
+    src = (_GEN_ROOT / 'gfx1250' / 'sop1.cpp').read_text()
+
+    assert 'flags_ |= PC_OPERAND;' in _ctor_body(src, 'SGetPcI64Sop1')
+    assert 'flags_ |= PC_OPERAND;' in _ctor_body(src, 'SRfeI64Sop1')
+    assert 'flags_ |= PC_OPERAND;' not in _ctor_body(src, 'SMovB32Sop1')

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.cpp
@@ -14,9 +14,7 @@
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
 
-#include <array>
 #include <cstring>
-#include <string_view>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -24,32 +22,6 @@
 namespace rocjitsu {
 
 namespace {
-
-// PC-reading / PC-relative instructions to reject as anchors: relocating any of
-// them into a trampoline changes the PC value they read (s_getpc) or the target
-// they branch to. s_getpc and the s_rfe_ family carry no control-flow flag or
-// branch_offset_bytes, so validate_anchor's flag/offset checks miss them and the
-// denylist is the only thing that catches them. The s_call / s_setpc / s_swappc
-// entries are already rejected upstream by their INDIRECT_BRANCH / INDIRECT_CALL
-// flags and are listed only as defense-in-depth. gfx1250 renames the whole
-// family from *_b64 to *_i64 (e.g. s_getpc_b64 -> s_get_pc_i64), so both
-// spellings are listed; the s_rfe_ prefix match below covers s_rfe_b64,
-// s_rfe_i64, and s_rfe_restore_b64.
-constexpr std::array<std::string_view, 8> kPcRelativeDenylist = {
-    "s_getpc_b64",  "s_call_b64", "s_setpc_b64",  "s_swappc_b64",
-    "s_get_pc_i64", "s_call_i64", "s_set_pc_i64", "s_swap_pc_i64",
-};
-
-constexpr std::string_view kRfePrefix = "s_rfe_";
-
-[[nodiscard]] bool is_denylisted_mnemonic(std::string_view mnemonic) {
-  for (auto m : kPcRelativeDenylist)
-    if (mnemonic == m)
-      return true;
-  if (mnemonic.size() >= kRfePrefix.size() && mnemonic.substr(0, kRfePrefix.size()) == kRfePrefix)
-    return true;
-  return false;
-}
 
 // Per-site result of Instrumentor::patch's preflight: the chosen trampoline
 // offset and the concrete bytes we'll splice in once all preflights succeed.
@@ -96,8 +68,11 @@ bool is_relocatable_anchor(const Instruction &anchor, uint64_t anchor_offset,
     report(error_out, "anchor instruction has a PC-relative branch offset");
     return false;
   }
-  if (is_denylisted_mnemonic(anchor.mnemonic())) {
-    report(error_out, "anchor mnemonic is in the PC-relative denylist");
+  // Reject instructions that read or write the program counter (the ISA spec
+  // gives them an OPR_PC operand). Relocating their bytes into a trampoline
+  // would change the PC value they read or the target they compute.
+  if (anchor.is_pc_operand()) {
+    report(error_out, "anchor instruction reads or writes the program counter");
     return false;
   }
   return true;

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/patch/instrumentor.h
@@ -150,10 +150,10 @@ struct InstrumentedCodeObjectDebug : InstrumentedCodeObject {
 ///   - anchor.raw_encoding() is non-null.
 ///   - anchor is not a branch/cond branch/indirect branch/indirect call/
 ///     program terminator, and branch_offset_bytes() is nullopt.
-///   - anchor.mnemonic() is not in the small PC-relative denylist
-///     (s_getpc_b64, s_call_b64, s_setpc_b64, s_swappc_b64, s_rfe_*).
+///   - anchor does not read or write the program counter, i.e. is_pc_operand()
+///     is false.
 ///
-/// @p arch is accepted now so a future denylist can grow ISA-specific entries
+/// @p arch is accepted now so a future check can grow ISA-specific behavior
 /// without an API change; today's checks are uniform across all AMDGPU ISAs.
 [[nodiscard]] bool is_relocatable_anchor(const Instruction &anchor, uint64_t anchor_offset,
                                          std::span<const uint8_t> text_bytes, rj_code_arch_t arch,

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/sop1.cpp
@@ -544,6 +544,7 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
   dst_operands_[0] = &sdst;
   num_src_ = 0;
   num_dst_ = 1;
+  flags_ |= PC_OPERAND;
 }
 
 void SGetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { sdst.write_scalar64(wf, wf.pc + size_); }
@@ -560,6 +561,7 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_BRANCH;
+  flags_ |= PC_OPERAND;
 }
 
 void SSetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { wf.pc = ssrc0.read_scalar64(wf) - size_; }
@@ -578,6 +580,7 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 void SSwappcB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
@@ -596,6 +599,7 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
     ssrc0 = Operand(
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SRfeB64Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_rfe_b64_sop1(*this, wf); }
@@ -909,6 +913,7 @@ SCbranchJoinSop1::SCbranchJoinSop1(const MachineInst *inst)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SCbranchJoinSop1::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/sop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/sop2.cpp
@@ -976,6 +976,7 @@ SCbranchGForkSop2::SCbranchGForkSop2(const MachineInst *inst)
     ssrc1 = Operand(
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop2InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SCbranchGForkSop2::execute_impl(amdgpu::Wavefront &wf) {
@@ -1025,6 +1026,7 @@ SRfeRestoreB64Sop2::SRfeRestoreB64Sop2(const MachineInst *inst)
     ssrc1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop2InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SRfeRestoreB64Sop2::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna1/sopk.cpp
@@ -392,6 +392,7 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
   num_src_ = 1;
   num_dst_ = 1;
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 std::optional<int64_t> SCallB64Sopk::branch_offset_bytes() const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/sop1.cpp
@@ -544,6 +544,7 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
   dst_operands_[0] = &sdst;
   num_src_ = 0;
   num_dst_ = 1;
+  flags_ |= PC_OPERAND;
 }
 
 void SGetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { sdst.write_scalar64(wf, wf.pc + size_); }
@@ -560,6 +561,7 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_BRANCH;
+  flags_ |= PC_OPERAND;
 }
 
 void SSetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { wf.pc = ssrc0.read_scalar64(wf) - size_; }
@@ -578,6 +580,7 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 void SSwappcB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
@@ -596,6 +599,7 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
     ssrc0 = Operand(
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SRfeB64Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_rfe_b64_sop1(*this, wf); }
@@ -909,6 +913,7 @@ SCbranchJoinSop1::SCbranchJoinSop1(const MachineInst *inst)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SCbranchJoinSop1::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/sop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/sop2.cpp
@@ -976,6 +976,7 @@ SCbranchGForkSop2::SCbranchGForkSop2(const MachineInst *inst)
     ssrc1 = Operand(
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop2InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SCbranchGForkSop2::execute_impl(amdgpu::Wavefront &wf) {
@@ -1025,6 +1026,7 @@ SRfeRestoreB64Sop2::SRfeRestoreB64Sop2(const MachineInst *inst)
     ssrc1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop2InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SRfeRestoreB64Sop2::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna2/sopk.cpp
@@ -392,6 +392,7 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
   num_src_ = 1;
   num_dst_ = 1;
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 std::optional<int64_t> SCallB64Sopk::branch_offset_bytes() const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/sop1.cpp
@@ -544,6 +544,7 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
   dst_operands_[0] = &sdst;
   num_src_ = 0;
   num_dst_ = 1;
+  flags_ |= PC_OPERAND;
 }
 
 void SGetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { sdst.write_scalar64(wf, wf.pc + size_); }
@@ -560,6 +561,7 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_BRANCH;
+  flags_ |= PC_OPERAND;
 }
 
 void SSetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { wf.pc = ssrc0.read_scalar64(wf) - size_; }
@@ -578,6 +580,7 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 void SSwappcB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
@@ -596,6 +599,7 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
     ssrc0 = Operand(
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SRfeB64Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_rfe_b64_sop1(*this, wf); }
@@ -909,6 +913,7 @@ SCbranchJoinSop1::SCbranchJoinSop1(const MachineInst *inst)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SCbranchJoinSop1::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/sop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/sop2.cpp
@@ -976,6 +976,7 @@ SCbranchGForkSop2::SCbranchGForkSop2(const MachineInst *inst)
     ssrc1 = Operand(
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop2InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SCbranchGForkSop2::execute_impl(amdgpu::Wavefront &wf) {
@@ -1025,6 +1026,7 @@ SRfeRestoreB64Sop2::SRfeRestoreB64Sop2(const MachineInst *inst)
     ssrc1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop2InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SRfeRestoreB64Sop2::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna3/sopk.cpp
@@ -392,6 +392,7 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
   num_src_ = 1;
   num_dst_ = 1;
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 std::optional<int64_t> SCallB64Sopk::branch_offset_bytes() const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/sop1.cpp
@@ -542,6 +542,7 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
   dst_operands_[0] = &sdst;
   num_src_ = 0;
   num_dst_ = 1;
+  flags_ |= PC_OPERAND;
 }
 
 void SGetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { sdst.write_scalar64(wf, wf.pc + size_); }
@@ -558,6 +559,7 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_BRANCH;
+  flags_ |= PC_OPERAND;
 }
 
 void SSetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { wf.pc = ssrc0.read_scalar64(wf) - size_; }
@@ -576,6 +578,7 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 void SSwappcB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
@@ -594,6 +597,7 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
     ssrc0 = Operand(
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SRfeB64Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_rfe_b64_sop1(*this, wf); }
@@ -907,6 +911,7 @@ SCbranchJoinSop1::SCbranchJoinSop1(const MachineInst *inst)
     ssrc0 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SCbranchJoinSop1::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/sop2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/sop2.cpp
@@ -976,6 +976,7 @@ SCbranchGForkSop2::SCbranchGForkSop2(const MachineInst *inst)
     ssrc1 = Operand(
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop2InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SCbranchGForkSop2::execute_impl(amdgpu::Wavefront &wf) {
@@ -1025,6 +1026,7 @@ SRfeRestoreB64Sop2::SRfeRestoreB64Sop2(const MachineInst *inst)
     ssrc1 = Operand(
         32, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop2InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SRfeRestoreB64Sop2::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/cdna4/sopk.cpp
@@ -395,6 +395,7 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
   num_src_ = 1;
   num_dst_ = 1;
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 std::optional<int64_t> SCallB64Sopk::branch_offset_bytes() const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/sop1.cpp
@@ -1592,6 +1592,7 @@ SGetPcI64Sop1::SGetPcI64Sop1(const MachineInst *inst)
   dst_operands_[0] = &sdst;
   num_src_ = 0;
   num_dst_ = 1;
+  flags_ |= PC_OPERAND;
 }
 
 void SGetPcI64Sop1::execute_impl(amdgpu::Wavefront &wf) { sdst.write_scalar64(wf, wf.pc + size_); }
@@ -1615,6 +1616,7 @@ SSetPcI64Sop1::SSetPcI64Sop1(const MachineInst *inst)
     ssrc0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
   flags_ |= INDIRECT_BRANCH;
+  flags_ |= PC_OPERAND;
 }
 
 void SSetPcI64Sop1::execute_impl(amdgpu::Wavefront &wf) { wf.pc = ssrc0.read_scalar64(wf) - size_; }
@@ -1640,6 +1642,7 @@ SSwapPcI64Sop1::SSwapPcI64Sop1(const MachineInst *inst)
     ssrc0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 void SSwapPcI64Sop1::execute_impl(amdgpu::Wavefront &wf) {
@@ -1665,6 +1668,7 @@ SRfeI64Sop1::SRfeI64Sop1(const MachineInst *inst)
         (static_cast<uint64_t>(words[literal_word + 1]) << 32) | words[literal_word];
     ssrc0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
+  flags_ |= PC_OPERAND;
 }
 
 void SRfeI64Sop1::execute_impl(amdgpu::Wavefront &wf) { (void)wf; }
@@ -1688,6 +1692,7 @@ SAddPcI64Sop1::SAddPcI64Sop1(const MachineInst *inst)
     ssrc0 = Operand(64, OperandType::OPR_SIMM64, literal64, true);
   }
   flags_ |= INDIRECT_BRANCH;
+  flags_ |= PC_OPERAND;
 }
 
 void SAddPcI64Sop1::execute_impl(amdgpu::Wavefront &wf) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/sopk.cpp
@@ -243,6 +243,7 @@ SCallI64Sopk::SCallI64Sopk(const MachineInst *inst)
   num_src_ = 1;
   num_dst_ = 1;
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 std::optional<int64_t> SCallI64Sopk::branch_offset_bytes() const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/sop1.cpp
@@ -544,6 +544,7 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
   dst_operands_[0] = &sdst;
   num_src_ = 0;
   num_dst_ = 1;
+  flags_ |= PC_OPERAND;
 }
 
 void SGetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { sdst.write_scalar64(wf, wf.pc + size_); }
@@ -560,6 +561,7 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_BRANCH;
+  flags_ |= PC_OPERAND;
 }
 
 void SSetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { wf.pc = ssrc0.read_scalar64(wf) - size_; }
@@ -578,6 +580,7 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 void SSwappcB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
@@ -596,6 +599,7 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
     ssrc0 = Operand(
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SRfeB64Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_rfe_b64_sop1(*this, wf); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna1/sopk.cpp
@@ -388,6 +388,7 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
   num_src_ = 1;
   num_dst_ = 1;
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 std::optional<int64_t> SCallB64Sopk::branch_offset_bytes() const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/sop1.cpp
@@ -544,6 +544,7 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
   dst_operands_[0] = &sdst;
   num_src_ = 0;
   num_dst_ = 1;
+  flags_ |= PC_OPERAND;
 }
 
 void SGetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { sdst.write_scalar64(wf, wf.pc + size_); }
@@ -560,6 +561,7 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_BRANCH;
+  flags_ |= PC_OPERAND;
 }
 
 void SSetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { wf.pc = ssrc0.read_scalar64(wf) - size_; }
@@ -578,6 +580,7 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 void SSwappcB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
@@ -596,6 +599,7 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
     ssrc0 = Operand(
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SRfeB64Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_rfe_b64_sop1(*this, wf); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna2/sopk.cpp
@@ -388,6 +388,7 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
   num_src_ = 1;
   num_dst_ = 1;
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 std::optional<int64_t> SCallB64Sopk::branch_offset_bytes() const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/sop1.cpp
@@ -1166,6 +1166,7 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
   dst_operands_[0] = &sdst;
   num_src_ = 0;
   num_dst_ = 1;
+  flags_ |= PC_OPERAND;
 }
 
 void SGetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { sdst.write_scalar64(wf, wf.pc + size_); }
@@ -1182,6 +1183,7 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_BRANCH;
+  flags_ |= PC_OPERAND;
 }
 
 void SSetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { wf.pc = ssrc0.read_scalar64(wf) - size_; }
@@ -1200,6 +1202,7 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 void SSwappcB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
@@ -1218,6 +1221,7 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
     ssrc0 = Operand(
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SRfeB64Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_rfe_b64_sop1(*this, wf); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/sopk.cpp
@@ -388,6 +388,7 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
   num_src_ = 1;
   num_dst_ = 1;
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 std::optional<int64_t> SCallB64Sopk::branch_offset_bytes() const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/sop1.cpp
@@ -1166,6 +1166,7 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
   dst_operands_[0] = &sdst;
   num_src_ = 0;
   num_dst_ = 1;
+  flags_ |= PC_OPERAND;
 }
 
 void SGetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { sdst.write_scalar64(wf, wf.pc + size_); }
@@ -1182,6 +1183,7 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_BRANCH;
+  flags_ |= PC_OPERAND;
 }
 
 void SSetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { wf.pc = ssrc0.read_scalar64(wf) - size_; }
@@ -1200,6 +1202,7 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 void SSwappcB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
@@ -1218,6 +1221,7 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
     ssrc0 = Operand(
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SRfeB64Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_rfe_b64_sop1(*this, wf); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/sopk.cpp
@@ -388,6 +388,7 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
   num_src_ = 1;
   num_dst_ = 1;
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 std::optional<int64_t> SCallB64Sopk::branch_offset_bytes() const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/sop1.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/sop1.cpp
@@ -1166,6 +1166,7 @@ SGetpcB64Sop1::SGetpcB64Sop1(const MachineInst *inst)
   dst_operands_[0] = &sdst;
   num_src_ = 0;
   num_dst_ = 1;
+  flags_ |= PC_OPERAND;
 }
 
 void SGetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { sdst.write_scalar64(wf, wf.pc + size_); }
@@ -1182,6 +1183,7 @@ SSetpcB64Sop1::SSetpcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_BRANCH;
+  flags_ |= PC_OPERAND;
 }
 
 void SSetpcB64Sop1::execute_impl(amdgpu::Wavefront &wf) { wf.pc = ssrc0.read_scalar64(wf) - size_; }
@@ -1200,6 +1202,7 @@ SSwappcB64Sop1::SSwappcB64Sop1(const MachineInst *inst)
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 void SSwappcB64Sop1::execute_impl(amdgpu::Wavefront &wf) {
@@ -1218,6 +1221,7 @@ SRfeB64Sop1::SRfeB64Sop1(const MachineInst *inst)
     ssrc0 = Operand(
         64, OperandType::OPR_SIMM32,
         static_cast<int>(reinterpret_cast<const Sop1InstLiteralMachineInst *>(inst)->simm32));
+  flags_ |= PC_OPERAND;
 }
 
 void SRfeB64Sop1::execute_impl(amdgpu::Wavefront &wf) { amdgpu::execute_s_rfe_b64_sop1(*this, wf); }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/sopk.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/sopk.cpp
@@ -215,6 +215,7 @@ SCallB64Sopk::SCallB64Sopk(const MachineInst *inst)
   num_src_ = 1;
   num_dst_ = 1;
   flags_ |= INDIRECT_CALL;
+  flags_ |= PC_OPERAND;
 }
 
 std::optional<int64_t> SCallB64Sopk::branch_offset_bytes() const {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/instruction.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/instruction.h
@@ -46,7 +46,9 @@ enum InstFlags : uint64_t {
   /// @brief AccVGPR move instruction (v_accvgpr_write, v_accvgpr_read, v_accvgpr_mov).
   ACCVGPR = (1ULL << 10),
   /// @brief Destination update is conditional and must not kill the old value.
-  PREDICATED_DEF = (1ULL << 11)
+  PREDICATED_DEF = (1ULL << 11),
+  /// @brief Instruction includes PC as an operand
+  PC_OPERAND = (1ULL << 12)
 };
 
 class BasicBlock;
@@ -204,6 +206,11 @@ public:
   bool is_mfma() const { return flags_ & MFMA; }
 
   bool is_accvgpr() const { return flags_ & ACCVGPR; }
+
+  /// @brief Whether this instruction reads or writes the program counter.
+  /// @retval true The instruction has the PC_OPERAND flag (OPR_PC operand).
+  /// @retval false The instruction does not access PC as an operand.
+  bool is_pc_operand() const { return flags_ & PC_OPERAND; }
 
   /// @brief Signed byte offset for a direct branch target.
   ///

--- a/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
+++ b/emulation/rocjitsu/tests/patch/instrumentor_test.cpp
@@ -236,24 +236,81 @@ TEST(Validator, RejectsForceFullExec) {
   EXPECT_FALSE(err.empty());
 }
 
-TEST(Validator, RejectsDenylistedMnemonic) {
+// PC-reading / PC-writing instructions (e.g., s_getpc and s_setpc) cannot
+// currently be relocated because they depend on the VA, which will change
+// when the instruction is relocated. Until these are properly handled,
+// the validator must reject instructions with the PC_OPERAND flag.
+TEST(Validator, RejectsPcOperandAnchor) {
   static constexpr uint32_t kRaw = 0xCAFEBABEu;
   auto text = dummy_text();
   InstrumentationPoint pt;
 
-  // PC-relative semantics that may not surface in flags / branch_offset_bytes.
-  // Includes gfx1250's renamed _i64 family (s_getpc_b64 -> s_get_pc_i64, etc.);
-  // s_rfe_b64 / s_rfe_i64 exercise the s_rfe_ prefix match.
-  for (const char *m :
-       {"s_getpc_b64", "s_call_b64", "s_setpc_b64", "s_swappc_b64", "s_rfe_b64", "s_get_pc_i64",
-        "s_call_i64", "s_set_pc_i64", "s_swap_pc_i64", "s_rfe_i64"}) {
-    TestInstruction anchor(m, 4, /*flags=*/0, std::nullopt, &kRaw);
-    std::string err;
-    EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value())
-        << "mnemonic " << m << " should be rejected";
-    EXPECT_FALSE(err.empty());
-  }
+  TestInstruction anchor("opaque_pc_reader", 4, /*flags=*/PC_OPERAND, std::nullopt, &kRaw);
+  std::string err;
+  EXPECT_FALSE(validate_anchor(anchor, 0, text, pt, ROCJITSU_CODE_ARCH_CDNA4, &err).has_value());
+  EXPECT_FALSE(err.empty());
+
+  // An 8-byte PC_OPERAND anchor is rejected too (size is independent of the flag).
+  TestInstruction anchor8("opaque_pc_reader", 8, /*flags=*/PC_OPERAND, std::nullopt, &kRaw);
+  std::string err8;
+  EXPECT_FALSE(
+      validate_anchor(anchor8, 0, dummy_text(16), pt, ROCJITSU_CODE_ARCH_CDNA4, &err8).has_value());
 }
+
+//==============================================================================
+// Section 1b: PC_OPERAND end-to-end (real decode)
+//==============================================================================
+
+// Decode real AMDGPU encodings and assert the structural PC_OPERAND flag is set
+// for PC-reading/writing instructions and clear for an ordinary one. This proves
+// the ISA codegen actually marks the flag, and that the validator rejects the
+// decoded anchors without any mnemonic matching. Covers a CDNA target and
+// gfx1250, whose mnemonics are s_getpc_b64 and s_get_pc_i64) but whose
+// OPR_PC operand is unchanged.
+namespace {
+struct PcDecodeCase {
+  rj_code_arch_t arch;
+  const char *arch_name;
+  std::array<uint32_t, 2> words;
+  const char *mnemonic;
+  bool expect_pc_operand;
+};
+} // namespace
+
+class PcOperandDecodeTest : public ::testing::TestWithParam<PcDecodeCase> {};
+
+TEST_P(PcOperandDecodeTest, FlagMatchesAndValidatorAgrees) {
+  const PcDecodeCase &tc = GetParam();
+  auto decoder = Decoder::create(tc.arch);
+  ASSERT_NE(decoder, nullptr) << "no decoder for " << tc.arch_name;
+  std::unique_ptr<Instruction> inst(decoder->decode(tc.words.data()));
+  ASSERT_NE(inst, nullptr) << "decode failed for " << tc.mnemonic << " on " << tc.arch_name;
+
+  EXPECT_EQ(inst->is_pc_operand(), tc.expect_pc_operand)
+      << tc.mnemonic << " on " << tc.arch_name << ": PC_OPERAND flag mismatch";
+
+  // The validator's verdict must follow the flag: PC_OPERAND anchors rejected,
+  // ordinary ones accepted. Use a .text big enough for the (4- or 8-byte) inst.
+  const auto size = static_cast<size_t>(inst->size());
+  std::vector<uint8_t> text(size + 8, 0xCCu);
+  std::string err;
+  const bool ok = is_relocatable_anchor(*inst, 0, text, tc.arch, &err);
+  EXPECT_EQ(ok, !tc.expect_pc_operand) << tc.mnemonic << " on " << tc.arch_name;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    PcOperand, PcOperandDecodeTest,
+    ::testing::Values(
+        // CDNA4: s_getpc reads PC, s_rfe writes PC; s_mov_b32 touches neither.
+        PcDecodeCase{ROCJITSU_CODE_ARCH_CDNA4, "cdna4", {0xBE801C00U, 0U}, "s_getpc_b64", true},
+        PcDecodeCase{ROCJITSU_CODE_ARCH_CDNA4, "cdna4", {0xBE801F00U, 0U}, "s_rfe_b64", true},
+        PcDecodeCase{ROCJITSU_CODE_ARCH_CDNA4, "cdna4", {0xBE800000U, 0U}, "s_mov_b32", false},
+        // gfx1250: s_get_pc_i64 reads, s_rfe_i64 writes; s_mov_b32 neither.
+        PcDecodeCase{
+            ROCJITSU_CODE_ARCH_GFX1250, "gfx1250", {0xBE804700U, 0U}, "s_get_pc_i64", true},
+        PcDecodeCase{ROCJITSU_CODE_ARCH_GFX1250, "gfx1250", {0xBE804A00U, 0U}, "s_rfe_i64", true},
+        PcDecodeCase{
+            ROCJITSU_CODE_ARCH_GFX1250, "gfx1250", {0xBE800000U, 0U}, "s_mov_b32", false}));
 
 // Instruction::size() is a signed int; the `size != 4 && size != 8` check must
 // reject negative sizes (which decoders never emit in practice) rather than let


### PR DESCRIPTION
## Motivation

DBI cannot currently relocate PC-relative instructions or instructions that read/write the PC because  this requires more care. PC read/writes were originally rejected through a fragile denylist based on mnemonic spelling. This refactors the denylist by adding a `is_pc_operand` function to `instruction.h` which checks if the PC is an operand of the instruction (i.e., if it reads or writes the PC).

## Technical Details

* `is_pc_operand` just checks the new `PC_OPERAND` flag, which gets set by instructions that have the PC as in implicit operand.
* I couldn't find an example of the PC being written through an explicit operand so I `is_pc_operand` does not search the explicit operands.
* To set PC_OPERAND, I needed to add `implicit_operands` to gpuisa, since `operands` only included explicit ones.
* I chose to set a PC_OPERAND flag rather than something broader that might include all branches (which would change the PC) since branches are already covered by their own flags and because this was not possible to gather from the MR ISA. 

## Test Plan

* Implement amdisa tests for `implicit_operands` and `PC_OPERAND`.
* Update Instrumentation tests to forgo denylist and make sure that the instructions originally denied are still being denied.
* Make sure all amdisa tests pass
* Make sure all overall tests pass

## Test Result

All tests pass.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
