### PR TITLE
fix(rocprofiler-systems): Replace oshrun version gate with live -- strip probe

### DIFF
--- a/projects/rocprofiler-systems/tests/pytest/conftest.py
+++ b/projects/rocprofiler-systems/tests/pytest/conftest.py
@@ -1363,6 +1363,12 @@ def _generate_rocprofsys_config_header() -> list[str]:
     else:
         oshrun_version_str = "Not found"
 
+    oshrun_strips_str = (
+        "Yes (decoy '--' inserted)"
+        if cap.oshrun_strips_double_dash
+        else "No" if cap.oshrun_exec else "N/A"
+    )
+
     if cap.amdsmi_version is not None:
         amdsmi_version_str = f"{cap.amdsmi_version[0]}.{cap.amdsmi_version[1]}"
     else:
@@ -1419,6 +1425,7 @@ def _generate_rocprofsys_config_header() -> list[str]:
         _row("Julia:", cap.julia_exec),
         _row("Oshrun:", cap.oshrun_exec),
         _subrow("Version:", oshrun_version_str),
+        _subrow("Strips '--':", oshrun_strips_str),
         _row("Offload tool:", offload_msg),
         _row("Rocminfo:", rocminfo_path if rocminfo_path else rocminfo_err_msg),
         "-" * 70,

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -462,6 +462,43 @@ class SystemCapabilities:
             return None
 
     @cached_property
+    def oshrun_strips_double_dash(self) -> bool:
+        """Return True if this oshrun strips the first '--' from application argv.
+
+        Probes the live binary by running:
+            oshrun -n 1 probe.sh -- SENTINEL
+        and checking whether the script receives 'SENTINEL' (stripped) or '--'
+        (preserved).  Falls back to False when oshrun is absent or the probe
+        fails.
+        """
+        if not self.oshrun_exec:
+            return False
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".sh", delete=False
+        ) as probe_file:
+            probe_file.write("#!/bin/sh\nprintf '%s\\n' \"$1\"\n")
+            probe_path = probe_file.name
+        os.chmod(probe_path, 0o755)
+
+        try:
+            for extra in ([], ["--allow-run-as-root"]):
+                cmd = (
+                    [str(self.oshrun_exec)]
+                    + extra
+                    + ["-n", "1", probe_path, "--", "SENTINEL"]
+                )
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+                if result.returncode == 0:
+                    return result.stdout.strip() == "SENTINEL"
+            return False
+        except (subprocess.SubprocessError, OSError):
+            return False
+        finally:
+            os.unlink(probe_path)
+
+    @cached_property
     def rocprofiler_sdk_version(self) -> Optional[tuple[int, int, int]]:
         """Return rocprofiler-sdk (major, minor, patch) from ``version.h`` under ROCm.
 

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -480,9 +480,8 @@ class SystemCapabilities:
         ) as probe_file:
             probe_file.write("#!/bin/sh\nprintf '%s\\n' \"$1\"\n")
             probe_path = probe_file.name
-        os.chmod(probe_path, 0o755)
-
         try:
+            os.chmod(probe_path, 0o755)
             for extra in ([], ["--allow-run-as-root"]):
                 cmd = (
                     [str(self.oshrun_exec)]

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/capabilities.py
@@ -481,7 +481,7 @@ class SystemCapabilities:
             probe_file.write("#!/bin/sh\nprintf '%s\\n' \"$1\"\n")
             probe_path = probe_file.name
         try:
-            os.chmod(probe_path, 0o755)
+            os.chmod(probe_path, 0o700)
             for extra in ([], ["--allow-run-as-root"]):
                 cmd = (
                     [str(self.oshrun_exec)]

--- a/projects/rocprofiler-systems/tests/pytest/rocprofsys/runners.py
+++ b/projects/rocprofiler-systems/tests/pytest/rocprofsys/runners.py
@@ -253,13 +253,13 @@ class BaseRunner(ABC):
                 pass
 
         if self.launcher is type(self).Launcher.SHMEM and command:
-            # PRRTE-based oshrun (Open MPI >= 5.0) strips the first literal
-            # `--` from the program argv, breaking `rocprof-sys-run -- <binary>`.
-            # A second `--` survives, so insert a decoy right after the program
-            # name to absorb the strip. Older ORTE-based oshrun (4.x) preserves
-            # `--` and would forward the decoy verbatim, so gate on version.
-            oshrun_version = self.config.capabilities.oshrun_version
-            if oshrun_version is not None and oshrun_version[0] >= 5:
+            # Some PRRTE-based oshrun builds strip the first literal `--` from
+            # the application argv, breaking `rocprof-sys-run -- <binary>`.
+            # A second `--` survives the strip, so insert a decoy to absorb it.
+            # The condition is probed at runtime (see capabilities.oshrun_strips_double_dash)
+            # rather than checked by version number, because distro packages may
+            # bundle a different PRRTE than the upstream Open MPI tarball.
+            if self.config.capabilities.oshrun_strips_double_dash:
                 command = [command[0], "--"] + command[1:]
 
         return cmd + command


### PR DESCRIPTION
## Motivation

The `shmem_pingpong` test was failing on machines with Open MPI 5.0.9 installed from source. A previous commit had added an extra `--` decoy to the oshrun command for any `oshrun_version[0] >= 5`, to work around PRRTE-based launchers that strip the first `--` from the application argv (breaking `rocprof-sys-run -- <binary>`). However, empirical testing across Open MPI 5.0.0–5.0.10 showed that only 5.0.0 strips `--` when built from upstream source. RHEL 10's distro package of Open MPI 5.0.2 independently bundles PRRTE 3.0.2 (which strips), while upstream 5.0.2 does not. A major-version comparison is therefore an unreliable discriminant — the stripping depends on which PRRTE version a given build actually links, not on the Open MPI version number.

## Technical Details

Adds `oshrun_strips_double_dash` as a `cached_property` on `SystemCapabilities` (`capabilities.py`). At session startup it spawns `oshrun -n 1 probe.sh -- SENTINEL` and checks whether the probe script receives `SENTINEL` as `$1` (stripped) or `--` (preserved). It retries with `--allow-run-as-root` if the first attempt fails due to a root-guard rejection. The probe runs once and is memoised for the rest of the session. `runners.py` now gates the decoy `--` insertion on `capabilities.oshrun_strips_double_dash` instead of `oshrun_version[0] >= 5`. `conftest.py` adds a `Strips '--':` row to the test session header so the behaviour is visible in CI logs.

## Test Plan
- [x] Verified probe returns `STRIPPED` in `dgaliffiamd/rocprofiler-systems:ci-rocm-7.1-rhel-10` (Open MPI 5.0.2, PRRTE 3.0.2)
- [x] Verified probe returns `PRESERVED` in Ubuntu 22.04/24.04 CI images (Open MPI 4.1.x, ORTE)
- [x] Built and probed all 11 upstream Open MPI releases 5.0.0–5.0.10 in a container; only 5.0.0 strips
- [x] `shmem_pingpong` test passes on machine with Open MPI 5.0.9 from source

---
JIRA ID - AIPROFSYST-557