### PR TITLE
fix(rocjitsu): Avoid signed overflow UB in scalar add/sub SCC execution

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
@@ -507,6 +507,18 @@ class _ScalarBinop(_ScalarDeriver):
             result = SemaNode(
                 SemaNodeKind.CALL, ty=ty, call_name=fn, children=(_id(fn), src0, src1)
             )
+        elif op in ('add', 'sub') and ty.base == 'I':
+            # Perform the wrapping add/sub in unsigned to avoid signed-overflow
+            # UB. GCC13+ assumes no overflow with a bare signed `s0 + s1` and
+            # so the overflow check is always false if not done unsigned. Then,
+            # reinterpret the unsigned result back to signd for the overflow check.
+            u_ty = SemaType.U32 if ty.size == 32 else SemaType.U64
+            arith = SemaNode(
+                kind,
+                ty=u_ty,
+                children=(_cast(src0, u_ty), _cast(src1, u_ty)),
+            )
+            result = _cast(arith, ty)
         else:
             result = SemaNode(kind, ty=ty, children=(src0, src1))
 

--- a/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
@@ -559,35 +559,14 @@ class _ScalarBinop(_ScalarDeriver):
                     ),
                 )
             elif sem.sets_scc == 'overflow':
-                # Signed overflow via the sign-bit identity:
-                # For add, overflow iff the operands share a sign that differs
-                # from the result's.
-                # For sub, overflow iff the operands differ in sign and src0's
-                # sign differs from the result's.
-                res_id = _id('result', result_ty)
-                if op == 'sub':
-                    x0 = SemaNode(SemaNodeKind.XOR, ty=result_ty, children=(src0, src1))
-                    x1 = SemaNode(
-                        SemaNodeKind.XOR, ty=result_ty, children=(src0, res_id)
-                    )
-                else:
-                    x0 = SemaNode(
-                        SemaNodeKind.XOR, ty=result_ty, children=(src0, res_id)
-                    )
-                    x1 = SemaNode(
-                        SemaNodeKind.XOR, ty=result_ty, children=(src1, res_id)
-                    )
-                sign_mask = _lit(
-                    '0x80000000u' if result_ty.size == 32 else '0x8000000000000000',
-                    result_ty,
-                )
+                # Signed-overflow SCC detected in unsigned via the sign-bit
+                # identity
+                fn = 'signed_sub_overflows' if op == 'sub' else 'signed_add_overflows'
                 scc_expr = SemaNode(
-                    SemaNodeKind.AND,
-                    ty=result_ty,
-                    children=(
-                        SemaNode(SemaNodeKind.AND, ty=result_ty, children=(x0, x1)),
-                        sign_mask,
-                    ),
+                    SemaNodeKind.CALL,
+                    ty=SemaType.U1,
+                    call_name=fn,
+                    children=(_id(fn), src0, src1),
                 )
             elif sem.sets_scc == 'compare':
                 cmp_kind = SemaNodeKind.GE if op == 'max' else SemaNodeKind.LT

--- a/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
@@ -398,7 +398,9 @@ class _ScalarBinop(_ScalarDeriver):
     def derive(sem: InstructionSemantics) -> SemaBlock:
         op = sem.operation
         ty = _dtype_to_sema(sem.data_type)
-        raw_carry_bits = sem.sets_scc in ('carry', 'borrow') and ty.base == 'I'
+        raw_carry_bits = (
+            sem.sets_scc in ('carry', 'borrow', 'overflow') and ty.base == 'I'
+        )
         calc_ty = SemaType('U', ty.size) if raw_carry_bits else ty
         src0 = _cast(_src(0), calc_ty)
         src1 = _cast(_src(1), calc_ty)
@@ -508,22 +510,21 @@ class _ScalarBinop(_ScalarDeriver):
                 SemaNodeKind.CALL, ty=ty, call_name=fn, children=(_id(fn), src0, src1)
             )
         elif op in ('add', 'sub') and ty.base == 'I':
-            # Perform the wrapping add/sub in unsigned to avoid signed-overflow
-            # UB. GCC13+ assumes no overflow with a bare signed `s0 + s1` and
-            # so the overflow check is always false if not done unsigned. Then,
-            # reinterpret the unsigned result back to signd for the overflow check.
+            # Emulate the hardware's wrap-around arithmetic in unsigned. A bare
+            # signed `s0 + s1` is undefined on overflow, which GCC -O1+ exploits
+            # to fold away the signed-overflow SCC check. Derive SCC from the
+            # the sign-bit identity
             u_ty = SemaType.U32 if ty.size == 32 else SemaType.U64
