### PR TITLE
[kpack] Pin relocated PHDR vaddr to file offset for old-kernel exec compat (#7681)

### DIFF
--- a/shared/kpack/python/rocm_kpack/elf/__init__.py
+++ b/shared/kpack/python/rocm_kpack/elf/__init__.py
@@ -31,6 +31,7 @@ from .phdr_manager import (
     ProgramHeaderManager,
     PhdrResizeResult,
     create_load_segment,
+    normalize_phdr_vaddr,
 )
 from .operations import (
     map_section_to_load,
@@ -146,6 +147,7 @@ __all__ = [
     "SetPointerResult",
     "UpdateRelocationResult",
     "create_load_segment",
+    "normalize_phdr_vaddr",
     # Zero-page operations
     "conservative_zero_page",
     "zero_page_section",

--- a/shared/kpack/python/rocm_kpack/elf/kpack_transform.py
+++ b/shared/kpack/python/rocm_kpack/elf/kpack_transform.py
@@ -21,6 +21,7 @@ import msgpack
 from ..kpack_transform import NotFatBinaryError
 from .surgery import ElfSurgery, SectionInfo, AddSectionResult
 from .operations import map_section_to_load, set_pointer
+from .phdr_manager import normalize_phdr_vaddr
 from .verify import ElfVerifier
 from .zero_page import conservative_zero_page
 from .types import SHT_PROGBITS
@@ -383,6 +384,10 @@ def kpack_offload_binary(
                 "\nPhases 2-3: No .hip_fatbin section, skipping semantic "
                 "transformation and zero-page"
             )
+
+    # Pin the relocated PHDR table to p_vaddr == p_offset so the binary execs
+    # on old kernels (e.g. EL8 4.18). Must run after all size-changing phases.
+    normalize_phdr_vaddr(surgery)
 
     # Post-transform verification: catch structural corruption at build time
     verify_result = ElfVerifier.verify_data(surgery.data)

--- a/shared/kpack/python/rocm_kpack/elf/phdr_manager.py
+++ b/shared/kpack/python/rocm_kpack/elf/phdr_manager.py
@@ -13,6 +13,9 @@ Key invariants:
 - (p_offset % PAGE_SIZE) == (p_vaddr % PAGE_SIZE) for all PT_LOAD segments
 - PT_PHDR (if present) must point to the program header table location
 - The program header table must be covered by a PT_LOAD segment
+
+See normalize_phdr_vaddr() for the additional p_vaddr == p_offset constraint
+that old kernels (e.g. EL8 4.18) require on the relocated PHDR segment.
 """
 
 from dataclasses import dataclass
@@ -24,6 +27,7 @@ from .types import (
     PAGE_SIZE,
     PT_LOAD,
     PT_PHDR,
+    PT_INTERP,
     PF_R,
     round_up_to_page,
     page_align_offset,
@@ -313,3 +317,101 @@ def create_load_segment(
         p_memsz=size,
         p_align=PAGE_SIZE,
     )
+
+
+def normalize_phdr_vaddr(surgery: ElfSurgery) -> bool:
+    """Pin the relocated PHDR PT_LOAD to p_vaddr == p_offset.
+
+    When the program header table has been relocated to a trailing PT_LOAD, its
+    p_vaddr is only page-congruent with its file offset. Old kernels (e.g. EL8
+    4.18) compute AT_PHDR = load_bias + e_phoff without translating e_phoff
+    through the covering segment, so direct exec maps an unmapped address and
+    SIGSEGVs in ld.so before main. Making p_vaddr == p_offset fixes that and
+    stays valid on newer kernels.
+
+    Run as the final step, after all size-changing transforms. When the table
+    already sits above every other segment's address range (the common case for
+    real binaries) this is a pure metadata edit; otherwise the table is moved to
+    a fresh end-of-file offset at/above the address ceiling, which grows the file
+    (only happens for fully zero-paged binaries whose file shrank below it).
+
+    Only applied to executables (those with a PT_INTERP). Shared libraries are
+    always mapped by ld.so, which handles a relocated PHDR correctly, so they are
+    left untouched to avoid needless file growth.
+
+    Returns True if the binary was modified.
+    """
+    ehdr = surgery.ehdr
+    e_phoff = ehdr.e_phoff
+
+    if not any(ph.p_type == PT_INTERP for _, ph in surgery.iter_program_headers()):
+        return False
+
+    cover_idx = None
+    cover = None
+    pt_phdr_idx = None
+    ceiling = 0  # max p_vaddr+p_memsz over OTHER PT_LOAD segments
+    for idx, ph in surgery.iter_program_headers():
+        if ph.p_type == PT_PHDR:
+            pt_phdr_idx = idx
+        if ph.p_type == PT_LOAD and ph.p_offset <= e_phoff < ph.p_offset + ph.p_filesz:
+            cover_idx, cover = idx, ph
+    for idx, ph in surgery.iter_program_headers():
+        if ph.p_type == PT_LOAD and idx != cover_idx:
+            ceiling = max(ceiling, ph.p_vaddr + ph.p_memsz)
+
+    # Only act on a *relocated* PHDR table: a dedicated PT_LOAD that begins
+    # exactly at e_phoff. This excludes the non-relocated case where the PHDR
+    # still lives in the first PT_LOAD (e.g. ET_EXEC, where that segment has
+    # p_vaddr != p_offset and must not be rewritten). Also skip if already
+    # normalized (p_vaddr == p_offset).
+    if cover is None or cover.p_offset != e_phoff or cover.p_vaddr == cover.p_offset:
+        return False
+
+    page_ceiling = round_up_to_page(ceiling)
+    pt_phdr = surgery._phdrs[pt_phdr_idx] if pt_phdr_idx is not None else None
+
+    def _pin(idx: int, source: ProgramHeader, vaddr: int, offset: int) -> None:
+        surgery.update_program_header(
+            idx,
+            ProgramHeader(
+                p_type=source.p_type,
+                p_flags=source.p_flags,
+                p_offset=offset,
+                p_vaddr=vaddr,
+                p_paddr=vaddr,
+                p_filesz=source.p_filesz,
+                p_memsz=source.p_memsz,
+                p_align=source.p_align,
+            ),
+        )
+
+    if e_phoff >= page_ceiling:
+        # Table already clears every other segment's address range: just pin
+        # vaddr to the existing offset. No file growth.
+        _pin(cover_idx, cover, cover.p_offset, cover.p_offset)
+        if pt_phdr is not None:
+            _pin(pt_phdr_idx, pt_phdr, pt_phdr.p_offset, pt_phdr.p_offset)
+        return True
+
+    # Table offset is below the address ceiling; pinning vaddr there would
+    # overlap another segment. Copy the table to a fresh end-of-file offset
+    # at/above the ceiling so vaddr == offset holds without overlap.
+    # Copy the covering segment's full p_filesz (table entries plus any spare
+    # slots), not just e_phnum*e_phentsize, so the file actually contains every
+    # byte the relocated PT_LOAD claims (otherwise it could map past EOF).
+    table = bytes(surgery.data[e_phoff : e_phoff + cover.p_filesz])
+    new_off = round_up_to_page(max(len(surgery.data), page_ceiling))
+    pad = new_off - len(surgery.data)
+    if pad > 0:
+        surgery.append_bytes(b"\x00" * pad, "padding for PHDR vaddr normalization")
+    surgery.append_bytes(table, "relocated PHDR table (vaddr==offset)")
+
+    surgery._ehdr.e_phoff = new_off
+    surgery.update_elf_header()
+
+    _pin(cover_idx, cover, new_off, new_off)
+    if pt_phdr is not None:
+        _pin(pt_phdr_idx, pt_phdr, new_off, new_off)
+    surgery._phdrs = surgery._parse_program_headers()
+    return True

--- a/shared/kpack/tests/elf/test_kpack_transform.py
+++ b/shared/kpack/tests/elf/test_kpack_transform.py
@@ -45,10 +45,12 @@ class TestKpackOffloadBinary:
         # Verify output exists
         assert output_binary.exists()
 
-        # Verify size reduction
+        # Device code is removed (.hip_fatbin -> NOBITS, verified below). On-disk
+        # size is not asserted to shrink: executables get their PHDR table
+        # normalized to p_vaddr == p_offset for old-kernel (EL8 4.18) direct exec,
+        # and on a tiny fully-zero-paged fixture that overhead can exceed the
+        # savings. Real binaries (host image >> stub .hip_fatbin) are unaffected.
         new_size = output_binary.stat().st_size
-        assert new_size < original_size
-        assert result["removed"] > 0
         assert result["original_size"] == original_size
         assert result["new_size"] == new_size
 

--- a/shared/kpack/tests/elf/test_zero_page.py
+++ b/shared/kpack/tests/elf/test_zero_page.py
@@ -258,6 +258,52 @@ class TestFullPipelineAlignment:
         min_offset = surgery.get_min_content_offset()
         assert min_offset > 0, "get_min_content_offset should not return 0"
 
+    def test_relocated_phdr_vaddr_equals_offset(
+        self, test_assets_dir: Path, tmp_path: Path
+    ):
+        """Relocated PHDR PT_LOAD must use p_vaddr == p_offset.
+
+        EL8's 4.18 kernel computes AT_PHDR = load_bias + e_phoff without
+        translating e_phoff through the covering segment, so a merely
+        page-congruent mapping (p_vaddr != p_offset) makes direct exec
+        SIGSEGV in ld.so before main. Regression test for ROCm/TheRock#5430.
+        """
+        input_binary = (
+            test_assets_dir / "bundled_binaries/linux/cov5/test_kernel_single.exe"
+        )
+        output_binary = tmp_path / "phdr_vaddr_output.exe"
+
+        kpack_offload_binary(
+            input_path=input_binary,
+            output_path=output_binary,
+            kpack_search_paths=["test.kpack"],
+            kernel_name="test_kernel",
+        )
+
+        surgery = ElfSurgery.load(output_binary)
+        e_phoff = surgery.ehdr.e_phoff
+        covering = [
+            phdr
+            for _, phdr in surgery.iter_program_headers()
+            if phdr.p_type == PT_LOAD
+            and phdr.p_offset <= e_phoff < phdr.p_offset + phdr.p_filesz
+        ]
+        assert covering, "no PT_LOAD covers the program header table"
+        # The pipeline must have relocated the PHDR table into a dedicated
+        # trailing PT_LOAD that begins at e_phoff (otherwise this test would
+        # pass trivially on a non-relocated PIE whose first PT_LOAD already has
+        # p_vaddr == p_offset == 0, exercising nothing).
+        assert any(phdr.p_offset == e_phoff for phdr in covering), (
+            f"expected a dedicated PHDR PT_LOAD starting at e_phoff=0x{e_phoff:x}; "
+            "the table was not relocated as expected"
+        )
+        for phdr in covering:
+            assert phdr.p_vaddr == phdr.p_offset, (
+                "PHDR-covering PT_LOAD must have p_vaddr == p_offset for "
+                f"old-kernel exec; got p_vaddr=0x{phdr.p_vaddr:x}, "
+                f"p_offset=0x{phdr.p_offset:x}"
+            )
+
 
 class TestNobitsCollision:
     """Tests for NOBITS offset collision when section ends on page boundary."""

--- a/shared/kpack/tests/test_unbundling_visitor.py
+++ b/shared/kpack/tests/test_unbundling_visitor.py
@@ -195,20 +195,14 @@ def test_unbundling_visitor_unbundles_binaries(
     assert (output_dir / "bins" / "test_kernel_multi.exe").exists()
     assert (output_dir / "bins" / "libtest_kernel_single.so").exists()
 
-    # Verify host-only binaries are smaller than originals (device code removed)
-    original_multi_size = (
-        (bundled_test_tree / "bins" / "test_kernel_multi.exe").stat().st_size
-    )
+    # Note: executables get their PHDR table normalized to p_vaddr == p_offset
+    # for old-kernel (EL8 4.18) direct exec; on a tiny fully-zero-paged fixture
+    # that overhead can exceed the device-code savings. Real binaries shrink.
     host_only_multi_size = (
         (output_dir / "bins" / "test_kernel_multi.exe").stat().st_size
     )
-    assert (
-        host_only_multi_size < original_multi_size
-    ), "Host-only binary should be smaller"
+    assert host_only_multi_size > 0, "Host-only binary should exist and be valid"
 
-    original_single_size = (
-        (bundled_test_tree / "bins" / "libtest_kernel_single.so").stat().st_size
-    )
     host_only_single_size = (
         (output_dir / "bins" / "libtest_kernel_single.so").stat().st_size
     )


### PR DESCRIPTION
Cherry-picks 872b4f6 into the 7.14 release branch.

---

## Motivation

Fixes https://github.com/ROCm/TheRock/issues/5430

kpack-split ROCm **executables** SIGSEGV in the dynamic loader before `main` when run directly on RHEL/Rocky 8.x (kernel 4.18) baremetal. `test_hip_api`/`clang-offload-bundler` crash with no output, while `/lib64/ld-linux-x86-64.so.2 <binary>` works.

## Technical Details

When kpack relocates the program header table to a trailing `PT_LOAD`, that segment's `p_vaddr` is only page-*congruent* with its file offset (`p_vaddr != p_offset`). Kernel 4.18 computes `AT_PHDR = load_bias + e_phoff` **without** translating `e_phoff` through the covering segment, so `ld.so` is handed an unmapped address and crashes before `main`. Newer kernels (>= 5.x) translate correctly, so it only reproduces on EL8.

Fix: a dedicated `normalize_phdr_vaddr()` pass (in `elf/phdr_manager.py`), called as the **last** step of `kpack_offload_binary` after all size-changing phases, pins the relocated PHDR `PT_LOAD`/`PT_PHDR` to `p_vaddr == p_offset`.

- **Executables only** (gated on `PT_INTERP`). Shared libraries are always mapped by `ld.so`, which handles a relocated PHDR correctly, so they are left untouched — avoiding needless file growth.
- **No size change for real binaries:** when the table already clears every other segment's address range (the case for shipped binaries, whose host image dwarfs the residual stub `.hip_fatbin`), this is a pure metadata edit.
- It only moves the table to a fresh end-of-file offset (growing the file) when a *fully zero-paged* binary's file has shrunk below the address ceiling — which in practice is just the small synthetic test fixtures, not shipped binaries.

Single chokepoint, so it covers both the wheel and tarball paths.

## Test Plan

- Reproduced on Rocky Linux 8.10, kernel 4.18.0-553 — both a GPU-free KVM VM and RHEL 8.10 baremetal with a gfx1100.
- Applied the resulting `p_vaddr == p_offset` layout to a real kpack-split `test_hip_api` and re-ran on kernel 4.18 (direct exec and via `ld.so`).
- Added a regression test (`TestFullPipelineAlignment::test_relocated_phdr_vaddr_equals_offset`) asserting the relocated PHDR `PT_LOAD` satisfies `p_vaddr == p_offset` after the full pipeline.

## Test Result

- **Before:** direct exec -> SIGSEGV (exit 139) in `ld-2.28.so` before `main`.
- **After:** direct exec runs normally. On a real RHEL 8.10 gfx1100 box, `test_hip_api` went from segfault to a full pass (`[ OK ] HIPTests.Saxpy`, exit 0), matching the `ld-linux` workaround.
- The normalization is verified (via kpack's own loader) to be a zero-byte metadata edit on real binaries, idempotent, and a no-op on shared libraries and on non-relocated binaries.
- CI: Python tests (ubuntu + windows, 3.10/3.12) and C++ runtime tests pass.

### Test changes

- Two `.exe`-fixture size assertions (`test_kpack_fat_binary`, `test_unbundling_visitor`) were relaxed: a tiny *fully zero-paged* executable can grow when its PHDR is normalized for old-kernel exec, so they now assert validity + device-code removal (`.hip_fatbin` -> NOBITS) instead of raw shrink. Real binaries are unaffected.
- The shared-library size test (`test_artifact_with_fat_binaries`) is unchanged and still passes, since libraries are no longer touched.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

---------

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
