### PR TITLE
docs(amdsmi): add security review audit checklist

### DIFF
--- a/projects/amdsmi/.github/agents/amdsmi-review-security.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-security.agent.md
@@ -22,6 +22,87 @@ Project structure and API cascade path are stored in repo memories.
 4. Check for insecure defaults or missing access controls
 5. Review library loading paths for hijacking risks (`amdsmi_wrapper.py`)
 6. Verify no sensitive data in logs or error messages
+7. Work through the **Audit Checklist** below against every changed file
+
+## Audit Checklist (derived from issue #3634)
+
+This is the concrete pattern list the #3634 code-hygiene / sanitizer / safety audit
+surfaced. Treat each row as a grep target on the diff. A hit is at least
+⚠️ IMPORTANT; anything reachable from untrusted input (sysfs/procfs contents,
+file data, CLI args, device responses) is ❌ BLOCKING.
+
+### C / C++ — memory & strings
+- **Unbounded formatting / copies** — `sprintf`, `vsprintf`, `strcpy`, `strcat`,
+  and `sscanf`/`fscanf` with a bare `%s` (no field-width). Require `snprintf`,
+  `strncpy` + explicit NUL-termination, or width-limited `%Ns`. Watch chained
+  `sprintf(buf + off, …)` writers — sum the offsets vs the buffer size.
+- **Uninitialized locals** — a value declared without an initializer and later
+  returned, especially the result of a `switch` that has **no `default:`**.
+  Require init-at-declaration *and* a `default:` that errors out.
+- **Unchecked allocations** — `malloc` / `calloc` / `realloc` return not checked;
+  the `p = realloc(p, …)` self-assign leak-on-failure. Use a temp pointer.
+- **Resource leaks** — `new[]` paired with scalar `delete`; early `return` /
+  `continue` / `goto` paths that skip `free` / `delete[]` / `close(fd)` /
+  `pclose` / `fclose`; a `c_str()` / raw pointer kept past the lifetime of the
+  temporary or local string it came from.
+- **Out-of-bounds indexing** — `vec[0]` / `arr[i]` where the container can be
+  empty or `i` is unvalidated (bitmask/socket/node lists). Guard on size first.
+- **Unaligned access / type punning** — `*(uint16_t*)p` / `*(uint32_t*)p` reads
+  off a `uint8_t*`/byte buffer at arbitrary offsets. Use `memcpy` into a typed
+  local.
+- **Discarded status** — ignored `pclose` / `fclose` / `read` / `write` returns;
+  `pclose(NULL)` when `popen` failed.
+- **VLAs** — runtime-sized stack arrays (`buf[n]`); use a fixed cap or heap.
+- **Math UB** — `log10(0)`/`log(0)` → `-inf`, and `NaN`/`inf` cast to integer.
+
+### C / C++ — command execution & boundaries
+- **Shell-out** — `popen` / `system` / `exec*` built from a constructed string is
+  ❌ BLOCKING unless every interpolated value is allow-list / regex validated
+  (e.g. a BDF matched against a strict hex pattern). A library shelling out at
+  all is a smell — prefer a syscall/sysfs read.
+- **Unvalidated offsets/sizes** — CPER / record / header offsets and lengths used
+  to index a buffer without first checking them against the buffer bounds.
+- **TOCTOU** — re-validate after a check; if a race is inherent, document it.
+
+### Public ABI header — `include/amd_smi/amdsmi.h`
+- Bitfield total width exceeding its carrier type (`uint16_t a:15; uint16_t b:9;`).
+- `static` / array **object** definitions in the header (ODR across TUs).
+- Array function parameters declared with no max-size / count contract.
+- `#include` placed **inside** an `extern "C"` block.
+- Reserved identifiers (`__NAME__`) used as include guards.
+- Integer width too small for the physical quantity (e.g. `uint32_t` MB → 4 TB cap).
+- `char*` / caller-frees out-params whose ownership & lifetime aren't documented.
+
+### Supply chain / build / filesystem
+- Unpinned `git clone` / `FetchContent` (no `GIT_TAG` / commit) and unpinned
+  `pip` / `apt` installs in Dockerfiles.
+- World-writable or predictable temp paths; `mkdir(..., 0o777)` → `0o700`.
+- **CWD or any relative dir in a dynamic-library search path** (`.so`/DLL hijack),
+  including loaders emitted by a generator.
+- Missing hardening flags in example / auxiliary builds.
+
+### Python hygiene
+- Bare `except:` / blanket `except Exception:` that swallows and returns `None`.
+- Wildcard `import *`.
+- `sys.getsizeof` where `ctypes.sizeof` is meant; unvalidated sizes / pointer
+  arithmetic passed into ctypes / C; hardcoded capacity constants with no
+  retry-on-overflow; copy-pasted or wrong enum / exception description strings.
+
+### Generated code
+- **Fix the generator, never the artifact.** `py-interface/amdsmi_wrapper.py` is
+  emitted by `tools/generator.py` — a finding in the wrapper must be fixed in the
+  generator and the wrapper regenerated.
+
+### Mechanical enforcement to recommend
+When you see these patterns, also flag the gap in tooling so they're caught
+automatically next time:
+- **C/C++** — keep `bugprone-*` / `clang-analyzer-*` in `.clang-tidy`; re-enable
+  `clang-analyzer-security.insecureAPI.*` (strcpy/strcat) and consider
+  `cert-err33-c` (unchecked returns) + `bugprone-unsafe-functions`.
+- **Python** — add `ruff check` (not just `ruff-format`) with `E722` (bare except)
+  and `F403`/`F405` (wildcard import); consider `bandit`.
+- **CI** — an ASan + UBSan sanitizer job; this audit is exactly what sanitizers
+  and static analysis catch.
 
 ## Severity
 

