### PR TITLE
Users/karthikarum/qpsharing rocm ib

### DIFF
--- a/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
+++ b/projects/rccl/src/transport/net_ib_cast/CMakeLists.txt
@@ -11,6 +11,7 @@ set(NET_IB_CAST_SOURCES
     src/transport/net_ib_cast/p2p_resiliency_recovery_cast.h
     src/transport/net_ib_cast/p2p_resiliency_recovery_internal.h
     src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.h
+    src/transport/net_ib_cast/qp_sharing.h
     src/transport/net_ib_cast/common.cc
     src/transport/net_ib_cast/connect.cc
     src/transport/net_ib_cast/gdr.cc
@@ -23,6 +24,7 @@ set(NET_IB_CAST_SOURCES
     src/transport/net_ib_cast/reg.cc
     src/transport/net_ib_cast/scheduler.cc
     src/transport/net_ib_cast/gin.cc
+    src/transport/net_ib_cast/qp_sharing.cc
 )
 
 # The cast headers (common_cast.h, p2p_cast.h, etc.) live in this directory.

--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -23,6 +23,9 @@ NCCL_PARAM(IbCastSplitDataOnQps, "IB_SPLIT_DATA_ON_QPS", 0);
 NCCL_PARAM(IbCastPrepostReceiveWorkRequests, "IB_PREPOST_RECEIVE_WORK_REQUESTS", -2);
 NCCL_PARAM(IbCastAsyncEvents, "IB_RETURN_ASYNC_EVENTS", 1);
 extern int ncclParamIbCastOooRq();
+extern int ncclParamIbCastResiliencyPortFailover();
+extern int64_t rcclParamIbCastCommNGroups();
+
 
 ncclResult_t IbCastStatsCheckFatalCount(struct ncclIbStats* stat, const char* funcName) {
   if (ncclParamIbCastAsyncEvents() && COMPILER_ATOMIC_LOAD(&stat->fatalErrorCount, std::memory_order_relaxed)) {
@@ -81,6 +84,15 @@ ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm) {
   if (ncclParamIbCastOooRq()) {
     if (ncclParamIbCastPrepostReceiveWorkRequests() == 0) {
       INFO(NCCL_NET, "NET/IB: %s: OOO RQ is enabled, Overriding pre-posting to true (1).", __func__);
+    }
+    recvComm->prepostReceiveWorkRequests = true;
+  }
+  if (rcclParamIbCastCommNGroups() > 0) {
+    // WQE posted by one comm can be consumed by another comm, so the per-comm counters drift
+    // and the RQ starves. Prepost mode reposts one WQE per completion with no per-comm counter,
+    // which is correct for a shared RQ.
+    if (ncclParamIbCastPrepostReceiveWorkRequests() == 0) {
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing is enabled, Overriding pre-posting to true (1).", __func__);
     }
     recvComm->prepostReceiveWorkRequests = true;
   }

--- a/projects/rccl/src/transport/net_ib_cast/common.cc
+++ b/projects/rccl/src/transport/net_ib_cast/common.cc
@@ -87,6 +87,7 @@ ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm) {
     }
     recvComm->prepostReceiveWorkRequests = true;
   }
+#if 0
   if (rcclParamIbCastCommNGroups() > 0) {
     // WQE posted by one comm can be consumed by another comm, so the per-comm counters drift
     // and the RQ starves. Prepost mode reposts one WQE per completion with no per-comm counter,
@@ -96,6 +97,7 @@ ncclResult_t IbCastRecvCommInit(struct ncclIbRecvComm* recvComm) {
     }
     recvComm->prepostReceiveWorkRequests = true;
   }
+#endif
 
   INFO(NCCL_NET, "NET/IB: %s: Receive work requests will be %s", __func__,
        recvComm->prepostReceiveWorkRequests ? "pre-posted" : "posted on-demand");

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -144,6 +144,11 @@ extern bool IbCastUseInline;
 #define WR_IMM_RX_REQ_IDX_SHIFT 24
 #define WR_IMM_SPLIT_DATA_FLAG 0x00800000
 #define WR_IMM_SIZE_MASK 0x007fffff
+// QP sharing BY_ID imm_data layout: reqId in bits[7:0], receiver commId in bits[23:8].
+// reqId fits in 8 bits (NET_IB_MAX_REQUESTS <= 256); commId fits in 16 bits.
+#define WR_IMM_BYID_REQ_ID_MASK   0xff
+#define WR_IMM_BYID_COMM_ID_SHIFT 8
+#define WR_IMM_BYID_COMM_ID_MASK  0xffff
 extern int IbCastGdrFlushDisable;
 extern bool IbCastAinicRoce;
 extern bool rcclCtsInlineData;
@@ -371,7 +376,6 @@ struct alignas(32) ncclIbSendFifoCtsInline {
   uint16_t rxReqIndex;
   uint16_t tag;
   uint32_t idx;
-  // TODO - adjusted padding to align to 32B
   char padding[7];
 } __attribute__((packed));
 

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -369,7 +369,8 @@ struct alignas(32) ncclIbSendFifoCtsInline {
   uint16_t rxReqIndex;
   uint16_t tag;
   uint32_t idx;
-  char padding[9];
+  // TODO - adjusted padding to align to 32B
+  char padding[7];
 } __attribute__((packed));
 
 struct ncclIbQpInitAttr {
@@ -505,6 +506,13 @@ struct alignas(32) ncclIbNetCommBase {
   bool faultQpError[NCCL_IB_MAX_QPS];
 #endif
   struct ncclIbResiliency* resiliency;
+
+  // QP Sharing fields
+  uint16_t commId;              // 0 = not shared
+  bool     isSharedQpPrimary;
+  int      sharedGroupIdx;      // -1 = not shared
+  int      remIbDevIdx;
+  int      sharedPrimaryNqps;
 };
 
 struct ncclIbNetCommDevBase* IbCastGetNetCommDevBase(ncclIbNetCommBase* base, int devIndex);
@@ -595,6 +603,7 @@ struct ncclIbSendComm {
   int ar; // Use adaptive routing when all merged devices have it enabled
   uint64_t putSignalScratchpad;
   bool useCtsOffload;
+  uint16_t remCommId;           // receiver's commId for imm_data encoding (QP sharing)
 };
 // The SendFifo needs to be 32-byte aligned and each element needs
 // to be a 32-byte multiple, so that an entry does not get split and

--- a/projects/rccl/src/transport/net_ib_cast/common_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/common_cast.h
@@ -138,6 +138,8 @@ extern struct ncclIbDev IbCastDevs[MAX_IB_DEVS];
 extern int IbCastRelaxedOrderingEnabled;
 extern bool IbCastUseInline;
 
+#define WR_ID_RX_COMM_ID_MASK  0xffff
+#define WR_ID_RX_COMM_ID_SHIFT 48
 #define WR_IMM_RX_REQ_IDX_MASK 0xff
 #define WR_IMM_RX_REQ_IDX_SHIFT 24
 #define WR_IMM_SPLIT_DATA_FLAG 0x00800000

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1805,26 +1805,26 @@ ib_recv:
   // QP Sharing: receiver-side primary/secondary determination
   if (rcclParamIbCastCommNGroups() > 0 && !remMeta.isRMA && remMeta.sharedGroupIdx >= 0) {
     int recvGroupIdx = remMeta.sharedGroupIdx;
+    int recvProbeIbDevN;
 
     rComm->base.commId = IbCastAllocCommId(rComm, false);
     if (rComm->base.commId == 0) {
       goto qp_sharing_skip_recv;
     }
-    rComm->base.sharedGroupIdx = recvGroupIdx;
-
     // Build probe key from peer address
     union ncclSocketAddress recvPeerAddr;
     ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
     IbCastStripPort(&recvPeerAddr);
 
-    int recvProbeIbDevN;
+    rComm->base.sharedGroupIdx = recvGroupIdx;
+	rComm->base.remIbDevIdx = remMeta.senderIbDevIdx;
     recvProbeIbDevN = (rComm->base.vProps.ndevs > 0) ? rComm->base.vProps.devs[0] : 0;
 
     IbCastSharedQpKey recvProbeKey;
     memset(&recvProbeKey, 0, sizeof(recvProbeKey));
     recvProbeKey.ibDevN = recvProbeIbDevN;
     recvProbeKey.peerAddr = recvPeerAddr;
-    recvProbeKey.remIbDevIdx = 0;
+    recvProbeKey.remIbDevIdx = remMeta.senderIbDevIdx;
     recvProbeKey.isSend = false;
     recvProbeKey.groupIdx = recvGroupIdx;
     recvProbeKey.qpIdx = 0;
@@ -1838,18 +1838,24 @@ ib_recv:
            __func__, rComm->base.commId, recvGroupIdx);
 
       rComm->base.isSharedQpPrimary = false;
+	  int primaryNqps = IbCastCountGroupQpSlots(&recvPeerAddr, remMeta.senderIbDevIdx, false, remMeta.sharedGroupIdx);
+
+      rComm->base.sharedPrimaryNqps = primaryNqps;
       rComm->useCtsOffload = false;
+
+      IbCastSharedQpKey recvKey;
+      memset(&recvKey, 0, sizeof(recvKey));
+      recvKey.peerAddr = recvPeerAddr;
+      recvKey.isSend = false;
+      recvKey.groupIdx = recvGroupIdx;
 
       int nqps = rComm->base.nqps;
       for (int q = 0; q < nqps; q++) {
-        IbCastSharedQpKey recvKey;
-        memset(&recvKey, 0, sizeof(recvKey));
-        recvKey.ibDevN = rComm->base.vProps.devs[q % rComm->base.vProps.ndevs];
-        recvKey.peerAddr = recvPeerAddr;
-        recvKey.remIbDevIdx = 0;
-        recvKey.isSend = false;
-        recvKey.groupIdx = recvGroupIdx;
-        recvKey.qpIdx = q;
+		int mappedQ = q % primaryNqps;
+		int localDevIdx = mappedQ % rComm->base.vProps.ndevs;
+		recvKey.ibDevN = rComm->base.vProps.devs[localDevIdx];
+        recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
+        recvKey.qpIdx = mappedQ
 
         struct IbCastSharedQp* recvSlot = IbCastFindSharedQp(&recvKey);
         if (recvSlot == NULL) {
@@ -1884,7 +1890,7 @@ ib_recv:
       INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d depthMult=%d",
            __func__, rComm->base.commId, recvGroupIdx, recvDepthMult);
       rComm->base.isSharedQpPrimary = true;
-      rComm->useCtsOffload = false;
+      rComm->useCtsOffload = false; // TODO - QP sharing: check connect side
     }
   }
 
@@ -1897,26 +1903,27 @@ qp_sharing_skip_recv:
     ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
     IbCastStripPort(&recvPeerAddr);
 
+    IbCastSharedQpKey recvKey;
+    memset(&recvKey, 0, sizeof(recvKey));
+    recvKey.peerAddr = recvPeerAddr;
+    recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
+    recvKey.isSend = false;
+    recvKey.groupIdx = rComm->base.sharedGroupIdx;
+
     int nqps = rComm->base.nqps;
     for (int q = 0; q < nqps; q++) {
-      IbCastSharedQpKey recvKey;
-      memset(&recvKey, 0, sizeof(recvKey));
       recvKey.ibDevN = rComm->base.vProps.devs[q % rComm->base.vProps.ndevs];
-      recvKey.peerAddr = recvPeerAddr;
-      recvKey.remIbDevIdx = 0;
-      recvKey.isSend = false;
-      recvKey.groupIdx = rComm->base.sharedGroupIdx;
       recvKey.qpIdx = q;
 
       int devIdx = q % rComm->base.vProps.ndevs;
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
           rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
           &rComm->devs[devIdx].base, rComm->base.qps[q].devIndex, 1);
-      if (entry && q == 0) {
-        entry->cqRefcount = 1;
-      }
       if (entry) {
         entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
+        if (q == 0) {
+          entry->cqRefcount = 1;
+        }
       }
     }
   }

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -8,6 +8,7 @@
 #include "connect_cast.h"
 #include "common_cast.h"
 #include "p2p_resiliency_cast.h"
+#include "qp_sharing.h"
 
 NCCL_PARAM(IbCastGidIndex, "IB_GID_INDEX", -1);
 NCCL_PARAM(IbCastRoutableFlidIbGidIndex, "IB_ROUTABLE_FLID_GID_INDEX", 1);
@@ -86,7 +87,7 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
   return requested;
 }
 
-ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int cqSize) {
+ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int cqSize, int depthMultiplier = 1) {
   base->ibDevN = ibDevN;
   ncclIbDev* ibDev = IbCastDevs + ibDevN;
   {
@@ -97,7 +98,8 @@ ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base
     base->pd = ibDev->pd;
   }
 
-  NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, cqSize, cq_context, NULL, 0));
+  int scaledCqSize = cqSize * depthMultiplier;
+  NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, scaledCqSize, cq_context, NULL, 0));
 
   return ncclSuccess;
 }
@@ -471,12 +473,32 @@ void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, s
   }
 }
 
-ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs) {
+ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs, int depthMultiplier, int groupIdx) {
+  // Scale WR depths for QP sharing
+  uint32_t origMaxSend = createQpAttrs->maxSendWorkRequest;
+  uint32_t origMaxRecv = createQpAttrs->maxRecvWorkRequest;
+  createQpAttrs->maxSendWorkRequest *= depthMultiplier;
+  createQpAttrs->maxRecvWorkRequest *= depthMultiplier;
+
+  // When QP sharing is active (groupIdx >= 0), disable CTS offload for shared QPs
+  if (groupIdx >= 0) {
+    createQpAttrs->isCtsEnabled = false;
+  }
+
+  ncclResult_t ret = ncclSuccess;
   if (createQpAttrs->oooRq) {
     NCCLCHECK(ncclIbCreateQpMlx5(createQpAttrs, qp));
     return ncclSuccess;
   }
   if (createQpAttrs->useIonic && createQpAttrs->type != IBV_QPT_UD) {
+    // For Ionic with QP sharing, use groupIdx for UDMA mask selection
+    if (groupIdx >= 0) {
+      if (groupIdx % 2 == 0) {
+        wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_LOW);
+      } else {
+        wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_HIGH);
+      }
+    }
     NCCLCHECK(ncclIbCreateQpIonic(createQpAttrs, qp));
     return ncclSuccess;
   }
@@ -713,6 +735,24 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
 // was delivered from the receiver side) on the QPs before modifying the QPs
 // to RTR.
 static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* remMeta) {
+  // Capture receiver's commId for QP sharing imm_data encoding
+  comm->remCommId = remMeta->commId;
+
+  // If secondary shared QP, skip RTR/RTS -- QPs are already in RTS from primary
+  if (comm->base.commId != 0 && !comm->base.isSharedQpPrimary) {
+    // Just assign remDevIdx from remote metadata
+    uint nqps = comm->base.nqps;
+    for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
+      ncclIbQp* localQp = &comm->base.qps[qpIndex];
+      ncclIbQpInfo* remQpInfo = &remMeta->qpInfo[qpIndex];
+      localQp->remDevIdx = remQpInfo->devIndex;
+    }
+    if (comm->base.resiliency) {
+      NCCLCHECK(IbCastResiliencySenderQpsToRts(comm->base.resiliency, remMeta));
+    }
+    return ncclSuccess;
+  }
+
   uint nqps = comm->base.nqps;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     ncclIbQp* localQp = &comm->base.qps[qpIndex];
@@ -877,9 +917,26 @@ ib_recv_dev_list:
 
   comm->base.nDataQps = std::max(comm->base.vProps.ndevs, remoteVProps.ndevs);
 
+  // Initialize QP sharing fields
+  comm->base.commId = 0;
+  comm->base.isSharedQpPrimary = false;
+  comm->base.sharedGroupIdx = -1;
+  comm->base.remIbDevIdx = -1;
+  comm->base.sharedPrimaryNqps = 0;
+  comm->remCommId = 0;
+
+  // Initialize activeQps identity mapping
+  for (int q = 0; q < NCCL_IB_MAX_QPS; q++) {
+    comm->base.activeQps[q] = &comm->base.qps[q];
+  }
+
   if (comm->base.resiliency) {
     NCCLCHECK(IbCastResiliencyDeviceNumSet(comm->base.resiliency, comm->base.vProps.ndevs, remoteVProps.ndevs));
   }
+
+  // Compute depth multiplier for QP sharing
+  int depthMult;
+  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
 
   // Init PD, Ctx for each IB device
   comm->ar = 1; // Set to 1 for logic
@@ -892,7 +949,7 @@ ib_recv_dev_list:
     if (comm->base.resiliency) {
       IbCastResiliencyDataCqSizeGet(comm->base.resiliency, i, &cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, cqSize), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, cqSize, depthMult), ret, fail);
     comm->ar = comm->ar && IbCastDevs[ibDevN].ar; // ADAPTIVE_ROUTING - if all merged devs have it enabled
     if (comm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(comm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
@@ -903,9 +960,150 @@ ib_recv_dev_list:
   meta.ndevs = comm->base.vProps.ndevs;
   meta.isP2p = isP2p;
   meta.isRMA = handle->isRMA;
+  meta.sharedGroupIdx = -1;
+  meta.commId = 0;
+  meta.senderIbDevIdx = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : -1;
 
+  // QP Sharing: sender-side primary/secondary determination
+  if (rcclParamIbCastCommNGroups() > 0 && !handle->isRMA) {
+    int ngroups = rcclParamIbCastCommNGroups();
+
+    // Allocate commId for this comm
+    comm->base.commId = IbCastAllocCommId(comm, true);
+    if (comm->base.commId == 0) {
+      // Fallback to non-sharing if pool exhausted
+      goto qp_sharing_skip_sender;
+    }
+
+    // Build probe key from peer address
+    union ncclSocketAddress peerAddr;
+    ncclSocketGetAddr(&comm->base.sock, &peerAddr);
+    IbCastStripPort(&peerAddr);
+
+    // Use first device's ibDevN for the probe
+    int probeIbDevN;
+    probeIbDevN = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : 0;
+
+    // Count existing refs to determine groupIdx
+    int totalRefs;
+    totalRefs = IbCastCountPeerTotalRefcount(probeIbDevN, &peerAddr, 0, true);
+    int groupIdx;
+    groupIdx = totalRefs % ngroups;
+    comm->base.sharedGroupIdx = groupIdx;
+
+    // Check if primary exists for this group
+    IbCastSharedQpKey probeKey;
+    memset(&probeKey, 0, sizeof(probeKey));
+    probeKey.ibDevN = probeIbDevN;
+    probeKey.peerAddr = peerAddr;
+    probeKey.remIbDevIdx = 0;
+    probeKey.isSend = true;
+    probeKey.groupIdx = groupIdx;
+    probeKey.qpIdx = 0;
+
+    struct IbCastSharedQp* existingSlot;
+    existingSlot = IbCastFindSharedQp(&probeKey);
+
+    if (existingSlot != NULL) {
+      // SECONDARY: reuse existing QPs from pool
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY sender commId=%u group=%d totalRefs=%d",
+           __func__, comm->base.commId, groupIdx, totalRefs);
+
+      comm->base.isSharedQpPrimary = false;
+      comm->useCtsOffload = false;
+
+      int nqps = comm->base.nqps;
+      for (int q = 0; q < nqps; q++) {
+        IbCastSharedQpKey key;
+        memset(&key, 0, sizeof(key));
+        key.ibDevN = comm->base.vProps.devs[q % comm->base.vProps.ndevs];
+        key.peerAddr = peerAddr;
+        key.remIbDevIdx = 0;
+        key.isSend = true;
+        key.groupIdx = groupIdx;
+        key.qpIdx = q;
+
+        struct IbCastSharedQp* slot = IbCastFindSharedQp(&key);
+        if (slot == NULL) {
+          WARN("NET/IB: %s: QP sharing SECONDARY: could not find shared QP for qpIdx=%d group=%d", __func__, q, groupIdx);
+          // Fallback: free commId and go non-sharing
+          IbCastFreeCommId(comm->base.commId);
+          comm->base.commId = 0;
+          comm->base.sharedGroupIdx = -1;
+          goto qp_sharing_skip_sender;
+        }
+
+        // Copy QP info from shared pool to this comm
+        comm->base.qps[q].qp = slot->qp;
+        comm->base.qps[q].devIndex = slot->devIndex;
+        comm->base.qps[q].ctsQpSlot = slot->ctsQpSlot;
+        comm->base.activeQps[q] = &comm->base.qps[q];
+
+        // Populate metadata with shared QP info
+        meta.qpInfo[q].qpn = slot->qp->qp_num;
+        meta.qpInfo[q].devIndex = slot->devIndex;
+
+        slot->refcount++;
+      }
+
+      // Redirect CQs: destroy per-comm CQs and point to primary's CQs
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        NCCLCHECK(wrap_ibv_destroy_cq(comm->devs[i].base.cq));
+        comm->devs[i].base.cq = existingSlot->primaryCq;
+      }
+      existingSlot->cqRefcount++;
+
+      // Skip QP creation; metadata is already populated
+      goto qp_sharing_done_sender;
+    } else {
+      // PRIMARY: create QPs with scaled depth, then register in pool
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY sender commId=%u group=%d depthMult=%d",
+           __func__, comm->base.commId, groupIdx, depthMult);
+
+      comm->base.isSharedQpPrimary = true;
+      comm->useCtsOffload = false;
+    }
+  }
+
+qp_sharing_skip_sender:
   // Create QPs on the sender side
   NCCLCHECKGOTO(IbCastSenderQpsCreate(comm, &meta, channelId), ret, fail);
