### PR TITLE
docs(rocprofiler-compute): move 7.15 changelog items out of 7.14

### DIFF
--- a/projects/rocprofiler-compute/CHANGELOG.md
+++ b/projects/rocprofiler-compute/CHANGELOG.md
@@ -7,35 +7,11 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 ### Added
 
-### Changed
-
-### Removed
-
-### Optimized
-
-### Resolved issues
-
-### Upcoming changes
-
-### Known issues
-
-## ROCm Compute Profiler 3.7.0 for ROCm 7.14.0
-
-### Added
-
 * Added ``--pc-sampling-rows`` analyze option to cap the PC sampling table at the top N rows (default 10); set ``0`` to show all. Must be non-negative.
-
-* Added ``--bench-only`` profile mode option to run the roofline microbenchmark standalone (without profiling an application or collecting performance counters). No application run is required. Useful for regenerating ``roofline.csv`` in an existing workload directory or running the microbenchmark on systems where only HIP is available but rocprofiler-sdk is not.
 
 * Added ``--overwrite`` profile mode option to explicitly allow replacing existing workload output.
 
-* Added LDS arithmetic intensity as a roofline plot point and analysis database field.
-
-* Added backward compatibility for live attach mode to work with older ROCm 7.x.x releases.
-
-* Added AMD Strix Point (gfx1150) and Krackan Point (gfx1152) support
-
-* Added GPU Benchmarking and Roofline profiling/analysis support for gfx1150/gfx1151/gfx1152 architectures.
+* Improved GPU Benchmarking and Roofline profiling/analysis support for gfx1150/gfx1151/gfx1152 architectures.
   * gfx11 supports Wave Matrix Multiply Accumulate (WMMA), replacing MFMA operations.
 
 ### Changed
@@ -43,6 +19,44 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 * `--pc-sampling-sorting-type` now defaults to `count` (was `offset`), so the PC sampling table shows the most-sampled instructions first.
 
 * Renamed the `Pct of Peak` / `PoP` analysis column to `Percent of Peak` in analysis output.
+
+* `--torch-trace` now wraps the tensor methods `to`, `cpu`, `cuda`, and `contiguous` by default. Previously these wraps were enabled by setting `ROCPROFCOMPUTE_ROCTX_DEEP_TENSOR_WRAPS=1`. Set `ROCPROFCOMPUTE_ROCTX_DEEP_TENSOR_WRAPS=0` (or `false`, `no`, `off`) to disable them.
+
+* Renamed the torch-trace output files and directory from `torch_trace_*` to `ml_api_trace_*`.
+
+* Profile mode now errors when the target workload directory is non-empty unless `--overwrite` is passed. `--bench-only` likewise requires `--overwrite` before replacing an existing `roofline.csv`.
+
+### Removed
+
+* Removed the multi-node analysis options ``--nodes``, ``--list-nodes`` (analyze mode) and the experimental ``--spatial-multiplexing`` option (profile and analyze modes). These features did not work as expected and will be redesigned in a future release.
+
+### Optimized
+
+### Resolved issues
+
+* The Dual VALU (VOPD) instruction mix metric is now reported for gfx115x in the WGP panel.
+
+### Upcoming changes
+
+### Known issues
+
+* CLI mode block 4 Roofline plot's legend will not appear if there are too many kernels to list, in relation to the user's terminal size. Same per-kernel roofline rate metrics and AI plot point details can be read in block 4's preceding tables.
+
+## ROCm Compute Profiler 3.7.0 for ROCm 7.14.0
+
+### Added
+
+* Added ``--bench-only`` profile mode option to run the roofline microbenchmark standalone (without profiling an application or collecting performance counters). No application run is required. Useful for regenerating ``roofline.csv`` in an existing workload directory or running the microbenchmark on systems where only HIP is available but rocprofiler-sdk is not.
+
+* Added LDS arithmetic intensity as a roofline plot point and analysis database field.
+
+* Added backward compatibility for live attach mode to work with older ROCm 7.x.x releases.
+
+* Added support for GPU metrics on gfx1150 and gfx1152 hardware.
+
+* Added roofline benchmarking support for gfx1150 and gfx1152 hardware.
+
+### Changed
 
 * Moved `--gui` and `--tui` analyze options to experimental status. These features now require the `--experimental` flag to be enabled (e.g., `rocprof-compute analyze --experimental --gui`).
 