--- a/projects/amdsmi/.github/agents/amdsmi-review-security.agent.md
+++ b/projects/amdsmi/.github/agents/amdsmi-review-security.agent.md
@@ -54,6 +54,21 @@ file data, CLI args, device responses) is ❌ BLOCKING.
   `pclose(NULL)` when `popen` failed.
 - **VLAs** — runtime-sized stack arrays (`buf[n]`); use a fixed cap or heap.
 - **Math UB** — `log10(0)`/`log(0)` → `-inf`, and `NaN`/`inf` cast to integer.
+- **Use-after-free / dangling pointers** — raw pointer stored after the owning object is
+  destroyed; `std::string::c_str()` / iterator kept past a container modification;
+  object freed then passed to a callback. Use RAII or `std::unique_ptr`.
+- **Double-free** — `free(p)` on an already-freed pointer; `delete` after RAII wrapper
+  also holds the allocation; mismatched `delete` vs `delete[]`.
+- **Integer overflow before size computation** — signed/unsigned arithmetic wrapping
+  before the result is used in `malloc` / `new` / an index (e.g. `size_t n = a + b`
+  where `a + b` wraps). Check with `__builtin_add_overflow` or saturating arithmetic.
+- **Signed integer overflow** — UB when signed arithmetic wraps; compilers can optimize
+  away security checks that rely on wrap-around behaviour.
+- **Pointer arithmetic overflow** — `ptr + offset` where `offset` is attacker-influenced
+  and can wrap past the end of the allocation.
+- **Format string injection** — `printf(user_string)` / `fprintf(f, user_string)` where
+  the format argument is not a string literal; attacker-controlled `%n` writes,
+  `%p`/`%x` memory disclosure. Always use `printf("%s", s)` or `-Wformat-security`.
 
 ### C / C++ — command execution & boundaries
 - **Shell-out** — `popen` / `system` / `exec*` built from a constructed string is
@@ -87,6 +102,14 @@ file data, CLI args, device responses) is ❌ BLOCKING.
 - `sys.getsizeof` where `ctypes.sizeof` is meant; unvalidated sizes / pointer
   arithmetic passed into ctypes / C; hardcoded capacity constants with no
   retry-on-overflow; copy-pasted or wrong enum / exception description strings.
+
+### Python — CLI boundaries & injection
+- **Deserialization of untrusted data** — `pickle.load` / `pickle.loads` on data from a
+  file, socket, or env var; `yaml.load` without `Loader=yaml.SafeLoader`.
+- **`eval` / `exec` on constructed strings** — any call where user input reaches the
+  expression argument; prefer `ast.literal_eval` for data, never `eval` for commands.
+- **Shell injection via `subprocess`** — `subprocess.run(cmd, shell=True)` with
+  unsanitized input. Use a list-form invocation (`shell=False`) and validate args.
 
 ### Generated code
 - **Fix the generator, never the artifact.** `py-interface/amdsmi_wrapper.py` is


### PR DESCRIPTION
## Motivation

The issue #3634 code-hygiene audit surfaced a recurring set of memory-safety,
command-execution, ABI, and Python-hygiene patterns. Capture them as a concrete
checklist in the security review agent so the same classes of issue are flagged
automatically on future diffs instead of relying on memory.

## Technical Details

**Security review agent** (`.github/agents/amdsmi-review-security.agent.md`):
- Add an audit checklist (C/C++ memory & strings, command execution & boundaries, public ABI header, supply chain / build / filesystem, Python hygiene, generated code) with grep-target patterns and severity guidance
- Recommend the mechanical enforcement (clang-tidy `bugprone-*`, `ruff check` E722/F403, ASan/UBSan) that would catch each class automatically

## JIRA ID

JIRA ID: AILITOOLS-278

## Test Plan

- Docs-only change to an agent prompt; `pre-commit` clean
- No code or build files touched

## Test Result

- Pre-commit passed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
