### PR TITLE
fix(rocjitsu): make MFMA SIMD reads visible to plugins

### DIFF
--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/checkpoint.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/config/checkpoint.cpp
@@ -119,7 +119,8 @@ void save_checkpoint(const std::string &path, const SoC &soc, uint64_t tick,
               builder.CreateVector(cu->sgpr_data(w->sgpr_alloc().base), w->num_sgprs());
           size_t vgpr_bytes = static_cast<size_t>(cu->vgpr_allocation_block_size()) *
                               static_cast<size_t>(w->wf_size()) * sizeof(uint32_t);
-          auto vgprs_vec = builder.CreateVector(cu->vgpr_data(w->vgpr_alloc().base), vgpr_bytes);
+          auto vgprs_vec =
+              builder.CreateVector(cu->raw_vgpr_data(w->vgpr_alloc().base), vgpr_bytes);
 
           auto wfs = fb::CreateWavefrontState(builder, w->wf_id(), w->wg_id(), w->pc, w->exec(),
                                               w->vcc(), w->m0(), w->is_halted(), w->status_raw(),
@@ -255,7 +256,7 @@ LoadedConfig restore_checkpoint(const std::string &path) {
             size_t vgpr_bytes = static_cast<size_t>(cu->vgpr_allocation_block_size()) *
                                 static_cast<size_t>(wf->wf_size()) * sizeof(uint32_t);
             size_t copy_size = std::min<size_t>(vgprs->size(), vgpr_bytes);
-            std::memcpy(cu->vgpr_data(wf->vgpr_alloc().base), vgprs->data(), copy_size);
+            std::memcpy(cu->raw_vgpr_data(wf->vgpr_alloc().base), vgprs->data(), copy_size);
           }
         }
       }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -1618,7 +1618,7 @@ void exec_wmma_f32(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N, uint32_t
 /// unroll the 16-row x 32-K matmul into straight-line AVX-512 FMAs; the f16
 /// inputs are bulk-converted once with F16C (one vector op per 16 halves)
 /// instead of branchy per-element extract_f16; VGPRs are accessed through one
-/// vgpr_data base pointer per operand and the result scatters directly (no
+/// raw_vgpr_data base pointer per operand and the result scatters directly (no
 /// Result staging vector). Falls back to the generic exec_wmma_f32 without
 /// AVX-512 / under force-scalar.
 inline void exec_wmma_f32_16x16x32_f16(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
@@ -1637,9 +1637,9 @@ inline void exec_wmma_f32_16x16x32_f16(amdgpu::ComputeUnitCore &cu, uint32_t dst
     }
     require_wmma_wave32(cu);
     const uint32_t wf = cu.wf_size();
-    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
-    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
-    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
     alignas(64) float A_buf[M * K]; // A[row][k]
     alignas(64) float B_buf[K * N]; // B[k][col]
     alignas(64) float C_buf[M * N]; // C[row][col]
@@ -1683,7 +1683,7 @@ inline void exec_wmma_f32_16x16x32_f16(amdgpu::ComputeUnitCore &cu, uint32_t dst
       c_row.copy_to(&C_buf[row * N], util::stdx::vector_aligned);
     }
     // Scatter directly back to VGPRs (no Result staging vector).
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.raw_vgpr_data(dst));
     for (uint32_t row = 0; row < M; ++row)
       for (uint32_t col = 0; col < N; ++col) {
         auto out = wmma_output_loc_32(M, N, row, col);
@@ -1713,9 +1713,9 @@ inline void exec_wmma_f32_16x16x32_bf16(amdgpu::ComputeUnitCore &cu, uint32_t ds
     }
     require_wmma_wave32(cu);
     const uint32_t wf = cu.wf_size();
-    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
-    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
-    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
     alignas(64) float A_buf[M * K]; // A[row][k]
     alignas(64) float B_buf[K * N]; // B[k][col]
     alignas(64) float C_buf[M * N]; // C[row][col]
@@ -1759,7 +1759,7 @@ inline void exec_wmma_f32_16x16x32_bf16(amdgpu::ComputeUnitCore &cu, uint32_t ds
       c_row.copy_to(&C_buf[row * N], util::stdx::vector_aligned);
     }
     // Scatter directly back to VGPRs (no Result staging vector).
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.raw_vgpr_data(dst));
     for (uint32_t row = 0; row < M; ++row)
       for (uint32_t col = 0; col < N; ++col) {
         auto out = wmma_output_loc_32(M, N, row, col);
@@ -1807,10 +1807,10 @@ void exec_wmma_f32_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s
     require_wmma_wave32(cu);
     constexpr uint32_t W = 16;
     const uint32_t wf = cu.wf_size();
-    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
-    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
-    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.raw_vgpr_data(dst));
     alignas(64) float A_buf[M * K]; // A[row][k]
     alignas(64) float B_buf[K * N]; // B[k][col]
     alignas(64) float C_buf[M * N]; // C[row][col]
@@ -1861,7 +1861,7 @@ void exec_wmma_f32_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s
 }
 
 /// Fast path for the f32-input WMMA shapes (v_wmma_f32_*_f32). f32 inputs, so no
-/// F16C convert — the hoist reads each operand word straight through vgpr_data.
+/// F16C convert — the hoist reads each operand word straight through raw_vgpr_data.
 /// Compile-time M/N/K fully unroll the matmul, looped over N in zmm-width chunks
 /// (N a multiple of 16). Falls back to generic exec_wmma_f32 without AVX-512 /
 /// under force-scalar.
@@ -1884,10 +1884,10 @@ void exec_wmma_f32_f32_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t 
     require_wmma_wave32(cu);
     constexpr uint32_t W = 16;
     const uint32_t wf = cu.wf_size();
-    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
-    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
-    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.raw_vgpr_data(dst));
     alignas(64) float A_buf[M * K];
     alignas(64) float B_buf[K * N];
     alignas(64) float C_buf[M * N];
@@ -2323,10 +2323,10 @@ void exec_wmma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0, 
     require_wmma_wave32(cu);
     constexpr uint32_t W = 16;
     const uint32_t wf = cu.wf_size();
-    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
-    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
-    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.raw_vgpr_data(dst));
     alignas(64) float A_buf[M * K];
     alignas(64) float B_buf[K * N];
     alignas(64) float C_buf[M * N];
@@ -2447,10 +2447,10 @@ void exec_wmma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s0,
     require_wmma_wave32(cu);
     constexpr uint32_t W = 16;
     const uint32_t wf = cu.wf_size();
-    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
-    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
-    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.raw_vgpr_data(dst));
     alignas(64) float A_buf[M * K];
     alignas(64) float B_buf[K * N];
     alignas(64) float C_buf[M * N];
@@ -2545,10 +2545,10 @@ void exec_wmma_f16_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s
     require_wmma_wave32(cu);
     constexpr uint32_t W = 16;
     const uint32_t wf = cu.wf_size();
-    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
-    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
-    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.raw_vgpr_data(dst));
     alignas(64) float A_buf[M * K];
     alignas(64) float B_buf[K * N];
     alignas(64) float C_buf[M * N];
