### PR TITLE
ci(rocjitsu): use gcc and sanitizers

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -66,6 +66,14 @@ jobs:
             enable_ubsan: 1
             enable_tsan: 0
             enable_msan: 0
+          - name: asan-ubsan-gcc
+            build_type: RelWithDebInfo
+            enable_asan: 1
+            enable_ubsan: 1
+            enable_tsan: 0
+            enable_msan: 0
+            c_compiler: gcc
+            cxx_compiler: g++
 
     steps:
       - name: Install base dependencies
@@ -172,15 +180,24 @@ jobs:
           )
 
           CMAKE_CONFIG_FLAGS=()
-          if [[ "${{ matrix.name }}" == "asan-ubsan" ]]; then
+          if [[ "${{ matrix.enable_asan }}" == "1" && "${{ matrix.enable_ubsan }}" == "1" ]]; then
             EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${ASAN_UBSAN_EXCLUDED_TESTS[*]}")"
             CMAKE_CONFIG_FLAGS+=(
               -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -g"
               -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -g"
             )
           fi
+          if [[ -n "${{ matrix.c_compiler }}" ]]; then
+            CMAKE_CONFIG_FLAGS+=(-DCMAKE_C_COMPILER="${{ matrix.c_compiler }}")
+          fi
+          if [[ -n "${{ matrix.cxx_compiler }}" ]]; then
+            CMAKE_CONFIG_FLAGS+=(-DCMAKE_CXX_COMPILER="${{ matrix.cxx_compiler }}")
+          fi
 
-          CXXFLAGS="-Wno-error=unknown-warning-option -Wno-error=nested-anon-types"
+          CXXFLAGS=""
+          if [[ -z "${{ matrix.cxx_compiler }}" || "${{ matrix.cxx_compiler }}" == *clang* ]]; then
+            CXXFLAGS="-Wno-error=unknown-warning-option -Wno-error=nested-anon-types"
+          fi
           ROCM_PATH=`rocm-sdk path --root` \
             cmake -B "${ROCJITSU_BUILD_DIR}" -G Ninja \
             -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}" \

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 include(rj_configure_target)
+include(rj_find_amdcxx)
 
 # Device kernels (compiled from HIP sources for simulator testing).
 add_subdirectory(kernels)
@@ -872,10 +873,10 @@ else()
     message(STATUS "HSA init test disabled (libhsa-runtime64 not found)")
 endif()
 
-# --- HIP tests (requires hipcc + CLI launcher) ---
+# --- HIP tests (requires amdclang++ + CLI launcher) ---
 
-find_program(HIPCC_EXECUTABLE hipcc PATHS "${ROCM_PATH}" PATH_SUFFIXES bin)
-if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
+rj_find_amdcxx(AMDCXX)
+if(AMDCXX AND HSA_RUNTIME64)
     set(GTEST_INC ${googletest_SOURCE_DIR}/googletest/include)
     set(GTEST_LIB_DIR ${CMAKE_BINARY_DIR}/lib)
     set(RJ_HIP_SANITIZER_FLAGS)
@@ -890,11 +891,8 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
             ${_rj_sanitizer_flag}
         )
     endforeach()
-    if(RJ_HIP_SANITIZER_FLAGS OR RJ_HIP_SANITIZER_LINK_FLAGS)
-        list(APPEND RJ_HIP_SANITIZER_FLAGS -Xarch_device -fno-sanitize=all)
-    endif()
 
-    # Helper: build a HIP test binary with hipcc + gtest.
+    # Helper: build a HIP test binary with amdclang++ + gtest.
     function(rj_add_hip_test TEST_NAME)
         cmake_parse_arguments(ARG "" "ARCH;SOURCE" "EXTRA_LIBS" ${ARGN})
         if(NOT ARG_ARCH)
@@ -921,7 +919,7 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
                 -Wl,-rpath,${GTEST_LIB_DIR} -Wl,-rpath,${RJ_HSA_LIBRARY_DIR}
                 ${RJ_HIP_SANITIZER_LINK_FLAGS}
             DEPENDS ${HIP_TEST_SRC} GTest::gtest GTest::gtest_main
-            COMMENT "Building ${TEST_NAME} with hipcc (${ARG_ARCH})"
+            COMMENT "Building ${TEST_NAME} with amdclang++ -x hip (${ARG_ARCH})"
             VERBATIM
         )
         add_custom_target(${TEST_NAME}_target ALL DEPENDS ${HIP_TEST_BIN})
@@ -1208,25 +1206,28 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
 
     add_subdirectory(race-detector)
 
-    message(STATUS "HIP tests enabled (found ${HIPCC_EXECUTABLE})")
+    message(STATUS "HIP tests enabled (found ${AMDCXX})")
 else()
-    message(STATUS "HIP tests disabled (hipcc or libhsa-runtime64 not found)")
+    message(
+        STATUS
+        "HIP tests disabled (amdclang++ or libhsa-runtime64 not found)"
+    )
 endif()
 
 # --- Narrow conversion HIP CTS tests ---
