### PR TITLE
Leave PC at trap instruction for debugtrap (ROCM-22957)

### DIFF
--- a/projects/rocdbgapi/CMakeLists.txt
+++ b/projects/rocdbgapi/CMakeLists.txt
@@ -62,7 +62,7 @@
 
 cmake_minimum_required(VERSION 3.8)
 
-project(amd-dbgapi VERSION 0.80.0)
+project(amd-dbgapi VERSION 0.81.0)
 
 include(CheckIncludeFile)
 include(CheckIncludeFiles)

--- a/projects/rocdbgapi/src/architecture.cpp
+++ b/projects/rocdbgapi/src/architecture.cpp
@@ -723,7 +723,7 @@ amdgcn_architecture_t::terminating_instruction () const
 size_t
 amdgcn_architecture_t::breakpoint_instruction_pc_adjust () const
 {
-  return breakpoint_instruction ().size ();
+  return 0;
 }
 
 bool

--- a/projects/rocdbgapi/src/runtime_rdebug.h
+++ b/projects/rocdbgapi/src/runtime_rdebug.h
@@ -42,16 +42,18 @@
 10: New trap handler ABI. Except for gfx940: set status.skip_export before
    halting the wave.
 11: Remove scratch_backing_memory_byte_size from the aql_queue_t.
+12: New trap handler ABI. Halt the wave at the s_trap instruction instead of
+   the next instruction.
 */
 
 using runtime_rdebug_version_t = decltype (r_debug::r_version);
 
 constexpr runtime_rdebug_version_t RUNTIME_RDEBUG_VERSION_INVALID = 0;
 #if defined(__linux__)
-constexpr runtime_rdebug_version_t RUNTIME_RDEBUG_VERSION_MIN = 8;
+constexpr runtime_rdebug_version_t RUNTIME_RDEBUG_VERSION_MIN = 12;
 #elif defined(_WIN32)
-constexpr runtime_rdebug_version_t RUNTIME_RDEBUG_VERSION_MIN = 10;
+constexpr runtime_rdebug_version_t RUNTIME_RDEBUG_VERSION_MIN = 12;
 #endif
-constexpr runtime_rdebug_version_t RUNTIME_RDEBUG_VERSION_MAX = 11;
+constexpr runtime_rdebug_version_t RUNTIME_RDEBUG_VERSION_MAX = 12;
 
 #endif /* RUNTIME_RDEBUG_H */

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp
@@ -2481,7 +2481,7 @@ Runtime::Runtime()
   xnack_enabled_ = false;
   g_use_interrupt_wait = true;
   g_use_mwaitx = true;
