### PR TITLE
feat(rocSHMEM): Add unaligned fallback for device memcpy helper

### DIFF
--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -760,11 +760,52 @@ make_buffer_resource(const void* base, uint32_t num_bytes) {
   i32x4_t rsrc;
   rsrc[0] = static_cast<int32_t>(addr & 0xFFFFFFFFu);
   rsrc[1] = static_cast<int32_t>(addr >> 32);
+#if defined(__gfx1250__)
+  // MI400/gfx1250 V# descriptor:
+  //   bits  56:0   base address
+  //   bits 101:57  num_records; all ones disables OOB checking
+  //   bits 127:102 zero, including Type[127:126] == 0 for buffer
+  rsrc[1] = static_cast<int32_t>(((addr >> 32) & 0x01FFFFFFull) |
+                                 (0x7Full << 25));
+  rsrc[2] = static_cast<int32_t>(0xFFFFFFFFu);
+  rsrc[3] = 0x0000003F;
+#elif defined(__gfx1201__) || defined(__gfx1100__)
+  // GFX12 gaming (Navi4/gfx1201, gfx1100)
   rsrc[2] = static_cast<int32_t>(num_bytes);
-#if defined(__gfx1201__) || defined(__gfx1100__)
-  rsrc[3] = 0x31014000;  // raw buffer descriptor: no stride/swizzle
+  rsrc[3] = 0x31014000;
 #else
-  rsrc[3] = 0x00020000;  // raw buffer descriptor: no stride/swizzle
+  // GFX9
+  rsrc[2] = static_cast<int32_t>(num_bytes);
+  rsrc[3] = 0x00020000;
+#endif
+  return rsrc;
+}
+
+// Same encoding as make_buffer_resource, but forces rsrc[0]/rsrc[1] (the
+// address) through v_readfirstlane_b32 so the result is provably wave-uniform
+// to the compiler. Only valid when base/num_bytes are genuinely the same
+// across every active lane (e.g. a workgroup-wide bulk copy) -- callers are
+// responsible for that invariant, since the hardware has no way to check it.
+// Without this, raw.buffer.* operand legalization inserts a full
+// readfirstlane/compare/exec-mask waterfall at *every* use of the resulting
+// i32x4_t, even if it's a single loop-invariant SSA value.
+__device__ __forceinline__ i32x4_t
+make_buffer_resource_uniform(const void* base, uint32_t num_bytes) {
+  uint64_t addr = reinterpret_cast<uint64_t>(base);
+  i32x4_t rsrc;
+  rsrc[0] = __builtin_amdgcn_readfirstlane(static_cast<int32_t>(addr & 0xFFFFFFFFu));
+  rsrc[1] = __builtin_amdgcn_readfirstlane(static_cast<int32_t>(addr >> 32));
+#if defined(__gfx1250__)
+  rsrc[1] = __builtin_amdgcn_readfirstlane(static_cast<int32_t>(
+      ((addr >> 32) & 0x01FFFFFFull) | (0x7Full << 25)));
+  rsrc[2] = static_cast<int32_t>(0xFFFFFFFFu);
+  rsrc[3] = 0x0000003F;
+#elif defined(__gfx1201__) || defined(__gfx1100__)
+  rsrc[2] = static_cast<int32_t>(num_bytes);
+  rsrc[3] = 0x31014000;
+#else
+  rsrc[2] = static_cast<int32_t>(num_bytes);
+  rsrc[3] = 0x00020000;
 #endif
   return rsrc;
 }
