### PR TITLE
fix(rdc): replace curl|bash NodeSource installer with signed APT repo

### DIFF
--- a/projects/rdc/.github/workflows/main.yml
+++ b/projects/rdc/.github/workflows/main.yml
@@ -36,8 +36,15 @@ jobs:
         cat /etc/os-release
         apt update -y
         # provides add-apt-repository and support for caching actions
-        apt install -y software-properties-common jq curl
-        curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+        apt install -y software-properties-common jq curl ca-certificates gnupg
+        # Install Node.js from the NodeSource APT repository with a signed-by
+        # keyring instead of piping a remote installer script into bash
+        install -d -m 0755 /etc/apt/keyrings
+        curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor | tee /etc/apt/keyrings/nodesource.gpg > /dev/null
+        # ensure the keyring is world-readable so the _apt user (gpgv) can verify signatures
+        chmod a+r /etc/apt/keyrings/nodesource.gpg
+        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
+        apt update -y
         apt install -y nodejs
         add-apt-repository -y ppa:apt-fast/stable
         apt update -y
@@ -150,8 +157,15 @@ jobs:
         cat /etc/os-release
         apt update -y
         # provides add-apt-repository and support for caching actions
-        apt install -y software-properties-common jq curl
-        curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+        apt install -y software-properties-common jq curl ca-certificates gnupg
+        # Install Node.js from the NodeSource APT repository with a signed-by
+        # keyring instead of piping a remote installer script into bash
+        install -d -m 0755 /etc/apt/keyrings
+        curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor | tee /etc/apt/keyrings/nodesource.gpg > /dev/null
+        # ensure the keyring is world-readable so the _apt user (gpgv) can verify signatures
+        chmod a+r /etc/apt/keyrings/nodesource.gpg
+        echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
+        apt update -y
         apt install -y nodejs
 
     - name: Package RDC


### PR DESCRIPTION
## Summary

Security fix for **SEC-00291** (High, supply-chain: *download and execute without integrity check*).

`projects/rdc/.github/workflows/main.yml` piped the NodeSource installer script straight into `bash` in **both** the `build` and `test` jobs:

```sh
curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
```

A compromise of the NodeSource CDN, a DNS hijack, or a TLS-intercepting proxy would yield arbitrary code execution on the CI runner with access to all of its secrets.

## What changed

Node.js is now installed from the NodeSource APT repository using a `signed-by` keyring, matching the pattern already used elsewhere in this repo (e.g. `.github/workflows/rocprofiler-sdk-codeql.yml`):

- fetch the NodeSource signing key into `/etc/apt/keyrings/nodesource.gpg` via `tee` + `chmod a+r`, so the `_apt`/`gpgv` user can read it for signature verification
- register the repo: `deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main`
- `apt update` + `apt install -y nodejs`

apt now cryptographically verifies the downloaded `.deb` packages against the keyring, so a compromised CDN can no longer inject executable content. No `curl | bash` remains.

## Validation

- `yaml.safe_load` parses the workflow cleanly (jobs: `build`, `test`)
- `bash -n` passes on every `run:` block
- pre-commit hooks pass (codespell, check-yaml, trailing-whitespace, end-of-file)

> Note: this workflow only triggers on PRs targeting `dgalants/ci` / `amd-staging` / `amd-mainline`, so it will not execute on this `develop` PR; the change was validated locally as above.

## Tracking

JIRA ID: ROCM-26817
Security finding: SEC-00291
