### PR TITLE
ci: Drop `fetch-depth: 0` from pr-org-label.yml

### DIFF
--- a/.github/workflows/pr-org-label.yml
+++ b/.github/workflows/pr-org-label.yml
@@ -36,7 +36,6 @@ jobs:
             ${{ github.event.inputs.subrepo-prefix }}
           sparse-checkout-cone-mode: true
           token: ${{ steps.generate-token.outputs.token }}
-          fetch-depth: 0  #for subtree operations
 
       - name: Get open PR numbers
         env:


### PR DESCRIPTION
## Motivation

We recently removed a lot of unnecessary `fetch-depth: 0` lines from the hipFile CI, so we should also look to see if other actions have unnecessary lines.

## Technical Details

The pr-org-label.yml action does not inspect the git history. The comment associated with it refers to git subtree commands that do not exist (and never existed, according to the history).

## JIRA ID

N/A

## Test Plan

CI Passes

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
