### PR TITLE
Fix segfault in IB-CAST port recovery AH cleanup

### DIFF
--- a/projects/rccl/src/include/ibvwrap.h
+++ b/projects/rccl/src/include/ibvwrap.h
@@ -67,6 +67,27 @@ ncclResult_t wrap_ibv_destroy_qp(struct ibv_qp *qp);
 ncclResult_t wrap_ibv_query_ece(struct ibv_qp *qp, struct ibv_ece *ece, int* supported);
 ncclResult_t wrap_ibv_set_ece(struct ibv_qp *qp, struct ibv_ece *ece, int* supported);
 
+static inline ncclResult_t wrap_ibv_create_ah(struct ibv_ah **ret, struct ibv_pd *pd, struct ibv_ah_attr *attr) {
+  struct ibv_ah *ah = pd->context->ops.create_ah(pd, attr);
+  if (ah == NULL) {
+    WARN("Call to ibv_create_ah() failed");
+    return ncclSystemError;
+  }
+  ah->context = pd->context;
+  ah->pd = pd;
+  *ret = ah;
+  return ncclSuccess;
+}
+
+static inline ncclResult_t wrap_ibv_destroy_ah(struct ibv_ah *ah) {
+  int ret = ah->context->ops.destroy_ah(ah); /*returns 0 on success, or the value of errno on failure*/
+  if (ret != IBV_SUCCESS) {
+    WARN("ibv_destroy_ah() failed with error %s", strerror(ret));
+    return ncclSystemError;
+  }
+  return ncclSuccess;
+}
+
 static inline ncclResult_t wrap_ibv_post_send(struct ibv_qp *qp, struct ibv_send_wr *wr, struct ibv_send_wr **bad_wr) {
   int ret = qp->context->ops.post_send(qp, wr, bad_wr); /*returns 0 on success, or the value of errno on failure (which indicates the failure reason)*/
   if (ret != IBV_SUCCESS) {

--- a/projects/rccl/src/include/ibvwrap.h
+++ b/projects/rccl/src/include/ibvwrap.h
@@ -17,6 +17,8 @@
 #endif
 
 #include "core.h"
+#include <errno.h>
+#include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -68,9 +70,14 @@ ncclResult_t wrap_ibv_query_ece(struct ibv_qp *qp, struct ibv_ece *ece, int* sup
 ncclResult_t wrap_ibv_set_ece(struct ibv_qp *qp, struct ibv_ece *ece, int* supported);
 
 static inline ncclResult_t wrap_ibv_create_ah(struct ibv_ah **ret, struct ibv_pd *pd, struct ibv_ah_attr *attr) {
-  struct ibv_ah *ah = pd->context->ops.create_ah(pd, attr);
+  if (ret) *ret = NULL; /*don't leave a stale pointer behind if creation fails*/
+  if (ret == NULL || pd == NULL || pd->context == NULL || attr == NULL) {
+    WARN("wrap_ibv_create_ah() called with invalid arguments (ret=%p, pd=%p, context=%p, attr=%p)", ret, pd, pd ? pd->context : NULL, attr);
+    return ncclSystemError;
+  }
+  struct ibv_ah *ah = pd->context->ops.create_ah(pd, attr); /*returns NULL on failure, with errno set*/
   if (ah == NULL) {
-    WARN("Call to ibv_create_ah() failed");
+    WARN("ibv_create_ah() failed: %s", strerror(errno));
     return ncclSystemError;
   }
   ah->context = pd->context;
@@ -80,9 +87,13 @@ static inline ncclResult_t wrap_ibv_create_ah(struct ibv_ah **ret, struct ibv_pd
 }
 
 static inline ncclResult_t wrap_ibv_destroy_ah(struct ibv_ah *ah) {
+  if (ah == NULL || ah->context == NULL) {
+    WARN("wrap_ibv_destroy_ah() called with invalid AH (ah=%p, context=%p)", ah, ah ? ah->context : NULL);
+    return ncclSystemError;
+  }
   int ret = ah->context->ops.destroy_ah(ah); /*returns 0 on success, or the value of errno on failure*/
   if (ret != IBV_SUCCESS) {
-    WARN("ibv_destroy_ah() failed with error %s", strerror(ret));
+    WARN("ibv_destroy_ah() failed with error %s (%d)", strerror(ret), ret);
     return ncclSystemError;
   }
   return ncclSuccess;

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -339,11 +339,7 @@ ncclResult_t IbCastPortRecoverySenderQpsToRts(struct ncclIbResiliency* resCtx, s
     } else {
       ahAttr.dlid = remDevInfo->lid;
     }
-    resCtx->portRecoveryAh[localDevIndex] = sendCommDev->base.pd->context->ops.create_ah(sendCommDev->base.pd, &ahAttr);
-    if (!resCtx->portRecoveryAh[localDevIndex]) {
-      WARN("NET/IB: %s: Failed to create AH for recovery QP on device %d (comm=%p)", __func__, localDevIndex, resCtx->baseComm);
-      return ncclSystemError;
-    }
+    NCCLCHECK(wrap_ibv_create_ah(&resCtx->portRecoveryAh[localDevIndex], sendCommDev->base.pd, &ahAttr));
     resCtx->portRecoveryRemoteQpn[localDevIndex] = remQpInfo->qpn;
 
     INFO(NCCL_NET, "NET/IB: %s: To RTS done on recovery UD QP (index=%d, qp_num=%u, remote_qpn=%u, deviceIndex=%d, comm=%p)", __func__, localQpIndex, localQp->qp->qp_num, remQpInfo->qpn, localDevIndex, resCtx->baseComm);
@@ -393,11 +389,7 @@ ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* r
     } else {
       ahAttr.dlid = remDevInfo->lid;
     }
-    resCtx->portRecoveryAh[localDevIndex] = recvCommDev->base.pd->context->ops.create_ah(recvCommDev->base.pd, &ahAttr);
-    if (!resCtx->portRecoveryAh[localDevIndex]) {
-      WARN("NET/IB: %s: Failed to create AH for recovery QP on device %d (comm=%p)", __func__, localDevIndex, resCtx->baseComm);
-      return ncclSystemError;
-    }
+    NCCLCHECK(wrap_ibv_create_ah(&resCtx->portRecoveryAh[localDevIndex], recvCommDev->base.pd, &ahAttr));
     resCtx->portRecoveryRemoteQpn[localDevIndex] = remQpInfo->qpn;
     INFO(NCCL_NET, "NET/IB: %s: To RTS done on recovery UD QP (index=%d, qp_num=%u, remote_qpn=%u, deviceIndex=%d, comm=%p)", __func__, localQpIndex, localQp->qp->qp_num, remQpInfo->qpn, localDevIndex, resCtx->baseComm);
   }
@@ -407,7 +399,7 @@ ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* r
 ncclResult_t IbCastPortRecoveryQpsDestroy(struct ncclIbResiliency* resCtx, int nQps) {
   for (int qpIndex = 0; qpIndex < nQps; qpIndex++) {
     if (resCtx->portRecoveryAh[qpIndex]) {
-      resCtx->portRecoveryAh[qpIndex]->context->ops.destroy_ah(resCtx->portRecoveryAh[qpIndex]);
+      NCCLCHECK(wrap_ibv_destroy_ah(resCtx->portRecoveryAh[qpIndex]));
       resCtx->portRecoveryAh[qpIndex] = nullptr;
     }
     struct ncclIbQp* recoveryQp = &resCtx->portRecoveryQps[qpIndex];


### PR DESCRIPTION
## Motivation

- The IB-CAST port-recovery tests segfault during teardown on Mellanox CX-7 (pure IB), making the recovery path unusable on that hardware.

## Technical Details

- Recovery code built Address Handles via the low-level pd->context->ops.create_ah(...), which leaves ah->context/ah->pd NULL (the public ibv_create_ah() normally sets them).
- Teardown then dereferenced ah->context->ops.destroy_ah(...) on a NULL context, causing SIGSEGV near offset 0xe8; new wrap_ibv_create_ah/wrap_ibv_destroy_ah wrappers in ibvwrap.h set those fields and are used at the two create sites and one destroy site.

## JIRA ID

AICOMRCCL-1437

## Test Plan

- Build librccl + rccl unit tests and run Resiliency_Recovery* via test_runner.py with mi300x_mellanox_ib.json on the 2-node CX-7 setup.

## Test Result

- No more SIGSEGV in IbCastPortRecoveryQpsDestroy; recovery tests run to completion and the process exits cleanly.

```
Detailed Results:
------------------------------------------------------------------------------------------------------------------------
Test Suite                               Test Name                                Result     Duration
------------------------------------------------------------------------------------------------------------------------
NET IB - Resiliency Port Recovery        Resiliency_RecoveryThreadStartedOnlyWithParam PASSED     2.923 seconds
NET IB - Resiliency Port Recovery        Resiliency_RecoverySuccessRestoresTraffic PASSED     2.422 seconds
NET IB - Resiliency Port Recovery        Resiliency_RecoveryPendingWhileLinkDown  PASSED     1.971 seconds
NET IB - Resiliency Port Recovery        Resiliency_RecoveryDeviceOneFailure      PASSED     2.823 seconds
NET IB - Resiliency Port Recovery        Resiliency_RecoveryUdTimeoutExhaustsAttempts PASSED     27.233 seconds
------------------------------------------------------------------------------------------------------------------------
```

<img width="1482" height="43" alt="Screenshot 2026-06-25 221643" src="https://github.com/user-attachments/assets/345a2ab3-3bf9-42a3-a551-829a6e407d28" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
