### PR TITLE
[hip-tests] [ASAN] fix hiprtc kernel count when asan is enabled

### DIFF
--- a/projects/hip-tests/catch/unit/library/library_get_global.cc
+++ b/projects/hip-tests/catch/unit/library/library_get_global.cc
@@ -378,7 +378,13 @@ HIP_TEST_CASE(Unit_hipLibraryGetKernel_CountAndEnumerate) {
   // kGlobalSrc defines two kernels (write_d_var, read_d_var).
   unsigned int count = 0;
   HIP_CHECK(hipLibraryGetKernelCount(&count, lib));
-  REQUIRE(count == 2);
+  // If user builds with ASAN, we can get 2 additional kernels (init/fini) in the code object.
+  // The thing is, it only adds in device asan and not in host asan.
+  // So this check needs to cater for both
+  constexpr int expected_count = 2;
+  constexpr int asan_expected_count = expected_count + 2;
+  INFO("The count we got is: " << count);
+  REQUIRE((count == expected_count || count == asan_expected_count));
 
   hipKernel_t writer = nullptr;
   hipKernel_t reader = nullptr;
@@ -398,13 +404,17 @@ HIP_TEST_CASE(Unit_hipLibraryGetKernel_CountAndEnumerate) {
   HIP_CHECK_ERROR(hipLibraryGetKernel(&missing, lib, "nonexistent_kernel"), hipErrorNotFound);
 
   // EnumerateKernels must return both handles (order is implementation-defined).
-  hipKernel_t enumerated[2] = {nullptr, nullptr};
-  HIP_CHECK(hipLibraryEnumerateKernels(enumerated, 2, lib));
-  REQUIRE(enumerated[0] != nullptr);
-  REQUIRE(enumerated[1] != nullptr);
-  REQUIRE(enumerated[0] != enumerated[1]);
-  const bool covers_writer = (enumerated[0] == writer) || (enumerated[1] == writer);
-  const bool covers_reader = (enumerated[0] == reader) || (enumerated[1] == reader);
+  // asan adjusted count (init/fini)
+  hipKernel_t enumerated[asan_expected_count]{};
+  HIP_CHECK(hipLibraryEnumerateKernels(enumerated, asan_expected_count, lib));
+  bool covers_writer = false, covers_reader = false;
+  for (int i = 0; i < asan_expected_count; i++) {
+    if (enumerated[i] == writer) {
+      covers_writer = true;
+    } else if (enumerated[i] == reader) {
+      covers_reader = true;
+    }
+  }
   REQUIRE(covers_writer);
   REQUIRE(covers_reader);
 

--- a/projects/hip-tests/catch/unit/library/loadlib_co.cc
+++ b/projects/hip-tests/catch/unit/library/loadlib_co.cc
@@ -58,7 +58,13 @@ HIP_TEST_CASE(Unit_hip_library_load_co) {
 
     unsigned int count = 0;
     HIP_CHECK(hipLibraryGetKernelCount(&count, library));
-    REQUIRE(count == 9);  // 3 arithmetic + 6 d_var/m_var write/read/read_modify (see library_code_load.cc)
+    // 3 arithmetic + 6 d_var/m_var write/read/read_modify (see library_code_load.cc)
+    constexpr int expected_count = 9;
+    // If user builds with ASAN, we can get 2 additional kernels (init/fini) in the code object.
+    // The thing is, it only adds in device asan and not in host asan.
+    // So this check needs to cater for both
+    INFO("The count we got is: " << count);
+    REQUIRE((count == expected_count || count == expected_count + 2));
 
     size_t offset, paramsize;
     for (size_t k = 0; k < 3; ++k) {  // add/sub/mul_kernel each take 3 float* args
@@ -93,7 +99,13 @@ HIP_TEST_CASE(Unit_hip_library_load_co) {
 
     unsigned int count = 0;
     HIP_CHECK(hipLibraryGetKernelCount(&count, library));
-    REQUIRE(count == 9);  // 3 arithmetic + 6 d_var/m_var write/read/read_modify (see library_code_load.cc)
+    // 3 arithmetic + 6 d_var/m_var write/read/read_modify (see library_code_load.cc)
+    constexpr int expected_count = 9;
+    // If user builds with ASAN, we can get 2 additional kernels (init/fini) in the code object.
+    // The thing is, it only adds in device asan and not in host asan.
+    // So this check needs to cater for both
+    INFO("The count we got is: " << count);
+    REQUIRE((count == expected_count || count == expected_count + 2));
 
     size_t offset, paramsize;
     for (size_t k = 0; k < 3; ++k) {  // add/sub/mul_kernel each take 3 float* args
@@ -128,7 +140,13 @@ HIP_TEST_CASE(Unit_hip_library_load_co) {
 
     unsigned int count = 0;
     HIP_CHECK(hipLibraryGetKernelCount(&count, library));
-    REQUIRE(count == 9);  // 3 arithmetic + 6 d_var/m_var write/read/read_modify (see library_code_load.cc)
+    // 3 arithmetic + 6 d_var/m_var write/read/read_modify (see library_code_load.cc)
+    constexpr int expected_count = 9;
+    // If user builds with ASAN, we can get 2 additional kernels (init/fini) in the code object.
+    // The thing is, it only adds in device asan and not in host asan.
+    // So this check needs to cater for both
+    INFO("The count we got is: " << count);
+    REQUIRE((count == expected_count || count == expected_count + 2));
 
     size_t offset, paramsize;
     for (size_t k = 0; k < 3; ++k) {  // add/sub/mul_kernel each take 3 float* args

--- a/projects/hip-tests/catch/unit/library/loadlib_rtc.cc
+++ b/projects/hip-tests/catch/unit/library/loadlib_rtc.cc
@@ -76,7 +76,13 @@ HIP_TEST_CASE(Unit_hip_library_load_rtc) {
 
     unsigned int count = 0;
     HIP_CHECK(hipLibraryGetKernelCount(&count, library));
-    REQUIRE(count == 1);
+  
+    // If user builds with ASAN, we can get 2 additional kernels (init/fini) in the code object.
+    // The thing is, it only adds in device asan and not in host asan.
+    // So this check needs to cater for both
+    constexpr int expected_count = 1;
+    INFO("The count we got is: " << count);
+    REQUIRE((count == expected_count || count == expected_count + 2));
 
     void* args[] = {&d_out, &d_in1, &d_in2};
 
@@ -106,7 +112,10 @@ HIP_TEST_CASE(Unit_hip_library_load_rtc) {
 
     unsigned int count = 0;
     HIP_CHECK(hipLibraryGetKernelCount(&count, library));
-    REQUIRE(count == 2);
+
+    constexpr int expected_count = 2;
+    INFO("The count we got is: " << count);
+    REQUIRE((count == expected_count || count == expected_count + 2));
 
     void* args[] = {&d_out, &d_in1, &d_in2};
 
@@ -136,7 +145,10 @@ HIP_TEST_CASE(Unit_hip_library_load_rtc) {
 
     unsigned int count = 0;
     HIP_CHECK(hipLibraryGetKernelCount(&count, library));
-    REQUIRE(count == 3);
+
+    constexpr int expected_count = 3;
+    INFO("The count we got is: " << count);
+    REQUIRE((count == expected_count || count == expected_count + 2));
 
     void* args[] = {&d_out, &d_in1, &d_in2};
 

--- a/projects/hip-tests/catch/unit/library/loadlib_rtc.cc
+++ b/projects/hip-tests/catch/unit/library/loadlib_rtc.cc
@@ -77,12 +77,13 @@ HIP_TEST_CASE(Unit_hip_library_load_rtc) {
     unsigned int count = 0;
     HIP_CHECK(hipLibraryGetKernelCount(&count, library));
   
-    // If user builds with ASAN, we can get 2 additional kernels (init/fini) in the code object.
+    // If user builds with ASAN, we can get 2 additional kernels (init/fini) in the code object depending on the entire code object.
+    // In this case we should have just 1 since there are no `__managed__` var in code.
     // The thing is, it only adds in device asan and not in host asan.
     // So this check needs to cater for both
     constexpr int expected_count = 1;
     INFO("The count we got is: " << count);
-    REQUIRE((count == expected_count || count == expected_count + 2));
+    REQUIRE((count == expected_count || count == expected_count + 1));
 
     void* args[] = {&d_out, &d_in1, &d_in2};
 
@@ -115,7 +116,7 @@ HIP_TEST_CASE(Unit_hip_library_load_rtc) {
 
     constexpr int expected_count = 2;
     INFO("The count we got is: " << count);
-    REQUIRE((count == expected_count || count == expected_count + 2));
+    REQUIRE((count == expected_count || count == expected_count + 1));
 
     void* args[] = {&d_out, &d_in1, &d_in2};
 
@@ -148,7 +149,7 @@ HIP_TEST_CASE(Unit_hip_library_load_rtc) {
 
     constexpr int expected_count = 3;
     INFO("The count we got is: " << count);
-    REQUIRE((count == expected_count || count == expected_count + 2));
+    REQUIRE((count == expected_count || count == expected_count + 1));
 
     void* args[] = {&d_out, &d_in1, &d_in2};
 


### PR DESCRIPTION
## Motivation

Fix the count of kernels in library apis

## Technical Details

When user enables ASAN, we might get incorrect kernel count since compiler embeds a few kernel to help with its init/fini.
This takes care of it.

## JIRA ID

Resolves ROCM-27236

## Test Plan

These are existing tests, which fail with ASAN. Retest with ASAN.

## Test Result

test passes although one of them is failing, awaiting inputs from compiler team.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
