### PR TITLE
rocjitsu: block gfx1250 split barrier waits

### DIFF
--- a/emulation/rocjitsu/lib/python/amdisa/semantics.py
+++ b/emulation/rocjitsu/lib/python/amdisa/semantics.py
@@ -317,8 +317,12 @@ def _derive_sopp(name: str) -> InstructionSemantics | None:
     }
     if name in _SPLIT_WAIT:
         return InstructionSemantics(name, 'wait_counter', operation=name[2:].lower())
-    # S_BARRIER: workgroup synchronization. Set WfState::BARRIER.
-    if name == 'S_BARRIER':
+    # S_BARRIER_WAIT uses the existing whole-workgroup barrier model for the
+    # common split form where S_BARRIER_SIGNAL is immediately followed by
+    # S_BARRIER_WAIT. Arrival accounting and named-barrier ids are not modeled
+    # yet: signal stays a no-op, wait parks the wavefront, and CU release logic
+    # keys only on all non-halted sibling waves in the same workgroup.
+    if name in ('S_BARRIER', 'S_BARRIER_WAIT'):
         return InstructionSemantics(name, 'barrier')
 
     if name == 'S_SET_GPR_IDX_OFF':

--- a/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
+++ b/emulation/rocjitsu/lib/python/amdisa/tests/test_sema_derive.py
@@ -564,6 +564,12 @@ class TestDeriveScalarMovrel:
 
 
 class TestDeriveScalarSplitBarrier:
+    def test_barrier_wait_derives_current_workgroup_barrier_model(self):
+        sem = derive_semantics('S_BARRIER_WAIT', 'ENC_SOPP')
+        assert sem is not None
+        assert sem.semantic_class == 'barrier'
+        assert sem.sets_scc is None
+
     def test_get_barrier_state_derives_idle_state_read(self):
         sem = derive_semantics('S_GET_BARRIER_STATE', 'ENC_SOP1')
         assert sem is not None
@@ -574,6 +580,8 @@ class TestDeriveScalarSplitBarrier:
     @pytest.mark.parametrize(
         'name',
         [
+            'S_BARRIER_SIGNAL',
+            'S_BARRIER_SIGNAL_ISFIRST',
             'S_BARRIER_INIT',
             'S_BARRIER_JOIN',
             'S_WAKEUP_BARRIER',

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/execute_shared.h
@@ -736,7 +736,9 @@ inline void execute_s_barrier_signal_isfirst_sop1([[maybe_unused]] Inst &inst,
 
 template <typename Inst>
 inline void execute_s_barrier_wait_sopp([[maybe_unused]] Inst &inst,
-                                        [[maybe_unused]] Wavefront &wf) {}
+                                        [[maybe_unused]] Wavefront &wf) {
+  wf.set_state(amdgpu::WfState::BARRIER);
+}
 
 template <typename Inst>
 inline void execute_s_bcnt0_i32_b32_sop1([[maybe_unused]] Inst &inst,

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -2526,6 +2526,26 @@ TEST(Gfx1250ExecutionTest, TensorDmaAtomicBarrierArrivesAfterCopy) {
   EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(state));
 }
 
+TEST(Gfx1250ExecutionTest, SBarrierWaitBlocksWavefront) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf, nullptr);
+  ASSERT_EQ(wf->state(), amdgpu::WfState::RUNNING);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+
+  const std::array<uint32_t, 2> wait_words = {0xBF940000u, 0u};
+  std::unique_ptr<Instruction> wait_inst(decoder->decode(wait_words.data()));
+  ASSERT_NE(wait_inst, nullptr);
+  ASSERT_EQ(std::string_view(wait_inst->mnemonic()), "s_barrier_wait");
+
+  cu->execute_instruction(wait_inst.get(), *wf);
+
+  EXPECT_EQ(wf->state(), amdgpu::WfState::BARRIER);
+}
+
 TEST(Gfx1250ExecutionTest, ReleaseWaitCounterWakesWaitcntWhenTargetIsSatisfied) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();