-# Uses hipcc (rocjitsu emulator does not yet support amdclang++ -x hip binaries).
-if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
+# Uses the same HIP compiler path as the other HIP tests.
+if(AMDCXX AND HSA_RUNTIME64)
     set(CVT_NARROW_BIN ${CMAKE_CURRENT_BINARY_DIR}/hip_cvt_narrow_test)
     add_custom_command(
         OUTPUT ${CVT_NARROW_BIN}
         COMMAND
-            ${HIPCC_EXECUTABLE} --offload-arch=gfx950 -std=c++20
-            ${RJ_HIP_SANITIZER_FLAGS} -I${CMAKE_SOURCE_DIR}/lib/util/include -o
-            ${CVT_NARROW_BIN}
+            ${AMDCXX} -x hip --offload-arch=gfx950 --rocm-path=${ROCM_PATH}
+            -std=c++20 ${RJ_HIP_SANITIZER_FLAGS}
+            -I${CMAKE_SOURCE_DIR}/lib/util/include -o ${CVT_NARROW_BIN}
             ${CMAKE_CURRENT_SOURCE_DIR}/hip_cvt_narrow_test.cpp
             ${RJ_HIP_SANITIZER_LINK_FLAGS}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hip_cvt_narrow_test.cpp
-        COMMENT "Building hip_cvt_narrow_test with hipcc (gfx950)"
+        COMMENT "Building hip_cvt_narrow_test with amdclang++ -x hip (gfx950)"
         VERBATIM
     )
     add_custom_target(hip_cvt_narrow_test_target ALL DEPENDS ${CVT_NARROW_BIN})

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -876,7 +876,19 @@ endif()
 # --- HIP tests (requires amdclang++ + CLI launcher) ---
 
 rj_find_amdcxx(AMDCXX)
-if(AMDCXX AND HSA_RUNTIME64)
+set(RJ_ENABLE_HIP_TESTS ON)
+if(NOT AMDCXX)
+    set(RJ_ENABLE_HIP_TESTS OFF)
+    message(STATUS "HIP tests disabled (amdclang++ not found)")
+elseif(NOT HSA_RUNTIME64)
+    set(RJ_ENABLE_HIP_TESTS OFF)
+    message(STATUS "HIP tests disabled (libhsa-runtime64 not found)")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND RJ_SANITIZER_LINK_OPTIONS)
+    set(RJ_ENABLE_HIP_TESTS OFF)
+    message(STATUS "HIP tests disabled (GNU host compiler with sanitizers)")
+endif()
+
+if(RJ_ENABLE_HIP_TESTS)
     set(GTEST_INC ${googletest_SOURCE_DIR}/googletest/include)
     set(GTEST_LIB_DIR ${CMAKE_BINARY_DIR}/lib)
     set(RJ_HIP_SANITIZER_FLAGS)
@@ -1207,16 +1219,11 @@ if(AMDCXX AND HSA_RUNTIME64)
     add_subdirectory(race-detector)
 
     message(STATUS "HIP tests enabled (found ${AMDCXX})")
-else()
-    message(
-        STATUS
-        "HIP tests disabled (amdclang++ or libhsa-runtime64 not found)"
-    )
 endif()
 
 # --- Narrow conversion HIP CTS tests ---
 # Uses the same HIP compiler path as the other HIP tests.
-if(AMDCXX AND HSA_RUNTIME64)
+if(RJ_ENABLE_HIP_TESTS)
     set(CVT_NARROW_BIN ${CMAKE_CURRENT_BINARY_DIR}/hip_cvt_narrow_test)
     add_custom_command(
         OUTPUT ${CVT_NARROW_BIN}

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -11,18 +11,8 @@
 # found the kernel targets are silently skipped and tests that depend on them
 # are disabled at runtime via the HAS_DEVICE_KERNELS compile definition.
 
-# Prefer the compiler from the ROCm tree selected by ROCM_PATH. Some systems
-# also expose /usr/bin/amdclang++ through alternatives; deriving --rocm-path
-# from that wrapper gives /usr, which mixes headers and device libraries from
-# different installs.
-find_program(
-    AMDCXX
-    amdclang++
-    PATHS ${ROCM_PATH}
-    PATH_SUFFIXES lib/llvm/bin bin
-    DOC "Path to the ROCm amdclang++ compiler"
-    NO_DEFAULT_PATH
-)
+include(rj_find_amdcxx)
+rj_find_amdcxx(AMDCXX)
 
 if(NOT AMDCXX)
     message(


### PR DESCRIPTION
## Motivation

Increase portability across compilers

## Technical Details

Compile in CI using gcc + sanitizers.
Skip hip tests if using gcc + sanitizers.
I will add use -fno-sanitize-recover=all to discover all possible errors once the present errors are fixed.

## JIRA ID

#7891

## Test Plan

Use CI to test

## Test Result

CI passes.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
