### PR TITLE
ci: bump OPENBLAS_NUM_THREADS and OMP_NUM_THREADS to 24

### DIFF
--- a/.github/workflows/therock-test-component.yml
+++ b/.github/workflows/therock-test-component.yml
@@ -112,8 +112,8 @@ jobs:
           # components leave it empty. See: https://github.com/ROCm/TheRock/issues/3587
           GPU_ENABLE_PAL: ${{ fromJSON(inputs.component).gpu_enable_pal }}
           # Limit thread count to prevent CPU over-subscription during tests
-          OPENBLAS_NUM_THREADS: "14"
-          OMP_NUM_THREADS: "14"
+          OPENBLAS_NUM_THREADS: "24"
+          OMP_NUM_THREADS: "24"
         run: |
           ${{ fromJSON(inputs.component).test_script }}
 


### PR DESCRIPTION
Bump OPENBLAS_NUM_THREADS and OMP_NUM_THREADS to 24 due to new runners in cluster

vultr cluster cores: https://github.com/ROCm/TheRock/actions/runs/28425216714/job/84245693135#step:9:45
ccs cluster cores: https://github.com/ROCm/TheRock/actions/runs/28425216714/job/84245692887#step:9:45
ccs csp clustser cores: https://github.com/ROCm/TheRock/actions/runs/28425216714/job/84245692987#step:9:45

Closes #8027