### PR TITLE
fix(clr): pre-touch large-BAR device kernarg pool CPU PTEs

### DIFF
--- a/projects/clr/rocclr/device/rocm/rocvirtual.cpp
+++ b/projects/clr/rocclr/device/rocm/rocvirtual.cpp
@@ -2192,8 +2192,13 @@ bool VirtualGPU::ManagedBuffer::Create(Device::MemorySegment mem_segment) {
     pool_base_ = reinterpret_cast<address>(gpu_.dev().deviceLocalAlloc(pool_size_, flags, false));
     if (pool_base_ != nullptr) {
       // @note Workaround first access penalty.
-      // KFD may update CPU page tables on the first CPU access
-      *pool_base_ = 0;
+      // KFD/TTM maps CPU PTEs lazily, and TTM prefaults 16 4KiB pages
+      // from the faulting address.
+      constexpr size_t kCpuPtePrefaultSpan = 64 * Ki;
+      volatile unsigned char* ptr = pool_base_;
+      for (size_t offset = 0; offset < pool_size_; offset += kCpuPtePrefaultSpan) {
+        ptr[offset] = 0;
+      }
     }
   } else {
     pool_base_ = reinterpret_cast<address>(gpu_.dev().hostAlloc(pool_size_, 0, mem_segment, nullptr, false));


### PR DESCRIPTION
Fix a periodic HIP launch timing bump caused by lazy CPU PTE population for large-BAR device kernarg pools.

On large-BAR systems, ROCclr can allocate kernel arguments from GPU-local but CPU-visible VRAM. That allocation is exposed to userspace through a CPU mapping, but Linux TTM does not populate all CPU PTEs eagerly. The first CPU access to a cold page enters the amdgpu/TTM fault path, and TTM prefaults up to 16 forward 4KiB pages, i.e. one 64KiB span.

ROCclr uses a bump allocator for the device kernarg pool. As launches advance through the pool, the first access to each new cold 64KiB span can add roughly 15-18us to the host launch path. In hipBLASLt raw timing this appears as a phase-locked bump: the underlying period is 64KiB / 128B = 512 kernarg slots, which can project to 256 samples or other periods depending on how many kernarg bytes each measured sample consumes.

This change keeps the existing large-BAR device kernarg policy. It only expands the existing first-access workaround in `VirtualGPU::ManagedBuffer::Create()` from touching the first byte of the pool to touching one byte every 64KiB across the whole pool. That moves CPU PTE population to pool creation instead of paying it later inside the launch hot path.

## Why this approach

The fix is intentionally local to the large-BAR device kernarg allocation path:

- It does not switch back to host kernargs.
- It does not change `kernel_arg_impl_` policy.
- It does not add work to `Acquire()` or chunk-switch paths.
- It does not change TTM/kernel prefault behavior.
- It preserves the existing device kernarg allocation behavior and only warms the CPU mapping.

The 64KiB stride matches the current Linux TTM prefault window:

```text
TTM_BO_VM_NUM_PREFAULT * PAGE_SIZE = 16 * 4096 = 64KiB
```

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## JIRA ID

JIRA ID : DCCS-6390

## Test Plan

hipblaslt-bench \
  --api_method cpp \
  -m 12288 -n 2496 -k 16384 \
  --a_type f16_r --b_type f16_r --c_type f16_r --d_type f16_r \
  --compute_type f32_r \
  --adaptive \
  --adaptive_warmup_time 0 \
  --adaptive_sample_time 0 \
  --adaptive_measure_time 0 \
  --adaptive_max_measure_time 0 \
  --adaptive_min_iters 2048 \
  --adaptive_max_iters 2048 \
  --adaptive_noise_threshold 0 \
  --adaptive_stability_threshold 0 \
  --use_gpu_timer

## Test Result

<img width="1500" height="660" alt="image" src="https://github.com/user-attachments/assets/b567f95c-aa1b-4511-81b3-6d2d80154bd4" />

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
