### PR TITLE
test(hipfile): Suppress sanitizer allocations from HIP

### DIFF
--- a/projects/hipfile/cmake/AISUseGTest.cmake
+++ b/projects/hipfile/cmake/AISUseGTest.cmake
@@ -86,8 +86,31 @@ endforeach()
 
 include(GoogleTest)
 
+# Absolute path to the LeakSanitizer suppression file. Only applied when
+# building with the (non-TSAN) sanitizers.
+set(AIS_LSAN_SUPPRESSIONS_FILE "${HIPFILE_ROOT_PATH}/cmake/lsan-suppressions.supp")
+
 function(ais_gtest_discover_tests target)
-    cmake_language(CALL gtest_discover_tests ${ARGV})
+    set(forwarded_args ${ARGV})
+
+    # When the address sanitizer is on, force every discovered test to load the
+    # LSan suppression file via LSAN_OPTIONS. We splice an ENVIRONMENT entry into
+    # the PROPERTIES list that gtest_discover_tests applies to each test case, so
+    # the suppression travels with the test regardless of how ctest is invoked.
+    if(AIS_USE_SANITIZERS)
+        set(lsan_env "LSAN_OPTIONS=suppressions=${AIS_LSAN_SUPPRESSIONS_FILE}")
+        list(FIND forwarded_args "PROPERTIES" props_idx)
+        if(props_idx EQUAL -1)
+            list(APPEND forwarded_args PROPERTIES ENVIRONMENT "${lsan_env}")
+        else()
+            # Insert ENVIRONMENT right after the PROPERTIES keyword so it joins
+            # the existing property name/value pairs the caller passed.
+            math(EXPR insert_idx "${props_idx} + 1")
+            list(INSERT forwarded_args ${insert_idx} ENVIRONMENT "${lsan_env}")
+        endif()
+    endif()
+
+    cmake_language(CALL gtest_discover_tests ${forwarded_args})
 
     if(AIS_USE_CODE_COVERAGE)
         set(options)

--- a/projects/hipfile/cmake/lsan-suppressions.supp
+++ b/projects/hipfile/cmake/lsan-suppressions.supp
@@ -1,0 +1,10 @@
+# LeakSanitizer suppressions for hipFile
+#
+# These suppress leak reports whose stack traces include frames from ROCm
+# runtime libraries that allocate process-lifetime state once and do not
+# free it on exit.
+#
+# Note: matching is a substring search against stack frames (incl. module names),
+# so these rules may also hide leaks that pass through these libraries.
+leak:libhsa-runtime64.so
+leak:libamdhip64.so


### PR DESCRIPTION
## Motivation

The sanitizers report small allocations from HIP that are due to our singleton. This is a shutdown ordering issue and not a real leak.

## Technical Details

Add a module-name LSan suppression file (cmake/lsan-suppressions.supp) and wire it into ais_gtest_discover_tests: when AIS_USE_SANITIZERS is on, splice an ENVIRONMENT entry setting LSAN_OPTIONS=suppressions=<file> into the PROPERTIES applied to each discovered test case. This travels with the test regardless of how ctest is invoked and works for both the existing-PROPERTIES and no-PROPERTIES call sites.

## JIRA ID

JIRA ID: AIHIPFILE-154

## Test Plan

Manual verification of the suppression

## Test Result

HIP allocations suppressed

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
