### PR TITLE
fix(kpack): guard splitting against empty target matches

### DIFF
--- a/shared/kpack/python/rocm_kpack/artifact_splitter.py
+++ b/shared/kpack/python/rocm_kpack/artifact_splitter.py
@@ -799,6 +799,21 @@ class ArtifactSplitter:
                 all_kernels_by_arch, output_dir
             )
 
+        if (
+            fat_binaries_by_prefix
+            and self.gpu_targets is not None
+            and not kpack_info_by_arch
+        ):
+            target_list = ", ".join(sorted(self.gpu_targets))
+            fat_binary_count = sum(
+                len(paths) for paths in fat_binaries_by_prefix.values()
+            )
+            raise RuntimeError(
+                f"Found {fat_binary_count} fat binaries, but no device code objects "
+                f"matched --gpu-targets ({target_list}). Refusing to emit an "
+                "untransformed generic artifact."
+            )
+
         # Phase 6: Inject kpack references and strip device code from fat binaries
         if fat_binaries_by_prefix and kpack_info_by_arch:
             generic_artifact_dir = output_dir / f"{self.artifact_prefix}_generic"

--- a/shared/kpack/python/rocm_kpack/tools/verify_artifacts.py
+++ b/shared/kpack/python/rocm_kpack/tools/verify_artifacts.py
@@ -4,7 +4,7 @@
 Tool for verifying split artifacts meet expected invariants.
 
 This tool validates that artifact splitting produced correct output:
-- Fat binaries converted to host-only (PROGBITS -> NOBITS)
+- Fat binaries transformed for kpack (device sections stripped/zero-paged)
 - Architecture separation is correct
 - Kpack archives are valid
 - Manifest files are present and valid
@@ -12,6 +12,7 @@ This tool validates that artifact splitting produced correct output:
 
 import argparse
 import re
+import struct
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -19,7 +20,21 @@ from typing import Optional
 
 import msgpack
 
-from rocm_kpack.binutils import Toolchain, has_section, get_section_type
+from rocm_kpack.binutils import Toolchain
+from rocm_kpack.coff.kpack_transform import (
+    HIPF_MAGIC as COFF_HIPF_MAGIC,
+    HIPK_MAGIC as COFF_HIPK_MAGIC,
+    WRAPPER_SIZE as COFF_WRAPPER_SIZE,
+)
+from rocm_kpack.coff.surgery import CoffSurgery
+from rocm_kpack.elf.kpack_transform import (
+    HIPF_MAGIC as ELF_HIPF_MAGIC,
+    HIPK_MAGIC as ELF_HIPK_MAGIC,
+    WRAPPER_SIZE as ELF_WRAPPER_SIZE,
+)
+from rocm_kpack.elf.surgery import ElfSurgery
+from rocm_kpack.elf.types import SHT_NOBITS, SHT_PROGBITS
+from rocm_kpack.format_detect import detect_binary_format, UnsupportedBinaryFormat
 
 
 @dataclass
@@ -30,6 +45,21 @@ class VerificationResult:
     passed: bool
     message: str
     details: list[str]
+
+
+@dataclass
+class FatBinaryInspection:
+    """Generic-artifact fat binary conversion state."""
+
+    binary_format: str
+    fatbin_section: str
+    section_state: str
+    has_kpack_ref: bool
+    hipf_magic: int
+    hipk_magic: int
+    wrapper_magics: list[int]
+    wrapper_error: Optional[str] = None
+    inspection_error: Optional[str] = None
 
 
 class ArtifactVerifier:
@@ -120,15 +150,17 @@ class ArtifactVerifier:
             VerificationResult(
                 "Artifact Manifests",
                 all_passed,
-                "All manifests present and valid"
-                if all_passed
-                else "Some manifests missing or invalid",
+                (
+                    "All manifests present and valid"
+                    if all_passed
+                    else "Some manifests missing or invalid"
+                ),
                 details,
             )
         )
 
     def _check_fat_binary_conversion(self, artifacts: list[Path]) -> None:
-        """Verify fat binaries were converted to host-only (PROGBITS -> NOBITS)."""
+        """Verify generic fat binaries were converted to kpack host binaries."""
         print("CHECK: Fat Binary Conversion")
         print("-" * 70)
 
@@ -147,55 +179,54 @@ class ArtifactVerifier:
             return
 
         for artifact in generic_artifacts:
-            # Find all .so files
-            so_files = list(artifact.glob("**/*.so*"))
-            # Filter to actual files (not symlinks)
-            so_files = [f for f in so_files if f.is_file() and not f.is_symlink()]
+            artifact_files = [
+                f for f in artifact.rglob("*") if f.is_file() and not f.is_symlink()
+            ]
 
             converted_binaries = []
             host_only_binaries = []
             failed_binaries = []
 
-            for so_file in so_files:
-                file_size = so_file.stat().st_size
+            for binary_path in artifact_files:
+                file_size = binary_path.stat().st_size
                 size_mb = file_size / (1024 * 1024)
-                rel_path = so_file.relative_to(artifact)
+                rel_path = binary_path.relative_to(artifact)
 
-                # Check if has .hip_fatbin section
-                section_info = self._get_hip_fatbin_section(so_file)
-                if section_info is None:
-                    host_only_binaries.append((rel_path, size_mb))
+                inspection, is_binary = self._inspect_fat_binary_conversion(binary_path)
+                if inspection is None:
+                    if is_binary:
+                        host_only_binaries.append((rel_path, size_mb))
                     continue
 