--- a/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
+++ b/emulation/rocjitsu/tests/gfx1250_sim_test.cpp
@@ -2526,7 +2526,7 @@ TEST(Gfx1250ExecutionTest, TensorDmaAtomicBarrierArrivesAfterCopy) {
   EXPECT_TRUE(amdgpu::lds_barrier_cell_phase_parity(state));
 }
 
-TEST(Gfx1250ExecutionTest, SBarrierWaitBlocksWavefront) {
+TEST(Gfx1250ExecutionTest, SBarrierWaitEntersBarrierState) {
   Gfx1250Sim sim;
   auto *cu = sim.cu();
   auto *wf = cu->dispatch_wf(0, 0, kGfx1250ScalarSlots, 32);
@@ -2544,6 +2544,47 @@ TEST(Gfx1250ExecutionTest, SBarrierWaitBlocksWavefront) {
   cu->execute_instruction(wait_inst.get(), *wf);
 
   EXPECT_EQ(wf->state(), amdgpu::WfState::BARRIER);
+}
+
+TEST(Gfx1250ExecutionTest, SBarrierWaitReleasesOnlyAfterAllSiblingsWait) {
+  Gfx1250Sim sim;
+  auto *cu = sim.cu();
+  constexpr uint64_t kEndPgmPc = 0x150000;
+  const std::array<uint32_t, 1> endpgm_words = {S_ENDPGM_GFX12};
+  sim.memory->load_image(reinterpret_cast<const uint8_t *>(endpgm_words.data()), sizeof(uint32_t),
+                         kEndPgmPc);
+
+  auto *wf0 = cu->dispatch_wf(0, kEndPgmPc, kGfx1250ScalarSlots, 32);
+  auto *wf1 = cu->dispatch_wf(0, kEndPgmPc, kGfx1250ScalarSlots, 32);
+  ASSERT_NE(wf0, nullptr);
+  ASSERT_NE(wf1, nullptr);
+  cu->begin_workgroup(0, 0, 2);
+
+  auto decoder = Decoder::create(ROCJITSU_CODE_ARCH_GFX1250);
+  ASSERT_NE(decoder, nullptr);
+
+  const std::array<uint32_t, 2> wait_words = {0xBF940000u, 0u};
+  std::unique_ptr<Instruction> wait_inst(decoder->decode(wait_words.data()));
+  ASSERT_NE(wait_inst, nullptr);
+  ASSERT_EQ(std::string_view(wait_inst->mnemonic()), "s_barrier_wait");
+
+  cu->execute_instruction(wait_inst.get(), *wf0);
+  wf1->wait_counters().increment(amdgpu::WaitCounterType::TENSORCNT);
+  wf1->set_wait_target_tensorcnt(0);
+  wf1->set_state(amdgpu::WfState::WAITCNT);
+
+  ASSERT_TRUE(cu->step());
+  EXPECT_EQ(wf0->state(), amdgpu::WfState::BARRIER);
+  EXPECT_EQ(wf1->state(), amdgpu::WfState::WAITCNT);
+
+  wf1->release_wait_counter(amdgpu::WaitCounterType::TENSORCNT);
+  ASSERT_EQ(wf1->state(), amdgpu::WfState::RUNNING);
+  cu->execute_instruction(wait_inst.get(), *wf1);
+  ASSERT_EQ(wf1->state(), amdgpu::WfState::BARRIER);
+
+  EXPECT_FALSE(cu->step());
+  EXPECT_TRUE(wf0->is_halted());
+  EXPECT_TRUE(wf1->is_halted());
 }
 
 TEST(Gfx1250ExecutionTest, ReleaseWaitCounterWakesWaitcntWhenTargetIsSatisfied) {


### PR DESCRIPTION
Treat gfx1250 s_barrier_wait as the workgroup rendezvous point in the shared AMDGPU execution helper. Split barrier signal instructions remain non-blocking; the wait instruction now enters the existing WfState::BARRIER path so the scheduler holds the wavefront until the workgroup reaches the rendezvous.

Add a gfx1250 regression that decodes s_barrier_wait and checks that executing it moves a running wavefront into WfState::BARRIER.

This is PR 2 out of 2 needed to have rocjitsu/gfx1250 pass https://github.com/bjacob/hip-moi tests.