### PR TITLE
fix(rocprofiler-systems): initialize GPU and NIC when initializing AMD SMI

### DIFF
--- a/projects/rocprofiler-systems/source/lib/backends/amd_smi/backend.hpp
+++ b/projects/rocprofiler-systems/source/lib/backends/amd_smi/backend.hpp
@@ -25,10 +25,10 @@ struct backend
 {
     /**
      * @brief Initialize the AMD SMI library.
-     * @param init_flags Initialization flags (default: AMDSMI_INIT_AMD_GPUS).
+     * @param init_flags Initialization flags (e.g. AMDSMI_INIT_AMD_GPUS, AMDSMI_INIT_AMD_NICS).
      * @return AMD SMI status code indicating success or failure.
      */
-    static amdsmi_status_t init(std::uint64_t init_flags = AMDSMI_INIT_AMD_GPUS)
+    static amdsmi_status_t init(std::uint64_t init_flags)
     {
         return amdsmi_init(init_flags);
     }

--- a/projects/rocprofiler-systems/source/lib/backends/amd_smi/backend.hpp
+++ b/projects/rocprofiler-systems/source/lib/backends/amd_smi/backend.hpp
@@ -25,7 +25,8 @@ struct backend
 {
     /**
      * @brief Initialize the AMD SMI library.
-     * @param init_flags Initialization flags (e.g. AMDSMI_INIT_AMD_GPUS, AMDSMI_INIT_AMD_NICS).
+     * @param init_flags Initialization flags (e.g. AMDSMI_INIT_AMD_GPUS,
+     * AMDSMI_INIT_AMD_NICS).
      * @return AMD SMI status code indicating success or failure.
      */
     static amdsmi_status_t init(std::uint64_t init_flags)

--- a/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/device_providers/amd_smi/provider.hpp
+++ b/projects/rocprofiler-systems/source/lib/rocprof-sys/library/pmc/device_providers/amd_smi/provider.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "backends/amd_smi/ainic_feature.hpp"
 #include "backends/amd_smi/backend.hpp"
 #include "library/pmc/common/types.hpp"
 
@@ -225,7 +226,11 @@ public:
     : m_backend_api(BackendFactory::create_backend())
     {
         // Initialize AMD SMI backend
-        check_amd_smi_status(m_backend_api->init(),
+        std::uint64_t init_flags = AMDSMI_INIT_AMD_GPUS;
+#ifdef AINIC_SUPPORTED
+        init_flags |= AMDSMI_INIT_AMD_NICS;
+#endif
+        check_amd_smi_status(m_backend_api->init(init_flags),
                              "Failed to initialize AMD SMI backend!");
 
         // Get and store version information

--- a/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
+++ b/projects/rocprofiler-systems/tests/pytest/test_ainic_perf.py
@@ -10,6 +10,11 @@ and the ROCpd (.db) database.
 
 AI NIC devices are discovered at runtime via ``amd-smi static | grep -i netdev``.
 The test is skipped automatically when no AI NIC devices are present on the system.
+
+Coverage note: these tests exercise the AMD SMI provider initialization path
+fixed in source/lib/rocprof-sys/library/pmc/device_providers/amd_smi/provider.hpp
+(AMDSMI_INIT_AMD_NICS flag, ROCM-25722). CI runners do not have AI NIC hardware,
+so the tests run only on systems with AI NIC devices present.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Motivation

AI NIC device enumeration was silently failing when rocprofiler-systems was built from an
official package. The root cause is a regression introduced during the PMC policy-based
design refactor (PR #3703, March 2026): the original `amd_smi::setup()` called
`gpu::initialize_amdsmi()` which passed both `AMDSMI_INIT_AMD_GPUS` and
`AMDSMI_INIT_AMD_NICS` to `amdsmi_init()`. The refactored PMC provider called
`backend::init()` with a default argument of `AMDSMI_INIT_AMD_GPUS` only, dropping the
NIC flag.

Since `amdsmi_init()` uses a ref-count guard — the first call initializes devices and
subsequent calls return success without re-initializing — NIC devices were never populated
regardless of whether a second call with the NIC flag was made later.

## Technical Details

- **`source/lib/backends/amd_smi/backend.hpp`**: Removed the default argument from
  `backend::init()`. Callers must now explicitly pass initialization flags, turning future
  omissions into compile-time errors rather than silent runtime failures.

- **`source/lib/rocprof-sys/library/pmc/device_providers/amd_smi/provider.hpp`**: The
  `provider` constructor now includes `backends/amd_smi/ainic_feature.hpp` and
  conditionally ORs `AMDSMI_INIT_AMD_NICS` into the flags when `AINIC_SUPPORTED` is
  defined (AMD SMI ≥ 26.3 and `ROCPROFSYS_USE_AINIC` enabled), mirroring the existing
  logic in `core/gpu.cpp`.

## JIRA ID

* ROCM-25722

## Test Plan

* Build with `ROCPROFSYS_USE_AINIC=ON` against AMD SMI ≥ 26.3 and verify
  `ROCPROFSYS_BUILD_AINIC=1` is set
* Run rocprofiler-systems against a simulated NIC sysfs and confirm AI NIC devices are
  enumerated
* Verify GPU enumeration is unaffected (no regression)
* Confirm the build fails to compile if any caller of `backend::init()` omits the flags
  argument

## Test Result

Tested against a simulated NIC sysfs on a development system with AMD SMI 26.5. AI NIC
devices are now correctly enumerated. GPU monitoring is unaffected.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.