### PR TITLE
fix(rocjitsu): improve kernel name reporting

### DIFF
--- a/emulation/rocjitsu/docs/race-detector.md
+++ b/emulation/rocjitsu/docs/race-detector.md
@@ -76,7 +76,7 @@ RJ_RACE=1 build/tools/rocjitsu/rocjitsu --config configs/gfx950_cdna4.json -- /t
 You should see output:
 
 ```
-RACE type=LDS reg=508 wave=0 lane=0 wg=0,0,0 conflict=unknown
+RACE kernel=transpose_lds symbol=_Z13transpose_ldsPKiPi dispatch=1 type=LDS reg=508 wave=0 lane=0 wg=0,0,0 conflict=unknown
 Race on LDS byte 508 [workgroup (0, 0, 0), wave 0, lane 0]
   ==>  ds_write_b32 v0, v1  ; <-- wave 1
        v_sub_u32_e32 v1, 0, v0
@@ -84,8 +84,11 @@ Race on LDS byte 508 [workgroup (0, 0, 0), wave 0, lane 0]
 END_RACE
 ```
 
-This tells you that wave 1 wrote to LDS (`ds_write_b32`) and wave 0 read from
-the same address (`ds_read_b32`) without a barrier in between. The fix is to add
+This tells you that dispatch 1 of `transpose_lds` reported a race: wave 1 wrote
+to LDS (`ds_write_b32`) and wave 0 read from the same address (`ds_read_b32`)
+without a barrier in between. The `kernel` field is a compact display name, and
+`symbol` is the exact ELF symbol when rocjitsu can resolve it. If a name cannot
+be resolved, rocjitsu reports `?` for the unresolved field. The fix is to add
 `__syncthreads()` between the write and the read.
 
 ### Running your own application

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_symbol.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_symbol.cpp
@@ -5,6 +5,9 @@
 
 #include "rocjitsu/code/amdgpu_elf.h"
 
+#include <cctype>
+#include <cstdlib>
+#include <cxxabi.h>
 #include <string_view>
 
 namespace rocjitsu {
@@ -133,6 +136,33 @@ std::string find_kernel_symbol(const uint8_t *kernel_object_ptr, const uint8_t *
       return best_name;
   }
   return {};
+}
+
+std::string demangle_kernel_symbol(std::string_view symbol) {
+  if (symbol.empty())
+    return {};
+
+  std::string symbol_string(symbol);
+  int status = 0;
+  char *demangled = abi::__cxa_demangle(symbol_string.c_str(), nullptr, nullptr, &status);
+  if (status != 0 || demangled == nullptr)
+    return symbol_string;
+
+  std::string result(demangled);
+  std::free(demangled);
+  return result;
+}
+
+std::string kernel_display_name(std::string_view symbol) {
+  std::string result = demangle_kernel_symbol(symbol);
+  size_t parenthesis_position = result.find('(');
+  if (parenthesis_position != std::string::npos)
+    result.resize(parenthesis_position);
+  if (result.starts_with("void "))
+    result.erase(0, 5);
+
+  std::erase_if(result, [](unsigned char c) { return std::isspace(c); });
+  return result;
 }
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_symbol.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_symbol.cpp
@@ -20,6 +20,38 @@ bool in_range(const uint8_t *ptr, uint64_t size, const uint8_t *base, uint64_t r
          static_cast<uint64_t>(ptr - base) <= range_size - size;
 }
 
