### PR TITLE
Add "project: cuid" auto-label rule

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -10,6 +10,10 @@
 - changed-files:
   - any-glob-to-any-file: 'projects/clr/**/*'
 
+"project: cuid":
+- changed-files:
+  - any-glob-to-any-file: 'projects/cuid/**/*'
+
 "project: hip":
 - changed-files:
   - any-glob-to-any-file: 'projects/hip/**/*'


### PR DESCRIPTION
Adds a path-based labeler rule so PRs touching `projects/cuid/**` automatically get the new `project: cuid` label, matching the existing convention for the other subprojects and making it possible to filter CUID PRs in GitHub. The `project: cuid` label itself has already been created on the repo.

Made with [Cursor](https://cursor.com)