-  ::_amdgpu_r_debug = {11,
+  ::_amdgpu_r_debug = {12,
                      nullptr,
                      reinterpret_cast<uintptr_t>(
                                 &_loader_debug_state),

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s
@@ -300,21 +300,19 @@ trap_entry:
 .endif
 
 .not_host_trap:
-  // It's an s_trap; advance the PC
-  s_add_u32                             ttmp0, ttmp0, 0x4
-  s_addc_u32                            ttmp1, ttmp1, 0x0
-
   // If llvm.debugtrap and debugger is not attached.
   s_cmp_eq_u32                          ttmp2, TRAP_ID_DEBUGTRAP
-  s_cbranch_scc0                        .no_skip_debugtrap
+  s_cbranch_scc0                        .not_debugtrap
 .if (.amdgcn.gfx_generation_number == 9 && .amdgcn.gfx_generation_minor < 4) || .amdgcn.gfx_generation_number >= 10
   s_bitcmp0_b32                         ttmp11, TTMP_DEBUG_ENABLED_SHIFT
 .else
   s_bitcmp0_b32                         ttmp13, TTMP_DEBUG_ENABLED_SHIFT
 .endif
-  s_cbranch_scc0                        .no_skip_debugtrap
+  s_cbranch_scc0                        .not_debugtrap
 
-  // Ignore llvm.debugtrap.
+  // Ignore llvm.debugtrap. Advance the PC and return to the shader.
+  s_add_u32                             ttmp0, ttmp0, 0x4
+  s_addc_u32                            ttmp1, ttmp1, 0x0
   s_branch                              .exit_trap
 
 .not_s_trap:
@@ -322,7 +320,7 @@ trap_entry:
   //Check for stochastic trap on gfx9.4+
   s_getreg_b32                          ttmp7, hwreg(HW_REG_TRAPSTS)             // On gfx94x, TRAPSTS bit 26 ...
   s_bitcmp1_b32                         ttmp7, SQ_WAVE_TRAPSTS_PERF_SNAPSHOT_SHIFT   // is stochastic_sample_trap
-  s_cbranch_scc0                        .no_skip_debugtrap
+  s_cbranch_scc0                        .not_debugtrap
 
   // Handle stochastic trap
   s_setreg_imm32_b32                    hwreg(HW_REG_TRAPSTS, SQ_WAVE_TRAPSTS_PERF_SNAPSHOT_SHIFT, 1), 0
@@ -333,7 +331,7 @@ trap_entry:
   s_mov_b64                             ttmp[14:15], ttmp[2:3]
   s_branch                              .profile_trap_handlers_gfx9      // Off to the profile handlers
 .else
-  s_branch                              .no_skip_debugtrap
+  s_branch                              .not_debugtrap
 .endif // PC_SAMPLING_GFX9
 
 .if (.amdgcn.gfx_generation_number == 9) // PC_SAMPLING_GFX9
@@ -430,7 +428,7 @@ trap_entry:
 .endif
   // If neither bit is set, this is unexpected.
   // This branch is not expected to be taken.
-  s_branch                              .no_skip_debugtrap
+  s_branch                              .not_debugtrap
 
   // ttmp7 contains local_entry, ttmp[4:5] contains "&bufferX",
   // ttmp[14:15] holds 'tma->host_trap_buffers' pointer
@@ -644,12 +642,12 @@ trap_entry:
   s_or_b32                              ttmp3, ttmp3, (1 << SQ_WAVE_TRAPSTS_MEM_VIOL_SHIFT | 1 << SQ_WAVE_TRAPSTS_ILLEGAL_INST_SHIFT | 1 << SQ_WAVE_TRAPSTS_XNACK_ERROR_SHIFT)
   s_and_b32                             ttmp2, ttmp2, ttmp3
   // SCC will be 1 if either a maskable instruction was set, or one of MEM_VIOL, ILL_INST, XNACK_ERROR
-  s_cbranch_scc1                        .no_skip_debugtrap              // if any of those are set, handle exceptions
+  s_cbranch_scc1                        .not_debugtrap              // if any of those are set, handle exceptions
 
   // Check for maskable exceptions
   s_getreg_b32                          ttmp3, hwreg(HW_REG_MODE, SQ_WAVE_MODE_EXCP_EN_SHIFT, SQ_WAVE_MODE_EXCP_EN_SIZE)
   s_and_b32                             ttmp3, ttmp2, ttmp3
-  s_cbranch_scc1                        .no_skip_debugtrap
+  s_cbranch_scc1                        .not_debugtrap
 
   // Since we are in PC sampling, it is safe to ignore watch1/2/3 and single step
   // as those should only be enabled by the debugger.
@@ -658,7 +656,7 @@ trap_entry:
   s_branch                              .exit_trap
 
 .endif // PC_SAMPLING_GFX9
-.no_skip_debugtrap:
+.not_debugtrap:
   // Save trap id and halt status in ttmp6.
   s_andn2_b32                           ttmp6, ttmp6, (TTMP6_SAVED_TRAP_ID_MASK | TTMP6_SAVED_STATUS_HALT_MASK)
   s_bfe_u32                             ttmp2, ttmp1, SQ_WAVE_PC_HI_TRAP_ID_BFE

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s
@@ -250,22 +250,26 @@
   s_bfe_u32         ttmp2, ttmp1, SQ_WAVE_PC_HI_TRAP_ID_BFE // ttmp2 = TrapID
   s_cbranch_scc0    .check_exceptions			    // If TrapID is 0, it's an exception, so branch.
 
-  // If caused by s_trap then advance PC, then figure out the trap ID:
-  // - if trapID is DEBUGTRAP and debugger is attach, report WAVE_TRAP,
-  // - if trapID is ABORTTRAP, report WAVE_ABORT,
-  // - report WAVE_TRAP for any other trap ID.
-  s_add_u32         ttmp0, ttmp0, 0x4                       // PC_LO += 4
-  s_addc_u32        ttmp1, ttmp1, 0x0                       // PC_HI += carry.
-
   // If llvm.debugtrap and debugger is not attached.
   s_cmp_eq_u32      ttmp2, TRAP_ID_DEBUGTRAP
   s_cbranch_scc0    .not_debug_trap
 
   s_bitcmp1_b32     ttmp11, TTMP11_DEBUG_ENABLED_SHIFT
-  s_cbranch_scc0    .check_exceptions
+  s_cbranch_scc1    .debugtrap_with_debugger
+
+  // Debugtrap with no debugger - advance PC and exit
+  s_add_u32         ttmp0, ttmp0, 0x4                       // PC_LO += 4
+  s_addc_u32        ttmp1, ttmp1, 0x0                       // PC_HI += carry.
+  s_branch          .check_exceptions
+
+.debugtrap_with_debugger:
+  // Debugger is attached - halt at trap instruction, set WAVE_TRAP
   s_or_b32          ttmp3, ttmp3, EC_QUEUE_WAVE_TRAP_M0
 
 .not_debug_trap:
+  // Other trap types - advance PC
+  s_add_u32         ttmp0, ttmp0, 0x4                       // PC_LO += 4
+  s_addc_u32        ttmp1, ttmp1, 0x0                       // PC_HI += carry.
   s_cmp_eq_u32      ttmp2, TRAP_ID_ABORT
   s_cbranch_scc0    .not_abort_trap
   s_or_b32          ttmp3, ttmp3, EC_QUEUE_WAVE_ABORT_M0

--- a/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp
@@ -82,6 +82,8 @@ using namespace rocr::amd::hsa::common;
 // 9: New trap handler ABI. For gfx11: Save PC in ttmp11[22:7] ttmp6[31:0], and park the wave if stopped.
 // 10: New trap handler ABI. Set status.skip_export when halting the wave.
 //                           For gfx942, set ttmp6[31] = 0 if ttmp11[31] == 0.
+// 11: Remove scratch_backing_memory_byte_size from the aql_queue_t.
+// 12: New trap handler ABI. Halt the wave at the s_trap instruction instead of the next instruction.
 
 HSA_API r_debug _amdgpu_r_debug;
 static __forceinline link_map*& r_debug_tail() {


### PR DESCRIPTION
Motivation

  Make rocm-dbgapi and hsa-runtime compliant with the LLVM llvm.debugtrap reference document specification for
  s_trap 3 instruction handling. Per the specification, when the debugger is enabled, the trap handler must leave
  the PC at the s_trap 3 instruction, and the debugger is responsible for incrementing the PC before resuming
  execution.

  Fixes: https://amd-hub.atlassian.net/browse/ROCM-22957

  Technical Details
 
  This is based on: https://gerrit-git.amd.com/plugins/gitiles/compute/ec/rocm-dbgapi/+/refs/heads/lmoriche/pc_adjust%5E%21/ (dbgapi) and https://gerrit-git.amd.com/plugins/gitiles/hsa/ec/hsa-runtime/+/refs/heads/lmoriche/pc_adjust%5E%21/ (runtime)
  rocm-dbgapi changes:
  - projects/rocdbgapi/src/architecture.cpp: Change breakpoint_instruction_pc_adjust() to return 0 (no automatic PC
  rewind)
  - projects/rocdbgapi/src/runtime_rdebug.h: Bump ABI version from 11 to 12, add version 12 comment documenting new
  trap handler behavior
  - projects/rocdbgapi/CMakeLists.txt: Bump project version from 0.80.0 to 0.81.0

  hsa-runtime changes:
  - projects/rocr-runtime/runtime/hsa-runtime/core/runtime/runtime.cpp: Set r_version to 12
  - projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler.s: Move PC advancement logic -
  only advance PC when debugtrap fires without debugger attached, leave PC at trap when debugger is enabled
  - projects/rocr-runtime/runtime/hsa-runtime/core/runtime/trap_handler/trap_handler_gfx12.s: Apply same PC
  advancement logic for gfx12 architecture
  - projects/rocr-runtime/runtime/hsa-runtime/loader/executable.cpp: Add ABI version 12 documentation

  Coordinated Changes Required:

  This PR must be merged together with corresponding changes in:
  - ROCgdb: Detect trap instructions, advance PC before resuming execution ( https://github.com/ROCm/ROCgdb/pull/189 )

  Test Plan

  - Verified gdb.rocm/debugtrap.exp test passes with new behavior (PC at trap instruction)
  - Full gdb.rocm/*.exp test suite executed with patched rocm-dbgapi, hsa-runtime, and ROCgdb

  Test Result

  All gdb.rocm tests passing: 1,945 expected passes, 0 unexpected failures when used with coordinated ROCgdb changes