@@ -56,10 +70,6 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
     * Min/Max/Mean and Total duration of kernel dispatches
 
 * `--torch-trace` now captures backward-pass and nested operators that were previously missed or misattributed. The first run builds and caches a helper under `~/.cache/rocprofiler-compute/`, so it takes longer than later runs.
-
-* `--torch-trace` now wraps the tensor methods `to`, `cpu`, `cuda`, and `contiguous` by default. Previously these wraps were enabled by setting `ROCPROFCOMPUTE_ROCTX_DEEP_TENSOR_WRAPS=1`. Set `ROCPROFCOMPUTE_ROCTX_DEEP_TENSOR_WRAPS=0` (or `false`, `no`, `off`) to disable them.
-
-* Renamed the torch-trace output files and directory from `torch_trace_*` to `ml_api_trace_*`.
 
 * Profile workload output folder name for Strix Halo series (gfx1151) is changed from `strix_halo` to `rdna35_halo`
 
@@ -75,11 +85,7 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * `--pc-sampling-interval` now defaults to a method-appropriate value (512 microseconds for `host_trap`, 1048576 cycles for `stochastic`). Stochastic intervals are validated to be a power of 2 and at least 65536; previously invalid values were passed through silently.
 
-* Profile mode now errors when the target workload directory is non-empty unless `--overwrite` is passed. `--bench-only` likewise requires `--overwrite` before replacing an existing `roofline.csv`.
-
 ### Removed
-
-* Removed the multi-node analysis options ``--nodes``, ``--list-nodes`` (analyze mode) and the experimental ``--spatial-multiplexing`` option (profile and analyze modes). These features did not work as expected and will be redesigned in a future release.
 
 * ``--path`` and ``--subpath`` options have been removed from profile mode. Use ``--output-directory`` instead.
 
@@ -105,19 +111,15 @@ Full documentation for ROCm Compute Profiler is available at [https://rocm.docs.
 
 * PC sampling collection now runs when requested via the `pc_sampling` block alias (`--block pc_sampling`), instead of being silently skipped.
 
-* The Dual VALU (VOPD) instruction mix metric is now reported for gfx115x in the WGP panel.
+### Upcoming changes
 
 * Roofline support for RDNA3.5 gfx115x devices.
-
-### Upcoming changes
 
 ### Known issues
 
 * On gfx1151, `TCP_REQ_sum` is zero in single-pass counter collection, so the related `GL0` metrics always reports zero. This will be fixed in a future release.
 
 * On gfx1151, `$max_mclk` is not automatically populated in sysinfo, so the related bandwidth metrics may be incorrect. Use `amd-smi` to obtain the maximum memory clock and provide it via `--specs-correction`.
-
-* CLI mode block 4 Roofline plot's legend will not appear if there are too many kernels to list, in relation to the user's terminal size. Same per-kernel roofline rate metrics and AI plot point details can be read in block 4's preceding tables.
 
 * In analyze mode, `--nodes` is not suitable for multi-rank analysis. Use `--path` with the rank-specific path (such as, `--path workload/1`) instead of `--path workload --nodes 1`.
 


### PR DESCRIPTION
## Summary

- The 3.7.0 (ROCm 7.14.0) changelog section had accumulated entries from the 7.15 development cycle. `develop` holds the correct, finalized 7.14 changelog.
- Restored the 3.7.0 section to match `develop` verbatim, and moved the net-new items into the 3.8.0 (ROCm 7.15.0) section.

### Moved to 7.15
- Added: `--pc-sampling-rows`; `--overwrite`; improved GPU benchmarking and roofline support for gfx1150/gfx1151/gfx1152 (WMMA).
- Changed: `--pc-sampling-sorting-type` default; `Percent of Peak` rename; torch-trace tensor-method wraps; `ml_api_trace_*` rename; non-empty-dir error.
- Removed: multi-node `--nodes`/`--list-nodes`/`--spatial-multiplexing`.
- Resolved issues: Dual VALU (VOPD) for gfx115x.
- Known issues: block-4 roofline legend.

## Test plan

- [ ] Confirm the 3.7.0 section matches `develop` (diff is empty).
- [ ] Confirm the 3.8.0 section lists the relocated items.