### PR TITLE
Add support for device-side leak detection

### DIFF
--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -1554,7 +1554,7 @@ void Device::reportDeviceMemoryLeaks() {
   }
 
   for (const auto& pair : uriCache) {
-    close(pair.second.fd);
+    amd::Os::CloseFileHandle(pair.second.fd);
   }
 
   delete uriLocator;

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -1400,7 +1400,7 @@ extern "C" void __asan_report_nonself_leak(uint64_t alloc_pc, uint64_t alloc_siz
 // Helper structures and functions for leak detection
 namespace {
   struct CachedUri {
-    int fd;
+    amd::Os::FileDesc fd;
     uint64_t offset;
     uint64_t size;
   };

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -1388,7 +1388,7 @@ void Device::RemoveHostcallMemory(amd::Memory* memory) {
 void Device::ClearHostcallMemories() { hostcall_allocated_memories_.clear(); }
 
 // ================================================================================================
-#if defined(__clang__)
+#if defined(__clang__) && defined(__linux__)
 #if __has_feature(address_sanitizer)
 
 extern "C" void __asan_report_nonself_leak(uint64_t alloc_pc, uint64_t alloc_size,

--- a/projects/clr/rocclr/device/device.cpp
+++ b/projects/clr/rocclr/device/device.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cstdlib>
 #include <cstring>
 
 #if defined(WITH_HSA_DEVICE)
@@ -1001,6 +1002,11 @@ void Device::registerDevice() {
 
   if (devices_ == nullptr) {
     devices_ = new std::vector<Device*>;
+#if defined(__clang__)
+#if __has_feature(address_sanitizer)
+    atexit(reportAllDeviceMemoryLeaks);
+#endif
+#endif
   }
 
   if (info_.available_) {
@@ -1380,6 +1386,195 @@ void Device::RemoveHostcallMemory(amd::Memory* memory) {
 }
 
 void Device::ClearHostcallMemories() { hostcall_allocated_memories_.clear(); }
+
+// ================================================================================================
+#if defined(__clang__)
+#if __has_feature(address_sanitizer)
+
+extern "C" void __asan_report_nonself_leak(uint64_t alloc_pc, uint64_t alloc_size,
+                                           int device_id, const char* device_name,
+                                           int64_t vma_adjust, int fd,
+                                           uint64_t file_extent_size,
+                                           uint64_t file_extent_start);
+
+// Helper structures and functions for leak detection
+namespace {
+  struct CachedUri {
+    int fd;
+    uint64_t offset;
+    uint64_t size;
+  };
+
+  constexpr uint64_t kAllocMagic = 0xfedcba1ee1abcdefULL;
+  constexpr uint32_t kAllocHeaderBytes = 32;
+  constexpr size_t   kSlabBytes = 2u * Mi;
+  constexpr uint32_t kSlabHeaderBytes = 32;
+  constexpr uint32_t kSlabAlign = 4096;
+  constexpr uint32_t kMinAlign = 16;
+  constexpr uint32_t kAsanShadow = 3;
+  constexpr uint8_t  kHeapFreeMagic = 0xfd;
+  constexpr uint8_t  kHeapLeftRedzoneMagic = 0xfa;
+  constexpr uint64_t kShadowOffset = 0x7FFFFFFF & (~0xFFFULL << kAsanShadow);
+
+  inline uint8_t* memToShadow(uint64_t addr) {
+    return reinterpret_cast<uint8_t*>((addr >> kAsanShadow) + kShadowOffset);
+  }
+
+  __attribute__((no_sanitize("address")))
+  bool scanSlabForLeaks(uint64_t va, device::UriLocator* uriLocator, int devIdx,
+                        std::map<std::string, CachedUri>& uriCache) {
+    auto base = reinterpret_cast<uint8_t*>(va);
+    auto usable = base + kSlabHeaderBytes;
+    auto end = base + kSlabBytes;
+    bool foundLeak = false;
+
+    for (auto p = usable; p + kAllocHeaderBytes <= end; p += kMinAlign) {
+      auto words = reinterpret_cast<uint64_t*>(p);
+      if (words[0] != kAllocMagic || words[1] != va)
+        continue;
+
+      uint64_t pc  = words[2];
+      uint32_t usz = reinterpret_cast<uint32_t*>(p)[7];
+
+      uint64_t ret_addr = reinterpret_cast<uint64_t>(p) + kAllocHeaderBytes;
+      uint8_t shadow = *memToShadow(ret_addr);
+      if (shadow == kHeapFreeMagic || shadow == kHeapLeftRedzoneMagic)
+        continue;
+
+      foundLeak = true;
+      auto uri_fd = amd::Os::FDescInit();
+      uint64_t offset = 0, size = 0;
+      int64_t loadAddrAdjust = 0;
+      std::string uriPath;
+      if (uriLocator) {
+        device::UriLocator::UriInfo uri_info = uriLocator->lookUpUri(pc);
+        uriPath = uri_info.uriPath;
+        loadAddrAdjust = uri_info.loadAddressDiff;
+
+        auto it = uriCache.find(uriPath);
+        if (it != uriCache.end()) {
+          uri_fd = it->second.fd;
+          offset = it->second.offset;
+          size = it->second.size;
+        } else {
+          auto extent = uriLocator->decodeUriAndGetFd(uri_info, &uri_fd);
+          offset = extent.first;
+          size = extent.second;
+          if (uri_fd != amd::Os::FDescInit()) {
+            uriCache[uriPath] = {uri_fd, offset, size};
+          }
+        }
+      }
+      __asan_report_nonself_leak(pc, usz, devIdx, "amdgpu",
+                                 loadAddrAdjust, uri_fd, size, offset);
+    }
+    return foundLeak;
+  }
+
+  __attribute__((no_sanitize("address")))
+  bool scanLargeAllocationForLeaks(uint64_t va, device::UriLocator* uriLocator, int devIdx,
+                                    std::map<std::string, CachedUri>& uriCache) {
+    auto header = reinterpret_cast<uint64_t*>(va + kSlabAlign - kAllocHeaderBytes);
+    if (header[0] != kAllocMagic || header[1] != 0)
+      return false;
+
+    uint64_t pc  = header[2];
+    uint32_t usz = reinterpret_cast<uint32_t*>(header)[7];
+    auto uri_fd = amd::Os::FDescInit();
+    uint64_t offset = 0, size = 0;
+    int64_t loadAddrAdjust = 0;
+    std::string uriPath;
+    if (uriLocator) {
+      device::UriLocator::UriInfo uri_info = uriLocator->lookUpUri(pc);
+      uriPath = uri_info.uriPath;
+      loadAddrAdjust = uri_info.loadAddressDiff;
+
+      auto it = uriCache.find(uriPath);
+      if (it != uriCache.end()) {
+        uri_fd = it->second.fd;
+        offset = it->second.offset;
+        size = it->second.size;
+      } else {
+        auto extent = uriLocator->decodeUriAndGetFd(uri_info, &uri_fd);
+        offset = extent.first;
+        size = extent.second;
+        if (uri_fd != amd::Os::FDescInit()) {
+          uriCache[uriPath] = {uri_fd, offset, size};
+        }
+      }
+    }
+    __asan_report_nonself_leak(pc, usz, devIdx, "amdgpu",
+                               loadAddrAdjust, uri_fd, size, offset);
+    return true;
+  }
+}  // anonymous namespace
+
+void Device::reportDeviceMemoryLeaks() {
+  if (hostcall_allocated_memories_.empty() && initial_heap_buffer_ == nullptr) {
+    return;
+  }
+
+  device::UriLocator* uriLocator = createUriLocator();
+  int devIdx = static_cast<int>(index());
+  bool hasLeaks = false;
+  std::map<std::string, CachedUri> uriCache;
+
+  // Scan initial heap buffer if present
+  if (initial_heap_buffer_ != nullptr) {
+    uint64_t va = initial_heap_buffer_->virtualAddress();
+    if (va != 0 && initial_heap_size_ > 0) {
+      size_t numSlabs = initial_heap_size_ / kSlabBytes;
+      for (size_t i = 0; i < numSlabs; ++i) {
+        hasLeaks |= scanSlabForLeaks(va + i * kSlabBytes, uriLocator, devIdx, uriCache);
+      }
+    }
+  }
+
+  // Scan hostcall-allocated memories
+  for (auto memory : hostcall_allocated_memories_) {
+    if (memory == nullptr) continue;
+
+    device::Memory* dm = memory->getDeviceMemory(*this, false);
+    if (dm == nullptr) continue;
+
+    uint64_t va = dm->virtualAddress();
+    if (va == 0) continue;
+
+    size_t bufSize = memory->getSize();
+
+    if (bufSize == kSlabBytes) {
+      hasLeaks |= scanSlabForLeaks(va, uriLocator, devIdx, uriCache);
+    } else {
+      hasLeaks |= scanLargeAllocationForLeaks(va, uriLocator, devIdx, uriCache);
+    }
+  }
+
+  if (hasLeaks) {
+    __asan_report_nonself_leak(0, 0, -1, "amdgpu", 0, -1, 0, 0);
+  }
+
+  for (const auto& pair : uriCache) {
+    close(pair.second.fd);
+  }
+
+  delete uriLocator;
+}
+
+void Device::reportAllDeviceMemoryLeaks() {
+  if (devices_ == nullptr) {
+    return;
+  }
+
+  for (uint i = 0; i < devices_->size(); ++i) {
+    Device* device = devices_->at(i);
+    if (device != nullptr) {
+      device->reportDeviceMemoryLeaks();
+    }
+  }
+}
+
+#endif
+#endif
 
 // ================================================================================================
 void Device::AddDevMemObj(const void* k, amd::Memory* memObj) {

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -2395,7 +2395,7 @@ class Device : public RuntimeObject {
   //! Sets the group memory carveout percentage hint for the device
   void UpdateGroupMemCarveout(uint8_t percent) { group_mem_carveout_hint_ = percent; }
 
-#if defined(__clang__)
+#if defined(__clang__) && defined(__linux__)
 #if __has_feature(address_sanitizer)
   virtual device::UriLocator* createUriLocator() const = 0;
   void reportDeviceMemoryLeaks();

--- a/projects/clr/rocclr/device/device.hpp
+++ b/projects/clr/rocclr/device/device.hpp
@@ -2398,6 +2398,8 @@ class Device : public RuntimeObject {
 #if defined(__clang__)
 #if __has_feature(address_sanitizer)
   virtual device::UriLocator* createUriLocator() const = 0;
+  void reportDeviceMemoryLeaks();
+  static void reportAllDeviceMemoryLeaks();
 #endif
 #endif
 


### PR DESCRIPTION
## Motivation

This patch enables detection of leaks when using device-side malloc.

## Technical Details

This adds a scan over hostcall requested memory allocations for leaked device malloc allocations and notifies the ASAN host runtime of any discovered.

## JIRA ID

N/A

## Test Plan

Applications with explicit device memory leaks were written and run with this patch in place.

## Test Result

The expected leak reports were generated.

## Submission Checklist

- [ x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
