### PR TITLE
feat(amdsmi) : env var skipping gpu_metrics reads on a idle GPU

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -8,6 +8,12 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 
 ### Added
 
+- **Added opt-in idle gating for GPU metrics reads (`AMDSMI_SKIP_GPU_METRICS_ON_IDLE`)**.  
+  - On GPUs with runtime power management / GFXOFF (for example Navi/RDNA), reading `gpu_metrics` while the GPU is runtime-suspended forces a wake whose first firmware sample latches GFX activity and clock high for several seconds, producing false spikes on an otherwise idle GPU.
+  - Set `AMDSMI_SKIP_GPU_METRICS_ON_IDLE` (to `1`/`true`/`on`/`yes`) so `amdsmi_get_gpu_metrics_info` (and APIs that read metrics internally, such as `amdsmi_get_gpu_activity` and `amdsmi_get_clock_info`) return `AMDSMI_STATUS_BUSY` on a runtime-suspended device instead of reading `gpu_metrics` and waking it. Disabled by default, so existing behavior is unchanged.
+  - Not applicable to Instinct (MI2xx/MI3xx): those GPUs have no runtime PM, so their `power/runtime_status` is never `suspended` and the gate never fires; their metrics are unaffected.
+  - CLI effect: with the variable set, `amd-smi metric`/`amd-smi monitor` show `N/A` for metrics-derived fields on a runtime-suspended Navi GPU.
+
 - **Added NIC processor discovery and information API surface**.  
   - New C APIs: `amdsmi_get_nic_processor_handles()`, `amdsmi_get_nic_device_bdf()`, `amdsmi_get_nic_fw_info()`, `amdsmi_get_nic_port_statistics()`, and `amdsmi_get_nic_vendor_statistics()`.
   - `amdsmi_get_nic_processor_handles()` enumerates NIC processors by socket; the BDF, firmware, and port/vendor statistics getters are reserved and currently return `AMDSMI_STATUS_NOT_YET_IMPLEMENTED`.

--- a/projects/amdsmi/docs/how-to/amdsmi-cpp-lib.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cpp-lib.md
@@ -35,6 +35,33 @@ These can be set in the shell before running your application:
     export AMDSMI_GPU_METRICS_CACHE_MS=200
 ```
 
+```{note}
+On GPUs with runtime power management / GFXOFF (for example Navi/RDNA), reading
+the `gpu_metrics` sysfs node while the GPU is runtime-suspended forces a wake
+(D3→D0). The first firmware sample after that wake reports GFX activity and clock
+latched high for several seconds, so a tool that polls an idle GPU sees false
+spikes and keeps the GPU awake.
+
+Set ``AMDSMI_SKIP_GPU_METRICS_ON_IDLE`` (to ``1``/``true``/``on``/``yes``) to opt
+in to idle gating. When enabled, `amdsmi_get_gpu_metrics_info` (and APIs that read
+metrics internally, such as `amdsmi_get_gpu_activity` and `amdsmi_get_clock_info`)
+return ``AMDSMI_STATUS_BUSY`` on a runtime-suspended device instead of reading
+`gpu_metrics` and waking it.
+
+| Variable | Description | Default |
+|---|---|---|
+| ``AMDSMI_SKIP_GPU_METRICS_ON_IDLE`` | Skip `gpu_metrics` reads on a runtime-suspended GPU and return ``AMDSMI_STATUS_BUSY`` instead of waking it | disabled |
+
+**Not applicable to Instinct (MI2xx/MI3xx):** those GPUs have no runtime PM, so
+their `power/runtime_status` is never ``suspended`` and the gate never fires;
+enabling the variable is a no-op there and does not affect their metrics.
+
+**CLI effect:** with this variable set, `amd-smi metric` (and `amd-smi monitor`)
+show `N/A` for metrics-derived fields on a runtime-suspended Navi GPU, because the
+underlying read is intentionally skipped. Leave the variable unset (the default)
+for the previous behavior.
+```
+
 ```{seealso}
 Refer to the [C/C++ library API reference](../reference/amdsmi-cpp-api/index.md).
 ```

--- a/projects/amdsmi/docs/how-to/amdsmi-py-lib.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-py-lib.md
@@ -65,6 +65,26 @@ You can set these in one of two ways:
    AMDSMI_GPU_METRICS_CACHE_MS=200 python tools/amdsmi_quick_start.py
    ```
 