+
+  // If primary, register QPs in shared pool
+  if (comm->base.commId != 0 && comm->base.isSharedQpPrimary) {
+    union ncclSocketAddress peerAddr;
+    ncclSocketGetAddr(&comm->base.sock, &peerAddr);
+    IbCastStripPort(&peerAddr);
+
+    int nqps = comm->base.nqps;
+    for (int q = 0; q < nqps; q++) {
+      IbCastSharedQpKey key;
+      memset(&key, 0, sizeof(key));
+      key.ibDevN = comm->base.vProps.devs[q % comm->base.vProps.ndevs];
+      key.peerAddr = peerAddr;
+      key.remIbDevIdx = 0;
+      key.isSend = true;
+      key.groupIdx = comm->base.sharedGroupIdx;
+      key.qpIdx = q;
+
+      int devIdx = q % comm->base.vProps.ndevs;
+      struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
+          comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
+          &comm->devs[devIdx].base, devIdx, 1);
+      if (entry && q == 0) {
+        entry->cqRefcount = 1;
+      }
+      if (entry) {
+        entry->ctsQpSlot = comm->base.qps[q].ctsQpSlot;
+      }
+    }
+  }
+
+qp_sharing_done_sender:
+  // Populate QP sharing metadata
+  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
+  meta.commId = comm->base.commId;
+  meta.senderIbDevIdx = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : -1;
 
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
     ncclIbSendCommDev* commDev = comm->devs + i;
@@ -1465,6 +1663,18 @@ ib_recv:
   rComm->base.nqps = IbCastCalculateNqps(remMeta.isP2p, rComm->base.vProps.ndevs, remMeta.ndevs, __func__);
   rComm->base.nDataQps = std::max(rComm->base.vProps.ndevs, remMeta.ndevs);
 
+  // Initialize QP sharing fields on receiver
+  rComm->base.commId = 0;
+  rComm->base.isSharedQpPrimary = false;
+  rComm->base.sharedGroupIdx = -1;
+  rComm->base.remIbDevIdx = -1;
+  rComm->base.sharedPrimaryNqps = 0;
+
+  // Initialize activeQps identity mapping
+  for (int q = 0; q < NCCL_IB_MAX_QPS; q++) {
+    rComm->base.activeQps[q] = &rComm->base.qps[q];
+  }
+
   // IB setup
   // Pre-declare variables because of goto
   struct ncclIbDev* ibDev;
@@ -1481,6 +1691,11 @@ ib_recv:
   // Metadata to send back to requestor (sender)
   struct ncclIbConnectionMetadata meta;
   memset(&meta, 0, sizeof(meta));
+
+  // Compute depth multiplier for receiver QP sharing
+  int recvDepthMult;
+  recvDepthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int)rcclParamIbCastQpDepthMultiplier(), 1) : 1;
+
   // Receiver's CQ size needs to accomodate receive requests that can generate
   // up to 2 completions (one for the CTS message and one for the completion
   // of a receive request) per QP, in the worst case.
@@ -1492,7 +1707,7 @@ ib_recv:
     if (rComm->base.resiliency) {
       IbCastResiliencyDataCqSizeGet(rComm->base.resiliency, i, &cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, cqSize), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, cqSize, recvDepthMult), ret, fail);
     if (rComm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(rComm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
     }
@@ -1546,7 +1761,131 @@ ib_recv:
                           1 :
                           0;
 
+  // QP Sharing: receiver-side primary/secondary determination
+  if (rcclParamIbCastCommNGroups() > 0 && !remMeta.isRMA && remMeta.sharedGroupIdx >= 0) {
+    int recvGroupIdx;
+    recvGroupIdx = remMeta.sharedGroupIdx;
+
+    rComm->base.commId = IbCastAllocCommId(rComm, false);
+    if (rComm->base.commId == 0) {
+      goto qp_sharing_skip_recv;
+    }
+    rComm->base.sharedGroupIdx = recvGroupIdx;
+
+    // Build probe key from peer address
+    union ncclSocketAddress recvPeerAddr;
+    ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
+    IbCastStripPort(&recvPeerAddr);
+
+    int recvProbeIbDevN;
+    recvProbeIbDevN = (rComm->base.vProps.ndevs > 0) ? rComm->base.vProps.devs[0] : 0;
+
+    IbCastSharedQpKey recvProbeKey;
+    memset(&recvProbeKey, 0, sizeof(recvProbeKey));
+    recvProbeKey.ibDevN = recvProbeIbDevN;
+    recvProbeKey.peerAddr = recvPeerAddr;
+    recvProbeKey.remIbDevIdx = 0;
+    recvProbeKey.isSend = false;
+    recvProbeKey.groupIdx = recvGroupIdx;
+    recvProbeKey.qpIdx = 0;
+
+    struct IbCastSharedQp* recvExistingSlot;
+    recvExistingSlot = IbCastFindSharedQp(&recvProbeKey);
+
+    if (recvExistingSlot != NULL) {
+      // SECONDARY receiver: reuse existing QPs
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing SECONDARY receiver commId=%u group=%d",
+           __func__, rComm->base.commId, recvGroupIdx);
+
+      rComm->base.isSharedQpPrimary = false;
+      rComm->useCtsOffload = false;
+
+      int nqps = rComm->base.nqps;
+      for (int q = 0; q < nqps; q++) {
+        IbCastSharedQpKey recvKey;
+        memset(&recvKey, 0, sizeof(recvKey));
+        recvKey.ibDevN = rComm->base.vProps.devs[q % rComm->base.vProps.ndevs];
+        recvKey.peerAddr = recvPeerAddr;
+        recvKey.remIbDevIdx = 0;
+        recvKey.isSend = false;
+        recvKey.groupIdx = recvGroupIdx;
+        recvKey.qpIdx = q;
+
+        struct IbCastSharedQp* recvSlot = IbCastFindSharedQp(&recvKey);
+        if (recvSlot == NULL) {
+          WARN("NET/IB: %s: QP sharing SECONDARY recv: could not find shared QP for qpIdx=%d group=%d", __func__, q, recvGroupIdx);
+          IbCastFreeCommId(rComm->base.commId);
+          rComm->base.commId = 0;
+          rComm->base.sharedGroupIdx = -1;
+          goto qp_sharing_skip_recv;
+        }
+
+        rComm->base.qps[q].qp = recvSlot->qp;
+        rComm->base.qps[q].devIndex = recvSlot->devIndex;
+        rComm->base.qps[q].ctsQpSlot = recvSlot->ctsQpSlot;
+        rComm->base.activeQps[q] = &rComm->base.qps[q];
+
+        meta.qpInfo[q].qpn = recvSlot->qp->qp_num;
+        meta.qpInfo[q].devIndex = recvSlot->devIndex;
+
+        recvSlot->refcount++;
+      }
+
+      // Redirect CQs
+      for (int i = 0; i < rComm->base.vProps.ndevs; i++) {
+        NCCLCHECK(wrap_ibv_destroy_cq(rComm->devs[i].base.cq));
+        rComm->devs[i].base.cq = recvExistingSlot->primaryCq;
+      }
+      recvExistingSlot->cqRefcount++;
+
+      goto qp_sharing_done_recv;
+    } else {
+      // PRIMARY receiver: create QPs with scaled depth, register in pool
+      INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d depthMult=%d",
+           __func__, rComm->base.commId, recvGroupIdx, recvDepthMult);
+      rComm->base.isSharedQpPrimary = true;
+      rComm->useCtsOffload = false;
+    }
+  }
+
+qp_sharing_skip_recv:
   NCCLCHECKGOTO(IbCastReceiverQpsCreateToRts(rComm, &remMeta, &meta, channelId), ret, fail);
+
+  // If primary receiver, register QPs in shared pool
+  if (rComm->base.commId != 0 && rComm->base.isSharedQpPrimary) {
+    union ncclSocketAddress recvPeerAddr;
+    ncclSocketGetAddr(&rComm->base.sock, &recvPeerAddr);
+    IbCastStripPort(&recvPeerAddr);
+
+    int nqps = rComm->base.nqps;
+    for (int q = 0; q < nqps; q++) {
+      IbCastSharedQpKey recvKey;
+      memset(&recvKey, 0, sizeof(recvKey));
+      recvKey.ibDevN = rComm->base.vProps.devs[q % rComm->base.vProps.ndevs];
+      recvKey.peerAddr = recvPeerAddr;
+      recvKey.remIbDevIdx = 0;
+      recvKey.isSend = false;
+      recvKey.groupIdx = rComm->base.sharedGroupIdx;
+      recvKey.qpIdx = q;
+
+      int devIdx = q % rComm->base.vProps.ndevs;
+      struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
+          rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
+          &rComm->devs[devIdx].base, devIdx, 1);
+      if (entry && q == 0) {
+        entry->cqRefcount = 1;
+      }
+      if (entry) {
+        entry->ctsQpSlot = rComm->base.qps[q].ctsQpSlot;
+      }
+    }
+  }
+
+qp_sharing_done_recv:
+  // Populate QP sharing metadata in response
+  meta.sharedGroupIdx = rComm->base.sharedGroupIdx;
+  meta.commId = rComm->base.commId;
+
   if (rComm->prepostReceiveWorkRequests) {
     NCCLCHECKGOTO(IbCastReceiverPrePostReceiveWorkRequests(rComm), ret, fail);
   }
@@ -1689,8 +2028,61 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
   if (comm) {
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    for (int q = 0; q < comm->base.nqps; q++)
-      if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
+    if (comm->base.commId != 0) {
+      // QP sharing teardown: refcount-based
+      std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+      struct IbCastSharedQp* slot0 = NULL;
+      for (int q = 0; q < comm->base.nqps; q++) {
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(
+            comm->base.qps[q].qp ? comm->base.qps[q].qp->qp_num : 0, true);
+        if (slot) {
+          if (q == 0) slot0 = slot;
+          slot->refcount--;
+          if (slot->refcount <= 0 && slot->qp) {
+            INFO(NCCL_NET, "IB CAST TEARDOWN: destroying shared send QP qpn=%u group=%d qpIdx=%d",
+                 slot->qp->qp_num, slot->key.groupIdx, slot->key.qpIdx);
+            wrap_ibv_destroy_qp(slot->qp);
+            slot->qp = NULL;
+          }
+        }
+      }
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
+      }
+      IbCastFreeCommId(comm->base.commId);
+
+      // Deregister per-comm MRs (not shared)
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbSendCommDev* commDev = comm->devs + i;
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (commDev->putSignalScratchpadMr != NULL)
+          NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
+        if (comm->base.resiliency) {
+          NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
+        }
+        // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+    } else {
+      // Non-shared: original teardown
+      for (int q = 0; q < comm->base.nqps; q++)
+        if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
+
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbSendCommDev* commDev = comm->devs + i;
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (commDev->putSignalScratchpadMr != NULL)
+          NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
+        if (comm->base.resiliency) {
+           NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
+        }
+        NCCLCHECK(IbCastDestroyBase(&commDev->base));
+      }
+    }
 
     if (comm->base.resiliency) {
       NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
@@ -1720,8 +2112,79 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
   if (comm) {
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    for (int q = 0; q < comm->base.nqps; q++)
-      if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
+    if (comm->base.commId != 0) {
+      // QP sharing teardown: refcount-based
+      std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+      struct IbCastSharedQp* slot0 = NULL;
+      for (int q = 0; q < comm->base.nqps; q++) {
+        struct IbCastSharedQp* slot = IbCastFindSharedQpByQpn(
+            comm->base.qps[q].qp ? comm->base.qps[q].qp->qp_num : 0, false);
+        if (slot) {
+          if (q == 0) slot0 = slot;
+          slot->refcount--;
+          if (slot->refcount <= 0 && slot->qp) {
+            INFO(NCCL_NET, "IB CAST TEARDOWN: destroying shared recv QP qpn=%u group=%d qpIdx=%d",
+                 slot->qp->qp_num, slot->key.groupIdx, slot->key.qpIdx);
+            wrap_ibv_destroy_qp(slot->qp);
+            slot->qp = NULL;
+          }
+        }
+      }
+      if (slot0) {
+        slot0->cqRefcount--;
+        if (slot0->cqRefcount <= 0) {
+          IbCastCleanupGroupCqs(slot0);
+        }
+      }
+      IbCastFreeCommId(comm->base.commId);
+
+      // GPU flush cleanup remains per-comm
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbRecvCommDev* commDev = comm->devs + i;
+        if (comm->flushEnabled) {
+          if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
+            NCCLCHECK(ncclCudaFree(commDev->gpuFlush.gpuFlushGpuMem, /*manager=*/nullptr));
+            commDev->gpuFlush.gpuFlushGpuMem = nullptr;
+            if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
+            commDev->gpuFlush.gpuMr = nullptr;
+            if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
+          }
+          if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+          if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
+        }
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (comm->base.resiliency) {
+          IbCastResiliencyDevDestroy(comm->base.resiliency, i);
+        }
+        // Skip IbCastDestroyBase for shared comms -- CQ/PD managed by pool
+      }
+    } else {
+      // Non-shared: original teardown
+      for (int q = 0; q < comm->base.nqps; q++)
+        if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
+
+      for (int i = 0; i < comm->base.vProps.ndevs; i++) {
+        struct ncclIbRecvCommDev* commDev = comm->devs + i;
+        if (comm->flushEnabled) {
+          if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
+            NCCLCHECK(ncclCudaFree(commDev->gpuFlush.gpuFlushGpuMem, /*manager=*/nullptr));
+            commDev->gpuFlush.gpuFlushGpuMem = nullptr;
+            if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
+            commDev->gpuFlush.gpuMr = nullptr;
+            if(commDev->gpuFlush.dmabufFd > 0) { close(commDev->gpuFlush.dmabufFd);}
+          }
+          if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
+          if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
+        }
+        if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
+        if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
+        if (comm->base.resiliency) {
+          IbCastResiliencyDevDestroy(comm->base.resiliency, i);
+        }
+        NCCLCHECK(IbCastDestroyBase(&commDev->base));
+      }
+    }
 
     if (comm->base.resiliency) {
       NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -1038,8 +1038,8 @@ ib_recv_dev_list:
       int nqps = comm->base.nqps;
       for (int q = 0; q < nqps; q++) {
         int mappedQP = q % primaryNqps;
-        key.ibDevN = comm->base.vProps.devs[mappedQ % comm->base.vProps.ndevs];
-        key.remIbDevIdx = remoteVProps.devs[mappedQ % remoteVProps.ndevs];
+        key.ibDevN = comm->base.vProps.devs[mappedQP % comm->base.vProps.ndevs];
+        key.remIbDevIdx = remoteVProps.devs[mappedQP % remoteVProps.ndevs];
         key.qpIdx = mappedQP;
 
         struct IbCastSharedQp* slot = IbCastFindSharedQp(&key);
@@ -1855,7 +1855,7 @@ ib_recv:
 		int localDevIdx = mappedQ % rComm->base.vProps.ndevs;
 		recvKey.ibDevN = rComm->base.vProps.devs[localDevIdx];
         recvKey.remIbDevIdx = remMeta.senderIbDevIdx;
-        recvKey.qpIdx = mappedQ
+        recvKey.qpIdx = mappedQ;
 
         struct IbCastSharedQp* recvSlot = IbCastFindSharedQp(&recvKey);
         if (recvSlot == NULL) {
@@ -2202,7 +2202,7 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
         struct ncclIbRecvCommDev* commDev = comm->devs + i;
         if (comm->flushEnabled) {
           if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-            NCCLCHECK(ncclCudaFree(commDev->gpuFlush.gpuFlushGpuMem, /*manager=*/nullptr));
+            CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
             commDev->gpuFlush.gpuFlushGpuMem = nullptr;
             if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
             commDev->gpuFlush.gpuMr = nullptr;
@@ -2231,7 +2231,7 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
         struct ncclIbRecvCommDev* commDev = comm->devs + i;
         if (comm->flushEnabled) {
           if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-            NCCLCHECK(ncclCudaFree(commDev->gpuFlush.gpuFlushGpuMem, /*manager=*/nullptr));
+            CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
             commDev->gpuFlush.gpuFlushGpuMem = nullptr;
             if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
             commDev->gpuFlush.gpuMr = nullptr;

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -490,8 +490,8 @@ void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, s
 
 ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs) {
   if (createQpAttrs->oooRq) {
-     NCCLCHECK(ncclIbCreateQpMlx5(createQpAttrs, qp));
-     return ncclSuccess;
+    NCCLCHECK(ncclIbCreateQpMlx5(createQpAttrs, qp));
+    return ncclSuccess;
   }
   if (createQpAttrs->useIonic && createQpAttrs->type != IBV_QPT_UD) {
     NCCLCHECK(ncclIbCreateQpIonic(createQpAttrs, qp));

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -87,7 +87,7 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
   return requested;
 }
 
-ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int cqSize, int depthMultiplier = 1) {
+ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base, void* cq_context, int cqSize) {
   base->ibDevN = ibDevN;
   ncclIbDev* ibDev = IbCastDevs + ibDevN;
   {
@@ -98,8 +98,7 @@ ncclResult_t IbCastInitCommDevBase(int ibDevN, struct ncclIbNetCommDevBase* base
     base->pd = ibDev->pd;
   }
 
-  int scaledCqSize = cqSize * depthMultiplier;
-  NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, scaledCqSize, cq_context, NULL, 0));
+  NCCLCHECK(wrap_ibv_create_cq(&base->cq, ibDev->context, cqSize, cq_context, NULL, 0));
 
   return ncclSuccess;
 }
@@ -403,6 +402,10 @@ static ncclResult_t ncclIbCreateQpMlx5(struct ncclIbQpCreateAttr* createQpAttrs,
   return ncclSuccess;
 }
 
+
+// TODO - QP sharing: Cts offload to do disabled
+//        ensure comm level useCtsOffload flag is forced to false when QP sharing is enabled
+//        that inturn ensures createQpAttr->isCtsEnabled will be set to false from wherever QP create is called.
 static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs, struct ncclIbQp* qp) {
   struct ibv_qp_init_attr qpInitAttr;
   enum ncclIbChannelType channel_type = (createQpAttrs->isDataQp ? ncclIbChannelTypeData : ncclIbChannelTypeCts);
@@ -411,8 +414,14 @@ static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs
   qpInitAttr.send_cq = createQpAttrs->cq;
   qpInitAttr.recv_cq = createQpAttrs->cq;
   qpInitAttr.qp_type = createQpAttrs->type;
-  qpInitAttr.cap.max_recv_wr = createQpAttrs->maxRecvWorkRequest;
-  qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest;
+  // Scale WR depths for QP sharing
+  if (createQpAttrs->isQpSharingEnabled) {
+    qpInitAttr.cap.max_recv_wr = createQpAttrs->maxRecvWorkRequest * createQpAttrs->cqDepthMultiplier;
+    qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest * createQpAttrs->cqDepthMultiplier;
+  } else {
+    qpInitAttr.cap.max_recv_wr = createQpAttrs->maxRecvWorkRequest;
+    qpInitAttr.cap.max_send_wr = createQpAttrs->maxSendWorkRequest;
+  }
   qpInitAttr.cap.max_send_sge = 1;
   qpInitAttr.cap.max_recv_sge = 1;
   qpInitAttr.cap.max_inline_data = IbCastUseInline ? sizeof(struct ncclIbSendFifo) * NCCL_NET_IB_MAX_RECVS : 0;
@@ -432,17 +441,23 @@ static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs
     qpInitAttr.sq_sig_all &= (~(1 << 19));
   }
 
-  if (!nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated) {
-    bool lud = nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type];
-    nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId = lud;
-    nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated = true;
-    nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type] =
-      !(nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type]);
-  }
-  if (nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId) {
-    wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_HIGH);
+  if (createQpAttrs->isQpSharingEnabled) {
+    // For Ionic with QP sharing, use groupIdx for UDMA mask selection
+    uint8_t mask = (createQpAttrs->qpSharingGroupIdx % 2 == 0) ? IONIC_UDMA_MASK_LOW : IONIC_UDMA_MASK_HIGH;
+    wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, mask);
   } else {
-    wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_LOW);
+    if (!nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated) {
+      bool lud = nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type];
+      nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId = lud;
+      nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udAllocated = true;
+      nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type] =
+        !(nccl_channel_last_ud[createQpAttrs->ibDevN][channel_type]);
+    }
+    if (nccl_channel_ud_map[createQpAttrs->ibDevN][createQpAttrs->channelId][channel_type].udId) {
+      wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_HIGH);
+    } else {
+      wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_LOW);
+    }
   }
 
   NCCLCHECK(wrap_ibv_create_qp(&qp->qp, createQpAttrs->pd, &qpInitAttr));
@@ -473,32 +488,12 @@ void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, s
   }
 }
 
-ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs, int depthMultiplier, int groupIdx) {
-  // Scale WR depths for QP sharing
-  uint32_t origMaxSend = createQpAttrs->maxSendWorkRequest;
-  uint32_t origMaxRecv = createQpAttrs->maxRecvWorkRequest;
-  createQpAttrs->maxSendWorkRequest *= depthMultiplier;
-  createQpAttrs->maxRecvWorkRequest *= depthMultiplier;
-
-  // When QP sharing is active (groupIdx >= 0), disable CTS offload for shared QPs
-  if (groupIdx >= 0) {
-    createQpAttrs->isCtsEnabled = false;
-  }
-
-  ncclResult_t ret = ncclSuccess;
+ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs) {
   if (createQpAttrs->oooRq) {
-    NCCLCHECK(ncclIbCreateQpMlx5(createQpAttrs, qp));
-    return ncclSuccess;
+     NCCLCHECK(ncclIbCreateQpMlx5(createQpAttrs, qp));
+     return ncclSuccess;
   }
   if (createQpAttrs->useIonic && createQpAttrs->type != IBV_QPT_UD) {
-    // For Ionic with QP sharing, use groupIdx for UDMA mask selection
-    if (groupIdx >= 0) {
-      if (groupIdx % 2 == 0) {
-        wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_LOW);
-      } else {
-        wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, IONIC_UDMA_MASK_HIGH);
-      }
-    }
     NCCLCHECK(ncclIbCreateQpIonic(createQpAttrs, qp));
     return ncclSuccess;
   }
