### PR TITLE
fix(rocr): throttle AsyncEventsLoop polling fallback on Linux idle path

### DIFF
--- a/projects/rocr-runtime/rocrtst/common/utils_test/CMakeLists.txt
+++ b/projects/rocr-runtime/rocrtst/common/utils_test/CMakeLists.txt
@@ -4,6 +4,7 @@
 set (rocrtstUtilsTestSrcs utils_timer_gtest.cpp)
 set (rocrtstUtilsTestSrcs ${rocrtstUtilsTestSrcs} utils_timer_test.cpp)
 set (rocrtstUtilsTestSrcs ${rocrtstUtilsTestSrcs} utils_cpp11_gtest.cpp)
+set (rocrtstUtilsTestSrcs ${rocrtstUtilsTestSrcs} utils_poll_backoff_test.cpp)
 
 #
 # Header files include path(s).

--- a/projects/rocr-runtime/rocrtst/common/utils_test/utils_poll_backoff_test.cpp
+++ b/projects/rocr-runtime/rocrtst/common/utils_test/utils_poll_backoff_test.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "gtest/gtest.h"
+#include "../../../runtime/hsa-runtime/core/util/poll_backoff.h"
+
+TEST(rocrtstPollBackoff, StartsAtFloor) {
+  ASSERT_EQ(rocr::core::kAsyncEventsPollNapFloorUs,
+            rocr::core::NextAsyncEventsPollNapUs(0));
+}
+
+TEST(rocrtstPollBackoff, DoublesUntilCeiling) {
+  auto value = rocr::core::kAsyncEventsPollNapFloorUs;
+  value = rocr::core::NextAsyncEventsPollNapUs(value);
+  ASSERT_EQ(40u, value);
+  value = rocr::core::NextAsyncEventsPollNapUs(value);
+  ASSERT_EQ(80u, value);
+}
+
+TEST(rocrtstPollBackoff, CapsAtCeiling) {
+  auto value = rocr::core::kAsyncEventsPollNapCeilingUs;
+  ASSERT_EQ(rocr::core::kAsyncEventsPollNapCeilingUs,
+            rocr::core::NextAsyncEventsPollNapUs(value));
+}

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -75,6 +75,7 @@ extern "C" void __sanitizer_purge_allocator(void);
 #include "core/inc/amd_gpu_agent.h"
 #include "core/inc/amd_aql_queue.h"
 #include "core/inc/amd_memory_region.h"
+#include "core/util/poll_backoff.h"
 #include "core/inc/amd_topology.h"
 #include "core/inc/exceptions.h"
 #include "core/inc/host_queue.h"
@@ -1909,6 +1910,7 @@ void Runtime::AsyncEventsLoop(void* _eventsInfo) {
       bool finish = false;
       bool polling = false;
       bool init_age = true;
+      uint32_t poll_nap_us = kAsyncEventsPollNapFloorUs;
 
       while (!finish) {
         // If exception or WaitAny(), then finish with just one iterration
@@ -1933,6 +1935,7 @@ void Runtime::AsyncEventsLoop(void* _eventsInfo) {
             if (!wait_any) {
               finish = true;
               init_age = true;
+              poll_nap_us = kAsyncEventsPollNapFloorUs;
             }
           }
 
@@ -2003,6 +2006,9 @@ void Runtime::AsyncEventsLoop(void* _eventsInfo) {
             break;
           }
           init_age = false;
+        } else if (polling && !finish) {
+          rocr::os::uSleep(poll_nap_us);
+          poll_nap_us = NextAsyncEventsPollNapUs(poll_nap_us);
         }
       }
     }

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/poll_backoff.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/poll_backoff.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+namespace rocr {
+namespace core {
+
+constexpr uint32_t kAsyncEventsPollNapFloorUs = 20;
+constexpr uint32_t kAsyncEventsPollNapCeilingUs = 2000;
+
+inline uint32_t NextAsyncEventsPollNapUs(uint32_t current) {
+  if (current < kAsyncEventsPollNapFloorUs) {
+    return kAsyncEventsPollNapFloorUs;
+  }
+  return std::min(current * 2, kAsyncEventsPollNapCeilingUs);
+}
+
+}  // namespace core
+}  // namespace rocr