+```{note}
+On GPUs with runtime power management / GFXOFF (for example Navi/RDNA), reading
+GPU metrics while the GPU is runtime-suspended forces a wake whose first firmware
+sample latches GFX activity and clock high for several seconds. Set
+``AMDSMI_SKIP_GPU_METRICS_ON_IDLE`` (to ``1``/``true``/``on``/``yes``) to opt in
+to idle gating, so `amdsmi_get_gpu_metrics_info` (and `amdsmi_get_gpu_activity`,
+which reads metrics internally) raise ``AmdSmiLibraryException`` with status
+``AMDSMI_STATUS_BUSY`` on a runtime-suspended device instead of waking it.
+
+| Variable | Description | Default |
+|---|---|---|
+| ``AMDSMI_SKIP_GPU_METRICS_ON_IDLE`` | Skip GPU metrics reads on a runtime-suspended GPU and raise ``AMDSMI_STATUS_BUSY`` instead of waking it | disabled |
+
+**Not applicable to Instinct (MI2xx/MI3xx):** those GPUs have no runtime PM, so
+the gate never fires and enabling the variable is a no-op there. With the
+variable set, `amd-smi metric` shows `N/A` for metrics-derived fields on a
+runtime-suspended Navi GPU; leave it unset (the default) for the previous
+behavior.
+```
+
 To get started, the `amdsmi` folder should be copied and placed next to
 the importing script. Import it as follows:
 

