### PR TITLE
rocjitsu: preserve SCC across scalar conversions

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
+++ b/emulation/rocjitsu/lib/python/amdisa/codegen/_generator.py
@@ -2581,7 +2581,15 @@ class CodeGenerator:
                     if is_vop3 and len(src_ops) >= 3:
                         lctx.vcc_read = f'{src_ops[2]}.read_scalar64(wf)'
                     lctx.vcc_dst = dst_ops[1] if len(dst_ops) > 1 else '__vcc__'
-                return lower_sema_block(sema_block, lctx)
+                body = lower_sema_block(sema_block, lctx)
+                if (
+                    cls == 'scalar_unary'
+                    and op is not None
+                    and op.startswith('cvt_')
+                    and scc == 'none'
+                ):
+                    body = '  // SOP1 scalar conversions preserve SCC.\n' + body
+                return body
 
         # Try the registry (covers all extracted gen_ functions).
         from amdisa.codegen.execute import ExecuteContext, DISPATCH

--- a/emulation/rocjitsu/lib/python/amdisa/semantics.py
+++ b/emulation/rocjitsu/lib/python/amdisa/semantics.py
@@ -239,6 +239,22 @@ _SCC_NONE_OPS = frozenset(
 # Operations where SCC = (result == src0) i.e. "compare" semantics (min/max).
 _SCC_COMPARE_OPS = frozenset({'min', 'max'})
 
+_SOP1_SCC_NONE_OPS = frozenset(
+    {
+        'bitset0',
+        'bitset1',
+        # SOP1 scalar conversions preserve SCC; only count/bit-scan style
+        # scalar unary ops write SCC from the computed result.
+        'cvt_f16_f32',
+        'cvt_f32_f16',
+        'cvt_f32_i32',
+        'cvt_f32_u32',
+        'cvt_hi_f32_f16',
+        'cvt_i32_f32',
+        'cvt_u32_f32',
+    }
+)
+
 
 def _scalar_binop_scc(op: str, dtype: str) -> str:
     """Determine SCC semantics for a scalar binary operation."""
@@ -478,7 +494,7 @@ def _derive_sop1(name: str) -> InstructionSemantics | None:
             dtype = entry_dtype
         scc = None
         if cls == 'scalar_unary':
-            if op in ('bitset0', 'bitset1'):
+            if op in _SOP1_SCC_NONE_OPS:
                 scc = 'none'
             else:
                 scc = 'nonzero'

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -117,6 +117,29 @@ class TestDeriveScalarUnary:
         cpp = lower_sema_block(block)
         assert 'write_scc' in cpp
 
+    @pytest.mark.parametrize(
+        'name,operation',
+        [
+            ('S_CVT_F32_I32', 'cvt_f32_i32'),
+            ('S_CVT_F32_U32', 'cvt_f32_u32'),
+            ('S_CVT_I32_F32', 'cvt_i32_f32'),
+            ('S_CVT_U32_F32', 'cvt_u32_f32'),
+            ('S_CVT_F16_F32', 'cvt_f16_f32'),
+            ('S_CVT_F32_F16', 'cvt_f32_f16'),
+            ('S_CVT_HI_F32_F16', 'cvt_hi_f32_f16'),
+        ],
+    )
+    def test_scalar_cvt_preserves_scc(self, name, operation):
+        sem = derive_semantics(name, 'ENC_SOP1')
+        assert sem is not None
+        assert sem.semantic_class == 'scalar_unary'
+        assert sem.operation == operation
+        assert sem.sets_scc == 'none'
+
+        block = derive_sema_block(sem)
+        cpp = lower_sema_block(block)
+        assert 'write_scc' not in cpp
+
     @pytest.mark.parametrize('name', ['S_CLZ_I32_U32', 'S_CLZ_I32_U64'])
     def test_clz_zero_returns_all_ones(self, name):
         sem = derive_semantics(name, 'ENC_SOP1')

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -1485,7 +1485,6 @@ inline void execute_s_cvt_f16_f32_sop1([[maybe_unused]] Inst &inst,
   uint32_t result =
       util::f32_to_f16(std::bit_cast<float>(static_cast<uint32_t>(inst.ssrc0.read_scalar(wf))));
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc((result != 0));
 }
 
 template <typename Inst>
@@ -1494,7 +1493,6 @@ inline void execute_s_cvt_f32_f16_sop1([[maybe_unused]] Inst &inst,
   uint32_t result =
       std::bit_cast<uint32_t>(util::f16_to_f32(static_cast<uint16_t>(inst.ssrc0.read_scalar(wf))));
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc((result != 0));
 }
 
 template <typename Inst>
@@ -1503,7 +1501,6 @@ inline void execute_s_cvt_f32_i32_sop1([[maybe_unused]] Inst &inst,
   uint32_t result =
       std::bit_cast<uint32_t>(static_cast<float>(static_cast<int32_t>(inst.ssrc0.read_scalar(wf))));
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc((result != 0));
 }
 
 template <typename Inst>
@@ -1511,7 +1508,6 @@ inline void execute_s_cvt_f32_u32_sop1([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
   uint32_t result = std::bit_cast<uint32_t>(static_cast<float>(inst.ssrc0.read_scalar(wf)));
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc((result != 0));
 }
 
 template <typename Inst>
@@ -1520,7 +1516,6 @@ inline void execute_s_cvt_hi_f32_f16_sop1([[maybe_unused]] Inst &inst,
   uint32_t result = std::bit_cast<uint32_t>(
       util::f16_to_f32(static_cast<uint16_t>((inst.ssrc0.read_scalar(wf)) >> 16)));
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc((result != 0));
 }
 
 template <typename Inst>
@@ -1537,7 +1532,6 @@ inline void execute_s_cvt_i32_f32_sop1([[maybe_unused]] Inst &inst,
     return static_cast<uint32_t>(static_cast<int32_t>(s));
   }();
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc((result != 0));
 }
 
 template <typename Inst>
@@ -1562,7 +1556,6 @@ inline void execute_s_cvt_u32_f32_sop1([[maybe_unused]] Inst &inst,
     return static_cast<uint32_t>(s);
   }();
   inst.sdst.write_scalar(wf, result);
-  wf.write_scc((result != 0));
 }
 
 template <typename Inst>

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -1482,6 +1482,7 @@ inline void execute_s_ctz_i32_b64_sop1([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_s_cvt_f16_f32_sop1([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  // SOP1 scalar conversions preserve SCC.
   uint32_t result =
       util::f32_to_f16(std::bit_cast<float>(static_cast<uint32_t>(inst.ssrc0.read_scalar(wf))));
   inst.sdst.write_scalar(wf, result);
@@ -1490,6 +1491,7 @@ inline void execute_s_cvt_f16_f32_sop1([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_s_cvt_f32_f16_sop1([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  // SOP1 scalar conversions preserve SCC.
   uint32_t result =
       std::bit_cast<uint32_t>(util::f16_to_f32(static_cast<uint16_t>(inst.ssrc0.read_scalar(wf))));
   inst.sdst.write_scalar(wf, result);
@@ -1498,6 +1500,7 @@ inline void execute_s_cvt_f32_f16_sop1([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_s_cvt_f32_i32_sop1([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  // SOP1 scalar conversions preserve SCC.
   uint32_t result =
       std::bit_cast<uint32_t>(static_cast<float>(static_cast<int32_t>(inst.ssrc0.read_scalar(wf))));
   inst.sdst.write_scalar(wf, result);
@@ -1506,6 +1509,7 @@ inline void execute_s_cvt_f32_i32_sop1([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_s_cvt_f32_u32_sop1([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  // SOP1 scalar conversions preserve SCC.
   uint32_t result = std::bit_cast<uint32_t>(static_cast<float>(inst.ssrc0.read_scalar(wf)));
   inst.sdst.write_scalar(wf, result);
 }
@@ -1513,6 +1517,7 @@ inline void execute_s_cvt_f32_u32_sop1([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_s_cvt_hi_f32_f16_sop1([[maybe_unused]] Inst &inst,
                                           [[maybe_unused]] Wavefront &wf) {
+  // SOP1 scalar conversions preserve SCC.
   uint32_t result = std::bit_cast<uint32_t>(
       util::f16_to_f32(static_cast<uint16_t>((inst.ssrc0.read_scalar(wf)) >> 16)));
   inst.sdst.write_scalar(wf, result);
@@ -1521,6 +1526,7 @@ inline void execute_s_cvt_hi_f32_f16_sop1([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_s_cvt_i32_f32_sop1([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  // SOP1 scalar conversions preserve SCC.
   uint32_t result = [&]() -> uint32_t {
     float s = std::bit_cast<float>(static_cast<uint32_t>(inst.ssrc0.read_scalar(wf)));
     if (std::isnan(s))
@@ -1547,6 +1553,7 @@ inline void execute_s_cvt_pk_rtz_f16_f32_sop2([[maybe_unused]] Inst &inst,
 template <typename Inst>
 inline void execute_s_cvt_u32_f32_sop1([[maybe_unused]] Inst &inst,
                                        [[maybe_unused]] Wavefront &wf) {
+  // SOP1 scalar conversions preserve SCC.
   uint32_t result = [&]() -> uint32_t {
     float s = std::bit_cast<float>(static_cast<uint32_t>(inst.ssrc0.read_scalar(wf)));
     if (std::isnan(s) || s < 0.0f)

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -78,6 +78,10 @@ constexpr std::array<uint32_t, 2> encode_vop2(uint32_t op, uint32_t vdst, uint32
           0u};
 }
 
+constexpr std::array<uint32_t, 2> encode_sop1(uint32_t op, uint32_t sdst, uint32_t ssrc0) {
+  return {(ssrc0 & 0xFFu) | ((op & 0xFFu) << 8) | ((sdst & 0x7Fu) << 16) | 0xBE800000u, 0u};
+}
+
 constexpr std::array<uint32_t, 2> encode_sop2(uint32_t op, uint32_t sdst, uint32_t ssrc0,
                                               uint32_t ssrc1) {
   return {(ssrc0 & 0xFFu) | ((ssrc1 & 0xFFu) << 8) | ((sdst & 0x7Fu) << 16) | ((op & 0x7Fu) << 23) |
@@ -330,6 +334,66 @@ TEST(Rdna4ScalarSccTest, AddSubCoI32UseSignedOverflow) {
   run(add, "s_add_co_i32", 0x7FFFFFFFu, 0u, 0x7FFFFFFFu, false);
   run(sub, "s_sub_co_i32", 0x80000000u, 1u, 0x7FFFFFFFu, true);
   run(sub, "s_sub_co_i32", 5u, 3u, 2u, false);
+
+  cu->reset_all_wf();
+}
+
+TEST(Gfx1250ScalarSccTest, ScalarCvtPreservesScc) {
+  amdgpu::GpuMemory gpu_mem("gfx1250_s_cvt_scc_mem");
+  amdgpu::L2Cache l2("gfx1250_s_cvt_scc_l2");
+
+  amdgpu::ComputeUnitCore::Config cfg{};
+  cfg.arch = ROCJITSU_CODE_ARCH_GFX1250;
+  cfg.num_wf_slots = 1;
+  cfg.sgprs_per_wf = 106;
+  cfg.vgprs_per_wf = 256;
+  cfg.lds_size_kb = 64;
+
+  auto cu = amdgpu::ComputeUnitCore::create("gfx1250", cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+
+  auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
+  ASSERT_NE(wf, nullptr);
+
+  const uint32_t sb = wf->sgpr_alloc().base;
+  const uint32_t one_f32 = std::bit_cast<uint32_t>(1.0f);
+  const uint32_t one_f16 = util::f32_to_f16(1.0f);
+
+  struct Case {
+    uint32_t op;
+    const char *mnemonic;
+    uint32_t src;
+    uint32_t expected;
+  };
+  const std::array<Case, 7> cases{{
+      {0x64u, "s_cvt_f32_i32", 1u, one_f32},
+      {0x65u, "s_cvt_f32_u32", 1u, one_f32},
+      {0x66u, "s_cvt_i32_f32", one_f32, 1u},
+      {0x67u, "s_cvt_u32_f32", one_f32, 1u},
+      {0x68u, "s_cvt_f16_f32", one_f32, one_f16},
+      {0x69u, "s_cvt_f32_f16", one_f16, one_f32},
+      {0x6Au, "s_cvt_hi_f32_f16", one_f16 << 16, one_f32},
+  }};
+
+  for (const auto &tc : cases) {
+    const auto words = encode_sop1(tc.op, /*sdst=*/1, /*ssrc0=*/0);
+    for (bool initial_scc : std::array<bool, 2>{false, true}) {
+      std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
+      ASSERT_NE(inst, nullptr);
+      ASSERT_EQ(std::string_view(inst->mnemonic()), tc.mnemonic);
+
+      cu->write_sgpr(sb + 0, tc.src);
+      cu->write_sgpr(sb + 1, 0u);
+      wf->write_scc(initial_scc);
+      cu->execute_instruction(inst.get(), *wf);
+
+      EXPECT_EQ(cu->read_sgpr(sb + 1), tc.expected) << tc.mnemonic;
+      EXPECT_EQ(wf->read_scc(), initial_scc) << tc.mnemonic << " initial_scc=" << initial_scc;
+    }
+  }
 
   cu->reset_all_wf();
 }

--- a/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
+++ b/emulation/rocjitsu/tests/instruction_execution_harness_test.cpp
@@ -338,64 +338,85 @@ TEST(Rdna4ScalarSccTest, AddSubCoI32UseSignedOverflow) {
   cu->reset_all_wf();
 }
 
-TEST(Gfx1250ScalarSccTest, ScalarCvtPreservesScc) {
-  amdgpu::GpuMemory gpu_mem("gfx1250_s_cvt_scc_mem");
-  amdgpu::L2Cache l2("gfx1250_s_cvt_scc_l2");
+struct ScalarCvtSccCase {
+  uint32_t op;
+  const char *mnemonic;
+  uint32_t src;
+  uint32_t expected;
+};
+
+void run_scalar_cvt_preserves_scc(rj_code_arch_t arch, std::string_view arch_name,
+                                  const ScalarCvtSccCase *cases, size_t num_cases) {
+  amdgpu::GpuMemory gpu_mem(std::string(arch_name) + "_s_cvt_scc_mem");
+  amdgpu::L2Cache l2(std::string(arch_name) + "_s_cvt_scc_l2");
 
   amdgpu::ComputeUnitCore::Config cfg{};
-  cfg.arch = ROCJITSU_CODE_ARCH_GFX1250;
+  cfg.arch = arch;
   cfg.num_wf_slots = 1;
   cfg.sgprs_per_wf = 106;
   cfg.vgprs_per_wf = 256;
   cfg.lds_size_kb = 64;
 
-  auto cu = amdgpu::ComputeUnitCore::create("gfx1250", cfg, &gpu_mem, &l2);
-  ASSERT_NE(cu, nullptr);
+  auto cu = amdgpu::ComputeUnitCore::create(std::string(arch_name), cfg, &gpu_mem, &l2);
+  ASSERT_NE(cu, nullptr) << arch_name;
 
-  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
-  ASSERT_NE(decoder, nullptr);
+  auto decoder = Decoder::create(arch);
+  ASSERT_NE(decoder, nullptr) << arch_name;
 
   auto *wf = cu->dispatch_wf(0, 0, cfg.sgprs_per_wf, cfg.vgprs_per_wf);
-  ASSERT_NE(wf, nullptr);
+  ASSERT_NE(wf, nullptr) << arch_name;
 
   const uint32_t sb = wf->sgpr_alloc().base;
-  const uint32_t one_f32 = std::bit_cast<uint32_t>(1.0f);
-  const uint32_t one_f16 = util::f32_to_f16(1.0f);
 
-  struct Case {
-    uint32_t op;
-    const char *mnemonic;
-    uint32_t src;
-    uint32_t expected;
-  };
-  const std::array<Case, 7> cases{{
-      {0x64u, "s_cvt_f32_i32", 1u, one_f32},
-      {0x65u, "s_cvt_f32_u32", 1u, one_f32},
-      {0x66u, "s_cvt_i32_f32", one_f32, 1u},
-      {0x67u, "s_cvt_u32_f32", one_f32, 1u},
-      {0x68u, "s_cvt_f16_f32", one_f32, one_f16},
-      {0x69u, "s_cvt_f32_f16", one_f16, one_f32},
-      {0x6Au, "s_cvt_hi_f32_f16", one_f16 << 16, one_f32},
-  }};
-
-  for (const auto &tc : cases) {
+  for (size_t i = 0; i < num_cases; ++i) {
+    const auto &tc = cases[i];
     const auto words = encode_sop1(tc.op, /*sdst=*/1, /*ssrc0=*/0);
     for (bool initial_scc : std::array<bool, 2>{false, true}) {
       std::unique_ptr<Instruction> inst(decoder->decode(words.data()));
       ASSERT_NE(inst, nullptr);
-      ASSERT_EQ(std::string_view(inst->mnemonic()), tc.mnemonic);
+      ASSERT_EQ(std::string_view(inst->mnemonic()), tc.mnemonic) << arch_name;
 
       cu->write_sgpr(sb + 0, tc.src);
       cu->write_sgpr(sb + 1, 0u);
       wf->write_scc(initial_scc);
       cu->execute_instruction(inst.get(), *wf);
 
-      EXPECT_EQ(cu->read_sgpr(sb + 1), tc.expected) << tc.mnemonic;
-      EXPECT_EQ(wf->read_scc(), initial_scc) << tc.mnemonic << " initial_scc=" << initial_scc;
+      EXPECT_EQ(cu->read_sgpr(sb + 1), tc.expected) << arch_name << " " << tc.mnemonic;
+      EXPECT_EQ(wf->read_scc(), initial_scc)
+          << arch_name << " " << tc.mnemonic << " initial_scc=" << initial_scc;
     }
   }
 
   cu->reset_all_wf();
+}
+
+TEST(ScalarSccTest, ScalarCvtPreservesScc) {
+  const uint32_t one_f32 = std::bit_cast<uint32_t>(1.0f);
+  const uint32_t one_f16 = util::f32_to_f16(1.0f);
+  const uint32_t qnan_f32 = 0x7FC00000u;
+  const uint32_t i32_overflow_f32 = std::bit_cast<uint32_t>(2147483648.0f);
+  const uint32_t below_i32_min_f32 = std::bit_cast<uint32_t>(-2147483904.0f);
+  const uint32_t u32_overflow_f32 = std::bit_cast<uint32_t>(4294967296.0f);
+
+  const std::array<ScalarCvtSccCase, 13> cases{{
+      {0x64u, "s_cvt_f32_i32", 1u, one_f32},
+      {0x65u, "s_cvt_f32_u32", 1u, one_f32},
+      {0x66u, "s_cvt_i32_f32", one_f32, 1u},
+      {0x66u, "s_cvt_i32_f32", qnan_f32, 0u},
+      {0x66u, "s_cvt_i32_f32", i32_overflow_f32, 0x7FFFFFFFu},
+      {0x66u, "s_cvt_i32_f32", below_i32_min_f32, 0x80000000u},
+      {0x67u, "s_cvt_u32_f32", one_f32, 1u},
+      {0x67u, "s_cvt_u32_f32", qnan_f32, 0u},
+      {0x67u, "s_cvt_u32_f32", std::bit_cast<uint32_t>(-1.0f), 0u},
+      {0x67u, "s_cvt_u32_f32", u32_overflow_f32, 0xFFFFFFFFu},
+      {0x68u, "s_cvt_f16_f32", one_f32, one_f16},
+      {0x69u, "s_cvt_f32_f16", one_f16, one_f32},
+      {0x6Au, "s_cvt_hi_f32_f16", one_f16 << 16, one_f32},
+  }};
+
+  run_scalar_cvt_preserves_scc(ROCJITSU_CODE_ARCH_RDNA3_5, "rdna3_5", cases.data(), cases.size());
+  run_scalar_cvt_preserves_scc(ROCJITSU_CODE_ARCH_RDNA4, "rdna4", cases.data(), cases.size());
+  run_scalar_cvt_preserves_scc(ROCJITSU_CODE_ARCH_GFX1250, "gfx1250", cases.data(), cases.size());
 }
 
 TEST(Rdna3Dot2ExecutionTest, Vop2Dot2accF32F16AccumulatesDst) {


### PR DESCRIPTION
Scalar conversion SOP1 instructions write their destination register but do not update SCC. The old shared implementation set SCC from the converted value, which can corrupt compare/select sequences when a scalar conversion is scheduled between the compare and the consuming s_cselect.

Drop the SCC side effect from the shared scalar conversion helpers and add a gfx1250 regression that runs every scalar conversion form with SCC initialized both ways.

This is PR 1 out of 2 needed to have rocjitsu/gfx1250 pass https://github.com/bjacob/hip-moi tests.