-                section_type, section_size = section_info
-
-                if section_type == "PROGBITS":
-                    failed_binaries.append(
-                        (rel_path, size_mb, "Still has PROGBITS .hip_fatbin")
-                    )
+                failures = self._fat_binary_conversion_failures(inspection)
+                if failures:
+                    failed_binaries.append((rel_path, size_mb, "; ".join(failures)))
                     all_passed = False
-                elif section_type == "NOBITS":
-                    # Check for .rocm_kpack_ref marker
-                    has_marker = self._has_kpack_ref(so_file)
-                    if has_marker:
-                        converted_binaries.append((rel_path, size_mb))
-                    else:
-                        failed_binaries.append(
-                            (rel_path, size_mb, "NOBITS but missing .rocm_kpack_ref")
+                else:
+                    converted_binaries.append(
+                        (
+                            rel_path,
+                            size_mb,
+                            inspection.binary_format,
+                            inspection.section_state,
                         )
-                        all_passed = False
+                    )
 
             # Print summary
             details.append(
-                f"  Summary: {len(converted_binaries)} converted, {len(host_only_binaries)} host-only, {len(failed_binaries)} failed"
+                f"  Summary: {len(converted_binaries)} kpack-transformed, {len(host_only_binaries)} host-only, {len(failed_binaries)} failed"
             )
             details.append("")
 
             # Print converted binaries
             if converted_binaries:
-                details.append("  Converted (fat → host-only):")
-                for path, size in sorted(converted_binaries):
-                    details.append(f"    ✓ {path} ({size:.1f}M)")
+                details.append("  Kpack-transformed fat binaries:")
+                for path, size, binary_format, section_state in sorted(
+                    converted_binaries
+                ):
+                    details.append(
+                        f"    ✓ {path} ({size:.1f}M, {binary_format}, {section_state})"
+                    )
                 details.append("")
 
             # Print host-only binaries
@@ -207,15 +238,15 @@ class ArtifactVerifier:
 
             # Print failures
             if failed_binaries:
-                details.append("  Failed conversions:")
+                details.append("  Failed kpack transformations:")
                 for path, size, reason in sorted(failed_binaries):
                     details.append(f"    ✗ {path} ({size:.1f}M) - {reason}")
                 details.append("")
 
         if all_passed:
-            print("✓ All fat binaries correctly converted to NOBITS\n")
+            print("✓ All fat binaries are kpack-transformed\n")
         else:
-            print("✗ Some binaries still have PROGBITS .hip_fatbin sections\n")
+            print("✗ Some binaries are not kpack-transformed\n")
             self.errors += 1
 
         for detail in details:
@@ -226,9 +257,11 @@ class ArtifactVerifier:
             VerificationResult(
                 "Fat Binary Conversion",
                 all_passed,
-                "All fat binaries converted"
-                if all_passed
-                else "Some binaries not converted",
+                (
+                    "All fat binaries are kpack-transformed"
+                    if all_passed
+                    else "Some binaries are not kpack-transformed"
+                ),
                 details,
             )
         )
@@ -304,9 +337,11 @@ class ArtifactVerifier:
             VerificationResult(
                 "Architecture Separation",
                 all_passed,
-                "All archs separated"
-                if all_passed
-                else "Architecture cross-contamination detected",
+                (
+                    "All archs separated"
+                    if all_passed
+                    else "Architecture cross-contamination detected"
+                ),
                 details,
             )
         )
@@ -408,26 +443,216 @@ class ArtifactVerifier:
             VerificationResult(
                 "Kpack Archives",
                 all_passed,
-                "All kpack archives valid"
-                if all_passed
-                else "Some kpack archives invalid",
+                (
+                    "All kpack archives valid"
+                    if all_passed
+                    else "Some kpack archives invalid"
+                ),
                 details,
             )
         )
 
-    def _get_hip_fatbin_section(self, binary_path: Path) -> Optional[tuple[str, int]]:
-        """Get .hip_fatbin section type and size. Returns None if no section."""
-        section_type = get_section_type(
-            binary_path, ".hip_fatbin", toolchain=self.toolchain
-        )
-        if section_type is None:
-            return None
-        # Size is not critical for verification, just need to know type
-        return (section_type, 0)
+    def _inspect_fat_binary_conversion(
+        self, binary_path: Path
+    ) -> tuple[Optional[FatBinaryInspection], bool]:
+        """Inspect a generic artifact file. Returns (inspection, is_binary)."""
+        try:
+            binary_format = detect_binary_format(binary_path)
+        except UnsupportedBinaryFormat:
+            return None, False
+        except Exception as e:
+            if self.verbose:
+                print(f"  Skipping unreadable binary {binary_path}: {e}")
+            return None, False
 
