### PR TITLE
[rocjitsu] Fixes overflows detected by ubsan

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -66,6 +66,14 @@ jobs:
             enable_ubsan: 1
             enable_tsan: 0
             enable_msan: 0
+          - name: asan-ubsan-gcc
+            build_type: RelWithDebInfo
+            enable_asan: 1
+            enable_ubsan: 1
+            enable_tsan: 0
+            enable_msan: 0
+            c_compiler: gcc
+            cxx_compiler: g++
 
     steps:
       - name: Install base dependencies
@@ -172,15 +180,24 @@ jobs:
           )
 
           CMAKE_CONFIG_FLAGS=()
-          if [[ "${{ matrix.name }}" == "asan-ubsan" ]]; then
+          if [[ "${{ matrix.enable_asan }}" == "1" && "${{ matrix.enable_ubsan }}" == "1" ]]; then
             EXCLUDED_TESTS="${EXCLUDED_TESTS}|$(IFS='|'; echo "${ASAN_UBSAN_EXCLUDED_TESTS[*]}")"
             CMAKE_CONFIG_FLAGS+=(
               -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -g"
               -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -g"
             )
           fi
+          if [[ -n "${{ matrix.c_compiler }}" ]]; then
+            CMAKE_CONFIG_FLAGS+=(-DCMAKE_C_COMPILER="${{ matrix.c_compiler }}")
+          fi
+          if [[ -n "${{ matrix.cxx_compiler }}" ]]; then
+            CMAKE_CONFIG_FLAGS+=(-DCMAKE_CXX_COMPILER="${{ matrix.cxx_compiler }}")
+          fi
 
-          CXXFLAGS="-Wno-error=unknown-warning-option -Wno-error=nested-anon-types"
+          CXXFLAGS=""
+          if [[ -z "${{ matrix.cxx_compiler }}" || "${{ matrix.cxx_compiler }}" == *clang* ]]; then
+            CXXFLAGS="-Wno-error=unknown-warning-option -Wno-error=nested-anon-types"
+          fi
           ROCM_PATH=`rocm-sdk path --root` \
             cmake -B "${ROCJITSU_BUILD_DIR}" -G Ninja \
             -DCMAKE_BUILD_TYPE="${{ matrix.build_type }}" \

