### PR TITLE
[RCCL] Centralize HIP/ROCm version gating into shared rocmwrap.h macros

### DIFF
--- a/projects/rccl/CMakeLists.txt
+++ b/projects/rccl/CMakeLists.txt
@@ -348,6 +348,19 @@ check_cxx_source_compiles("
 ### Check for hipMemcpyBatchAsync support (Copy Engine batch API)
 check_symbol_exists("hipMemcpyBatchAsync" "hip/hip_runtime_api.h" HIP_MEMCPY_BATCH_ASYNC)
 
+### Check for cuMem VMM DMA-BUF export support (driver-level dmabuf export).
+check_symbol_exists("hipMemGetHandleForAddressRange" "hip/hip_runtime_api.h" HIP_MEM_GET_HANDLE_FOR_ADDR_RANGE)
+
+### Check for uncached VMM allocation type (hipMemAllocationTypeUncached).
+check_cxx_source_compiles("
+  #include <hip/hip_runtime_api.h>
+  int main() {
+    hipMemAllocationType t = hipMemAllocationTypeUncached;
+    (void)t;
+    return 0;
+  }
+" HIP_VMM_UNCACHED_MEMORY_AVAILABLE)
+
 unset(CMAKE_REQUIRED_LIBRARIES)
 
 ### Check for indirect function call support
@@ -380,6 +393,15 @@ if(HIP_MEMCPY_BATCH_ASYNC)
 else()
   set(CE_ENABLED OFF)
   message(STATUS "Copy Engine (CE) batch API disabled - hipMemcpyBatchAsync not found in hip/hip_runtime_api.h")
+endif()
+
+## Check for cuMem VMM DMA-BUF export support
+if(HIP_MEM_GET_HANDLE_FOR_ADDR_RANGE)
+  set(CUMEM_DMABUF_EXPORT_ENABLED ON)
+  message(STATUS "cuMem DMA-BUF export enabled - hipMemGetHandleForAddressRange found")
+else()
+  set(CUMEM_DMABUF_EXPORT_ENABLED OFF)
+  message(STATUS "cuMem DMA-BUF export disabled - hipMemGetHandleForAddressRange not found in hip/hip_runtime_api.h")
 endif()
 
 ## Check for hsa-runtime64

--- a/projects/rccl/src/CMakeLists.txt
+++ b/projects/rccl/src/CMakeLists.txt
@@ -744,8 +744,16 @@ endif()
 if(ENABLE_ROCSHMEM)
   target_compile_definitions(rccl PRIVATE ENABLE_ROCSHMEM)
 endif()
-if("${hip_version_string}" VERSION_GREATER_EQUAL "7.12.60540")
+# Uncached (fine-grained) VMM/cuMem allocation type. Available natively on
+# HIP >= 7.12.60540 and via the ROCm 7.0.2.x backport range [7.0.51831, 7.0.60000).
+if(HIP_VMM_UNCACHED_MEMORY_AVAILABLE AND
+   (("${hip_version_string}" VERSION_GREATER_EQUAL "7.12.60540") OR
+    (("${hip_version_string}" VERSION_GREATER_EQUAL "7.0.51831") AND
+     ("${hip_version_string}" VERSION_LESS "7.0.60000"))))
   target_compile_definitions(rccl PRIVATE HIP_VMM_UNCACHED_MEMORY)
+  message(STATUS "HIP_VMM_UNCACHED_MEMORY enabled")
+else()
+  message(STATUS "HIP_VMM_UNCACHED_MEMORY disabled")
 endif()
 
 # ==== rocSHMEM integration (optional) ====
@@ -845,6 +853,10 @@ endif()
 if(CE_ENABLED)
   target_compile_definitions(rccl PRIVATE CE_BATCH_ASYNC_SUPPORTED)
   message(STATUS "CE_BATCH_ASYNC_SUPPORTED compile definition enabled")
+endif()
+if(CUMEM_DMABUF_EXPORT_ENABLED)
+  target_compile_definitions(rccl PRIVATE RCCL_CUMEM_DMABUF_EXPORT_SUPPORTED)
+  message(STATUS "RCCL_CUMEM_DMABUF_EXPORT_SUPPORTED compile definition enabled")
 endif()
 
 ## Set RCCL compile options

--- a/projects/rccl/src/ce_coll.cc
+++ b/projects/rccl/src/ce_coll.cc
@@ -31,14 +31,11 @@ RCCL_PARAM(CeBatchAsyncEnable, "CE_BATCH_ASYNC_ENABLE", -2);
 
 #ifdef CE_BATCH_ASYNC_SUPPORTED
 // Runtime detection: does the running driver actually implement hipMemcpyBatchAsync?
-//   ROCm 7.12+   → >= 71200000
-//   ROCm 7.0.2.x → [70051831, 70060000)  (backport range; no device-attribute
-//                  probe exists for the batch API, so the version range is the
-//                  only runtime guard and must include the backport runtime)
+// Window (native 7.12 OR 7.0.2.x backport) is defined once in rocmwrap.h.
 static int ncclCeBatchAsyncSupported() {
   int driverVersion;
   if (ncclCudaDriverVersion(&driverVersion) != ncclSuccess) return 0;
-  return (driverVersion >= 71200000 || (driverVersion >= 70051831 && driverVersion < 70060000));
+  return NCCL_CE_BATCH_ASYNC_VERSION_SUPPORTED(driverVersion);
 }
 #endif
 

--- a/projects/rccl/src/gin/gin_host_proxy.cc
+++ b/projects/rccl/src/gin/gin_host_proxy.cc
@@ -87,7 +87,7 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
 
   // GIN's symmetric windows are cuMem/VMM allocations registered with the NIC via ibv_reg_dmabuf_mr.
   // the cuMem/hipMemGetHandleForAddressRange that exports the DMA-BUF FD requires this HIP version.
-#if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
   static size_t hostPageSize = sysconf(_SC_PAGESIZE);
   size_t alignedSize = length;
   ALIGN_SIZE(alignedSize, hostPageSize);

--- a/projects/rccl/src/gin/gin_host_proxy.cc
+++ b/projects/rccl/src/gin/gin_host_proxy.cc
@@ -87,7 +87,7 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
 
   // GIN's symmetric windows are cuMem/VMM allocations registered with the NIC via ibv_reg_dmabuf_mr.
   // the cuMem/hipMemGetHandleForAddressRange that exports the DMA-BUF FD requires this HIP version.
-#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
   static size_t hostPageSize = sysconf(_SC_PAGESIZE);
   size_t alignedSize = length;
   ALIGN_SIZE(alignedSize, hostPageSize);

--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -16,6 +16,55 @@
 #define CU_STREAM_WRITE_VALUE_DEFAULT 0
 #endif
 
+// === ROCm/HIP version milestones ==========================================
+// Every "magic" version number lives here, once. HIP_VERSION (compile time)
+// and cudaDriverGetVersion() (runtime) both encode as
+// MAJOR*10000000 + MINOR*100000 + PATCH.
+#define ROCM_VER_7_0_2_2     70051831  // 7.0.2.x backport range, lower bound
+#define ROCM_VER_7_0_3_0     70060000  // 7.0.2.x backport range, exclusive upper bound
+#define ROCM_VER_7_12_0      71200000  // hipMemcpyBatchAsync native min
+#define ROCM_VER_7_12_60540  71260540  // upstream cuMem/VMM + DMA-BUF export
+
+// === Generic version-range predicates =====================================
+// Constant expressions, so they are valid in both #if directives (compile
+// time, against HIP_VERSION) and regular C++ (runtime driver version).
+#define NCCL_VER_GE(v, lo)      ((v) >= (lo))
+#define NCCL_VER_IN(v, lo, hi)  ((v) >= (lo) && (v) < (hi))
+
+// === Per-feature VERSION predicates ========================================
+// Each capability names its own support window by composing milestones; do NOT
+// reuse a predicate across features that have different windows.
+
+// cuMem VMM + DMA-BUF driver export: native 7.12 OR the 7.0.2.x backport.
+#define NCCL_CUMEM_VERSION_SUPPORTED(v) \
+  (NCCL_VER_GE(v, ROCM_VER_7_12_60540) || NCCL_VER_IN(v, ROCM_VER_7_0_2_2, ROCM_VER_7_0_3_0))
+
+// cuMem HOST allocations: native only. NOT part of the 7.0.2.x backport (relies
+// on hipDeviceAttributeHostNumaId, which is absent there).
+#define NCCL_CUMEM_HOST_VERSION_SUPPORTED(v) \
+  NCCL_VER_GE(v, ROCM_VER_7_12_60540)
+
+// Back-compat alias for the few call sites that compare against the native
+// minimum directly.
+#define NCCL_CUMEM_NATIVE_MIN_VERSION  ROCM_VER_7_12_60540
+
+// hipMemcpyBatchAsync: native 7.12 OR the 7.0.2.x backport. No device-attribute
+// probe exists for the batch API, so this version window is the only runtime guard.
+#define NCCL_CE_BATCH_ASYNC_VERSION_SUPPORTED(v) \
+  (NCCL_VER_GE(v, ROCM_VER_7_12_0) || NCCL_VER_IN(v, ROCM_VER_7_0_2_2, ROCM_VER_7_0_3_0))
+
+// === Capability gates: prefer the CMake symbol probe, fall back to version ==
+// Method 1 (preferred): CMake check_symbol_exists() defines
+//   RCCL_CUMEM_DMABUF_EXPORT_SUPPORTED when hipMemGetHandleForAddressRange is
+//   present in the SDK headers (see CMakeLists.txt).
+// Method 2 (fallback):  the version predicate above, for builds where the probe
+//   did not run / was not wired in.
+#if defined(RCCL_CUMEM_DMABUF_EXPORT_SUPPORTED)
+  #define NCCL_CUMEM_DMABUF_EXPORT_GATE 1
+#else
+  #define NCCL_CUMEM_DMABUF_EXPORT_GATE NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#endif
+
 // HIP: implemented in rma_proxy_launch.cc (hipStreamBatchMemOp + old-HIP fallback).
 // CUDA: implemented in cudawrap.cc (cuStreamBatchMemOp).
 ncclResult_t ncclCuStreamBatchMemOp(cudaStream_t stream, unsigned int numOps,

--- a/projects/rccl/src/include/rocmwrap.h
+++ b/projects/rccl/src/include/rocmwrap.h
@@ -54,10 +54,9 @@
   (NCCL_VER_GE(v, ROCM_VER_7_12_0) || NCCL_VER_IN(v, ROCM_VER_7_0_2_2, ROCM_VER_7_0_3_0))
 
 // === Capability gates: prefer the CMake symbol probe, fall back to version ==
-// Method 1 (preferred): CMake check_symbol_exists() defines
-//   RCCL_CUMEM_DMABUF_EXPORT_SUPPORTED when hipMemGetHandleForAddressRange is
-//   present in the SDK headers (see CMakeLists.txt).
-// Method 2 (fallback):  the version predicate above, for builds where the probe
+// Method 1 (preferred): CMake sets RCCL_CUMEM_DMABUF_EXPORT_SUPPORTED when
+//   check_symbol_exists(hipMemGetHandleForAddressRange ...) succeeds.
+// Method 2 (fallback): the version predicate above, for builds where the probe
 //   did not run / was not wired in.
 #if defined(RCCL_CUMEM_DMABUF_EXPORT_SUPPORTED)
   #define NCCL_CUMEM_DMABUF_EXPORT_GATE 1

--- a/projects/rccl/src/misc/rocmwrap.cc
+++ b/projects/rccl/src/misc/rocmwrap.cc
@@ -41,16 +41,6 @@ CUmemAllocationHandleType ncclCuMemHandleType = CU_MEM_HANDLE_TYPE_POSIX_FILE_DE
 
 static int ncclCuMemSupported = 0;
 
-// cuMem VMM API availability by HIP/driver version.
-#define NCCL_CUMEM_NATIVE_MIN_VERSION   71260540
-#define NCCL_CUMEM_BACKPORT_MIN_VERSION 70051831
-#define NCCL_CUMEM_BACKPORT_MAX_VERSION 70060000
-
-#define NCCL_CUMEM_VERSION_SUPPORTED(version)                  \
-  ((version) >= NCCL_CUMEM_NATIVE_MIN_VERSION ||               \
-   ((version) >= NCCL_CUMEM_BACKPORT_MIN_VERSION &&            \
-    (version) < NCCL_CUMEM_BACKPORT_MAX_VERSION))
-
 #define KERNEL_VERSION_CODE(major, minor) ((major << 16) | (minor << 8))
 
 static int ncclGetKernelVersionCode() {
@@ -116,7 +106,10 @@ static int ncclCumemHostEnable = -1;
 int ncclCuMemHostEnable() {
   if (ncclCumemHostEnable != -1)
     return ncclCumemHostEnable;
-#if HIP_VERSION < 71260540
+  // NOTE: the cuMem *host* allocation path is NOT part of the ROCm 7.0.2.x
+  // backport (it relies on hipDeviceAttributeHostNumaId, which is absent there),
+  // so it has its own native-only gate rather than NCCL_CUMEM_VERSION_SUPPORTED().
+#if !NCCL_CUMEM_HOST_VERSION_SUPPORTED(HIP_VERSION)
   ncclCumemHostEnable = 0;
   return ncclCumemHostEnable;
 #else
@@ -124,7 +117,7 @@ int ncclCuMemHostEnable() {
   int cudaDriverVersion;
   int paramValue = -1;
   CUDACHECKGOTO(cudaDriverGetVersion(&cudaDriverVersion), ret, error);
-  if (cudaDriverVersion < 71260540) {
+  if (!NCCL_CUMEM_HOST_VERSION_SUPPORTED(cudaDriverVersion)) {
     ncclCumemHostEnable = 0;
   }
   else {
@@ -132,7 +125,7 @@ int ncclCuMemHostEnable() {
     if (paramValue != -1)
       ncclCumemHostEnable = paramValue;
     else
-      ncclCumemHostEnable = (cudaDriverVersion >= 71260540) ? 1 : 0;
+      ncclCumemHostEnable = NCCL_CUMEM_HOST_VERSION_SUPPORTED(cudaDriverVersion) ? 1 : 0;
     if (ncclCumemHostEnable) {
       // Verify that host allocations actually work.  Docker in particular is known to disable "get_mempolicy",
       // causing such allocations to fail (this can be fixed by invoking Docker with "--cap-add SYS_NICE").

--- a/projects/rccl/src/proxy.cc
+++ b/projects/rccl/src/proxy.cc
@@ -1295,7 +1295,7 @@ ncclResult_t ncclProxyClientGetFdBlocking(struct ncclComm* comm, int proxyRank, 
   if (comm->gproxyConn[proxyRank].initialized == false) {
     NCCLCHECKGOTO(ncclProxyConnect(comm, TRANSPORT_P2P, 1, proxyRank, &comm->gproxyConn[proxyRank]), ret, error);
   }
-#if (defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)) && HIP_VERSION < 71260540
+#if (defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)) && !NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
   {
     uint64_t hipHandleVal = (uint64_t)(uintptr_t)(*(hipMemGenericAllocationHandle_t*)handle);
     NCCLCHECKGOTO(ncclProxyCallBlockingUDS(comm, &comm->gproxyConn[proxyRank], ncclProxyMsgGetFd, (void*)&hipHandleVal, sizeof(hipHandleVal), NULL, 0, NULL, convertedFd), ret, error);

--- a/projects/rccl/src/register/register.cc
+++ b/projects/rccl/src/register/register.cc
@@ -16,7 +16,7 @@
 
 using namespace rccl;
 
-#if HIP_VERSION >= 71260540
+#if NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
 NCCL_PARAM(LocalRegister, "LOCAL_REGISTER", 1);
 #else
 NCCL_PARAM(LocalRegister, "LOCAL_REGISTER", 0);

--- a/projects/rccl/src/rma/rma_proxy.cc
+++ b/projects/rccl/src/rma/rma_proxy.cc
@@ -78,7 +78,7 @@ static ncclResult_t getDmaBufFd(void *addr, size_t length, int *fd,
   uint64_t offset;
   ncclResult_t ret = ncclSuccess;
   ALIGN_SIZE(alignedSize, hostPageSize);
-#if HIP_VERSION >= 71260540
+#if NCCL_CUMEM_DMABUF_EXPORT_GATE
   if (ncclCuMemEnable() && sym_buffer) {
     CUCHECK(cuMemGetHandleForAddressRange((void *)fd, (CUdeviceptr)addr, alignedSize,
                                           CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0));
@@ -377,7 +377,7 @@ ncclResult_t ncclRmaProxyRegister(struct ncclComm* comm, void* address, size_t s
   struct ncclRmaProxyState* rmaProxyState = &comm->rmaState.rmaProxyState;
   for (int n = 0; n < rmaProxyState->ginCommCount; n++) {
     ncclNetProperties_t props_tmp = rmaProxyState->props[n];
-#if HIP_VERSION >= 71260540
+#if NCCL_CUMEM_DMABUF_EXPORT_GATE
     if (!ncclCuMemEnable()) {
       props_tmp.ptrSupport &= ~NCCL_PTR_DMABUF;
     }

--- a/projects/rccl/src/transport/coll_net.cc
+++ b/projects/rccl/src/transport/coll_net.cc
@@ -151,7 +151,7 @@ static ncclResult_t canConnect(int* ret, struct ncclComm* comm, struct ncclTopoG
 // Returns the flags to be used by a call to cuMemGetHandleForAddressRange.
 static inline int getHandleForAddressRangeFlags(ncclTopoGdrMode useGdr) {
   int flags = 0;
-#if CUDA_VERSION >= 12080 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#if CUDA_VERSION >= 12080 || NCCL_CUMEM_DMABUF_EXPORT_GATE
   // Force mapping on PCIe on systems with both PCI and C2C attachments.
   if (useGdr == ncclTopoGdrModePci) flags = CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE;
 #endif
@@ -520,7 +520,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   int dmabuf_fd = -1;
   (void)dmabuf_fd; /*compiler warnings fix - unused variable*/
   bool needReg = true;
-#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
   /* DMA-BUF support */
   if (resources->useGdr && resources->useDmaBuf && ncclCuMemEnable()) {
     CUCHECKGOTO(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)mapMem->cpuPtr, mapMem->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem_send);
@@ -617,7 +617,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   int dmabuf_fd = -1;
   (void)dmabuf_fd; /*compiler warnings fix - unused variable*/
   bool needReg = true;
-#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
   /* DMA-BUF support */
   if (resources->useGdr && resources->useDmaBuf && ncclCuMemEnable()) {
     CUCHECKGOTO(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)mapMem->cpuPtr, mapMem->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem_recv);
@@ -1358,7 +1358,7 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
   assert(respSize == sizeof(void*));
 
   int dmabuf_fd = -1;
-  #if CUDART_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+  #if CUDART_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
   /* DMA-BUF support */
   if (resources->useGdr && resources->useDmaBuf && ncclCuMemEnable()) {
     CUCHECKGOTO(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem);
@@ -1408,7 +1408,7 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
   assert(reqSize == sizeof(struct collnetRegInfo));
   assert(respSize == sizeof(void*));
   int dmabuf_fd = -1;
-#if CUDART_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#if CUDART_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
   /* DMA-BUF support */
   if (resources->useGdr && resources->useDmaBuf && ncclCuMemEnable()) {
     CUCHECKGOTO(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem);

--- a/projects/rccl/src/transport/coll_net.cc
+++ b/projects/rccl/src/transport/coll_net.cc
@@ -151,7 +151,7 @@ static ncclResult_t canConnect(int* ret, struct ncclComm* comm, struct ncclTopoG
 // Returns the flags to be used by a call to cuMemGetHandleForAddressRange.
 static inline int getHandleForAddressRangeFlags(ncclTopoGdrMode useGdr) {
   int flags = 0;
-#if CUDA_VERSION >= 12080 || HIP_VERSION >= 71260540
+#if CUDA_VERSION >= 12080 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
   // Force mapping on PCIe on systems with both PCI and C2C attachments.
   if (useGdr == ncclTopoGdrModePci) flags = CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE;
 #endif
@@ -520,7 +520,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   int dmabuf_fd = -1;
   (void)dmabuf_fd; /*compiler warnings fix - unused variable*/
   bool needReg = true;
-#if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
   /* DMA-BUF support */
   if (resources->useGdr && resources->useDmaBuf && ncclCuMemEnable()) {
     CUCHECKGOTO(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)mapMem->cpuPtr, mapMem->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem_send);
@@ -617,7 +617,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   int dmabuf_fd = -1;
   (void)dmabuf_fd; /*compiler warnings fix - unused variable*/
   bool needReg = true;
-#if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
   /* DMA-BUF support */
   if (resources->useGdr && resources->useDmaBuf && ncclCuMemEnable()) {
     CUCHECKGOTO(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)mapMem->cpuPtr, mapMem->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem_recv);
@@ -1358,7 +1358,7 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
   assert(respSize == sizeof(void*));
 
   int dmabuf_fd = -1;
-  #if CUDART_VERSION >= 11070 || HIP_VERSION >= 71260540
+  #if CUDART_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
   /* DMA-BUF support */
   if (resources->useGdr && resources->useDmaBuf && ncclCuMemEnable()) {
     CUCHECKGOTO(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem);
@@ -1408,7 +1408,7 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
   assert(reqSize == sizeof(struct collnetRegInfo));
   assert(respSize == sizeof(void*));
   int dmabuf_fd = -1;
-#if CUDART_VERSION >= 11070 || HIP_VERSION >= 71260540
+#if CUDART_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
   /* DMA-BUF support */
   if (resources->useGdr && resources->useDmaBuf && ncclCuMemEnable()) {
     CUCHECKGOTO(cuMemGetHandleForAddressRange((void *)&dmabuf_fd, (CUdeviceptr)info->buffer, info->size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, getHandleForAddressRangeFlags(resources->useGdr)), ret, peermem);

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -452,7 +452,7 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
 // Returns the flags to be used by a call to cuMemGetHandleForAddressRange.
 static inline int getHandleForAddressRangeFlags(ncclTopoGdrMode useGdr) {
   int flags = 0;
-#if CUDA_VERSION >= 12080 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#if CUDA_VERSION >= 12080 || NCCL_CUMEM_DMABUF_EXPORT_GATE
   // Force mapping on PCIe on systems with both PCI and C2C attachments.
   if (useGdr == ncclTopoGdrModePci) flags = CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE;
 #endif
@@ -1195,7 +1195,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
         ALIGN_SIZE(map->mems[NCCL_NET_MAP_DEVMEM].size, CUDA_IPC_MIN);
         NCCLCHECK(ncclP2pAllocateShareableBuffer(map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
                                                 (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, /*peerRank=*/-1, proxyState->memManager));
-#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
         // Get DMA-BUF fd for cuMem VMM allocations via cuMemGetHandleForAddressRange.
         // Required even when DMA-BUF is globally disabled: ibv_reg_mr on cuMem RDMA
         // memory fails ("Bad address") and corrupts VMM state, so ibv_reg_dmabuf_mr
@@ -1257,7 +1257,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
     resources->buffers[p] = NCCL_NET_MAP_GET_POINTER(map, cpu, buffs[p]);
     if (resources->buffers[p]) {
-#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
       /* DMA-BUF support */
       int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
       if (type == NCCL_PTR_CUDA && resources->useDmaBuf && ncclCuMemEnable()) {
@@ -1421,7 +1421,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
       if (ncclCuMemEnable()) {
         NCCLCHECK(ncclP2pAllocateShareableBuffer(map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
                                                 (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, /*peerRank=*/-1, proxyState->memManager));
-#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
         // Get DMA-BUF fd for cuMem VMM allocations. Required even when DMA-BUF is
         // globally disabled to avoid ibv_reg_mr on VMM memory.
         {
@@ -1474,7 +1474,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
     resources->buffers[p] = NCCL_NET_MAP_GET_POINTER(map, cpu, buffs[p]);
     if (resources->buffers[p]) {
-#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
       /* DMA-BUF support */
       int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
       if (type == NCCL_PTR_CUDA && resources->useDmaBuf && ncclCuMemEnable()) {
@@ -2260,7 +2260,7 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
   assert(reqSize == sizeof(struct netRegInfo));
   assert(respSize == sizeof(void*));
 
-#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
   /* DMA-BUF support */
   if (resources->useDmaBuf && ncclCuMemEnable()) {
     int dmabuf_fd;
@@ -2318,7 +2318,7 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
   assert(reqSize == sizeof(struct netRegInfo));
   assert(respSize == sizeof(void*));
 
-#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
   /* DMA-BUF support */
   if (resources->useDmaBuf && ncclCuMemEnable()) {
     int dmabuf_fd;

--- a/projects/rccl/src/transport/net.cc
+++ b/projects/rccl/src/transport/net.cc
@@ -452,7 +452,7 @@ static ncclResult_t sendProxyProgress(struct ncclProxyState* proxyState, struct 
 // Returns the flags to be used by a call to cuMemGetHandleForAddressRange.
 static inline int getHandleForAddressRangeFlags(ncclTopoGdrMode useGdr) {
   int flags = 0;
-#if CUDA_VERSION >= 12080 || HIP_VERSION >= 71260540
+#if CUDA_VERSION >= 12080 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
   // Force mapping on PCIe on systems with both PCI and C2C attachments.
   if (useGdr == ncclTopoGdrModePci) flags = CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE;
 #endif
@@ -1195,7 +1195,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
         ALIGN_SIZE(map->mems[NCCL_NET_MAP_DEVMEM].size, CUDA_IPC_MIN);
         NCCLCHECK(ncclP2pAllocateShareableBuffer(map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
                                                 (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, /*peerRank=*/-1, proxyState->memManager));
-#if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
         // Get DMA-BUF fd for cuMem VMM allocations via cuMemGetHandleForAddressRange.
         // Required even when DMA-BUF is globally disabled: ibv_reg_mr on cuMem RDMA
         // memory fails ("Bad address") and corrupts VMM state, so ibv_reg_dmabuf_mr
@@ -1257,7 +1257,7 @@ static ncclResult_t sendProxyConnect(struct ncclProxyConnection* connection, str
   for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
     resources->buffers[p] = NCCL_NET_MAP_GET_POINTER(map, cpu, buffs[p]);
     if (resources->buffers[p]) {
-#if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
       /* DMA-BUF support */
       int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
       if (type == NCCL_PTR_CUDA && resources->useDmaBuf && ncclCuMemEnable()) {
@@ -1421,7 +1421,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
       if (ncclCuMemEnable()) {
         NCCLCHECK(ncclP2pAllocateShareableBuffer(map->mems[NCCL_NET_MAP_DEVMEM].size, 0, &map->mems[NCCL_NET_MAP_DEVMEM].ipcDesc,
                                                 (void**)&map->mems[NCCL_NET_MAP_DEVMEM].gpuPtr, /*peerRank=*/-1, proxyState->memManager));
-#if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
         // Get DMA-BUF fd for cuMem VMM allocations. Required even when DMA-BUF is
         // globally disabled to avoid ibv_reg_mr on VMM memory.
         {
@@ -1474,7 +1474,7 @@ static ncclResult_t recvProxyConnect(struct ncclProxyConnection* connection, str
   for (int p=0; p<NCCL_NUM_PROTOCOLS; p++) {
     resources->buffers[p] = NCCL_NET_MAP_GET_POINTER(map, cpu, buffs[p]);
     if (resources->buffers[p]) {
-#if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
       /* DMA-BUF support */
       int type = NCCL_NET_MAP_DEV_MEM(map, buffs[p]) ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
       if (type == NCCL_PTR_CUDA && resources->useDmaBuf && ncclCuMemEnable()) {
@@ -2260,7 +2260,7 @@ static ncclResult_t sendProxyRegBuffer(struct ncclProxyConnection* connection, s
   assert(reqSize == sizeof(struct netRegInfo));
   assert(respSize == sizeof(void*));
 
-#if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
   /* DMA-BUF support */
   if (resources->useDmaBuf && ncclCuMemEnable()) {
     int dmabuf_fd;
@@ -2318,7 +2318,7 @@ static ncclResult_t recvProxyRegBuffer(struct ncclProxyConnection* connection, s
   assert(reqSize == sizeof(struct netRegInfo));
   assert(respSize == sizeof(void*));
 
-#if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
+#if CUDA_VERSION >= 11070 || NCCL_CUMEM_VERSION_SUPPORTED(HIP_VERSION)
   /* DMA-BUF support */
   if (resources->useDmaBuf && ncclCuMemEnable()) {
     int dmabuf_fd;

--- a/projects/rccl/src/transport/net_ib/connect.cc
+++ b/projects/rccl/src/transport/net_ib/connect.cc
@@ -1413,7 +1413,7 @@ ib_recv:
       rCommDev->gpuFlush.dmabuf_fd = -1;
 
       if (rcclParamIbGdrFlushGpuMemNoRelaxedOrdering()) {
-        #if CUDA_VERSION >= 11070 || HIP_VERSION >= 71260540
+        #if CUDA_VERSION >= 11070 || NCCL_CUMEM_DMABUF_EXPORT_GATE
         if (ncclCuMemEnable()) {
           NCCLCHECKGOTO(ncclMemAlloc((void**)&rCommDev->gpuFlush.gpuFlushGpuMem, sizeof(int)), ret, fail);
           CUCHECKGOTO(cuMemGetHandleForAddressRange((void*)&rCommDev->gpuFlush.dmabuf_fd,

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -178,6 +178,7 @@ if(BUILD_TESTS)
     ReduceTests.cpp
     RegisterTests.cpp
     ScatterTests.cpp
+    VersionGateTests.cpp
     SendRecvTests.cpp
     StandaloneTests.cpp
     TeardownStressTests.cpp

--- a/projects/rccl/test/VersionGateTests.cpp
+++ b/projects/rccl/test/VersionGateTests.cpp
@@ -1,0 +1,74 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+// Unit tests for the centralized ROCm/HIP version-gating macros in rocmwrap.h.
+// These macros are constant expressions evaluated against both HIP_VERSION
+// (compile time) and the runtime driver version, so the support windows are
+// asserted here against representative version codes to prevent silent drift.
+
+#include "rocmwrap.h"
+#include "gtest/gtest.h"
+
+namespace RcclUnitTesting
+{
+
+// Milestone constants must not drift (call sites and the predicates below
+// depend on these exact encodings: MAJOR*10000000 + MINOR*100000 + PATCH).
+static_assert(ROCM_VER_7_0_2_2     == 70051831, "7.0.2.x backport lower bound changed");
+static_assert(ROCM_VER_7_0_3_0     == 70060000, "7.0.2.x backport upper bound changed");
+static_assert(ROCM_VER_7_12_0      == 71200000, "7.12 native min changed");
+static_assert(ROCM_VER_7_12_60540  == 71260540, "cuMem/DMA-BUF native min changed");
+static_assert(NCCL_CUMEM_NATIVE_MIN_VERSION == ROCM_VER_7_12_60540, "native-min alias drifted");
+
+// Generic range predicates.
+static_assert(NCCL_VER_GE(ROCM_VER_7_12_60540, ROCM_VER_7_12_60540), "GE boundary");
+static_assert(!NCCL_VER_GE(ROCM_VER_7_12_60540 - 1, ROCM_VER_7_12_60540), "GE below boundary");
+static_assert(NCCL_VER_IN(ROCM_VER_7_0_2_2, ROCM_VER_7_0_2_2, ROCM_VER_7_0_3_0), "IN lower-inclusive");
+static_assert(!NCCL_VER_IN(ROCM_VER_7_0_3_0, ROCM_VER_7_0_2_2, ROCM_VER_7_0_3_0), "IN upper-exclusive");
+
+TEST(VersionGateTests, CuMemVersionSupported)
+{
+    // Native 7.12+ window (open-ended).
+    EXPECT_TRUE (NCCL_CUMEM_VERSION_SUPPORTED(ROCM_VER_7_12_60540));
+    EXPECT_TRUE (NCCL_CUMEM_VERSION_SUPPORTED(ROCM_VER_7_12_60540 + 1));
+    EXPECT_FALSE(NCCL_CUMEM_VERSION_SUPPORTED(ROCM_VER_7_12_60540 - 1));
+
+    // 7.0.2.x backport window [70051831, 70060000).
+    EXPECT_TRUE (NCCL_CUMEM_VERSION_SUPPORTED(ROCM_VER_7_0_2_2));
+    EXPECT_TRUE (NCCL_CUMEM_VERSION_SUPPORTED(ROCM_VER_7_0_3_0 - 1));
+    EXPECT_FALSE(NCCL_CUMEM_VERSION_SUPPORTED(ROCM_VER_7_0_2_2 - 1));
+    EXPECT_FALSE(NCCL_CUMEM_VERSION_SUPPORTED(ROCM_VER_7_0_3_0));
+
+    // The gap between the backport upper bound and the native min is unsupported.
+    EXPECT_FALSE(NCCL_CUMEM_VERSION_SUPPORTED(ROCM_VER_7_12_0));
+}
+
+TEST(VersionGateTests, CuMemHostIsNativeOnly)
+{
+    EXPECT_TRUE (NCCL_CUMEM_HOST_VERSION_SUPPORTED(ROCM_VER_7_12_60540));
+    EXPECT_FALSE(NCCL_CUMEM_HOST_VERSION_SUPPORTED(ROCM_VER_7_12_60540 - 1));
+
+    // Host allocations are deliberately NOT part of the 7.0.2.x backport
+    // (they rely on hipDeviceAttributeHostNumaId, absent there).
+    EXPECT_FALSE(NCCL_CUMEM_HOST_VERSION_SUPPORTED(ROCM_VER_7_0_2_2));
+    EXPECT_FALSE(NCCL_CUMEM_HOST_VERSION_SUPPORTED(ROCM_VER_7_0_3_0 - 1));
+}
+
+TEST(VersionGateTests, CeBatchAsyncWindow)
+{
+    // Native 7.12+ (note: 7.12.0, lower than the cuMem milestone).
+    EXPECT_TRUE (NCCL_CE_BATCH_ASYNC_VERSION_SUPPORTED(ROCM_VER_7_12_0));
+    EXPECT_TRUE (NCCL_CE_BATCH_ASYNC_VERSION_SUPPORTED(ROCM_VER_7_12_60540));
+    EXPECT_FALSE(NCCL_CE_BATCH_ASYNC_VERSION_SUPPORTED(ROCM_VER_7_12_0 - 1));
+
+    // 7.0.2.x backport window also enables the batch API.
+    EXPECT_TRUE (NCCL_CE_BATCH_ASYNC_VERSION_SUPPORTED(ROCM_VER_7_0_2_2));
+    EXPECT_TRUE (NCCL_CE_BATCH_ASYNC_VERSION_SUPPORTED(ROCM_VER_7_0_3_0 - 1));
+    EXPECT_FALSE(NCCL_CE_BATCH_ASYNC_VERSION_SUPPORTED(ROCM_VER_7_0_2_2 - 1));
+    EXPECT_FALSE(NCCL_CE_BATCH_ASYNC_VERSION_SUPPORTED(ROCM_VER_7_0_3_0));
+}
+
+}  // namespace RcclUnitTesting


### PR DESCRIPTION
## Motivation

Scattered `#if`/`HIP_VERSION`/`ROCM_VERSION` checks with bare magic numbers were duplicated across the cuMem, proxy, register, RMA, and net transport paths. This made the per-feature version requirements hard to audit, easy to get subtly wrong, and painful to bump on new ROCm/HIP milestones. The goal is to consolidate them into a single documented set of milestone constants and feature-predicate macros so each call site expresses intent rather than re-deriving a raw version comparison. Also, it enables cuMem/GIN features on backport version.

## Technical Details

- Added milestone version constants and feature-predicate macros to `src/include/rocmwrap.h ` (e.g. `NCCL_CUMEM_VERSION_SUPPORTED` and related gates) as the single source of truth.
- Replaced inline version comparisons with the new macros across files.
- Behavior-preserving refactor: effective gates are unchanged; only their definitions are centralized.
- Added `test/VersionGateTests.cpp` (wired into `test/CMakeLists.txt`) with compile-time `static_assert`s for milestone ordering plus gtest cases for the runtime predicates.

## JIRA ID

AICOMRCCL-1456

## Test Plan

- `./install.sh -t -l`
- `./build/release/test/rccl-UnitTests --gtest_filter='VersionGateTests.*'`
- Existing `rccl-UnitTests` / `rccl-UnitTestsMPI` suites for regression.

## Test Result

- Clean build; compile-time `static_assert`s validate milestone ordering.
- `VersionGateTests.*` (3 cases) PASS.
- No functional/perf change expected (gates unchanged).

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
