### PR TITLE
docs(amdsmi): align commit and PR skills with Systems PR bot policy

### DIFF
--- a/projects/amdsmi/.claude/skills/amdsmi-commit-and-pr-conventions/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-commit-and-pr-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amdsmi-commit-and-pr-conventions
-description: "Use when writing or restructuring git commits or opening/updating a pull request for amd-smi — composing commit titles, commit message bodies, PR titles, or PR descriptions. Defines the [AMD-SMI] title convention, the rocm-systems PR template sections, brevity caps, and the rule that JIRA tickets appear only in the PR JIRA ID section, never in code comments or commit bodies."
+description: "Use when writing or restructuring git commits or opening/updating a pull request for amd-smi — composing commit titles, commit message bodies, PR titles, or PR descriptions. Defines the Conventional Commits `type(amdsmi):` title convention enforced by the Systems PR bot, the rocm-systems PR template sections, the unit-test and JIRA/ISSUE-reference gates, brevity caps, and the rule that JIRA tickets appear only in the PR JIRA ID section, never in code comments or commit bodies."
 ---
 
 # Commit & PR Conventions — amd-smi
@@ -14,23 +14,31 @@ not prose. State *what changed and why* — never narrate *how the code works*.
 
 ## Title Convention (commits AND PRs)
 
-`[TAG] Imperative summary`
+`type(amdsmi): imperative summary`
+
+The PR bot (`tools/systems_pr_bot`) enforces Conventional Commits on PR titles.
+Use the same form for commit subjects so a single-commit / squash PR auto-titles
+correctly.
 
 | Rule | Value |
 |------|-------|
-| Tag | `[AMD-SMI]` by default. Use `[ROCM-NNNNN]` / `[SWDEV-NNNNNN]` / `[AILITOOLS-NNN]` **only** when the commit or PR is 1:1 with that ticket |
-| Mood | Imperative ("Add", "Fix", "Remove" — not "Added"/"Fixes"/"Fixing") |
-| Length | ≤ 72 characters including the tag |
+| Type | One of `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert` |
+| Scope | `(amdsmi)` by default; a narrower lowercase scope is fine (`fix(cli): …`, `feat(fabric): …`) |
+| Mood | Imperative ("add", "fix", "remove" — not "added"/"fixes"/"fixing") |
+| Length | PR title 10–80 chars (bot limit); keep commit subjects ≤ 72 (git norm, safely under the cap) |
 | Punctuation | No trailing period |
-| Casing | Exactly `[AMD-SMI]` — uppercase, hyphen, square brackets |
+| Breaking | Append `!` before the colon (`feat(amdsmi)!: …`) for an ABI/behavior break |
 
-Good: `[AMD-SMI] Reject nullptr mode pointer in compute-partition getter`
-Bad: `[amd-smi] fixed the partition bug.` (lowercase tag, past tense, period)
+Good: `fix(amdsmi): reject nullptr mode pointer in compute-partition getter`
+Bad: `[AMD-SMI] Fixed the partition bug.` (legacy tag, past tense, period)
+
+**No `[AMD-SMI]` / `[ROCM-NNNNN]` tag** — the `[…]` form fails the bot's title
+regex. Ticket references live only in the PR's `JIRA ID` section (below).
 
 ## Commit Message Body
 
 ```
-[AMD-SMI] Imperative summary
+type(amdsmi): imperative summary
 
 - Verb-first bullet: what changed and why it was needed
 - One bullet per distinct logical change
@@ -61,7 +69,7 @@ Follow the rocm-systems template
 |---------|---------|---------|
 | `## Motivation` | Why this PR exists, the problem it solves | 1-3 sentences |
 | `## Technical Details` | What changed, grouped **by file/layer** with bullets | Bulleted, no prose walls |
-| `## JIRA ID` | `Resolves ROCM-NNNNN` — the **only** place a ticket appears. No links | One line |
+| `## JIRA ID` | `JIRA ID: ROCM-NNNNN` (or `Closes #NNNN` for a GitHub issue) — the **only** place a ticket appears. No links | One line |
 | `## Test Plan` | How it was verified (commands, hardware) | Bulleted |
 | `## Test Result` | Outcome of those tests | Brief |
 | `## Submission Checklist` | The template checkboxes | Leave intact |
