### PR TITLE
refactor(rocr): Make EXPORT_MEMORY_FLAGS a KfdDriver internal implementation

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -485,7 +485,6 @@ hsa_status_t KfdDriver::ExportMemoryHandleImpl(const core::Agent& agent,
       return HSA_STATUS_SUCCESS;
     }
 #endif
-    (void)export_offset;
     const auto& gpu_agent = static_cast<const GpuAgent&>(agent);
 
     HsaHandleExportDesc desc = {};
@@ -504,7 +503,6 @@ hsa_status_t KfdDriver::ExportMemoryHandleImpl(const core::Agent& agent,
     return HSA_STATUS_SUCCESS;
   }
   case core::ShareType::FABRIC_HANDLE: {
-    (void)export_offset;
 #if !defined(__linux__)
     assert(!"Unimplemented!");
     return HSA_STATUS_ERROR;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/kfd/amd_kfd_driver.cpp
@@ -454,15 +454,23 @@ hsa_status_t KfdDriver::AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
   return HSA_STATUS_SUCCESS;
 }
 
-hsa_status_t KfdDriver::ExportMemoryHandle(const core::Agent& agent, const core::DriverMemoryHandle& handle,
-                                           core::ShareType type, uint32_t flags, void* export_handle,
-                                           uint64_t* export_offset) {
+hsa_status_t KfdDriver::ExportMemoryHandle(const core::Agent& agent,
+                                           const core::DriverMemoryHandle& handle,
+                                           core::ShareType type, void* export_handle) {
+  return ExportMemoryHandleImpl(agent, handle, type, EXPORT_MEMORY_FLAGS_NONE, export_handle,
+                                nullptr);
+}
+
+hsa_status_t KfdDriver::ExportMemoryHandleImpl(const core::Agent& agent,
+                                               const core::DriverMemoryHandle& handle,
+                                               core::ShareType type, uint32_t flags,
+                                               void* export_handle, uint64_t* export_offset) {
   if (export_handle == nullptr) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
   switch (type) {
   case core::ShareType::DMABUF_FD: {
     auto* dmabuf_fd = static_cast<int*>(export_handle);
-    if (flags & core::EXPORT_MEMORY_FLAGS_KFD_DMABUF) {
+    if (flags & EXPORT_MEMORY_FLAGS_KFD_DMABUF) {
       if (export_offset == nullptr) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
       void* mem = reinterpret_cast<void*>(handle.handle);
       if (HSAKMT_CALL(hsaKmtExportDMABufHandle(mem, handle.size, dmabuf_fd, export_offset)) !=
@@ -624,9 +632,9 @@ hsa_status_t KfdDriver::CreateShareableHandle(void* va, void* mem, size_t size,
   core::DriverMemoryHandle kfd_alloc = {};
   kfd_alloc.handle = reinterpret_cast<uint64_t>(mem);
   kfd_alloc.size = size;
-  if (ExportMemoryHandle(agent, kfd_alloc, core::ShareType::DMABUF_FD,
-                         core::EXPORT_MEMORY_FLAGS_KFD_DMABUF, &source_fd, offset) !=
-      HSA_STATUS_SUCCESS) {
+  if (ExportMemoryHandleImpl(agent, kfd_alloc, core::ShareType::DMABUF_FD,
+                             EXPORT_MEMORY_FLAGS_KFD_DMABUF, &source_fd,
+                             offset) != HSA_STATUS_SUCCESS) {
     return HSA_STATUS_ERROR;
   }
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/virtio/amd_kfd_virtio_driver.cpp
@@ -463,12 +463,10 @@ hsa_status_t KfdVirtioDriver::AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_G
   return HSA_STATUS_ERROR;
 }
 
-hsa_status_t KfdVirtioDriver::ExportMemoryHandle(const core::Agent& agent, const core::DriverMemoryHandle& handle,
-                                                 core::ShareType type, uint32_t flags, void* export_handle,
-                                                 uint64_t* export_offset) {
+hsa_status_t KfdVirtioDriver::ExportMemoryHandle(const core::Agent& agent,
+                                                 const core::DriverMemoryHandle& handle,
+                                                 core::ShareType type, void* export_handle) {
   (void)agent;
-  (void)flags;
-  (void)export_offset;
   if (export_handle == nullptr) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
   switch (type) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/driver/xdna/amd_xdna_driver.cpp
@@ -816,12 +816,10 @@ hsa_status_t XdnaDriver::AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
   return HSA_STATUS_ERROR_INVALID_QUEUE;
 }
 
-hsa_status_t XdnaDriver::ExportMemoryHandle(const core::Agent& agent, const core::DriverMemoryHandle& handle,
-                                            core::ShareType type, uint32_t flags, void* export_handle,
-                                            uint64_t* export_offset) {
+hsa_status_t XdnaDriver::ExportMemoryHandle(const core::Agent& agent,
+                                            const core::DriverMemoryHandle& handle,
+                                            core::ShareType type, void* export_handle) {
   (void)agent;
-  (void)flags;
-  (void)export_offset;
   if (export_handle == nullptr) return HSA_STATUS_ERROR_INVALID_ARGUMENT;
 
   switch (type) {

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_kfd_driver.h
@@ -108,8 +108,7 @@ public:
   hsa_status_t AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
                              uint32_t* first_gws) const override;
   hsa_status_t ExportMemoryHandle(const core::Agent& agent, const core::DriverMemoryHandle& handle,
-                                  core::ShareType type, uint32_t flags, void* export_handle,
-                                  uint64_t* export_offset = nullptr) override;
+                                  core::ShareType type, void* export_handle) override;
   hsa_status_t ImportMemoryHandle(const core::Agent& agent, core::DriverMemoryHandle* handle,
                                   core::ShareType type, void* import_handle,
                                   void* mem = nullptr) override;
@@ -159,6 +158,27 @@ public:
   hsa_status_t GetQueueSaveAreaInfo(HSA_QUEUEID queue_id, void** address, size_t* size) const override;
 
  private:
+  /// @brief Flags for @ref ExportMemoryHandleImpl.
+  enum ExportMemoryFlags : uint32_t {
+    EXPORT_MEMORY_FLAGS_NONE = 0,
+    /// Export a KFD allocation via @c hsaKmtExportDMABufHandle. @p handle.handle is the
+    /// allocation address and @p handle.size is the allocation size. @p export_offset is required.
+    EXPORT_MEMORY_FLAGS_KFD_DMABUF = 1,
+  };
+
+  /// @brief Internal export implementation supporting KFD-specific flags and offset.
+  ///
+  /// @param[in] agent agent that owns the memory
+  /// @param[in] handle driver memory handle to export
+  /// @param[in] type @ref core::ShareType to export
+  /// @param[in] flags @ref ExportMemoryFlags
+  /// @param[out] export_handle output handle; @p int* for @p DMABUF_FD,
+  ///             @p hsa_fabric_handle_t* for @p FABRIC_HANDLE
+  /// @param[out] export_offset allocation offset; required when @p EXPORT_MEMORY_FLAGS_KFD_DMABUF
+  ///             is set in @p flags
+  hsa_status_t ExportMemoryHandleImpl(const core::Agent& agent,
+                                      const core::DriverMemoryHandle& handle, core::ShareType type,
+                                      uint32_t flags, void* export_handle, uint64_t* export_offset);
 
   /// @brief Query for user preference and use that to determine Xnack mode
   /// of ROCm system. Return true if Xnack mode is ON or false if OFF. Xnack

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_virtio_driver.h
@@ -102,8 +102,7 @@ class KfdVirtioDriver final : public core::Driver {
                               uint32_t* cu_mask) const override;
   hsa_status_t AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_GWS, uint32_t* GWS) const override;
   hsa_status_t ExportMemoryHandle(const core::Agent& agent, const core::DriverMemoryHandle& handle,
-                                  core::ShareType type, uint32_t flags, void* export_handle,
-                                  uint64_t* export_offset = nullptr) override;
+                                  core::ShareType type, void* export_handle) override;
   hsa_status_t ImportMemoryHandle(const core::Agent& agent, core::DriverMemoryHandle* handle,
                                   core::ShareType type, void* import_handle,
                                   void* mem = nullptr) override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_xdna_driver.h
@@ -136,8 +136,7 @@ public:
   hsa_status_t AllocQueueGWS(HSA_QUEUEID queue_id, uint32_t num_gws,
                              uint32_t* first_gws) const override;
   hsa_status_t ExportMemoryHandle(const core::Agent& agent, const core::DriverMemoryHandle& handle,
-                                  core::ShareType type, uint32_t flags, void* export_handle,
-                                  uint64_t* export_offset = nullptr) override;
+                                  core::ShareType type, void* export_handle) override;
   hsa_status_t ImportMemoryHandle(const core::Agent& agent, core::DriverMemoryHandle* handle,
                                   core::ShareType type, void* import_handle,
                                   void* mem = nullptr) override;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/driver.h
@@ -93,14 +93,6 @@ enum ShareType {
   FABRIC_HANDLE,
 };
 
-/// @brief Flags for @ref ExportMemoryHandle.
-enum ExportMemoryFlags : uint32_t {
-  EXPORT_MEMORY_FLAGS_NONE = 0,
-  /// Export a KFD allocation via @c hsaKmtExportDMABufHandle. @p handle.handle is the
-  /// allocation address and @p handle.size is the allocation size. @p export_offset is required.
-  EXPORT_MEMORY_FLAGS_KFD_DMABUF = 1,
-};
-
 /// @brief Kernel driver interface.
 ///
 /// @details A class used to provide an interface between the core runtime
@@ -229,14 +221,11 @@ public:
   /// @param[in] agent agent that owns the memory
   /// @param[in] handle driver memory handle to export
   /// @param[in] type @ref ShareType to export
-  /// @param[in] flags @ref ExportMemoryFlags
   /// @param[out] export_handle output handle; @p int* for @p DMABUF_FD,
   ///             @p hsa_fabric_handle_t* for @p FABRIC_HANDLE
-  /// @param[out] export_offset allocation offset; required when @p EXPORT_MEMORY_FLAGS_KFD_DMABUF
-  ///             is set in @p flags
-  virtual hsa_status_t ExportMemoryHandle(const core::Agent& agent, const DriverMemoryHandle& handle,
-                                          ShareType type, uint32_t flags, void* export_handle,
-                                          uint64_t* export_offset = nullptr) = 0;
+  virtual hsa_status_t ExportMemoryHandle(const core::Agent& agent,
+                                          const DriverMemoryHandle& handle, ShareType type,
+                                          void* export_handle) = 0;
 
   /// @brief Imports a memory object from a shareable handle.
   ///

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -4240,7 +4240,7 @@ Runtime::VMemorySetAccessPerHandle(void *va, MappedHandle &mappedHandle,
     Agent *exportAgent = memHandle->drmAgent();
     int dmabuf_fd = -1;
     hsa_status_t status = exportAgent->driver().ExportMemoryHandle(
-        *exportAgent, memHandle->driver_handle, ShareType::DMABUF_FD, 0, &dmabuf_fd);
+        *exportAgent, memHandle->driver_handle, ShareType::DMABUF_FD, &dmabuf_fd);
     if (status != HSA_STATUS_SUCCESS)
       return status;
     memHandle->driver_handle.dmabuf_fd = dmabuf_fd;
@@ -4454,8 +4454,7 @@ hsa_status_t Runtime::VMemoryExportShareableHandle(int* dmabuf_fd,
   auto agentOwner = memoryHandle->drmAgent();
 
   return agentOwner->driver().ExportMemoryHandle(*agentOwner, memoryHandle->driver_handle,
-                                                 ShareType::DMABUF_FD,
-                                                 0, dmabuf_fd);
+                                                 ShareType::DMABUF_FD, dmabuf_fd);
 }
 
 hsa_status_t Runtime::VMemoryImportShareableHandle(int dmabuf_fd,
@@ -4485,8 +4484,7 @@ hsa_status_t Runtime::VMemoryExportFabricHandle(hsa_fabric_handle_t* fabric_hand
   auto agentOwner = memoryHandle->region->owner();
 
   return agentOwner->driver().ExportMemoryHandle(*agentOwner, memoryHandle->driver_handle,
-                                                 ShareType::FABRIC_HANDLE,
-                                                 0, fabric_handle);
+                                                 ShareType::FABRIC_HANDLE, fabric_handle);
 }
 
 hsa_status_t Runtime::VMemoryImportFabricHandle(hsa_fabric_handle_t fabric_handle,


### PR DESCRIPTION
## Motivation

The export memory flags are only applicable to KFD and moving them in `KfdDriver` simplifies the internal API.

## Technical Details

Create a `KfdDriver::ExportMemoryHandleImpl` that is used with KFD-only ExportMemoryFlags

## JIRA ID

Closes https://github.com/ROCm/rocm-systems/issues/8138

## Test Plan

rocrtst

## Test Result

Success.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