-            arith = SemaNode(
+            result = SemaNode(
                 kind,
                 ty=u_ty,
                 children=(_cast(src0, u_ty), _cast(src1, u_ty)),
             )
-            result = _cast(arith, ty)
         else:
             result = SemaNode(kind, ty=ty, children=(src0, src1))
 
         result_ty = calc_ty if raw_carry_bits else ty
-        if op == 'mul' and ty.base == 'I':
+        if op in ('mul', 'add', 'sub') and ty.base == 'I':
             result_ty = result.ty or result_ty
         if ty.base in ('F', 'BF') and ty.size == 16:
             result_ty = SemaType.F32
@@ -558,21 +559,34 @@ class _ScalarBinop(_ScalarDeriver):
                     ),
                 )
             elif sem.sets_scc == 'overflow':
-                overflow_kind = SemaNodeKind.SUB if op == 'sub' else SemaNodeKind.ADD
-                wide = SemaNode(
-                    overflow_kind,
-                    ty=SemaType.I64,
-                    children=(
-                        _cast(src0, SemaType.I64),
-                        _cast(src1, SemaType.I64),
-                    ),
+                # Signed overflow via the sign-bit identity:
+                # For add, overflow iff the operands share a sign that differs
+                # from the result's.
+                # For sub, overflow iff the operands differ in sign and src0's
+                # sign differs from the result's.
+                res_id = _id('result', result_ty)
+                if op == 'sub':
+                    x0 = SemaNode(SemaNodeKind.XOR, ty=result_ty, children=(src0, src1))
+                    x1 = SemaNode(
+                        SemaNodeKind.XOR, ty=result_ty, children=(src0, res_id)
+                    )
+                else:
+                    x0 = SemaNode(
+                        SemaNodeKind.XOR, ty=result_ty, children=(src0, res_id)
+                    )
+                    x1 = SemaNode(
+                        SemaNodeKind.XOR, ty=result_ty, children=(src1, res_id)
+                    )
+                sign_mask = _lit(
+                    '0x80000000u' if result_ty.size == 32 else '0x8000000000000000',
+                    result_ty,
                 )
                 scc_expr = SemaNode(
-                    SemaNodeKind.NE,
-                    ty=SemaType.U1,
+                    SemaNodeKind.AND,
+                    ty=result_ty,
                     children=(
-                        wide,
-                        _cast(_id('result', ty), SemaType.I64),
+                        SemaNode(SemaNodeKind.AND, ty=result_ty, children=(x0, x1)),
+                        sign_mask,
                     ),
                 )
             elif sem.sets_scc == 'compare':

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -207,9 +207,8 @@ class TestDeriveScalarBinop:
         assert 'uint32_t result = (s0 + s1)' in cpp
         assert re.search(r'\bint32_t\b', cpp) is None
         assert re.search(r'\bint64_t\b', cpp) is None
-        # add overflow: (s0 ^ result) & (s1 ^ result) & sign-bit
-        assert '(s0 ^ result) & (s1 ^ result)' in cpp
-        assert '0x80000000u' in cpp
+        # SCC overflow is detected by the unsigned helper (simd_glue.h).
+        assert 'wf.write_scc(signed_add_overflows(s0, s1))' in cpp
 
         sem = derive_semantics('S_SUB_CO_I32', 'ENC_SOP2')
         assert sem.sets_scc == 'overflow'
@@ -218,9 +217,7 @@ class TestDeriveScalarBinop:
         assert 'uint32_t result = (s0 - s1)' in cpp
         assert re.search(r'\bint32_t\b', cpp) is None
         assert re.search(r'\bint64_t\b', cpp) is None
-        # sub overflow: (s0 ^ s1) & (s0 ^ result) & sign-bit
-        assert '(s0 ^ s1) & (s0 ^ result)' in cpp
-        assert '0x80000000u' in cpp
+        assert 'wf.write_scc(signed_sub_overflows(s0, s1))' in cpp
 
     @pytest.mark.parametrize(
         'name,operation,dtype,scc',

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -195,25 +195,32 @@ class TestDeriveScalarBinop:
         assert 'uint32_t result' in cpp
         assert re.search(r'\bint32_t\s+result\b', cpp) is None
 
-    def test_signed_co_uses_signed_overflow(self):
+    def test_signed_co_uses_unsigned_overflow(self):
+        # Signed s_add_co_i32 / s_sub_co_i32 must emulate the hardware's
+        # wrap-around add/sub entirely in unsigned (signed overflow is undefined
+        # behavior and unnecessary).
         sem = derive_semantics('S_ADD_CO_I32', 'ENC_SOP2')
         assert sem.sets_scc == 'overflow'
         block = derive_sema_block(sem)
         cpp = lower_sema_block(block)
 
-        assert 'int32_t' in cpp
-        assert 'int64_t' in cpp
-        assert 'write_scc' in cpp
-        assert 'static_cast<uint64_t>' not in cpp
+        assert 'uint32_t result = (s0 + s1)' in cpp
+        assert re.search(r'\bint32_t\b', cpp) is None
+        assert re.search(r'\bint64_t\b', cpp) is None
+        # add overflow: (s0 ^ result) & (s1 ^ result) & sign-bit
+        assert '(s0 ^ result) & (s1 ^ result)' in cpp
+        assert '0x80000000u' in cpp
 
         sem = derive_semantics('S_SUB_CO_I32', 'ENC_SOP2')
         assert sem.sets_scc == 'overflow'
         block = derive_sema_block(sem)
         cpp = lower_sema_block(block)
-        assert 'int32_t' in cpp
-        assert 'int64_t' in cpp
-        assert 'write_scc' in cpp
-        assert 'static_cast<uint64_t>' not in cpp
+        assert 'uint32_t result = (s0 - s1)' in cpp
+        assert re.search(r'\bint32_t\b', cpp) is None
+        assert re.search(r'\bint64_t\b', cpp) is None
+        # sub overflow: (s0 ^ s1) & (s0 ^ result) & sign-bit
+        assert '(s0 ^ s1) & (s0 ^ result)' in cpp
+        assert '0x80000000u' in cpp
 
     @pytest.mark.parametrize(
         'name,operation,dtype,scc',

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -406,12 +406,11 @@ inline void execute_s_add_co_ci_u32_sop2([[maybe_unused]] Inst &inst,
 
 template <typename Inst>
 inline void execute_s_add_co_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  int32_t s0 = static_cast<int32_t>(inst.ssrc0.read_scalar(wf));
-  int32_t s1 = static_cast<int32_t>(inst.ssrc1.read_scalar(wf));
-  int32_t result = static_cast<int32_t>((static_cast<uint32_t>(s0) + static_cast<uint32_t>(s1)));
+  uint32_t s0 = inst.ssrc0.read_scalar(wf);
+  uint32_t s1 = inst.ssrc1.read_scalar(wf);
+  uint32_t result = (s0 + s1);
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc(
-      ((static_cast<int64_t>(s0) + static_cast<int64_t>(s1)) != static_cast<int64_t>(result)));
+  wf.write_scc((((s0 ^ result) & (s1 ^ result)) & 0x80000000u));
 }
 
 template <typename Inst>
@@ -439,12 +438,11 @@ inline void execute_s_add_f32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]]
 
 template <typename Inst>
 inline void execute_s_add_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  int32_t s0 = static_cast<int32_t>(inst.ssrc0.read_scalar(wf));
-  int32_t s1 = static_cast<int32_t>(inst.ssrc1.read_scalar(wf));
-  int32_t result = static_cast<int32_t>((static_cast<uint32_t>(s0) + static_cast<uint32_t>(s1)));
+  uint32_t s0 = inst.ssrc0.read_scalar(wf);
+  uint32_t s1 = inst.ssrc1.read_scalar(wf);
+  uint32_t result = (s0 + s1);
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc(
-      ((static_cast<int64_t>(s0) + static_cast<int64_t>(s1)) != static_cast<int64_t>(result)));
+  wf.write_scc((((s0 ^ result) & (s1 ^ result)) & 0x80000000u));
 }
 
 template <typename Inst>
