### PR TITLE
feat(rocprofiler-sdk): Introduce thread trace rocpd support.

### DIFF
--- a/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/generateRocpd.cpp
@@ -24,6 +24,7 @@
 #include "lib/common/uuid_v7.hpp"
 #include "metadata.hpp"
 #include "output_stream.hpp"
+#include "lib/rocprofiler-sdk-tool/config.hpp"
 #include "statistics.hpp"
 #include "stream_info.hpp"
 #include "timestamps.hpp"
@@ -65,10 +66,13 @@
 #include <cctype>
 #include <chrono>
 #include <filesystem>
+#include <fstream>
 #include <initializer_list>
 #include <limits>
+#include <map>
 #include <set>
 #include <type_traits>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -109,7 +113,7 @@ using function_args_t = std::vector<argument_info>;
 struct sql_insert_value
 {
     std::string_view                                                                     name  = {};
-    std::variant<std::monostate, int64_t, uint64_t, double, std::string, std::nullptr_t> value = {};
+    std::variant<std::monostate, int64_t, uint64_t, double, std::string, std::vector<uint8_t>, std::nullptr_t> value = {};
 };
 
 struct pending_insert_batch
@@ -224,6 +228,76 @@ auto
 replace_uuid(const rocpd_db& db, std::string_view inp)
 {
     return replace_all(std::string{inp}, std::string_view{"{{uuid}}"}, db.uuid);
+}
+
+std::optional<std::string>
+read_text_file(const fs::path& inp)
+{
+    std::ifstream ifs{inp};
+    if(!ifs) return std::nullopt;
+
+    auto ss = std::stringstream{};
+    ss << ifs.rdbuf();
+    return ss.str();
+}
+
+std::optional<std::vector<uint8_t>>
+read_binary_file(const fs::path& inp)
+{
+    std::ifstream ifs{inp, std::ios::binary};
+    if(!ifs) return std::nullopt;
+
+    return std::vector<uint8_t>{std::istreambuf_iterator<char>{ifs}, std::istreambuf_iterator<char>{}};
+}
+
+std::optional<std::string>
+to_output_relative_path(const fs::path& output_root, const fs::path& file_path)
+{
+    if(file_path.empty()) return std::nullopt;
+
+    auto preferred_file = file_path.lexically_normal();
+    auto preferred_root = output_root.lexically_normal();
+    if(preferred_file.string().find(preferred_root.string()) == 0)
+        return preferred_file.lexically_relative(preferred_root).string();
+
+    return preferred_file.string();
+}
+
+template <typename Tp>
+std::string
+to_command_line_arg_string(const Tp& arg)
+{
+    using arg_type = common::mpl::unqualified_type_t<Tp>;
+
+    if constexpr(std::is_same_v<arg_type, std::string>)
+    {
+        return arg;
+    }
+    else if constexpr(std::is_same_v<arg_type, std::string_view>)
+    {
+        return std::string{arg};
+    }
+    else if constexpr(std::is_pointer_v<arg_type> &&
+                      std::is_same_v<std::remove_cv_t<std::remove_pointer_t<arg_type>>, char>)
+    {
+        return (arg) ? std::string{arg} : std::string{};
+    }
+    else
+    {
+        return fmt::format("{}", arg);
+    }
+}
+
+template <typename ContainerT>
+std::string
+join_command_line_args(const ContainerT& command_line)
+{
+    auto safe_args = std::vector<std::string>{};
+    safe_args.reserve(command_line.size());
+    for(const auto& itr : command_line)
+        safe_args.emplace_back(to_command_line_arg_string(itr));
+
+    return fmt::format("{}", fmt::join(safe_args, " "));
 }
 
 template <typename... Args>
@@ -361,6 +435,10 @@ insert_value(std::string_view _name, const Tp& _value, TraitT = {})
     {
         return sql_insert_value{_name, static_cast<double>(_value)};
     }