@@ -86,6 +94,24 @@ Rules:
 - Mention the cascade layers touched (header → impl → wrapper → interface → CLI
   → docs) so reviewers can check coverage.
 
+## PR Bot Policy Gate
+
+Every PR to `develop` is checked by the *Systems PR Bot* (`tools/systems_pr_bot`).
+Two failures add the **"Not ready to Review"** label and block the PR; the rest
+are advisory rows in the bot's results comment.
+
+| Check | Blocking? | Pass condition |
+|-------|-----------|----------------|
+| **Unit Test** | ❌ yes | Any changed `.c/.cc/.cpp/.h/.hpp/.py/.go/.rs` needs a `test_*` / `*_test.*` file in the **same** PR. Doc/config-only PRs auto-pass |
+| **JIRA/ISSUE reference** | ❌ yes | Description has a `JIRA ID: <KEY>` / `ISSUE ID: <KEY>` line, a closing keyword (`Closes #N`), or a bare `#N`. A bare `Resolves ROCM-NNNNN` (no `#`) does **not** pass |
+| Title (Conventional Commits) | advisory | `type(scope): …`, 10–80 chars |
+| Description length | advisory | ≥ 30 chars |
+| Forbidden files | advisory | No `.pem` / `.key` / `.env` / `.crt` / private keys |
+| pre-commit | required check | `pre-commit` CI must be green |
+
+A source change with no accompanying test is the most common block — pair every
+code change with a test, or split a docs-only PR out, before opening.
+
 ## Brevity Caps
 
 | Symptom | Cap |
@@ -99,9 +125,11 @@ Rules:
 
 | Mistake | Fix |
 |---------|-----|
-| Lowercase or reformatted tag (`[amd-smi]`, `(AMD-SMI)`) | Exactly `[AMD-SMI]` |
-| Past-tense subject ("Fixed…", "Added…") | Imperative ("Fix", "Add") |
+| Legacy `[AMD-SMI]` / `[ROCM-NNNNN]` tag in the title | Conventional Commits `type(amdsmi): …` (the `[…]` form fails the bot) |
+| Past-tense subject ("Fixed…", "Added…") | Imperative ("fix", "add") |
 | `ROCM-NNNNN` in commit body or code comment | PR `JIRA ID` section only |
+| Source change with no `test_*` / `*_test.*` file | Add a test in the same PR (bot blocks otherwise) |
+| `Resolves ROCM-NNNNN` as the only ticket ref | Use `JIRA ID: ROCM-NNNNN` or `Closes #N` (bot needs the prefix or `#`) |
 | Comma-list of changes in body or changelog | One bullet per change |
 | Paragraph-length code comments | One-line root-cause note, or ask |
 | PR body free-form, skipping template sections | Use all six template sections |

--- a/projects/amdsmi/.claude/skills/amdsmi-commit-and-pr-conventions/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-commit-and-pr-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: amdsmi-commit-and-pr-conventions
-description: "Use when writing or restructuring git commits or opening/updating a pull request for amd-smi — composing commit titles, commit message bodies, PR titles, or PR descriptions. Defines the Conventional Commits `type(amdsmi):` title convention enforced by the Systems PR bot, the rocm-systems PR template sections, the unit-test and JIRA/ISSUE-reference gates, brevity caps, and the rule that JIRA tickets appear only in the PR JIRA ID section, never in code comments or commit bodies."
+description: "Use when writing or restructuring git commits or opening/updating a pull request for amd-smi — composing commit titles, commit message bodies, PR titles, or PR descriptions. Defines the Conventional Commits `type(amdsmi):` title convention enforced by the Systems PR Bot, the rocm-systems PR template sections, the unit-test and JIRA/ISSUE-reference gates, brevity caps, and the rule that JIRA tickets appear only in the PR JIRA ID section, never in code comments or commit bodies."
 ---
 
 # Commit & PR Conventions — amd-smi
@@ -102,15 +102,16 @@ are advisory rows in the bot's results comment.
 
 | Check | Blocking? | Pass condition |
 |-------|-----------|----------------|
