### PR TITLE
build(hipfile): Add IWYU mapping files for gtest and libc headers

### DIFF
--- a/projects/hipfile/cmake/AISIWYU.cmake
+++ b/projects/hipfile/cmake/AISIWYU.cmake
@@ -13,6 +13,28 @@ option(AIS_USE_IWYU "Run include-what-you-use when compiling" OFF)
 
 if(AIS_USE_IWYU)
     find_program(IWYU_EXE NAMES include-what-you-use REQUIRED)
-    set(CMAKE_C_INCLUDE_WHAT_YOU_USE ${IWYU_EXE})
-    set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${IWYU_EXE})
+
+    # GoogleTest/GoogleMock expose their public API through umbrella headers
+    # (gtest/gtest.h, gmock/gmock.h) but define symbols in private sub-headers.
+    # Without a mapping, IWYU suggests including those private headers and
+    # confuses the quoted vs. angle-bracket spellings. This mapping file
+    # redirects all gtest/gmock private headers to the public umbrella headers.
+    # libstdc++/glibc declare some symbols in private bits/* headers that IWYU
+    # would otherwise suggest including directly (e.g. <bits/chrono.h> for
+    # std::chrono, <bits/statx-generic.h> for statx). These are not part of the
+    # bundled IWYU mappings, so redirect them to their public headers.
+    set(IWYU_MAPPINGS
+        "${CMAKE_CURRENT_LIST_DIR}/iwyu-gtest.imp"
+        "${CMAKE_CURRENT_LIST_DIR}/iwyu-libc.imp")
+
+    set(IWYU_COMMAND "${IWYU_EXE}")
+    foreach(mapping IN LISTS IWYU_MAPPINGS)
+        if(NOT EXISTS "${mapping}")
+            message(FATAL_ERROR "IWYU mapping file not found: ${mapping}")
+        endif()
+        list(APPEND IWYU_COMMAND "-Xiwyu" "--mapping_file=${mapping}")
+    endforeach()
+
+    set(CMAKE_C_INCLUDE_WHAT_YOU_USE ${IWYU_COMMAND})
+    set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${IWYU_COMMAND})
 endif()

--- a/projects/hipfile/cmake/iwyu-gtest.imp
+++ b/projects/hipfile/cmake/iwyu-gtest.imp
@@ -1,0 +1,9 @@
+[
+  { "include": ["@[\"<]gtest/gtest-.*[\">]", "private", "<gtest/gtest.h>", "public"] },
+  { "include": ["@[\"<]gtest/internal/.*", "private", "<gtest/gtest.h>", "public"] },
+  { "include": ["@[\"<]gtest/gtest_pred_impl\\.h[\">]", "private", "<gtest/gtest.h>", "public"] },
+  { "include": ["\"gtest/gtest.h\"", "private", "<gtest/gtest.h>", "public"] },
+  { "include": ["@[\"<]gmock/gmock-.*[\">]", "private", "<gmock/gmock.h>", "public"] },
+  { "include": ["@[\"<]gmock/internal/.*", "private", "<gmock/gmock.h>", "public"] },
+  { "include": ["\"gmock/gmock.h\"", "private", "<gmock/gmock.h>", "public"] }
+]

--- a/projects/hipfile/cmake/iwyu-libc.imp
+++ b/projects/hipfile/cmake/iwyu-libc.imp
@@ -1,0 +1,4 @@
+[
+  { "include": ["<bits/chrono.h>", "private", "<chrono>", "public"] },
+  { "include": ["@<bits/statx.*\\.h>", "private", "<sys/stat.h>", "public"] }
+]


### PR DESCRIPTION
## Motivation

hipFile has IWYU support in CMake, but GTest and libc generate false positives due to the way their headers are set up.

## Technical Details

Wire custom IWYU mapping files into the AIS_USE_IWYU build path so include-what-you-use stops suggesting private implementation headers.

- iwyu-gtest.imp redirects gtest/gmock private and internal headers to the public <gtest/gtest.h> and <gmock/gmock.h> umbrella headers.
- iwyu-libc.imp redirects libstdc++/glibc private bits/* headers (e.g. <bits/chrono.h>, <bits/statx*.h>) to their public counterparts.

AISIWYU.cmake now passes each mapping via -Xiwyu --mapping_file= and fails configuration with a clear error if a mapping file is missing.

## JIRA ID

JIRA ID: AISHIPFILE-232

## Test Plan

Manual verification of GTest/libc suppression. We don't have an IWYU action because we aren't going to fix everything it identifies.

## Test Result

Success

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
