### PR TITLE
build(hipfile): Remove `fetch-depth: 0` where unnecessary

### DIFF
--- a/.github/workflows/hipfile-build-nvidia.yml
+++ b/.github/workflows/hipfile-build-nvidia.yml
@@ -45,7 +45,6 @@ jobs:
       - name: Fetching code repository...
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
           path: rocm-systems
           sparse-checkout: |
             projects/hipfile

--- a/.github/workflows/hipfile-build.yml
+++ b/.github/workflows/hipfile-build.yml
@@ -107,7 +107,6 @@ jobs:
       - name: Fetching code repository...
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
           path: rocm-systems
           sparse-checkout: |
             projects/hipfile

--- a/.github/workflows/hipfile-ci-system.yml
+++ b/.github/workflows/hipfile-ci-system.yml
@@ -74,7 +74,6 @@ jobs:
       - name: Fetching hipFile repository...
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
           path: rocm-systems
           sparse-checkout: |
             projects/hipfile

--- a/.github/workflows/hipfile-image-build.yml
+++ b/.github/workflows/hipfile-image-build.yml
@@ -69,7 +69,6 @@ jobs:
       - name: Fetching code repository...
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
           sparse-checkout: |
             projects/hipfile
             .github/workflows

--- a/.github/workflows/hipfile-image-update.yml
+++ b/.github/workflows/hipfile-image-update.yml
@@ -63,7 +63,6 @@ jobs:
       - name: Fetching code repository...
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
           sparse-checkout: |
             projects/hipfile
             .github/workflows

--- a/.github/workflows/hipfile-python-bindings.yml
+++ b/.github/workflows/hipfile-python-bindings.yml
@@ -70,7 +70,6 @@ jobs:
       - name: Fetching code repository...
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
           path: rocm-systems
           sparse-checkout: |
             projects/hipfile

--- a/.github/workflows/hipfile-sanitizers.yml
+++ b/.github/workflows/hipfile-sanitizers.yml
@@ -54,7 +54,6 @@ jobs:
       - name: Fetching code repository...
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
           path: rocm-systems
           sparse-checkout: |
             projects/hipfile


### PR DESCRIPTION
## Motivation

A comment in an earlier PR noticed that we were using `fetch-depth: 0` in GitHub actions that don't inspect the git history. That level of fetch-depth pulls in the entire history of rocm-systems, which is enormous.

## Technical Details

Remove `fetch-depth: 0` from these actions, so they default to a sparse checkout:

* hipfile-build-nvidia.yml
* hipfile-build.yml
* hipfile-ci-system.yml
* hipfile-image-build.yml
* hipfile-image-update.yml
* hipfile-python-bindings.yml
* hipfile-sanitizers.yml

## JIRA ID

AIHIPFILE-232

## Test Plan

CI Passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
