### PR TITLE
[AMD-SMI] Improve CLI help formatting and standardize CPU metavars

### DIFF
--- a/projects/amdsmi/CHANGELOG.md
+++ b/projects/amdsmi/CHANGELOG.md
@@ -90,6 +90,12 @@ Full documentation for amd_smi_lib is available at [https://rocm.docs.amd.com/pr
 - **Renamed "AINIC version" to "ionic version" in `amd-smi version` output**.  
   - The label now correctly reflects that it shows the ionic kernel driver version.
 
+- **Modernized `amd-smi` CLI help output and standardized CPU option metavars**.  
+  - Subcommand `--help` screens use a consistent layout (short options inline, options with arguments or multi-line help stacked beneath, uppercased section headings) so long CPU options no longer push help text off-screen.
+  - Standardized CPU/core metavars shown in help and error messages: `BW_TYPE`/`LINK_ID` (was `IO_BW`/`XGMI_BW`/`LINKID_NAME`), `OFFSET`/`SPACE` (was `REG_OFFSET`/`REG_SPACE`), and `MIN_WIDTH`/`MAX_WIDTH` (was `MIN_LW`/`MAX_LW`).
+  - `--help` now shows the real argument grammar for `--cpu-svi3-vr-controller-temp` (`TYPE [RAIL_INDEX]`) and `--cpu-pwr-eff-mode` (`MODE [UTIL PPT_LIMIT]`) instead of argparse's repeated-metavar default.
+  - Flag names and CLI behavior are unchanged.
+
 ### Removed
 
 - **Removed the non-functional `--decode` flag from `amd-smi ras`**. Out-of-band CPER decoding is available via `amd-smi ras --afid --cper-file <path>` or `--afid --folder <DIR>`.

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -25,6 +25,7 @@ import os
 import sys
 import time
 import collections
+import textwrap
 from amdsmi import amdsmi_interface
 from typing import Optional
 from typing import Union
@@ -55,9 +56,64 @@ class AMDSMIParserHelpFormatter(argparse.HelpFormatter):
         super().__init__(prog=prog, indent_increment=2, max_help_position=24, width=90)
         self._action_max_length = 20
 
+    def start_section(self, heading):
+        # Uppercase section headings for a consistent, scannable layout.
+        super().start_section(heading.upper() if heading else heading)
+
+
+class _AMDSMIHybridHelpFormatter:
+    """Shared help layout for amd-smi subcommand screens.
+
+    Short single-line options render inline (help aligned in a column); options
+    that take arguments or carry multi-line help stack the help beneath the
+    option. A blank line separates entries, and section headings are uppercased.
+    """
+
+    INLINE_HELP_COLUMN = 26
+    STACKED_HELP_INDENT = 4
+
+    def start_section(self, heading):
+        super().start_section(heading.upper() if heading else heading)
+
+    def _fill_text(self, text, width, indent):
+        # RawText preserves author newlines; also strip trailing whitespace that
+        # line-continuations bake into multi-line description/help source strings.
+        return "\n".join((indent + line).rstrip() for line in text.splitlines())
+
+    def _format_action(self, action):
+        help_text = self._expand_help(action) if (action.help and action.help.strip()) else ""
+        invocation = self._format_action_invocation(action)
+        indent = " " * self._current_indent
+        body = " " * (self._current_indent + self.STACKED_HELP_INDENT)
+        parts = []
+
+        if help_text and "\n" not in help_text:
+            if len(indent) + len(invocation) < self.INLINE_HELP_COLUMN:
+                wrapped = textwrap.wrap(
+                    help_text, max(self._width - self.INLINE_HELP_COLUMN, 11)
+                ) or [""]
+                pad = self.INLINE_HELP_COLUMN - len(indent) - len(invocation)
+                cont = " " * self.INLINE_HELP_COLUMN
+                parts.append(f"{indent}{invocation}{' ' * pad}{wrapped[0]}\n")
+                parts.extend(f"{cont}{line}\n" for line in wrapped[1:])
+            else:
+                wrapped = textwrap.wrap(help_text, max(self._width - len(body), 11)) or [""]
+                parts.append(f"{indent}{invocation}\n")
+                parts.extend(f"{body}{line}\n" for line in wrapped)
+        else:
+            parts.append(f"{indent}{invocation}\n")
+            for line in help_text.splitlines():
+                rendered = f"{body}{line}".rstrip()
+                parts.append(f"{rendered}\n" if rendered else "\n")
+
+        for subaction in self._iter_indented_subactions(action):
+            parts.append(self._format_action(subaction))
+        parts.append("\n")
+        return "".join(parts)
+
 
 # Custom Help Formatter for not duplicating the metavar in the subparsers
-class AMDSMISubparserHelpFormatter(argparse.RawTextHelpFormatter):
+class AMDSMISubparserHelpFormatter(_AMDSMIHybridHelpFormatter, argparse.RawTextHelpFormatter):
     def __init__(self, prog):
         super().__init__(prog, indent_increment=2, max_help_position=33, width=90)
         self._action_max_length = 20

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -59,12 +59,17 @@ class AMDSMIParserHelpFormatter(argparse.HelpFormatter):
 # Custom Help Formatter for not duplicating the metavar in the subparsers
 class AMDSMISubparserHelpFormatter(argparse.RawTextHelpFormatter):
     def __init__(self, prog):
-        super().__init__(prog, indent_increment=2, max_help_position=80, width=90)
+        super().__init__(prog, indent_increment=2, max_help_position=33, width=90)
         self._action_max_length = 20
 
     def _format_action_invocation(self, action):
         if not action.option_strings or action.nargs == 0:
             return super()._format_action_invocation(action)
+        # nargs="+" otherwise renders as "X [X ...]"; let an action opt into a
+        # literal metavar string that shows the real argument grammar.
+        display_metavar = getattr(action, "display_metavar", None)
+        if display_metavar is not None:
+            return ", ".join(action.option_strings) + " " + display_metavar
         default = self._get_default_metavar_for_optional(action)
         args_string = self._format_args(action, default)
         return ", ".join(action.option_strings) + " " + args_string
@@ -1790,53 +1795,66 @@ class AMDSMIParser(argparse.ArgumentParser):
         xgmi_help = "Table of current XGMI metrics information"
 
         # Help text for cpu options
-        cpu_power_metrics_help = "CPU power metrics"
-        cpu_proc_help = "Displays prochot status"
-        cpu_freq_help = "Displays currentFclkMemclk frequencies and cclk frequency limit"
+        cpu_power_metrics_help = "Displays CPU power metrics"
+        cpu_proc_help = "Displays PROCHOT status"
+        cpu_freq_help = "Displays current FCLK/MCLK frequencies and CCLK frequency limit"
         cpu_c0_res_help = "Displays C0 residency"
-        cpu_lclk_dpm_help = "Displays lclk dpm level range. Requires socket ID and NBOID as inputs"
-        cpu_pwr_eff_mode_help = "Displays current power efficiency mode.\
-        \n For Family 1Ah Models 50h-57h onwards and MODE= 4 or 5, displays utilization percentage and PPT limit in Watts."
-        cpu_pwr_svi_telemetry_rails_help = "Displays svi based telemetry for all rails"
-        cpu_io_bandwidth_help = "Displays current IO bandwidth for the selected CPU.\
-        \n input parameters are bandwidth type(1) and link ID encodings\
-        \n i.e. P2, P3, G0 - G7"
-        cpu_xgmi_bandwidth_help = "Displays current XGMI bandwidth for the selected CPU\
-        \n input parameters are bandwidth type(1,2,4) and link ID encodings\
-        \n i.e. P2, P3, G0 - G7"
-        cpu_metrics_ver_help = "Displays metrics table version"
-        cpu_metrics_table_help = "Displays metric table"
-        cpu_socket_energy_help = "Displays socket energy for the selected CPU socket"
-        cpu_ddr_bandwidth_help = "Displays per socket max ddr bw, current utilized bw,\
-        \n and current utilized ddr bw in percentage"
-        cpu_temp_help = "Displays cpu socket temperature"
-        cpu_dimm_temp_range_rate_help = "Displays dimm temperature range and refresh rate"
-        cpu_dimm_pow_consumption_help = "Displays dimm power consumption"
-        cpu_dimm_thermal_sensor_help = "Displays dimm thermal sensor"
-        cpu_xgmi_pstate_range_help = (
-            "Displays XGMI pstate range, min and max values for the selected CPU"
+        cpu_lclk_dpm_help = "Displays LCLK DPM level range for the given NBIO"
+        cpu_pwr_eff_mode_help = (
+            "Displays current power efficiency mode\n"
+            "For Family 1Ah Models 50h-57h+ with MODE 4 or 5, also\n"
+            "displays utilization percentage and PPT limit in Watts"
         )
+        cpu_pwr_svi_telemetry_rails_help = "Displays SVI-based telemetry for all rails"
+        cpu_io_bandwidth_help = (
+            "Displays IO bandwidth for the selected CPU\n"
+            "BW_TYPE: bandwidth type (1)\n"
+            "LINK_ID: link ID encoding (P2, P3, G0-G7)"
+        )
+        cpu_xgmi_bandwidth_help = (
+            "Displays XGMI bandwidth for the selected CPU\n"
+            "BW_TYPE: bandwidth type (1, 2, 4)\n"
+            "LINK_ID: link ID encoding (P2, P3, G0-G7)"
+        )
+        cpu_metrics_ver_help = "Displays metrics table version"
+        cpu_metrics_table_help = "Displays metrics table"
+        cpu_socket_energy_help = "Displays socket energy for the selected CPU socket"
+        cpu_ddr_bandwidth_help = (
+            "Displays per-socket DDR bandwidth: max, current utilized,\n"
+            "and current utilized percentage"
+        )
+        cpu_temp_help = "Displays CPU socket temperature"
+        cpu_dimm_temp_range_rate_help = "Displays DIMM temperature range and refresh rate"
+        cpu_dimm_pow_consumption_help = "Displays DIMM power consumption"
+        cpu_dimm_thermal_sensor_help = "Displays DIMM thermal sensor"
+        cpu_xgmi_pstate_range_help = "Displays XGMI pstate range (min, max) for the selected CPU"
         cpu_railisofreq_policy_help = "Displays CPU ISO frequency policy"
         cpu_dfcstate_ctrl_help = "Displays DFCState control status"
         cpu_pc6_enable_help = "Displays PC6 enable control"
         cpu_cc6_enable_help = "Displays CC6 enable control"
         cpu_dimm_sb_reg_help = (
-            "Read DIMM sideband register.Requires DIMM_ADDR, LID(0x2->TS0,0x6->TS1,0x9->PMIC0,0xA->SPDHub)\
-        \n REG_OFFSET (hex), REG_SPACE (REGSPACE:0->Volatile,1->NVM)"
+            "Read DIMM sideband register\n"
+            "LID: 0x2=TS0  0x6=TS1  0x9=PMIC0  0xA=SPDHub\n"
+            "OFFSET in hex; SPACE: 0=Volatile, 1=NVM"
         )
-        cpu_tdelta_help = "Displays CPU thermal delta (TDELTA) value for the selected CPU socket"
-        cpu_svi3_vr_controller_temp_help = "Get SVI3 VR controller temperature. TYPE: 0=HottestRail, 1=IndividualRail, RAIL_INDEX:\
-        \n (RAIL_INDEX:0->VDDCR_CPU0,1->VDDCR_CPU1,2->VDDCR_SOC,3->VDDIO,4->VDDIO_MEM_S3) must be, specified if TYPE is 1"
+        cpu_tdelta_help = "Displays CPU thermal delta (TDELTA) for the selected socket"
+        cpu_svi3_vr_controller_temp_help = (
+            "Displays SVI3 VR controller temperature\n"
+            "TYPE: 0=HottestRail, 1=IndividualRail\n"
+            "RAIL_INDEX (when TYPE=1):\n"
+            "  0=VDDCR_CPU0  1=VDDCR_CPU1  2=VDDCR_SOC\n"
+            "  3=VDDIO  4=VDDIO_MEM_S3"
+        )
         cpu_enabled_commands_help = (
-            "Displays HSMP enabled commands bit masks (Read/Write EnabledCommandsBitMask0-2)"
+            "Displays HSMP enabled commands bit masks (EnabledCommandsBitMask0-2)"
         )
         cpu_sdps_limit_help = "Displays CPU SDPS limit for the selected CPU socket in Watts"
 
         # Help text for core options
         core_energy_help = "Displays core energy for the selected core"
-        core_boost_limit_help = "Get boost limit for the selected cores"
-        core_curr_active_freq_core_limit_help = "Get Current CCLK limit set per Core"
-        core_ccd_power_help = "Displays ccd power consumption for the selected core"
+        core_boost_limit_help = "Displays boost limit for the selected cores"
+        core_curr_active_freq_core_limit_help = "Displays current CCLK limit per core"
+        core_ccd_power_help = "Displays CCD power consumption for the selected core"
         core_floor_limit_help = "Displays floor limit frequency for the selected core in MHz"
         core_eff_floor_limit_help = (
             "Displays effective floor limit frequency for the selected core in MHz"
@@ -2011,7 +2029,7 @@ class AMDSMIParser(argparse.ArgumentParser):
                 action="append",
                 required=False,
                 nargs=2,
-                metavar=("IO_BW", "LINKID_NAME"),
+                metavar=("BW_TYPE", "LINK_ID"),
                 help=cpu_io_bandwidth_help,
             )
             cpu_group.add_argument(
@@ -2019,7 +2037,7 @@ class AMDSMIParser(argparse.ArgumentParser):
                 action="append",
                 required=False,
                 nargs=2,
-                metavar=("XGMI_BW", "LINKID_NAME"),
+                metavar=("BW_TYPE", "LINK_ID"),
                 help=cpu_xgmi_bandwidth_help,
             )
             cpu_group.add_argument(
@@ -2109,21 +2127,22 @@ class AMDSMIParser(argparse.ArgumentParser):
                 required=False,
                 type=lambda x: int(x, 0),
                 nargs=4,
-                metavar=("DIMM_ADDR", "LID", "REG_OFFSET", "REG_SPACE"),
+                metavar=("DIMM_ADDR", "LID", "OFFSET", "SPACE"),
                 help=cpu_dimm_sb_reg_help,
             )
             cpu_group.add_argument(
                 "--cpu-tdelta", action="store_true", required=False, help=cpu_tdelta_help
             )
-            cpu_group.add_argument(
+            svi3_vr_temp_action = cpu_group.add_argument(
                 "--cpu-svi3-vr-controller-temp",
                 action=self._cpu_svi3_vr_controller_temp_options(),
                 required=False,
                 type=int,
                 nargs="+",
-                metavar=("TYPE [RAIL_INDEX]"),
+                metavar="TYPE",
                 help=cpu_svi3_vr_controller_temp_help,
             )
+            svi3_vr_temp_action.display_metavar = "TYPE [RAIL_INDEX]"
             cpu_group.add_argument(
                 "--cpu-enabled-commands",
                 action="store_true",
@@ -2426,45 +2445,51 @@ class AMDSMIParser(argparse.ArgumentParser):
             set_process_isolation_help = "Enable or disable the GPU process isolation on a per partition basis:\n    0 for disable and 1 for enable.\n"
 
         # Help text for CPU set options
-        set_cpu_pwr_limit_help = (
-            "Set power limit for the given socket. Input parameter is power limit value."
+        set_cpu_pwr_limit_help = "Sets power limit for the given socket (PWR_LIMIT value)"
+        set_cpu_xgmi_link_width_help = f"Sets min and max XGMI link width (MAX >= MIN, values {_cpu_set_range_label(CPU_XGMI_LINK_WIDTH_RANGE)})"
+        set_cpu_lclk_dpm_level_help = (
+            "Sets the min and max DPM level on a given NBIO\n"
+            f"Inputs are NBIO ID, min DPM, max DPM (MAX >= MIN, values {_cpu_set_range_label(CPU_LCLK_DPM_LEVEL_RANGE)})"
         )
-        set_cpu_xgmi_link_width_help = f"Set min and max linkwidth. Input parameters are min and max link width values (MAX >= MIN, values {_cpu_set_range_label(CPU_XGMI_LINK_WIDTH_RANGE)})"
-        set_cpu_lclk_dpm_level_help = f"Sets the min and max dpm level on a given NBIO.\
-        \n Input parameters are die_index, min dpm, max dpm (MAX >= MIN, values {_cpu_set_range_label(CPU_LCLK_DPM_LEVEL_RANGE)})."
-        set_cpu_pwr_eff_mode_help = "Sets the power efficiency mode policy. Input parameters,\
-        \n MODE(0=HighPerformance, 1=PowerEfficiency, 2=IOPerformance, 3=BalancedMemory, 4=BalancedCore, 5=BalancedCoreMemory),\n For Family 1Ah Models 50h-57h onwards, UTIL(%%)(0-100) and PPT_limit (in mW) required if MODE= 4 or 5"
-        set_cpu_gmi3_link_width_help = f"Sets min and max gmi3 link width range (MAX >= MIN, values {_cpu_set_range_label(CPU_GMI3_LINK_WIDTH_RANGE)})"
-        set_cpu_pcie_link_rate_help = "Sets pcie link rate"
-        set_cpu_df_pstate_range_help = "Sets min and max df-pstates (MAX <= MIN)"
-        set_cpu_enable_apb_help = "Enables the DF p-state performance boost algorithm"
-        set_cpu_disable_apb_help = f"Disables the DF p-state performance boost algorithm. Input parameter is DFPstate ({_cpu_set_range_label(CPU_DISABLE_APB_RANGE)})"
-        set_soc_boost_limit_help = (
-            "Sets the boost limit for the given socket. Input parameter is socket BOOST_LIMIT value"
+        set_cpu_pwr_eff_mode_help = (
+            "Sets the power efficiency mode policy\n"
+            "MODE: 0=HighPerformance, 1=PowerEfficiency, 2=IOPerformance,\n"
+            "      3=BalancedMemory, 4=BalancedCore, 5=BalancedCoreMemory\n"
+            "For Family 1Ah Models 50h-57h+, UTIL (0-100) and PPT_LIMIT\n"
+            "(in mW) are required if MODE is 4 or 5"
         )
+        set_cpu_gmi3_link_width_help = f"Sets min and max GMI3 link width (MAX >= MIN, values {_cpu_set_range_label(CPU_GMI3_LINK_WIDTH_RANGE)})"
+        set_cpu_pcie_link_rate_help = "Sets PCIe link rate"
+        set_cpu_df_pstate_range_help = "Sets min and max DF pstates (MAX <= MIN)"
+        set_cpu_enable_apb_help = "Enables the DF pstate performance boost algorithm"
+        set_cpu_disable_apb_help = f"Disables the DF pstate performance boost algorithm (DF_PSTATE {_cpu_set_range_label(CPU_DISABLE_APB_RANGE)})"
+        set_soc_boost_limit_help = "Sets the boost limit for the given socket (BOOST_LIMIT value)"
         set_cpu_xgmi_pstate_range_help = (
-            "Sets xgmi pstate range. Input parameters are min (0-1) and max (0-1), (MAX <= MIN)"
+            "Sets XGMI pstate range, min (0-1) and max (0-1) (MAX <= MIN)"
         )
-        set_cpu_railisofreq_policy_help = (
-            "Sets the CPU ISO frequency policy. Input parameter is value (0-1)"
+        set_cpu_railisofreq_policy_help = "Sets the CPU ISO frequency policy (value 0-1)"
+        set_cpu_dfcstate_ctrl_help = "Sets the DFCState control (value 0-1)"
+        set_cpu_pc6_enable_help = "Sets PC6 enable control (value 0-1)"
+        set_cpu_cc6_enable_help = "Sets CC6 enable control (value 0-1)"
+        set_cpu_floor_limit_help = (
+            "Sets the floor limit for the given CPU socket (FLOOR_LIMIT in MHz)"
         )
-        set_cpu_dfcstate_ctrl_help = "Sets the DFCState control. Input parameter is value (0-1)"
-        set_cpu_pc6_enable_help = "Sets PC6 enable control. Input parameter is value (0-1)"
-        set_cpu_cc6_enable_help = "Sets CC6 enable control. Input parameter is value (0-1)"
-        set_cpu_floor_limit_help = "Sets the floor limit for the given CPU socket. Input parameter is CPU FLOOR_LIMIT value in MHz"
-        cpu_msr_floor_limit_help = "Sets the CPU MSR floor limit frequency for the given socket. Input parameter is MSR_FLOOR_LIMIT value in MHz"
+        cpu_msr_floor_limit_help = (
+            "Sets the CPU MSR floor limit frequency for the given socket (MSR_FLOOR_LIMIT in MHz)"
+        )
         cpu_dimm_sb_reg_write_help = (
-            "Write data to DIMM sideband register. Requires DIMM_ADDR, LID(0x2->TS0,0x6->TS1,0x9->PMIC0,0xA->SPDHub)\
-        \n REG_OFFSET (hex), REG_SPACE (REGSPACE:0->Volatile,1->NVM), WRITE_DATA (hex)"
+            "Write data to DIMM sideband register\n"
+            "LID: 0x2=TS0  0x6=TS1  0x9=PMIC0  0xA=SPDHub\n"
+            "OFFSET in hex; SPACE: 0=Volatile, 1=NVM; WRITE_DATA in hex"
         )
-        set_cpu_sdps_limit_help = "Set CPU SDPS limit for the given socket. Input parameter is SDPS limit value in milliwatts (mW)."
+        set_cpu_sdps_limit_help = "Sets CPU SDPS limit for the given socket (SDPS limit in mW)"
 
         # Help text for CPU Core set options
-        set_core_boost_limit_help = (
-            "Sets the boost limit for the given core. Input parameter is core BOOST_LIMIT value"
+        set_core_boost_limit_help = "Sets the boost limit for the given core (BOOST_LIMIT value)"
+        set_core_floor_limit_help = "Sets the floor limit for the given core (FLOOR_LIMIT in MHz)"
+        set_core_msr_floor_limit_help = (
+            "Sets the MSR floor limit for the given core (MSR_FLOOR_LIMIT in MHz)"
         )
-        set_core_floor_limit_help = "Sets the floor limit for the given core. Input parameter is core FLOOR_LIMIT value in MHz"
-        set_core_msr_floor_limit_help = "Sets the MSR floor limit for the given core. Input parameter is core MSR_FLOOR_LIMIT value in MHz"
 
         # Create set_value subparser
         set_value_parser = subparsers.add_parser(
@@ -2686,15 +2711,16 @@ class AMDSMIParser(argparse.ArgumentParser):
                     metavar=("NBIOID", "MIN_DPM", "MAX_DPM"),
                     help=set_cpu_lclk_dpm_level_help,
                 )
-                cpu_group.add_argument(
+                pwr_eff_mode_action = cpu_group.add_argument(
                     "--cpu-pwr-eff-mode",
                     action=self._cpu_power_eff_mode_options(),
                     required=False,
                     type=self._not_negative_int,
                     nargs="+",
-                    metavar="MODE [UTIL PPT_LIMIT]",
+                    metavar="MODE",
                     help=set_cpu_pwr_eff_mode_help,
                 )
+                pwr_eff_mode_action.display_metavar = "MODE [UTIL PPT_LIMIT]"
                 cpu_group.add_argument(
                     "--cpu-gmi3-link-width",
                     action="append",
@@ -2702,7 +2728,7 @@ class AMDSMIParser(argparse.ArgumentParser):
                     type=self._not_negative_int,
                     nargs=2,
                     choices=CPU_GMI3_LINK_WIDTH_RANGE,
-                    metavar=("MIN_LW", "MAX_LW"),
+                    metavar=("MIN_WIDTH", "MAX_WIDTH"),
                     help=set_cpu_gmi3_link_width_help,
                 )
                 cpu_group.add_argument(
@@ -2817,7 +2843,7 @@ class AMDSMIParser(argparse.ArgumentParser):
                     required=False,
                     type=lambda x: int(x, 0),
                     nargs=5,
-                    metavar=("DIMM_ADDR", "LID", "REG_OFFSET", "REG_SPACE", "WRITE_DATA"),
+                    metavar=("DIMM_ADDR", "LID", "OFFSET", "SPACE", "WRITE_DATA"),
                     help=cpu_dimm_sb_reg_write_help,
                 )
                 cpu_group.add_argument(

--- a/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
+++ b/projects/amdsmi/amdsmi_cli/amdsmi_parser.py
@@ -61,6 +61,22 @@ class AMDSMIParserHelpFormatter(argparse.HelpFormatter):
         super().start_section(heading.upper() if heading else heading)
 
 
+def _set_display_metavar(action, metavar):
+    """Give an argparse action a literal usage/help metavar.
+
+    argparse renders ``nargs="+"`` as ``X [X ...]``; attaching ``display_metavar``
+    lets an option advertise its real grammar (e.g. ``TYPE [RAIL_INDEX]``) in both
+    the usage line and the options list. Consumed by
+    ``_AMDSMIHybridHelpFormatter._format_args``.
+    """
+    action.display_metavar = metavar
+
+
+# NOTE: The layout below overrides several non-public argparse methods
+# (_format_action, _format_args, _fill_text) and reads argparse-internal state
+# (_current_indent, _width, _expand_help, _iter_indented_subactions). These are
+# stable across CPython 3.9-3.13; re-verify against argparse if the minimum
+# supported Python version is bumped.
 class _AMDSMIHybridHelpFormatter:
     """Shared help layout for amd-smi subcommand screens.
 
@@ -71,17 +87,28 @@ class _AMDSMIHybridHelpFormatter:
 
     INLINE_HELP_COLUMN = 26
     STACKED_HELP_INDENT = 4
+    MIN_WRAP_WIDTH = 11
 
     def start_section(self, heading):
         super().start_section(heading.upper() if heading else heading)
 
+    def _format_args(self, action, default_metavar):
+        # Honor a literal display_metavar (see _set_display_metavar) so the real
+        # grammar shows in BOTH the usage line and the options list.
+        display_metavar = getattr(action, "display_metavar", None)
+        if display_metavar is not None:
+            return display_metavar
+        return super()._format_args(action, default_metavar)
+
     def _fill_text(self, text, width, indent):
-        # RawText preserves author newlines; also strip trailing whitespace that
-        # line-continuations bake into multi-line description/help source strings.
-        return "\n".join((indent + line).rstrip() for line in text.splitlines())
+        # RawText preserves author newlines; also expand tabs baked into help
+        # source strings and strip trailing whitespace from line continuations.
+        return "\n".join((indent + line).rstrip() for line in text.expandtabs(4).splitlines())
 
     def _format_action(self, action):
-        help_text = self._expand_help(action) if (action.help and action.help.strip()) else ""
+        help_text = (
+            self._expand_help(action).expandtabs(4) if (action.help and action.help.strip()) else ""
+        )
         invocation = self._format_action_invocation(action)
         indent = " " * self._current_indent
         body = " " * (self._current_indent + self.STACKED_HELP_INDENT)
@@ -90,14 +117,16 @@ class _AMDSMIHybridHelpFormatter:
         if help_text and "\n" not in help_text:
             if len(indent) + len(invocation) < self.INLINE_HELP_COLUMN:
                 wrapped = textwrap.wrap(
-                    help_text, max(self._width - self.INLINE_HELP_COLUMN, 11)
+                    help_text, max(self._width - self.INLINE_HELP_COLUMN, self.MIN_WRAP_WIDTH)
                 ) or [""]
                 pad = self.INLINE_HELP_COLUMN - len(indent) - len(invocation)
                 cont = " " * self.INLINE_HELP_COLUMN
                 parts.append(f"{indent}{invocation}{' ' * pad}{wrapped[0]}\n")
                 parts.extend(f"{cont}{line}\n" for line in wrapped[1:])
             else:
-                wrapped = textwrap.wrap(help_text, max(self._width - len(body), 11)) or [""]
+                wrapped = textwrap.wrap(
+                    help_text, max(self._width - len(body), self.MIN_WRAP_WIDTH)
+                ) or [""]
                 parts.append(f"{indent}{invocation}\n")
                 parts.extend(f"{body}{line}\n" for line in wrapped)
         else:
@@ -119,13 +148,11 @@ class AMDSMISubparserHelpFormatter(_AMDSMIHybridHelpFormatter, argparse.RawTextH
         self._action_max_length = 20
 
     def _format_action_invocation(self, action):
+        # Render "-s, --long METAVAR" once; argparse's base repeats the metavar
+        # per option string. Metavar comes from _format_args, which honors
+        # display_metavar for nargs="+" options.
         if not action.option_strings or action.nargs == 0:
             return super()._format_action_invocation(action)
-        # nargs="+" otherwise renders as "X [X ...]"; let an action opt into a
-        # literal metavar string that shows the real argument grammar.
-        display_metavar = getattr(action, "display_metavar", None)
-        if display_metavar is not None:
-            return ", ".join(action.option_strings) + " " + display_metavar
         default = self._get_default_metavar_for_optional(action)
         args_string = self._format_args(action, default)
         return ", ".join(action.option_strings) + " " + args_string
@@ -2198,7 +2225,7 @@ class AMDSMIParser(argparse.ArgumentParser):
                 metavar="TYPE",
                 help=cpu_svi3_vr_controller_temp_help,
             )
-            svi3_vr_temp_action.display_metavar = "TYPE [RAIL_INDEX]"
+            _set_display_metavar(svi3_vr_temp_action, "TYPE [RAIL_INDEX]")
             cpu_group.add_argument(
                 "--cpu-enabled-commands",
                 action="store_true",
@@ -2776,7 +2803,7 @@ class AMDSMIParser(argparse.ArgumentParser):
                     metavar="MODE",
                     help=set_cpu_pwr_eff_mode_help,
                 )
-                pwr_eff_mode_action.display_metavar = "MODE [UTIL PPT_LIMIT]"
+                _set_display_metavar(pwr_eff_mode_action, "MODE [UTIL PPT_LIMIT]")
                 cpu_group.add_argument(
                     "--cpu-gmi3-link-width",
                     action="append",

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -119,42 +119,58 @@ BDF or UUID to select a specific card.
 
 ```shell-session
 ~$ amd-smi list --help
-usage: amd-smi list [-h] [--json | --csv] [--file FILE] [--loglevel LEVEL]
-                    [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]]
+usage: amd-smi list [-h] [-e] [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]]
+                    [--json | --csv] [--file FILE] [--overwrite] [--append]
+                    [--loglevel LEVEL]
 
 Lists all detected devices on the system.
 Lists the BDF, UUID, KFD_ID, NODE_ID, and Partition ID for each GPU and/or CPUs.
 In virtualization environments, it can also list VFs associated to each
 GPU with some basic information for each VF.
 
-List Arguments:
-  -h, --help               show this help message and exit
-  -e, --enumeration        Enumeration mapping to other features.
-                               Includes CARD, RENDER, HSA_ID, HIP_ID, HIP_UUID, and OAM_ID.
+LIST ARGUMENTS:
+  -h, --help              show this help message and exit
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]  Select a GPU ID, BDF, or UUID from the possible choices:
-                           ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                             all | Selects all devices
-  -U, --cpu CPU [CPU ...]     Select a CPU ID from the possible choices:
-                              ID: 0
-                              ID: 1
-                              ID: 2
-                              ID: 3
-                                all | Selects all devices
-  -O, --core CORE [CORE ...]  Select a Core ID from the possible choices:
-                              ID: 0 - 95
-                                all  | Selects all devices
+  -e, --enumeration
+      Enumeration mapping to other features.
+          Includes CARD, RENDER, HSA_ID, HIP_ID, HIP_UUID, and OAM_ID
 
-Command Modifiers:
-  --json                       Displays output in JSON format (human readable by default).
-  --csv                        Displays output in CSV format (human readable by default).
-  --file FILE                  Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL             Set the logging level from the possible choices:
-                                DEBUG, INFO, WARNING, ERROR, CRITICAL
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
+
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+  -O, --core CORE [CORE ...]
+      Select a Core ID from the possible choices:
+      ID: 0 - 95
+        all  | Selects all devices
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 (cmd-static)=
@@ -165,57 +181,98 @@ output](#cli-ex-static) for `amd-smi static`.
 
 ```shell-session
 ~$ amd-smi static --help
-usage: amd-smi static [-h] [-g GPU [GPU ...] | -U CPU [CPU ...]] [-a] [-b] [-V] [-d] [-v]
-                      [-c] [-B] [-R] [-r] [-p] [-l] [-P] [-x] [-u] [-s] [-i]
-                      [--json | --csv] [--file FILE] [--loglevel LEVEL]
+usage: amd-smi static [-h] [-a] [-b] [-I] [-d] [-v] [-c] [-B] [-R] [-r] [-C [CLOCK ...]]
+                      [-p] [-m] [-l] [-P] [-x] [-o] [-u] [-s] [-i] [-g GPU [GPU ...] | -U
+                      CPU [CPU ...]] [--json | --csv] [--file FILE] [--overwrite]
+                      [--append] [--loglevel LEVEL]
 
 If no GPU is specified, returns static information for all GPUs on the system.
 If no static argument is provided, all static information will be displayed.
 
-Static Arguments:
-  -h, --help               show this help message and exit
-  -a, --asic               All asic information
-  -b, --bus                All bus information
-  -I, --ifwi               All video bios\IFWI information (if available)
-  -d, --driver             Displays driver version
-  -v, --vram               All vram information
-  -c, --cache              All cache information
-  -B, --board              All board information
-  -R, --process-isolation  The process isolation status
-  -r, --ras                Displays RAS features information;
-                                Sudo may be required for some features
-  -C, --clock [CLOCK ...]  Show one or more valid clock frequency levels. Available options:
-                                SYS, DF, DCEF, SOC, MEM, VCLK0, VCLK1, DCLK0, DCLK1, ALL
-  -p, --partition          Partition information
-  -l, --limit              All limit metric values (i.e. power and thermal limits)
-  -P, --soc-pstate         The available soc pstate policy
-  -x, --xgmi-plpd          The available XGMI per-link power down policy
-  -u, --numa               All numa node information
+STATIC ARGUMENTS:
+  -h, --help              show this help message and exit
 
-CPU Arguments:
-  -s, --smu                All SMU FW information
-  -i, --interface-ver      Displays hsmp interface version
+  -a, --asic              All asic information
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]  Select a GPU ID, BDF, or UUID from the possible choices:
-                           ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                             all | Selects all devices
-  -U, --cpu CPU [CPU ...]  Select a CPU ID from the possible choices:
-                           ID: 0
-                           ID: 1
-                           ID: 2
-                           ID: 3
-                             all | Selects all devices
+  -b, --bus               All bus information
 
-Command Modifiers:
-  --json                       Displays output in JSON format (human readable by default).
-  --csv                        Displays output in CSV format (human readable by default).
-  --file FILE                  Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL             Set the logging level from the possible choices:
-                                DEBUG, INFO, WARNING, ERROR, CRITICAL
+  -I, --ifwi              All video bios/IFWI information (if available)
+
+  -d, --driver            Displays driver version
+
+  -v, --vram              All vram information
+
+  -c, --cache             All cache information
+
+  -B, --board             All board information
+
+  -R, --process-isolation The process isolation status
+
+  -r, --ras
+      Displays RAS features information;
+      	Sudo may be required for some features
+
+  -C, --clock [CLOCK ...]
+      Show one or more valid clock frequency levels. Available options:
+      	SYS, DF, DCEF, SOC, MEM, VCLK0, VCLK1, DCLK0, DCLK1, ALL
+
+  -p, --partition
+      Partition information:
+      	No longer available in default output.
+      	Argument is required to display.
+      	Ex. `amd-smi static -p` or use
+      	`amd-smi partition -c -m`/`sudo amd-smi partition -a`
+
+  -m, --mem-carveout
+      Display VRAM carveout memory options and current setting.
+      	Only supported on some APUs.
+
+  -l, --limit             All limit metric values (i.e. power and thermal limits)
+
+  -P, --soc-pstate        The available soc pstate policy
+
+  -x, --xgmi-plpd         The available XGMI per-link power down policy
+
+  -o, --profile           Display current and available power profiles
+
+  -u, --numa              All numa node information
+
+CPU ARGUMENTS:
+  -s, --smu               All SMU FW information
+
+  -i, --interface-ver     Displays hsmp interface version
+
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
+
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 (cmd-firmware)=
@@ -225,38 +282,54 @@ Gets firmware information about the specified GPU.
 
 ```shell-session
 ~$ amd-smi firmware --help
-usage: amd-smi firmware [-h] [--json | --csv] [--file FILE] [--loglevel LEVEL]
-                        [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]] [-f]
+usage: amd-smi firmware [-h] [-f] [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE
+                        [CORE ...]] [--json | --csv] [--file FILE] [--overwrite]
+                        [--append] [--loglevel LEVEL]
 
 If no GPU is specified, return firmware information for all GPUs on the system.
 
-Firmware Arguments:
-  -h, --help                   show this help message and exit
-  -f, --ucode-list, --fw-list  All FW list information
+FIRMWARE ARGUMENTS:
+  -h, --help              show this help message and exit
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]      Select a GPU ID, BDF, or UUID from the possible choices:
-                               ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                               ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                               ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                               ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                                 all | Selects all devices
-  -U, --cpu CPU [CPU ...]     Select a CPU ID from the possible choices:
-                              ID: 0
-                              ID: 1
-                              ID: 2
-                              ID: 3
-                                all | Selects all devices
-  -O, --core CORE [CORE ...]  Select a Core ID from the possible choices:
-                              ID: 0 - 95
-                                all  | Selects all devices
+  -f, --ucode-list, --fw-list
+      All FW list information
 
-Command Modifiers:
-  --json                       Displays output in JSON format (human readable by default).
-  --csv                        Displays output in CSV format (human readable by default).
-  --file FILE                  Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL             Set the logging level from the possible choices:
-                                DEBUG, INFO, WARNING, ERROR, CRITICAL
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
+
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+  -O, --core CORE [CORE ...]
+      Select a Core ID from the possible choices:
+      ID: 0 - 95
+        all  | Selects all devices
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 (cmd-bad-pages)=
@@ -266,41 +339,59 @@ Gets bad page information about the specified GPU.
 
 ```shell-session
 ~$ amd-smi bad-pages --help
-usage: amd-smi bad-pages [-h] [--json | --csv] [--file FILE] [--loglevel LEVEL]
-                         [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]] [-p]
-                         [-r] [-u]
+usage: amd-smi bad-pages [-h] [-p] [-r] [-u] [-x] [-g GPU [GPU ...] | -U CPU [CPU ...] |
+                         -O CORE [CORE ...]] [--json | --csv] [--file FILE] [--overwrite]
+                         [--append] [--loglevel LEVEL]
 
 If no GPU is specified, return bad page information for all GPUs on the system.
 
-Bad Pages Arguments:
-  -h, --help               show this help message and exit
-  -p, --pending            Displays all pending retired pages
-  -r, --retired            Displays retired pages
-  -u, --un-res             Displays unreservable pages
+BAD PAGES ARGUMENTS:
+  -h, --help              show this help message and exit
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]  Select a GPU ID, BDF, or UUID from the possible choices:
-                           ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                             all | Selects all devices
-  -U, --cpu CPU [CPU ...]     Select a CPU ID from the possible choices:
-                              ID: 0
-                              ID: 1
-                              ID: 2
-                              ID: 3
-                                all | Selects all devices
-  -O, --core CORE [CORE ...]  Select a Core ID from the possible choices:
-                              ID: 0 - 95
-                                all  | Selects all devices
+  -p, --pending           Displays all pending retired pages
 
-Command Modifiers:
-  --json                      Displays output in JSON format (human readable by default).
-  --csv                       Displays output in CSV format (human readable by default).
-  --file FILE                 Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL            Set the logging level from the possible choices:
-                                DEBUG, INFO, WARNING, ERROR, CRITICAL
+  -r, --retired           Displays retired pages
+
+  -u, --un-res            Displays unreservable pages
+
+  -x, --hex               Displays page addresses and sizes in hexadecimal format
+
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
+
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+  -O, --core CORE [CORE ...]
+      Select a Core ID from the possible choices:
+      ID: 0 - 95
+        all  | Selects all devices
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 (cmd-metric)=
@@ -310,120 +401,216 @@ Gets metrics and performance information about the specified GPU.
 
 ```shell-session
 ~$ amd-smi metric --help
-usage: amd-smi metric [-h] [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]]
-                      [-w INTERVAL] [-W TIME] [-i ITERATIONS] [-m] [-u] [-p] [-c] [-t]
-                      [-P] [-e] [-k] [-f] [-C] [-o] [-l] [-x] [-E] [-X] [--cpu-power-metrics]
+usage: amd-smi metric [-h] [-m] [-u] [-p] [-c] [-t] [-P] [-e] [-k] [-V] [-b] [-G] [-f]
+                      [-C] [-o] [-l] [-x] [-E] [-v] [-X] [--cpu-power-metrics]
                       [--cpu-prochot] [--cpu-freq-metrics] [--cpu-c0-res]
                       [--cpu-lclk-dpm-level NBIOID] [--cpu-pwr-svi-telemetry-rails]
-                      [--cpu-io-bandwidth IO_BW LINKID_NAME]
-                      [--cpu-xgmi-bandwidth XGMI_BW LINKID_NAME] [--cpu-metrics-ver]
-                      [--cpu-metrics-table] [--cpu-socket-energy] [--cpu-ddr-bandwidth]
-                      [--cpu-temp] [--cpu-dimm-temp-range-rate DIMM_ADDR]
+                      [--cpu-io-bandwidth BW_TYPE LINK_ID]
+                      [--cpu-xgmi-bandwidth BW_TYPE LINK_ID] [--cpu-pwr-eff-mode]
+                      [--cpu-metrics-ver] [--cpu-metrics-table] [--cpu-socket-energy]
+                      [--cpu-ddr-bandwidth] [--cpu-temp]
+                      [--cpu-dimm-temp-range-rate DIMM_ADDR]
                       [--cpu-dimm-pow-consumption DIMM_ADDR]
-                      [--cpu-dimm-thermal-sensor DIMM_ADDR] [--core-boost-limit]
+                      [--cpu-dimm-thermal-sensor DIMM_ADDR] [--cpu-xgmi-pstate-range]
+                      [--cpu-railisofreq-policy] [--cpu-dfcstate-ctrl] [--cpu-pc6-enable]
+                      [--cpu-cc6-enable] [--cpu-dimm-sb-reg DIMM_ADDR LID OFFSET SPACE]
+                      [--cpu-tdelta] [--cpu-svi3-vr-controller-temp TYPE [TYPE ...]]
+                      [--cpu-enabled-commands] [--cpu-sdps-limit] [--core-boost-limit]
                       [--core-curr-active-freq-core-limit] [--core-energy]
-                      [--json | --csv] [--file FILE] [--loglevel LEVEL]
+                      [--core-ccd-power] [--core-floor-limit] [--core-eff-floor-limit]
+                      [-w INTERVAL] [-W TIME] [-i ITERATIONS] [-g GPU [GPU ...] | -U CPU
+                      [CPU ...] | -O CORE [CORE ...]] [--json | --csv] [--file FILE]
+                      [--overwrite] [--append] [--loglevel LEVEL]
 
 If no GPU is specified, returns metric information for all GPUs on the system.
 If no metric argument is provided, all metric information will be displayed.
 
-Metric arguments:
-  -h, --help                   show this help message and exit
-  -m, --mem-usage              Memory usage per block
-  -u, --usage                  Displays engine usage information
-  -p, --power                  Current power usage
-  -c, --clock                  Average, max, and current clock frequencies
-  -t, --temperature            Current temperatures
-  -P, --pcie                   Current PCIe speed, width, and replay count
-  -e, --ecc                    Total number of ECC errors
-  -k, --ecc-blocks             Number of ECC errors per block
-  -V, --voltage                GPU voltage
-  -f, --fan                    Current fan speed
-  -C, --voltage-curve          Display voltage curve
-  -o, --overdrive              Current GFX and MEM clock overdrive level
-  -l, --perf-level             Current DPM performance level
-  -x, --xgmi-err               XGMI error information since last read
-  -E, --energy                 Amount of energy consumed
-  -v, --violation              Displays throttle accumulators;
-                                   Only available for MI300 or newer ASICs
-  -X, --partition              Switch temperature, clock, and usage to partition-scoped
-                                   (XCP/AID/MID) data sources; combine with those flags to scope it;
-                                   Only available for MI300 or newer ASICs
+METRIC ARGUMENTS:
+  -h, --help              show this help message and exit
 
-Watch Arguments:
-  -w, --watch INTERVAL         Reprint the command in a loop of INTERVAL seconds
-  -W, --watch_time TIME        The total duration of TIME to watch the command
-  -i, --iterations ITERATIONS  The total number of ITERATIONS to repeat the command
+  -m, --mem-usage         Memory usage per block
 
-CPU Arguments:
-  --cpu-power-metrics                       CPU power metrics
-  --cpu-prochot                             Displays prochot status
-  --cpu-freq-metrics                        Displays currentFclkMemclk frequencies and cclk frequency limit
-  --cpu-c0-res                              Displays C0 residency
-  --cpu-lclk-dpm-level NBIOID               Displays lclk dpm level range. Requires socket ID and NBOID as inputs
-  --cpu-pwr-svi-telemetry-rails             Displays svi based telemetry for all rails
-  --cpu-io-bandwidth IO_BW LINKID_NAME      Displays current IO bandwidth for the selected CPU.
-                                             input parameters are bandwidth type(1) and link ID encodings
-                                             i.e. P2, P3, G0 - G7
-  --cpu-xgmi-bandwidth XGMI_BW LINKID_NAME  Displays current XGMI bandwidth for the selected CPU
-                                             input parameters are bandwidth type(1,2,4) and link ID encodings
-                                             i.e. P2, P3, G0 - G7
-  --cpu-pwr-eff-mode                        Displays current power efficiency mode.
-                                             For Family 1Ah Models 50h-57h onwards and MODE= 4 or 5, displays utilization percentage and PPT limit in Watts.
-  --cpu-metrics-ver                         Displays metrics table version
-  --cpu-metrics-table                       Displays metric table
-  --cpu-socket-energy                       Displays socket energy for the selected CPU socket
-  --cpu-ddr-bandwidth                       Displays per socket max ddr bw, current utilized bw,
-                                             and current utilized ddr bw in percentage
-  --cpu-temp                                Displays cpu socket temperature
-  --cpu-dimm-temp-range-rate DIMM_ADDR      Displays dimm temperature range and refresh rate
-  --cpu-dimm-pow-consumption DIMM_ADDR      Displays dimm power consumption
-  --cpu-dimm-thermal-sensor DIMM_ADDR       Displays dimm thermal sensor
-  --cpu-xgmi-pstate-range                   Displays XGMI pstate range (min and max values) for the selected CPU
-  --cpu-railisofreq-policy                  Displays CPU rail isolated frequency policy
-  --cpu-dfcstate-ctrl                       Displays DFCState control status
-  --cpu-pc6-enable                          Displays PC6 enable control
-  --cpu-cc6-enable                          Displays CC6 enable control
-  --cpu-dimm-sb-reg                         Read DIMM sideband register.Requires DIMM_ADDR, LID(0x2->TS0,0x6->TS1,0x9->PMIC0,0xA->SPDHub),
-                                             REG_OFFSET (hex), REG_SPACE (REGSPACE:0->Volatile,1->NVM)
-  --cpu-tdelta                              Displays CPU thermal delta (TDELTA) value for the selected CPU socket
-  --cpu-svi3-vr-controller-temp TYPE [RAIL_INDEX ...]
-                                            Get SVI3 VR controller temperature. TYPE: 0=HottestRail, 1=IndividualRail.
-                                             If TYPE=1, RAIL_INDEX: (RAIL_INDEX:0->VDDCR_CPU0,1->VDDCR_CPU1,2->VDDCR_SOC,3->VDDIO,4->VDDIO_MEM_S3) must be specified
-  --cpu-enabled-commands                    Displays HSMP enabled commands bit masks (Read/Write EnabledCommandsBitMask0-2)
-  --cpu-sdps-limit                          Displays CPU SDPS limit for the selected CPU socket (in Watts)
+  -u, --usage             Displays engine usage information
 
-CPU Core Arguments:
-  --core-boost-limit                        Get boost limit for the selected cores
-  --core-curr-active-freq-core-limit        Get Current CCLK limit set per Core
-  --core-energy                             Displays core energy for the selected core
-  --core-ccd-power                          Displays CCD (Core Complex Die) power consumption for the selected core
-  --core-floor-limit                        Get floor limit frequency for the selected core (MHz)
-  --core-eff-floor-limit                    Get effective floor limit frequency for the selected core (MHz)
+  -p, --power             Current power usage
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]      Select a GPU ID, BDF, or UUID from the possible choices:
-                               ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                               ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                               ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                               ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                                 all | Selects all devices
-  -U, --cpu CPU [CPU ...]     Select a CPU ID from the possible choices:
-                              ID: 0
-                              ID: 1
-                              ID: 2
-                              ID: 3
-                                all | Selects all devices
-  -O, --core CORE [CORE ...]  Select a Core ID from the possible choices:
-                              ID: 0 - 95
-                                all  | Selects all devices
+  -c, --clock             Average, max, and current clock frequencies
 
-Command Modifiers:
-  --json                                    Displays output in JSON format (human readable by default).
-  --csv                                     Displays output in CSV format (human readable by default).
-  --file FILE                               Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL                          Set the logging level from the possible choices:
-                                                DEBUG, INFO, WARNING, ERROR, CRITICAL
+  -t, --temperature       Current temperatures
+
+  -P, --pcie              Current PCIe speed, width, and replay count
+
+  -e, --ecc               Total number of ECC errors
+
+  -k, --ecc-blocks        Number of ECC errors per block
+
+  -V, --voltage           GPU voltage
+
+  -b, --base-board        base_board temperatures
+
+  -G, --gpu-board         gpu_board temperatures
+
+  -f, --fan               Current fan speed
+
+  -C, --voltage-curve     Display voltage curve
+
+  -o, --overdrive         Current GFX and MEM clock overdrive level
+
+  -l, --perf-level        Current DPM performance level
+
+  -x, --xgmi-err          XGMI error information since last read
+
+  -E, --energy            Amount of energy consumed
+
+  -v, --violation
+      Displays throttle accumulators;
+          Only available for MI300 or newer ASICs and APUs
+
+  -X, --partition
+      Switch temperature, clock, and usage to partition-scoped
+          (XCP/AID/MID) data sources; combine with those flags to scope it;
+          Only available for MI300 or newer ASICs
+
+CPU ARGUMENTS:
+  --cpu-power-metrics     Displays CPU power metrics
+
+  --cpu-prochot           Displays PROCHOT status
+
+  --cpu-freq-metrics      Displays current FCLK/MCLK frequencies and CCLK frequency limit
+
+  --cpu-c0-res            Displays C0 residency
+
+  --cpu-lclk-dpm-level NBIOID
+      Displays LCLK DPM level range for the given NBIO
+
+  --cpu-pwr-svi-telemetry-rails
+      Displays SVI-based telemetry for all rails
+
+  --cpu-io-bandwidth BW_TYPE LINK_ID
+      Displays IO bandwidth for the selected CPU
+      BW_TYPE: bandwidth type (1)
+      LINK_ID: link ID encoding (P2, P3, G0-G7)
+
+  --cpu-xgmi-bandwidth BW_TYPE LINK_ID
+      Displays XGMI bandwidth for the selected CPU
+      BW_TYPE: bandwidth type (1, 2, 4)
+      LINK_ID: link ID encoding (P2, P3, G0-G7)
+
+  --cpu-pwr-eff-mode
+      Displays current power efficiency mode
+      For Family 1Ah Models 50h-57h+ with MODE 4 or 5, also
+      displays utilization percentage and PPT limit in Watts
+
+  --cpu-metrics-ver       Displays metrics table version
+
+  --cpu-metrics-table     Displays metrics table
+
+  --cpu-socket-energy     Displays socket energy for the selected CPU socket
+
+  --cpu-ddr-bandwidth
+      Displays per-socket DDR bandwidth: max, current utilized,
+      and current utilized percentage
+
+  --cpu-temp              Displays CPU socket temperature
+
+  --cpu-dimm-temp-range-rate DIMM_ADDR
+      Displays DIMM temperature range and refresh rate
+
+  --cpu-dimm-pow-consumption DIMM_ADDR
+      Displays DIMM power consumption
+
+  --cpu-dimm-thermal-sensor DIMM_ADDR
+      Displays DIMM thermal sensor
+
+  --cpu-xgmi-pstate-range Displays XGMI pstate range (min, max) for the selected CPU
+
+  --cpu-railisofreq-policy
+      Displays CPU ISO frequency policy
+
+  --cpu-dfcstate-ctrl     Displays DFCState control status
+
+  --cpu-pc6-enable        Displays PC6 enable control
+
+  --cpu-cc6-enable        Displays CC6 enable control
+
+  --cpu-dimm-sb-reg DIMM_ADDR LID OFFSET SPACE
+      Read DIMM sideband register
+      LID: 0x2=TS0  0x6=TS1  0x9=PMIC0  0xA=SPDHub
+      OFFSET in hex; SPACE: 0=Volatile, 1=NVM
+
+  --cpu-tdelta            Displays CPU thermal delta (TDELTA) for the selected socket
+
+  --cpu-svi3-vr-controller-temp TYPE [RAIL_INDEX]
+      Displays SVI3 VR controller temperature
+      TYPE: 0=HottestRail, 1=IndividualRail
+      RAIL_INDEX (when TYPE=1):
+        0=VDDCR_CPU0  1=VDDCR_CPU1  2=VDDCR_SOC
+        3=VDDIO  4=VDDIO_MEM_S3
+
+  --cpu-enabled-commands  Displays HSMP enabled commands bit masks
+                          (EnabledCommandsBitMask0-2)
+
+  --cpu-sdps-limit        Displays CPU SDPS limit for the selected CPU socket in Watts
+
+CPU CORE ARGUMENTS:
+  --core-boost-limit      Displays boost limit for the selected cores
+
+  --core-curr-active-freq-core-limit
+      Displays current CCLK limit per core
+
+  --core-energy           Displays core energy for the selected core
+
+  --core-ccd-power        Displays CCD power consumption for the selected core
+
+  --core-floor-limit      Displays floor limit frequency for the selected core in MHz
+
+  --core-eff-floor-limit  Displays effective floor limit frequency for the selected core
+                          in MHz
+
+WATCH ARGUMENTS:
+  -w, --watch INTERVAL    Reprint the command in a loop of INTERVAL seconds
+
+  -W, --watch_time TIME   The total duration of TIME to watch the command
+
+  -i, --iterations ITERATIONS
+      The total number of ITERATIONS to repeat the command
+
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
+
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+  -O, --core CORE [CORE ...]
+      Select a Core ID from the possible choices:
+      ID: 0 - 95
+        all  | Selects all devices
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 (cmd-process)=
@@ -434,51 +621,75 @@ output](#cli-ex-process) for `amd-smi process`.
 
 ```shell-session
 ~$ amd-smi process --help
-usage: amd-smi process [-h] [--json | --csv] [--file FILE] [--loglevel LEVEL]
-                       [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]]
-                       [-w INTERVAL] [-W TIME] [-i ITERATIONS] [-G] [-e] [-p PID]
-                       [-n NAME]
+usage: amd-smi process [-h] [-G] [-e] [-p PID] [-n NAME] [--sort-by-pid] [-w INTERVAL]
+                       [-W TIME] [-i ITERATIONS] [-g GPU [GPU ...] | -U CPU [CPU ...] | -O
+                       CORE [CORE ...]] [--json | --csv] [--file FILE] [--overwrite]
+                       [--append] [--loglevel LEVEL]
 
 If no GPU is specified, returns information for all GPUs on the system.
 If no process argument is provided, all process information will be displayed.
 
-Process arguments:
-Process arguments:
-  -h, --help                   show this help message and exit
-  -G, --general                pid, process name, memory usage
-  -e, --engine                 All engine usages
-  -p, --pid PID                Gets all process information about the specified process based on Process ID
-  -n, --name NAME              Gets all process information about the specified process based on Process Name.
-                               If multiple processes have the same name, information is returned for all of them.
+PROCESS ARGUMENTS:
+  -h, --help              show this help message and exit
 
-Watch Arguments:
-  -w, --watch INTERVAL         Reprint the command in a loop of INTERVAL seconds
-  -W, --watch_time TIME        The total duration of TIME to watch the command
-  -i, --iterations ITERATIONS  The total number of ITERATIONS to repeat the command
+  -G, --general           pid, process name, memory usage
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]      Select a GPU ID, BDF, or UUID from the possible choices:
-                               ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                               ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                               ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                               ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                                 all | Selects all devices
-  -U, --cpu CPU [CPU ...]      Select a CPU ID from the possible choices:
-                               ID: 0
-                               ID: 1
-                               ID: 2
-                               ID: 3
-                                 all | Selects all devices
-  -O, --core CORE [CORE ...]   Select a Core ID from the possible choices:
-                               ID: 0 - 95
-                                 all  | Selects all devices
+  -e, --engine            All engine usages
 
-Command Modifiers:
-  --json                       Displays output in JSON format (human readable by default).
-  --csv                        Displays output in CSV format (human readable by default).
-  --file FILE                  Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL             Set the logging level from the possible choices:
-                                DEBUG, INFO, WARNING, ERROR, CRITICAL
+  -p, --pid PID           Gets compute process GPU information about the specified process
+                          based on Process ID
+
+  -n, --name NAME
+      Gets compute process GPU information about the specified process based on Process Name.
+      If multiple processes have the same name, information is returned for all of them.
+      Process Name may require elevated permissions.
+
+  --sort-by-pid           Group process output by PID instead of GPU.
+
+WATCH ARGUMENTS:
+  -w, --watch INTERVAL    Reprint the command in a loop of INTERVAL seconds
+
+  -W, --watch_time TIME   The total duration of TIME to watch the command
+
+  -i, --iterations ITERATIONS
+      The total number of ITERATIONS to repeat the command
+
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
+
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+  -O, --core CORE [CORE ...]
+      Select a Core ID from the possible choices:
+      ID: 0 - 95
+        all  | Selects all devices
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 (cmd-event)=
@@ -488,37 +699,51 @@ Displays event information for the given GPU.
 
 ```shell-session
 ~$ amd-smi event --help
-usage: amd-smi event [-h] [--json | --csv] [--file FILE] [--loglevel LEVEL]
-                     [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]]
+usage: amd-smi event [-h] [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]]
+                     [--json | --csv] [--file FILE] [--overwrite] [--append]
+                     [--loglevel LEVEL]
 
 If no GPU is specified, returns event information for all GPUs on the system.
 
-Event Arguments:
-  -h, --help                  show this help message and exit
+EVENT ARGUMENTS:
+  -h, --help              show this help message and exit
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]     Select a GPU ID, BDF, or UUID from the possible choices:
-                              ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                                all | Selects all devices
-  -U, --cpu CPU [CPU ...]     Select a CPU ID from the possible choices:
-                              ID: 0
-                              ID: 1
-                              ID: 2
-                              ID: 3
-                                all | Selects all devices
-  -O, --core CORE [CORE ...]  Select a Core ID from the possible choices:
-                              ID: 0 - 95
-                                all  | Selects all devices
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
 
-Command Modifiers:
-  --json                      Displays output in JSON format (human readable by default).
-  --csv                       Displays output in CSV format (human readable by default).
-  --file FILE                 Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL            Set the logging level from the possible choices:
-                                DEBUG, INFO, WARNING, ERROR, CRITICAL
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+  -O, --core CORE [CORE ...]
+      Select a Core ID from the possible choices:
+      ID: 0 - 95
+        all  | Selects all devices
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 (cmd-topology)=
@@ -528,48 +753,72 @@ Displays topology information of the specified devices.
 
 ```shell-session
 ~$ amd-smi topology --help
-usage: amd-smi topology [-h] [--json | --csv] [--file FILE] [--loglevel LEVEL]
-                        [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]] [-a]
-                        [-w] [-o] [-t] [-b]
+usage: amd-smi topology [-h] [--json | --csv] [--file FILE] [--overwrite] [--append]
+                        [--loglevel LEVEL] [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE
+                        [CORE ...]] [-a] [-w] [-o] [-t] [-b] [-c] [-n] [-d] [-z]
 
 If no GPU is specified, returns information for all GPUs on the system.
 If no topology argument is provided, all topology information will be displayed.
 
-Topology arguments:
-  -h, --help               show this help message and exit
-  -a, --access             Displays link accessibility between GPUs
-  -w, --weight             Displays relative weight between GPUs
-  -o, --hops               Displays the number of hops between GPUs
-  -t, --link-type          Displays the link type between GPUs
-  -b, --numa-bw            Display max and min bandwidth between nodes
-  -c, --coherent           Display cache coherent (or non-coherent) link capability between nodes
-  -n, --atomics            Display 32 and 64-bit atomic io link capability between nodes
-  -d, --dma                Display P2P direct memory access (DMA) link capability between nodes
-  -z, --bi-dir             Display P2P bi-directional link capability between nodes
+TOPOLOGY ARGUMENTS:
+  -h, --help              show this help message and exit
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]     Select a GPU ID, BDF, or UUID from the possible choices:
-                              ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                                all | Selects all devices
-  -U, --cpu CPU [CPU ...]     Select a CPU ID from the possible choices:
-                              ID: 0
-                              ID: 1
-                              ID: 2
-                              ID: 3
-                                all | Selects all devices
-  -O, --core CORE [CORE ...]  Select a Core ID from the possible choices:
-                              ID: 0 - 95
-                                all  | Selects all devices
+  -a, --access            Displays link accessibility between GPUs
 
-Command Modifiers:
-  --json                      Displays output in JSON format (human readable by default).
-  --csv                       Displays output in CSV format (human readable by default).
-  --file FILE                 Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL            Set the logging level from the possible choices:
-                                DEBUG, INFO, WARNING, ERROR, CRITICAL
+  -w, --weight            Displays relative weight between GPUs
+
+  -o, --hops              Displays the number of hops between GPUs
+
+  -t, --link-type         Displays the link type between GPUs
+
+  -b, --numa-bw           Display max and min bandwidth between nodes
+
+  -c, --coherent          Display cache coherent (or non-coherent) link capability between
+                          nodes
+
+  -n, --atomics           Display 32 and 64-bit atomic io link capability between nodes
+
+  -d, --dma               Display P2P direct memory access (DMA) link capability between
+                          nodes
+
+  -z, --bi-dir            Display P2P bi-directional link capability between nodes
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
+
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
+
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+  -O, --core CORE [CORE ...]
+      Select a Core ID from the possible choices:
+      ID: 0 - 95
+        all  | Selects all devices
 ```
 
 #### Interpreting hops and weight
@@ -609,111 +858,213 @@ Set options for specified devices.
 
 ```shell-session
 ~$ amd-smi set --help
-usage: amd-smi set [-h] (-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]) [-f %]
-                   [-l LEVEL] [-P SETPROFILE] [-d SCLKMAX] [-C PARTITION] [-M PARTITION]
-                   [-a MODE] [-o WATTS] [-p POLICY_ID] [-x POLICY_ID] [-R STATUS]
-                   [--cpu-pwr-limit PWR_LIMIT] [--cpu-xgmi-link-width MIN_WIDTH MAX_WIDTH]
-                   [--cpu-lclk-dpm-level NBIOID MIN_DPM MAX_DPM] [--cpu-pwr-eff-mode MODE [UTIL PPT_LIMIT]]
-                   [--cpu-gmi3-link-width MIN_LW MAX_LW] [--cpu-pcie-link-rate LINK_RATE]
-                   [--cpu-df-pstate-range MAX_PSTATE MIN_PSTATE] [--cpu-enable-apb]
+usage: amd-smi set [-h]
+                   [-f % | -l LEVEL | -P PROFILE_LEVEL | -d SCLKMAX | -C TYPE/INDEX | -M PARTITION | -a MODE | -o WATTS [[PWR_TYPE]
+                   ...] | -p POLICY_ID | -x POLICY_ID | -c CLK_TYPE [PERF_LEVELS ...] | -S
+                   STATUS | -F FRMT1,FRMT2 | -L CLK_TYPE LIM_TYPE VALUE | -R STATUS | -m
+                   INDEX | -G GB] [--cpu-pwr-limit PWR_LIMIT]
+                   [--cpu-xgmi-link-width MIN_WIDTH MAX_WIDTH]
+                   [--cpu-lclk-dpm-level NBIOID MIN_DPM MAX_DPM]
+                   [--cpu-pwr-eff-mode MODE [MODE ...]]
+                   [--cpu-gmi3-link-width MIN_WIDTH MAX_WIDTH]
+                   [--cpu-pcie-link-rate LINK_RATE]
+                   [--cpu-df-pstate-range MIN_PSTATE MAX_PSTATE] [--cpu-enable-apb]
                    [--cpu-disable-apb DF_PSTATE] [--soc-boost-limit BOOST_LIMIT]
-                   [--core-boost-limit BOOST_LIMIT] [--json | --csv] [--file FILE]
-                   [--loglevel LEVEL] [--cpu-xgmi-pstate-range MIN_PSTATE MAX_PSTATE] [--cpu-railisofreq-policy VALUE]
-                   [--cpu-dfcstate-ctrl VALUE] [--cpu-pc6-enable VALUE] [--cpu-cc6-enable VALUE]
+                   [--cpu-xgmi-pstate-range MIN_PSTATE MAX_PSTATE]
+                   [--cpu-railisofreq-policy VALUE] [--cpu-dfcstate-ctrl VALUE]
+                   [--cpu-pc6-enable VALUE] [--cpu-cc6-enable VALUE]
                    [--cpu-floor-limit FLOOR_LIMIT] [--cpu-msr-floor-limit MSR_FLOOR_LIMIT]
-                   [--core-floor-limit FLOOR_LIMIT] [--core-msr-floor-limit MSR_FLOOR_LIMIT]
-                   [--cpu-dimm-sb-reg DIMM_ADDR LID REG_OFFSET REG_SPACE WRITE_DATA] [--cpu-sdps-limit SDPS_LIMIT]
+                   [--cpu-dimm-sb-reg DIMM_ADDR LID OFFSET SPACE WRITE_DATA]
+                   [--cpu-sdps-limit SDPS_LIMIT] [--core-boost-limit BOOST_LIMIT]
+                   [--core-floor-limit FLOOR_LIMIT]
+                   [--core-msr-floor-limit MSR_FLOOR_LIMIT] [-g GPU [GPU ...] | -U CPU
+                   [CPU ...] | -O CORE [CORE ...]] [--json | --csv] [--file FILE]
+                   [--overwrite] [--append] [--loglevel LEVEL]
 
 If no GPU is specified, will select all GPUs on the system.
 A set argument must be provided; Multiple set arguments are accepted.
 Requires 'sudo' privileges.
 
-Set Arguments:
-  -h, --help                                  show this help message and exit
-  -f, --fan %                                 Set GPU fan speed :
-                                                GPU 0: 0-255 or 0-100%
-                                                GPU 1: 20-100 or 0-100%
-  -l, --perf-level LEVEL                      Set one of the following performance levels:
-                                                AUTO, LOW, HIGH, MANUAL, STABLE_STD, STABLE_PEAK, STABLE_MIN_MCLK, STABLE_MIN_SCLK, DETERMINISM
-  -P, --profile PROFILE_LEVEL                 Set power profile level (#) or choose one of available profiles:
-                                                CUSTOM_MASK, VIDEO_MASK, POWER_SAVING_MASK, COMPUTE_MASK, VR_MASK, THREE_D_FULL_SCR_MASK, BOOTUP_DEFAULT
-  -d, --perf-determinism SCLKMAX              Enable performance determinism mode and set GFXCLK softmax limit (in MHz)
+SET ARGUMENTS:
+  -h, --help              show this help message and exit
+
+  -f, --fan %             Set GPU fan speed (N/A)
+
+  -l, --perf-level LEVEL
+      Set one of the following performance levels:
+      	AUTO, LOW, HIGH, MANUAL, STABLE_STD, STABLE_PEAK, STABLE_MIN_MCLK, STABLE_MIN_SCLK, DETERMINISM
+
+  -P, --profile PROFILE_LEVEL
+      Set power profile level (#) or choose one of available profiles:
+      	CUSTOM, VIDEO, POWER_SAVING, COMPUTE, VR, 3D_FULL_SCREEN, BOOTUP_DEFAULT
+
+  -d, --perf-determinism SCLKMAX
+      Enable performance determinism mode and set GFXCLK softmax limit (in MHz)
+
   -C, --compute-partition, --accelerator-partition TYPE/INDEX
-                                              Set one of the following the accelerator TYPE or profile INDEX:
-                                                N/A.
-                                                Use `sudo amd-smi partition --accelerator` to find acceptable values.
-  -M, --memory-partition PARTITION            Set one of the following the memory partition modes:
-                                                NPS1, NPS2, NPS4, NPS8
-  -a, --compute-partition-mem-alloc-mode MODE Set compute partition memory allocation mode (requires sudo):
-                                                CAPPING - each XCP is capped to an even share of partition memory
-                                                ALL     - each XCP may use the full partition memory
-  -o, --power-cap WATTS                       Set power capacity limit:
-                                                min cap: 0 W, max cap: 550 W
-  -p, --soc-pstate POLICY_ID                  Set the GPU soc pstate policy using policy id, an integer. Valid id's include:
-                                                N/A
-  -x, --xgmi-plpd POLICY_ID                   Set the GPU XGMI per-link power down policy using policy id, an integer. Valid id's include:
-                                                N/A
-  -c, --clk-level CLK_TYPE [FREQ_LEVELS ...]  Set one or more sclk (aka gfxclk), mclk, fclk, pcie, or socclk frequency levels.
-                                                Use `amd-smi static --clock` to find acceptable levels.
-  -L, --clk-limit CLK_TYPE LIM_TYPE VALUE     Sets the sclk (aka gfxclk), mclk, or fclk minimum and maximum frequencies.
-                                                ex: amd-smi set -L (sclk | mclk | fclk) (min | max) value
-  -R, --process-isolation STATUS              Enable or disable the GPU process isolation on a per partition basis: 0 for disable and 1 for enable.
-  --ptl-status STATUS                         Enable or disable the PTL on a GPU processor: 0 for disable and 1 for enable
-  --ptl-format FRMT1,FRMT2                    Set the PTL format on a GPU processor. For example, --ptl-format I8,F32
+      Set one of the following accelerator TYPE or profile INDEX:
+      	N, /, A.
+      	Use `sudo amd-smi partition --accelerator` to find acceptable values.
 
-CPU Arguments:
-  --cpu-pwr-limit PWR_LIMIT                                      Set power limit for the given socket. Input parameter is power limit value.
-  --cpu-xgmi-link-width MIN_WIDTH MAX_WIDTH                      Set max and Min linkwidth. Input parameters are min and max link width values
-  --cpu-lclk-dpm-level NBIOID MIN_DPM MAX_DPM                    Sets the max and min dpm level on a given NBIO.
-                                                                  Input parameters are die_index, min dpm, max dpm.
-  --cpu-pwr-eff-mode MODE [UTIL PPT_LIMIT] [MODE [UTIL PPT_LIMIT] ...]
-                                                                 Sets the power efficiency mode policy. Input parameters,
-                                                                  MODE(0=HighPerformance, 1=PowerEfficiency, 2=IOPerformance, 3=BalancedMemory, 4=BalancedCore, 5=BalancedCoreMemory),
-                                                                  For Family 1Ah Models 50h-57h onwards, UTIL(%)(0-100) and PPT_limit (in mW) required if MODE= 4 or 5
-  --cpu-gmi3-link-width MIN_LW MAX_LW                            Sets max and min gmi3 link width range
-  --cpu-pcie-link-rate LINK_RATE                                 Sets pcie link rate
-  --cpu-df-pstate-range MAX_PSTATE MIN_PSTATE                    Sets max and min df-pstates
-  --cpu-enable-apb                                               Enables the DF p-state performance boost algorithm
-  --cpu-disable-apb DF_PSTATE                                    Disables the DF p-state performance boost algorithm. Input parameter is DFPstate (0-3)
-  --soc-boost-limit BOOST_LIMIT                                  Sets the boost limit for the given socket. Input parameter is socket BOOST_LIMIT value
-  --cpu-xgmi-pstate-range MIN_PSTATE MAX_PSTATE                  Sets min and max for xgmi pstate range (MAX <= MIN)
-  --cpu-railisofreq-policy VALUE                                 Sets the CPU rail isolated frequency policy. Input parameter is VALUE (0-1)
-  --cpu-dfcstate-ctrl VALUE                                      Sets the DFCState control for the given socket. Input parameter is VALUE (0-1)
-  --cpu-pc6-enable VALUE                                         Sets PC6 enable control. Input parameter is value (0-1)
-  --cpu-cc6-enable VALUE                                         Sets CC6 enable control. Input parameter is value (0-1)
-  --cpu-floor-limit FLOOR_LIMIT                                  Sets the floor limit for the given CPU socket. Input parameter is CPU FLOOR_LIMIT value MHz
-  --cpu-msr-floor-limit MSR_FLOOR_LIMIT                          Sets the CPU MSR floor limit frequency for the given socket. Input parameter is MSR_FLOOR_LIMIT value in MHz
-  --cpu-dimm-sb-reg DIMM_ADDR LID REG_OFFSET REG_SPACE WRITE_DATA
-                                                                 Write data to DIMM sideband register. Requires DIMM_ADDR, LID(0x2->TS0,0x6->TS1,0x9->PMIC0,0xA->SPDHub)
-                                                                  REG_OFFSET (hex), REG_SPACE (REGSPACE:0->Volatile,1->NVM), WRITE_DATA (hex)
-  --cpu-sdps-limit SDPS_LIMIT                                    Set CPU SDPS limit for the given socket. Input parameter is SDPS limit value in milliwatts (mW).
+  -M, --memory-partition PARTITION
+      Set one of the following the memory partition modes:
+      	NPS1, NPS2, NPS4, NPS8
 
-CPU Core Arguments:
-  --core-boost-limit BOOST_LIMIT                                 Sets the boost limit for the given core. Input parameter is core BOOST_LIMIT value
+  -a, --compute-partition-mem-alloc-mode MODE
+      Set compute partition memory allocation mode (CAPPING or ALL). Requires sudo.
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]                      Select a GPU ID, BDF, or UUID from the possible choices:
-                                               ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                                               ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                                               ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                                               ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                                                 all | Selects all devices
-  -U, --cpu CPU [CPU ...]                                        Select a CPU ID from the possible choices:
-                                                                 ID: 0
-                                                                 ID: 1
-                                                                 ID: 2
-                                                                 ID: 3
-                                                                   all | Selects all devices
-  -O, --core CORE [CORE ...]                                     Select a Core ID from the possible choices:
-                                                                 ID: 0 - 95
-                                                                   all  | Selects all devices
+  -o, --power-cap WATTS [[PWR_TYPE] ...]
+      Set either PPT0 or PPT1 power capacity limit:
+      	Ex: `amd-smi set -o 1300 ppt0`
+      	PPT0 min cap: 0 W, PPT0 max cap: 550 W
+      	PPT1 min cap: N/A, PPT1 max cap: N/A
 
-Command Modifiers:
-  --json                                                         Displays output in JSON format (human readable by default).
-  --csv                                                          Displays output in CSV format (human readable by default).
-  --file FILE                                                    Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL                                               Set the logging level from the possible choices:
-                                                                        DEBUG, INFO, WARNING, ERROR, CRITICAL
+  -p, --soc-pstate POLICY_ID
+      Set the GPU soc pstate policy using policy id, an integer. Valid id's include:
+      	N/A
+
+  -x, --xgmi-plpd POLICY_ID
+      Set the GPU XGMI per-link power down policy using policy id, an integer. Valid id's include:
+      	N/A
+
+  -c, --clk-level CLK_TYPE [PERF_LEVELS ...]
+      Set one or more sclk (aka gfxclk), mclk, fclk, pcie, or socclk frequency levels.
+      	Use `amd-smi static --clock` to find acceptable levels.
+      	Use `amd-smi static --bus` to find acceptable pcie levels.
+
+  -S, --ptl-status STATUS
+      Enable or disable the PTL on a GPU processor:
+          0 for disable and 1 for enable.
+
+  -F, --ptl-format FRMT1,FRMT2
+      Set the PTL format on a GPU processor. For example, --ptl-format I8,F32
+      	Set to one of the following PTL formats: I8, F16, BF16, F32, F64, F8, VECTOR
+
+  -L, --clk-limit CLK_TYPE LIM_TYPE VALUE
+      Sets the sclk (aka gfxclk), mclk, or fclk minimum and maximum frequencies.
+      	ex: amd-smi set -L (sclk | mclk | fclk) (min | max) value
+
+  -R, --process-isolation STATUS
+      Enable or disable the GPU process isolation on a per partition basis:
+          0 for disable and 1 for enable.
+
+  -m, --mem-carveout INDEX
+      Set VRAM carveout size by option index.
+      	Use `amd-smi static --mem-carveout` to see available options.
+      	Only supported on some APUs; a reboot is required after setting.
+
+  -G, --gtt GB
+      Set GTT (shared GPU memory) size in GB.
+      	This is a system-wide setting, not per-GPU.
+
+CPU ARGUMENTS:
+  --cpu-pwr-limit PWR_LIMIT
+      Sets power limit for the given socket (PWR_LIMIT value)
+
+  --cpu-xgmi-link-width MIN_WIDTH MAX_WIDTH
+      Sets min and max XGMI link width (MAX >= MIN, values 0-1)
+
+  --cpu-lclk-dpm-level NBIOID MIN_DPM MAX_DPM
+      Sets the min and max DPM level on a given NBIO
+      Inputs are NBIO ID, min DPM, max DPM (MAX >= MIN, values 0-3)
+
+  --cpu-pwr-eff-mode MODE [UTIL PPT_LIMIT]
+      Sets the power efficiency mode policy
+      MODE: 0=HighPerformance, 1=PowerEfficiency, 2=IOPerformance,
+            3=BalancedMemory, 4=BalancedCore, 5=BalancedCoreMemory
+      For Family 1Ah Models 50h-57h+, UTIL (0-100) and PPT_LIMIT
+      (in mW) are required if MODE is 4 or 5
+
+  --cpu-gmi3-link-width MIN_WIDTH MAX_WIDTH
+      Sets min and max GMI3 link width (MAX >= MIN, values 0-2)
+
+  --cpu-pcie-link-rate LINK_RATE
+      Sets PCIe link rate
+
+  --cpu-df-pstate-range MIN_PSTATE MAX_PSTATE
+      Sets min and max DF pstates (MAX <= MIN)
+
+  --cpu-enable-apb        Enables the DF pstate performance boost algorithm
+
+  --cpu-disable-apb DF_PSTATE
+      Disables the DF pstate performance boost algorithm (DF_PSTATE 0-3)
+
+  --soc-boost-limit BOOST_LIMIT
+      Sets the boost limit for the given socket (BOOST_LIMIT value)
+
+  --cpu-xgmi-pstate-range MIN_PSTATE MAX_PSTATE
+      Sets XGMI pstate range, min (0-1) and max (0-1) (MAX <= MIN)
+
+  --cpu-railisofreq-policy VALUE
+      Sets the CPU ISO frequency policy (value 0-1)
+
+  --cpu-dfcstate-ctrl VALUE
+      Sets the DFCState control (value 0-1)
+
+  --cpu-pc6-enable VALUE  Sets PC6 enable control (value 0-1)
+
+  --cpu-cc6-enable VALUE  Sets CC6 enable control (value 0-1)
+
+  --cpu-floor-limit FLOOR_LIMIT
+      Sets the floor limit for the given CPU socket (FLOOR_LIMIT in MHz)
+
+  --cpu-msr-floor-limit MSR_FLOOR_LIMIT
+      Sets the CPU MSR floor limit frequency for the given socket (MSR_FLOOR_LIMIT in MHz)
+
+  --cpu-dimm-sb-reg DIMM_ADDR LID OFFSET SPACE WRITE_DATA
+      Write data to DIMM sideband register
+      LID: 0x2=TS0  0x6=TS1  0x9=PMIC0  0xA=SPDHub
+      OFFSET in hex; SPACE: 0=Volatile, 1=NVM; WRITE_DATA in hex
+
+  --cpu-sdps-limit SDPS_LIMIT
+      Sets CPU SDPS limit for the given socket (SDPS limit in mW)
+
+CPU CORE ARGUMENTS:
+  --core-boost-limit BOOST_LIMIT
+      Sets the boost limit for the given core (BOOST_LIMIT value)
+
+  --core-floor-limit FLOOR_LIMIT
+      Sets the floor limit for the given core (FLOOR_LIMIT in MHz)
+
+  --core-msr-floor-limit MSR_FLOOR_LIMIT
+      Sets the MSR floor limit for the given core (MSR_FLOOR_LIMIT in MHz)
+
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
+
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+  -O, --core CORE [CORE ...]
+      Select a Core ID from the possible choices:
+      ID: 0 - 95
+        all  | Selects all devices
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 (cmd-reset)=
@@ -737,48 +1088,72 @@ more information.
 
 ```shell-session
 ~$ amd-smi reset --help
-usage: amd-smi reset [-h] [--json | --csv] [--file FILE] [--loglevel LEVEL]
-                     (-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]) [-G] [-c]
-                     [-f] [-p] [-x] [-d] [-C] [-M] [-o] [-l]
+usage: amd-smi reset [-h] [-G | -c | -f | -p | -x | -d | -o | --gtt | -l]
+                     [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]]
+                     [--json | --csv] [--file FILE] [--overwrite] [--append]
+                     [--loglevel LEVEL]
 
 If no GPU is specified, will select all GPUs on the system.
 A reset argument must be provided; Multiple reset arguments are accepted.
 Requires 'sudo' privileges.
 
-Reset Arguments:
-  -h, --help               show this help message and exit
-  -G, --gpureset           Reset the specified GPU
-  -c, --clocks             Reset clocks and overdrive to default
-  -f, --fans               Reset fans to automatic (driver) control
-  -p, --profile            Reset power profile back to default
-  -x, --xgmierr            Reset XGMI error counts
-  -d, --perf-determinism   Disable performance determinism
-  -o, --power-cap          Reset power capacity limit to max capable
-  -l, --clean-local-data   Clean up local data in LDS/GPRs on a per partition basis
+RESET ARGUMENTS:
+  -h, --help              show this help message and exit
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]     Select a GPU ID, BDF, or UUID from the possible choices:
-                              ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                                all | Selects all devices
-  -U, --cpu CPU [CPU ...]     Select a CPU ID from the possible choices:
-                              ID: 0
-                              ID: 1
-                              ID: 2
-                              ID: 3
-                                all | Selects all devices
-  -O, --core CORE [CORE ...]  Select a Core ID from the possible choices:
-                              ID: 0 - 95
-                                all  | Selects all devices
+  -G, --gpureset          Reset the specified GPU
 
-Command Modifiers:
-  --json                      Displays output in JSON format (human readable by default).
-  --csv                       Displays output in CSV format (human readable by default).
-  --file FILE                 Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL            Set the logging level from the possible choices:
-                                DEBUG, INFO, WARNING, ERROR, CRITICAL
+  -c, --clocks            Reset clocks and overdrive to default
+
+  -f, --fans              Reset fans to automatic (driver) control
+
+  -p, --profile           Reset power profile back to default
+
+  -x, --xgmierr           Reset XGMI error counts
+
+  -d, --perf-determinism  Disable performance determinism
+
+  -o, --power-cap         Reset the PPT0 and PPT1 power capacity limit to max capable
+
+  --gtt                   Reset GTT (shared GPU memory) to system default
+
+  -l, --clean-local-data  Clean up local data in LDS/GPRs on a per partition basis
+
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
+
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+  -O, --core CORE [CORE ...]
+      Select a Core ID from the possible choices:
+      ID: 0 - 95
+        all  | Selects all devices
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 (cmd-monitor)=
@@ -789,58 +1164,97 @@ for `amd-smi monitor`.
 
 ```shell-session
 ~$ amd-smi monitor --help
-usage: amd-smi monitor [-h] [--json | --csv] [--file FILE] [--loglevel LEVEL]
+usage: amd-smi monitor [-h] [-p] [-t] [-b] [-o] [-u] [-m] [-n] [-d] [-e] [-v] [-r] [-q]
+                       [-V] [--sort-by-pid] [-w INTERVAL] [-W TIME] [-i ITERATIONS]
                        [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]]
-                       [-w INTERVAL] [-W TIME] [-i ITERATIONS] [-p] [-t] [-u] [-m] [-n]
-                       [-d] [-e] [-v] [-r] [-q]
+                       [--json | --csv] [--file FILE] [--overwrite] [--append]
+                       [--loglevel LEVEL]
 
 Monitor a target device for the specified arguments.
 If no arguments are provided, all arguments will be enabled.
 Use the watch arguments to run continuously.
 
-Monitor Arguments:
-  -h, --help                   show this help message and exit
-  -p, --power-usage            Monitor power usage and power cap in Watts
-  -t, --temperature            Monitor temperature in Celsius
-  -u, --gfx                    Monitor graphics utilization (%) and clock (MHz)
-  -m, --mem                    Monitor memory utilization (%) and clock (MHz)
-  -n, --encoder                Monitor encoder utilization (%) and clock (MHz)
-  -d, --decoder                Monitor decoder utilization (%) and clock (MHz)
-  -e, --ecc                    Monitor ECC single bit, ECC double bit, and PCIe replay error counts
-  -v, --vram-usage             Monitor memory usage in MB
-  -r, --pcie                   Monitor PCIe bandwidth in Mb/s
-  -q, --process                Enable Process information table below monitor output
-  -V, --violation              Monitor power and thermal violation status (%);
-                                   Only available for MI300 or newer ASICs
+MONITOR ARGUMENTS:
+  -h, --help              show this help message and exit
 
-Watch Arguments:
-  -w, --watch INTERVAL         Reprint the command in a loop of INTERVAL seconds
-  -W, --watch_time TIME        The total duration of TIME to watch the command
-  -i, --iterations ITERATIONS  The total number of ITERATIONS to repeat the command
+  -p, --power-usage       Monitor power usage and power cap in Watts
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]      Select a GPU ID, BDF, or UUID from the possible choices:
-                               ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                               ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                               ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                               ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                                 all | Selects all devices
-  -U, --cpu CPU [CPU ...]      Select a CPU ID from the possible choices:
-                               ID: 0
-                               ID: 1
-                               ID: 2
-                               ID: 3
-                                 all | Selects all devices
-  -O, --core CORE [CORE ...]   Select a Core ID from the possible choices:
-                               ID: 0 - 95
-                                 all  | Selects all devices
+  -t, --temperature       Monitor temperature in Celsius
 
-Command Modifiers:
-  --json                       Displays output in JSON format (human readable by default).
-  --csv                        Displays output in CSV format (human readable by default).
-  --file FILE                  Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL             Set the logging level from the possible choices:
-                                DEBUG, INFO, WARNING, ERROR, CRITICAL
+  -b, --base-board-temps  Monitor base board temperatures in Celsius
+
+  -o, --gpu-board-temps   Monitor GPU board temperatures in Celsius
+
+  -u, --gfx               Monitor graphics utilization (%) and clock (MHz)
+
+  -m, --mem               Monitor memory utilization (%) and clock (MHz)
+
+  -n, --encoder           Monitor encoder utilization (%) and clock (MHz)
+
+  -d, --decoder           Monitor decoder utilization (%) and clock (MHz)
+
+  -e, --ecc               Monitor ECC single bit, ECC double bit, and PCIe replay error
+                          counts
+
+  -v, --vram-usage        Monitor memory usage in MB
+
+  -r, --pcie              Monitor PCIe bandwidth in Mb/s
+
+  -q, --process
+      Enable Process information table below monitor output;
+          Process Name may require elevated permissions
+
+  -V, --violation
+      Monitor power and thermal violation status (%);
+          Only available for MI300 or newer ASICs
+
+  --sort-by-pid           Group process output by PID instead of GPU. Only applies when
+                          --process is used.
+
+WATCH ARGUMENTS:
+  -w, --watch INTERVAL    Reprint the command in a loop of INTERVAL seconds
+
+  -W, --watch_time TIME   The total duration of TIME to watch the command
+
+  -i, --iterations ITERATIONS
+      The total number of ITERATIONS to repeat the command
+
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
+
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+  -O, --core CORE [CORE ...]
+      Select a Core ID from the possible choices:
+      ID: 0 - 95
+        all  | Selects all devices
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 (cmd-xgmi)=
@@ -850,40 +1264,58 @@ Displays XGMI information of specified devices.
 
 ```shell-session
 ~$ amd-smi xgmi --help
-usage: amd-smi xgmi [-h] [--json | --csv] [--file FILE] [--loglevel LEVEL]
-                    [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE [CORE ...]] [-m]
+usage: amd-smi xgmi [-h] [-m] [-s] [-l] [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE
+                    [CORE ...]] [--json | --csv] [--file FILE] [--overwrite] [--append]
+                    [--loglevel LEVEL]
 
 If no GPU is specified, returns information for all GPUs on the system.
 If no xgmi argument is provided, all xgmi information will be displayed.
 
-XGMI arguments:
-  -h, --help               show this help message and exit
-  -m, --metric             Metric XGMI information
-  -l, --link-status        XGMI Link Status information
+XGMI ARGUMENTS:
+  -h, --help              show this help message and exit
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]     Select a GPU ID, BDF, or UUID from the possible choices:
-                              ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                                all | Selects all devices
-  -U, --cpu CPU [CPU ...]     Select a CPU ID from the possible choices:
-                              ID: 0
-                              ID: 1
-                              ID: 2
-                              ID: 3
-                                all | Selects all devices
-  -O, --core CORE [CORE ...]  Select a Core ID from the possible choices:
-                              ID: 0 - 95
-                                all  | Selects all devices
+  -m, --metric            Metric XGMI information
 
-Command Modifiers:
-  --json                      Displays output in JSON format (human readable by default).
-  --csv                       Displays output in CSV format (human readable by default).
-  --file FILE                 Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL            Set the logging level from the possible choices:
-                                DEBUG, INFO, WARNING, ERROR, CRITICAL
+  -s, --source-status     Source GPU XGMI Link information
+
+  -l, --link-status       XGMI Link Status information
+
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
+
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+  -O, --core CORE [CORE ...]
+      Select a Core ID from the possible choices:
+      ID: 0 - 95
+        all  | Selects all devices
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 (cmd-partition)=
@@ -893,31 +1325,58 @@ Displays partition information of the devices.
 
 ```shell-session
 ~$ amd-smi partition --help
-usage: amd-smi partition [-h] [-g GPU [GPU ...]] [-c] [-m] [-a] [--json | --csv]
-                         [--file FILE] [--loglevel LEVEL]
+usage: amd-smi partition [-h] [-c] [-m] [-a] [-g GPU [GPU ...] | -U CPU [CPU ...] | -O
+                         CORE [CORE ...]] [--json | --csv] [--file FILE] [--overwrite]
+                         [--append] [--loglevel LEVEL]
 
 If no GPU is specified, returns information for all GPUs on the system.
 If no partition argument is provided, all partition information will be displayed.
 
-Partition arguments:
-  -h, --help               show this help message and exit
-  -c, --current            display the current partition information
-  -m, --memory             display the current memory partition mode and capabilities
-  -a, --accelerator        display accelerator partition information
+PARTITION ARGUMENTS:
+  -h, --help              show this help message and exit
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]  Select a GPU ID, BDF, or UUID from the possible choices:
-                           ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                             all | Selects all devices
+  -c, --current           display the current partition information
 
-Command Modifiers:
-  --json                   Displays output in JSON format (human readable by default).
-  --csv                    Displays output in CSV format (human readable by default).
-  --file FILE              Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL         Set the logging level from the possible choices:
+  -m, --memory            display the current memory partition mode and capabilities
+
+  -a, --accelerator       display accelerator partition information
+
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
+
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+  -O, --core CORE [CORE ...]
+      Select a Core ID from the possible choices:
+      ID: 0 - 95
+        all  | Selects all devices
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 ### amd-smi ras
@@ -928,53 +1387,76 @@ Displays RAS information of specified devices.
 ~$ amd-smi ras --help
 usage: amd-smi ras [-h] (--cper | --afid) [--severity SEVERITY [SEVERITY ...]]
                    [--folder FOLDER] [--file-limit FILE_LIMIT] [--follow]
-                   [--cper-file CPER_FILE] [-g GPU [GPU ...]] [--json | --csv]
-                   [--file FILE] [--overwrite] [--append] [--loglevel LEVEL]
+                   [--cper-file CPER_FILE] [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE
+                   [CORE ...]] [--json | --csv] [--file FILE] [--overwrite] [--append]
+                   [--loglevel LEVEL]
 
 Retrieve and decode RAS (CPER) entries from the kernel driver.
 Supports filtering by severity, exporting to different formats, and continuous monitoring.
 This command accepts options only; no positional arguments are required.
 
-RAS arguments:
-  -h, --help                          show this help message and exit
-  --cper                              Trigger current CPER data retrieval
-  --afid                              Generate an AFID (AMD Field ID) given a CPER record file or folder
+RAS ARGUMENTS:
+  -h, --help              show this help message and exit
 
-CPER Arguments:
-  --severity SEVERITY [SEVERITY ...]  Set the SEVERITY filters from the following:
-                                          nonfatal-uncorrected, fatal, nonfatal-corrected, all
-  --folder FOLDER                     With --cper: folder to dump current CPER report files (created if missing).
-                                          With --afid: existing folder of CPER records to decode.
-  --file-limit FILE_LIMIT             Maximum number of current CPER files in target folder
-                                          Older files beyond limit will be deleted
-  --follow                            Continuously monitor for new CPER entries
+  --cper                  Trigger current CPER data retrieval
 
-AFID Arguments:
-  --cper-file CPER_FILE               Full path of a retrieved CPER record file to generate the AFID
+  --afid                  Generate an AFID (AMD Field ID) given a CPER record file or
+                          folder
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]     Select a GPU ID, BDF, or UUID from the possible choices:
-                              ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                              ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                                all | Selects all devices
-  -U, --cpu CPU [CPU ...]     Select a CPU ID from the possible choices:
-                              ID: 0
-                              ID: 1
-                              ID: 2
-                              ID: 3
-                                all | Selects all devices
-  -O, --core CORE [CORE ...]  Select a Core ID from the possible choices:
-                              ID: 0 - 95
-                                all  | Selects all devices
+CPER ARGUMENTS:
+  --severity SEVERITY [SEVERITY ...]
+      Set the SEVERITY filters from the following:
+          nonfatal-uncorrected, fatal, nonfatal-corrected, all
 
-Command Modifiers:
-  --json                      Displays output in JSON format (human readable by default).
-  --csv                       Displays output in CSV format (human readable by default).
-  --file FILE                 Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL            Set the logging level from the possible choices:
-                                DEBUG, INFO, WARNING, ERROR, CRITICAL
+  --folder FOLDER
+      With --cper: folder to dump current CPER report files (created if missing).
+          With --afid: existing folder of CPER records to decode.
+
+  --file-limit FILE_LIMIT
+      Maximum number of current CPER files in target folder
+          Older files beyond limit will be deleted
+
+  --follow                Continuously monitor for new CPER entries
+
+AFID ARGUMENTS:
+  --cper-file CPER_FILE   Full path of a retrieved CPER record file to generate the AFID
+
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
+
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+  -O, --core CORE [CORE ...]
+      Select a Core ID from the possible choices:
+      ID: 0 - 95
+        all  | Selects all devices
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 ### amd-smi fabric
@@ -989,31 +1471,58 @@ not supported.
 
 ```shell-session
 ~$ amd-smi fabric --help
-usage: amd-smi fabric [-h] [-t] [-i] [-g GPU [GPU ...]] [--json | --csv]
-                      [--file FILE] [--loglevel LEVEL]
+usage: amd-smi fabric [-h] [-t] [-i] [-g GPU [GPU ...] | -U CPU [CPU ...] | -O CORE
+                      [CORE ...]] [--json | --csv] [--file FILE] [--overwrite] [--append]
+                      [--loglevel LEVEL]
 
 If no GPU is specified, returns information for all GPUs on the system.
 If no fabric argument is provided, all fabric information will be displayed.
 
-Fabric arguments:
-  -h, --help               show this help message and exit
-  -t, --topology           Display fabric topology data (counters per category, instance, and item)
-  -i, --info               Display fabric device configuration (BDF, bandwidth, latency, vPoD/pPoD, accelerator state)
+FABRIC ARGUMENTS:
+  -h, --help              show this help message and exit
 
-Device Arguments:
-  -g, --gpu GPU [GPU ...]  Select a GPU ID, BDF, or UUID from the possible choices:
-                           ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                           ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-                             all | Selects all devices
+  -t, --topology          Display fabric topology data (counters per category, instance,
+                          and item)
 
-Command Modifiers:
-  --json                   Displays output in JSON format (human readable by default).
-  --csv                    Displays output in CSV format (human readable by default).
-  --file FILE              Saves output into a file on the provided path (stdout by default).
-  --loglevel LEVEL         Set the logging level from the possible choices:
-                             DEBUG, INFO, WARNING, ERROR, CRITICAL
+  -i, --info              Display fabric device configuration (BDF, bandwidth, latency,
+                          vPoD/pPoD, accelerator state)
+
+DEVICE ARGUMENTS:
+  -g, --gpu GPU [GPU ...]
+      Select a GPU ID, BDF, or UUID from the possible choices:
+      ID: 0 | BDF: 0000:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 1 | BDF: 0001:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 2 | BDF: 0002:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+      ID: 3 | BDF: 0003:01:00.0 | UUID: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
+        all | Selects all devices
+
+  -U, --cpu CPU [CPU ...]
+      Select a CPU ID from the possible choices:
+      ID: 0
+      ID: 1
+      ID: 2
+      ID: 3
+        all | Selects all devices
+
+  -O, --core CORE [CORE ...]
+      Select a Core ID from the possible choices:
+      ID: 0 - 95
+        all  | Selects all devices
+
+COMMAND MODIFIERS:
+  --json                  Displays output in JSON format
+
+  --csv                   Displays output in CSV format
+
+  --file FILE             Saves output into a file on the provided path
+
+  --overwrite             Overwrite the file
+
+  --append                Append to the file
+
+  --loglevel LEVEL
+      Set the logging level from the possible choices:
+          DEBUG, INFO, WARNING, ERROR, CRITICAL
 ```
 
 ## Interpreting the output

--- a/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
+++ b/projects/amdsmi/docs/how-to/amdsmi-cli-tool.md
@@ -210,22 +210,22 @@ STATIC ARGUMENTS:
 
   -r, --ras
       Displays RAS features information;
-      	Sudo may be required for some features
+          Sudo may be required for some features
 
   -C, --clock [CLOCK ...]
       Show one or more valid clock frequency levels. Available options:
-      	SYS, DF, DCEF, SOC, MEM, VCLK0, VCLK1, DCLK0, DCLK1, ALL
+          SYS, DF, DCEF, SOC, MEM, VCLK0, VCLK1, DCLK0, DCLK1, ALL
 
   -p, --partition
       Partition information:
-      	No longer available in default output.
-      	Argument is required to display.
-      	Ex. `amd-smi static -p` or use
-      	`amd-smi partition -c -m`/`sudo amd-smi partition -a`
+          No longer available in default output.
+          Argument is required to display.
+          Ex. `amd-smi static -p` or use
+          `amd-smi partition -c -m`/`sudo amd-smi partition -a`
 
   -m, --mem-carveout
       Display VRAM carveout memory options and current setting.
-      	Only supported on some APUs.
+          Only supported on some APUs.
 
   -l, --limit             All limit metric values (i.e. power and thermal limits)
 
@@ -414,7 +414,7 @@ usage: amd-smi metric [-h] [-m] [-u] [-p] [-c] [-t] [-P] [-e] [-k] [-V] [-b] [-G
                       [--cpu-dimm-thermal-sensor DIMM_ADDR] [--cpu-xgmi-pstate-range]
                       [--cpu-railisofreq-policy] [--cpu-dfcstate-ctrl] [--cpu-pc6-enable]
                       [--cpu-cc6-enable] [--cpu-dimm-sb-reg DIMM_ADDR LID OFFSET SPACE]
-                      [--cpu-tdelta] [--cpu-svi3-vr-controller-temp TYPE [TYPE ...]]
+                      [--cpu-tdelta] [--cpu-svi3-vr-controller-temp TYPE [RAIL_INDEX]]
                       [--cpu-enabled-commands] [--cpu-sdps-limit] [--core-boost-limit]
                       [--core-curr-active-freq-core-limit] [--core-energy]
                       [--core-ccd-power] [--core-floor-limit] [--core-eff-floor-limit]
@@ -865,7 +865,7 @@ usage: amd-smi set [-h]
                    INDEX | -G GB] [--cpu-pwr-limit PWR_LIMIT]
                    [--cpu-xgmi-link-width MIN_WIDTH MAX_WIDTH]
                    [--cpu-lclk-dpm-level NBIOID MIN_DPM MAX_DPM]
-                   [--cpu-pwr-eff-mode MODE [MODE ...]]
+                   [--cpu-pwr-eff-mode MODE [UTIL PPT_LIMIT]]
                    [--cpu-gmi3-link-width MIN_WIDTH MAX_WIDTH]
                    [--cpu-pcie-link-rate LINK_RATE]
                    [--cpu-df-pstate-range MIN_PSTATE MAX_PSTATE] [--cpu-enable-apb]
@@ -892,45 +892,45 @@ SET ARGUMENTS:
 
   -l, --perf-level LEVEL
       Set one of the following performance levels:
-      	AUTO, LOW, HIGH, MANUAL, STABLE_STD, STABLE_PEAK, STABLE_MIN_MCLK, STABLE_MIN_SCLK, DETERMINISM
+          AUTO, LOW, HIGH, MANUAL, STABLE_STD, STABLE_PEAK, STABLE_MIN_MCLK, STABLE_MIN_SCLK, DETERMINISM
 
   -P, --profile PROFILE_LEVEL
       Set power profile level (#) or choose one of available profiles:
-      	CUSTOM, VIDEO, POWER_SAVING, COMPUTE, VR, 3D_FULL_SCREEN, BOOTUP_DEFAULT
+          CUSTOM, VIDEO, POWER_SAVING, COMPUTE, VR, 3D_FULL_SCREEN, BOOTUP_DEFAULT
 
   -d, --perf-determinism SCLKMAX
       Enable performance determinism mode and set GFXCLK softmax limit (in MHz)
 
   -C, --compute-partition, --accelerator-partition TYPE/INDEX
       Set one of the following accelerator TYPE or profile INDEX:
-      	N, /, A.
-      	Use `sudo amd-smi partition --accelerator` to find acceptable values.
+          N, /, A.
+          Use `sudo amd-smi partition --accelerator` to find acceptable values.
 
   -M, --memory-partition PARTITION
       Set one of the following the memory partition modes:
-      	NPS1, NPS2, NPS4, NPS8
+          NPS1, NPS2, NPS4, NPS8
 
   -a, --compute-partition-mem-alloc-mode MODE
       Set compute partition memory allocation mode (CAPPING or ALL). Requires sudo.
 
   -o, --power-cap WATTS [[PWR_TYPE] ...]
       Set either PPT0 or PPT1 power capacity limit:
-      	Ex: `amd-smi set -o 1300 ppt0`
-      	PPT0 min cap: 0 W, PPT0 max cap: 550 W
-      	PPT1 min cap: N/A, PPT1 max cap: N/A
+          Ex: `amd-smi set -o 1300 ppt0`
+          PPT0 min cap: 0 W, PPT0 max cap: 550 W
+          PPT1 min cap: N/A, PPT1 max cap: N/A
 
   -p, --soc-pstate POLICY_ID
       Set the GPU soc pstate policy using policy id, an integer. Valid id's include:
-      	N/A
+          N/A
 
   -x, --xgmi-plpd POLICY_ID
       Set the GPU XGMI per-link power down policy using policy id, an integer. Valid id's include:
-      	N/A
+          N/A
 
   -c, --clk-level CLK_TYPE [PERF_LEVELS ...]
       Set one or more sclk (aka gfxclk), mclk, fclk, pcie, or socclk frequency levels.
-      	Use `amd-smi static --clock` to find acceptable levels.
-      	Use `amd-smi static --bus` to find acceptable pcie levels.
+          Use `amd-smi static --clock` to find acceptable levels.
+          Use `amd-smi static --bus` to find acceptable pcie levels.
 
   -S, --ptl-status STATUS
       Enable or disable the PTL on a GPU processor:
@@ -938,11 +938,11 @@ SET ARGUMENTS:
 
   -F, --ptl-format FRMT1,FRMT2
       Set the PTL format on a GPU processor. For example, --ptl-format I8,F32
-      	Set to one of the following PTL formats: I8, F16, BF16, F32, F64, F8, VECTOR
+          Set to one of the following PTL formats: I8, F16, BF16, F32, F64, F8, VECTOR
 
   -L, --clk-limit CLK_TYPE LIM_TYPE VALUE
       Sets the sclk (aka gfxclk), mclk, or fclk minimum and maximum frequencies.
-      	ex: amd-smi set -L (sclk | mclk | fclk) (min | max) value
+          ex: amd-smi set -L (sclk | mclk | fclk) (min | max) value
 
   -R, --process-isolation STATUS
       Enable or disable the GPU process isolation on a per partition basis:
@@ -950,12 +950,12 @@ SET ARGUMENTS:
 
   -m, --mem-carveout INDEX
       Set VRAM carveout size by option index.
-      	Use `amd-smi static --mem-carveout` to see available options.
-      	Only supported on some APUs; a reboot is required after setting.
+          Use `amd-smi static --mem-carveout` to see available options.
+          Only supported on some APUs; a reboot is required after setting.
 
   -G, --gtt GB
       Set GTT (shared GPU memory) size in GB.
-      	This is a system-wide setting, not per-GPU.
+          This is a system-wide setting, not per-GPU.
 
 CPU ARGUMENTS:
   --cpu-pwr-limit PWR_LIMIT

--- a/projects/amdsmi/tests/python_unittest/cli_unit_test.py
+++ b/projects/amdsmi/tests/python_unittest/cli_unit_test.py
@@ -196,8 +196,16 @@ class TestAmdSmiCli(unittest.TestCase):
         options = []
         for index, line in enumerate(lines):
             if found:
-                if not line:
+                # The hybrid help formatter separates entries with blank lines,
+                # stacks help beneath long options, and uppercases headings.
+                # Skip blank lines and stacked help/continuation lines; stop at
+                # the next section header (the first non-indented line).
+                if not line.strip():
+                    continue
+                if not line[:1].isspace():
                     break
+                if line.strip()[0] != "-":
+                    continue
                 items = line.split()
                 for item_index, item in enumerate(items):
                     items[item_index] = item.strip()
@@ -250,7 +258,7 @@ class TestAmdSmiCli(unittest.TestCase):
                             pass
                         else:
                             print(f"ERROR: bad sub arg {items[item_index]}")
-                    elif len(items) > item_index:
+                    elif len(items) > item_index + 1:
                         if items[item_index + 1][0:1] == self.openBracket:
                             items[item_index + 1] = items[item_index + 1][1:]
                         sub_arg = items[item_index + 1]
@@ -335,7 +343,7 @@ class TestAmdSmiCli(unittest.TestCase):
                             pass
                         else:
                             options.append(items[item_index])
-            if match_str in line:
+            if match_str.lower() in line.lower():
                 found = True
         if not options:
             return ["pass"]
@@ -746,6 +754,50 @@ class TestAmdSmiCli(unittest.TestCase):
             msg = f"\n{self.tab}".join(errors)
             self.fail(f"Fail:\n{self.tab}{msg}")
         return
+
+    def test_help_formatter(self):
+        """Guard the hybrid help formatter output contract.
+
+        Verifies the hybrid formatter contract: uppercased section headings, a
+        blank line between entries, no literal tab characters, and that
+        nargs="+" options advertise their real grammar (display_metavar) in the
+        usage line instead of argparse's "X [X ...]".
+        """
+        self.common.print_func_name("")
+
+        (rc, std_out, std_err) = self.util.RunCmdSync("amd-smi static --help")
+        self.assertEqual(rc, 0, f"'amd-smi static --help' failed: {std_err}")
+
+        # Section headings are uppercased
+        self.assertIn("STATIC ARGUMENTS:", std_out)
+        self.assertIn("DEVICE ARGUMENTS:", std_out)
+
+        # Tabs in source help strings are expanded, never rendered literally
+        self.assertNotIn("\t", std_out, "help output contains literal tab characters")
+
+        # The hybrid layout separates entries with a blank line
+        lines = std_out.split("\n")
+        self.assertTrue(
+            any(
+                lines[i].startswith("  -") and not lines[i + 1].strip()
+                for i in range(len(lines) - 1)
+            ),
+            "expected a blank line after an option entry (hybrid layout)",
+        )
+
+        # nargs="+" options show their real grammar, not "X [X ...]", in usage.
+        # CPU options only appear when HSMP is initialized, so guard on presence.
+        (rc, metric_out, std_err) = self.util.RunCmdSync("amd-smi metric --help")
+        self.assertEqual(rc, 0, f"'amd-smi metric --help' failed: {std_err}")
+        if "--cpu-svi3-vr-controller-temp" in metric_out:
+            self.assertIn("TYPE [RAIL_INDEX]", metric_out)
+            self.assertNotIn("TYPE [TYPE ...]", metric_out)
+
+        (rc, set_out, std_err) = self.util.RunCmdSync("amd-smi set --help")
+        self.assertEqual(rc, 0, f"'amd-smi set --help' failed: {std_err}")
+        if "--cpu-pwr-eff-mode" in set_out:
+            self.assertIn("MODE [UTIL PPT_LIMIT]", set_out)
+            self.assertNotIn("MODE [MODE ...]", set_out)
 
     def test_help(self):
         self.common.print_func_name("")


### PR DESCRIPTION
## Motivation

The `amd-smi` CLI help screens are hard to read, especially for CPU
subcommands. A single long CPU option (e.g. `--cpu-svi3-vr-controller-temp`)
pushed the help column to ~70 characters for every option in that subcommand,
leaving a large gap and overflowing 90 columns so terminals wrapped help
mid-word. CPU/core metavars were also inconsistent (`IO_BW`/`LINKID_NAME`,
`MIN_LW`/`MAX_LW`, `REG_OFFSET`/`REG_SPACE`) and several help strings carried
typos and trailing-whitespace line continuations.

This PR reworks the CLI help **presentation** only. No flags are renamed, no
arguments change, and parsing/behavior is identical.

## Technical Details

**CLI parser** (`amdsmi_cli/amdsmi_parser.py`):
- Standardized CPU/core metavars across `metric` and `set`
  (`BW_TYPE`/`LINK_ID`, `OFFSET`/`SPACE`, `MIN_WIDTH`/`MAX_WIDTH`) and tightened
  CPU help strings (imperative verbs, capitalized acronyms, no trailing-ws
  continuations).
- Added a `display_metavar` hook so `nargs="+"` options show their real grammar
  (`TYPE [RAIL_INDEX]`, `MODE [UTIL PPT_LIMIT]`) instead of `X [X ...]`.
- Replaced the subcommand help formatter with a hybrid layout: short
  single-line options render inline; options that take arguments or carry
  multi-line help stack the help beneath them, separated by a blank line, with
  uppercased section headings. Device choice lists (`--gpu` BDF/UUID, `--nic`,
  `--cpu`/`--core`) keep their explicit line breaks.
- Stripped trailing whitespace baked into multi-line help/description source
  strings so rendered lines no longer overflow the target width.

**Docs** (`docs/how-to/amdsmi-cli-tool.md`):
- Regenerated every `--help` code block to match the new layout (version banner
  stripped, UUIDs anonymized, BDFs kept).

## JIRA ID

N/A

## Test Plan

- Verified rendering of every subcommand `--help` on MI300A (ppac) with a
  parser overlay on the installed `7.14.0` CLI: top-level index, `static`
  (GPU), `metric` and `set` (CPU/core), plus an overflow scan across all 17
  subcommands.
- Rendered the `fabric` + NIC/`--nic` device screens from the real argument
  specs to confirm BDF/UUID choice lists stay intact.
- Read-only functional sanity on hardware
  (`metric --cpu 0 --cpu-svi3-vr-controller-temp 0/1`, `--cpu-io-bandwidth`,
  `--cpu-tdelta`) to confirm parsing/validation is unchanged.
- `python3 -m py_compile` + pre-commit (black/ruff) on the parser.

## Test Result

- Help is now left-aligned with help text starting near column 26; content
  lines no longer exceed 90 columns. Overflow on the worst subcommands dropped
  from ~79 (`metric`) and ~78 (`set`) lines >90 to 0 content lines >90; the only
  remaining long lines are the inherent version banner and argparse's own
  `usage:` block.
- All subcommand `--help` invocations exit 0; functional commands return data
  unchanged.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
