### PR TITLE
fix(rocprofiler-sdk): Make thread trace usable before hsa_init()

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -74,10 +74,8 @@ struct cbdata_t
 // operations so we can gate new traces while one is active.
 common::Synchronized<std::optional<int64_t>> client;
 
-// Tracks whether the HSA runtime has been registered with rocprofiler. Thread
-// trace cannot touch HSA (queues, memory pools, packet buffers) before this is
-// true, so start requests issued earlier are cached in the active-context array
-// and replayed from initialize() once HSA becomes available.
+// True once the HSA runtime is registered. Gates start_context() so pre-init
+// start requests are deferred and replayed by initialize().
 std::atomic<bool>&
 hsa_inited()
 {
@@ -483,15 +481,8 @@ DispatchThreadTracer::start_context()
 {
     using corr_id_map_t = hsa::queue_info_session_t::external_corr_id_map_t;
 
-    // The queue controller does not exist until HSA is registered. The request
-    // is already recorded in the active-context array, so defer here and let
-    // initialize() replay start_context() once HSA is available.
-    if(!hsa_inited().load())
-    {
-        ROCP_INFO << "Dispatch thread trace start requested before hsa_init; deferring";
-        return;
-    }
-
+    // Only installs queue-controller callbacks (cached and applied to queues as
+    // they are created), so this is safe to call before hsa_init.
     CHECK_NOTNULL(hsa::get_queue_controller())->enable_serialization();
 
     // Only one thread should be attempting to enable/disable this context
@@ -581,9 +572,8 @@ DeviceThreadTracer::resource_deinit()
 void
 DeviceThreadTracer::start_context()
 {
-    // Before HSA is registered the per-agent resources do not exist yet. The
-    // request is already recorded in the active-context array, so simply return
-    // here; initialize() replays start_context() once HSA is available.
+    // Per-agent resources don't exist until HSA is registered; the request is
+    // cached in the active-context array and replayed by initialize().
     if(!hsa_inited().load())
     {
         ROCP_INFO << "Device thread trace start requested before hsa_init; deferring";
@@ -650,13 +640,11 @@ initialize(HsaApiTable* table)
     // HSA resources now exist; allow start_context() to program the hardware.
     hsa_inited().store(true);
 
-    // Replay any thread trace contexts that the user started before hsa_init().
-    // Those start_context() calls returned early (cached) above, so start them
-    // now that the per-agent resources have been constructed.
+    // Replay device contexts started before hsa_init() (their start_context()
+    // returned early above). Dispatch mode needs no replay.
     for(auto& ctx : context::get_active_contexts())
     {
         if(ctx->device_thread_trace) ctx->device_thread_trace->start_context();
-        if(ctx->dispatch_thread_trace) ctx->dispatch_thread_trace->start_context();
     }
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk/thread_trace/core.cpp
@@ -74,6 +74,17 @@ struct cbdata_t
 // operations so we can gate new traces while one is active.
 common::Synchronized<std::optional<int64_t>> client;
 
+// Tracks whether the HSA runtime has been registered with rocprofiler. Thread
+// trace cannot touch HSA (queues, memory pools, packet buffers) before this is
+// true, so start requests issued earlier are cached in the active-context array
+// and replayed from initialize() once HSA becomes available.
+std::atomic<bool>&
+hsa_inited()
+{
+    static std::atomic<bool> inited{false};
+    return inited;
+}
+
 hsa_status_t
 thread_trace_callback(uint32_t shader, void* buffer, uint64_t size, void* callback_data)
 {
@@ -472,6 +483,15 @@ DispatchThreadTracer::start_context()
 {
     using corr_id_map_t = hsa::queue_info_session_t::external_corr_id_map_t;
 
+    // The queue controller does not exist until HSA is registered. The request
+    // is already recorded in the active-context array, so defer here and let
+    // initialize() replay start_context() once HSA is available.
+    if(!hsa_inited().load())
+    {
+        ROCP_INFO << "Dispatch thread trace start requested before hsa_init; deferring";
+        return;
+    }
+
     CHECK_NOTNULL(hsa::get_queue_controller())->enable_serialization();
 
     // Only one thread should be attempting to enable/disable this context
@@ -561,6 +581,15 @@ DeviceThreadTracer::resource_deinit()
 void
 DeviceThreadTracer::start_context()
 {
+    // Before HSA is registered the per-agent resources do not exist yet. The
+    // request is already recorded in the active-context array, so simply return
+    // here; initialize() replays start_context() once HSA is available.
+    if(!hsa_inited().load())
+    {
+        ROCP_INFO << "Device thread trace start requested before hsa_init; deferring";
+        return;
+    }
+
     ROCP_INFO << "Start device thread trace context";
     std::unique_lock<std::mutex> lk(agent_mut);
 
@@ -616,6 +645,18 @@ initialize(HsaApiTable* table)
     {
         if(ctx->device_thread_trace) ctx->device_thread_trace->resource_init();
         if(ctx->dispatch_thread_trace) ctx->dispatch_thread_trace->resource_init();
+    }
+
+    // HSA resources now exist; allow start_context() to program the hardware.
+    hsa_inited().store(true);
+
+    // Replay any thread trace contexts that the user started before hsa_init().
+    // Those start_context() calls returned early (cached) above, so start them
+    // now that the per-agent resources have been constructed.
+    for(auto& ctx : context::get_active_contexts())
+    {
+        if(ctx->device_thread_trace) ctx->device_thread_trace->start_context();
+        if(ctx->dispatch_thread_trace) ctx->dispatch_thread_trace->start_context();
     }
 }
 

--- a/projects/rocprofiler-sdk/tests/thread-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/thread-trace/CMakeLists.txt
@@ -34,6 +34,16 @@ rocprofiler_add_integration_execute_test(
     LABELS "integration-tests"
     PRELOAD "$<TARGET_FILE:thread-trace-agent-tool>")
 
+# Starts the device thread trace context before hsa_init() to verify the start request is
+# cached, replayed once HSA is registered, and trace data collected.
+rocprofiler_add_integration_execute_test(
+    thread-trace-api-agent-before-hsa-init-test
+    TARGET thread-trace-test-app
+    TIMEOUT 10
+    LABELS "integration-tests"
+    PRELOAD "$<TARGET_FILE:thread-trace-agent-tool>"
+    ENVIRONMENT "ATT_START_BEFORE_HSA_INIT=1")
+
 # Feature introduced in ROCm 7.1, however some pre-release CI builds for 7.1 dont have
 # this feature in aqlprofile. Disable the next tests for ROCm < 7.2.
 set(IS_DISABLED True)

--- a/projects/rocprofiler-sdk/tests/thread-trace/CMakeLists.txt
+++ b/projects/rocprofiler-sdk/tests/thread-trace/CMakeLists.txt
@@ -34,8 +34,7 @@ rocprofiler_add_integration_execute_test(
     LABELS "integration-tests"
     PRELOAD "$<TARGET_FILE:thread-trace-agent-tool>")
 
-# Starts the device thread trace context before hsa_init() to verify the start request is
-# cached, replayed once HSA is registered, and trace data collected.
+# Start before hsa_init(): verifies the request is cached and replayed once HSA registers.
 rocprofiler_add_integration_execute_test(
     thread-trace-api-agent-before-hsa-init-test
     TARGET thread-trace-test-app
@@ -43,6 +42,15 @@ rocprofiler_add_integration_execute_test(
     LABELS "integration-tests"
     PRELOAD "$<TARGET_FILE:thread-trace-agent-tool>"
     ENVIRONMENT "ATT_START_BEFORE_HSA_INIT=1")
+
+# Start+stop before hsa_init(): verifies the cached request is dropped and not replayed.
+rocprofiler_add_integration_execute_test(
+    thread-trace-api-agent-start-stop-before-hsa-init-test
+    TARGET thread-trace-test-app
+    TIMEOUT 10
+    LABELS "integration-tests"
+    PRELOAD "$<TARGET_FILE:thread-trace-agent-tool>"
+    ENVIRONMENT "ATT_START_BEFORE_HSA_INIT=1;ATT_STOP_BEFORE_HSA_INIT=1")
 
 # Feature introduced in ROCm 7.1, however some pre-release CI builds for 7.1 dont have
 # this feature in aqlprofile. Disable the next tests for ROCm < 7.2.

--- a/projects/rocprofiler-sdk/tests/tools/thread-trace-agent-tool.cpp
+++ b/projects/rocprofiler-sdk/tests/tools/thread-trace-agent-tool.cpp
@@ -88,6 +88,20 @@ dispatch_tracing_callback(rocprofiler_callback_tracing_record_t record,
     {
         if(dispatch_id == begin_dispatch)
         {
+            // A start cancelled before hsa_init must not be replayed, so the
+            // context must still be inactive here.
+            static const bool stop_before_init =
+                std::getenv("ATT_STOP_BEFORE_HSA_INIT")
+                    ? atoi(std::getenv("ATT_STOP_BEFORE_HSA_INIT")) != 0
+                    : false;
+            if(stop_before_init)
+            {
+                int is_active = -1;
+                ROCPROFILER_CALL(rocprofiler_context_is_active(agent_ctx, &is_active),
+                                 "context active query");
+                assert(is_active == 0 && "cancelled pre-hsa_init start must not be replayed");
+            }
+
             ROCPROFILER_CALL(rocprofiler_start_context(agent_ctx), "context start");
             callback_state->isprofiling.store(true);
         }

--- a/projects/rocprofiler-sdk/tests/tools/thread-trace-agent-tool.cpp
+++ b/projects/rocprofiler-sdk/tests/tools/thread-trace-agent-tool.cpp
@@ -221,15 +221,18 @@ tool_init(rocprofiler_client_finalize_t /* fini_func */, void* /* tool_data */)
 
     ROCPROFILER_CALL(rocprofiler_start_context(tracing_ctx), "context start");
 
-    // tool_init runs before the application initializes the HSA runtime. Starting
-    // the device thread trace context here exercises the deferred-start path: the
-    // request is cached and automatically replayed once HSA is registered. The
-    // trace then runs device-wide until the dispatch callback stops it (or
-    // tool_fini), and finalize() asserts data was collected.
+    // tool_init runs before hsa_init: start here to exercise the deferred-start path.
     if(const char* var = std::getenv("ATT_START_BEFORE_HSA_INIT"); var && atoi(var))
     {
         ROCPROFILER_CALL(rocprofiler_start_context(agent_ctx),
                          "starting device thread trace context before hsa_init");
+    }
+
+    // Cancel the deferred start before hsa_init; the dispatch callback starts it later.
+    if(const char* var = std::getenv("ATT_STOP_BEFORE_HSA_INIT"); var && atoi(var))
+    {
+        ROCPROFILER_CALL(rocprofiler_stop_context(agent_ctx),
+                         "stopping device thread trace context before hsa_init");
     }
 
     // no errors

--- a/projects/rocprofiler-sdk/tests/tools/thread-trace-agent-tool.cpp
+++ b/projects/rocprofiler-sdk/tests/tools/thread-trace-agent-tool.cpp
@@ -221,6 +221,17 @@ tool_init(rocprofiler_client_finalize_t /* fini_func */, void* /* tool_data */)
 
     ROCPROFILER_CALL(rocprofiler_start_context(tracing_ctx), "context start");
 
+    // tool_init runs before the application initializes the HSA runtime. Starting
+    // the device thread trace context here exercises the deferred-start path: the
+    // request is cached and automatically replayed once HSA is registered. The
+    // trace then runs device-wide until the dispatch callback stops it (or
+    // tool_fini), and finalize() asserts data was collected.
+    if(const char* var = std::getenv("ATT_START_BEFORE_HSA_INIT"); var && atoi(var))
+    {
+        ROCPROFILER_CALL(rocprofiler_start_context(agent_ctx),
+                         "starting device thread trace context before hsa_init");
+    }
+
     // no errors
     return 0;
 }


### PR DESCRIPTION
## Motivation

Starting a device thread trace context before the application calls `hsa_init()`
did not work. Thread trace needs HSA-allocated memory for its packets and trace buffer, so the per-agent resources cannot be built until HSA is registered. A `rocprofiler_start_context()` issued before `hsa_init()` silently dropped the trace and was never retried once HSA came up.

This PR caches the start request and starts the trace automatically once HSA is
available.

## Technical Details

Mirrors the device-counting deferred-start pattern:

* `DeviceThreadTracer::start_context()` returns early when HSA is not yet registered; the context is already recorded in the active-context array.
* `thread_trace::initialize()` (at HSA table registration, after `resource_init()` builds the per-agent resources) replays `start_context()` for every active device thread trace context.

## JIRA ID

JIRA ID : AIPROFSDK-887

## Test Plan

Added integration test `thread-trace-api-agent-before-hsa-init-test`, which starts the device thread trace context during `tool_init` (before `hsa_init()`) and
asserts trace data is collected. Verified existing thread trace tests still pass.

## Test Result

On MI300X (gfx942): `thread-trace-api-agent-before-hsa-init-test`, plus the existing `agent`, `single`, and `multi` thread trace tests all PASS.

## Submission Checklist

- [V] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.