+    else if constexpr(std::is_same_v<value_type, std::vector<uint8_t>>)
+    {
+        return sql_insert_value{_name, _value};
+    }
     else
     {
         return sql_insert_value{_name, fmt::format("{}", _value)};
@@ -440,6 +518,15 @@ bind_sql_value(sqlite3_stmt* stmt, int idx, const sql_insert_value& value)
             else if constexpr(common::mpl::is_string_type<value_type>::value)
             {
                 return sqlite3_bind_text(stmt, idx, val.c_str(), -1, SQLITE_TRANSIENT);
+            }
+            else if constexpr(std::is_same_v<value_type, std::vector<uint8_t>>)
+            {
+                if(val.empty()) return sqlite3_bind_null(stmt, idx);
+                return sqlite3_bind_blob(stmt,
+                                         idx,
+                                         reinterpret_cast<const void*>(val.data()),
+                                         static_cast<int>(val.size()),
+                                         SQLITE_TRANSIENT);
             }
             else
             {
@@ -1288,9 +1375,7 @@ write_rocpd(
             }
         });
 
-        auto command = fmt::format(
-            "{}",
-            fmt::join(tool_metadata.command_line.begin(), tool_metadata.command_line.end(), " "));
+        auto command = join_command_line_args(tool_metadata.command_line);
 
         get_insert_statement(db,
                              "rocpd_info_process{{uuid}}",
@@ -2021,6 +2106,175 @@ write_rocpd(
             }
         };
 
