### PR TITLE
fix(rocprofiler-sdk): PMC FETCH_SIZE returns 0 on gfx12xx

### DIFF
--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
@@ -735,8 +735,9 @@ rocprofiler-sdk:
             - gfx12
             - gfx1200
             - gfx1201
+            - gfx1250
           expression: 
-            (GL2C_EA_RDREQ_32B_sum*32+GL2C_EA_RDREQ_64B_sum*64+GL2C_EA_RDREQ_128B_sum*128)/1024
+            (GL2C_EA_RDREQ_32B_sum*32+GL2C_EA_RDREQ_64B_sum*64+GL2C_EA_RDREQ_128B_sum*128+GL2C_EA_RDREQ_256B_sum*256)/1024
     - name: BANDWIDTH_EA
       description: Memory Bandwidth measured at the TCC_EA interface. In units of bytes/cycle.
       properties: []
@@ -987,6 +988,30 @@ rocprofiler-sdk:
             - gfx1200
             - gfx1201
           expression: reduce(GL2C_EA_RDREQ_128B,sum)
+    - name: GL2C_EA_RDREQ_256B
+      description: Number of 256-byte GL2C/EA read requests
+      properties: []
+      definitions:
+        - architectures:
+            - gfx12
+            - gfx1200
+            - gfx1201
+          block: GL2C
+          event: 149
+        - architectures:
+            - gfx1250
+          block: GL2C
+          event: 122
+    - name: GL2C_EA_RDREQ_256B_sum
+      description: Number of 256-byte GL2C/EA read requests. Sum over GL2C instances.
+      properties: []
+      definitions:
+        - architectures:
+            - gfx12
+            - gfx1200
+            - gfx1201
+            - gfx1250
+          expression: reduce(GL2C_EA_RDREQ_256B,sum)
     - name: GL2C_EA_RDREQ_32B
       description: Number of 32-byte GL2C/EA read requests
       properties: []

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk/config.yaml
@@ -775,6 +775,7 @@ rocprofiler-sdk:
             - gfx12
             - gfx1200
             - gfx1201
+            - gfx1250
           expression: FETCH_SIZE
     - name: FlatLDSInsts
       description: The average number of FLAT instructions that read or write to LDS executed per 
@@ -987,6 +988,7 @@ rocprofiler-sdk:
             - gfx12
             - gfx1200
             - gfx1201
+            - gfx1250
           expression: reduce(GL2C_EA_RDREQ_128B,sum)
     - name: GL2C_EA_RDREQ_256B
       description: Number of 256-byte GL2C/EA read requests
@@ -1063,6 +1065,7 @@ rocprofiler-sdk:
             - gfx12
             - gfx1200
             - gfx1201
+            - gfx1250
           expression: reduce(GL2C_EA_RDREQ_32B,sum)
     - name: GL2C_EA_RDREQ_64B
       description: Number of 64-byte GL2C/EA read requests
@@ -1115,6 +1118,7 @@ rocprofiler-sdk:
             - gfx12
             - gfx1200
             - gfx1201
+            - gfx1250
           expression: reduce(GL2C_EA_RDREQ_64B,sum)
     - name: GL2C_EA_RDREQ_96B
       description: Number of 96-byte GL2C/EA read requests


### PR DESCRIPTION
JIRA ID: ROCM-15816

root cause: FETCH_SIZE formula is missing the GL2C_EA_RDREQ_256B component for gfx12xx.
