### PR TITLE
fix(rocjitsu): tolerate early mmap during interposer load

### DIFF
--- a/.github/workflows/rocjitsu-corpus-tests.yml
+++ b/.github/workflows/rocjitsu-corpus-tests.yml
@@ -147,6 +147,7 @@ jobs:
             "LoggingTest\.dispatch_logged"
             "ProfiledPluginTest\.hook_profile_output"
             "CvtNarrow\.AllTests"
+            "InterposerTest\..*"
             "RaceTest\..*"
           )
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -142,6 +142,7 @@ std::optional<std::string> child_config_path() {
 }
 
 void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+  // syscall(2) is the libc wrapper: on kernel errors it returns -1 and sets errno.
   long rc = syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
   if (rc == -1)
     return MAP_FAILED;
@@ -149,7 +150,9 @@ void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, o
 }
 
 int raw_munmap_syscall(void *addr, size_t length) {
-  return static_cast<int>(syscall(SYS_munmap, addr, length));
+  long rc = syscall(SYS_munmap, addr, length);
+  assert(rc == 0 || rc == -1);
+  return static_cast<int>(rc);
 }
 
 void rj_sigsegv_handler(int, siginfo_t *, void *) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -148,6 +148,10 @@ void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, o
   return reinterpret_cast<void *>(static_cast<uintptr_t>(rc));
 }
 