@@ -3065,7 +3065,7 @@ inline void exec_wmma_i32_i8(amdgpu::ComputeUnitCore &cu, uint32_t M, uint32_t N
 /// Fast path for v_wmma_i32_16x16x64_iu8 (gfx1250, wave32, dense). Same recipe
 /// as the f16/bf16 specializations: bulk sign-/zero-extend the packed i8
 /// inputs (per the A/B sign selects from the neg bits) to int32 once, then run
-/// a constexpr-unrolled int32 matmul with direct vgpr_data access. The K-sum
+/// a constexpr-unrolled int32 matmul with direct raw_vgpr_data access. The K-sum
 /// of products is exact in int32 (|sum| <= 64 * 16384) and is added to the
 /// int32 accumulator in 64-bit at pack time, so clamp saturation matches the
 /// scalar int64 reference bit for bit; with clamp off both wrap mod 2^32.
@@ -3089,9 +3089,9 @@ inline void exec_wmma_i32_16x16x64_iu8(amdgpu::ComputeUnitCore &cu, uint32_t dst
     }
     require_wmma_wave32(cu);
     const uint32_t wf = cu.wf_size();
-    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
-    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
-    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
     // Accumulate in unsigned 32-bit (wrap is well-defined; identical mod 2^32
     // to the intended signed wrap), sign-restore via int32 cast at pack time.
     alignas(64) uint32_t A_buf[M * K]; // A[row][k] (sign-/zero-extended bits)
@@ -3133,7 +3133,7 @@ inline void exec_wmma_i32_16x16x64_iu8(amdgpu::ComputeUnitCore &cu, uint32_t dst
     }
     // Add the accumulator in 64-bit and pack (saturating when clamp is set),
     // scattering directly back to VGPRs.
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.raw_vgpr_data(dst));
     for (uint32_t row = 0; row < M; ++row)
       for (uint32_t col = 0; col < N; ++col) {
         auto out = wmma_output_loc_32(M, N, row, col);
@@ -3726,7 +3726,7 @@ void exec_smfmac_f32_32x32x64_fp8(ComputeUnitCore &cu, uint32_t dst, uint32_t s0
 /// path. Hoists A and B into dense f32 buffers via extract_f16, runs the
 /// matmul as 16 zmm-wide f32 FMA rows (512 zmm FMAs per MFMA), and scatters
 /// directly back to VGPRs (no Result staging vector). VGPR access is batched
-/// through vgpr_data (one base pointer per operand, no per-element virtual
+/// through raw_vgpr_data (one base pointer per operand, no per-element virtual
 /// read_vgpr/write_vgpr). Falls back to the generic exec_f32 when:
 ///   - <experimental/simd> is unavailable
 ///   - host native_simd<float> is not 16 lanes (i.e. no AVX-512)
@@ -3734,7 +3734,7 @@ void exec_smfmac_f32_32x32x64_fp8(ComputeUnitCore &cu, uint32_t dst, uint32_t s0
 ///   - RJ_FORCE_SCALAR is set
 /// Fast path for the f32-input MFMA shapes (v_mfma_f32_*_f32). Like the f16
 /// specialization but the inputs are already f32, so there is no F16C convert —
-/// the hoist reads each operand word straight through vgpr_data. BATCH covers
+/// the hoist reads each operand word straight through raw_vgpr_data. BATCH covers
 /// the batched shapes (e.g. 32x32x1x2). Compile-time M/N/K/BATCH fully unroll
 /// the matmul; it loops over N in zmm-width chunks (N must be a multiple of 16,
 /// so the 4x4 shape stays on the generic path). Falls back to the generic
@@ -3758,10 +3758,10 @@ void exec_f32_mfma_f32_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t 
     }
     constexpr uint32_t W = 16;
     const uint32_t wf = cu.wf_size();
-    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
-    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
-    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.raw_vgpr_data(dst));
     alignas(64) float A_buf[M * K];
     alignas(64) float B_buf[K * N];
     alignas(64) float C_buf[M * N];
@@ -3833,10 +3833,10 @@ void exec_f32_mfma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t 
     }
     constexpr uint32_t W = 16; // guaranteed by the native<float>::size()==16 guard above
     const uint32_t wf = cu.wf_size();
-    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
-    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
-    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.raw_vgpr_data(dst));
     alignas(64) float A_buf[M * K]; // A[row][k] (one batch block)
     alignas(64) float B_buf[K * N]; // B[k][col] (one batch block)
     alignas(64) float C_buf[M * N]; // C[row][col] (one batch block)
@@ -3922,10 +3922,10 @@ void exec_f32_mfma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t
     }
     constexpr uint32_t W = 16; // guaranteed by the native<float>::size()==16 guard above
     const uint32_t wf = cu.wf_size();
-    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
-    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
-    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.raw_vgpr_data(dst));
     alignas(64) float A_buf[M * K]; // A[row][k] (one batch block)
     alignas(64) float B_buf[K * N]; // B[k][col] (one batch block)
     alignas(64) float C_buf[M * N]; // C[row][col] (one batch block)
@@ -4011,9 +4011,9 @@ void exec_f32_mfma_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s
     }
     constexpr uint32_t W = 16; // guaranteed by the native<float>::size()==16 guard above
     const uint32_t wf = cu.wf_size();
-    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
-    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
-    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
     alignas(64) float A_buf[M * K]; // A[row][k]
     alignas(64) float B_buf[K * N]; // B[k][col]
     alignas(64) float C_buf[M * N]; // C[row][col]
@@ -4055,7 +4055,7 @@ void exec_f32_mfma_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s
         c_row.copy_to(&C_buf[row * N + c0], util::stdx::vector_aligned);
       }
     // Scatter directly back to VGPRs (no Result staging vector).
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.raw_vgpr_data(dst));
     bool has_nan_or_inf = false;
     for (uint32_t row = 0; row < M; ++row)
       for (uint32_t col = 0; col < N; ++col) {
@@ -4098,13 +4098,13 @@ void exec_i32_mfma_i8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s
     }
     constexpr uint32_t W = 16; // guaranteed by the native<float>::size()==16 guard above
     const uint32_t wf = cu.wf_size();
-    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s0));
-    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s1));
-    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.vgpr_data(s2));
+    const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
+    const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
+    const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
     // Accumulate in unsigned 32-bit (wrap is well-defined and identical mod
     // 2^32 to the intended signed wrap), so the SIMD path has no signed-
     // overflow UB.
-    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.vgpr_data(dst));
+    uint32_t *d_words = reinterpret_cast<uint32_t *>(cu.raw_vgpr_data(dst));
     alignas(64) uint32_t A_buf[M * K]; // A[row][k] (sign-extended bits, one batch block)
     alignas(64) uint32_t B_buf[K * N]; // B[k][col] (sign-extended bits, one batch block)
     alignas(64) uint32_t C_buf[M * N]; // C[row][col] (one batch block)

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/mma_exec.h
@@ -938,6 +938,40 @@ inline PackedOutputLoc physicalize_packed_out(const PackedOutputLoc &loc, uint32
   return {loc.reg * stride + loc.lane / wf_size, loc.lane % wf_size, loc.sub_element};
 }
 
+inline uint64_t mfma_full_lane_mask(uint32_t wf_size) {
+  return wf_size >= 64 ? ~uint64_t{0} : ((uint64_t{1} << wf_size) - 1);
+}
+
+inline uint32_t mfma_dense_reg_count(uint64_t element_count, uint32_t element_bits,
+                                     uint32_t wf_size) {
+  uint64_t bits_per_reg = static_cast<uint64_t>(wf_size) * 32u;
+  return static_cast<uint32_t>((element_count * element_bits + bits_per_reg - 1) / bits_per_reg);
+}
+
+inline void observe_contiguous_vgpr_reads(amdgpu::ComputeUnitCore &cu, uint32_t base,
+                                          uint32_t reg_count, uint32_t wf_size,
+                                          uint8_t byte_mask = 0xF) {
+  if (cu.plugin_group().empty())
+    return;
+  uint64_t lane_mask = mfma_full_lane_mask(wf_size);
+  for (uint32_t reg = 0; reg < reg_count; ++reg)
+    cu.notify_vgpr_read_by_reg(base + reg, lane_mask, byte_mask);
+}
+
+inline void observe_mfma_input_reads(amdgpu::ComputeUnitCore &cu, uint32_t base, uint32_t dim,
+                                     uint32_t K, uint32_t B, uint32_t data_bits, uint32_t wf_size) {
+  uint64_t element_count = static_cast<uint64_t>(dim) * K * B;
+  observe_contiguous_vgpr_reads(cu, base, mfma_dense_reg_count(element_count, data_bits, wf_size),
+                                wf_size);
+}
+
+inline void observe_mfma_acc32_reads(amdgpu::ComputeUnitCore &cu, uint32_t base, uint32_t M,
+                                     uint32_t N, uint32_t B, uint32_t wf_size) {
+  uint64_t element_count = static_cast<uint64_t>(M) * N * B;
+  observe_contiguous_vgpr_reads(cu, base, mfma_dense_reg_count(element_count, 32, wf_size),
+                                wf_size);
+}
+
 /// Map f32 output position to packed 16-bit output position using GFX9 layout.
 /// Two consecutive f32 register positions pack into one 32-bit VGPR as two
 /// 16-bit sub-elements: reg/2 holds the VGPR offset, reg%2 the sub-element.
@@ -3758,6 +3792,10 @@ void exec_f32_mfma_f32_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t 
     }
     constexpr uint32_t W = 16;
     const uint32_t wf = cu.wf_size();
+    observe_mfma_input_reads(cu, s0, M, K, BATCH, in_bits, wf);
+    observe_mfma_input_reads(cu, s1, N, K, BATCH, in_bits, wf);
+    if (const_acc == ACC_FROM_VGPR)
+      observe_mfma_acc32_reads(cu, s2, M, N, BATCH, wf);
     const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
     const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
     const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
@@ -3833,6 +3871,10 @@ void exec_f32_mfma_f16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t 
     }
     constexpr uint32_t W = 16; // guaranteed by the native<float>::size()==16 guard above
     const uint32_t wf = cu.wf_size();
+    observe_mfma_input_reads(cu, s0, M, K, B, in_bits, wf);
+    observe_mfma_input_reads(cu, s1, N, K, B, in_bits, wf);
+    if (const_acc == ACC_FROM_VGPR)
+      observe_mfma_acc32_reads(cu, s2, M, N, B, wf);
     const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
     const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
     const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
