### PR TITLE
fix: [clr] Add metadata prefetch packet capture infrastructure for graphs

### DIFF
--- a/projects/clr/hipamd/src/hip_graph_internal.cpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.cpp
@@ -616,6 +616,8 @@ void GraphExec::BuildSyncPlan() {
           firstBatch.dispatchPackets.insert(firstBatch.dispatchPackets.begin(), barrier_pkt);
           firstBatch.dispatchKernelNames.insert(firstBatch.dispatchKernelNames.begin(),
                                                 kBarrierKernelNamePtr);
+          firstBatch.dispatchMetadataPackets.insert(
+              firstBatch.dispatchMetadataPackets.begin(), nullptr);
         }
 
         // nodeRanges[i].startIndex was recorded before barrier packets were prepended.
@@ -641,6 +643,7 @@ void GraphExec::BuildSyncPlan() {
 
       lastBatch.dispatchPackets.push_back(completion_barrier);
       lastBatch.dispatchKernelNames.push_back(kBarrierKernelNamePtr);
+      lastBatch.dispatchMetadataPackets.push_back(nullptr);
 
       sync_plan_.patch_list.push_back(
           {completion_barrier, nullptr, hw_slot,
@@ -1618,11 +1621,14 @@ void GraphExec::PacketBatch::rebuildFilteredLists(
   enabledKernelNames.clear();
   filteredFlatPacketData.clear();
   filteredValidPacketFullHeaders.clear();
+  filteredFlatMetadataData.clear();
 
   enabledPackets.reserve(dispatchPackets.size());
   enabledKernelNames.reserve(dispatchPackets.size());
   filteredFlatPacketData.reserve(dispatchPackets.size() * kAqlPktSize);
   filteredValidPacketFullHeaders.reserve(dispatchPackets.size());
+
+  const bool hasMetadata = !dispatchMetadataPackets.empty();
 
   // packet pointer -> index in the filtered flat buffer, built during the
   // single pass below so patch_list resolution is O(patches) not O(p*n).
@@ -1635,6 +1641,15 @@ void GraphExec::PacketBatch::rebuildFilteredLists(
       enabledKernelNames.push_back(dispatchKernelNames[i]);
       appendPacketToFlatBuffer(dispatchPackets[i], filteredFlatPacketData,
                                filteredValidPacketFullHeaders);
+      // Append corresponding metadata slot (zero-filled for barriers)
+      if (hasMetadata) {
+        size_t metaOff = filteredFlatMetadataData.size();
+        filteredFlatMetadataData.resize(metaOff + kMetadataPktSize, 0);
+        if (i < dispatchMetadataPackets.size() && dispatchMetadataPackets[i] != nullptr) {
+          std::memcpy(filteredFlatMetadataData.data() + metaOff,
+                      dispatchMetadataPackets[i], kMetadataPktSize);
+        }
+      }
       packetToFilteredIndex[dispatchPackets[i]] = filteredIdx;
     }
   }
@@ -1738,8 +1753,9 @@ hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
           // Capture packets for this node
           std::vector<uint8_t*> nodePackets;
           std::vector<const std::string*> nodeKernelNames;
+          std::vector<uint8_t*> nodeMetadataPackets;
           status = currentNode->CaptureAndFormPacket(GetKernelArgManager(), &nodePackets,
-                                                     &nodeKernelNames);
+                                                     &nodeKernelNames, &nodeMetadataPackets);
 
           if (status != hipSuccess || nodePackets.empty()) {
             LogError("Packet capture failed");
@@ -1755,12 +1771,16 @@ hipError_t GraphExec::CaptureAndFormPacketsForGraph() {
           // Reserve space to avoid reallocations during insertion
           newBatch.dispatchPackets.reserve(startIndex + packetCount);
           newBatch.dispatchKernelNames.reserve(startIndex + packetCount);
+          newBatch.dispatchMetadataPackets.reserve(startIndex + packetCount);
 
           // Add to dispatch lists (initially all enabled)
           newBatch.dispatchPackets.insert(newBatch.dispatchPackets.end(), nodePackets.begin(),
                                           nodePackets.end());
           newBatch.dispatchKernelNames.insert(newBatch.dispatchKernelNames.end(),
                                               nodeKernelNames.begin(), nodeKernelNames.end());
+          newBatch.dispatchMetadataPackets.insert(newBatch.dispatchMetadataPackets.end(),
+                                                  nodeMetadataPackets.begin(),
+                                                  nodeMetadataPackets.end());
 
           // Store node mapping with range info
           newBatch.nodeRanges.push_back({startIndex, packetCount, true});
@@ -2058,11 +2078,23 @@ void GraphExec::PacketBatch::rebuildFlatBuffer() {
   const size_t n = dispatchPackets.size();
   flatPacketData.clear();
   validPacketFullHeaders.clear();
+  flatMetadataData.clear();
   filteredCacheValid = false;
   flatPacketData.reserve(n * kAqlPktSize);
   validPacketFullHeaders.reserve(n);
   for (const uint8_t* pkt_raw : dispatchPackets) {
     appendPacketToFlatBuffer(pkt_raw, flatPacketData, validPacketFullHeaders);
+  }
+  // Build flat metadata buffer (kMetadataPktSize per slot).
+  // Entries without metadata (barriers) are zero-filled.
+  if (!dispatchMetadataPackets.empty()) {
+    flatMetadataData.resize(n * kMetadataPktSize, 0);
+    for (size_t i = 0; i < n && i < dispatchMetadataPackets.size(); ++i) {
+      if (dispatchMetadataPackets[i] != nullptr) {
+        std::memcpy(flatMetadataData.data() + i * kMetadataPktSize,
+                    dispatchMetadataPackets[i], kMetadataPktSize);
+      }
+    }
   }
 }
 
@@ -2306,11 +2338,15 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
     const std::vector<const std::string*>* kernelNamesToDispatch;
     const std::vector<uint8_t>* flatData;
     const std::vector<uint32_t>* flatHdrs;
+    const std::vector<uint8_t>* metaData = nullptr;
 
     if (packetBatch.disabledNodeCount == 0) {
       kernelNamesToDispatch = &packetBatch.dispatchKernelNames;
       flatData = &packetBatch.flatPacketData;
       flatHdrs = &packetBatch.validPacketFullHeaders;
+      if (!packetBatch.flatMetadataData.empty()) {
+        metaData = &packetBatch.flatMetadataData;
+      }
     } else {
       // Guard against stale filtered buffers: rebuildFlatBuffer (called from
       // UpdateAQLPacket) invalidates the cache. This is a no-op when valid.
@@ -2318,11 +2354,15 @@ hipError_t GraphExec::EnqueueSegment(const Segment& segment, hip::Stream* stream
       kernelNamesToDispatch = &packetBatch.enabledKernelNames;
       flatData = &packetBatch.filteredFlatPacketData;
       flatHdrs = &packetBatch.filteredValidPacketFullHeaders;
+      if (!packetBatch.filteredFlatMetadataData.empty()) {
+        metaData = &packetBatch.filteredFlatMetadataData;
+      }
     }
 
     if (!flatData->empty()) {
       bool batchStatus = stream->vdev()->dispatchAqlPacketBatchFlat(
-          *flatData, *flatHdrs, accumulate, attach_signal, kernelNamesToDispatch, true);
+          *flatData, *flatHdrs, accumulate, attach_signal, kernelNamesToDispatch, true,
+          false, metaData);
       if (!batchStatus) {
         return hipErrorUnknown;
       }

--- a/projects/clr/hipamd/src/hip_graph_internal.hpp
+++ b/projects/clr/hipamd/src/hip_graph_internal.hpp
@@ -239,6 +239,9 @@ class GraphNode : public hipGraphNodeDOTAttribute {
     for (auto packet : gpuPackets_) {
       delete[] packet;
     }
+    for (auto packet : gpuMetadataPackets_) {
+      delete[] packet;
+    }
     amd::ScopedLock lock(nodeSetLock_);
     nodeSet_.erase(this);
   }
@@ -262,7 +265,8 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   //! Capture packets and accumulate them into a batch if provided
   hipError_t CaptureAndFormPacket(GraphKernelArgManager* kernArgMgr,
                                   std::vector<uint8_t*>* batchPackets = nullptr,
-                                  std::vector<const std::string*>* batchKernelNames = nullptr) {
+                                  std::vector<const std::string*>* batchKernelNames = nullptr,
+                                  std::vector<uint8_t*>* batchMetadataPackets = nullptr) {
     auto capture_stream = hip::getNullStream(g_devices[dev_id_]->devices()[0]->context(), false);
     hipError_t status = CreateCommand(capture_stream);
     if (status != hipSuccess) {
@@ -271,11 +275,14 @@ class GraphNode : public hipGraphNodeDOTAttribute {
 
     // Release last created packet memory before they are overwritten with new packets
     std::for_each(gpuPackets_.begin(), gpuPackets_.end(), [](auto p) { delete[] p; });
-    // Clear the pointer array
+    std::for_each(gpuMetadataPackets_.begin(), gpuMetadataPackets_.end(),
+                  [](auto p) { delete[] p; });
     gpuPackets_.clear();
+    gpuMetadataPackets_.clear();
 
     for (auto& command : commands_) {
-      command->setPktCapturingState(true, &gpuPackets_, kernArgMgr, &capturedKernelName_);
+      command->setPktCapturingState(true, &gpuPackets_, kernArgMgr, &capturedKernelName_,
+                                    &gpuMetadataPackets_);
       // Enqueue command to capture GPU Packet. The packet is not submitted to the device.
       // The packet is stored in gpuPacket_ and submitted during graph launch.
       command->submit(*(command->queue())->vdev());
@@ -284,9 +291,13 @@ class GraphNode : public hipGraphNodeDOTAttribute {
 
     // Accumulate packets directly into the batch (only if batch vectors are provided)
     if (batchPackets != nullptr && batchKernelNames != nullptr) {
-      for (auto& packet : gpuPackets_) {
-        batchPackets->push_back(packet);
+      for (size_t i = 0; i < gpuPackets_.size(); ++i) {
+        batchPackets->push_back(gpuPackets_[i]);
         batchKernelNames->push_back(capturedKernelName_);
+        if (batchMetadataPackets != nullptr) {
+          batchMetadataPackets->push_back(
+              i < gpuMetadataPackets_.size() ? gpuMetadataPackets_[i] : nullptr);
+        }
       }
     }
 
@@ -499,6 +510,7 @@ class GraphNode : public hipGraphNodeDOTAttribute {
   unsigned int isEnabled_;
   bool signal_is_required_ = false;   //!< This node requires a signal on the command
   std::vector<uint8_t*> gpuPackets_;  //!< GPU Packet to enqueue during graph launch
+  std::vector<uint8_t*> gpuMetadataPackets_;  //!< Metadata prefetch packets (parallel to gpuPackets_)
   const std::string* capturedKernelName_ = nullptr;
   size_t alignedKernArgSize_ = 256;       //!< Aligned size required for kernel args
   size_t kernargSegmentByteSize_ = 512;   //!< Kernel arg segment byte size
@@ -1129,10 +1141,14 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
   struct PacketBatch {
     // Size of one AQL packet
     static constexpr size_t kAqlPktSize = 64;
+    // Size of one metadata prefetch packet (256 bytes per AQL slot)
+    static constexpr size_t kMetadataPktSize = 256;
 
     // Main dispatch vectors - always ready for batch dispatch
     std::vector<uint8_t*> dispatchPackets;
     std::vector<const std::string*> dispatchKernelNames;
+    // Parallel metadata packets (one per dispatchPacket entry, nullptr for barriers)
+    std::vector<uint8_t*> dispatchMetadataPackets;
 
     // Cached filtered lists - built on-demand when nodes are disabled
     std::vector<uint8_t*> enabledPackets;
@@ -1141,11 +1157,14 @@ class GraphExec : public amd::ReferenceCountedObject, public Graph {
     // Pre-built flat packet buffer for fast bulk dispatch (all nodes enabled).
     std::vector<uint8_t> flatPacketData;
     std::vector<uint32_t> validPacketFullHeaders;
+    // Pre-built flat metadata buffer (kMetadataPktSize per AQL packet).
+    std::vector<uint8_t> flatMetadataData;
 
     // Filtered flat buffer - built alongside enabledPackets when some nodes are disabled.
     // Allows the fast flat-dispatch path even in the partially-disabled case.
     std::vector<uint8_t> filteredFlatPacketData;
     std::vector<uint32_t> filteredValidPacketFullHeaders;
+    std::vector<uint8_t> filteredFlatMetadataData;
     bool filteredCacheValid = false;
 
     // Node tracking

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -1376,7 +1376,8 @@ class VirtualDevice : public amd::ReferenceCountedObject {
                                           bool attach_signal = false,
                                           const std::vector<const std::string*>* kernelNames = nullptr,
                                           bool pre_patched = false,
-                                          bool blocking = false) {
+                                          bool blocking = false,
+                                          const std::vector<uint8_t>* flatMetadataData = nullptr) {
     return false;
   }
 

--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -1456,6 +1456,14 @@ bool VirtualGPU::dispatchAqlPacket(hsa_kernel_dispatch_packet_t* packet, uint16_
       packet->setup = rest;
     }
     std::memcpy(const_cast<uint8_t*>(aqlPacket), packet, sizeof(hsa_kernel_dispatch_packet_t));
+
+    // Capture the metadata prefetch packet into a host buffer (if supported).
+    if (metadata_preloader_.HasMetadataQueue() && command_ != nullptr) {
+      uint8_t* metaBuf = command_->getMetadataPacket();
+      if (metaBuf != nullptr) {
+        metadata_preloader_.CaptureMetadata(packet, header, metaBuf);
+      }
+    }
     return true;
   } else {
     dispatchBlockingWait(packet);
@@ -1479,7 +1487,8 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
                                             const std::vector<uint32_t>& validFullHeaders,
                                             amd::AccumulateCommand* vcmd, bool attach_signal,
                                             const std::vector<const std::string*>* kernelNames,
-                                            bool pre_patched, bool blocking) {
+                                            bool pre_patched, bool blocking,
+                                            const std::vector<uint8_t>* flatMetadataData) {
   if (vcmd == nullptr || flatPacketData.empty() || validFullHeaders.empty()) {
     return false;
   }
@@ -1559,6 +1568,21 @@ bool VirtualGPU::dispatchAqlPacketBatchFlat(const std::vector<uint8_t>& flatPack
       memcpy(queueBase + chunkSlot * kPacketSize, srcData, firstCount * kPacketSize);
       memcpy(queueBase, srcData + firstCount * kPacketSize,
              (thisChunk - firstCount) * kPacketSize);
+    }
+
+    // Copy this chunk's metadata packets to the metadata ring buffer.
+    if (flatMetadataData != nullptr && metadata_preloader_.HasMetadataQueue()) {
+      static constexpr size_t kMetaSize = 256;
+      auto* metaBase = static_cast<uint8_t*>(metadata_preloader_.GetQueueBase());
+      const uint8_t* metaSrc = flatMetadataData->data() + chunkStart * kMetaSize;
+      if (chunkSlot + thisChunk <= queueSize) {
+        memcpy(metaBase + chunkSlot * kMetaSize, metaSrc, thisChunk * kMetaSize);
+      } else {
+        const size_t firstCount = queueSize - chunkSlot;
+        memcpy(metaBase + chunkSlot * kMetaSize, metaSrc, firstCount * kMetaSize);
+        memcpy(metaBase, metaSrc + firstCount * kMetaSize,
+               (thisChunk - firstCount) * kMetaSize);
+      }
     }
 
     // Attach signal to the last packet when requested (before per-packet logging).

--- a/projects/clr/rocclr/device/rocm/rocvirtual.hpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.hpp
@@ -395,6 +395,35 @@ class VirtualGPU : public device::VirtualDevice {
         dyn_data_prefetch_enabled_ = false;
       }
 
+      //! Whether the preloader has a metadata queue attached
+      bool HasMetadataQueue() const { return IsAttached(); }
+
+      //! Returns the metadata ring buffer base (nullptr if not attached)
+      void* GetQueueBase() const { return queue_base_; }
+
+      //! Capture a metadata packet into a host buffer (for graph capture).
+      //! Fills the 256-byte buffer with the same content that Set() would write
+      //! to the queue metadata ring, but targets an arbitrary host pointer instead.
+      template <class AqlPacket>
+      void CaptureMetadata(AqlPacket* packet, uint16_t header, uint8_t* host_metadata) {
+        if (host_metadata == nullptr || !IsAttached()) {
+          return;
+        }
+        if constexpr (std::is_same_v<AqlPacket, hsa_kernel_dispatch_packet_t>) {
+          if (pending_descriptor_ == nullptr) {
+            return;
+          }
+          auto* metadata = reinterpret_cast<hsa_amd_metadata_kernel_dispatch_packet_t*>(
+              host_metadata);
+          SetPacket(packet, header, metadata);
+        } else if constexpr (std::is_same_v<AqlPacket, hsa_barrier_and_packet_t> ||
+                             std::is_same_v<AqlPacket, hsa_amd_barrier_value_packet_t>) {
+          auto* metadata = reinterpret_cast<hsa_amd_metadata_barrier_packet_t*>(
+              host_metadata);
+          SetPacket(packet, header, metadata);
+        }
+      }
+
     private:
       //! Return whether the loader is attached to a gpu queue
       bool IsAttached() const { return queue_base_ != nullptr; }
@@ -639,7 +668,8 @@ class VirtualGPU : public device::VirtualDevice {
                                   bool attach_signal = false,
                                   const std::vector<const std::string*>* kernelNames = nullptr,
                                   bool pre_patched = false,
-                                  bool blocking = false) override;
+                                  bool blocking = false,
+                                  const std::vector<uint8_t>* flatMetadataData = nullptr) override;
 
   template <typename AqlPacket> bool dispatchGenericAqlPacket(AqlPacket* packet, uint16_t header,
                                                               uint16_t rest, bool blocking,

--- a/projects/clr/rocclr/platform/command.hpp
+++ b/projects/clr/rocclr/platform/command.hpp
@@ -327,6 +327,7 @@ class Command : public Event {
 
   bool packetCapturing_ = false;       //!< Flag to enable/disable graph gpu packet capture
   std::vector<uint8_t*>* gpuPackets_;  //!< GPU packets captured when graph capturing is enabled
+  std::vector<uint8_t*>* gpuMetadataPackets_ = nullptr;  //!< Metadata packets (parallel to gpuPackets_)
   GraphKernelArgManager* graphKernArgMgr_ = nullptr;  //!< KernelMgr for graph
   address kernArgOffset_ = nullptr;  //!< KernelArg buffer to used when graph capturing is enabled
   const std::string** capturedKernelName_ = nullptr;  //!< Kernel under capture
@@ -377,9 +378,11 @@ class Command : public Event {
   //! Sets AQL capture state, aql packet to capture and where to copy kernArgs
   void setPktCapturingState(bool state, std::vector<uint8_t*>* packet,
                             amd::GraphKernelArgManager* graphKernArgMgr,
-                            const std::string** capturedKernelName) {
+                            const std::string** capturedKernelName,
+                            std::vector<uint8_t*>* metadataPackets = nullptr) {
     packetCapturing_ = state;
     gpuPackets_ = packet;
+    gpuMetadataPackets_ = metadataPackets;
     graphKernArgMgr_ = graphKernArgMgr;
     capturedKernelName_ = capturedKernelName;
   }
@@ -395,6 +398,17 @@ class Command : public Event {
   const uint8_t* getAqlPacket() const {
     uint8_t* packet = new uint8_t[64];
     gpuPackets_->push_back(packet);
+    return packet;
+  }
+
+  //! Allocates and returns a metadata packet buffer for graph capture.
+  //! Returns nullptr if metadata capture is not enabled.
+  uint8_t* getMetadataPacket() const {
+    if (gpuMetadataPackets_ == nullptr) {
+      return nullptr;
+    }
+    uint8_t* packet = new uint8_t[256]();
+    gpuMetadataPackets_->push_back(packet);
     return packet;
   }
 


### PR DESCRIPTION
clr: Add metadata prefetch packet capture/dispatch for graph batches

Extend the HIP graph packet-capture and batch-dispatch paths to handle
gfx1250 metadata prefetch packets alongside regular AQL packets.

During graph capture, MetaDataPreloader::CaptureMetadata() fills a
host-side 256-byte buffer with the same content that the live
Set() path would write to the HW metadata ring.  These buffers are
carried through GraphNode, PacketBatch, and the flat-buffer rebuild
stages in parallel with the AQL packet vectors.

At dispatch time, dispatchAqlPacketBatchFlat() copies the flat metadata
buffer into the metadata ring using the same chunked wrap-around logic
as the AQL queue copy, ensuring metadata is in place before valid
headers are committed to the CP.

No functional change on platforms without metadata prefetch support
(flatMetadataData will be nullptr).

## Motivation

Graphs did not support writing metadata packets yet. This change addresses that

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID
JIRA ID: AIRUNTIME-2368

<!-- Do not post any JIRA links here. -->

## Test Plan

Not needed, existing tests should suffice

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