--- a/emulation/rocjitsu/CMakeLists.txt
+++ b/emulation/rocjitsu/CMakeLists.txt
@@ -169,6 +169,7 @@ if(_rj_sanitizer_count GREATER 0)
         list(
             APPEND RJ_SANITIZER_COMPILE_OPTIONS
             -fsanitize=${_rj_sanitizer_arg}
+            -fno-sanitize-recover=all
         )
         list(APPEND RJ_SANITIZER_LINK_OPTIONS -fsanitize=${_rj_sanitizer_arg})
         if(

--- a/emulation/rocjitsu/cmake/rj_find_amdcxx.cmake
+++ b/emulation/rocjitsu/cmake/rj_find_amdcxx.cmake
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# Locate the ROCm amdclang++ compiler selected by ROCM_PATH.
+#
+# Some systems expose /usr/bin/amdclang++ through alternatives; using that
+# wrapper can derive --rocm-path as /usr and mix headers/device libraries from
+# different installs. Keep this lookup constrained to ROCM_PATH.
+function(rj_find_amdcxx out_var)
+    find_program(
+        _rj_amdcxx
+        NAMES amdclang++
+        PATHS "${ROCM_PATH}"
+        PATH_SUFFIXES lib/llvm/bin bin
+        NO_DEFAULT_PATH
+        NO_CACHE
+    )
+    set(${out_var} "${_rj_amdcxx}" PARENT_SCOPE)
+endfunction()

--- a/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/sema_derive.py
@@ -916,6 +916,14 @@ _BINOP_KIND_MAP: dict[str, SemaNodeKind] = {
 }
 
 
+def _uses_unsigned_arithmetic(ty: SemaType) -> bool:
+    return ty.base in ('I', 'U') and ty.size <= 64
+
+
+def _unsigned_arithmetic_ty(ty: SemaType) -> SemaType:
+    return SemaType.U64 if ty.size == 64 else SemaType.U32
+
+
 def _vec_unary_expr(op: str | None, src0: SemaNode, ty: SemaType) -> SemaNode:
     if op is None:
         return src0
@@ -934,8 +942,16 @@ def _vec_binop_expr(
     ty: SemaType,
 ) -> SemaNode:
     if op is None:
+        if _uses_unsigned_arithmetic(ty):
+            ty = _unsigned_arithmetic_ty(ty)
+            src0 = _cast(src0, ty)
+            src1 = _cast(src1, ty)
         return SemaNode(SemaNodeKind.ADD, ty=ty, children=(src0, src1))
     if op in ('subrev', 'rsub'):
+        if _uses_unsigned_arithmetic(ty):
+            ty = _unsigned_arithmetic_ty(ty)
+            src0 = _cast(src0, ty)
+            src1 = _cast(src1, ty)
         return SemaNode(SemaNodeKind.SUB, ty=ty, children=(src1, src0))
     if op in ('lshlrev', 'lshrrev', 'shl', 'shr'):
         base = {
@@ -988,6 +1004,15 @@ def _vec_binop_expr(
         return SemaNode(
             SemaNodeKind.CALL, ty=ty, call_name=fn, children=(_id(fn), src0, src1)
         )
+    if _uses_unsigned_arithmetic(ty) and kind in (
+        SemaNodeKind.ADD,
+        SemaNodeKind.SUB,
+        SemaNodeKind.MUL,
+    ):
+        ty = _unsigned_arithmetic_ty(ty)
+        src0 = _cast(src0, ty)
+        src1 = _cast(src1, ty)
+        return SemaNode(kind, ty=ty, children=(src0, src1))
     return SemaNode(kind, ty=ty, children=(src0, src1))
 
 
@@ -1219,8 +1244,16 @@ class _VectorTernary(_ScalarDeriver):
         src1 = _cast(_src(1), ty)
         src2 = _cast(_src(2), ty)
         if op == 'mad':
-            mul = SemaNode(SemaNodeKind.MUL, ty=ty, children=(src0, src1))
-            result = SemaNode(SemaNodeKind.ADD, ty=ty, children=(mul, src2))
+            if _uses_unsigned_arithmetic(ty):
+                u_ty = _unsigned_arithmetic_ty(ty)
+                u_src0 = _cast(src0, u_ty)
+                u_src1 = _cast(src1, u_ty)
+                u_src2 = _cast(src2, u_ty)
+                mul = SemaNode(SemaNodeKind.MUL, ty=u_ty, children=(u_src0, u_src1))
+                result = SemaNode(SemaNodeKind.ADD, ty=u_ty, children=(mul, u_src2))
+            else:
+                mul = SemaNode(SemaNodeKind.MUL, ty=ty, children=(src0, src1))
+                result = SemaNode(SemaNodeKind.ADD, ty=ty, children=(mul, src2))
         elif op in ('fma', 'fmac'):
             result = SemaNode(SemaNodeKind.FMA, ty=ty, children=(src0, src1, src2))
         else:

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -1021,6 +1021,19 @@ class TestDeriveVectorBinop:
         assert '::rocjitsu::amdgpu::mul_i24_u32' in cpp
         assert 'a * b' not in cpp
 
+    def test_signed_add_lowers_through_unsigned_wrap(self):
+        sem = _FakeSem('V_ADD_I32', 'vector_binop', 'add', 'i32')
+        block = derive_sema_block(sem)
+        nodes = list(block.body.walk())
+        cpp = lower_sema_block(block)
+
+        assert any(n.kind == SemaNodeKind.ADD and n.ty == SemaType.U32 for n in nodes)
+        assert cpp.count('static_cast<uint32_t>(static_cast<int32_t>(') >= 2
+        assert (
+            'static_cast<int32_t>(inst.src0.read_lane(wf, lane)) + '
+            'static_cast<int32_t>(inst.src1.read_lane(wf, lane))'
+        ) not in cpp
+
     def test_min_max_use_call(self):
         for op in ['min', 'max']:
             sem = _FakeSem(f'V_{op.upper()}_F32', 'vector_binop', op, 'f32')
@@ -1143,6 +1156,20 @@ class TestDeriveVectorTernary:
 
         assert '::rocjitsu::amdgpu::mad_i24_u32' in cpp
         assert 'a * b' not in cpp
+
+    def test_u16_mad_lowers_through_unsigned_wrap(self):
+        sem = _FakeSem('V_MAD_LEGACY_U16', 'vector_ternary', 'mad', 'u16')
+        block = derive_sema_block(sem)
+        nodes = list(block.body.walk())
+        cpp = lower_sema_block(block)
+
+        assert any(n.kind == SemaNodeKind.ADD and n.ty == SemaType.U32 for n in nodes)
+        assert any(n.kind == SemaNodeKind.MUL and n.ty == SemaType.U32 for n in nodes)
+        assert cpp.count('static_cast<uint32_t>(static_cast<uint16_t>(') >= 3
+        assert (
+            'static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) * '
+            'static_cast<uint16_t>(inst.src1.read_lane(wf, lane))'
+        ) not in cpp
 
     def test_signed_bfe_keeps_braced_one_literal(self):
         sem = _FakeSem('V_BFE_I32', 'vector_ternary', 'bfe_i', 'i32')

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu.cpp
@@ -10542,13 +10542,14 @@ void VAddNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                            ? (src0.read_lane(wf, lane) >> 16)
-                                                            : src0.read_lane(wf, lane))) +
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                            ? (src1.read_lane(wf, lane) >> 16)
-                                                            : src1.read_lane(wf, lane))))))));
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane)))) +
+               static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane)))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -10650,13 +10651,14 @@ void VSubNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                            ? (src0.read_lane(wf, lane) >> 16)
-                                                            : src0.read_lane(wf, lane))) -
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                            ? (src1.read_lane(wf, lane) >> 16)
-                                                            : src1.read_lane(wf, lane))))))));
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane)))) -
+               static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane)))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu_2.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_alu_2.cpp
@@ -420,14 +420,14 @@ void VAddNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) +
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                               ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane)))) +
+               static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                               ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -529,14 +529,14 @@ void VSubNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) -
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                               ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane)))) -
+               static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                               ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_ternary.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/gfx1250/vop3_ternary.cpp
@@ -4038,16 +4038,17 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>(((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                             ? (src0.read_lane(wf, lane) >> 16)
-                                                             : src0.read_lane(wf, lane))) *
-                                  static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                             ? (src1.read_lane(wf, lane) >> 16)
-                                                             : src1.read_lane(wf, lane)))) +
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                            ? (src2.read_lane(wf, lane) >> 16)
-                                                            : src2.read_lane(wf, lane))))))));
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              ((static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane)))) *
+                static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                 ? (src1.read_lane(wf, lane) >> 16)
+                                                                 : src1.read_lane(wf, lane))))) +
+               static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
+                                                                ? (src2.read_lane(wf, lane) >> 16)
+                                                                : src2.read_lane(wf, lane)))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -5502,17 +5503,17 @@ void VMadI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>(((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                               ? (src0.read_lane(wf, lane) >> 16)
-                                                               : src0.read_lane(wf, lane))) *
-                                     static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                               ? (src1.read_lane(wf, lane) >> 16)
-                                                               : src1.read_lane(wf, lane)))) +
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                              ? (src2.read_lane(wf, lane) >> 16)
-                                                              : src2.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              ((static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane)))) *
+                static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))))) +
+               static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
+                                                               ? (src2.read_lane(wf, lane) >> 16)
+                                                               : src2.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3/vop3.cpp
@@ -12260,16 +12260,17 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>(((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                             ? (src0.read_lane(wf, lane) >> 16)
-                                                             : src0.read_lane(wf, lane))) *
-                                  static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                             ? (src1.read_lane(wf, lane) >> 16)
-                                                             : src1.read_lane(wf, lane)))) +
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                            ? (src2.read_lane(wf, lane) >> 16)
-                                                            : src2.read_lane(wf, lane))))))));
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              ((static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane)))) *
+                static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                 ? (src1.read_lane(wf, lane) >> 16)
+                                                                 : src1.read_lane(wf, lane))))) +
+               static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
+                                                                ? (src2.read_lane(wf, lane) >> 16)
+                                                                : src2.read_lane(wf, lane)))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -13829,17 +13830,17 @@ void VMadI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>(((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                               ? (src0.read_lane(wf, lane) >> 16)
-                                                               : src0.read_lane(wf, lane))) *
-                                     static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                               ? (src1.read_lane(wf, lane) >> 16)
-                                                               : src1.read_lane(wf, lane)))) +
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                              ? (src2.read_lane(wf, lane) >> 16)
-                                                              : src2.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              ((static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane)))) *
+                static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))))) +
+               static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
+                                                               ? (src2.read_lane(wf, lane) >> 16)
+                                                               : src2.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -15891,13 +15892,14 @@ void VAddNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                            ? (src0.read_lane(wf, lane) >> 16)
-                                                            : src0.read_lane(wf, lane))) +
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                            ? (src1.read_lane(wf, lane) >> 16)
-                                                            : src1.read_lane(wf, lane))))))));
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane)))) +
+               static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane)))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -15982,13 +15984,14 @@ void VSubNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                            ? (src0.read_lane(wf, lane) >> 16)
-                                                            : src0.read_lane(wf, lane))) -
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                            ? (src1.read_lane(wf, lane) >> 16)
-                                                            : src1.read_lane(wf, lane))))))));
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane)))) -
+               static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane)))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -16703,14 +16706,14 @@ void VAddNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) +
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                               ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane)))) +
+               static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                               ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -16795,14 +16798,14 @@ void VSubNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) -
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                               ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane)))) -
+               static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                               ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna3_5/vop3.cpp
@@ -12260,16 +12260,17 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>(((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                             ? (src0.read_lane(wf, lane) >> 16)
-                                                             : src0.read_lane(wf, lane))) *
-                                  static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                             ? (src1.read_lane(wf, lane) >> 16)
-                                                             : src1.read_lane(wf, lane)))) +
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                            ? (src2.read_lane(wf, lane) >> 16)
-                                                            : src2.read_lane(wf, lane))))))));
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              ((static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane)))) *
+                static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                 ? (src1.read_lane(wf, lane) >> 16)
+                                                                 : src1.read_lane(wf, lane))))) +
+               static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
+                                                                ? (src2.read_lane(wf, lane) >> 16)
+                                                                : src2.read_lane(wf, lane)))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -13829,17 +13830,17 @@ void VMadI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>(((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                               ? (src0.read_lane(wf, lane) >> 16)
-                                                               : src0.read_lane(wf, lane))) *
-                                     static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                               ? (src1.read_lane(wf, lane) >> 16)
-                                                               : src1.read_lane(wf, lane)))) +
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                              ? (src2.read_lane(wf, lane) >> 16)
-                                                              : src2.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              ((static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane)))) *
+                static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))))) +
+               static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
+                                                               ? (src2.read_lane(wf, lane) >> 16)
+                                                               : src2.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -15891,13 +15892,14 @@ void VAddNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                            ? (src0.read_lane(wf, lane) >> 16)
-                                                            : src0.read_lane(wf, lane))) +
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                            ? (src1.read_lane(wf, lane) >> 16)
-                                                            : src1.read_lane(wf, lane))))))));
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane)))) +
+               static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane)))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -15982,13 +15984,14 @@ void VSubNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                            ? (src0.read_lane(wf, lane) >> 16)
-                                                            : src0.read_lane(wf, lane))) -
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                            ? (src1.read_lane(wf, lane) >> 16)
-                                                            : src1.read_lane(wf, lane))))))));
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane)))) -
+               static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane)))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -16703,14 +16706,14 @@ void VAddNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) +
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                               ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane)))) +
+               static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                               ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -16795,14 +16798,14 @@ void VSubNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) -
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                               ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane)))) -
+               static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                               ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/rdna4/vop3.cpp
@@ -13715,16 +13715,17 @@ void VMadU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>(((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                             ? (src0.read_lane(wf, lane) >> 16)
-                                                             : src0.read_lane(wf, lane))) *
-                                  static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                             ? (src1.read_lane(wf, lane) >> 16)
-                                                             : src1.read_lane(wf, lane)))) +
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                            ? (src2.read_lane(wf, lane) >> 16)
-                                                            : src2.read_lane(wf, lane))))))));
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              ((static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                 ? (src0.read_lane(wf, lane) >> 16)
+                                                                 : src0.read_lane(wf, lane)))) *
+                static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                 ? (src1.read_lane(wf, lane) >> 16)
+                                                                 : src1.read_lane(wf, lane))))) +
+               static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
+                                                                ? (src2.read_lane(wf, lane) >> 16)
+                                                                : src2.read_lane(wf, lane)))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -14878,17 +14879,17 @@ void VMadI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>(((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                               ? (src0.read_lane(wf, lane) >> 16)
-                                                               : src0.read_lane(wf, lane))) *
-                                     static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                               ? (src1.read_lane(wf, lane) >> 16)
-                                                               : src1.read_lane(wf, lane)))) +
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
-                                                              ? (src2.read_lane(wf, lane) >> 16)
-                                                              : src2.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              ((static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane)))) *
+                static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane))))) +
+               static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x4u) != 0
+                                                               ? (src2.read_lane(wf, lane) >> 16)
+                                                               : src2.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -18181,13 +18182,14 @@ void VAddNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                            ? (src0.read_lane(wf, lane) >> 16)
-                                                            : src0.read_lane(wf, lane))) +
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                            ? (src1.read_lane(wf, lane) >> 16)
-                                                            : src1.read_lane(wf, lane))))))));
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane)))) +
+               static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane)))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -18272,13 +18274,14 @@ void VSubNcU16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half = static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(
-          static_cast<uint16_t>((static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                            ? (src0.read_lane(wf, lane) >> 16)
-                                                            : src0.read_lane(wf, lane))) -
-                                 static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                            ? (src1.read_lane(wf, lane) >> 16)
-                                                            : src1.read_lane(wf, lane))))))));
+      uint32_t src_half =
+          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
+              (static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                                ? (src0.read_lane(wf, lane) >> 16)
+                                                                : src0.read_lane(wf, lane)))) -
+               static_cast<uint32_t>(static_cast<uint16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                                ? (src1.read_lane(wf, lane) >> 16)
+                                                                : src1.read_lane(wf, lane)))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -18993,14 +18996,14 @@ void VAddNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) +
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                               ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane)))) +
+               static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                               ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }
@@ -19085,14 +19088,14 @@ void VSubNcI16Vop3::execute_impl(amdgpu::Wavefront &wf) {
     if (!(exec & (1ULL << lane)))
       continue;
     {
-      uint32_t src_half =
-          static_cast<uint32_t>(static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(
-              static_cast<int16_t>((static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
-                                                              ? (src0.read_lane(wf, lane) >> 16)
-                                                              : src0.read_lane(wf, lane))) -
-                                    static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
-                                                              ? (src1.read_lane(wf, lane) >> 16)
-                                                              : src1.read_lane(wf, lane)))))))));
+      uint32_t src_half = static_cast<uint32_t>(
+          static_cast<uint16_t>(static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+              (static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x1u) != 0
+                                                               ? (src0.read_lane(wf, lane) >> 16)
+                                                               : src0.read_lane(wf, lane)))) -
+               static_cast<uint32_t>(static_cast<int16_t>(((amdgpu::vop3_opsel(inst_) & 0x2u) != 0
+                                                               ? (src1.read_lane(wf, lane) >> 16)
+                                                               : src1.read_lane(wf, lane))))))))));
       ::rocjitsu::amdgpu::write_vop3_true16_dst(vdst, wf, lane, amdgpu::vop3_opsel(inst_) & 0x8u,
                                                 src_half);
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -3012,10 +3012,11 @@ inline void execute_v_add_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
-                             (static_cast<int16_t>(inst.src0.read_lane(wf, lane)) +
-                              static_cast<int16_t>(inst.src1.read_lane(wf, lane)))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+            (static_cast<uint32_t>(static_cast<int16_t>(inst.src0.read_lane(wf, lane))) +
+             static_cast<uint32_t>(static_cast<int16_t>(inst.src1.read_lane(wf, lane))))))));
   }
 }
 
