### PR TITLE
feat(rocshmem): Implement wave-level fcollect collective operation

### DIFF
--- a/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
@@ -674,7 +674,7 @@ __device__ ATTR_NO_INLINE void rocshmem_ctx_ulonglong_fcollect_wg(
     const unsigned long long *source, int nelems);
 
 /**
- * @name ROCSSHMEM_CTX_FCOLLECTMEM_WG
+ * @name ROCSHMEM_CTX_FCOLLECTMEM_WG
  * @brief Concatenates @p nelems bytes from each PE's @p source into every PE's
  * @p dest buffer.
  * Must be called as a work-group collective.
@@ -689,11 +689,11 @@ __device__ ATTR_NO_INLINE void rocshmem_ctx_ulonglong_fcollect_wg(
  *
  * @return void
  */
-__device__ ATTR_NO_INLINE void rocshmem_ctx_fcollectmem_wg( rocshmem_ctx_t ctx,
+__device__ ATTR_NO_INLINE void rocshmem_ctx_fcollectmem_wg(rocshmem_ctx_t ctx,
     rocshmem_team_t team, void *dest, const void *source, int nelems);
 
 /**
- * @name ROCSSHMEM_CTX_FCOLLECT_WAVE
+ * @name ROCSHMEM_CTX_FCOLLECT_WAVE
  * @brief Concatenates blocks of data from multiple PEs to an array in every
  * PE participating in the collective routine.
  *
@@ -762,11 +762,12 @@ __device__ ATTR_NO_INLINE int rocshmem_ctx_ulonglong_fcollect_wave(
     const unsigned long long *source, int nelems);
 
 /**
- * @name ROCSSHMEM_CTX_FCOLLECTMEM_WAVE
+ * @name ROSSHMEM_CTX_FCOLLECTMEM_WAVE
  * @brief Concatenates @p nelems bytes from each PE's @p source into every PE's
  * @p dest buffer.
  * Must be called as a wave-level collective.
  *
+ * @param[in] ctx          The context associated with this operation.
  * @param[in] team         The team participating in the collective.
  * @param[in] dest         Destination address. Must be an address on the
  *                         symmetric heap.
@@ -776,7 +777,7 @@ __device__ ATTR_NO_INLINE int rocshmem_ctx_ulonglong_fcollect_wave(
  *
  * @return int (Zero on successful local completion. Nonzero otherwise.)
  */
-__device__ ATTR_NO_INLINE int rocshmem_fcollectmem_wave(
+__device__ ATTR_NO_INLINE int rocshmem_ctx_fcollectmem_wave(rocshmem_ctx_t ctx,
     rocshmem_team_t team, void *dest, const void *source, int nelems);
 
 

--- a/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
@@ -673,6 +673,111 @@ __device__ ATTR_NO_INLINE void rocshmem_ctx_ulonglong_fcollect_wg(
     rocshmem_ctx_t ctx, rocshmem_team_t team, unsigned long long *dest,
     const unsigned long long *source, int nelems);
 
+/**
+ * @name ROCSSHMEM_CTX_FCOLLECTMEM_WG
+ * @brief Concatenates @p nelems bytes from each PE's @p source into every PE's
+ * @p dest buffer.
+ * Must be called as a work-group collective.
+ *
+ * @param[in] team         The team participating in the collective.
+ * @param[in] dest         Destination address. Must be an address on the
+ *                         symmetric heap.
+ * @param[in] source       Source address. Must be an address on the symmetric
+ *                         heap.
+ * @param[in] nelems       Number of bytes contributed by each PE.
+ *
+ * @return void
+ */
+__device__ ATTR_NO_INLINE void rocshmem_fcollectmem_wg(
+    rocshmem_team_t team, void *dest, const void *source, int nelems);
+
+/**
+ * @name ROCSSHMEM_CTX_FCOLLECT_WAVE
+ * @brief Concatenates blocks of data from multiple PEs to an array in every
+ * PE participating in the collective routine.
+ *
+ * This function must be called as a wave-front collective.
+ *
+ * @param[in] ctx          The context associated with this operation.
+ * @param[in] team         The team participating in the collective.
+ * @param[in] dest         Destination address. Must be an address on the
+ *                         symmetric heap.
+ * @param[in] source       Source address. Must be an address on the symmetric
+ *                         heap.
+ * @param[in] nelems       Number of data elements contributed by each PE.
+ *
+ * @return int (Zero on successful local completion. Nonzero otherwise.)
+ */
+__device__ ATTR_NO_INLINE int rocshmem_ctx_float_fcollect_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, float *dest,
+    const float *source, int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_double_fcollect_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, double *dest,
+    const double *source, int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_char_fcollect_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, char *dest,
+    const char *source, int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_schar_fcollect_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, signed char *dest,
+    const signed char *source, int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_short_fcollect_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, short *dest,
+    const short *source, int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_int_fcollect_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, int *dest,
+    const int *source, int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_long_fcollect_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long *dest,
+    const long *source, int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_longlong_fcollect_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, long long *dest,
+    const long long *source, int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_uchar_fcollect_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, unsigned char *dest,
+    const unsigned char *source, int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_ushort_fcollect_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, unsigned short *dest,
+    const unsigned short *source, int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_uint_fcollect_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, unsigned int *dest,
+    const unsigned int *source, int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_ulong_fcollect_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, unsigned long *dest,
+    const unsigned long *source, int nelems);
+
+__device__ ATTR_NO_INLINE int rocshmem_ctx_ulonglong_fcollect_wave(
+    rocshmem_ctx_t ctx, rocshmem_team_t team, unsigned long long *dest,
+    const unsigned long long *source, int nelems);
+
+/**
+ * @name ROCSSHMEM_CTX_FCOLLECTMEM_WAVE
+ * @brief Concatenates @p nelems bytes from each PE's @p source into every PE's
+ * @p dest buffer.
+ * Must be called as a wave-level collective.
+ *
+ * @param[in] team         The team participating in the collective.
+ * @param[in] dest         Destination address. Must be an address on the
+ *                         symmetric heap.
+ * @param[in] source       Source address. Must be an address on the symmetric
+ *                         heap.
+ * @param[in] nelems       Number of bytes contributed by each PE.
+ *
+ * @return int (Zero on successful local completion. Nonzero otherwise.)
+ */
+__device__ ATTR_NO_INLINE int rocshmem_fcollectmem_wave(
+    rocshmem_team_t team, void *dest, const void *source, int nelems);
+
 
 /**
  * @name SHMEM_REDUCE_SCATTER

--- a/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
+++ b/projects/rocshmem/include/rocshmem/rocshmem_COLL.hpp
@@ -679,6 +679,7 @@ __device__ ATTR_NO_INLINE void rocshmem_ctx_ulonglong_fcollect_wg(
  * @p dest buffer.
  * Must be called as a work-group collective.
  *
+ * @param[in] ctx          The context associated with this operation.
  * @param[in] team         The team participating in the collective.
  * @param[in] dest         Destination address. Must be an address on the
  *                         symmetric heap.
@@ -688,7 +689,7 @@ __device__ ATTR_NO_INLINE void rocshmem_ctx_ulonglong_fcollect_wg(
  *
  * @return void
  */
-__device__ ATTR_NO_INLINE void rocshmem_fcollectmem_wg(
+__device__ ATTR_NO_INLINE void rocshmem_ctx_fcollectmem_wg( rocshmem_ctx_t ctx,
     rocshmem_team_t team, void *dest, const void *source, int nelems);
 
 /**

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -166,6 +166,7 @@ declare -A TEST_NUMBERS=(
   ["teamreducescatter"]="149"
   ["broadcast_wave"]="150"
   ["alltoall_wave"]="151"
+  ["fcollect_wave"]="152"
 )
 
 # Detect which runtime to use
@@ -757,6 +758,7 @@ TestColl() {
   if [[ $TEST != ro* ]]; then #AIROCSHMEM-409: wave tests not supported on RO
     ExecTest  "broadcast_wave"   2       1            $WAVE_SIZE        32768
     ExecTest  "alltoall_wave"    2       1            $WAVE_SIZE        512
+    ExecTest  "fcollect_wave"    2       1            64        32768
   else echo "Skip:   *_wave (AIROCSHMEM-409: wave tests not supported on RO)"; fi
 }
 

--- a/projects/rocshmem/scripts/functional_tests/driver.sh
+++ b/projects/rocshmem/scripts/functional_tests/driver.sh
@@ -758,7 +758,7 @@ TestColl() {
   if [[ $TEST != ro* ]]; then #AIROCSHMEM-409: wave tests not supported on RO
     ExecTest  "broadcast_wave"   2       1            $WAVE_SIZE        32768
     ExecTest  "alltoall_wave"    2       1            $WAVE_SIZE        512
-    ExecTest  "fcollect_wave"    2       1            64        32768
+    ExecTest  "fcollect_wave"    2       1            $WAVE_SIZE        32768
   else echo "Skip:   *_wave (AIROCSHMEM-409: wave tests not supported on RO)"; fi
 }
 

--- a/projects/rocshmem/src/context.hpp
+++ b/projects/rocshmem/src/context.hpp
@@ -249,8 +249,18 @@ class Context {
                             const size_t source_displs[]);
 
   template <typename T>
-  __device__ void fcollect(rocshmem_team_t team, T* dest, const T* source,
+  __device__ void fcollect_wg(rocshmem_team_t team, T* dest, const T* source,
                            int nelems);
+
+  __device__ void fcollectmem_wg(rocshmem_team_t team, void *dest,
+                                  const void *source, int nelems);
+
+  template <typename T>
+  __device__ int fcollect_wave(rocshmem_team_t team, T *dest,
+                                    const T *source, int nelems);
+
+  __device__ int fcollectmem_wave(rocshmem_team_t team, void *dest,
+                                    const void *source, int nelems);
 
   template <typename T>
   __device__ void broadcast_wg(rocshmem_team_t team, T* dest, const T* source,

--- a/projects/rocshmem/src/context_device.cpp
+++ b/projects/rocshmem/src/context_device.cpp
@@ -358,4 +358,33 @@ __device__ int Context::tile_collective_wait(rocshmem_team_t team, uint64_t flag
   DISPATCH_RET(tile_collective_wait(team, flags));
 }
 
+
+__device__ int Context::fcollectmem_wave(rocshmem_team_t team, void *dest,
+                                  const void *source, int nelems) {
+  if (nelems == 0) {
+    return ROCSHMEM_SUCCESS;
+  }
+
+  if (is_thread_zero_in_block()) {
+    ctxStats.incStat(NUM_FCOLLECT);
+  }
+
+  DISPATCH_RET(fcollectmem_wave(team, dest, source, nelems));
+}
+
+
+__device__ void Context::fcollectmem_wg(rocshmem_team_t team, void *dest,
+                                  const void *source, int nelems) {
+  if (nelems == 0) {
+    return;
+  }
+
+  if (is_thread_zero_in_block()) {
+    ctxStats.incStat(NUM_FCOLLECT);
+  }
+
+  DISPATCH(fcollectmem_wg(team, dest, source, nelems));
+}
+
+
 }  // namespace rocshmem

--- a/projects/rocshmem/src/context_tmpl_device.hpp
+++ b/projects/rocshmem/src/context_tmpl_device.hpp
@@ -202,7 +202,7 @@ __device__ void Context::alltoallv(rocshmem_team_t team,
 }
 
 template <typename T>
-__device__ void Context::fcollect(rocshmem_team_t team, T *dest,
+__device__ void Context::fcollect_wg(rocshmem_team_t team, T *dest,
                                   const T *source, int nelems) {
   if (nelems == 0) {
     return;
@@ -212,7 +212,21 @@ __device__ void Context::fcollect(rocshmem_team_t team, T *dest,
     ctxStats.incStat(NUM_FCOLLECT);
   }
 
-  DISPATCH(fcollect<T>(team, dest, source, nelems));
+  DISPATCH(fcollect_wg<T>(team, dest, source, nelems));
+}
+
+template <typename T>
+__device__ int Context::fcollect_wave(rocshmem_team_t team, T *dest,
+                                  const T *source, int nelems) {
+  if (nelems == 0) {
+    return ROCSHMEM_SUCCESS;
+  }
+
+  if (is_thread_zero_in_block()) {
+    ctxStats.incStat(NUM_FCOLLECT);
+  }
+
+  DISPATCH_RET(fcollect_wave<T>(team, dest, source, nelems));
 }
 
 template <typename T>

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -201,7 +201,7 @@ class GDAContext : public Context {
   __device__ void fcollect_wg(rocshmem_team_t team, T *dest, const T *source,
                            int nelems);
 
-  __device__ int fcollectmem_wg(rocshmem_team_t team, void *dest, const void *source,
+  __device__ void fcollectmem_wg(rocshmem_team_t team, void *dest, const void *source,
                            int nelems);
 
   template <typename T>
@@ -322,6 +322,9 @@ class GDAContext : public Context {
   template <typename T>
   __device__ void fcollect_linear_wg(rocshmem_team_t team, T *dest,
       const T *source, int nelems);
+      
+  __device__ void fcollectmem_linear_wg(rocshmem_team_t team, void *dest,
+      const void *source, int nelems);
 
   __device__ void fcollectmem_linear_wave(rocshmem_team_t team, void *dest,
       const void *source, int nelems);

--- a/projects/rocshmem/src/gda/context_gda_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_device.hpp
@@ -198,9 +198,18 @@ class GDAContext : public Context {
                                   const void* source, int nelems);
 
   template <typename T>
-  __device__ void fcollect(rocshmem_team_t team, T *dest, const T *source,
+  __device__ void fcollect_wg(rocshmem_team_t team, T *dest, const T *source,
                            int nelems);
 
+  __device__ int fcollectmem_wg(rocshmem_team_t team, void *dest, const void *source,
+                           int nelems);
+
+  template <typename T>
+  __device__ int fcollect_wave(rocshmem_team_t team, T *dest, const T *source,
+                           int nelems);
+
+  __device__ int fcollectmem_wave(rocshmem_team_t team, void *dest, const void *source,
+                           int nelems);
 
   // Block/wave functions
   __device__ void putmem_wg(void *dest, const void *source, size_t nelems,
@@ -311,8 +320,11 @@ class GDAContext : public Context {
     ActiveWFInfo &wf_info);
 
   template <typename T>
-  __device__ void fcollect_linear(rocshmem_team_t team, T *dest,
+  __device__ void fcollect_linear_wg(rocshmem_team_t team, T *dest,
       const T *source, int nelems);
+
+  __device__ void fcollectmem_linear_wave(rocshmem_team_t team, void *dest,
+      const void *source, int nelems);
 
   template <typename T>
   __device__ void alltoall_linear_wg(rocshmem_team_t team, T *dest,

--- a/projects/rocshmem/src/gda/context_gda_device_coll.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device_coll.cpp
@@ -543,4 +543,43 @@ __device__ void GDAContext::alltoallmem_linear_thread_puts_wave(rocshmem_team_t 
   sync_wave(team);
 }
 
+__device__ int GDAContext::fcollectmem_wave(rocshmem_team_t team, void *dst,
+                                     const void *src, int nelems) {
+  if (dst == nullptr || src == nullptr || team == ROCSHMEM_TEAM_INVALID)
+    return ROCSHMEM_ERROR;
+
+  fcollectmem_linear_wave(team, dst, src, nelems);
+
+  return ROCSHMEM_SUCCESS;
+}
+
+__device__ void GDAContext::fcollectmem_linear_wave(rocshmem_team_t team, void *dst,
+    const void *src, int nelems) {
+  GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
+
+  int pe_start = team_obj->tinfo_wrt_world->pe_start;
+  int pe_size = team_obj->num_pes;
+  int stride = team_obj->tinfo_wrt_world->stride;
+  long *pSync = team_obj->alltoall_pSync;
+  int my_pe_in_team = team_obj->my_pe;
+
+  ActiveWFInfo wf_info(ctx_id_, ThreadScope::wave);
+  // Have each PE put their designated data to the other PEs
+  for (int j = 0; j < pe_size; j++) {
+    int dest_pe = team_obj->get_pe_in_world(j);
+    internal_putmem_nbi_wave(reinterpret_cast<char *>(dst) + my_pe_in_team * nelems, src,
+      nelems, dest_pe, dest_pe, wf_info);
+  }
+
+  if (is_thread_zero_in_block()) {
+    // Iterate through 0th qp of each PE
+    for (int j = 0; j < pe_size; j++) {
+      int dest_pe = team_obj->get_pe_in_world(j);
+      qps[dest_pe].quiet(wf_info);
+    }
+  }
+  // wait until everyone has obtained their designated data
+  internal_sync_wave(constmem.my_pe, pe_start, stride, pe_size, pSync, wf_info);
+}
+
 }  // namespace rocshmem

--- a/projects/rocshmem/src/gda/context_gda_device_coll.cpp
+++ b/projects/rocshmem/src/gda/context_gda_device_coll.cpp
@@ -543,6 +543,40 @@ __device__ void GDAContext::alltoallmem_linear_thread_puts_wave(rocshmem_team_t 
   sync_wave(team);
 }
 
+__device__ void GDAContext::fcollectmem_wg(rocshmem_team_t team, void *dst,
+                                     const void *src, int nelems) {
+  fcollectmem_linear_wg(team, dst, src, nelems);
+}
+
+__device__ void GDAContext::fcollectmem_linear_wg(rocshmem_team_t team, void *dst,
+    const void *src, int nelems) {
+  GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
+
+  int pe_start = team_obj->tinfo_wrt_world->pe_start;
+  int pe_size = team_obj->num_pes;
+  int stride = team_obj->tinfo_wrt_world->stride;
+  long *pSync = team_obj->alltoall_pSync;
+  int my_pe_in_team = team_obj->my_pe;
+
+  ActiveWFInfo wf_info(ctx_id_, ThreadScope::wg);
+  // Have each PE put their designated data to the other PEs
+  for (int j = 0; j < pe_size; j++) {
+    int dest_pe = team_obj->get_pe_in_world(j);
+    internal_putmem_nbi_wg(reinterpret_cast<char *>(dst) + my_pe_in_team * nelems, src,
+      nelems, dest_pe, dest_pe, wf_info);
+  }
+
+  if (is_thread_zero_in_block()) {
+    // Iterate through 0th qp of each PE
+    for (int j = 0; j < pe_size; j++) {
+      int dest_pe = team_obj->get_pe_in_world(j);
+      qps[dest_pe].quiet(wf_info);
+    }
+  }
+  // wait until everyone has obtained their designated data
+  internal_sync_wg(constmem.my_pe, pe_start, stride, pe_size, pSync, wf_info);
+}
+
 __device__ int GDAContext::fcollectmem_wave(rocshmem_team_t team, void *dst,
                                      const void *src, int nelems) {
   if (dst == nullptr || src == nullptr || team == ROCSHMEM_TEAM_INVALID)

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -945,13 +945,24 @@ __device__ int GDAContext::alltoall_wave(rocshmem_team_t team,
 }
 
 template <typename T>
-__device__ void GDAContext::fcollect(rocshmem_team_t team, T *dst,
+__device__ void GDAContext::fcollect_wg(rocshmem_team_t team, T *dst,
                                      const T *src, int nelems) {
-  fcollect_linear(team, dst, src, nelems);
+  fcollect_linear_wg(team, dst, src, nelems);
 }
 
 template <typename T>
-__device__ void GDAContext::fcollect_linear(rocshmem_team_t team, T *dst,
+__device__ int GDAContext::fcollect_wave(rocshmem_team_t team, T *dst,
+                                     const T *src, int nelems) {
+  if (dst == nullptr || src == nullptr || team == ROCSHMEM_TEAM_INVALID)
+    return ROCSHMEM_ERROR;
+
+  fcollectmem_linear_wave(team, dst, src, nelems * sizeof(T));
+
+  return ROCSHMEM_SUCCESS;
+}
+
+template <typename T>
+__device__ void GDAContext::fcollect_linear_wg(rocshmem_team_t team, T *dst,
     const T *src, int nelems) {
   GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
 

--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -947,7 +947,7 @@ __device__ int GDAContext::alltoall_wave(rocshmem_team_t team,
 template <typename T>
 __device__ void GDAContext::fcollect_wg(rocshmem_team_t team, T *dst,
                                      const T *src, int nelems) {
-  fcollect_linear_wg(team, dst, src, nelems);
+  fcollectmem_linear_wg(team, dst, src, nelems * sizeof(T));
 }
 
 template <typename T>
@@ -959,36 +959,6 @@ __device__ int GDAContext::fcollect_wave(rocshmem_team_t team, T *dst,
   fcollectmem_linear_wave(team, dst, src, nelems * sizeof(T));
 
   return ROCSHMEM_SUCCESS;
-}
-
-template <typename T>
-__device__ void GDAContext::fcollect_linear_wg(rocshmem_team_t team, T *dst,
-    const T *src, int nelems) {
-  GDATeam *team_obj = reinterpret_cast<GDATeam *>(team);
-
-  int pe_start = team_obj->tinfo_wrt_world->pe_start;
-  int pe_size = team_obj->num_pes;
-  int stride = team_obj->tinfo_wrt_world->stride;
-  long *pSync = team_obj->alltoall_pSync;
-  int my_pe_in_team = team_obj->my_pe;
-
-  ActiveWFInfo wf_info(ctx_id_, ThreadScope::wg);
-  // Have each PE put their designated data to the other PEs
-  for (int j = 0; j < pe_size; j++) {
-    int dest_pe = team_obj->get_pe_in_world(j);
-    internal_putmem_nbi_wg(&dst[my_pe_in_team * nelems], src,
-      nelems * sizeof(T), dest_pe, dest_pe, wf_info);
-  }
-
-  if (is_thread_zero_in_block()) {
-    // Iterate through 0th qp of each PE
-    for (int j = 0; j < pe_size; j++) {
-      int dest_pe = team_obj->get_pe_in_world(j);
-      qps[dest_pe].quiet(wf_info);
-    }
-  }
-  // wait until everyone has obtained their designated data
-  internal_sync_wg(constmem.my_pe, pe_start, stride, pe_size, pSync, wf_info);
 }
 
 // Block/wave functions

--- a/projects/rocshmem/src/ipc/context_ipc_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.hpp
@@ -190,6 +190,9 @@ class IPCContext : public Context {
   __device__ int fcollectmem_wave(rocshmem_team_t team, void *dest, const void *source,
                            int nelems);
 
+  __device__ void fcollectmem_wg(rocshmem_team_t team, void *dest, const void *source,
+                           int nelems);
+
   // Block/wave functions
   __device__ void putmem_wg(void *dest, const void *source, size_t nelems,
                             int pe);
@@ -422,6 +425,9 @@ class IPCContext : public Context {
   template <typename T>
   __device__ void fcollect_linear_wg(rocshmem_team_t team, T *dest,
                                   const T *source, int nelems);
+                                  
+  __device__ void fcollectmem_linear_wg(rocshmem_team_t team, void *dest,
+                                  const void *source, int nelems);
 
   __device__ void internal_alltoallmem_wg(rocshmem_team_t team, void *dst,
                                           const void *src, int nelems);

--- a/projects/rocshmem/src/ipc/context_ipc_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device.hpp
@@ -180,9 +180,15 @@ class IPCContext : public Context {
                                   const void* source, int nelems);
 
   template <typename T>
-  __device__ void fcollect(rocshmem_team_t team, T *dest, const T *source,
+  __device__ void fcollect_wg(rocshmem_team_t team, T *dest, const T *source,
                            int nelems);
 
+  template <typename T>
+  __device__ int fcollect_wave(rocshmem_team_t team, T *dest, const T *source,
+                           int nelems);
+
+  __device__ int fcollectmem_wave(rocshmem_team_t team, void *dest, const void *source,
+                           int nelems);
 
   // Block/wave functions
   __device__ void putmem_wg(void *dest, const void *source, size_t nelems,
@@ -414,7 +420,7 @@ class IPCContext : public Context {
   __device__ void internal_get_broadcast_wave(T *dst, const T *src, int nelems, int pe_root);
 
   template <typename T>
-  __device__ void fcollect_linear(rocshmem_team_t team, T *dest,
+  __device__ void fcollect_linear_wg(rocshmem_team_t team, T *dest,
                                   const T *source, int nelems);
 
   __device__ void internal_alltoallmem_wg(rocshmem_team_t team, void *dst,
@@ -425,6 +431,9 @@ class IPCContext : public Context {
 
   __device__ void alltoallmem_wg_linear_thread_puts(rocshmem_team_t team, void *dest,
                                                     const void *source, int nelems);
+
+  __device__ void fcollectmem_linear_wave(rocshmem_team_t team, void *dest,
+                                  const void *source, int nelems);
 
   __device__ void internal_sync(int pe, int PE_start, int stride, int PE_size,
                                 int64_t *pSync);

--- a/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
@@ -503,4 +503,39 @@ __device__ void IPCContext::alltoallmem_linear_thread_puts_wave(rocshmem_team_t 
 
   sync_wave(team);
 }
+
+
+__device__ int IPCContext::fcollectmem_wave(rocshmem_team_t team, void *dst,
+                                            const void *src, int nelems) {
+  if (dst == nullptr || src == nullptr || team == ROCSHMEM_TEAM_INVALID)
+    return ROCSHMEM_ERROR;
+  
+  fcollectmem_linear_wave(team, dst, src, nelems);
+
+  return ROCSHMEM_SUCCESS;
+}
+
+__device__ void IPCContext::fcollectmem_linear_wave(rocshmem_team_t team, void *dst,
+                                            const void *src, int nelems) {
+  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
+
+  int pe_start = team_obj->tinfo_wrt_world->pe_start;
+  int pe_size = team_obj->num_pes;
+  int stride = team_obj->tinfo_wrt_world->stride;
+  long *pSync = team_obj->alltoall_pSync;
+  int my_pe_in_team = team_obj->my_pe;
+
+  // Have each PE put their designated data to the other PEs
+  for (int j = 0; j < pe_size; j++) {
+    int dest_pe = team_obj->get_pe_in_world(j);
+    putmem_nbi_wave(reinterpret_cast<char *>(dst) + my_pe_in_team * nelems, src, nelems, dest_pe);
+  }
+
+  if (is_thread_zero_in_block()) {
+    quiet();
+  }
+  // wait until everyone has obtained their designated data
+  internal_sync_wave(my_pe, pe_start, stride, pe_size, pSync);
+}
+
 }  // namespace rocshmem

--- a/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
+++ b/projects/rocshmem/src/ipc/context_ipc_device_coll.cpp
@@ -538,4 +538,32 @@ __device__ void IPCContext::fcollectmem_linear_wave(rocshmem_team_t team, void *
   internal_sync_wave(my_pe, pe_start, stride, pe_size, pSync);
 }
 
+__device__ void IPCContext::fcollectmem_wg(rocshmem_team_t team, void *dst,
+                                     const void *src, int nelems) {
+  fcollectmem_linear_wg(team, dst, src, nelems);
+}
+
+__device__ void IPCContext::fcollectmem_linear_wg(rocshmem_team_t team, void *dst,
+                                            const void *src, int nelems) {
+  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
+
+  int pe_start = team_obj->tinfo_wrt_world->pe_start;
+  int pe_size = team_obj->num_pes;
+  int stride = team_obj->tinfo_wrt_world->stride;
+  long *pSync = team_obj->alltoall_pSync;
+  int my_pe_in_team = team_obj->my_pe;
+
+  // Have each PE put their designated data to the other PEs
+  for (int j = 0; j < pe_size; j++) {
+    int dest_pe = team_obj->get_pe_in_world(j);
+    putmem_nbi_wg(reinterpret_cast<char *>(dst) + my_pe_in_team * nelems, src, nelems, dest_pe);
+  }
+
+  if (is_thread_zero_in_block()) {
+    quiet();
+  }
+  // wait until everyone has obtained their designated data
+  internal_sync_wg(my_pe, pe_start, stride, pe_size, pSync);
+}
+
 }  // namespace rocshmem

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -582,13 +582,13 @@ __device__ void IPCContext::alltoallv([[maybe_unused]] rocshmem_team_t team,
 }
 
 template <typename T>
-__device__ void IPCContext::fcollect(rocshmem_team_t team, T *dst,
+__device__ void IPCContext::fcollect_wg(rocshmem_team_t team, T *dst,
                                      const T *src, int nelems) {
-  fcollect_linear(team, dst, src, nelems);
+  fcollect_linear_wg(team, dst, src, nelems);
 }
 
 template <typename T>
-__device__ void IPCContext::fcollect_linear(rocshmem_team_t team, T *dst,
+__device__ void IPCContext::fcollect_linear_wg(rocshmem_team_t team, T *dst,
                                             const T *src, int nelems) {
   IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
 
@@ -609,6 +609,17 @@ __device__ void IPCContext::fcollect_linear(rocshmem_team_t team, T *dst,
   }
   // wait until everyone has obtained their designated data
   internal_sync_wg(constmem.my_pe, pe_start, stride, pe_size, pSync);
+}
+
+template <typename T>
+__device__ int IPCContext::fcollect_wave(rocshmem_team_t team, T *dst,
+                                     const T *src, int nelems) {
+  if (dst == nullptr || src == nullptr || team == ROCSHMEM_TEAM_INVALID)
+    return ROCSHMEM_ERROR;
+  
+  fcollectmem_linear_wave(team, dst, src, nelems * sizeof(T));
+
+  return ROCSHMEM_SUCCESS;
 }
 
 // Block/wave functions

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -584,31 +584,7 @@ __device__ void IPCContext::alltoallv([[maybe_unused]] rocshmem_team_t team,
 template <typename T>
 __device__ void IPCContext::fcollect_wg(rocshmem_team_t team, T *dst,
                                      const T *src, int nelems) {
-  fcollect_linear_wg(team, dst, src, nelems);
-}
-
-template <typename T>
-__device__ void IPCContext::fcollect_linear_wg(rocshmem_team_t team, T *dst,
-                                            const T *src, int nelems) {
-  IPCTeam *team_obj = reinterpret_cast<IPCTeam *>(team);
-
-  int pe_start = team_obj->tinfo_wrt_world->pe_start;
-  int pe_size = team_obj->num_pes;
-  int stride = team_obj->tinfo_wrt_world->stride;
-  long *pSync = team_obj->alltoall_pSync;
-  int my_pe_in_team = team_obj->my_pe;
-
-  // Have each PE put their designated data to the other PEs
-  for (int j = 0; j < pe_size; j++) {
-    int dest_pe = team_obj->get_pe_in_world(j);
-    put_nbi_wg(&dst[my_pe_in_team * nelems], src, nelems, dest_pe);
-  }
-
-  if (is_thread_zero_in_block()) {
-    quiet();
-  }
-  // wait until everyone has obtained their designated data
-  internal_sync_wg(constmem.my_pe, pe_start, stride, pe_size, pSync);
+  fcollectmem_linear_wg(team, dst, src, nelems * sizeof(T));
 }
 
 template <typename T>

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
@@ -832,5 +832,12 @@ __device__ void ROContext::broadcastmem_wg(rocshmem_team_t team, void *dest,
   __syncthreads();
 }
 
+__device__ int ROContext::fcollectmem_wave([[maybe_unused]] rocshmem_team_t team,
+                                            [[maybe_unused]] void *dest,
+                                            [[maybe_unused]] const void *source,
+                                            [[maybe_unused]] int nelems) {
+  LOGD_WARN("fcollectmem_wave is not available on reverse offload backend");
+  return ROCSHMEM_ERROR;
+}
 
 }  // namespace rocshmem

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.cpp
@@ -840,4 +840,19 @@ __device__ int ROContext::fcollectmem_wave([[maybe_unused]] rocshmem_team_t team
   return ROCSHMEM_ERROR;
 }
 
+__device__ void ROContext::fcollectmem_wg(rocshmem_team_t team, void *dest,
+                                    const void *source, int nelems) {
+  if (is_thread_zero_in_block()) {
+    ROTeam *team_obj{reinterpret_cast<ROTeam *>(team)};
+
+    build_queue_element(RO_NET_FCOLLECT, dest, const_cast<void *>(source), nelems, 0,
+                        0, 0, 0, team_obj->ata_buffer, nullptr,
+                        (intptr_t)team_obj->mpi_comm, ro_net_win_id, block_handle, true,
+                        get_status_flag(), is_default_ctx, ROCSHMEM_SUM,
+                        RO_NET_CHAR);
+  }  
+
+  __syncthreads();
+}
+
 }  // namespace rocshmem

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
@@ -190,8 +190,11 @@ class ROContext : public Context {
                                   const void* source, int nelems);
 
   template <typename T>
-  __device__ void fcollect(rocshmem_team_t team, T *dest, const T *source,
+  __device__ void fcollect_wg(rocshmem_team_t team, T *dest, const T *source,
                            int nelems);
+
+  __device__ void fcollectmem_wg(rocshmem_team_t team, void *dest,
+                                  const void *source, int nelems);
 
   template <typename T>
   __device__ int fcollect_wave(rocshmem_team_t team, T *dest, const T *source,

--- a/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_device.hpp
@@ -193,6 +193,13 @@ class ROContext : public Context {
   __device__ void fcollect(rocshmem_team_t team, T *dest, const T *source,
                            int nelems);
 
+  template <typename T>
+  __device__ int fcollect_wave(rocshmem_team_t team, T *dest, const T *source,
+                               int nelems);
+
+  __device__ int fcollectmem_wave(rocshmem_team_t team, void *dest,
+                                  const void *source, int nelems);
+
   __device__ void putmem_wg(void *dest, const void *source, size_t nelems,
                             int pe);
 

--- a/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
@@ -396,7 +396,7 @@ __device__ void ROContext::alltoallv([[maybe_unused]] rocshmem_team_t team,
 }
 
 template <typename T>
-__device__ void ROContext::fcollect(rocshmem_team_t team, T *dest,
+__device__ void ROContext::fcollect_wg(rocshmem_team_t team, T *dest,
                                     const T *source, int nelems) {
   if (!is_thread_zero_in_block()) {
     __syncthreads();

--- a/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
+++ b/projects/rocshmem/src/reverse_offload/context_ro_tmpl_device.hpp
@@ -741,6 +741,16 @@ __device__ inline int ROContext::tile_min_reduce_wg([[maybe_unused]] rocshmem_te
 // Rooted SUM Reduction operations
 // Rooted MAX Reduction operations
 // Rooted MIN Reduction operations
+
+template <typename T>
+__device__ int ROContext::fcollect_wave([[maybe_unused]] rocshmem_team_t team,
+                                        [[maybe_unused]] T *dest,
+                                        [[maybe_unused]] const T *source,
+                                        [[maybe_unused]] int nelems) {
+  LOGD_WARN("fcollect_wave is not available on reverse offload backend");
+  return ROCSHMEM_ERROR;
+}
+
 }  // namespace rocshmem
 
 #endif  // LIBRARY_SRC_REVERSE_OFFLOAD_RO_NET_GPU_TEMPLATES_HPP_

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -758,7 +758,7 @@ __device__ void rocshmem_fcollect_wg(rocshmem_ctx_t ctx,
   get_internal_ctx(ctx)->fcollect_wg<T>(team, dest, source, nelem);
 }
 
-__device__ void rocshmem_fcollectmem_wg(rocshmem_ctx_t ctx,
+__device__ void rocshmem_ctx_fcollectmem_wg(rocshmem_ctx_t ctx,
                                       rocshmem_team_t team, void *dest,
                                       const void *source, int nelem) {
   LOGD_API("device::fcollectmem_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d",

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -755,8 +755,28 @@ __device__ void rocshmem_fcollect_wg(rocshmem_ctx_t ctx,
   LOGD_API("device::fcollect_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d",
     ctx.ctx_opaque, team, dest, source, nelem);
 
-  get_internal_ctx(ctx)->fcollect<T>(team, dest, source, nelem);
+  get_internal_ctx(ctx)->fcollect_wg<T>(team, dest, source, nelem);
 }
+
+template <typename T>
+__device__ int rocshmem_fcollect_wave(rocshmem_ctx_t ctx,
+                                      rocshmem_team_t team, T *dest,
+                                      const T *source, int nelem) {
+  LOGD_API("device::fcollect_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d",
+    ctx.ctx_opaque, team, dest, source, nelem);
+
+  return get_internal_ctx(ctx)->fcollect_wave<T>(team, dest, source, nelem);
+}
+
+__device__ int rocshmem_ctx_fcollectmem_wave(rocshmem_ctx_t ctx,
+                                      rocshmem_team_t team, void *dest,
+                                      const void *source, int nelem) {
+  LOGD_API("device::fcollectmem_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d",
+    ctx.ctx_opaque, team, dest, source, nelem);
+
+  return get_internal_ctx(ctx)->fcollectmem_wave(team, dest, source, nelem);
+}
+
 
 template <typename T>
 __device__ void rocshmem_wait_until(T *ivars, int cmp, T val) {
@@ -1486,6 +1506,9 @@ __device__ int rocshmem_team_translate_pe(rocshmem_team_t src_team,
   template __device__ void rocshmem_fcollect_wg<T>(                            \
       rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,     \
       int nelem);                                                              \
+  template __device__ int rocshmem_fcollect_wave<T>(                           \
+      rocshmem_ctx_t ctx, rocshmem_team_t team, T * dest, const T *source,     \
+      int nelem);                                                              \
   template __device__ void rocshmem_put_wave<T>(                               \
       rocshmem_ctx_t ctx, T * dest, const T *source, size_t nelems, int pe);   \
   template __device__ void rocshmem_put_wg<T>(                                 \
@@ -1842,6 +1865,11 @@ __device__ int rocshmem_team_translate_pe(rocshmem_team_t src_team,
       rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,     \
       int nelem) {                                                            \
     rocshmem_fcollect_wg<T>(ctx, team, dest, source, nelem);                  \
+  }                                                                           \
+   __device__ int rocshmem_ctx_##TNAME##_fcollect_wave(                       \
+      rocshmem_ctx_t ctx, rocshmem_team_t team, T *dest, const T *source,     \
+      int nelem) {                                                            \
+    return rocshmem_fcollect_wave<T>(ctx, team, dest, source, nelem);         \
   }
 
 #define AMO_STANDARD_DEF_GEN(T, TNAME)                                        \

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -758,6 +758,15 @@ __device__ void rocshmem_fcollect_wg(rocshmem_ctx_t ctx,
   get_internal_ctx(ctx)->fcollect_wg<T>(team, dest, source, nelem);
 }
 
+__device__ void rocshmem_fcollectmem_wg(rocshmem_ctx_t ctx,
+                                      rocshmem_team_t team, void *dest,
+                                      const void *source, int nelem) {
+  LOGD_API("device::fcollectmem_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d",
+    ctx.ctx_opaque, team, dest, source, nelem);
+
+  get_internal_ctx(ctx)->fcollectmem_wg(team, dest, source, nelem);
+}
+
 template <typename T>
 __device__ int rocshmem_fcollect_wave(rocshmem_ctx_t ctx,
                                       rocshmem_team_t team, T *dest,

--- a/projects/rocshmem/src/rocshmem_gpu.cpp
+++ b/projects/rocshmem/src/rocshmem_gpu.cpp
@@ -759,8 +759,7 @@ __device__ void rocshmem_fcollect_wg(rocshmem_ctx_t ctx,
 }
 
 __device__ void rocshmem_ctx_fcollectmem_wg(rocshmem_ctx_t ctx,
-                                      rocshmem_team_t team, void *dest,
-                                      const void *source, int nelem) {
+    rocshmem_team_t team, void *dest, const void *source, int nelem) {
   LOGD_API("device::fcollectmem_wg (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d",
     ctx.ctx_opaque, team, dest, source, nelem);
 
@@ -769,8 +768,7 @@ __device__ void rocshmem_ctx_fcollectmem_wg(rocshmem_ctx_t ctx,
 
 template <typename T>
 __device__ int rocshmem_fcollect_wave(rocshmem_ctx_t ctx,
-                                      rocshmem_team_t team, T *dest,
-                                      const T *source, int nelem) {
+    rocshmem_team_t team, T *dest, const T *source, int nelem) {
   LOGD_API("device::fcollect_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d",
     ctx.ctx_opaque, team, dest, source, nelem);
 
@@ -778,14 +776,12 @@ __device__ int rocshmem_fcollect_wave(rocshmem_ctx_t ctx,
 }
 
 __device__ int rocshmem_ctx_fcollectmem_wave(rocshmem_ctx_t ctx,
-                                      rocshmem_team_t team, void *dest,
-                                      const void *source, int nelem) {
+    rocshmem_team_t team, void *dest, const void *source, int nelem) {
   LOGD_API("device::fcollectmem_wave (ctx=%zd, team=%zd, dest=%p, source=%p, nelem=%d",
     ctx.ctx_opaque, team, dest, source, nelem);
 
   return get_internal_ctx(ctx)->fcollectmem_wave(team, dest, source, nelem);
 }
-
 
 template <typename T>
 __device__ void rocshmem_wait_until(T *ivars, int cmp, T val) {

--- a/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
+++ b/projects/rocshmem/tests/functional_tests/CTestFunctionalTests.cmake
@@ -167,6 +167,7 @@ set(TEST_host_wait_until_some_status 148)
 set(TEST_teamreducescatter 149)
 set(TEST_broadcast_wave 150)
 set(TEST_alltoall_wave 151)
+set(TEST_fcollect_wave 152)
 
 # MPI should already be found by the parent CMakeLists.txt
 # Use standard CMake MPI variables set by find_package(MPI)
@@ -1072,6 +1073,7 @@ function(add_coll_tests)
     begin_test_group(CATEGORY "COLLECTIVE;WAVE" TIER full BACKENDS "ipc;gda" GPUS "all")
         add_rocshmem_functional_test(NAME broadcast_wave RANKS 2 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 32768)
         add_rocshmem_functional_test(NAME alltoall_wave RANKS 2 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 512)
+        add_rocshmem_functional_test(NAME fcollect_wave RANKS 2 WORKGROUPS 1 THREADS 64 MAX_MSG_SIZE 32768)
     end_test_group()
 endfunction()
 

--- a/projects/rocshmem/tests/functional_tests/fcollect_wave_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/fcollect_wave_tester.cpp
@@ -62,24 +62,26 @@ __global__ void FcollectWaveTest(int loop, int skip, long long int *start_time,
                                  ShmemContextType ctx_type,
                                  int wf_size, rocshmem_team_t *teams) {
   __shared__ rocshmem_ctx_t ctx;
-  int t_id  = get_flat_block_id();
+  int t_id = get_flat_block_id();
   int wg_id = get_flat_grid_id();
   int wf_id = t_id / wf_size;
+  int wf_per_wg = (get_flat_block_size() - 1) / wf_size + 1;
+  int flat_wf_id = wf_id + wg_id * wf_per_wg;
 
-  rocshmem_wg_team_create_ctx(teams[wg_id], ctx_type, &ctx);
+  rocshmem_wg_ctx_create(ctx_type, &ctx);
 
   int n_pes = rocshmem_ctx_n_pes(ctx);
-  source_buf += wg_id * num_elems;
-  dest_buf += wg_id * num_elems * n_pes;
+  source_buf += flat_wf_id * num_elems;
+  dest_buf += flat_wf_id * num_elems * n_pes;
 
   __syncthreads();
 
   for (int i = 0; i < loop + skip; i++) {
-    if (i == skip && hipThreadIdx_x == 0) {
-      start_time[wg_id] = wall_clock64();
+    if (i == skip && t_id % wf_size == 0) {
+      start_time[flat_wf_id] = wall_clock64();
     }
     if (wf_id == 0) {
-      wave_fcollect<T1>(ctx, teams[wg_id],
+      wave_fcollect<T1>(ctx, teams[flat_wf_id],
                         dest_buf,    // T* dest
                         source_buf,  // const T* source
                         num_elems);  // int nelems
@@ -89,8 +91,8 @@ __global__ void FcollectWaveTest(int loop, int skip, long long int *start_time,
 
   __syncthreads();
 
-  if (hipThreadIdx_x == 0) {
-    end_time[wg_id] = wall_clock64();
+  if (t_id % wf_size == 0) {
+    end_time[flat_wf_id] = wall_clock64();
   }
 
   rocshmem_wg_ctx_destroy(&ctx);
@@ -105,34 +107,34 @@ FcollectWaveTester<T1>::FcollectWaveTester(TesterArguments args)
   my_pe = rocshmem_team_my_pe(ROCSHMEM_TEAM_WORLD);
   n_pes = rocshmem_team_n_pes(ROCSHMEM_TEAM_WORLD);
 
-  // Total number of elements in src buffer
-  int total_elems = (max_msg_size / sizeof(T1)) * args.num_wgs;
+  // Total number of elements in src buffer — one slot per wavefront across all WGs
+  int total_elems = (max_msg_size / sizeof(T1)) * args.num_wgs * num_warps;
   int buff_size = total_elems * sizeof(T1);
 
   source_buf = (T1 *)alloc_test_buffer(buff_size, args.local_buf_type);
   dest_buf = (T1 *)alloc_test_buffer(buff_size * n_pes);
 
-  if constexpr (std::is_same<T1, char>::value ||
-                std::is_same<T1, signed char>::value ||
-                std::is_same<T1, unsigned char>::value) {
-    for (int i = 0; i < total_elems; ++i) {
-      source_buf[i] = static_cast<T1>('a' + my_pe);
-    }
-  }
-  else if constexpr (std::is_floating_point<T1>::value) {
+  if constexpr (std::is_floating_point<T1>::value) {
     for (int i = 0; i < total_elems; ++i) {
       source_buf[i] = static_cast<T1>(3.14 + my_pe);
     }
   }
-  else if constexpr (std::is_integral<T1>::value) {
+  else {
     for (int i = 0; i < total_elems; i++) {
-      source_buf[i] = static_cast<T1>(my_pe);
+      source_buf[i] = static_cast<T1>('a' + my_pe);
     }
   }
 
   char* value{nullptr};
   if ((value = getenv("ROCSHMEM_MAX_NUM_TEAMS"))) {
     num_teams = atoi(value);
+  }
+
+  if (num_teams < static_cast<int>(args.num_wgs * num_warps)) {
+    std::cerr << "Not enough teams (" << num_teams << ") for "
+              << args.num_wgs * num_warps << " wavefronts. "
+              << "Set ROCSHMEM_MAX_NUM_TEAMS accordingly." << std::endl;
+    abort();
   }
 
   CHECK_HIP(hipMalloc(&team_fcollect_wave_world_dup,
@@ -173,8 +175,8 @@ void FcollectWaveTester<T1>::launchKernel(dim3 gridSize, dim3 blockSize,
                      source_buf, dest_buf, num_elems, _shmem_context,
                      wf_size, team_fcollect_wave_world_dup);
 
-  num_msgs = (loop + args.skip) * gridSize.x;
-  num_timed_msgs = loop * gridSize.x;
+  num_msgs = (loop + args.skip) * gridSize.x * num_warps;
+  num_timed_msgs = loop * gridSize.x * num_warps;
 }
 
 template <typename T1>
@@ -187,7 +189,7 @@ void FcollectWaveTester<T1>::postLaunchKernel() {
 template <typename T1>
 void FcollectWaveTester<T1>::resetBuffers(size_t size) {
   int num_elems = (size / sizeof(T1));
-  int buff_size = num_elems * sizeof(T1) * args.num_wgs * n_pes;
+  int buff_size = num_elems * sizeof(T1) * args.num_wgs * num_warps * n_pes;
 
   memset(dest_buf, -1, buff_size);
 }
@@ -199,20 +201,16 @@ void FcollectWaveTester<T1>::verifyResults(size_t size) {
   int idx = 0;
   T1 expected;
 
-  for(unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
+  int total_wfs = args.num_wgs * num_warps;
+  for(int flat_wf_id = 0; flat_wf_id < total_wfs; flat_wf_id++) {
     for(int pe = 0; pe < n_pes; pe++) {
       for(unsigned int i = 0; i < static_cast<unsigned int>(num_elems); i++) {
-        idx = (wg_id * n_pes + pe) * num_elems + i;
-        if constexpr (std::is_same<T1, char>::value ||
-              std::is_same<T1, signed char>::value ||
-              std::is_same<T1, unsigned char>::value) {
-          expected = static_cast<T1>('a' + pe);
-        }
-        else if constexpr (std::is_floating_point<T1>::value) {
+        idx = (flat_wf_id * n_pes + pe) * num_elems + i;
+        if constexpr (std::is_floating_point<T1>::value) {
           expected = static_cast<T1>(3.14 + pe);
         }
-        else if constexpr (std::is_integral<T1>::value) {
-          expected = pe;
+        else {
+          expected = static_cast<T1>('a' + pe);
         }
         if (dest_buf[idx] != expected) {
           std::cerr << "Data validation error at idx " << idx << std::endl;

--- a/projects/rocshmem/tests/functional_tests/fcollect_wave_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/fcollect_wave_tester.cpp
@@ -1,0 +1,226 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+/* Declare the template with a generic implementation */
+template <typename T>
+__device__ int wave_fcollect([[maybe_unused]] rocshmem_ctx_t ctx, [[maybe_unused]] rocshmem_team_t team,
+                              [[maybe_unused]] T *dest, [[maybe_unused]] const T *source, [[maybe_unused]] int nelems) {
+  return ROCSHMEM_SUCCESS;
+}
+
+/* Define templates to call rocSHMEM */
+#define FCOLLECT_WAVE_DEF_GEN(T, TNAME)                                          \
+  template <>                                                                    \
+  __device__ int wave_fcollect<T>(rocshmem_ctx_t ctx, rocshmem_team_t team,      \
+                                  T *dest, const T *source, int nelem) {         \
+    return rocshmem_ctx_##TNAME##_fcollect_wave(ctx, team, dest, source, nelem); \
+  }
+
+FCOLLECT_WAVE_DEF_GEN(float, float)
+FCOLLECT_WAVE_DEF_GEN(double, double)
+FCOLLECT_WAVE_DEF_GEN(char, char)
+// FCOLLECT_WAVE_DEF_GEN(long double, longdouble)
+FCOLLECT_WAVE_DEF_GEN(signed char, schar)
+FCOLLECT_WAVE_DEF_GEN(short, short)
+FCOLLECT_WAVE_DEF_GEN(int, int)
+FCOLLECT_WAVE_DEF_GEN(long, long)
+FCOLLECT_WAVE_DEF_GEN(long long, longlong)
+FCOLLECT_WAVE_DEF_GEN(unsigned char, uchar)
+FCOLLECT_WAVE_DEF_GEN(unsigned short, ushort)
+FCOLLECT_WAVE_DEF_GEN(unsigned int, uint)
+FCOLLECT_WAVE_DEF_GEN(unsigned long, ulong)
+FCOLLECT_WAVE_DEF_GEN(unsigned long long, ulonglong)
+
+/******************************************************************************
+ * DEVICE TEST KERNEL
+ *****************************************************************************/
+template <typename T1>
+__global__ void FcollectWaveTest(int loop, int skip, long long int *start_time,
+                                 long long int *end_time, T1 *source_buf,
+                                 T1 *dest_buf, int num_elems,
+                                 ShmemContextType ctx_type,
+                                 int wf_size, rocshmem_team_t *teams) {
+  __shared__ rocshmem_ctx_t ctx;
+  int t_id  = get_flat_block_id();
+  int wg_id = get_flat_grid_id();
+  int wf_id = t_id / wf_size;
+
+  rocshmem_wg_team_create_ctx(teams[wg_id], ctx_type, &ctx);
+
+  int n_pes = rocshmem_ctx_n_pes(ctx);
+  source_buf += wg_id * num_elems;
+  dest_buf += wg_id * num_elems * n_pes;
+
+  __syncthreads();
+
+  for (int i = 0; i < loop + skip; i++) {
+    if (i == skip && hipThreadIdx_x == 0) {
+      start_time[wg_id] = wall_clock64();
+    }
+    if (wf_id == 0) {
+      wave_fcollect<T1>(ctx, teams[wg_id],
+                        dest_buf,    // T* dest
+                        source_buf,  // const T* source
+                        num_elems);  // int nelems
+    }
+    __syncthreads();
+  }
+
+  __syncthreads();
+
+  if (hipThreadIdx_x == 0) {
+    end_time[wg_id] = wall_clock64();
+  }
+
+  rocshmem_wg_ctx_destroy(&ctx);
+}
+
+/******************************************************************************
+ * HOST TESTER CLASS METHODS
+ *****************************************************************************/
+template <typename T1>
+FcollectWaveTester<T1>::FcollectWaveTester(TesterArguments args)
+    : Tester(args) {
+  my_pe = rocshmem_team_my_pe(ROCSHMEM_TEAM_WORLD);
+  n_pes = rocshmem_team_n_pes(ROCSHMEM_TEAM_WORLD);
+
+  // Total number of elements in src buffer
+  int total_elems = (max_msg_size / sizeof(T1)) * args.num_wgs;
+  int buff_size = total_elems * sizeof(T1);
+
+  source_buf = (T1 *)alloc_test_buffer(buff_size, args.local_buf_type);
+  dest_buf = (T1 *)alloc_test_buffer(buff_size * n_pes);
+
+  if constexpr (std::is_same<T1, char>::value ||
+                std::is_same<T1, signed char>::value ||
+                std::is_same<T1, unsigned char>::value) {
+    for (int i = 0; i < total_elems; ++i) {
+      source_buf[i] = static_cast<T1>('a' + my_pe);
+    }
+  }
+  else if constexpr (std::is_floating_point<T1>::value) {
+    for (int i = 0; i < total_elems; ++i) {
+      source_buf[i] = static_cast<T1>(3.14 + my_pe);
+    }
+  }
+  else if constexpr (std::is_integral<T1>::value) {
+    for (int i = 0; i < total_elems; i++) {
+      source_buf[i] = static_cast<T1>(my_pe);
+    }
+  }
+
+  char* value{nullptr};
+  if ((value = getenv("ROCSHMEM_MAX_NUM_TEAMS"))) {
+    num_teams = atoi(value);
+  }
+
+  CHECK_HIP(hipMalloc(&team_fcollect_wave_world_dup,
+                      sizeof(rocshmem_team_t) * num_teams));
+}
+
+template <typename T1>
+FcollectWaveTester<T1>::~FcollectWaveTester() {
+  free_test_buffer(source_buf, args.local_buf_type);
+  free_test_buffer(dest_buf);
+  CHECK_HIP(hipFree(team_fcollect_wave_world_dup));
+}
+
+template <typename T1>
+void FcollectWaveTester<T1>::preLaunchKernel() {
+  bw_factor = n_pes * 2;
+
+  for (int team_i = 0; team_i < num_teams; team_i++) {
+    team_fcollect_wave_world_dup[team_i] = ROCSHMEM_TEAM_INVALID;
+    rocshmem_team_split_strided(ROCSHMEM_TEAM_WORLD, 0, 1, n_pes, nullptr, 0,
+                                 &team_fcollect_wave_world_dup[team_i]);
+    if (team_fcollect_wave_world_dup[team_i] == ROCSHMEM_TEAM_INVALID) {
+      std::cout << "Team " << team_i << " is invalid!" << std::endl;
+      abort();
+    }
+  }
+}
+
+template <typename T1>
+void FcollectWaveTester<T1>::launchKernel(dim3 gridSize, dim3 blockSize,
+                                          int loop, size_t size) {
+  size_t shared_bytes = 0;
+
+  int num_elems = size / sizeof(T1);
+
+  hipLaunchKernelGGL(FcollectWaveTest<T1>, gridSize, blockSize, shared_bytes,
+                     stream, loop, args.skip, start_time, end_time,
+                     source_buf, dest_buf, num_elems, _shmem_context,
+                     wf_size, team_fcollect_wave_world_dup);
+
+  num_msgs = (loop + args.skip) * gridSize.x;
+  num_timed_msgs = loop * gridSize.x;
+}
+
+template <typename T1>
+void FcollectWaveTester<T1>::postLaunchKernel() {
+  for (int team_i = 0; team_i < num_teams; team_i++) {
+    rocshmem_team_destroy(team_fcollect_wave_world_dup[team_i]);
+  }
+}
+
+template <typename T1>
+void FcollectWaveTester<T1>::resetBuffers(size_t size) {
+  int num_elems = (size / sizeof(T1));
+  int buff_size = num_elems * sizeof(T1) * args.num_wgs * n_pes;
+
+  memset(dest_buf, -1, buff_size);
+}
+
+template <typename T1>
+void FcollectWaveTester<T1>::verifyResults(size_t size) {
+
+  int num_elems = size / sizeof(T1);
+  int idx = 0;
+  T1 expected;
+
+  for(unsigned int wg_id = 0; wg_id < args.num_wgs; wg_id++) {
+    for(int pe = 0; pe < n_pes; pe++) {
+      for(unsigned int i = 0; i < static_cast<unsigned int>(num_elems); i++) {
+        idx = (wg_id * n_pes + pe) * num_elems + i;
+        if constexpr (std::is_same<T1, char>::value ||
+              std::is_same<T1, signed char>::value ||
+              std::is_same<T1, unsigned char>::value) {
+          expected = static_cast<T1>('a' + pe);
+        }
+        else if constexpr (std::is_floating_point<T1>::value) {
+          expected = static_cast<T1>(3.14 + pe);
+        }
+        else if constexpr (std::is_integral<T1>::value) {
+          expected = pe;
+        }
+        if (dest_buf[idx] != expected) {
+          std::cerr << "Data validation error at idx " << idx << std::endl;
+          std::cerr << "PE " << my_pe << " Got " << dest_buf[idx]
+          << ", Expected " << expected << std::endl;
+          exit(-1);
+        }
+      }
+    }
+  }
+}

--- a/projects/rocshmem/tests/functional_tests/fcollect_wave_tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/fcollect_wave_tester.cpp
@@ -134,7 +134,7 @@ FcollectWaveTester<T1>::FcollectWaveTester(TesterArguments args)
     std::cerr << "Not enough teams (" << num_teams << ") for "
               << args.num_wgs * num_warps << " wavefronts. "
               << "Set ROCSHMEM_MAX_NUM_TEAMS accordingly." << std::endl;
-    abort();
+    exit(0);
   }
 
   CHECK_HIP(hipMalloc(&team_fcollect_wave_world_dup,

--- a/projects/rocshmem/tests/functional_tests/fcollect_wave_tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/fcollect_wave_tester.hpp
@@ -1,0 +1,72 @@
+/******************************************************************************
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#ifndef _FCOLLECT_WAVE_TESTER_HPP_
+#define _FCOLLECT_WAVE_TESTER_HPP_
+
+#include <functional>
+#include <utility>
+
+#include "tester.hpp"
+
+using namespace rocshmem;
+
+/******************************************************************************
+ * HOST TESTER CLASS
+ *****************************************************************************/
+template <typename T1>
+class FcollectWaveTester : public Tester {
+ public:
+  explicit FcollectWaveTester(TesterArguments args);
+  virtual ~FcollectWaveTester();
+
+ protected:
+  virtual void resetBuffers(size_t size) override;
+
+  virtual void preLaunchKernel() override;
+
+  virtual void launchKernel(dim3 gridSize, dim3 blockSize, int loop,
+                            size_t size) override;
+
+  virtual void postLaunchKernel() override;
+
+  virtual void verifyResults(size_t size) override;
+
+  T1 *source_buf;
+  T1 *dest_buf;
+
+ private:
+  int my_pe = 0;
+  int n_pes = 0;
+  /**
+   * This constant should equal ROCSHMEM_MAX_NUM_TEAMS - 1.
+   * The default value for the maximum number of teams is 40.
+   */
+  int num_teams = 39;
+  rocshmem_team_t *team_fcollect_wave_world_dup;
+};
+
+#include "fcollect_wave_tester.cpp"
+
+#endif

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -62,6 +62,7 @@
 #include "team_ctx_infra_tester.hpp"
 #include "team_ctx_primitive_tester.hpp"
 #include "team_fcollect_tester.hpp"
+#include "fcollect_wave_tester.hpp"
 #include "team_reduction_tester.hpp"
 #include "team_reduce_scatter_tester.hpp"
 #include "wavefront_primitives.hpp"
@@ -156,6 +157,7 @@ Tester::Tester(TesterArguments args) : args(args) {
       case TeamReductionTestType:
       case TeamReduceScatterTestType:
       case TeamFCollectTestType:
+      case FcollectWaveTestType:
       case CollectTestType:
       case TeamAllToAllTestType:
       case TeamAllToAllvTestType:
@@ -501,6 +503,16 @@ std::vector<Tester*> Tester::create(TesterArguments args) {
       testers.push_back(new TeamFcollectTester<double>(args));
       testers.push_back(new TeamFcollectTester<char>(args));
       testers.push_back(new TeamFcollectTester<unsigned char>(args));
+      break;
+    case FcollectWaveTestType:
+      test_name = "Fcollect Wave Test";
+      testers.push_back(new FcollectWaveTester<int64_t>(args));
+      testers.push_back(new FcollectWaveTester<int>(args));
+      testers.push_back(new FcollectWaveTester<long long>(args));
+      testers.push_back(new FcollectWaveTester<float>(args));
+      testers.push_back(new FcollectWaveTester<double>(args));
+      testers.push_back(new FcollectWaveTester<char>(args));
+      testers.push_back(new FcollectWaveTester<unsigned char>(args));
       break;
     case AMO_FAddTestType:
       test_name = "AMO Fetch_Add";
@@ -1014,6 +1026,7 @@ bool Tester::peLaunchesKernel() {
     case TeamAllToAllTestType:
     case TeamAllToAllvTestType:
     case TeamFCollectTestType:
+    case FcollectWaveTestType:
     case PingPongTestType:
     case BarrierAllTestType:
     case WAVEBarrierAllTestType:

--- a/projects/rocshmem/tests/functional_tests/tester.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester.cpp
@@ -106,6 +106,7 @@ Tester::Tester(TesterArguments args) : args(args) {
     case WAVEPutNBITestType:
     case BroadcastWaveTestType:
     case AllToAllWaveTestType:
+    case FcollectWaveTestType:
       num_timers = args.num_wgs * num_warps;
       break;
     default:

--- a/projects/rocshmem/tests/functional_tests/tester.hpp
+++ b/projects/rocshmem/tests/functional_tests/tester.hpp
@@ -193,8 +193,9 @@
   X(HostWaitUntilSomeStatus,   148)  \
   X(TeamReduceScatter,         149)  \
   X(BroadcastWave,             150)  \
-  X(AllToAllWave,              151)
-
+  X(AllToAllWave,              151)  \
+  X(FcollectWave,              152)
+  
 #define _ROCSHMEM_ENUM_ENTRY(name, val) name##TestType = val,
 enum TestType {
   ROCSHMEM_FOREACH_TEST_TYPE(_ROCSHMEM_ENUM_ENTRY)

--- a/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
+++ b/projects/rocshmem/tests/functional_tests/tester_arguments.cpp
@@ -204,6 +204,7 @@ TesterArguments::TesterArguments(int argc, char *argv[]) {
       min_msg_size = 4;
       break;
     case TeamFCollectTestType:
+    case FcollectWaveTestType:
     case TeamAllToAllTestType:
     case TeamAllToAllvTestType:
     case TeamBroadcastTestType:
@@ -287,6 +288,7 @@ void TesterArguments::get_arguments() {
     case TeamAllToAllvTestType:
     case AllToAllWaveTestType:
     case TeamFCollectTestType:
+    case FcollectWaveTestType:
     case TeamReductionTestType:
     case TeamReduceScatterTestType:
     case TeamBroadcastTestType:

--- a/projects/rocshmem/tests/test_categories.yaml
+++ b/projects/rocshmem/tests/test_categories.yaml
@@ -153,6 +153,8 @@ test_categories:
       - "teamwgsync_.*"
       - "teamsplit2d_.*"
       - "alltoall_wave_.*"
+      - "broadcast_wave_.*"
+      - "fcollect_wave_.*"
 
       # Extended signal operations
       - "wgputsignal_.*"

--- a/projects/rocshmem/utils/header_files_gen/COLL.py
+++ b/projects/rocshmem/utils/header_files_gen/COLL.py
@@ -201,6 +201,79 @@ def generate_fcollect_api():
     for type_, tname_ in types:
         expanded_code += fcollect_api(type_, tname_)
 
+    expanded_code += """
+/**
+ * @name ROCSSHMEM_CTX_FCOLLECTMEM_WG
+ * @brief Concatenates @p nelems bytes from each PE's @p source into every PE's
+ * @p dest buffer.
+ * Must be called as a work-group collective.
+ *
+ * @param[in] team         The team participating in the collective.
+ * @param[in] dest         Destination address. Must be an address on the
+ *                         symmetric heap.
+ * @param[in] source       Source address. Must be an address on the symmetric
+ *                         heap.
+ * @param[in] nelems       Number of bytes contributed by each PE.
+ *
+ * @return void
+ */
+__device__ ATTR_NO_INLINE void rocshmem_fcollectmem_wg(
+    rocshmem_team_t team, void *dest, const void *source, int nelems);\n
+"""
+
+    return expanded_code
+
+
+def fcollect_wave_api(T, TNAME):
+    return (
+        f"__device__ ATTR_NO_INLINE int rocshmem_ctx_{TNAME}_fcollect_wave(\n"
+        f"    rocshmem_ctx_t ctx, rocshmem_team_t team, {T} *dest,\n"
+        f"    const {T} *source, int nelems);\n\n"
+    )
+
+
+def generate_fcollect_wave_api():
+    expanded_code = """
+/**
+ * @name ROCSHMEM_CTX_FCOLLECT_WAVE
+ * @brief Concatenates blocks of data from multiple PEs to an array in every
+ * PE participating in the collective routine.
+ *
+ * This function must be called as a wave-front collective.
+ *
+ * @param[in] ctx          The context associated with this operation.
+ * @param[in] team         The team participating in the collective.
+ * @param[in] dest         Destination address. Must be an address on the
+ *                         symmetric heap.
+ * @param[in] source       Source address. Must be an address on the symmetric
+ *                         heap.
+ * @param[in] nelems       Number of data elements contributed by each PE.
+ *
+ * @return int (Zero on successful local completion. Nonzero otherwise.)
+ */\n"""
+    for type_, tname_ in types:
+        expanded_code += fcollect_wave_api(type_, tname_)
+
+    expanded_code += """
+/**
+ * @name ROCSSHMEM_CTX_FCOLLECTMEM_WAVE
+ * @brief Concatenates @p nelems bytes from each PE's @p source into every PE's
+ * @p dest buffer.
+ * Must be called as a wave-level collective.
+ *
+ * @param[in] team         The team participating in the collective.
+ * @param[in] dest         Destination address. Must be an address on the
+ *                         symmetric heap.
+ * @param[in] source       Source address. Must be an address on the symmetric
+ *                         heap.
+ * @param[in] nelems       Number of bytes contributed by each PE.
+ *
+ * @return int (Zero on successful local completion. Nonzero otherwise.)
+ */
+__device__ ATTR_NO_INLINE int rocshmem_fcollectmem_wave(
+    rocshmem_team_t team, void *dest, const void *source, int nelems);\n
+"""
+
     return expanded_code
 
 
@@ -398,6 +471,7 @@ namespace rocshmem {
         generate_alltoall_wave_api() +
         generate_broadcast_api() +
         generate_fcollect_api() +
+        generate_fcollect_wave_api() +
         generate_reduction_api() +
         generate_reduce_on_stream_api() +
         generate_broadcast_wave_api()

--- a/projects/rocshmem/utils/header_files_gen/COLL.py
+++ b/projects/rocshmem/utils/header_files_gen/COLL.py
@@ -203,7 +203,7 @@ def generate_fcollect_api():
 
     expanded_code += """
 /**
- * @name ROCSSHMEM_CTX_FCOLLECTMEM_WG
+ * @name ROCSHMEM_CTX_FCOLLECTMEM_WG
  * @brief Concatenates @p nelems bytes from each PE's @p source into every PE's
  * @p dest buffer.
  * Must be called as a work-group collective.
@@ -217,7 +217,7 @@ def generate_fcollect_api():
  *
  * @return void
  */
-__device__ ATTR_NO_INLINE void rocshmem_fcollectmem_wg(
+__device__ ATTR_NO_INLINE void rocshmem_ctx_fcollectmem_wg(rocshmem_ctx_t
     rocshmem_team_t team, void *dest, const void *source, int nelems);\n
 """
 
@@ -256,7 +256,7 @@ def generate_fcollect_wave_api():
 
     expanded_code += """
 /**
- * @name ROCSSHMEM_CTX_FCOLLECTMEM_WAVE
+ * @name ROCSHMEM_CTX_FCOLLECTMEM_WAVE
  * @brief Concatenates @p nelems bytes from each PE's @p source into every PE's
  * @p dest buffer.
  * Must be called as a wave-level collective.
@@ -270,7 +270,7 @@ def generate_fcollect_wave_api():
  *
  * @return int (Zero on successful local completion. Nonzero otherwise.)
  */
-__device__ ATTR_NO_INLINE int rocshmem_fcollectmem_wave(
+__device__ ATTR_NO_INLINE int rocshmem_ctx_fcollectmem_wave(rocshmem_ctx_t ctx,
     rocshmem_team_t team, void *dest, const void *source, int nelems);\n
 """
 


### PR DESCRIPTION
## Motivation

Develop:
- `nvshmemx_##TYPE##_fcollect_warp()`
- `nvshmemx_fcollectmem_warp()`

to provide wave-level broadcast capabilities in rocSHMEM, matching NVSHMEM's API and semantics.

## Technical Details

add wave-level fcollect implementation `rocshmem_ctx_##TYPE##_fcollect_wave()` and `rocshmem_ctx_fcollectmem_wave()`

- [x] Add IPC backend implementation
- [x] Add GDA backend implementation

add fcollectmem_wg implementation `rocshmem_ctx_fcollectmem_wg()`

- [x] Add IPC backend implementation
- [x] Add GDA backend implementation
- [x] Add RO backend implementation

## JIRA ID

JIRA ID: AIROCSHMEM-438

## Test Plan

- [x] build functional test for wave level fcollect to verify functionality

## Test Result

- [x] passing functional test
- [x] functions as expected

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