+    auto insert_thread_trace_chunks = [&db, &tool_metadata, &cfg, node_id, this_pid]() {
+        auto _sqlgenperf_rocpd = get_simple_timer("rocpd_thread_trace_chunks");
+
+        const auto chunks = tool_metadata.get_att_trace_chunks();
+        if(chunks.empty()) return;
+
+        auto params = std::vector<std::string>{};
+        params.emplace_back("trace_mode=mixed");
+
+        auto perf_values = std::vector<std::string>{};
+        for(const auto& ctr : tool::get_config().att_param_perfcounters)
+        {
+            if(ctr.simd_mask != 0xF)
+                perf_values.emplace_back(fmt::format("{}:{:#x}", ctr.counter_name, ctr.simd_mask));
+            else
+                perf_values.emplace_back(ctr.counter_name);
+        }
+
+        if(!perf_values.empty())
+            params.emplace_back(fmt::format("att_perfcounters={}", fmt::join(perf_values, ",")));
+
+        params.emplace_back(
+            fmt::format("serialize_all={}", tool::get_config().att_serialize_all ? 1 : 0));
+        params.emplace_back(fmt::format("shader_engine_mask={:#x}",
+                                        tool::get_config().att_param_shader_engine_mask));
+        params.emplace_back(
+            fmt::format("store_chunk_inline={}", tool::get_config().att_param_store_chunk_inline ? 1 : 0));
+
+        auto output_root = fs::path{tool::format_path(cfg.output_path)};
+        auto params_text = fmt::format("{}", fmt::join(params, ";"));
+        auto inline_blob = tool::get_config().att_param_store_chunk_inline;
+
+        // index chunk row id by chunk identity to support text linkage
+        auto chunk_id_map = std::map<std::tuple<uint64_t, int64_t, uint32_t, uint64_t>, uint64_t>{};
+
+        auto _deferred = sql::deferred_transaction{db.conn};
+        for(const auto& chunk : chunks)
+        {
+            auto file_path = fs::path{chunk.filename};
+            auto rel_path  = to_output_relative_path(output_root, file_path).value_or(std::string{});
+
+            auto att_blob_id = fmt::format("{}:{}:{}:{}",
+                                           chunk.dispatch_id,
+                                           chunk.agent_id,
+                                           chunk.shader_engine_id,
+                                           chunk.chunk_id);
+
+            auto row_id = static_cast<uint64_t>(db.get_event_id());
+            chunk_id_map.emplace(std::make_tuple(chunk.agent_id,
+                                                 chunk.shader_engine_id,
+                                                 chunk.chunk_id,
+                                                 chunk.dispatch_id),
+                                 row_id);
+
+            auto row = std::vector<sql_insert_value>{
+                insert_value("id", row_id),
+                insert_value("nid", node_id),
+                insert_value("pid", this_pid),
+                insert_value("agent_id", chunk.agent_id),
+                insert_value("shader_engine_id", chunk.shader_engine_id),
+                insert_value("chunk_id", chunk.chunk_id),
+                insert_value("time_begin", chunk.time_begin),
+                insert_value("time_end", chunk.time_end),
+                insert_value("trace_mode", chunk.dispatch_mode ? "dispatch" : "agent"),
+                insert_value("parameters", params_text),
+                insert_value("correlation_id", chunk.correlation_id),
+                insert_value("dispatch_begin", chunk.dispatch_id),
+                insert_value("dispatch_end", chunk.dispatch_id),
+                insert_value("att_blob_id", att_blob_id),
+                insert_value("flags", chunk.flags),
+                insert_value("binary_chunk_size", chunk.data_size),
+            };
+
+            if(inline_blob && !file_path.empty())
+            {
+                if(auto blob = read_binary_file(file_path); blob.has_value())
+                {
+                    row.emplace_back(insert_value("binary_chunk", blob.value()));
+                }
+                else
+                {
+                    row.emplace_back(insert_value("binary_chunk_path", rel_path));
+                }
+            }
+            else
+            {
+                row.emplace_back(insert_value("binary_chunk_path", rel_path));
+            }
+
+            get_insert_statement(db, "rocpd_gpu_thread_trace_chunk{{uuid}}", std::move(row));
+        }
+
+        // ATT decoder emits text artifacts under ui_output_agent_*_dispatch_* directories.
+        // Persist text content and link to thread-trace chunks so DB consumers can resolve snapshots.
+        auto text_blob_id_counter = uint64_t{1};
+        auto text_blob_by_path    = std::unordered_map<std::string, uint64_t>{};
+
+        for(const auto& chunk : chunks)
+        {
+            auto ui_dir = output_root / fmt::format("ui_output_agent_{}_dispatch_{}",
+                                                    chunk.agent_id,
+                                                    chunk.dispatch_id);
+            if(!fs::exists(ui_dir) || !fs::is_directory(ui_dir)) continue;
+
+            auto chunk_key = std::make_tuple(
+                chunk.agent_id, chunk.shader_engine_id, chunk.chunk_id, chunk.dispatch_id);
+            auto chunk_row_itr = chunk_id_map.find(chunk_key);
+            if(chunk_row_itr == chunk_id_map.end()) continue;
+            auto chunk_row_id = chunk_row_itr->second;
+
+            auto link_text_file = [&](const fs::path& pth, const char* kind, int ordinal) {
+                if(!fs::exists(pth) || !fs::is_regular_file(pth)) return;
+
+                auto rel = to_output_relative_path(output_root, pth).value_or(pth.string());
+                auto itr = text_blob_by_path.find(rel);
+                auto text_id = uint64_t{0};
+                if(itr != text_blob_by_path.end())
+                {
+                    text_id = itr->second;
+                }
+                else
+                {
+                    auto txt = read_text_file(pth);
+                    if(!txt.has_value()) return;
+
+                    text_id = text_blob_id_counter++;
+                    text_blob_by_path.emplace(rel, text_id);
+
+                    get_insert_statement(db,
+                                         "rocpd_info_text_blob{{uuid}}",
+                                         {
+                                             insert_value("id", text_id),
+                                             insert_value("nid", node_id),
+                                             insert_value("pid", this_pid),
+                                             insert_value("path", rel),
+                                             insert_value("md5", common::compute_md5sum(txt.value())),
+                                             insert_value("size", static_cast<uint64_t>(txt->size())),
+                                             insert_value("text", txt.value(), allow_empty_string{}),
+                                         });
+                }
+
+                get_insert_statement(db,
+                                     "rocpd_gpu_thread_trace_text_link{{uuid}}",
+                                     {
+                                         insert_value("chunk_id", chunk_row_id),
+                                         insert_value("text_blob_id", text_id),
+                                         insert_value("kind", std::string_view{kind}),
+                                         insert_value("ordinal", ordinal),
+                                     });
+            };
+
+            link_text_file(ui_dir / "code.json", "code_json", 0);
+            link_text_file(ui_dir / "snapshots.json", "snapshot_manifest", 0);
+
+            auto src_idx       = 0;
+            auto source_paths = std::vector<fs::path>{};
+            for(const auto& entry : fs::directory_iterator{ui_dir})
+            {
+                if(!entry.is_regular_file()) continue;
+                auto fname = entry.path().filename().string();
+                if(fname.rfind("source_", 0) != 0) continue;
+                source_paths.emplace_back(entry.path());
+            }
+            std::sort(source_paths.begin(), source_paths.end());
+            for(const auto& pth : source_paths)
+                link_text_file(pth, "snapshot_source", src_idx++);
+        }
+    };
+
     auto dispatch_to_evt_id = common::container::stable_vector<uint64_t, 512>{};
 
     insert_node_data();