@@ -3026,9 +3027,10 @@ inline void execute_v_add_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) +
-                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
+    inst.vdst.write_lane(
+        wf, lane,
+        (static_cast<uint32_t>(static_cast<int32_t>(inst.src0.read_lane(wf, lane))) +
+         static_cast<uint32_t>(static_cast<int32_t>(inst.src1.read_lane(wf, lane)))));
   }
 }
 
@@ -3054,10 +3056,11 @@ inline void execute_v_add_nc_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
-                             (static_cast<int16_t>(inst.src0.read_lane(wf, lane)) +
-                              static_cast<int16_t>(inst.src1.read_lane(wf, lane)))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+            (static_cast<uint32_t>(static_cast<int16_t>(inst.src0.read_lane(wf, lane))) +
+             static_cast<uint32_t>(static_cast<int16_t>(inst.src1.read_lane(wf, lane))))))));
   }
 }
 
@@ -3068,9 +3071,10 @@ inline void execute_v_add_nc_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) +
-                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
+    inst.vdst.write_lane(
+        wf, lane,
+        (static_cast<uint32_t>(static_cast<int32_t>(inst.src0.read_lane(wf, lane))) +
+         static_cast<uint32_t>(static_cast<int32_t>(inst.src1.read_lane(wf, lane)))));
   }
 }
 
