### PR TITLE
ci(rocjitsu): Update rocm pip package in CI

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -108,7 +108,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --pre \
             --index-url https://rocm.nightlies.amd.com/whl-multi-arch/ \
-            "rocm[devel,libraries]==7.14.0a20260619"
+            "rocm[devel,libraries]==7.14.0a20260624"
           ROCM_LIB="$(rocm-sdk path --root)"/lib
           echo "LD_LIBRARY_PATH=${ROCM_LIB}:${LD_LIBRARY_PATH:-}" >> "${GITHUB_ENV}"
 


### PR DESCRIPTION
## Motivation

Keep up to date rocm's pip package on CI.

## Technical Details

Longer term: combined with composite actions https://github.com/ROCm/rocm-systems/pull/7811 I believe we can configure dependabot to query the nightly index. I know dependabot can be configured to be used with third party private index/registry. https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/configure-access-to-private-registries This would allow us to set dependabot to look for rocm on the nightly index at a frequency of our liking (possibly weekly).

## JIRA ID

ISSUE ID: #7891 

## Test Plan

Passes on ci.

## Test Result

Passes on ci

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
