### PR TITLE
[rocprofiler-compute] Drop scipy test dependency, use pandas z-score

### DIFF
--- a/projects/rocprofiler-compute/requirements-test.txt
+++ b/projects/rocprofiler-compute/requirements-test.txt
@@ -1,4 +1,3 @@
 pytest==8.0.2
 pytest-cov==5.0.0
 pytest-xdist==3.5.0
-scipy==1.11.4

--- a/projects/rocprofiler-compute/tests/test_profile_general.py
+++ b/projects/rocprofiler-compute/tests/test_profile_general.py
@@ -13,12 +13,10 @@ import time
 from pathlib import Path
 
 import common
-import numpy as np
 import pandas as pd
 import pytest
 import yaml
 from conftest import require_torch
-from scipy.stats import zscore
 
 from utils.utils_common import canonical_config_arch
 
@@ -436,7 +434,10 @@ def are_stochastic_counters_similar(test_dfs, baseline_df):
             z_score_threshold = 2.0
 
             test_z_scores_list = [
-                np.abs(zscore(test_counters)) for test_counters in test_counters_list
+                (
+                    (test_counters - test_counters.mean()) / test_counters.std(ddof=0)
+                ).abs()
+                for test_counters in test_counters_list
             ]
             test_counters_list_trimmed = [
                 test_counters[test_z_scores < z_score_threshold]


### PR DESCRIPTION
## Motivation

The only scipy usage is a single z-score call in the test suite. Computing it directly with pandas removes scipy from the test requirements and supports the full Python 3.9-3.13 range without pinning a scipy version (scipy 1.11.4 has no cp313 wheel; 1.14.1 drops 3.9).

## Technical Details

- tests/test_profile_general.py: replace `scipy.stats.zscore` with `(s - s.mean()) / s.std(ddof=0)` (ddof=0 matches scipy's population std); drop unused numpy/scipy imports.
- requirements-test.txt: remove scipy.

## JIRA ID

ROCM-26919

## Test Plan

- Run the profiling test suite on Python 3.9 through 3.13; confirm the stochastic-counter similarity check is unchanged.

## Test Result

- Verified the pandas z-score matches scipy.stats.zscore numerically, including the zero-variance NaN case.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.