@@ -3080,10 +3084,11 @@ inline void execute_v_add_nc_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(
-                             (static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) +
-                              static_cast<uint16_t>(inst.src1.read_lane(wf, lane))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(
+            (static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) +
+             static_cast<uint32_t>(static_cast<uint16_t>(inst.src1.read_lane(wf, lane)))))));
   }
 }
 
@@ -3117,10 +3122,11 @@ inline void execute_v_add_u16_vop2([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(
-                             (static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) +
-                              static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(
+            (static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) +
+             static_cast<uint32_t>(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)))))));
   }
 }
 
@@ -3130,10 +3136,11 @@ inline void execute_v_add_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(
-                             (static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) +
-                              static_cast<uint16_t>(inst.src1.read_lane(wf, lane))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(
+            (static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) +
+             static_cast<uint32_t>(static_cast<uint16_t>(inst.src1.read_lane(wf, lane)))))));
   }
 }
 
@@ -13281,11 +13288,12 @@ inline void execute_v_mad_legacy_i16_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
-                             ((static_cast<int16_t>(inst.src0.read_lane(wf, lane)) *
-                               static_cast<int16_t>(inst.src1.read_lane(wf, lane))) +
-                              static_cast<int16_t>(inst.src2.read_lane(wf, lane)))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+            ((static_cast<uint32_t>(static_cast<int16_t>(inst.src0.read_lane(wf, lane))) *
+              static_cast<uint32_t>(static_cast<int16_t>(inst.src1.read_lane(wf, lane)))) +
+             static_cast<uint32_t>(static_cast<int16_t>(inst.src2.read_lane(wf, lane))))))));
   }
 }
 