@@ -3922,6 +3964,10 @@ void exec_f32_mfma_bf16_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t
     }
     constexpr uint32_t W = 16; // guaranteed by the native<float>::size()==16 guard above
     const uint32_t wf = cu.wf_size();
+    observe_mfma_input_reads(cu, s0, M, K, B, in_bits, wf);
+    observe_mfma_input_reads(cu, s1, N, K, B, in_bits, wf);
+    if (const_acc == ACC_FROM_VGPR)
+      observe_mfma_acc32_reads(cu, s2, M, N, B, wf);
     const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
     const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
     const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
@@ -4011,6 +4057,10 @@ void exec_f32_mfma_f8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s
     }
     constexpr uint32_t W = 16; // guaranteed by the native<float>::size()==16 guard above
     const uint32_t wf = cu.wf_size();
+    observe_mfma_input_reads(cu, s0, M, K, B, in_bits, wf);
+    observe_mfma_input_reads(cu, s1, N, K, B, in_bits, wf);
+    if (const_acc == ACC_FROM_VGPR)
+      observe_mfma_acc32_reads(cu, s2, M, N, B, wf);
     const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
     const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
     const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));
@@ -4098,6 +4148,10 @@ void exec_i32_mfma_i8_spec(amdgpu::ComputeUnitCore &cu, uint32_t dst, uint32_t s
     }
     constexpr uint32_t W = 16; // guaranteed by the native<float>::size()==16 guard above
     const uint32_t wf = cu.wf_size();
+    observe_mfma_input_reads(cu, s0, M, K, B, in_bits, wf);
+    observe_mfma_input_reads(cu, s1, N, K, B, in_bits, wf);
+    if (const_acc == ACC_FROM_VGPR)
+      observe_mfma_acc32_reads(cu, s2, M, N, B, wf);
     const uint32_t *a_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s0));
     const uint32_t *b_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s1));
     const uint32_t *c_words = reinterpret_cast<const uint32_t *>(cu.raw_vgpr_data(s2));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -619,7 +619,7 @@ template <typename T, typename Inst, typename BinOp>
   const uint64_t exec = wf.exec();
   // Resolve each operand's `VgprStorage*` ONCE (a single virtual
   // simd_vgpr_storage dispatch -> resolved_vgpr_offset -> the localized
