### PR TITLE
ci(amdsmi) : Pin docker images and add download verification

### DIFF
--- a/projects/amdsmi/py-interface/Dockerfile
+++ b/projects/amdsmi/py-interface/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu@sha256:4f838adc7181d9039ac795a7d0aba05a9bd9ecd480d294483169c5def983b64d
 
 # do not prompt in apt
 # https://github.com/moby/moby/issues/4032#issuecomment-163689851
@@ -8,6 +8,8 @@ ARG DEBCONF_NONINTERACTIVE_SEEN=true
 # set timezone
 ENV TZ="America/Chicago"
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone
+
+RUN useradd -m rocm && USER rocm
 
 RUN apt update --yes \
         && apt install --yes \
@@ -39,10 +41,17 @@ RUN TEMPDIR=$(mktemp -d) \
         && rm -rf $TEMPDIR
 
 # install cmake
+ARG CMAKE_VERSION=3.29.2
 RUN TEMPDIR=$(mktemp -d) \
         && cd $TEMPDIR \
-        && wget https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-linux-x86_64.sh && chmod +x cmake*.sh \
-        && ./cmake*.sh --skip-license --prefix=/usr \
+        && gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys CBA23971357C2E6590D9EFD3EC8FEF3A7BFB4EDA \
+        && wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.sh \
+        && wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-SHA-256.txt \
+        && wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-SHA-256.txt.asc \
+        && gpg --verify cmake-${CMAKE_VERSION}-SHA-256.txt.asc cmake-${CMAKE_VERSION}-SHA-256.txt \
+        && grep "cmake-${CMAKE_VERSION}-linux-x86_64.sh" cmake-${CMAKE_VERSION}-SHA-256.txt | sha256sum -c \
+        && chmod +x cmake-${CMAKE_VERSION}-linux-x86_64.sh \
+        && ./cmake-${CMAKE_VERSION}-linux-x86_64.sh --skip-license --prefix=/usr \
         && rm -rf $TEMPDIR
 
 WORKDIR /src

--- a/projects/amdsmi/rust-interface/Dockerfile
+++ b/projects/amdsmi/rust-interface/Dockerfile
@@ -9,8 +9,6 @@ ARG DEBCONF_NONINTERACTIVE_SEEN=true
 ENV TZ="America/Chicago"
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone
 
-RUN useradd -m rocm && USER rocm
-
 RUN apt update --yes \
         && apt install --yes \
             build-essential \

--- a/projects/amdsmi/rust-interface/Dockerfile
+++ b/projects/amdsmi/rust-interface/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu@sha256:4f838adc7181d9039ac795a7d0aba05a9bd9ecd480d294483169c5def983b64d
 
 # do not prompt in apt
 # https://github.com/moby/moby/issues/4032#issuecomment-163689851
@@ -8,6 +8,8 @@ ARG DEBCONF_NONINTERACTIVE_SEEN=true
 # set timezone
 ENV TZ="America/Chicago"
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone
+
+RUN useradd -m rocm && USER rocm
 
 RUN apt update --yes \
         && apt install --yes \
@@ -25,14 +27,14 @@ RUN apt update --yes \
         && rm -rf /var/cache/apt/ /var/lib/apt/lists/*
 
 # install Rust toolchain
-# The .sha256 file lists a relative path (./rustup-init), so verify from the same dir.
+# Installer hash from: curl -sSf https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init.sha256
+ARG RUSTUP_INIT_SHA256=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
 WORKDIR /tmp
 RUN curl -sSf -O https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init \
-    && curl -sSf -O https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init.sha256 \
-    && sha256sum -c rustup-init.sha256 \
+    && echo "${RUSTUP_INIT_SHA256}  rustup-init" | sha256sum -c \
     && chmod +x rustup-init \
     && ./rustup-init -y --default-toolchain stable \
-    && rm rustup-init rustup-init.sha256
+    && rm rustup-init
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR /src


### PR DESCRIPTION
## Motivation
Static scan found supply chain vulnerabilities in Dockerfiles.

## Technical Details
Updated docker files by pinning image hash of ubuntu image and added checksum verification of downloaded install files.

## JIRA ID
JIRA ID : ROCM-26673