-    def _has_kpack_ref(self, binary_path: Path) -> bool:
-        """Check if binary has .rocm_kpack_ref section."""
-        return has_section(binary_path, ".rocm_kpack_ref", toolchain=self.toolchain)
+        try:
+            if binary_format == "elf":
+                surgery = ElfSurgery.load(binary_path)
+                fatbin = surgery.find_section(".hip_fatbin")
+                if fatbin is None:
+                    return None, True
+
+                wrapper_magics, wrapper_error = self._read_wrapper_magics(
+                    surgery, ".hipFatBinSegment", ELF_WRAPPER_SIZE
+                )
+                return (
+                    FatBinaryInspection(
+                        binary_format="ELF",
+                        fatbin_section=".hip_fatbin",
+                        section_state=self._elf_section_state(fatbin.header.sh_type),
+                        has_kpack_ref=surgery.find_section(".rocm_kpack_ref")
+                        is not None,
+                        hipf_magic=ELF_HIPF_MAGIC,
+                        hipk_magic=ELF_HIPK_MAGIC,
+                        wrapper_magics=wrapper_magics,
+                        wrapper_error=wrapper_error,
+                    ),
+                    True,
+                )
+
+            surgery = CoffSurgery.load(binary_path)
+            fatbin = surgery.find_section(".hip_fat")
+            if fatbin is None:
+                return None, True
+
+            wrapper_magics, wrapper_error = self._read_wrapper_magics(
+                surgery, ".hipFatB", COFF_WRAPPER_SIZE
+            )
+            return (
+                FatBinaryInspection(
+                    binary_format="COFF",
+                    fatbin_section=".hip_fat",
+                    section_state=self._coff_section_state(fatbin),
+                    has_kpack_ref=surgery.find_section(".kpackrf") is not None,
+                    hipf_magic=COFF_HIPF_MAGIC,
+                    hipk_magic=COFF_HIPK_MAGIC,
+                    wrapper_magics=wrapper_magics,
+                    wrapper_error=wrapper_error,
+                ),
+                True,
+            )
+        except Exception as e:
+            if self.verbose:
+                print(f"  Failed to inspect binary {binary_path}: {e}")
+            return self._failed_binary_inspection(binary_format, e), True
+
+    def _failed_binary_inspection(
+        self, binary_format: str, error: Exception
+    ) -> FatBinaryInspection:
+        """Create a failing inspection result for an unreadable ELF/COFF binary."""
+        if binary_format == "elf":
+            return FatBinaryInspection(
+                binary_format="ELF",
+                fatbin_section=".hip_fatbin",
+                section_state="unreadable",
+                has_kpack_ref=False,
+                hipf_magic=ELF_HIPF_MAGIC,
+                hipk_magic=ELF_HIPK_MAGIC,
+                wrapper_magics=[],
+                inspection_error=f"failed to inspect ELF binary: {error}",
+            )
+
+        return FatBinaryInspection(
+            binary_format="COFF",
+            fatbin_section=".hip_fat",
+            section_state="unreadable",
+            has_kpack_ref=False,
+            hipf_magic=COFF_HIPF_MAGIC,
+            hipk_magic=COFF_HIPK_MAGIC,
+            wrapper_magics=[],
+            inspection_error=f"failed to inspect COFF binary: {error}",
+        )
+
+    def _read_wrapper_magics(
+        self, surgery, section_name: str, wrapper_size: int
+    ) -> tuple[list[int], Optional[str]]:
+        """Read HIP fat binary wrapper magic values from a wrapper section."""
+        section = surgery.find_section(section_name)
+        if section is None:
+            return [], f"missing {section_name} wrapper section"
+
+        try:
+            section_data = surgery.get_section_content(section)
+        except ValueError as e:
+            return [], str(e)
+
+        logical_size = getattr(section, "virtual_size", None)
+        if logical_size is not None:
+            if len(section_data) < logical_size:
+                section_data = section_data + b"\x00" * (
+                    logical_size - len(section_data)
+                )
+            else:
+                section_data = section_data[:logical_size]
+
+        if len(section_data) % wrapper_size != 0:
+            return (
+                [],
+                f"{section_name} size {len(section_data)} is not a multiple "
+                f"of wrapper size {wrapper_size}",
+            )
+
+        return (
+            [
+                struct.unpack_from("<I", section_data, offset)[0]
+                for offset in range(0, len(section_data), wrapper_size)
+            ],
+            None,
+        )
+
+    def _fat_binary_conversion_failures(
+        self, inspection: FatBinaryInspection
+    ) -> list[str]:
+        """Return conversion failures for a generic artifact fat binary."""
+        if inspection.inspection_error:
+            return [inspection.inspection_error]
+
+        failures = []
+
+        if inspection.binary_format == "ELF" and inspection.section_state != "NOBITS":
+            failures.append(
+                f"still has {inspection.section_state} {inspection.fatbin_section}"
+            )
+        elif inspection.binary_format == "COFF" and inspection.section_state.startswith(
+            "unstripped"
+        ):
+            failures.append(
+                f"still has {inspection.section_state} {inspection.fatbin_section}"
+            )
+
+        if not inspection.has_kpack_ref:
+            marker = (
+                ".rocm_kpack_ref" if inspection.binary_format == "ELF" else ".kpackrf"
+            )
+            failures.append(f"missing {marker} marker")
+
+        if inspection.wrapper_error:
+            failures.append(inspection.wrapper_error)
+        elif not inspection.wrapper_magics:
+            failures.append("no HIP fat binary wrappers found")
+        else:
+            hipf_count = sum(
+                1
+                for magic in inspection.wrapper_magics
+                if magic == inspection.hipf_magic
+            )
+            if hipf_count:
+                failures.append(f"{hipf_count} wrapper(s) still use HIPF magic")
+
+            unexpected = [
+                magic
+                for magic in inspection.wrapper_magics
+                if magic not in (inspection.hipf_magic, inspection.hipk_magic)
+            ]
+            if unexpected:
+                formatted = ", ".join(f"0x{magic:08x}" for magic in unexpected)
+                failures.append(f"unexpected wrapper magic value(s): {formatted}")
+
+        return failures
+
+    def _elf_section_state(self, section_type: int) -> str:
+        """Return a readable ELF section state."""
+        if section_type == SHT_NOBITS:
+            return "NOBITS"
+        if section_type == SHT_PROGBITS:
+            return "PROGBITS"
+        return f"type {section_type}"
+
+    def _coff_section_state(self, fatbin_section) -> str:
+        """Return a readable COFF fatbin section state."""
+        if fatbin_section.raw_size == 0:
+            return "zero-paged (raw-size=0)"
+        if fatbin_section.raw_size < fatbin_section.virtual_size:
+            return (
+                "partially zero-paged "
+                f"(raw-size={fatbin_section.raw_size}, "
+                f"virtual-size={fatbin_section.virtual_size})"
+            )
+        return (
+            "unstripped "
+            f"(raw-size={fatbin_section.raw_size}, "
+            f"virtual-size={fatbin_section.virtual_size})"
+        )
 
     def _fail(self, check_name: str, message: str) -> None:
         """Record a failed check."""
