### PR TITLE
fix(rccl): disable DDA IPC init on gfx1100, since there is no xgmi 

### DIFF
--- a/projects/rccl/src/ipc_init.cu
+++ b/projects/rccl/src/ipc_init.cu
@@ -56,11 +56,22 @@ ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
   }
 
   // DDA IPC requires cross-GPU IPC memory mapping (hipIpcOpenMemHandle).
-  // On non-P2P topologies (e.g. RDNA3 over PCIe) this fails with
-  // hipErrorInvalidDevicePointer and poisons the HIP device context.
-  if (!comm->isAllCudaP2p) {
-    INFO(NCCL_INIT, "ncclDdaIpcCommInit: skipping DDA IPC (no P2P between all GPUs)");
-    return ncclSuccess;
+  // comm->isAllCudaP2p is set via ncclTopoCheckP2p which on AMD/HIP returns true
+  // whenever ranks share a hostHash, regardless of actual P2P support (paths.cc).
+  // Use hipDeviceCanAccessPeer directly — the authoritative runtime check for IPC
+  // capability, and the same check used in init.cc for hasPeerAccess.
+  for (int i = 0; i < comm->nRanks; i++) {
+    for (int j = i + 1; j < comm->nRanks; j++) {
+      int canAccess = 0;
+      hipError_t err = hipDeviceCanAccessPeer(
+          &canAccess, comm->peerInfo[i].cudaDev, comm->peerInfo[j].cudaDev);
+      if (err != hipSuccess || !canAccess) {
+        INFO(NCCL_INIT,
+             "ncclDdaIpcCommInit: no P2P between GPU %d and GPU %d, skipping DDA IPC",
+             comm->peerInfo[i].cudaDev, comm->peerInfo[j].cudaDev);
+        return ncclSuccess;
+      }
+    }
   }
 
   size_t bytes = DDA_IPC_BUFFER_SIZE;

--- a/projects/rccl/src/ipc_init.cu
+++ b/projects/rccl/src/ipc_init.cu
@@ -55,6 +55,12 @@ ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
     return ncclSuccess;
   }
 