@@ -872,17 +913,30 @@ struct AsmAccess<16, LoadPolicy, StorePolicy> {
   static __device__ __forceinline__ type load_buffer(const void *ptr,
                                                      uint32_t buf_size,
                                                      uint32_t offset) {
-    i32x4_t rsrc = make_buffer_resource(ptr, buf_size);
-    constexpr uint32_t aux = cache_policy_aux(LoadPolicy);
-    return __builtin_bit_cast(type,
-        llvm_amdgcn_raw_buffer_load_b128(rsrc, offset, 0, aux));
+    return load_buffer(make_buffer_resource(ptr, buf_size), offset);
   }
 
   static __device__ __forceinline__ void store_buffer(void *ptr,
                                                       uint32_t buf_size,
                                                       uint32_t offset,
                                                       type val) {
-    i32x4_t rsrc = make_buffer_resource(ptr, buf_size);
+    store_buffer(make_buffer_resource(ptr, buf_size), offset, val);
+  }
+
+  // rsrc-taking overloads: let callers hoist make_buffer_resource() out of a
+  // loop so the compiler doesn't have to prove src/dst are wave-uniform on
+  // every iteration (it can't, across a __noinline__ boundary, and falls
+  // back to an expensive v_readfirstlane waterfall per call otherwise).
+  static __device__ __forceinline__ type load_buffer(i32x4_t rsrc,
+                                                     uint32_t offset) {
+    constexpr uint32_t aux = cache_policy_aux(LoadPolicy);
+    return __builtin_bit_cast(type,
+        llvm_amdgcn_raw_buffer_load_b128(rsrc, offset, 0, aux));
+  }
+
+  static __device__ __forceinline__ void store_buffer(i32x4_t rsrc,
+                                                      uint32_t offset,
+                                                      type val) {
     constexpr uint32_t aux = cache_policy_aux(StorePolicy);
     llvm_amdgcn_raw_buffer_store_b128(static_cast<__uint128_t>(val),
                                       rsrc, offset, 0, aux);
@@ -988,17 +1042,26 @@ struct AsmAccess<8, LoadPolicy, StorePolicy> {
   static __device__ __forceinline__ type load_buffer(const void *ptr,
                                                      uint32_t buf_size,
                                                      uint32_t offset) {
-    i32x4_t rsrc = make_buffer_resource(ptr, buf_size);
-    constexpr uint32_t aux = cache_policy_aux(LoadPolicy);
-    return __builtin_bit_cast(type,
-        llvm_amdgcn_raw_buffer_load_b64(rsrc, offset, 0, aux));
+    return load_buffer(make_buffer_resource(ptr, buf_size), offset);
   }
 
   static __device__ __forceinline__ void store_buffer(void *ptr,
                                                       uint32_t buf_size,
                                                       uint32_t offset,
                                                       type val) {
-    i32x4_t rsrc = make_buffer_resource(ptr, buf_size);
+    store_buffer(make_buffer_resource(ptr, buf_size), offset, val);
+  }
+
+  static __device__ __forceinline__ type load_buffer(i32x4_t rsrc,
+                                                     uint32_t offset) {
+    constexpr uint32_t aux = cache_policy_aux(LoadPolicy);
+    return __builtin_bit_cast(type,
+        llvm_amdgcn_raw_buffer_load_b64(rsrc, offset, 0, aux));
+  }
+
+  static __device__ __forceinline__ void store_buffer(i32x4_t rsrc,
+                                                      uint32_t offset,
+                                                      type val) {
     constexpr uint32_t aux = cache_policy_aux(StorePolicy);
     llvm_amdgcn_raw_buffer_store_b64(static_cast<uint64_t>(val),
                                      rsrc, offset, 0, aux);
@@ -1104,17 +1167,26 @@ struct AsmAccess<4, LoadPolicy, StorePolicy> {
   static __device__ __forceinline__ type load_buffer(const void *ptr,
                                                      uint32_t buf_size,
                                                      uint32_t offset) {
-    i32x4_t rsrc = make_buffer_resource(ptr, buf_size);
-    constexpr uint32_t aux = cache_policy_aux(LoadPolicy);
-    return __builtin_bit_cast(type,
-        llvm_amdgcn_raw_buffer_load_b32(rsrc, offset, 0, aux));
+    return load_buffer(make_buffer_resource(ptr, buf_size), offset);
   }
 
   static __device__ __forceinline__ void store_buffer(void *ptr,
                                                       uint32_t buf_size,
                                                       uint32_t offset,
                                                       type val) {
-    i32x4_t rsrc = make_buffer_resource(ptr, buf_size);
+    store_buffer(make_buffer_resource(ptr, buf_size), offset, val);
+  }
+
+  static __device__ __forceinline__ type load_buffer(i32x4_t rsrc,
+                                                     uint32_t offset) {
+    constexpr uint32_t aux = cache_policy_aux(LoadPolicy);
+    return __builtin_bit_cast(type,
+        llvm_amdgcn_raw_buffer_load_b32(rsrc, offset, 0, aux));
+  }
+
+  static __device__ __forceinline__ void store_buffer(i32x4_t rsrc,
+                                                      uint32_t offset,
+                                                      type val) {
     constexpr uint32_t aux = cache_policy_aux(StorePolicy);
     llvm_amdgcn_raw_buffer_store_b32(static_cast<uint32_t>(val),
                                      rsrc, offset, 0, aux);
@@ -1251,17 +1323,26 @@ struct AsmAccess<2, LoadPolicy, StorePolicy> {
   static __device__ __forceinline__ type load_buffer(const void *ptr,
                                                      uint32_t buf_size,
                                                      uint32_t offset) {
-    i32x4_t rsrc = make_buffer_resource(ptr, buf_size);
-    constexpr uint32_t aux = cache_policy_aux(LoadPolicy);
-    return static_cast<type>(
-        llvm_amdgcn_raw_buffer_load_b16(rsrc, offset, 0, aux));
+    return load_buffer(make_buffer_resource(ptr, buf_size), offset);
   }
 
   static __device__ __forceinline__ void store_buffer(void *ptr,
                                                       uint32_t buf_size,
                                                       uint32_t offset,
                                                       type val) {
-    i32x4_t rsrc = make_buffer_resource(ptr, buf_size);
+    store_buffer(make_buffer_resource(ptr, buf_size), offset, val);
+  }
+
+  static __device__ __forceinline__ type load_buffer(i32x4_t rsrc,
+                                                     uint32_t offset) {
+    constexpr uint32_t aux = cache_policy_aux(LoadPolicy);
+    return static_cast<type>(
+        llvm_amdgcn_raw_buffer_load_b16(rsrc, offset, 0, aux));
+  }
+
+  static __device__ __forceinline__ void store_buffer(i32x4_t rsrc,
+                                                      uint32_t offset,
+                                                      type val) {
     constexpr uint32_t aux = cache_policy_aux(StorePolicy);
     llvm_amdgcn_raw_buffer_store_b16(static_cast<uint16_t>(val),
                                      rsrc, offset, 0, aux);
@@ -1398,17 +1479,26 @@ struct AsmAccess<1, LoadPolicy, StorePolicy> {
   static __device__ __forceinline__ type load_buffer(const void *ptr,
                                                      uint32_t buf_size,
                                                      uint32_t offset) {
-    i32x4_t rsrc = make_buffer_resource(ptr, buf_size);
-    constexpr uint32_t aux = cache_policy_aux(LoadPolicy);
-    return static_cast<type>(
-        llvm_amdgcn_raw_buffer_load_b8(rsrc, offset, 0, aux));
+    return load_buffer(make_buffer_resource(ptr, buf_size), offset);
   }
 
   static __device__ __forceinline__ void store_buffer(void *ptr,
                                                       uint32_t buf_size,
                                                       uint32_t offset,
                                                       type val) {
-    i32x4_t rsrc = make_buffer_resource(ptr, buf_size);
+    store_buffer(make_buffer_resource(ptr, buf_size), offset, val);
+  }
+
+  static __device__ __forceinline__ type load_buffer(i32x4_t rsrc,
+                                                     uint32_t offset) {
+    constexpr uint32_t aux = cache_policy_aux(LoadPolicy);
+    return static_cast<type>(
+        llvm_amdgcn_raw_buffer_load_b8(rsrc, offset, 0, aux));
+  }
+
+  static __device__ __forceinline__ void store_buffer(i32x4_t rsrc,
+                                                      uint32_t offset,
+                                                      type val) {
     constexpr uint32_t aux = cache_policy_aux(StorePolicy);
     llvm_amdgcn_raw_buffer_store_b8(val, rsrc, offset, 0, aux);
   }

--- a/projects/rocshmem/src/assembly.hpp
+++ b/projects/rocshmem/src/assembly.hpp
@@ -761,7 +761,7 @@ make_buffer_resource(const void* base, uint32_t num_bytes) {
   rsrc[0] = static_cast<int32_t>(addr & 0xFFFFFFFFu);
   rsrc[1] = static_cast<int32_t>(addr >> 32);
 #if defined(__gfx1250__)
-  // MI400/gfx1250 V# descriptor:
+  // gfx1250 V# descriptor:
   //   bits  56:0   base address
   //   bits 101:57  num_records; all ones disables OOB checking
   //   bits 127:102 zero, including Type[127:126] == 0 for buffer
@@ -775,35 +775,6 @@ make_buffer_resource(const void* base, uint32_t num_bytes) {
   rsrc[3] = 0x31014000;
 #else
   // GFX9
-  rsrc[2] = static_cast<int32_t>(num_bytes);
-  rsrc[3] = 0x00020000;
-#endif
-  return rsrc;
-}
-
-// Same encoding as make_buffer_resource, but forces rsrc[0]/rsrc[1] (the
-// address) through v_readfirstlane_b32 so the result is provably wave-uniform
-// to the compiler. Only valid when base/num_bytes are genuinely the same
-// across every active lane (e.g. a workgroup-wide bulk copy) -- callers are
-// responsible for that invariant, since the hardware has no way to check it.
-// Without this, raw.buffer.* operand legalization inserts a full
-// readfirstlane/compare/exec-mask waterfall at *every* use of the resulting
-// i32x4_t, even if it's a single loop-invariant SSA value.
-__device__ __forceinline__ i32x4_t
-make_buffer_resource_uniform(const void* base, uint32_t num_bytes) {
-  uint64_t addr = reinterpret_cast<uint64_t>(base);
-  i32x4_t rsrc;
-  rsrc[0] = __builtin_amdgcn_readfirstlane(static_cast<int32_t>(addr & 0xFFFFFFFFu));
-  rsrc[1] = __builtin_amdgcn_readfirstlane(static_cast<int32_t>(addr >> 32));
-#if defined(__gfx1250__)
-  rsrc[1] = __builtin_amdgcn_readfirstlane(static_cast<int32_t>(
-      ((addr >> 32) & 0x01FFFFFFull) | (0x7Full << 25)));
-  rsrc[2] = static_cast<int32_t>(0xFFFFFFFFu);
-  rsrc[3] = 0x0000003F;
-#elif defined(__gfx1201__) || defined(__gfx1100__)
-  rsrc[2] = static_cast<int32_t>(num_bytes);
-  rsrc[3] = 0x31014000;
-#else
   rsrc[2] = static_cast<int32_t>(num_bytes);
   rsrc[3] = 0x00020000;
 #endif

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -531,15 +531,6 @@ __device__ __forceinline__ void copy_remainder(uint8_t* dst, uint8_t* src, int s
   }
 }
 
-// Prefix/tail bytes (< ChunkSize) are copied via copy_bulk<1, ...> rather
-// than a single tid==0 lane running copy_remainder: with group-cooperative
-// callers (stride > 1), gating a multi-step byte copy behind one lane forces
-// every other active lane to sit masked-off through the branch until
-// reconvergence -- paid on *every* call. Routing it through copy_bulk<1>
-// spreads the (at most ChunkSize-1) leftover bytes one-per-lane across
-// tid/stride instead, so it costs a single parallel step. For memcpy_lane
-// (tid=0, stride=1) this degenerates back to the same serial byte-by-byte
-// copy it already did.
 template <int ChunkSize, CachePolicy LP, CachePolicy SP, int Unroll,
           bool UniformBase = false>
 __device__ __forceinline__ void copy_aligned_body(uint8_t* dst, uint8_t* src,
@@ -578,8 +569,6 @@ __device__ __forceinline__ void copy_aligned_body(uint8_t* dst, uint8_t* src,
 // LANE, WAVE, AND WG IMPLEMENTATIONS
 // ==============================================================================
 
-// Blocking variants additionally drain all in-flight VMEM ops before returning.
-//
 // memcpy_lane is per-lane: many lanes may call it concurrently, each with its
 // own independent dst/src (see e.g. tile_put's element-by-element fallback).
 // It must NOT set UniformBase=true on copy_aligned_best_effort/copy_bulk --
@@ -627,7 +616,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
 
 // memcpy_wave is group-cooperative: every lane in the wave passes the same
 // dst/src and only differs by wave_tid/wave_size (folded into the per-access
-// offset inside copy_bulk), so UniformBase=true is safe here.
+// offset inside copy_bulk), so UniformBase=true
 template <MemcpyKind Kind = MemcpyKind::Put>
 [[maybe_unused]] __device__ __forceinline__ void memcpy_wave(void* dst, void* src, size_t size) {
   if (size == 0) return;
@@ -645,7 +634,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
                                                 static_cast<uint8_t*>(src),
                                                 size, wave_tid, wave_size);
   } else {
-    // The "Whatever Else" Path: Small sizes skip bulk setup entirely
+    // Small sizes skip bulk setup entirely
     if (wave_tid == 0) {
       copy_remainder<LP, SP>(static_cast<uint8_t*>(dst),
                              static_cast<uint8_t*>(src),
@@ -656,7 +645,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
 
 // memcpy_wg is group-cooperative: every lane in the workgroup passes the same
 // dst/src and only differs by tid/stride (folded into the per-access offset
-// inside copy_bulk), so UniformBase=true is safe here.
+// inside copy_bulk), so UniformBase=true 
 template <MemcpyKind Kind = MemcpyKind::Put>
 [[maybe_unused]] __device__ __forceinline__ void memcpy_wg(void* dst, void* src, size_t size) {
   if (size == 0) return;

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -400,43 +400,17 @@ constexpr bool is_blocking(MemcpyKind k) {
   return k == MemcpyKind::PutBlocking || k == MemcpyKind::GetBlocking;
 }
 
-// UniformBase: true iff every active lane calling this copy_bulk instance is
-// guaranteed to pass the *same* dst/src (a group-cooperative copy, where only
-// tid/stride vary the per-lane offset -- e.g. memcpy_wave/memcpy_wg). This is
-// a correctness precondition, not a hint: when true, the buffer descriptor's
-// address is forced through v_readfirstlane_b32 (see
-// make_buffer_resource_uniform), which broadcasts whatever address is in lane
-// 0 to every active lane. If some lanes actually hold different dst/src (as
-// in memcpy_lane, where each lane copies its own independent element), that
-// broadcast silently corrupts every lane but lane 0's transfer. Callers must
-// only set UniformBase=true when they can prove the shared-base invariant
-// themselves; the hardware/compiler cannot check it.
-//
-// The perf motivation: dst/src are plain VGPR args across this __noinline__
-// boundary, so LLVM's divergence analysis can't prove uniformity on its own
-// even when it happens to be loop-invariant. Operand legalization for
-// raw.buffer.* checks uniformity per *use*, not per SSA value, so a
-// non-provably-uniform descriptor re-triggers a full
-// readfirstlane/compare/exec-mask waterfall at every one of the Unroll
-// load_buffer/store_buffer calls below. Forcing it through readfirstlane once
-// up front (only where it's actually safe) turns that into a single upfront
-// broadcast.
-template <int ChunkSize, CachePolicy LoadPolicy, CachePolicy StorePolicy,
-          int Unroll, bool UniformBase = false>
-__device__ __noinline__ void copy_bulk(void* dst, void* src,
-                                          int n_chunks, int tid, int stride) {
+template <int ChunkSize, CachePolicy LoadPolicy, CachePolicy StorePolicy, int Unroll>
+__device__ __forceinline__ void copy_bulk(void* dst, void* src, int n_chunks, 
+                                          int tid, int stride) {
   using Acc = AsmAccess<ChunkSize, LoadPolicy, StorePolicy>;
   using T = typename Acc::type;
 
   const uint32_t buf_bytes = static_cast<uint32_t>(n_chunks * ChunkSize);
   i32x4_t src_rsrc, dst_rsrc;
-  if constexpr (UniformBase) {
-    src_rsrc = make_buffer_resource_uniform(src, buf_bytes);
-    dst_rsrc = make_buffer_resource_uniform(dst, buf_bytes);
-  } else {
-    src_rsrc = make_buffer_resource(src, buf_bytes);
-    dst_rsrc = make_buffer_resource(dst, buf_bytes);
-  }
+  src_rsrc = make_buffer_resource(src, buf_bytes);
+  dst_rsrc = make_buffer_resource(dst, buf_bytes);
+
   int chunk_batch = stride * Unroll;
   int offset = 0;
   T regs[Unroll] = {};
@@ -531,8 +505,7 @@ __device__ __forceinline__ void copy_remainder(uint8_t* dst, uint8_t* src, int s
   }
 }
 
-template <int ChunkSize, CachePolicy LP, CachePolicy SP, int Unroll,
-          bool UniformBase = false>
+template <int ChunkSize, CachePolicy LP, CachePolicy SP, int Unroll>
 __device__ __forceinline__ void copy_aligned_body(uint8_t* dst, uint8_t* src,
                                                   size_t size, int tid,
                                                   int stride) {
@@ -554,7 +527,7 @@ __device__ __forceinline__ void copy_aligned_body(uint8_t* dst, uint8_t* src,
   int n_chunks = static_cast<int>(size / ChunkSize);
   int remainder = static_cast<int>(size % ChunkSize);
 
-  copy_bulk<ChunkSize, LP, SP, Unroll, UniformBase>(dst, src, n_chunks, tid, stride);
+  copy_bulk<ChunkSize, LP, SP, Unroll>(dst, src, n_chunks, tid, stride);
 
   if (tid == 0 && remainder > 0) {
     copy_suffix<LP, SP>(
@@ -564,20 +537,12 @@ __device__ __forceinline__ void copy_aligned_body(uint8_t* dst, uint8_t* src,
   }
 }
 
-
 // ==============================================================================
 // LANE, WAVE, AND WG IMPLEMENTATIONS
 // ==============================================================================
-
-// memcpy_lane is per-lane: many lanes may call it concurrently, each with its
-// own independent dst/src (see e.g. tile_put's element-by-element fallback).
-// It must NOT set UniformBase=true on copy_aligned_best_effort/copy_bulk --
-// doing so would broadcast one lane's address to every lane via
-// readfirstlane and silently corrupt the others' transfers. Contrast with
-// memcpy_wave/memcpy_wg below, which are group-cooperative: every
-// participating lane is guaranteed to pass the same dst/src.
 template <MemcpyKind Kind = MemcpyKind::Put>
-[[maybe_unused]] __device__ __forceinline__ void memcpy_lane(void* dst, void* src, size_t size) {
+[[maybe_unused]] __device__ __forceinline__ 
+  void memcpy_lane(void* dst, void* src, size_t size) {
   if (size == 0) return;
 
   constexpr int Unroll = 8;
@@ -601,12 +566,12 @@ template <MemcpyKind Kind = MemcpyKind::Put>
     }
   }
   // Normal cache-bypass path for small transfers or single-lane execution
-  else {
+  else [[likely]] {
     if (size >= 16) {
       copy_aligned_body<16, LP, SP, Unroll>(static_cast<uint8_t*>(dst),
                                             static_cast<uint8_t*>(src),
                                             size, 0, 1);
-    } else {
+    } else [[likely]] {
       copy_remainder<LP, SP>(static_cast<uint8_t*>(dst),
                              static_cast<uint8_t*>(src),
                              size);
@@ -618,7 +583,8 @@ template <MemcpyKind Kind = MemcpyKind::Put>
 // dst/src and only differs by wave_tid/wave_size (folded into the per-access
 // offset inside copy_bulk), so UniformBase=true
 template <MemcpyKind Kind = MemcpyKind::Put>
-[[maybe_unused]] __device__ __forceinline__ void memcpy_wave(void* dst, void* src, size_t size) {
+[[maybe_unused]] __device__ __forceinline__ 
+  void memcpy_wave(void* dst, void* src, size_t size) {
   if (size == 0) return;
 
   constexpr int Unroll = 8;
@@ -630,10 +596,10 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   int wave_size{wave_SZ()};
 
   if (size >= 16) {
-    copy_aligned_body<16, LP, SP, Unroll, true>(static_cast<uint8_t*>(dst),
-                                                static_cast<uint8_t*>(src),
-                                                size, wave_tid, wave_size);
-  } else {
+    copy_aligned_body<16, LP, SP, Unroll>(static_cast<uint8_t*>(dst),
+                                          static_cast<uint8_t*>(src),
+                                          size, wave_tid, wave_size);
+  } else [[likely]] {
     // Small sizes skip bulk setup entirely
     if (wave_tid == 0) {
       copy_remainder<LP, SP>(static_cast<uint8_t*>(dst),
@@ -643,11 +609,9 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   }
 }
 
-// memcpy_wg is group-cooperative: every lane in the workgroup passes the same
-// dst/src and only differs by tid/stride (folded into the per-access offset
-// inside copy_bulk), so UniformBase=true 
 template <MemcpyKind Kind = MemcpyKind::Put>
-[[maybe_unused]] __device__ __forceinline__ void memcpy_wg(void* dst, void* src, size_t size) {
+[[maybe_unused]] __device__ __forceinline__ 
+  void memcpy_wg(void* dst, void* src, size_t size) {
   if (size == 0) return;
 
   constexpr int Unroll = 8;
@@ -659,10 +623,10 @@ template <MemcpyKind Kind = MemcpyKind::Put>
   int stride = get_flat_block_size();
 
   if (size >= 16) {
-    copy_aligned_body<16, LP, SP, Unroll, true>(static_cast<uint8_t*>(dst),
-                                                static_cast<uint8_t*>(src),
-                                                size, tid, stride);
-  } else {
+    copy_aligned_body<16, LP, SP, Unroll>(static_cast<uint8_t*>(dst),
+                                          static_cast<uint8_t*>(src),
+                                          size, tid, stride);
+  } else [[likely]] {
     // Small sizes skip bulk setup entirely
     if (tid == 0) {
       copy_remainder<LP, SP>(static_cast<uint8_t*>(dst),

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -387,7 +387,6 @@ __device__ __forceinline__ bool is_last_active_lane() {
   }
 }
 
-
 #define LOAD(VAR) __atomic_load_n((VAR), __ATOMIC_SEQ_CST)
 #define STORE(DST, SRC) __atomic_store_n((DST), (SRC), __ATOMIC_SEQ_CST)
 
@@ -401,13 +400,43 @@ constexpr bool is_blocking(MemcpyKind k) {
   return k == MemcpyKind::PutBlocking || k == MemcpyKind::GetBlocking;
 }
 
-template <int ChunkSize, CachePolicy LoadPolicy, CachePolicy StorePolicy, int Unroll>
+// UniformBase: true iff every active lane calling this copy_bulk instance is
+// guaranteed to pass the *same* dst/src (a group-cooperative copy, where only
+// tid/stride vary the per-lane offset -- e.g. memcpy_wave/memcpy_wg). This is
+// a correctness precondition, not a hint: when true, the buffer descriptor's
+// address is forced through v_readfirstlane_b32 (see
+// make_buffer_resource_uniform), which broadcasts whatever address is in lane
+// 0 to every active lane. If some lanes actually hold different dst/src (as
+// in memcpy_lane, where each lane copies its own independent element), that
+// broadcast silently corrupts every lane but lane 0's transfer. Callers must
+// only set UniformBase=true when they can prove the shared-base invariant
+// themselves; the hardware/compiler cannot check it.
+//
+// The perf motivation: dst/src are plain VGPR args across this __noinline__
+// boundary, so LLVM's divergence analysis can't prove uniformity on its own
+// even when it happens to be loop-invariant. Operand legalization for
+// raw.buffer.* checks uniformity per *use*, not per SSA value, so a
+// non-provably-uniform descriptor re-triggers a full
+// readfirstlane/compare/exec-mask waterfall at every one of the Unroll
+// load_buffer/store_buffer calls below. Forcing it through readfirstlane once
+// up front (only where it's actually safe) turns that into a single upfront
+// broadcast.
+template <int ChunkSize, CachePolicy LoadPolicy, CachePolicy StorePolicy,
+          int Unroll, bool UniformBase = false>
 __device__ __noinline__ void copy_bulk(void* dst, void* src,
                                           int n_chunks, int tid, int stride) {
   using Acc = AsmAccess<ChunkSize, LoadPolicy, StorePolicy>;
   using T = typename Acc::type;
 
   const uint32_t buf_bytes = static_cast<uint32_t>(n_chunks * ChunkSize);
+  i32x4_t src_rsrc, dst_rsrc;
+  if constexpr (UniformBase) {
+    src_rsrc = make_buffer_resource_uniform(src, buf_bytes);
+    dst_rsrc = make_buffer_resource_uniform(dst, buf_bytes);
+  } else {
+    src_rsrc = make_buffer_resource(src, buf_bytes);
+    dst_rsrc = make_buffer_resource(dst, buf_bytes);
+  }
   int chunk_batch = stride * Unroll;
   int offset = 0;
   T regs[Unroll] = {};
@@ -417,12 +446,12 @@ __device__ __noinline__ void copy_bulk(void* dst, void* src,
   for (; offset + chunk_batch <= n_chunks; offset += chunk_batch) {
     #pragma unroll
     for (int u = 0; u < Unroll; ++u) {
-      regs[u] = Acc::load_buffer(src, buf_bytes,
+      regs[u] = Acc::load_buffer(src_rsrc,
           static_cast<uint32_t>((offset + tid + u * stride) * ChunkSize));
     }
     #pragma unroll
     for (int u = 0; u < Unroll; ++u) {
-      Acc::store_buffer(dst, buf_bytes,
+      Acc::store_buffer(dst_rsrc,
           static_cast<uint32_t>((offset + tid + u * stride) * ChunkSize), regs[u]);
     }
   }
@@ -434,156 +463,223 @@ __device__ __noinline__ void copy_bulk(void* dst, void* src,
   }
 }
 
-// ==============================================================================
-// REMAINDER COPY (< 16 Bytes Fast Path)
-// ==============================================================================
 template <CachePolicy LP, CachePolicy SP>
-__device__ __forceinline__ void copy_remainder(uint8_t* dst,
-                                               uint8_t* src,
-                                               int remainder) {
-  if (remainder == 0) return;
-
-  if (remainder & 1) {
-    auto val = AsmAccess<1, LP, SP>::load(src);
-    AsmAccess<1, LP, SP>::store(dst, val);
-    if (remainder == 1) {
-      return;
-    }
-    dst += 1;
-    src += 1;
+__device__ __forceinline__ void copy_prefix(uint8_t* dst, uint8_t* src, size_t prefix) {
+  // Bottom-up evaluation mathematically guarantees alignment buildup without checking
+  if (prefix & 1) {
+    AsmAccess<1, LP, SP>::store(dst, AsmAccess<1, LP, SP>::load(src));
+    dst += 1; src += 1;
   }
-  if (remainder & 2) {
-    auto val = AsmAccess<2, LP, SP>::load(src);
-    AsmAccess<2, LP, SP>::store(dst, val);
-    if (remainder == 2) {
-      return;
-    }
-    dst += 2;
-    src += 2;
+  if (prefix & 2) {
+    AsmAccess<2, LP, SP>::store(dst, AsmAccess<2, LP, SP>::load(src));
+    dst += 2; src += 2;
   }
-  if (remainder & 4) {
-    auto val = AsmAccess<4, LP, SP>::load(src);
-    AsmAccess<4, LP, SP>::store(dst, val);
-    if (remainder == 4) {
-      return;
-    }
-    dst += 4;
-    src += 4;
+  if (prefix & 4) {
+    AsmAccess<4, LP, SP>::store(dst, AsmAccess<4, LP, SP>::load(src));
+    dst += 4; src += 4;
   }
-  if (remainder & 8) {
-    auto val = AsmAccess<8, LP, SP>::load(src);
-    AsmAccess<8, LP, SP>::store(dst, val);
+  if (prefix & 8) {
+    AsmAccess<8, LP, SP>::store(dst, AsmAccess<8, LP, SP>::load(src));
   }
 }
+
+template <CachePolicy LP, CachePolicy SP>
+__device__ __forceinline__ void copy_suffix(uint8_t* dst, uint8_t* src, size_t remainder) {
+  if (remainder & 8) {
+    AsmAccess<8, LP, SP>::store(dst, AsmAccess<8, LP, SP>::load(src));
+    dst += 8; src += 8;
+  }
+  if (remainder & 4) {
+    AsmAccess<4, LP, SP>::store(dst, AsmAccess<4, LP, SP>::load(src));
+    dst += 4; src += 4;
+  }
+  if (remainder & 2) {
+    AsmAccess<2, LP, SP>::store(dst, AsmAccess<2, LP, SP>::load(src));
+    dst += 2; src += 2;
+  }
+  if (remainder & 1) {
+    AsmAccess<1, LP, SP>::store(dst, AsmAccess<1, LP, SP>::load(src));
+  }
+}
+
+template <CachePolicy LP, CachePolicy SP>
+__device__ __forceinline__ void copy_remainder(uint8_t* dst, uint8_t* src, int size) {
+  while (size > 0) {
+    // Dynamically check alignment at the current pointer position
+    uintptr_t align = reinterpret_cast<uintptr_t>(dst) | reinterpret_cast<uintptr_t>(src);
+
+    if (size >= 8 && (align & 7) == 0) {
+      auto val = AsmAccess<8, LP, SP>::load(src);
+      AsmAccess<8, LP, SP>::store(dst, val);
+      dst += 8; src += 8; size -= 8;
+    }
+    else if (size >= 4 && (align & 3) == 0) {
+      auto val = AsmAccess<4, LP, SP>::load(src);
+      AsmAccess<4, LP, SP>::store(dst, val);
+      dst += 4; src += 4; size -= 4;
+    }
+    else if (size >= 2 && (align & 1) == 0) {
+      auto val = AsmAccess<2, LP, SP>::load(src);
+      AsmAccess<2, LP, SP>::store(dst, val);
+      dst += 2; src += 2; size -= 2;
+    }
+    else {
+      auto val = AsmAccess<1, LP, SP>::load(src);
+      AsmAccess<1, LP, SP>::store(dst, val);
+      dst += 1; src += 1; size -= 1;
+    }
+  }
+}
+
+// Prefix/tail bytes (< ChunkSize) are copied via copy_bulk<1, ...> rather
+// than a single tid==0 lane running copy_remainder: with group-cooperative
+// callers (stride > 1), gating a multi-step byte copy behind one lane forces
+// every other active lane to sit masked-off through the branch until
+// reconvergence -- paid on *every* call. Routing it through copy_bulk<1>
+// spreads the (at most ChunkSize-1) leftover bytes one-per-lane across
+// tid/stride instead, so it costs a single parallel step. For memcpy_lane
+// (tid=0, stride=1) this degenerates back to the same serial byte-by-byte
+// copy it already did.
+template <int ChunkSize, CachePolicy LP, CachePolicy SP, int Unroll,
+          bool UniformBase = false>
+__device__ __forceinline__ void copy_aligned_body(uint8_t* dst, uint8_t* src,
+                                                  size_t size, int tid,
+                                                  int stride) {
+  uintptr_t dst_addr = reinterpret_cast<uintptr_t>(dst);
+  size_t prefix = (-dst_addr) & (ChunkSize - 1);
+
+  if (prefix > size) {
+    prefix = size;
+  }
+
+  if (tid == 0 && prefix > 0) {
+    copy_prefix<LP, SP>(dst, src, prefix);
+  }
+
+  dst += prefix;
+  src += prefix;
+  size -= prefix;
+
+  int n_chunks = static_cast<int>(size / ChunkSize);
+  int remainder = static_cast<int>(size % ChunkSize);
+
+  copy_bulk<ChunkSize, LP, SP, Unroll, UniformBase>(dst, src, n_chunks, tid, stride);
+
+  if (tid == 0 && remainder > 0) {
+    copy_suffix<LP, SP>(
+        dst + static_cast<size_t>(n_chunks) * ChunkSize,
+        src + static_cast<size_t>(n_chunks) * ChunkSize,
+        remainder);
+  }
+}
+
 
 // ==============================================================================
 // LANE, WAVE, AND WG IMPLEMENTATIONS
 // ==============================================================================
 
 // Blocking variants additionally drain all in-flight VMEM ops before returning.
+//
+// memcpy_lane is per-lane: many lanes may call it concurrently, each with its
+// own independent dst/src (see e.g. tile_put's element-by-element fallback).
+// It must NOT set UniformBase=true on copy_aligned_best_effort/copy_bulk --
+// doing so would broadcast one lane's address to every lane via
+// readfirstlane and silently corrupt the others' transfers. Contrast with
+// memcpy_wave/memcpy_wg below, which are group-cooperative: every
+// participating lane is guaranteed to pass the same dst/src.
 template <MemcpyKind Kind = MemcpyKind::Put>
-[[maybe_unused]] __device__ __forceinline__ void memcpy_lane(void* dst, void* src,
-                                                             size_t size) {
+[[maybe_unused]] __device__ __forceinline__ void memcpy_lane(void* dst, void* src, size_t size) {
   if (size == 0) return;
 
-  constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 8;
-  // Compile-time bypass policy: cache-bypass in the direction of the remote side.
-  constexpr CachePolicy LP = is_put(Kind) ? CachePolicy::Standard    : CachePolicy::SystemScope;
+  constexpr int Unroll = 8;
+
+  constexpr CachePolicy LP = is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;
   constexpr CachePolicy SP = is_put(Kind) ? CachePolicy::SystemScope : CachePolicy::Standard;
 
-  int n_chunks  = static_cast<int>(size / ChunkSize);
-  int remainder = static_cast<int>(size % ChunkSize);
-
+  // Many threads, large transfer: use cached Standard policy + system fences
   if (size >= 16 && get_flat_block_size() > 4) {
-    // Many threads, large transfer: use cached Standard policy.
-    // Fences are direction-specific to maintain system-scope coherence.
     if constexpr (!is_put(Kind)) {
       detail::atomic::threadfence<detail::atomic::memory_scope_system,
                                   detail::atomic::memory_order_acquire>();
     }
 
-    if (n_chunks > 0) {
-      copy_bulk<ChunkSize, CachePolicy::Standard, CachePolicy::Standard, 8>(
-          dst, src, n_chunks, 0, 1);
-    }
-    copy_remainder<CachePolicy::Standard, CachePolicy::Standard>(
-        static_cast<uint8_t*>(dst) + n_chunks * ChunkSize,
-        static_cast<uint8_t*>(src) + n_chunks * ChunkSize, remainder);
+    copy_aligned_body<16, CachePolicy::Standard, CachePolicy::Standard, Unroll>(
+        static_cast<uint8_t*>(dst), static_cast<uint8_t*>(src), size, 0, 1);
 
     if constexpr (is_put(Kind)) {
       detail::atomic::threadfence<detail::atomic::memory_scope_system,
                                   detail::atomic::memory_order_release>();
     }
-  } else {
-    // Small transfer or single-lane: cache-bypass policy provides direct
-    // remote visibility without explicit fences.
-    if (n_chunks > 0) {
-      copy_bulk<ChunkSize, LP, SP, Unroll>(dst, src, n_chunks, 0, 1);
+  }
+  // Normal cache-bypass path for small transfers or single-lane execution
+  else {
+    if (size >= 16) {
+      copy_aligned_body<16, LP, SP, Unroll>(static_cast<uint8_t*>(dst),
+                                            static_cast<uint8_t*>(src),
+                                            size, 0, 1);
+    } else {
+      copy_remainder<LP, SP>(static_cast<uint8_t*>(dst),
+                             static_cast<uint8_t*>(src),
+                             size);
     }
-    copy_remainder<LP, SP>(
-        static_cast<uint8_t*>(dst) + n_chunks * ChunkSize,
-        static_cast<uint8_t*>(src) + n_chunks * ChunkSize, remainder);
   }
 }
 
+// memcpy_wave is group-cooperative: every lane in the wave passes the same
+// dst/src and only differs by wave_tid/wave_size (folded into the per-access
+// offset inside copy_bulk), so UniformBase=true is safe here.
 template <MemcpyKind Kind = MemcpyKind::Put>
-[[maybe_unused]] __device__ __forceinline__ void memcpy_wave(void* dst, void* src,
-                                                             size_t size) {
+[[maybe_unused]] __device__ __forceinline__ void memcpy_wave(void* dst, void* src, size_t size) {
   if (size == 0) return;
 
-  constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 8;
+  constexpr int Unroll = 8;
 
-  constexpr CachePolicy LP =
-      is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;
-  constexpr CachePolicy SP =
-      is_put(Kind) ? CachePolicy::SystemScope : CachePolicy::Standard;
+  constexpr CachePolicy LP = is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;
+  constexpr CachePolicy SP = is_put(Kind) ? CachePolicy::SystemScope : CachePolicy::Standard;
 
   int wave_tid = get_flat_block_id() % WF_SIZE;
   int wave_size{wave_SZ()};
-  int n_chunks = size / ChunkSize;
-  int remainder = size % ChunkSize;
 
-  if (n_chunks > 0) {
-    copy_bulk<ChunkSize, LP, SP, Unroll>(dst, src, n_chunks, wave_tid, wave_size);
-  }
-
-  // Remainder handled uniquely by the first thread in the wave
-  if (wave_tid == 0) {
-    copy_remainder<LP, SP>(static_cast<uint8_t*>(dst) + n_chunks * ChunkSize,
-                           static_cast<uint8_t*>(src) + n_chunks * ChunkSize, 
-                           remainder);
+  if (size >= 16) {
+    copy_aligned_body<16, LP, SP, Unroll, true>(static_cast<uint8_t*>(dst),
+                                                static_cast<uint8_t*>(src),
+                                                size, wave_tid, wave_size);
+  } else {
+    // The "Whatever Else" Path: Small sizes skip bulk setup entirely
+    if (wave_tid == 0) {
+      copy_remainder<LP, SP>(static_cast<uint8_t*>(dst),
+                             static_cast<uint8_t*>(src),
+                             size);
+    }
   }
 }
 
+// memcpy_wg is group-cooperative: every lane in the workgroup passes the same
+// dst/src and only differs by tid/stride (folded into the per-access offset
+// inside copy_bulk), so UniformBase=true is safe here.
 template <MemcpyKind Kind = MemcpyKind::Put>
-[[maybe_unused]] __device__ __forceinline__ void memcpy_wg(void* dst, void* src,
-                                                           size_t size) {
+[[maybe_unused]] __device__ __forceinline__ void memcpy_wg(void* dst, void* src, size_t size) {
   if (size == 0) return;
 
-  constexpr int ChunkSize = 16;
-  constexpr int Unroll    = 8;
+  constexpr int Unroll = 8;
 
-  constexpr CachePolicy LP =
-      is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;
-  constexpr CachePolicy SP =
-      is_put(Kind) ? CachePolicy::SystemScope : CachePolicy::Standard;
+  constexpr CachePolicy LP = is_put(Kind) ? CachePolicy::Standard : CachePolicy::SystemScope;
+  constexpr CachePolicy SP = is_put(Kind) ? CachePolicy::SystemScope : CachePolicy::Standard;
 
-  int thread_id = get_flat_block_id();
-  int block_size = get_flat_block_size();
-  int n_chunks = size / ChunkSize;
-  int remainder = size % ChunkSize;
+  int tid = get_flat_block_id();
+  int stride = get_flat_block_size();
 
-  if (n_chunks > 0) {
-    copy_bulk<ChunkSize, LP, SP, Unroll>(dst, src, n_chunks, thread_id, block_size);
-  }
-
-  // Remainder handled uniquely by the first thread in the workgroup
-  if (thread_id == 0) {
-    copy_remainder<LP, SP>(static_cast<uint8_t*>(dst) + n_chunks * ChunkSize,
-                           static_cast<uint8_t*>(src) + n_chunks * ChunkSize,
-                           remainder);
+  if (size >= 16) {
+    copy_aligned_body<16, LP, SP, Unroll, true>(static_cast<uint8_t*>(dst),
+                                                static_cast<uint8_t*>(src),
+                                                size, tid, stride);
+  } else {
+    // Small sizes skip bulk setup entirely
+    if (tid == 0) {
+      copy_remainder<LP, SP>(static_cast<uint8_t*>(dst),
+                             static_cast<uint8_t*>(src),
+                             size);
+    }
   }
 }
 

--- a/projects/rocshmem/src/util.hpp
+++ b/projects/rocshmem/src/util.hpp
@@ -511,11 +511,7 @@ __device__ __forceinline__ void copy_aligned_body(uint8_t* dst, uint8_t* src,
                                                   int stride) {
   uintptr_t dst_addr = reinterpret_cast<uintptr_t>(dst);
   size_t prefix = (-dst_addr) & (ChunkSize - 1);
-
-  if (prefix > size) {
-    prefix = size;
-  }
-
+  
   if (tid == 0 && prefix > 0) {
     copy_prefix<LP, SP>(dst, src, prefix);
   }
@@ -541,8 +537,7 @@ __device__ __forceinline__ void copy_aligned_body(uint8_t* dst, uint8_t* src,
 // LANE, WAVE, AND WG IMPLEMENTATIONS
 // ==============================================================================
 template <MemcpyKind Kind = MemcpyKind::Put>
-[[maybe_unused]] __device__ __forceinline__ 
-  void memcpy_lane(void* dst, void* src, size_t size) {
+[[maybe_unused]] __device__ __forceinline__ void memcpy_lane(void* dst, void* src, size_t size) {
   if (size == 0) return;
 
   constexpr int Unroll = 8;
@@ -566,12 +561,12 @@ template <MemcpyKind Kind = MemcpyKind::Put>
     }
   }
   // Normal cache-bypass path for small transfers or single-lane execution
-  else [[likely]] {
+  else {
     if (size >= 16) {
       copy_aligned_body<16, LP, SP, Unroll>(static_cast<uint8_t*>(dst),
                                             static_cast<uint8_t*>(src),
                                             size, 0, 1);
-    } else [[likely]] {
+    } else {
       copy_remainder<LP, SP>(static_cast<uint8_t*>(dst),
                              static_cast<uint8_t*>(src),
                              size);
@@ -581,10 +576,9 @@ template <MemcpyKind Kind = MemcpyKind::Put>
 
 // memcpy_wave is group-cooperative: every lane in the wave passes the same
 // dst/src and only differs by wave_tid/wave_size (folded into the per-access
-// offset inside copy_bulk), so UniformBase=true
+// offset inside copy_bulk)
 template <MemcpyKind Kind = MemcpyKind::Put>
-[[maybe_unused]] __device__ __forceinline__ 
-  void memcpy_wave(void* dst, void* src, size_t size) {
+[[maybe_unused]] __device__ __forceinline__ void memcpy_wave(void* dst, void* src, size_t size) {
   if (size == 0) return;
 
   constexpr int Unroll = 8;
@@ -599,7 +593,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
     copy_aligned_body<16, LP, SP, Unroll>(static_cast<uint8_t*>(dst),
                                           static_cast<uint8_t*>(src),
                                           size, wave_tid, wave_size);
-  } else [[likely]] {
+  } else {
     // Small sizes skip bulk setup entirely
     if (wave_tid == 0) {
       copy_remainder<LP, SP>(static_cast<uint8_t*>(dst),
@@ -610,8 +604,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
 }
 
 template <MemcpyKind Kind = MemcpyKind::Put>
-[[maybe_unused]] __device__ __forceinline__ 
-  void memcpy_wg(void* dst, void* src, size_t size) {
+[[maybe_unused]] __device__ __forceinline__ void memcpy_wg(void* dst, void* src, size_t size) {
   if (size == 0) return;
 
   constexpr int Unroll = 8;
@@ -626,7 +619,7 @@ template <MemcpyKind Kind = MemcpyKind::Put>
     copy_aligned_body<16, LP, SP, Unroll>(static_cast<uint8_t*>(dst),
                                           static_cast<uint8_t*>(src),
                                           size, tid, stride);
-  } else [[likely]] {
+  } else {
     // Small sizes skip bulk setup entirely
     if (tid == 0) {
       copy_remainder<LP, SP>(static_cast<uint8_t*>(dst),


### PR DESCRIPTION
## Motivation

This PR adds an unaligned fallback path for the device memcpy helpers in `src/util.hpp`. The existing 16-byte chunk path is preserved for aligned operands, while unaligned operands are copied through the fallback chain. 

## Technical Details

The memcpy helpers use 16-byte chunks for efficient device copies. If either operand is not aligned for that access size, the vectorized load/store can fault and appear as an illegal memory access. The fallback avoids issuing those 16-byte accesses for unaligned copies

## JIRA ID

JIRA ID: AIROCSHMEM-445

## Test Result

- Unit tests and functional tests pass on gfx950 and gfx942
- DeepEP works fine
- Although the all-to-all test should not produce unaligned addresses in the first place, but the illegal memory access causing from that function is now fixed as a side effect of this PR.