@@ -2058,6 +2312,8 @@ write_rocpd(
         insert_kfd_data(kfd_pmc_ids);
         insert_kfd_event_data(kfd_gen, kfd_pmc_ids);
     }
+
+    insert_thread_trace_chunks();
 
     {
         auto _deferred = sql::deferred_transaction{db.conn};

--- a/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
+++ b/projects/rocprofiler-sdk/source/lib/output/metadata.cpp
@@ -413,6 +413,13 @@ metadata::get_att_filenames() const
     return data;
 }
 
+att_trace_chunk_info_vec_t
+metadata::get_att_trace_chunks() const
+{
+    return att_trace_chunks.rlock(
+        [](const auto& _data_v) -> att_trace_chunk_info_vec_t { return _data_v; });
+}
+
 const kernel_symbol_info*
 metadata::get_kernel_symbol(uint64_t kernel_id) const
 {

--- a/projects/rocprofiler-sdk/source/lib/output/metadata.hpp
+++ b/projects/rocprofiler-sdk/source/lib/output/metadata.hpp
@@ -104,6 +104,23 @@ using att_dispatch_agent_key_t =
     std::pair<rocprofiler_dispatch_id_t, uint64_t>;  // (dispatch_id, agent_handle)
 using att_filenames_map_t         = std::map<att_dispatch_agent_key_t, std::vector<std::string>>;
 using code_object_load_info_vec_t = std::vector<rocprofiler::att_wrapper::CodeobjLoadInfo>;
+
+struct att_trace_chunk_info
+{
+    rocprofiler_dispatch_id_t dispatch_id      = 0;
+    uint64_t                  agent_id         = 0;
+    int64_t                   shader_engine_id = 0;
+    uint32_t                  chunk_id         = 0;
+    uint32_t                  flags            = 0;
+    uint64_t                  time_begin       = 0;
+    uint64_t                  time_end         = 0;
+    bool                      dispatch_mode    = true;
+    uint64_t                  correlation_id   = 0;
+    uint64_t                  data_size        = 0;
+    std::string               filename         = {};
+};
+
+using att_trace_chunk_info_vec_t = std::vector<att_trace_chunk_info>;
 template <typename Tp>
 using synced_map = common::Synchronized<Tp, true>;
 template <typename Tp>
@@ -167,6 +184,7 @@ struct metadata
     synced_map<code_object_load_info_vec_t>  code_object_load           = {};
     synced_map<kernel_rename_map_t>          kernel_rename_map          = {};
     att_filenames_map_t                      att_filenames              = {};
+    synced_map<att_trace_chunk_info_vec_t>   att_trace_chunks           = {};
     synced_obj<pc_sampling_stats_t>          pc_sampling_stats          = {};
     synced_obj<runtime_initialization_set_t> runtime_initialization_set = {};
     node_info                                node_data                  = {};
@@ -199,6 +217,7 @@ struct metadata
     const counter_dimension_info_vec_t* get_counter_dimension_info(uint64_t instance_id) const;
 
     std::vector<std::string> get_att_filenames() const;
+    att_trace_chunk_info_vec_t get_att_trace_chunks() const;
     code_object_data_vec_t   get_code_objects() const;
     kernel_symbol_data_vec_t get_kernel_symbols() const;
     host_function_data_vec_t get_host_symbols() const;

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocpd/sql.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-rocpd/sql.cpp
@@ -52,6 +52,7 @@
 #include <cstddef>
 #include <initializer_list>
 #include <unordered_map>
+#include <vector>
 
 bool
 operator==(rocpd_version_triplet_t lhs, rocpd_version_triplet_t rhs)
@@ -165,12 +166,22 @@ build_schema_paths_string(const char** schema_path_hints, uint64_t num_schema_pa
 {
     const auto _lib_schema_path = get_install_path();
     const auto _env_schema_path = rocprofiler::common::get_env("ROCPD_SCHEMA_PATH", "");
+
+    auto _usr_paths = std::vector<std::string>{};
+    if(schema_path_hints && num_schema_path_hints > 0)
+    {
+        _usr_paths.reserve(static_cast<size_t>(num_schema_path_hints));
+        for(uint64_t i = 0; i < num_schema_path_hints; ++i)
+        {
+            const char* hint = schema_path_hints[i];
+            if(!hint || hint[0] == '\0') continue;
+            _usr_paths.emplace_back(hint);
+        }
+    }
+
     const auto _usr_schema_path =
-        (schema_path_hints)
-            ? fmt::format(
-                  "{}",
-                  fmt::join(schema_path_hints, schema_path_hints + num_schema_path_hints, ":"))
-            : std::string{};
+        _usr_paths.empty() ? std::string{} : fmt::format("{}", fmt::join(_usr_paths, ":"));
+
     return fmt::format("{}:{}:{}", _usr_schema_path, _env_schema_path, _lib_schema_path);
 }
 

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/config.hpp
@@ -137,6 +137,8 @@ struct config : output_config
     bool   list_metrics_output_file      = get_env("ROCPROF_OUTPUT_LIST_METRICS_FILE", false);
     bool   advanced_thread_trace         = get_env("ROCPROF_ADVANCED_THREAD_TRACE", false);
     bool   att_serialize_all             = get_env("ROCPROF_ATT_PARAM_SERIALIZE_ALL", false);
+    bool   att_param_store_chunk_inline  =
+        get_env("ROCPROF_ATT_PARAM_STORE_CHUNK_INLINE", false);
     bool   enable_signal_handlers        = get_env("ROCPROF_SIGNAL_HANDLERS", true);
     bool   enable_process_sync           = get_env("ROCPROF_PROCESS_SYNC", false);
     bool   selected_regions              = get_env("ROCPROF_SELECTED_REGIONS", false);
@@ -231,6 +233,7 @@ config::get_attach_invariants() const
                            att_library_path,
                            att_param_perfcounters,
                            att_param_perf_ctrl,
+                           att_param_store_chunk_inline,
                            pc_sampling_method,
                            pc_sampling_unit,
                            kernel_filter_include,
@@ -337,6 +340,7 @@ config::save(ArchiveT& ar) const
     CFG_SERIALIZE_MEMBER(att_library_path);
     CFG_SERIALIZE_MEMBER(att_param_perfcounters);
     CFG_SERIALIZE_MEMBER(att_param_perf_ctrl);
+    CFG_SERIALIZE_MEMBER(att_param_store_chunk_inline);
     CFG_SERIALIZE_MEMBER(att_consecutive_kernels);
 
     // serialize the base class

--- a/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
+++ b/projects/rocprofiler-sdk/source/lib/rocprofiler-sdk-tool/tool.cpp
@@ -98,6 +98,7 @@
 #include <future>
 #include <iomanip>
 #include <limits>
+#include <map>
 #include <mutex>
 #include <optional>
 #include <shared_mutex>
@@ -281,6 +282,8 @@ auto  att_device_context     = rocprofiler_context_id_t{0};
 auto  att_device_trace_id =
     std::atomic<rocprofiler_dispatch_id_t>{std::numeric_limits<uint64_t>::max()};
 std::mutex att_shader_data;
+auto       att_trace_chunk_counters =
+    std::map<std::pair<uint64_t, int64_t>, uint32_t>{};
 
 thread_local auto thread_dispatch_rename      = as_pointer<kernel_rename_stack_t>();
 thread_local auto thread_dispatch_rename_dtor = common::scope_destructor{[]() {
@@ -1659,8 +1662,38 @@ att_shader_data_callback(rocprofiler_agent_id_t                       agent,
     std::string output_filename = get_output_filename(tool::get_config(), filename.str(), ".att");
 
     output_stream.stream->write(reinterpret_cast<char*>(se_data), data_size);
+
+    auto ts_begin = rocprofiler_timestamp_t{};
+    auto ts_end   = rocprofiler_timestamp_t{};
+    rocprofiler_get_timestamp(&ts_begin);
+    rocprofiler_get_timestamp(&ts_end);
+
+    const auto chunk_key = std::make_pair(agent.handle, se_id);
+    auto       chunk_id  = uint32_t{0};
+    if(auto itr = att_trace_chunk_counters.find(chunk_key); itr != att_trace_chunk_counters.end())
+    {
+        chunk_id = itr->second++;
+    }
+    else
+    {
+        att_trace_chunk_counters.emplace(chunk_key, 1);
+    }
+
     auto key = tool::att_dispatch_agent_key_t{dispatch_id, agent.handle};
     tool_metadata->att_filenames[key].emplace_back(output_filename);
+    tool_metadata->att_trace_chunks.wlock([&](auto& _chunks) {
+        _chunks.emplace_back(tool::att_trace_chunk_info{dispatch_id,
+                                                        agent.handle,
+                                                        se_id,
+                                                        chunk_id,
+                                                        static_cast<uint32_t>(flags),
+                                                        ts_begin,
+                                                        ts_end,
+                                                        userdata.value != 0,
+                                                        static_cast<uint64_t>(dispatch_id),
+                                                        static_cast<uint64_t>(data_size),
+                                                        output_filename});
+    });
 }
 
 rocprofiler_thread_trace_control_flags_t
@@ -3504,6 +3537,40 @@ generate_output(cleanup_mode _cleanup_mode)
                              rocjpeg_output.get_generator());
     }
 
+    if(tool::get_config().advanced_thread_trace)
+    {
+        auto decoder = rocprofiler::att_wrapper::ATTDecoder(tool::get_config().att_library_path);
+        ROCP_FATAL_IF(!decoder.valid()) << "Decoder library not found!";
+
+        auto codeobj     = tool_metadata->get_code_object_load_info();
+        auto output_path = tool::format_path(tool::get_config().output_path);
+
+        std::vector<std::string> perf{};
+        for(auto& counter : tool::get_config().att_param_perfcounters)
+        {
+            std::stringstream ss;
+            ss << counter.counter_name;
+
+            if(counter.simd_mask != 0xF) ss << ':' << std::hex << counter.simd_mask;
+
+            perf.emplace_back(ss.str());
+        }
+
+        for(auto& [key, att_files] : tool_metadata->att_filenames)
+        {
+            auto [dispatch_id, agent_handle] = key;
+            std::string formats              = "json,csv";
+
+            auto ui_name = std::stringstream{};
+            ui_name << fmt::format(
+                "ui_output_agent_{}_dispatch_{}", std::to_string(agent_handle), dispatch_id);
+            auto out_path = fmt::format("{}/{}", output_path, ui_name.str());
+            auto in_path  = std::string(".");
+
+            decoder.parse(in_path, out_path, att_files, codeobj, perf, formats);
+        }
+    }
+
     if(tool::get_config().rocpd_output && outdata.num_output > 0 &&
        outdata.num_bytes >= tool::get_config().minimum_output_bytes)
     {
@@ -3561,39 +3628,7 @@ generate_output(cleanup_mode _cleanup_mode)
         tool::generate_stats(tool::get_config(), *tool_metadata, contributions);
     }
 
-    if(tool::get_config().advanced_thread_trace)
-    {
-        auto decoder = rocprofiler::att_wrapper::ATTDecoder(tool::get_config().att_library_path);
-        ROCP_FATAL_IF(!decoder.valid()) << "Decoder library not found!";
 
-        auto codeobj     = tool_metadata->get_code_object_load_info();
-        auto output_path = tool::format_path(tool::get_config().output_path);
-
-        std::vector<std::string> perf{};
-        for(auto& counter : tool::get_config().att_param_perfcounters)
-        {
-            std::stringstream ss;
-            ss << counter.counter_name;
-
-            if(counter.simd_mask != 0xF) ss << ':' << std::hex << counter.simd_mask;
-
-            perf.emplace_back(ss.str());
-        }
-
-        for(auto& [key, att_files] : tool_metadata->att_filenames)
-        {
-            auto [dispatch_id, agent_handle] = key;
-            std::string formats              = "json,csv";
-
-            auto ui_name = std::stringstream{};
-            ui_name << fmt::format(
-                "ui_output_agent_{}_dispatch_{}", std::to_string(agent_handle), dispatch_id);
-            auto out_path = fmt::format("{}/{}", output_path, ui_name.str());
-            auto in_path  = std::string(".");
-
-            decoder.parse(in_path, out_path, att_files, codeobj, perf, formats);
-        }
-    }
 
     run_cleanup();
 }

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/rocpd_tables.sql
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/rocpd_tables.sql
@@ -363,3 +363,58 @@ CREATE TABLE IF NOT EXISTS
         FOREIGN KEY (queue_id) REFERENCES `rocpd_info_queue{{uuid}}` (id) ON UPDATE CASCADE,
         FOREIGN KEY (event_id) REFERENCES `rocpd_event{{uuid}}` (id) ON UPDATE CASCADE
     );