-  // vgpr_reg<64> cast). The resolved register object is chunk-independent, so the
+  // raw_vgpr_reg<64> cast). The resolved register object is chunk-independent, so the
   // per-chunk loop issues a value-semantic `r->simd_load<T>(base)` off it instead
   // of re-dispatching the resolution every chunk — and no raw base pointer
   // escapes the kernel body. Operands that aren't contiguous VGPR storage

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -355,7 +355,7 @@ inline util::native<float> apply_vop3_dst_mod_f32(util::native<float> v, uint32_
 template <typename Op> const VgprStorage *simd_src_reg(const Op &op, const Wavefront &wf) {
   const VgprStorage *r = SimdAccess::vgpr_storage(op, wf);
   if (r)
-    SimdAccess::notify_read(op, wf, 0, wf.wf_size(), 0xF);
+    SimdAccess::notify_read(op, wf, wf.exec(), 0xF);
   return r;
 }
 
@@ -373,7 +373,7 @@ template <typename Op> VgprStorage *simd_dst_reg(const Op &op, Wavefront &wf) {
 template <typename Op> ConstVgprStoragePair64 simd_src_reg64(const Op &op, const Wavefront &wf) {
   ConstVgprStoragePair64 p = SimdAccess::vgpr_storage64(op, wf);
   if (p.lo)
-    SimdAccess::notify_read(op, wf, 0, wf.wf_size(), 0xF);
+    SimdAccess::notify_read(op, wf, wf.exec(), 0xF);
   return p;
 }
 
@@ -429,7 +429,9 @@ inline util::native<T> read_simd(const Op &op, const Wavefront &wf, uint32_t lan
   static_assert(sizeof(T) == sizeof(uint32_t), "read_simd: T must be a 32-bit lane type");
   if (const VgprStorage *r = SimdAccess::vgpr_storage(op, wf)) {
     constexpr auto W = static_cast<uint32_t>(util::native_width_v<T>);
-    SimdAccess::notify_read(op, wf, lane_base, lane_base + W, 0xF);
+    const uint64_t lane_mask =
+        ((wf.exec() >> lane_base) & util::mask<uint64_t>(static_cast<int>(W))) << lane_base;
+    SimdAccess::notify_read(op, wf, lane_mask, 0xF);
     return r->template simd_load<T>(lane_base);
   }
   return util::broadcast<T>(op.read_scalar(wf));
@@ -1015,7 +1017,9 @@ inline util::narrow32<T> read_narrow(const Op &op, const Wavefront &wf, uint32_t
   static_assert(sizeof(T) == sizeof(uint32_t), "read_narrow: T must be a 32-bit lane type");
   if (const VgprStorage *r = SimdAccess::vgpr_storage(op, wf)) {
     constexpr auto W = static_cast<uint32_t>(util::native_width64);
-    SimdAccess::notify_read(op, wf, lane_base, lane_base + W, 0xF);
+    const uint64_t lane_mask =
+        ((wf.exec() >> lane_base) & util::mask<uint64_t>(static_cast<int>(W))) << lane_base;
+    SimdAccess::notify_read(op, wf, lane_mask, 0xF);
     return r->template simd_load_narrow<T>(lane_base);
   }
   return util::broadcast_narrow<T>(op.read_scalar(wf));

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/arch/amdgpu/shared/simd_glue.h
@@ -345,18 +345,25 @@ inline util::native<float> apply_vop3_dst_mod_f32(util::native<float> v, uint32_
   return apply_vop3_dst_mod<float>(v, omod, clamp);
 }
 
-/// Resolve an operand's read-side VGPR storage to a `VgprStorage*` (the
-/// per-lane register object), or null for a non-VGPR operand (SGPR / immediate
-/// / inline-const / DPP delegate). This is the single virtual dispatch
-/// (`simd_vgpr_storage`) the SIMD hot path takes to bind a source register; the
-/// per-chunk loop then issues a value-semantic `r->simd_load<T>(base)` directly
-/// off the resolved (loop-invariant) object with no further dispatch and no raw
-/// pointer in the kernel body — the storage pointer never escapes `VgprStorage`.
-template <typename Op> const VgprStorage *simd_src_reg(const Op &op, const Wavefront &wf) {
+/// Resolve an operand's read-side VGPR storage and notify plugins for the lanes
+/// being read. Returns null for non-VGPR operands (SGPR / immediate /
+/// inline-const / DPP delegate). This is the observed-read bottleneck for SIMD
+/// helpers that bind raw VGPR storage.
+template <typename Op>
+const VgprStorage *observed_simd_src_reg(const Op &op, const Wavefront &wf, uint64_t lane_mask,
+                                         uint8_t byte_mask = 0xF) {
   const VgprStorage *r = SimdAccess::vgpr_storage(op, wf);
   if (r)
-    SimdAccess::notify_read(op, wf, wf.exec(), 0xF);
+    SimdAccess::notify_read(op, wf, lane_mask, byte_mask);
   return r;
+}
+
+/// Resolve an operand's read-side VGPR storage to a `VgprStorage*` (the
+/// per-lane register object), or null for a non-VGPR operand. This observes the
+/// full active EXEC mask once when the register is bound, then the per-chunk loop
+/// issues value-semantic loads from the resolved storage.
+template <typename Op> const VgprStorage *simd_src_reg(const Op &op, const Wavefront &wf) {
+  return observed_simd_src_reg(op, wf, wf.exec());
 }
 
 /// Mutable counterpart of `simd_src_reg` for the dst write path (single
@@ -365,16 +372,24 @@ template <typename Op> VgprStorage *simd_dst_reg(const Op &op, Wavefront &wf) {
   return SimdAccess::vgpr_storage_mut(op, wf);
 }
 
+/// Resolve a 64-bit-lane source operand's lo/hi VGPR pair and notify plugins
+/// for the lanes being read.
+template <typename Op>
+ConstVgprStoragePair64 observed_simd_src_reg64(const Op &op, const Wavefront &wf,
+                                               uint64_t lane_mask, uint8_t byte_mask = 0xF) {
+  ConstVgprStoragePair64 p = SimdAccess::vgpr_storage64(op, wf);
+  if (p.lo)
+    SimdAccess::notify_read(op, wf, lane_mask, byte_mask);
+  return p;
+}
+
 /// Resolve a 64-bit-lane source operand's lo/hi register pair in one virtual
 /// dispatch (`simd_vgpr_storage64`). `{lo, hi}` are `VgprStorage*` (lo = reg N,
 /// hi = reg N+1), or `{nullptr, nullptr}` for a non-VGPR operand. The glue's
 /// 64-bit kernels structured-bind this and issue value-semantic
 /// `lo->simd_load64<T>(*hi, base)` — no raw pointer in the kernel body.
 template <typename Op> ConstVgprStoragePair64 simd_src_reg64(const Op &op, const Wavefront &wf) {
-  ConstVgprStoragePair64 p = SimdAccess::vgpr_storage64(op, wf);
-  if (p.lo)
-    SimdAccess::notify_read(op, wf, wf.exec(), 0xF);
-  return p;
+  return observed_simd_src_reg64(op, wf, wf.exec());
 }
 
 /// Mutable counterpart of `simd_src_reg64` for the 64-bit dst write path
@@ -427,13 +442,11 @@ template <typename T, typename Op>
   requires(util::has_stdx_simd)
 inline util::native<T> read_simd(const Op &op, const Wavefront &wf, uint32_t lane_base) {
   static_assert(sizeof(T) == sizeof(uint32_t), "read_simd: T must be a 32-bit lane type");
-  if (const VgprStorage *r = SimdAccess::vgpr_storage(op, wf)) {
-    constexpr auto W = static_cast<uint32_t>(util::native_width_v<T>);
-    const uint64_t lane_mask =
-        ((wf.exec() >> lane_base) & util::mask<uint64_t>(static_cast<int>(W))) << lane_base;
-    SimdAccess::notify_read(op, wf, lane_mask, 0xF);
+  constexpr auto W = static_cast<uint32_t>(util::native_width_v<T>);
+  const uint64_t lane_mask = ((wf.exec() >> lane_base) & util::mask<uint64_t>(static_cast<int>(W)))
+                             << lane_base;
+  if (const VgprStorage *r = observed_simd_src_reg(op, wf, lane_mask))
     return r->template simd_load<T>(lane_base);
-  }
   return util::broadcast<T>(op.read_scalar(wf));
 }
 
@@ -1015,13 +1028,11 @@ template <typename T, typename Op>
   requires(util::has_stdx_simd)
 inline util::narrow32<T> read_narrow(const Op &op, const Wavefront &wf, uint32_t lane_base) {
   static_assert(sizeof(T) == sizeof(uint32_t), "read_narrow: T must be a 32-bit lane type");
-  if (const VgprStorage *r = SimdAccess::vgpr_storage(op, wf)) {
-    constexpr auto W = static_cast<uint32_t>(util::native_width64);
-    const uint64_t lane_mask =
-        ((wf.exec() >> lane_base) & util::mask<uint64_t>(static_cast<int>(W))) << lane_base;
-    SimdAccess::notify_read(op, wf, lane_mask, 0xF);
+  constexpr auto W = static_cast<uint32_t>(util::native_width64);
+  const uint64_t lane_mask = ((wf.exec() >> lane_base) & util::mask<uint64_t>(static_cast<int>(W)))
+                             << lane_base;
+  if (const VgprStorage *r = observed_simd_src_reg(op, wf, lane_mask))
     return r->template simd_load_narrow<T>(lane_base);
-  }
   return util::broadcast_narrow<T>(op.read_scalar(wf));
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_operand_simd_inl.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_operand_simd_inl.h
@@ -111,12 +111,12 @@ amdgpu::VgprStorage *AmdgpuIsaOperand<Isa>::simd_vgpr_storage_mut(amdgpu::Wavefr
 }
 
 template <typename Isa>
-void AmdgpuIsaOperand<Isa>::simd_notify_read(const amdgpu::Wavefront &wf, uint32_t lane_begin,
-                                             uint32_t lane_end, uint8_t byte_mask) const {
+void AmdgpuIsaOperand<Isa>::simd_notify_read(const amdgpu::Wavefront &wf, uint64_t lane_mask,
+                                             uint8_t byte_mask) const {
   if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
     uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
     uint32_t physical_reg = wf.vgpr_alloc().base + voff;
-    wf.cu().notify_vgpr_read(&wf, physical_reg, lane_begin, lane_end, byte_mask);
+    wf.cu().notify_vgpr_read(&wf, physical_reg, lane_mask, byte_mask);
   }
 }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_operand_simd_inl.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/isa_operand_simd_inl.h
@@ -51,7 +51,7 @@ void AmdgpuIsaOperand<Isa>::read_lane_chunk(const amdgpu::Wavefront &wf, uint32_
   }
   if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
     uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
-    const uint8_t *src = wf.cu().vgpr_data(wf.vgpr_alloc().base + voff);
+    const uint8_t *src = wf.cu().raw_vgpr_data(wf.vgpr_alloc().base + voff);
     std::memcpy(out, src + lane_base * sizeof(uint32_t), count * sizeof(uint32_t));
     return;
   }
@@ -71,7 +71,7 @@ void AmdgpuIsaOperand<Isa>::write_lane_chunk(amdgpu::Wavefront &wf, uint32_t lan
   uint32_t reg = wf.vgpr_alloc().base + voff;
   uint64_t full_mask = util::mask<uint64_t>(static_cast<int>(count));
   if ((mask & full_mask) == full_mask) {
-    uint8_t *dst = wf.cu().vgpr_data(reg);
+    uint8_t *dst = wf.cu().raw_vgpr_data(reg);
     std::memcpy(dst + lane_base * sizeof(uint32_t), vals, count * sizeof(uint32_t));
     return;
   }
@@ -96,7 +96,7 @@ AmdgpuIsaOperand<Isa>::simd_vgpr_storage(const amdgpu::Wavefront &wf) const {
     return amdgpu::SimdAccess::vgpr_storage(*this->delegate(), wf);
   if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
     uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
-    return &wf.cu().template vgpr_reg<64>(wf.vgpr_alloc().base + voff);
+    return &wf.cu().template raw_vgpr_reg<64>(wf.vgpr_alloc().base + voff);
   }
   return nullptr;
 }
@@ -105,7 +105,7 @@ template <typename Isa>
 amdgpu::VgprStorage *AmdgpuIsaOperand<Isa>::simd_vgpr_storage_mut(amdgpu::Wavefront &wf) const {
   if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
     uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
-    return &wf.cu().template vgpr_reg<64>(wf.vgpr_alloc().base + voff);
+    return &wf.cu().template raw_vgpr_reg<64>(wf.vgpr_alloc().base + voff);
   }
   return nullptr;
 }
@@ -128,7 +128,7 @@ AmdgpuIsaOperand<Isa>::simd_vgpr_storage64(const amdgpu::Wavefront &wf) const {
   if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
     uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, false) : *off;
     uint32_t reg = wf.vgpr_alloc().base + voff;
-    return {&wf.cu().template vgpr_reg<64>(reg), &wf.cu().template vgpr_reg<64>(reg + 1)};
+    return {&wf.cu().template raw_vgpr_reg<64>(reg), &wf.cu().template raw_vgpr_reg<64>(reg + 1)};
   }
   return {nullptr, nullptr};
 }
@@ -139,7 +139,7 @@ AmdgpuIsaOperand<Isa>::simd_vgpr_storage64_mut(amdgpu::Wavefront &wf) const {
   if (auto off = detail::resolved_vgpr_offset_for_operand<Isa>(wf, *this)) {
     uint32_t voff = wf.gpr_idx_en() ? amdgpu::apply_gpr_idx(wf, *off, true) : *off;
     uint32_t reg = wf.vgpr_alloc().base + voff;
-    return {&wf.cu().template vgpr_reg<64>(reg), &wf.cu().template vgpr_reg<64>(reg + 1)};
+    return {&wf.cu().template raw_vgpr_reg<64>(reg), &wf.cu().template raw_vgpr_reg<64>(reg + 1)};
   }
   return {nullptr, nullptr};
 }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
@@ -374,7 +374,7 @@ private:
   /// The pre-permuted lane data is held in a `MAX_LANES`-wide `uint32_t` array
   /// that is bit-layout-identical to `VgprStorage` (`simdojo::VectorReg<64,
   /// uint32_t>` — a `std::array<uint32_t,64>` with the layout `static_assert`
-  /// enforced in `ComputeUnitCore::vgpr_reg`). Unused lanes are zero (the
+  /// enforced in `ComputeUnitCore::raw_vgpr_reg`). Unused lanes are zero (the
   /// EXEC mask gates them off in the glue), so the whole array is a valid
   /// read-only register view. The cast targets the forward-declared
   /// `VgprStorage`; the glue dereferences it where the full type is visible.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/isa/operand.h
@@ -245,9 +245,9 @@ private:
   }
 
   /// @brief Notify the plugin system that this operand's VGPR was read
-  /// for lanes [lane_begin, lane_end). No-op for non-VGPR operands.
-  virtual void simd_notify_read(const amdgpu::Wavefront & /*wf*/, uint32_t /*lane_begin*/,
-                                uint32_t /*lane_end*/, uint8_t /*byte_mask*/) const {}
+  /// by lanes in `lane_mask`. No-op for non-VGPR operands.
+  virtual void simd_notify_read(const amdgpu::Wavefront & /*wf*/, uint64_t /*lane_mask*/,
+                                uint8_t /*byte_mask*/) const {}
 
   /// @brief 64-bit-lane counterpart of `simd_vgpr_storage`. A per-lane f64/i64
   /// value occupies two consecutive VGPRs (reg N + reg N+1), so this returns a
@@ -323,7 +323,7 @@ private:
   amdgpu::VgprStorage *simd_vgpr_storage_mut(amdgpu::Wavefront &wf) const override;
   amdgpu::ConstVgprStoragePair64 simd_vgpr_storage64(const amdgpu::Wavefront &wf) const override;
   amdgpu::VgprStoragePair64 simd_vgpr_storage64_mut(amdgpu::Wavefront &wf) const override;
-  void simd_notify_read(const amdgpu::Wavefront &wf, uint32_t lane_begin, uint32_t lane_end,
+  void simd_notify_read(const amdgpu::Wavefront &wf, uint64_t lane_mask,
                         uint8_t byte_mask) const override;
 };
 
@@ -421,9 +421,9 @@ struct SimdAccess {
     return op.simd_vgpr_storage64_mut(wf);
   }
   template <typename Op>
-  static void notify_read(const Op &op, const Wavefront &wf, uint32_t lane_begin, uint32_t lane_end,
+  static void notify_read(const Op &op, const Wavefront &wf, uint64_t lane_mask,
                           uint8_t byte_mask) {
-    op.simd_notify_read(wf, lane_begin, lane_end, byte_mask);
+    op.simd_notify_read(wf, lane_mask, byte_mask);
   }
 };
 } // namespace amdgpu

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.cpp
@@ -124,7 +124,7 @@ Wavefront *ComputeUnitCore::dispatch_wf(uint32_t wg_id, uint64_t pc, uint32_t sg
   // Zero the allocated register blocks so reused slots don't inherit stale
   // values from previous kernel runs.
   std::fill(&sgpr_file_[sgpr_base], &sgpr_file_[sgpr_base] + config_.sgprs_per_wf, 0u);
-  std::memset(vgpr_data(static_cast<uint32_t>(vgpr_base)), 0,
+  std::memset(raw_vgpr_data(static_cast<uint32_t>(vgpr_base)), 0,
               vgpr_allocation_block_size() * wf_size_ * sizeof(uint32_t));
 
   // Invalidate the L1 scalar cache so this wavefront reads fresh kernel

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -381,6 +381,9 @@ public:
       plugin_group_->onAmdgpuReadVgprLanes(wf, reg_idx, lane_mask, byte_mask);
   }
 
+  virtual void notify_vgpr_read_by_reg(uint32_t reg_idx, uint64_t lane_mask,
+                                       uint8_t byte_mask = 0xF) const = 0;
+
   /// @brief Read a vector register lane from the physical VGPR file.
   /// @param reg_idx Physical register index.
   /// @param lane Lane index within the wavefront.
@@ -626,10 +629,14 @@ public:
 
   /// @returns Lane value from the VGPR file.
   uint32_t read_vgpr(uint32_t reg_idx, uint32_t lane) const override {
-    if (auto *wf = vgpr_to_wave_[reg_idx]) {
-      this->plugin_group_->onAmdgpuReadVgprLanes(wf, reg_idx, uint64_t{1} << lane);
-    }
+    notify_vgpr_read_by_reg(reg_idx, uint64_t{1} << lane);
     return vgpr_file_[reg_idx][lane];
+  }
+
+  void notify_vgpr_read_by_reg(uint32_t reg_idx, uint64_t lane_mask,
+                               uint8_t byte_mask = 0xF) const override {
+    if (auto *wf = vgpr_to_wave_[reg_idx])
+      this->notify_vgpr_read(wf, reg_idx, lane_mask, byte_mask);
   }
 
   void fill_vgpr_to_wave(uint32_t base, uint32_t count, Wavefront *wf) override {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -375,10 +375,10 @@ public:
   /// @param val Value to write.
   void write_sgpr(uint32_t reg_idx, uint32_t val) { sgpr_file_[reg_idx] = val; }
 
-  void notify_vgpr_read(const Wavefront *wf, uint32_t reg_idx, uint32_t lane_begin,
-                        uint32_t lane_end, uint8_t byte_mask = 0xF) const {
-    if (wf)
-      plugin_group_->onAmdgpuReadVgprs(wf, reg_idx, lane_begin, lane_end, byte_mask);
+  void notify_vgpr_read(const Wavefront *wf, uint32_t reg_idx, uint64_t lane_mask,
+                        uint8_t byte_mask = 0xF) const {
+    if (wf && lane_mask != 0)
+      plugin_group_->onAmdgpuReadVgprLanes(wf, reg_idx, lane_mask, byte_mask);
   }
 
   /// @brief Read a vector register lane from the physical VGPR file.
@@ -621,7 +621,7 @@ public:
   /// @returns Lane value from the VGPR file.
   uint32_t read_vgpr(uint32_t reg_idx, uint32_t lane) const override {
     if (auto *wf = vgpr_to_wave_[reg_idx]) {
-      this->plugin_group_->onAmdgpuReadVgprs(wf, reg_idx, lane, lane + 1);
+      this->plugin_group_->onAmdgpuReadVgprLanes(wf, reg_idx, uint64_t{1} << lane);
     }
     return vgpr_file_[reg_idx][lane];
   }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/amdgpu/compute_unit.h
@@ -398,35 +398,41 @@ public:
   /// @returns Pointer to the contiguous SGPR data.
   const uint32_t *sgpr_data(uint32_t base) const { return &sgpr_file_[base]; }
 
-  /// @brief Return a pointer to a wavefront's VGPR data in the physical file.
+  /// @brief Return a raw pointer to a wavefront's VGPR data in the physical file.
+  /// @details This bypasses plugin read hooks. Instruction-visible reads should use
+  /// read_vgpr() or notify_vgpr_read() unless the caller is deliberately taking
+  /// responsibility for plugin notification.
   /// @param base Base register index in the VGPR file.
   /// @returns Const pointer to the raw VGPR data.
-  virtual const uint8_t *vgpr_data(uint32_t base) const = 0;
+  virtual const uint8_t *raw_vgpr_data(uint32_t base) const = 0;
 
-  /// @brief Return a mutable pointer to a wavefront's VGPR data.
+  /// @brief Return a mutable raw pointer to a wavefront's VGPR data.
+  /// @details This bypasses plugin write hooks. It is intended for raw storage
+  /// operations such as memory completion and tightly controlled SIMD paths.
   /// @param base Base register index in the VGPR file.
   /// @returns Mutable pointer to the raw VGPR data.
-  virtual uint8_t *vgpr_data(uint32_t base) = 0;
+  virtual uint8_t *raw_vgpr_data(uint32_t base) = 0;
 
   /// @brief Number of physical VGPR registers in one allocation block.
   virtual uint32_t vgpr_allocation_block_size() const = 0;
 
-  /// @brief Typed view of a single VGPR as the file's @c simdojo::VectorReg.
+  /// @brief Raw typed view of a single VGPR as the file's @c simdojo::VectorReg.
   /// @details The abstract CU exposes the VGPR file only as a byte pointer
-  /// (@c vgpr_data), which erases the wavefront-size template parameter. The
+  /// (@c raw_vgpr_data), which erases the wavefront-size template parameter. The
   /// file actually stores @c simdojo::VectorReg<N,uint32_t>, so this recovers
   /// the typed register with the design's single localized @c reinterpret_cast.
+  /// Like @c raw_vgpr_data, this bypasses plugin hooks.
   /// The @c static_assert pins @c VectorReg<N> to @c N contiguous @c uint32_t
   /// (no padding / vtable) so the byte view and the typed view coincide.
-  template <size_t N> simdojo::VectorReg<N, uint32_t> &vgpr_reg(uint32_t base) {
+  template <size_t N> simdojo::VectorReg<N, uint32_t> &raw_vgpr_reg(uint32_t base) {
     static_assert(sizeof(simdojo::VectorReg<N, uint32_t>) == N * sizeof(uint32_t),
                   "VectorReg must be layout-compatible with raw lane storage");
-    return *reinterpret_cast<simdojo::VectorReg<N, uint32_t> *>(vgpr_data(base));
+    return *reinterpret_cast<simdojo::VectorReg<N, uint32_t> *>(raw_vgpr_data(base));
   }
-  template <size_t N> const simdojo::VectorReg<N, uint32_t> &vgpr_reg(uint32_t base) const {
+  template <size_t N> const simdojo::VectorReg<N, uint32_t> &raw_vgpr_reg(uint32_t base) const {
     static_assert(sizeof(simdojo::VectorReg<N, uint32_t>) == N * sizeof(uint32_t),
                   "VectorReg must be layout-compatible with raw lane storage");
-    return *reinterpret_cast<const simdojo::VectorReg<N, uint32_t> *>(vgpr_data(base));
+    return *reinterpret_cast<const simdojo::VectorReg<N, uint32_t> *>(raw_vgpr_data(base));
   }
 
   /// @brief Return the SGPR register file (for serialization).
@@ -636,12 +642,12 @@ public:
   }
 
   /// @returns Const pointer to the raw VGPR data.
-  const uint8_t *vgpr_data(uint32_t base) const override {
+  const uint8_t *raw_vgpr_data(uint32_t base) const override {
     return reinterpret_cast<const uint8_t *>(&vgpr_file_[base]);
   }
 
   /// @returns Mutable pointer to the raw VGPR data.
-  uint8_t *vgpr_data(uint32_t base) override {
+  uint8_t *raw_vgpr_data(uint32_t base) override {
     return reinterpret_cast<uint8_t *>(&vgpr_file_[base]);
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin.h
@@ -107,12 +107,11 @@ public:
   /// Called when a VGPR is read during instruction execution.
   /// @param wf Owning wavefront, or nullptr if the register is unallocated.
   /// @param physical_reg Physical register index in the VGPR file.
-  /// @param lane_begin First lane in the read range.
-  /// @param lane_end One past the last lane in the read range.
+  /// @param lane_mask Bit mask of lanes read by the instruction.
   /// @param byte_mask Sub-dword byte mask (kFullByteMask = full dword).
-  virtual void onAmdgpuReadVgprs(const amdgpu::Wavefront * /*wf*/, uint32_t /*physical_reg*/,
-                                 uint32_t /*lane_begin*/, uint32_t /*lane_end*/,
-                                 uint8_t /*byte_mask*/ = kFullByteMask) {}
+  virtual void onAmdgpuReadVgprLanes(const amdgpu::Wavefront * /*wf*/, uint32_t /*physical_reg*/,
+                                     uint64_t /*lane_mask*/,
+                                     uint8_t /*byte_mask*/ = kFullByteMask) {}
 
   /// Called when an SGPR is read during instruction execution.
   /// @param wf Owning wavefront, or nullptr if the register is unallocated.

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/execution_plugin_group.h
@@ -125,11 +125,11 @@ public:
       p->onAmdgpuWavefrontHalted(wf);
   }
 
-  virtual void onAmdgpuReadVgprs(const amdgpu::Wavefront *wf, uint32_t physical_reg,
-                                 uint32_t lane_begin, uint32_t lane_end,
-                                 uint8_t byte_mask = ExecutionPlugin::kFullByteMask) {
+  virtual void onAmdgpuReadVgprLanes(const amdgpu::Wavefront *wf, uint32_t physical_reg,
+                                     uint64_t lane_mask,
+                                     uint8_t byte_mask = ExecutionPlugin::kFullByteMask) {
     for (auto &p : plugins_)
-      p->onAmdgpuReadVgprs(wf, physical_reg, lane_begin, lane_end, byte_mask);
+      p->onAmdgpuReadVgprLanes(wf, physical_reg, lane_mask, byte_mask);
   }
 
   virtual void onAmdgpuReadSgpr(const amdgpu::Wavefront *wf, uint32_t physical_reg) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/profiled_execution_plugin_group.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/profiled_execution_plugin_group.h
@@ -120,11 +120,10 @@ public:
                       [&]() { ExecutionPluginGroup::onAmdgpuWavefrontHalted(wf); });
   }
 
-  void onAmdgpuReadVgprs(const amdgpu::Wavefront *wf, uint32_t physical_reg, uint32_t lane_begin,
-                         uint32_t lane_end,
-                         uint8_t byte_mask = ExecutionPlugin::kFullByteMask) override {
+  void onAmdgpuReadVgprLanes(const amdgpu::Wavefront *wf, uint32_t physical_reg, uint64_t lane_mask,
+                             uint8_t byte_mask = ExecutionPlugin::kFullByteMask) override {
     profiled_dispatch(prof_read_vgpr_, [&]() {
-      ExecutionPluginGroup::onAmdgpuReadVgprs(wf, physical_reg, lane_begin, lane_end, byte_mask);
+      ExecutionPluginGroup::onAmdgpuReadVgprLanes(wf, physical_reg, lane_mask, byte_mask);
     });
   }
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/wave_race_state.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/wave_race_state.cpp
@@ -172,10 +172,17 @@ void WaveRaceState::flushWaveCompleteMemoryEvents() {
 }
 
 void WaveRaceState::checkVgprRead(int reg, int lane, uint8_t byteMask) const {
+  checkVgprReadLanes(reg, uint64_t{1} << lane, byteMask);
+}
+
+void WaveRaceState::checkVgprReadLanes(int reg, uint64_t laneMask, uint8_t byteMask) const {
+  if (laneMask == 0)
+    return;
   for (EventId eid : vgprMemoryEvents[reg]) {
+    uint64_t conflictMask = laneMask & detector->events().execMask(eid);
     if (isToVgpr(detector->events().type(eid)) &&
-        (detector->events().byteMask(eid) & byteMask) != 0 &&
-        detector->events().isActiveForLane(eid, lane)) {
+        (detector->events().byteMask(eid) & byteMask) != 0 && conflictMask != 0) {
+      int lane = std::countr_zero(conflictMask);
       detector->getRaceHandler()(
           {RaceViolation::Space::VGPR, reg, waveId.value, lane, false, detector->getWorkgroupId()});
     }

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/wave_race_state.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/core/wave_race_state.h
@@ -69,6 +69,9 @@ public:
   /// Check a full VGPR read for races. Calls the RaceHandler on violation.
   void checkVgprRead(int reg, int lane, uint8_t byteMask) const;
 
+  /// Check a VGPR read by a set of lanes for races. Calls the RaceHandler on violation.
+  void checkVgprReadLanes(int reg, uint64_t laneMask, uint8_t byteMask) const;
+
   /// Check all lanes of a VGPR for races (used by bulk register reads).
   void checkVgprReadAllLanes(int reg) const;
 

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.cpp
@@ -336,14 +336,12 @@ void RaceDetectorPlugin::onAmdgpuRouteMemoryInstruction(const Instruction &inst,
   }
 }
 
-void RaceDetectorPlugin::onAmdgpuReadVgprs(const amdgpu::Wavefront *wf, uint32_t physical_reg,
-                                           uint32_t lane_begin, uint32_t /*lane_end*/,
-                                           uint8_t byte_mask) {
+void RaceDetectorPlugin::onAmdgpuReadVgprLanes(const amdgpu::Wavefront *wf, uint32_t physical_reg,
+                                               uint64_t lane_mask, uint8_t byte_mask) {
   auto *s = get_state(wf);
   assert(s && s->race_state);
   uint32_t logical_reg = physical_reg - wf->vgpr_alloc().base;
-  s->race_state->checkVgprRead(static_cast<int>(logical_reg), static_cast<int>(lane_begin),
-                               byte_mask);
+  s->race_state->checkVgprReadLanes(static_cast<int>(logical_reg), lane_mask, byte_mask);
 }
 
 void RaceDetectorPlugin::onAmdgpuReadSgpr(const amdgpu::Wavefront *wf, uint32_t physical_reg) {

--- a/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
+++ b/emulation/rocjitsu/lib/rocjitsu/src/rocjitsu/vm/plugins/race_detector/plugin.h
@@ -117,8 +117,8 @@ public:
 
   void onAmdgpuRouteMemoryInstruction(const Instruction &inst, amdgpu::Wavefront &wf) override;
 
-  void onAmdgpuReadVgprs(const amdgpu::Wavefront *wf, uint32_t physical_reg, uint32_t lane_begin,
-                         uint32_t lane_end, uint8_t byte_mask = 0xF) override;
+  void onAmdgpuReadVgprLanes(const amdgpu::Wavefront *wf, uint32_t physical_reg, uint64_t lane_mask,
+                             uint8_t byte_mask = 0xF) override;
 
   void onAmdgpuReadSgpr(const amdgpu::Wavefront *wf, uint32_t physical_reg) override;
 

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -8,8 +8,11 @@
 
 #include "embedded_schema.h"
 #include "rocjitsu/config/config_loader.h"
+#include "rocjitsu/isa/arch/amdgpu/shared/mma_exec.h"
 #include "rocjitsu/isa/instruction.h"
 #include "rocjitsu/vm/soc.h"
+#include "util/simd.h"
+#include "util/simd_test_hooks.h"
 
 #include "rocjitsu/base/rj_compiler.h"
 RJ_DIAGNOSTIC_PUSH
@@ -22,6 +25,8 @@ RJ_DIAGNOSTIC_POP
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
+#include <bit>
 #include <cstdint>
 #include <format>
 #include <map>
@@ -33,6 +38,7 @@ namespace {
 
 using namespace rocjitsu;
 using namespace rocjitsu::amdgpu;
+using namespace rocjitsu::plugins::race_detector;
 
 // SOPP encoding: bits[31:23]=0x17F, bits[22:16]=op, bits[15:0]=simm16.
 constexpr uint32_t sopp(uint32_t op, uint16_t simm16 = 0) {
@@ -70,6 +76,9 @@ struct HookEvent {
   uint32_t wf_id = 0;
   uint32_t physical_vgpr_count = 0;
   uint32_t sgpr_count = 0;
+  uint32_t physical_reg = 0;
+  uint64_t lane_mask = 0;
+  uint8_t byte_mask = 0;
   uint64_t pc = 0;
   std::string mnemonic;
 };
@@ -167,13 +176,17 @@ public:
     events.push_back(e);
   }
 
-  void onAmdgpuReadVgprLanes(const amdgpu::Wavefront *wf, uint32_t, uint64_t, uint8_t) override {
+  void onAmdgpuReadVgprLanes(const amdgpu::Wavefront *wf, uint32_t physical_reg, uint64_t lane_mask,
+                             uint8_t byte_mask) override {
     HookEvent e{HookEvent::READ_VGPR};
     if (wf) {
       e.dispatch_id = wf->dispatch_id();
       e.wg_id = wf->wg_id();
       e.wf_id = wf->wf_id();
     }
+    e.physical_reg = physical_reg;
+    e.lane_mask = lane_mask;
+    e.byte_mask = byte_mask;
     events.push_back(e);
   }
 
@@ -195,6 +208,43 @@ public:
     }
     events.push_back(e);
   }
+};
+
+class MfmaRacePlugin : public ExecutionPlugin {
+public:
+  MfmaRacePlugin() : ExecutionPlugin("mfma_race_probe") {}
+
+  void onAmdgpuWorkgroupDispatched(uint32_t, uint32_t wg_id, uint32_t physical_vgpr_count,
+                                   uint32_t sgpr_count,
+                                   std::span<amdgpu::Wavefront *> wavefronts) override {
+    detector_ = std::make_unique<RaceDetector>(
+        static_cast<int>(wavefronts.size()), static_cast<int>(physical_vgpr_count),
+        static_cast<int>(sgpr_count), Dim3d(static_cast<int>(wg_id)),
+        [this](RaceViolation v) { violations.push_back(v); });
+    wf_ = wavefronts.front();
+    state_ = &detector_->getWaveRaceState(0);
+  }
+
+  void onAmdgpuReadVgprLanes(const amdgpu::Wavefront *wf, uint32_t physical_reg, uint64_t lane_mask,
+                             uint8_t byte_mask) override {
+    if (wf != wf_ || !state_)
+      return;
+    uint32_t logical_reg = physical_reg - wf->vgpr_alloc().base;
+    state_->checkVgprReadLanes(static_cast<int>(logical_reg), lane_mask, byte_mask);
+  }
+
+  void registerOutstandingLoad(uint32_t logical_reg, uint64_t exec_mask, uint8_t byte_mask = 0xF) {
+    ASSERT_NE(state_, nullptr);
+    state_->registerEvent(/*pc=*/0x1000, MemoryEventType::GLOBAL_TO_VGPR, {logical_reg}, exec_mask,
+                          byte_mask);
+  }
+
+  std::vector<RaceViolation> violations;
+
+private:
+  std::unique_ptr<RaceDetector> detector_;
+  amdgpu::Wavefront *wf_ = nullptr;
+  WaveRaceState *state_ = nullptr;
 };
 
 const char *kindName(HookEvent::Kind k) {
@@ -465,6 +515,119 @@ TEST(ExecutionPluginTest, NoPluginNoCrash) {
   PluginFixture f;
   const uint32_t code[] = {S_NOP, S_ENDPGM};
   f.run_kernel(code, 2);
+}
+
+TEST(ExecutionPluginTest, MfmaReadObservationUsesLaneMasks) {
+  PluginFixture f(/*num_wf_slots=*/1);
+  auto *plugin = f.attach_ordering_plugin();
+  auto *cu = f.cu();
+  auto *wf = cu->dispatch_wf(0, 0, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wf, nullptr);
+  ASSERT_EQ(wf->wf_size(), 64u);
+
+  const uint32_t vb = wf->vgpr_alloc().base;
+  constexpr uint32_t S0 = 0, S1 = 16, ACC = 32;
+
+  amdgpu::observe_mfma_input_reads(*cu, vb + S0, /*dim=*/16, /*K=*/32, /*B=*/1,
+                                   /*data_bits=*/16, wf->wf_size());
+  amdgpu::observe_mfma_input_reads(*cu, vb + S1, /*dim=*/16, /*K=*/32, /*B=*/1,
+                                   /*data_bits=*/16, wf->wf_size());
+  amdgpu::observe_mfma_acc32_reads(*cu, vb + ACC, /*M=*/16, /*N=*/16, /*B=*/1, wf->wf_size());
+
+  uint32_t read_hooks = 0;
+  bool saw_multi_lane = false;
+  for (const HookEvent &e : plugin->events) {
+    if (e.kind != HookEvent::READ_VGPR)
+      continue;
+    ++read_hooks;
+    saw_multi_lane |= std::popcount(e.lane_mask) > 1;
+    EXPECT_NE(e.lane_mask, 0u);
+    EXPECT_NE(e.byte_mask, 0u);
+  }
+  EXPECT_GT(read_hooks, 0u);
+  EXPECT_LT(read_hooks, 32u);
+  EXPECT_TRUE(saw_multi_lane);
+}
+
+TEST(ExecutionPluginTest, MfmaReadObservationReportsRace) {
+  PluginFixture f(/*num_wf_slots=*/1);
+  f.plugin_group_ = std::make_shared<ExecutionPluginGroup>();
+  auto plugin = std::make_unique<MfmaRacePlugin>();
+  auto *race_plugin = plugin.get();
+  f.plugin_group_->add(std::move(plugin));
+  f.soc->set_plugin_group(f.plugin_group_);
+  f.plugin_group_->onInit();
+
+  auto *cu = f.cu();
+  auto *wf = cu->dispatch_wf(0, 0, /*sgprs=*/104, /*vgprs=*/256);
+  ASSERT_NE(wf, nullptr);
+  ASSERT_EQ(wf->wf_size(), 64u);
+  std::array<amdgpu::Wavefront *, 1> waves{wf};
+  f.plugin_group_->onAmdgpuWorkgroupDispatched(/*dispatch_id=*/1, /*wg_id=*/0,
+                                               /*physical_vgpr_count=*/256, /*sgpr_count=*/104,
+                                               waves);
+
+  const uint32_t vb = wf->vgpr_alloc().base;
+  constexpr uint32_t S0 = 0;
+
+  race_plugin->registerOutstandingLoad(S0, /*exec_mask=*/1u);
+  amdgpu::observe_mfma_input_reads(*cu, vb + S0, /*dim=*/16, /*K=*/32, /*B=*/1,
+                                   /*data_bits=*/16, wf->wf_size());
+
+  ASSERT_FALSE(race_plugin->violations.empty());
+  const auto &violation = race_plugin->violations.front();
+  EXPECT_EQ(violation.space, RaceViolation::Space::VGPR);
+  EXPECT_EQ(violation.index, static_cast<int>(S0));
+  EXPECT_EQ(violation.lane, 0);
+}
+
+TEST(ExecutionPluginTest, MfmaFastPathReadHookReportsRace) {
+  if constexpr (!util::has_stdx_simd) {
+    GTEST_SKIP() << "stdx SIMD is unavailable";
+  } else {
+    if (util::native<float>::size() != 16)
+      GTEST_SKIP() << "MFMA fast path requires 16-lane native<float>";
+
+    struct ForceScalarGuard {
+      bool old = util::force_scalar();
+      ~ForceScalarGuard() { util::set_force_scalar_for_testing(old); }
+    } force_scalar_guard;
+    util::set_force_scalar_for_testing(false);
+
+    PluginFixture f(/*num_wf_slots=*/1);
+    f.plugin_group_ = std::make_shared<ExecutionPluginGroup>();
+    auto plugin = std::make_unique<MfmaRacePlugin>();
+    auto *race_plugin = plugin.get();
+    f.plugin_group_->add(std::move(plugin));
+    f.soc->set_plugin_group(f.plugin_group_);
+    f.plugin_group_->onInit();
+
+    auto *cu = f.cu();
+    auto *wf = cu->dispatch_wf(0, 0, /*sgprs=*/104, /*vgprs=*/256);
+    ASSERT_NE(wf, nullptr);
+    ASSERT_EQ(wf->wf_size(), 64u);
+    std::array<amdgpu::Wavefront *, 1> waves{wf};
+    f.plugin_group_->onAmdgpuWorkgroupDispatched(/*dispatch_id=*/1, /*wg_id=*/0,
+                                                 /*physical_vgpr_count=*/256, /*sgpr_count=*/104,
+                                                 waves);
+
+    const uint32_t vb = wf->vgpr_alloc().base;
+    constexpr uint32_t S0 = 0, S1 = 16, ACC = 32, DST = 48;
+    for (uint32_t reg = 0; reg < 64; ++reg)
+      for (uint32_t lane = 0; lane < 64; ++lane)
+        cu->write_vgpr(vb + reg, lane, 0x3c003c00u);
+
+    race_plugin->registerOutstandingLoad(S0, /*exec_mask=*/1u);
+    amdgpu::exec_f32_mfma_f16_spec<16, 16, 32>(*cu, vb + DST, vb + S0, vb + S1, vb + ACC,
+                                               amdgpu::ACC_FROM_VGPR, /*cbsz=*/0, /*abid=*/0,
+                                               /*blgp=*/0);
+
+    ASSERT_FALSE(race_plugin->violations.empty());
+    const auto &violation = race_plugin->violations.front();
+    EXPECT_EQ(violation.space, RaceViolation::Space::VGPR);
+    EXPECT_EQ(violation.index, static_cast<int>(S0));
+    EXPECT_EQ(violation.lane, 0);
+  }
 }
 
 // -- Ordering tests ----------------------------------------------------------

--- a/emulation/rocjitsu/tests/execution_plugin_test.cpp
+++ b/emulation/rocjitsu/tests/execution_plugin_test.cpp
@@ -167,8 +167,7 @@ public:
     events.push_back(e);
   }
 
-  void onAmdgpuReadVgprs(const amdgpu::Wavefront *wf, uint32_t, uint32_t, uint32_t,
-                         uint8_t) override {
+  void onAmdgpuReadVgprLanes(const amdgpu::Wavefront *wf, uint32_t, uint64_t, uint8_t) override {
     HookEvent e{HookEvent::READ_VGPR};
     if (wf) {
       e.dispatch_id = wf->dispatch_id();

--- a/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
+++ b/emulation/rocjitsu/tests/mfma_simd_benchmark.cpp
@@ -538,7 +538,7 @@ TEST(MfmaSimdBenchmark, F64_16x16x4_f64) {
 }
 
 // f32-input MFMA shapes (no F16C convert; specialization gain is the
-// addressing-unroll + raw vgpr_data + no-heap, not a convert).
+// addressing-unroll + raw raw_vgpr_data + no-heap, not a convert).
 TEST(MfmaSimdBenchmark, F32_32x32x2_f32_Specialized) {
   SKIP_IF_NO_SIMD();
   BenchFixture fx;

--- a/emulation/rocjitsu/tests/race-detector/race_detector_tests.cpp
+++ b/emulation/rocjitsu/tests/race-detector/race_detector_tests.cpp
@@ -828,6 +828,18 @@ TEST(RaceDetector, CheckVgprReadAllLanes) {
   EXPECT_FALSE(b3.hasRace());
 }
 
+TEST(RaceDetector, CheckVgprReadLanesReportsMaskedLane) {
+  RaceTestBuilder b(/*numWaves=*/1, /*vgprs=*/4, /*sgprs=*/4);
+  b.globalLoad(/*wave=*/0, /*vgprBase=*/1, /*numRegs=*/1, /*exec=*/1ULL << 5);
+  b.checkVgprReadLanes(/*wave=*/0, /*reg=*/1, /*laneMask=*/(1ULL << 0) | (1ULL << 5));
+
+  ASSERT_EQ(b.raceCount(), 1);
+  const auto &v = b.violations()[0];
+  EXPECT_EQ(v.space, RaceViolation::Space::VGPR);
+  EXPECT_EQ(v.index, 1);
+  EXPECT_EQ(v.lane, 5);
+}
+
 // ---- Mixed counter types ----
 
 TEST(RaceDetector, Mixed_VmcntAndLgkmcnt) {

--- a/emulation/rocjitsu/tests/race-detector/race_test_builder.h
+++ b/emulation/rocjitsu/tests/race-detector/race_test_builder.h
@@ -130,6 +130,10 @@ public:
     waves_[wave]->checkVgprRead(reg, lane, byteMask);
   }
 
+  void checkVgprReadLanes(int wave, int reg, uint64_t laneMask, uint8_t byteMask = 0xF) {
+    waves_[wave]->checkVgprReadLanes(reg, laneMask, byteMask);
+  }
+
   void checkSgprRead(int wave, int reg) { waves_[wave]->checkSgprRead(reg); }
 
   void checkLdsRead(int wave, int lane, int addr, int bytes) {

--- a/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
+++ b/emulation/rocjitsu/tests/simd_correctness/vop2_fma_f64_simd_correctness_test.cpp
@@ -150,8 +150,8 @@ TEST(Vop2FmaF64SimdCorrectness, LaneLayoutRoundTrip) {
     expected[lane] = v;
     fx.write64(vb + 0, lane, v);
   }
-  const uint32_t *lo = reinterpret_cast<const uint32_t *>(fx.cu->vgpr_data(vb + 0));
-  const uint32_t *hi = reinterpret_cast<const uint32_t *>(fx.cu->vgpr_data(vb + 1));
+  const uint32_t *lo = reinterpret_cast<const uint32_t *>(fx.cu->raw_vgpr_data(vb + 0));
+  const uint32_t *hi = reinterpret_cast<const uint32_t *>(fx.cu->raw_vgpr_data(vb + 1));
   constexpr std::size_t W = util::native_width64;
   for (uint32_t base = 0; base < WF_SIZE; base += static_cast<uint32_t>(W)) {
     util::native<uint64_t> v = util::load64<uint64_t>(lo + base, hi + base);


### PR DESCRIPTION
fixes : #8040
replaced by: https://github.com/ROCm/rocm-systems/pull/8075

## Motivation

The MFMA SIMD fast paths deliberately avoid `read_vgpr()` in their inner loops. They stage matrix inputs through `raw_vgpr_data()` so the emulator can keep MFMA execution vectorized instead of paying per-lane virtual read overhead. That is good for performance, but it currently means there is a gap for the race detector plugin.

A pending memory operation can still own the value of a VGPR lane when a later instruction reads that VGPR. For ordinary instruction paths, the VGPR read hook gives the race detector a chance to validate the access. For the specialized MFMA SIMD paths, the raw pointer staging skipped that hook, so an MFMA could read an unresolved source register without the race detector seeing the read.

## Technical Details

This PR keeps the raw staging model, but makes the read observation explicit. Before the MFMA fast path reads through raw VGPR storage, it observes the contiguous VGPR windows used for A, B, and the accumulator source. Those windows are reported through lane-mask VGPR read notifications, so the detector still validates with its existing mask-based logic while the MFMA implementation remains vectorized.

I do not see this as the final shape for all register observation. Long term, I would like the emulator to have a tighter bottleneck for instruction-visible register reads so that raw storage access is harder to use accidentally. This PR is a focused step for the MFMA fast-path blind spot.

The supporting VGPR read-hook changes in this branch make that representation natural. A lane mask is a better fit than a contiguous lane range for vectorized instruction paths, and it lets MFMA describe full-window reads without turning the observation path back into a loop of scalar hook calls.

## Test Plan

The tests cover the change at two levels.

The build-independent tests exercise the MFMA read-observation layer itself. One checks that observation emits multi-lane VGPR read hooks. Another wires that observation into the race detector and shows that an unresolved source register read is reported as a race.

The fast-path regression test executes the specialized MFMA SIMD path. In an AVX-512 build, that test fails on `origin/develop` because the race detector sees no read, and passes with this PR because the MFMA source read is now explicitly observed.

## Test Result

Normal Clang build: focused MFMA, race-detector, and plugin tests pass. The AVX-512-only fast-path regression test skips in this build when the 16-lane native float fast path is not active.

GCC `-march=native` AVX-512 regression check: the fast-path regression test fails on `origin/develop` with no race violation reported, and passes with this PR.
