### PR TITLE
ci(rocprofiler-systems): Modify quick test regex in `test_categories.yaml`

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -845,18 +845,10 @@ def _load_test_categories() -> Optional[dict]:
     """Load and compile test_categories.yaml from rocprofsys_tests_dir.
 
     Reads the YAML that CMake installs/configures into
-    ``<build|install>/share/rocprofiler-systems/tests`` (resolved via
-    ``get_rocprof_config().rocprofsys_tests_dir``) rather than the
-    source-tree copy, so build-tree edits and the installed layout both
-    pick up the right file.
+    ``<build|install>/share/rocprofiler-systems/tests``
 
     Returns ``None`` (with a single STDERR warning) when the YAML is missing or
-    PyYAML isn't importable - the conftest stays usable in sparse / standalone
-    checkouts that don't carry the test-filter standardisation files.
-
-    Pattern semantics intentionally mirror CTest ``--tests-regex`` (substring
-    regex via ``re.search``), so legacy patterns from
-    test_rocprofiler_systems.py port over unchanged.
+    PyYAML isn't importable
     """
     if yaml is None:
         print(
@@ -890,12 +882,9 @@ def _load_test_categories() -> Optional[dict]:
     def _compile_list(patterns):
         compiled = []
         for p in patterns or []:
-            # A YAML alias of a sequence (e.g. `- *common_excludes`) substitutes
-            # the anchored list as a single element, producing a list-of-lists
-            # here. Flatten one level so callers can mix shared anchors with
-            # per-tier additions, mirroring the idiom at
-            # shared/ctest/parse_test_categories.py (`exclude_gpu.test_patterns`,
-            # see comment "test_patterns may be either a flat list or list-of-lists").
+            # Flatten one level: a YAML alias item (e.g. `- *common_excludes`)
+            # expands to a nested list, so callers can mix a shared anchor with
+            # per-tier additions.
             for pattern in p if isinstance(p, list) else [p]:
                 try:
                     compiled.append(re.compile(pattern))
@@ -907,15 +896,9 @@ def _load_test_categories() -> Optional[dict]:
         return compiled
 
     def _flatten_labels(values):
-        # Mirror _compile_list's one-level flattening for plain label lists
-        # (excluded_labels / labels). A YAML alias of a sequence (e.g.
-        # `- *heavy_labels`) substitutes the anchored list as a single element,
-        # so callers can mix a shared anchor with per-tier additions, e.g.
-        #   excluded_labels:
-        #     - *heavy_labels
-        #     - "openmp"
-        # Without flattening, set([[...], "openmp"]) raises TypeError on the
-        # unhashable inner list.
+        # One-level flatten (like _compile_list) so a YAML alias item expands
+        # to a nested list without raising TypeError on the unhashable inner
+        # list when set()-ed.
         flat = []
         for v in values or []:
             flat.extend(v if isinstance(v, list) else [v])
@@ -925,13 +908,11 @@ def _load_test_categories() -> Optional[dict]:
     for tier in TIER_ORDER:
         cfg = (data.get("test_categories", {}) or {}).get(tier) or {}
         tier_cfg[tier] = {
-            "include": _compile_list(cfg.get("test_patterns")),
-            "exclude": _compile_list(cfg.get("exclude")),
-            "excluded_labels": set(_flatten_labels(cfg.get("excluded_labels"))),
-            # Supplementary CTest labels declared by the tier (e.g. quick's
-            # `pre-commit` / `smoke`, comprehensive's `nightly`). Emitted in
-            # addition to the tier name by _resolve_tier_labels().
-            "labels": _flatten_labels(cfg.get("labels")),
+            "include": _compile_list(cfg.get("regex_includes")),
+            "exclude": _compile_list(cfg.get("regex_excludes")),
+            "label_excludes": _compile_list(cfg.get("label_excludes")),
+            "label_includes": _compile_list(cfg.get("label_includes")),
+            "labels": _flatten_labels(cfg.get("added_supplementary_labels")),
         }
 
     return {"tiers": tier_cfg}
@@ -940,23 +921,21 @@ def _load_test_categories() -> Optional[dict]:
 def _resolve_tier_labels(test_name: str, existing_labels: set[str]) -> set[str]:
     """Return tier labels (subset of TIER_ORDER) for *test_name*.
 
-    Each tier is evaluated independently. A test is granted tier T iff:
-      * its name matches any of T's ``test_patterns``,
-      * its name does NOT match any of T's ``exclude`` patterns, AND
-      * none of its ``existing_labels`` (pytest-marker-derived) appear in
-        T's ``excluded_labels``.
+    Each tier is evaluated independently with the *exact* CTest filter model.
+    The four YAML axes map to CTest options as (labels are pytest MARKERs):
+      * ``regex_includes`` -> ``-R``   * ``regex_excludes`` -> ``-E``
+      * ``label_includes``  -> ``-L``  * ``label_excludes`` -> ``-LE``
 
     The rocJenkins-style cascade ("matching quick also yields standard /
     comprehensive / full") is achieved by having those higher tiers use
-    broad include patterns (typically ``test_patterns: [".*"]``). Per-tier
-    ``exclude`` punches a hole through the cascade for individual tests:
-    listing ``testA`` under ``standard.exclude`` drops ``standard`` from
-    its label set even if ``quick`` / ``comprehensive`` / ``full`` match.
+    broad include patterns (typically ``regex_includes: [".*"]``). Per-tier
+    ``regex_excludes`` punches a hole through the cascade for individual
+    tests: listing ``testA`` under ``standard.regex_excludes`` drops
+    ``standard`` from its label set even if ``quick`` / ``comprehensive`` /
+    ``full`` match.
 
     In addition to the tier name, each matched tier contributes its
-    supplementary ``labels:`` (e.g. ``pre-commit`` / ``smoke`` for quick,
-    ``nightly`` for comprehensive), so ``ctest -L <alias>`` works for the
-    aliases declared in test_categories.yaml.
+    ``added_supplementary_labels:`` to the test's labels.
     """
     categories = _load_test_categories()
     if not categories:
@@ -965,11 +944,24 @@ def _resolve_tier_labels(test_name: str, existing_labels: set[str]) -> set[str]:
     extra_labels: set[str] = set()
     for i, tier in enumerate(TIER_ORDER):
         cfg = categories["tiers"].get(tier) or {}
-        if not any(p.search(test_name) for p in cfg.get("include", [])):
+        include_regex = cfg.get("include", [])
+        include_labels = cfg.get("label_includes", [])
+        exclude_regex = cfg.get("exclude", [])
+        exclude_labels = cfg.get("label_excludes", [])
+        # -R: an empty include is a pass-through; otherwise the NAME must match.
+        if include_regex and not any(p.search(test_name) for p in include_regex):
             continue
-        if any(p.search(test_name) for p in cfg.get("exclude", [])):
+        # -L: an empty include is a pass-through; otherwise a marker label must
+        # match. AND-combined with the -R axis above, exactly like CTest.
+        if include_labels and not any(
+            p.search(label) for p in include_labels for label in existing_labels
+        ):
             continue
-        if existing_labels & cfg.get("excluded_labels", set()):
+        # -E: NAME matching any exclude pattern vetoes the test.
+        if any(p.search(test_name) for p in exclude_regex):
+            continue
+        # -LE: any marker label matching an exclude pattern vetoes the test.
+        if any(p.search(label) for p in exclude_labels for label in existing_labels):
             continue
         matched_indices.append(i)
         extra_labels.update(cfg.get("labels", []))

--- a/projects/rocprofiler-systems/tests/test_categories.yaml
+++ b/projects/rocprofiler-systems/tests/test_categories.yaml
@@ -11,27 +11,27 @@
 # so `ctest -L <tier>` works directly against the installed
 # share/rocprofiler-systems/tests directory.
 #
-# Two independent exclude mechanisms; a test is dropped from a tier if EITHER
-# matches:
-#   - `test_patterns` / `exclude`: matched against the test NAME via re.search
-#     (substring regex), mirroring CTest `--tests-regex` and the legacy
-#     test_rocprofiler_systems.py.
-#   - `excluded_labels`: matched against the test's pytest-MARKER labels (e.g.
-#     `mpi`, `annotate`), independent of the name.
+# Per-tier selection keys mirror CTest's filter options EXACTLY (-R/-E/-L/-LE):
+#   - `regex_includes`  (-R):  include if test NAME matches (re.search regex).
+#   - `label_includes`  (-L):  include if a pytest-MARKER label matches (regex).
+#   - `regex_excludes`  (-E):  exclude if test NAME matches (regex).
+#   - `label_excludes`  (-LE): exclude if a pytest-MARKER label matches (regex).
+#   - `added_supplementary_labels`: extra CTest labels stamped onto every test
+#     that matches the tier.
+#
+# Note that combination rules are identical to that of CTest.
 #
 # Source of truth for the always-excluded sets is the legacy
 # TheRock/build_tools/.../test_executable_scripts/test_rocprofiler_systems.py
 # (EXCLUDED_TESTS, EXCLUDED_LABELS, QUICK_TESTS_REGEX).  Keep this YAML and
 # that script in sync until the legacy script is retired.
 
-# Always-excluded test NAME patterns (matched against the test name via
-# re.search). For tests that are currently broken (AIPROFSYST-441).
-_common_excludes: &common_excludes
+# Tests that have been known to cause problems on TheRock
+# (either because of failure or the example binary is never built)
+_common_therock_regex_excludes: &_common_therock_regex_excludes
   - "transferbench-sys-run"
   - "fork.*"
   - "openmp-target.*"
-  - "roctx-sampling"
-  - "roctx-runtime-instrument"
   - "jacobi-usm-sys-run"
   - "jacobi-roctx.*"
   - "jpeg-decode.*"
@@ -43,10 +43,8 @@ _common_excludes: &common_excludes
   - "shmem-pingpong.*"
   - "video-decode.*"
 
-# Always-excluded pytest-MARKER labels (e.g. mpi, lulesh) for tests that run
-# but are slow/heavy. A different axis from _common_excludes (name patterns);
-# heavy markers are excluded for now, pending AIPROFSYST-441.
-_heavy_labels: &heavy_labels
+# Labels that have been known to cause problems on TheRock
+_common_therock_labels_exclude: &_common_therock_labels_exclude
   - "annotate"
   - "mpi"
   - "julia"
@@ -58,69 +56,62 @@ _heavy_labels: &heavy_labels
 
 test_categories:
   quick:
-    description: "Fast sanity checks (target: < 15 min) - subset of curated test families"
-    # Mirrors QUICK_TESTS_REGEX from test_rocprofiler_systems.py.
-    test_patterns:
+    description: "Fast sanity checks (target: < 5 min) - subset of curated test families"
+    regex_includes:
       - "transpose.*"
       - "rocprofiler-systems.*"  # rocprof-sys-* binary smoke tests
-      - "config.*"
-      - "openmp.*"
-      - "roctx.*"
-      - "trace-time-window.*"
-    exclude: *common_excludes
-    excluded_labels: *heavy_labels
-    labels:
+      - "config-invalid"
+      - "config-missing"
+      - "cli-help.*"
+      - "openmp-fortran-offload-sys-run"
+      - "roctx-sampling"
+      # Jpeg and video decode should be added once the binaries can be built on TheRock
+    regex_excludes:
+      - *_common_therock_regex_excludes
+      - "transpose-runtime-instrument"
+    label_excludes: *_common_therock_labels_exclude
+    added_supplementary_labels:
       - "quick"
       - "pre-commit"
       - "smoke"
 
   standard:
-    description: "Default PR tier (target: < 60 min) - mirrors legacy TEST_TYPE=full"
-    # Everything that isn't always-broken and isn't tagged with a heavy marker.
-    # Equivalent to the legacy `ctest --label-exclude annotate|mpi|...` default.
-    test_patterns:
+    description: "Default PR tier (target: < 30 min)"
+    regex_includes:
       - ".*"
-    exclude: *common_excludes
-    excluded_labels: *heavy_labels
-    labels:
+    regex_excludes: *_common_therock_regex_excludes
+    label_excludes: *_common_therock_labels_exclude
+    added_supplementary_labels:
       - "standard"
       - "pr"
       - "precheckin"
 
   comprehensive:
-    description: "Nightly tier (target: < 7 hours)"
-    # Honours the always-broken AIPROFSYST-441 exclude list.  Heavy markers
-    # remain excluded for now (pending AIPROFSYST-441); revisit once that
-    # ticket lands so the nightly tier can run the full marker set.
-    test_patterns:
+    description: "Nightly tier (target: < 2 hours)"
+    regex_includes:
       - ".*"
-    exclude: *common_excludes
-    excluded_labels: *heavy_labels
-    labels:
+    regex_excludes: *_common_therock_regex_excludes
+    label_excludes: *_common_therock_labels_exclude
+    added_supplementary_labels:
       - "comprehensive"
       - "nightly"
       - "extended"
 
   full:
     description: "Complete suite - everything that can run"
-    # No marker exclusions: heavy tests run fine, just slowly, so they belong
-    # in "everything that can run". Only the always-broken name patterns
-    # (_common_excludes, AIPROFSYST-441) are dropped since they cannot run.
-    test_patterns:
+    regex_includes:
       - ".*"
-    exclude: *common_excludes
-    labels:
+    regex_excludes: *_common_therock_regex_excludes
+    added_supplementary_labels:
       - "full"
       - "all"
 
-# Reserved for test_categories.yaml parity with other components.
-# rocprofiler-systems currently relies on existing per-test timeout markers
-# (and env/default fallbacks), so these settings are not consumed yet.
+# Execution times must match times provided by `TheRock/docs/development/test_filtering.md`
 execution_settings:
   default_timeout: 300
   timeout_multiplier: 1
   category_timeouts:
-    quick: 900            # 15 minutes
-    standard: 3600        # 60 minutes
-    comprehensive: 25200  # 7 hours
-    full: 28800           # 8 hours
+    quick: 300            # 5 minutes
+    standard: 1800        # 30 minutes
+    comprehensive: 7200   # 2 hours
+    full: 28800           # 2+ hours (manually limited to 8 hours)

--- a/projects/rocprofiler-systems/tests/test_categories.yaml
+++ b/projects/rocprofiler-systems/tests/test_categories.yaml
@@ -11,7 +11,7 @@
 # so `ctest -L <tier>` works directly against the installed
 # share/rocprofiler-systems/tests directory.
 #
-# Per-tier selection keys mirror CTest's filter options EXACTLY (-R/-E/-L/-LE):
+# Per-tier selection keys follow CTest's filter semantics (-R/-E/-L/-LE):
 #   - `regex_includes`  (-R):  include if test NAME matches (re.search regex).
 #   - `label_includes`  (-L):  include if a pytest-MARKER label matches (regex).
 #   - `regex_excludes`  (-E):  exclude if test NAME matches (regex).
@@ -19,7 +19,9 @@
 #   - `added_supplementary_labels`: extra CTest labels stamped onto every test
 #     that matches the tier.
 #
-# Note that combination rules are identical to that of CTest.
+# Combination rules: patterns within a single axis are OR-ed (a test matches the
+# axis if it matches any one pattern), and the axes are AND-ed together (as in
+# CTest, an empty include axis is a pass-through, and the exclude axes veto).
 #
 # Source of truth for the always-excluded sets is the legacy
 # TheRock/build_tools/.../test_executable_scripts/test_rocprofiler_systems.py
@@ -114,4 +116,4 @@ execution_settings:
     quick: 300            # 5 minutes
     standard: 1800        # 30 minutes
     comprehensive: 7200   # 2 hours
-    full: 28800           # 2+ hours (manually limited to 8 hours)
+    full: 28800           # 8 hours (manually limited)


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Per https://github.com/ROCm/TheRock/blob/main/docs/development/test_filtering.md, `quick` tests need to take `<5` minutes. Currently, we take ~10 minutes (this is only seen on TheRock CI).

The actual change needs to be done on TheRock, but @dileepr1 PR on TheRock (https://github.com/ROCm/TheRock/pull/5522) is switching to using `test_categories.yaml`. This PR modifies `test_categories.yaml` to match the updated tests we want to run (see https://github.com/ROCm/TheRock/pull/6177)

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Modified `quick` test regexes:
```
    regex_includes:
      - "transpose.*"
      - "rocprofiler-systems.*"  # rocprof-sys-* binary smoke tests
      - "config-invalid"
      - "config-missing"
      - "cli-help.*"
      - "openmp-fortran-offload-sys-run"
      - "roctx-sampling"
      # Jpeg and video decode should be added once the binaries can be built on TheRock
    regex_excludes:
      - *_common_therock_regex_excludes
      - "transpose-runtime-instrument"
 ```

 - Updated `test_categories.yaml` data to match `test_filtering.md`
 - Rename:
   - `labels` -> `added_supplementary_labels`
   - `test_patterns` -> `regex_includes`
   - `exclude` -> `regex_excludes`
   - `excluded_labels` -> `label_excludes`
   - `heavy_labels` -> `_common_therock_labels_exclude` 
   - `common_excludes` -> `_common_therock_regex_excludes`

 - Added support for `label` inclusion
 - Trim comments

**Note**: A total of 128 (126 + setup + cleanup) tests are now ran.

The reason for the name changes is that I aim to make `test_categories-yaml` also used by our workflows (by adding more presets). So, some name changes are needed.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

Jira ID : AIPROFSYST-585

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

**Local - Our CI does not use `quick` and TheRock CI that runs below uses `standard`, not `quick`**.
Testing with `ctest --test-dir <build-dir> -L quick`

## Test Result

<!-- Briefly summarize test outcomes. -->

Stats:
 - 128 tests ran
 - Total Test time (real) = 117.22 sec
 
List of tests ran:
 ```
rocprofiler-systems-pytest-config: 0.67
rocprofiler-systems-instrument-help: 0.16
rocprofiler-systems-instrument-simulate-ls: 5.83
rocprofiler-systems-instrument-simulate-lib: 2.52
rocprofiler-systems-instrument-simulate-lib-basename: 2.04
rocprofiler-systems-instrument-write-log: 4.20
rocprofiler-systems-avail-help: 0.18
rocprofiler-systems-avail-all: 0.27
rocprofiler-systems-avail-all-expand-keys: 0.27
rocprofiler-systems-avail-all-only-available-alphabetical: 0.27
rocprofiler-systems-avail-all-csv: 0.27
rocprofiler-systems-avail-filter-wall-clock-available: 0.18
rocprofiler-systems-avail-category-filter-rocprofiler-systems: 0.20
rocprofiler-systems-avail-category-filter-timemory: 0.19
rocprofiler-systems-avail-regex-negation: 0.19
rocprofiler-systems-avail-write-config: 0.26
rocprofiler-systems-avail-write-config-tweak: 0.19
rocprofiler-systems-avail-format-consistency: 0.18
rocprofiler-systems-avail-list-keys: 0.20
rocprofiler-systems-avail-list-keys-markdown: 0.19
rocprofiler-systems-avail-list-categories: 0.19
rocprofiler-systems-avail-core-categories: 0.18
rocprofiler-systems-avail-list-domains: 0.18
rocprofiler-systems-avail-list-operations-no-domain: 0.19
rocprofiler-systems-avail-list-operations-found: 0.19
rocprofiler-systems-avail-list-operations-error: 0.18
rocprofiler-systems-avail-settings-no-gpu: 0.18
rocprofiler-systems-avail-components-no-gpu: 0.18
rocprofiler-systems-avail-settings-description-no-gpu: 0.18
rocprofiler-systems-avail-settings-rocm-available: 0.19
rocprofiler-systems-run-help: 0.17
rocprofiler-systems-run-args: 5.61
cli-help-domain-cpu-run: 0.18
cli-help-domain-cpu-sample: 0.18
cli-help-domain-gpu-run: 0.18
cli-help-domain-gpu-sample: 0.18
cli-help-domain-parallel-run: 0.19
cli-help-domain-parallel-sample: 0.18
cli-help-domain-rocm-run: 0.18
cli-help-domain-rocm-sample: 0.18
cli-help-explain-balanced-run: 0.19
cli-help-explain-balanced-sample: 0.18
cli-help-explain-detailed-run: 0.17
cli-help-explain-detailed-sample: 0.19
cli-help-explain-profile-mpi-run: 0.18
cli-help-explain-profile-mpi-sample: 0.19
cli-help-explain-profile-only-run: 0.18
cli-help-explain-profile-only-sample: 0.19
cli-help-explain-runtime-trace-run: 0.18
cli-help-explain-runtime-trace-sample: 0.19
cli-help-explain-sys-trace-run: 0.18
cli-help-explain-sys-trace-sample: 0.17
cli-help-explain-trace-gpu-run: 0.19
cli-help-explain-trace-gpu-sample: 0.18
cli-help-explain-trace-hpc-run: 0.17
cli-help-explain-trace-hpc-sample: 0.19
cli-help-explain-trace-hw-counters-run: 0.18
cli-help-explain-trace-hw-counters-sample: 0.18
cli-help-explain-trace-openmp-run: 0.18
cli-help-explain-trace-openmp-sample: 0.19
cli-help-explain-workload-trace-run: 0.18
cli-help-explain-workload-trace-sample: 0.18
cli-help-all-run: 0.20
cli-help-all-sample: 0.21
cli-help-compact-long-run: 0.17
cli-help-compact-long-sample: 0.18
cli-help-compact-short-h-run: 0.17
cli-help-compact-short-h-sample: 0.18
cli-help-compact-short-q-run: 0.21
cli-help-compact-short-q-sample: 0.18
cli-help-list-presets-run: 0.18
cli-help-list-presets-sample: 0.17
cli-help-topic-backend-run: 0.18
cli-help-topic-backend-sample: 0.18
cli-help-topic-counters-run: 0.18
cli-help-topic-counters-sample: 0.18
cli-help-topic-debug-run: 0.19
cli-help-topic-debug-sample: 0.18
cli-help-topic-general-run: 0.19
cli-help-topic-general-sample: 0.18
cli-help-topic-misc-run: 0.18
cli-help-topic-misc-sample: 0.18
cli-help-topic-preset-run: 0.18
cli-help-topic-preset-sample: 0.21
cli-help-topic-process-run: 0.18
cli-help-topic-process-sample: 0.18
cli-help-topic-profiling-run: 0.19
cli-help-topic-profiling-sample: 0.18
cli-help-topic-sampling-run: 0.18
cli-help-topic-sampling-sample: 0.18
cli-help-topic-tracing-run: 0.18
cli-help-topic-tracing-sample: 0.19
cli-help-unknown-topic-run: 0.18
cli-help-unknown-topic-sample: 0.18
cli-help-version-run: 0.18
cli-help-version-sample: 0.18
cli-help-explain-invalid-run: 0.19
cli-help-explain-invalid-sample: 0.18
cli-help-explain-requires-value-run: 0.17
cli-help-explain-requires-value-sample: 0.19
cli-help-unrecognized-option-run: 0.18
cli-help-unrecognized-option-sample: 0.18
config-invalid: 6.63
config-missing: 0.15
openmp-fortran-offload-sys-run: 0.49
roctx-sampling: 2.33
transpose-baseline: 2.33
transpose-binary-rewrite: 7.00
transpose-sys-run: 4.11
transpose-sampling: 7.35
transpose-two-kernels-sampling: 1.25
transpose-two-kernels-sys-run: 1.23
transpose-loops-sampling: 1.76
transpose-loops-binary-rewrite: 4.56
transpose-parametrized-1-16-16-sampling: 1.30
transpose-parametrized-1-16-16-sys-run: 1.25
transpose-parametrized-2-32-32-sampling: 1.56
transpose-parametrized-2-32-32-sys-run: 1.57
transpose-parametrized-5-64-64-sampling: 2.48
transpose-parametrized-5-64-64-sys-run: 2.62
transpose-hip-stream-group-by-queue-sampling: 2.91
transpose-hip-stream-group-by-queue-sys-run: 2.94
transpose-hip-stream-group-by-stream-sampling: 2.91
transpose-hip-stream-group-by-stream-sys-run: 2.86
transpose-rocprofiler-sampling: 5.18
transpose-rocprofiler-binary-rewrite: 6.29
transpose-gpu-perf-counters: 5.17
rocprofiler-systems-test-cleanup: 0.10
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