-| **Unit Test** | ❌ yes | Any changed `.c/.cc/.cpp/.h/.hpp/.py/.go/.rs` needs a `test_*` / `*_test.*` file in the **same** PR. Doc/config-only PRs auto-pass |
+| **Unit Test** | ❌ yes | Any changed source file (the amd-smi-relevant set is `.c/.cc/.cpp/.h/.hpp/.py/.go/.rs`; full list in `tools/systems_pr_bot/policy.yml`) needs a `test_*` / `*_test.*` file in the **same** PR. Doc/config-only PRs auto-pass |
 | **JIRA/ISSUE reference** | ❌ yes | Description has a `JIRA ID: <KEY>` / `ISSUE ID: <KEY>` line, a closing keyword (`Closes #N`), or a bare `#N`. A bare `Resolves ROCM-NNNNN` (no `#`) does **not** pass |
 | Title (Conventional Commits) | advisory | `type(scope): …`, 10–80 chars |
 | Description length | advisory | ≥ 30 chars |
 | Forbidden files | advisory | No `.pem` / `.key` / `.env` / `.crt` / private keys |
-| pre-commit | required check | `pre-commit` CI must be green |
 
 A source change with no accompanying test is the most common block — pair every
-code change with a test, or split a docs-only PR out, before opening.
+code change with a test, or split a docs-only PR out, before opening. Separately,
+`pre-commit` is a required CI status check (must be green to merge) but is not part
+of the bot's label logic above.
 
 ## Brevity Caps
 

--- a/projects/amdsmi/.claude/skills/amdsmi-restructure-commits/SKILL.md
+++ b/projects/amdsmi/.claude/skills/amdsmi-restructure-commits/SKILL.md
@@ -160,13 +160,13 @@ git branch -D backup/BRANCH_NAME   # only after Step 6 passes
 ## Commit Message Format
 
 **REQUIRED SUB-SKILL:** Use the `amdsmi-commit-and-pr-conventions` skill for the commit
-title and body format — it is the single source of truth for the `[AMD-SMI]`
-tag, the bulleted body, the no-ticket-in-body rule, and brevity caps. Apply it
-to every commit you create here.
+title and body format — it is the single source of truth for the
+Conventional Commits `type(amdsmi):` title, the bulleted body, the
+no-ticket-in-body rule, and brevity caps. Apply it to every commit you create here.
 
 Quick reminder while restaging (see the skill for the full convention):
 
-- Subject: `[AMD-SMI] imperative summary`, ≤72 chars, no trailing period
+- Subject: `type(amdsmi): imperative summary`, ≤72 chars, no trailing period
 - Body: blank line, verb-first bullets, no `ROCM-NNNNN` refs in the body
 - `Signed-off-by` required; preserve original authors and `Co-authored-by:`
 

--- a/projects/amdsmi/.claude/skills/writing-plans/SKILL.md
+++ b/projects/amdsmi/.claude/skills/writing-plans/SKILL.md
@@ -98,7 +98,7 @@ Expected: FAIL — symbol not defined.
 
 ```bash
 git add include/amd_smi/amdsmi.h src/amd_smi/amd_smi.cc tests/amd_smi_test/test_file.cc
-git commit -s -m "[AMD-SMI] Add amdsmi_get_gpu_new_feature"
+git commit -s -m "feat(amdsmi): add amdsmi_get_gpu_new_feature"
 ```
 ````
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-style.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-style.agent.md
@@ -34,7 +34,7 @@ Additional hooks: `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `che
 | **Go** | `GO_<subsystem>_<verb>_<noun>` (uppercase prefix, underscore-separated) |
 | **Rust** | Functions: `snake_case` mirroring C API. Types: `PascalCase`. Returns `AmdsmiResult<T>` |
 | **CMake** | Functions: `snake_case`. Variables: `UPPER_CASE`. Commands: lowercase |
-| **Commits / PR titles** | Conventional Commits `type(amdsmi): summary` (lowercase type/scope, 10–80 chars). Legacy `[AMD-SMI]` tags fail the PR bot |
+| **Commits / PR titles** | Conventional Commits `type(amdsmi): summary` (lowercase type/scope, 10–80 chars). Legacy `[AMD-SMI]` tags fail the Systems PR Bot |
 
 ## Severity
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-style.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-style.agent.md
@@ -34,7 +34,7 @@ Additional hooks: `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `che
 | **Go** | `GO_<subsystem>_<verb>_<noun>` (uppercase prefix, underscore-separated) |
 | **Rust** | Functions: `snake_case` mirroring C API. Types: `PascalCase`. Returns `AmdsmiResult<T>` |
 | **CMake** | Functions: `snake_case`. Variables: `UPPER_CASE`. Commands: lowercase |