@@ -2479,12 +2477,11 @@ inline void execute_s_sub_co_ci_u32_sop2([[maybe_unused]] Inst &inst,
 
 template <typename Inst>
 inline void execute_s_sub_co_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  int32_t s0 = static_cast<int32_t>(inst.ssrc0.read_scalar(wf));
-  int32_t s1 = static_cast<int32_t>(inst.ssrc1.read_scalar(wf));
-  int32_t result = static_cast<int32_t>((static_cast<uint32_t>(s0) - static_cast<uint32_t>(s1)));
+  uint32_t s0 = inst.ssrc0.read_scalar(wf);
+  uint32_t s1 = inst.ssrc1.read_scalar(wf);
+  uint32_t result = (s0 - s1);
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc(
-      ((static_cast<int64_t>(s0) - static_cast<int64_t>(s1)) != static_cast<int64_t>(result)));
+  wf.write_scc((((s0 ^ s1) & (s0 ^ result)) & 0x80000000u));
 }
 
 template <typename Inst>
@@ -2512,12 +2509,11 @@ inline void execute_s_sub_f32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]]
 
 template <typename Inst>
 inline void execute_s_sub_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
-  int32_t s0 = static_cast<int32_t>(inst.ssrc0.read_scalar(wf));
-  int32_t s1 = static_cast<int32_t>(inst.ssrc1.read_scalar(wf));
-  int32_t result = static_cast<int32_t>((static_cast<uint32_t>(s0) - static_cast<uint32_t>(s1)));
+  uint32_t s0 = inst.ssrc0.read_scalar(wf);
+  uint32_t s1 = inst.ssrc1.read_scalar(wf);
+  uint32_t result = (s0 - s1);
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc(
-      ((static_cast<int64_t>(s0) - static_cast<int64_t>(s1)) != static_cast<int64_t>(result)));
+  wf.write_scc((((s0 ^ s1) & (s0 ^ result)) & 0x80000000u));
 }
 
 template <typename Inst>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -408,7 +408,7 @@ template <typename Inst>
 inline void execute_s_add_co_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   int32_t s0 = static_cast<int32_t>(inst.ssrc0.read_scalar(wf));
   int32_t s1 = static_cast<int32_t>(inst.ssrc1.read_scalar(wf));
