### PR TITLE
ci: don't select profiler test legs for core-only builds

### DIFF
--- a/.github/scripts/tests/therock_configure_ci_test.py
+++ b/.github/scripts/tests/therock_configure_ci_test.py
@@ -462,6 +462,34 @@ class ConfigureCITest(unittest.TestCase):
         project_to_run = therock_configure_ci.retrieve_projects(args)
         self.assertEqual(len(project_to_run), 0)
 
+    @patch("therock_configure_ci.get_modified_paths")
+    def test_amdsmi_pr_core_build_selects_no_profiler_test_legs(
+        self, mock_get_modified
+    ):
+        """Regression test: an amdsmi (core) PR builds core-only
+        (THEROCK_ENABLE_ALL=OFF), so it must NOT select the aqlprofile/rocprofiler
+        test legs -- those components aren't built, so their artifacts
+        (run_tests.sh, tests/requirements.txt) don't exist and the legs fail at
+        setup. See PRs #7870 and #7942.
+        """
+        args = {
+            "is_pull_request": True,
+            "base_ref": "HEAD^",
+            "platform": "linux",
+        }
+
+        mock_get_modified.return_value = [
+            "projects/amdsmi/tests/python_unittest/partition_metric_unit_test.py",
+        ]
+
+        project_to_run = therock_configure_ci.retrieve_projects(args)
+        self.assertEqual(len(project_to_run), 1)
+        cmake_options = project_to_run[0]["cmake_options"]
+        self.assertIn("DTHEROCK_ENABLE_CORE=ON", cmake_options)
+        self.assertNotIn("DTHEROCK_ENABLE_ALL=ON", cmake_options)
+        # Core-only build must not pull in profiler test legs.
+        self.assertEqual(project_to_run[0]["projects_to_test"], "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/.github/scripts/therock_matrix.py
+++ b/.github/scripts/therock_matrix.py
@@ -36,7 +36,12 @@ subtree_to_project_map = {
 project_map = {
     "core": {
         "cmake_options": ["-DTHEROCK_ENABLE_CORE=ON", "-DTHEROCK_ENABLE_ALL=OFF"],
-        "projects_to_test": "aqlprofile, rocprofiler-compute, rocprofiler-sdk, rocprofiler-systems",  # will run sanity test to cover rocminfo and amdsmi
+        # A core-only build (THEROCK_ENABLE_ALL=OFF) does not build the
+        # profiler/aqlprofile components, so they must not be selected as test
+        # legs here -- their artifacts (run_tests.sh, tests/requirements.txt)
+        # won't exist and the legs fail at setup. The always-on sanity test
+        # covers rocminfo and amdsmi.
+        "projects_to_test": "",
     },
     "emulation": {
         "cmake_options": ["-DTHEROCK_ENABLE_ALL=OFF", "-DTHEROCK_ENABLE_EMULATION=ON"],


### PR DESCRIPTION
## Motivation

amdsmi (and other `core`) PRs show red CI on the `aqlprofile / rocprofiler-compute / rocprofiler-sdk / rocprofiler-systems` test legs even though the change is unrelated. The `core` build is core-only (`-DTHEROCK_ENABLE_ALL=OFF`) and never builds those profiler components, so the legs fail at setup with missing artifacts (`build/share/hsa-amd-aqlprofile/run_tests.sh`, `build/share/rocprofiler-*/tests/requirements.txt`). Reproduced on #7870 and #7942.

## Technical Details

- `.github/scripts/therock_matrix.py`: the `core` group listed the profiler projects under `projects_to_test`, but a core-only build never produces them. Set `projects_to_test` to `""` — the always-on sanity leg already covers rocminfo and amdsmi (matching the existing comment's intent), and this mirrors the other core-only groups (`dc_tools`, `storage_libs`, `emulation`) that already use an empty list.
- `.github/scripts/tests/therock_configure_ci_test.py`: add a regression test asserting an amdsmi PR yields a core-only build with no profiler test legs.

## JIRA ID

Related: #7870, #7942 (swap in the tracking ticket if one is filed)

## Test Plan

`python3 -m unittest therock_configure_ci_test` in `.github/scripts/tests/`.

## Test Result

New `test_amdsmi_pr_core_build_selects_no_profiler_test_legs` passes locally: the core build keeps `THEROCK_ENABLE_CORE=ON`, has no `ENABLE_ALL=ON`, and `projects_to_test` is empty. (Pre-existing rccl tests in the file require a git-checkout context and are unaffected.)

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

Made with [Cursor](https://cursor.com)