### PR TITLE
fix(rccl): Fix devrState leak on the non-symmetric window path

### DIFF
--- a/projects/rccl/src/init.cc
+++ b/projects/rccl/src/init.cc
@@ -455,8 +455,9 @@ static ncclResult_t commFree(ncclComm_t comm) {
 
   if (comm->symmetricSupport) {
     NCCLCHECK(ncclSymkFinalize(comm));
-    NCCLCHECK(ncclDevrFinalize(comm));
   }
+  // RCCL: !symmetricSupport comms still init devrState via the non-sym window-register path (dev_runtime.cc), so finalize unconditionally to free lsaRankList.
+  NCCLCHECK(ncclDevrFinalize(comm));
   NCCLCHECK(ncclRasCommFini(comm));
 
   /* in commReclaim, we have guaranteed only last rank which calls ncclCommDestroy() will

--- a/projects/rccl/test/RegisterTests.cpp
+++ b/projects/rccl/test/RegisterTests.cpp
@@ -212,7 +212,7 @@ static void testWindowRegisterSingleRankNonSymTeardown() {
     ncclComm_t comm;
     NCCLCHECK(initSingleRankComm(&comm));
 
-    const size_t bufferSize = 4096; // NCCL_WIN_REQUIRED_ALIGNMENT
+    const size_t bufferSize = NCCL_WIN_REQUIRED_ALIGNMENT; // required alignment for window registration
     void* buf = nullptr;
     NCCLCHECK(ncclMemAlloc(&buf, bufferSize));
 

--- a/projects/rccl/test/RegisterTests.cpp
+++ b/projects/rccl/test/RegisterTests.cpp
@@ -189,6 +189,44 @@ static void testDeregisterNullHandle() {
     NCCLCHECK(ncclCommDestroy(comm));
 }
 
+/**
+ * @brief Exercises the non-symmetric window register/deregister/destroy path
+ *        on a single-rank communicator.
+ *
+ * With cuMem disabled, symmetricSupport is false, so ncclCommWindowRegister
+ * takes the non-symmetric fallback path. This initializes devrState (via
+ * ncclDevrInitOnce) and then tears it down through ncclDevrFinalize when the
+ * comm is destroyed. The test verifies that register, deregister and destroy
+ * all complete cleanly on that path (no crash / error).
+ *
+ * Window register/deregister errors are tolerated (they depend on cuMem
+ * availability); the comm must still register and destroy without error.
+ * (Byte-level leak verification is done separately via the standalone ASan
+ * reproducer, since the isolated test runner _exit()s and bypasses LSan.)
+ */
+static void testWindowRegisterSingleRankNonSymTeardown() {
+    SKIP_IF_NO_GPU();
+
+    HIPCALL(hipSetDevice(0));
+
+    ncclComm_t comm;
+    NCCLCHECK(initSingleRankComm(&comm));
+
+    const size_t bufferSize = 4096; // NCCL_WIN_REQUIRED_ALIGNMENT
+    void* buf = nullptr;
+    NCCLCHECK(ncclMemAlloc(&buf, bufferSize));
+
+    ncclWindow_t win = nullptr;
+    ncclResult_t reg = ncclCommWindowRegister(comm, buf, bufferSize, &win,
+                                              NCCL_WIN_COLL_SYMMETRIC);
+    if (reg == ncclSuccess && win != nullptr) {
+        NCCLCHECK(ncclCommWindowDeregister(comm, win));
+    }
+
+    NCCLCHECK(ncclMemFree(buf));
+    NCCLCHECK(ncclCommDestroy(comm));
+}
+
 //==============================================================================
 // Test configuration helpers
 //==============================================================================
@@ -241,7 +279,12 @@ TEST(Register, ProcessIsolatedRegisterTests)
             []() { testVariableSizeBuffers(true); }),
 
         // DeregisterNullHandle test (no enable/disable variants needed)
-        ProcessIsolatedTestRunner::TestConfig("DeregisterNullHandle", testDeregisterNullHandle)
+        ProcessIsolatedTestRunner::TestConfig("DeregisterNullHandle", testDeregisterNullHandle),
+
+        // Force the non-sym path (NCCL_CUMEM_ENABLE=0 => symmetricSupport=false) so the
+        // non-symmetric register/teardown is exercised; NCCL_LOCAL_REGISTER=1 ensures the register path runs.
+        ProcessIsolatedTestRunner::TestConfig("WindowRegisterSingleRankNonSymTeardown", testWindowRegisterSingleRankNonSymTeardown)
+            .withEnvironment({{"NCCL_CUMEM_ENABLE", "0"}, {"NCCL_LOCAL_REGISTER", "1"}})
     );
 }
 


### PR DESCRIPTION
## Motivation

On a `!symmetricSupport comm` (e.g. cuMem disabled), `ncclCommWindowRegister` still inits `devrState` but `commFree` only freed it under `if (symmetricSupport)`, leaking lsaRankList (24 B/comm).
```
Direct leak of 24 byte(s) in 6 object(s) allocated from:
    #1 ... ncclDevrInitOnce(ncclComm*) dev_runtime.cc
```
## Technical Details

`ncclCommWindowRegister_impl` calls `ncclDevrInitOnce` unconditionally, so non-sym comms allocate devrState too. 
Fix: call `ncclDevrFinalize` unconditionally in `commFree` (self-guards on bigSize == 0).

It doesn't happen on NCCL because:
- NCCL's `ncclCommWindowRegister` returns early for non-symmetric comms before `ncclDevrInitOnce`, so it never allocates this state. RCCL can't, because it falls back to a non-symmetric window path (IPC/proxy) that needs devrState.
- NCCL defaults `NCCL_CUMEM_ENABLE` to auto-on (-2) vs RCCL's 0, so NCCL comms are usually symmetric and rarely hit this path.

## JIRA ID

ROCM-27249

## Test Plan

Add a test to exercise the non-symmetric window register/deregister/destroy path on a single-rank comm (cuMem disabled).

## Test Result

Added test `Register.ProcessIsolatedRegisterTests (WindowRegisterSingleRankNonSymTeardown)` - passes. 
Reproducer's `lsaRankList/devrState` leaks are gone

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.