### PR TITLE
[RCCL] Adapt topology and P2P routing to NCCL 2.30 DEV nodes (#7792)

### DIFF
--- a/projects/rccl/src/graph/paths.cc
+++ b/projects/rccl/src/graph/paths.cc
@@ -337,18 +337,20 @@ ncclResult_t ncclTopoCheckP2p(struct ncclComm* comm, struct ncclTopoSystem* syst
   #endif
   // Set intermediate GPU rank, if routing through an intermediate GPU.
   struct ncclTopoLinkList* path = gpu1->paths[GPU]+g2;
+  // xGMI fabric routes non-adjacent GPU pairs directly in hardware, so a
+  // software GPU relay is unnecessary and slower.
+#if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
   if (path->count == 4) { // Intermediate goes through DEV, not GPU.
     // path is GPU1 - DEV1 - DEV2 - DEV3 - GPU2, so the intermediate DEV is located at path->list[1]->remNode
     struct ncclTopoNode* intermediateNode = path->list[1]->remNode;
     if (intermediateNode->type == DEV) {
       int interRank;
       NCCLCHECK(ncclTopoDevToRank(system, NCCL_TOPO_ID_SYSTEM_ID(intermediateNode->id), intermediateNode->dev.dev, /*warn=*/true, &interRank));
-      #if !defined(__HIP_PLATFORM_AMD__) && !defined(__HIPCC__)
       NCCLCHECK(ncclTopoRankToIndex(system, interRank, &intermediateIndex, true));
-      #endif
       if (intermediateRank) *intermediateRank = interRank;
     }
   }
+#endif
 
   // In general, use P2P whenever we can.
   int p2pLevel = PATH_SYS;

--- a/projects/rccl/src/graph/rome_models.cc
+++ b/projects/rccl/src/graph/rome_models.cc
@@ -2135,12 +2135,9 @@ ncclResult_t parseChordalRing(struct ncclTopoSystem* system, struct ncclTopoGrap
     int sum = ngpus*(ngpus-1)/2 - node->gpu.dev;
     int count = 0;
     for (int n = 0; n<ngpus; n++) {
-      struct ncclTopoLink* link;
-      for (link = node->links; link->remNode; link++) {
-        if (link->remNode->gpu.dev == n) break;
-      }
-      if (!link->remNode) continue;
-      if (link->type != LINK_NVL) continue;
+      // Direct XGMI neighbor: post NCCL-2.30 a direct GPU->GPU path is GPU-DEV-DEV-GPU (count<=3).
+      struct ncclTopoLinkList* path = node->paths[GPU] + n;
+      if (path->type != PATH_NVL || path->count > 3) continue;
       sum -= system->nodes[GPU].nodes[n].gpu.dev;
       count ++;
     }
@@ -2278,7 +2275,9 @@ static ncclResult_t parseRomeSystem(struct ncclTopoSystem* system, struct rcclRo
     for (n = 0; n < romeTopo->nGpus; n++) {
       romeTopo->connMatrix[i*romeTopo->nGpus+n] = 0;
       struct ncclTopoLinkList *path = node->paths[GPU] + gpu_scores[n].g;
-      if (path->type != LINK_NVL) continue;
+      // Only count direct XGMI links: since NCCL 2.30, GPU->GPU routes via DEV nodes, so direct is
+      // count==3 and indirect count==4. Counting indirect breaks Rome matching on sparse topos.
+      if (path->type != PATH_NVL || path->count > 3) continue;
       romeTopo->connMatrix[i*romeTopo->nGpus+n] = path->bw/ncclTopoXGMISpeed(node->gpu.gcn);
       count ++;
     }

--- a/projects/rccl/src/graph/search.cc
+++ b/projects/rccl/src/graph/search.cc
@@ -367,14 +367,11 @@ static int ncclTopoCountXGMI(struct ncclTopoSystem* system, struct ncclTopoGraph
       if (j<ngpus) {
         node = system->nodes[GPU].nodes+j;
         for (int k = 0; k<system->nodes[GPU].count; k++) {
-          if (node->paths[GPU][k].count == 1) {
-            struct ncclTopoLink* link = node->paths[GPU][k].list[0];
-            struct ncclTopoNode* remNode = link->remNode;
-            if (remNode->gpu.rank == n) {
-              if (link->type == LINK_NVL)
-                count ++;
-            }
-          }
+          // Direct XGMI link: post NCCL-2.30 a direct GPU->GPU path is GPU-DEV-DEV-GPU (count<=3).
+          struct ncclTopoLinkList* path = node->paths[GPU] + k;
+          if (path->type == PATH_NVL && path->count <= 3
+              && system->nodes[GPU].nodes[k].gpu.rank == n)
+            count ++;
         }
       }
     }

--- a/projects/rccl/test/graph/TopoTests.cpp
+++ b/projects/rccl/test/graph/TopoTests.cpp
@@ -355,6 +355,66 @@ TEST_F(TopoTest, GetSystemFromXml_SingleSystem_BuildsLinks) {
   ncclTopoFree(built);
 }
 
+// Under the 2.30 DEV model a direct XGMI GPU->GPU path is the 3-hop
+// GPU-DEV-DEV-GPU route, typed PATH_NVL — the predicate the matching fixes use.
+TEST_F(TopoTest, DevModel_DirectXgmiPath_IsThreeHopNvl) {
+  const uint64_t host = 0x55;
+  struct ncclXmlNode* cpu = addSystemCpu(host);
+  struct ncclXmlNode* pci0 = addGpuPci(cpu, "0000:01:00.0", "gfx942", 0, 0);
+  struct ncclXmlNode* pci1 = addGpuPci(cpu, "0000:02:00.0", "gfx942", 1, 1);
+  addGpuLink(pci0, "0000:02:00.0", 8);
+  addGpuLink(pci1, "0000:01:00.0", 8);
+
+  struct ncclTopoSystem* built = nullptr;
+  ASSERT_EQ(ncclTopoGetSystemFromXml(xml, &built, host), ncclSuccess);
+  ASSERT_NE(built, nullptr);
+  ASSERT_EQ(ncclTopoComputePaths(built, nullptr), ncclSuccess);
+  ASSERT_EQ(built->nodes[GPU].count, 2);
+
+  // paths[GPU] is indexed by GPU node index; GPU 0 -> GPU 1 is direct.
+  struct ncclTopoLinkList* p01 = built->nodes[GPU].nodes[0].paths[GPU] + 1;
+  EXPECT_EQ(p01->type, PATH_NVL);
+  EXPECT_EQ(p01->count, 3);
+
+  ncclTopoFree(built);
+}
+
+// An indirect XGMI route (through a middle GPU's DEV) is the 4-hop path and must
+// not be mistaken for a direct link; the count<=3 filters depend on this.
+TEST_F(TopoTest, DevModel_IndirectXgmiPath_IsFourHops) {
+  const uint64_t host = 0x56;
+  struct ncclXmlNode* cpu = addSystemCpu(host);
+  struct ncclXmlNode* pci0 = addGpuPci(cpu, "0000:01:00.0", "gfx942", 0, 0);
+  struct ncclXmlNode* pci1 = addGpuPci(cpu, "0000:02:00.0", "gfx942", 1, 1);
+  struct ncclXmlNode* pci2 = addGpuPci(cpu, "0000:03:00.0", "gfx942", 2, 2);
+  // Chain 0<->1 and 1<->2 are direct XGMI; 0 and 2 are not directly linked.
+  addGpuLink(pci0, "0000:02:00.0", 8);
+  addGpuLink(pci1, "0000:01:00.0", 8);
+  addGpuLink(pci1, "0000:03:00.0", 8);
+  addGpuLink(pci2, "0000:02:00.0", 8);
+
+  struct ncclTopoSystem* built = nullptr;
+  ASSERT_EQ(ncclTopoGetSystemFromXml(xml, &built, host), ncclSuccess);
+  ASSERT_NE(built, nullptr);
+  ASSERT_EQ(ncclTopoComputePaths(built, nullptr), ncclSuccess);
+  ASSERT_EQ(built->nodes[GPU].count, 3);
+
+  auto idxByRank = [&](int rank) -> int {
+    for (int i = 0; i < built->nodes[GPU].count; i++)
+      if (built->nodes[GPU].nodes[i].gpu.rank == rank) return i;
+    return -1;
+  };
+  int i0 = idxByRank(0), i2 = idxByRank(2);
+  ASSERT_GE(i0, 0);
+  ASSERT_GE(i2, 0);
+
+  struct ncclTopoLinkList* p02 = built->nodes[GPU].nodes[i0].paths[GPU] + i2;
+  EXPECT_EQ(p02->count, 4);
+  EXPECT_GT(p02->count, 3); // excluded by the direct-XGMI filter
+
+  ncclTopoFree(built);
+}
+
 #else // !(__HIP_PLATFORM_AMD__ || __HIPCC__)
 
 // ncclTopoAddXGMI() is not built on non-HIP platforms, so register one skipped


### PR DESCRIPTION
Cherry-picks 52aecd1 into the 7.14 release branch.
JIRA ID ROCM-26913

---

## Motivation

RCCL 2.30.4 regresses collective bandwidth ~50–70% on MI250X (gfx90a) across all_reduce/reduce/reduce_scatter/all_gather/broadcast, and ~25–35% on alltoall/gather. Bisected to the NCCL v2.30.4-1 sync (#6837). sendrecv is unaffected. The same sync left several RCCL topology/P2P functions on the pre-2.30 model.

## Technical Details

NCCL 2.30 inserts a parent DEV topology node above each GPU and moves inter-GPU XGMI links onto DEV nodes. A GPU→GPU path is now 3 hops when direct (GPU-DEV-DEV-GPU) and 4 when indirect; `type == PATH_NVL` no longer implies a direct link, and a GPU node's raw `links` no longer point GPU→GPU. Four RCCL sites were not adapted for AMD:

- **`parseRomeSystem`** (rome_models.cc) — treated every `PATH_NVL` path as direct XGMI, over-populating the Rome `connMatrix`/`nLinks`. On MI250's sparse 4P2H fabric the Rome model stopped matching → generic ring search → channels halved (4→2) → ~−58%. Fix: count direct XGMI only when `path->count <= 3`.
- **`ncclTopoCountXGMI`** (search.cc) — gated on `path->count == 1`, never true post-DEV, so it always returned 0 and the XGMI tie-breaker in `ncclTopoCompareGraphs` was dead on every AMD arch. Fix: path-based direct test (`type == PATH_NVL && count <= 3`), neighbor read from the GPU node instead of `list[0]->remNode`.
- **`parseChordalRing`** (rome_models.cc) — walked `node->links` reading `remNode->gpu.dev`; XGMI links now live on DEV nodes, so chordal-ring (CR8G/8P6L) topologies stopped matching and fell back to generic search (channels 24→4). Fix: read direct XGMI neighbors from `node->paths[GPU]` with `count <= 3`.
- **`ncclTopoCheckP2p`** (paths.cc) — the upstream NCCL code routes a non-adjacent GPU pair (`path->count == 4`) through a software GPU relay (`*intermediateRank`), i.e. NCCL's NVB-style indirect P2P. This is correct for NVLink (non-adjacent peers are not directly reachable) but wrong for AMD: the xGMI fabric routes non-adjacent pairs directly in hardware (`isAllCudaP2p == 1`), so the relay is pure overhead — it flips `isAllDirectP2p` 1→0 and sends distant alltoall/gather traffic over a 2-hop relayed copy (~−27% alltoall, ~−35% gather). Fix: guard the relay block with `#if !defined(__HIP_PLATFORM_AMD__)` so AMD uses direct P2P, restoring `isAllDirectP2p == 1`.

Path-type comparisons use `PATH_NVL` (the `ncclTopoLinkList::type` domain). All changes are intra-node only — they affect per-node XGMI topology matching, graph search, and same-node GPU-GPU P2P. Cross-node pairs return early in `ncclTopoCheckP2p` and never reach the relay block; multi-node GPU→NIC (PXN) routing uses a separate path and is untouched. No-op on fully-connected arches (gfx942/gfx950), where every GPU pair is direct (`count==3`) so the sparse/relay branches never fire.

## JIRA ID

Resolves ROCM-26913 and AICOMRCCL-1394.

## Test Plan

- MI250X, 8 GPU: rccl-tests, all collectives, 8K–1G; clean 3-way (2.29.7 / develop / develop-fixed) on one node.
- P2P relay fix: alltoall/gather/all_reduce 256M–1G vs 2.29.7 baseline, with `NCCL_DEBUG=INFO` confirming `isAllDirectP2p` 0→1 and no `P2P/indirect` routing.
- topo_expl offline replay of the 8p6l (gfx908 1H6XGMI) chordal-ring models on a gfx950 host, before vs after the parseChordalRing fix.
- Unit tests (`rccl-UnitTestsFixturesDebug --gtest_filter=TopoTest.*`): updated the stale topology fixture for the 2.30 DEV-node model and added DEV-node path-hop invariant tests (direct = 3-hop PATH_NVL, indirect = 4-hop).

## Test Result

- MI250X ring collectives: large-message busbw ~2× restored — all_reduce 60→129, broadcast 58→119, reduce 62→129, all_gather 53→113, reduce_scatter 60→119 GB/s.
- MI250X P2P collectives (P2P relay fix): alltoall 45→62 and gather 89→137 GB/s @1G — fully back to 2.29.7 (alltoall 61.8, gather 136.6); all_reduce control unchanged (127); rings unaffected.
- topo_expl 8p6l models: chordal-ring match restored — Broadcast 1G maxChannels 4 (pre-fix) → 24 (post-fix) across all six 8p6l configs.
- TopoTest suite: 9/9 pass. Broader topology suites (NetDevsPolicy/Xml/NetDev) also pass.
- No regressions observed on gfx942 and gfx950

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.

---------

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