@@ -469,7 +694,7 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 This tool validates that artifact splitting produced correct output:
-  - Fat binaries converted to host-only (PROGBITS -> NOBITS)
+  - Fat binaries transformed for kpack
   - Architecture separation is correct
   - Kpack archives are valid
   - Manifest files are present

--- a/shared/kpack/tests/test_artifact_splitter_integration.py
+++ b/shared/kpack/tests/test_artifact_splitter_integration.py
@@ -5,8 +5,10 @@ These tests simulate real artifact splitting scenarios with mock data.
 """
 
 import shutil
+import struct
 from argparse import Namespace
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -18,7 +20,14 @@ from rocm_kpack.artifact_splitter import (
     base_arch,
 )
 from rocm_kpack.artifact_utils import read_artifact_manifest, write_artifact_manifest
+from rocm_kpack.coff.kpack_transform import HIPF_MAGIC as COFF_HIPF_MAGIC
+from rocm_kpack.coff.kpack_transform import HIPK_MAGIC as COFF_HIPK_MAGIC
+from rocm_kpack.coff.kpack_transform import WRAPPER_SIZE as COFF_WRAPPER_SIZE
+from rocm_kpack.coff.surgery import CoffSurgery
 from rocm_kpack.database_handlers import MIOpenHandler, RocBLASHandler
+from rocm_kpack.elf.kpack_transform import HIPF_MAGIC as ELF_HIPF_MAGIC
+from rocm_kpack.elf.surgery import ElfSurgery
+from rocm_kpack.kpack_transform import kpack_offload_binary
 from rocm_kpack.tools.split_artifacts import batch_split, parse_artifact_name
 from rocm_kpack.tools.verify_artifacts import ArtifactVerifier
 
@@ -52,6 +61,32 @@ class TestBaseArch:
 
 class TestArtifactSplitterIntegration:
     """Integration tests for the complete artifact splitting workflow."""
+
+    @staticmethod
+    def _require_materialized_binary(binary_path: Path, magic: bytes) -> None:
+        with open(binary_path, "rb") as f:
+            assert (
+                f.read(len(magic)) == magic
+            ), f"{binary_path.name} must be materialized by Git LFS"
+
+    @staticmethod
+    def _create_generic_artifact_binary(
+        tmp_path: Path, binary_relpath: str
+    ) -> tuple[Path, str, Path]:
+        artifacts_dir = tmp_path / "artifacts"
+        generic_dir = artifacts_dir / "rocwmma_test_generic"
+        generic_dir.mkdir(parents=True)
+
+        prefix = "math-libs/rocWMMA/stage"
+        write_artifact_manifest(generic_dir, [prefix])
+
+        binary_path = generic_dir / prefix / binary_relpath
+        binary_path.parent.mkdir(parents=True)
+        return artifacts_dir, prefix, binary_path
+
+    @staticmethod
+    def _details_text(details: list[str]) -> str:
+        return "\n".join(details).replace("\\", "/")
 
     @pytest.fixture
     def create_test_artifact(self, tmp_path):
@@ -778,9 +813,9 @@ class TestArtifactSplitterIntegration:
             visitor.visit_file(ck_so, test_dir)
 
         # Should be in database_files_by_arch, NOT in fat_binaries
-        assert len(visitor.fat_binaries) == 0, (
-            "CK .so should not be classified as a fat binary"
-        )
+        assert (
+            len(visitor.fat_binaries) == 0
+        ), "CK .so should not be classified as a fat binary"
         assert "gfx942" in visitor.database_files_by_arch
         assert len(visitor.database_files_by_arch["gfx942"]) == 1
         assert visitor.database_files_by_arch["gfx942"][0][0] == ck_so
@@ -808,9 +843,9 @@ class TestArtifactSplitterIntegration:
             visitor.visit_file(ck_dll, test_dir)
 
         # Should be in database_files_by_arch, NOT in fat_binaries
-        assert len(visitor.fat_binaries) == 0, (
-            "CK .dll should not be classified as a fat binary"
-        )
+        assert (
+            len(visitor.fat_binaries) == 0
+        ), "CK .dll should not be classified as a fat binary"
         assert "gfx942" in visitor.database_files_by_arch
         assert len(visitor.database_files_by_arch["gfx942"]) == 1
         assert visitor.database_files_by_arch["gfx942"][0][0] == ck_dll
@@ -866,32 +901,30 @@ class TestArtifactSplitterIntegration:
         # gfx942 db file should NOT be in generic
         generic_dir = output_dir / "miopen_lib_generic"
         generic_gfx942_db = generic_dir / prefix / "share/miopen/db/gfx942_68.HIP.model"
-        assert not generic_gfx942_db.exists(), (
-            "gfx942 db file should not be in generic artifact"
-        )
+        assert (
+            not generic_gfx942_db.exists()
+        ), "gfx942 db file should not be in generic artifact"
 
         # Filtered-out architectures should NOT have per-arch directories
-        assert not (output_dir / "miopen_lib_gfx1100").exists(), (
-            "gfx1100 per-arch directory should not exist when filtered out"
-        )
-        assert not (output_dir / "miopen_lib_gfx90a").exists(), (
-            "gfx90a per-arch directory should not exist when filtered out"
-        )
+        assert not (
+            output_dir / "miopen_lib_gfx1100"
+        ).exists(), "gfx1100 per-arch directory should not exist when filtered out"
+        assert not (
+            output_dir / "miopen_lib_gfx90a"
+        ).exists(), "gfx90a per-arch directory should not exist when filtered out"
 
         # Filtered-out database files should NOT be in generic either
         # (per-arch content doesn't belong in generic — the correct arch job produces it)
         generic_gfx1100_db = (
             generic_dir / prefix / "share/miopen/db/gfx1100_68.HIP.model"
         )
-        generic_gfx90a_db = (
-            generic_dir / prefix / "share/miopen/db/gfx90a_68.HIP.model"
-        )
-        assert not generic_gfx1100_db.exists(), (
-            "gfx1100 db file should not be in generic artifact"
-        )
-        assert not generic_gfx90a_db.exists(), (
-            "gfx90a db file should not be in generic artifact"
-        )
+        generic_gfx90a_db = generic_dir / prefix / "share/miopen/db/gfx90a_68.HIP.model"
+        assert (
+            not generic_gfx1100_db.exists()
+        ), "gfx1100 db file should not be in generic artifact"
+        assert (
+            not generic_gfx90a_db.exists()
+        ), "gfx90a db file should not be in generic artifact"
 
         # Regular library should be in generic
         generic_lib = generic_dir / prefix / "lib/libMIOpen.so"
@@ -937,15 +970,15 @@ class TestArtifactSplitterIntegration:
         splitter.split(input_dir, output_dir)
 
         # All three per-arch directories should exist
-        assert (output_dir / "miopen_lib_gfx942").exists(), (
-            "gfx942 per-arch directory should exist"
-        )
-        assert (output_dir / "miopen_lib_gfx1100").exists(), (
-            "gfx1100 per-arch directory should exist"
-        )
-        assert (output_dir / "miopen_lib_gfx90a").exists(), (
-            "gfx90a per-arch directory should exist"
-        )
+        assert (
+            output_dir / "miopen_lib_gfx942"
+        ).exists(), "gfx942 per-arch directory should exist"
+        assert (
+            output_dir / "miopen_lib_gfx1100"
+        ).exists(), "gfx1100 per-arch directory should exist"
+        assert (
+            output_dir / "miopen_lib_gfx90a"
+        ).exists(), "gfx90a per-arch directory should exist"
 
         # All database files should be in their respective per-arch directories
         assert (
@@ -1016,15 +1049,17 @@ class TestArtifactSplitterIntegration:
         splitter.split(input_dir, output_dir)
 
         # Only gfx942 per-arch directory should exist (feature flags stripped)
-        assert (output_dir / "miopen_lib_gfx942").exists(), (
+        assert (
+            output_dir / "miopen_lib_gfx942"
+        ).exists(), (
             "gfx942 per-arch directory should exist despite feature flags in target"
         )
-        assert not (output_dir / "miopen_lib_gfx1100").exists(), (
-            "gfx1100 per-arch directory should not exist when filtered out"
-        )
-        assert not (output_dir / "miopen_lib_gfx90a").exists(), (
-            "gfx90a per-arch directory should not exist when filtered out"
-        )
+        assert not (
+            output_dir / "miopen_lib_gfx1100"
+        ).exists(), "gfx1100 per-arch directory should not exist when filtered out"
+        assert not (
+            output_dir / "miopen_lib_gfx90a"
+        ).exists(), "gfx90a per-arch directory should not exist when filtered out"
 
     def test_gpu_targets_keeps_xnack_variant_database_files(self, toolchain, tmp_path):
         """