+
+CREATE TABLE IF NOT EXISTS
+    `rocpd_gpu_thread_trace_chunk{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "pid" INTEGER NOT NULL,
+        "agent_id" INTEGER NOT NULL,
+        "shader_engine_id" INTEGER NOT NULL,
+        "chunk_id" INTEGER NOT NULL,
+        "time_begin" BIGINT,
+        "time_end" BIGINT,
+        "trace_mode" TEXT,
+        "parameters" TEXT,
+        "correlation_id" INTEGER,
+        "dispatch_begin" INTEGER,
+        "dispatch_end" INTEGER,
+        "att_blob_id" TEXT,
+        "flags" INTEGER,
+        "binary_chunk_path" TEXT,
+        "binary_chunk" BLOB,
+        "binary_chunk_size" BIGINT,
+        "extdata" JSONB DEFAULT "{}" NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (pid) REFERENCES `rocpd_info_process{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (agent_id) REFERENCES `rocpd_info_agent{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+CREATE TABLE IF NOT EXISTS
+    `rocpd_info_text_blob{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "nid" INTEGER NOT NULL,
+        "pid" INTEGER NOT NULL,
+        "path" TEXT,
+        "md5" TEXT,
+        "size" BIGINT,
+        "text" TEXT NOT NULL,
+        "extdata" JSONB DEFAULT "{}" NOT NULL,
+        FOREIGN KEY (nid) REFERENCES `rocpd_info_node{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (pid) REFERENCES `rocpd_info_process{{uuid}}` (id) ON UPDATE CASCADE
+    );
+
+CREATE TABLE IF NOT EXISTS
+    `rocpd_gpu_thread_trace_text_link{{uuid}}` (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "guid" TEXT DEFAULT "{{guid}}" NOT NULL,
+        "chunk_id" INTEGER NOT NULL,
+        "text_blob_id" INTEGER NOT NULL,
+        "kind" TEXT,
+        "ordinal" INTEGER,
+        "extdata" JSONB DEFAULT "{}" NOT NULL,
+        FOREIGN KEY (chunk_id) REFERENCES `rocpd_gpu_thread_trace_chunk{{uuid}}` (id) ON UPDATE CASCADE,
+        FOREIGN KEY (text_blob_id) REFERENCES `rocpd_info_text_blob{{uuid}}` (id) ON UPDATE CASCADE
+    );

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/rocpd_views.sql
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/rocpd_views.sql
@@ -137,3 +137,24 @@ SELECT
     *
 FROM
     `rocpd_memory_allocate{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_gpu_thread_trace_chunk` AS
+SELECT
+    *
+FROM
+    `rocpd_gpu_thread_trace_chunk{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_info_text_blob` AS
+SELECT
+    *
+FROM
+    `rocpd_info_text_blob{{uuid}}`;
+
+CREATE VIEW IF NOT EXISTS
+    `rocpd_gpu_thread_trace_text_link` AS
+SELECT
+    *
+FROM
+    `rocpd_gpu_thread_trace_text_link{{uuid}}`;

--- a/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/versions.yml
+++ b/projects/rocprofiler-sdk/source/share/rocprofiler-sdk-rocpd/versions.yml
@@ -24,3 +24,4 @@ rocprofiler-sdk-rocpd:
 # Version 3.0.1
 # - rocpd_info_pmc.target_arch added NIC type
 # - rocpd_info_agent.type added NIC type
+


### PR DESCRIPTION
## Motivation

This PR adds thread trace support for rocpd output format. When --att is combined with --output-format rocpd, the profiler now persists raw ATT chunk metadata, decoder-generated text artifacts, and DWARF-derived source snapshots directly into the rocpd SQLite database.

## Technical Details

**New schema tables**

rocpd_gpu_thread_trace_chunk
One row per raw ATT data chunk. Each chunk corresponds to one shader engine's raw SQTT binary output for one dispatch.

Fields:
agent_id, shader_engine_id, chunk_id — uniquely identify the chunk within the session
time_begin, time_end — wall-clock timestamps bounding the collection window
trace_mode — whether collection was dispatch-triggered or agent-wide
parameters — semicolon-separated key=value string capturing all ATT session parameters (shader engine mask, perfcounters, serialize_all, inline storage mode) so a DB consumer can reproduce the collection context without the config file
att_blob_id — colon-joined identity string dispatch:agent:se:chunk for external cross-referencing
binary_chunk_path — relative filesystem path to the .att file (default mode)
binary_chunk — raw .att bytes stored inline (optional, enabled via ROCPROF_ATT_PARAM_STORE_CHUNK_INLINE)
binary_chunk_size — size in bytes of the raw binary payload

the rocpd database has no record that thread trace was collected, which kernels produced trace data, where those files are, or their timing relationship to other GPU events. This table is the primary anchor for all thread trace information in the DB. It also allows portable DB packages where the .att binary is embedded rather than left on disk.

rocpd_info_text_blob:
One row per unique text artifact file, deduped by output-relative path within the session.

Fields:
path (relative to output root), 
md5 (hex digest for integrity verification), 
size (byte count), 
text (full UTF-8 content of the file).

The ATT decoder emits human-readable artifacts — an instruction-level decode map (code.json), a source snapshot manifest (snapshots.json), and copies of DWARF-referenced source files (source_*). If these are left only on disk, a consumer holding only the .db file cannot access them. Persisting them inline makes the database self-contained: instruction maps, source attribution, and snapshot metadata are all available without the original filesystem layout or source tree.

rocpd_gpu_thread_trace_text_link
Junction table linking each chunk row to one or more text artifact rows.

Fields:
chunk_id (FK to chunk table), text_blob_id (FK to text blob table), kind (one of code_json, snapshot_manifest, snapshot_source), ordinal (position within kind, stable across runs because source paths are sorted before assignment).

A single chunk maps to multiple artifacts of different types. Without this table a consumer cannot determine which code.json belongs to which chunk, or enumerate all source snapshots for a given dispatch in order. The kind column distinguishes artifact roles and the ordinal provides a stable ordering for multi-file kinds, enabling queries like "give me all source files for chunk X, in order" with a single join.


## JIRA ID

AIPROFSDK-152

## Test Plan

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
