### PR TITLE
fix(rocSHMEM): correct size for non-double element size in reduce

### DIFF
--- a/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
+++ b/projects/rocshmem/src/gda/context_gda_tmpl_device.hpp
@@ -516,7 +516,8 @@ __device__ int GDAContext::reduce(rocshmem_team_t team, T *dest,
   size_t direct_pWrk = PE_size * nreduce;
   size_t direct_pSync = PE_size;
   size_t ring_pSync = 2 * PE_size;
-  size_t provided_pWrk = max(nreduce / 2 + 1, ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE);
+  size_t provided_pWrk = max(nreduce / 2 + 1,
+          (ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE * sizeof(double)) / sizeof(T));
   size_t provided_pSync = ROCSHMEM_REDUCE_SYNC_SIZE;
 
   ActiveWFInfo wf_info(ctx_id_, ThreadScope::wg);
@@ -525,7 +526,8 @@ __device__ int GDAContext::reduce(rocshmem_team_t team, T *dest,
     internal_direct_allreduce<T, Op>(dest, source, nreduce, team_obj, wf_info);
   } else {
     if (ring_pSync <= ROCSHMEM_REDUCE_SYNC_SIZE) {
-      size_t ring_pWrk = ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE;
+      size_t ring_pWrk =
+          (ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE * sizeof(double)) / sizeof(T);
       // integer division truncating value
       int chunk_size = ring_pWrk / PE_size;
       int seg_size = chunk_size * PE_size;

--- a/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
+++ b/projects/rocshmem/src/ipc/context_ipc_tmpl_device.hpp
@@ -361,14 +361,16 @@ __device__ int IPCContext::reduce(rocshmem_team_t team, T *dest,
   size_t direct_pWrk = PE_size * nreduce;
   size_t direct_pSync = PE_size;
   size_t ring_pSync = 2 * PE_size;
-  size_t provided_pWrk = max(nreduce / 2 + 1, ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE);
+  size_t provided_pWrk = max(nreduce / 2 + 1,
+          (ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE * sizeof(double)) / sizeof(T));
   size_t provided_pSync = ROCSHMEM_REDUCE_SYNC_SIZE;
 
   if (provided_pWrk >= direct_pWrk && provided_pSync >= direct_pSync) {
     internal_direct_allreduce<T, Op>(dest, source, nreduce, team_obj);
   } else {
     if (ring_pSync <= ROCSHMEM_REDUCE_SYNC_SIZE) {
-      size_t ring_pWrk = ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE;
+      size_t ring_pWrk =
+          (ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE * sizeof(double)) / sizeof(T);
       // integer division truncating value
       int chunk_size = ring_pWrk / PE_size;
       int seg_size = chunk_size * PE_size;


### PR DESCRIPTION
## Motivation

In the _reduce device_ paths we use `ROCSHMEM_REDUCE_MIN_WRKDATA_SIZE` for deciding whether the provided work buffer is large enough for the direct allreduce path and for sizing the ring allreduce work chunk. That constant represents the minimum work-data capacity in double-sized units, but the IPC and GDA reduce implementations were using it directly as a count of `T` elements.

For element types smaller than `double`, this underestimates the number of available work elements and can cause the reduce implementation to select a segment size that causes unaligned work-buffer accesses. This contributes to incorrect indexing and illegal memory accesses in IPC backend. 

## Technical Details

This issue will be silenced with another in-progress PR: https://github.com/ROCm/rocm-systems/pull/7955
But we can still improve this issue here with aligned memory accesses.

## JIRA ID

JIRA ID: AIROCSHMEM-437

## Test Result

- Functional tests pass with no change in performance on gfx950 and gfx942