### PR TITLE
[rccl-tests] JIRA ID ROCM-25479 Add support for static linking against librccl.a

### DIFF
--- a/projects/rccl-tests/src/Makefile
+++ b/projects/rccl-tests/src/Makefile
@@ -142,6 +142,14 @@ ifeq ($(ENABLE_DEVICE_API), 1)
 HIPCUFLAGS += -DENABLE_DEVICE_API
 endif
 
+# Statically link against a librccl.a that was built with -fgpu-rdc.
+# This requires compiling the test objects with -fgpu-rdc as well and
+# performing the HIP device link step (--hip-link) at final link time.
+ifeq ($(STATIC_RCCL), 1)
+HIPCUFLAGS += -fgpu-rdc
+HIPLDFLAGS += -fgpu-rdc --hip-link $(GPU_TARGETS_FLAGS) -lroctx64
+endif
+
 LIBRARIES += rccl dl
 HIPLDFLAGS += $(LIBRARIES:%=-l%)
 

--- a/projects/rccl-tests/src/common.cu
+++ b/projects/rccl-tests/src/common.cu
@@ -59,7 +59,7 @@ static void loadRcclSyms() {
 
 // RCCL_FLOAT8 support
 bool rccl_float8_useFnuz = false;
-bool IsArchMatch(char const* arch, char const* target) {
+static bool IsArchMatch(char const* arch, char const* target) {
   // helper function to reduce clutter in code elsewhere.  Returns true on match.
   return (strncmp(arch, target, strlen(target)) == 0);
 }


### PR DESCRIPTION
## Motivation

Resolve rccl-tests issues with static linking for reproduce performance issue in statically linked executables

## Technical Details

Add an opt-in STATIC_RCCL=1 build mode that statically links rccl-tests against a librccl.a built with -fgpu-rdc. This compiles the test objects with -fgpu-rdc and performs the HIP device link (--hip-link) at final link time, and pulls in -lroctx64.

Also give the test-local IsArchMatch internal linkage to avoid a duplicate symbol clash with rccl's own IsArchMatch when statically linked.

## JIRA ID

<!-- If applicable, mention the JIRA ID resolved by this PR (Example: Resolves SWDEV-12345). -->
<!-- Do not post any JIRA links here. -->

## Test Plan

Build static rccl library and rccl-tests

## Test Result

Pass

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