-  int32_t result = (s0 + s1);
+  int32_t result = static_cast<int32_t>((static_cast<uint32_t>(s0) + static_cast<uint32_t>(s1)));
   inst.sdst.write_scalar(wf, result);
   wf.write_scc(
       ((static_cast<int64_t>(s0) + static_cast<int64_t>(s1)) != static_cast<int64_t>(result)));
@@ -441,7 +441,7 @@ template <typename Inst>
 inline void execute_s_add_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   int32_t s0 = static_cast<int32_t>(inst.ssrc0.read_scalar(wf));
   int32_t s1 = static_cast<int32_t>(inst.ssrc1.read_scalar(wf));
-  int32_t result = (s0 + s1);
+  int32_t result = static_cast<int32_t>((static_cast<uint32_t>(s0) + static_cast<uint32_t>(s1)));
   inst.sdst.write_scalar(wf, result);
   wf.write_scc(
       ((static_cast<int64_t>(s0) + static_cast<int64_t>(s1)) != static_cast<int64_t>(result)));
@@ -2481,7 +2481,7 @@ template <typename Inst>
 inline void execute_s_sub_co_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   int32_t s0 = static_cast<int32_t>(inst.ssrc0.read_scalar(wf));
   int32_t s1 = static_cast<int32_t>(inst.ssrc1.read_scalar(wf));
-  int32_t result = (s0 - s1);
+  int32_t result = static_cast<int32_t>((static_cast<uint32_t>(s0) - static_cast<uint32_t>(s1)));
   inst.sdst.write_scalar(wf, result);
   wf.write_scc(
       ((static_cast<int64_t>(s0) - static_cast<int64_t>(s1)) != static_cast<int64_t>(result)));
@@ -2514,7 +2514,7 @@ template <typename Inst>
 inline void execute_s_sub_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
   int32_t s0 = static_cast<int32_t>(inst.ssrc0.read_scalar(wf));
   int32_t s1 = static_cast<int32_t>(inst.ssrc1.read_scalar(wf));
-  int32_t result = (s0 - s1);
+  int32_t result = static_cast<int32_t>((static_cast<uint32_t>(s0) - static_cast<uint32_t>(s1)));
   inst.sdst.write_scalar(wf, result);
   wf.write_scc(
       ((static_cast<int64_t>(s0) - static_cast<int64_t>(s1)) != static_cast<int64_t>(result)));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -410,7 +410,7 @@ inline void execute_s_add_co_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unuse
   uint32_t s1 = inst.ssrc1.read_scalar(wf);
   uint32_t result = (s0 + s1);
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc((((s0 ^ result) & (s1 ^ result)) & 0x80000000u));
+  wf.write_scc(signed_add_overflows(s0, s1));
 }
 
 template <typename Inst>
@@ -442,7 +442,7 @@ inline void execute_s_add_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]]
   uint32_t s1 = inst.ssrc1.read_scalar(wf);
   uint32_t result = (s0 + s1);
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc((((s0 ^ result) & (s1 ^ result)) & 0x80000000u));
+  wf.write_scc(signed_add_overflows(s0, s1));
 }
 
 template <typename Inst>
@@ -2481,7 +2481,7 @@ inline void execute_s_sub_co_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unuse
   uint32_t s1 = inst.ssrc1.read_scalar(wf);
   uint32_t result = (s0 - s1);
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc((((s0 ^ s1) & (s0 ^ result)) & 0x80000000u));
+  wf.write_scc(signed_sub_overflows(s0, s1));
 }
 
 template <typename Inst>