+size_t find_outer_argument_list(std::string_view text) {
+  size_t argument_list = std::string_view::npos;
+  int angle_depth = 0;
+  int parenthesis_depth = 0;
+
+  for (size_t pos = 0; pos < text.size(); ++pos) {
+    switch (text[pos]) {
+    case '<':
+      if (parenthesis_depth == 0)
+        ++angle_depth;
+      break;
+    case '>':
+      if (angle_depth > 0 && parenthesis_depth == 0)
+        --angle_depth;
+      break;
+    case '(':
+      if (angle_depth == 0 && parenthesis_depth == 0)
+        argument_list = pos;
+      ++parenthesis_depth;
+      break;
+    case ')':
+      if (parenthesis_depth > 0)
+        --parenthesis_depth;
+      break;
+    default:
+      break;
+    }
+  }
+
+  return argument_list;
+}
+
 } // namespace
 
 std::string find_kernel_symbol(const uint8_t *kernel_object_ptr, const uint8_t *elf_base,
@@ -166,7 +198,7 @@ std::string demangle_kernel_symbol(std::string_view symbol) {
 
 std::string kernel_display_name(std::string_view symbol) {
   std::string result = demangle_kernel_symbol(symbol);
-  size_t parenthesis_position = result.find('(');
+  size_t parenthesis_position = find_outer_argument_list(result);
   if (parenthesis_position != std::string::npos)
     result.resize(parenthesis_position);
   if (result.starts_with("void "))

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_symbol.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_symbol.cpp
@@ -7,6 +7,7 @@
 
 #include <cctype>
 #include <cstdlib>
+#include <cstring>
 #include <cxxabi.h>
 #include <string_view>
 
@@ -76,21 +77,28 @@ std::string find_kernel_symbol(const uint8_t *kernel_object_ptr, const uint8_t *
       auto *hash = reinterpret_cast<const uint32_t *>(elf_base + hash_off);
       nsyms = hash[1];
     }
+    if (syment < sizeof(Elf64_Sym))
+      break;
     if (nsyms == 0 ||
         !in_range(elf_base + symtab_off, uint64_t{nsyms} * syment, elf_base, elf_accessible))
       break;
     if (!in_range(elf_base + strtab_off, strsz, elf_base, elf_accessible))
       break;
 
-    auto *syms = reinterpret_cast<const Elf64_Sym *>(elf_base + symtab_off);
     auto *strtab = reinterpret_cast<const char *>(elf_base + strtab_off);
 
     for (uint32_t s = 0; s < nsyms; ++s) {
-      if (syms[s].st_value != kd_offset)
+      auto *sym = reinterpret_cast<const Elf64_Sym *>(elf_base + symtab_off + uint64_t{s} * syment);
+      if (sym->st_value != kd_offset)
         continue;
-      if (syms[s].st_name >= strsz)
+      if (sym->st_name >= strsz)
         continue;
-      std::string_view name(strtab + syms[s].st_name);
+      const char *symbol_name = strtab + sym->st_name;
+      size_t max_name_size = strsz - sym->st_name;
+      size_t name_size = strnlen(symbol_name, max_name_size);
+      if (name_size == max_name_size)
+        continue;
+      std::string_view name(symbol_name, name_size);
       if (name.size() > 3 && name.substr(name.size() - 3) == ".kd")
         name = name.substr(0, name.size() - 3);
       if (!name.empty())
@@ -145,8 +153,10 @@ std::string demangle_kernel_symbol(std::string_view symbol) {
   std::string symbol_string(symbol);
   int status = 0;
   char *demangled = abi::__cxa_demangle(symbol_string.c_str(), nullptr, nullptr, &status);
-  if (status != 0 || demangled == nullptr)
+  if (status != 0 || demangled == nullptr) {
+    std::free(demangled);
     return symbol_string;
+  }
 
   std::string result(demangled);
   std::free(demangled);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_symbol.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_symbol.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <cxxabi.h>
+#include <memory>
 #include <string_view>
 
 namespace rocjitsu {
@@ -151,16 +152,16 @@ std::string demangle_kernel_symbol(std::string_view symbol) {
     return {};
 
   std::string symbol_string(symbol);
-  int status = 0;
-  char *demangled = abi::__cxa_demangle(symbol_string.c_str(), nullptr, nullptr, &status);
-  if (status != 0 || demangled == nullptr) {
-    std::free(demangled);
+  if (!symbol_string.starts_with("_Z"))
     return symbol_string;
-  }
 
-  std::string result(demangled);
-  std::free(demangled);
-  return result;
+  int status = 0;
+  std::unique_ptr<char, decltype(&std::free)> demangled(
+      abi::__cxa_demangle(symbol_string.c_str(), nullptr, nullptr, &status), &std::free);
+  if (status != 0 || demangled == nullptr)
+    return symbol_string;
+
+  return std::string(demangled.get());
 }
 
 std::string kernel_display_name(std::string_view symbol) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_symbol.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/code/kernel_symbol.h
@@ -5,6 +5,7 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 
 namespace rocjitsu {
 
@@ -22,5 +23,19 @@ namespace rocjitsu {
 /// @returns Kernel name (without ".kd" suffix), or empty string on failure.
 std::string find_kernel_symbol(const uint8_t *kernel_object_ptr, const uint8_t *elf_base,
                                uint64_t elf_accessible);
+
+/// Return a readable form of a kernel symbol.
+///
+/// C++/HIP kernels usually appear in ELF symbol tables as Itanium ABI mangled
+/// names. This returns the demangled spelling when demangling succeeds, and
+/// the original symbol otherwise.
+std::string demangle_kernel_symbol(std::string_view symbol);
+
+/// Return a compact kernel name suitable for key=value logs.
+///
+/// This strips the demangled argument list and whitespace so report headers can
+/// keep using simple space-delimited fields. The original symbol should be
+/// reported separately when exact identity matters.
+std::string kernel_display_name(std::string_view symbol);
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -31,6 +31,7 @@ RJ_DIAGNOSTIC_POP
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <sys/mman.h>
 #include <thread>
 
@@ -70,6 +71,10 @@ struct PlannedWorkgroup {
 };
 
 uint32_t nonzero_or_one(uint32_t v) { return v == 0 ? 1 : v; }
+
+std::string unknown_if_empty(std::string_view value) {
+  return value.empty() ? "?" : std::string(value);
+}
 
 uint32_t checked_ext_dispatch_grid_size(uint32_t cluster_count, uint32_t cluster_size,
                                         uint32_t workgroup_size, const char *axis) {
@@ -1261,7 +1266,7 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
       cu->flush_all(queue.process_id);
   }
 
-  std::string kernel_sym;
+  std::string kernel_symbol;
   if (host_accessible && memory_) {
     auto [range_base, range_size] = memory_->find_host_range(pkt.kernel_object, queue.process_id);
     auto *mapped_page = memory_->resolve_host_ptr(pkt.kernel_object, queue.process_id);
@@ -1271,17 +1276,21 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
       auto *elf = find_elf_base(ko, range_start);
       if (elf) {
         uint64_t accessible = range_size - static_cast<uint64_t>(elf - range_start);
-        kernel_sym = find_kernel_symbol(ko, elf, accessible);
+        kernel_symbol = find_kernel_symbol(ko, elf, accessible);
       }
     }
   }
+  std::string kernel_name = kernel_display_name(kernel_symbol);
+  std::string kernel_name_log = unknown_if_empty(kernel_name);
+  std::string kernel_symbol_log = unknown_if_empty(kernel_symbol);
   ++total_dispatched_;
 
   KernelDispatchInfo dispatch_info{};
   dispatch_info.dispatch_id = dp.dispatch_id;
   dispatch_info.kernel_object = pkt.kernel_object;
   dispatch_info.entry_pc = entry_pc;
-  dispatch_info.kernel_name = kernel_sym;
+  dispatch_info.kernel_symbol = kernel_symbol;
+  dispatch_info.kernel_name = kernel_name;
   dispatch_info.grid_size_x = pkt.grid_size_x;
   dispatch_info.grid_size_y = pkt.grid_size_y;
   dispatch_info.grid_size_z = pkt.grid_size_z;
@@ -1295,18 +1304,18 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   plugin_group_->onAmdgpuDispatchPacketProcessed(dispatch_info);
 
   util::Logger::vm([&](auto &os) {
-    os << std::format("dispatch #{} d={} \"{}\" grid=[{},{},{}] wg=[{},{},{}] wgs={} "
+    os << std::format("dispatch #{} d={} \"{}\" symbol=\"{}\" grid=[{},{},{}] wg=[{},{},{}] wgs={} "
                       "lds={} mode={} sgpr={} vgpr={} sig={:#x}",
-                      total_dispatched_, dp.dispatch_id, kernel_sym.empty() ? "?" : kernel_sym,
+                      total_dispatched_, dp.dispatch_id, kernel_name_log, kernel_symbol_log,
                       pkt.grid_size_x, pkt.grid_size_y, pkt.grid_size_z, pkt.workgroup_size_x,
                       pkt.workgroup_size_y, pkt.workgroup_size_z, total_wgs,
                       kd.group_segment_fixed_size, dp.wgp_mode ? "WGP" : "CU", dp.sgprs_per_wf,
                       dp.vgprs_per_wf, dp.completion_signal);
   });
   util::Logger::cp([&](auto &os) {
-    os << std::format("DISPATCH #{} d={} \"{}\" wgs={} wfs/wg={} sig={:#x} pid={} ko={:#x} pc={:#x}"
-                      " kernarg={:#x} user_sgprs={}",
-                      total_dispatched_, dp.dispatch_id, kernel_sym.empty() ? "?" : kernel_sym,
+    os << std::format("DISPATCH #{} d={} \"{}\" symbol=\"{}\" wgs={} wfs/wg={} sig={:#x} pid={} "
+                      "ko={:#x} pc={:#x} kernarg={:#x} user_sgprs={}",
+                      total_dispatched_, dp.dispatch_id, kernel_name_log, kernel_symbol_log,
                       total_wgs, wfs_per_wg, dp.completion_signal, dp.process_id, pkt.kernel_object,
                       entry_pc, dp.kernarg_addr, dp.num_user_sgprs);
     if (memory_) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1270,8 +1270,7 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   if (host_accessible && memory_) {
     auto [host_range_base, host_range_size] =
         memory_->find_host_range(pkt.kernel_object, queue.process_id);
-    auto *kernel_object_page =
-        memory_->resolve_host_ptr(pkt.kernel_object, queue.process_id);
+    auto *kernel_object_page = memory_->resolve_host_ptr(pkt.kernel_object, queue.process_id);
     if (host_range_base != 0 && kernel_object_page) {
       auto *kernel_object_host_ptr =
           kernel_object_page + (pkt.kernel_object & GpuMemory::PAGE_MASK);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -1268,15 +1268,19 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
 
   std::string kernel_symbol;
   if (host_accessible && memory_) {
-    auto [range_base, range_size] = memory_->find_host_range(pkt.kernel_object, queue.process_id);
-    auto *mapped_page = memory_->resolve_host_ptr(pkt.kernel_object, queue.process_id);
-    if (range_base != 0 && mapped_page) {
-      auto *ko = mapped_page + (pkt.kernel_object & GpuMemory::PAGE_MASK);
-      auto *range_start = reinterpret_cast<const uint8_t *>(range_base);
-      auto *elf = find_elf_base(ko, range_start);
-      if (elf) {
-        uint64_t accessible = range_size - static_cast<uint64_t>(elf - range_start);
-        kernel_symbol = find_kernel_symbol(ko, elf, accessible);
+    auto [host_range_base, host_range_size] =
+        memory_->find_host_range(pkt.kernel_object, queue.process_id);
+    auto *kernel_object_page =
+        memory_->resolve_host_ptr(pkt.kernel_object, queue.process_id);
+    if (host_range_base != 0 && kernel_object_page) {
+      auto *kernel_object_host_ptr =
+          kernel_object_page + (pkt.kernel_object & GpuMemory::PAGE_MASK);
+      auto *host_range_begin = reinterpret_cast<const uint8_t *>(host_range_base);
+      auto *elf_base = find_elf_base(kernel_object_host_ptr, host_range_begin);
+      if (elf_base) {
+        uint64_t elf_accessible =
+            host_range_size - static_cast<uint64_t>(elf_base - host_range_begin);
+        kernel_symbol = find_kernel_symbol(kernel_object_host_ptr, elf_base, elf_accessible);
       }
     }
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/command_processor.cpp
@@ -31,7 +31,6 @@ RJ_DIAGNOSTIC_POP
 #include <optional>
 #include <stdexcept>
 #include <string>
-#include <string_view>
 #include <sys/mman.h>
 #include <thread>
 
@@ -71,10 +70,6 @@ struct PlannedWorkgroup {
 };
 
 uint32_t nonzero_or_one(uint32_t v) { return v == 0 ? 1 : v; }
-
-std::string unknown_if_empty(std::string_view value) {
-  return value.empty() ? "?" : std::string(value);
-}
 
 uint32_t checked_ext_dispatch_grid_size(uint32_t cluster_count, uint32_t cluster_size,
                                         uint32_t workgroup_size, const char *axis) {
@@ -1284,8 +1279,6 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
     }
   }
   std::string kernel_name = kernel_display_name(kernel_symbol);
-  std::string kernel_name_log = unknown_if_empty(kernel_name);
-  std::string kernel_symbol_log = unknown_if_empty(kernel_symbol);
   ++total_dispatched_;
 
   KernelDispatchInfo dispatch_info{};
@@ -1309,18 +1302,20 @@ void CommandProcessor::process_aql_packet(const hsa_kernel_dispatch_packet_t &pk
   util::Logger::vm([&](auto &os) {
     os << std::format("dispatch #{} d={} \"{}\" symbol=\"{}\" grid=[{},{},{}] wg=[{},{},{}] wgs={} "
                       "lds={} mode={} sgpr={} vgpr={} sig={:#x}",
-                      total_dispatched_, dp.dispatch_id, kernel_name_log, kernel_symbol_log,
-                      pkt.grid_size_x, pkt.grid_size_y, pkt.grid_size_z, pkt.workgroup_size_x,
-                      pkt.workgroup_size_y, pkt.workgroup_size_z, total_wgs,
-                      kd.group_segment_fixed_size, dp.wgp_mode ? "WGP" : "CU", dp.sgprs_per_wf,
-                      dp.vgprs_per_wf, dp.completion_signal);
+                      total_dispatched_, dp.dispatch_id, dispatch_info.kernelNameOrUnknown(),
+                      dispatch_info.kernelSymbolOrUnknown(), pkt.grid_size_x, pkt.grid_size_y,
+                      pkt.grid_size_z, pkt.workgroup_size_x, pkt.workgroup_size_y,
+                      pkt.workgroup_size_z, total_wgs, kd.group_segment_fixed_size,
+                      dp.wgp_mode ? "WGP" : "CU", dp.sgprs_per_wf, dp.vgprs_per_wf,
+                      dp.completion_signal);
   });
   util::Logger::cp([&](auto &os) {
     os << std::format("DISPATCH #{} d={} \"{}\" symbol=\"{}\" wgs={} wfs/wg={} sig={:#x} pid={} "
                       "ko={:#x} pc={:#x} kernarg={:#x} user_sgprs={}",
-                      total_dispatched_, dp.dispatch_id, kernel_name_log, kernel_symbol_log,
-                      total_wgs, wfs_per_wg, dp.completion_signal, dp.process_id, pkt.kernel_object,
-                      entry_pc, dp.kernarg_addr, dp.num_user_sgprs);
+                      total_dispatched_, dp.dispatch_id, dispatch_info.kernelNameOrUnknown(),
+                      dispatch_info.kernelSymbolOrUnknown(), total_wgs, wfs_per_wg,
+                      dp.completion_signal, dp.process_id, pkt.kernel_object, entry_pc,
+                      dp.kernarg_addr, dp.num_user_sgprs);
     if (memory_) {
       auto *ko_ptr = memory_->translate_debug(pkt.kernel_object, queue.process_id);
       auto *pc_ptr = memory_->translate_debug(entry_pc, queue.process_id);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -51,8 +51,6 @@ public:
     });
   }
 
-  using SparseMemory::find_host_range;
-
   simdojo::Port *cpl_port() { return cpl_; }
 
   /// @brief Register a process's page table in the VMID table.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/gpu_memory.h
@@ -51,6 +51,8 @@ public:
     });
   }
 
+  using SparseMemory::find_host_range;
+
   simdojo::Port *cpl_port() { return cpl_; }
 
   /// @brief Register a process's page table in the VMID table.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/kernel_dispatch_info.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/kernel_dispatch_info.h
@@ -13,6 +13,7 @@ struct KernelDispatchInfo {
   uint32_t dispatch_id = 0;
   uint64_t kernel_object = 0;
   uint64_t entry_pc = 0;
+  std::string kernel_symbol;
   std::string kernel_name;
   uint32_t grid_size_x = 0, grid_size_y = 0, grid_size_z = 0;
   uint32_t workgroup_size_x = 0, workgroup_size_y = 0, workgroup_size_z = 0;
@@ -20,6 +21,9 @@ struct KernelDispatchInfo {
   uint32_t wfs_per_workgroup = 0;
   uint32_t sgprs_per_wf = 0;
   uint32_t vgprs_per_wf = 0;
+
+  std::string kernelNameOrUnknown() const { return kernel_name.empty() ? "?" : kernel_name; }
+  std::string kernelSymbolOrUnknown() const { return kernel_symbol.empty() ? "?" : kernel_symbol; }
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/kernel_dispatch_info.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/kernel_dispatch_info.h
@@ -8,6 +8,8 @@
 
 namespace rocjitsu {
 
+inline constexpr char kUnknownKernelIdentity[] = "?";
+
 /// @brief Metadata for an AMDGPU kernel dispatch, passed to plugins.
 struct KernelDispatchInfo {
   uint32_t dispatch_id = 0;
@@ -22,8 +24,12 @@ struct KernelDispatchInfo {
   uint32_t sgprs_per_wf = 0;
   uint32_t vgprs_per_wf = 0;
 
-  std::string kernelNameOrUnknown() const { return kernel_name.empty() ? "?" : kernel_name; }
-  std::string kernelSymbolOrUnknown() const { return kernel_symbol.empty() ? "?" : kernel_symbol; }
+  std::string kernelNameOrUnknown() const {
+    return kernel_name.empty() ? kUnknownKernelIdentity : kernel_name;
+  }
+  std::string kernelSymbolOrUnknown() const {
+    return kernel_symbol.empty() ? kUnknownKernelIdentity : kernel_symbol;
+  }
 };
 
 } // namespace rocjitsu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/profiled_execution_plugin_group.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/profiled_execution_plugin_group.h
@@ -167,7 +167,8 @@ private:
   }
 
   void print_profile_summary() {
-    const char *kname = current_kernel_name_.empty() ? "?" : current_kernel_name_.c_str();
+    const char *kname =
+        current_kernel_name_.empty() ? kUnknownKernelIdentity : current_kernel_name_.c_str();
     sink().write(std::format("HOOK_PROFILE --- {} ---\n", kname));
     auto print_hook = [this](const char *name, const HookProfile &p) {
       if (p.count == 0)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
@@ -173,8 +173,10 @@ std::string RaceDetectorPlugin::getSummary() const {
 
 void RaceDetectorPlugin::onAmdgpuDispatchPacketProcessed(const KernelDispatchInfo &info) {
   std::lock_guard<std::mutex> lock(report_mutex_);
-  sink().write(std::format("[rocjitsu] Kernel dispatch: \"{}\"\n",
-                           info.kernel_name.empty() ? "?" : info.kernel_name));
+  KernelNames kernel_names{info.kernelNameOrUnknown(), info.kernelSymbolOrUnknown()};
+  dispatch_kernel_names_[info.dispatch_id] = kernel_names;
+  sink().write(std::format("[rocjitsu] Kernel dispatch: \"{}\" symbol=\"{}\"\n", kernel_names.name,
+                           kernel_names.symbol));
 }
 
 void RaceDetectorPlugin::onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint32_t wg_id,
@@ -229,9 +231,16 @@ void RaceDetectorPlugin::onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint3
         const char *space = v.space == RaceViolation::Space::VGPR   ? "VGPR"
                             : v.space == RaceViolation::Space::SGPR ? "SGPR"
                                                                     : "LDS";
-        sink().write(std::format(
-            "RACE type={} reg={} wave={} lane={} wg={},{},{} conflict=unknown\n{}END_RACE\n", space,
-            v.index, v.wave, v.lane, v.workgroupId.x, v.workgroupId.y, v.workgroupId.z, oss.str()));
+        auto kernel_name_iter = dispatch_kernel_names_.find(dispatch_id);
+        const KernelNames kernel_names = kernel_name_iter == dispatch_kernel_names_.end()
+                                             ? KernelNames{"?", "?"}
+                                             : kernel_name_iter->second;
+        sink().write(
+            std::format("RACE kernel={} symbol={} dispatch={} type={} reg={} wave={} lane={} "
+                        "wg={},{},{} "
+                        "conflict=unknown\n{}END_RACE\n",
+                        kernel_names.name, kernel_names.symbol, dispatch_id, space, v.index, v.wave,
+                        v.lane, v.workgroupId.x, v.workgroupId.y, v.workgroupId.z, oss.str()));
       }
     }
   };

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
@@ -232,9 +232,10 @@ void RaceDetectorPlugin::onAmdgpuWorkgroupDispatched(uint32_t dispatch_id, uint3
                             : v.space == RaceViolation::Space::SGPR ? "SGPR"
                                                                     : "LDS";
         auto kernel_name_iter = dispatch_kernel_names_.find(dispatch_id);
-        const KernelNames kernel_names = kernel_name_iter == dispatch_kernel_names_.end()
-                                             ? KernelNames{"?", "?"}
-                                             : kernel_name_iter->second;
+        const KernelNames kernel_names =
+            kernel_name_iter == dispatch_kernel_names_.end()
+                ? KernelNames{kUnknownKernelIdentity, kUnknownKernelIdentity}
+                : kernel_name_iter->second;
         sink().write(
             std::format("RACE kernel={} symbol={} dispatch={} type={} reg={} wave={} lane={} "
                         "wg={},{},{} "

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
@@ -16,6 +16,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <unordered_map>
 
@@ -125,6 +126,11 @@ private:
     }
   };
 
+  struct KernelNames {
+    std::string name;
+    std::string symbol;
+  };
+
   RaceWavefrontState *get_state(const amdgpu::Wavefront &wf) {
     return static_cast<RaceWavefrontState *>(wf.plugin_state(slot_index()));
   }
@@ -138,6 +144,7 @@ private:
 
   std::mutex report_mutex_;
   std::set<std::pair<uint32_t, uint64_t>> observed_races_;
+  std::unordered_map<uint32_t, KernelNames> dispatch_kernel_names_;
 };
 
 } // namespace rocjitsu::plugins::race_detector

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
@@ -16,7 +16,6 @@
 #include <optional>
 #include <set>
 #include <string>
-#include <string_view>
 #include <tuple>
 #include <unordered_map>
 

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -396,26 +396,9 @@ TEST(RdnaDispatchTest, WgpModeRequiresConfiguredSiblingCuPair) {
   EXPECT_THROW((void)f.engine->step(), std::runtime_error);
 }
 
-TEST(GpuMemoryTest, FindHostRangeUsesVmidPageTable) {
-  amdgpu::GpuMemory mem("vmid_range_mem");
-  KfdProcess process(/*process_id=*/123);
-  std::vector<uint8_t> backing(3 * amdgpu::GpuMemory::PAGE_SIZE);
-  constexpr uint64_t gpu_va = 0x100000;
-
-  mem.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_);
-  process.map_pages(gpu_va, backing.data(), backing.size());
-
-  auto [host_base, size] =
-      mem.find_host_range(gpu_va + amdgpu::GpuMemory::PAGE_SIZE + 0x123, process.process_id());
-  EXPECT_EQ(host_base, reinterpret_cast<uint64_t>(backing.data()));
-  EXPECT_EQ(size, backing.size());
-
-  mem.unregister_process(process.process_id());
-}
-
 TEST(GpuMemoryTest, VmidMappedKernelSymbolUsesTranslatedHostPointer) {
   amdgpu::GpuMemory mem("vmid_kernel_symbol_mem");
-  KfdProcess process(/*process_id=*/124);
+  KfdProcess process(/*process_id=*/125);
   constexpr uint64_t gpu_va = 0x5400200000;
   constexpr uint64_t kernel_descriptor_offset = 0x800;
   auto image = make_loaded_kernel_symbol_elf(kernel_descriptor_offset, "vmid_kernel.kd");
@@ -426,6 +409,10 @@ TEST(GpuMemoryTest, VmidMappedKernelSymbolUsesTranslatedHostPointer) {
   uint64_t kernel_object = gpu_va + kernel_descriptor_offset;
   auto [host_base, host_size] = mem.find_host_range(kernel_object, process.process_id());
   ASSERT_NE(host_base, 0u);
+
+  // Kernel descriptors arrive as GPU VAs. Symbol lookup needs the translated
+  // host pointer so pointer subtraction against the loaded ELF image produces
+  // the descriptor offset recorded in .dynsym.
   auto *mapped_page = mem.translate_debug(kernel_object, process.process_id());
   ASSERT_NE(mapped_page, nullptr);
   auto *kernel_object_host = mapped_page + (kernel_object & amdgpu::GpuMemory::PAGE_MASK);

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -171,7 +171,8 @@ void step_until_halted(simdojo::SimulationEngine &engine,
 }
 
 std::vector<uint8_t> make_loaded_kernel_symbol_elf(uint64_t kernel_descriptor_offset,
-                                                   std::string_view symbol_name) {
+                                                   std::string_view symbol_name,
+                                                   bool include_symbol_terminator = true) {
   constexpr uint64_t dyn_offset = 0x100;
   constexpr uint64_t symtab_offset = 0x200;
   constexpr uint64_t strtab_offset = 0x300;
@@ -204,7 +205,7 @@ std::vector<uint8_t> make_loaded_kernel_symbol_elf(uint64_t kernel_descriptor_of
   dyn[1].d_tag = DT_STRTAB;
   dyn[1].d_un.d_val = strtab_offset;
   dyn[2].d_tag = DT_STRSZ;
-  dyn[2].d_un.d_val = symbol_name.size() + 2;
+  dyn[2].d_un.d_val = 1 + symbol_name.size() + (include_symbol_terminator ? 1 : 0);
   dyn[3].d_tag = DT_HASH;
   dyn[3].d_un.d_val = hash_offset;
   dyn[4].d_tag = DT_NULL;
@@ -220,6 +221,17 @@ std::vector<uint8_t> make_loaded_kernel_symbol_elf(uint64_t kernel_descriptor_of
   hash[1] = 2; // nchain: null symbol + kernel descriptor symbol.
 
   return image;
+}
+
+TEST(KernelSymbolTest, RejectsDynstrSymbolWithoutTerminator) {
+  constexpr uint64_t kernel_descriptor_offset = 0x800;
+  constexpr std::string_view symbol_name = "unterminated_kernel.kd";
+  auto image = make_loaded_kernel_symbol_elf(kernel_descriptor_offset, symbol_name,
+                                             /*include_symbol_terminator=*/false);
+
+  EXPECT_TRUE(
+      find_kernel_symbol(image.data() + kernel_descriptor_offset, image.data(), image.size())
+          .empty());
 }
 
 TEST(GpuMemoryTest, ReadWriteRoundTrip) {

--- a/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
+++ b/emulation/rocjitsu/tests/amdgpu_vm_test.cpp
@@ -5,6 +5,8 @@
 #include "halt_snapshot_plugin.h"
 
 #include "embedded_schema.h"
+#include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/kernel_symbol.h"
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/isa/arch/amdgpu/cdna4/vop3p.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
@@ -166,6 +168,58 @@ void step_until_halted(simdojo::SimulationEngine &engine,
     else if (saw_work)
       break;
   }
+}
+
+std::vector<uint8_t> make_loaded_kernel_symbol_elf(uint64_t kernel_descriptor_offset,
+                                                   std::string_view symbol_name) {
+  constexpr uint64_t dyn_offset = 0x100;
+  constexpr uint64_t symtab_offset = 0x200;
+  constexpr uint64_t strtab_offset = 0x300;
+  constexpr uint64_t hash_offset = 0x380;
+
+  std::vector<uint8_t> image(4096, 0);
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
+  ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  ehdr.e_type = ET_DYN;
+  ehdr.e_machine = EM_AMDGPU;
+  ehdr.e_version = 1;
+  ehdr.e_phoff = sizeof(Elf64_Ehdr);
+  ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  ehdr.e_phentsize = sizeof(Elf64_Phdr);
+  ehdr.e_phnum = 1;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  Elf64_Phdr phdr{};
+  phdr.p_type = PT_DYNAMIC;
+  phdr.p_vaddr = dyn_offset;
+  phdr.p_memsz = 5 * sizeof(Elf64_Dyn);
+  std::memcpy(image.data() + ehdr.e_phoff, &phdr, sizeof(phdr));
+
+  auto *dyn = reinterpret_cast<Elf64_Dyn *>(image.data() + dyn_offset);
+  dyn[0].d_tag = DT_SYMTAB;
+  dyn[0].d_un.d_val = symtab_offset;
+  dyn[1].d_tag = DT_STRTAB;
+  dyn[1].d_un.d_val = strtab_offset;
+  dyn[2].d_tag = DT_STRSZ;
+  dyn[2].d_un.d_val = symbol_name.size() + 2;
+  dyn[3].d_tag = DT_HASH;
+  dyn[3].d_un.d_val = hash_offset;
+  dyn[4].d_tag = DT_NULL;
+
+  image[strtab_offset] = '\0';
+  std::memcpy(image.data() + strtab_offset + 1, symbol_name.data(), symbol_name.size());
+
+  auto *sym = reinterpret_cast<Elf64_Sym *>(image.data() + symtab_offset);
+  sym[1].st_name = 1;
+  sym[1].st_value = kernel_descriptor_offset;
+
+  auto *hash = reinterpret_cast<uint32_t *>(image.data() + hash_offset);
+  hash[1] = 2; // nchain: null symbol + kernel descriptor symbol.
+
+  return image;
 }
 
 TEST(GpuMemoryTest, ReadWriteRoundTrip) {
@@ -340,6 +394,48 @@ TEST(RdnaDispatchTest, WgpModeRequiresConfiguredSiblingCuPair) {
   queue.dispatch(ko, 64, 64);
 
   EXPECT_THROW((void)f.engine->step(), std::runtime_error);
+}
+
+TEST(GpuMemoryTest, FindHostRangeUsesVmidPageTable) {
+  amdgpu::GpuMemory mem("vmid_range_mem");
+  KfdProcess process(/*process_id=*/123);
+  std::vector<uint8_t> backing(3 * amdgpu::GpuMemory::PAGE_SIZE);
+  constexpr uint64_t gpu_va = 0x100000;
+
+  mem.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_);
+  process.map_pages(gpu_va, backing.data(), backing.size());
+
+  auto [host_base, size] =
+      mem.find_host_range(gpu_va + amdgpu::GpuMemory::PAGE_SIZE + 0x123, process.process_id());
+  EXPECT_EQ(host_base, reinterpret_cast<uint64_t>(backing.data()));
+  EXPECT_EQ(size, backing.size());
+
+  mem.unregister_process(process.process_id());
+}
+
+TEST(GpuMemoryTest, VmidMappedKernelSymbolUsesTranslatedHostPointer) {
+  amdgpu::GpuMemory mem("vmid_kernel_symbol_mem");
+  KfdProcess process(/*process_id=*/124);
+  constexpr uint64_t gpu_va = 0x5400200000;
+  constexpr uint64_t kernel_descriptor_offset = 0x800;
+  auto image = make_loaded_kernel_symbol_elf(kernel_descriptor_offset, "vmid_kernel.kd");
+
+  mem.register_process(process.process_id(), &process.page_table_, &process.page_table_mutex_);
+  process.map_pages(gpu_va, image.data(), image.size());
+
+  uint64_t kernel_object = gpu_va + kernel_descriptor_offset;
+  auto [host_base, host_size] = mem.find_host_range(kernel_object, process.process_id());
+  ASSERT_NE(host_base, 0u);
+  auto *mapped_page = mem.translate_debug(kernel_object, process.process_id());
+  ASSERT_NE(mapped_page, nullptr);
+  auto *kernel_object_host = mapped_page + (kernel_object & amdgpu::GpuMemory::PAGE_MASK);
+
+  EXPECT_NE(reinterpret_cast<uint64_t>(kernel_object_host), kernel_object);
+  EXPECT_EQ(find_kernel_symbol(kernel_object_host, reinterpret_cast<const uint8_t *>(host_base),
+                               host_size),
+            "vmid_kernel");
+
+  mem.unregister_process(process.process_id());
 }
 
 TEST(VmLifecycleTest, CreateAndDestroy) {

--- a/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
+++ b/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
@@ -254,6 +254,11 @@ TEST(KernelSymbolTest, DisplayNameIsHeaderSafe) {
       "Cijk_Ailk_Bjlk_S_B_UserArgs_MT8x8x8_SN_LDSB0_ISA1151_WG8_8_1_WGMXCC1";
 
   EXPECT_EQ(kernel_display_name("_Z11racy_kernelPKfPf"), "racy_kernel");
+
+  // This is a fixture for a real-world HIP/Clang-style nested template symbol.
+  // The important behavior is that display names keep useful template context
+  // while stripping the argument list and whitespace that would break the
+  // race-detector's space-delimited log headers.
   EXPECT_EQ(kernel_display_name("_ZN2at6native29vectorized_elementwise_kernelILi4ENS0_"
                                 "15CUDAFunctor_addIfEESt5arrayIPcLm3EEEEviT0_T1_"),
             "at::native::vectorized_elementwise_kernel<4,at::native::CUDAFunctor_add<float>,std::"

--- a/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
+++ b/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
@@ -250,12 +250,16 @@ TEST(KernelSymbolTest, DemanglesMangledKernelSymbol) {
 }
 
 TEST(KernelSymbolTest, DisplayNameIsHeaderSafe) {
+  constexpr std::string_view tensile_symbol =
+      "Cijk_Ailk_Bjlk_S_B_UserArgs_MT8x8x8_SN_LDSB0_ISA1151_WG8_8_1_WGMXCC1";
+
   EXPECT_EQ(kernel_display_name("_Z11racy_kernelPKfPf"), "racy_kernel");
   EXPECT_EQ(kernel_display_name("_ZN2at6native29vectorized_elementwise_kernelILi4ENS0_"
                                 "15CUDAFunctor_addIfEESt5arrayIPcLm3EEEEviT0_T1_"),
             "at::native::vectorized_elementwise_kernel<4,at::native::CUDAFunctor_add<float>,std::"
             "array<char*,3ul>>");
   EXPECT_EQ(kernel_display_name("__amd_rocclr_copyBuffer"), "__amd_rocclr_copyBuffer");
+  EXPECT_EQ(kernel_display_name(tensile_symbol), tensile_symbol);
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
+++ b/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
@@ -17,6 +17,7 @@
 // \NPI new GPU: extend these tests with its MACH/triple -> target mapping.
 #include "rocjitsu/code/amdgpu_code_object.h"
 #include "rocjitsu/code/amdgpu_elf.h"
+#include "rocjitsu/code/kernel_symbol.h"
 #include "rocjitsu/code/rj_code.h"
 
 #include <gtest/gtest.h>
@@ -242,6 +243,19 @@ TEST(GfxCodeObjectTargets, CApiAcceptsGfx1201ForBasicBlockList) {
 
 TEST(GfxCodeObjectTargets, CApiAcceptsGfx1250ForBasicBlockList) {
   expect_c_api_accepts_target(EF_AMDGPU_MACH_AMDGCN_GFX1250, ROCJITSU_CODE_TARGET_GFX1250);
+}
+
+TEST(KernelSymbolTest, DemanglesMangledKernelSymbol) {
+  EXPECT_EQ(demangle_kernel_symbol("_Z11racy_kernelPKfPf"), "racy_kernel(float const*, float*)");
+}
+
+TEST(KernelSymbolTest, DisplayNameIsHeaderSafe) {
+  EXPECT_EQ(kernel_display_name("_Z11racy_kernelPKfPf"), "racy_kernel");
+  EXPECT_EQ(kernel_display_name("_ZN2at6native29vectorized_elementwise_kernelILi4ENS0_"
+                                "15CUDAFunctor_addIfEESt5arrayIPcLm3EEEEviT0_T1_"),
+            "at::native::vectorized_elementwise_kernel<4,at::native::CUDAFunctor_add<float>,std::"
+            "array<char*,3ul>>");
+  EXPECT_EQ(kernel_display_name("__amd_rocclr_copyBuffer"), "__amd_rocclr_copyBuffer");
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
+++ b/emulation/rocjitsu/tests/code/code_object_target_id_test.cpp
@@ -263,6 +263,8 @@ TEST(KernelSymbolTest, DisplayNameIsHeaderSafe) {
                                 "15CUDAFunctor_addIfEESt5arrayIPcLm3EEEEviT0_T1_"),
             "at::native::vectorized_elementwise_kernel<4,at::native::CUDAFunctor_add<float>,std::"
             "array<char*,3ul>>");
+  EXPECT_EQ(kernel_display_name("_ZN12_GLOBAL__N_16kernelEPf"), "(anonymousnamespace)::kernel");
+  EXPECT_EQ(kernel_display_name("_Z3fooIPFviEEvv"), "foo<void(*)(int)>");
   EXPECT_EQ(kernel_display_name("__amd_rocclr_copyBuffer"), "__amd_rocclr_copyBuffer");
   EXPECT_EQ(kernel_display_name(tensile_symbol), tensile_symbol);
 }

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -914,8 +914,9 @@ TEST(ExecutionPluginTest, DispatchPacketNameResolvesForVmidMappedCodeObject) {
   packet.kernel_object = code_object_va + kernel_descriptor_offset;
   std::memcpy(ring.data(), &packet, sizeof(packet));
 
+  constexpr uint32_t queue_id = 7;
   amdgpu::HwQueue queue{};
-  queue.queue_id = 7;
+  queue.queue_id = queue_id;
   queue.process_id = process_id;
   queue.ring_base_va = ring_va;
   queue.ring_size = static_cast<uint32_t>(ring.size());
@@ -930,12 +931,17 @@ TEST(ExecutionPluginTest, DispatchPacketNameResolvesForVmidMappedCodeObject) {
   auto it = std::find_if(plugin->events.begin(), plugin->events.end(), [](const HookEvent &event) {
     return event.kind == HookEvent::DISPATCH_PACKET_PROCESSED;
   });
-  ASSERT_NE(it, plugin->events.end());
-  EXPECT_EQ(it->kernel_name, "vmid_dispatch_kernel");
-  EXPECT_EQ(it->kernel_symbol, "vmid_dispatch_kernel");
+  bool found_dispatch = it != plugin->events.end();
+  std::string kernel_name = found_dispatch ? it->kernel_name : "";
+  std::string kernel_symbol = found_dispatch ? it->kernel_symbol : "";
 
+  f.cp()->unregister_queue(queue_id, process_id);
   f.shutdown();
   f.mem->unregister_process(process_id);
+
+  ASSERT_TRUE(found_dispatch);
+  EXPECT_EQ(kernel_name, "vmid_dispatch_kernel");
+  EXPECT_EQ(kernel_symbol, "vmid_dispatch_kernel");
 }
 
 // -- Ordering tests ----------------------------------------------------------

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -7,11 +7,13 @@
 #include "aql_queue.h"
 
 #include "embedded_schema.h"
+#include "rocjitsu/code/amdgpu_elf.h"
 #include "rocjitsu/code/rj_code.h"
 #include "rocjitsu/config/config_loader.h"
 #include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
 #include "rocjitsu/isa/decoder.h"
 #include "rocjitsu/isa/instruction.h"
+#include "rocjitsu/kmd/linux/kfd_process.h"
 #include "rocjitsu/vm/amdgpu/compute_unit.h"
 #include "rocjitsu/vm/amdgpu/gpu_memory.h"
 #include "rocjitsu/vm/amdgpu/l2_cache.h"
@@ -25,6 +27,8 @@ RJ_DIAGNOSTIC_IGNORE_PEDANTIC
 #include "hsa/AMDHSAKernelDescriptor.h"
 RJ_DIAGNOSTIC_POP
 
+#include "rocjitsu/vm/plugins/execution_plugin_group.h"
+#include "rocjitsu/vm/plugins/plugin_sink.h"
 #include "rocjitsu/vm/plugins/race_detector/plugin.h"
 
 #include <gtest/gtest.h>
@@ -32,11 +36,13 @@ RJ_DIAGNOSTIC_POP
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <format>
 #include <map>
 #include <memory>
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace {
@@ -108,6 +114,8 @@ struct HookEvent {
   uint8_t byte_mask = 0;
   uint64_t pc = 0;
   std::string mnemonic;
+  std::string kernel_name;
+  std::string kernel_symbol;
 };
 
 /// A plugin that records an ordered event log for ordering assertions.
@@ -123,6 +131,8 @@ public:
   void onAmdgpuDispatchPacketProcessed(const KernelDispatchInfo &info) override {
     HookEvent e{HookEvent::DISPATCH_PACKET_PROCESSED};
     e.dispatch_id = info.dispatch_id;
+    e.kernel_name = info.kernel_name;
+    e.kernel_symbol = info.kernel_symbol;
     events.push_back(e);
   }
 
@@ -592,6 +602,9 @@ struct Wave32PluginFixture {
   }
 };
 
+std::vector<uint8_t> make_loaded_kernel_symbol_elf(uint64_t kernel_descriptor_offset,
+                                                   std::string_view symbol_name);
+
 TEST(ExecutionPluginTest, NoPluginNoCrash) {
   PluginFixture f;
   const uint32_t code[] = {S_NOP, S_ENDPGM};
@@ -860,6 +873,71 @@ TEST(ExecutionPluginTest, MfmaFastPathReadHookReportsRace) {
   }
 }
 
+TEST(ExecutionPluginTest, DispatchPacketNameResolvesForVmidMappedCodeObject) {
+  PluginFixture f;
+  auto *plugin = f.attach_ordering_plugin();
+
+  constexpr uint32_t process_id = 123;
+  constexpr uint64_t code_object_va = 0x5400200000;
+  constexpr uint64_t kernel_descriptor_offset = 0x800;
+  auto image = make_loaded_kernel_symbol_elf(kernel_descriptor_offset, "vmid_dispatch_kernel.kd");
+  std::vector<uint8_t> image_backing(image.size() + amdgpu::GpuMemory::PAGE_SIZE, 0);
+  auto image_host = reinterpret_cast<uint8_t *>(
+      (reinterpret_cast<uintptr_t>(image_backing.data()) + amdgpu::GpuMemory::PAGE_MASK) &
+      ~static_cast<uintptr_t>(amdgpu::GpuMemory::PAGE_MASK));
+  std::memcpy(image_host, image.data(), image.size());
+
+  KfdProcess process(process_id);
+  f.mem->register_process(process_id, &process.page_table_, &process.page_table_mutex_);
+  process.map_pages(code_object_va, image_host, image.size());
+
+  std::vector<uint8_t> ring(4096, 0);
+  std::array<uint8_t, 4096> queue_state{};
+  *reinterpret_cast<uint64_t *>(queue_state.data()) = 0;
+  *reinterpret_cast<uint64_t *>(queue_state.data() + 8) = 1;
+  uint64_t doorbell = 0;
+  constexpr uint64_t ring_va = 0x6100000000;
+  constexpr uint64_t read_ptr_va = 0x6100010000;
+  constexpr uint64_t write_ptr_va = 0x6100010008;
+  process.map_pages(ring_va, ring.data(), ring.size());
+  process.map_pages(read_ptr_va, queue_state.data(), queue_state.size());
+
+  hsa_kernel_dispatch_packet_t packet{};
+  packet.header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  packet.setup = 1;
+  packet.workgroup_size_x = 64;
+  packet.workgroup_size_y = 1;
+  packet.workgroup_size_z = 1;
+  packet.grid_size_x = 64;
+  packet.grid_size_y = 1;
+  packet.grid_size_z = 1;
+  packet.kernel_object = code_object_va + kernel_descriptor_offset;
+  std::memcpy(ring.data(), &packet, sizeof(packet));
+
+  amdgpu::HwQueue queue{};
+  queue.queue_id = 7;
+  queue.process_id = process_id;
+  queue.ring_base_va = ring_va;
+  queue.ring_size = static_cast<uint32_t>(ring.size());
+  queue.read_ptr_va = read_ptr_va;
+  queue.write_ptr_va = write_ptr_va;
+  queue.doorbell_base = &doorbell;
+  queue.host_accessible = true;
+  f.cp()->register_queue(std::move(queue));
+  f.cp()->engine()->schedule_event_now(f.cp()->doorbell_event());
+  f.run_until_idle();
+
+  auto it = std::find_if(plugin->events.begin(), plugin->events.end(), [](const HookEvent &event) {
+    return event.kind == HookEvent::DISPATCH_PACKET_PROCESSED;
+  });
+  ASSERT_NE(it, plugin->events.end());
+  EXPECT_EQ(it->kernel_name, "vmid_dispatch_kernel");
+  EXPECT_EQ(it->kernel_symbol, "vmid_dispatch_kernel");
+
+  f.shutdown();
+  f.mem->unregister_process(process_id);
+}
+
 // -- Ordering tests ----------------------------------------------------------
 //
 // These tests use functional mode (the PluginFixture default). Tests that
@@ -1069,6 +1147,70 @@ auto make_trace(std::initializer_list<uint64_t> pcs) {
   return rb;
 }
 
+std::vector<uint8_t> make_loaded_kernel_symbol_elf(uint64_t kernel_descriptor_offset,
+                                                   std::string_view symbol_name) {
+  constexpr uint64_t dyn_offset = 0x100;
+  constexpr uint64_t symtab_offset = 0x200;
+  constexpr uint64_t strtab_offset = 0x300;
+  constexpr uint64_t hash_offset = 0x380;
+  constexpr uint64_t text_offset = 0x900;
+
+  std::vector<uint8_t> image(4096, 0);
+
+  Elf64_Ehdr ehdr{};
+  std::memcpy(ehdr.e_ident, EI_MAGIC, EI_MAGIC_SIZE);
+  ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  ehdr.e_type = ET_DYN;
+  ehdr.e_machine = EM_AMDGPU;
+  ehdr.e_version = 1;
+  ehdr.e_phoff = sizeof(Elf64_Ehdr);
+  ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  ehdr.e_phentsize = sizeof(Elf64_Phdr);
+  ehdr.e_phnum = 1;
+  std::memcpy(image.data(), &ehdr, sizeof(ehdr));
+
+  Elf64_Phdr phdr{};
+  phdr.p_type = PT_DYNAMIC;
+  phdr.p_vaddr = dyn_offset;
+  phdr.p_memsz = 5 * sizeof(Elf64_Dyn);
+  std::memcpy(image.data() + ehdr.e_phoff, &phdr, sizeof(phdr));
+
+  auto *dyn = reinterpret_cast<Elf64_Dyn *>(image.data() + dyn_offset);
+  dyn[0].d_tag = DT_SYMTAB;
+  dyn[0].d_un.d_val = symtab_offset;
+  dyn[1].d_tag = DT_STRTAB;
+  dyn[1].d_un.d_val = strtab_offset;
+  dyn[2].d_tag = DT_STRSZ;
+  dyn[2].d_un.d_val = symbol_name.size() + 2;
+  dyn[3].d_tag = DT_HASH;
+  dyn[3].d_un.d_val = hash_offset;
+  dyn[4].d_tag = DT_NULL;
+
+  image[strtab_offset] = '\0';
+  std::memcpy(image.data() + strtab_offset + 1, symbol_name.data(), symbol_name.size());
+
+  auto *sym = reinterpret_cast<Elf64_Sym *>(image.data() + symtab_offset);
+  sym[1].st_name = 1;
+  sym[1].st_value = kernel_descriptor_offset;
+
+  auto *hash = reinterpret_cast<uint32_t *>(image.data() + hash_offset);
+  hash[1] = 2; // nchain: null symbol + kernel descriptor symbol.
+
+  using namespace rocr::llvm::amdhsa;
+  kernel_descriptor_t kd{};
+  kd.kernel_code_entry_byte_offset = text_offset - kernel_descriptor_offset;
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT, 31);
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc1, COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT, 12);
+  AMDHSA_BITS_SET(kd.compute_pgm_rsrc2, COMPUTE_PGM_RSRC2_USER_SGPR_COUNT, 2);
+  std::memcpy(image.data() + kernel_descriptor_offset, &kd, sizeof(kd));
+
+  const std::array<uint32_t, 2> code = {S_NOP, S_ENDPGM};
+  std::memcpy(image.data() + text_offset, code.data(), code.size() * sizeof(code[0]));
+
+  return image;
+}
+
 TEST(FormatTraceTest, WaveLaneAnnotations) {
   auto trace = make_trace({0x100, 0x108, 0x10c});
   std::unordered_map<uint64_t, std::string> disasm = {
@@ -1126,6 +1268,36 @@ TEST(DisasmCacheTest, HandlesNonMonotonicPcOrder) {
   auto disasm = cache.to_map();
   EXPECT_EQ(disasm.at(0x540024b100), "s_nop 0");
   EXPECT_EQ(disasm.at(0x100002a100), "s_endpgm");
+}
+
+TEST(RaceDetectorPluginOutputTest, DispatchLineUsesQuestionMarksForUnresolvedKernel) {
+  StringSink sink;
+  ExecutionPluginGroup plugin_group;
+  plugin_group.add_sink(&sink);
+  ASSERT_TRUE(plugin_group.add(std::make_unique<plugins::race_detector::RaceDetectorPlugin>()));
+
+  KernelDispatchInfo info{};
+  info.dispatch_id = 17;
+  plugin_group.onAmdgpuDispatchPacketProcessed(info);
+
+  EXPECT_NE(sink.str().find("[rocjitsu] Kernel dispatch: \"?\" symbol=\"?\"\n"), std::string::npos);
+}
+
+TEST(RaceDetectorPluginOutputTest, DispatchLineUsesReadableNameAndExactSymbol) {
+  StringSink sink;
+  ExecutionPluginGroup plugin_group;
+  plugin_group.add_sink(&sink);
+  ASSERT_TRUE(plugin_group.add(std::make_unique<plugins::race_detector::RaceDetectorPlugin>()));
+
+  KernelDispatchInfo info{};
+  info.dispatch_id = 18;
+  info.kernel_name = "racy_kernel";
+  info.kernel_symbol = "_Z11racy_kernelPKfPf";
+  plugin_group.onAmdgpuDispatchPacketProcessed(info);
+
+  EXPECT_NE(sink.str().find("[rocjitsu] Kernel dispatch: \"racy_kernel\" "
+                            "symbol=\"_Z11racy_kernelPKfPf\"\n"),
+            std::string::npos);
 }
 
 } // namespace

--- a/emulation/rocjitsu/tests/race-detector/hip_race_gfx950_test.hip
+++ b/emulation/rocjitsu/tests/race-detector/hip_race_gfx950_test.hip
@@ -214,11 +214,21 @@ protected:
   }
 
   void ExpectDispatchContext(const RaceRecord &r, const std::string &kernel_name_substring) {
+    // Race reports should carry resolved dispatch context, not just the
+    // instruction trace. "?" would mean kernel-symbol resolution failed.
     EXPECT_FALSE(r.kernel.empty());
     EXPECT_NE(r.kernel, "?");
     EXPECT_FALSE(r.symbol.empty());
     EXPECT_NE(r.symbol, "?");
+
+    // The dispatch id ties the race back to the AQL dispatch that produced it.
+    // This catches regressions where the plugin logs a default-constructed
+    // context instead of the dispatch packet metadata.
     EXPECT_GE(r.dispatch, 1);
+
+    // Match on the source kernel name rather than the whole demangled spelling:
+    // the exact symbol can include ABI/compiler-specific type detail, while the
+    // kernel name substring is the user-facing identity the report must preserve.
     EXPECT_NE(r.kernel.find(kernel_name_substring), npos) << "kernel: " << r.kernel;
     EXPECT_NE(r.symbol.find(kernel_name_substring), npos) << "symbol: " << r.symbol;
   }

--- a/emulation/rocjitsu/tests/race-detector/hip_race_gfx950_test.hip
+++ b/emulation/rocjitsu/tests/race-detector/hip_race_gfx950_test.hip
@@ -33,6 +33,9 @@
 // ============================================================
 
 struct RaceRecord {
+  std::string kernel;   // compact readable kernel name, or "?" if unresolved
+  std::string symbol;   // exact ELF symbol name, or "?" if unresolved
+  int dispatch = -1;    // rocjitsu dispatch id
   std::string type;     // "VGPR", "SGPR", "LDS"
   int reg = -1;         // register index (VGPR/SGPR) or byte address (LDS)
   int wave = -1;
@@ -47,7 +50,8 @@ struct RaceRecord {
 ///
 /// Example log file content:
 ///
-///   RACE type=VGPR reg=2 wave=0 lane=0 wg=0,0,0 conflict=global_load_dword
+///   RACE kernel=vgpr_race_kernel symbol=_Z16vgpr_race_kernelPKfPf dispatch=1
+///       type=VGPR reg=2 wave=0 lane=0 wg=0,0,0 conflict=global_load_dword
 ///   Race on VGPR v2 [workgroup (0, 0, 0), wave 0, lane 0]
 ///    ==>  0x5400021940  global_load_dword v2, v[2:3], off
 ///         0x5400021948  s_nop 0
@@ -80,7 +84,10 @@ static std::vector<RaceRecord> parse_race_log() {
       if (sp == std::string::npos) sp = rest.size();
       std::string key = rest.substr(pos, eq - pos);
       std::string val = rest.substr(eq + 1, sp - eq - 1);
-      if (key == "type")          r.type = val;
+      if (key == "kernel")        r.kernel = val;
+      else if (key == "symbol")   r.symbol = val;
+      else if (key == "dispatch") r.dispatch = std::stoi(val);
+      else if (key == "type")     r.type = val;
       else if (key == "reg")      r.reg = std::stoi(val);
       else if (key == "wave")     r.wave = val.empty() ? -1 : std::stoi(val);
       else if (key == "lane")     r.lane = val.empty() ? -1 : std::stoi(val);
@@ -188,9 +195,9 @@ protected:
     auto r = records();
     if (!r.empty()) {
       for (auto &rec : r)
-        fprintf(stderr, "  [%s reg=%d wg=%s] %s\n",
-                rec.type.c_str(), rec.reg, rec.wg.c_str(),
-                rec.message.c_str());
+        fprintf(stderr, "  [%s symbol=%s dispatch=%d %s reg=%d wg=%s] %s\n",
+                rec.kernel.c_str(), rec.symbol.c_str(), rec.dispatch, rec.type.c_str(),
+                rec.reg, rec.wg.c_str(), rec.message.c_str());
     }
     EXPECT_TRUE(r.empty()) << "Expected no races, got " << r.size();
   }
@@ -204,6 +211,16 @@ protected:
     auto r = records();
     EXPECT_EQ(static_cast<int>(r.size()), n)
         << "Expected " << n << " race(s), got " << r.size();
+  }
+
+  void ExpectDispatchContext(const RaceRecord &r, const std::string &kernel_name_substring) {
+    EXPECT_FALSE(r.kernel.empty());
+    EXPECT_NE(r.kernel, "?");
+    EXPECT_FALSE(r.symbol.empty());
+    EXPECT_NE(r.symbol, "?");
+    EXPECT_GE(r.dispatch, 1);
+    EXPECT_NE(r.kernel.find(kernel_name_substring), npos) << "kernel: " << r.kernel;
+    EXPECT_NE(r.symbol.find(kernel_name_substring), npos) << "symbol: " << r.symbol;
   }
 };
 
@@ -249,6 +266,7 @@ TEST_F(Gfx950RaceTest, vgpr_waitcnt_race) {
   sync();
   auto r = records();
   ASSERT_EQ(r.size(), 1u);
+  ExpectDispatchContext(r[0], "vgpr_race_kernel");
   auto t = parseTrace(r[0]);
   EXPECT_NE(t.header.find("VGPR"), npos);
   EXPECT_NE(t.header.find("wave 0"), npos);
@@ -483,6 +501,7 @@ TEST_F(Gfx950RaceTest, partial_vmcnt_race) {
   sync();
   auto r = records();
   ASSERT_EQ(r.size(), 1u);
+  ExpectDispatchContext(r[0], "partial_vmcnt_kernel");
   auto t = parseTrace(r[0]);
   EXPECT_NE(t.header.find("VGPR"), npos);
   EXPECT_NE(t.header.find("wave 0"), npos);
@@ -562,6 +581,7 @@ TEST_F(Gfx950RaceTest, multi_kernel_race) {
   sync();
   auto r = records();
   ASSERT_EQ(r.size(), 1u);
+  ExpectDispatchContext(r[0], "racy_kernel");
   auto t = parseTrace(r[0]);
   EXPECT_NE(t.header.find("VGPR"), npos);
   EXPECT_NE(t.header.find("wave 0"), npos);


### PR DESCRIPTION
Fixes #7948

## Summary

Improve kernel-name reporting for rocjitsu dispatches and race reports.

The main correctness fix is for KFD/daemon VMID-mapped dispatches: the AQL
`kernel_object` field is a GPU virtual address, not a directly readable host
pointer. Kernel-symbol lookup now resolves that GPU VA through the process page
table, finds the daemon-accessible host range for the loaded code object, and
then scans ELF metadata from the translated host pointer.

The reporting change separates two concepts:

- `kernel_symbol`: the exact ELF symbol, useful for identity/debugging.
- `kernel_name`: a compact readable display name, useful in logs and structured
  race reports.

Race reports now include `kernel=...`, `symbol=...`, and `dispatch=...` fields,
so a race can be tied back to the dispatch and exact kernel symbol while keeping
the common log header readable.

## Changes

- Add VMID-aware host-range lookup in `GpuMemory`.
- Translate VMID-mapped `pkt.kernel_object` before ELF symbol lookup.
- Add exact `kernel_symbol` dispatch metadata alongside readable `kernel_name`.
- Demangle C++/HIP symbols for display, with fallback to the original symbol.
- Include kernel name, exact symbol, and dispatch id in race report headers.
- Add focused coverage for VMID host ranges, VMID-mapped dispatch metadata,
  demangling/display names, unresolved-name fallback, and race-log parsing.
