### PR TITLE
JIRA ID #2369 - Fixes a CTS api sub-test failure

### DIFF
--- a/projects/clr/opencl/amdocl/cl_command.cpp
+++ b/projects/clr/opencl/amdocl/cl_command.cpp
@@ -95,9 +95,17 @@ RUNTIME_ENTRY_RET(cl_command_queue, clCreateCommandQueueWithProperties,
             *not_null(errcode_ret) = CL_INVALID_VALUE;
             return (cl_command_queue)0;
           }
-          else if (properties & ~queueProperty) {
-            *not_null(errcode_ret) = CL_INVALID_QUEUE_PROPERTIES;
-            return (cl_command_queue)0;
+          else {
+            // Device queues are validated against the on-device property mask
+            // (plus the ON_DEVICE/ON_DEVICE_DEFAULT bits), not the host mask.
+            cl_command_queue_properties validMask =
+                (properties & CL_QUEUE_ON_DEVICE)
+                ? (queueonDeviceProperty | CL_QUEUE_ON_DEVICE | CL_QUEUE_ON_DEVICE_DEFAULT)
+                : queueProperty;
+            if (properties & ~validMask) {
+              *not_null(errcode_ret) = CL_INVALID_QUEUE_PROPERTIES;
+              return (cl_command_queue)0;
+            }
           }
           break;
         case CL_QUEUE_SIZE:

--- a/projects/clr/opencl/amdocl/cl_command.cpp
+++ b/projects/clr/opencl/amdocl/cl_command.cpp
@@ -96,8 +96,6 @@ RUNTIME_ENTRY_RET(cl_command_queue, clCreateCommandQueueWithProperties,
             return (cl_command_queue)0;
           }
           else {
-            // Device queues are validated against the on-device property mask
-            // (plus the ON_DEVICE/ON_DEVICE_DEFAULT bits), not the host mask.
             cl_command_queue_properties validMask =
                 (properties & CL_QUEUE_ON_DEVICE)
                 ? (queueonDeviceProperty | CL_QUEUE_ON_DEVICE | CL_QUEUE_ON_DEVICE_DEFAULT)


### PR DESCRIPTION
## Motivation

To fix a CTS api sub-test failure.

## Technical Details

Update command property queue handling to fix CTS api sub-test failure in get_command_queue_info

## JIRA ID

(https://amd-hub.atlassian.net/browse/AIRUNTIME-2369)

## Test Plan

Build OpenCL binary and run CTS sub-test ./api/test_api

## Test Result

109 test cases should pass.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