@@ -13296,11 +13304,12 @@ inline void execute_v_mad_legacy_u16_vop3([[maybe_unused]] Inst &inst,
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(
-                             ((static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) *
-                               static_cast<uint16_t>(inst.src1.read_lane(wf, lane))) +
-                              static_cast<uint16_t>(inst.src2.read_lane(wf, lane))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(
+            ((static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) *
+              static_cast<uint32_t>(static_cast<uint16_t>(inst.src1.read_lane(wf, lane)))) +
+             static_cast<uint32_t>(static_cast<uint16_t>(inst.src2.read_lane(wf, lane)))))));
   }
 }
 
@@ -18474,10 +18483,11 @@ inline void execute_v_sub_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
-                             (static_cast<int16_t>(inst.src0.read_lane(wf, lane)) -
-                              static_cast<int16_t>(inst.src1.read_lane(wf, lane)))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+            (static_cast<uint32_t>(static_cast<int16_t>(inst.src0.read_lane(wf, lane))) -
+             static_cast<uint32_t>(static_cast<int16_t>(inst.src1.read_lane(wf, lane))))))));
   }
 }
 
@@ -18488,9 +18498,10 @@ inline void execute_v_sub_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) -
-                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
+    inst.vdst.write_lane(
+        wf, lane,
+        (static_cast<uint32_t>(static_cast<int32_t>(inst.src0.read_lane(wf, lane))) -
+         static_cast<uint32_t>(static_cast<int32_t>(inst.src1.read_lane(wf, lane)))));
   }
 }
 