@@ -638,12 +633,19 @@ fail:
 // establishment process.
 static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* meta, int channelId) {
   uint nqps = comm->base.nqps;
+  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Send requests are sent using at most 2 messages (RDMA Write and RDMA Write with Immediate)
   qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
+  // TODO - QP sharing:
+  //        handle settings QP sharing attributes; call only for primary/no-sharing
+  qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
+  qpCreateAttrs.qpSharingGroupIdx = meta->sharedGroupIdx;
+  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
+  qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
     // For example, if there are 2 devices and 4 QPs, the QPs will be created
@@ -738,8 +740,9 @@ static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConn
   // Capture receiver's commId for QP sharing imm_data encoding
   comm->remCommId = remMeta->commId;
 
+  // TODO - QP sharing:
   // If secondary shared QP, skip RTR/RTS -- QPs are already in RTS from primary
-  if (comm->base.commId != 0 && !comm->base.isSharedQpPrimary) {
+  if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && !comm->base.isSharedQpPrimary) {
     // Just assign remDevIdx from remote metadata
     uint nqps = comm->base.nqps;
     for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
@@ -949,7 +952,7 @@ ib_recv_dev_list:
     if (comm->base.resiliency) {
       IbCastResiliencyDataCqSizeGet(comm->base.resiliency, i, &cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, cqSize, depthMult), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &comm->devs[i].base, &comm->base.stats, (cqSize * depthMult)), ret, fail);
     comm->ar = comm->ar && IbCastDevs[ibDevN].ar; // ADAPTIVE_ROUTING - if all merged devs have it enabled
     if (comm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(comm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
@@ -1334,6 +1337,7 @@ ncclResult_t IbCastCheckVProps(ncclNetVDeviceProps_t* vProps1, ncclNetVDevicePro
 static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct ncclIbConnectionMetadata* remMeta,
                                                  struct ncclIbConnectionMetadata* meta, int channelId) {
   uint nqps = rComm->base.nqps;
+  int depthMult;
   struct ncclIbQpCreateAttr qpCreateAttrs;
   memset(&qpCreateAttrs, 0, sizeof(struct ncclIbQpCreateAttr));
   qpCreateAttrs.type = IBV_QPT_RC;
@@ -1344,6 +1348,14 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
   // When resiliency is enabled, the number of send work requests is as the
   // number of max requests because every CTS message is signaled.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS * (rComm->base.resiliency ? 1 : 2);
+
+  // TODO - QP sharing:
+  //        handle settings QP sharing attributes
+  //        skip QP creation & call to IbCastQpRtr/IbCastQpRts for secondary comm
+  qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
+  qpCreateAttrs.qpSharingGroupIdx = remMeta->sharedGroupIdx;
+  depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
+  qpCreateAttrs.cqDepthMultiplier = depthMult;
   for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
     // The QPs are created in a "striped" manner across the available devices.
     // For example, if there are 2 devices and 4 QPs, the QPs will be created
@@ -1398,6 +1410,7 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
         return ncclInternalError;
       }
     }
+
     NCCLCHECK(IbCastQpCreate(localQp, &qpCreateAttrs));
     localQp->channelId = channelId;
     localQp->isDataQp = qpCreateAttrs.isDataQp;
@@ -1484,6 +1497,10 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
       qpCreateAttrs.channelId = channelId;
       qpCreateAttrs.ibDevN = rCommDev->base.ibDevN;
       qpCreateAttrs.useIonic = IbCastAinicRoce;
+      // QP sharing is disabled for flush QP
+      qpCreateAttrs.isQpSharingEnabled = false;
+      qpCreateAttrs.qpSharingGroupIdx = -1;
+      qpCreateAttrs.cqDepthMultiplier = 1;
 
       NCCLCHECK(IbCastQpCreate(&rCommDev->gpuFlush.qp, &qpCreateAttrs));
       rCommDev->gpuFlush.qp.channelId = channelId;
@@ -1707,7 +1724,7 @@ ib_recv:
     if (rComm->base.resiliency) {
       IbCastResiliencyDataCqSizeGet(rComm->base.resiliency, i, &cqSize);
     }
-    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, cqSize, recvDepthMult), ret, fail);
+    NCCLCHECKGOTO(IbCastInitCommDevBase(ibDevN, &rCommDev->base, &rComm->base.stats, (cqSize * recvDepthMult)), ret, fail);
     if (rComm->base.resiliency) {
       NCCLCHECKGOTO(IbCastResiliencyDevInit(rComm->base.resiliency, i, &IbCastDevs[ibDevN]), ret, fail);
     }

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -640,8 +640,6 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Send requests are sent using at most 2 messages (RDMA Write and RDMA Write with Immediate)
   qpCreateAttrs.maxSendWorkRequest = 2 * NET_IB_MAX_REQUESTS;
-  // TODO - QP sharing:
-  //        handle settings QP sharing attributes; call only for primary/no-sharing
   qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
   qpCreateAttrs.qpSharingGroupIdx = meta->sharedGroupIdx;
   depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
@@ -737,23 +735,25 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
 // was delivered from the receiver side) on the QPs before modifying the QPs
 // to RTR.
 static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* remMeta) {
-  // Capture receiver's commId for QP sharing imm_data encoding
-  comm->remCommId = remMeta->commId;
-
   // TODO - QP sharing:
-  // If secondary shared QP, skip RTR/RTS -- QPs are already in RTS from primary
-  if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && !comm->base.isSharedQpPrimary) {
-    // Just assign remDevIdx from remote metadata
-    uint nqps = comm->base.nqps;
-    for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
-      ncclIbQp* localQp = &comm->base.qps[qpIndex];
-      ncclIbQpInfo* remQpInfo = &remMeta->qpInfo[qpIndex];
-      localQp->remDevIdx = remQpInfo->devIndex;
+  // Capture receiver's commId for QP sharing imm_data encoding
+  if (rcclParamIbCastCommNGroups() > 0) {
+    comm->remCommId = remMeta->commId;
+
+    // If secondary shared QP, skip RTR/RTS -- QPs are already in RTS from primary
+    if (comm->base.commId != 0 && !comm->base.isSharedQpPrimary) {
+      // Just assign remDevIdx from remote metadata
+      uint nqps = comm->base.nqps;
+      for (int qpIndex = 0; qpIndex < nqps; qpIndex++) {
+        ncclIbQp* localQp = &comm->base.qps[qpIndex];
+        ncclIbQpInfo* remQpInfo = &remMeta->qpInfo[qpIndex];
+        localQp->remDevIdx = remQpInfo->devIndex;
+      }
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencySenderQpsToRts(comm->base.resiliency, remMeta));
+      }
+      return ncclSuccess;
     }
-    if (comm->base.resiliency) {
-      NCCLCHECK(IbCastResiliencySenderQpsToRts(comm->base.resiliency, remMeta));
-    }
-    return ncclSuccess;
   }
 
   uint nqps = comm->base.nqps;
@@ -782,8 +782,9 @@ static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConn
       localQp->ece = {0};
     }
 
-    struct ncclIbQpRtrAttr* rtrAttr = &localQp->rtrAttr;
-    rtrAttr->mtu = std::min(remDevInfo->mtu, ibDev->portAttr.active_mtu);
+    struct ncclIbQpRtrAttr *rtrAttr = &localQp->rtrAttr;
+    remDevInfo->mtu = std::min(remDevInfo->mtu, ibDev->portAttr.active_mtu);
+    rtrAttr->mtu = remDevInfo->mtu;
     rtrAttr->linkLayer = remDevInfo->link_layer;
     rtrAttr->tc = remDevInfo->link_layer == IBV_LINK_LAYER_ETHERNET ? remMeta->tc : -1;
     rtrAttr->sl = remMeta->sl;
@@ -847,6 +848,8 @@ ncclResult_t IbCastConnect(void* ctx, int dev, void* opaqueHandle, void** sendCo
   stage->buffer = NULL;
 
   NCCLCHECK(ncclIbMalloc((void**)&comm, sizeof(struct ncclIbSendComm)));
+  // TODO - QP sharing:
+  //        double check if IbCastBaseCommInit() called inside IbCastSendCommInit to copy the base->qps to base->activeQPs is taken care for secondary comm's QP 
   NCCLCHECKGOTO(IbCastSendCommInit(comm), ret, fail);
   NCCLCHECKGOTO(IbCastStatsInit(&comm->base.stats), ret, fail);
   NCCLCHECKGOTO(ncclSocketInit(&comm->base.sock, &handle->connectAddr, handle->magic, ncclSocketTypeNetIb, NULL, 1),
@@ -928,10 +931,14 @@ ib_recv_dev_list:
   comm->base.sharedPrimaryNqps = 0;
   comm->remCommId = 0;
 
+#if 0
+  // TODO - QP sharing
+  //        do we need to update activeQps here or leave it for IbCastSendCommInit() which is already doing it ?
   // Initialize activeQps identity mapping
   for (int q = 0; q < NCCL_IB_MAX_QPS; q++) {
     comm->base.activeQps[q] = &comm->base.qps[q];
   }
+#endif
 
   if (comm->base.resiliency) {
     NCCLCHECK(IbCastResiliencyDeviceNumSet(comm->base.resiliency, comm->base.vProps.ndevs, remoteVProps.ndevs));
@@ -965,6 +972,8 @@ ib_recv_dev_list:
   meta.isRMA = handle->isRMA;
   meta.sharedGroupIdx = -1;
   meta.commId = 0;
+  // TODO - QP sharing
+  //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
   meta.senderIbDevIdx = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : -1;
 
   // QP Sharing: sender-side primary/secondary determination
@@ -978,28 +987,32 @@ ib_recv_dev_list:
       goto qp_sharing_skip_sender;
     }
 
-    // Build probe key from peer address
-    union ncclSocketAddress peerAddr;
-    ncclSocketGetAddr(&comm->base.sock, &peerAddr);
-    IbCastStripPort(&peerAddr);
-
-    // Use first device's ibDevN for the probe
-    int probeIbDevN;
-    probeIbDevN = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : 0;
-
-    // Count existing refs to determine groupIdx
-    int totalRefs;
-    totalRefs = IbCastCountPeerTotalRefcount(probeIbDevN, &peerAddr, 0, true);
-    int groupIdx;
-    groupIdx = totalRefs % ngroups;
-    comm->base.sharedGroupIdx = groupIdx;
-
     // Check if primary exists for this group
     IbCastSharedQpKey probeKey;
     memset(&probeKey, 0, sizeof(probeKey));
+    // Build probe key from peer address
+    memcpy(&probeKey.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
+    IbCastStripPort(&probeKey.peerAddr);
+
+    // Use first device's ibDevN for the probe
+    int probeIbDevN;
+    int probeRemIbDevIdx;
+    // TODO - QP sharing
+    //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
+    //        handle for Fusion/Cast where remoteVProps.ndevs > 1
+    probeIbDevN = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : 0;
+    probeRemIbDevIdx = remoteVProps.devs[0];
+
+    // Count existing refs to determine groupIdx
+    int totalRefs;
+    totalRefs = IbCastCountPeerTotalRefcount(probeIbDevN, &probeKey.peerAddr, probeRemIbDevIdx, true);
+    int groupIdx;
+    groupIdx = totalRefs % ngroups;
+    comm->base.sharedGroupIdx = groupIdx;
+    comm->base.remIbDevIdx = probeRemIbDevIdx;
+
     probeKey.ibDevN = probeIbDevN;
-    probeKey.peerAddr = peerAddr;
-    probeKey.remIbDevIdx = 0;
+    probeKey.remIbDevIdx = probeRemIbDevIdx;
     probeKey.isSend = true;
     probeKey.groupIdx = groupIdx;
     probeKey.qpIdx = 0;
@@ -1013,18 +1026,21 @@ ib_recv_dev_list:
            __func__, comm->base.commId, groupIdx, totalRefs);
 
       comm->base.isSharedQpPrimary = false;
-      comm->useCtsOffload = false;
+	  int primaryNqps = IbCastCountGroupQpSlots(&probeKey.peerAddr, probeRemIbDevIdx, true, groupIdx);
+      comm->base.sharedPrimaryNqps = primaryNqps;
+
+      IbCastSharedQpKey key;
+      memset(&key, 0, sizeof(key));
+      memcpy(&key.peerAddr, &probeKey.peerAddr, sizeof(union ncclSocketAddress));
+      key.isSend = true;
+      key.groupIdx = groupIdx;
 
       int nqps = comm->base.nqps;
       for (int q = 0; q < nqps; q++) {
-        IbCastSharedQpKey key;
-        memset(&key, 0, sizeof(key));
-        key.ibDevN = comm->base.vProps.devs[q % comm->base.vProps.ndevs];
-        key.peerAddr = peerAddr;
-        key.remIbDevIdx = 0;
-        key.isSend = true;
-        key.groupIdx = groupIdx;
-        key.qpIdx = q;
+        int mappedQP = q % primaryNqps;
+        key.ibDevN = comm->base.vProps.devs[mappedQ % comm->base.vProps.ndevs];
+        key.remIbDevIdx = remoteVProps.devs[mappedQ % remoteVProps.ndevs];
+        key.qpIdx = mappedQP;
 
         struct IbCastSharedQp* slot = IbCastFindSharedQp(&key);
         if (slot == NULL) {
@@ -1064,7 +1080,6 @@ ib_recv_dev_list:
            __func__, comm->base.commId, groupIdx, depthMult);
 
       comm->base.isSharedQpPrimary = true;
-      comm->useCtsOffload = false;
     }
   }
 
@@ -1082,17 +1097,18 @@ qp_sharing_skip_sender:
     for (int q = 0; q < nqps; q++) {
       IbCastSharedQpKey key;
       memset(&key, 0, sizeof(key));
+      memcpy(&key.peerAddr, &handle->connectAddr, sizeof(union ncclSocketAddress));
+      IbCastStripPort(&key.peerAddr);
       key.ibDevN = comm->base.vProps.devs[q % comm->base.vProps.ndevs];
-      key.peerAddr = peerAddr;
-      key.remIbDevIdx = 0;
-      key.isSend = true;
+      key.remIbDevIdx = remoteVProps.devs[q % remoteVProps.ndevs];
       key.groupIdx = comm->base.sharedGroupIdx;
+      key.isSend = true;
       key.qpIdx = q;
 
       int devIdx = q % comm->base.vProps.ndevs;
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&key,
           comm->base.qps[q].qp, comm->devs[devIdx].base.cq,
-          &comm->devs[devIdx].base, devIdx, 1);
+          &comm->devs[devIdx].base, comm->base.qps[q].devIndex, 1);
       if (entry && q == 0) {
         entry->cqRefcount = 1;
       }
@@ -1106,6 +1122,8 @@ qp_sharing_done_sender:
   // Populate QP sharing metadata
   meta.sharedGroupIdx = comm->base.sharedGroupIdx;
   meta.commId = comm->base.commId;
+  // TODO - QP sharing
+  //        handle for Fusion/Cast where comm->base.vProps.ndevs > 1
   meta.senderIbDevIdx = (comm->base.vProps.ndevs > 0) ? comm->base.vProps.devs[0] : -1;
 
   for (int i = 0; i < comm->base.vProps.ndevs; i++) {
@@ -1601,6 +1619,8 @@ ncclResult_t IbCastAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle
   }
 
   NCCLCHECK(ncclIbMalloc((void**)&rComm, sizeof(struct ncclIbRecvComm)));
+  // TODO - QP sharing:
+  //        double check if IbCastBaseCommInit() called inside IbCastRecvCommInit to copy the base->qps to base->activeQPs is taken care for secondary comm's QP 
   NCCLCHECKGOTO(IbCastRecvCommInit(rComm), ret, fail);
   NCCLCHECKGOTO(IbCastStatsInit(&rComm->base.stats), ret, fail);
   stage->comm = rComm;
@@ -1687,10 +1707,14 @@ ib_recv:
   rComm->base.remIbDevIdx = -1;
   rComm->base.sharedPrimaryNqps = 0;
 
+#if 0
+  // TODO - QP sharing
+  //        do we need to update activeQps here or leave it for IbCastSendCommInit() which is already doing it ?
   // Initialize activeQps identity mapping
   for (int q = 0; q < NCCL_IB_MAX_QPS; q++) {
     rComm->base.activeQps[q] = &rComm->base.qps[q];
   }
+#endif
 
   // IB setup
   // Pre-declare variables because of goto