--- a/projects/amdsmi/include/amd_smi/amdsmi.h
+++ b/projects/amdsmi/include/amd_smi/amdsmi.h
@@ -4970,6 +4970,14 @@ amdsmi_status_t amdsmi_get_gpu_metrics_header_info(amdsmi_processor_handle proce
  *  ::amdsmi_apu_metrics_t structure immediately after the call to preserve the data.
  *  For non-APU devices, @p pgpu_metrics->apu_metrics will be nullptr.
  *
+ *  **Idle/runtime-suspend gating (opt-in):**
+ *  If the ``AMDSMI_SKIP_GPU_METRICS_ON_IDLE`` environment variable is enabled
+ *  (``1``/``true``/``on``/``yes``) and the device is runtime-suspended (its
+ *  ``power/runtime_status`` reads ``suspended``), this function returns
+ *  ::AMDSMI_STATUS_BUSY without reading @c gpu_metrics, so the GPU is not woken
+ *  from a low-power (e.g. GFXOFF) state. Applies to GPUs with runtime PM (e.g.
+ *  Navi); Instinct GPUs have no runtime PM and are unaffected. Disabled by default.
+ *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_get_gpu_metrics_info(amdsmi_processor_handle processor_handle,
@@ -7636,6 +7644,11 @@ amdsmi_status_t amdsmi_get_temp_metric(amdsmi_processor_handle processor_handle,
  *
  *  @param[out] info Reference to the gpu engine usage structure. Must be allocated by user.
  *
+ *  @note This reads @c gpu_metrics internally, so the
+ *  ``AMDSMI_SKIP_GPU_METRICS_ON_IDLE`` opt-in described on
+ *  ::amdsmi_get_gpu_metrics_info applies here too: on a runtime-suspended GPU it
+ *  returns ::AMDSMI_STATUS_BUSY instead of waking the device.
+ *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */
 amdsmi_status_t amdsmi_get_gpu_activity(amdsmi_processor_handle processor_handle,
@@ -7693,6 +7706,11 @@ amdsmi_status_t amdsmi_is_gpu_power_management_enabled(amdsmi_processor_handle p
  *
  *  @param[out] info Reference to the gpu clock structure.
  *              Must be allocated by user.
+ *
+ *  @note This reads @c gpu_metrics internally, so the
+ *  ``AMDSMI_SKIP_GPU_METRICS_ON_IDLE`` opt-in described on
+ *  ::amdsmi_get_gpu_metrics_info applies here too: on a runtime-suspended GPU it
+ *  returns ::AMDSMI_STATUS_BUSY instead of waking the device.
  *
  *  @return ::amdsmi_status_t | ::AMDSMI_STATUS_SUCCESS on success, non-zero on fail
  */

--- a/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
+++ b/projects/amdsmi/include/amd_smi/impl/amd_smi_utils.h
@@ -171,6 +171,31 @@ amdsmi_status_t get_gpu_device_from_handle(amdsmi_processor_handle processor_han
  */
 int read_env_ms(const char* name, int def);
 
+/**
+ *  @brief Whether gpu_metrics idle gating is enabled via environment variable.
+ *
+ *  @details Reads the ``AMDSMI_SKIP_GPU_METRICS_ON_IDLE`` environment variable.
+ *  Enabled when set to ``1``, ``true``, ``on`` or ``yes`` (case-insensitive).
+ *
+ *  @retval true if the feature is enabled, false otherwise (including when unset)
+ */
+bool skip_gpu_metrics_on_idle_enabled();
+
+/**
+ *  @brief Whether a GPU is runtime-suspended, read from a non-waking PM node.
+ *
+ *  @details Reads the ``power/runtime_status`` sysfs node at @p runtime_status_path
+ *  (a PM-core attribute that does not touch the device) and reports whether the
+ *  GPU is runtime-suspended. GPUs without runtime PM (e.g. Instinct) never report
+ *  ``suspended``, so this returns false for them.
+ *
+ *  @param[in] runtime_status_path full path to the ``power/runtime_status`` node
+ *
+ *  @retval true if the file's first line equals ``suspended``; false on any
+ *          other value or if the file cannot be opened
+ */
+bool is_gpu_runtime_suspended(const std::string& runtime_status_path);
+
 template <typename>
 constexpr bool is_dependent_false_v = false;
 

--- a/projects/amdsmi/src/amd_smi/amd_smi.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi.cc
@@ -4031,6 +4031,28 @@ amdsmi_status_t amdsmi_get_gpu_metrics_info(amdsmi_processor_handle processor_ha
   }
 
   *pgpu_metrics = amdsmi_gpu_metrics_t{};
+
+  // Opt-in (AMDSMI_SKIP_GPU_METRICS_ON_IDLE): on runtime-PM/GFXOFF GPUs (Navi),
+  // reading gpu_metrics while runtime-suspended forces a D3->D0 resume whose
+  // first FW sample latches gfx activity/clock high for several seconds. Skip
+  // the read and report BUSY instead of waking the device. Instinct has no
+  // runtime PM, so runtime_status is never "suspended" and this never fires.
+  if (skip_gpu_metrics_on_idle_enabled()) {
+    amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
+    if (get_gpu_device_from_handle(processor_handle, &gpu_device) == AMDSMI_STATUS_SUCCESS) {
+      const std::string runtime_status_path =
+          "/sys/class/drm/" + gpu_device->get_gpu_path() + "/device/power/runtime_status";
+      if (is_gpu_runtime_suspended(runtime_status_path)) {
+        std::ostringstream ss;
+        ss << __PRETTY_FUNCTION__ << " | AMDSMI_SKIP_GPU_METRICS_ON_IDLE active and "
+           << runtime_status_path
+           << " = suspended; skipping gpu_metrics read, returning AMDSMI_STATUS_BUSY";
+        LOG_DEBUG(ss);
+        return AMDSMI_STATUS_BUSY;
+      }
+    }
+  }
+
   rsmi_gpu_metrics_t rsmi_metrics{};
   auto status = rsmi_wrapper(rsmi_dev_gpu_metrics_info_get, processor_handle, 0, &rsmi_metrics);
   if (status != AMDSMI_STATUS_SUCCESS) {

--- a/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
+++ b/projects/amdsmi/src/amd_smi/amd_smi_utils.cc
@@ -1129,6 +1129,27 @@ int read_env_ms(const char* name, int def) {
   return def;
 }
 
+bool skip_gpu_metrics_on_idle_enabled() {
+  const char* val = std::getenv("AMDSMI_SKIP_GPU_METRICS_ON_IDLE");
+  if (val == nullptr) {
+    return false;
+  }
+  std::string s(val);
+  std::transform(s.begin(), s.end(), s.begin(),
+                 [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  return (s == "1" || s == "true" || s == "on" || s == "yes");
+}
+
+bool is_gpu_runtime_suspended(const std::string& runtime_status_path) {
+  std::ifstream file(runtime_status_path, std::ifstream::in);
+  if (!file.is_open()) {
+    return false;
+  }
+  std::string line;
+  std::getline(file, line);
+  return line == "suspended";
+}
+
 uint64_t get_product_serial_number(amdsmi_processor_handle processor_handle) {
   uint64_t serial_number = 0;
   amdsmi_board_info_t board_info = {};

--- a/projects/amdsmi/tests/amd_smi_test/amdsmitst.exclude
+++ b/projects/amdsmi/tests/amd_smi_test/amdsmitst.exclude
@@ -8,7 +8,11 @@ declare -A FILTER
 # Permanent exclusions
 # These tests are included for debugging, but are not executed in normal
 # execution on any ASIC:
-PERMANENT_BLACKLIST_ALL_ASICS=
+# - TestIdleMetricsRead manipulates the process-wide
+#   AMDSMI_SKIP_GPU_METRICS_ON_IDLE env var and asserts runtime-suspend gating
+#   that CI cannot reliably reproduce; run it explicitly with
+#   --gtest_filter=amdsmitstReadOnly.TestIdleMetricsRead.
+PERMANENT_BLACKLIST_ALL_ASICS="amdsmitstReadOnly.TestIdleMetricsRead"
 
 # This is the temporary blacklist for all ASICs. This is to be used when a test
 # is failing consistently

--- a/projects/amdsmi/tests/amd_smi_test/functional/idle_metrics_read.cc
+++ b/projects/amdsmi/tests/amd_smi_test/functional/idle_metrics_read.cc
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "idle_metrics_read.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+
+#include "../test_common.h"
+#include "amd_smi/amdsmi.h"
+#include "amd_smi/impl/amd_smi_utils.h"
+
+namespace {
+constexpr const char* kIdleEnv = "AMDSMI_SKIP_GPU_METRICS_ON_IDLE";
+
+void WriteFile(const std::string& path, const std::string& contents) {
+  std::ofstream f(path, std::ios::trunc);
+  f << contents;
+}
+}  // namespace
+
+TestIdleMetricsRead::TestIdleMetricsRead() : TestBase() {
+  set_title("AMDSMI Idle Metrics Gating Test");
+  set_description(
+      "Verifies AMDSMI_SKIP_GPU_METRICS_ON_IDLE: gpu_metrics reads are skipped "
+      "(returning AMDSMI_STATUS_BUSY) on a runtime-suspended GPU, and are left "
+      "unchanged on non-suspended GPUs such as Instinct (no runtime PM).");
+}
+
+TestIdleMetricsRead::~TestIdleMetricsRead(void) {}
+
+void TestIdleMetricsRead::SetUp(void) {
+  TestBase::SetUp();
+  return;
+}
+
+void TestIdleMetricsRead::DisplayTestInfo(void) { TestBase::DisplayTestInfo(); }
+
+void TestIdleMetricsRead::DisplayResults(void) const {
+  TestBase::DisplayResults();
+  return;
+}
+
+void TestIdleMetricsRead::Close() { TestBase::Close(); }
+
+void TestIdleMetricsRead::Run(void) {
+  TestBase::Run();
+  PRINT_VERBOSITY();
+  if (setup_failed_) {
+    std::cout << "** SetUp Failed for this test. Skipping.**" << std::endl;
+    return;
+  }
+
+  // Save/restore the env var so the test never leaks process-wide state.
+  const char* orig = std::getenv(kIdleEnv);
+  const bool had_orig = (orig != nullptr);
+  const std::string orig_val = had_orig ? std::string(orig) : std::string();
+
+  // ---- Part A: hardware-free helper coverage (runs on every ASIC) ----
+
+  // skip_gpu_metrics_on_idle_enabled() env parsing.
+  unsetenv(kIdleEnv);
+  EXPECT_FALSE(skip_gpu_metrics_on_idle_enabled()) << "unset must be disabled";
+  for (const char* on : {"1", "true", "TRUE", "On", "yes", "YES"}) {
+    setenv(kIdleEnv, on, 1);
+    EXPECT_TRUE(skip_gpu_metrics_on_idle_enabled()) << "value=" << on;
+  }
+  for (const char* off : {"0", "false", "no", "", "garbage"}) {
+    setenv(kIdleEnv, off, 1);
+    EXPECT_FALSE(skip_gpu_metrics_on_idle_enabled()) << "value=" << off;
+  }
+
+  // is_gpu_runtime_suspended() parsing of runtime_status contents. Only an
+  // exact "suspended" gates; "active"/"unsupported" (Instinct / no runtime PM),
+  // the "suspending" transient, empty, and a missing file all return false.
+  const std::string dir = ::testing::TempDir();
+  const std::string suspended = dir + "amdsmi_idle_suspended";
+  const std::string suspended_nonl = dir + "amdsmi_idle_suspended_nonl";
+  const std::string active = dir + "amdsmi_idle_active";
+  const std::string suspending = dir + "amdsmi_idle_suspending";
+  const std::string unsupported = dir + "amdsmi_idle_unsupported";
+  const std::string empty = dir + "amdsmi_idle_empty";
+
+  WriteFile(suspended, "suspended\n");
+  WriteFile(suspended_nonl, "suspended");
+  WriteFile(active, "active\n");
+  WriteFile(suspending, "suspending\n");
+  WriteFile(unsupported, "unsupported\n");
+  WriteFile(empty, "");
+
+  EXPECT_TRUE(is_gpu_runtime_suspended(suspended));
+  EXPECT_TRUE(is_gpu_runtime_suspended(suspended_nonl));
+  EXPECT_FALSE(is_gpu_runtime_suspended(active));
+  EXPECT_FALSE(is_gpu_runtime_suspended(suspending));
+  EXPECT_FALSE(is_gpu_runtime_suspended(unsupported));
+  EXPECT_FALSE(is_gpu_runtime_suspended(empty));
+  EXPECT_FALSE(is_gpu_runtime_suspended(dir + "amdsmi_idle_missing"));
+
+  for (const std::string& f : {suspended, suspended_nonl, active, suspending, unsupported, empty}) {
+    std::remove(f.c_str());
+  }
+
+  // ---- Part B: per-device behavior (gating + Instinct/awake no-op guard) ----
+  for (uint32_t i = 0; i < num_monitor_devs(); ++i) {
+    PrintDeviceHeader(processor_handles_[i]);
+
+    // Baseline with the feature OFF.
+    unsetenv(kIdleEnv);
+    amdsmi_gpu_metrics_t base_metrics = {};
+    amdsmi_status_t base = amdsmi_get_gpu_metrics_info(processor_handles_[i], &base_metrics);
+    // EXPECT (not ASSERT) so the env-var restore at the end of Run() still runs.
+    EXPECT_TRUE(base == AMDSMI_STATUS_SUCCESS || base == AMDSMI_STATUS_NOT_SUPPORTED ||
+                base == AMDSMI_STATUS_BUSY)
+        << "unexpected baseline status: " << base;
+
+    // Determine suspend state via the non-waking PM node.
+    bool dev_suspended = false;
+    amd::smi::AMDSmiGPUDevice* gpu_device = nullptr;
+    if (get_gpu_device_from_handle(processor_handles_[i], &gpu_device) == AMDSMI_STATUS_SUCCESS) {
+      const std::string rt_path =
+          "/sys/class/drm/" + gpu_device->get_gpu_path() + "/device/power/runtime_status";
+      dev_suspended = is_gpu_runtime_suspended(rt_path);
+    }
+
+    // Enable the feature and re-query.
+    setenv(kIdleEnv, "1", 1);
+    amdsmi_gpu_metrics_t gated_metrics = {};
+    amdsmi_status_t gated = amdsmi_get_gpu_metrics_info(processor_handles_[i], &gated_metrics);
+
+    if (dev_suspended) {
+      // Gate should short-circuit to BUSY. The device can leave "suspended"
+      // between our check and the gate's own check (inherent TOCTOU), so accept
+      // either BUSY or the same status the ungated read produced.
+      EXPECT_TRUE(gated == AMDSMI_STATUS_BUSY || gated == base)
+          << "expected BUSY or the ungated result on a runtime-suspended GPU";
+    } else {
+      // Instinct (no runtime PM) and awake GPUs must be unaffected: enabling the
+      // feature must not change the outcome versus the baseline.
+      EXPECT_EQ(gated, base) << "idle gating changed the result on a non-suspended GPU";
+    }
+
+    IF_VERB(STANDARD) {
+      std::cout << "\truntime_suspended: " << (dev_suspended ? "true" : "false")
+                << " | baseline status: " << base << " | gated status: " << gated << std::endl;
+    }
+  }
+
+  // Restore original env state.
+  if (had_orig) {
+    setenv(kIdleEnv, orig_val.c_str(), 1);
+  } else {
+    unsetenv(kIdleEnv);
+  }
+}

--- a/projects/amdsmi/tests/amd_smi_test/functional/idle_metrics_read.h
+++ b/projects/amdsmi/tests/amd_smi_test/functional/idle_metrics_read.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef TESTS_AMD_SMI_TEST_FUNCTIONAL_IDLE_METRICS_READ_H_
+#define TESTS_AMD_SMI_TEST_FUNCTIONAL_IDLE_METRICS_READ_H_
+
+#include "../test_base.h"
+
+// Exercises AMDSMI_SKIP_GPU_METRICS_ON_IDLE: the opt-in gate that skips
+// gpu_metrics reads on a runtime-suspended GPU (so an idle Navi GPU is not
+// woken) while remaining a no-op on GPUs without runtime PM (e.g. Instinct).
+class TestIdleMetricsRead : public TestBase {
+ public:
+  TestIdleMetricsRead();
+
+  // @Brief: Destructor for test case of TestIdleMetricsRead
+  virtual ~TestIdleMetricsRead();
+
+  // @Brief: Setup the environment for measurement
+  virtual void SetUp();
+
+  // @Brief: Core measurement execution
+  virtual void Run();
+
+  // @Brief: Clean up and retrieve the resource
+  virtual void Close();
+
+  // @Brief: Display  results
+  virtual void DisplayResults() const;
+
+  // @Brief: Display information about what this test does
+  virtual void DisplayTestInfo(void);
+};
+
+#endif  // TESTS_AMD_SMI_TEST_FUNCTIONAL_IDLE_METRICS_READ_H_

--- a/projects/amdsmi/tests/amd_smi_test/main.cc
+++ b/projects/amdsmi/tests/amd_smi_test/main.cc
@@ -41,6 +41,7 @@
 #include "functional/gpu_partition_metrics_read.h"
 #include "functional/hw_topology_read.h"
 #include "functional/id_info_read.h"
+#include "functional/idle_metrics_read.h"
 #include "functional/kfd_atfork_read.h"
 #include "functional/mem_page_info_read.h"
 #include "functional/mem_util_read.h"
@@ -266,6 +267,10 @@ TEST(amdsmitstReadOnly, TestHWTopologyRead) {
 
 TEST(amdsmitstReadOnly, TestGpuMetricsRead) {
   TestGpuMetricsRead tst;
+  RunGenericTest(&tst);
+}
+TEST(amdsmitstReadOnly, TestIdleMetricsRead) {
+  TestIdleMetricsRead tst;
   RunGenericTest(&tst);
 }
 TEST(amdsmitstReadOnly, TestGpuPartitionMetricsRead) {

--- a/projects/amdsmi/tests/python_unittest/integration_test.py
+++ b/projects/amdsmi/tests/python_unittest/integration_test.py
@@ -379,6 +379,71 @@ class TestAmdSmiPython(unittest.TestCase):
         return
 
     # integration
+    def test_skip_gpu_metrics_on_idle(self):
+        """AMDSMI_SKIP_GPU_METRICS_ON_IDLE surfaces through the Python binding:
+        a runtime-suspended GPU raises AMDSMI_STATUS_BUSY instead of waking the
+        device, while a non-suspended GPU (Instinct/no runtime PM, or awake) is
+        unaffected (same outcome with the flag on or off)."""
+        self.common.print_func_name("")
+
+        env_key = "AMDSMI_SKIP_GPU_METRICS_ON_IDLE"
+        busy_code = amdsmi.amdsmi_wrapper.AMDSMI_STATUS_BUSY
+        orig_env = os.environ.get(env_key)
+
+        def runtime_status(gpu):
+            # Non-waking read of the PM-core node via the device BDF.
+            try:
+                bdf = amdsmi.amdsmi_get_gpu_device_bdf(gpu)
+            except amdsmi.AmdSmiException:
+                return None
+            try:
+                with open(f"/sys/bus/pci/devices/{bdf}/power/runtime_status") as f:
+                    return f.read().strip()
+            except OSError:
+                return None
+
+        def query(gpu):
+            # Returns "OK" on success or the amdsmi_status_t error code.
+            try:
+                amdsmi.amdsmi_get_gpu_metrics_info(gpu)
+                return "OK"
+            except amdsmi.AmdSmiLibraryException as e:
+                return e.get_error_code()
+
+        try:
+            for i, gpu in enumerate(self.common.processors):
+                self.common.print_device_header(i)
+                rt = runtime_status(gpu)
+
+                # Baseline: feature disabled.
+                os.environ.pop(env_key, None)
+                base = query(gpu)
+
+                # Feature enabled.
+                os.environ[env_key] = "1"
+                gated = query(gpu)
+
+                msg = f"\t### amdsmi_get_gpu_metrics_info(gpu={i}) runtime_status={rt}: base={base} gated={gated}"
+                self.common.print(msg, gated)
+                if rt == "suspended":
+                    # Gate should short-circuit to BUSY. The device can leave
+                    # "suspended" between our read and the gate's own check
+                    # (inherent TOCTOU), so accept either BUSY or the same
+                    # result the ungated read produced - never a third outcome.
+                    self.assertIn(
+                        gated, (busy_code, base), f"{msg} unexpected result on a suspended GPU"
+                    )
+                else:
+                    # Instinct (no runtime PM) and awake GPUs: pure no-op.
+                    self.assertEqual(gated, base, f"{msg} idle gating changed a non-suspended GPU")
+        finally:
+            if orig_env is None:
+                os.environ.pop(env_key, None)
+            else:
+                os.environ[env_key] = orig_env
+        return
+
+    # integration
     def test_gpu_counter(self):
         self.common.print_func_name("")
 


### PR DESCRIPTION
## Motivation

On Navi, reading `gpu_metrics` while the GPU is runtime-suspended forces a wake (D3->D0). The first firmware sample after that wake reports gfx activity and clock latched high for ~9-15s, so a tool polling an idle GPU sees false spikes and keeps the GPU awake. The fix belongs on the tool side: don't trigger a wakeup just to report activity.

## Technical Details

Add an opt-in env var `AMDSMI_SKIP_GPU_METRICS_ON_IDLE` (disabled by default). When enabled and the GPU is runtime-suspended, `amdsmi_get_gpu_metrics_info` returns `AMDSMI_STATUS_BUSY` instead of reading `gpu_metrics`.

- Gated at the single `gpu_metrics` read, so `amdsmi_get_gpu_activity` and `amdsmi_get_clock_info` inherit it.
- Suspend is detected via the non-waking `power/runtime_status` sysfs node. Instinct has no runtime PM, so it never reads `suspended` and the gate never fires there (no-op, metrics unaffected).
- No signature change (no ABI / wrapper impact). The skip is logged under `RSMI_LOGGING`.
- CLI: with the var set, `amd-smi metric`/`monitor` show `N/A` for metrics-derived fields on a suspended GPU. No CLI code change.

```text
  amdsmi_get_gpu_metrics_info()        also: amdsmi_get_gpu_activity()
            │                                amdsmi_get_clock_info()
            ▼
  AMDSMI_SKIP_GPU_METRICS_ON_IDLE enabled?
            │
            ├── no ───────────────► read gpu_metrics        (default, unchanged)
            │
            └── yes
                 │
                 ▼
        runtime_status == "suspended"?   (non-waking read; never true on Instinct)
                 │
                 ├── no ──────────► read gpu_metrics
                 │
                 └── yes ─────────► return AMDSMI_STATUS_BUSY
                                    (skip read; GPU stays asleep, no false spike)
```

## JIRA ID

JIRA ID : ROCM-26020

## Test Plan

- C++ `TestIdleMetricsRead` (helper parsing + per-device gating/no-op) and Python `test_skip_gpu_metrics_on_idle`, plus the existing `TestGpuMetricsRead`/`TestGPUBusyRead` regression.
- Hardware: Navi31 (runtime-suspended), Navi32, MI210, MI300X, MI300A.
- `pre-commit run` on all changed files.

## Test Result

- Suspended Navi31: returns `AMDSMI_STATUS_BUSY`, device stays suspended (no wake).
- Instinct (MI210/MI300X/MI300A) and awake GPUs: no-op, identical result flag on or off.
- Default (flag unset): unchanged; tests and pre-commit pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