+  // gfx1100 (RDNA3) lacks XGMI; IPC handles fail with hipErrorInvalidDevicePointer.
+  if (comm->archName != nullptr && strstr(comm->archName, "gfx1100") != nullptr) {
+    INFO(NCCL_INIT, "ncclDdaIpcCommInit: skipping DDA IPC on %s", comm->archName);
+    return ncclSuccess;
+  }
+
   size_t bytes = DDA_IPC_BUFFER_SIZE;
   if (bytes == 0) {
     return ncclSuccess;

--- a/projects/rccl/src/ipc_init.cu
+++ b/projects/rccl/src/ipc_init.cu
@@ -55,9 +55,11 @@ ncclResult_t ncclDdaIpcCommInit(ncclComm* comm) {
     return ncclSuccess;
   }
 
-  // gfx1100 (RDNA3) lacks XGMI; IPC handles fail with hipErrorInvalidDevicePointer.
-  if (comm->archName != nullptr && strstr(comm->archName, "gfx1100") != nullptr) {
-    INFO(NCCL_INIT, "ncclDdaIpcCommInit: skipping DDA IPC on %s", comm->archName);
+  // DDA IPC requires cross-GPU IPC memory mapping (hipIpcOpenMemHandle).
+  // On non-P2P topologies (e.g. RDNA3 over PCIe) this fails with
+  // hipErrorInvalidDevicePointer and poisons the HIP device context.
+  if (!comm->isAllCudaP2p) {
+    INFO(NCCL_INIT, "ncclDdaIpcCommInit: skipping DDA IPC (no P2P between all GPUs)");
     return ncclSuccess;
   }
 

--- a/projects/rccl/test/CMakeLists.txt
+++ b/projects/rccl/test/CMakeLists.txt
@@ -180,6 +180,7 @@ if(BUILD_TESTS)
     ScatterTests.cpp
     SendRecvTests.cpp
     StandaloneTests.cpp
+    DdaIpcTests.cpp
     TeardownStressTests.cpp
     _RecorderTests.cpp
     common/main.cpp

--- a/projects/rccl/test/DdaIpcTests.cpp
+++ b/projects/rccl/test/DdaIpcTests.cpp
@@ -1,0 +1,152 @@
+/*************************************************************************
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+#include <gtest/gtest.h>
+#include <rccl/rccl.h>
+#include <hip/hip_runtime.h>
+
+#include "StandaloneUtils.hpp"
+#include "common/ProcessIsolatedTestRunner.hpp"
+
+namespace RcclUnitTesting
+{
+  /**
+   * \brief Verify that ncclCommInitAll + AllReduce succeeds regardless of
+   *        whether the GPUs support P2P/IPC (DDA IPC must be skipped
+   *        gracefully on non-P2P topologies like RDNA3 over PCIe).
+   */
+  TEST(DdaIpc, CommInitDoesNotCrashWithoutP2p)
+  {
+    RUN_ISOLATED_TEST("CommInitDoesNotCrashWithoutP2p", []()
+    {
+      int numDevices;
+      HIPCALL(hipGetDeviceCount(&numDevices));
+      if (numDevices < 2) {
+        GTEST_SKIP() << "This test requires at least 2 devices.";
+      }
+
+      // Cap at 8 GPUs (DDA IPC is hardcoded for exactly 8 ranks)
+      int numRanks = std::min(numDevices, 8);
+
+      // Create communicators -- this is where the crash occurred before the fix
+      std::vector<ncclComm_t> comms(numRanks);
+      ncclResult_t res = ncclCommInitAll(comms.data(), numRanks, nullptr);
+      ASSERT_EQ(res, ncclSuccess) << "ncclCommInitAll failed: " << ncclGetErrorString(res);
+
+      // Run a small AllReduce to verify the communicator is functional
+      std::vector<float*> sendbuffs(numRanks);
+      std::vector<float*> recvbuffs(numRanks);
+      std::vector<hipStream_t> streams(numRanks);
+      const int numElements = 1024;
+
+      for (int i = 0; i < numRanks; i++) {
+        HIPCALL(hipSetDevice(i));
+        HIPCALL(hipMalloc(&sendbuffs[i], numElements * sizeof(float)));
+        HIPCALL(hipMalloc(&recvbuffs[i], numElements * sizeof(float)));
+        HIPCALL(hipStreamCreate(&streams[i]));
+        HIPCALL(hipMemset(sendbuffs[i], 0, numElements * sizeof(float)));
+        HIPCALL(hipMemset(recvbuffs[i], 0, numElements * sizeof(float)));
+      }
+
+      NCCLCHECK(ncclGroupStart());
+      for (int i = 0; i < numRanks; i++) {
+        HIPCALL(hipSetDevice(i));
+        NCCLCHECK(ncclAllReduce(sendbuffs[i], recvbuffs[i], numElements,
+                                ncclFloat32, ncclSum, comms[i], streams[i]));
+      }
+      NCCLCHECK(ncclGroupEnd());
+
+      for (int i = 0; i < numRanks; i++) {
+        HIPCALL(hipSetDevice(i));
+        HIPCALL(hipStreamSynchronize(streams[i]));
+      }
+
+      // Cleanup
+      for (int i = 0; i < numRanks; i++) {
+        HIPCALL(hipSetDevice(i));
+        HIPCALL(hipFree(sendbuffs[i]));
+        HIPCALL(hipFree(recvbuffs[i]));
+        HIPCALL(hipStreamDestroy(streams[i]));
+      }
+      for (auto& comm : comms)
+        NCCLCHECK(ncclCommDestroy(comm));
+    });
+  }
+
+  /**
+   * \brief Verify that DDA IPC is explicitly disabled via RCCL_DDA_ENABLE=0
+   *        and AllReduce still works using standard algorithms.
+   */
+  TEST(DdaIpc, AllReduceWorksWithDdaDisabled)
+  {
+    RUN_ISOLATED_TEST_WITH_ENV("AllReduceWorksWithDdaDisabled", []()
+    {
+      int numDevices;
+      HIPCALL(hipGetDeviceCount(&numDevices));
+      if (numDevices < 2) {
+        GTEST_SKIP() << "This test requires at least 2 devices.";
+      }
+
+      int numRanks = std::min(numDevices, 8);
+
+      std::vector<ncclComm_t> comms(numRanks);
+      ncclResult_t res = ncclCommInitAll(comms.data(), numRanks, nullptr);
+      ASSERT_EQ(res, ncclSuccess) << "ncclCommInitAll failed: " << ncclGetErrorString(res);
+
+      std::vector<float*> sendbuffs(numRanks);
+      std::vector<float*> recvbuffs(numRanks);
+      std::vector<hipStream_t> streams(numRanks);
+      const int numElements = 1024;
+
+      for (int i = 0; i < numRanks; i++) {
+        HIPCALL(hipSetDevice(i));
+        HIPCALL(hipMalloc(&sendbuffs[i], numElements * sizeof(float)));
+        HIPCALL(hipMalloc(&recvbuffs[i], numElements * sizeof(float)));
+        HIPCALL(hipStreamCreate(&streams[i]));
+
+        // Fill send buffer: each rank sends (rank + 1) for all elements
+        std::vector<float> hostData(numElements, static_cast<float>(i + 1));
+        HIPCALL(hipMemcpy(sendbuffs[i], hostData.data(),
+                          numElements * sizeof(float), hipMemcpyHostToDevice));
+        HIPCALL(hipMemset(recvbuffs[i], 0, numElements * sizeof(float)));
+      }
+
+      NCCLCHECK(ncclGroupStart());
+      for (int i = 0; i < numRanks; i++) {
+        HIPCALL(hipSetDevice(i));
+        NCCLCHECK(ncclAllReduce(sendbuffs[i], recvbuffs[i], numElements,
+                                ncclFloat32, ncclSum, comms[i], streams[i]));
+      }
+      NCCLCHECK(ncclGroupEnd());
+
+      // Verify results: sum of (1 + 2 + ... + numRanks)
+      float expectedSum = static_cast<float>(numRanks * (numRanks + 1) / 2);
+      for (int i = 0; i < numRanks; i++) {
+        HIPCALL(hipSetDevice(i));
+        HIPCALL(hipStreamSynchronize(streams[i]));
+
+        std::vector<float> hostResult(numElements);
+        HIPCALL(hipMemcpy(hostResult.data(), recvbuffs[i],
+                          numElements * sizeof(float), hipMemcpyDeviceToHost));
+
+        for (int e = 0; e < numElements; e++) {
+          ASSERT_FLOAT_EQ(hostResult[e], expectedSum)
+              << "Mismatch at rank " << i << " element " << e;
+        }
+      }
+
+      // Cleanup
+      for (int i = 0; i < numRanks; i++) {
+        HIPCALL(hipSetDevice(i));
+        HIPCALL(hipFree(sendbuffs[i]));
+        HIPCALL(hipFree(recvbuffs[i]));
+        HIPCALL(hipStreamDestroy(streams[i]));
+      }
+      for (auto& comm : comms)
+        NCCLCHECK(ncclCommDestroy(comm));
+    },
+    {{"RCCL_DDA_ENABLE", "0"}});
+  }
+}


### PR DESCRIPTION
## Motivation

RCCL's DDA IPC all-reduce optimization unconditionally attemps cross-GPU IPC memory mapping during communicator init.

## Technical Details
vLLM's 8-GPU tensor-parallel setup crashes with hipErrorInvalidDevicePointer on gfx1100 (Radeon Pro W7900) GPUs. Root cause: RCCL's DDA IPC all-reduce optimization unconditionally attempts cross-GPU IPC memory mapping during communicator init. This requires XGMI interconnects (present on CDNA/MI-series GPUs) but gfx1100 is RDNA3 connected via PCIe, where P2P memory mapping is unsupported. The failed hipIpcOpenMemHandle poisons the HIP device context, crashing all workers. vLLM and PyTorch are not at fault — a minimal torchrun    reproducer confirms the issue is purely in RCCL. Fix: skip DDA IPC init on gfx1100.


## JIRA ID

JIRA ID : ROCM-26074

## Test Plan

Verify disabling DDA IPC gfx1100 fixes crash in minimal torchrun reproducer

## Test Result

Verified that DDA IPC init removal in gfx1100 fixes crash in minimal torchrun reproducer

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