@@ -1780,8 +1804,7 @@ ib_recv:
 
   // QP Sharing: receiver-side primary/secondary determination
   if (rcclParamIbCastCommNGroups() > 0 && !remMeta.isRMA && remMeta.sharedGroupIdx >= 0) {
-    int recvGroupIdx;
-    recvGroupIdx = remMeta.sharedGroupIdx;
+    int recvGroupIdx = remMeta.sharedGroupIdx;
 
     rComm->base.commId = IbCastAllocCommId(rComm, false);
     if (rComm->base.commId == 0) {
@@ -1888,7 +1911,7 @@ qp_sharing_skip_recv:
       int devIdx = q % rComm->base.vProps.ndevs;
       struct IbCastSharedQp* entry = IbCastRegisterSharedQp(&recvKey,
           rComm->base.qps[q].qp, rComm->devs[devIdx].base.cq,
-          &rComm->devs[devIdx].base, devIdx, 1);
+          &rComm->devs[devIdx].base, rComm->base.qps[q].devIndex, 1);
       if (entry && q == 0) {
         entry->cqRefcount = 1;
       }
@@ -2045,7 +2068,7 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
   if (comm) {
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    if (comm->base.commId != 0) {
+    if ((rcclParamIbCastCommNGroups() > 0) && (comm->base.commId != 0)) {
       // QP sharing teardown: refcount-based
       std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
       struct IbCastSharedQp* slot0 = NULL;
@@ -2069,6 +2092,10 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
           IbCastCleanupGroupCqs(slot0);
         }
       }
+
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+      }
       IbCastFreeCommId(comm->base.commId);
 
       // Deregister per-comm MRs (not shared)
@@ -2087,6 +2114,10 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
       // Non-shared: original teardown
       for (int q = 0; q < comm->base.nqps; q++)
         if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
+
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+      }
 
       for (int i = 0; i < comm->base.vProps.ndevs; i++) {
         struct ncclIbSendCommDev* commDev = comm->devs + i;
@@ -2129,7 +2160,7 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
   if (comm) {
     NCCLCHECK(ncclSocketClose(&comm->base.sock));
 
-    if (comm->base.commId != 0) {
+    if ((rcclParamIbCastCommNGroups() > 0) && (comm->base.commId != 0)) {
       // QP sharing teardown: refcount-based
       std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
       struct IbCastSharedQp* slot0 = NULL;
@@ -2147,6 +2178,10 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
           }
         }
       }
+
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+	  }
       if (slot0) {
         slot0->cqRefcount--;
         if (slot0->cqRefcount <= 0) {
@@ -2181,6 +2216,10 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
       for (int q = 0; q < comm->base.nqps; q++)
         if (comm->base.qps[q].qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(comm->base.qps[q].qp));
 
+      if (comm->base.resiliency) {
+        NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
+      }
+
       for (int i = 0; i < comm->base.vProps.ndevs; i++) {
         struct ncclIbRecvCommDev* commDev = comm->devs + i;
         if (comm->flushEnabled) {
@@ -2202,7 +2241,6 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
         NCCLCHECK(IbCastDestroyBase(&commDev->base));
       }
     }
-
     if (comm->base.resiliency) {
       NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
     }

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -442,7 +442,7 @@ static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs
     qpInitAttr.sq_sig_all &= (~(1 << 19));
   }
 
-  if (createQpAttrs->isQpSharingEnabled) {
+  if (createQpAttrs->isQpSharingEnabled && (createQpAttrs->qpSharingGroupIdx >= 0)) {
     // For Ionic with QP sharing, use groupIdx for UDMA mask selection
     uint8_t mask = (createQpAttrs->qpSharingGroupIdx % 2 == 0) ? IONIC_UDMA_MASK_LOW : IONIC_UDMA_MASK_HIGH;
     wrap_ionicdv_pd_set_udma_mask(createQpAttrs->pd, mask);
@@ -1070,6 +1070,7 @@ ib_recv_dev_list:
       comm->base.isSharedQpPrimary = true;
     }
   }
+  meta.sharedGroupIdx = comm->base.sharedGroupIdx;
 
 qp_sharing_skip_sender:
   // Create QPs on the sender side

--- a/projects/rccl/src/transport/net_ib_cast/connect.cc
+++ b/projects/rccl/src/transport/net_ib_cast/connect.cc
@@ -76,6 +76,10 @@ static int IbCastResolveRecvMatchingScheme(bool useCtsOffload) {
     return BY_ORDER;
   }
 
+  if (rcclParamIbCastCommNGroups() > 0) {
+    return BY_ID;
+  }
+
   if (ncclParamIbCastOooRq() || (ncclParamIbCastResiliencyPortFailover() == 1)) {
     return BY_ID;
   }
@@ -403,9 +407,6 @@ static ncclResult_t ncclIbCreateQpMlx5(struct ncclIbQpCreateAttr* createQpAttrs,
 }
 
 
-// TODO - QP sharing: Cts offload to do disabled
-//        ensure comm level useCtsOffload flag is forced to false when QP sharing is enabled
-//        that inturn ensures createQpAttr->isCtsEnabled will be set to false from wherever QP create is called.
 static ncclResult_t ncclIbCreateQpIonic(struct ncclIbQpCreateAttr* createQpAttrs, struct ncclIbQp* qp) {
   struct ibv_qp_init_attr qpInitAttr;
   enum ncclIbChannelType channel_type = (createQpAttrs->isDataQp ? ncclIbChannelTypeData : ncclIbChannelTypeCts);
@@ -735,8 +736,6 @@ static ncclResult_t IbCastSenderQpsCreate(ncclIbSendComm* comm, struct ncclIbCon
 // was delivered from the receiver side) on the QPs before modifying the QPs
 // to RTR.
 static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConnectionMetadata* remMeta) {
-  // TODO - QP sharing:
-  // Capture receiver's commId for QP sharing imm_data encoding
   if (rcclParamIbCastCommNGroups() > 0) {
     comm->remCommId = remMeta->commId;
 
@@ -782,9 +781,9 @@ static ncclResult_t IbCastSenderQpsToRts(ncclIbSendComm* comm, struct ncclIbConn
       localQp->ece = {0};
     }
 
-    struct ncclIbQpRtrAttr *rtrAttr = &localQp->rtrAttr;
-    remDevInfo->mtu = std::min(remDevInfo->mtu, ibDev->portAttr.active_mtu);
-    rtrAttr->mtu = remDevInfo->mtu;
+    struct ncclIbQpRtrAttr* rtrAttr = &localQp->rtrAttr;
+    rtrAttr->mtu = std::min(remDevInfo->mtu, ibDev->portAttr.active_mtu);
+    remDevInfo->mtu = rtrAttr->mtu;
     rtrAttr->linkLayer = remDevInfo->link_layer;
     rtrAttr->tc = remDevInfo->link_layer == IBV_LINK_LAYER_ETHERNET ? remMeta->tc : -1;
     rtrAttr->sl = remMeta->sl;
@@ -848,8 +847,6 @@ ncclResult_t IbCastConnect(void* ctx, int dev, void* opaqueHandle, void** sendCo
   stage->buffer = NULL;
 
   NCCLCHECK(ncclIbMalloc((void**)&comm, sizeof(struct ncclIbSendComm)));
-  // TODO - QP sharing:
-  //        double check if IbCastBaseCommInit() called inside IbCastSendCommInit to copy the base->qps to base->activeQPs is taken care for secondary comm's QP 
   NCCLCHECKGOTO(IbCastSendCommInit(comm), ret, fail);
   NCCLCHECKGOTO(IbCastStatsInit(&comm->base.stats), ret, fail);
   NCCLCHECKGOTO(ncclSocketInit(&comm->base.sock, &handle->connectAddr, handle->magic, ncclSocketTypeNetIb, NULL, 1),
@@ -930,15 +927,6 @@ ib_recv_dev_list:
   comm->base.remIbDevIdx = -1;
   comm->base.sharedPrimaryNqps = 0;
   comm->remCommId = 0;
-
-#if 0
-  // TODO - QP sharing
-  //        do we need to update activeQps here or leave it for IbCastSendCommInit() which is already doing it ?
-  // Initialize activeQps identity mapping
-  for (int q = 0; q < NCCL_IB_MAX_QPS; q++) {
-    comm->base.activeQps[q] = &comm->base.qps[q];
-  }
-#endif
 
   if (comm->base.resiliency) {
     NCCLCHECK(IbCastResiliencyDeviceNumSet(comm->base.resiliency, comm->base.vProps.ndevs, remoteVProps.ndevs));
@@ -1367,9 +1355,6 @@ static ncclResult_t IbCastReceiverQpsCreateToRts(ncclIbRecvComm* rComm, struct n
   // number of max requests because every CTS message is signaled.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS * (rComm->base.resiliency ? 1 : 2);
 
-  // TODO - QP sharing:
-  //        handle settings QP sharing attributes
-  //        skip QP creation & call to IbCastQpRtr/IbCastQpRts for secondary comm
   qpCreateAttrs.isQpSharingEnabled = (rcclParamIbCastCommNGroups() > 0) ? true : false;
   qpCreateAttrs.qpSharingGroupIdx = remMeta->sharedGroupIdx;
   depthMult = (rcclParamIbCastCommNGroups() > 0) ? std::max((int64_t)1, rcclParamIbCastQpDepthMultiplier()) : 1;
@@ -1619,8 +1604,6 @@ ncclResult_t IbCastAccept(void* listenComm, void** recvComm, ncclNetDeviceHandle
   }
 
   NCCLCHECK(ncclIbMalloc((void**)&rComm, sizeof(struct ncclIbRecvComm)));
-  // TODO - QP sharing:
-  //        double check if IbCastBaseCommInit() called inside IbCastRecvCommInit to copy the base->qps to base->activeQPs is taken care for secondary comm's QP 
   NCCLCHECKGOTO(IbCastRecvCommInit(rComm), ret, fail);
   NCCLCHECKGOTO(IbCastStatsInit(&rComm->base.stats), ret, fail);
   stage->comm = rComm;
@@ -1706,15 +1689,6 @@ ib_recv:
   rComm->base.sharedGroupIdx = -1;
   rComm->base.remIbDevIdx = -1;
   rComm->base.sharedPrimaryNqps = 0;
-
-#if 0
-  // TODO - QP sharing
-  //        do we need to update activeQps here or leave it for IbCastSendCommInit() which is already doing it ?
-  // Initialize activeQps identity mapping
-  for (int q = 0; q < NCCL_IB_MAX_QPS; q++) {
-    rComm->base.activeQps[q] = &rComm->base.qps[q];
-  }
-#endif
 
   // IB setup
   // Pre-declare variables because of goto
@@ -1869,6 +1843,9 @@ ib_recv:
         rComm->base.qps[q].qp = recvSlot->qp;
         rComm->base.qps[q].devIndex = recvSlot->devIndex;
         rComm->base.qps[q].ctsQpSlot = recvSlot->ctsQpSlot;
+        // remDevIdx is normally set by IbCastReceiverQpsCreateToRts, which is
+        // skipped for secondary comms; set it here or CTS rkey selection is wrong.
+        rComm->base.qps[q].remDevIdx = remMeta.qpInfo[q].devIndex;
         rComm->base.activeQps[q] = &rComm->base.qps[q];
 
         meta.qpInfo[q].qpn = recvSlot->qp->qp_num;
@@ -1890,7 +1867,7 @@ ib_recv:
       INFO(NCCL_NET, "NET/IB: %s: QP sharing PRIMARY receiver commId=%u group=%d depthMult=%d",
            __func__, rComm->base.commId, recvGroupIdx, recvDepthMult);
       rComm->base.isSharedQpPrimary = true;
-      rComm->useCtsOffload = false; // TODO - QP sharing: check connect side
+      rComm->useCtsOffload = false; // sender useCtsOffload is also false: IbCastOffloadEnabled=false at init (init.cc)
     }
   }
 
@@ -2103,7 +2080,7 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
       if (comm->base.resiliency) {
         NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
       }
-      IbCastFreeCommId(comm->base.commId);
+      IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
 
       // Deregister per-comm MRs (not shared)
       for (int i = 0; i < comm->base.vProps.ndevs; i++) {
@@ -2140,20 +2117,6 @@ ncclResult_t IbCastCloseSend(void* sendComm) {
     }
 
     if (comm->base.resiliency) {
-      NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-    }
-
-    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-      struct ncclIbSendCommDev* commDev = comm->devs + i;
-      if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-      if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-      if (commDev->putSignalScratchpadMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->putSignalScratchpadMr));
-      if (comm->base.resiliency) {
-        NCCLCHECK(IbCastResiliencyDevDestroy(comm->base.resiliency, i));
-      }
-      NCCLCHECK(IbCastDestroyBase(&commDev->base));
-    }
-    if (comm->base.resiliency) {
       NCCLCHECK(IbCastResiliencyDestroy(&comm->base.resiliency));
     }
     free(comm);
@@ -2188,14 +2151,14 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
 
       if (comm->base.resiliency) {
         NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-	  }
+      }
       if (slot0) {
         slot0->cqRefcount--;
         if (slot0->cqRefcount <= 0) {
           IbCastCleanupGroupCqs(slot0);
         }
       }
-      IbCastFreeCommId(comm->base.commId);
+      IbCastFreeCommIdLocked(comm->base.commId);  // caller holds g_IbCastSharedQpMutex
 
       // GPU flush cleanup remains per-comm
       for (int i = 0; i < comm->base.vProps.ndevs; i++) {
@@ -2247,32 +2210,6 @@ ncclResult_t IbCastCloseRecv(void* recvComm) {
         }
         NCCLCHECK(IbCastDestroyBase(&commDev->base));
       }
-    }
-    if (comm->base.resiliency) {
-      NCCLCHECK(IbCastResiliencyClose(comm->base.resiliency));
-    }
-
-    for (int i = 0; i < comm->base.vProps.ndevs; i++) {
-      struct ncclIbRecvCommDev* commDev = comm->devs + i;
-      if (comm->flushEnabled) {
-        if (commDev->gpuFlush.gpuFlushGpuMem != nullptr) {
-          CUDACHECK(hipFree(commDev->gpuFlush.gpuFlushGpuMem));
-          commDev->gpuFlush.gpuFlushGpuMem = nullptr;
-          if (commDev->gpuFlush.gpuMr != nullptr) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.gpuMr));
-          commDev->gpuFlush.gpuMr = nullptr;
-          if (commDev->gpuFlush.dmabufFd > 0) {
-            close(commDev->gpuFlush.dmabufFd);
-          }
-        }
-        if (commDev->gpuFlush.qp.qp != NULL) NCCLCHECK(wrap_ibv_destroy_qp(commDev->gpuFlush.qp.qp));
-        if (commDev->gpuFlush.hostMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->gpuFlush.hostMr));
-      }
-      if (commDev->ctsFifoMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->ctsFifoMr));
-      if (commDev->cmplsRecordsMr != NULL) NCCLCHECK(wrap_ibv_dereg_mr(commDev->cmplsRecordsMr));
-      if (comm->base.resiliency) {
-        IbCastResiliencyDevDestroy(comm->base.resiliency, i);
-      }
-      NCCLCHECK(IbCastDestroyBase(&commDev->base));
     }
     if (comm->base.resiliency) {
       NCCLCHECK(IbCastResiliencyDestroy(&comm->base.resiliency));

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -101,9 +101,14 @@ struct ncclIbConnectionMetadata {
   int sl;
   int isP2p;
   bool isRMA;
+
+  // QP Sharing metadata
+  int      sharedGroupIdx;      // QP sharing group index (-1 = not shared)
+  uint16_t commId;              // QP sharing comm ID (0 = not shared)
+  int      senderIbDevIdx;      // sender's IB device index
 };
 
-ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs);
+ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs, int depthMultiplier = 1, int groupIdx = -1);
 void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, struct ncclIbQpCreateAttr* out);
 ncclResult_t IbCastQpInit(struct ncclIbQp* qp);
 ncclResult_t IbCastQpRtr(struct ncclIbQp* qp);

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -53,6 +53,9 @@ struct ncclIbQpCreateAttr {
   int channelId;
   int ibDevN;
   bool useIonic;
+  bool isQpSharingEnabled;
+  int  cqDepthMultiplier;
+  int  qpSharingGroupIdx;
 };
 
 // Per-QP connection metatdata

--- a/projects/rccl/src/transport/net_ib_cast/connect_cast.h
+++ b/projects/rccl/src/transport/net_ib_cast/connect_cast.h
@@ -111,7 +111,7 @@ struct ncclIbConnectionMetadata {
   int      senderIbDevIdx;      // sender's IB device index
 };
 
-ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs, int depthMultiplier = 1, int groupIdx = -1);
+ncclResult_t IbCastQpCreate(struct ncclIbQp* qp, struct ncclIbQpCreateAttr* createQpAttrs);
 void IbCastBuildDataQpCreateAttr(struct ncclIbNetCommBase* base, int devIndex, struct ncclIbQpCreateAttr* out);
 ncclResult_t IbCastQpInit(struct ncclIbQp* qp);
 ncclResult_t IbCastQpRtr(struct ncclIbQp* qp);

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -548,6 +548,12 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
       // for AINIC IbUseInline is enabled by default always
       IbCastUseInline = true;
 
+      // CTS offload and QP sharing are mutually exclusive. disable CTS offload when QP sharing is enabled
+      if (IbCastOffloadEnabled && (rcclParamIbCastCommNGroups() > 0)) {
+        INFO(NCCL_INIT|NCCL_NET, "NET/IB : QP sharing enabled - disabling CTS Offload (not yet supported with QP sharing)");
+        IbCastOffloadEnabled = false;
+      }
+  
       INFO(NCCL_INIT | NCCL_NET,
            "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
            "IB Use Inline: enabled; GDR Flush: disabled",

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -569,6 +569,10 @@ exit:
                                "(load balancer integration with resiliency is pending)");
     castGlobalQpSchedParms.enable = false;
   }