### PR DESCRIPTION
Title: fix(rocr): throttle AsyncEventsLoop polling fallback on Linux idle path

Suggested branch name:
users/jan/async-events-poll-backoff-gfx1151

Problem
-------
On this Linux host, a process that loads a GPU-backed SentenceTransformer(..., device="cuda") can leave one ROCr runtime thread at ~100% CPU while otherwise idle.

A local symbolized GDB session resolves the hot thread to:
- rocr::core::Runtime::AsyncEventsLoop(void*)

with a sibling thread blocked in:
- ioctl()
- hsaKmtWaitOnMultipleEvents_ExtCtx
- rocr::core::Signal::WaitAnyExceptions(...)
- AsyncEventsLoop

The hot loop is not triggered by:
- import torch
- torch.cuda.is_available()
- torch.empty(..., device="cuda")

It is triggered by the higher-level model load path (SentenceTransformer(..., device="cuda")), after which the process can sit idle while still burning roughly one CPU core.

Fix
---
Throttle only the explicit polling fallback inside Runtime::AsyncEventsLoop:
- add a small poll nap floor (20 us)
- exponentially back off to a small ceiling (2 ms)
- reset the nap floor whenever an event is processed

This leaves the normal interrupt-backed path unchanged:
- if (interrupt_wait) { WaitForInterrupt(); }

and only affects the polling && !finish fallback path.

Minimal diff
------------
```diff
diff --git a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@
-      bool init_age = true;
+      bool init_age = true;
+      constexpr uint32_t kPollNapFloorUs = 20;
+      constexpr uint32_t kPollNapCeilingUs = 2000;
+      uint32_t poll_nap_us = kPollNapFloorUs;
@@
-            if (!wait_any) {
-              finish = true;
-              init_age = true;
-            }
+            if (!wait_any) {
+              finish = true;
+              init_age = true;
+              poll_nap_us = kPollNapFloorUs;
+            }
@@
-        if (interrupt_wait) {
+        if (interrupt_wait) {
           // Active poll before the expensive kernel wait, matching WaitMultiple's
           // 200us polling window. During this window, new async handlers can wake
           // the thread via atomic stores on the wake signal without needing the
           // expensive(~1.5us) hsaKmtSetEvent ioctl call.
@@
-          init_age = false;
-        }
+          init_age = false;
+        } else if (polling && !finish) {
+          rocr::os::uSleep(poll_nap_us);
+          poll_nap_us = std::min(poll_nap_us * 2, kPollNapCeilingUs);
+        }
       }
```

Local validation
----------------
Before patch:
- one thread ~99–100% CPU in AsyncEventsLoop

After patch:
- no hot thread remains
- process samples at 0.0% CPU while idle in top -H

The same patched runtime was also exercised through a GraphRAG MCP service using LD_LIBRARY_PATH, where embedding-backed search remained functional and the MCP main process stayed idle at 0.0% CPU.

Related issues
--------------
- https://github.com/ROCm/librocdxg/issues/60
- https://github.com/ROCm/rocm-systems/pull/7898
- https://github.com/ROCm/rocm-systems/issues/277
- https://github.com/ROCm/ROCm/issues/2715
- https://github.com/ROCm/ROCm/issues/3483

Risk
----
This patch does not alter the normal interrupt-backed path.
It only reduces CPU burn when the runtime is already in the polling fallback.

Notes for submission
--------------------
- Contributing guide requests branches named users/<github-username>/<branch-name>.
- Branches in the main repo are preferred over forks because CI has more privileges.
- CI is still build-centric, and gfx1151 is not part of the normal validation matrix, so the PR body should be explicit that the primary proof is a local Linux reproduction on gfx1151.
