### PR TITLE
ci: PR Bot failure updations

### DIFF
--- a/.github/workflows/systems-pr-bot.yml
+++ b/.github/workflows/systems-pr-bot.yml
@@ -85,4 +85,4 @@ jobs:
           REPO: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           SHA: ${{ github.event.pull_request.head.sha }}
-        run: python tools/systems_pr_bot/policy_check.py --policy tools/systems_pr_bot/policy.yml --timeout-seconds 900 --poll-seconds 15
+        run: python tools/systems_pr_bot/policy_check.py --timeout-seconds 900 --poll-seconds 15

--- a/tools/systems_pr_bot/policy.yml
+++ b/tools/systems_pr_bot/policy.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 3
 
 pr:
   # Branch naming rules:

--- a/tools/systems_pr_bot/policy.yml
+++ b/tools/systems_pr_bot/policy.yml
@@ -1,4 +1,4 @@
-version: 3
+version: 2
 
 pr:
   # Branch naming rules:

--- a/tools/systems_pr_bot/policy_check.py
+++ b/tools/systems_pr_bot/policy_check.py
@@ -3,7 +3,7 @@ Main script to policy-check PRs and report results in a comment. This is the
 core of the bot's logic: it loads policy.yml, validates the pull request
 (branch name, title, description, forbidden files, unit tests), waits for the
 required CI checks, posts a single results-table comment, and manages the
-"Not ready to Review" label addition.
+"Not ready to Review" label.
 """
 
 #!/usr/bin/env python3

--- a/tools/systems_pr_bot/policy_check.py
+++ b/tools/systems_pr_bot/policy_check.py
@@ -3,7 +3,7 @@ Main script to policy-check PRs and report results in a comment. This is the
 core of the bot's logic: it loads policy.yml, validates the pull request
 (branch name, title, description, forbidden files, unit tests), waits for the
 required CI checks, posts a single results-table comment, and manages the
-"Not ready to Review" label.
+"Not ready to Review" label addition.
 """
 
 #!/usr/bin/env python3

--- a/tools/systems_pr_bot/policy_check.py
+++ b/tools/systems_pr_bot/policy_check.py
@@ -1019,10 +1019,18 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     pr_number = int(pr_number_s)  # type: ignore[arg-type]
 
-    # Resolve the policy path relative to THIS script.
+    # Resolve the policy path. A relative --policy is resolved FIRST against the
+    # current working directory (the repo root, which is how the workflow passes
+    # `tools/systems_pr_bot/policy.yml`); only if not found there do we fall back
+    # to the directory next to THIS script. This prevents accidentally doubling
+    # the path (e.g. `tools/systems_pr_bot/tools/systems_pr_bot/policy.yml`).
     policy_path = Path(args.policy)
     if not policy_path.is_absolute():
-        policy_path = (THIS_SCRIPT_DIR / policy_path).resolve()
+        cwd_candidate = (Path.cwd() / policy_path).resolve()
+        if cwd_candidate.is_file():
+            policy_path = cwd_candidate
+        else:
+            policy_path = (THIS_SCRIPT_DIR / policy_path).resolve()
     policy = load_policy(policy_path)
 
     pr = get_pr(owner=owner, repo=repo, pr_number=pr_number, token=token)  # type: ignore[arg-type]


### PR DESCRIPTION
Motivation
TheRock-pr-bot tool to add policy based checks on PRs.
right now we are adding label "not ready for review" for PRs that does
not have issue/jira linked and PRs that has zero unit test to it. We
have other checks at place around forbidden files, pre-commit failure,
branch name convention. and more checks marked as soon to enabled.

Technical Details
The checks are purely based on config file named policy.yml based PR
BOT. this is not a llm/AI based bot. This is using code to
deterministically provide checks.

What is added in this PR?

This PR addresses a fix for the path related issue comes up while running systems-pr-bot 

Test Plan
Currently tested in therock-infra repo and on this PR, further plan to
extend for systems and libraries repo.

Test Result
ISSUE ID : https://github.com/ROCm/rocm-systems/issues/7879