@@ -18500,10 +18511,11 @@ inline void execute_v_sub_nc_i16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
-                             (static_cast<int16_t>(inst.src0.read_lane(wf, lane)) -
-                              static_cast<int16_t>(inst.src1.read_lane(wf, lane)))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(static_cast<int16_t>(
+            (static_cast<uint32_t>(static_cast<int16_t>(inst.src0.read_lane(wf, lane))) -
+             static_cast<uint32_t>(static_cast<int16_t>(inst.src1.read_lane(wf, lane))))))));
   }
 }
 
@@ -18514,9 +18526,10 @@ inline void execute_v_sub_nc_i32_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         (static_cast<int32_t>(inst.src0.read_lane(wf, lane)) -
-                          static_cast<int32_t>(inst.src1.read_lane(wf, lane))));
+    inst.vdst.write_lane(
+        wf, lane,
+        (static_cast<uint32_t>(static_cast<int32_t>(inst.src0.read_lane(wf, lane))) -
+         static_cast<uint32_t>(static_cast<int32_t>(inst.src1.read_lane(wf, lane)))));
   }
 }
 
@@ -18526,10 +18539,11 @@ inline void execute_v_sub_nc_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(
-                             (static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) -
-                              static_cast<uint16_t>(inst.src1.read_lane(wf, lane))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(
+            (static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) -
+             static_cast<uint32_t>(static_cast<uint16_t>(inst.src1.read_lane(wf, lane)))))));
   }
 }
 
@@ -18563,10 +18577,11 @@ inline void execute_v_sub_u16_vop2([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(
-                             (static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) -
-                              static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(
+            (static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) -
+             static_cast<uint32_t>(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)))))));
   }
 }
 
@@ -18576,10 +18591,11 @@ inline void execute_v_sub_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unused]]
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(
-                             (static_cast<uint16_t>(inst.src0.read_lane(wf, lane)) -
-                              static_cast<uint16_t>(inst.src1.read_lane(wf, lane))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(
+            (static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane))) -
+             static_cast<uint32_t>(static_cast<uint16_t>(inst.src1.read_lane(wf, lane)))))));
   }
 }
 
@@ -18974,10 +18990,11 @@ inline void execute_v_subrev_u16_vop2([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(
-                             (static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane)) -
-                              static_cast<uint16_t>(inst.src0.read_lane(wf, lane))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(
+            (static_cast<uint32_t>(static_cast<uint16_t>(inst.vsrc1.read_lane(wf, lane))) -
+             static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)))))));
   }
 }
 
