### PR TITLE
[RCCL] Add opt-in LL128 protocol for send/recv kernels

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -90,7 +90,8 @@ option(ENABLE_CODE_COVERAGE                    "Enable code coverage"           
 option(ENABLE_IFC                              "Enable indirect function call"                 OFF)
 option(ENABLE_DEVICE_LINKER                    "Build with assembly-extract device linker"     ON)
 option(EMIT_LLVM_IR                            "Emit LLVM IR/bitcode for nccl_device APIs"     OFF)
-option(GENERATE_SYM_KERNELS                    "Generate symmetric memory kernels"             ON)
+option(DISABLE_KERNARG_PRELOAD                 "Disable amdgpu-kernarg-preload-count compile/link flag" OFF)
+option(GENERATE_SYM_KERNELS                    "Generate symmetric memory kernels"             OFF)
 option(INSTALL_DEPENDENCIES                    "Force install dependencies"                    OFF)
 option(REPORT_KERNEL_RESOURCE_USE              "Append -Rpass-analysis=kernel to CXX flags"    OFF)
 option(ROCTX                                   "Enable ROCTX"                                  ${RCCL_DEFAULT_ROCTX})
@@ -510,8 +511,10 @@ endif()
 
 # Check for --amdgpu-kernarg-preload-count
 check_cxx_compiler_flag("-mllvm --amdgpu-kernarg-preload-count=16" HAVE_KERNARG_PRELOAD)
-if (HAVE_KERNARG_PRELOAD)
+if (HAVE_KERNARG_PRELOAD AND NOT DISABLE_KERNARG_PRELOAD)
   message(STATUS "Kernarg preloading to SGPR enabled")
+elseif (HAVE_KERNARG_PRELOAD AND DISABLE_KERNARG_PRELOAD)
+  message(STATUS "Kernarg preloading to SGPR disabled by DISABLE_KERNARG_PRELOAD=ON")
 endif()
 
 check_cxx_compiler_flag("-parallel-jobs=12" HAVE_PARALLEL_JOBS)

--- a/projects/rccl/cmake/DeviceLinker.cmake
+++ b/projects/rccl/cmake/DeviceLinker.cmake
@@ -238,6 +238,15 @@ foreach(DL_GPU_TARGET ${DL_GPU_TARGETS})
     ${DL_OPT_FLAGS}
     -std=c++17
     ${DL_HIP_COMPILER_FLAGS}
+    # -fPIC is required so amdclang++ emits GOT-relative relocations for
+    # cross-function calls inside the device .o files. Without it, larger
+    # ncclDevFunc_* bodies (e.g. unroll=8/16 reductions on f8e4m3/f8e5m2 or
+    # PAT/LL ReduceScatter) exceed the compiler's inlining threshold and
+    # produce R_AMDGPU_REL64 references, which `ld.lld -shared` then rejects
+    # against default-visibility symbols ("recompile with -fPIC"). Every
+    # other device compile step in this file already passes -fPIC; this
+    # brings the per-kernel OBJECT build in line with the rest.
+    -fPIC
   )
   target_compile_definitions(${_dev_target} PRIVATE RCCL_DEVICE_LINKER)
   target_link_libraries(${_dev_target} PRIVATE rccl_device_defs)

--- a/projects/rccl/install.sh
+++ b/projects/rccl/install.sh
@@ -38,6 +38,7 @@ force_reduce_pipeline=false
 generate_sym_kernels=true
 device_linker=true
 warp_speed_enabled=true # note that this flag will be overridden to false for non MI350/MI300 platforms
+kernarg_preload=true
 quiet_warnings=false
 build_rocshmem_support=false
 rocshmem_mono_hash="0e2998b11f99e8302c72f1ac2ce9f2b8c1816587"
@@ -60,6 +61,7 @@ function display_help()
     echo "       --disable-roctx         Build without ROCTX logging"
     echo "       --disable-sym-kernels   Disable symmetric memory kernels"
     echo "       --disable-warp-speed    Disable WARP_SPEED kernel optimizations"
+    echo "       --disable-kernarg-preload  Disable -mllvm --amdgpu-kernarg-preload-count=16 compile/link flag"
     echo "       --dump-asm              Disassemble code and dump assembly with inline code"
     echo "    -c|--enable-code-coverage  Enable code coverage"
     echo "       --enable_backtrace      Build with custom backtrace support"
@@ -114,7 +116,7 @@ function display_help()
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ "$?" -eq 4 ]]; then
-    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,amdgpu_targets:,cmake-options:,debug,debug-fast,dependencies,device-linker,disable-roctx,disable-sym-kernels,disable-warp-speed,dump-asm,enable-code-coverage,enable_backtrace,enable-mpi-tests,fast,force-reduce-pipeline,generate-sym-kernels,help,install,jobs:,kernel-resource-use,local_gpu_only,log-trace,no_clean,no-device-linker,openmp-test-enable,package_build,prefix:,quiet-warnings,rm-legacy-include-dir,rocshmem,roctx-enable,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
+    GETOPT_PARSE=$(getopt --name "${0}" --options cdfhij:lprtq --longoptions address-sanitizer,amdgpu_targets:,cmake-options:,debug,debug-fast,dependencies,device-linker,disable-colltrace,disable-kernarg-preload,disable-warp-speed,dump-asm,enable-code-coverage,enable_backtrace,enable-mpi-tests,fast,force-reduce-pipeline,generate-sym-kernels,help,install,jobs:,kernel-resource-use,local_gpu_only,log-trace,no_clean,no-device-linker,npkit-enable,openmp-test-enable,package_build,prefix:,quiet-warnings,rm-legacy-include-dir,rocshmem,roctx-enable,run_tests_all,run_tests_quick,static,tests_build,time-trace,verbose -- "$@")
 else
     echo "Need a new version of getopt"
     exit 1
@@ -139,6 +141,7 @@ while true; do
          --disable-roctx)            roctx_enabled=false;                                                                              shift ;;
          --disable-sym-kernels)      generate_sym_kernels=false;                                                                       shift ;;
          --disable-warp-speed)       warp_speed_enabled=false;                                                                         shift ;;
+         --disable-kernarg-preload)  kernarg_preload=false;                                                                            shift ;;
          --dump-asm)                 dump_asm=true;                                                                                    shift ;;
     -c | --enable-code-coverage)     enable_code_coverage=true;                                                                        shift ;;
          --enable_backtrace)         build_bfd=true;                                                                                   shift ;;
@@ -401,6 +404,11 @@ fi
 # Enable WARP_SPEED only on MI350/MI300 platforms
 if [[ "${warp_speed_enabled}" == true ]]; then
     cmake_common_options="${cmake_common_options} -DENABLE_WARP_SPEED=ON"
+fi
+
+# Disable amdgpu-kernarg-preload-count compile/link flag
+if [[ "${kernarg_preload}" == false ]]; then
+    cmake_common_options="${cmake_common_options} -DDISABLE_KERNARG_PRELOAD=ON"
 fi
 
 # Suppress Warnings

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -926,7 +926,7 @@ else()  # Enable hidden visibility for library without tests/code coverage enabl
   target_compile_options(rccl PRIVATE -fvisibility=hidden)
 endif()
 
-if (HAVE_KERNARG_PRELOAD)
+if (HAVE_KERNARG_PRELOAD AND NOT DISABLE_KERNARG_PRELOAD)
   target_compile_options(rccl PRIVATE -mllvm --amdgpu-kernarg-preload-count=16)
 endif()
 
@@ -1137,7 +1137,7 @@ if(NOT BUILD_SHARED_LIBS)
 else()
   message(STATUS "Building shared RCCL library")
 endif()
-if (HAVE_KERNARG_PRELOAD AND NOT ENABLE_DEVICE_LINKER)
+if (HAVE_KERNARG_PRELOAD AND NOT ENABLE_DEVICE_LINKER AND NOT DISABLE_KERNARG_PRELOAD)
   target_link_options(rccl PRIVATE "SHELL:-Xoffload-linker -mllvm=-amdgpu-kernarg-preload-count=16")
 endif()
 

