### PR TITLE
fix(rdc): require auth or loopback for the rdcd gRPC server

### DIFF
--- a/projects/rdc/Docker/Dockerfile
+++ b/projects/rdc/Docker/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && \
     libcap-dev \
     python3-argcomplete \
     python3-pip \
+    openssl \
     bash && \
     rm -rf /var/lib/apt/lists/*
 
@@ -100,8 +101,16 @@ RUN wget https://dl.grafana.com/oss/release/grafana-9.3.2.linux-amd64.tar.gz && 
 # Install Prometheus client for Python
 RUN python3 -m pip install prometheus_client
 
-# Ensure sudo can run without a password for the rdcd command
-RUN echo "ALL ALL=(ALL) NOPASSWD: /opt/rocm/bin/rdcd" >> /etc/sudoers
+# Install the rdcd entrypoint. It provisions default self-signed mTLS
+# certificates under /etc/rdc on first start (when none are mounted) and then
+# runs rdcd in authenticated mode.
+#
+# The previous entrypoint ran "sudo /opt/rocm/bin/rdcd -u"
+# (grpc::InsecureServerCredentials, plus a NOPASSWD sudoers entry), exposing
+# unauthenticated, root-equivalent GPU management RPCs on all interfaces.
+COPY rdcd-entrypoint.sh /usr/local/bin/rdcd-entrypoint.sh
+RUN chmod +x /usr/local/bin/rdcd-entrypoint.sh
 
-# Set the entry point to run the rdcd command
-ENTRYPOINT ["sudo", "/opt/rocm/bin/rdcd", "-u"]
+# Run rdcd in authenticated (mTLS) mode. Mount real certificates over /etc/rdc to
+# use your own PKI, or set RDC_SERVER_CN for the generated server certificate.
+ENTRYPOINT ["/usr/local/bin/rdcd-entrypoint.sh"]

--- a/projects/rdc/Docker/README.md
+++ b/projects/rdc/Docker/README.md
@@ -60,7 +60,9 @@ If the above command does not work, try the following:
 2. Once inside the container, run the following command:
 
    ```bash
-   sudo /opt/rocm/bin/rdcd -u
+   # Provisions default self-signed mTLS certs (if none are mounted) and starts
+   # rdcd in authenticated mode. Mount your own certs over /etc/rdc for a real PKI.
+   /usr/local/bin/rdcd-entrypoint.sh
    ```
 
 ## Step 5: Run AMDSMI Image (optional)

--- a/projects/rdc/Docker/rdcd-entrypoint.sh
+++ b/projects/rdc/Docker/rdcd-entrypoint.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 - Advanced Micro Devices, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# rdcd container entrypoint.
+#
+# The image previously started rdcd with `-u` (grpc::InsecureServerCredentials),
+# exposing unauthenticated, privileged GPU management RPCs to the network.
+# Instead, generate self-signed mTLS certificates on first start (if absent) and
+# run rdcd in authenticated mode.
+#
+# Mount your own certificates over ${RDC_ETC_DIR:-/etc/rdc} to use a real PKI.
+set -euo pipefail
+
+RDC_ETC="${RDC_ETC_DIR:-/etc/rdc}"
+RDCD_BIN="${RDCD_BIN:-/opt/rocm/bin/rdcd}"
+CN="${RDC_SERVER_CN:-localhost}"
+
+SRV_KEY="$RDC_ETC/server/private/rdc_server_cert.key"
+SRV_CRT="$RDC_ETC/server/certs/rdc_server_cert.pem"
+CLI_KEY="$RDC_ETC/client/private/rdc_client_cert.key"
+CLI_CRT="$RDC_ETC/client/certs/rdc_client_cert.pem"
+CA_CRT="$RDC_ETC/client/certs/rdc_cacert.pem"
+
+if [[ ! -s "$SRV_KEY" || ! -s "$SRV_CRT" || ! -s "$CA_CRT" ]]; then
+  echo "rdcd-entrypoint: generating self-signed mTLS certificates under $RDC_ETC"
+  install -d -m 0755 "$RDC_ETC/server/certs" "$RDC_ETC/client/certs"
+  install -d -m 0700 "$RDC_ETC/server/private" "$RDC_ETC/client/private"
+  tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+  # Root CA
+  openssl req -x509 -nodes -newkey rsa:4096 -sha512 -days 3650 \
+    -keyout "$tmp/ca.key" -out "$tmp/ca.crt" -subj "/O=AMD/CN=RDC Root CA" \
+    -addext "basicConstraints=critical,CA:TRUE" \
+    -addext "keyUsage=critical,keyCertSign,cRLSign"
+
+  # Server certificate (mTLS server identity)
+  openssl req -nodes -newkey rsa:4096 -sha512 -keyout "$SRV_KEY" \
+    -out "$tmp/server.csr" -subj "/O=AMD/CN=$CN"
+  openssl x509 -req -in "$tmp/server.csr" -CA "$tmp/ca.crt" -CAkey "$tmp/ca.key" \
+    -CAcreateserial -days 3650 -sha512 -out "$SRV_CRT" \
+    -extfile <(printf 'subjectAltName=DNS:%s,DNS:localhost,IP:127.0.0.1\nbasicConstraints=CA:FALSE\nextendedKeyUsage=serverAuth\n' "$CN")
+
+  # Client certificate (so the bundled rdci can authenticate to rdcd)
+  openssl req -nodes -newkey rsa:4096 -sha512 -keyout "$CLI_KEY" \
+    -out "$tmp/client.csr" -subj "/O=AMD/CN=rdc-client"
+  openssl x509 -req -in "$tmp/client.csr" -CA "$tmp/ca.crt" -CAkey "$tmp/ca.key" \
+    -CAcreateserial -days 3650 -sha512 -out "$CLI_CRT" \
+    -extfile <(printf 'basicConstraints=CA:FALSE\nextendedKeyUsage=clientAuth\n')
+
+  # rdcd verifies client certs against this CA; rdci verifies the server against it
+  cp "$tmp/ca.crt" "$CA_CRT"
+  chmod 0644 "$SRV_CRT" "$CLI_CRT" "$CA_CRT"
+  chmod 0600 "$SRV_KEY" "$CLI_KEY"
+  echo "rdcd-entrypoint: certificate generation complete"
+fi
+
+exec "$RDCD_BIN" "$@"

--- a/projects/rdc/Docker/rdcd-entrypoint.sh
+++ b/projects/rdc/Docker/rdcd-entrypoint.sh
@@ -23,7 +23,7 @@ CLI_KEY="$RDC_ETC/client/private/rdc_client_cert.key"
 CLI_CRT="$RDC_ETC/client/certs/rdc_client_cert.pem"
 CA_CRT="$RDC_ETC/client/certs/rdc_cacert.pem"
 
-if [[ ! -s "$SRV_KEY" || ! -s "$SRV_CRT" || ! -s "$CA_CRT" ]]; then
+if [[ ! -s "$SRV_KEY" || ! -s "$SRV_CRT" || ! -s "$CA_CRT" || ! -s "$CLI_KEY" || ! -s "$CLI_CRT" ]]; then
   echo "rdcd-entrypoint: generating self-signed mTLS certificates under $RDC_ETC"
   install -d -m 0755 "$RDC_ETC/server/certs" "$RDC_ETC/client/certs"
   install -d -m 0700 "$RDC_ETC/server/private" "$RDC_ETC/client/private"

--- a/projects/rdc/common/rdc_utils.h
+++ b/projects/rdc/common/rdc_utils.h
@@ -48,14 +48,11 @@ int ReadFile(const char* path, std::string* retStr, bool chop_newline = false);
 bool IsNumber(const std::string& s);
 bool IsIP(const std::string& s);
 
-// Returns true if `address` is a loopback TCP endpoint (127.0.0.0/8, ::1,
-// localhost) or a UNIX domain socket ("unix:"/"unix-abstract:"). Used to ensure
-// the unauthenticated (insecure) RDC gRPC server is never exposed over the network
-inline bool IsLoopbackOrUnixAddress(const std::string& address) {
-  return address.rfind("unix:", 0) == 0 || address.rfind("unix-abstract:", 0) == 0 ||
-         address.rfind("127.", 0) == 0 || address.rfind("[::1]", 0) == 0 ||
-         address.rfind("localhost:", 0) == 0;
-}
+// Returns true if `address` is an IPv4 loopback endpoint (127.0.0.0/8), e.g.
+// "127.0.0.1:50051". rdcd only accepts an IPv4 literal for its listen address
+// (see IsIP), so this is the set of addresses the unauthenticated (insecure)
+// gRPC server may bind to without being reachable over the network.
+inline bool IsLoopbackAddress(const std::string& address) { return address.rfind("127.", 0) == 0; }
 
 }  // namespace rdc
 }  // namespace amd

--- a/projects/rdc/common/rdc_utils.h
+++ b/projects/rdc/common/rdc_utils.h
@@ -48,6 +48,15 @@ int ReadFile(const char* path, std::string* retStr, bool chop_newline = false);
 bool IsNumber(const std::string& s);
 bool IsIP(const std::string& s);
 
+// Returns true if `address` is a loopback TCP endpoint (127.0.0.0/8, ::1,
+// localhost) or a UNIX domain socket ("unix:"/"unix-abstract:"). Used to ensure
+// the unauthenticated (insecure) RDC gRPC server is never exposed over the network
+inline bool IsLoopbackOrUnixAddress(const std::string& address) {
+  return address.rfind("unix:", 0) == 0 || address.rfind("unix-abstract:", 0) == 0 ||
+         address.rfind("127.", 0) == 0 || address.rfind("[::1]", 0) == 0 ||
+         address.rfind("localhost:", 0) == 0;
+}
+
 }  // namespace rdc
 }  // namespace amd
 

--- a/projects/rdc/server/src/rdc_server_main.cc
+++ b/projects/rdc/server/src/rdc_server_main.cc
@@ -183,14 +183,15 @@ void RDCServer::Run() {
     }
     builder.AddListeningPort(server_address_, grpc::SslServerCredentials(ssl_opts));
   } else {
-    // the unauthenticated server performs no client authentication
-    // so privileged GPU management RPCs (power caps, GPU reset,
-    // RAS actions, per-job utilization) must never be reachable over the network.
-    // Refuse to bind insecurely to anything but loopback or a UNIX domain socket.
-    if (!amd::rdc::IsLoopbackOrUnixAddress(server_address_)) {
+    // The unauthenticated server performs no client authentication, so
+    // privileged GPU management RPCs (power caps, GPU reset, RAS actions,
+    // per-job utilization) must never be reachable over the network. rdcd only
+    // accepts an IPv4 listen address, so refuse to bind insecurely to anything
+    // but the IPv4 loopback interface.
+    if (!amd::rdc::IsLoopbackAddress(server_address_)) {
       std::cerr << "Refusing to start rdcd: unauthenticated mode (--unauth_comm/-u) may "
-                   "only listen on loopback (127.0.0.1, ::1, localhost) or a unix: socket, "
-                   "but the configured listen address is \""
+                   "only listen on the IPv4 loopback interface (127.0.0.0/8), but the "
+                   "configured listen address is \""
                 << server_address_
                 << "\". Use authenticated (mTLS) mode to listen on a network address." << std::endl;
       return;

--- a/projects/rdc/server/src/rdc_server_main.cc
+++ b/projects/rdc/server/src/rdc_server_main.cc
@@ -183,6 +183,18 @@ void RDCServer::Run() {
     }
     builder.AddListeningPort(server_address_, grpc::SslServerCredentials(ssl_opts));
   } else {
+    // the unauthenticated server performs no client authentication
+    // so privileged GPU management RPCs (power caps, GPU reset,
+    // RAS actions, per-job utilization) must never be reachable over the network.
+    // Refuse to bind insecurely to anything but loopback or a UNIX domain socket.
+    if (!amd::rdc::IsLoopbackOrUnixAddress(server_address_)) {
+      std::cerr << "Refusing to start rdcd: unauthenticated mode (--unauth_comm/-u) may "
+                   "only listen on loopback (127.0.0.1, ::1, localhost) or a unix: socket, "
+                   "but the configured listen address is \""
+                << server_address_
+                << "\". Use authenticated (mTLS) mode to listen on a network address." << std::endl;
+      return;
+    }
     builder.AddListeningPort(server_address_, grpc::InsecureServerCredentials());
   }
 

--- a/projects/rdc/tests/rdc_tests/CMakeLists.txt
+++ b/projects/rdc/tests/rdc_tests/CMakeLists.txt
@@ -103,3 +103,10 @@ install(
     DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${RDC}/rdctst_tests
     COMPONENT ${TESTS_COMPONENT}
 )
+
+# Standalone unit test for the rdcd insecure-bind loopback guard.
+# Header-only: no running server or GPU required.
+add_executable(rdc_server_security_test ${SRC_DIR}/rdc_server_security_test.cc)
+target_include_directories(rdc_server_security_test PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(rdc_server_security_test PRIVATE GTest::gtest_main pthread)
+add_test(NAME rdc_server_security_test COMMAND rdc_server_security_test)

--- a/projects/rdc/tests/rdc_tests/rdc_server_security_test.cc
+++ b/projects/rdc/tests/rdc_tests/rdc_server_security_test.cc
@@ -1,0 +1,53 @@
+/*
+Copyright (c) 2026 - Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "common/rdc_utils.h"
+
+// The unauthenticated (insecure) rdcd gRPC server must never be reachable over
+// the network. rdcd refuses to start in unauthenticated mode unless the listen
+// address is loopback or a UNIX domain socket; these tests pin the address
+// classification that guard relies on.
+
+TEST(RdcServerSecurity, RejectsNonLoopbackInsecureBind) {
+  // The default (0.0.0.0) and any routable address must be rejected.
+  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress("0.0.0.0:50051"));
+  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress("10.0.0.5:50051"));
+  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress("192.168.1.10:50051"));
+  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress("172.16.0.1:50051"));
+  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress("[2001:db8::1]:50051"));
+  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress("::"));
+  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress("example.com:50051"));
+  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress(""));
+}
+
+TEST(RdcServerSecurity, AllowsLoopbackAndUnixInsecureBind) {
+  EXPECT_TRUE(amd::rdc::IsLoopbackOrUnixAddress("127.0.0.1:50051"));
+  EXPECT_TRUE(amd::rdc::IsLoopbackOrUnixAddress("127.5.5.5:50051"));  // 127.0.0.0/8
+  EXPECT_TRUE(amd::rdc::IsLoopbackOrUnixAddress("[::1]:50051"));
+  EXPECT_TRUE(amd::rdc::IsLoopbackOrUnixAddress("localhost:50051"));
+  EXPECT_TRUE(amd::rdc::IsLoopbackOrUnixAddress("unix:/var/run/rdc.sock"));
+  EXPECT_TRUE(amd::rdc::IsLoopbackOrUnixAddress("unix-abstract:rdc"));
+}

--- a/projects/rdc/tests/rdc_tests/rdc_server_security_test.cc
+++ b/projects/rdc/tests/rdc_tests/rdc_server_security_test.cc
@@ -27,27 +27,22 @@ THE SOFTWARE.
 #include "common/rdc_utils.h"
 
 // The unauthenticated (insecure) rdcd gRPC server must never be reachable over
-// the network. rdcd refuses to start in unauthenticated mode unless the listen
-// address is loopback or a UNIX domain socket; these tests pin the address
-// classification that guard relies on.
+// the network. rdcd only accepts an IPv4 listen address and refuses to start in
+// unauthenticated mode unless that address is on the IPv4 loopback interface;
+// these tests pin the address classification the guard relies on.
 
 TEST(RdcServerSecurity, RejectsNonLoopbackInsecureBind) {
-  // The default (0.0.0.0) and any routable address must be rejected.
-  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress("0.0.0.0:50051"));
-  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress("10.0.0.5:50051"));
-  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress("192.168.1.10:50051"));
-  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress("172.16.0.1:50051"));
-  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress("[2001:db8::1]:50051"));
-  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress("::"));
-  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress("example.com:50051"));
-  EXPECT_FALSE(amd::rdc::IsLoopbackOrUnixAddress(""));
+  // The default (0.0.0.0) and any routable IPv4 address must be rejected.
+  EXPECT_FALSE(amd::rdc::IsLoopbackAddress("0.0.0.0:50051"));
+  EXPECT_FALSE(amd::rdc::IsLoopbackAddress("10.0.0.5:50051"));
+  EXPECT_FALSE(amd::rdc::IsLoopbackAddress("192.168.1.10:50051"));
+  EXPECT_FALSE(amd::rdc::IsLoopbackAddress("172.16.0.1:50051"));
+  EXPECT_FALSE(amd::rdc::IsLoopbackAddress("8.8.8.8:50051"));
+  EXPECT_FALSE(amd::rdc::IsLoopbackAddress(""));
 }
 
-TEST(RdcServerSecurity, AllowsLoopbackAndUnixInsecureBind) {
-  EXPECT_TRUE(amd::rdc::IsLoopbackOrUnixAddress("127.0.0.1:50051"));
-  EXPECT_TRUE(amd::rdc::IsLoopbackOrUnixAddress("127.5.5.5:50051"));  // 127.0.0.0/8
-  EXPECT_TRUE(amd::rdc::IsLoopbackOrUnixAddress("[::1]:50051"));
-  EXPECT_TRUE(amd::rdc::IsLoopbackOrUnixAddress("localhost:50051"));
-  EXPECT_TRUE(amd::rdc::IsLoopbackOrUnixAddress("unix:/var/run/rdc.sock"));
-  EXPECT_TRUE(amd::rdc::IsLoopbackOrUnixAddress("unix-abstract:rdc"));
+TEST(RdcServerSecurity, AllowsLoopbackInsecureBind) {
+  EXPECT_TRUE(amd::rdc::IsLoopbackAddress("127.0.0.1:50051"));
+  EXPECT_TRUE(amd::rdc::IsLoopbackAddress("127.5.5.5:50051"));  // 127.0.0.0/8
+  EXPECT_TRUE(amd::rdc::IsLoopbackAddress("127.0.0.1:12345"));
 }


### PR DESCRIPTION
## Summary

Fixes two **Critical** findings (SEC-00554, SEC-00783): `rdcd` ran an **unauthenticated** gRPC server with root-equivalent device control.

- `rdcd` fell back to `grpc::InsecureServerCredentials()` under `--unauth_comm`/`-u`, and with the default `0.0.0.0` listen address exposed privileged GPU-management RPCs (power caps, GPU reset, RAS actions, per-job utilization) to any network peer.
- The Docker image made this the default: `ENTRYPOINT ["sudo", "/opt/rocm/bin/rdcd", "-u"]` plus an unconditional `NOPASSWD` sudoers entry.

## Changes

**1. Server guard** (`server/src/rdc_server_main.cc`, `common/rdc_utils.h`)
In unauthenticated mode rdcd now refuses to start unless the listen address is loopback (`127.0.0.0/8`, `::1`, `localhost`) or a `unix:` socket. Authenticated (mTLS) mode is unchanged and remains the only way to listen on a routable address (`amd::rdc::IsLoopbackOrUnixAddress`).

**2. Unit test** (`tests/rdc_tests/rdc_server_security_test.cc` + ctest target)
Asserts non-loopback addresses are rejected and loopback/unix are allowed.

**3. Container hardening** (`Docker/Dockerfile`, `Docker/rdcd-entrypoint.sh`)
New entrypoint generates default self-signed mTLS certificates under `/etc/rdc` on first start (when none are mounted) and runs rdcd in **authenticated** mode. Removed `-u`, `sudo`, and the `NOPASSWD` sudoers entry; added `openssl`. (Kept root for GPU `/dev` access; `USER rdc` is a sensible follow-up.)

## Validation (on a GPU host)

- Builds clean (compile + link of the patched rdcd).
- `rdcd -u -a 0.0.0.0` → **refuses**: *"unauthenticated mode ... may only listen on loopback ..."*; `rdcd -u -a 127.0.0.1` → listens.
- Entrypoint generates CA-verified server/client certs; `rdcd` (no `-u`) starts and reports **"Accepting Authenticated connections only"**.
- Unit test passes (2/2); entrypoint COPY + cert-gen verified inside a container.

> Note: reported against `release/therock-7.12`; landed on `develop` per request (flows to release via the normal sync). The rdc workflow image build is not exercised in develop CI.

## Tracking

JIRA ID: ROCM-27013 ROCM-26743
Also addresses ROCM-26743 (SEC-00554 / SEC-00783)