+int raw_munmap_syscall(void *addr, size_t length) {
+  return static_cast<int>(syscall(SYS_munmap, addr, length));
+}
+
 void rj_sigsegv_handler(int, siginfo_t *, void *) {
   signal(SIGSEGV, SIG_DFL);
   raise(SIGSEGV);
@@ -1247,6 +1251,9 @@ RJ_INTERPOSER_EXPORT int madvise(void *addr, size_t length, int advice) {
 }
 
 RJ_INTERPOSER_EXPORT int munmap(void *addr, size_t length) {
+  if (!InterposerContext::real().ready() || !InterposerContext::real().munmap)
+    return raw_munmap_syscall(addr, length);
+
   assert(InterposerContext::real().ready());
   if (auto *remote = InterposerContext::ctx.remote_lookup(InterposerContext::ctx.remote_kfd_fd())) {
     int ret = remote->munmap(addr, length);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -141,6 +141,13 @@ std::optional<std::string> child_config_path() {
   return std::string(cfg_buf);
 }
 
+void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
+  long rc = syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
+  if (rc == -1)
+    return MAP_FAILED;
+  return reinterpret_cast<void *>(static_cast<uintptr_t>(rc));
+}
+
 void rj_sigsegv_handler(int, siginfo_t *, void *) {
   signal(SIGSEGV, SIG_DFL);
   raise(SIGSEGV);
@@ -1176,6 +1183,9 @@ RJ_INTERPOSER_EXPORT int fcntl64(int fd, int cmd, ...) {
 
 RJ_INTERPOSER_EXPORT void *mmap(void *addr, size_t length, int prot, int flags, int fd,
                                 off_t offset) {
+  if (!InterposerContext::real().ready() || !InterposerContext::real().mmap)
+    return raw_mmap_syscall(addr, length, prot, flags, fd, offset);
+
   assert(InterposerContext::real().ready());
   if (auto *remote = InterposerContext::ctx.remote_lookup(fd))
     return remote->mmap(addr, length, prot, flags, offset);

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/kmd/linux/interposer.cpp
@@ -142,7 +142,9 @@ std::optional<std::string> child_config_path() {
 }
 
 void *raw_mmap_syscall(void *addr, size_t length, int prot, int flags, int fd, off_t offset) {
-  // syscall(2) is the libc wrapper: on kernel errors it returns -1 and sets errno.
+  // syscall(2) is the libc wrapper, not a raw inline syscall instruction: on
+  // kernel errors it returns -1 and sets errno. For mmap(2), success returns
+  // the mapped address; for munmap(2), success returns exactly 0.
   long rc = syscall(SYS_mmap, addr, length, prot, flags, fd, offset);
   if (rc == -1)
     return MAP_FAILED;

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -687,7 +687,7 @@ set_tests_properties(
     "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
     PROPERTIES
         ENVIRONMENT
-            "LD_PRELOAD=$<TARGET_FILE:early_mmap_preload>:$<TARGET_FILE:rocjitsu_shared>"
+            "LD_PRELOAD=$<TARGET_FILE:rocjitsu_shared>:$<TARGET_FILE:early_mmap_preload>"
 )
 
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -670,6 +670,23 @@ target_link_libraries(
 rj_configure_target(hsa_hooks_unit_test TEST)
 gtest_discover_tests(hsa_hooks_unit_test)
 
+# --- Interposer loader initialization regression tests ---
+
+add_library(early_mmap_preload SHARED early_mmap_preload_test.cpp)
+rj_configure_target(early_mmap_preload TEST)
+add_dependencies(early_mmap_preload rocjitsu_kmd_shim)
+
+add_test(
+    NAME "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
+    COMMAND /bin/true
+)
+set_tests_properties(
+    "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
+    PROPERTIES
+        ENVIRONMENT
+            "LD_PRELOAD=$<TARGET_FILE:early_mmap_preload>:$<TARGET_FILE:rocjitsu_kmd_shim>"
+)
+
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---
 # Spawns rocminfo via the rocjitsu CLI and validates output.
 

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -679,15 +679,27 @@ add_dependencies(early_mmap_preload rocjitsu_shared)
 add_executable(early_mmap_driver early_mmap_driver_test.cpp)
 rj_configure_target(early_mmap_driver TEST)
 
-add_test(
+if(RJ_INSTALL_TESTS)
+    rj_install_test_target(early_mmap_driver)
+    install(
+        TARGETS early_mmap_preload
+        LIBRARY DESTINATION ${RJ_INSTALL_TEST_BIN_DIR}
+    )
+endif()
+
+# Keep rocjitsu first in LD_PRELOAD. The loader maps it before
+# early_mmap_preload, but runs early_mmap_preload's constructor before
+# init_interposer(). That constructor calls mmap/munmap early enough to exercise
+# the pre-init fallback; verifying the exact path directly would require adding
+# observable test state to the interposer.
+rj_add_test(
     NAME "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
     COMMAND $<TARGET_FILE:early_mmap_driver>
-)
-set_tests_properties(
-    "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
-    PROPERTIES
-        ENVIRONMENT
-            "LD_PRELOAD=$<TARGET_FILE:rocjitsu_shared>:$<TARGET_FILE:early_mmap_preload>"
+    ENVIRONMENT
+        "LD_PRELOAD=$<TARGET_FILE:rocjitsu_shared>:$<TARGET_FILE:early_mmap_preload>"
+    INSTALL_COMMAND "bin/early_mmap_driver"
+    INSTALL_ENVIRONMENT
+        "LD_PRELOAD=\${RJ_INSTALLED_LIBDIR}/${CMAKE_SHARED_LIBRARY_PREFIX}rocjitsu${CMAKE_SHARED_LIBRARY_SUFFIX}:bin/${CMAKE_SHARED_LIBRARY_PREFIX}early_mmap_preload${CMAKE_SHARED_LIBRARY_SUFFIX}"
 )
 
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---

--- a/emulation/rocjitsu/tests/CMakeLists.txt
+++ b/emulation/rocjitsu/tests/CMakeLists.txt
@@ -674,17 +674,20 @@ gtest_discover_tests(hsa_hooks_unit_test)
 
 add_library(early_mmap_preload SHARED early_mmap_preload_test.cpp)
 rj_configure_target(early_mmap_preload TEST)
-add_dependencies(early_mmap_preload rocjitsu_kmd_shim)
+add_dependencies(early_mmap_preload rocjitsu_shared)
+
+add_executable(early_mmap_driver early_mmap_driver_test.cpp)
+rj_configure_target(early_mmap_driver TEST)
 
 add_test(
     NAME "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
-    COMMAND /bin/true
+    COMMAND $<TARGET_FILE:early_mmap_driver>
 )
 set_tests_properties(
     "InterposerTest.EarlyMmapBeforeRocjitsuConstructor"
     PROPERTIES
         ENVIRONMENT
-            "LD_PRELOAD=$<TARGET_FILE:early_mmap_preload>:$<TARGET_FILE:rocjitsu_kmd_shim>"
+            "LD_PRELOAD=$<TARGET_FILE:early_mmap_preload>:$<TARGET_FILE:rocjitsu_shared>"
 )
 
 # --- rocminfo test (requires rocminfo binary + HSA runtime + CLI launcher) ---

--- a/emulation/rocjitsu/tests/early_mmap_driver_test.cpp
+++ b/emulation/rocjitsu/tests/early_mmap_driver_test.cpp
@@ -1,0 +1,7 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file early_mmap_driver_test.cpp
+/// @brief Minimal executable used by the early-mmap preload regression test.
+
+int main() { return 0; }

--- a/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
+++ b/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
@@ -4,16 +4,36 @@
 /// @file early_mmap_preload_test.cpp
 /// @brief Test helper whose constructor calls mmap before rocjitsu initializes.
 
+#include <cerrno>
+#include <cstdlib>
 #include <sys/mman.h>
 #include <unistd.h>
 
+namespace {
+
+template <size_t N> [[noreturn]] void fail(const char (&message)[N]) {
+  static_cast<void>(write(STDERR_FILENO, message, N - 1));
+  _exit(EXIT_FAILURE);
+}
+
+} // namespace
+
 __attribute__((constructor)) static void early_mmap_constructor() {
+  errno = 0;
+  if (mmap(nullptr, 0, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0) != MAP_FAILED ||
+      errno != EINVAL)
+    fail("early mmap preload: zero-length mmap did not fail with EINVAL\n");
+
   void *ptr = mmap(nullptr, 4096, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   if (ptr == MAP_FAILED)
-    _exit(101);
+    fail("early mmap preload: mmap failed\n");
 
   static_cast<char *>(ptr)[0] = 7;
 
+  errno = 0;
+  if (munmap(ptr, 0) == 0 || errno != EINVAL)
+    fail("early mmap preload: zero-length munmap did not fail with EINVAL\n");
+
   if (munmap(ptr, 4096) != 0)
-    _exit(102);
+    fail("early mmap preload: munmap failed\n");
 }

--- a/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
+++ b/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+
+/// @file early_mmap_preload_test.cpp
+/// @brief Test helper whose constructor calls mmap before rocjitsu initializes.
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+__attribute__((constructor)) static void early_mmap_constructor() {
+  void *ptr = mmap(nullptr, 4096, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (ptr == MAP_FAILED)
+    _exit(101);
+
+  static_cast<char *>(ptr)[0] = 7;
+
+  if (munmap(ptr, 4096) != 0)
+    _exit(102);
+}

--- a/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
+++ b/emulation/rocjitsu/tests/early_mmap_preload_test.cpp
@@ -12,7 +12,8 @@
 namespace {
 
 template <size_t N> [[noreturn]] void fail(const char (&message)[N]) {
-  static_cast<void>(write(STDERR_FILENO, message, N - 1));
+  ssize_t ignored = write(STDERR_FILENO, message, N - 1);
+  static_cast<void>(ignored);
   _exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
ISSUE ID: #8037

This fix is suggested by AI. The goal is to address an interposer startup ordering issue.

## Summary

Fix an interposer startup issue where another preloaded library can call
`mmap()` or `munmap()` before rocjitsu has resolved its libc passthrough
symbols.

The fix adds a small bootstrap path for early `mmap()` / `munmap()` calls. Before
`InterposerContext::real` is ready, these wrappers bypass rocjitsu state and call
`SYS_mmap` / `SYS_munmap` directly. Once initialization is complete, both
wrappers continue through the normal interposer logic.

## Rationale

A loader-ordering fix is not general enough here. An explicit ELF dependency can
force constructor order for libraries rocjitsu controls, but the early caller may
be an arbitrary third-party preload or application dependency. Rocjitsu cannot
add dependency edges from every possible DSO back to itself, and constructor
priorities only order constructors within one shared object.

The direct-syscall fallback is intentionally narrow: it avoids rocjitsu state,
allocation, logging, and `dlsym()` during dynamic-loader startup.

## Testing

Built focused targets:

```bash
cmake --build <rocjitsu-build> --parallel 8 --target \
  early_mmap_preload early_mmap_driver rocjitsu_shared
```

Ran targeted test:

```bash
ctest --test-dir <rocjitsu-build> \
  -R 'InterposerTest\.EarlyMmapBeforeRocjitsuConstructor' \
  --output-on-failure
```

Result:

```text
1/1 tests passed
```

Verified the regression test exercises the intended constructor order with
`LD_DEBUG=libs`: the helper preload initializes before `librocjitsu.so`, and the
program exits successfully.

Ran pre-commit on the changed files:

```text
Passed
```
