### PR TITLE
fix: Compilation error on windows

### DIFF
--- a/projects/rocprof-trace-decoder/source/quick_scan_export.cpp
+++ b/projects/rocprof-trace-decoder/source/quick_scan_export.cpp
@@ -604,12 +604,12 @@ ROCPROF_TRACE_DECODER_API rocprofiler_thread_trace_decoder_status_t rocprof_trac
     if (!quick_scan::avx512_available()) return ROCPROFILER_THREAD_TRACE_DECODER_STATUS_ERROR_NOT_IMPLEMENTED;
 
     size_t ntokens = 0;
+    const uint64_t header_offset = (gfxip == 9 && chunk_index == 0) ? sizeof(uint64_t) : 0;
 #if ROCPROF_TRACE_DECODER_QUICK_SCAN_HAS_SIMD
     auto scanner = (gfxip == 9) ? &quick_scan::scan_gfx9 : &scan_none;
     if (gfxip == 12) scanner = &quick_scan::scan_gfx12;
     if (gfxip == 1250) scanner = &quick_scan::scan_mi400;
 
-    const uint64_t header_offset = (gfxip == 9 && chunk_index == 0) ? sizeof(uint64_t) : 0;
     if (header_offset != 0)
     {
         buf += header_offset;


### PR DESCRIPTION
## Motivation

The quick_scan component does not compile on windows due to a single variable being declared inside the #if condition.

JIRA ID : AIPROFSDK-830
