### PR TITLE
ci(hip-tests): Add option to enforce label settings for new hip-tests

### DIFF
--- a/.github/workflows/therock-ci-linux.yml
+++ b/.github/workflows/therock-ci-linux.yml
@@ -41,6 +41,7 @@ jobs:
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
       TEATIME_FORCE_INTERACTIVE: 0
       AWS_SHARED_CREDENTIALS_FILE: /home/awsconfig/credentials.ini
+      THEROCK_REQUIRE_HIP_YAML_ENTRIES: 1
     steps:
       - name: "Checking out repository for rocm-systems"
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/projects/hip-tests/catch/config/check_sources.py
+++ b/projects/hip-tests/catch/config/check_sources.py
@@ -78,7 +78,7 @@ def main():
             missing.append(f"  {group}/{name}")
 
     if missing:
-        strict = os.environ.get("THEROCK_REQUIRE_HIP_YAML_ENTRIES", "").strip()
+        strict = os.environ.get("THEROCK_REQUIRE_HIP_YAML_ENTRIES", "").strip().lower() in ("1", "true", "yes", "on")
         level = "ERROR" if strict else "WARNING"
         color = ERROR if strict else WARNING
         print(

--- a/projects/hip-tests/catch/config/check_sources.py
+++ b/projects/hip-tests/catch/config/check_sources.py
@@ -7,7 +7,7 @@ import os
 import re
 import sys
 
-from common import NON_UNIT_GROUPS, iter_group_configs, WARNING, RESET
+from common import NON_UNIT_GROUPS, iter_group_configs, ERROR, WARNING, RESET
 
 CPP_EXTENSIONS = (".cc", ".cpp", ".cxx", ".c++", ".C", ".cp", ".CPP")
 
@@ -78,12 +78,17 @@ def main():
             missing.append(f"  {group}/{name}")
 
     if missing:
+        strict = os.environ.get("THEROCK_REQUIRE_HIP_YAML_ENTRIES", "").strip()
+        level = "ERROR" if strict else "WARNING"
+        color = ERROR if strict else WARNING
         print(
-            f"[check_sources] {WARNING}WARNING: The following Catch2 test cases have no entry in their YAML config:{RESET}",
+            f"[check_sources] {color}{level}: The following Catch2 test cases have no entry in their YAML config:{RESET}",
             file=sys.stderr,
         )
         for entry in missing:
-            print(f"[check_sources] {WARNING}{entry}{RESET}", file=sys.stderr)
+            print(f"[check_sources] {color}{entry}{RESET}", file=sys.stderr)
+        if strict:
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/projects/hip-tests/catch/config/configs/multiproc.yaml
+++ b/projects/hip-tests/catch/config/configs/multiproc.yaml
@@ -15,7 +15,7 @@ multiproc:
   Unit_hipDeviceGetAttribute_MaskedDevices: *level_2
   Unit_hipGetDeviceCount_MaskedDevices: *level_2
   Unit_hipGetDeviceProperties_MaskedDevices: *level_2
-  Unit_hipIpcEventHandle_Functional: *level_2
+  # Unit_hipIpcEventHandle_Functional: *level_2
   Unit_hipIpcEventHandle_ParameterValidation: *level_2
   Unit_hipIpcMemAccess_Semaphores:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/multiproc.yaml
+++ b/projects/hip-tests/catch/config/configs/multiproc.yaml
@@ -15,7 +15,7 @@ multiproc:
   Unit_hipDeviceGetAttribute_MaskedDevices: *level_2
   Unit_hipGetDeviceCount_MaskedDevices: *level_2
   Unit_hipGetDeviceProperties_MaskedDevices: *level_2
-  # Unit_hipIpcEventHandle_Functional: *level_2
+  Unit_hipIpcEventHandle_Functional: *level_2
   Unit_hipIpcEventHandle_ParameterValidation: *level_2
   Unit_hipIpcMemAccess_Semaphores:
     <<: *level_2

--- a/projects/hip-tests/catch/config/configs/performance.yaml
+++ b/projects/hip-tests/catch/config/configs/performance.yaml
@@ -252,3 +252,4 @@ performance:
   Performance_hipPerfMultiStreamKernelLaunch: *level_2
   Performance_hipPerfVMMAllocSpeed_test: *level_2
   Performance_hipPerfHostNumaAlloc_test_preferred_host_numa_node_on_each_GPU: *level_2
+  Performance_Graph_CollapseCorrectness: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/deviceLib.yaml
@@ -503,6 +503,9 @@ deviceLib:
   Unit_hipTestHalfConstexpr_DeviceConstexpr:
     <<: *level_2
     tags: [types]
+  Unit_device_memcpy_async:
+    <<: *level_2
+    tags: [memory]
   Unit_MemcpyToSymbolInParallelWithStreamLaunch:
     <<: *level_3
     tags: [misc]

--- a/projects/hip-tests/catch/config/configs/unit/graph.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/graph.yaml
@@ -1747,3 +1747,6 @@ graph:
   Unit_hipGraphAllocNodeMemReuse_CaptureEscapedUseAfterDestroy:
     <<: *level_2
     tags: [node]
+  Unit_hipGraph_SimpleGraphWithKernel_kernel_arg_prefetch:
+    <<: *level_2
+    tags: [exec]

--- a/projects/hip-tests/catch/config/configs/unit/hrr.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/hrr.yaml
@@ -114,3 +114,81 @@ hrr:
   Unit_HRR_MultiThreadRoundtrip:
     <<: *level_2
     tags: [capture, multithread, playback, roundtrip]
+  Unit_HRR_AllApis_Direct:
+    <<: *level_2
+    tags: [direct, allapis]
+  Unit_HRR_ChevronLaunch_Direct:
+    <<: *level_2
+    tags: [direct, launch]
+  Unit_HRR_Context_Direct:
+    <<: *level_2
+    tags: [direct, context]
+  Unit_HRR_DeviceExtra_Direct:
+    <<: *level_2
+    tags: [direct, device]
+  Unit_HRR_DeviceInfo_Direct:
+    <<: *level_2
+    tags: [direct, device]
+  Unit_HRR_DrvMemcpy3D_Direct:
+    <<: *level_2
+    tags: [direct, memcpy]
+  Unit_HRR_DrvMemcpy_Direct:
+    <<: *level_2
+    tags: [direct, memcpy]
+  Unit_HRR_GpuWorkload_Direct:
+    <<: *level_2
+    tags: [direct]
+  Unit_HRR_GraphExplicit_Direct:
+    <<: *level_2
+    tags: [direct, graph]
+  Unit_HRR_GraphWorkload_Direct:
+    <<: *level_2
+    tags: [direct, graph]
+  Unit_HRR_HostAliases_Direct:
+    <<: *level_2
+    tags: [direct, hostmem]
+  Unit_HRR_HostMemWorkload_Direct:
+    <<: *level_2
+    tags: [direct, hostmem]
+  Unit_HRR_HostRegLaunch_Direct:
+    <<: *level_2
+    tags: [direct, hostmem, launch]
+  Unit_HRR_MemPoolExtended_Direct:
+    <<: *level_2
+    tags: [direct, mempool]
+  Unit_HRR_MemcpyExtra_Direct:
+    <<: *level_2
+    tags: [direct, memcpy]
+  Unit_HRR_MemsetExtra_Direct:
+    <<: *level_2
+    tags: [direct, memset]
+  Unit_HRR_MemsetVariants_Direct:
+    <<: *level_2
+    tags: [direct, memset]
+  Unit_HRR_MiscAPIs_Direct:
+    <<: *level_2
+    tags: [direct, misc]
+  Unit_HRR_ModuleAPI_Direct:
+    <<: *level_2
+    tags: [direct, module, launch]
+  Unit_HRR_ModuleExtra_Direct:
+    <<: *level_2
+    tags: [direct, module]
+  Unit_HRR_Occupancy_Direct:
+    <<: *level_2
+    tags: [direct, occupancy]
+  Unit_HRR_StreamAdvanced2_Direct:
+    <<: *level_2
+    tags: [direct, stream]
+  Unit_HRR_StreamAdvanced_Direct:
+    <<: *level_2
+    tags: [direct, stream]
+  Unit_HRR_StressApis_Direct:
+    <<: *level_2
+    tags: [direct, stress]
+  Unit_HRR_Texture_Direct:
+    <<: *level_2
+    tags: [direct, texture]
+  Unit_HRR_VMM_Direct:
+    <<: *level_2
+    tags: [direct, vmm]

--- a/projects/hip-tests/catch/config/configs/unit/kernel.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/kernel.yaml
@@ -104,3 +104,12 @@ kernel:
     disabled: [amd_linux, amd_windows, amd_wsl]
   Unit_Validate_User_Sgpr_Count:
     <<: *level_2
+  Unit_hipGridLaunch_MaxGridDim_DeviceProperties:
+    <<: *level_2
+    tags: [launch]
+  Unit_hipGridLaunch_MaxGridDim_GetDeviceAttribute:
+    <<: *level_2
+    tags: [launch]
+  Unit_hipLaunchParmFunctor_kernel_arg_prefetch:
+    <<: *level_2
+    tags: [launch]

--- a/projects/hip-tests/catch/config/configs/unit/occupancy.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/occupancy.yaml
@@ -57,3 +57,9 @@ occupancy:
   Unit_hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags_InvalidArgs: *level_2
   Unit_hipOccupancyAvailableDynamicSMemPerBlock_Negative: *level_2
   Unit_hipOccupancyAvailableDynamicSMemPerBlock_Positive: *level_2
+  Unit_hipOccupancyMaxActiveClusters_Negative_Parameters: *level_2
+  Unit_hipOccupancyMaxActiveClusters_Negative_Zero_Cluster: *level_2
+  Unit_hipOccupancyMaxActiveClusters_Positive_RangeValidation: *level_2
+  Unit_hipOccupancyMaxPotentialClusterSize_Negative_Parameters: *level_2
+  Unit_hipOccupancyMaxPotentialClusterSize_Positive_RangeValidation: *level_2
+  Unit_hipOccupancyMaxPotentialClusterSize_Verify_Launch: *level_2

--- a/projects/hip-tests/catch/config/configs/unit/rtc.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/rtc.yaml
@@ -221,3 +221,9 @@ rtc:
     <<: *level_2
     # Rock_Window_Failures_on_gfx1151
     disabled: [amd_windows]
+  Unit_RTC_BUNDLE_FROM_FILE:
+    <<: *level_2
+    tags: [link]
+  Unit_hiprtc_fp8_simple:
+    <<: *level_2
+    tags: [compile]

--- a/projects/hip-tests/catch/config/configs/unit/stream.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/stream.yaml
@@ -439,3 +439,15 @@ stream:
   Unit_hipStreamValue_Wait_Blocking:
     <<: *level_2
     tags: [synchronization]
+  Unit_hipStreamWriteValue_Decrement_Default:
+    <<: *level_2
+    tags: [synchronization]
+  Unit_hipStreamWriteValue_Decrement_MultiStream_MultiDevice:
+    <<: *level_2
+    tags: [synchronization, multigpu]
+  Unit_hipStreamWriteValue_Increment_Default:
+    <<: *level_2
+    tags: [synchronization]
+  Unit_hipStreamWriteValue_Increment_MultiStream_MultiDevice:
+    <<: *level_2
+    tags: [synchronization, multigpu]

--- a/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
+++ b/projects/hip-tests/catch/config/configs/unit/virtualMemoryManagement.yaml
@@ -263,3 +263,4 @@ virtualMemoryManagement:
     # Below tests are failing PSDB
     disabled: [nvidia_linux, nvidia_windows]
   Unit_hipMemSetAccess_SegmentsAccess: *level_2
+  Unit_hipMemExportFabricHandleToStdout_Positive_Basic: *level_2


### PR DESCRIPTION
## Motivation
Enforcement of the label's creation for new hip-tests was disabled by default by https://github.com/ROCm/rocm-systems/pull/6018/changes. This PR adds environment variable to enforce it in CI. 
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
Adds a new variable, THEROCK_REQUIRE_HIP_YAML_ENTRIES, which will enforce all hip-tests have an entry in the yaml configs, with at minimum test level label set.
<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
NA
<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan
- Default build should not be impacted
- Build should fail if any test is added to the *.cpp files, but not present in hip-tests config
<!-- Explain any relevant testing done to verify this PR. -->

## Test Result
- Waiting for PSDB with new labels
- The tests without labels were added to develop already, see https://github.com/ROCm/rocm-systems/actions/runs/28375497488/job/84064154510?pr=7936#step:12:302
<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
