### PR TITLE
Revert "CLR: set imagePitchAlignment unconditionally so pitched allocs work w…"

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocdevice.cpp
+++ b/projects/clr/rocclr/device/rocm/rocdevice.cpp
@@ -1524,16 +1524,14 @@ bool Device::populateOCLDeviceConstants() {
     }
     info_.imageMaxBufferSize_ = (amd::IS_HIP) ? image_max_dim[0] : (1 << 27);
 
+    info_.imagePitchAlignment_ = 256;
+
+    info_.imageBaseAddressAlignment_ = 256;
+
+    info_.bufferFromImageSupport_ = false;
+
     info_.imageSupport_ = (info_.maxReadWriteImageArgs_ > 0) ? true : false;
   }
-
-  // These are properties of the device's linear memory layout, not the image
-  // extension.  They must be set unconditionally so that hipMallocPitch /
-  // hipMalloc3D produce correct pitch alignment even when IMAGE_SUPPORT is
-  // off.  The PAL backend already sets them unconditionally.
-  info_.imagePitchAlignment_ = 256;
-  info_.imageBaseAddressAlignment_ = 256;
-  info_.bufferFromImageSupport_ = false;
 
   // Enable SVM Capabilities of Hsa device. Ensure
   // user has not setup memory to be non-coherent


### PR DESCRIPTION
Reverts PR: ROCm/rocm-systems#7705
Fixes Issue: https://github.com/ROCm/rocm-libraries/issues/8894