@@ -1132,9 +1167,7 @@ class TestArtifactSplitterIntegration:
             },
         )()
 
-        with patch(
-            "rocm_kpack.artifact_splitter.BundledBinary"
-        ) as MockBinary:
+        with patch("rocm_kpack.artifact_splitter.BundledBinary") as MockBinary:
             MockBinary.return_value.unbundle.return_value = mock_unbundled
 
             # With gpu_targets=["gfx1100"], only gfx1100 kernels should appear
@@ -1166,23 +1199,404 @@ class TestArtifactSplitterIntegration:
             )
 
         # Filtered: only targeted architecture should be present
-        assert "gfx1100" in result_filtered, (
-            "gfx1100 should be in filtered results (in gpu_targets)"
-        )
-        assert len(result_filtered["gfx1100"]) == 1, (
-            "gfx1100 kernel should be preserved intact"
-        )
-        assert result_filtered["gfx1100"][0].kernel_data == b"\x00" * 100, (
-            "gfx1100 kernel data should be unchanged by filtering"
-        )
-        assert "gfx906" not in result_filtered, (
-            "gfx906 should not be in filtered results (not in gpu_targets)"
-        )
+        assert (
+            "gfx1100" in result_filtered
+        ), "gfx1100 should be in filtered results (in gpu_targets)"
+        assert (
+            len(result_filtered["gfx1100"]) == 1
+        ), "gfx1100 kernel should be preserved intact"
+        assert (
+            result_filtered["gfx1100"][0].kernel_data == b"\x00" * 100
+        ), "gfx1100 kernel data should be unchanged by filtering"
+        assert (
+            "gfx906" not in result_filtered
+        ), "gfx906 should not be in filtered results (not in gpu_targets)"
 
         # Unfiltered: all architectures should be present
