### PR TITLE
rocjitsu: keep L2 coherent for uncached accesses

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.cpp
@@ -72,12 +72,21 @@ void L2Cache::ensure_line(uint64_t addr, uint32_t vmid) {
 }
 
 void L2Cache::read(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype, uint32_t vmid) {
+  uint32_t copied = 0;
   if (mtype == Mtype::UC) {
-    send_backing(addr, dst, size, simdojo::MessageOp::READ, vmid);
+    while (copied < size) {
+      const uint64_t ea = addr + copied;
+      const uint32_t line_offset = CacheStore::line_offset(ea);
+      const uint32_t chunk = std::min(size - copied, LINE_SIZE - line_offset);
+
+      flush_line(ea, vmid);
+      send_backing(ea, dst + copied, chunk, simdojo::MessageOp::READ, vmid);
+      copied += chunk;
+    }
     return;
   }
 
-  uint32_t copied = 0;
+  copied = 0;
   while (copied < size) {
     const uint64_t ea = addr + copied;
     const uint32_t line_offset = CacheStore::line_offset(ea);
@@ -97,12 +106,21 @@ void L2Cache::read(uint64_t addr, uint8_t *dst, uint32_t size, Mtype mtype, uint
 }
 
 void L2Cache::write(uint64_t addr, const uint8_t *src, uint32_t size, Mtype mtype, uint32_t vmid) {
+  uint32_t copied = 0;
   if (mtype == Mtype::UC) {
-    send_backing(addr, const_cast<uint8_t *>(src), size, simdojo::MessageOp::WRITE, vmid);
+    while (copied < size) {
+      const uint64_t ea = addr + copied;
+      const uint32_t line_offset = CacheStore::line_offset(ea);
+      const uint32_t chunk = std::min(size - copied, LINE_SIZE - line_offset);
+
+      flush_line(ea, vmid);
+      send_backing(ea, const_cast<uint8_t *>(src + copied), chunk, simdojo::MessageOp::WRITE, vmid);
+      copied += chunk;
+    }
     return;
   }
 
-  uint32_t copied = 0;
+  copied = 0;
   while (copied < size) {
     const uint64_t ea = addr + copied;
     const uint32_t line_offset = CacheStore::line_offset(ea);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/l2_cache.h
@@ -32,7 +32,8 @@ class GpuMemory; // Forward declaration for backing store writeback.
 /// (HBM controller or memory-side cache) via the requester port.
 ///
 /// Mtype-aware behavior:
-///   - UC: Bypass L2, forward directly to backing store.
+///   - UC: Flush/invalidate any resident L2 line, then bypass L2 and
+///         forward directly to backing store.
 ///   - CC: Allocate in L2, MOESI coherence state tracking for CPU-GPU
 ///         shared memory. Write-through on CC stores.
 ///   - RW/WB: Allocate in L2, with functional-mode stores written through to

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -55,6 +55,7 @@
 #include <array>
 #include <bit>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <string>
 #include <utility>
@@ -653,6 +654,55 @@ TEST(MfmaExecTest, ResolveAccAccVgpr) {
       /*vb=*/100, /*dst=*/200, /*src2_ev=*/770, const_acc, [&]() -> uint32_t { return 99u; });
   EXPECT_EQ(const_acc, amdgpu::ACC_FROM_VGPR);
   EXPECT_EQ(result, 100u + amdgpu::ACC_VGPR_OFFSET + 2u);
+}
+
+// ---------------------------------------------------------------------------
+// L2 cache tests
+// ---------------------------------------------------------------------------
+
+TEST(L2CacheTest, UcStoreInvalidatesResidentLineBeforeAtomicRmw) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache l2("test_l2");
+  l2.set_backing_memory(&mem);
+
+  constexpr uint64_t kAddr = 0x2000;
+  mem.write32(kAddr, 1);
+
+  uint32_t first_old = 0;
+  l2.atomic_rmw(kAddr, sizeof(uint32_t), [&](uint8_t *line, uint32_t offset) {
+    std::memcpy(&first_old, line + offset, sizeof(first_old));
+    std::memcpy(line + offset, &first_old, sizeof(first_old));
+  });
+  ASSERT_EQ(first_old, 1u);
+
+  const uint32_t unlocked = 0;
+  l2.write(kAddr, reinterpret_cast<const uint8_t *>(&unlocked), sizeof(unlocked),
+           amdgpu::Mtype::UC);
+
+  uint32_t second_old = 1;
+  l2.atomic_rmw(kAddr, sizeof(uint32_t), [&](uint8_t *line, uint32_t offset) {
+    std::memcpy(&second_old, line + offset, sizeof(second_old));
+    std::memcpy(line + offset, &second_old, sizeof(second_old));
+  });
+  EXPECT_EQ(second_old, 0u);
+}
+
+TEST(L2CacheTest, UcReadFlushesDirtyResidentLine) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache l2("test_l2");
+  l2.set_backing_memory(&mem);
+
+  constexpr uint64_t kAddr = 0x2080;
+  mem.write32(kAddr, 7);
+
+  uint8_t line[amdgpu::L2Cache::LINE_SIZE] = {};
+  uint32_t dirty_value = 9;
+  std::memcpy(line, &dirty_value, sizeof(dirty_value));
+  l2.writeback_line(kAddr, line, amdgpu::Mtype::RW);
+
+  uint32_t read_value = 0;
+  l2.read(kAddr, reinterpret_cast<uint8_t *>(&read_value), sizeof(read_value), amdgpu::Mtype::UC);
+  EXPECT_EQ(read_value, 9u);
 }
 
 // ---------------------------------------------------------------------------

--- a/emulation/rocjitsu/tests/shared_infra_test.cpp
+++ b/emulation/rocjitsu/tests/shared_infra_test.cpp
@@ -705,6 +705,72 @@ TEST(L2CacheTest, UcReadFlushesDirtyResidentLine) {
   EXPECT_EQ(read_value, 9u);
 }
 
+TEST(L2CacheTest, UcReadCrossingLineBoundaryFlushesBothDirtyResidentLines) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache l2("test_l2");
+  l2.set_backing_memory(&mem);
+
+  constexpr uint64_t kBase = 0x3000;
+  constexpr uint64_t kAddr = kBase + amdgpu::L2Cache::LINE_SIZE - 4;
+  static_assert((kBase & (amdgpu::L2Cache::LINE_SIZE - 1)) == 0);
+
+  std::array<uint8_t, amdgpu::L2Cache::LINE_SIZE> first_line{};
+  std::array<uint8_t, amdgpu::L2Cache::LINE_SIZE> second_line{};
+  for (uint32_t i = 0; i < amdgpu::L2Cache::LINE_SIZE; ++i) {
+    first_line[i] = static_cast<uint8_t>(0x10u + i);
+    second_line[i] = static_cast<uint8_t>(0x80u + i);
+    mem.write8(kBase + i, 0xA0u);
+    mem.write8(kBase + amdgpu::L2Cache::LINE_SIZE + i, 0xB0u);
+  }
+
+  l2.writeback_line(kBase, first_line.data(), amdgpu::Mtype::RW);
+  l2.writeback_line(kBase + amdgpu::L2Cache::LINE_SIZE, second_line.data(), amdgpu::Mtype::RW);
+
+  std::array<uint8_t, 8> read_value{};
+  l2.read(kAddr, read_value.data(), read_value.size(), amdgpu::Mtype::UC);
+
+  for (uint32_t i = 0; i < 4; ++i) {
+    EXPECT_EQ(read_value[i], first_line[amdgpu::L2Cache::LINE_SIZE - 4 + i])
+        << "first line byte " << i;
+    EXPECT_EQ(read_value[4 + i], second_line[i]) << "second line byte " << i;
+  }
+}
+
+TEST(L2CacheTest, UcWriteCrossingLineBoundaryFlushesBothDirtyResidentLines) {
+  amdgpu::GpuMemory mem("test_mem");
+  amdgpu::L2Cache l2("test_l2");
+  l2.set_backing_memory(&mem);
+
+  constexpr uint64_t kBase = 0x4000;
+  constexpr uint64_t kAddr = kBase + amdgpu::L2Cache::LINE_SIZE - 4;
+  static_assert((kBase & (amdgpu::L2Cache::LINE_SIZE - 1)) == 0);
+
+  std::array<uint8_t, amdgpu::L2Cache::LINE_SIZE> first_line{};
+  std::array<uint8_t, amdgpu::L2Cache::LINE_SIZE> second_line{};
+  for (uint32_t i = 0; i < amdgpu::L2Cache::LINE_SIZE; ++i) {
+    first_line[i] = static_cast<uint8_t>(0x20u + i);
+    second_line[i] = static_cast<uint8_t>(0x90u + i);
+    mem.write8(kBase + i, 0xC0u);
+    mem.write8(kBase + amdgpu::L2Cache::LINE_SIZE + i, 0xD0u);
+  }
+
+  l2.writeback_line(kBase, first_line.data(), amdgpu::Mtype::RW);
+  l2.writeback_line(kBase + amdgpu::L2Cache::LINE_SIZE, second_line.data(), amdgpu::Mtype::RW);
+
+  const std::array<uint8_t, 8> store_value = {0x01u, 0x02u, 0x03u, 0x04u,
+                                              0x05u, 0x06u, 0x07u, 0x08u};
+  l2.write(kAddr, store_value.data(), store_value.size(), amdgpu::Mtype::UC);
+
+  for (uint32_t i = 0; i < 4; ++i) {
+    EXPECT_EQ(mem.read8(kAddr + i), store_value[i]) << "first line store byte " << i;
+    EXPECT_EQ(mem.read8(kAddr + 4 + i), store_value[4 + i]) << "second line store byte " << i;
+  }
+  EXPECT_EQ(mem.read8(kBase), first_line[0])
+      << "dirty byte outside the first-line UC store should be preserved";
+  EXPECT_EQ(mem.read8(kBase + amdgpu::L2Cache::LINE_SIZE + 4), second_line[4])
+      << "dirty byte outside the second-line UC store should be preserved";
+}
+
 // ---------------------------------------------------------------------------
 // CU factory tests — verify all 9 ISAs can be instantiated
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
RocJITsu's L2 model treated Mtype::UC reads and writes as pure bypasses to backing memory. That allowed stale clean lines to remain resident in L2. A failed global atomic compare-and-swap could pull a line into L2, then a later uncached global store to the same address would update backing memory while leaving the stale L2 line in place. Subsequent atomics could keep reading the old value and spin forever.

Fix the UC read/write paths to operate in cache-line chunks, flush and invalidate any resident L2 line first, and then bypass to backing memory. This preserves dirty resident data before UC reads and makes UC stores visible to later cached or atomic accesses.

Add focused L2Cache regression tests for a UC store followed by atomic_rmw, and for a UC read of a dirty resident line.

This was exposed by https://github.com/bjacob/hip-moi gfx950 RocJITsu coverage: the relaxed compare-exchange lock handoff tests passed on real gfx950 but timed out under RocJITsu before this fix.