@@ -2513,7 +2513,7 @@ inline void execute_s_sub_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]]
   uint32_t s1 = inst.ssrc1.read_scalar(wf);
   uint32_t result = (s0 - s1);
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc((((s0 ^ s1) & (s0 ^ result)) & 0x80000000u));
+  wf.write_scc(signed_sub_overflows(s0, s1));
 }
 
 template <typename Inst>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -70,6 +70,25 @@ inline uint32_t mad_i24_u32(uint32_t lhs, uint32_t rhs, uint32_t addend) {
   return mul_i24_u32(lhs, rhs) + addend;
 }
 
+/// Return whether signed integer add/sub overflows. The unsigned parameter type
+/// is deduced, so the same helper serves 32- and 64-bit scalar add/sub.
+template <typename U> inline bool signed_add_overflows(U a, U b) {
+  static_assert(std::is_unsigned_v<U>, "operands must be unsigned");
+  const U sum = static_cast<U>(a + b);
+  constexpr U sign_bit = U{1} << (sizeof(U) * 8 - 1);
+  // Overflow iff the operands share a sign that differs from the result's.
+  return ((a ^ sum) & (b ^ sum) & sign_bit) != 0;
+}
+
+template <typename U> inline bool signed_sub_overflows(U a, U b) {
+  static_assert(std::is_unsigned_v<U>, "operands must be unsigned");
+  const U diff = static_cast<U>(a - b);
+  constexpr U sign_bit = U{1} << (sizeof(U) * 8 - 1);
+  // Overflow iff the operands differ in sign and a's sign differs from the
+  // result's.
+  return ((a ^ b) & (a ^ diff) & sign_bit) != 0;
+}
+
 /// Write an explicit SGPR lane-mask destination. Wave32 targets use the low
 /// dword only; writing a pair would clobber the next SGPR, which codegen may
 /// legally use for unrelated scalar state.


### PR DESCRIPTION
## Motivation
The autogenerated executors for `s_add_co_i32`, `s_sub_co_i32`, `s_add_i32`, and `s_sub_i32` computed the result with a bare signed int32. This failed with GCC13+ builds with optimizations because signed integer overflow is undefined and assumed that it does not happen, and optimized out our overflow check.

Edit: To fix this, we perform the operation unsigned and check whether to set SCC via the sign-bit identity, as suggested by reviewers.

NOTE: This fix was not done to avoid sanitizers. ASAN was a red herring. It was done to fix a bug that surfaces when using GCC13 with optimizations.

## Technical Details

The original code looked like this:

```C
1: inline void execute_s_add_i32_sop2([[maybe_unused]] Inst &inst, [[maybe_unused]] Wavefront &wf) {
2:  int32_t s0 = static_cast<int32_t>(inst.ssrc0.read_scalar(wf));
3:  int32_t s1 = static_cast<int32_t>(inst.ssrc1.read_scalar(wf));
4:  int32_t result = s0 + s1;
5:  inst.sdst.write_scalar(wf, result);
6:  wf.write_scc(
      ((static_cast<int64_t>(s0) + static_cast<int64_t>(s1)) != static_cast<int64_t>(result)));
```

The important lines of this code snippet are lines 4 and 6. Line 4 does the addition. Line 6 is where the bug surfaced. Line 6 checks and sets SCC if we carry.

### Why unit tests were failing

We have 2 unit tests (`Rdna4ScalarSccTest.AddSubCoI32UseSignedOverflow` and `Rdna4ScalarSccTest.AddSubCoI32UseSignedOverflow`) which made sure that SCC was set correctly in the event that the result overflowed. When rocjitsu is compiled with clang or gcc + O0, there is no issue here. However, when optimizations are enabled, GCC optimizes out line 6, because according to C++, line 4 is undefined behavior and it assumes that line 4 will never overflow. This allows it to say that `(static_cast<int64_t>(s0) + static_cast<int64_t>(s1)) != static_cast<int64_t>(result))` is FALSE every time. Which means the SCC bit never gets set.

### The Fix

Since we allow GCC as a compiler, we have to fix line 4 to do the sum and avoid line 6 from being optimized out. I originally chose to do this by casting to unsigned ints to do the sum (not undefined behavior) and casting back to the signed integer to get the actual sum. Reviewers suggested to instead just do the sum unsigned and check the SCC bit via the sign-bit identity, so the code and tests have been updated to reflect that.

## JIRA ID

Resolves JIRA ID : ROCM-27230

## Test Plan

Python tests should still pass.
Build with gcc13. All tests should pass.

## Test Result

Python tests still pass.
Tests pass with gcc13.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