@@ -18988,10 +19005,11 @@ inline void execute_v_subrev_u16_vop3([[maybe_unused]] Inst &inst, [[maybe_unuse
   for (uint32_t lane = 0; lane < wf.wf_size(); ++lane) {
     if (!(exec & (1ULL << lane)))
       continue;
-    inst.vdst.write_lane(wf, lane,
-                         static_cast<uint32_t>(static_cast<uint16_t>(
-                             (static_cast<uint16_t>(inst.src1.read_lane(wf, lane)) -
-                              static_cast<uint16_t>(inst.src0.read_lane(wf, lane))))));
+    inst.vdst.write_lane(
+        wf, lane,
+        static_cast<uint32_t>(static_cast<uint16_t>(
+            (static_cast<uint32_t>(static_cast<uint16_t>(inst.src1.read_lane(wf, lane))) -
+             static_cast<uint32_t>(static_cast<uint16_t>(inst.src0.read_lane(wf, lane)))))));
   }
 }
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -613,14 +613,18 @@ if(AMDCXX AND HSA_RUNTIME64)
             set(HIP_TEST_SRC ${CMAKE_CURRENT_SOURCE_DIR}/${TEST_NAME}.cpp)
         endif()
         set(HIP_TEST_BIN ${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME})
+        set(HIP_EXTRA_LIBS)
+        if(ARG_EXTRA_LIBS)
+            set(HIP_EXTRA_LIBS -x none ${ARG_EXTRA_LIBS})
+        endif()
         add_custom_command(
             OUTPUT ${HIP_TEST_BIN}
             COMMAND
                 ${AMDCXX} -x hip --offload-arch=${ARG_ARCH}
                 --rocm-path=${ROCM_PATH} -std=c++20 ${RJ_HIP_SANITIZER_FLAGS}
                 -isystem ${GTEST_INC} -I${CMAKE_CURRENT_SOURCE_DIR} -o
-                ${HIP_TEST_BIN} ${HIP_TEST_SRC} -x none -L${GTEST_LIB_DIR}
-                -lgtest -lpthread ${ARG_EXTRA_LIBS} -Wl,-rpath,${GTEST_LIB_DIR}
+                ${HIP_TEST_BIN} ${HIP_TEST_SRC} ${HIP_EXTRA_LIBS}
+                -L${GTEST_LIB_DIR} -lgtest -lpthread -Wl,-rpath,${GTEST_LIB_DIR}
                 -Wl,-rpath,${RJ_HSA_LIBRARY_DIR}
             DEPENDS ${HIP_TEST_SRC} GTest::gtest GTest::gtest_main
             COMMENT "Building ${TEST_NAME} with amdclang++ -x hip (${ARG_ARCH})"

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 include(rj_configure_target)
+include(rj_find_amdcxx)
 
 # Device kernels (compiled from HIP sources for simulator testing).
 add_subdirectory(kernels)
@@ -588,15 +589,19 @@ else()
     message(STATUS "HSA init test disabled (libhsa-runtime64 not found)")
 endif()
 
-# --- HIP tests (requires hipcc + CLI launcher) ---
+# --- HIP tests (requires amdclang++ + CLI launcher) ---
 
-find_program(HIPCC_EXECUTABLE hipcc PATHS "${ROCM_PATH}" PATH_SUFFIXES bin)
-if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
+rj_find_amdcxx(AMDCXX)
+if(AMDCXX AND HSA_RUNTIME64)
     set(GTEST_INC ${googletest_SOURCE_DIR}/googletest/include)
     set(GTEST_LIB_DIR ${CMAKE_BINARY_DIR}/lib)
     set(RJ_HIP_SANITIZER_FLAGS ${RJ_SANITIZER_COMPILE_OPTIONS})
+    if(RJ_HIP_SANITIZER_FLAGS)
+        # Sanitizer runtimes are host-side only for these HIP tests.
+        list(APPEND RJ_HIP_SANITIZER_FLAGS -Xarch_device -fno-sanitize=all)
+    endif()
 
-    # Helper: build a HIP test binary with hipcc + gtest.
+    # Helper: build a HIP test binary with amdclang++ + gtest.
     function(rj_add_hip_test TEST_NAME)
         cmake_parse_arguments(ARG "" "ARCH;SOURCE" "EXTRA_LIBS" ${ARGN})
         if(NOT ARG_ARCH)
@@ -611,14 +616,14 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
         add_custom_command(
             OUTPUT ${HIP_TEST_BIN}
             COMMAND
-                ${HIPCC_EXECUTABLE} --offload-arch=${ARG_ARCH} -std=c++20
-                ${RJ_HIP_SANITIZER_FLAGS} -isystem ${GTEST_INC}
-                -I${CMAKE_CURRENT_SOURCE_DIR} -L${GTEST_LIB_DIR} -lgtest
-                -lpthread ${ARG_EXTRA_LIBS} -Wl,-rpath,${GTEST_LIB_DIR}
-                -Wl,-rpath,${RJ_HSA_LIBRARY_DIR} -o ${HIP_TEST_BIN}
-                ${HIP_TEST_SRC}
+                ${AMDCXX} -x hip --offload-arch=${ARG_ARCH}
+                --rocm-path=${ROCM_PATH} -std=c++20 ${RJ_HIP_SANITIZER_FLAGS}
+                -isystem ${GTEST_INC} -I${CMAKE_CURRENT_SOURCE_DIR} -o
+                ${HIP_TEST_BIN} ${HIP_TEST_SRC} -x none -L${GTEST_LIB_DIR}
+                -lgtest -lpthread ${ARG_EXTRA_LIBS} -Wl,-rpath,${GTEST_LIB_DIR}
+                -Wl,-rpath,${RJ_HSA_LIBRARY_DIR}
             DEPENDS ${HIP_TEST_SRC} GTest::gtest GTest::gtest_main
-            COMMENT "Building ${TEST_NAME} with hipcc (${ARG_ARCH})"
+            COMMENT "Building ${TEST_NAME} with amdclang++ -x hip (${ARG_ARCH})"
             VERBATIM
         )
         add_custom_target(${TEST_NAME}_target ALL DEPENDS ${HIP_TEST_BIN})
@@ -820,24 +825,27 @@ if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
 
     add_subdirectory(race-detector)
 
-    message(STATUS "HIP tests enabled (found ${HIPCC_EXECUTABLE})")
+    message(STATUS "HIP tests enabled (found ${AMDCXX})")
 else()
-    message(STATUS "HIP tests disabled (hipcc or libhsa-runtime64 not found)")
+    message(
+        STATUS
+        "HIP tests disabled (amdclang++ or libhsa-runtime64 not found)"
+    )
 endif()
 
 # --- Narrow conversion HIP CTS tests ---
-# Uses hipcc (rocjitsu emulator does not yet support amdclang++ -x hip binaries).
-if(HIPCC_EXECUTABLE AND HSA_RUNTIME64)
+# Uses the same HIP compiler path as the other HIP tests.
+if(AMDCXX AND HSA_RUNTIME64)
     set(CVT_NARROW_BIN ${CMAKE_CURRENT_BINARY_DIR}/hip_cvt_narrow_test)
     add_custom_command(
         OUTPUT ${CVT_NARROW_BIN}
         COMMAND
-            ${HIPCC_EXECUTABLE} --offload-arch=gfx950 -std=c++20
-            ${RJ_HIP_SANITIZER_FLAGS} -I${CMAKE_SOURCE_DIR}/lib/util/include -o
-            ${CVT_NARROW_BIN}
+            ${AMDCXX} -x hip --offload-arch=gfx950 --rocm-path=${ROCM_PATH}
+            -std=c++20 ${RJ_HIP_SANITIZER_FLAGS}
+            -I${CMAKE_SOURCE_DIR}/lib/util/include -o ${CVT_NARROW_BIN}
             ${CMAKE_CURRENT_SOURCE_DIR}/hip_cvt_narrow_test.cpp
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hip_cvt_narrow_test.cpp
-        COMMENT "Building hip_cvt_narrow_test with hipcc (gfx950)"
+        COMMENT "Building hip_cvt_narrow_test with amdclang++ -x hip (gfx950)"
         VERBATIM
     )
     add_custom_target(hip_cvt_narrow_test_target ALL DEPENDS ${CVT_NARROW_BIN})

--- a/emulation/rocjitsu/tests/kernels/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/kernels/CMakeLists.txt
@@ -11,18 +11,8 @@
 # found the kernel targets are silently skipped and tests that depend on them
 # are disabled at runtime via the HAS_DEVICE_KERNELS compile definition.
 
-# Prefer the compiler from the ROCm tree selected by ROCM_PATH. Some systems
-# also expose /usr/bin/amdclang++ through alternatives; deriving --rocm-path
-# from that wrapper gives /usr, which mixes headers and device libraries from
-# different installs.
-find_program(
-    AMDCXX
-    amdclang++
-    PATHS ${ROCM_PATH}
-    PATH_SUFFIXES lib/llvm/bin bin
-    DOC "Path to the ROCm amdclang++ compiler"
-    NO_DEFAULT_PATH
-)
+include(rj_find_amdcxx)
+rj_find_amdcxx(AMDCXX)
 
 if(NOT AMDCXX)
     message(


### PR DESCRIPTION
* Adds gcc with sanitizers to CI.
* Uses -fno-sanitize-recover=all to fail hard on error instead of recovering, discovering more bugs.
* Uses amdclang++ instead of hipcc in tests.
* Fixes overflows detected by ubsan.
* Regenerates ISA

## Motivation

* Correctness and improve sanitizer coverage

## Technical Details

* Casting to avoid ubsan errors.

## JIRA ID

#7891

## Test Plan

Test on CI

## Test Result

CI passes.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