-        assert "gfx1100" in result_unfiltered, (
-            "gfx1100 should be in unfiltered results"
+        assert "gfx1100" in result_unfiltered, "gfx1100 should be in unfiltered results"
+        assert "gfx906" in result_unfiltered, "gfx906 should be in unfiltered results"
+
+    def test_gpu_targets_rejects_generic_when_all_fat_binary_kernels_filtered(
+        self, toolchain, tmp_path
+    ):
+        """
+        Test that split() fails instead of emitting a raw generic artifact when
+        gpu_targets filters out every code object from detected fat binaries.
+        """
+        input_dir = tmp_path / "input"
+        input_dir.mkdir()
+
+        prefix = "math-libs/rocWMMA/stage"
+        write_artifact_manifest(input_dir, [prefix])
+
+        lib_dir = input_dir / prefix / "lib"
+        lib_dir.mkdir(parents=True)
+        fat_binary = lib_dir / "librocwmma.so"
+        fat_binary.write_text("placeholder")
+
+        mock_unbundled = type(
+            "MockUnbundled",
+            (),
+            {
+                "target_list": [("hipv4-amdgcn-amd-amdhsa--gfx906", "gfx906.hsaco")],
+                "dest_dir": tmp_path / "unbundled",
+                "__enter__": lambda s: s,
+                "__exit__": lambda s, *a: None,
+            },
+        )()
+        mock_unbundled.dest_dir.mkdir()
+
+        with patch(
+            "rocm_kpack.artifact_splitter.is_fat_binary", return_value=True
+        ), patch("rocm_kpack.artifact_splitter.BundledBinary") as MockBinary:
+            MockBinary.return_value.unbundle.return_value = mock_unbundled
+
+            splitter = ArtifactSplitter(
+                artifact_prefix="rocwmma_test",
+                toolchain=toolchain,
+                database_handlers=[],
+                verbose=True,
+                gpu_targets=["gfx1100"],
+            )
+
+            with pytest.raises(
+                RuntimeError,
+                match="no device code objects matched --gpu-targets",
+            ):
+                splitter.split(input_dir, tmp_path / "output")
+
+    @pytest.mark.parametrize(
+        ("fixture_name", "binary_relpath", "wrapper_failure"),
+        [
+            (
+                "test_kernel_single.exe",
+                "bin/vector_iterator_test",
+                "1 wrapper(s) still use HIPF magic",
+            ),
+            (
+                "test_kernel_multi.exe",
+                "bin/multi_arch_vector_iterator_test",
+                "1 wrapper(s) still use HIPF magic",
+            ),
+            (
+                "libtest_multi_wrapper.so",
+                "lib/libtest_multi_wrapper.so",
+                "2 wrapper(s) still use HIPF magic",
+            ),
+        ],
+    )
+    def test_verifier_rejects_raw_generic_elf_fat_binaries(
+        self,
+        fixture_name,
+        binary_relpath,
+        wrapper_failure,
+        test_assets_dir,
+        toolchain,
+        tmp_path,
+    ):
+        """
+        Test that verification scans generic executables and libraries, then
+        rejects raw untransformed ELF HIPF fat binaries.
+        """
+        raw_fat_binary = test_assets_dir / "bundled_binaries/linux/cov5" / fixture_name
+        self._require_materialized_binary(raw_fat_binary, b"\x7fELF")
+        artifacts_dir, prefix, generic_binary = self._create_generic_artifact_binary(
+            tmp_path, binary_relpath
         )
-        assert "gfx906" in result_unfiltered, (
-            "gfx906 should be in unfiltered results"
+        shutil.copy2(raw_fat_binary, generic_binary)
+
+        verifier = ArtifactVerifier(artifacts_dir, toolchain, verbose=False)
+
+        assert verifier.run_all_checks() is False
+
+        fat_binary_result = next(
+            result
+            for result in verifier.results
+            if result.check_name == "Fat Binary Conversion"
+        )
+        assert fat_binary_result.passed is False
+        details = self._details_text(fat_binary_result.details)
+        assert f"{prefix}/{binary_relpath}" in details
+        assert "still has PROGBITS .hip_fatbin" in details
+        assert "missing .rocm_kpack_ref marker" in details
+        assert wrapper_failure in details
+
+    def test_verifier_accepts_kpack_transformed_elf_multi_wrapper_fat_binary(
+        self, test_assets_dir, toolchain, tmp_path
+    ):
+        """Test that all wrappers in a transformed ELF multi-wrapper binary pass."""
+        raw_fat_binary = (
+            test_assets_dir / "bundled_binaries/linux/cov5/libtest_multi_wrapper.so"
+        )
+        self._require_materialized_binary(raw_fat_binary, b"\x7fELF")
+        artifacts_dir, prefix, generic_binary = self._create_generic_artifact_binary(
+            tmp_path, "lib/libtest_multi_wrapper.so"
+        )
+
+        kpack_offload_binary(
+            input_path=raw_fat_binary,
+            output_path=generic_binary,
+            kpack_search_paths=["../.kpack/rocwmma_test_@GFXARCH@.kpack"],
+            kernel_name=f"{prefix}/lib/libtest_multi_wrapper.so",
+        )
+
+        verifier = ArtifactVerifier(artifacts_dir, toolchain, verbose=False)
+
+        assert verifier.run_all_checks() is True
+
+        fat_binary_result = next(
+            result
+            for result in verifier.results
+            if result.check_name == "Fat Binary Conversion"
+        )
+        details = self._details_text(fat_binary_result.details)
+        assert "lib/libtest_multi_wrapper.so" in details
+        assert "ELF" in details
+        assert "NOBITS" in details
+
+    def test_verifier_rejects_transformed_elf_with_stale_hipf_wrapper_magic(
+        self, test_assets_dir, toolchain, tmp_path
+    ):
+        """
+        Test that a binary with stripped fatbin contents and a kpack marker still
+        fails if any wrapper remains HIPF instead of HIPK.
+        """
+        raw_fat_binary = (
+            test_assets_dir / "bundled_binaries/linux/cov5/test_kernel_single.exe"
+        )
+        self._require_materialized_binary(raw_fat_binary, b"\x7fELF")
+        artifacts_dir, prefix, generic_binary = self._create_generic_artifact_binary(
+            tmp_path, "bin/vector_iterator_test"
+        )
+
+        kpack_offload_binary(
+            input_path=raw_fat_binary,
+            output_path=generic_binary,
+            kpack_search_paths=["../.kpack/rocwmma_test_@GFXARCH@.kpack"],
+            kernel_name=f"{prefix}/bin/vector_iterator_test",
+        )
+
+        surgery = ElfSurgery.load(generic_binary)
+        wrapper_section = surgery.find_section(".hipFatBinSegment")
+        assert wrapper_section is not None
+        wrapper_offset = surgery.vaddr_to_file_offset(wrapper_section.header.sh_addr)
+        assert wrapper_offset is not None
+        surgery.write_bytes_at_offset(
+            wrapper_offset,
+            struct.pack("<I", ELF_HIPF_MAGIC),
+            "restore stale HIPF wrapper magic",
+        )
+        surgery.save(generic_binary)
+
+        verifier = ArtifactVerifier(artifacts_dir, toolchain, verbose=False)
+
+        assert verifier.run_all_checks() is False
+
+        fat_binary_result = next(
+            result
+            for result in verifier.results
+            if result.check_name == "Fat Binary Conversion"
+        )
+        assert fat_binary_result.passed is False
+        details = self._details_text(fat_binary_result.details)
+        assert f"{prefix}/bin/vector_iterator_test" in details
+        assert "1 wrapper(s) still use HIPF magic" in details
+        assert "still has PROGBITS .hip_fatbin" not in details
+        assert "missing .rocm_kpack_ref marker" not in details
+
+    def test_verifier_rejects_raw_generic_coff_fat_binary(
+        self, test_assets_dir, toolchain, tmp_path
+    ):
+        """Test that generic PE/COFF HIPF fat binaries are rejected."""
+        raw_fat_binary = (
+            test_assets_dir / "bundled_binaries/windows/cov5/test_kernel_single.exe"
+        )
+        self._require_materialized_binary(raw_fat_binary, b"MZ")
+        artifacts_dir, prefix, generic_binary = self._create_generic_artifact_binary(
+            tmp_path, "bin/vector_iterator_test.exe"
+        )
+        shutil.copy2(raw_fat_binary, generic_binary)
+
+        verifier = ArtifactVerifier(artifacts_dir, toolchain, verbose=False)
+
+        assert verifier.run_all_checks() is False
+
+        fat_binary_result = next(
+            result
+            for result in verifier.results
+            if result.check_name == "Fat Binary Conversion"
+        )
+        assert fat_binary_result.passed is False
+        details = self._details_text(fat_binary_result.details)
+        assert f"{prefix}/bin/vector_iterator_test.exe" in details
+        assert "still has unstripped" in details
+        assert ".hip_fat" in details
+        assert "missing .kpackrf marker" in details
+        assert "1 wrapper(s) still use HIPF magic" in details
+
+    def test_verifier_accepts_kpack_transformed_coff_fat_binary(
+        self, test_assets_dir, toolchain, tmp_path
+    ):
+        """Test that transformed PE/COFF fat binaries pass verifier checks."""
+        raw_fat_binary = (
+            test_assets_dir / "bundled_binaries/windows/cov5/test_kernel_single.exe"
+        )
+        self._require_materialized_binary(raw_fat_binary, b"MZ")
+        artifacts_dir, prefix, generic_binary = self._create_generic_artifact_binary(
+            tmp_path, "bin/vector_iterator_test.exe"
+        )
+
+        kpack_offload_binary(
+            input_path=raw_fat_binary,
+            output_path=generic_binary,
+            kpack_search_paths=["../.kpack/rocwmma_test_@GFXARCH@.kpack"],
+            kernel_name=f"{prefix}/bin/vector_iterator_test.exe",
+        )
+
+        verifier = ArtifactVerifier(artifacts_dir, toolchain, verbose=False)
+
+        assert verifier.run_all_checks() is True
+
+        fat_binary_result = next(
+            result
+            for result in verifier.results
+            if result.check_name == "Fat Binary Conversion"
+        )
+        details = self._details_text(fat_binary_result.details)
+        assert "bin/vector_iterator_test.exe" in details
+        assert "COFF" in details
+
+    def test_verifier_pads_coff_wrapper_section_to_virtual_size(
+        self, toolchain, tmp_path
+    ):
+        """Test that virtual wrapper bytes are included when reading COFF magic."""
+        raw_wrapper = struct.pack("<I", COFF_HIPK_MAGIC) + b"\x00" * (
+            COFF_WRAPPER_SIZE - 4
+        )
+        section = SimpleNamespace(virtual_size=COFF_WRAPPER_SIZE * 2)
+
+        class FakeSurgery:
+            def find_section(self, section_name):
+                assert section_name == ".hipFatB"
+                return section
+
+            def get_section_content(self, found_section):
+                assert found_section is section
+                return raw_wrapper
+
+        verifier = ArtifactVerifier(tmp_path, toolchain, verbose=False)
+
+        wrapper_magics, wrapper_error = verifier._read_wrapper_magics(
+            FakeSurgery(), ".hipFatB", COFF_WRAPPER_SIZE
+        )
+
+        assert wrapper_error is None
+        assert wrapper_magics == [COFF_HIPK_MAGIC, 0]
+
+    def test_verifier_rejects_transformed_coff_with_stale_hipf_wrapper_magic(
+        self, test_assets_dir, toolchain, tmp_path
+    ):
+        """Test that transformed-looking PE/COFF binaries fail on stale HIPF magic."""
+        raw_fat_binary = (
+            test_assets_dir / "bundled_binaries/windows/cov5/test_kernel_single.exe"
+        )
+        self._require_materialized_binary(raw_fat_binary, b"MZ")
+        artifacts_dir, prefix, generic_binary = self._create_generic_artifact_binary(
+            tmp_path, "bin/vector_iterator_test.exe"
+        )
+
+        kpack_offload_binary(
+            input_path=raw_fat_binary,
+            output_path=generic_binary,
+            kpack_search_paths=["../.kpack/rocwmma_test_@GFXARCH@.kpack"],
+            kernel_name=f"{prefix}/bin/vector_iterator_test.exe",
+        )
+
+        surgery = CoffSurgery.load(generic_binary)
+        wrapper_section = surgery.find_section(".hipFatB")
+        assert wrapper_section is not None
+        surgery.write_bytes_at_offset(
+            wrapper_section.file_offset,
+            struct.pack("<I", COFF_HIPF_MAGIC),
+            "restore stale HIPF wrapper magic",
+        )
+        surgery.save(generic_binary)
+
+        verifier = ArtifactVerifier(artifacts_dir, toolchain, verbose=False)
+
+        assert verifier.run_all_checks() is False
+
+        fat_binary_result = next(
+            result
+            for result in verifier.results
+            if result.check_name == "Fat Binary Conversion"
+        )
+        assert fat_binary_result.passed is False
+        details = self._details_text(fat_binary_result.details)
+        assert f"{prefix}/bin/vector_iterator_test.exe" in details
+        assert "1 wrapper(s) still use HIPF magic" in details
+        assert "missing .kpackrf marker" not in details
+
+    def test_verifier_rejects_unreadable_generic_binary(self, toolchain, tmp_path):
+        """
+        Test that a file with ELF magic that cannot be parsed does not get
+        classified as a host-only binary.
+        """
+        artifacts_dir = tmp_path / "artifacts"
+        generic_dir = artifacts_dir / "rocwmma_test_generic"
+        generic_dir.mkdir(parents=True)
+
+        prefix = "math-libs/rocWMMA/stage"
+        write_artifact_manifest(generic_dir, [prefix])
+
+        bin_dir = generic_dir / prefix / "bin"
+        bin_dir.mkdir(parents=True)
+        (bin_dir / "truncated_test").write_bytes(b"\x7fELF")
+
+        verifier = ArtifactVerifier(artifacts_dir, toolchain, verbose=False)
+
+        assert verifier.run_all_checks() is False
+
+        fat_binary_result = next(
+            result
+            for result in verifier.results
+            if result.check_name == "Fat Binary Conversion"
+        )
+        assert fat_binary_result.passed is False
+        assert any("truncated_test" in detail for detail in fat_binary_result.details)
+        assert any(
+            "failed to inspect ELF binary" in detail
+            for detail in fat_binary_result.details
+        )
+
+    def test_verifier_rejects_unreadable_generic_coff_binary(self, toolchain, tmp_path):
+        """
+        Test that a file with PE/COFF magic that cannot be parsed does not get
+        classified as a host-only binary.
+        """
+        artifacts_dir, _, generic_binary = self._create_generic_artifact_binary(
+            tmp_path, "bin/truncated_test.exe"
+        )
+        truncated_coff = bytearray(0x44)
+        truncated_coff[0:2] = b"MZ"
+        truncated_coff[0x3C:0x40] = (0x40).to_bytes(4, "little")
+        truncated_coff[0x40:0x44] = b"PE\x00\x00"
+        generic_binary.write_bytes(truncated_coff)
+
+        verifier = ArtifactVerifier(artifacts_dir, toolchain, verbose=False)
+
+        assert verifier.run_all_checks() is False
+
+        fat_binary_result = next(
+            result
+            for result in verifier.results
+            if result.check_name == "Fat Binary Conversion"
+        )
+        assert fat_binary_result.passed is False
+        assert any(
+            "truncated_test.exe" in detail for detail in fat_binary_result.details
+        )
+        assert any(
+            "failed to inspect COFF binary" in detail
+            for detail in fat_binary_result.details
         )


### PR DESCRIPTION
## Summary
- re-land the kpack split guard from ROCm/rocm-systems#7633 after its revert in ROCm/rocm-systems#7863
- fail artifact splitting when fat binaries are present but `--gpu-targets` filters out every device code object, instead of emitting an untransformed generic artifact
- strengthen generic artifact verification across ELF and PE/COFF binaries, including kpack marker and wrapper magic checks
- restore regression coverage for the empty-filter guard and transformed/raw/stale-wrapper verifier cases

## Sequencing
This PR is predicated on the order agreed from ROCm/rocm-systems#7862:
1. Land ROCm/TheRock#6042 first so unsupported rocWMMA target shards (`gfx101X-dgpu`, `gfx103X-all`, `gfx900`, `gfx906`) no longer build or publish `rocwmma_test_generic`.
2. Re-land this rocm-systems kpack guard.
3. Bump TheRock rocm-systems submodule to the re-landed commit.

Without ROCm/TheRock#6042 first, TheRock bump validation can hit this intended guard while rocWMMA is still producing test artifacts for unsupported target shards.

## Validation
- `git diff --check origin/develop...HEAD`
- `uv run --with pytest --with msgpack --with zstandard --directory shared/kpack pytest tests/test_artifact_splitter_integration.py -q` (42 passed)
- `uv run --with pre-commit --directory shared/kpack pre-commit run --files python/rocm_kpack/tools/verify_artifacts.py tests/test_artifact_splitter_integration.py`

ISSUE ID: https://github.com/ROCm/rocm-libraries/issues/8660