--- a/projects/rccl/src/device/all_gather.h
+++ b/projects/rccl/src/device/all_gather.h
@@ -11,7 +11,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto, bool isNetOffload = false>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
   __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {

--- a/projects/rccl/src/device/all_reduce.h
+++ b/projects/rccl/src/device/all_reduce.h
@@ -11,7 +11,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto, int RCCLMetadata>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
   __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
@@ -106,7 +106,7 @@ namespace {
   }
 
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__ void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
   __device__ __attribute__((noinline)) void runTreeUpDown(int tid, int nthreads, struct ncclDevWorkColl* work) {
@@ -179,7 +179,7 @@ namespace {
   }
 
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__ void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
   __device__ __attribute__((noinline)) void runTreeSplit(int tid, int nthreads, struct ncclDevWorkColl* work) {

--- a/projects/rccl/src/device/broadcast.h
+++ b/projects/rccl/src/device/broadcast.h
@@ -11,7 +11,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
   __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {

--- a/projects/rccl/src/device/common.cu
+++ b/projects/rccl/src/device/common.cu
@@ -28,6 +28,15 @@ __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_2(
 __launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
   ncclKernelMain<-1, RunWorkNop, /*Unroll*/4>(&argsStorage.args);
 }
+__launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_8(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
+  ncclKernelMain<-1, RunWorkNop, /*Unroll*/8>(&argsStorage.args);
+}
+__launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_16(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
+  ncclKernelMain<-1, RunWorkNop, /*Unroll*/16>(&argsStorage.args);
+}
+__launch_bounds__(NCCL_MAX_NTHREADS, 1) __global__ void ncclDevKernel_Generic_32(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {
+  ncclKernelMain<-1, RunWorkNop, /*Unroll*/32>(&argsStorage.args);
+}
 
 #if defined(USE_INDIRECT_FUNCTION_CALL) || defined(RCCL_DEVICE_LINKER)
 __device__ void ncclDevFunc_Nop();

--- a/projects/rccl/src/device/common.h
+++ b/projects/rccl/src/device/common.h
@@ -419,7 +419,7 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
   int tn = blockDim.x;
   int x = tid;
   int total = 0, y;
-  int num = MAXCHANNELS/64 > 0 ? MAXCHANNELS/64 : 1;
+  int num = MAXCHANNELS/CHANNELS_PER_MASK_WORD > 0 ? MAXCHANNELS/CHANNELS_PER_MASK_WORD : 1;
 #ifdef ENABLE_WARP_SPEED
   int warpCount    = tn / WARP_SIZE;
   int localWarpId  = tid / WARP_SIZE;
@@ -440,11 +440,20 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
   case 0:
   //ncclShmem.channelId = blockIdx.x;
     for (int i = 0; i < num; i++) {
+      // WARP_SIZE<64 path leaves `x` set to (WARP_SIZE+tid) from the
+      // previous iteration, so the first check of masks[i] for i>=1 was reading
+      // the upper 32 bits twice and never the lower 32 bits. Reset to tid here.
+      x = tid;
       if (args->channelMask.masks[i] & (1ull<<x)) {
         y = __popcll(args->channelMask.masks[i] & ((1ull<<x)-1));
         y = total + y;
         if (blockIdx.x == y) {
-          ncclShmem.channelId = x + total;
+          // channelId is the absolute bit position in the global mask:
+          // i*CHANNELS_PER_MASK_WORD + x. Using `x + total` was only correct
+          // when prior mask words were densely packed (which broke for sparse
+          // channel sets, e.g. SATURATE_P2P_NCHANNELS with small messages or
+          // non-pow2 tilings, causing the wrong channel to be loaded -> IMA).
+          ncclShmem.channelId = x + i*CHANNELS_PER_MASK_WORD;
           break;
         }
       }
@@ -454,7 +463,7 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
           y = __popcll(args->channelMask.masks[i] & ((1ull<<x)-1));
           y = y + total;
           if (blockIdx.x == y) {
-            ncclShmem.channelId = x + total;
+            ncclShmem.channelId = x + i*CHANNELS_PER_MASK_WORD;
             break;
           }
         }
@@ -532,7 +541,10 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
         y = __popcll(args->channelMask.masks[i] & ((1ull<<laneId)-1));
         y = total + y;
         if (globalWarpId == y) {
-          ncclShmem.warpChannelId[localWarpId] = laneId + total;
+          // Same fix as the non-WS path: channelId is the absolute bit
+          // position (i*CHANNELS_PER_MASK_WORD + laneId), not total bits
+          // seen so far.
+          ncclShmem.warpChannelId[localWarpId] = laneId + i*CHANNELS_PER_MASK_WORD;
           break;
         }
       }
@@ -566,15 +578,27 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
         ncclDevFuncTable_1[ncclShmem.funcId]();
       else if (COLL_UNROLL == 2)
         ncclDevFuncTable_2[ncclShmem.funcId]();
-      else
+      else if (COLL_UNROLL == 4)
         ncclDevFuncTable_4[ncclShmem.funcId]();
+      else if (COLL_UNROLL == 8)
+        ncclDevFuncTable_8[ncclShmem.funcId]();
+      else if (COLL_UNROLL == 16)
+        ncclDevFuncTable_16[ncclShmem.funcId]();
+      else
+        ncclDevFuncTable_32[ncclShmem.funcId]();
 #else
       if (COLL_UNROLL == 1)
         NCCL_CALL_FUNCTIONS_1(ncclShmem.funcId);
       else if (COLL_UNROLL == 2)
         NCCL_CALL_FUNCTIONS_2(ncclShmem.funcId);
-      else
+      else if (COLL_UNROLL == 4)
         NCCL_CALL_FUNCTIONS_4(ncclShmem.funcId);
+      else if (COLL_UNROLL == 8)
+        NCCL_CALL_FUNCTIONS_8(ncclShmem.funcId);
+      else if (COLL_UNROLL == 16)
+        NCCL_CALL_FUNCTIONS_16(ncclShmem.funcId);
+      else
+        NCCL_CALL_FUNCTIONS_32(ncclShmem.funcId);
 #endif
 #endif
     }
@@ -602,6 +626,9 @@ __device__ __forceinline__ void ncclKernelMain(struct ncclDevKernelArgs const* a
 __global__ void ncclDevKernel_Generic_1(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
 __global__ void ncclDevKernel_Generic_2(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
 __global__ void ncclDevKernel_Generic_4(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
+__global__ void ncclDevKernel_Generic_8(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
+__global__ void ncclDevKernel_Generic_16(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
+__global__ void ncclDevKernel_Generic_32(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage);
 
 #define DEFINE_ncclDevKernel_nop(suffix, coll, redop, ty, algo, proto, specializedFnId) \
   __global__ void ncclDevKernel_##suffix(ncclDevKernelArgsDefaultStorage NCCL_GRID_CONSTANT const argsStorage) {}

--- a/projects/rccl/src/device/generate.py
+++ b/projects/rccl/src/device/generate.py
@@ -14,7 +14,7 @@ all_protos    = ["LL","LL128","SIMPLE"]
 all_algos     = ["TREE","RING", "", "", "", "", "PAT"]
 all_accs      = ["0", "1"]
 all_pipelines = ["0", "1"]
-all_unrolls   = ["1", "2", "4"]
+all_unrolls   = ["1", "2", "4", "8", "16", "32"]
 
 all_params = [all_colls, all_algos, all_protos, all_redops, all_tys, all_accs, all_pipelines, all_unrolls]
 
@@ -222,13 +222,18 @@ def calc_unroll_and_pipeline_for_local_arch():
   # Use (gfx_name, cu_count) as key for dictionary and convert it to list here
   gfx_targets = list(gfx_targets.keys())
   
-  # Homogeneous system is required to build for only 1 variant of unroll factor (except for gfx950)
+  # Homogeneous system is required to build for only 1 variant of unroll factor (except for gfx950 and gfx1250)
   if len(gfx_targets) == 1:
     gfx_name, cu_count = gfx_targets[0]
     if "gfx950" == gfx_name:
       return (["1", "2"], ["0"])  # Disable pipelining for gfx950
     elif "gfx908" == gfx_name or ("gfx942" == gfx_name and cu_count > 80):
       return (["2"], all_pipelines)
+    elif "gfx1250" == gfx_name:
+      # gfx1250 (MI450) benefits from larger unrolls; keep 4 as the safe default
+      # and additionally build 8/16/32 so RCCL_UNROLL_FACTOR=3, =4 or =5 is
+      # usable without falling off into empty ncclDevFuncTable_8/_16/_32 slots.
+      return (["4", "8", "16", "32"], all_pipelines)
     else:
       return (["4"], all_pipelines)
   else:
@@ -369,9 +374,9 @@ def get_arch_guard(fn):
   cond = None
 
   if fn.proto == "LL128" and fn.acc == "1":
-      cond = "(defined(__gfx942__) || defined(__gfx950__)) && defined(ENABLE_LL128)"
+      cond = "(defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)) && defined(ENABLE_LL128)"
   elif fn.proto == "LL128":
-      cond = "(defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__)) && defined(ENABLE_LL128)"
+      cond = "(defined(__gfx90a__) || defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)) && defined(ENABLE_LL128)"
   elif fn.acc == "1":
       cond = "defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)"
 

--- a/projects/rccl/src/device/op128.h
+++ b/projects/rccl/src/device/op128.h
@@ -348,7 +348,7 @@ DEFINE_ld_st__size(8, uint64_t, b64, l)
 
 __device__ __forceinline__ void store16global(uintptr_t addr, BytePack<16> value){  
   #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-    // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950. 
+    // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950/gfx1250.
     __builtin_amdgcn_global_store_b128((v4u_gptr) addr, value.v4u, RCCL_SYSTEM_SYNCSCOPE); 
   #elif defined(__gfx950__)
     *(v4u_gptr) addr = value.v4u;
@@ -361,7 +361,7 @@ __device__ __forceinline__ void store16global(uintptr_t addr, BytePack<16> value
 __device__ __forceinline__ BytePack<16> load16global(uintptr_t addr){
   BytePack<16> ans;
   #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-    // System scope load that bypasses the hardware caches, should generate global_load_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950.
+    // System scope load that bypasses the hardware caches, should generate global_load_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950/gfx1250.
     ans.v4u = __builtin_amdgcn_global_load_b128((v4u_gptr) addr, RCCL_SYSTEM_SYNCSCOPE);
   #else
     *(u64_gptr) ans.u64 = __builtin_nontemporal_load((u64_gptr)addr); 

--- a/projects/rccl/src/device/prims_ll.h
+++ b/projects/rccl/src/device/prims_ll.h
@@ -58,7 +58,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
   inline __device__ void barrier() {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
     if (nthreads != WARP_SIZE)
-      #if defined(__gfx942__) || (defined(__gfx950__) && defined(HIP_HOST_UNCACHED_MEMORY))
+      #if defined(__gfx942__) || (defined(__gfx950__) && defined(HIP_HOST_UNCACHED_MEMORY)) || defined(__gfx1250__)
         barrier_generic(__threadfence_block(), nthreads, barrier_next, barriers);
       #else
         barrier_generic(__threadfence(), nthreads, barrier_next, barriers);
@@ -211,7 +211,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL, P2p, isNetOffload, Metadata, Pi
     i4.data2 = (val >> 32);
     i4.flag2 = flag;
     #if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
-    // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950.
+    // System scope store that bypasses the hardware caches, should generate global_store_dwordx4 instruction with sc0 and sc1 bits set to 1 on gfx942/gfx950/gfx1250.
     __builtin_amdgcn_global_store_b128((v4u_gptr) dst->v, i4.v4u, RCCL_SYSTEM_SYNCSCOPE);
     #else
 #if defined(__gfx1200__) ||  defined(__gfx1201__)

--- a/projects/rccl/src/device/prims_ll128.h
+++ b/projects/rccl/src/device/prims_ll128.h
@@ -64,7 +64,7 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
   inline __device__ void barrier() {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
   if (nthreads != WARP_SIZE)
-    #if defined(__gfx942__) || defined(__gfx950__)
+    #if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
       barrier_generic(__threadfence_block(), nthreads, barrier_next, barriers);
     #else
       barrier_generic(__threadfence(), nthreads, barrier_next, barriers);
@@ -127,10 +127,17 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
   template<int WordPerThread>
   __device__ __forceinline__ void loadRegsBegin(uint64_t(&regs)[WordPerThread], T const *src, int eltN) {
     constexpr int EltPer16B = 16/sizeof(T);
+    // Parametrize the warp-local addressing on the LL128 line geometry.
+    // The literals "16" and "4" originally hard-coded 2*LINEELEMS and
+    // LINEELEMS/2 for the 64-byte-line case; gfx1250 doubles LINEELEMS
+    // (128-byte non-tearing line) so the stride and flag-subgroup width
+    // both double accordingly.
+    constexpr int LineElems = NCCL_LL128_LINEELEMS;
+    constexpr int LineSkip = 2*WARP_SIZE/LineElems;
     int ix[WordPerThread/2];
     #pragma unroll
     for(int g=0; g < WordPerThread/2; g++) {
-      ix[g] = g*WARP_SIZE - 16*(g/2) + wid - (g%2)*(wid/4);
+      ix[g] = g*WARP_SIZE - LineSkip*(g/2) + wid - (g%2)*(wid/(LineElems/2));
     }
     if(reinterpret_cast<uintptr_t>(src)%16 == 0) {
       /* We are aligned to 16 bytes, so load directly to registers no shmem.
@@ -198,9 +205,11 @@ class Primitives<T, RedOp, Fan, Direct, ProtoLL128, P2p, isNetOffload, Metadata,
     // Write to dst if 4-byte aligned, shmem otherwise.
     int misalignment = reinterpret_cast<uintptr_t>(dst)%16;
     uint64_t *shm8 = shmemCvtPtr((uint64_t*)ncclScratchForWarp(warpInBlock));
+    constexpr int LineElems = NCCL_LL128_LINEELEMS;
+    constexpr int LineSkip = 2*WARP_SIZE/LineElems;
     #pragma unroll
     for(int g=0; g < WordPerThread/2; g++) {
-      int ix = g*WARP_SIZE - 16*(g/2) + wid - (g%2)*(wid/4);
+      int ix = g*WARP_SIZE - LineSkip*(g/2) + wid - (g%2)*(wid/(LineElems/2));
       if (!flagThread || g%2==0) {
         if(misalignment == 0 && (ix+1)*EltPer16B <= eltN)
           store128((uint64_t*)(dst + ix*EltPer16B), regs[2*g+0], regs[2*g+1]);

--- a/projects/rccl/src/device/prims_simple.h
+++ b/projects/rccl/src/device/prims_simple.h
@@ -70,8 +70,10 @@ class Primitives<
     if (nthreads == WARP_SIZE)
       __syncwarp();
     else
+      // gfx942/gfx950/gfx1250 all use intra-block fence; __threadfence() is
+      // device-wide and doesn't add system-scope ordering here.
       // To be revisited for correctness on gfx1250
-      #if defined(__gfx942__) || defined(__gfx950__)
+      #if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
         barrier_generic(__threadfence_block(), nworkers, barrier_next, barriers);
       #else
         barrier_generic(__threadfence(), nworkers, barrier_next, barriers);
@@ -85,7 +87,7 @@ class Primitives<
 
   inline __device__ void patBarrier() {
     // To be revisited for correctness on gfx1250
-    #if defined(__gfx942__) || defined(__gfx950__)
+    #if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
       barrier_generic(__threadfence_block(), NCCL_PAT_NWORKERS, barrier_next_pat, barriers_pat);
     #else
       barrier_generic(__threadfence(), NCCL_PAT_NWORKERS, barrier_next_pat, barriers_pat);
@@ -116,7 +118,7 @@ class Primitives<
     // NET no-GDR can publish host-staged payloads from the CPU proxy.
     // Acquire the tail before GPU workers consume the payload.
     return ld_acquire_sys_global(ptr);
-#elif defined(__gfx1200__) || defined(__gfx1201__)
+#elif defined(__gfx1200__) || defined(__gfx1201__) || defined(__gfx1250__)
     return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
 #else
     return __atomic_load_n(ptr, __ATOMIC_RELAXED);
@@ -773,16 +775,16 @@ public:
       patBarrier();
     }
     if(collWork){
-      skip_fence = !collWork -> gfx9CheapFenceOff;
-#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS && (defined(__GFX9__))
-      // DWORDX4 builtins use system-scope cache-bypassing stores, so the
-      // cheap s_waitcnt fence is sufficient when UBR is active.
+      skip_fence = !collWork -> cheapPostSendFenceOff;
+#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
+      // DWORDX4 builtins use system-scope cache-bypassing stores (sc0+sc1),
+      // so the cheap s_waitcnt fence is sufficient when UBR/IPC-reg is active.
       if (collWork->regUsed || collWork->netRegUsed) {
         skip_fence = true;
       }
 #endif
     }
-#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS && (defined(__GFX9__))
+#if RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS
     else if(p2pWork) {
       // the postPeer fence is gated by RolePostSend and protects
       // send-side stores only.

--- a/projects/rccl/src/device/reduce.h
+++ b/projects/rccl/src/device/reduce.h
@@ -11,7 +11,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
   __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {

--- a/projects/rccl/src/device/reduce_scatter.h
+++ b/projects/rccl/src/device/reduce_scatter.h
@@ -11,7 +11,7 @@
 
 namespace {
   template<typename T, typename RedOp, typename Proto>
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__ void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {
 #else
   __device__ __attribute__((noinline)) void runRing(int tid, int nthreads, struct ncclDevWorkColl* work) {

--- a/projects/rccl/src/device/sendrecv.h
+++ b/projects/rccl/src/device/sendrecv.h
@@ -53,7 +53,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 
   }
 
-#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__)
+#if defined(USE_INDIRECT_FUNCTION_CALL) && !defined(__gfx942__) && !defined(__gfx950__) && !defined(__gfx1250__)
   __device__  void run() {
 #else
   __device__  __attribute__((noinline)) void run() {
@@ -166,7 +166,7 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
     }
 
     if (isCopy) {
-#if defined(__gfx942__) || defined(__gfx950__)
+#if defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)
       reduceCopy<COLL_UNROLL*2, 0, RedOp, T, 0,1,1, 0,1,1, /*PreOpSrcs=*/0>
         (subtid, subtn, 0, false, 1, &work->sendAddr, 1, &work->recvAddr, (ssize_t)work->sendBytes);
 #else
@@ -181,6 +181,8 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
         runSend<ProtoSimple<1,1,0,8>>(subtid, subtn, group, work);
 #elif defined(__gfx908__) || defined(__gfx942__) || defined(__gfx950__)
         runSend<ProtoSimple<1,1,0,4>>(subtid, subtn, group, work);
+#elif defined(__gfx1250__)
+        runSend<ProtoSimple<1,1,0,COLL_UNROLL>>(subtid, subtn, group, work);
 #else
         runSend<ProtoSimple<1,1>>(subtid, subtn, group, work);
 #endif
@@ -193,6 +195,8 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
         runRecv<ProtoSimple<1,1,0,8>>(subtid, subtn, group, work);
 #elif defined(__gfx908__) || defined(__gfx942__) || defined(__gfx950__)
         runRecv<ProtoSimple<1,1,0,4>>(subtid, subtn, group, work);
+#elif defined(__gfx1250__)
+        runRecv<ProtoSimple<1,1,0,COLL_UNROLL>>(subtid, subtn, group, work);
 #else
         runRecv<ProtoSimple<1,1>>(subtid, subtn, group, work);
 #endif

--- a/projects/rccl/src/device/sendrecv.h
+++ b/projects/rccl/src/device/sendrecv.h
@@ -174,7 +174,9 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
         (subtid, subtn, 0, false, 1, &work->sendAddr, 1, &work->recvAddr, (ssize_t)work->sendBytes);
 #endif
     } else if (isSend) {
-      if (work->sendProtoLL) {
+      if (work->sendProtoLL128) {
+        runSend<ProtoLL128>(subtid, subtn, group, work);
+      } else if (work->sendProtoLL) {
         runSend<ProtoLL>(subtid, subtn, group, work);
       } else {
 #if defined(__gfx90a__)
@@ -188,7 +190,9 @@ struct RunWorkBatch<ncclFuncSendRecv, T, RedOp, NCCL_ALGO_RING, NCCL_PROTO_SIMPL
 #endif
       }
     } else {
-      if (work->recvProtoLL) {
+      if (work->recvProtoLL128) {
+        runRecv<ProtoLL128>(subtid, subtn, group, work);
+      } else if (work->recvProtoLL) {
         runRecv<ProtoLL>(subtid, subtn, group, work);
       } else {
 #if defined(__gfx90a__)

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -1080,6 +1080,12 @@ static ncclResult_t scheduleCollTasksToPlan(
 NCCL_PARAM(P2pLLThreshold, "P2P_LL_THRESHOLD", 8192);
 RCCL_PARAM(P2pNetThreshold, "P2P_NET_THRESHOLD", 131072);
 NCCL_PARAM(ChunkSize, "CHUNK_SIZE", 0);
+// Opt-in (default off) enablement of the LL128 protocol for send/recv kernels.
+// Currently restricted to gfx1250 (MI450X). When enabled, LL128 takes precedence
+// over LL. P2P_LL128_THRESHOLD bounds the per-channel payload (bytes) that may use
+// LL128; 0 means no upper bound (use LL128 for all message sizes when eligible).
+NCCL_PARAM(P2pLL128Enable, "P2P_LL128_ENABLE", 0);
+NCCL_PARAM(P2pLL128Threshold, "P2P_LL128_THRESHOLD", 0);
 
 
 // Need this temporary parameter to disable p2p batching to avoid some dips at 4MB - 32 MB message size at large scale
@@ -1118,6 +1124,10 @@ static ncclResult_t addP2pToPlan(
   void* addrs[2] = {recvAddr, sendAddr};
   ssize_t bytes[2] = {recvBytes, sendBytes};
   bool protoLL[2] = {!selfSend, !selfSend};
+  // LL128 for send/recv is opt-in and currently limited to gfx1250 (MI450X).
+  bool p2pLL128Eligible = ncclParamP2pLL128Enable() && !selfSend &&
+      IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1250");
+  bool protoLL128[2] = {p2pLL128Eligible, p2pLL128Eligible};
   bool network[2] = {false, false};
   bool proxySameProcess[2] = {true, true};
   void** handles[2] = {NULL, NULL};
@@ -1149,6 +1159,7 @@ static ncclResult_t addP2pToPlan(
         struct ncclConnector* conn = dir ? &channelPeers[peerRank]->send[connIndex[dir]]
                                          : &channelPeers[peerRank]->recv[connIndex[dir]];
         protoLL[dir] &= conn->conn.buffs[NCCL_PROTO_LL] != nullptr && !IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx12");
+        protoLL128[dir] &= conn->conn.buffs[NCCL_PROTO_LL128] != nullptr;
         network[dir] |= conn->transportComm == (dir ? &netTransport.send : &netTransport.recv);
         proxySameProcess[dir] &= conn->proxyConn.sameProcess;
       }
@@ -1185,10 +1196,23 @@ static ncclResult_t addP2pToPlan(
     // Update number of channels propagated to the profiler
     if (p2pTasks[dir]) p2pTasks[dir]->nChannels = nChannels[dir];
 
-    // Select protocol (LL vs SIMPLE) used based on payload per channel
+    // Select protocol (LL128 vs LL vs SIMPLE) used based on payload per channel.
     if (bytes[dir] != -1)
       protoLL[dir] &= bytes[dir] <= nChannels[dir] * ncclParamP2pLLThreshold();
-    protocol[dir] = protoLL[dir] ? NCCL_PROTO_LL : NCCL_PROTO_SIMPLE;
+    if (bytes[dir] != -1) {
+      ssize_t ll128Threshold = ncclParamP2pLL128Threshold();
+      if (ll128Threshold > 0)
+        protoLL128[dir] &= bytes[dir] <= nChannels[dir] * ll128Threshold;
+    } else {
+      protoLL128[dir] = false;
+    }
+    // LL128 takes precedence over LL when eligible.
+    if (protoLL128[dir]) {
+      protoLL[dir] = false;
+      protocol[dir] = NCCL_PROTO_LL128;
+    } else {
+      protocol[dir] = protoLL[dir] ? NCCL_PROTO_LL : NCCL_PROTO_SIMPLE;
+    }
 
     stepSize[dir] = comm->buffSizes[protocol[dir]]/NCCL_STEPS;
     if (protocol[dir] == NCCL_PROTO_SIMPLE) stepSize[dir] = comm->p2pChunkSize;
@@ -1203,10 +1227,12 @@ static ncclResult_t addP2pToPlan(
 
     chunkDataSize[dir] = chunkSize[dir];
     if (protocol[dir] == NCCL_PROTO_LL) chunkDataSize[dir] /= 2;
+    else if (protocol[dir] == NCCL_PROTO_LL128) chunkDataSize[dir] = (chunkDataSize[dir] / comm->ll128LineElems) * comm->ll128DataElems;
     chunkDataSize_u32fp8[dir] = u32fp8Encode(chunkDataSize[dir]);
     chunkDataSize[dir] = u32fp8Decode(chunkDataSize_u32fp8[dir]);
     chunkSize[dir] = chunkDataSize[dir];
     if (protocol[dir] == NCCL_PROTO_LL) chunkSize[dir] *= 2;
+    else if (protocol[dir] == NCCL_PROTO_LL128) chunkSize[dir] = (chunkSize[dir] / comm->ll128DataElems) * comm->ll128LineElems;
 
     if (network[dir]) {
       bool pxnUsed = !ncclPxnDisable(comm) && comm->isAllNvlink && comm->maxLocalRanks > 1;
@@ -1275,6 +1301,7 @@ static ncclResult_t addP2pToPlan(
   work->channelBase = base;
   work->nSendChannels = nChannels[1];
   work->sendProtoLL = protoLL[1];
+  work->sendProtoLL128 = protoLL128[1];
   work->sendNetReg = netRegistered[1];
   work->sendIpcReg = ipcRegistered[1];
   work->sendChunkSize_u32fp8 = chunkDataSize_u32fp8[1];
@@ -1285,6 +1312,7 @@ static ncclResult_t addP2pToPlan(
   work->sendOpCount = sendOpCount;
   work->nRecvChannels = nChannels[0];
   work->recvProtoLL = protoLL[0];
+  work->recvProtoLL128 = protoLL128[0];
   work->recvNetReg = netRegistered[0];
   work->recvIpcReg = ipcRegistered[0];
   work->recvChunkSize_u32fp8 = chunkDataSize_u32fp8[0];

--- a/projects/rccl/src/enqueue.cc
+++ b/projects/rccl/src/enqueue.cc
@@ -51,12 +51,14 @@ struct ncclKernelMatch {
 
 
 #define ncclGetKernelIndex(p_comm) ((p_comm)->unroll)
-static ncclKernelMatch const ncclKerns[3] = {
+static ncclKernelMatch const ncclKerns[6] = {
   {(void*)ncclDevKernel_Generic_1, true},
   {(void*)ncclDevKernel_Generic_2, true},
-  {(void*)ncclDevKernel_Generic_4, true}
+  {(void*)ncclDevKernel_Generic_4, true},
+  {(void*)ncclDevKernel_Generic_8, true},
+  {(void*)ncclDevKernel_Generic_16, true},
+  {(void*)ncclDevKernel_Generic_32, true}
 };
-
 static int rcclProtoGrainSize(int proto, ncclComm *comm){
   switch (proto) {
     case NCCL_PROTO_LL: return 16;
@@ -390,7 +392,7 @@ bool ncclTestBudget(
 
 // Returns whether this should be disabled at the device level.  Should be called after devWork fields have been set for what
 // it depends on.
-bool gfx9CheapFenceOff(const ncclDevWorkColl& devWork, bool disabledByPrecheck){
+bool cheapPostSendFenceOff(const ncclDevWorkColl& devWork, bool disabledByPrecheck){
     bool fenceOk = devWork.regUsed == 0 && devWork.netRegUsed == 0 && !disabledByPrecheck;
     return !fenceOk;
 }
@@ -476,7 +478,7 @@ ncclResult_t ncclTasksRegAndEnqueue(struct ncclComm* comm) {
       devWork.netRegUsed = 1;
     if (task->regBufType & (NCCL_IPC_REG_BUFFER | NCCL_NVLS_REG_BUFFER))
       devWork.regUsed = 1;
-    devWork.gfx9CheapFenceOff = gfx9CheapFenceOff(devWork, comm->gfx9CheapFenceOff);
+    devWork.cheapPostSendFenceOff = cheapPostSendFenceOff(devWork, comm->cheapPostSendFenceOff);
 
     if (task->regBufType & NCCL_NVLS_REG_BUFFER) {
       struct ncclDevWorkCollReg workReg = {};
@@ -826,8 +828,9 @@ static ncclResult_t scheduleCollTasksToPlan(
       devWork->channelLo = 0;
       devWork->channelHi = nChannels-1;
       // RCCL: CollNet path never set task->nChannels; profiler received 0.
-      // Clamp to UINT8_MAX: ENABLE_WARP_SPEED pushes MAXCHANNELS to 512 which wraps uint8.
-      task->nChannels = (nChannels <= UINT8_MAX) ? (uint8_t)nChannels : UINT8_MAX;
+      // task->nChannels is uint16_t — clamp to UINT16_MAX so ENABLE_WARP_SPEED
+      // (MAXCHANNELS=512) doesn't wrap.
+      task->nChannels = (nChannels <= UINT16_MAX) ? (uint16_t)nChannels : UINT16_MAX;
       devWork->collnet.count = task->count;
       devWork->collnet.chunkCount = chunkSize/ncclTypeSize(task->datatype);
       devWork->direct = directFlags;
@@ -887,12 +890,9 @@ static ncclResult_t scheduleCollTasksToPlan(
       (countHi != 0 ? countHi : countLo) -= cells*elementsPerCell - task->count;
 
       nChannels = (countLo!=0 ? 1 : 0) + nMidChannels + (cellsHi!=0 ? 1 : 0);
-      // Update number of channels propagated to the profiler
-#ifdef ENABLE_WARP_SPEED
-      task->nChannels = nChannels;
-#else
-      task->nChannels = (uint8_t) nChannels;
-#endif
+      // Update number of channels propagated to the profiler. task->nChannels
+      // is uint16_t — wide enough for MAXCHANNELS=256 without wrap.
+      task->nChannels = (uint16_t) nChannels;
       // Ensure room for worst case of one new batch per channel
       if (!ncclTestBudget(budget, plan->nWorkBatches + nChannels, plan->workBytes + workNode->size)) {
         return ncclSuccess;
@@ -2035,7 +2035,7 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
   ncclResult_t ret = ncclSuccess;
   struct ncclKernelPlanner* planner = &comm->planner;
   int nChannels = 0;
-  for (int i = 0; i < MAXCHANNELS/64; i++)
+  for (int i = 0; i < MAXCHANNELS/CHANNELS_PER_MASK_WORD; i++)
     nChannels += countOneBits(plan->channelMask.masks[i]);
   void* sym = plan->kernelFn;
 #ifdef ENABLE_WARP_SPEED
@@ -2046,6 +2046,13 @@ ncclResult_t ncclLaunchKernel(struct ncclComm* comm, struct ncclKernelPlan* plan
   dim3 block = {(unsigned)plan->threadPerBlock, 1, 1};
   int smem = plan->isSymColl ? plan->kernelDynSmem : rcclShmemDynamicSize(comm->cudaArch, comm->WarpSize);
   cudaStream_t launchStream = planner->streams->stream;
+
+  // Verify actual kernel launch geometry against init-time channel counts.
+  bool isP2pPlan = !ncclIntruQueueEmpty(&plan->p2pTaskQueue);
+  INFO(NCCL_COLL,
+       "Launch %s kernel: gridDim.x=%u blockDim.x=%u (p2pnChannels=%d, p2pnChannelsPerPeer=%d, nChannels=%d, nWorkBatches=%d)",
+       isP2pPlan ? "P2P" : "COLL", grid.x, block.x,
+       comm->p2pnChannels, comm->p2pnChannelsPerPeer, comm->nChannels, plan->nWorkBatches);
 
   NCCLCHECK(ncclProfilerStartKernelLaunchEvent(plan, launchStream));
 
@@ -2331,8 +2338,17 @@ static ncclResult_t updateCollCostTable(
         if (!inRange) continue;
       }
     }
+    // Cache NCCL_PROTO env once: when the user explicitly asks for LL128
+    // (e.g. NCCL_PROTO=LL128 cross-node), bypass the XGMI-only gate below.
+    static bool userProtoInputCached = false;
+    static int userProtoInput = 0;
+    if (!userProtoInputCached) {
+      const char* protoEnv = ncclGetEnv("NCCL_PROTO");
+      userProtoInput = !protoEnv ? 0 : 1;
+      userProtoInputCached = true;
+    }
     for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
-      if (p == NCCL_PROTO_LL128 && !(comm->topo->type & RCCL_TOPO_XGMI_ALL)) {
+      if (p == NCCL_PROTO_LL128 && !(comm->topo->type & RCCL_TOPO_XGMI_ALL) && !userProtoInput) {
         table[a][p] = NCCL_ALGO_PROTO_IGNORE;
         continue;
       }
@@ -2518,8 +2534,18 @@ static ncclResult_t topoGetAlgoInfo(
   } else if (info->algorithm == NCCL_ALGO_TREE) {
     nc = std::min(nc, 64); // Tree uses at most 64 channels as we don't support WarpSpeed Tree.
 #else
+    // Mirror the WarpSpeed cap: TREE multi-node correctness has not been
+    // validated past 64 channels even though MAXCHANNELS now permits 256.
+    // Cap nc to 64 here so an opt-in NCCL_MAX_NCHANNELS=256 doesn't push TREE
+    // into the unvalidated regime; RING is unaffected and scales to 256.
+    nc = std::min(nc, 64);
     info->nMaxChannels = nc;
 #endif
+  } else if (info->algorithm == NCCL_ALGO_TREE) {
+    // Same TREE cap for the non-AllReduce path (in case a tree-only collective
+    // ends up here under an opt-in higher max).
+    nc = std::min(nc, 64);
+    info->nMaxChannels = nc;
   } else {
     info->nMaxChannels = nc;
   }

--- a/projects/rccl/src/graph/connect.cc
+++ b/projects/rccl/src/graph/connect.cc
@@ -1180,7 +1180,8 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") && comm->nNodes > 1) {
     int userMax = ncclParamMaxNchannels();
     if (userMax != -2) {
-      maxChannels = std::max(std::min(userMax, 64), 1);
+      // Honor NCCL_MAX_NCHANNELS up to MAXCHANNELS (was hard-capped at 64).
+      maxChannels = std::max(std::min(userMax, MAXCHANNELS), 1);
       INFO(NCCL_TUNING, "RCCL MaxChannels is capped to: %d", maxChannels);
     } else {
       maxChannels = 48;
@@ -1195,10 +1196,17 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
   }
 #else
   // Skip the 64-channel cap for gfx1250 single-node P2P and for MNNVL transports.
-  // Retain the 64-channel cap for gfx1250 multi-node non-MNNVL (NET path) and all other arches.
-  if (!comm->MNNVL && !(isGfx1250 && comm->nNodes == 1) &&
-      (graphs[NCCL_ALGO_RING]->nIntraChannels > 0 || comm->nNodes > 1)) {
-    maxChannels = std::min(64, maxChannels);
+  // Also skip when the user explicitly raised NCCL_MAX_NCHANNELS past 64 — the
+  // request is then taken as an opt-in to the extended upper bound.
+  // Otherwise retain the 64-channel cap for gfx1250 multi-node non-MNNVL (NET
+  // path) and all other arches.
+  {
+    int userMax = (int)ncclParamMaxNchannels();
+    bool userOptedHigher = (userMax != -2 && userMax > 64);
+    if (!userOptedHigher && !comm->MNNVL && !(isGfx1250 && comm->nNodes == 1) &&
+        (graphs[NCCL_ALGO_RING]->nIntraChannels > 0 || comm->nNodes > 1)) {
+      maxChannels = std::min(64, maxChannels);
+    }
   }
 #endif
   // Duplicate ringPrev/ringNext for ncclBuildRing
@@ -1288,7 +1296,9 @@ ncclResult_t ncclTopoPostset(struct ncclComm* comm, int* firstRanks, int* treePa
 
   minNchannels = ncclMinNchannels();
   if (comm->nNodes > 1 && !comm->MNNVL) {
-    minNchannels = std::min(64, minNchannels);
+    // Was hard-capped at 64; lift to MAXCHANNELS so multi-node runs can opt
+    // into the extended channel range via NCCL_MIN_NCHANNELS.
+    minNchannels = std::min((int)MAXCHANNELS, minNchannels);
   }
   // gfx1250 can support high channel counts with fewer than 8 GPUs;
   // skip the nRanks < 8 clamp so NCCL_MIN_NCHANNELS is respected.

--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -1134,6 +1134,11 @@ NCCL_PARAM(MaxP2pNChannels, "MAX_P2P_NCHANNELS", MAXCHANNELS);
 // When enabled, caps p2pnChannels to 16 on gfx950 (MI350) for large-scale jobs
 // (nNodes >= 16) to reduce P2P CU usage. Disabled by default.
 NCCL_PARAM(P2pCuReduceScaleEnable, "P2P_CU_REDUCE_SCALE_ENABLE", 0);
+// When set, pick p2pnChannelsPerPeer so that a P2P plan touches every channel
+// in the pool: ppp = pow2Down(p2pnChannels / nRanks). The pow2 step matters --
+// ncclP2pChannelForPart mods channel ids by the pool, so ppp*nRanks > pool
+// causes round bases to wrap and channels to collide.
+RCCL_PARAM(SaturateP2pNChannels, "SATURATE_P2P_NCHANNELS", 0);
 extern int64_t ncclParamWorkArgsBytes();
 
 ncclResult_t ncclTopoComputeP2pChannelsPerPeer(struct ncclComm* comm) {
@@ -1183,23 +1188,38 @@ ncclResult_t ncclTopoComputeP2pChannels(struct ncclComm* comm) {
         (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") ||
          IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950") ||
          IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx1250"))) comm->p2pnChannelsPerPeer *= 2;
-    // p2pnChannels must be >= p2pnChannelsPerPeer: the device-side inverse
-    // ncclP2pChannelToPart cannot recover part indices >= nP2pChannels, so
-    // higher parts silently alias onto lower ones and produce wrong data
-    // (seen on MI455 2x1p1g alltoall when topology fallback yields 2 channels
-    // but the gfx1250 single-node doubling above asks for 4 parts per peer).
-    comm->p2pnChannels = std::min(std::max(pow2Up(comm->p2pnChannels), pow2Up(comm->p2pnChannelsPerPeer)), 4*CHANNEL_LIMIT);
-    // p2pnChannelsPerPeer cannot be greater than MAXCHANNELS
-    // Capping the comm->p2pnChannels to 32 for send/recv based collectives on multi-node MI350 (2 and 4 nodes)
-    if (((comm->nNodes == 2 && comm->topo->nRanks == 16) || (comm->nNodes == 4 && comm->topo->nRanks == 32)) && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950"))) comm->p2pnChannels = std::min(comm->p2pnChannels, 32);
-    // Capping the comm->p2pnChannels to 16 for send/recv based collectives with half-subscription (4 GPUs per node) multi-node MI350 (2 and 4 nodes)
-    if (((comm->nNodes == 2 && comm->topo->nRanks == 8) || (comm->nNodes == 4 && comm->topo->nRanks == 16)) && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950"))) comm->p2pnChannels = std::min(comm->p2pnChannels, 16);
-    // Opt-in P2P CU reduction on gfx950 (MI350) at scale: cap p2pnChannels to 16 when nNodes >= 16
-    if (ncclParamP2pCuReduceScaleEnable() && comm->nNodes >= 16 && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) comm->p2pnChannels = std::min(comm->p2pnChannels, 16);
+    // When the user explicitly raises NCCL_MAX_P2P_NCHANNELS past 4*CHANNEL_LIMIT
+    // (=64), treat it as an opt-in to the extended upper bound (up to MAXCHANNELS).
+    // Otherwise keep the historical 64 cap and per-arch multi-node caps below.
+    {
+      int userMaxP2p = (int)ncclParamMaxP2pNChannels();
+      int defaultMax = 4*CHANNEL_LIMIT;
+      int upper = (userMaxP2p > defaultMax) ? std::min(userMaxP2p, (int)MAXCHANNELS) : defaultMax;
+      comm->p2pnChannels = std::min(pow2Up(comm->p2pnChannels), upper);
+      if (upper == defaultMax) {
+        // p2pnChannelsPerPeer cannot be greater than MAXCHANNELS
+        // Capping the comm->p2pnChannels to 32 for send/recv based collectives on multi-node MI350 (2 and 4 nodes)
+        if (((comm->nNodes == 2 && comm->topo->nRanks == 16) || (comm->nNodes == 4 && comm->topo->nRanks == 32)) && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950"))) comm->p2pnChannels = std::min(comm->p2pnChannels, 32);
+        // Capping the comm->p2pnChannels to 16 for send/recv based collectives with half-subscription (4 GPUs per node) multi-node MI350 (2 and 4 nodes)
+        if (((comm->nNodes == 2 && comm->topo->nRanks == 8) || (comm->nNodes == 4 && comm->topo->nRanks == 16)) && (IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950"))) comm->p2pnChannels = std::min(comm->p2pnChannels, 16);
+        // Opt-in P2P CU reduction on gfx950 (MI350) at scale: cap p2pnChannels to 16 when nNodes >= 16
+        if (ncclParamP2pCuReduceScaleEnable() && comm->nNodes >= 16 && IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) comm->p2pnChannels = std::min(comm->p2pnChannels, 16);
+      }
+    }
     comm->p2pnChannelsPerPeer = std::min(comm->p2pnChannelsPerPeer, MAXCHANNELS);
   }
 
-  if (comm->nNodes > 1 && comm->config.nChannelsPerNetPeer == NCCL_CONFIG_UNDEF_INT) {
+  // Opt-in: pick p2pnChannelsPerPeer so a P2P plan tiles the channel pool
+  // without wrapping. Saturates gridDim.x for alltoall-style workloads.
+  if (rcclParamSaturateP2pNChannels() && comm->nRanks > 0) {
+    int target = std::max(1, comm->p2pnChannels / comm->nRanks);
+    int newPpp = std::min(pow2Down(target), (int)MAXCHANNELS);
+    INFO(NCCL_INIT|NCCL_TUNING,
+         "RCCL_SATURATE_P2P_NCHANNELS: p2pnChannelsPerPeer %d -> %d (p2pnChannels=%d, nRanks=%d)",
+         comm->p2pnChannelsPerPeer, newPpp, comm->p2pnChannels, comm->nRanks);
+    comm->p2pnChannelsPerPeer = newPpp; 
+  }
+   if (comm->nNodes > 1 && comm->config.nChannelsPerNetPeer == NCCL_CONFIG_UNDEF_INT) {
     // In the case of >1 NVLD (and the user didn't set nChannelsPerNetPeer), the network is the bottleneck.
     // Reduce the number of channels per host to avoid going above p2pnChannels to fit all the peers within a single round.
     while (comm->p2pnChannelsPerPeer * divUp(comm->nRanks, NCCL_MAX_DEV_WORK_P2P_PER_BATCH) >= comm->p2pnChannels && comm->p2pnChannelsPerPeer > 1) comm->p2pnChannelsPerPeer /= 2;

--- a/projects/rccl/src/graph/tuning.cc
+++ b/projects/rccl/src/graph/tuning.cc
@@ -989,11 +989,24 @@ ncclResult_t ncclTopoTuneModel(struct ncclComm* comm, int minCompCap, int maxCom
     if (pEnable != 0 && p == NCCL_PROTO_LL128) {
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #if defined(ENABLE_LL128)
+      // protoEnable[LL128] starts at 2 (tentative default-on); explicit
+      // NCCL_PROTO=LL128 from the user sets it to 1. Preserve that signal so
+      // the path/arch/ll128Enabled gate below doesn't silently downgrade a
+      // user-requested LL128 (e.g. multi-node MNNVL where typeInter > PXB).
+      const bool userOptedInLL128 = (pEnable == 1);
+      const char* gcn = comm->topo->nodes[GPU].nodes[0].gpu.gcn;
+      const bool archOk = IsArchMatch(gcn, "gfx90a") ||
+                          IsArchMatch(gcn, "gfx942") ||
+                          IsArchMatch(gcn, "gfx950") ||
+                          IsArchMatch(gcn, "gfx1250");
       // Enable LL128 by default only on gfx90a with available tuning table
       pEnable = (graphs[a]->typeInter <= PATH_PXB) && graphs[a]->typeIntra <= PATH_NVL &&
-        ((IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx90a") ||
-          IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx942") ||
-          IsArchMatch(comm->topo->nodes[GPU].nodes[0].gpu.gcn, "gfx950")) && comm->topo->ll128Enabled) ? 1 : 0;
+        (archOk && comm->topo->ll128Enabled) ? 1 : 0;
+      // Restore an explicit NCCL_PROTO=LL128 only when the arch supports LL128
+      // (the path-check is what we want to override, not the arch gate); on
+      // unsupported archs let dispatch fall back rather than failing later in
+      // rcclIsArchSupportedForFunc.
+      if (pEnable == 0 && userOptedInLL128 && archOk) pEnable = 1;
 #else
       pEnable = 0;
 #endif

--- a/projects/rccl/src/group.cc
+++ b/projects/rccl/src/group.cc
@@ -446,7 +446,7 @@ static void reclaimPlannerState(struct ncclComm* comm) {
   comm->preconnectNext = reinterpret_cast<struct ncclComm*>(0x1);
   // connectSend/connectRecv are allocated as comm->nRanks * NCCL_MAX_CONNS
   for (int i = 0; i < comm->nRanks * NCCL_MAX_CONNS; i++) {
-    for (int j = 0; j < MAXCHANNELS/64; j++) {
+    for (int j = 0; j < MAXCHANNELS/CHANNELS_PER_MASK_WORD; j++) {
       comm->connectSend[i].masks[j] = 0UL;
       comm->connectRecv[i].masks[j] = 0UL;
     }

--- a/projects/rccl/src/include/archinfo.h
+++ b/projects/rccl/src/include/archinfo.h
@@ -46,4 +46,14 @@ inline int rcclLL128DataElemsFromArch(char const* arch) {
   return rcclLL128LineElemsFromArch(arch) - 1;
 }
 
+/* Host Code: lines per thread is 8 on gfx12xx (matches NCCL upstream's 128 byte
+ * non tearing line layout) and 4 on gfx9xx (64 byte lines). Total elems per
+ * thread is linesPerThread * dataElemsPerLine, so gfx12xx = 8 * 15 = 120 and
+ * gfx9xx = 4 * 7 = 28. Derived from rcclLL128DataElemsFromArch so the value
+ * stays in sync if the line size ever changes. */
+inline int rcclLL128ElemsPerThreadFromArch(char const* arch) {
+  int linesPerThread = IsArchMatch(arch, "gfx1250") ? 8 : 4;
+  return linesPerThread * rcclLL128DataElemsFromArch(arch);
+}
+
 #endif // ARCHINFO_H

--- a/projects/rccl/src/include/comm.h
+++ b/projects/rccl/src/include/comm.h
@@ -225,7 +225,9 @@ struct ncclTaskColl {
   int32_t nMaxChannels:16;
   bool useWarpSpeed;
 #else
-  int32_t nMaxChannels:8;
+  // 16-bit so MAXCHANNELS=256 fits without sign-bit truncation
+  // (an 8-bit signed field caps at 127).
+  int32_t nMaxChannels:16;
 #endif
 #ifdef ENABLE_ROCSHMEM
   size_t* sizes;
@@ -258,7 +260,8 @@ struct ncclTaskColl {
   void* groupApiEventHandle;
   void* collApiEventHandle;
   void* eventHandle;
-  uint8_t nChannels;
+  // 16-bit so MAXCHANNELS=256 fits without wrap-to-zero.
+  uint16_t nChannels;
 };
 
 
@@ -655,7 +658,7 @@ struct ncclComm {
   int node;
   int nNodes;
   int rcclUseOneSlice; // RCCL: true if this comm is using one slice per primitive
-  int gfx9CheapFenceOff; // RCCL: true if gfx9 cheap fence is disabled
+  int cheapPostSendFenceOff; // RCCL: true if cheap post-send fence is disabled
   int localRank;
   int localRanks;
   int maxLocalRanks;

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -351,6 +351,7 @@ struct alignas(16) ncclDevWorkP2p {
   uint8_t sendChunkSize_u32fp8, recvChunkSize_u32fp8;
 
   uint8_t sendProtoLL:1, recvProtoLL:1;
+  uint8_t sendProtoLL128:1, recvProtoLL128:1;
   uint8_t sendNetReg:1, recvNetReg:1;
   uint8_t sendIpcReg:1, recvIpcReg:1;
 

--- a/projects/rccl/src/include/device.h
+++ b/projects/rccl/src/include/device.h
@@ -143,8 +143,15 @@ union ncclLLFifoLine {
 #ifdef ENABLE_WARP_SPEED
 #define MAXCHANNELS 512
 #else
-#define MAXCHANNELS 128
+// Raised from 128 -> 256 to let single- and multi-node configurations request
+// up to 256 channels via NCCL_MAX_NCHANNELS / NCCL_MIN_NCHANNELS. The actual
+// per-call channel count is still picked by the existing tuner; this only
+// lifts the upper bound.
+#define MAXCHANNELS 256
 #endif
+// Number of channel bits packed into one uint64_t word of channelMasks. The
+// global channelId for bit `x` in word `i` is `i*CHANNELS_PER_MASK_WORD + x`.
+#define CHANNELS_PER_MASK_WORD 64
 #define CHANNEL_LIMIT 16 // this is used to limit channels for pre MI3xx GPUs
 #define NCCL_MAX_LOCAL_RANKS 72
 #define NCCL_MIN_NTHREADS (4*WARP_SIZE)
@@ -182,7 +189,13 @@ static_assert(NCCL_LL_CLEAN_MASK % NCCL_STEPS == 0, "Invalid NCCL_LL_CLEAN_MASK 
 #define NCCL_LL128_DATAELEMS (NCCL_LL128_LINEELEMS-1)
 
 #define NCCL_LL128_MAX_NTHREADS 256
-#define NCCL_LL128_ELEMS_PER_THREAD 28
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
+// Upstream NCCL value (120 = 8 lines * 15 dataElems for 128-byte lines).
+// On RCCL/HIP the host derives the per-channel LL128 buffer size from
+// rcclLL128ElemsPerThreadFromArch() (see rcclSetDefaultBuffSizes), so this
+// macro is unused on HIP and intentionally left undefined to prevent drift.
+#define NCCL_LL128_ELEMS_PER_THREAD 120
+#endif
 
 #define NCCL_LL128_SHMEM_ELEMS_PER_THREAD 8
 #define NCCL_LL128_SHMEM_SIZE (NCCL_LL128_SHMEM_ELEMS_PER_THREAD*NCCL_LL128_MAX_NTHREADS)
@@ -404,7 +417,7 @@ struct alignas(16) ncclDevWorkColl {
   uint32_t channelLo:8, channelHi:8;
 #endif
   uint32_t nWarps:8;
-  uint32_t redOpArgIsPtr:1, regUsed:1, netRegUsed:1, oneNode:1, direct:2, isOneRPN:1, rcclUseOneSlice:1, gfx9CheapFenceOff:1;
+  uint32_t redOpArgIsPtr:1, regUsed:1, netRegUsed:1, oneNode:1, direct:2, isOneRPN:1, rcclUseOneSlice:1, cheapPostSendFenceOff:1;
   uint32_t root:30, connIndex:2;
   uint16_t pivotA2ANumBiRings:15, profilerEnabled:1;
   void* recvbuff;
@@ -626,8 +639,10 @@ enum ncclDevWorkStorageType: uint8_t {
 };
 
 struct channelMasks {
-  uint64_t masks[MAXCHANNELS/64];
+  uint64_t masks[MAXCHANNELS/CHANNELS_PER_MASK_WORD];
 };
+static_assert(MAXCHANNELS % CHANNELS_PER_MASK_WORD == 0,
+              "MAXCHANNELS must be a multiple of CHANNELS_PER_MASK_WORD");
 
 struct alignas(16) ncclDevKernelArgs {
   struct ncclKernelComm* comm;
@@ -660,7 +675,9 @@ typedef ncclDevKernelArgsStorage<(4<<10)> ncclDevKernelArgs4K;
 // 5KB should be sufficient for now
 typedef ncclDevKernelArgs5K ncclDevKernelArgsDefaultStorage;
 #else
-typedef ncclDevKernelArgs4K ncclDevKernelArgsDefaultStorage;
+// 5KB needed so 256-channel non-WarpSpeed builds can fit one batch per channel
+// in the kernel-args buffer (4KB only fits ~252 batches).
+typedef ncclDevKernelArgs5K ncclDevKernelArgsDefaultStorage;
 #endif
 __host__ __device__ constexpr int ncclMaxKernelArgsSize(/*int cudaDriver, */int cudaArch=NCCL_CUDA_ARCH) {
   //return (cudaArch < 700 || cudaDriver < 12010) ? 4<<10 : (32<<10)-4;

--- a/projects/rccl/src/include/nccl_device/hip_compat.h
+++ b/projects/rccl/src/include/nccl_device/hip_compat.h
@@ -115,7 +115,8 @@
 #if defined(NCCL_HIP_PLATFORM)
   // AMD GPUs use 64-wide waves (or 32 in wave32 mode)
   #if defined(__GFX10__) || defined(__GFX11__) || defined(__gfx1100__) || \
-      defined(__gfx1101__) || defined(__gfx1102__) || defined(__gfx1200__) || defined(__gfx1201__)
+      defined(__gfx1101__) || defined(__gfx1102__) || defined(__gfx1200__) || defined(__gfx1201__) || \
+      defined(__gfx1250__)
     #define NCCL_WARP_SIZE 32
   #else
     #define NCCL_WARP_SIZE 64

--- a/projects/rccl/src/include/nccl_device/rccl_ptr.h
+++ b/projects/rccl/src/include/nccl_device/rccl_ptr.h
@@ -36,12 +36,15 @@ using u16_gptr = __attribute__((address_space(1))) uint16_t*;
 using u8_gptr = __attribute__((address_space(1))) uint8_t*;
 
 #ifdef __HIP_DEVICE_COMPILE__
-#if (defined(__gfx942__) || defined(__gfx950__)) && __has_builtin(__builtin_amdgcn_global_load_b128) && __has_builtin(__builtin_amdgcn_global_store_b128) && !defined(DWORDX4_INTRINSICS_FORCE_OFF)
+#if (defined(__gfx942__) || defined(__gfx950__) || defined(__gfx1250__)) && \
+    __has_builtin(__builtin_amdgcn_global_load_b128) && \
+    __has_builtin(__builtin_amdgcn_global_store_b128) && \
+    !defined(DWORDX4_INTRINSICS_FORCE_OFF)
 #define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 1
-//#pragma message "RCCL DWORDX4 Builtins Enabled on GFX942/GFX950"
+//#pragma message "RCCL DWORDX4 Builtins Enabled on GFX942/GFX950/GFX1250"
 #else
 #define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 0
-//#pragma message "RCCL DWORDX4 Builtins Disabled on GFX942/GFX950"
+//#pragma message "RCCL DWORDX4 Builtins Disabled"
 #endif
 #else
 #define RCCL_HAVE_GLOBAL_DWORDX4_BUILTINS 0

--- a/projects/rccl/src/include/plugin/nccl_tuner.h
+++ b/projects/rccl/src/include/plugin/nccl_tuner.h
@@ -42,10 +42,13 @@ typedef ncclNvlDomainInfo_v6_t ncclNvlDomainInfo_t;
 
 #define NCCL_ALGO_PROTO_IGNORE -1.0
 
-#define NCCL_NUM_UNROLLS 3 // 1/2/4
-#define NCCL_UNROLL_1 0
-#define NCCL_UNROLL_2 1
-#define NCCL_UNROLL_4 2
+#define NCCL_NUM_UNROLLS 6 // 1/2/4/8/16/32
+#define NCCL_UNROLL_1  0
+#define NCCL_UNROLL_2  1
+#define NCCL_UNROLL_4  2
+#define NCCL_UNROLL_8  3
+#define NCCL_UNROLL_16 4
+#define NCCL_UNROLL_32 5
 
 #define NCCL_NUM_FLOATS 6 // half/float/double/rccl_bfloat16/rccl_float8/rccl_bfloat8
 

--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -184,7 +184,7 @@ std::unordered_map<ncclComm_t, rocshmem::rocshmem_team_t> ncclCommToRshmemTeam;
 #endif
 
 // Turn off cheap fence for gfx942/gfx950
-RCCL_PARAM(Gfx9CheapFenceOff, "GFX9_CHEAP_FENCE_OFF", 0);
+RCCL_PARAM(CheapPostSendFenceOff, "CHEAP_POST_SEND_FENCE_OFF", 0);
 
 /**
  * Used on gfx1151 (StrixHalo) to set the nChannels for ncclTopoPreset before determining number of nodes. 
@@ -1693,17 +1693,21 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
     allGather3Data[rank].nc = std::max(allGather3Data[rank].nc, 4/ringGraph->nChannels);
   if (ringGraph->nChannels > MAXCHANNELS/2)
     allGather3Data[rank].nc = 1;
-  comm -> gfx9CheapFenceOff = 1;
+  comm -> cheapPostSendFenceOff = 1;
   #ifdef HIP_UNCACHED_MEMORY
-  if(!rcclParamGfx9CheapFenceOff()){
+  if(!rcclParamCheapPostSendFenceOff()){
     if(IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942")){
-      comm -> gfx9CheapFenceOff = 0;
+      comm -> cheapPostSendFenceOff = 0;
     }
     else if(IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")){
-      comm -> gfx9CheapFenceOff = ROCM_VERSION < 70002 && nNodes > 1; // Enable for single node only prior to ROCm 7.0.2
+      comm -> cheapPostSendFenceOff = ROCM_VERSION < 70002 && nNodes > 1; // Enable for single node only prior to ROCm 7.0.2
+    }
+    else if(IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx1250")){
+      // DWORDX4 sc0+sc1 builtins now active for gfx1250; cheap fence is sufficient.
+      comm -> cheapPostSendFenceOff = 0;
     }
   }
-  INFO(NCCL_INIT, "GFX9 cheap fence is %s", comm -> gfx9CheapFenceOff ? "OFF" : "ON");
+  INFO(NCCL_INIT, "Cheap post-send fence is %s", comm -> cheapPostSendFenceOff ? "OFF" : "ON");
   #endif
   // RCCL: Only use one slice per primitive on some single node gfx9xx systems, only currently enabled for AllReduce, ReduceScatter, and AllGather
   if (IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx942") || IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx950")){
@@ -1748,7 +1752,10 @@ static ncclResult_t initTransportsRank(struct ncclComm* comm, struct ncclComm* p
   }
 
   allGather3Data[rank].pivotA2AEnabled = comm->topo->pivotA2AEnabled && rcclParamPivotAlltoallEnable();
-  comm->topo->ll128Enabled =  comm->topo->ll128Enabled || rcclParamLL128ForceEnable();
+  // Default-enable LL128 on gfx1250 so NCCL_PROTO=LL128 is honored without
+  // also requiring RCCL_LL128_FORCE_ENABLE=1.
+  comm->topo->ll128Enabled =  comm->topo->ll128Enabled || rcclParamLL128ForceEnable()
+    || IsArchMatch(comm->topo->nodes[GPU].nodes[idx].gpu.gcn, "gfx1250");
   allGather3Data[rank].ll128Enabled = comm->topo->ll128Enabled;
 
   if (comm->ncclNet && comm->ncclNet->devices) {
@@ -2403,7 +2410,7 @@ static ncclResult_t ncclCommInitRankFunc(struct ncclAsyncJob* job_) {
   // Set the maximum kernel stack size of all kernels to avoid
   // a CUDA memory reconfig on load (c.f. NVSHMEM issue)
 #ifdef USE_INDIRECT_FUNCTION_CALL
-  if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName,"gfx942") && !IsArchMatch(archName,"gfx950")) {
+  if (ncclParamSetStackSize() == 1 && !IsArchMatch(archName,"gfx942") && !IsArchMatch(archName,"gfx950") && !IsArchMatch(archName,"gfx1250")) {
     stackSize = rcclParamStackSizeOverride() ? rcclParamStackSizeOverride() : maxLocalSizeBytes;
     if (stackSize == 0) {
       if (IsArchMatch(archName,"gfx906"))

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -45,9 +45,10 @@ CUmemAllocationHandleType ncclCuMemHandleType = CU_MEM_HANDLE_TYPE_POSIX_FILE_DE
 static int ncclCuMemSupported = 0;
 
 // cuMem VMM API availability by HIP/driver version.
-#define NCCL_CUMEM_NATIVE_MIN_VERSION   71260540
+#define NCCL_CUMEM_NATIVE_MIN_VERSION   70200000
 #define NCCL_CUMEM_BACKPORT_MIN_VERSION 70051831
 #define NCCL_CUMEM_BACKPORT_MAX_VERSION 70060000
+#define RCCL_CUMEM_MIN_HIP_VERSION 70200000
 
 #define NCCL_CUMEM_VERSION_SUPPORTED(version)                  \
   ((version) >= NCCL_CUMEM_NATIVE_MIN_VERSION ||               \
@@ -85,7 +86,7 @@ int ncclIsCuMemSupported() {
     // Block scope prevents the goto in CUDACHECKGOTO from jumping over the bool initialization.
     bool cuMemSupported = NCCL_CUMEM_VERSION_SUPPORTED(cudaDriverVersion);
     if (!cuMemSupported) {
-      WARN("cuMem support requires HIP_VERSION >= 7.12.60540 (or ROCm 7.0.2.x backport)");
+      WARN("cuMem support requires HIP_VERSION >= 7.2.0 (or ROCm 7.0.2.x backport)");
       supported = 0;
     }
   }
@@ -119,15 +120,16 @@ static int ncclCumemHostEnable = -1;
 int ncclCuMemHostEnable() {
   if (ncclCumemHostEnable != -1)
     return ncclCumemHostEnable;
-#if HIP_VERSION < 71260540
+#if HIP_VERSION < RCCL_CUMEM_MIN_HIP_VERSION
   ncclCumemHostEnable = 0;
   return ncclCumemHostEnable;
 #else
   ncclResult_t ret = ncclSuccess;
   int cudaDriverVersion;
   int paramValue = -1;
+  int cudaDev;
   CUDACHECKGOTO(cudaDriverGetVersion(&cudaDriverVersion), ret, error);
-  if (cudaDriverVersion < 71260540) {
+  if (cudaDriverVersion < RCCL_CUMEM_MIN_HIP_VERSION) {
     ncclCumemHostEnable = 0;
   }
   else {
@@ -135,11 +137,10 @@ int ncclCuMemHostEnable() {
     if (paramValue != -1)
       ncclCumemHostEnable = paramValue;
     else
-      ncclCumemHostEnable = (cudaDriverVersion >= 71260540) ? 1 : 0;
+      ncclCumemHostEnable = (cudaDriverVersion >= RCCL_CUMEM_MIN_HIP_VERSION) ? 1 : 0;
     if (ncclCumemHostEnable) {
       // Verify that host allocations actually work.  Docker in particular is known to disable "get_mempolicy",
       // causing such allocations to fail (this can be fixed by invoking Docker with "--cap-add SYS_NICE").
-      int cudaDev;
       CUdevice currentDev;
       int cpuNumaNodeId = -1;
       CUmemAllocationProp prop = {};

--- a/projects/rccl/src/rccl_wrap.cc
+++ b/projects/rccl/src/rccl_wrap.cc
@@ -828,7 +828,7 @@ void rcclSetDefaultBuffSizes(struct ncclComm* comm, int defaultBuffSizes[]) {
   static int maxNthreads[NCCL_NUM_PROTOCOLS] = {0};
   if (maxNthreads[NCCL_PROTO_SIMPLE] == 0) rcclGetMaxNthreads(comm, maxNthreads);
   defaultBuffSizes[NCCL_PROTO_LL]     = NCCL_LL_LINES_PER_THREAD*maxNthreads[NCCL_PROTO_LL]*NCCL_STEPS*sizeof(union ncclLLFifoLine);
-  defaultBuffSizes[NCCL_PROTO_LL128]  = NCCL_LL128_ELEMS_PER_THREAD*maxNthreads[NCCL_PROTO_LL128]*NCCL_STEPS*sizeof(uint64_t);
+  defaultBuffSizes[NCCL_PROTO_LL128]  = rcclLL128ElemsPerThreadFromArch(comm->archName)*maxNthreads[NCCL_PROTO_LL128]*NCCL_STEPS*sizeof(uint64_t);
   defaultBuffSizes[NCCL_PROTO_SIMPLE] = (1 << 22); /* 4MiB */
 }
 
@@ -842,7 +842,7 @@ ncclResult_t commSetUnrollFactor(struct ncclComm* comm) {
   if( rcclParamUnrollFactor() != -1 ) {
     comm->unroll = rcclParamUnrollFactor(); //-1 to map to 0 based indexing
     if(comm->unroll < NCCL_UNROLL_1 || comm->unroll >= NCCL_NUM_UNROLLS) {
-      WARN("Invalid RCCL_UNROLL_FACTOR %d specified. Valid values are 0 to 2 corresponding to unroll factors of 1, 2, and 4 respectively.", comm->unroll);
+      WARN("Invalid RCCL_UNROLL_FACTOR %d specified. Valid values are 0 to %d corresponding to unroll factors of 1, 2, 4, 8, 16, and 32 respectively.", comm->unroll, NCCL_NUM_UNROLLS - 1);
       return ncclInvalidArgument;
     }
     INFO(NCCL_INIT, "RCCL Unroll Factor (user set): %d", (int) (pow(2.0, (double)comm->unroll)));
@@ -909,9 +909,9 @@ bool rcclIsArchSupportedForFunc(struct ncclTaskColl* info, const char* archName)
   if (info->protocol == NCCL_PROTO_LL128) {
 #if defined(ENABLE_LL128)
     if (info->acc)
-      supported = (IsArchMatch(archName, "gfx942") || IsArchMatch(archName, "gfx950"));
+      supported = (IsArchMatch(archName, "gfx942") || IsArchMatch(archName, "gfx950") || IsArchMatch(archName, "gfx1250"));
     else
-      supported = (IsArchMatch(archName, "gfx942") || IsArchMatch(archName, "gfx950") || IsArchMatch(archName, "gfx90a"));
+      supported = (IsArchMatch(archName, "gfx942") || IsArchMatch(archName, "gfx950") || IsArchMatch(archName, "gfx90a") || IsArchMatch(archName, "gfx1250"));
 #else
     supported = false;
 #endif

--- a/projects/rccl/src/transport.cc
+++ b/projects/rccl/src/transport.cc
@@ -149,7 +149,7 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
   cudaStream_t hostStream, deviceStream;
 
   int count = 0;
-  int num = MAXCHANNELS/64;
+  int num = MAXCHANNELS/CHANNELS_PER_MASK_WORD;
 
   NCCLCHECK(ncclCalloc(&data, maxPeers));
   NCCLCHECKGOTO(ncclCalloc(&recvData, maxPeers), ret, fail);
@@ -324,7 +324,7 @@ ncclResult_t ncclTransportP2pSetup(struct ncclComm* comm, struct ncclTopoGraph* 
     int recvPeer = (comm->rank - i + comm->nRanks) % comm->nRanks;
     int sendPeer = (comm->rank + i) % comm->nRanks;
 
-    for (int j = 0; j < MAXCHANNELS/64; j++) {
+    for (int j = 0; j < MAXCHANNELS/CHANNELS_PER_MASK_WORD; j++) {
     if (recvPeer != sendPeer) {
       if (comm->connectSend[sendPeer].masks[j] != 0UL) NCCLCHECKGOTO(bootstrapSend(comm->bootstrap, sendPeer, bootstrapTag, NULL, 0), ret, fail);
       if (comm->connectRecv[recvPeer].masks[j] != 0UL) NCCLCHECKGOTO(bootstrapSend(comm->bootstrap, recvPeer, bootstrapTag, NULL, 0), ret, fail);


### PR DESCRIPTION
Added opt-in LL128 protocol for send/recv kernels (gfx1250) gated behind NCCL_P2P_LL128_ENABLE (default off) and limited to gfx1250, with NCCL_P2P_LL128_THRESHOLD (default 0 = no upper bound) to bound the per-channel payload size.

## Motivation

The send/recv kernels currently only support the LL and SIMPLE protocols, and this effort investigates whether the more bandwidth-efficient LL128 could help on MI450X (gfx1250) even for large messages; this PR adds an opt-in, gfx1250-only LL128 path for send/recv so we can measure that impact while leaving default behavior on all existing architectures unchanged.

## Technical Details

LL128 is added as a third protocol in the per-direction/per-connection selection in addP2pToPlan() (precedence LL128 → LL → SIMPLE) and dispatched in the send/recv device kernel via new sendProtoLL128/recvProtoLL128 work flags; no primitives changes are needed since the Primitives wrapper already maps directSend/directRecv to LL128's send/recv. It is gated by NCCL_P2P_LL128_ENABLE (default 0), bounded by NCCL_P2P_LL128_THRESHOLD (default 0 = no upper bound), and requires arch gfx1250 plus an allocated LL128 connection buffer; when selected, the LL128 chunk math chunkDataSize = (chunkSize / ll128LineElems) * ll128DataElems is applied, matching the collective path and the device-side ProtoLL128::calcBytePerStep().

## JIRA ID

AICOMRCCL-1402

## Test Plan

On gfx1250, run the 2-rank single-node sendrecv perf benchmark with NCCL_P2P_LL128_ENABLE=1 NCCL_P2P_LL128_THRESHOLD=0 and sweep message sizes, confirming correctness and bandwidth vs the default LL/SIMPLE path.

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