+  if (ret == ncclSuccess && castGlobalQpSchedParms.enable && rcclParamIbCastCommNGroups() > 0) {
+    INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling QP scheduler");
+    castGlobalQpSchedParms.enable = false;
+  }
   if (ret == ncclSuccess && IbCastOffloadEnabled &&
       (ncclParamIbCastResiliencyPortFailover() || ncclParamIbCastResiliencyPortRecovery())) {
     INFO(NCCL_INIT | NCCL_NET, "NET/IB : PORT_FAILOVER/RECOVERY enabled - disabling CTS offload "

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -551,10 +551,10 @@ ncclResult_t IbCastInitDevices(ncclDebugLogger_t logFunction, ncclProfilerCallba
 
       // CTS offload and QP sharing are mutually exclusive. disable CTS offload when QP sharing is enabled
       if (IbCastOffloadEnabled && (rcclParamIbCastCommNGroups() > 0)) {
-        INFO(NCCL_INIT|NCCL_NET, "NET/IB : QP sharing enabled - disabling CTS Offload (not yet supported with QP sharing)");
+        INFO(NCCL_INIT | NCCL_NET, "NET/IB : QP sharing enabled - disabling CTS Offload (not yet supported with QP sharing)");
         IbCastOffloadEnabled = false;
       }
-  
+
       INFO(NCCL_INIT | NCCL_NET,
            "NET/IB : AINIC RoCEv2 optimizations enabled: CTS Inline Data: %s; CTS Offload: %s; "
            "IB Use Inline: enabled; GDR Flush: disabled",

--- a/projects/rccl/src/transport/net_ib_cast/init.cc
+++ b/projects/rccl/src/transport/net_ib_cast/init.cc
@@ -7,6 +7,7 @@
 
 #include "common_cast.h"
 #include "p2p_resiliency_recovery_cast.h"
+#include "qp_sharing.h"
 
 extern int64_t ncclParamIbCastQpsPerConn();
 RCCL_PARAM(IbCastQpsPerP2p, "IB_QPS_PER_P2P", 0);

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -156,17 +156,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
       }
     } else {
       uint32_t rxReqIdx = (uint32_t)slots[0].rxReqIndex;
-#if 0 // TODO QP sharing: check if we need to support it for BY_INDEX scheme or not.
-      // TODO - QP Sharing: MSB(bits 31-24) 8bits rxReqIdx & LSB 16bits remCommId
-      // QP Sharing: encode receiver's commId + rxReqIndex in imm_data
-      if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && comm->remCommId != 0) {
-        immData = ((uint32_t)rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT) | (uint32_t)comm->remCommId;
-      } else {
-#endif
-        immData = (rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT);
-#if 0
-      }
-#endif
+      immData = (rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT);
       if (nqps > 1) {
         immData |= WR_IMM_SPLIT_DATA_FLAG;
       }
@@ -800,33 +790,16 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
     uint32_t immDataHost = be32toh(wc->imm_data);
     if (rcclParamIbCastCommNGroups() > 0) {
-      uint16_t immCommId = (immDataHost >> WR_IMM_BYID_COMM_ID_SHIFT) & WR_IMM_BYID_COMM_ID_MASK;
       uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
-      if (immCommId != 0 && immCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[immCommId].used) {
-        recvComm = (struct ncclIbRecvComm*)g_IbCastCommTable[immCommId].comm;
-      }
       *req = recvComm->recvReqs[reqSlot % NET_IB_MAX_REQUESTS];
     } else {
       *req = recvComm->recvReqs[immDataHost % NET_IB_MAX_REQUESTS];
     }
   } else if (!base->isSend && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM && base->recvMatchingScheme == BY_INDEX) {
     // BY_INDEX (non-sharing CAST default): rxReqIndex is echoed in imm_data[31:24].
-#if 0
-    // QP Sharing: recv-side completion routing via imm_data
-#endif
     uint32_t immDataHost = be32toh(wc->imm_data);
     uint8_t reqIdx = (immDataHost >> WR_IMM_RX_REQ_IDX_SHIFT) & WR_IMM_RX_REQ_IDX_MASK;
-#if 0
-    uint16_t immCommId = immDataHost & WR_ID_RX_COMM_ID_MASK;
-    if ((rcclParamIbCastCommNGroups() > 0) && (immCommId != 0) && (immCommId < IBCAST_MAX_COMMS) && (g_IbCastCommTable[immCommId].used)) {
-      struct ncclIbRecvComm* targetComm = (struct ncclIbRecvComm*)g_IbCastCommTable[immCommId].comm;
-      *req = &targetComm->base.reqs[reqIdx];
-    } else {
-#endif
-      *req = &base->reqs[reqIdx];
-#if 0
-    }
-#endif
+    *req = &base->reqs[reqIdx];
   } else if (!base->isSend && wc->opcode == IBV_WC_RDMA_READ) { // Flush request completion
     // wr_id[63:48] may carry a commId for completion routing (zero if sharing is
     // disabled). Strip it to recover the original request index.
@@ -1135,11 +1108,11 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
         req->recv.cmplsRecords->completions[qpIndex] = 1;
         IbCastPostRecvWorkRequest(qp->qp, &recvComm->ibRecvWorkRequest);
       } else {
-#if 0
+#if 1
         // In the prepost path wr_id is UINT64_MAX (sentinel); only decrement rxPosts
         // in the non-prepost path where wr_id is a valid slot index.
         // TODO: QP sharing - mask commId bits (msb 16 bits) and confirm if there are any assumption on if all 64 bits of wr_id is used anywhere
-        uint64_t rawWrId = (wc->wr_id & ~((uint64_t) WR_ID_RX_COMM_ID_MASK << WR_ID_RX_COMM_ID_SHIFT));
+        uint64_t rawWrId = IbCastStripCommId(wc->wr_id);
         commBase->rxPosts[rawWrId]--;
 #else
         commBase->rxPosts[wc->wr_id]--;
@@ -1261,6 +1234,9 @@ ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
           if (wc->opcode != IBV_WC_RECV_RDMA_WITH_IMM) {
             struct ncclIbNetCommBase* routed = IbCastRouteCommFromWrId(wc->wr_id);
             if (routed) targetBase = routed;
+          } else {
+            struct ncclIbNetCommBase* routed = IbCastRouteCommFromImmData((struct ncclIbNetCommBase*)r->base, be32toh(wc->imm_data));
+            if (routed && !routed->isSend && (routed->recvMatchingScheme == BY_ID)) targetBase = routed;
           }
 
           TRACE(NCCL_NET, "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=0x%lx, qp_num=%d)", __func__, i, targetBase, targetBase->isSend ? "send" : "recv", r, wc->wr_id, wc->qp_num);

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -929,7 +929,8 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   }
 
   if (commBase->isSend) {
-    req = commBase->sendReqs[wc->wr_id & 0xff][0];
+    struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
+    req = sendComm->sendReqs[wc->wr_id & 0xff][0];
   } else {
     // TODO - QP sharing: 
     //        confirm for matchingScheme ByOrder, limiting num requests (from wr_id) to 8 bits is correct. 
@@ -1238,7 +1239,7 @@ ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
           if (rcclParamIbCastCommNGroups() > 0) {
               uint16_t wridCommId = (wc->wr_id >> WR_ID_RX_COMM_ID_SHIFT) & WR_ID_RX_COMM_ID_MASK;
               if (wridCommId != 0 && wridCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[wridCommId].used) {
-                if (g_commTable[wridCommId].isSend) {
+                if (g_IbCastCommTable[wridCommId].isSend) {
                   targetBase = &((struct ncclIbSendComm*)g_IbCastCommTable[wridCommId].comm)->base;
                 } else {
                   targetBase = &((struct ncclIbRecvComm*)g_IbCastCommTable[wridCommId].comm)->base;

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -67,14 +67,14 @@ static ncclResult_t IbCastPrintWr(struct ibv_send_wr* wr, char* wrStr) {
   switch (wr->opcode) {
   case IBV_WR_RDMA_WRITE:
     sprintf(wrStr,
-            "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
+            "wr=%p, wr_id=0x%lx, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
             ", rdma.remote_addr=0x%016" PRIx64 ", rdma.rkey=0x%x",
             wr, wr->wr_id, opcodeStr, wr->num_sge, (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
             (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0, wr->wr.rdma.remote_addr, wr->wr.rdma.rkey);
     break;
   case IBV_WR_RDMA_WRITE_WITH_IMM:
     sprintf(wrStr,
-            "wr=%p, wr_id=%ld, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
+            "wr=%p, wr_id=0x%lx, opcode=%s, num_sge=%d, sge[0].length=%" PRIu32 ", sge[0].addr=0x%016" PRIx64
             ", rdma.remote_addr=0x%016" PRIx64 ",  rdma.rkey=0x%x, imm_data=0x%x",
             wr, wr->wr_id, opcodeStr, wr->num_sge, (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->length : 0,
             (wr->num_sge > 0 && wr->sg_list) ? wr->sg_list->addr : 0, wr->wr.rdma.remote_addr, wr->wr.rdma.rkey,
@@ -114,9 +114,10 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     wr->wr.rdma.remote_addr = comm->useCtsOffload ? 0xdeadbeef : slots[r].addr;
     wr->next = wr + 1;
     wr_id += (uint64_t)(slot & 0xff) << (r * 8);
+    // TODO - QP sharing: ib-cast change - check why wr_id is encoded in each wr-> instead of lastWr.
     // QP Sharing: encode commId in upper 16 bits of wr_id for completion routing
     if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-      wr->wr_id = wr_id | ((uint64_t)comm->base.commId << 48);
+      wr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
     } else {
       wr->wr_id = wr_id;
     }
@@ -147,19 +148,23 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     uint32_t immData;
     if (comm->base.recvMatchingScheme != BY_INDEX) {
       immData = (uint32_t)(reqs[0]->id % UINT32_MAX);
+      // TODO - QP sharing
+      //        check for matchingScheme BY_ID or BY_ORDER, do we have free bits available for encoding rxReqIdx & remCommId
+      //        if no, free bits available, then for this matchingSchemes we need to disable QP sharing or change matchingScheme to BY_INDEX if QP sharing is enabled.
+      //if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && comm->remCommId != 0) {
+      //  immData = ((uint32_t)rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT) | (uint32_t)comm->remCommId;
+      //}
     } else {
       uint32_t rxReqIdx = (uint32_t)slots[0].rxReqIndex;
+      // TODO - QP Sharing: MSB(bits 31-24) 8bits rxReqIdx & LSB 16bits remCommId
       // QP Sharing: encode receiver's commId + rxReqIndex in imm_data
       if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && comm->remCommId != 0) {
-        immData = ((uint32_t)rxReqIdx << 16) | (uint32_t)comm->remCommId;
-        if (nqps > 1) {
-          immData |= WR_IMM_SPLIT_DATA_FLAG;
-        }
+        immData = ((uint32_t)rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT) | (uint32_t)comm->remCommId;
       } else {
         immData = (rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT);
-        if (nqps > 1) {
-          immData |= WR_IMM_SPLIT_DATA_FLAG;
-        }
+      }
+      if (nqps > 1) {
+        immData |= WR_IMM_SPLIT_DATA_FLAG;
       }
     }
 
@@ -180,7 +185,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   }
   // QP Sharing: encode commId in upper 16 bits of final wr_id
   if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-    lastWr->wr_id = wr_id | ((uint64_t)comm->base.commId << 48);
+    lastWr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
   } else {
     lastWr->wr_id = wr_id;
   }
@@ -195,7 +200,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     NCCLCHECK(IbCastCommBaseGetQpForRequest(&comm->base, startQpIndex, i, &qp, &qpIndex));
 
     TRACE(NCCL_NET,
-          "NET/IB: %s: Posting send (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld) on QP (qp_num=%u, "
+          "NET/IB: %s: Posting send (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx) on QP (qp_num=%u, "
           "devIndex=%d, qpIndex=%d)",
           __func__, reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id, qp->qp->qp_num, qp->devIndex, qpIndex);
 
@@ -340,8 +345,8 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
       reqs[r]->send.sentData[qpIndex] = true;
 
       TRACE(NCCL_VERBS,
-            "Posted send wr_id=%lu, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%d, opcode=%d, send_flags=%d, "
-            "imm_data=%d, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
+            "Posted send wr_id=0x%lx, wr_indx=%d, qp_num=%d, src_nic=%d, dst_nic=%d, dlid=%d, opcode=%d, send_flags=%d, "
+            "imm_data=0x%x, remote_addr=%lx, rkey=%x, length=%d, lkey=%x",
             comm->wrs[r].wr_id, r, qp->qp->qp_num, comm->devs[qp->devIndex].base.ibDevN,
             comm->base.remDevs[qp->remDevIdx].ibv_dev_index, comm->base.remDevs[qp->remDevIdx].lid, comm->wrs[r].opcode,
             comm->wrs[r].send_flags, comm->wrs[r].imm_data, comm->wrs[r].wr.rdma.remote_addr, comm->wrs[r].wr.rdma.rkey,
@@ -350,7 +355,7 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     }
   }
 
-  TRACE(NCCL_NET, "NET/IB: %s: Send request posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld)", __func__,
+  TRACE(NCCL_NET, "NET/IB: %s: Send request posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx)", __func__,
         reqs[0], reqs[0]->base, reqs[0]->id, slot, nreqs, wr_id);
   if (nowNs) {
     if (comm->base.nextQpTxSchedUpdateNs == 0)
@@ -556,23 +561,19 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   if (comm->useCtsOffload && (slot == ctsQp->ctsQpSlot)) {
     wr.send_flags |= IBV_SEND_SIGNALED;
     wr.wr_id = (req - req->base->reqs);
-    // QP Sharing: encode commId in upper bits of CTS wr_id
-    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-      wr.wr_id |= ((uint64_t)comm->base.commId << 48);
-    }
     IbCastAddEvent(req, ctsQp->devIndex);
   } else if (!comm->useCtsOffload && (slot == ctsQp->devIndex || comm->base.resiliency)) {
     wr.send_flags |= IBV_SEND_SIGNALED;
     wr.wr_id = slot;
     // QP Sharing: encode commId in upper bits of CTS wr_id
     if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
-      wr.wr_id |= ((uint64_t)comm->base.commId << 48);
+      wr.wr_id |= ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
     }
     IbCastAddEventCTS(req, ctsQp->devIndex);
   }
 
   TRACE(NCCL_NET,
-        "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
+        "NET/IB: %s: Posting a CTS (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx, opcode=%d, send_flags=%d, "
         "qp_num=%u)",
         __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
 
@@ -580,7 +581,7 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   NCCLCHECK(wrap_ibv_post_send(ctsQp->qp, &wr, &bad_wr));
 
   TRACE(NCCL_NET,
-        "NET/IB: %s: CTS posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=%ld, opcode=%d, send_flags=%d, "
+        "NET/IB: %s: CTS posted (req=%p, comm=%p, id=%ld, slot=%d, nreqs=%d, wr_id=0x%lx, opcode=%d, send_flags=%d, "
         "qp_num=%u)",
         __func__, req, req->base, req->id, slot, req->nreqs, wr.wr_id, wr.opcode, wr.send_flags, ctsQp->qp->qp_num);
 
@@ -743,7 +744,7 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
     wr.opcode = IBV_WR_RDMA_READ;
     wr.send_flags = IBV_SEND_SIGNALED;
 
-    TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+    TRACE(NCCL_NET, "NET/IB: %s: Posting a flush request (req=%p, comm=%p, wr_id=0x%lx)", __func__, req, req->base,
           wr.wr_id);
     TIME_START(4);
     struct ibv_send_wr* bad_wr;
@@ -752,7 +753,7 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
 
     IbCastAddEvent(req, i);
 
-    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=%ld)", __func__, req, req->base,
+    TRACE(NCCL_NET, "NET/IB: %s: Flush request posted (req=%p, comm=%p, wr_id=0x%lx)", __func__, req, req->base,
           wr.wr_id);
   }
 
@@ -774,6 +775,7 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
 
 static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetCommBase* base, ibv_wc* wc,
                                                                ncclIbRequest** req) {
+  // QP sharing: incoming base is the targetBase routed based on commId encoded in wr_id 
   assert(req != NULL);
   assert(wc != NULL);
 
@@ -781,73 +783,58 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
   // of the completion are valid.
   assert(wc->status == IBV_WC_SUCCESS);
 
-  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=%ld, opcode=%s)", __func__,
+  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=0x%lx, opcode=%s)", __func__,
         base->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
   if (!base->isSend && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM && base->recvMatchingScheme == BY_ID) {
-    TRACE(NCCL_NET, "NET/IB: %s: Retrieving a receive request (wr_id=%ld, opcode=%s, imm_data=%d, byte_len=%d)",
+    TRACE(NCCL_NET, "NET/IB: %s: Retrieving a receive request (wr_id=0x%lx, opcode=%s, imm_data=0x%x, byte_len=%d)",
           __func__, wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len);
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
+    // TODO - QP sharing:
+    //        though at sender side all 32 bits of imm_data seems to encode reqs[0]->id (32bits max), here at receiver it is limiting the requests to 256 (8 bits) only.
+    //        if so then we are good with using similar mechanism for QP sharing encoding of remmCommid(lsb 16 bits) and rxReqIdx (msb 8 bits) ?
+    //        find out what is max value for NET_IB_MAX_REQUESTS across all use case (cast/fusion).
     *req = recvComm->recvReqs[be32toh(wc->imm_data) % NET_IB_MAX_REQUESTS];
   } else if (!base->isSend && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM && base->recvMatchingScheme == BY_INDEX) {
     // QP Sharing: recv-side completion routing via imm_data
-    if (rcclParamIbCastCommNGroups() > 0) {
-      uint32_t immDataHost = be32toh(wc->imm_data);
-      uint16_t immCommId = immDataHost & 0xFFFF;
-      if (immCommId != 0 && immCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[immCommId].used) {
-        uint8_t reqIdx = (immDataHost >> 16) & 0xFF;
-        struct ncclIbRecvComm* targetComm = (struct ncclIbRecvComm*)g_IbCastCommTable[immCommId].comm;
-        *req = &targetComm->base.reqs[reqIdx];
-        return ncclSuccess;
-      }
+    uint32_t immDataHost = be32toh(wc->imm_data);
+    uint8_t reqIdx = (immDataHost >> WR_IMM_RX_REQ_IDX_SHIFT) & WR_IMM_RX_REQ_IDX_MASK;
+    uint16_t immCommId = immDataHost & WR_ID_RX_COMM_ID_MASK;
+    if ((rcclParamIbCastCommNGroups() > 0) && (immCommId != 0) && (immCommId < IBCAST_MAX_COMMS) && (g_IbCastCommTable[immCommId].used)) {
+      struct ncclIbRecvComm* targetComm = (struct ncclIbRecvComm*)g_IbCastCommTable[immCommId].comm;
+      *req = &targetComm->base.reqs[reqIdx];
+    } else {
+      *req = &base->reqs[reqIdx];
     }
-    *req = &base->reqs[((be32toh(wc->imm_data) >> WR_IMM_RX_REQ_IDX_SHIFT) & WR_IMM_RX_REQ_IDX_MASK)];
   } else if (!base->isSend && wc->opcode == IBV_WC_RDMA_READ) { // Flush request completion
     NCCLCHECK(IbCastRequestRetrieveAsIndex(base->reqs, (wc->wr_id - NCCL_IB_FLUSH_REQ_WR_ID_OFFSET), req));
   } else if (!base->isSend) {
-    // QP Sharing: extract commId from upper bits and route to correct recv comm
-    uint64_t rawWrId = wc->wr_id;
+    // TODO - QP sharing for (non-wr-imm) rdma wr messages, fetch req based on wr_id; target base is already routed from the caller.
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
-    if (rcclParamIbCastCommNGroups() > 0) {
-      uint16_t wridCommId = (rawWrId >> 48) & 0xFFFF;
-      if (wridCommId != 0 && wridCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[wridCommId].used) {
-        recvComm = (struct ncclIbRecvComm*)g_IbCastCommTable[wridCommId].comm;
-      }
-    }
-    *req = recvComm->recvReqs[rawWrId & 0xFFFF];
+    *req = recvComm->recvReqs[wc->wr_id & 0xFFFF];
   } else {
+    // TODO - QP sharing:
+    //        for sender the caller has routed the targetBase based on wr_id
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)base;
     if (base->recvMatchingScheme == BY_INDEX) {
+      // TODO - QP sharing
+      //        for remapped wr_id at sender side use the origWrId from remappedWr for extracting commId
       // BY_INDEX: wr_id was remapped by CAST scheduler for RTT timing
       struct ncclIbRemapWrId* remapWrId = (struct ncclIbRemapWrId*)wc->wr_id;
       assert(remapWrId != NULL);
       assert(remapWrId->state == NCCL_NET_IB_REMAP_USED);
-      uint64_t origWrId = remapWrId->origWrId;
-      // QP Sharing: send-side completion routing via commId in upper bits of wr_id
-      if (rcclParamIbCastCommNGroups() > 0) {
-        uint16_t wridCommId = (origWrId >> 48) & 0xFFFF;
-        if (wridCommId != 0 && wridCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[wridCommId].used) {
-          sendComm = (struct ncclIbSendComm*)g_IbCastCommTable[wridCommId].comm;
-        }
-      }
-      *req = sendComm->sendReqs[origWrId & 0xff][0];
+      *req = sendComm->sendReqs[remapWrId->origWrId & 0xff][0];
       if (remapWrId->parms.enable) IbCastQpSchedUpdateTxStats(remapWrId, base);
       IbCastQpSchedFreeRemap(remapWrId);
     } else {
+      // TODO - QP sharing
+      //        check and confirm for recvMatchingScheme BY_ID/BY_ORDER do we even have QP sharing use-case
       // BY_ID / other: wr_id is raw slot-encoded value (no remap)
-      uint64_t rawWrId = wc->wr_id;
-      // QP Sharing: send-side completion routing via commId in upper bits of wr_id
-      if (rcclParamIbCastCommNGroups() > 0) {
-        uint16_t wridCommId = (rawWrId >> 48) & 0xFFFF;
-        if (wridCommId != 0 && wridCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[wridCommId].used) {
-          sendComm = (struct ncclIbSendComm*)g_IbCastCommTable[wridCommId].comm;
-        }
-      }
-      *req = sendComm->sendReqs[rawWrId & 0xff][0];
+      *req = sendComm->sendReqs[wc->wr_id & 0xff][0];
     }
   }
   TRACE(NCCL_NET,
-        "NET/IB: %s: Retrieved a %s request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, wc.opcode=%s, "
-        "wc.imm_data=%d, wc.byte_len=%d, wc.qp_num=%u)",
+        "NET/IB: %s: Retrieved a %s request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=0x%lx, wc.opcode=%s, "
+        "wc.imm_data=0x%x, wc.byte_len=%d, wc.qp_num=%u)",
         __func__, base->isSend ? "send" : "recv", *req, (*req)->base, (*req)->id, IbCastReqTypeStr[(*req)->type],
         wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len, wc->qp_num);
   return ncclSuccess;
@@ -933,21 +920,24 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   assert(wc->status == IBV_WC_SUCCESS);
   ncclIbRequest* req = nullptr;
 
-  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=%ld, opcode=%s)", __func__,
+  // QP sharing: incoming commBase is the targetBase routed based on commId encoded in wr_id 
+  TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=0x%lx, opcode=%s)", __func__,
         commBase->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
   if (commBase->recvMatchingScheme != BY_ORDER) {
     WARN("NET/IB: %s: recvMatchingScheme not supported", __func__);
     return ncclInternalError;
   }
+
   if (commBase->isSend) {
-    struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
-    req = sendComm->sendReqs[wc->wr_id & 0xff][0];
+    req = commBase->sendReqs[wc->wr_id & 0xff][0];
   } else {
-    req = &(commBase->reqs[wc->wr_id]);
+    // TODO - QP sharing: 
+    //        confirm for matchingScheme ByOrder, limiting num requests (from wr_id) to 8 bits is correct. 
+    req = &(commBase->reqs[wc->wr_id & 0xff]);
   }
 
   if (req == NULL) {
-    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, "
+    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=0x%lx, "
          "opcode=%d, qp_num=%u)",
          __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
     return ncclInternalError;
@@ -958,7 +948,7 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   union ncclSocketAddress addr;
   ncclSocketGetAddr(&commBase->sock, &addr);
   TRACE(NCCL_NET,
-        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, "
+        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=0x%lx r=%p type=%d events={%d,%d,%d,%d}, "
         "devIndex=%d",
         ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->wr_id, req, req->type,
         req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
@@ -966,7 +956,7 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
 
   if (commBase->isSend) {
     if (req->type != NCCL_NET_IB_REQ_SEND) {
-      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
            "wc.opcode=%s(%d), wc.qp_num=%u)",
            __func__, IbCastReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode),
            wc->opcode, wc->qp_num);
@@ -995,7 +985,7 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   } else {
     if (wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
       if (req->type != NCCL_NET_IB_REQ_RECV && !commBase->resiliency) {
-        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
              "wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)",
              __func__, IbCastReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status),
              wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
@@ -1021,8 +1011,8 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
       req->events[devIndex]--;
       return ncclSuccess;
     } else {
-      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, "
-           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=0x%lx, "
+           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=0x%x)",
            __func__, req, commBase, req ? req->id : -1, devIndex, IbCastReqTypeStr[req->type], wc->wr_id,
            ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
       return ncclInternalError;
@@ -1047,7 +1037,7 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
   struct ncclIbRequest* req = NULL;
   NCCLCHECK(IbCastRequestRetrieveFromCompletion(commBase, wc, &req));
   if (req == NULL) {
-    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=%ld, "
+    WARN("NET/IB: %s: %s comm could not retreive a request found for a successful completion (comm=%p, wc.wr_id=0x%lx, "
          "opcode=%d, qp_num=%u)",
          __func__, commBase->isSend ? "Send" : "Recv", commBase, wc->wr_id, wc->opcode, wc->qp_num);
     return ncclInternalError;
@@ -1056,7 +1046,7 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
 #ifdef ENABLE_TRACE
   char line[SOCKET_NAME_MAXLEN + 1];
   TRACE(NCCL_NET,
-        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=%lu r=%p type=%d events={%d,%d,%d,%d}, "
+        "Got completion from peer %s with status=%d opcode=%d len=%u wr_id=0x%lx r=%p type=%d events={%d,%d,%d,%d}, "
         "devIndex=%d",
         ncclSocketToString(&addr, line), wc->status, wc->opcode, wc->byte_len, wc->wr_id, req, req->type,
         req->events[0], req->events[1], req->events[2], req->events[3], devIndex);
@@ -1064,7 +1054,7 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
 
   if (commBase->isSend) {
     if (req->type != NCCL_NET_IB_REQ_SEND) {
-      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+      WARN("NET/IB: %s: Sender expected a 'send' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
            "wc.opcode=%s(%d), wc.qp_num=%u)",
            __func__, IbCastReqTypeStr[req->type], req, commBase, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode),
            wc->opcode, wc->qp_num);
@@ -1096,13 +1086,13 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
       if (req->type == NCCL_NET_IB_REQ_UNUSED && commBase->resiliency) {
         INFO(NCCL_NET,
              "NET/IB: %s: Receiver got a completion for a data transfer but retrieved an 'unused' request (req=%p, "
-             "comm=%p, id=%ld, wc.status=%s(%d), wc.wr_id=%ld, wc.imm_data=%d, wc.opcode=%s(%d), wc.qp_num=%u)",
+             "comm=%p, id=%ld, wc.status=%s(%d), wc.wr_id=0x%lx, wc.imm_data=0x%x, wc.opcode=%s(%d), wc.qp_num=%u)",
              __func__, req, commBase, req->id, ibvWcStatusStr(wc->status), wc->status, wc->wr_id, be32toh(wc->imm_data),
              ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
         return ncclSuccess;
       }
       if (req->type != NCCL_NET_IB_REQ_RECV && !commBase->resiliency) {
-        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=%ld, "
+        WARN("NET/IB: %s: Receiver expected a 'recv' request but got '%s' (req=%p, comm=%p, id=%ld, wc.wr_id=0x%lx, "
              "wc.status=%s(%d) wc.opcode=%s(%d), wc.qp_num=%u)",
              __func__, IbCastReqTypeStr[req->type], req, req->base, req->id, wc->wr_id, ibvWcStatusStr(wc->status),
              wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num);
@@ -1129,14 +1119,12 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
       } else {
         // In the prepost path wr_id is UINT64_MAX (sentinel); only decrement rxPosts
         // in the non-prepost path where wr_id is a valid slot index.
-        commBase->rxPosts[wc->wr_id]--;
+        // TODO: QP sharing - mask commId bits (msb 16 bits) and confirm if there are any assumption on if all 64 bits of wr_id is used anywhere
+        uint64_t rawWrId = (wc->wr_id & ~((uint64_t) WR_ID_RX_COMM_ID_MASK << WR_ID_RX_COMM_ID_SHIFT));
+        commBase->rxPosts[rawWrId]--;
       }
 
       if (commBase->recvMatchingScheme == BY_INDEX) {
-        // QP Sharing: split_data_flag is in bit 23 of original layout, but for QP sharing
-        // the imm_data layout is (rxReqIdx << 16) | commId, so check WR_IMM_SPLIT_DATA_FLAG
-        // which is bit 23 — this falls in rxReqIdx area for sharing layout but the sender
-        // encodes it correctly in both layouts
         if (be32toh(wc->imm_data) & WR_IMM_SPLIT_DATA_FLAG) {
           req->events[devIndex]--;
         } else { // Single QP send path
@@ -1165,14 +1153,14 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
       if (req->type == NCCL_NET_IB_REQ_UNUSED) {
         INFO(NCCL_NET,
              "NET/IB: %s: Receiver got a completion for a CTS but retrieved an 'unused' request (req=%p, comm=%p, "
-             "id=%ld, wc.wr_id=%ld, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+             "id=%ld, wc.wr_id=0x%lx, wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=0x%x)",
              __func__, req, req->base, req->id, wc->wr_id, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num,
              be32toh(wc->imm_data));
         return ncclSuccess;
       }
     } else {
-      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=%ld, "
-           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=%d)",
+      WARN("NET/IB: %s: Unknown completion (req=%p, comm=%p, id=%ld, devIndex=%d, req->type=%s, wc.wr_id=0x%lx, "
+           "wc.opcode=%s(%d), wc.qp_num=%u, wc.imm_data=0x%x)",
            __func__, req, commBase, req ? req->id : -1, devIndex, IbCastReqTypeStr[req->type], wc->wr_id,
            ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->qp_num, be32toh(wc->imm_data));
       return ncclInternalError;
@@ -1235,7 +1223,7 @@ ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
         struct ibv_wc* wc = wcs + w;
         if (wc->status != IBV_WC_SUCCESS) {
           if (r->base->resiliency == NULL) {
-            WARN("NET/IB: %s: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=%lu, qp_num=%d)", __func__,
+            WARN("NET/IB: %s: Got CQE with error (devIndex=%d, req=%p, comm=%p (%s), wr_id=0x%lx, qp_num=%d)", __func__,
                  i, r, r->base, r->base->isSend ? "send" : "recv", wc->wr_id, wc->qp_num);
             IbCastLogCompletionWithError(r->base, wc, i);
             // If resiliency is not enabled, we cannot recover from any error.
@@ -1243,13 +1231,30 @@ ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
           }
           NCCLCHECK(IbCastResiliencyHandleCompletionError(r->base->resiliency, wc, i));
         } else {
+          // TODO - QP sharing:
+          //        extract wr_id based to get targetBase and use that for checking mactching scheme and not on incoming req->base's matching scheme
+          //        route the completions based on commId in wr_id. Pick target commBase based on the encoded commId
+          struct ncclIbNetCommBase* targetBase = (struct ncclIbNetCommBase*)r->base;
+          if (rcclParamIbCastCommNGroups() > 0) {
+              uint16_t wridCommId = (wc->wr_id >> WR_ID_RX_COMM_ID_SHIFT) & WR_ID_RX_COMM_ID_MASK;
+              if (wridCommId != 0 && wridCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[wridCommId].used) {
+                if (g_commTable[wridCommId].isSend) {
+                  targetBase = &((struct ncclIbSendComm*)g_IbCastCommTable[wridCommId].comm)->base;
+                } else {
+                  targetBase = &((struct ncclIbRecvComm*)g_IbCastCommTable[wridCommId].comm)->base;
+                }
+              }
+          }
+
+          // TODO - QP sharing: for display of req ptr 'r' see how we can fetch the info from targetBase or just remove req from trace
           TRACE(NCCL_NET,
-                "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=%lu, qp_num=%d)",
+                "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=0x%lx, qp_num=%d)",
                 __func__, i, r->base, r->base->isSend ? "send" : "recv", r, wc->wr_id, wc->qp_num);
           if (r->base->recvMatchingScheme != BY_ORDER) {
-            NCCLCHECK(IbCastCompletionEventProcess(r->base, wc, i));
+            // TODO - QP sharing: check for sender BY_INDEX scheme, routing target base above base on wr_id is correct or not, as there is a possibility of wr_id remapped by CAST scheduler for RTT timing. 
+            NCCLCHECK(IbCastCompletionEventProcess(targetBase, wc, i));
           } else {
-            NCCLCHECK(IbCastCompletionEventByOrder(r->base, wc, i));
+            NCCLCHECK(IbCastCompletionEventByOrder(targetBase, wc, i));
           }
         }
       }

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -114,7 +114,6 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     wr->wr.rdma.remote_addr = comm->useCtsOffload ? 0xdeadbeef : slots[r].addr;
     wr->next = wr + 1;
     wr_id += (uint64_t)(slot & 0xff) << (r * 8);
-    // TODO - QP sharing: ib-cast change - check why wr_id is encoded in each wr-> instead of lastWr.
     // QP Sharing: encode commId in upper 16 bits of wr_id for completion routing
     if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
       wr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
@@ -137,6 +136,9 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
   }
 
   // For ID-based matching scheme, immData carries the request ID.
+  //   If QP sharing is enabled, immData also carries the receiver's commId:
+  //       reqId in bits[7:0],
+  //       remCommId in bits[23:8].
   // For index-based matching scheme, immData layout (BY_INDEX):
   //   bits [31:24] - rxReqIndex: receiver's request slot index (from CTS fifo)
   //   bit  [23]    - WR_IMM_SPLIT_DATA_FLAG: set when sending across >1 QPs
@@ -148,21 +150,23 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     uint32_t immData;
     if (comm->base.recvMatchingScheme != BY_INDEX) {
       immData = (uint32_t)(reqs[0]->id % UINT32_MAX);
-      // TODO - QP sharing
-      //        check for matchingScheme BY_ID or BY_ORDER, do we have free bits available for encoding rxReqIdx & remCommId
-      //        if no, free bits available, then for this matchingSchemes we need to disable QP sharing or change matchingScheme to BY_INDEX if QP sharing is enabled.
-      //if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && comm->remCommId != 0) {
-      //  immData = ((uint32_t)rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT) | (uint32_t)comm->remCommId;
-      //}
+      if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && comm->remCommId != 0) {
+        immData = ((uint32_t)reqs[0]->id & WR_IMM_BYID_REQ_ID_MASK) |
+                  (((uint32_t)comm->remCommId & WR_IMM_BYID_COMM_ID_MASK) << WR_IMM_BYID_COMM_ID_SHIFT);
+      }
     } else {
       uint32_t rxReqIdx = (uint32_t)slots[0].rxReqIndex;
+#if 0 // TODO QP sharing: check if we need to support it for BY_INDEX scheme or not.
       // TODO - QP Sharing: MSB(bits 31-24) 8bits rxReqIdx & LSB 16bits remCommId
       // QP Sharing: encode receiver's commId + rxReqIndex in imm_data
       if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && comm->remCommId != 0) {
         immData = ((uint32_t)rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT) | (uint32_t)comm->remCommId;
       } else {
+#endif
         immData = (rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT);
+#if 0
       }
+#endif
       if (nqps > 1) {
         immData |= WR_IMM_SPLIT_DATA_FLAG;
       }
@@ -183,7 +187,9 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     lastWr->opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
     lastWr->imm_data = htobe32(immData);
   }
-  // QP Sharing: encode commId in upper 16 bits of final wr_id
+  // QP Sharing: encode the sender's own commId in wr_id[63:48] so IbCastTest can
+  // route the send completion to the right comm on a shared QP. The scheduler
+  // (BY_INDEX) is disabled under sharing, so wr_id is not remapped here.
   if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
     lastWr->wr_id = wr_id | ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
   } else {
@@ -736,6 +742,9 @@ ncclResult_t IbCastIflush(void* recvComm, int n, void** data, int* sizes, void**
     struct ibv_send_wr wr;
     memset(&wr, 0, sizeof(wr));
     wr.wr_id = (req - comm->base.reqs) + NCCL_IB_FLUSH_REQ_WR_ID_OFFSET;
+    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+      wr.wr_id |= ((uint64_t)comm->base.commId << WR_ID_RX_COMM_ID_SHIFT);
+    }
 
     wr.wr.rdma.remote_addr = (uint64_t)data[last];
     wr.wr.rdma.rkey = mhandle->mrs[i]->rkey;
@@ -773,9 +782,9 @@ static int getReqQpIndex(struct ncclIbRequest* req, int request, int qpNumber) {
 }
 #endif
 
+// QP sharing: incoming base is the targetBase routed based on commId encoded in wr_id
 static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetCommBase* base, ibv_wc* wc,
                                                                ncclIbRequest** req) {
-  // QP sharing: incoming base is the targetBase routed based on commId encoded in wr_id 
   assert(req != NULL);
   assert(wc != NULL);
 
@@ -789,36 +798,49 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
     TRACE(NCCL_NET, "NET/IB: %s: Retrieving a receive request (wr_id=0x%lx, opcode=%s, imm_data=0x%x, byte_len=%d)",
           __func__, wc->wr_id, ibvWcOpcodeStr(wc->opcode), be32toh(wc->imm_data), wc->byte_len);
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
-    // TODO - QP sharing:
-    //        though at sender side all 32 bits of imm_data seems to encode reqs[0]->id (32bits max), here at receiver it is limiting the requests to 256 (8 bits) only.
-    //        if so then we are good with using similar mechanism for QP sharing encoding of remmCommid(lsb 16 bits) and rxReqIdx (msb 8 bits) ?
-    //        find out what is max value for NET_IB_MAX_REQUESTS across all use case (cast/fusion).
-    *req = recvComm->recvReqs[be32toh(wc->imm_data) % NET_IB_MAX_REQUESTS];
+    uint32_t immDataHost = be32toh(wc->imm_data);
+    if (rcclParamIbCastCommNGroups() > 0) {
+      uint16_t immCommId = (immDataHost >> WR_IMM_BYID_COMM_ID_SHIFT) & WR_IMM_BYID_COMM_ID_MASK;
+      uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
+      if (immCommId != 0 && immCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[immCommId].used) {
+        recvComm = (struct ncclIbRecvComm*)g_IbCastCommTable[immCommId].comm;
+      }
+      *req = recvComm->recvReqs[reqSlot % NET_IB_MAX_REQUESTS];
+    } else {
+      *req = recvComm->recvReqs[immDataHost % NET_IB_MAX_REQUESTS];
+    }
   } else if (!base->isSend && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM && base->recvMatchingScheme == BY_INDEX) {
+    // BY_INDEX (non-sharing CAST default): rxReqIndex is echoed in imm_data[31:24].
+#if 0
     // QP Sharing: recv-side completion routing via imm_data
+#endif
     uint32_t immDataHost = be32toh(wc->imm_data);
     uint8_t reqIdx = (immDataHost >> WR_IMM_RX_REQ_IDX_SHIFT) & WR_IMM_RX_REQ_IDX_MASK;
+#if 0
     uint16_t immCommId = immDataHost & WR_ID_RX_COMM_ID_MASK;
     if ((rcclParamIbCastCommNGroups() > 0) && (immCommId != 0) && (immCommId < IBCAST_MAX_COMMS) && (g_IbCastCommTable[immCommId].used)) {
       struct ncclIbRecvComm* targetComm = (struct ncclIbRecvComm*)g_IbCastCommTable[immCommId].comm;
       *req = &targetComm->base.reqs[reqIdx];
     } else {
+#endif
       *req = &base->reqs[reqIdx];
+#if 0
     }
+#endif
   } else if (!base->isSend && wc->opcode == IBV_WC_RDMA_READ) { // Flush request completion
-    NCCLCHECK(IbCastRequestRetrieveAsIndex(base->reqs, (wc->wr_id - NCCL_IB_FLUSH_REQ_WR_ID_OFFSET), req));
+    // wr_id[63:48] may carry a commId for completion routing (zero if sharing is
+    // disabled). Strip it to recover the original request index.
+    NCCLCHECK(IbCastRequestRetrieveAsIndex(base->reqs, (IbCastStripCommId(wc->wr_id) - NCCL_IB_FLUSH_REQ_WR_ID_OFFSET), req));
   } else if (!base->isSend) {
-    // TODO - QP sharing for (non-wr-imm) rdma wr messages, fetch req based on wr_id; target base is already routed from the caller.
+    // Non-wr-imm recv (e.g. signalled CTS completion). base is the polling comm.
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
     *req = recvComm->recvReqs[wc->wr_id & 0xFFFF];
   } else {
-    // TODO - QP sharing:
-    //        for sender the caller has routed the targetBase based on wr_id
+    // Sender completion. targetBase was routed by IbCastTest via commId in wr_id[63:48];
+    // the low byte is the request slot. (BY_ID / BY_ORDER: no scheduler remap.)
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)base;
     if (base->recvMatchingScheme == BY_INDEX) {
-      // TODO - QP sharing
-      //        for remapped wr_id at sender side use the origWrId from remappedWr for extracting commId
-      // BY_INDEX: wr_id was remapped by CAST scheduler for RTT timing
+      // BY_INDEX: wr_id was remapped by the CAST scheduler for RTT timing.
       struct ncclIbRemapWrId* remapWrId = (struct ncclIbRemapWrId*)wc->wr_id;
       assert(remapWrId != NULL);
       assert(remapWrId->state == NCCL_NET_IB_REMAP_USED);
@@ -826,9 +848,6 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
       if (remapWrId->parms.enable) IbCastQpSchedUpdateTxStats(remapWrId, base);
       IbCastQpSchedFreeRemap(remapWrId);
     } else {
-      // TODO - QP sharing
-      //        check and confirm for recvMatchingScheme BY_ID/BY_ORDER do we even have QP sharing use-case
-      // BY_ID / other: wr_id is raw slot-encoded value (no remap)
       *req = sendComm->sendReqs[wc->wr_id & 0xff][0];
     }
   }
@@ -920,7 +939,7 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
   assert(wc->status == IBV_WC_SUCCESS);
   ncclIbRequest* req = nullptr;
 
-  // QP sharing: incoming commBase is the targetBase routed based on commId encoded in wr_id 
+  // QP sharing: incoming commBase is the targetBase routed based on commId encoded in wr_id
   TRACE(NCCL_NET, "NET/IB: %s: Retrieving a %s request (wr_id=0x%lx, opcode=%s)", __func__,
         commBase->isSend ? "send" : "recv", wc->wr_id, ibvWcOpcodeStr(wc->opcode));
   if (commBase->recvMatchingScheme != BY_ORDER) {
@@ -932,8 +951,6 @@ static ncclResult_t IbCastCompletionEventByOrder(struct ncclIbNetCommBase* commB
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
     req = sendComm->sendReqs[wc->wr_id & 0xff][0];
   } else {
-    // TODO - QP sharing: 
-    //        confirm for matchingScheme ByOrder, limiting num requests (from wr_id) to 8 bits is correct. 
     req = &(commBase->reqs[wc->wr_id & 0xff]);
   }
 
@@ -1118,11 +1135,15 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
         req->recv.cmplsRecords->completions[qpIndex] = 1;
         IbCastPostRecvWorkRequest(qp->qp, &recvComm->ibRecvWorkRequest);
       } else {
+#if 0
         // In the prepost path wr_id is UINT64_MAX (sentinel); only decrement rxPosts
         // in the non-prepost path where wr_id is a valid slot index.
         // TODO: QP sharing - mask commId bits (msb 16 bits) and confirm if there are any assumption on if all 64 bits of wr_id is used anywhere
         uint64_t rawWrId = (wc->wr_id & ~((uint64_t) WR_ID_RX_COMM_ID_MASK << WR_ID_RX_COMM_ID_SHIFT));
         commBase->rxPosts[rawWrId]--;
+#else
+        commBase->rxPosts[wc->wr_id]--;
+#endif
       }
 
       if (commBase->recvMatchingScheme == BY_INDEX) {
@@ -1232,27 +1253,18 @@ ncclResult_t IbCastTest(void* request, int* done, int* sizes) {
           }
           NCCLCHECK(IbCastResiliencyHandleCompletionError(r->base->resiliency, wc, i));
         } else {
-          // TODO - QP sharing:
-          //        extract wr_id based to get targetBase and use that for checking mactching scheme and not on incoming req->base's matching scheme
-          //        route the completions based on commId in wr_id. Pick target commBase based on the encoded commId
           struct ncclIbNetCommBase* targetBase = (struct ncclIbNetCommBase*)r->base;
-          if (rcclParamIbCastCommNGroups() > 0) {
-              uint16_t wridCommId = (wc->wr_id >> WR_ID_RX_COMM_ID_SHIFT) & WR_ID_RX_COMM_ID_MASK;
-              if (wridCommId != 0 && wridCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[wridCommId].used) {
-                if (g_IbCastCommTable[wridCommId].isSend) {
-                  targetBase = &((struct ncclIbSendComm*)g_IbCastCommTable[wridCommId].comm)->base;
-                } else {
-                  targetBase = &((struct ncclIbRecvComm*)g_IbCastCommTable[wridCommId].comm)->base;
-                }
-              }
+          // RECV_RDMA_WITH_IMM (data receive) carries commId in imm_data and is
+          // routed in IbCastRequestRetrieveFromCompletion. All other completions
+          // (send, CTS/RDMA_WRITE, flush/RDMA_READ) carry commId in wr_id[63:48]
+          // and are routed here.
+          if (wc->opcode != IBV_WC_RECV_RDMA_WITH_IMM) {
+            struct ncclIbNetCommBase* routed = IbCastRouteCommFromWrId(wc->wr_id);
+            if (routed) targetBase = routed;
           }
 
-          // TODO - QP sharing: for display of req ptr 'r' see how we can fetch the info from targetBase or just remove req from trace
-          TRACE(NCCL_NET,
-                "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=0x%lx, qp_num=%d)",
-                __func__, i, r->base, r->base->isSend ? "send" : "recv", r, wc->wr_id, wc->qp_num);
-          if (r->base->recvMatchingScheme != BY_ORDER) {
-            // TODO - QP sharing: check for sender BY_INDEX scheme, routing target base above base on wr_id is correct or not, as there is a possibility of wr_id remapped by CAST scheduler for RTT timing. 
+          TRACE(NCCL_NET, "NET/IB: %s: Processing a completion event (devIndex=%d, comm=%p (%s), req=%p, wr_id=0x%lx, qp_num=%d)", __func__, i, targetBase, targetBase->isSend ? "send" : "recv", r, wc->wr_id, wc->qp_num);
+          if (targetBase->recvMatchingScheme != BY_ORDER) {
             NCCLCHECK(IbCastCompletionEventProcess(targetBase, wc, i));
           } else {
             NCCLCHECK(IbCastCompletionEventByOrder(targetBase, wc, i));

--- a/projects/rccl/src/transport/net_ib_cast/p2p.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p.cc
@@ -12,6 +12,7 @@
 #ifdef ENABLE_FAULT_INJECTION
 #include "net_ib_ops_fault.h"
 #endif
+#include "qp_sharing.h"
 
 NCCL_PARAM(IbCastArThreshold, "IB_AR_THRESHOLD", -2);
 int64_t IbCastArThreshold = 8192;
@@ -113,7 +114,12 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     wr->wr.rdma.remote_addr = comm->useCtsOffload ? 0xdeadbeef : slots[r].addr;
     wr->next = wr + 1;
     wr_id += (uint64_t)(slot & 0xff) << (r * 8);
-    wr->wr_id = wr_id;
+    // QP Sharing: encode commId in upper 16 bits of wr_id for completion routing
+    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+      wr->wr_id = wr_id | ((uint64_t)comm->base.commId << 48);
+    } else {
+      wr->wr_id = wr_id;
+    }
 #ifdef NCCL_ENABLE_NET_PROFILING
     reqs[r]->pInfo[0].nEventHandles = 0;
 #endif
@@ -143,9 +149,17 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
       immData = (uint32_t)(reqs[0]->id % UINT32_MAX);
     } else {
       uint32_t rxReqIdx = (uint32_t)slots[0].rxReqIndex;
-      immData = (rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT);
-      if (nqps > 1) {
-        immData |= WR_IMM_SPLIT_DATA_FLAG;
+      // QP Sharing: encode receiver's commId + rxReqIndex in imm_data
+      if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0 && comm->remCommId != 0) {
+        immData = ((uint32_t)rxReqIdx << 16) | (uint32_t)comm->remCommId;
+        if (nqps > 1) {
+          immData |= WR_IMM_SPLIT_DATA_FLAG;
+        }
+      } else {
+        immData = (rxReqIdx << WR_IMM_RX_REQ_IDX_SHIFT);
+        if (nqps > 1) {
+          immData |= WR_IMM_SPLIT_DATA_FLAG;
+        }
       }
     }
 
@@ -164,7 +178,12 @@ ncclResult_t IbCastMultiSend(struct ncclIbSendComm* comm, int slot, int nqps, in
     lastWr->opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
     lastWr->imm_data = htobe32(immData);
   }
-  lastWr->wr_id = wr_id;
+  // QP Sharing: encode commId in upper 16 bits of final wr_id
+  if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+    lastWr->wr_id = wr_id | ((uint64_t)comm->base.commId << 48);
+  } else {
+    lastWr->wr_id = wr_id;
+  }
   lastWr->next = NULL;
   lastWr->send_flags = IBV_SEND_SIGNALED;
 
@@ -537,10 +556,18 @@ ncclResult_t IbCastPostFifo(struct ncclIbRecvComm* comm, struct ncclIbRequest* r
   if (comm->useCtsOffload && (slot == ctsQp->ctsQpSlot)) {
     wr.send_flags |= IBV_SEND_SIGNALED;
     wr.wr_id = (req - req->base->reqs);
+    // QP Sharing: encode commId in upper bits of CTS wr_id
+    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+      wr.wr_id |= ((uint64_t)comm->base.commId << 48);
+    }
     IbCastAddEvent(req, ctsQp->devIndex);
   } else if (!comm->useCtsOffload && (slot == ctsQp->devIndex || comm->base.resiliency)) {
     wr.send_flags |= IBV_SEND_SIGNALED;
     wr.wr_id = slot;
+    // QP Sharing: encode commId in upper bits of CTS wr_id
+    if (rcclParamIbCastCommNGroups() > 0 && comm->base.commId != 0) {
+      wr.wr_id |= ((uint64_t)comm->base.commId << 48);
+    }
     IbCastAddEventCTS(req, ctsQp->devIndex);
   }
 
@@ -762,12 +789,31 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
     *req = recvComm->recvReqs[be32toh(wc->imm_data) % NET_IB_MAX_REQUESTS];
   } else if (!base->isSend && wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM && base->recvMatchingScheme == BY_INDEX) {
+    // QP Sharing: recv-side completion routing via imm_data
+    if (rcclParamIbCastCommNGroups() > 0) {
+      uint32_t immDataHost = be32toh(wc->imm_data);
+      uint16_t immCommId = immDataHost & 0xFFFF;
+      if (immCommId != 0 && immCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[immCommId].used) {
+        uint8_t reqIdx = (immDataHost >> 16) & 0xFF;
+        struct ncclIbRecvComm* targetComm = (struct ncclIbRecvComm*)g_IbCastCommTable[immCommId].comm;
+        *req = &targetComm->base.reqs[reqIdx];
+        return ncclSuccess;
+      }
+    }
     *req = &base->reqs[((be32toh(wc->imm_data) >> WR_IMM_RX_REQ_IDX_SHIFT) & WR_IMM_RX_REQ_IDX_MASK)];
   } else if (!base->isSend && wc->opcode == IBV_WC_RDMA_READ) { // Flush request completion
     NCCLCHECK(IbCastRequestRetrieveAsIndex(base->reqs, (wc->wr_id - NCCL_IB_FLUSH_REQ_WR_ID_OFFSET), req));
   } else if (!base->isSend) {
+    // QP Sharing: extract commId from upper bits and route to correct recv comm
+    uint64_t rawWrId = wc->wr_id;
     struct ncclIbRecvComm* recvComm = (struct ncclIbRecvComm*)base;
-    *req = recvComm->recvReqs[wc->wr_id];
+    if (rcclParamIbCastCommNGroups() > 0) {
+      uint16_t wridCommId = (rawWrId >> 48) & 0xFFFF;
+      if (wridCommId != 0 && wridCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[wridCommId].used) {
+        recvComm = (struct ncclIbRecvComm*)g_IbCastCommTable[wridCommId].comm;
+      }
+    }
+    *req = recvComm->recvReqs[rawWrId & 0xFFFF];
   } else {
     struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)base;
     if (base->recvMatchingScheme == BY_INDEX) {
@@ -775,12 +821,28 @@ static inline ncclResult_t IbCastRequestRetrieveFromCompletion(struct ncclIbNetC
       struct ncclIbRemapWrId* remapWrId = (struct ncclIbRemapWrId*)wc->wr_id;
       assert(remapWrId != NULL);
       assert(remapWrId->state == NCCL_NET_IB_REMAP_USED);
-      *req = sendComm->sendReqs[remapWrId->origWrId & 0xff][0];
+      uint64_t origWrId = remapWrId->origWrId;
+      // QP Sharing: send-side completion routing via commId in upper bits of wr_id
+      if (rcclParamIbCastCommNGroups() > 0) {
+        uint16_t wridCommId = (origWrId >> 48) & 0xFFFF;
+        if (wridCommId != 0 && wridCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[wridCommId].used) {
+          sendComm = (struct ncclIbSendComm*)g_IbCastCommTable[wridCommId].comm;
+        }
+      }
+      *req = sendComm->sendReqs[origWrId & 0xff][0];
       if (remapWrId->parms.enable) IbCastQpSchedUpdateTxStats(remapWrId, base);
       IbCastQpSchedFreeRemap(remapWrId);
     } else {
       // BY_ID / other: wr_id is raw slot-encoded value (no remap)
-      *req = sendComm->sendReqs[wc->wr_id & 0xff][0];
+      uint64_t rawWrId = wc->wr_id;
+      // QP Sharing: send-side completion routing via commId in upper bits of wr_id
+      if (rcclParamIbCastCommNGroups() > 0) {
+        uint16_t wridCommId = (rawWrId >> 48) & 0xFFFF;
+        if (wridCommId != 0 && wridCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[wridCommId].used) {
+          sendComm = (struct ncclIbSendComm*)g_IbCastCommTable[wridCommId].comm;
+        }
+      }
+      *req = sendComm->sendReqs[rawWrId & 0xff][0];
     }
   }
   TRACE(NCCL_NET,
@@ -1008,12 +1070,13 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
            wc->opcode, wc->qp_num);
       return ncclInternalError;
     }
-    struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)commBase;
+    // QP Sharing: use the target comm from the routed request, not the polling comm
+    struct ncclIbSendComm* sendComm = (struct ncclIbSendComm*)req->base;
     struct ncclIbRequest* sendReq = NULL;
     int slot = req->id % NET_IB_MAX_REQUESTS;
     for (int j = 0; j < req->nreqs; j++) {
       sendReq = sendComm->sendReqs[slot][j];
-      if (!commBase->resiliency && (sendReq->events[devIndex] <= 0)) {
+      if (!req->base->resiliency && (sendReq->events[devIndex] <= 0)) {
         WARN("NET/IB: sendReq(%p)->events={%d,%d,%d,%d}, devIndex=%d, reqIdx=%d <= 0", sendReq, sendReq->events[0],
              sendReq->events[1], sendReq->events[2], sendReq->events[3], devIndex, j);
         return ncclInternalError;
@@ -1070,6 +1133,10 @@ static inline ncclResult_t IbCastCompletionEventProcess(struct ncclIbNetCommBase
       }
 
       if (commBase->recvMatchingScheme == BY_INDEX) {
+        // QP Sharing: split_data_flag is in bit 23 of original layout, but for QP sharing
+        // the imm_data layout is (rxReqIdx << 16) | commId, so check WR_IMM_SPLIT_DATA_FLAG
+        // which is bit 23 — this falls in rxReqIdx area for sharing layout but the sender
+        // encodes it correctly in both layouts
         if (be32toh(wc->imm_data) & WR_IMM_SPLIT_DATA_FLAG) {
           req->events[devIndex]--;
         } else { // Single QP send path

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -17,6 +17,7 @@ NCCL_PARAM(IbCastResiliencyPortFailoverProbeDelay, "IB_RESILIENCY_PORT_FAILOVER_
 extern int64_t ncclParamIbCastPkey();
 extern int64_t ncclParamIbCastRetryCnt();
 extern int64_t ncclParamIbCastTimeout();
+extern int64_t rcclParamIbCastCommNGroups();
 
 #define MSEC_TO_NSEC 1000000ULL
 
@@ -268,9 +269,6 @@ static ncclResult_t IbCastResiliencyRepostRequest(struct ncclIbRequest* request)
   return ncclSuccess;
 }
 
-// TODO - QP sharing
-//        refer to all usage of wc->wr_id and extract needed bits only as it contains the 16bits commId for QP sharing
-//        refer to all usage of wc->imm_data and extract needed bits only as it contains 8 bits rxReqIdx & 16 bits CommId for QP sharing
 static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbResiliency* resCtx, struct ibv_wc* wc,
                                                                   int devIndex) {
   INFO(NCCL_NET, "NET/IB: %s: Handling an error on the receiver side (comm %p)", __func__, resCtx->baseComm);
@@ -344,9 +342,6 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbR
   return ncclSuccess;
 }
 
-// TODO - QP sharing
-//        refer to all usage of wc->wr_id and extract needed bits only as it contains the 16bits commId for QP sharing
-//        refer to all usage of wc->imm_data and extract needed bits only as it contains 8 bits rxReqIdx & 16 bits CommId for QP sharing
 static ncclResult_t IbCastResiliencyHandleCompletionErrorSender(struct ncclIbResiliency* resCtx, struct ibv_wc* wc,
                                                                 int devIndex) {
   ncclResult_t res;
@@ -604,9 +599,12 @@ static ncclResult_t IbCastResiliencyProbeProgress(struct ncclIbResiliencySend* s
 ncclResult_t IbCastResiliencyInit(struct ncclIbNetCommBase* baseComm, struct ncclIbResiliency** resCtx) {
   assert(baseComm != NULL);
   assert(resCtx != NULL);
-  if (ncclParamIbCastResiliencyPortFailover() == 0) {
-    INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)", __func__,
-         baseComm->isSend ? "send" : "recv", baseComm);
+  if (ncclParamIbCastResiliencyPortFailover() == 0 || rcclParamIbCastCommNGroups() > 0) {
+    // Resiliency and QP sharing are kept orthogonal for now: disable resiliency
+    // when QP sharing is enabled.
+    INFO(NCCL_NET, "NET/IB: %s: Resiliency is disabled on the %s communicator (comm=%p)%s", __func__,
+         baseComm->isSend ? "send" : "recv", baseComm,
+         (rcclParamIbCastCommNGroups() > 0) ? " (QP sharing enabled)" : "");
     *resCtx = NULL;
     return ncclSuccess;
   }
@@ -816,8 +814,6 @@ ncclResult_t IbCastResiliencySenderCreateQps(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Every send request can initiate at most one probing request.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
-  // TODO - QP sharing:
-  //        QP sharing disabled for resiliency sender QP
   qpCreateAttrs.isQpSharingEnabled = false;
   qpCreateAttrs.qpSharingGroupIdx = -1;
   qpCreateAttrs.cqDepthMultiplier = 1;
@@ -909,8 +905,6 @@ ncclResult_t IbCastResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* res
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   qpCreateAttrs.maxSendWorkRequest = 0;
-  // TODO - QP sharing:
-  //        QP sharing disabled for resiliency QP
   qpCreateAttrs.isQpSharingEnabled = false;
   qpCreateAttrs.qpSharingGroupIdx = -1;
   qpCreateAttrs.cqDepthMultiplier = 1;

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -810,6 +810,11 @@ ncclResult_t IbCastResiliencySenderCreateQps(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.maxRecvWorkRequest = 0;
   // Every send request can initiate at most one probing request.
   qpCreateAttrs.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
+  // TODO - QP sharing:
+  //        QP sharing disabled for resiliency sender QP
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < resCtx->nProbingQps; localQpIndex++) {
     // Sender creates a single probing QP per local device.
     int localDevIndex = localQpIndex;
@@ -898,6 +903,11 @@ ncclResult_t IbCastResiliencyReceiverQpsCreateToRts(struct ncclIbResiliency* res
   qpCreateAttrs.type = IBV_QPT_RC;
   qpCreateAttrs.maxRecvWorkRequest = 0;
   qpCreateAttrs.maxSendWorkRequest = 0;
+  // TODO - QP sharing:
+  //        QP sharing disabled for resiliency QP
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < resCtx->nProbingQps; localQpIndex++) {
     // When number of QPs on the receiver is larger than the number of devices
     // it has, the probing QPs on the receiver side are created in a "striped"

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -268,6 +268,9 @@ static ncclResult_t IbCastResiliencyRepostRequest(struct ncclIbRequest* request)
   return ncclSuccess;
 }
 
+// TODO - QP sharing
+//        refer to all usage of wc->wr_id and extract needed bits only as it contains the 16bits commId for QP sharing
+//        refer to all usage of wc->imm_data and extract needed bits only as it contains 8 bits rxReqIdx & 16 bits CommId for QP sharing
 static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbResiliency* resCtx, struct ibv_wc* wc,
                                                                   int devIndex) {
   INFO(NCCL_NET, "NET/IB: %s: Handling an error on the receiver side (comm %p)", __func__, resCtx->baseComm);
@@ -275,7 +278,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbR
   bool inFlushRange =
     (wc->wr_id >= NCCL_IB_FLUSH_REQ_WR_ID_OFFSET && wc->wr_id < (NCCL_IB_FLUSH_REQ_WR_ID_OFFSET + NET_IB_MAX_REQUESTS));
   if (!inRecvRange && !inFlushRange && (wc->wr_id != NCCL_IB_RECV_WR_ID_DUMMY)) {
-    WARN("NET/IB: %s: Invalid wr_id (%ld). Unable to retrieve a request on the receiver side (comm=%p)", __func__,
+    WARN("NET/IB: %s: Invalid wr_id (0x%lx). Unable to retrieve a request on the receiver side (comm=%p)", __func__,
          wc->wr_id, resCtx->baseComm);
     return ncclInternalError;
   }
@@ -286,7 +289,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbR
     // now flushed.
     assert(wc->status == IBV_WC_WR_FLUSH_ERR);
     // In this case, there is nothing left to do.
-    INFO(NCCL_NET, "NET/IB: %s: Ignoring flush error on a QP (comm=%p, wc.wr_id=%ld, wc.status=%s(%d)).", __func__,
+    INFO(NCCL_NET, "NET/IB: %s: Ignoring flush error on a QP (comm=%p, wc.wr_id=0x%lx, wc.status=%s(%d)).", __func__,
          resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status);
     return ncclSuccess;
   }
@@ -341,6 +344,9 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorReceiver(struct ncclIbR
   return ncclSuccess;
 }
 
+// TODO - QP sharing
+//        refer to all usage of wc->wr_id and extract needed bits only as it contains the 16bits commId for QP sharing
+//        refer to all usage of wc->imm_data and extract needed bits only as it contains 8 bits rxReqIdx & 16 bits CommId for QP sharing
 static ncclResult_t IbCastResiliencyHandleCompletionErrorSender(struct ncclIbResiliency* resCtx, struct ibv_wc* wc,
                                                                 int devIndex) {
   ncclResult_t res;
@@ -352,7 +358,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorSender(struct ncclIbRes
 
   if (request == NULL) {
     WARN("NET/IB: %s: Encountered a stale CQE with error for slot=%ld. Slot was already handled (comm=%p, "
-         "wc.wr_id=%ld, wc.status=%s(%d), wc.opcode=%s(%d)).",
+         "wc.wr_id=0x%lx, wc.status=%s(%d), wc.opcode=%s(%d)).",
          __func__, slot, resCtx->baseComm, wc->wr_id, ibvWcStatusStr(wc->status), wc->status,
          ibvWcOpcodeStr(wc->opcode), wc->opcode);
     return ncclSuccess;
@@ -361,7 +367,7 @@ static ncclResult_t IbCastResiliencyHandleCompletionErrorSender(struct ncclIbRes
   struct ncclIbResiliencySend* sendResCtx = (struct ncclIbResiliencySend*)resCtx;
   res = IbCastResiliencySendRequestInit(sendResCtx, request, devIndex);
   if (res != ncclSuccess) {
-    WARN("NET/IB: %s: Failed to initialize a resiliency send request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=%ld, "
+    WARN("NET/IB: %s: Failed to initialize a resiliency send request (req=%p, comm=%p, id=%ld, type=%s, wc.wr_id=0x%lx, "
          "wc.status=%s(%d), wc.opcode=%s(%d), slot=%ld).",
          __func__, request, request->base, request->id, IbCastReqTypeStr[request->type], wc->wr_id,
          ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, slot);
@@ -539,8 +545,9 @@ static ncclResult_t IbCastResiliencyProbePost(struct ncclIbResiliencySend* sendR
 
 static ncclResult_t IbCastResiliencyProbeHandleCompletionEvent(struct ncclIbResiliencySend* sendResCtx,
                                                                struct ibv_wc* probeWc, int devIndex) {
+
   INFO(NCCL_NET,
-       "NET/IB: %s: Got probing completion (devIndex=%d, wc->status=%d, wc->opcode=%d, wc->wr_id=%ld, wc->qp_num=%u)",
+       "NET/IB: %s: Got probing completion (devIndex=%d, wc->status=%d, wc->opcode=%d, wc->wr_id=0x%lx, wc->qp_num=%u)",
        __func__, devIndex, probeWc->status, probeWc->opcode, probeWc->wr_id, probeWc->qp_num);
 
   struct ncclIbResiliencyRequestSend* failedRequest = &sendResCtx->failedRequests[probeWc->wr_id % NET_IB_MAX_REQUESTS];
@@ -1057,7 +1064,7 @@ ncclResult_t IbCastResiliencyRequestIsComplete(struct ncclIbRequest* request, bo
 
 ncclResult_t IbCastResiliencyHandleCompletionError(struct ncclIbResiliency* resCtx, struct ibv_wc* wc, int devIndex) {
   INFO(NCCL_NET,
-       "NET/IB: %s: Got completion with error (devIndex=%d, wc->status=(%s)%d, wc->opcode=(%s)%d, wc->wr_id=%ld, "
+       "NET/IB: %s: Got completion with error (devIndex=%d, wc->status=(%s)%d, wc->opcode=(%s)%d, wc->wr_id=0x%lx, "
        "wc->qp_num=%u, wc->byte_len=%d)",
        __func__, devIndex, ibvWcStatusStr(wc->status), wc->status, ibvWcOpcodeStr(wc->opcode), wc->opcode, wc->wr_id,
        wc->qp_num, wc->byte_len);

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency.cc
@@ -545,7 +545,6 @@ static ncclResult_t IbCastResiliencyProbePost(struct ncclIbResiliencySend* sendR
 
 static ncclResult_t IbCastResiliencyProbeHandleCompletionEvent(struct ncclIbResiliencySend* sendResCtx,
                                                                struct ibv_wc* probeWc, int devIndex) {
-
   INFO(NCCL_NET,
        "NET/IB: %s: Got probing completion (devIndex=%d, wc->status=%d, wc->opcode=%d, wc->wr_id=0x%lx, wc->qp_num=%u)",
        __func__, devIndex, probeWc->status, probeWc->opcode, probeWc->wr_id, probeWc->qp_num);

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -313,8 +313,6 @@ ncclResult_t IbCastPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = 1;
   qpCreateAttrs.maxSendWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
-  // TODO - QP sharing:
-  //        disabled for recovery QP
   qpCreateAttrs.isQpSharingEnabled = false;
   qpCreateAttrs.qpSharingGroupIdx = -1;
   qpCreateAttrs.cqDepthMultiplier = 1;
@@ -389,8 +387,6 @@ ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* r
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
   qpCreateAttrs.maxSendWorkRequest = 1;
-  // TODO - QP sharing:
-  //        disabled for recovery QP
   qpCreateAttrs.isQpSharingEnabled = false;
   qpCreateAttrs.qpSharingGroupIdx = -1;
   qpCreateAttrs.cqDepthMultiplier = 1;
@@ -630,8 +626,6 @@ static inline ncclResult_t IbCastPortRecoveryHandleCompletionReceiver(struct ncc
            recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
     } else {
       assert(completion.opcode == IBV_WC_RECV);
-      // TODO - QP sharing: 
-      //        no change required, as this is specific to port recovery QP (not regular RC QP). confirm?
       uint32_t id = completion.imm_data;
       int seqSize = ncclParamIbCastResiliencyPortRecoveryAliveMsgSequenceSize();
       uint32_t windowEnd = recoveryContext->recv.windowBase + seqSize;

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -313,6 +313,11 @@ ncclResult_t IbCastPortRecoverySenderQpsCreate(struct ncclIbResiliency* resCtx,
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = 1;
   qpCreateAttrs.maxSendWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
+  // TODO - QP sharing:
+  //        disabled for recovery QP
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
     int localDevIndex = localQpIndex % sendComm->base.vProps.ndevs;
     ncclIbSendCommDev* sendCommDev = &sendComm->devs[localDevIndex];
@@ -384,6 +389,11 @@ ncclResult_t IbCastPortRecoveryReceiverQpsCreateToRts(struct ncclIbResiliency* r
   qpCreateAttrs.type = IBV_QPT_UD;
   qpCreateAttrs.maxRecvWorkRequest = NCCL_IB_RESILIENCY_PORT_RECOVERY_ALIVE_MSG_BATCH_SIZE_MAX;
   qpCreateAttrs.maxSendWorkRequest = 1;
+  // TODO - QP sharing:
+  //        disabled for recovery QP
+  qpCreateAttrs.isQpSharingEnabled = false;
+  qpCreateAttrs.qpSharingGroupIdx = -1;
+  qpCreateAttrs.cqDepthMultiplier = 1;
   for (int localQpIndex = 0; localQpIndex < nQps; localQpIndex++) {
     int localDevIndex = localQpIndex % recvComm->base.vProps.ndevs;
     ncclIbRecvCommDev* recvCommDev = &recvComm->devs[localDevIndex];

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery.cc
@@ -630,6 +630,8 @@ static inline ncclResult_t IbCastPortRecoveryHandleCompletionReceiver(struct ncc
            recoveryContext->devIndex, recoveryContext->resCtx->baseComm);
     } else {
       assert(completion.opcode == IBV_WC_RECV);
+      // TODO - QP sharing: 
+      //        no change required, as this is specific to port recovery QP (not regular RC QP). confirm?
       uint32_t id = completion.imm_data;
       int seqSize = ncclParamIbCastResiliencyPortRecoveryAliveMsgSequenceSize();
       uint32_t windowEnd = recoveryContext->recv.windowBase + seqSize;

--- a/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
+++ b/projects/rccl/src/transport/net_ib_cast/p2p_resiliency_recovery_ainic.cc
@@ -42,6 +42,13 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
     createAttr.isDataQp = localQp->isDataQp;
     // isCtsEnabled and ctsQpSlot are left at 0 (from memset in IbCastBuildDataQpCreateAttr).
     // CTS offload is disabled when resiliency features are enabled (init.cc).
+    // TODO - QP sharing:
+    //        as of now QP sharing disabled during recovery restore.
+    //        to analyze and set sharing accordingly for this QP during recovery restore.
+    //        identify if it is primary or secondary comm and set sharing attributes accordingly.
+    createAttr.isQpSharingEnabled = false;
+    createAttr.qpSharingGroupIdx = -1;
+    createAttr.cqDepthMultiplier = 1;
     NCCLCHECK(IbCastQpCreate(localQp, &createAttr));
 
     INFO(NCCL_NET, "NET/IB: %s: Recreated QP %d on device %d (comm=%p, old_qp_num=%u, new_qp_num=%u)", __func__,
@@ -73,6 +80,11 @@ ncclResult_t IbCastPortRecoveryQpsRestoreAinic(struct ncclIbPortRecoveryContext*
         flushCreateAttr.maxSendWorkRequest = NET_IB_MAX_REQUESTS;
         flushCreateAttr.channelId = flushQp->channelId;
         flushCreateAttr.isDataQp = flushQp->isDataQp;
+        // TODO - QP sharing:
+        //        disabled for flush QP
+        flushCreateAttr.isQpSharingEnabled = false;
+        flushCreateAttr.qpSharingGroupIdx = -1;
+        flushCreateAttr.cqDepthMultiplier = 1;
         NCCLCHECK(IbCastQpCreate(flushQp, &flushCreateAttr));
         INFO(NCCL_NET, "NET/IB: %s: Recreated Flush QP on device %d (comm=%p, new_qp_num=%u)", __func__, i,
              recoveryContext->resCtx->baseComm, flushQp->qp->qp_num);

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -1,0 +1,173 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * QP Sharing pool management implementation for IB CAST transport layer.
+ ************************************************************************/
+
+#include "qp_sharing.h"
+
+// QP sharing configuration parameters
+RCCL_PARAM(IbCastCommNGroups, "IB_COMM_NGROUPS", 0);
+RCCL_PARAM(IbCastQpDepthMultiplier, "IB_QP_DEPTH_MULTIPLIER", 1);
+
+// Pool and comm table globals
+struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
+int                         g_IbCastSharedQpPoolCount = 0;
+struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
+uint16_t                    g_IbCastNextCommId = 1;   // 0 reserved for "not shared"
+std::mutex                  g_IbCastSharedQpMutex;
+
+void IbCastStripPort(union ncclSocketAddress* addr) {
+    if (addr->sa.sa_family == AF_INET) {
+        addr->sin.sin_port = 0;
+    } else if (addr->sa.sa_family == AF_INET6) {
+        addr->sin6.sin6_port = 0;
+    }
+}
+
+bool IbCastSharedQpKeyMatch(const IbCastSharedQpKey* a, const IbCastSharedQpKey* b) {
+    if (a->ibDevN != b->ibDevN) return false;
+    if (a->isSend != b->isSend) return false;
+    if (a->groupIdx != b->groupIdx) return false;
+    if (a->qpIdx != b->qpIdx) return false;
+    if (a->remIbDevIdx != b->remIbDevIdx) return false;
+    if (memcmp(&a->peerAddr, &b->peerAddr, sizeof(union ncclSocketAddress)) != 0) return false;
+    return true;
+}
+
+struct IbCastSharedQp* IbCastFindSharedQp(const IbCastSharedQpKey* key) {
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (g_IbCastSharedQpPool[i].used && IbCastSharedQpKeyMatch(&g_IbCastSharedQpPool[i].key, key)) {
+            return &g_IbCastSharedQpPool[i];
+        }
+    }
+    return NULL;
+}
+
+struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend) {
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (g_IbCastSharedQpPool[i].used && g_IbCastSharedQpPool[i].qp &&
+            g_IbCastSharedQpPool[i].key.isSend == isSend &&
+            g_IbCastSharedQpPool[i].qp->qp_num == qpn) {
+            return &g_IbCastSharedQpPool[i];
+        }
+    }
+    return NULL;
+}
+
+struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
+    struct ibv_qp* qp, struct ibv_cq* primaryCq,
+    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount) {
+
+    if (g_IbCastSharedQpPoolCount >= IBCAST_MAX_SHARED_QPS) {
+        WARN("IB CAST QP Sharing: pool full (%d entries)", IBCAST_MAX_SHARED_QPS);
+        return NULL;
+    }
+    struct IbCastSharedQp* entry = &g_IbCastSharedQpPool[g_IbCastSharedQpPoolCount++];
+    entry->key = *key;
+    entry->qp = qp;
+    entry->primaryCq = primaryCq;
+    entry->primaryDevBase = primaryDevBase;
+    entry->devIndex = devIndex;
+    entry->refcount = initialRefcount;
+    entry->cqRefcount = 0;
+    entry->used = true;
+    entry->ctsQpSlot = IBCAST_CTS_QP_SLOT_INVALID;
+    return entry;
+}
+
+int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend, int groupIdx) {
+    int count = 0;
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (!g_IbCastSharedQpPool[i].used) continue;
+        if (g_IbCastSharedQpPool[i].key.isSend != isSend) continue;
+        if (g_IbCastSharedQpPool[i].key.groupIdx != groupIdx) continue;
+        if (g_IbCastSharedQpPool[i].key.remIbDevIdx != remIbDevIdx) continue;
+        if (memcmp(&g_IbCastSharedQpPool[i].key.peerAddr, peerAddr, sizeof(union ncclSocketAddress)) == 0) {
+            count++;
+        }
+    }
+    return count;
+}
+
+int IbCastCountPeerTotalRefcount(int ibDevN, const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend) {
+    int total = 0;
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (!g_IbCastSharedQpPool[i].used) continue;
+        if (g_IbCastSharedQpPool[i].key.qpIdx != 0) continue;
+        if (g_IbCastSharedQpPool[i].key.isSend != isSend) continue;
+        if (g_IbCastSharedQpPool[i].key.remIbDevIdx != remIbDevIdx) continue;
+        if (memcmp(&g_IbCastSharedQpPool[i].key.peerAddr, peerAddr, sizeof(union ncclSocketAddress)) == 0) {
+            total += g_IbCastSharedQpPool[i].refcount;
+        }
+    }
+    return total;
+}
+
+uint16_t IbCastAllocCommId(void* comm, bool isSend) {
+    std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+    if (g_IbCastNextCommId >= IBCAST_MAX_COMMS) {
+        WARN("NET/IB: commId pool exhausted (max %d), falling back to non-sharing", IBCAST_MAX_COMMS);
+        return 0;
+    }
+    uint16_t id = g_IbCastNextCommId++;
+    g_IbCastCommTable[id].comm = comm;
+    g_IbCastCommTable[id].isSend = isSend;
+    g_IbCastCommTable[id].used = true;
+    return id;
+}
+
+void IbCastFreeCommId(uint16_t commId) {
+    if (commId > 0 && commId < IBCAST_MAX_COMMS) {
+        std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
+        g_IbCastCommTable[commId].used = false;
+        g_IbCastCommTable[commId].comm = NULL;
+    }
+}
+
+void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry) {
+    struct ibv_cq* destroyedCqs[NCCL_IB_MAX_DEVS_PER_NIC];
+    int nDestroyed = 0;
+
+    for (int i = 0; i < g_IbCastSharedQpPoolCount; i++) {
+        if (!g_IbCastSharedQpPool[i].used) continue;
+        if (g_IbCastSharedQpPool[i].key.isSend != slot0Entry->key.isSend) continue;
+        if (g_IbCastSharedQpPool[i].key.groupIdx != slot0Entry->key.groupIdx) continue;
+        if (g_IbCastSharedQpPool[i].key.remIbDevIdx != slot0Entry->key.remIbDevIdx) continue;
+        if (memcmp(&g_IbCastSharedQpPool[i].key.peerAddr, &slot0Entry->key.peerAddr,
+                   sizeof(union ncclSocketAddress)) != 0) continue;
+
+        struct ibv_cq* cq = g_IbCastSharedQpPool[i].primaryCq;
+        bool alreadyDestroyed = false;
+        for (int j = 0; j < nDestroyed; j++) {
+            if (destroyedCqs[j] == cq) { alreadyDestroyed = true; break; }
+        }
+        if (!alreadyDestroyed && cq != NULL) {
+            INFO(NCCL_NET, "IB CAST TEARDOWN: destroying CQ %p group=%d ibDevN=%d isSend=%d remIbDev=%d qpIdx=%d refcount=%d",
+                 (void*)cq, g_IbCastSharedQpPool[i].key.groupIdx, g_IbCastSharedQpPool[i].key.ibDevN,
+                 g_IbCastSharedQpPool[i].key.isSend, g_IbCastSharedQpPool[i].key.remIbDevIdx,
+                 g_IbCastSharedQpPool[i].key.qpIdx, g_IbCastSharedQpPool[i].refcount);
+            ncclResult_t cqRet = wrap_ibv_destroy_cq(cq);
+            if (cqRet != ncclSuccess) {
+                WARN("IB CAST TEARDOWN: ibv_destroy_cq FAILED cq=%p errno=%d group=%d ibDevN=%d qpIdx=%d refcount=%d",
+                     (void*)cq, errno, g_IbCastSharedQpPool[i].key.groupIdx, g_IbCastSharedQpPool[i].key.ibDevN,
+                     g_IbCastSharedQpPool[i].key.qpIdx, g_IbCastSharedQpPool[i].refcount);
+            }
+            destroyedCqs[nDestroyed++] = cq;
+            if (g_IbCastSharedQpPool[i].primaryDevBase) {
+                int ibDevN2 = g_IbCastSharedQpPool[i].primaryDevBase->ibDevN;
+                std::lock_guard<std::mutex> lock(IbCastDevs[ibDevN2].mutex);
+                INFO(NCCL_NET, "IB CAST TEARDOWN: pdRefs ibDevN=%d: %d->%d %s",
+                     ibDevN2, IbCastDevs[ibDevN2].pdRefs, IbCastDevs[ibDevN2].pdRefs - 1,
+                     (IbCastDevs[ibDevN2].pdRefs == 1) ? "DEALLOC" : "");
+                if (0 == --IbCastDevs[ibDevN2].pdRefs) {
+                    wrap_ibv_dealloc_pd(IbCastDevs[ibDevN2].pd);
+                }
+            }
+        }
+        g_IbCastSharedQpPool[i].used = false;
+    }
+}

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -120,11 +120,29 @@ uint16_t IbCastAllocCommId(void* comm, bool isSend) {
     return id;
 }
 
+// Caller MUST hold g_IbCastSharedQpMutex. Used by the teardown paths, which take
+// the mutex across the whole shared-QP cleanup block.
+void IbCastFreeCommIdLocked(uint16_t commId) {
+    if (commId > 0 && commId < IBCAST_MAX_COMMS) {
+        g_IbCastCommTable[commId].used = false;
+        g_IbCastCommTable[commId].comm = NULL;
+    }
+}
+
+struct ncclIbNetCommBase* IbCastRouteCommFromWrId(uint64_t wr_id) {
+  uint16_t commId = (wr_id >> WR_ID_RX_COMM_ID_SHIFT) & WR_ID_RX_COMM_ID_MASK;
+  if (commId == 0 || commId >= IBCAST_MAX_COMMS || !g_IbCastCommTable[commId].used) return NULL;
+  return g_IbCastCommTable[commId].isSend
+    ? &((struct ncclIbSendComm*)g_IbCastCommTable[commId].comm)->base
+    : &((struct ncclIbRecvComm*)g_IbCastCommTable[commId].comm)->base;
+}
+
+// Self-locking variant for callers that do NOT already hold the mutex
+// (e.g. the connect/accept non-sharing fallback paths).
 void IbCastFreeCommId(uint16_t commId) {
     if (commId > 0 && commId < IBCAST_MAX_COMMS) {
         std::lock_guard<std::mutex> lock(g_IbCastSharedQpMutex);
-        g_IbCastCommTable[commId].used = false;
-        g_IbCastCommTable[commId].comm = NULL;
+        IbCastFreeCommIdLocked(commId);
     }
 }
 

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.cc
@@ -137,6 +137,19 @@ struct ncclIbNetCommBase* IbCastRouteCommFromWrId(uint64_t wr_id) {
     : &((struct ncclIbRecvComm*)g_IbCastCommTable[commId].comm)->base;
 }
 
+struct ncclIbNetCommBase* IbCastRouteCommFromImmData(struct ncclIbNetCommBase* base, uint32_t immDataHost) {
+  if (rcclParamIbCastCommNGroups() > 0) {
+    uint16_t immCommId = (immDataHost >> WR_IMM_BYID_COMM_ID_SHIFT) & WR_IMM_BYID_COMM_ID_MASK;
+    //uint8_t reqSlot = immDataHost & WR_IMM_BYID_REQ_ID_MASK;
+    if (immCommId != 0 && immCommId < IBCAST_MAX_COMMS && g_IbCastCommTable[immCommId].used) {
+      return g_IbCastCommTable[immCommId].isSend
+        ? &((struct ncclIbSendComm*)g_IbCastCommTable[immCommId].comm)->base
+        : &((struct ncclIbRecvComm*)g_IbCastCommTable[immCommId].comm)->base;
+    }
+  }
+  return NULL;
+}
+
 // Self-locking variant for callers that do NOT already hold the mutex
 // (e.g. the connect/accept non-sharing fallback paths).
 void IbCastFreeCommId(uint16_t commId) {

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -1,0 +1,100 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * QP Sharing infrastructure for IB CAST transport layer.
+ * Allows multiple RCCL communicator channels to share physical IB QPs,
+ * reducing QP count and improving scalability.
+ * Controlled via NCCL_IB_COMM_NGROUPS (0=disabled).
+ ************************************************************************/
+
+#ifndef NET_IB_CAST_QP_SHARING_H_
+#define NET_IB_CAST_QP_SHARING_H_
+
+#include "common_cast.h"
+#include "param.h"
+#include <mutex>
+
+// QP sharing configuration parameters
+// Accessible as RCCL_IB_COMM_NGROUPS / NCCL_IB_COMM_NGROUPS
+// 0 = disabled, >0 = enable QP sharing with N groups
+extern int64_t rcclParamIbCastCommNGroups();
+// CQ/WR depth scaling for primary QPs
+extern int64_t rcclParamIbCastQpDepthMultiplier();
+
+#define IBCAST_MAX_SHARED_QPS 1024
+#define IBCAST_MAX_COMMS      4096
+#define IBCAST_CTS_QP_SLOT_INVALID 0xFF
+
+// Pool key -- uniquely identifies a shared QP
+struct IbCastSharedQpKey {
+    int             ibDevN;              // local IB device index
+    union ncclSocketAddress peerAddr;    // remote peer address (port stripped)
+    int             remIbDevIdx;         // remote IB device index for disambiguation
+    bool            isSend;              // send vs recv direction
+    int             groupIdx;            // sharing group (0..m-1)
+    int             qpIdx;              // QP slot within the group (0..nqps-1)
+};
+
+// Pool entry -- one per physical shared QP
+struct IbCastSharedQp {
+    IbCastSharedQpKey key;
+    struct ibv_qp*    qp;                  // the physical QP
+    struct ibv_cq*    primaryCq;           // CQ for this device in this group
+    struct ncclIbNetCommDevBase* primaryDevBase;  // device base of primary comm's CQ
+    int      devIndex;                     // local device index within comm->devs[]
+    int      refcount;                     // number of comms using this QP
+    int      cqRefcount;                   // comms using this group's CQs (tracked on qpIdx==0 only)
+    bool     used;                         // slot in use
+    int8_t   ctsQpSlot;                    // CTS signaling slot from primary
+};
+
+// Global comm table for completion routing (commId -> comm pointer)
+struct IbCastCommTableEntry {
+    void*    comm;          // ncclIbSendComm* or ncclIbRecvComm*
+    bool     isSend;
+    bool     used;
+};
+
+// Pool and comm table globals (defined in qp_sharing.cc)
+extern struct IbCastSharedQp       g_IbCastSharedQpPool[IBCAST_MAX_SHARED_QPS];
+extern int                         g_IbCastSharedQpPoolCount;
+extern struct IbCastCommTableEntry g_IbCastCommTable[IBCAST_MAX_COMMS];
+extern uint16_t                    g_IbCastNextCommId;
+extern std::mutex                  g_IbCastSharedQpMutex;
+
+// Strip port from socket address for peer matching
+void IbCastStripPort(union ncclSocketAddress* addr);
+
+// Compare two pool keys
+bool IbCastSharedQpKeyMatch(const IbCastSharedQpKey* a, const IbCastSharedQpKey* b);
+
+// Find a shared QP by key
+struct IbCastSharedQp* IbCastFindSharedQp(const IbCastSharedQpKey* key);
+
+// Find a shared QP by QP number and direction (for teardown)
+struct IbCastSharedQp* IbCastFindSharedQpByQpn(uint32_t qpn, bool isSend);
+
+// Register a new shared QP in the pool
+struct IbCastSharedQp* IbCastRegisterSharedQp(const IbCastSharedQpKey* key,
+    struct ibv_qp* qp, struct ibv_cq* primaryCq,
+    struct ncclIbNetCommDevBase* primaryDevBase, int devIndex, int initialRefcount);
+
+// Count QP slots registered by the primary for a given group
+int IbCastCountGroupQpSlots(const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend, int groupIdx);
+
+// Count total comms connected to a peer (for channelSeq computation)
+int IbCastCountPeerTotalRefcount(int ibDevN, const union ncclSocketAddress* peerAddr,
+    int remIbDevIdx, bool isSend);
+
+// Allocate a commId and register in the global comm table (mutex-protected)
+uint16_t IbCastAllocCommId(void* comm, bool isSend);
+
+// Free a commId
+void IbCastFreeCommId(uint16_t commId);
+
+// Destroy all CQs for a group when cqRefcount reaches 0
+void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry);
+
+#endif // NET_IB_CAST_QP_SHARING_H_

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -91,10 +91,23 @@ int IbCastCountPeerTotalRefcount(int ibDevN, const union ncclSocketAddress* peer
 // Allocate a commId and register in the global comm table (mutex-protected)
 uint16_t IbCastAllocCommId(void* comm, bool isSend);
 
-// Free a commId
+// Free a commId (self-locking; for callers NOT holding g_IbCastSharedQpMutex)
 void IbCastFreeCommId(uint16_t commId);
+
+// Free a commId; caller MUST already hold g_IbCastSharedQpMutex (teardown paths)
+void IbCastFreeCommIdLocked(uint16_t commId);
 
 // Destroy all CQs for a group when cqRefcount reaches 0
 void IbCastCleanupGroupCqs(struct IbCastSharedQp* slot0Entry);
+
+// Strip the commId from wr_id[63:48], recovering the original index. Safe when
+// sharing is disabled (commId==0, so the mask is a no-op).
+static inline uint64_t IbCastStripCommId(uint64_t wr_id) {
+  return wr_id & ~((uint64_t)WR_ID_RX_COMM_ID_MASK << WR_ID_RX_COMM_ID_SHIFT);
+}
+
+// Look up the target comm from the commId encoded in wr_id[63:48]. Returns NULL
+// if sharing is disabled or the commId is invalid.
+struct ncclIbNetCommBase* IbCastRouteCommFromWrId(uint64_t wr_id);
 
 #endif // NET_IB_CAST_QP_SHARING_H_

--- a/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
+++ b/projects/rccl/src/transport/net_ib_cast/qp_sharing.h
@@ -110,4 +110,10 @@ static inline uint64_t IbCastStripCommId(uint64_t wr_id) {
 // if sharing is disabled or the commId is invalid.
 struct ncclIbNetCommBase* IbCastRouteCommFromWrId(uint64_t wr_id);
 
+// Look up the target comm from the commId encoded in immData.
+// Returns target base based on commId in immData if sharing is enabled or
+// returns NULL if sharing is disabled or commId is invalid.
+struct ncclIbNetCommBase* IbCastRouteCommFromImmData(
+    struct ncclIbNetCommBase* base, uint32_t immDataHost);
+
 #endif // NET_IB_CAST_QP_SHARING_H_


### PR DESCRIPTION
## Motivation
                                                                                                                                                                                                                                                                                                                                                       
  - At scale, each RCCL communicator channel creates its own set of IB Queue Pairs (QPs), leading to high QP count per node
  - High QP count increases memory consumption, HCA resource pressure, and can hit firmware/hardware limits on AINIC/Ionic NICs
  - QP sharing allows multiple communicator channels to multiplex onto a smaller set of physical QPs, improving scalability and reducing resource usage
  - This feature was previously implemented against the legacy monolithic net_ib_rocm.cc; this PR ports it to the refactored modular net_ib_cast/ architecture
  

## Technical Details

  - New files: qp_sharing.h / qp_sharing.cc — global shared QP pool (IbCastSharedQpPool[1024]), comm routing table (IbCastCommTable[4096]), and pool management functions (find, register, cleanup, commId allocation, refcount lifecycle)
  - Runtime control: NCCL_IB_COMM_NGROUPS (0=disabled, >0=number of sharing groups) and NCCL_IB_QP_DEPTH_MULTIPLIER (CQ/WR depth scaling for shared QPs)
  - Primary/Secondary pattern: First comm to a peer/group creates QPs (primary), subsequent comms reuse them (secondary) with refcount tracking
  - CQ depth scaling: Primary QP CQ and WR depths scaled by depthMultiplier to handle completions from multiple comms
  - Completion routing: commId encoded in wr_id upper 16 bits (bits 48-63) for send-side routing; imm_data carries (rxReqIdx << 24) | commId for recv-side routing via g_IbCastCommTable lookup
  - Completion dispatch: commId extraction and targetBase resolution done in IbCastTest() before dispatching to IbCastCompletionEventProcess() / IbCastCompletionEventByOrder()
  - Ionic UDMA mask: Shared QPs use groupIdx-based UDMA mask selection (even=LOW, odd=HIGH) instead of channel-based alternation
  - CTS offload: Mutually exclusive with QP sharing; auto-disabled at init when NCCL_IB_COMM_NGROUPS > 0
  - QP sharing attrs: isQpSharingEnabled, cqDepthMultiplier, qpSharingGroupIdx added to ncclIbQpCreateAttr struct; resiliency/recovery/flush QPs explicitly set isQpSharingEnabled=false
  - Refcount teardown: QPs destroyed only when last comm's refcount reaches 0; CQs cleaned up when cqRefcount reaches 0 via IbCastCleanupGroupCqs()
  - Backward compatible: Default NCCL_IB_COMM_NGROUPS=0 takes the original non-sharing code path with zero overhead
  - Files modified: 11 files (2 new, 9 modified), +998/-97 lines


## JIRA ID

N/A

## Test Plan

[TBD -  posted plan below]
  - Build RCCL with QP sharing changes — verify clean compilation
  - Run with NCCL_IB_COMM_NGROUPS=0 (default) — verify identical behavior to baseline (no regression)
  - Run with NCCL_IB_COMM_NGROUPS=2 — verify QP sharing active (check NCCL_DEBUG=INFO for primary/secondary logs)
  - Multi-node all_reduce correctness with sharing enabled (2+ nodes)
  - Verify clean teardown — no leaked QPs/CQs (check teardown logs with NCCL_DEBUG=INFO)
  - Verify NCCL_IB_QP_DEPTH_MULTIPLIER scales CQ/WR depths correctly
  - Stress test: multiple communicators connecting/disconnecting to exercise refcount logic


## Test Result

[TBD - posted plan below]
 - Build: Clean compilation verified on gfx942 (ROCm 7.0.2)
  - Functional testing: TBD

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
