### PR TITLE
fix(amdgpu-windows-interop): revert wkmi update #7865 (breaks gfx110X Windows)

### DIFF
--- a/shared/amdgpu-windows-interop/wkmi/lnx/lib/libwkmi.a.dvc
+++ b/shared/amdgpu-windows-interop/wkmi/lnx/lib/libwkmi.a.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 5c48f0f50d868cd048400223df6115bc
-  size: 337200
+- md5: 3cfd159fed350b67783617548dc98b1c
+  size: 337136
   hash: md5
   path: libwkmi.a

--- a/shared/amdgpu-windows-interop/wkmi/win/lib/wkmi.lib.dvc
+++ b/shared/amdgpu-windows-interop/wkmi/win/lib/wkmi.lib.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: a36e0bef8e4f893b8eba8c967f93a12b
-  size: 444426
+- md5: 049e4861d0a50c6e33c24f2ebc25c3ba
+  size: 444338
   hash: md5
   path: wkmi.lib


### PR DESCRIPTION
## Summary
reverts PR: https://github.com/ROCm/rocm-systems/pull/7865
fixes Issue: https://github.com/ROCm/rocm-libraries/issues/8894

This reverts the `amdgpu-windows-interop` (wkmi) update from #7865
(commit `0fa2bcf6a01adde73dbba23d7b2e2ae0d4660a4a`), restoring the previous
prebuilt wkmi binaries:

| Artifact | Reverted back to (md5 / size) | Was (from #7865) |
|----------|-------------------------------|------------------|
| `shared/amdgpu-windows-interop/wkmi/win/lib/wkmi.lib` | `049e4861d0a50c6e33c24f2ebc25c3ba` / 444338 | `a36e0bef8e4f893b8eba8c967f93a12b` / 444426 |
| `shared/amdgpu-windows-interop/wkmi/lnx/lib/libwkmi.a` | `3cfd159fed350b67783617548dc98b1c` / 337136 | `5c48f0f50d868cd048400223df6115bc` / 337200 |

## Why

The wkmi bump in #7865 introduced a regression in the **gfx110X (Navi 3x)
Windows** test pipeline, tracked downstream in
ROCm/rocm-libraries#8894. wkmi is the user-mode shim to the AMD
kernel-mode driver and sits directly on the Windows device-memory
allocation path, so this opaque binary update changed allocation behavior
on gfx110X-Windows.

This was isolated with a controlled **2×2 bisection** in TheRock, where each
arm branches from the same baseline and differs by exactly one variable (the
wkmi blob and the separately-tracked ROCR-enable from #6194):

| Arm | TheRock PR | wkmi bump (#7865) | ROCR-enable (#6194) | `Test gfx110X-all / Test hipsparse` (shards 1/2/3) |
|-----|-----|-----|-----|-----|
| Baseline (`develop`) | ROCm/TheRock#6255 | present (new) | reverted | **FAIL / FAIL / FAIL** |
| − wkmi | ROCm/TheRock#6256 | reverted (old) | reverted | **PASS / PASS / PASS** |
| − wkmi, ROCR re-enabled | ROCm/TheRock#6257 | reverted (old) | re-enabled | **FAIL / FAIL / FAIL** |

The only difference between ROCm/TheRock#6255 (fails) and ROCm/TheRock#6256
(passes) is this wkmi blob, which pins the regression to #7865. All three
shards agree on every arm (not flaky), and `Test Sanity Check` passes on all
arms (so it is not a broken build).

## Impact on hipsparse

On gfx110X-Windows with the new wkmi, hipsparse tests fail with spurious
device-memory allocation failures despite ample free VRAM:
`HIPSPARSE_STATUS_ALLOC_FAILED` / `hipErrorOutOfMemory`, first surfacing in
`bsrxmv` / `csrgeam2`, followed by an SEH `0xc0000005` access-violation
cascade across the remaining cases. Reverting to the previous wkmi binary
makes all three `Test hipsparse` shards pass (arm ROCm/TheRock#6256 above).

@agunashe 

Closes ROCm/rocm-libraries#8894