### PR TITLE
test(rccl): add CE null-stream dispatch coverage test

### DIFF
--- a/projects/rccl/test/ce/CeInternalMPITests.cpp
+++ b/projects/rccl/test/ce/CeInternalMPITests.cpp
@@ -441,6 +441,68 @@ TEST_F(CeInternalMPITest, LaunchFourOpsSucceeds)
     // srcGuards, dstGuards, and params freed automatically on scope exit.
 }
 
+// LAUNCH-03: ncclCeLaunchBatchOps on the legacy null/default stream (stream == 0).
+//
+// HIP-behaviour test (not a defect-fix validation): pins down that CE batch
+// dispatch on the legacy null/default stream is functionally correct on AMD.
+// Upstream NCCL 2.29.7 added an isLegacyStream fallback to per-op cudaMemcpyAsync
+// because cudaMemcpyBatchAsync rejects the legacy null stream on CUDA; on AMD/HIP
+// hipMemcpyBatchAsync accepts the null stream, so this passes with or without the
+// fallback. Kept as a regression guard for the null-stream contract on HIP.
+TEST_F(CeInternalMPITest, LaunchFourOpsNullStreamSucceeds)
+{
+    using namespace RCCLTestGuards;
+    constexpr int    kOps   = 4;
+    constexpr size_t kBytes = kOps * sizeof(float); // allocation size per src/dst buffer
+
+    // The legacy null/default stream is the exact trigger for the upstream defect.
+    hipStream_t nullStream = static_cast<hipStream_t>(0);
+
+    // DeviceBufferAutoGuard ensures hipFree is called on all paths, including early ASSERT exits.
+    std::vector<DeviceBufferAutoGuard> srcGuards(kOps), dstGuards(kOps);
+    for(int i = 0; i < kOps; ++i)
+    {
+        void* p = nullptr;
+        ASSERT_EQ(hipMalloc(&p, kBytes), hipSuccess);
+        srcGuards[i].set(p);
+        p = nullptr;
+        ASSERT_EQ(hipMalloc(&p, kBytes), hipSuccess);
+        dstGuards[i].set(p);
+
+        float pattern = static_cast<float>(i + 1);
+        ASSERT_EQ(hipMemset(srcGuards[i].get(), 0, kBytes), hipSuccess);
+        ASSERT_EQ(hipMemcpy(srcGuards[i].get(), &pattern, sizeof(float), hipMemcpyHostToDevice),
+                  hipSuccess);
+    }
+
+    ncclCeBatchOpsParams params{};
+    ASSERT_EQ(ncclCeInitBatchOpsParams(&params, kOps), ncclSuccess);
+    SCOPE_EXIT(ncclCeFreeBatchOpsParams(&params));
+
+    for(int i = 0; i < kOps; ++i)
+    {
+        params.srcs[i]  = static_cast<float*>(srcGuards[i].get());
+        params.dsts[i]  = static_cast<float*>(dstGuards[i].get());
+        params.sizes[i] = sizeof(float);
+    }
+    params.numOps = kOps;
+
+    ncclCeCollArgs collArgs{};
+    EXPECT_EQ(ncclCeLaunchBatchOps(ceComm, &collArgs, &params, nullStream), ncclSuccess)
+        << "ncclCeLaunchBatchOps must succeed on the legacy null stream";
+    ASSERT_EQ(hipStreamSynchronize(nullStream), hipSuccess);
+
+    for(int i = 0; i < kOps; ++i)
+    {
+        float result = 0.0f;
+        ASSERT_EQ(hipMemcpy(&result, dstGuards[i].get(), sizeof(float), hipMemcpyDeviceToHost),
+                  hipSuccess);
+        EXPECT_FLOAT_EQ(result, static_cast<float>(i + 1))
+            << "op " << i << " produced wrong data on the null stream";
+    }
+    // srcGuards, dstGuards, and params freed automatically on scope exit.
+}
+
 // ===========================================================================
 // CeInternal_Neg – ncclCeImplemented logic (no CE hardware required)
 // ===========================================================================


### PR DESCRIPTION

## Motivation

While investigating the NCCL 2.29.7 defect *"Fall back to cudaMemcpyAsync API when null/default stream is used for CE-based collective operations,"* we found the fix was already synced into RCCL (PR #6674, port commit 557141e7a6) and that the defect itself does **not** reproduce on AMD — `hipMemcpyBatchAsync` accepts the legacy null stream, whereas the CUDA `cudaMemcpyBatchAsync` it mirrors does not. A defect-validation test is therefore impossible (it can't fail on unfixed code). However, the investigation surfaced a genuine **coverage gap**: with the fix present, a CE collective on the null stream takes the per-op `hipMemcpyAsync` fallback loop in `ncclCeLaunchBatchOps`, and no existing CE test reaches that branch. This PR adds a focused test to close that gap.

## Technical Details

Adds `CeInternalMPITest.LaunchFourOpsNullStreamSucceeds` in `test/ce/CeInternalMPITests.cpp`. It mirrors the existing `LaunchFourOpsSucceeds` white-box test but invokes `ncclCeLaunchBatchOps` on the legacy null/default stream (`stream == 0`) instead of a regular stream, then verifies all 4 device-to-device copies completed correctly.

- With the fix in place, the null stream is detected by `ncclCudaStreamIsLegacyNull()` and dispatched through the per-op `hipMemcpyAsync` fallback (`ce_coll.cc`, the `if (capturing || isLegacyStream)` true-branch) rather than `hipMemcpyBatchAsync`.
- This is explicitly a **HIP-behaviour / regression test, not a defect-fix validation** — documented as such in the test comment. The defect was CUDA-specific; on AMD `hipMemcpyBatchAsync` accepts the null stream, so the test passes with or without the `isLegacyStream` fallback.
- Every other CE test uses a non-null stream (batch path) and there is no CE-under-graph-capture test, so this is currently the only coverage of the fallback loop.
- Reference: fix synced via https://github.com/ROCm/rocm-systems/pull/6674.

## JIRA ID

Resolves `AICOMRCCL-1113`

## Test Plan

Built RCCL debug with MPI unit tests and LLVM code coverage on a single MI350X (gfx950) node, ROCm 7.0.2.2 (HIP 70051831, within RCCL's CE backport range):

`MPI_PATH=<openmpi-prefix> ./install.sh -l --debug -t --enable-mpi-tests --enable-code-coverage --amdgpu_targets gfx950`

Ran the new test (and the existing `LaunchFourOps*` family) with CE dispatch enabled (`NCCL_CTA_POLICY=2 NCCL_LOCAL_REGISTER=0 NCCL_CUMEM_ENABLE=1`), 2 ranks. Also performed an A/B by reverting the `isLegacyStream` hunk to confirm behaviour, and an `llvm-cov` comparison to quantify the coverage delta on `ce_coll.cc`.

## Test Result

- `CeInternalMPITest.LaunchFourOpsNullStreamSucceeds` — **PASS** (~2.1s); data verified correct on the null stream.
- A/B: passes both **with** the fix and **with the `isLegacyStream` hunk reverted** (confirms it is a behaviour/regression test, not a discriminator — expected on AMD).
- Coverage of `ce_coll.cc` (vs. the existing batch-path test as baseline): **+10 lines, +12 regions, +6 branches**, all attributable to the previously-uncovered per-op `hipMemcpyAsync` fallback loop (lines 427–439).

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.