### PR TITLE
fix(rocjpeg): Fix integer overflow in SOF parser and CopyChannel

### DIFF
--- a/projects/rocjpeg/src/rocjpeg_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_decoder.cpp
@@ -21,7 +21,6 @@ THE SOFTWARE.
 */
 
 #include "rocjpeg_decoder.h"
-#include <limits>
 
 RocJpegDecoder::RocJpegDecoder(RocJpegBackend backend, int device_id) :
     num_devices_{0}, device_id_ {device_id}, hip_stream_ {0}, backend_{backend} {}
@@ -483,15 +482,8 @@ RocJpegStatus RocJpegDecoder::CopyChannel(HipInteropDeviceMem& hip_interop_dev_m
         }
 
         if (destination->pitch[channel_index] == hip_interop_dev_mem.pitch[channel_index]) {
-            // Use 64-bit arithmetic to detect pitch*height overflow before passing
-            // to the HIP copy API, which takes a size_t.
-            uint64_t channel_size_64 = static_cast<uint64_t>(destination->pitch[channel_index]) * static_cast<uint64_t>(channel_height);
-            if (channel_size_64 > static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())) {
-                ErrorLog(g_rocjpeg_logger, "Channel size overflows uint32_t (pitch=" +
-                    ROCJPEG_TOSTR(destination->pitch[channel_index]) + " height=" + ROCJPEG_TOSTR(channel_height) + ")!");
-                return ROCJPEG_STATUS_INVALID_PARAMETER;
-            }
-            uint32_t channel_size = static_cast<uint32_t>(channel_size_64);
+            // Compute pitch*height in 64-bit; hipMemcpyDtoDAsync takes size_t.
+            size_t channel_size = static_cast<size_t>(destination->pitch[channel_index]) * static_cast<size_t>(channel_height);
             CHECK_HIP(hipMemcpyDtoDAsync(destination->channel[channel_index], hip_interop_dev_mem.hip_mapped_device_mem + hip_interop_dev_mem.offset[channel_index] + roi_offset, channel_size, hip_stream_));
         } else {
             CHECK_HIP(hipMemcpy2DAsync(destination->channel[channel_index], destination->pitch[channel_index], hip_interop_dev_mem.hip_mapped_device_mem + hip_interop_dev_mem.offset[channel_index] + roi_offset, hip_interop_dev_mem.pitch[channel_index],

--- a/projects/rocjpeg/src/rocjpeg_decoder.cpp
+++ b/projects/rocjpeg/src/rocjpeg_decoder.cpp
@@ -21,6 +21,7 @@ THE SOFTWARE.
 */
 
 #include "rocjpeg_decoder.h"
+#include <limits>
 
 RocJpegDecoder::RocJpegDecoder(RocJpegBackend backend, int device_id) :
     num_devices_{0}, device_id_ {device_id}, hip_stream_ {0}, backend_{backend} {}
@@ -482,7 +483,15 @@ RocJpegStatus RocJpegDecoder::CopyChannel(HipInteropDeviceMem& hip_interop_dev_m
         }
 
         if (destination->pitch[channel_index] == hip_interop_dev_mem.pitch[channel_index]) {
-            uint32_t channel_size = destination->pitch[channel_index] * channel_height;
+            // Use 64-bit arithmetic to detect pitch*height overflow before passing
+            // to the HIP copy API, which takes a size_t.
+            uint64_t channel_size_64 = static_cast<uint64_t>(destination->pitch[channel_index]) * static_cast<uint64_t>(channel_height);
+            if (channel_size_64 > static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())) {
+                ErrorLog(g_rocjpeg_logger, "Channel size overflows uint32_t (pitch=" +
+                    ROCJPEG_TOSTR(destination->pitch[channel_index]) + " height=" + ROCJPEG_TOSTR(channel_height) + ")!");
+                return ROCJPEG_STATUS_INVALID_PARAMETER;
+            }
+            uint32_t channel_size = static_cast<uint32_t>(channel_size_64);
             CHECK_HIP(hipMemcpyDtoDAsync(destination->channel[channel_index], hip_interop_dev_mem.hip_mapped_device_mem + hip_interop_dev_mem.offset[channel_index] + roi_offset, channel_size, hip_stream_));
         } else {
             CHECK_HIP(hipMemcpy2DAsync(destination->channel[channel_index], destination->pitch[channel_index], hip_interop_dev_mem.hip_mapped_device_mem + hip_interop_dev_mem.offset[channel_index] + roi_offset, hip_interop_dev_mem.pitch[channel_index],

--- a/projects/rocjpeg/src/rocjpeg_parser.cpp
+++ b/projects/rocjpeg/src/rocjpeg_parser.cpp
@@ -24,6 +24,8 @@ THE SOFTWARE.
 #include <cmath>
 #include <iomanip>
 #include <sstream>
+#include <cstdint>
+#include <limits>
 
 RocJpegStreamParser::RocJpegStreamParser() : stream_{nullptr}, stream_start_{nullptr}, stream_end_{nullptr}, stream_length_{0},
     jpeg_stream_parameters_{} {
@@ -198,6 +200,23 @@ bool RocJpegStreamParser::ParseSOF() {
     jpeg_stream_parameters_.picture_parameter_buffer.picture_width = swap_bytes(stream_ + 5);
     jpeg_stream_parameters_.picture_parameter_buffer.num_components = stream_[7];
 
+    // Clamp SOF dimensions to the safe JPEG maximum (ISO 10918-1 allows up to
+    // 65535, but values that large cause downstream arithmetic to overflow).
+    static constexpr uint16_t kMaxSafeDimension = 65500;
+    if (jpeg_stream_parameters_.picture_parameter_buffer.picture_width > kMaxSafeDimension ||
+        jpeg_stream_parameters_.picture_parameter_buffer.picture_height > kMaxSafeDimension) {
+        ErrorLog(g_rocjpeg_logger, "JPEG dimensions exceed safe maximum (" +
+            ROCJPEG_TOSTR(kMaxSafeDimension) + "): " +
+            ROCJPEG_TOSTR(jpeg_stream_parameters_.picture_parameter_buffer.picture_width) + "x" +
+            ROCJPEG_TOSTR(jpeg_stream_parameters_.picture_parameter_buffer.picture_height));
+        return false;
+    }
+    if (jpeg_stream_parameters_.picture_parameter_buffer.picture_width == 0 ||
+        jpeg_stream_parameters_.picture_parameter_buffer.picture_height == 0) {
+        ErrorLog(g_rocjpeg_logger, "JPEG has zero dimension!");
+        return false;
+    }
+
     if (jpeg_stream_parameters_.picture_parameter_buffer.num_components > NUM_COMPONENTS - 1) {
         ErrorLog(g_rocjpeg_logger, "Unsupported JPEG: " +
             ROCJPEG_TOSTR(static_cast<int>(jpeg_stream_parameters_.picture_parameter_buffer.num_components)) +
@@ -225,8 +244,38 @@ bool RocJpegStreamParser::ParseSOF() {
     uint8_t max_h_factor = jpeg_stream_parameters_.picture_parameter_buffer.components[0].h_sampling_factor;
     uint8_t max_v_factor = jpeg_stream_parameters_.picture_parameter_buffer.components[0].v_sampling_factor;
 
-    jpeg_stream_parameters_.slice_parameter_buffer.num_mcus = ((jpeg_stream_parameters_.picture_parameter_buffer.picture_width + max_h_factor * 8 - 1) / (max_h_factor * 8)) *
-                                       ((jpeg_stream_parameters_.picture_parameter_buffer.picture_height + max_v_factor * 8 - 1) / (max_v_factor * 8));
+    // Validate sampling factors before using them as divisors.
+    if (max_h_factor == 0 || max_v_factor == 0) {
+        ErrorLog(g_rocjpeg_logger, "Invalid SOF sampling factor (zero)!");
+        return false;
+    }
+
+    // Compute pixel-count product in 64-bit to detect overflow before it
+    // propagates to allocations. Reject images whose raw pixel footprint
+    // (width * height * num_components) would exceed SIZE_MAX/4.
+    {
+        uint64_t w = jpeg_stream_parameters_.picture_parameter_buffer.picture_width;
+        uint64_t h = jpeg_stream_parameters_.picture_parameter_buffer.picture_height;
+        uint64_t nf = jpeg_stream_parameters_.picture_parameter_buffer.num_components;
+        uint64_t pixel_count = w * h * nf;
+        constexpr uint64_t kMaxPixelCount = static_cast<uint64_t>(SIZE_MAX) / 4;
+        if (pixel_count > kMaxPixelCount) {
+            ErrorLog(g_rocjpeg_logger, "JPEG pixel count (" + ROCJPEG_TOSTR(pixel_count) +
+                ") exceeds safe allocation limit!");
+            return false;
+        }
+    }
+
+    {
+        uint64_t mcus_h = (static_cast<uint64_t>(jpeg_stream_parameters_.picture_parameter_buffer.picture_width)  + max_h_factor * 8u - 1u) / (max_h_factor * 8u);
+        uint64_t mcus_v = (static_cast<uint64_t>(jpeg_stream_parameters_.picture_parameter_buffer.picture_height) + max_v_factor * 8u - 1u) / (max_v_factor * 8u);
+        uint64_t total_mcus = mcus_h * mcus_v;
+        if (total_mcus > static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())) {
+            ErrorLog(g_rocjpeg_logger, "JPEG MCU count overflows uint32_t!");
+            return false;
+        }
+        jpeg_stream_parameters_.slice_parameter_buffer.num_mcus = static_cast<uint32_t>(total_mcus);
+    }
 
     jpeg_stream_parameters_.chroma_subsampling = GetChromaSubsampling(jpeg_stream_parameters_.picture_parameter_buffer.components[0].h_sampling_factor,
                                                                       jpeg_stream_parameters_.picture_parameter_buffer.components[1].h_sampling_factor,


### PR DESCRIPTION
## Motivation

JIRA ID : ROCM-26827 - Fix integer overflow in SOF parser and CopyChannel Fix

## Technical Details

rocjpeg_parser.cpp — ParseSOF():
- Reject width/height > 65500 or == 0 before any arithmetic (ISO 10918-1 allows up to 65535, but values that large overflow downstream 32-bit expressions)
- Guard against zero luma sampling factors (divide-by-zero in MCU calculation)
- Compute width * height * num_components in uint64_t and reject if it exceeds SIZE_MAX/4, preventing undersized allocations from crafted JPEG files
- Compute MCU grid dimensions in uint64_t and range-check before narrowing to uint32_t

rocjpeg_decoder.cpp — CopyChannel():
- Compute pitch * height in uint64_t and check for uint32_t overflow before passing the size to the HIP copy API

## JIRA ID

Resolves ROCM-26827

## Test Plan

rocJPEG CTEST

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
