### PR TITLE
kfdtest: blacklist non-passing tests on gfx1250

### DIFF
--- a/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/kfdtest.exclude
+++ b/projects/rocr-runtime/libhsakmt/tests/kfdtest/scripts/kfdtest.exclude
@@ -356,7 +356,17 @@ FILTER[gfx1201]=\
 
 FILTER[gfx1250]=\
 "$BLACKLIST_ALL_ASICS:"\
-"$BLACKLIST_GFX12"
+"$BLACKLIST_GFX12:"\
+"KFDEventTest.SignalInvalidEvent:"\
+"KFDQMTest.ExtendedCuMasking:"\
+"KFDQMTest.MultipleCpQueuesStressDispatch:"\
+"KFDCWSRTest.InternalRegTest:"\
+"KFDEvictTest.QueueTest:"\
+"KFDRASTest.*:"\
+"KFDExceptionTest.AddressFault:"\
+"KFDQMTest.GpuMemCopyTest:"\
+"KFDDBGTest.HitTrapOnWaveStartEndEvent:"\
+"KFDNegativeTest.*"
 
 FILTER[RHEL9]=\
 "$BLACKLIST_ALL_ASICS:"\


### PR DESCRIPTION
Add gfx1250-specific blacklist entries for tests confirmed as failed, unrun, or unsupported. These will be re-enabled as fixes land.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

JIRA ID: ROCM-27228

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
