### PR TITLE
fix(amd-smi): Set ctypes _layout_ to 'ms' on packed structs

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -37,6 +37,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
   - `AMDSmiGPUDevice` opened the per-GPU IFoE/UALoE generic-netlink session in its constructor, so `amdsmi_init(AMDSMI_INIT_AMD_GPUS)` (and every CLI verb) blocked in an uninterruptible netlink wait when the Broadcom IFoE driver was wedged, even for queries that never use fabric data.
   - The UALoE session is now opened lazily on the first fabric query via `get_ualoe_handle()`, so initialization and non-fabric queries no longer touch the IFoE driver.
 
+- **Fixed ctypes `DeprecationWarning` from `amdsmi_wrapper.py` on Python 3.14**.  
+  - Python 3.14 deprecates the implicit ctypes structure layout when `_pack_` is set (slated to become an error in 3.19). Each packed structure/union in the generated wrapper now sets `_layout_ = 'ms'`, preserving the existing MSVC-compatible layout (no ABI change) while silencing the warning.
+
 ## amd_smi_lib for ROCm 7.14.0
 
 ### Added
@@ -138,9 +141,6 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Removed the unused `amdsmi_nic_link_type_t` enum from the public header**. No API or struct referenced it; NIC link types are reported through `amdsmi_link_type_t`, which gains `AMDSMI_LINK_TYPE_NUMA` and `AMDSMI_LINK_TYPE_XNUMA` in this release.
 
 ### Resolved Issues
-
-- **Fixed ctypes `DeprecationWarning` from `amdsmi_wrapper.py` on Python 3.14**.  
-  - Python 3.14 deprecates the implicit ctypes structure layout when `_pack_` is set (slated to become an error in 3.19). Each packed structure/union in the generated wrapper now sets `_layout_ = 'ms'`, preserving the existing MSVC-compatible layout (no ABI change) while silencing the warning.
 
 - **Fixed `amd-smi set --power-cap` rejecting the minimum allowed value**.  
   - The lower bound is now inclusive, so setting the power cap to the exact minimum of the reported range (e.g. `210` when the range is 210-300W) succeeds instead of failing validation, matching the inclusive range shown in the error message.

--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -139,6 +139,9 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Resolved Issues
 
+- **Fixed ctypes `DeprecationWarning` from `amdsmi_wrapper.py` on Python 3.14**.  
+  - Python 3.14 deprecates the implicit ctypes structure layout when `_pack_` is set (slated to become an error in 3.19). Each packed structure/union in the generated wrapper now sets `_layout_ = 'ms'`, preserving the existing MSVC-compatible layout (no ABI change) while silencing the warning.
+
 - **Fixed `amd-smi set --power-cap` rejecting the minimum allowed value**.  
   - The lower bound is now inclusive, so setting the power cap to the exact minimum of the reported range (e.g. `210` when the range is 210-300W) succeeds instead of failing validation, matching the inclusive range shown in the error message.
 

--- a/projects/amdsmi/py-interface/amdsmi_wrapper.py
+++ b/projects/amdsmi/py-interface/amdsmi_wrapper.py
@@ -321,6 +321,7 @@ class struct_amdsmi_hsmp_driver_version_t(Structure):
     pass
 
 struct_amdsmi_hsmp_driver_version_t._pack_ = 1 # source:False
