### PR TITLE
rocr: Use device-memory ring buffers for internal SDMA queues

### DIFF
--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_blit_sdma.h
@@ -563,6 +563,12 @@ template <bool useGCR, bool scopeFields> class BlitSdma : public BlitSdmaBase {
 
   /// True if SDMA supports the linear wait/signal-indirect copy packet (gfx1250).
   bool indirect_copy_supported_;
+
+  /// True if the ring buffer is allocated in device memory (Large BAR).
+  bool device_mem_ring_buf_;
+
+  /// Cached HDP flush register pointer (non-null on gfx942 with device-memory ring).
+  volatile uint32_t* hdp_flush_cntl_;
 };
 
 

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/inc/amd_gpu_agent.h
@@ -459,6 +459,9 @@ class GpuAgent : public GpuAgentInt {
   /// @brief Is large BAR support enabled for this GPU.
   __forceinline bool LargeBarEnabled() const { return large_bar_enabled_; }
 
+  /// @brief Pointer to the HDP memory flush control register (may be nullptr).
+  __forceinline volatile uint32_t* HdpFlushCntl() const { return HDP_flush_.HDP_MEM_FLUSH_CNTL; }
+
   /// @brief Total number of SDMA engines (regular + XGMI) addressable via the
   /// HSA_QUEUE_SDMA_BY_ENG_ID engine-id space.
   uint32_t NumSdmaEnginesTotal() const;

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/runtime/amd_blit_sdma.cpp
@@ -146,7 +146,9 @@ BlitSdma<useGCR, scopeFields>::BlitSdma()
       multicast_supported_(false),
       is_gfx1250_(false),
       swap_supported_(false),
-      indirect_copy_supported_(false) {
+      indirect_copy_supported_(false),
+      device_mem_ring_buf_(false),
+      hdp_flush_cntl_(nullptr) {
   std::memset(&queue_resource_, 0, sizeof(queue_resource_));
 }
 
@@ -217,9 +219,24 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::Initialize(const core::Agent& agent,
     swap_supported_ = (minor >= 4);
   }
 
-  // Allocate queue buffer.
-  queue_start_addr_ =
-      (char*)agent_->system_allocator()(kQueueSize, 0x1000, core::MemoryRegion::AllocateExecutable);
+  // Allocate queue buffer: prefer device memory on gfx94x/gfx125x with Large BAR.
+  const bool want_dev_ring = core::Runtime::runtime_singleton_->flag().sdma_dev_ring_buf() &&
+                             agent_->LargeBarEnabled() &&
+                             ((major == 9 && minor >= 4) || is_gfx1250_);
+  if (want_dev_ring) {
+    queue_start_addr_ =
+        (char*)agent_->coarsegrain_allocator()(kQueueSize,
+            static_cast<core::MemoryRegion::AllocateFlags>(
+                core::MemoryRegion::AllocateExecutable | core::MemoryRegion::AllocateUncached));
+  }
+  if (queue_start_addr_ != NULL) {
+    device_mem_ring_buf_ = true;
+    hdp_flush_cntl_ = agent_->HdpFlushCntl();
+  } else {
+    queue_start_addr_ =
+        (char*)agent_->system_allocator()(kQueueSize, 0x1000, core::MemoryRegion::AllocateExecutable);
+    device_mem_ring_buf_ = false;
+  }
 
   if (queue_start_addr_ == NULL) {
     return HSA_STATUS_ERROR_OUT_OF_RESOURCES;
@@ -275,6 +292,10 @@ hsa_status_t BlitSdma<useGCR, scopeFields>::Initialize(const core::Agent& agent,
 
   max_single_linear_copy_size_ = linear_copy_size_override;
 
+  if (device_mem_ring_buf_) {
+    LogPrint(HSA_AMD_LOG_FLAG_INFO, "SDMA queue using device-memory ring buffer (size=%zu)", kQueueSize);
+  }
+
   cleanupOnException.Dismiss();
   return HSA_STATUS_SUCCESS;
 }
@@ -292,7 +313,11 @@ template <bool useGCR, bool scopeFields> hsa_status_t BlitSdma<useGCR, scopeFiel
 
   if (queue_start_addr_ != NULL) {
     // Release queue buffer.
-    agent_->system_deallocator()(queue_start_addr_);
+    if (device_mem_ring_buf_) {
+      agent_->coarsegrain_deallocator()(queue_start_addr_);
+    } else {
+      agent_->system_deallocator()(queue_start_addr_);
+    }
   }
 
   queue_start_addr_ = NULL;
@@ -1964,6 +1989,16 @@ void BlitSdma<useGCR, scopeFields>::UpdateWriteAndDoorbellRegister(uint64_t curr
 
       // Update write pointer and doorbell register.
       *queue_wptr_ = new_index;
+
+      // For device-memory rings (WC-mapped via Large BAR), an explicit sfence
+      // is required to flush the write-combining buffer before the doorbell.
+      // On coherent system-memory rings, release semantics suffice.
+      if (device_mem_ring_buf_) {
+        _mm_sfence();
+        if (hdp_flush_cntl_) {
+          *hdp_flush_cntl_ = 1u;
+        }
+      }
 
       // Keep compiler ordering between wptr and doorbell writes. On x86 with
       // WB/coherent queue state, hardware ordering ensures the device observes

--- a/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
+++ b/projects/rocr-runtime/runtime/hsa-runtime/core/util/flag.h
@@ -136,6 +136,9 @@ class Flag {
     var = os::GetEnvVar("HSA_SDMA_WAIT_IDLE");
     sdma_wait_idle_ = (var == "1") ? true : false;
 
+    var = os::GetEnvVar("HSA_SDMA_DEV_RING_BUF");
+    sdma_dev_ring_buf_ = (var == "0") ? false : true;
+
     var = os::GetEnvVar("HSA_MAX_QUEUES");
     max_queues_ = static_cast<uint32_t>(atoi(var.c_str()));
 
@@ -378,6 +381,8 @@ class Flag {
 
   bool sdma_wait_idle() const { return sdma_wait_idle_; }
 
+  bool sdma_dev_ring_buf() const { return sdma_dev_ring_buf_; }
+
   bool report_tool_load_failures() const { return report_tool_load_failures_; }
 
   bool report_tool_register_failures() const { return report_tool_register_failures_; }
@@ -544,6 +549,7 @@ class Flag {
   bool enable_sdma_hdp_flush_;
   bool running_valgrind_;
   bool sdma_wait_idle_;
+  bool sdma_dev_ring_buf_;
   bool enable_queue_fault_message_;
   bool poison_sigbus_delay_set_ = false;
   uint32_t poison_sigbus_delay_ms_ = 0;


### PR DESCRIPTION
Allocate BlitSdma ring buffers in coarse-grain device memory (uncached+executable) on gfx94x/gfx125x with Large BAR, falling back to system memory. Flush the write-combining buffer (sfence) and HDP before the doorbell so the SDMA engine observes packet data. Controlled by HSA_SDMA_DEV_RING_BUF (default on, set 0 to disable).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