-| **Commits** | Prefer `[AMD-SMI]`, `[SWDEV-XXXXXX]`, or `[ROCM-XXXXXX]` prefix tags |
+| **Commits / PR titles** | Conventional Commits `type(amdsmi): summary` (lowercase type/scope, 10–80 chars). Legacy `[AMD-SMI]` tags fail the PR bot |
 
 ## Severity
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-tests.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-tests.agent.md
@@ -11,9 +11,11 @@ user-invocable: false
 You review test coverage, quality, and patterns for the amd-smi project.
 
 **PR bot gate:** the *Systems PR Bot* blocks any PR that changes source
-(`.c/.cc/.cpp/.h/.hpp/.py/.go/.rs`) without adding a `test_*` / `*_test.*` file
-in the same PR (it adds the "Not ready to Review" label). Treat a code change
-with no accompanying test as ❌ BLOCKING, not just a coverage gap.
+(`.c/.cc/.cpp/.h/.hpp/.py/.go/.rs`; full list in `tools/systems_pr_bot/policy.yml`)
+without adding a `test_*` / `*_test.*` file in the same PR (it adds the
+"Not ready to Review" label). Treat a code change with no accompanying test as
+❌ BLOCKING, not just a coverage gap. Doc/config-only changes (no source extension
+touched) are exempt and auto-pass.
 
 **Load `amdsmi-python-style-guide` skill when reviewing Python test files.**
 **Load `amdsmi-test-runner` skill for test execution commands and expected outputs.**

--- a/projects/amdsmi/.github/agents/amdsmi-review-tests.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-tests.agent.md
@@ -10,6 +10,11 @@ user-invocable: false
 
 You review test coverage, quality, and patterns for the amd-smi project.
 
+**PR bot gate:** the *Systems PR Bot* blocks any PR that changes source
+(`.c/.cc/.cpp/.h/.hpp/.py/.go/.rs`) without adding a `test_*` / `*_test.*` file
+in the same PR (it adds the "Not ready to Review" label). Treat a code change
+with no accompanying test as ❌ BLOCKING, not just a coverage gap.
+
 **Load `amdsmi-python-style-guide` skill when reviewing Python test files.**
 **Load `amdsmi-test-runner` skill for test execution commands and expected outputs.**
 **Load `amdsmi-packaging-test` skill when reviewing packaging, install scripts, or wheel build changes.**


### PR DESCRIPTION
## Motivation

The Systems PR bot (`tools/systems_pr_bot`) enforces Conventional Commits PR
titles, a JIRA/ISSUE reference, and a test for any source change. The amd-smi
commit/PR skills still taught the legacy `[AMD-SMI]` title tag and a
`Resolves ROCM-NNNNN` reference the bot rejects. Align the skills and review
agents with the policy actually enforced.

## Technical Details

**Conventions skill** (`.claude/skills/amdsmi-commit-and-pr-conventions/SKILL.md`):
- Replace the `[AMD-SMI]` title tag with Conventional Commits `type(amdsmi):`
- Document the PR bot policy gate (the blocking unit-test and JIRA/ISSUE checks vs. the advisory rows)
- Fix the JIRA ID guidance to the bot-accepted `JIRA ID: KEY` / `Closes #N` form

**Restructure-commits / writing-plans skills**:
- Update the example commit subjects to the new convention

**Style review agent** (`.github/agents/amdsmi-review-style.agent.md`):
- Expect Conventional Commits titles instead of `[AMD-SMI]` tags

**Test review agent** (`.github/agents/amdsmi-review-tests.agent.md`):
- Treat a source change with no accompanying test as BLOCKING, matching the bot

## JIRA ID

JIRA ID: AILITOOLS-278

## Test Plan

- Docs-only change; `pre-commit` clean
- Grepped the skills/agents tree to confirm no stale `[AMD-SMI]` title guidance remains (only the intentional "bad example" rows)

## Test Result

- Pre-commit passed; no functional code touched

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