+struct_amdsmi_hsmp_driver_version_t._layout_ = 'ms'
 struct_amdsmi_hsmp_driver_version_t._fields_ = [
     ('major', ctypes.c_uint32),
     ('minor', ctypes.c_uint32),
@@ -930,6 +931,7 @@ class struct_amdsmi_range_t(Structure):
     pass
 
 struct_amdsmi_range_t._pack_ = 1 # source:False
+struct_amdsmi_range_t._layout_ = 'ms'
 struct_amdsmi_range_t._fields_ = [
     ('lower_bound', ctypes.c_uint64),
     ('upper_bound', ctypes.c_uint64),
@@ -941,6 +943,7 @@ class struct_amdsmi_xgmi_info_t(Structure):
     pass
 
 struct_amdsmi_xgmi_info_t._pack_ = 1 # source:False
+struct_amdsmi_xgmi_info_t._layout_ = 'ms'
 struct_amdsmi_xgmi_info_t._fields_ = [
     ('xgmi_lanes', ctypes.c_ubyte),
     ('PADDING_0', ctypes.c_ubyte * 7),
@@ -955,6 +958,7 @@ class struct_amdsmi_vram_usage_t(Structure):
     pass
 
 struct_amdsmi_vram_usage_t._pack_ = 1 # source:False
+struct_amdsmi_vram_usage_t._layout_ = 'ms'
 struct_amdsmi_vram_usage_t._fields_ = [
     ('vram_total', ctypes.c_uint32),
     ('vram_used', ctypes.c_uint32),
@@ -966,6 +970,7 @@ class struct_amdsmi_violation_status_t(Structure):
     pass
 
 struct_amdsmi_violation_status_t._pack_ = 1 # source:False
+struct_amdsmi_violation_status_t._layout_ = 'ms'
 struct_amdsmi_violation_status_t._fields_ = [
     ('reference_timestamp', ctypes.c_uint64),
     ('violation_timestamp', ctypes.c_uint64),
@@ -1011,6 +1016,7 @@ class struct_amdsmi_frequency_range_t(Structure):
     pass
 
 struct_amdsmi_frequency_range_t._pack_ = 1 # source:False
+struct_amdsmi_frequency_range_t._layout_ = 'ms'
 struct_amdsmi_frequency_range_t._fields_ = [
     ('supported_freq_range', amdsmi_range_t),
     ('current_freq_range', amdsmi_range_t),
@@ -1025,6 +1031,7 @@ class struct_bdf_(Structure):
     pass
 
 struct_bdf_._pack_ = 1 # source:False
+struct_bdf_._layout_ = 'ms'
 struct_bdf_._fields_ = [
     ('function_number', ctypes.c_uint64, 3),
     ('device_number', ctypes.c_uint64, 5),
@@ -1036,6 +1043,7 @@ class struct_amdsmi_bdf_t_1(Structure):
     pass
 
 struct_amdsmi_bdf_t_1._pack_ = 1 # source:False
+struct_amdsmi_bdf_t_1._layout_ = 'ms'
 struct_amdsmi_bdf_t_1._fields_ = [
     ('function_number', ctypes.c_uint64, 3),
     ('device_number', ctypes.c_uint64, 5),
@@ -1044,6 +1052,7 @@ struct_amdsmi_bdf_t_1._fields_ = [
 ]
 
 union_amdsmi_bdf_t._pack_ = 1 # source:False
+union_amdsmi_bdf_t._layout_ = 'ms'
 
 union_amdsmi_bdf_t._fields_ = [
     ('bdf', struct_bdf_),
@@ -1056,6 +1065,7 @@ class struct_amdsmi_enumeration_info_t(Structure):
     pass
 
 struct_amdsmi_enumeration_info_t._pack_ = 1 # source:False
+struct_amdsmi_enumeration_info_t._layout_ = 'ms'
 struct_amdsmi_enumeration_info_t._fields_ = [
     ('drm_render', ctypes.c_uint32),
     ('drm_card', ctypes.c_uint32),
@@ -1086,6 +1096,7 @@ class struct_pcie_static_(Structure):
     pass
 
 struct_pcie_static_._pack_ = 1 # source:False
+struct_pcie_static_._layout_ = 'ms'
 struct_pcie_static_._fields_ = [
     ('max_pcie_width', ctypes.c_uint16),
     ('PADDING_0', ctypes.c_ubyte * 2),
@@ -1101,6 +1112,7 @@ class struct_pcie_metric_(Structure):
     pass
 
 struct_pcie_metric_._pack_ = 1 # source:False
+struct_pcie_metric_._layout_ = 'ms'
 struct_pcie_metric_._fields_ = [
     ('pcie_width', ctypes.c_uint16),
     ('PADDING_0', ctypes.c_ubyte * 2),
@@ -1118,6 +1130,7 @@ struct_pcie_metric_._fields_ = [
 ]
 
 struct_amdsmi_pcie_info_t._pack_ = 1 # source:False
+struct_amdsmi_pcie_info_t._layout_ = 'ms'
 struct_amdsmi_pcie_info_t._fields_ = [
     ('pcie_static', struct_pcie_static_),
     ('pcie_metric', struct_pcie_metric_),
@@ -1129,6 +1142,7 @@ class struct_amdsmi_power_cap_info_t(Structure):
     pass
 
 struct_amdsmi_power_cap_info_t._pack_ = 1 # source:False
+struct_amdsmi_power_cap_info_t._layout_ = 'ms'
 struct_amdsmi_power_cap_info_t._fields_ = [
     ('power_cap', ctypes.c_uint64),
     ('default_power_cap', ctypes.c_uint64),
@@ -1152,6 +1166,7 @@ class struct_amdsmi_vbios_info_t(Structure):
     pass
 
 struct_amdsmi_vbios_info_t._pack_ = 1 # source:False
+struct_amdsmi_vbios_info_t._layout_ = 'ms'
 struct_amdsmi_vbios_info_t._fields_ = [
     ('name', ctypes.c_char * 256),
     ('build_date', ctypes.c_char * 256),
@@ -1184,6 +1199,7 @@ class struct_cache_(Structure):
     pass
 
 struct_cache_._pack_ = 1 # source:False
+struct_cache_._layout_ = 'ms'
 struct_cache_._fields_ = [
     ('cache_properties', ctypes.c_uint32),
     ('cache_size', ctypes.c_uint32),
@@ -1194,6 +1210,7 @@ struct_cache_._fields_ = [
 ]
 
 struct_amdsmi_gpu_cache_info_t._pack_ = 1 # source:False
+struct_amdsmi_gpu_cache_info_t._layout_ = 'ms'
 struct_amdsmi_gpu_cache_info_t._fields_ = [
     ('num_cache_types', ctypes.c_uint32),
     ('cache', struct_cache_ * 10),
@@ -1208,6 +1225,7 @@ class struct_fw_info_list_(Structure):
     pass
 
 struct_fw_info_list_._pack_ = 1 # source:False
+struct_fw_info_list_._layout_ = 'ms'
 struct_fw_info_list_._fields_ = [
     ('fw_id', amdsmi_fw_block_t),
     ('PADDING_0', ctypes.c_ubyte * 4),
@@ -1216,6 +1234,7 @@ struct_fw_info_list_._fields_ = [
 ]
 
 struct_amdsmi_fw_info_t._pack_ = 1 # source:False
+struct_amdsmi_fw_info_t._layout_ = 'ms'
 struct_amdsmi_fw_info_t._fields_ = [
     ('num_fw_info', ctypes.c_ubyte),
     ('PADDING_0', ctypes.c_ubyte * 7),
@@ -1229,6 +1248,7 @@ class struct_amdsmi_asic_info_t(Structure):
     pass
 
 struct_amdsmi_asic_info_t._pack_ = 1 # source:False
+struct_amdsmi_asic_info_t._layout_ = 'ms'
 struct_amdsmi_asic_info_t._fields_ = [
     ('market_name', ctypes.c_char * 256),
     ('vendor_id', ctypes.c_uint32),
@@ -1252,6 +1272,7 @@ class struct_amdsmi_kfd_info_t(Structure):
     pass
 
 struct_amdsmi_kfd_info_t._pack_ = 1 # source:False
+struct_amdsmi_kfd_info_t._layout_ = 'ms'
 struct_amdsmi_kfd_info_t._fields_ = [
     ('kfd_id', ctypes.c_uint64),
     ('node_id', ctypes.c_uint32),
@@ -1267,6 +1288,7 @@ class struct_nps_flags_(Structure):
     pass
 
 struct_nps_flags_._pack_ = 1 # source:False
+struct_nps_flags_._layout_ = 'ms'
 struct_nps_flags_._fields_ = [
     ('nps1_cap', ctypes.c_uint32, 1),
     ('nps2_cap', ctypes.c_uint32, 1),
@@ -1276,6 +1298,7 @@ struct_nps_flags_._fields_ = [
 ]
 
 union_amdsmi_nps_caps_t._pack_ = 1 # source:False
+union_amdsmi_nps_caps_t._layout_ = 'ms'
 union_amdsmi_nps_caps_t._fields_ = [
     ('nps_flags', struct_nps_flags_),
     ('nps_cap_mask', ctypes.c_uint32),
@@ -1289,6 +1312,7 @@ class struct_numa_range_(Structure):
     pass
 
 struct_numa_range_._pack_ = 1 # source:False
+struct_numa_range_._layout_ = 'ms'
 struct_numa_range_._fields_ = [
     ('memory_type', amdsmi_vram_type_t),
     ('PADDING_0', ctypes.c_ubyte * 4),
@@ -1297,6 +1321,7 @@ struct_numa_range_._fields_ = [
 ]
 
 struct_amdsmi_memory_partition_config_t._pack_ = 1 # source:False
+struct_amdsmi_memory_partition_config_t._layout_ = 'ms'
 struct_amdsmi_memory_partition_config_t._fields_ = [
     ('partition_caps', amdsmi_nps_caps_t),
     ('mp_mode', amdsmi_memory_partition_type_t),
@@ -1311,6 +1336,7 @@ class struct_amdsmi_accelerator_partition_profile_t(Structure):
     pass
 
 struct_amdsmi_accelerator_partition_profile_t._pack_ = 1 # source:False
+struct_amdsmi_accelerator_partition_profile_t._layout_ = 'ms'
 struct_amdsmi_accelerator_partition_profile_t._fields_ = [
     ('profile_type', amdsmi_accelerator_partition_type_t),
     ('num_partitions', ctypes.c_uint32),
@@ -1327,6 +1353,7 @@ class struct_amdsmi_accelerator_partition_resource_profile_t(Structure):
     pass
 
 struct_amdsmi_accelerator_partition_resource_profile_t._pack_ = 1 # source:False
+struct_amdsmi_accelerator_partition_resource_profile_t._layout_ = 'ms'
 struct_amdsmi_accelerator_partition_resource_profile_t._fields_ = [
     ('profile_index', ctypes.c_uint32),
     ('resource_type', amdsmi_accelerator_partition_resource_type_t),
@@ -1340,6 +1367,7 @@ class struct_amdsmi_accelerator_partition_profile_config_t(Structure):
     pass
 
 struct_amdsmi_accelerator_partition_profile_config_t._pack_ = 1 # source:False
+struct_amdsmi_accelerator_partition_profile_config_t._layout_ = 'ms'
 struct_amdsmi_accelerator_partition_profile_config_t._fields_ = [
     ('num_profiles', ctypes.c_uint32),
     ('num_resource_profiles', ctypes.c_uint32),
@@ -1374,6 +1402,7 @@ class struct_amdsmi_cpu_util_t(Structure):
     pass
 
 struct_amdsmi_cpu_util_t._pack_ = 1 # source:False
+struct_amdsmi_cpu_util_t._layout_ = 'ms'
 struct_amdsmi_cpu_util_t._fields_ = [
     ('cpu_util_total', ctypes.c_uint32),
     ('cpu_util_user', ctypes.c_uint32),
@@ -1403,6 +1432,7 @@ class struct__links(Structure):
     pass
 
 struct__links._pack_ = 1 # source:False
+struct__links._layout_ = 'ms'
 struct__links._fields_ = [
     ('bdf', amdsmi_bdf_t),
     ('bit_rate', ctypes.c_uint32),
@@ -1417,6 +1447,7 @@ struct__links._fields_ = [
 ]
 
 struct_amdsmi_link_metrics_t._pack_ = 1 # source:False
+struct_amdsmi_link_metrics_t._layout_ = 'ms'
 struct_amdsmi_link_metrics_t._fields_ = [
     ('num_links', ctypes.c_uint32),
     ('PADDING_0', ctypes.c_ubyte * 4),
@@ -1429,6 +1460,7 @@ class struct_amdsmi_vram_info_t(Structure):
     pass
 
 struct_amdsmi_vram_info_t._pack_ = 1 # source:False
+struct_amdsmi_vram_info_t._layout_ = 'ms'
 struct_amdsmi_vram_info_t._fields_ = [
     ('vram_type', amdsmi_vram_type_t),
     ('vram_vendor', ctypes.c_char * 256),
@@ -1445,6 +1477,7 @@ class struct_amdsmi_driver_info_t(Structure):
     pass
 
 struct_amdsmi_driver_info_t._pack_ = 1 # source:False
+struct_amdsmi_driver_info_t._layout_ = 'ms'
 struct_amdsmi_driver_info_t._fields_ = [
     ('driver_version', ctypes.c_char * 256),
     ('driver_date', ctypes.c_char * 256),
@@ -1456,6 +1489,7 @@ class struct_amdsmi_board_info_t(Structure):
     pass
 
 struct_amdsmi_board_info_t._pack_ = 1 # source:False
+struct_amdsmi_board_info_t._layout_ = 'ms'
 struct_amdsmi_board_info_t._fields_ = [
     ('model_number', ctypes.c_char * 256),
     ('product_serial', ctypes.c_char * 256),
@@ -1470,6 +1504,7 @@ class struct_amdsmi_power_info_t(Structure):
     pass
 
 struct_amdsmi_power_info_t._pack_ = 1 # source:False
+struct_amdsmi_power_info_t._layout_ = 'ms'
 struct_amdsmi_power_info_t._fields_ = [
     ('socket_power', ctypes.c_uint64),
     ('current_socket_power', ctypes.c_uint32),
@@ -1487,6 +1522,7 @@ class struct_amdsmi_clk_info_t(Structure):
     pass
 
 struct_amdsmi_clk_info_t._pack_ = 1 # source:False
+struct_amdsmi_clk_info_t._layout_ = 'ms'
 struct_amdsmi_clk_info_t._fields_ = [
     ('clk', ctypes.c_uint32),
     ('min_clk', ctypes.c_uint32),
@@ -1502,6 +1538,7 @@ class struct_amdsmi_engine_usage_t(Structure):
     pass
 
 struct_amdsmi_engine_usage_t._pack_ = 1 # source:False
+struct_amdsmi_engine_usage_t._layout_ = 'ms'
 struct_amdsmi_engine_usage_t._fields_ = [
     ('gfx_activity', ctypes.c_uint32),
     ('umc_activity', ctypes.c_uint32),
@@ -1518,6 +1555,7 @@ class struct_engine_usage_(Structure):
     pass
 
 struct_engine_usage_._pack_ = 1 # source:False
+struct_engine_usage_._layout_ = 'ms'
 struct_engine_usage_._fields_ = [
     ('gfx', ctypes.c_uint64),
     ('enc', ctypes.c_uint64),
@@ -1528,6 +1566,7 @@ class struct_memory_usage_(Structure):
     pass
 
 struct_memory_usage_._pack_ = 1 # source:False
+struct_memory_usage_._layout_ = 'ms'
 struct_memory_usage_._fields_ = [
     ('gtt_mem', ctypes.c_uint64),
     ('cpu_mem', ctypes.c_uint64),
@@ -1536,6 +1575,7 @@ struct_memory_usage_._fields_ = [
 ]
 
 struct_amdsmi_proc_info_t._pack_ = 1 # source:False
+struct_amdsmi_proc_info_t._layout_ = 'ms'
 struct_amdsmi_proc_info_t._fields_ = [
     ('name', ctypes.c_char * 256),
     ('pid', ctypes.c_uint32),
@@ -1558,6 +1598,7 @@ class struct_amdsmi_proc_gpu_entry_t_engine_usage(Structure):
     pass
 
 struct_amdsmi_proc_gpu_entry_t_engine_usage._pack_ = 1 # source:False
+struct_amdsmi_proc_gpu_entry_t_engine_usage._layout_ = 'ms'
 struct_amdsmi_proc_gpu_entry_t_engine_usage._fields_ = [
     ('gfx', ctypes.c_uint64),
     ('enc', ctypes.c_uint64),
@@ -1568,6 +1609,7 @@ class struct_amdsmi_proc_gpu_entry_t_memory_usage(Structure):
     pass
 
 struct_amdsmi_proc_gpu_entry_t_memory_usage._pack_ = 1 # source:False
+struct_amdsmi_proc_gpu_entry_t_memory_usage._layout_ = 'ms'
 struct_amdsmi_proc_gpu_entry_t_memory_usage._fields_ = [
     ('gtt_mem', ctypes.c_uint64),
     ('cpu_mem', ctypes.c_uint64),
@@ -1576,6 +1618,7 @@ struct_amdsmi_proc_gpu_entry_t_memory_usage._fields_ = [
 ]
 
 struct_amdsmi_proc_gpu_entry_t._pack_ = 1 # source:False
+struct_amdsmi_proc_gpu_entry_t._layout_ = 'ms'
 struct_amdsmi_proc_gpu_entry_t._fields_ = [
     ('gpu_index', ctypes.c_uint32),
     ('PADDING_0', ctypes.c_ubyte * 4),
@@ -1593,6 +1636,7 @@ class struct_amdsmi_proc_info_by_pid_t(Structure):
     pass
 
 struct_amdsmi_proc_info_by_pid_t._pack_ = 1 # source:False
+struct_amdsmi_proc_info_by_pid_t._layout_ = 'ms'
 struct_amdsmi_proc_info_by_pid_t._fields_ = [
     ('pid', ctypes.c_uint32),
     ('name', ctypes.c_char * 256),
@@ -1606,6 +1650,7 @@ class struct_amdsmi_p2p_capability_t(Structure):
     pass
 
 struct_amdsmi_p2p_capability_t._pack_ = 1 # source:False
+struct_amdsmi_p2p_capability_t._layout_ = 'ms'
 struct_amdsmi_p2p_capability_t._fields_ = [
     ('is_iolink_coherent', ctypes.c_ubyte),
     ('is_iolink_atomics_32bit', ctypes.c_ubyte),
@@ -1714,6 +1759,7 @@ class struct_amdsmi_counter_value_t(Structure):
     pass
 
 struct_amdsmi_counter_value_t._pack_ = 1 # source:False
+struct_amdsmi_counter_value_t._layout_ = 'ms'
 struct_amdsmi_counter_value_t._fields_ = [
     ('value', ctypes.c_uint64),
     ('time_enabled', ctypes.c_uint64),
@@ -1762,6 +1808,7 @@ class struct_amdsmi_evt_notification_data_t(Structure):
     pass
 
 struct_amdsmi_evt_notification_data_t._pack_ = 1 # source:False
+struct_amdsmi_evt_notification_data_t._layout_ = 'ms'
 struct_amdsmi_evt_notification_data_t._fields_ = [
     ('processor_handle', ctypes.POINTER(None)),
     ('event', amdsmi_evt_notification_type_t),
@@ -1980,6 +2027,7 @@ class struct_amdsmi_gpu_ras_policy_v4_0_t(Structure):
     pass
 
 struct_amdsmi_gpu_ras_policy_v4_0_t._pack_ = 1 # source:False
+struct_amdsmi_gpu_ras_policy_v4_0_t._layout_ = 'ms'
 struct_amdsmi_gpu_ras_policy_v4_0_t._fields_ = [
     ('dram_non_critical_region_threshold', ctypes.c_uint16),
     ('dram_critical_region_threshold', ctypes.c_uint16),
@@ -1993,12 +2041,14 @@ class union_policy_data_(Union):
     pass
 
 union_policy_data_._pack_ = 1 # source:False
+union_policy_data_._layout_ = 'ms'
 union_policy_data_._fields_ = [
     ('v4_0', amdsmi_gpu_ras_policy_v4_0_t),
     ('info', ctypes.c_uint64 * 5),
 ]
 
 struct_amdsmi_gpu_ras_policy_info_t._pack_ = 1 # source:False
+struct_amdsmi_gpu_ras_policy_info_t._layout_ = 'ms'
 struct_amdsmi_gpu_ras_policy_info_t._fields_ = [
     ('major_version', ctypes.c_ubyte),
     ('minor_version', ctypes.c_ubyte),
@@ -2104,6 +2154,7 @@ class struct_amdsmi_utilization_counter_t(Structure):
     pass
 
 struct_amdsmi_utilization_counter_t._pack_ = 1 # source:False
+struct_amdsmi_utilization_counter_t._layout_ = 'ms'
 struct_amdsmi_utilization_counter_t._fields_ = [
     ('type', amdsmi_utilization_counter_type_t),
     ('PADDING_0', ctypes.c_ubyte * 4),
@@ -2118,6 +2169,7 @@ class struct_amdsmi_retired_page_record_t(Structure):
     pass
 
 struct_amdsmi_retired_page_record_t._pack_ = 1 # source:False
+struct_amdsmi_retired_page_record_t._layout_ = 'ms'
 struct_amdsmi_retired_page_record_t._fields_ = [
     ('page_address', ctypes.c_uint64),
     ('page_size', ctypes.c_uint64),
@@ -2130,6 +2182,7 @@ class struct_amdsmi_power_profile_status_t(Structure):
     pass
 
 struct_amdsmi_power_profile_status_t._pack_ = 1 # source:False
+struct_amdsmi_power_profile_status_t._layout_ = 'ms'
 struct_amdsmi_power_profile_status_t._fields_ = [
     ('available_profiles', ctypes.c_uint64),
     ('current', amdsmi_power_profile_preset_masks_t),
@@ -2142,6 +2195,7 @@ class struct_amdsmi_frequencies_t(Structure):
     pass
 
 struct_amdsmi_frequencies_t._pack_ = 1 # source:False
+struct_amdsmi_frequencies_t._layout_ = 'ms'
 struct_amdsmi_frequencies_t._fields_ = [
     ('has_deep_sleep', ctypes.c_bool),
     ('PADDING_0', ctypes.c_ubyte * 3),
@@ -2156,6 +2210,7 @@ class struct_amdsmi_dpm_policy_entry_t(Structure):
     pass
 
 struct_amdsmi_dpm_policy_entry_t._pack_ = 1 # source:False
+struct_amdsmi_dpm_policy_entry_t._layout_ = 'ms'
 struct_amdsmi_dpm_policy_entry_t._fields_ = [
     ('policy_id', ctypes.c_uint32),
     ('policy_description', ctypes.c_char * 256),
@@ -2166,6 +2221,7 @@ class struct_amdsmi_dpm_policy_t(Structure):
     pass
 
 struct_amdsmi_dpm_policy_t._pack_ = 1 # source:False
+struct_amdsmi_dpm_policy_t._layout_ = 'ms'
 struct_amdsmi_dpm_policy_t._fields_ = [
     ('num_supported', ctypes.c_uint32),
     ('current', ctypes.c_uint32),
@@ -2177,6 +2233,7 @@ class struct_amdsmi_pcie_bandwidth_t(Structure):
     pass
 
 struct_amdsmi_pcie_bandwidth_t._pack_ = 1 # source:False
+struct_amdsmi_pcie_bandwidth_t._layout_ = 'ms'
 struct_amdsmi_pcie_bandwidth_t._fields_ = [
     ('transfer_rate', amdsmi_frequencies_t),
     ('lanes', ctypes.c_uint32 * 33),
@@ -2188,6 +2245,7 @@ class struct_amdsmi_version_t(Structure):
     pass
 
 struct_amdsmi_version_t._pack_ = 1 # source:False
+struct_amdsmi_version_t._layout_ = 'ms'
 struct_amdsmi_version_t._fields_ = [
     ('major', ctypes.c_uint32),
     ('minor', ctypes.c_uint32),
@@ -2201,6 +2259,7 @@ class struct_amdsmi_od_vddc_point_t(Structure):
     pass
 
 struct_amdsmi_od_vddc_point_t._pack_ = 1 # source:False
+struct_amdsmi_od_vddc_point_t._layout_ = 'ms'
 struct_amdsmi_od_vddc_point_t._fields_ = [
     ('frequency', ctypes.c_uint64),
     ('voltage', ctypes.c_uint64),
@@ -2209,6 +2268,7 @@ struct_amdsmi_od_vddc_point_t._fields_ = [
 amdsmi_od_vddc_point_t = struct_amdsmi_od_vddc_point_t
 class struct_amdsmi_freq_volt_region_t(Structure):
     _pack_ = 1 # source:False
+    _layout_ = 'ms'
     _fields_ = [
     ('freq_range', amdsmi_range_t),
     ('volt_range', amdsmi_range_t),
@@ -2217,6 +2277,7 @@ class struct_amdsmi_freq_volt_region_t(Structure):
 amdsmi_freq_volt_region_t = struct_amdsmi_freq_volt_region_t
 class struct_amdsmi_od_volt_curve_t(Structure):
     _pack_ = 1 # source:False
+    _layout_ = 'ms'
     _fields_ = [
     ('vc_points', struct_amdsmi_od_vddc_point_t * 3),
      ]
@@ -2226,6 +2287,7 @@ class struct_amdsmi_od_volt_freq_data_t(Structure):
     pass
 
 struct_amdsmi_od_volt_freq_data_t._pack_ = 1 # source:False
+struct_amdsmi_od_volt_freq_data_t._layout_ = 'ms'
 struct_amdsmi_od_volt_freq_data_t._fields_ = [
     ('curr_sclk_range', amdsmi_range_t),
     ('curr_mclk_range', amdsmi_range_t),
@@ -2243,6 +2305,7 @@ class struct_amd_metrics_table_header_t(Structure):
     pass
 
 struct_amd_metrics_table_header_t._pack_ = 1 # source:False
+struct_amd_metrics_table_header_t._layout_ = 'ms'
 struct_amd_metrics_table_header_t._fields_ = [
     ('structure_size', ctypes.c_uint16),
     ('format_revision', ctypes.c_ubyte),
@@ -2254,6 +2317,7 @@ class struct_amdsmi_gpu_xcp_metrics_t(Structure):
     pass
 
 struct_amdsmi_gpu_xcp_metrics_t._pack_ = 1 # source:False
+struct_amdsmi_gpu_xcp_metrics_t._layout_ = 'ms'
 struct_amdsmi_gpu_xcp_metrics_t._fields_ = [
     ('gfx_busy_inst', ctypes.c_uint32 * 8),
     ('jpeg_busy', ctypes.c_uint16 * 40),
@@ -2272,6 +2336,7 @@ class struct_amdsmi_apu_metrics_t(Structure):
     pass
 
 struct_amdsmi_apu_metrics_t._pack_ = 1 # source:False
+struct_amdsmi_apu_metrics_t._layout_ = 'ms'
 struct_amdsmi_apu_metrics_t._fields_ = [
     ('temperature_gfx', ctypes.c_uint16),
     ('temperature_soc', ctypes.c_uint16),
@@ -2349,6 +2414,7 @@ class struct_amdsmi_gpu_metrics_t(Structure):
     pass
 
 struct_amdsmi_gpu_metrics_t._pack_ = 1 # source:False
+struct_amdsmi_gpu_metrics_t._layout_ = 'ms'
 struct_amdsmi_gpu_metrics_t._fields_ = [
     ('common_header', amd_metrics_table_header_t),
     ('temperature_edge', ctypes.c_uint16),
@@ -2449,6 +2515,7 @@ class struct_amdsmi_xgmi_link_status_t(Structure):
     pass
 
 struct_amdsmi_xgmi_link_status_t._pack_ = 1 # source:False
+struct_amdsmi_xgmi_link_status_t._layout_ = 'ms'
 struct_amdsmi_xgmi_link_status_t._fields_ = [
     ('total_links', ctypes.c_uint32),
     ('status', amdsmi_xgmi_link_status_type_t * 8),
@@ -2461,6 +2528,7 @@ class struct_amdsmi_name_value_t(Structure):
     pass
 
 struct_amdsmi_name_value_t._pack_ = 1 # source:False
+struct_amdsmi_name_value_t._layout_ = 'ms'
 struct_amdsmi_name_value_t._fields_ = [
     ('name', ctypes.c_char * 256),
     ('value', ctypes.c_uint64),
@@ -2489,6 +2557,7 @@ class struct_ras_info_(Structure):
     pass
 
 struct_ras_info_._pack_ = 1 # source:False
+struct_ras_info_._layout_ = 'ms'
 struct_ras_info_._fields_ = [
     ('dram_ecc', ctypes.c_uint32, 1),
     ('sram_ecc', ctypes.c_uint32, 1),
@@ -2497,6 +2566,7 @@ struct_ras_info_._fields_ = [
 ]
 
 struct_amdsmi_ras_feature_t._pack_ = 1 # source:False
+struct_amdsmi_ras_feature_t._layout_ = 'ms'
 struct_amdsmi_ras_feature_t._fields_ = [
     ('ras_eeprom_version', ctypes.c_uint32),
     ('ecc_correction_schema_flag', ctypes.c_uint32),
@@ -2510,6 +2580,7 @@ class struct_amdsmi_error_count_t(Structure):
     pass
 
 struct_amdsmi_error_count_t._pack_ = 1 # source:False
+struct_amdsmi_error_count_t._layout_ = 'ms'
 struct_amdsmi_error_count_t._fields_ = [
     ('correctable_count', ctypes.c_uint64),
     ('uncorrectable_count', ctypes.c_uint64),
@@ -2522,6 +2593,7 @@ class struct_amdsmi_process_info_t(Structure):
     pass
 
 struct_amdsmi_process_info_t._pack_ = 1 # source:False
+struct_amdsmi_process_info_t._layout_ = 'ms'
 struct_amdsmi_process_info_t._fields_ = [
     ('process_id', ctypes.c_uint32),
     ('PADDING_0', ctypes.c_ubyte * 4),
@@ -2536,6 +2608,7 @@ class struct_amdsmi_topology_nearest_t(Structure):
     pass
 
 struct_amdsmi_topology_nearest_t._pack_ = 1 # source:False
+struct_amdsmi_topology_nearest_t._layout_ = 'ms'
 struct_amdsmi_topology_nearest_t._fields_ = [
     ('count', ctypes.c_uint32),
     ('PADDING_0', ctypes.c_ubyte * 4),
@@ -2581,6 +2654,7 @@ class struct_amdsmi_npm_info_t(Structure):
     pass
 
 struct_amdsmi_npm_info_t._pack_ = 1 # source:False
+struct_amdsmi_npm_info_t._layout_ = 'ms'
 struct_amdsmi_npm_info_t._fields_ = [
     ('status', amdsmi_npm_status_t),
     ('PADDING_0', ctypes.c_ubyte * 4),
@@ -2616,6 +2690,7 @@ class struct_amdsmi_smu_fw_version_t(Structure):
     pass
 
 struct_amdsmi_smu_fw_version_t._pack_ = 1 # source:False
+struct_amdsmi_smu_fw_version_t._layout_ = 'ms'
 struct_amdsmi_smu_fw_version_t._fields_ = [
     ('debug', ctypes.c_ubyte),
     ('minor', ctypes.c_ubyte),
@@ -2628,6 +2703,7 @@ class struct_amdsmi_ddr_bw_metrics_t(Structure):
     pass
 
 struct_amdsmi_ddr_bw_metrics_t._pack_ = 1 # source:False
+struct_amdsmi_ddr_bw_metrics_t._layout_ = 'ms'
 struct_amdsmi_ddr_bw_metrics_t._fields_ = [
     ('max_bw', ctypes.c_uint32),
     ('utilized_bw', ctypes.c_uint32),
@@ -2639,6 +2715,7 @@ class struct_amdsmi_temp_range_refresh_rate_t(Structure):
     pass
 
 struct_amdsmi_temp_range_refresh_rate_t._pack_ = 1 # source:False
+struct_amdsmi_temp_range_refresh_rate_t._layout_ = 'ms'
 struct_amdsmi_temp_range_refresh_rate_t._fields_ = [
     ('range', ctypes.c_ubyte, 3),
     ('ref_rate', ctypes.c_ubyte, 1),
@@ -2650,6 +2727,7 @@ class struct_amdsmi_dimm_power_t(Structure):
     pass
 
 struct_amdsmi_dimm_power_t._pack_ = 1 # source:False
+struct_amdsmi_dimm_power_t._layout_ = 'ms'
 struct_amdsmi_dimm_power_t._fields_ = [
     ('power', ctypes.c_uint16, 15),
     ('PADDING_0', ctypes.c_uint8, 1),
@@ -2664,6 +2742,7 @@ class struct_amdsmi_dimm_thermal_t(Structure):
     pass
 
 struct_amdsmi_dimm_thermal_t._pack_ = 1 # source:False
+struct_amdsmi_dimm_thermal_t._layout_ = 'ms'
 struct_amdsmi_dimm_thermal_t._fields_ = [
     ('sensor', ctypes.c_uint16, 11),
     ('PADDING_0', ctypes.c_uint8, 5),
@@ -2690,6 +2769,7 @@ class struct_amdsmi_link_id_bw_type_t(Structure):
     pass
 
 struct_amdsmi_link_id_bw_type_t._pack_ = 1 # source:False
+struct_amdsmi_link_id_bw_type_t._layout_ = 'ms'
 struct_amdsmi_link_id_bw_type_t._fields_ = [
     ('bw_type', amdsmi_io_bw_encoding_t),
     ('PADDING_0', ctypes.c_ubyte * 4),
@@ -2701,6 +2781,7 @@ class struct_amdsmi_dpm_level_t(Structure):
     pass
 
 struct_amdsmi_dpm_level_t._pack_ = 1 # source:False
+struct_amdsmi_dpm_level_t._layout_ = 'ms'
 struct_amdsmi_dpm_level_t._fields_ = [
     ('max_dpm_level', ctypes.c_ubyte),
     ('min_dpm_level', ctypes.c_ubyte),
@@ -2711,6 +2792,7 @@ class struct_amdsmi_hsmp_metrics_table_t(Structure):
     pass
 
 struct_amdsmi_hsmp_metrics_table_t._pack_ = 1 # source:True
+struct_amdsmi_hsmp_metrics_table_t._layout_ = 'ms'
 struct_amdsmi_hsmp_metrics_table_t._fields_ = [
     ('accumulation_counter', ctypes.c_uint32),
     ('max_socket_temperature', ctypes.c_uint32),
@@ -2778,6 +2860,7 @@ class struct_amdsmi_cpu_info_t(Structure):
     pass
 
 struct_amdsmi_cpu_info_t._pack_ = 1 # source:False
+struct_amdsmi_cpu_info_t._layout_ = 'ms'
 struct_amdsmi_cpu_info_t._fields_ = [
     ('model_name', ctypes.c_char * 256),
     ('cpu_family_id', ctypes.c_uint32),
@@ -2807,6 +2890,7 @@ class struct_amdsmi_sock_info_t(Structure):
     pass
 
 struct_amdsmi_sock_info_t._pack_ = 1 # source:False
+struct_amdsmi_sock_info_t._layout_ = 'ms'
 struct_amdsmi_sock_info_t._fields_ = [
     ('socket_id', ctypes.c_uint32),
     ('cores_per_socket', ctypes.c_uint32),
@@ -2817,6 +2901,7 @@ class struct_amdsmi_nic_stat_t(Structure):
     pass
 
 struct_amdsmi_nic_stat_t._pack_ = 1 # source:False
+struct_amdsmi_nic_stat_t._layout_ = 'ms'
 struct_amdsmi_nic_stat_t._fields_ = [
     ('name', ctypes.c_char * 256),
     ('value', ctypes.c_uint64),
@@ -2827,6 +2912,7 @@ class struct_amdsmi_nic_asic_info_t(Structure):
     pass
 
 struct_amdsmi_nic_asic_info_t._pack_ = 1 # source:False
+struct_amdsmi_nic_asic_info_t._layout_ = 'ms'
 struct_amdsmi_nic_asic_info_t._fields_ = [
     ('vendor_id', ctypes.c_uint16),
     ('subvendor_id', ctypes.c_uint16),
@@ -2846,6 +2932,7 @@ class struct_amdsmi_nic_bus_info_t(Structure):
     pass
 
 struct_amdsmi_nic_bus_info_t._pack_ = 1 # source:False
+struct_amdsmi_nic_bus_info_t._layout_ = 'ms'
 struct_amdsmi_nic_bus_info_t._fields_ = [
     ('bdf', amdsmi_bdf_t),
     ('max_pcie_width', ctypes.c_ubyte),
@@ -2860,6 +2947,7 @@ class struct_amdsmi_nic_numa_info_t(Structure):
     pass
 
 struct_amdsmi_nic_numa_info_t._pack_ = 1 # source:False
+struct_amdsmi_nic_numa_info_t._layout_ = 'ms'
 struct_amdsmi_nic_numa_info_t._fields_ = [
     ('node', ctypes.c_ubyte),
     ('affinity', ctypes.c_char * 256),
@@ -2870,6 +2958,7 @@ class struct_amdsmi_nic_fw_t(Structure):
     pass
 
 struct_amdsmi_nic_fw_t._pack_ = 1 # source:False
+struct_amdsmi_nic_fw_t._layout_ = 'ms'
 struct_amdsmi_nic_fw_t._fields_ = [
     ('name', ctypes.c_char * 256),
     ('version', ctypes.c_char * 256),
@@ -2880,6 +2969,7 @@ class struct_amdsmi_nic_fw_info_t(Structure):
     pass
 
 struct_amdsmi_nic_fw_info_t._pack_ = 1 # source:False
+struct_amdsmi_nic_fw_info_t._layout_ = 'ms'
 struct_amdsmi_nic_fw_info_t._fields_ = [
     ('num_fw', ctypes.c_uint32),
     ('fw', struct_amdsmi_nic_fw_t * 16),
@@ -2890,6 +2980,7 @@ class struct_amdsmi_nic_port_t(Structure):
     pass
 
 struct_amdsmi_nic_port_t._pack_ = 1 # source:False
+struct_amdsmi_nic_port_t._layout_ = 'ms'
 struct_amdsmi_nic_port_t._fields_ = [
     ('bdf', amdsmi_bdf_t),
     ('port_num', ctypes.c_uint32),
@@ -2914,6 +3005,7 @@ class struct_amdsmi_nic_port_info_t(Structure):
     pass
 
 struct_amdsmi_nic_port_info_t._pack_ = 1 # source:False
+struct_amdsmi_nic_port_info_t._layout_ = 'ms'
 struct_amdsmi_nic_port_info_t._fields_ = [
     ('num_ports', ctypes.c_uint32),
     ('PADDING_0', ctypes.c_ubyte * 4),
@@ -2925,6 +3017,7 @@ class struct_amdsmi_nic_driver_info_t(Structure):
     pass
 
 struct_amdsmi_nic_driver_info_t._pack_ = 1 # source:False
+struct_amdsmi_nic_driver_info_t._layout_ = 'ms'
 struct_amdsmi_nic_driver_info_t._fields_ = [
     ('name', ctypes.c_char * 256),
     ('version', ctypes.c_char * 256),
@@ -2935,6 +3028,7 @@ class struct_amdsmi_nic_rdma_port_info_t(Structure):
     pass
 
 struct_amdsmi_nic_rdma_port_info_t._pack_ = 1 # source:False
+struct_amdsmi_nic_rdma_port_info_t._layout_ = 'ms'
 struct_amdsmi_nic_rdma_port_info_t._fields_ = [
     ('netdev', ctypes.c_char * 256),
     ('state', ctypes.c_char * 256),
@@ -2949,6 +3043,7 @@ class struct_amdsmi_nic_rdma_dev_info_t(Structure):
     pass
 
 struct_amdsmi_nic_rdma_dev_info_t._pack_ = 1 # source:False
+struct_amdsmi_nic_rdma_dev_info_t._layout_ = 'ms'
 struct_amdsmi_nic_rdma_dev_info_t._fields_ = [
     ('rdma_dev', ctypes.c_char * 256),
     ('node_guid', ctypes.c_char * 256),
@@ -2965,6 +3060,7 @@ class struct_amdsmi_nic_rdma_devices_info_t(Structure):
     pass
 
 struct_amdsmi_nic_rdma_devices_info_t._pack_ = 1 # source:False
+struct_amdsmi_nic_rdma_devices_info_t._layout_ = 'ms'
 struct_amdsmi_nic_rdma_devices_info_t._fields_ = [
     ('num_rdma_dev', ctypes.c_ubyte),
     ('PADDING_0', ctypes.c_ubyte),
@@ -3548,6 +3644,7 @@ class struct_amdsmi_fabric_telemetry_item_t(Structure):
     pass
 
 struct_amdsmi_fabric_telemetry_item_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_telemetry_item_t._layout_ = 'ms'
 struct_amdsmi_fabric_telemetry_item_t._fields_ = [
     ('id', ctypes.c_uint64),
     ('value', ctypes.c_uint64),
@@ -3558,6 +3655,7 @@ class struct_amdsmi_fabric_label_t(Structure):
     pass
 
 struct_amdsmi_fabric_label_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_label_t._layout_ = 'ms'
 struct_amdsmi_fabric_label_t._fields_ = [
     ('text', ctypes.c_char * 32),
 ]
@@ -3567,6 +3665,7 @@ class struct_amdsmi_fabric_telemetry_instance_t(Structure):
     pass
 
 struct_amdsmi_fabric_telemetry_instance_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_telemetry_instance_t._layout_ = 'ms'
 struct_amdsmi_fabric_telemetry_instance_t._fields_ = [
     ('name', amdsmi_fabric_label_t),
     ('logical_idx', ctypes.c_uint32),
@@ -3582,12 +3681,14 @@ class struct_timespec(Structure):
     pass
 
 struct_timespec._pack_ = 1 # source:False
+struct_timespec._layout_ = 'ms'
 struct_timespec._fields_ = [
     ('tv_sec', ctypes.c_int64),
     ('tv_nsec', ctypes.c_int64),
 ]
 
 struct_amdsmi_fabric_telemetry_dataset_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_telemetry_dataset_t._layout_ = 'ms'
 struct_amdsmi_fabric_telemetry_dataset_t._fields_ = [
     ('category', amdsmi_fabric_telemetry_category_t),
     ('PADDING_0', ctypes.c_ubyte * 4),
@@ -3603,6 +3704,7 @@ class struct_amdsmi_fabric_telemetry_t(Structure):
     pass
 
 struct_amdsmi_fabric_telemetry_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_telemetry_t._layout_ = 'ms'
 struct_amdsmi_fabric_telemetry_t._fields_ = [
     ('datasets', ctypes.POINTER(struct_amdsmi_fabric_telemetry_dataset_t) * 7),
 ]
@@ -3684,6 +3786,7 @@ class struct_amdsmi_fabric_info_v1_t(Structure):
     pass
 
 struct_amdsmi_fabric_info_v1_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_info_v1_t._layout_ = 'ms'
 struct_amdsmi_fabric_info_v1_t._fields_ = [
     ('accelerator_id', ctypes.c_uint32),
     ('fabric_type', amdsmi_fabric_type_t),
@@ -3705,11 +3808,13 @@ class struct_amdsmi_fabric_info_ver_t(Structure):
 
 class union_fabric_info_(Union):
     _pack_ = 1 # source:False
+    _layout_ = 'ms'
     _fields_ = [
     ('v1', amdsmi_fabric_info_v1_t),
      ]
 
 struct_amdsmi_fabric_info_ver_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_info_ver_t._layout_ = 'ms'
 struct_amdsmi_fabric_info_ver_t._fields_ = [
     ('version', ctypes.c_uint32),
     ('fabric_version', union_fabric_info_),
@@ -3720,6 +3825,7 @@ class struct_amdsmi_fabric_info_t(Structure):
     pass
 
 struct_amdsmi_fabric_info_t._pack_ = 1 # source:False
+struct_amdsmi_fabric_info_t._layout_ = 'ms'
 struct_amdsmi_fabric_info_t._fields_ = [
     ('bdf', amdsmi_bdf_t),
     ('fabric_info', amdsmi_fabric_info_ver_t),
@@ -3762,6 +3868,7 @@ class struct_amdsmi_cper_guid_t(Structure):
     pass
 
 struct_amdsmi_cper_guid_t._pack_ = 1 # source:False
+struct_amdsmi_cper_guid_t._layout_ = 'ms'
 struct_amdsmi_cper_guid_t._fields_ = [
     ('b', ctypes.c_ubyte * 16),
 ]
@@ -3771,6 +3878,7 @@ class struct_amdsmi_cper_timestamp_t(Structure):
     pass
 
 struct_amdsmi_cper_timestamp_t._pack_ = 1 # source:False
+struct_amdsmi_cper_timestamp_t._layout_ = 'ms'
 struct_amdsmi_cper_timestamp_t._fields_ = [
     ('seconds', ctypes.c_ubyte),
     ('minutes', ctypes.c_ubyte),
@@ -3790,6 +3898,7 @@ class struct_valid_bits_(Structure):
     pass
 
 struct_valid_bits_._pack_ = 1 # source:False
+struct_valid_bits_._layout_ = 'ms'
 struct_valid_bits_._fields_ = [
     ('platform_id', ctypes.c_uint32, 1),
     ('timestamp', ctypes.c_uint32, 1),
@@ -3798,6 +3907,7 @@ struct_valid_bits_._fields_ = [
 ]
 
 union_amdsmi_cper_valid_bits_t._pack_ = 1 # source:False
+union_amdsmi_cper_valid_bits_t._layout_ = 'ms'
 union_amdsmi_cper_valid_bits_t._fields_ = [
     ('valid_bits', struct_valid_bits_),
     ('valid_mask', ctypes.c_uint32),
@@ -3808,6 +3918,7 @@ class struct_amdsmi_cper_hdr_t(Structure):
     pass
 
 struct_amdsmi_cper_hdr_t._pack_ = 1 # source:False
+struct_amdsmi_cper_hdr_t._layout_ = 'ms'
 struct_amdsmi_cper_hdr_t._fields_ = [
     ('signature', ctypes.c_char * 4),
     ('revision', ctypes.c_uint16),
@@ -4696,6 +4807,7 @@ class struct_amdsmi_uma_carveout_option_t(Structure):
     pass
 
 struct_amdsmi_uma_carveout_option_t._pack_ = 1 # source:False
+struct_amdsmi_uma_carveout_option_t._layout_ = 'ms'
 struct_amdsmi_uma_carveout_option_t._fields_ = [
     ('index', ctypes.c_uint32),
     ('description', ctypes.c_char * 256),
@@ -4706,6 +4818,7 @@ class struct_amdsmi_uma_carveout_info_t(Structure):
     pass
 
 struct_amdsmi_uma_carveout_info_t._pack_ = 1 # source:False
+struct_amdsmi_uma_carveout_info_t._layout_ = 'ms'
 struct_amdsmi_uma_carveout_info_t._fields_ = [
     ('current_index', ctypes.c_uint32),
     ('num_options', ctypes.c_uint32),
@@ -4717,6 +4830,7 @@ class struct_amdsmi_ttm_info_t(Structure):
     pass
 
 struct_amdsmi_ttm_info_t._pack_ = 1 # source:False
+struct_amdsmi_ttm_info_t._layout_ = 'ms'
 struct_amdsmi_ttm_info_t._fields_ = [
     ('current_pages', ctypes.c_uint64),
 ]

--- a/projects/amdsmi/tools/generator.py
+++ b/projects/amdsmi/tools/generator.py
@@ -120,17 +120,29 @@ def insert_layout_ms(full_path_file_name):
     fh, abs_path = tempfile.mkstemp()
     standalone = re.compile(r"^(\s*)(\S+)\._pack_ = ")
     inline = re.compile(r"^(\s+)_pack_ = ")
+    pack_count = 0
+    layout_count = 0
     with os.fdopen(fh, "w", encoding="UTF-8") as new_file:
         with open(full_path_file_name, "r", encoding="UTF-8") as old_file:
             for line in old_file:
                 new_file.write(line)
+                if "._pack_ = " in line or line.lstrip().startswith("_pack_ = "):
+                    pack_count += 1
                 m = standalone.match(line)
                 if m:
+                    layout_count += 1
                     new_file.write(f"{m.group(1)}{m.group(2)}._layout_ = 'ms'\n")
                     continue
                 mi = inline.match(line)
                 if mi:
+                    layout_count += 1
                     new_file.write(f"{mi.group(1)}_layout_ = 'ms'\n")
+
+    if pack_count != layout_count:
+        raise RuntimeError(
+            f"_layout_ insertion missed a _pack_ style: found {pack_count} "
+            f"_pack_ lines but added {layout_count} _layout_ lines"
+        )
 
     shutil.copymode(full_path_file_name, abs_path)
     os.remove(full_path_file_name)

--- a/projects/amdsmi/tools/generator.py
+++ b/projects/amdsmi/tools/generator.py
@@ -18,6 +18,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import os
+import re
 import argparse
 import tempfile
 import shutil
@@ -106,6 +107,30 @@ def write_file(full_path_file_name, contents):
     with os.fdopen(fh, "w") as new_file:
         for line in contents:
             new_file.write(f"{line}\n")
+
+    shutil.copymode(full_path_file_name, abs_path)
+    os.remove(full_path_file_name)
+    shutil.move(abs_path, full_path_file_name)
+
+
+def insert_layout_ms(full_path_file_name):
+    # Python 3.14 deprecates the implicit ctypes layout when _pack_ is set
+    # (becomes an error in 3.19). _layout_ = 'ms' keeps the MSVC-compatible
+    # layout that packed structs already used pre-3.14, so the ABI is unchanged.
+    fh, abs_path = tempfile.mkstemp()
+    standalone = re.compile(r"^(\s*)(\S+)\._pack_ = ")
+    inline = re.compile(r"^(\s+)_pack_ = ")
+    with os.fdopen(fh, "w") as new_file:
+        with open(full_path_file_name, "r", encoding="UTF-8") as old_file:
+            for line in old_file:
+                new_file.write(line)
+                m = standalone.match(line)
+                if m:
+                    new_file.write(f"{m.group(1)}{m.group(2)}._layout_ = 'ms'\n")
+                    continue
+                mi = inline.match(line)
+                if mi:
+                    new_file.write(f"{mi.group(1)}_layout_ = 'ms'\n")
 
     shutil.copymode(full_path_file_name, abs_path)
     os.remove(full_path_file_name)
@@ -476,6 +501,8 @@ amdsmi_free_name_value_pairs.argtypes = [ctypes.POINTER(None)]"""
             output_file_array = output_file_array[:-1]
 
         write_file(output_file, output_file_array)
+
+    insert_layout_ms(output_file)
 
 
 if __name__ == "__main__":

--- a/projects/amdsmi/tools/generator.py
+++ b/projects/amdsmi/tools/generator.py
@@ -120,7 +120,7 @@ def insert_layout_ms(full_path_file_name):
     fh, abs_path = tempfile.mkstemp()
     standalone = re.compile(r"^(\s*)(\S+)\._pack_ = ")
     inline = re.compile(r"^(\s+)_pack_ = ")
-    with os.fdopen(fh, "w") as new_file:
+    with os.fdopen(fh, "w", encoding="UTF-8") as new_file:
         with open(full_path_file_name, "r", encoding="UTF-8") as old_file:
             for line in old_file:
                 new_file.write(line)


### PR DESCRIPTION
## Motivation

Fixes ROCm/amdsmi#106. On Python 3.14, importing `amdsmi_wrapper.py` warns
(`DeprecationWarning`) for every packed ctypes struct/union - Python 3.14
deprecated the implicit layout when `_pack_` is set (a hard error in 3.19).

## Technical Details

- `tools/generator.py`: post-processing pass emits `_layout_ = 'ms'` after every
  `_pack_` (both clang2py styles), and raises if `_pack_`/`_layout_` counts
  diverge. `'ms'` keeps the pre-3.14 MSVC layout, so the ABI is unchanged.
- `py-interface/amdsmi_wrapper.py`: regenerated; `_layout_ = 'ms'` on all 114
  packed structs/unions.
- `CHANGELOG.md`: Resolved Issues entry under ROCm 7.15.0.

## Test Plan / Result

Imported the regenerated wrapper with `-W error::DeprecationWarning`: clean on
Python 3.14.6, and clean with unchanged struct sizes on 3.12.3.